### PR TITLE
fix(daemon): discover Hermes config home safely

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -211,7 +211,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['deepseek', new Set(['DEEPSEEK_BIN'])],
   ['devin', new Set(['DEVIN_BIN'])],
   ['mimo', new Set(['MIMO_BIN'])],
-  ['hermes', new Set(['HERMES_BIN'])],
+  ['hermes', new Set(['HERMES_BIN', 'HERMES_HOME'])],
   ['kimi', new Set(['KIMI_BIN'])],
   ['kiro', new Set(['KIRO_BIN'])],
   ['kilo', new Set(['KILO_BIN'])],

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -135,6 +136,14 @@ export function spawnEnvForAgent(
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'codex') {
+    return finalizeRuntimeEnv(env, sandboxRuntime);
+  }
+  if (agentId === 'hermes') {
+    if (!envValue(env, 'HERMES_HOME') && !sandboxRuntime) {
+      const home = envValue(env, 'HOME') ?? envValue(env, 'USERPROFILE');
+      const hermesHome = discoverHermesHome(home ?? os.homedir());
+      if (hermesHome) env.HERMES_HOME = hermesHome;
+    }
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'opencode' || agentId === 'byok-opencode') {
@@ -337,6 +346,18 @@ function envValue(env: NodeJS.ProcessEnv, key: string): string | null {
   const value = existingKey ? env[existingKey] : undefined;
   const trimmed = typeof value === 'string' ? value.trim() : '';
   return trimmed ? (value as string) : null;
+}
+
+function discoverHermesHome(home: string): string | null {
+  const candidates = [
+    path.join(home, '.hermes', 'data'),
+    path.join(home, '.hermes'),
+  ];
+  return (
+    candidates.find((candidate) =>
+      existsSync(path.join(candidate, 'config.yaml')),
+    ) ?? null
+  );
 }
 
 function setEnvIfMissing(

--- a/apps/daemon/src/sandbox-mode.ts
+++ b/apps/daemon/src/sandbox-mode.ts
@@ -186,6 +186,7 @@ export function applySandboxRuntimeEnv(
   env.TMP = roots.tempDir;
   env.CODEX_HOME = codexHome;
   env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  env.HERMES_HOME = path.join(roots.agentHomeDir, '.hermes');
   env.OPENCODE_TEST_HOME = opencodeHome;
   env.OD_AGENT_PROFILES_CONFIG = sandboxAgentProfilesConfigPath(config);
   env.NPM_CONFIG_USERCONFIG = npmUserConfig;

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -436,6 +436,10 @@ describe('app-config', () => {
             OPENAI_BASE_URL: '  https://proxy.example/openai  ',
             OPENAI_API_KEY: '  sk-proxy-openai  ',
           },
+          hermes: {
+            HERMES_BIN: '  ~/bin/hermes  ',
+            HERMES_HOME: '  ~/.hermes/data  ',
+          },
           amr: {
             VELA_BIN: '~/bin/vela',
             VELA_API_URL: '  https://custom-amr.example  ',
@@ -463,6 +467,7 @@ describe('app-config', () => {
       expect(cfg.agentCliEnv).toEqual({
         claude: { CLAUDE_CONFIG_DIR: '~/.claude-2', ANTHROPIC_BASE_URL: 'https://proxy.example/anthropic', ANTHROPIC_API_KEY: 'sk-proxy-anthropic', ANTHROPIC_AUTH_TOKEN: 'sk-proxy-token', MMD_MODEL_ROUTES_FILE: '~/.config/mms/model-routes.json' },
         codex: { CODEX_HOME: '~/.codex-alt', CODEX_BIN: '~/bin/codex-next', OPENAI_BASE_URL: 'https://proxy.example/openai', OPENAI_API_KEY: 'sk-proxy-openai' },
+        hermes: { HERMES_BIN: '~/bin/hermes', HERMES_HOME: '~/.hermes/data' },
         amr: {
           VELA_BIN: '~/bin/vela',
           VELA_API_URL: 'https://custom-amr.example',

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -82,6 +82,98 @@ test('spawnEnvForAgent applies configured Codex env without mutating the base en
   assert.equal('CODEX_BIN' in base, false);
 });
 
+test('spawnEnvForAgent discovers the Hermes install-script home from the child HOME', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-hermes-home-'));
+  try {
+    const hermesHome = join(home, '.hermes', 'data');
+    mkdirSync(hermesHome, { recursive: true });
+    writeFileSync(join(hermesHome, 'config.yaml'), 'model: test\n');
+
+    const env = spawnEnvForAgent(
+      'hermes',
+      { HOME: home, PATH: '/usr/bin' },
+      {},
+      {},
+    );
+
+    assert.equal(env.HERMES_HOME, hermesHome);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('spawnEnvForAgent discovers the default Hermes home from USERPROFILE', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-hermes-userprofile-'));
+  try {
+    const hermesHome = join(home, '.hermes');
+    mkdirSync(hermesHome, { recursive: true });
+    writeFileSync(join(hermesHome, 'config.yaml'), 'model: test\n');
+
+    const env = spawnEnvForAgent(
+      'hermes',
+      { USERPROFILE: home, PATH: '/usr/bin' },
+      {},
+      {},
+    );
+
+    assert.equal(env.HERMES_HOME, hermesHome);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('spawnEnvForAgent preserves an explicit Hermes home over auto-detection', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-hermes-configured-home-'));
+  try {
+    const base = { HOME: home, PATH: '/usr/bin' };
+    const detectedHome = join(home, '.hermes', 'data');
+    mkdirSync(detectedHome, { recursive: true });
+    writeFileSync(join(detectedHome, 'config.yaml'), 'model: test\n');
+
+    const env = spawnEnvForAgent(
+      'hermes',
+      base,
+      { HERMES_HOME: '/configured/hermes' },
+      {},
+    );
+
+    assert.equal(env.HERMES_HOME, '/configured/hermes');
+    assert.equal('HERMES_HOME' in base, false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('spawnEnvForAgent preserves an inherited Hermes home', () => {
+  const env = spawnEnvForAgent(
+    'hermes',
+    {
+      HERMES_HOME: '/inherited/hermes',
+      PATH: '/usr/bin',
+    },
+    {},
+    {},
+  );
+
+  assert.equal(env.HERMES_HOME, '/inherited/hermes');
+});
+
+test('spawnEnvForAgent leaves Hermes home unset when no config is found', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-hermes-empty-home-'));
+  try {
+    const env = spawnEnvForAgent(
+      'hermes',
+      { HOME: home, PATH: '/usr/bin' },
+      {},
+      {},
+    );
+
+    assert.equal('HERMES_HOME' in env, false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test('spawnEnvForAgent backfills Windows cache directory env for Trae CLI launches', () => {
   const env = withPlatform('win32', () =>
     spawnEnvForAgent(
@@ -186,6 +278,22 @@ test('spawnEnvForAgent reapplies sandbox state roots after configured env overri
     assert.equal(
       amrEnv.OPENCODE_TEST_HOME,
       join(dataDir, 'sandbox', 'agent-home', '.opencode'),
+    );
+
+    const hermesEnv = spawnEnvForAgent(
+      'hermes',
+      {
+        OD_DATA_DIR: dataDir,
+        OD_SANDBOX_MODE: '1',
+        PATH: '/usr/bin',
+      },
+      {
+        HERMES_HOME: '/Users/test/.hermes-host',
+      },
+    );
+    assert.equal(
+      hermesEnv.HERMES_HOME,
+      join(dataDir, 'sandbox', 'agent-home', '.hermes'),
     );
   } finally {
     rmSync(dataDir, { recursive: true, force: true });

--- a/apps/daemon/tests/sandbox-mode.test.ts
+++ b/apps/daemon/tests/sandbox-mode.test.ts
@@ -78,6 +78,7 @@ describe('sandbox runtime roots', () => {
         HOME: '/real/home',
         CODEX_HOME: '/real/home/.codex',
         CLAUDE_CONFIG_DIR: '/real/home/.claude',
+        HERMES_HOME: '/real/home/.hermes',
         OPENCODE_TEST_HOME: '/real/home/.opencode',
         NPM_CONFIG_USERCONFIG: '/real/home/.npmrc',
         OD_DATA_DIR: dataDir,
@@ -91,6 +92,7 @@ describe('sandbox runtime roots', () => {
     expect(env.OD_AGENT_HOME).toBe(config.roots.agentHomeDir);
     expect(env.CODEX_HOME).toBe(path.join(config.roots.agentHomeDir, '.codex'));
     expect(env.CLAUDE_CONFIG_DIR).toBe(path.join(config.roots.configDir, 'claude'));
+    expect(env.HERMES_HOME).toBe(path.join(config.roots.agentHomeDir, '.hermes'));
     expect(env.OPENCODE_TEST_HOME).toBe(path.join(config.roots.agentHomeDir, '.opencode'));
     expect(env.NPM_CONFIG_USERCONFIG).toBe(path.join(config.roots.toolConfigDir, 'npmrc'));
     expect(env.PATH).toBe('/bin');


### PR DESCRIPTION
Fixes #4407

## Why

This issue was reopened after #4572 became inactive. I picked it up from the current `main` and carried forward two useful review points from that draft: Settings dropped `HERMES_HOME` from saved per-agent configuration, and sandbox mode did not isolate the Hermes profile.

Packaged launches may not inherit a shell-defined `HERMES_HOME`. When the config lives under `~/.hermes/data`, Hermes can look under `~/.hermes` instead and surface the generic `json-rpc id 2: Internal error` reported in the issue.

## What users will see

When `HERMES_HOME` is absent, the daemon checks the launched process's home for `~/.hermes/data/config.yaml` and then `~/.hermes/config.yaml`. It passes the first matching home to Hermes. An explicit Settings value or inherited environment value keeps priority.

`HERMES_HOME` can now be saved through the existing advanced Local CLI settings. Sandbox launches always use their isolated Hermes profile under the sandbox agent home.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change**: Hermes home is discovered only when no explicit value is present.
- [ ] **None**

## Screenshots

Not applicable. There is no UI change.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/env-and-detection.test.ts`
  - `apps/daemon/tests/app-config.test.ts`
  - `apps/daemon/tests/sandbox-mode.test.ts`
- Yes. The initial focused selection was red before the source change with 4 failures and 1 pass. The final selection passes all 7 tests on Windows and Linux.
- Coverage includes both recognized Hermes layouts, explicit and inherited precedence, the negative case, Settings persistence, and sandbox isolation.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/env-and-detection.test.ts tests/app-config.test.ts tests/sandbox-mode.test.ts -t 'Hermes|pins agent home and tool config env|persists supported per-agent CLI env keys'` (Windows): 7 passed
- The same focused checks in a clean Node 24 Linux container: 7 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard`
- `pnpm typecheck`

I also ran the full daemon suite in a clean Linux container. It completed 8,046 tests successfully and reported 20 failures in 15 unrelated files. Running those same 15 files against `upstream/main` in the same container reproduced the baseline failures (20 on `main`, 19 on this branch), so none are introduced by this change.