### PR TITLE
perf(guard): avoid unnecessary TypeScript parsing

### DIFF
--- a/e2e/tests/scripts/check-cross-app-imports.test.ts
+++ b/e2e/tests/scripts/check-cross-app-imports.test.ts
@@ -9,6 +9,7 @@ import {
   collectCrossAppImportViolationsFromSource,
   isCrossAppImportSourceFile,
   loadAppDirectoryRegistry,
+  sourceMayImportAnotherApp,
 } from "../../../scripts/check-cross-app-imports.ts";
 
 const registry: AppDirectoryRegistry = {
@@ -17,6 +18,57 @@ const registry: AppDirectoryRegistry = {
     ["web", "@open-design/web"],
   ]),
 };
+
+test("cross-app import prefilter keeps possible targets and escaped specifiers", () => {
+  assert.equal(
+    sourceMayImportAnotherApp(
+      "apps/web/src/runtime.ts",
+      "import { run } from '@open-design/daemon';",
+      registry,
+    ),
+    true,
+  );
+  assert.equal(
+    sourceMayImportAnotherApp(
+      "apps/web/src/runtime.ts",
+      "import { run } from '../../daemon/src/server.ts';",
+      registry,
+    ),
+    true,
+  );
+  assert.equal(
+    sourceMayImportAnotherApp(
+      "apps/web/src/runtime.ts",
+      String.raw`import { run } from '@open-design/\u0064aemon';`,
+      registry,
+    ),
+    true,
+  );
+  assert.equal(
+    sourceMayImportAnotherApp(
+      "apps/web/src/runtime.ts",
+      String.raw`import { run } from '@open-design/\d\a\e\m\o\n';`,
+      registry,
+    ),
+    true,
+  );
+  assert.equal(
+    sourceMayImportAnotherApp(
+      "apps/web/src/runtime.ts",
+      "import { Button } from '@open-design/components';",
+      registry,
+    ),
+    false,
+  );
+
+  const escapedViolations = collectCrossAppImportViolationsFromSource(
+    "apps/web/src/runtime.ts",
+    String.raw`import { run } from '@open-design/\u0064aemon';`,
+    registry,
+  );
+  assert.equal(escapedViolations.length, 1);
+  assert.equal(escapedViolations[0]?.targetApp, "daemon");
+});
 
 test("cross-app import check rejects web importing daemon src via relative path", () => {
   const violations = collectCrossAppImportViolationsFromSource(

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -754,9 +754,18 @@ test("daemon core matches only its certain rule while excluded daemon surfaces s
 });
 
 test("packaged-leaf consumption collector resolves imports, packages, and static paths", async () => {
-  const { collectPackagedLeafConsumptionFromSource } = await import(
+  const { collectPackagedLeafConsumptionFromSource, sourceMayConsumePackagedLeaf } = await import(
     "../../../scripts/check-packaged-leaf-boundary.ts"
   );
+  assert.equal(sourceMayConsumePackagedLeaf(`import "@open-design/desktop/main";`), true);
+  assert.equal(sourceMayConsumePackagedLeaf(`const source = path.join(repoRoot, "tools", "pack");`), true);
+  assert.equal(
+    sourceMayConsumePackagedLeaf(String.raw`import "@open-design/\u0064esktop/main";`),
+    true,
+  );
+  assert.equal(sourceMayConsumePackagedLeaf(String.raw`import "@open-design/\d\e\s\k\t\o\p/main";`), true);
+  assert.equal(sourceMayConsumePackagedLeaf(`import "@open-design/contracts";`), false);
+
   const violations = collectPackagedLeafConsumptionFromSource(
     "packages/example/src/index.ts",
     [
@@ -770,12 +779,31 @@ test("packaged-leaf consumption collector resolves imports, packages, and static
     violations.map((violation) => violation.lineNumber),
     [1, 2, 3],
   );
+  assert.equal(
+    collectPackagedLeafConsumptionFromSource(
+      "packages/example/src/index.ts",
+      String.raw`import "@open-design/\u0064esktop/main";`,
+    ).length,
+    1,
+  );
 });
 
 test("the consumption guard folds repository paths while allowing sandbox fixture writers", async () => {
-  const { collectCertainExemptConsumptionFromSource } = await import(
+  const { collectCertainExemptConsumptionFromSource, sourceMayConsumeCertainExemptSurface } = await import(
     "../../../scripts/check-certain-exempt-consumption.ts"
   );
+
+  assert.equal(sourceMayConsumeCertainExemptSurface(`readFileSync("docs/spec.md")`), true);
+  assert.equal(
+    sourceMayConsumeCertainExemptSurface(`readFileSync(path.join(repoRoot, "docs", "spec.md"))`),
+    true,
+  );
+  assert.equal(
+    sourceMayConsumeCertainExemptSurface(String.raw`readFileSync("d\u006fcs/spec.md")`),
+    true,
+  );
+  assert.equal(sourceMayConsumeCertainExemptSurface(String.raw`readFileSync("\d\o\c\s/spec.md")`), true);
+  assert.equal(sourceMayConsumeCertainExemptSurface(`readFileSync("skills/example.md")`), false);
 
   // Dot-relative resolution into docs/ is consumption anywhere, tests included.
   const relative = collectCertainExemptConsumptionFromSource(
@@ -783,6 +811,13 @@ test("the consumption guard folds repository paths while allowing sandbox fixtur
     `const spec = readFileSync("../../../docs/spec.md", "utf8");`,
   );
   assert.deepEqual(relative.map((violation) => violation.literal), ["../../../docs/spec.md"]);
+  assert.equal(
+    collectCertainExemptConsumptionFromSource(
+      "apps/daemon/tests/example.test.ts",
+      String.raw`const spec = readFileSync("../../../d\u006fcs/spec.md", "utf8");`,
+    ).length,
+    1,
+  );
 
   // Bare repo-relative literals are consumption in non-test source...
   const bareInSource = collectCertainExemptConsumptionFromSource(

--- a/scripts/check-certain-exempt-consumption.ts
+++ b/scripts/check-certain-exempt-consumption.ts
@@ -54,6 +54,33 @@ const checkedExtensions = new Set([".ts", ".tsx"]);
 // visible to the guard.
 const sandboxFixtureWriterNames = new Set(["writeProjectFile"]);
 
+const certainExemptSourceMarkers = [
+  ".vscode",
+  ".idea",
+  "docs",
+  "landing-page",
+  "ISSUE_TEMPLATE",
+  "LICENSE",
+  "CODEOWNERS",
+] as const;
+
+// A prefilter may skip parsing only when escaped spellings cannot hide a
+// guarded path. Unicode, hex, and line-continuation escapes always fall back;
+// removing slashes covers identity escapes such as `\d\o\c\s`.
+function hasPotentiallyEscapedLiteral(source: string): boolean {
+  if (source.includes("\\u") || source.includes("\\x") || /\\\r?\n/.test(source)) return true;
+  if (!source.includes("\\")) return false;
+  const unescapedSource = source.replaceAll("\\", "");
+  return certainExemptSourceMarkers.some((marker) => unescapedSource.includes(marker));
+}
+
+export function sourceMayConsumeCertainExemptSurface(source: string): boolean {
+  return (
+    hasPotentiallyEscapedLiteral(source) ||
+    certainExemptSourceMarkers.some((marker) => source.includes(marker))
+  );
+}
+
 // File-level exceptions. Every entry must explain why the reference is not
 // gate-lane consumption of exempt-file *content*; revisit the entry if the
 // file's relationship to the exempt surface changes.
@@ -385,6 +412,7 @@ export async function checkCertainExemptConsumption(): Promise<boolean> {
     for (const repositoryPath of await collectCheckedFiles(path.join(repoRoot, root))) {
       if (allowedConsumers.has(repositoryPath) || conditionallyAllowed.has(repositoryPath)) continue;
       const source = await readFile(path.join(repoRoot, repositoryPath), "utf8");
+      if (!sourceMayConsumeCertainExemptSurface(source)) continue;
       violations.push(...collectCertainExemptConsumptionFromSource(repositoryPath, source));
     }
   }

--- a/scripts/check-cross-app-imports.ts
+++ b/scripts/check-cross-app-imports.ts
@@ -66,6 +66,31 @@ function isCrossAppImportAllowlisted(repositoryPath: string, specifier: string):
   );
 }
 
+// A prefilter may skip parsing only when escaped spellings cannot hide a
+// registered app name. Unicode, hex, and line-continuation escapes always fall
+// back; removing slashes covers identity escapes such as `\d\a\e\m\o\n`.
+function hasPotentiallyEscapedLiteral(source: string, markers: readonly string[]): boolean {
+  if (source.includes("\\u") || source.includes("\\x") || /\\\r?\n/.test(source)) return true;
+  if (!source.includes("\\")) return false;
+  const unescapedSource = source.replaceAll("\\", "");
+  return markers.some((marker) => unescapedSource.includes(marker));
+}
+
+export function sourceMayImportAnotherApp(
+  repositoryPath: string,
+  source: string,
+  registry: AppDirectoryRegistry,
+): boolean {
+  const importingApp = appDirectoryForRepositoryPath(repositoryPath);
+  const targetMarkers: string[] = [];
+  for (const [appDirectory, packageName] of registry.packageNameByDirectory) {
+    if (appDirectory === importingApp) continue;
+    targetMarkers.push(appDirectory, packageName);
+    if (source.includes(appDirectory) || source.includes(packageName)) return true;
+  }
+  return hasPotentiallyEscapedLiteral(source, targetMarkers);
+}
+
 function targetAppForSpecifier(
   repositoryPath: string,
   specifier: string,
@@ -232,14 +257,7 @@ function isRequireResolveExpression(expression: ts.Expression, bindings: CreateR
   );
 }
 
-function collectImportSpecifierReferences(repositoryPath: string, source: string): ImportSpecifierReference[] {
-  const sourceFile = ts.createSourceFile(
-    repositoryPath,
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindForRepositoryPath(repositoryPath),
-  );
+function collectImportSpecifierReferences(sourceFile: ts.SourceFile): ImportSpecifierReference[] {
   const references: ImportSpecifierReference[] = [];
   const createRequireBindings = collectCreateRequireBindings(sourceFile);
 
@@ -292,11 +310,11 @@ export function collectCrossAppImportViolationsFromSource(
     repositoryPath,
     source,
     ts.ScriptTarget.Latest,
-    false,
+    true,
     scriptKindForRepositoryPath(repositoryPath),
   );
 
-  for (const reference of collectImportSpecifierReferences(repositoryPath, source)) {
+  for (const reference of collectImportSpecifierReferences(sourceFile)) {
     const dedupeKey = `${reference.index}\0${reference.specifier}`;
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
@@ -371,6 +389,7 @@ export async function checkCrossAppImports(): Promise<boolean> {
     for (const fullPath of await collectAppSourceFiles(path.join(repoRoot, "apps", appDirectory))) {
       const repositoryPath = path.relative(repoRoot, fullPath).split(path.sep).join("/");
       const source = await readFile(fullPath, "utf8");
+      if (!sourceMayImportAnotherApp(repositoryPath, source, registry)) continue;
       violations.push(...collectCrossAppImportViolationsFromSource(repositoryPath, source, registry));
     }
   }

--- a/scripts/check-packaged-leaf-boundary.ts
+++ b/scripts/check-packaged-leaf-boundary.ts
@@ -23,6 +23,24 @@ const skippedDirectories = new Set([
   "vendor",
 ]);
 const leafPackages = ["@open-design/desktop", "@open-design/packaged", "@open-design/tools-pack"] as const;
+const packagedLeafSourceMarkers = ["desktop", "packaged", "pack"] as const;
+
+// A prefilter may skip parsing only when escaped spellings cannot hide a
+// guarded path. Unicode, hex, and line-continuation escapes always fall back;
+// removing slashes covers identity escapes such as `\d\e\s\k\t\o\p`.
+function hasPotentiallyEscapedLiteral(source: string): boolean {
+  if (source.includes("\\u") || source.includes("\\x") || /\\\r?\n/.test(source)) return true;
+  if (!source.includes("\\")) return false;
+  const unescapedSource = source.replaceAll("\\", "");
+  return packagedLeafSourceMarkers.some((marker) => unescapedSource.includes(marker));
+}
+
+export function sourceMayConsumePackagedLeaf(source: string): boolean {
+  return (
+    hasPotentiallyEscapedLiteral(source) ||
+    packagedLeafSourceMarkers.some((marker) => source.includes(marker))
+  );
+}
 
 const allowedConsumerPrefixes = new Map([
   [
@@ -243,6 +261,7 @@ export async function checkPackagedLeafBoundary(): Promise<boolean> {
     for (const filePath of await collectCheckedFiles(path.join(repoRoot, root))) {
       if (isAllowedConsumer(filePath)) continue;
       const source = await readFile(path.join(repoRoot, filePath), "utf8");
+      if (!sourceMayConsumePackagedLeaf(source)) continue;
       violations.push(...collectPackagedLeafConsumptionFromSource(filePath, source));
     }
   }


### PR DESCRIPTION
Fixes #6417

## Why

I followed up on the repeated `scripts/guard.ts` CPU report by profiling a clean checkout at `f58027184` with Node 24. The guard runner is serial, but several checks independently parse overlapping repository-wide source inventories.

The first profile showed that three checks accounted for about 77% of the total guard time:

| Check | Mean elapsed |
| --- | ---: |
| daemon core boundary | 7.07 s |
| packaged leaf boundary | 4.61 s |
| certain-exempt surface consumption | 4.49 s |

The initial generated-directory hypothesis was not the main cost on a clean checkout: product neutrality averaged 0.49 s. The larger cost was TypeScript parsing. Certain-exempt inspected 3,044 TS/TSX files, packaged-leaf inspected 3,109 source files, and cross-app inspected 2,714 app sources. Cross-app also built two ASTs per file: one for import collection and another for line mapping.

This PR keeps the existing file inventories and guard semantics, but avoids building an AST when the raw source cannot possibly name a guarded target. Cross-app also reuses one parent-linked AST for import analysis and diagnostics.

The prefilters deliberately fall back to parsing for Unicode escapes, hex escapes, line continuations, and identity-escaped spellings. Tests cover ordinary, relative, split `path.join`, Unicode-escaped, and identity-escaped targets so the optimization cannot become an easy guard bypass.

I also tried broader caches before settling on this scope. A shared AST cache reduced elapsed time further but raised peak RSS to about 1.7 GB. A source-text cache only added a small speedup while raising RSS to about 590 MB. Neither tradeoff is included here; this PR retains no cross-check cache.

## What users will see

No product UI changes. Contributors and CI jobs running `pnpm guard` should spend substantially less wall time and CPU in repeated repository scans.

Five warm baseline runs averaged 20.88 s. Three branch runs averaged 12.45 s:

| Revision | Runs | Mean elapsed | Mean user + sys CPU |
| --- | ---: | ---: | ---: |
| `main` (`f58027184`) | 5 | 20.88 s | 24.20 s |
| this branch | 3 | 12.45 s | 15.21 s |

That is about 40.4% lower elapsed time and 37.1% less CPU time on this checkout. Branch peak RSS across the three measured runs was 481-496 MB; no persistent cache is retained.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal guard optimization and tests only

## Screenshots

Not applicable; this changes an internal repository guard only.

## Bug fix verification

- Test paths: `e2e/tests/scripts/check-cross-app-imports.test.ts` and `e2e/tests/scripts/scopes.test.ts`
- A deterministic timing assertion would be flaky, so the CPU symptom was reproduced with repeated process-level timing rather than encoded as a wall-clock test. The new behavior-contract cases were red on `main` because the safe prefilter functions did not exist, then green on this branch.
- The focused tests verify that normal, relative, split static paths, Unicode escapes, and identity escapes still reach the existing AST analyzers, while unrelated sources can skip parsing.

## Validation

- `pnpm guard` — pass, three measured runs: 12.57 s, 12.36 s, 12.41 s
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/e2e test tests/scripts/check-cross-app-imports.test.ts tests/scripts/scopes.test.ts` — 69/69 pass
- `pnpm --filter @open-design/e2e test tests/scripts` — 152/153 pass; the sole `postinstall.test.ts` failure reproduces unchanged on a clean `main` worktree
