### PR TITLE
fix(daemon): replace blanket .startsWith('.') file filter with explicit ignored-dir list

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -170,7 +170,6 @@ async function collectFolders(dir, relDir, out, shouldSkipDir?: (name: string) =
   }
   for (const e of entries) {
     if (!e.isDirectory()) continue;
-    if (e.name.startsWith('.')) continue;
     if (shouldSkipDir?.(e.name)) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
@@ -271,7 +270,6 @@ async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => 
     throw err;
   }
   for (const e of entries) {
-    if (e.name.startsWith('.')) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
@@ -496,7 +494,6 @@ async function collectArchiveEntries(dir, relDir, out) {
     throw err;
   }
   for (const e of entries) {
-    if (e.name.startsWith('.')) continue;
     if (!e.isDirectory() && !e.isFile()) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
@@ -1191,10 +1188,10 @@ async function collectArtifactManifestFiles(dir, relDir, out) {
     throw err;
   }
   for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue;
     const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      if (isIgnoredProjectDirName(entry.name)) continue;
       await collectArtifactManifestFiles(fullPath, relPath, out);
       continue;
     }


### PR DESCRIPTION
## Problem

Issue #6175: The @-mention autocomplete in the project composer never suggests any file or directory whose name starts with a dot (`.`). Common ecosystem examples such as `.github/`, `.vscode/`, `.storybook/`, `.husky/`, or a plain `.notes.md` file are all invisible.

The same blanket filter also excludes dot-prefixed entries from project-wide file search, making such content unreachable from both the mention picker and search.

## Root cause

Four functions in `apps/daemon/src/projects.ts` used a blanket `e.name.startsWith('.')` filter that excluded **all** dot-prefixed files and directories — including legitimate user content.

The project already has an explicit `IGNORED_PROJECT_DIR_NAMES` set (via `isIgnoredProjectDirName`) that correctly lists system/generated directories: `.git`, `.od`, `.next`, `.nuxt`, `.turbo`, `.cache`, `.output`, `.venv`, `.mypy_cache`, `.pytest_cache`, `.tox`, `.ruff_cache`, `.build`, `.gradle`, `.swiftpm`, `.tmp`.

## Fix

Replaced blanket `startsWith('.')` with `isIgnoredProjectDirName` where applicable, so:

- **System/generated dot dirs** (`.git`, `.od`, `.next`, `.nuxt`, `.turbo`, `.cache`, `.output`, `.venv`, etc.) → still hidden ✓
- **User dot content** (`.github/`, `.vscode/`, `.storybook/`, `.husky/`, `.notes.md`) → now visible ✓
- **Dot files** (`.notes.md`, `.env.example`) → now visible ✓
- **`.artifact.json` sidecars** → still excluded (separate filter) ✓

### Functions changed

| Function | Before | After |
|:---|:---|:---|
| `collectFolders` | `startsWith('.')` + `shouldSkipDir` | `shouldSkipDir` only |
| `collectFiles` | `startsWith('.')` + `shouldSkipDir` + `.artifact.json` | `shouldSkipDir` + `.artifact.json` |
| `collectArtifactManifestFiles` | `startsWith('.')` | `isIgnoredProjectDirName` |
| `collectArchiveEntries` | `startsWith('.')` + `isIgnoredProjectDirName` + `.artifact.json` | `isIgnoredProjectDirName` + `.artifact.json` |

Closes #6175
