### PR TITLE
fix(daemon): serve SPA shell via rooted sendFile to avoid dotfile 404

### DIFF
--- a/apps/daemon/src/static-spa.ts
+++ b/apps/daemon/src/static-spa.ts
@@ -29,6 +29,8 @@ export function registerStaticSpaFallback(app: Express, staticDir: string): void
   app.get('/*splat', (req, res, next) => {
     const indexPath = resolveStaticSpaFallbackPath(req, staticDir);
     if (indexPath == null) return next();
-    res.sendFile(indexPath);
+    // Serve the SPA shell relative to its root to avoid `send` treating dot
+    // segments in the absolute path as dotfiles (e.g. installs under ~/.hermes).
+    res.sendFile('index.html', { root: staticDir });
   });
 }


### PR DESCRIPTION
Closes #6613.

## Problem
Reloading a deep client route (e.g. /projects/<id>/...) can return an Express 404 instead of the SPA shell when Open Design is installed under a dot-prefixed path segment (e.g. ~/.hermes/...). `sendFile(<absolute path>)` can be treated as a dotfile by the underlying `send` package.

## Fix
Serve `index.html` relative to the static root:
- `res.sendFile("index.html", { root: staticDir })`

This preserves the existing fallback gating (GET/HEAD + Accept html + excludes /api,/artifacts,/frames,/_next) while making deep-route reloads reliably return 200.

## Test plan
- `pnpm --filter @open-design/daemon typecheck` (pass)
- Manual: start daemon serving built web export, open a deep project URL, reload; expect SPA shell 200 instead of 404.