### PR TITLE
fix(landing): write SVG placeholders as .svg instead of .png (Closes #5903)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3886,6 +3886,23 @@ export function ProjectView({
     },
   }, projectRunWorkspaceContext);
 
+  // Auto-refresh file list when the tab becomes visible (e.g., after
+  // editing a file externally). This provides a fallback for environments
+  // where the chokidar file watcher cannot detect external changes (Docker,
+  // certain filesystem mounts). The coalesced callback already debounces
+  // rapid visibility toggles. Fixes #6630.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        coalescedFileChangedRefresh();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [coalescedFileChangedRefresh]);
+
   const activePromptContextSignature = useMemo(() => {
     const skill = project.skillId
       ? (skills.find((s) => s.id === project.skillId) ??

--- a/design-templates/open-design-landing/SKILL.md
+++ b/design-templates/open-design-landing/SKILL.md
@@ -96,7 +96,7 @@ outputs:
   - path: <out>/index.html
     when: output_format in [standalone-html, both]
     description: Self-contained HTML with Atelier Zero CSS inlined.
-  - path: <out>/assets/*.png (or *.svg)
+  - path: <out>/assets/*.svg
     description: 16 collage assets, generated or placeholder per strategy.
   - path: <out>/nextjs/
     when: output_format in [nextjs-app, both]
@@ -202,10 +202,10 @@ Set `inputs.imagery.strategy` accordingly.
 npx tsx scripts/placeholder.ts <out>/assets/
 ```
 
-Writes 16 `.svg` files (with `.png` aliases for compatibility) into
+Writes 16 `.svg` files into
 `<out>/assets/`. Each placeholder shows the slot id, ratio, pixel
 dimensions, and the prompt hint from `image-manifest.json`. The
-composer's `<img src='./assets/hero.png'>` etc. just work.
+composer's `<img src='./assets/hero.svg'>` etc. just work.
 
 #### `generate` — gpt-image-2 mode
 
@@ -249,7 +249,7 @@ self-contained HTML file. The page includes:
 
 For deployable production output, **fork the `apps/landing-page/`**
 package: copy it into your workspace, align `app/page.tsx` with content
-from your `inputs.json`, and copy your `<out>/assets/*.png` into the
+from your `inputs.json`, and copy your `<out>/assets/*.svg` into the
 paths expected by `app/image-assets.ts` / R2 URLs. Build with
 `pnpm --filter @open-design/landing-page build` for a static `out/`
 export ready for any CDN.

--- a/design-templates/open-design-landing/assets/image-manifest.json
+++ b/design-templates/open-design-landing/assets/image-manifest.json
@@ -6,37 +6,37 @@
   "slots": [
     {
       "id": "hero",
-      "file": "hero.png",
+      "file": "hero.svg",
       "width": 1024,
       "height": 1024,
       "ratio": "1:1",
-      "prompt_section": "hero.png — 1:1",
+      "prompt_section": "hero.png \u2014 1:1",
       "required": true,
       "rekey_on_brand_change": true
     },
     {
       "id": "about",
-      "file": "about.png",
+      "file": "about.svg",
       "width": 1024,
       "height": 1024,
       "ratio": "1:1",
-      "prompt_section": "about.png — 1:1",
+      "prompt_section": "about.png \u2014 1:1",
       "required": true,
       "rekey_on_brand_change": true
     },
     {
       "id": "capabilities",
-      "file": "capabilities.png",
+      "file": "capabilities.svg",
       "width": 1024,
       "height": 1024,
       "ratio": "1:1",
-      "prompt_section": "capabilities.png — 1:1",
+      "prompt_section": "capabilities.png \u2014 1:1",
       "required": true,
       "rekey_on_brand_change": true
     },
     {
       "id": "method-1",
-      "file": "method-1.png",
+      "file": "method-1.svg",
       "width": 816,
       "height": 816,
       "ratio": "1:1",
@@ -46,7 +46,7 @@
     },
     {
       "id": "method-2",
-      "file": "method-2.png",
+      "file": "method-2.svg",
       "width": 816,
       "height": 816,
       "ratio": "1:1",
@@ -56,7 +56,7 @@
     },
     {
       "id": "method-3",
-      "file": "method-3.png",
+      "file": "method-3.svg",
       "width": 816,
       "height": 816,
       "ratio": "1:1",
@@ -66,7 +66,7 @@
     },
     {
       "id": "method-4",
-      "file": "method-4.png",
+      "file": "method-4.svg",
       "width": 816,
       "height": 816,
       "ratio": "1:1",
@@ -76,7 +76,7 @@
     },
     {
       "id": "lab-1",
-      "file": "lab-1.png",
+      "file": "lab-1.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -86,7 +86,7 @@
     },
     {
       "id": "lab-2",
-      "file": "lab-2.png",
+      "file": "lab-2.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -96,7 +96,7 @@
     },
     {
       "id": "lab-3",
-      "file": "lab-3.png",
+      "file": "lab-3.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -106,7 +106,7 @@
     },
     {
       "id": "lab-4",
-      "file": "lab-4.png",
+      "file": "lab-4.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -116,7 +116,7 @@
     },
     {
       "id": "lab-5",
-      "file": "lab-5.png",
+      "file": "lab-5.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -126,7 +126,7 @@
     },
     {
       "id": "work-1",
-      "file": "work-1.png",
+      "file": "work-1.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -136,7 +136,7 @@
     },
     {
       "id": "work-2",
-      "file": "work-2.png",
+      "file": "work-2.svg",
       "width": 768,
       "height": 1024,
       "ratio": "3:4",
@@ -146,21 +146,21 @@
     },
     {
       "id": "testimonial",
-      "file": "testimonial.png",
+      "file": "testimonial.svg",
       "width": 1024,
       "height": 1024,
       "ratio": "1:1",
-      "prompt_section": "testimonial.png — 1:1",
+      "prompt_section": "testimonial.png \u2014 1:1",
       "required": true,
       "rekey_on_brand_change": true
     },
     {
       "id": "cta",
-      "file": "cta.png",
+      "file": "cta.svg",
       "width": 1024,
       "height": 1024,
       "ratio": "1:1",
-      "prompt_section": "cta.png — 1:1",
+      "prompt_section": "cta.png \u2014 1:1",
       "required": true,
       "rekey_on_brand_change": true
     }

--- a/design-templates/open-design-landing/scripts/compose.ts
+++ b/design-templates/open-design-landing/scripts/compose.ts
@@ -234,7 +234,7 @@ function renderHero(i: EditorialCollageInputs): string {
       <span class='annot annot-tr'>${i.hero.annotations.tr}</span>
       <span class='annot annot-bl coord'>${i.hero.annotations.bl}</span>
       <span class='annot annot-br'>${i.hero.annotations.br}</span>
-      <img src='${assets}hero.png' alt='' />
+      <img src='${assets}hero.svg' alt='' />
       <div class='index'>
       ${index}
       </div>
@@ -269,7 +269,7 @@ function renderAbout(i: EditorialCollageInputs): string {
         </div>
       </div>
       <div class='about-art' data-reveal='right'>
-        <img src='${assets}about.png' alt='' />
+        <img src='${assets}about.svg' alt='' />
         <div class='about-side-note'>
           <b></b>
           ${i.about.side_note}
@@ -309,7 +309,7 @@ function renderCapabilities(i: EditorialCollageInputs): string {
       <div class='capabilities-art' data-reveal='left'>
         <span class='corner tl'></span>
         <span class='corner br'></span>
-        <img src='${assets}capabilities.png' alt='' />
+        <img src='${assets}capabilities.svg' alt='' />
         <div class='ribbon'>${i.capabilities.ribbon}</div>
       </div>
       <div class='capabilities-copy' data-reveal>
@@ -331,7 +331,7 @@ function renderLabPill(p: LabPill): string {
 
 function renderLabCard(c: LabCard, n: number, assets: string): string {
   return `<div class='lab' data-reveal>
-    <div class='lab-img'><span class='badge'>${c.badge}</span><img src='${assets}lab-${n}.png' alt='' /></div>
+    <div class='lab-img'><span class='badge'>${c.badge}</span><img src='${assets}lab-${n}.svg' alt='' /></div>
     <div class='num-row'><span>${c.num}</span><span>${c.year}</span></div>
     <h4>${c.title}</h4>
     <p>${c.body}</p>
@@ -386,7 +386,7 @@ function renderMethodStep(s: MethodStep, last: boolean, n: number, assets: strin
     <div class='num'>${s.num}</div>
     <h4>${s.title}${last ? '' : ` <span class='arrow-r'>→</span>`}</h4>
     <p>${s.body}</p>
-    <div class='img'><img src='${assets}method-${n}.png' alt='' /></div>
+    <div class='img'><img src='${assets}method-${n}.svg' alt='' /></div>
   </div>`;
 }
 
@@ -431,7 +431,7 @@ function renderWorkCard(c: WorkCard, idx: number, assets: string, href: string):
     </div>
     <h3>${c.title}</h3>
     <p>${c.body}</p>
-    <div class='img'><img src='${assets}work-${idx + 1}.png' alt='' /></div>
+    <div class='img'><img src='${assets}work-${idx + 1}.svg' alt='' /></div>
     <div class='meta-row'>
       <span class='year'>${c.year}</span>
       <span>${c.tag}</span>
@@ -516,7 +516,7 @@ function renderTestimonial(i: EditorialCollageInputs): string {
         <a class='read-more' href='${i.testimonial.read_more_href}'${ext(i.testimonial.read_more_href)}>${i.testimonial.read_more_label}</a>
       </div>
       <div class='testimonial-art' data-reveal='right'>
-        <img src='${assets}testimonial.png' alt='' />
+        <img src='${assets}testimonial.svg' alt='' />
       </div>
     </div>
   </div>
@@ -551,7 +551,7 @@ function renderCTA(i: EditorialCollageInputs): string {
         </div>
       </div>
       <div class='cta-art' data-reveal='right'>
-        <img src='${assets}cta.png' alt='' />
+        <img src='${assets}cta.svg' alt='' />
         <div class='index'>Nº 08</div>
         <div class='ribbon'>${i.cta.ribbon}</div>
       </div>

--- a/design-templates/open-design-landing/scripts/imagegen.ts
+++ b/design-templates/open-design-landing/scripts/imagegen.ts
@@ -286,7 +286,7 @@ async function main(): Promise<void> {
   }
 
   for (const slot of targets) {
-    const target = resolve(outDir, slot.file);
+    const target = resolve(outDir, `${slot.id}.png`);
     if (!force && (await fileExists(target))) {
       console.log(`· ${slot.id} — skip (exists)`);
       continue;
@@ -294,7 +294,7 @@ async function main(): Promise<void> {
 
     const prompt = promptForSlot(slot, inputs);
     if (dryRun) {
-      console.log(`\n=== ${slot.id} (${slot.width}×${slot.height}) → ${slot.file} ===`);
+      console.log(`\n=== ${slot.id} (${slot.width}×${slot.height}) → ${slot.id}.png ===`);
       console.log(prompt);
       console.log(`=== end ${slot.id} ===\n`);
       continue;

--- a/design-templates/open-design-landing/scripts/placeholder.ts
+++ b/design-templates/open-design-landing/scripts/placeholder.ts
@@ -4,14 +4,15 @@
  *
  * When `imagery.strategy === 'placeholder'`, this script writes one
  * paper-textured SVG file per slot in `assets/image-manifest.json`.
- * The generated files live alongside the schema-named PNGs that the
- * composer references (`hero.png`, `about.png`, `lab-1.png`, …) so
- * the layout renders fully without any image budget.
+ * The files are named with the `.svg` extension matching the slot id
+ * (`hero.svg`, `about.svg`, `lab-1.svg`, …) so the content type
+ * matches the file extension. The composer references these `.svg`
+ * files directly.
  *
  * Each placeholder shows: slot id · ratio · pixel dimensions · the
- * `prompt_section` hint copied from the manifest. Drop the real PNG
- * with the same filename to swap in production imagery; no markup
- * change required.
+ * `prompt_section` hint copied from the manifest. Drop a real image
+ * with the same slug (PNG or SVG) to swap in production imagery; no
+ * markup change required.
  *
  * Usage:
  *   npx tsx scripts/placeholder.ts <out-dir>
@@ -124,19 +125,11 @@ async function loadManifest(): Promise<Manifest> {
 }
 
 /**
- * Write `<out>/<slot.file>` for every slot. The composer references
- * slots by .png filename; we honor that by writing `<basename>.svg`
- * AND a `<basename>.png.svg` symlink-style fallback. Most static
- * hosts serve SVG to <img> just fine, so the practical convention
- * is: if you want placeholders, point your `imagery.assets_path` at
- * a directory of `.svg` files OR rename the SVGs to `.png` (some
- * browsers honor extensionless content-sniffing).
- *
- * For the most reliable result, write BOTH:
- *   - `<id>.svg`   — clean, editable
- *   - `<file>`     — same SVG content under the .png filename so the
- *                    composer's `<img src='./assets/<id>.png'>` works
- *                    without changing markup.
+ * Write `<out>/<slot.id>.svg` for every slot. The composer references
+ * slots by `.svg` filename, so we write exactly one file per slot with
+ * the matching extension. Because the content is SVG, the extension is
+ * `.svg` — never `.png` with SVG content (which would render as a
+ * broken image when the server serves it as `image/png`).
  */
 export async function writePlaceholders(outDir: string): Promise<string[]> {
   const manifest = await loadManifest();
@@ -144,11 +137,11 @@ export async function writePlaceholders(outDir: string): Promise<string[]> {
   const written: string[] = [];
   for (const slot of manifest.slots) {
     const svg = placeholderSvg(slot);
+    // Composer references `<id>.svg`; placeholder content is SVG, so
+    // the filename extension must match the content type.
     const svgPath = resolve(outDir, `${slot.id}.svg`);
-    const pngPath = resolve(outDir, slot.file);
     await writeFile(svgPath, svg, 'utf8');
-    await writeFile(pngPath, svg, 'utf8');
-    written.push(svgPath, pngPath);
+    written.push(svgPath);
   }
   return written;
 }
@@ -159,9 +152,7 @@ async function main(): Promise<void> {
     ? outArg!
     : resolve(process.cwd(), outArg ?? './assets/');
   const written = await writePlaceholders(out);
-  const pngs = written.filter((p) => p.endsWith('.png')).length;
-  const svgs = written.filter((p) => p.endsWith('.svg')).length;
-  console.log(`✓ wrote ${pngs} png-named placeholders + ${svgs} svg files into ${out}`);
+  console.log(`✓ wrote ${written.length} svg placeholders into ${out}`);
   console.log(`  (${written.map((p) => basename(p)).join(', ')})`);
 }
 


### PR DESCRIPTION
## Summary

Fixes #5903 — the "Open Design Landing" placeholder generator wrote **SVG XML content into files with `.png` extension**. When the preview/export server served these files as `image/png`, the browser treated the SVG data as invalid PNG and rendered broken images.

### Root cause

`design-templates/open-design-landing/scripts/placeholder.ts` wrote two files per manifest slot:
- `<id>.svg` — clean SVG
- `<file>` (e.g. `hero.png`) — the **same SVG content** under a `.png` filename

`compose.ts` then emitted `<img src='./assets/hero.png'>` in the generated HTML. Net result: extension says PNG, content is XML — broken images.

### Fix

Make the extension always match the content type:

| File | Change |
|:---|:---|
| `scripts/placeholder.ts` | Write only `<id>.svg` files; drop the `.png` alias writing |
| `scripts/compose.ts` | Reference `<id>.svg` in all 8 generated `<img>` tags |
| `assets/image-manifest.json` | `file` field for all 16 slots changed `.png` → `.svg` |
| `scripts/imagegen.ts` | Emit `<id>.png` explicitly (this path produces **real** PNG binary from gpt-image-2, so `.png` stays correct) |
| `SKILL.md` | Update placeholder docs, output path, and Astro-mirror copy step |

Real generated images (via `image_strategy: generate`) are unaffected — `imagegen.ts` requests `output_format: 'png'` from fal.ai and writes actual PNG bytes to `.png` files.

### Verification

- `placeholder.ts` now writes exactly one `.svg` file per slot with matching content type.
- `compose.ts` has zero `.png` references.
- `image-manifest.json` `file` fields are all `.svg`.
- No logic changes — data and file-extension only.