### PR TITLE
fix(daemon): authorize spawned-agent exports

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -483,7 +483,10 @@ async function runExport(args) {
     process.exit(2);
   }
   const base = await cliDaemonBaseUrl(flags);
-  const workspaceHeaders = workspaceHeadersFromExplicitFlags(flags) ?? {};
+  const token = process.env.OD_TOOL_TOKEN;
+  const requestHeaders = token
+    ? { authorization: `Bearer ${token}` }
+    : workspaceHeadersFromExplicitFlags(flags) ?? {};
   // All three formats rasterize through the desktop screenshot renderer so the
   // CLI matches the UI exactly. In particular `pdf` uses `/export/pdf-image`
   // (one raster page per deck slide / per viewport for a page) — NOT the generic
@@ -513,7 +516,7 @@ async function runExport(args) {
   try {
     resp = await fetch(`${base}/api/projects/${encodeURIComponent(projectId)}/${exportPath}`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', ...workspaceHeaders },
+      headers: { 'content-type': 'application/json', ...requestHeaders },
       body: JSON.stringify(requestBody),
     });
   } catch (err) {

--- a/apps/daemon/src/collab/project-request-authority.ts
+++ b/apps/daemon/src/collab/project-request-authority.ts
@@ -25,11 +25,18 @@ export type AuthorizeProjectRequest = (
   options: AuthorizeProjectRequestOptions,
 ) => Promise<boolean>;
 
+export type AuthorizedProjectToolRequest = {
+  readonly workspace: {
+    readonly workspaceId: string;
+    readonly workspaceMemberId: string;
+  } | null;
+};
+
 export type AuthorizeProjectToolRequest = (
   res: Response,
   projectId: string,
   options: AuthorizeProjectRequestOptions,
-) => Promise<boolean>;
+) => Promise<AuthorizedProjectToolRequest | null>;
 
 /**
  * Build the one project data-plane authority gate used by route modules.

--- a/apps/daemon/src/deck-export.ts
+++ b/apps/daemon/src/deck-export.ts
@@ -15,6 +15,7 @@ const PptxGenJS = PptxGenJSModule.default as unknown as { new (): PptxInstance }
 import { readProjectFile } from './projects.js';
 
 export interface BuildDeckRenderInputOptions {
+  baseHref?: string;
   daemonUrl: string;
   // Explicit page-vs-deck signal (the web knows whether the artifact is a deck).
   deck?: boolean;
@@ -52,8 +53,8 @@ export interface DeckRenderRequest {
 /**
  * Reads a deck HTML file and prepares the {@link DesktopRenderSlidesInput} the
  * desktop renderer needs. Mirrors {@link buildDesktopPdfExportInput} in
- * pdf-export.ts: same `<base href>` derivation so the rendered deck resolves
- * its relative CSS/JS/image assets through the daemon's `/raw/` route.
+ * pdf-export.ts: the default `<base href>` resolves relative assets through
+ * `/raw/`; authorized callers can supply a narrower renderer-only base.
  */
 export async function buildDeckRenderInput(
   options: BuildDeckRenderInputOptions,
@@ -69,7 +70,7 @@ export async function buildDeckRenderInput(
     defaultFilename: safeDisplayFilename(title, 'deck'),
     title,
     input: {
-      baseHref: rawBaseHref(options.daemonUrl, options.projectId, options.fileName),
+      baseHref: options.baseHref ?? rawBaseHref(options.daemonUrl, options.projectId, options.fileName),
       html: injectDeckStageFallback(html),
       ...(options.deck == null ? {} : { deck: options.deck }),
       ...(options.editable == null ? {} : { editable: options.editable }),

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -5,7 +5,13 @@ import os from 'node:os';
 import { readFile, rm } from 'node:fs/promises';
 import { isBlocked as isBlockedSystemDir } from './linked-dirs.js';
 import type { RouteDeps } from './server-context.js';
-import type { AuthorizeProjectRequest } from './collab/project-request-authority.js';
+import type {
+  AuthorizedProjectToolRequest,
+  AuthorizeProjectRequest,
+  AuthorizeProjectToolRequest,
+} from './collab/project-request-authority.js';
+import { workspaceResourceContextFromRequest } from './collab/workspace-resource-mutation.js';
+import { PROJECT_EXPORT_TOOL_ENDPOINT } from './tool-tokens.js';
 import {
   InlineAssetsLimitError,
   MAX_INLINE_OWNER_BYTES,
@@ -519,8 +525,36 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
 
 }
 
-export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'node' | 'ids' | 'projectStore' | 'exports' | 'projectFiles' | 'validation'> {
+const DESKTOP_RENDERER_IPC_TIMEOUT_MS = 600_000;
+const RENDERER_PREVIEW_SCOPE_SETUP_MARGIN_MS = 10_000;
+const SCREENSHOT_RENDER_PREVIEW_SCOPE_TTL_MS =
+  DESKTOP_RENDERER_IPC_TIMEOUT_MS + RENDERER_PREVIEW_SCOPE_SETUP_MARGIN_MS;
+
+type AuthorizedExportRead = {
+  readonly previewWorkspace: AuthorizedProjectToolRequest['workspace'];
+};
+
+type ScreenshotExportBody = {
+  readonly deck?: unknown;
+  readonly editable?: unknown;
+  readonly fileName?: unknown;
+  readonly height?: unknown;
+  readonly imageFormat?: unknown;
+  readonly index?: unknown;
+  readonly title?: unknown;
+  readonly versionId?: unknown;
+  readonly width?: unknown;
+};
+
+type ScreenshotExportRequest = {
+  readonly authority: AuthorizedExportRead;
+  readonly body: ScreenshotExportBody | null | undefined;
+};
+
+export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'node' | 'ids' | 'projectStore' | 'exports' | 'projectFiles' | 'validation' | 'auth' | 'projectPreviewScopes'> {
   authorizeProjectRequest: AuthorizeProjectRequest;
+  authorizeProjectToolRequest: AuthorizeProjectToolRequest;
+  isApiTokenAuthorization: (authorization: string | undefined) => boolean;
 }
 
 export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectExportRoutesDeps) {
@@ -546,9 +580,32 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   async function authorizeExportRead(
     req: any,
     res: any,
-    options: { allowNavigationQuery?: boolean } = {},
-  ): Promise<boolean> {
-    return ctx.authorizeProjectRequest(
+    options: { allowNavigationQuery?: boolean; toolEndpoint?: string } = {},
+  ): Promise<AuthorizedExportRead | null> {
+    const authorization = req.get('authorization');
+    if (
+      typeof authorization === 'string'
+      && !ctx.isApiTokenAuthorization(authorization)
+    ) {
+      const grant = ctx.auth.authorizeToolRequest(
+        req,
+        res,
+        'project:export',
+        { endpoint: options.toolEndpoint ?? req.path },
+      );
+      if (!grant) return null;
+      if (ctx.auth.requestProjectOverride(req.params.id, grant.projectId)) {
+        sendApiError(res, 403, 'FORBIDDEN', 'tool token belongs to a different project');
+        return null;
+      }
+      const authority = await ctx.authorizeProjectToolRequest(
+        res,
+        grant.projectId,
+        { mode: 'read' },
+      );
+      return authority ? { previewWorkspace: authority.workspace } : null;
+    }
+    const authorized = await ctx.authorizeProjectRequest(
       req,
       res,
       req.params.id,
@@ -556,10 +613,32 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         ? { mode: 'read', allowNavigationQuery: true }
         : { mode: 'read' },
     );
+    if (!authorized) return null;
+    const requestWorkspace = workspaceResourceContextFromRequest(req);
+    return {
+      previewWorkspace: requestWorkspace === null || requestWorkspace === 'missing'
+        ? null
+        : {
+            workspaceId: requestWorkspace.workspaceId,
+            workspaceMemberId: requestWorkspace.workspaceMemberId,
+          },
+    };
   }
 
   function isNoSlideDeckRenderError(rendered: { ok: boolean; error?: string }): boolean {
     return !rendered.ok && typeof rendered.error === 'string' && /no slide surfaces found/i.test(rendered.error);
+  }
+
+  function scopedProjectPreviewBaseHref(
+    projectId: string,
+    fileName: string,
+    scope: string,
+  ): string {
+    const previewDir = nodePath.posix.dirname(fileName.replace(/^\/+/, ''));
+    const previewRoot = `${daemonUrlRef.current.replace(/\/+$/, '')}/api/projects/${encodeURIComponent(projectId)}/preview/${encodeURIComponent(scope)}/`;
+    return !previewDir || previewDir === '.'
+      ? previewRoot
+      : `${previewRoot}${previewDir.split('/').filter(Boolean).map(encodeURIComponent).join('/')}/`;
   }
 
   function normalizeExportVersionId(raw: unknown): string | undefined {
@@ -620,9 +699,11 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     res: Response,
     format: 'pptx' | 'pdf' | 'image',
     projectId: string,
-    body: any,
+    request: ScreenshotExportRequest,
   ) {
+    const { authority, body } = request;
     let renderOutputDir: string | null = null;
+    let renderPreviewScope: string | null = null;
     try {
       const { fileName, title, index, imageFormat, width, height } = body || {};
       if (typeof fileName !== 'string' || fileName.length === 0) {
@@ -643,7 +724,13 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       }
       if (typeof desktopSlideRenderer !== 'function') {
         if (format === 'image' && typeof desktopArtifactExporter === 'function') {
+          renderPreviewScope = ctx.projectPreviewScopes.mint(
+            projectId,
+            authority.previewWorkspace,
+            { ttlMs: SCREENSHOT_RENDER_PREVIEW_SCOPE_TTL_MS },
+          );
           const input = await buildDesktopArtifactExportInput({
+            baseHref: scopedProjectPreviewBaseHref(projectId, fileName, renderPreviewScope),
             daemonUrl: daemonUrlRef.current,
             fileName,
             format,
@@ -667,6 +754,11 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
               'UPSTREAM_UNAVAILABLE',
               `desktop renderer unavailable: ${err?.message || String(err)}`,
             );
+          } finally {
+            if (renderPreviewScope) {
+              ctx.projectPreviewScopes.revoke(renderPreviewScope);
+              renderPreviewScope = null;
+            }
           }
           if (!result.ok || typeof result.path !== 'string') {
             return sendApiError(
@@ -722,6 +814,16 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         projectId,
         projectsRoot: PROJECTS_DIR,
       };
+      renderPreviewScope = ctx.projectPreviewScopes.mint(
+        projectId,
+        authority.previewWorkspace,
+        { ttlMs: SCREENSHOT_RENDER_PREVIEW_SCOPE_TTL_MS },
+      );
+      renderOptions.baseHref = scopedProjectPreviewBaseHref(
+        projectId,
+        fileName,
+        renderPreviewScope,
+      );
       if (sourceHtml !== undefined) renderOptions.sourceHtml = sourceHtml;
       if (typeof title === 'string') renderOptions.title = title;
       if (typeof width === 'number') renderOptions.width = width;
@@ -773,6 +875,11 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
           'UPSTREAM_UNAVAILABLE',
           `desktop renderer unavailable: ${err?.message || String(err)}`,
         );
+      } finally {
+        if (renderPreviewScope) {
+          ctx.projectPreviewScopes.revoke(renderPreviewScope);
+          renderPreviewScope = null;
+        }
       }
       const tRendered = Date.now();
 
@@ -947,6 +1054,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         String(err?.message || err),
       );
     } finally {
+      if (renderPreviewScope) {
+        ctx.projectPreviewScopes.revoke(renderPreviewScope);
+        renderPreviewScope = null;
+      }
       // Remove the scratch render dir regardless of success — these files are
       // pure transient handoff, never served or persisted.
       if (renderOutputDir) {
@@ -954,6 +1065,7 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       }
     }
   }
+
   // Streams a ZIP of the project's on-disk tree so the "Download as .zip"
   // share menu can hand the user the actual files they uploaded — e.g. the
   // imported `ui-design/` folder — instead of a one-file snapshot of the
@@ -1109,16 +1221,18 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // PNG and assemble a one-image-per-slide .pptx. Replaces the old "send a prompt
   // to the agent and hope it runs python-pptx" path with a deterministic export.
   app.post('/api/projects/:id/export/pptx', async (req, res) => {
-    if (!await authorizeExportRead(req, res)) return;
-    await handleScreenshotExport(res, 'pptx', req.params.id, req.body);
+    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    if (!authority) return;
+    await handleScreenshotExport(res, 'pptx', req.params.id, { authority, body: req.body });
   });
 
   // Programmatic screenshot-based (raster) PDF: one pixel-perfect page per slide.
   // The print-ready vector PDF stays on POST /export/pdf; this is the "exactly
   // what you see" counterpart that shares the slide renderer with PPTX.
   app.post('/api/projects/:id/export/pdf-image', async (req, res) => {
-    if (!await authorizeExportRead(req, res)) return;
-    await handleScreenshotExport(res, 'pdf', req.params.id, req.body);
+    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    if (!authority) return;
+    await handleScreenshotExport(res, 'pdf', req.params.id, { authority, body: req.body });
   });
 
   // Programmatic image export: a single pixel-perfect PNG. For a deck it renders
@@ -1126,8 +1240,9 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // the whole document at natural size. Viewport-independent — unlike the
   // host-compositor snapshot, the size never depends on the preview pane.
   app.post('/api/projects/:id/export/image', async (req, res) => {
-    if (!await authorizeExportRead(req, res)) return;
-    await handleScreenshotExport(res, 'image', req.params.id, req.body);
+    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    if (!authority) return;
+    await handleScreenshotExport(res, 'image', req.params.id, { authority, body: req.body });
   });
 
   // Generic programmatic export (PDF / image / PPTX) for the `od export` CLI and
@@ -1147,18 +1262,22 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     if (!isExportFormat(format)) {
       return sendApiError(res, 400, 'BAD_REQUEST', 'invalid export format');
     }
-    if (!await authorizeExportRead(req, res)) return;
+    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    if (!authority) return;
     await handleScreenshotExport(res, format, req.params.id, {
-      fileName,
-      // pptx is deck-only (handleScreenshotExport forces it); pdf/image honor the
-      // caller's deck flag when one is supplied. Omitted stays omitted so the
-      // renderer can auto-detect deck artifacts.
-      ...(typeof deck === 'boolean' ? { deck } : {}),
-      ...(typeof imageFormat === 'string' ? { imageFormat } : {}),
-      ...(width != null ? { width } : {}),
-      ...(height != null ? { height } : {}),
-      ...(typeof title === 'string' ? { title } : {}),
-      ...(typeof versionId === 'string' ? { versionId } : {}),
+      authority,
+      body: {
+        fileName,
+        // pptx is deck-only (handleScreenshotExport forces it); pdf/image honor the
+        // caller's deck flag when one is supplied. Omitted stays omitted so the
+        // renderer can auto-detect deck artifacts.
+        ...(typeof deck === 'boolean' ? { deck } : {}),
+        ...(typeof imageFormat === 'string' ? { imageFormat } : {}),
+        ...(width != null ? { width } : {}),
+        ...(height != null ? { height } : {}),
+        ...(typeof title === 'string' ? { title } : {}),
+        ...(typeof versionId === 'string' ? { versionId } : {}),
+      },
     });
   });
 

--- a/apps/daemon/src/pdf-export.ts
+++ b/apps/daemon/src/pdf-export.ts
@@ -42,6 +42,7 @@ export async function buildDesktopPdfExportInput(
 }
 
 export interface BuildDesktopArtifactExportInputOptions {
+  baseHref?: string;
   daemonUrl: string;
   deck?: boolean;
   fileName: string;
@@ -69,7 +70,7 @@ export async function buildDesktopArtifactExportInput(
   )).buffer.toString('utf8');
   const title = displayTitle(options.title, options.fileName);
   return {
-    baseHref: rawBaseHref(options.daemonUrl, options.projectId, options.fileName),
+    baseHref: options.baseHref ?? rawBaseHref(options.daemonUrl, options.projectId, options.fileName),
     deck: options.deck === true,
     format: options.format,
     html,

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -97,7 +97,9 @@ export interface ProjectPreviewScopeDeps {
   mint: (
     projectId: string,
     workspace?: { workspaceId: string; workspaceMemberId: string } | null,
+    options?: { readonly ttlMs?: number },
   ) => string;
+  revoke: (scope: string) => void;
   validate: (projectId: string, scope: string) => boolean;
   resolve: (
     projectId: string,
@@ -160,6 +162,7 @@ export interface ServerContext {
   projectStore: any;
   authorizeProjectRequest: AuthorizeProjectRequest;
   authorizeProjectToolRequest: AuthorizeProjectToolRequest;
+  isApiTokenAuthorization: (authorization: string | undefined) => boolean;
   projectFiles: any;
   conversations: any;
   templates: any;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -940,7 +940,7 @@ import {
   seedLibraryExtensionOrigins,
 } from './library-tokens.js';
 import { listLibraryTokenOrigins } from './library-store.js';
-import { apiTokenFromEnv, isApiAuthDisabled, isApiTokenMiddlewareEnabled } from './api-token-auth.js';
+import { apiTokenFromEnv, isApiAuthDisabled } from './api-token-auth.js';
 import { createOpenDesignPublicMetadataService } from './services/open-design-public-metadata.js';
 import { createWhatsNewService } from './services/whats-new.js';
 import { execCommandViaLoginShell } from './services/login-shell.js';
@@ -1969,15 +1969,18 @@ function createProjectPreviewScopeRegistry() {
   }
 
   return {
-    mint(projectId, workspace = null) {
+    mint(projectId, workspace = null, options = {}) {
       pruneExpired();
       const scope = randomUUID();
       scopes.set(scope, {
         projectId: String(projectId),
         workspace,
-        expiresAt: Date.now() + PROJECT_PREVIEW_SCOPE_TTL_MS,
+        expiresAt: Date.now() + (options.ttlMs ?? PROJECT_PREVIEW_SCOPE_TTL_MS),
       });
       return scope;
+    },
+    revoke(scope) {
+      scopes.delete(String(scope || ''));
     },
     validate(projectId, scope) {
       const key = String(scope || '');
@@ -2406,6 +2409,12 @@ export async function startServer({
   // are exempted so the desktop UI keeps working).
   const apiToken = apiTokenFromEnv();
   const apiAuthDisabled = isApiAuthDisabled();
+  const apiTokenAuthEnabled = apiToken.length > 0 && !apiAuthDisabled;
+  const isApiTokenAuthorization = (authorization: string | undefined): boolean => {
+    if (!apiTokenAuthEnabled) return false;
+    const match = /^Bearer\s+(\S+)\s*$/i.exec(authorization ?? '');
+    return match?.[1] === apiToken;
+  };
   if (!isLoopbackHostname(host) && apiToken.length === 0 && !apiAuthDisabled) {
     throw new Error(
       `OD_BIND_HOST=${host} requires OD_API_TOKEN to be set. ` +
@@ -2445,7 +2454,7 @@ export async function startServer({
   // browser iframes can load HTML/CSS/JS without privileged headers.
   // Rich daemon status stays authenticated because it includes local
   // runtime paths.
-  if (isApiTokenMiddlewareEnabled()) {
+  if (apiTokenAuthEnabled) {
     const openProbePaths = new Set([
       '/health',
       '/api/health',
@@ -2470,9 +2479,7 @@ export async function startServer({
       // bearer; the loopback bypass exists for the localhost desktop
       // UI which has no proxy in the path.
       if (isLoopbackPeerAddress(req.socket?.remoteAddress)) return next();
-      const auth = req.get('authorization') ?? '';
-      const match = /^Bearer\s+(\S+)\s*$/i.exec(auth);
-      if (!match || match[1] !== apiToken) {
+      if (!isApiTokenAuthorization(req.get('authorization'))) {
         return res.status(401).json({
           error: { code: 'API_TOKEN_REQUIRED', message: 'Authorization: Bearer <OD_API_TOKEN> required' },
         });
@@ -6674,7 +6681,7 @@ export async function startServer({
     options,
   ) => {
     const binding = getWorkspaceProjectByProjectId(db, projectId);
-    if (!binding?.workspaceId) return true;
+    if (!binding?.workspaceId) return { workspace: null };
 
     let authority;
     if (process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela') {
@@ -6689,7 +6696,7 @@ export async function startServer({
           'workspace membership authority is temporarily unavailable',
           { retryable: true },
         );
-        return false;
+        return null;
       }
       const item = directory.items.find(
         (candidate) => candidate.workspaceId === binding.workspaceId,
@@ -6701,7 +6708,7 @@ export async function startServer({
           'WORKSPACE_PROJECT_PERMISSION_DENIED',
           'workspace project access is not allowed',
         );
-        return false;
+        return null;
       }
       authority = workspaceContextFromDirectoryItem(item);
     } else {
@@ -6739,7 +6746,13 @@ export async function startServer({
         return undefined;
       },
     };
-    return scopedAuthorize(request, res, projectId, options);
+    if (!await scopedAuthorize(request, res, projectId, options)) return null;
+    return {
+      workspace: {
+        workspaceId: authority.workspaceId,
+        workspaceMemberId: authority.workspaceMemberId,
+      },
+    };
   };
   const projectFileDeps = {
     ensureProject,
@@ -7513,7 +7526,11 @@ export async function startServer({
     exports: projectExportDeps,
     projectFiles: projectFileDeps,
     validation: validationDeps,
+    auth: authDeps,
     authorizeProjectRequest,
+    authorizeProjectToolRequest,
+    isApiTokenAuthorization,
+    projectPreviewScopes,
   });
   registerProjectFileRoutes(app, {
     db,
@@ -13847,6 +13864,7 @@ export async function startServer({
     projectStore: projectStoreDeps,
     authorizeProjectRequest,
     authorizeProjectToolRequest,
+    isApiTokenAuthorization,
     projectFiles: projectFileDeps,
     conversations: conversationDeps,
     templates: templateDeps,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -902,7 +902,12 @@ import { assertServerContextSatisfiesRoutes } from './route-context-contract.js'
 import { configureConnectorCredentialStore, connectorService, FileConnectorCredentialStore } from './connectors/service.js';
 import { composioConnectorProvider } from './connectors/composio.js';
 import { configureComposioConfigStore } from './connectors/composio-config.js';
-import { CHAT_TOOL_ENDPOINTS, CHAT_TOOL_OPERATIONS, toolTokenRegistry } from './tool-tokens.js';
+import {
+  CHAT_TOOL_ENDPOINTS,
+  CHAT_TOOL_OPERATIONS,
+  PROJECT_EXPORT_TOOL_ENDPOINT,
+  toolTokenRegistry,
+} from './tool-tokens.js';
 import {
   buildDeployFileSet,
   checkDeploymentUrl,
@@ -969,7 +974,7 @@ import {
   requireLocalDaemonRequest,
 } from './http/local-daemon-request.js';
 import { renderOAuthResultPage } from './http/oauth-result-page.js';
-import { createToolRequestAuth } from './http/tool-request-auth.js';
+import { bearerTokenFromRequest, createToolRequestAuth } from './http/tool-request-auth.js';
 
 /** @typedef {import('@open-design/contracts').ApiErrorCode} ApiErrorCode */
 /** @typedef {import('@open-design/contracts').ApiError} ApiError */
@@ -1455,6 +1460,12 @@ export function createAgentRuntimeEnv(
     },
     SANDBOX_RUNTIME,
   );
+  // The daemon API token authorizes the whole non-loopback API surface. Agent
+  // children receive only their run-scoped tool capability, never that broad
+  // credential inherited from the daemon process (including Windows casing).
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === 'OD_API_TOKEN') delete env[key];
+  }
   const sidecarIpcPath = baseEnv[SIDECAR_ENV.IPC_PATH];
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;
@@ -1958,6 +1969,8 @@ export function shouldReportRunCompletionTelemetryFallbackStatus(status: unknown
 
 const PROJECT_PREVIEW_SCOPE_TTL_MS = 60 * 60 * 1000;
 const PROJECT_PREVIEW_ASSET_PATH_RE = /^\/projects\/([^/]+)\/preview\/([^/]+)\/.+$/u;
+const PROJECT_RUN_SCOPED_EXPORT_PATH_RE =
+  /^\/projects\/[^/]+\/export(?:\/(?:pptx|pdf-image|image))?$/u;
 
 function createProjectPreviewScopeRegistry() {
   const scopes = new Map();
@@ -2448,8 +2461,9 @@ export async function startServer({
   // Loopback origins skip the
   // check (the desktop UI / local CLI never carry a bearer); every
   // other request must present `Authorization: Bearer <token>` with a
-  // value matching `OD_API_TOKEN`. Health / readiness / version remain
-  // open so monitoring probes don't need the token. Server-minted
+  // value matching `OD_API_TOKEN`. A currently valid run-scoped token may
+  // pass only an exact screenshot-export endpoint; its route rechecks the
+  // operation and project. Health / readiness / version remain open. Server-minted
   // project preview asset scopes are also accepted for GETs so sandboxed
   // browser iframes can load HTML/CSS/JS without privileged headers.
   // Rich daemon status stays authenticated because it includes local
@@ -2479,12 +2493,20 @@ export async function startServer({
       // bearer; the loopback bypass exists for the localhost desktop
       // UI which has no proxy in the path.
       if (isLoopbackPeerAddress(req.socket?.remoteAddress)) return next();
-      if (!isApiTokenAuthorization(req.get('authorization'))) {
-        return res.status(401).json({
-          error: { code: 'API_TOKEN_REQUIRED', message: 'Authorization: Bearer <OD_API_TOKEN> required' },
-        });
+      if (isApiTokenAuthorization(req.get('authorization'))) return next();
+      if (
+        req.method === 'POST'
+        && PROJECT_RUN_SCOPED_EXPORT_PATH_RE.test(req.path)
+        && toolTokenRegistry.validate(bearerTokenFromRequest(req), {
+          endpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+          operation: 'project:export',
+        }).ok
+      ) {
+        return next();
       }
-      return next();
+      return res.status(401).json({
+        error: { code: 'API_TOKEN_REQUIRED', message: 'Authorization: Bearer <OD_API_TOKEN> required' },
+      });
     });
   }
 

--- a/apps/daemon/src/tool-tokens.ts
+++ b/apps/daemon/src/tool-tokens.ts
@@ -5,6 +5,7 @@ export const DEFAULT_TOOL_TOKEN_TTL_MS = 15 * 60 * 1000;
 // Capability key for the parameterized media wait route. Token grants cannot
 // enumerate a task id that is created after the grant is minted.
 export const MEDIA_TASK_WAIT_TOOL_ENDPOINT = '/api/media/tasks/:id/wait';
+export const PROJECT_EXPORT_TOOL_ENDPOINT = '/api/projects/:id/export/:format';
 
 export const CHAT_TOOL_ENDPOINTS = [
   '/api/tools/live-artifacts/create',
@@ -16,6 +17,7 @@ export const CHAT_TOOL_ENDPOINTS = [
   '/api/tools/design-systems/read',
   '/api/tools/media/generate',
   MEDIA_TASK_WAIT_TOOL_ENDPOINT,
+  PROJECT_EXPORT_TOOL_ENDPOINT,
   '/api/tools/library/search',
   '/api/tools/library/apply',
 ] as const;
@@ -29,6 +31,7 @@ export const CHAT_TOOL_OPERATIONS = [
   'connectors:execute',
   'design-systems:read',
   'media:generate',
+  'project:export',
   'library:search',
   'library:apply',
 ] as const;

--- a/apps/daemon/tests/export-tool-token-authority.test.ts
+++ b/apps/daemon/tests/export-tool-token-authority.test.ts
@@ -1,0 +1,507 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type {
+  DesktopExportArtifactInput,
+  DesktopExportArtifactResult,
+  DesktopRenderSlidesInput,
+  DesktopRenderSlidesResult,
+} from '@open-design/sidecar-proto';
+import {
+  closeDatabase,
+  ensureWorkspaceProject,
+  insertProject,
+  openDatabase,
+} from '../src/db.js';
+import { startServer } from '../src/server.js';
+import { toolTokenRegistry } from '../src/tool-tokens.js';
+
+const execFileP = promisify(execFile);
+const daemonRoot = fileURLToPath(new URL('..', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+const tsxCli = path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+const rendererCss = Buffer.from('main { color: rgb(12, 34, 56); }\n');
+const rendererImage = Buffer.from('renderer-image-exact-bytes');
+const daemonApiToken = 'configured-daemon-api-token';
+const legacyBaseHref = 'https://external.invalid/legacy/';
+const rendererStylesheetPath = 'styles/export.css';
+const rendererImagePath = 'assets/hero.png';
+
+describe('od export run-scoped project authority', () => {
+  let authorityServer: http.Server;
+  let daemonShutdown: () => Promise<void> | void;
+  let daemonUrl = '';
+  let lastRendererAssetUrl = '';
+  let rendererBlockingFile = '';
+  let pendingRenderer: {
+    readonly promise: Promise<DesktopRenderSlidesResult>;
+    readonly signalInvocation: () => void;
+  } | null = null;
+  let outputDir = '';
+  const projectId = `project_${randomUUID()}`;
+  const foreignProjectId = `project_${randomUUID()}`;
+  const unboundProjectId = `project_${randomUUID()}`;
+  const workspaceId = `workspace_${randomUUID()}`;
+  const memberId = `member_${randomUUID()}`;
+  const boundProjectHtml = `<!doctype html><html><head><base href="${legacyBaseHref}"><link rel="stylesheet" href="${rendererStylesheetPath}"></head><body><main data-renderer-asset-authority>${projectId}</main><img src="${rendererImagePath}" alt=""></body></html>`;
+
+  beforeAll(async () => {
+    outputDir = await mkdtemp(path.join(os.tmpdir(), 'od-export-tool-token-'));
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required by the daemon test harness');
+    const db = openDatabase(process.cwd(), { dataDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: projectId,
+      name: 'Token-bound export project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertProject(db, {
+      id: foreignProjectId,
+      name: 'Foreign export project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertProject(db, {
+      id: unboundProjectId,
+      name: 'Unbound export project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    ensureWorkspaceProject(db, {
+      projectId,
+      workspaceId,
+      visibility: 'team',
+      createdByWorkspaceMemberId: memberId,
+    });
+    ensureWorkspaceProject(db, {
+      projectId: foreignProjectId,
+      workspaceId: 'foreign-workspace',
+      visibility: 'team',
+      createdByWorkspaceMemberId: 'foreign-member',
+    });
+    for (const id of [projectId, foreignProjectId, unboundProjectId]) {
+      const projectDir = path.join(dataDir, 'projects', id);
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(
+        path.join(projectDir, 'index.html'),
+        id === projectId
+          ? boundProjectHtml
+          : `<main>${id}</main>`,
+      );
+      if (id === projectId) {
+        await mkdir(path.join(projectDir, 'styles'), { recursive: true });
+        await mkdir(path.join(projectDir, 'assets'), { recursive: true });
+        await writeFile(path.join(projectDir, 'styles', 'export.css'), rendererCss);
+        await writeFile(path.join(projectDir, 'assets', 'hero.png'), rendererImage);
+      }
+    }
+
+    authorityServer = http.createServer((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({
+        items: [
+          {
+            workspaceId: 'unrelated-workspace',
+            workspaceName: 'Unrelated workspace',
+            workspaceType: 'personal',
+            workspaceMemberId: 'unrelated-member',
+            role: 'owner',
+            memberStatus: 'active',
+            lifecycleState: 'active',
+          },
+          {
+            workspaceId,
+            workspaceName: 'Exact project workspace',
+            workspaceType: 'team',
+            workspaceMemberId: memberId,
+            role: 'owner',
+            memberStatus: 'active',
+            lifecycleState: 'active',
+          },
+        ],
+      }));
+    });
+    await new Promise<void>((resolve) => authorityServer.listen(0, '127.0.0.1', resolve));
+    const authorityAddress = authorityServer.address();
+    if (!authorityAddress || typeof authorityAddress === 'string') {
+      throw new Error('authority server did not bind');
+    }
+    vi.stubEnv('OD_WORKSPACE_CONTEXT_SOURCE', 'vela');
+    vi.stubEnv('VELA_CONTROL_KEY', 'test-control-key');
+    vi.stubEnv('VELA_API_URL', `http://127.0.0.1:${authorityAddress.port}`);
+    vi.stubEnv('OD_API_TOKEN', daemonApiToken);
+
+    const renderer = (input: DesktopRenderSlidesInput): Promise<DesktopRenderSlidesResult> => {
+      const pending = pendingRenderer;
+      if (pending) {
+        if (!input.outputDir) return Promise.resolve({ ok: false, error: 'outputDir required' });
+        lastRendererAssetUrl = new URL('styles/export.css', input.baseHref).href;
+        mkdirSync(input.outputDir, { recursive: true });
+        rendererBlockingFile = path.join(input.outputDir, 'settled-render.png');
+        execFileSync('mkfifo', [rendererBlockingFile]);
+        pending.signalInvocation();
+        return pending.promise;
+      }
+      return (async () => {
+        if (!input.outputDir) return { ok: false, error: 'outputDir required' };
+        if (input.html.includes('data-renderer-asset-authority')) {
+          expect(input.html).toBe(boundProjectHtml);
+          expect(input.baseHref).not.toBe(legacyBaseHref);
+          lastRendererAssetUrl = new URL(rendererStylesheetPath, input.baseHref).href;
+          const cssResponse = await fetch(lastRendererAssetUrl);
+          const cssBytes = Buffer.from(await cssResponse.arrayBuffer());
+          expect(cssResponse.status, cssBytes.toString()).toBe(200);
+          expect(cssBytes).toEqual(rendererCss);
+          const imageResponse = await fetch(new URL(rendererImagePath, input.baseHref));
+          const imageBytes = Buffer.from(await imageResponse.arrayBuffer());
+          expect(imageResponse.status, imageBytes.toString()).toBe(200);
+          expect(imageBytes).toEqual(rendererImage);
+        }
+        await mkdir(input.outputDir, { recursive: true });
+        const file = path.join(input.outputDir, 'export.png');
+        await writeFile(file, png);
+        return { ok: true, slideFiles: [file], width: 1, height: 1, mode: 'page' };
+      })();
+    };
+    const started = await startServer({
+      port: 0,
+      returnServer: true,
+      desktopSlideRenderer: renderer,
+    }) as { url: string; shutdown: () => Promise<void> | void };
+    daemonUrl = started.url;
+    daemonShutdown = started.shutdown;
+    vi.stubEnv('OD_API_TOKEN', 'changed-after-server-start');
+  });
+
+  afterAll(async () => {
+    await daemonShutdown?.();
+    await new Promise<void>((resolve) => authorityServer.close(() => resolve()));
+    toolTokenRegistry.clear();
+    closeDatabase();
+    vi.unstubAllEnvs();
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('accepts the configured daemon API token for screenshot export', async () => {
+    // Given: the API token captured by the daemon at startup, before the env changed.
+    const request = {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${daemonApiToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    } as const;
+
+    // When: the configured credential requests a screenshot export.
+    const response = await fetch(`${daemonUrl}/api/projects/${unboundProjectId}/export/image`, request);
+    const body = Buffer.from(await response.arrayBuffer());
+
+    // Then: it remains on the daemon API-token lane and the export succeeds.
+    expect(response.status, body.toString()).toBe(200);
+    expect(body).toEqual(png);
+  });
+
+  it('exports the exact token-bound project without explicit workspace flags', async () => {
+    // Given: a run-scoped token for a project bound to the second directory workspace.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    const outputPath = path.join(outputDir, 'token-bound.png');
+
+    // When: the documented spawned-agent wrapper command runs without workspace flags.
+    const result = await runExportCli(projectId, outputPath, token);
+
+    // Then: the exact project exports through its token authority.
+    expect(result.code, result.stderr).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
+  it('loads relative renderer assets for a bound project whose HTML already declares a base', async () => {
+    // Given: a valid run token bound to a Workspace project whose renderer needs relative assets
+    // and whose source HTML already declares an unrelated external base.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    lastRendererAssetUrl = '';
+
+    // When: the screenshot POST renders the project without forwarding its bearer to asset GETs.
+    const response = await fetch(`${daemonUrl}/api/projects/${projectId}/export/image`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    });
+    const body = Buffer.from(await response.arrayBuffer());
+
+    // Then: the daemon hands off the original HTML plus its scoped baseHref, and the renderer
+    // loads exact CSS/image bytes through that scope before the PNG export succeeds;
+    // the renderer-only capability is revoked as soon as rendering finishes.
+    expect(response.status, body.toString()).toBe(200);
+    expect(body).toEqual(png);
+    expect(lastRendererAssetUrl).not.toBe('');
+    const revokedAssetResponse = await fetch(lastRendererAssetUrl);
+    expect(revokedAssetResponse.status).toBe(404);
+  });
+
+  it('revokes renderer asset capability as soon as the renderer promise settles', async () => {
+    // Given: rendering can settle while downstream file validation/read and the HTTP response remain pending.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    let signalInvocation: (() => void) | null = null;
+    const invoked = new Promise<void>((resolve) => {
+      signalInvocation = resolve;
+    });
+    let settleRenderer = (_result: DesktopRenderSlidesResult): void => {
+      throw new Error('renderer settlement control was not installed');
+    };
+    const rendererPromise = new Promise<DesktopRenderSlidesResult>((resolve) => {
+      settleRenderer = resolve;
+    });
+    pendingRenderer = {
+      promise: rendererPromise,
+      signalInvocation: () => signalInvocation?.(),
+    };
+    lastRendererAssetUrl = '';
+    rendererBlockingFile = '';
+
+    // When: the route observes renderer settlement, then blocks reading the FIFO handoff.
+    const responsePromise = fetch(`${daemonUrl}/api/projects/${projectId}/export/image`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    });
+    await invoked;
+    const settlementObserved = rendererPromise.then(() => undefined);
+    settleRenderer({
+      ok: true,
+      slideFiles: [rendererBlockingFile],
+      width: 1,
+      height: 1,
+      mode: 'page',
+    });
+    await settlementObserved;
+
+    try {
+      // Then: the renderer-only URL is already unusable before the route can finish its response.
+      expect(lastRendererAssetUrl).not.toBe('');
+      const revokedAssetResponse = await fetch(lastRendererAssetUrl);
+      expect(revokedAssetResponse.status).toBe(404);
+    } finally {
+      pendingRenderer = null;
+      await writeFile(rendererBlockingFile, png);
+    }
+    const response = await responsePromise;
+    const body = Buffer.from(await response.arrayBuffer());
+    expect(response.status, body.toString()).toBe(200);
+    expect(body).toEqual(png);
+  }, 30_000);
+
+  it('loads relative assets through the desktopArtifactExporter fallback for an exact-project run token', async () => {
+    // Given: a bound Workspace project and a daemon with only the supported image exporter fallback.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    const fallbackArtifact = path.join(outputDir, `fallback-${randomUUID()}.png`);
+    let fallbackAssetUrl = '';
+    let wroteArtifactAfterAssets = false;
+    const exporter = async (
+      input: DesktopExportArtifactInput,
+    ): Promise<DesktopExportArtifactResult> => {
+      expect(input.html).toBe(boundProjectHtml);
+      expect(input.baseHref).not.toBe(legacyBaseHref);
+      fallbackAssetUrl = new URL(rendererStylesheetPath, input.baseHref).href;
+      const cssResponse = await fetch(fallbackAssetUrl);
+      const cssBytes = Buffer.from(await cssResponse.arrayBuffer());
+      expect(cssResponse.status, cssBytes.toString()).toBe(200);
+      expect(cssBytes).toEqual(rendererCss);
+      const imageResponse = await fetch(new URL(rendererImagePath, input.baseHref));
+      const imageBytes = Buffer.from(await imageResponse.arrayBuffer());
+      expect(imageResponse.status, imageBytes.toString()).toBe(200);
+      expect(imageBytes).toEqual(rendererImage);
+      await writeFile(fallbackArtifact, png);
+      wroteArtifactAfterAssets = true;
+      return { ok: true, path: fallbackArtifact, mime: 'image/png' };
+    };
+    const fallbackDaemon = await startServer({
+      port: 0,
+      returnServer: true,
+      desktopArtifactExporter: exporter,
+    }) as { url: string; shutdown: () => Promise<void> | void };
+
+    try {
+      // When: the run token requests an image and the exporter follows bearerless relative URLs.
+      const response = await fetch(`${fallbackDaemon.url}/api/projects/${projectId}/export/image`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ fileName: 'index.html' }),
+      });
+      const body = Buffer.from(await response.arrayBuffer());
+
+      // Then: both exact assets were authorized before the exporter wrote the exact returned PNG.
+      expect(response.status, body.toString()).toBe(200);
+      expect(wroteArtifactAfterAssets).toBe(true);
+      expect(body).toEqual(png);
+      const revokedAssetResponse = await fetch(fallbackAssetUrl);
+      expect(revokedAssetResponse.status).toBe(404);
+    } finally {
+      await fallbackDaemon.shutdown();
+      await rm(fallbackArtifact, { force: true });
+    }
+  }, 30_000);
+
+  it('rejects a valid run token when the requested project differs', async () => {
+    // Given: a token bound to the first project and an output for another bound project.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    const outputPath = path.join(outputDir, 'cross-project.png');
+
+    // When: the wrapper attempts to export the foreign project with that token.
+    const result = await runExportCli(foreignProjectId, outputPath, token);
+
+    // Then: project authority fails before rendering.
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('FORBIDDEN');
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  it.each(['invalid', 'expired'] as const)(
+    'does not downgrade an %s token to headerless unbound access',
+    async (kind) => {
+      // Given: an unbound project that succeeds headerless and a presented unusable token.
+      const token = kind === 'invalid'
+        ? 'forged-tool-token'
+        : toolTokenRegistry.mint({
+            projectId: unboundProjectId,
+            runId: `run_${randomUUID()}`,
+            nowMs: Date.now() - 120_000,
+            ttlMs: 60_000,
+          }).token;
+      const outputPath = path.join(outputDir, `${kind}-token.png`);
+
+      // When: the wrapper presents that token for the otherwise unbound project.
+      const result = await runExportCli(unboundProjectId, outputPath, token);
+
+      // Then: token validation fails closed instead of exporting headerless.
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain(
+        kind === 'invalid' ? 'TOOL_TOKEN_INVALID' : 'TOOL_TOKEN_EXPIRED',
+      );
+      expect(existsSync(outputPath)).toBe(false);
+    },
+  );
+
+  it('enforces the export capability on otherwise valid project tokens', async () => {
+    // Given: an exact-project token restricted to an unrelated media capability.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+      allowedEndpoints: ['/api/tools/media/generate'],
+      allowedOperations: ['media:generate'],
+    }).token;
+    const outputPath = path.join(outputDir, 'endpoint-denied.png');
+
+    // When: the wrapper attempts export through that restricted grant.
+    const result = await runExportCli(projectId, outputPath, token);
+
+    // Then: the endpoint allowlist rejects the request before rendering.
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('TOOL_ENDPOINT_DENIED');
+    expect(existsSync(outputPath)).toBe(false);
+  });
+
+  it('does not extend the CLI export capability to inline project reads', async () => {
+    // Given: a default run token whose export grant is limited to screenshot exports.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+
+    // When: the token is presented to the separate inline-HTML export surface.
+    const response = await fetch(`${daemonUrl}/api/projects/${projectId}/export/index.html?inline=1`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    // Then: endpoint authorization fails before project contents are returned.
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'TOOL_ENDPOINT_DENIED' },
+    });
+  });
+
+  async function runExportCli(
+    requestedProjectId: string,
+    outputPath: string,
+    token?: string,
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_OPTIONS: '',
+      OD_DAEMON_URL: daemonUrl,
+      OD_PROJECT_ID: requestedProjectId,
+    };
+    if (token) env.OD_TOOL_TOKEN = token;
+    else delete env.OD_TOOL_TOKEN;
+    try {
+      const { stdout, stderr } = await execFileP(
+        process.execPath,
+        [
+          tsxCli,
+          cliEntry,
+          'export',
+          'index.html',
+          '--project',
+          requestedProjectId,
+          '--format',
+          'image',
+          '--out',
+          outputPath,
+        ],
+        {
+          cwd: daemonRoot,
+          env,
+          timeout: 15_000,
+          maxBuffer: 4 * 1024 * 1024,
+        },
+      );
+      return { code: 0, stdout, stderr };
+    } catch (error) {
+      const failure = error as { code?: number; stdout?: string; stderr?: string };
+      return {
+        code: failure.code ?? 1,
+        stdout: failure.stdout ?? '',
+        stderr: failure.stderr ?? '',
+      };
+    }
+  }
+});

--- a/apps/daemon/tests/export-tool-token-nonloopback-authority.test.ts
+++ b/apps/daemon/tests/export-tool-token-nonloopback-authority.test.ts
@@ -1,0 +1,339 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { closeDatabase, insertProject, openDatabase } from '../src/db.js';
+import { startServer, type StartServerResult } from '../src/server.js';
+import { PROJECT_EXPORT_TOOL_ENDPOINT, toolTokenRegistry } from '../src/tool-tokens.js';
+
+const execFileP = promisify(execFile);
+const daemonRoot = fileURLToPath(new URL('..', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+const tsxCli = path.join(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+const daemonApiToken = 'nonloopback-daemon-api-token';
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+type StartedServer = Pick<StartServerResult, 'server' | 'shutdown' | 'url'>;
+
+function isStartedServer(value: unknown): value is StartedServer {
+  return typeof value === 'object' && value !== null
+    && typeof Reflect.get(value, 'server') === 'object'
+    && typeof Reflect.get(value, 'shutdown') === 'function'
+    && typeof Reflect.get(value, 'url') === 'string';
+}
+
+async function reachableNonLoopbackIpv4(): Promise<string> {
+  const candidates: string[] = [];
+  for (const addresses of Object.values(os.networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal) candidates.push(address.address);
+    }
+  }
+  const failures: string[] = [];
+  for (const address of [...new Set(candidates)].sort()) {
+    const probe = http.createServer((_req, res) => {
+      res.statusCode = 204;
+      res.end();
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        probe.once('error', reject);
+        probe.listen(0, address, resolve);
+      });
+      const bound = probe.address();
+      if (!bound || typeof bound === 'string') throw new Error('probe did not bind a TCP port');
+      const response = await fetch(`http://${address}:${bound.port}`);
+      if (response.status === 204) return address;
+      failures.push(`${address}: HTTP ${response.status}`);
+    } catch (error) {
+      failures.push(`${address}: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      if (probe.listening) {
+        await new Promise<void>((resolve) => probe.close(() => resolve()));
+      }
+    }
+  }
+  throw new Error(`no reachable non-loopback IPv4 interface: ${failures.join('; ')}`);
+}
+
+describe('od export non-loopback run-scoped authority', () => {
+  let daemon: StartedServer;
+  let daemonHost = '';
+  let outputDir = '';
+  const projectId = `project_${randomUUID()}`;
+  const foreignProjectId = `project_${randomUUID()}`;
+
+  beforeAll(async () => {
+    outputDir = await mkdtemp(path.join(os.tmpdir(), 'od-export-tool-token-nonloopback-'));
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required by the daemon test harness');
+    const db = openDatabase(process.cwd(), { dataDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: projectId,
+      name: 'Non-loopback token export project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertProject(db, {
+      id: foreignProjectId,
+      name: 'Foreign non-loopback export project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    for (const id of [projectId, foreignProjectId]) {
+      const projectDir = path.join(dataDir, 'projects', id);
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), `<main>${id}</main>`);
+    }
+
+    daemonHost = await reachableNonLoopbackIpv4();
+    vi.stubEnv('OD_API_TOKEN', daemonApiToken);
+    const started = await startServer({
+      port: 0,
+      host: daemonHost,
+      returnServer: true,
+      desktopSlideRenderer: async (input) => {
+        if (!input.outputDir) return { ok: false, error: 'outputDir required' };
+        await mkdir(input.outputDir, { recursive: true });
+        const output = path.join(input.outputDir, 'export.png');
+        await writeFile(output, png);
+        return { ok: true, slideFiles: [output], width: 1, height: 1, mode: 'page' };
+      },
+    });
+    if (!isStartedServer(started)) throw new Error('daemon did not return its server handle');
+    daemon = started;
+    vi.stubEnv('OD_API_TOKEN', 'changed-after-server-start');
+  });
+
+  afterAll(async () => {
+    toolTokenRegistry.clear();
+    if (daemon) {
+      await daemon.shutdown();
+      daemon.server.closeAllConnections?.();
+      await new Promise<void>((resolve) => daemon.server.close(() => resolve()));
+    }
+    closeDatabase();
+    vi.unstubAllEnvs();
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('exports through the actual CLI with a valid tool token over a non-loopback daemon URL', async () => {
+    // Given: the advertised daemon URL is a reachable non-loopback socket, and general API
+    // requests from this peer still require the configured broad daemon credential.
+    expect(new URL(daemon.url).hostname).toBe(daemonHost);
+    const unauthenticated = await fetch(`${daemon.url}/api/projects`);
+    expect(unauthenticated.status).toBe(401);
+    await expect(unauthenticated.json()).resolves.toMatchObject({
+      error: { code: 'API_TOKEN_REQUIRED' },
+    });
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+    const outputPath = path.join(outputDir, 'valid-tool-token.png');
+
+    // When: the real wrapper runs with only its run-scoped token and advertised daemon URL.
+    const result = await runExportCli(projectId, outputPath, token);
+
+    // Then: the outer daemon-token middleware admits only this endpoint capability, and the
+    // existing route authorization returns the renderer's exact bytes through the real CLI.
+    expect(result.code, result.stderr).toBe(0);
+    expect(await readFile(outputPath)).toEqual(png);
+  });
+
+  it('preserves the configured daemon API-token export lane over non-loopback HTTP', async () => {
+    // Given: the daemon credential captured at startup is distinct from every run-scoped token.
+    const response = await fetch(`${daemon.url}/api/projects/${projectId}/export/image`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${daemonApiToken}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html' }),
+    });
+
+    // When/Then: the matching broad token stays on project authorization and returns exact bytes.
+    expect(response.status).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(png);
+  });
+
+  it.each([
+    ['invalid', (): string => 'forged-tool-token'],
+    ['expired', (): string => toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+      nowMs: Date.now() - 120_000,
+      ttlMs: 60_000,
+    }).token],
+    ['revoked', (): string => {
+      const grant = toolTokenRegistry.mint({ projectId, runId: `run_${randomUUID()}` });
+      toolTokenRegistry.revokeToken(grant.token);
+      return grant.token;
+    }],
+    ['wrong endpoint', (): string => toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+      allowedEndpoints: ['/api/tools/media/generate'],
+      allowedOperations: ['project:export'],
+    }).token],
+  ] as const)('rejects the %s credential at the non-loopback outer boundary', async (kind, token) => {
+    // Given/When: an unusable or endpoint-inapplicable credential invokes the actual export CLI.
+    const outputPath = path.join(outputDir, `${kind.replaceAll(' ', '-')}.png`);
+    const result = await runExportCli(projectId, outputPath, token());
+
+    // Then: it cannot bypass broad daemon auth or create an export.
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('API_TOKEN_REQUIRED');
+    await expect(readFile(outputPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects a missing project:export capability at the non-loopback outer boundary', async () => {
+    // Given: a live exact-endpoint token that lacks the export operation.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+      allowedEndpoints: [PROJECT_EXPORT_TOOL_ENDPOINT],
+      allowedOperations: ['media:generate'],
+    }).token;
+
+    // When: the actual CLI reaches the non-loopback daemon boundary.
+    const result = await runExportCli(projectId, path.join(outputDir, 'wrong-operation.png'), token);
+
+    // Then: it cannot bypass broad daemon auth or reach route work.
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('API_TOKEN_REQUIRED');
+  });
+
+  it('enforces the exact token project after outer preauthorization', async () => {
+    // Given: a fully capable token bound to a different project.
+    const token = toolTokenRegistry.mint({
+      projectId,
+      runId: `run_${randomUUID()}`,
+    }).token;
+
+    // When: the actual CLI requests the foreign project.
+    const result = await runExportCli(
+      foreignProjectId,
+      path.join(outputDir, 'wrong-project.png'),
+      token,
+    );
+
+    // Then: route-level project matching remains fail-closed.
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('FORBIDDEN');
+  });
+
+  it('supports the generic run-scoped export endpoint over non-loopback HTTP', async () => {
+    // Given: the shared project export capability is used by the generic raster export route.
+    const token = toolTokenRegistry.mint({ projectId, runId: `run_${randomUUID()}` }).token;
+
+    // When: a non-loopback caller requests the generic endpoint with only that capability.
+    const response = await fetch(`${daemon.url}/api/projects/${projectId}/export`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ fileName: 'index.html', format: 'image' }),
+    });
+
+    // Then: it reaches the same route-level operation/project checks and returns exact bytes.
+    expect(response.status, await response.clone().text()).toBe(200);
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(png);
+  });
+
+  it.each([
+    ['GET screenshot path', 'GET', `/api/projects/${projectId}/export/image`],
+    ['vector PDF path', 'POST', `/api/projects/${projectId}/export/pdf`],
+  ] as const)('does not extend the run-scoped capability to the %s', async (_case, method, pathname) => {
+    // Given: a valid token whose capability is limited to run-scoped raster export routes.
+    const token = toolTokenRegistry.mint({ projectId, runId: `run_${randomUUID()}` }).token;
+
+    // When: the credential is presented to a neighboring method or vector export route.
+    const response = await fetch(`${daemon.url}${pathname}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        ...(method === 'POST' ? { 'content-type': 'application/json' } : {}),
+      },
+      ...(method === 'POST' ? { body: JSON.stringify({ fileName: 'index.html' }) } : {}),
+    });
+
+    // Then: the outer daemon-token boundary refuses it before any route work runs.
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'API_TOKEN_REQUIRED' },
+    });
+  });
+
+  it('does not extend an export token to a general non-loopback API route', async () => {
+    // Given: a valid token carrying only the screenshot export endpoint capability.
+    const token = toolTokenRegistry.mint({ projectId, runId: `run_${randomUUID()}` }).token;
+
+    // When: it is presented to a different API route.
+    const response = await fetch(`${daemon.url}/api/projects`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    // Then: the general daemon-token middleware remains unchanged.
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'API_TOKEN_REQUIRED' },
+    });
+  });
+
+  async function runExportCli(
+    requestedProjectId: string,
+    outputPath: string,
+    token: string,
+  ): Promise<{ readonly code: number; readonly stderr: string; readonly stdout: string }> {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      NODE_OPTIONS: '',
+      OD_DAEMON_URL: daemon.url,
+      OD_PROJECT_ID: requestedProjectId,
+      OD_TOOL_TOKEN: token,
+    };
+    delete env.OD_API_TOKEN;
+    try {
+      const { stdout, stderr } = await execFileP(
+        process.execPath,
+        [
+          tsxCli,
+          cliEntry,
+          'export',
+          'index.html',
+          '--project',
+          requestedProjectId,
+          '--format',
+          'image',
+          '--out',
+          outputPath,
+        ],
+        { cwd: daemonRoot, env, timeout: 15_000, maxBuffer: 4 * 1024 * 1024 },
+      );
+      return { code: 0, stdout, stderr };
+    } catch (error) {
+      const failure = typeof error === 'object' && error !== null ? error : {};
+      const code = Reflect.get(failure, 'code');
+      const stdout = Reflect.get(failure, 'stdout');
+      const stderr = Reflect.get(failure, 'stderr');
+      return {
+        code: typeof code === 'number' ? code : 1,
+        stdout: typeof stdout === 'string' ? stdout : '',
+        stderr: typeof stderr === 'string' ? stderr : '',
+      };
+    }
+  }
+});

--- a/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
@@ -102,6 +102,22 @@ describe('agent runtime tool environment', () => {
     expect(env.OD_TOOL_TOKEN).toBeUndefined();
   });
 
+  it('does not expose the broad daemon API token to run-scoped agent sessions', () => {
+    const env = createAgentRuntimeEnv(
+      {
+        PATH: '/bin',
+        OD_API_TOKEN: 'broad-daemon-token',
+        Od_Api_Token: 'windows-cased-broad-token',
+      },
+      'http://100.64.0.10:7456',
+      { token: 'run-scoped-token' },
+      '/opt/open-design/bin/node',
+    );
+
+    expect(env.OD_TOOL_TOKEN).toBe('run-scoped-token');
+    expect(Object.keys(env).some((key) => key.toUpperCase() === 'OD_API_TOKEN')).toBe(false);
+  });
+
   it('pins the daemon runtime data dir into agent sessions', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin' },

--- a/apps/desktop/tests/main/base-href-precedence.test.ts
+++ b/apps/desktop/tests/main/base-href-precedence.test.ts
@@ -1,0 +1,213 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const rendererState = vi.hoisted(() => ({ loadedUrls: [] as string[] }));
+
+vi.mock('electron', () => {
+  const image = {
+    getSize: () => ({ height: 1, width: 1 }),
+    toBitmap: () => Buffer.alloc(4),
+    toJPEG: () => Buffer.from('jpeg'),
+    toPNG: () => Buffer.from('png'),
+  };
+
+  class BrowserWindow {
+    readonly webContents = {
+      capturePage: async () => image,
+      debugger: {
+        attach: () => {
+          throw new Error('debugger unavailable in renderer-base test');
+        },
+        detach: () => undefined,
+        sendCommand: async () => undefined,
+      },
+      executeJavaScript: async (source: string): Promise<unknown> => {
+        if (source.includes("document.querySelectorAll('.slide")) return 0;
+        if (source.includes('document.documentElement.scrollHeight')) return 1;
+        if (source === 'window.devicePixelRatio || 1') return 1;
+        return true;
+      },
+      on: () => undefined,
+      printToPDF: async () => Buffer.from('pdf'),
+      setWindowOpenHandler: () => undefined,
+    };
+
+    async loadURL(url: string): Promise<void> {
+      rendererState.loadedUrls.push(url);
+    }
+
+    destroy(): void {}
+    getContentSize(): [number, number] { return [1440, 900]; }
+    isDestroyed(): boolean { return false; }
+    setContentSize(): void {}
+    setOpacity(): void {}
+    showInactive(): void {}
+  }
+
+  return {
+    BrowserWindow,
+    dialog: { showSaveDialog: async () => ({ canceled: true }) },
+    nativeImage: { createFromBitmap: () => image },
+  };
+});
+
+import { exportArtifact } from '../../src/main/artifact-export.js';
+import { renderDeckSlides } from '../../src/main/deck-capture.js';
+
+const execFileP = promisify(execFile);
+const desktopRoot = fileURLToPath(new URL('../..', import.meta.url));
+const legacyBaseHref = 'https://external.invalid/legacy/';
+const scopedBaseHref = 'http://127.0.0.1:43123/preview/export-scope/';
+const sourceHtml = `<!doctype html>
+<html>
+  <head>
+    <base href="${legacyBaseHref}">
+    <link rel="stylesheet" href="styles/x.css">
+  </head>
+  <body>
+    <img src="assets/hero.png" alt="">
+  </body>
+</html>`;
+
+type BaseResolution = {
+  readonly baseURI: string;
+  readonly imageSrc: string;
+  readonly stylesheetHref: string;
+};
+
+afterEach(() => {
+  rendererState.loadedUrls.length = 0;
+});
+
+describe('scoped renderer base precedence', () => {
+  it('uses the scoped base for deck-capture CSS and images when HTML already has an external base', async () => {
+    // Given: a deck-capture request whose source document already declares another base.
+    const input = {
+      baseHref: scopedBaseHref,
+      deck: true,
+      html: sourceHtml,
+    };
+
+    // When: deck-capture builds and loads its renderer document.
+    const result = await renderDeckSlides(input);
+
+    // Then: Electron Chromium proves the scoped base controls every relative renderer asset.
+    const resolution = await probeLoadedDocument(singleLoadedUrl());
+    expect(result).toMatchObject({ errorCode: 'NO_SLIDES', ok: false });
+    expect(resolution).toEqual(expectedResolution());
+  }, 30_000);
+
+  it('uses the scoped base for artifact-export CSS and images when HTML already has an external base', async () => {
+    // Given: an artifact-export request whose source document already declares another base.
+    const input = {
+      baseHref: scopedBaseHref,
+      deck: false,
+      format: 'image',
+      html: sourceHtml,
+      imageFormat: 'png',
+      title: 'Existing base precedence',
+    } as const;
+
+    // When: artifact-export builds and loads its renderer document.
+    const result = await exportArtifact(input);
+
+    try {
+      // Then: Electron Chromium proves the scoped base controls every relative renderer asset.
+      const resolution = await probeLoadedDocument(singleLoadedUrl());
+      expect(result.ok).toBe(true);
+      expect(resolution).toEqual(expectedResolution());
+    } finally {
+      if (result.path) await rm(dirname(result.path), { force: true, recursive: true });
+    }
+  }, 30_000);
+});
+
+function singleLoadedUrl(): string {
+  expect(rendererState.loadedUrls).toHaveLength(1);
+  const url = rendererState.loadedUrls[0];
+  if (!url) throw new Error('renderer did not load a document');
+  return url;
+}
+
+function expectedResolution(): BaseResolution {
+  return {
+    baseURI: scopedBaseHref,
+    imageSrc: new URL('assets/hero.png', scopedBaseHref).href,
+    stylesheetHref: new URL('styles/x.css', scopedBaseHref).href,
+  };
+}
+
+async function probeLoadedDocument(url: string): Promise<BaseResolution> {
+  const probeDir = await mkdtemp(join(tmpdir(), 'od-electron-base-probe-'));
+  const urlFile = join(probeDir, 'url.txt');
+  await writeFile(join(probeDir, 'package.json'), '{"main":"main.cjs"}\n');
+  await writeFile(urlFile, url);
+  await writeFile(join(probeDir, 'main.cjs'), `
+const { app, BrowserWindow } = require('electron');
+const { readFile } = require('node:fs/promises');
+
+app.whenReady().then(async () => {
+  const window = new BrowserWindow({
+    show: false,
+    webPreferences: { contextIsolation: true, nodeIntegration: false, sandbox: true },
+  });
+  await window.loadURL(await readFile(process.env.OD_BASE_PROBE_URL_FILE, 'utf8'));
+  const result = await window.webContents.executeJavaScript(\`({
+    baseURI: document.baseURI,
+    imageSrc: document.querySelector('img').src,
+    stylesheetHref: document.querySelector('link[rel="stylesheet"]').href,
+  })\`, true);
+  process.stdout.write('OD_BASE_PROBE:' + JSON.stringify(result) + '\\n');
+  window.destroy();
+  app.quit();
+}).catch((error) => {
+  process.stderr.write(String(error && error.stack ? error.stack : error) + '\\n');
+  app.exit(1);
+});
+`);
+
+  try {
+    const electronRelativePath = (await readFile(
+      join(desktopRoot, 'node_modules', 'electron', 'path.txt'),
+      'utf8',
+    )).trim();
+    const electronPath = join(desktopRoot, 'node_modules', 'electron', 'dist', electronRelativePath);
+    const electronArgs = [probeDir, '--no-sandbox', '--disable-gpu'];
+    const command = process.platform === 'linux' ? 'xvfb-run' : electronPath;
+    const args = process.platform === 'linux' ? ['-a', electronPath, ...electronArgs] : electronArgs;
+    const env: NodeJS.ProcessEnv = { ...process.env, OD_BASE_PROBE_URL_FILE: urlFile };
+    delete env.ELECTRON_RUN_AS_NODE;
+    const { stdout } = await execFileP(command, args, { env, timeout: 20_000 });
+    const marker = stdout.split(/\r?\n/).find((line) => line.startsWith('OD_BASE_PROBE:'));
+    if (!marker) throw new Error(`Electron renderer probe returned no result: ${stdout}`);
+    return parseBaseResolution(JSON.parse(marker.slice('OD_BASE_PROBE:'.length)));
+  } finally {
+    await rm(probeDir, { force: true, recursive: true });
+  }
+}
+
+function parseBaseResolution(value: unknown): BaseResolution {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || !('baseURI' in value)
+    || typeof value.baseURI !== 'string'
+    || !('imageSrc' in value)
+    || typeof value.imageSrc !== 'string'
+    || !('stylesheetHref' in value)
+    || typeof value.stylesheetHref !== 'string'
+  ) {
+    throw new Error('Electron renderer probe returned an invalid result');
+  }
+  return {
+    baseURI: value.baseURI,
+    imageSrc: value.imageSrc,
+    stylesheetHref: value.stylesheetHref,
+  };
+}


### PR DESCRIPTION
## Summary

- forward the existing run-scoped `OD_TOOL_TOKEN` from `od export` when it is available
- authorize screenshot export routes against a dedicated `project:export` capability and the token's exact project
- preserve the configured daemon `OD_API_TOKEN` lane instead of misclassifying it as a run-scoped tool token
- allow a valid exact export capability through the non-loopback outer API guard without handing the spawned agent the broad daemon token
- strip inherited `OD_API_TOKEN` variants from spawned-agent runtime environments
- reuse the existing fresh Workspace authority check for personal and Team projects without falling back to another auth lane
- hand the desktop renderer a project-bound, short-lived preview scope so bearerless relative CSS/image requests remain authorized
- keep explicit Workspace headers and legacy headerless unbound-project exports unchanged when no tool token is present

## Related issues

Closes #6657

## Changes

| Area | Change |
| --- | --- |
| `apps/daemon/src/cli.ts` | Prefer the injected Bearer tool token for spawned-agent exports; otherwise preserve the existing explicit Workspace-header path. |
| `apps/daemon/src/import-export-routes.ts` | Dispatch credentials through the correct API-token/tool-token lane, mint a project-bound renderer preview scope, and revoke it immediately when rendering settles. |
| `apps/daemon/src/tool-tokens.ts` | Add the parameterized screenshot-export endpoint and `project:export` operation to default run grants. |
| `apps/daemon/src/server.ts` / `server-context.ts` | Capture the active API-token classifier once at startup; on non-loopback peers, admit only `POST` requests on the bounded raster-export paths when the run token has the exact endpoint and `project:export` operation, then repeat project/capability authorization in the route. Remove inherited daemon API tokens from agent runtime environments. |
| `apps/daemon/src/deck-export.ts` / `pdf-export.ts` | Accept a scoped `baseHref` override only for screenshot-renderer inputs; vector PDF and unrelated callers retain their existing raw base. |
| `apps/daemon/tests/export-tool-token-authority.test.ts` | Exercise the real CLI-to-daemon flow, fail-closed adversarial cases, existing-`<base>` handoff, exact renderer asset bytes, fallback rendering, and immediate scope revocation. |
| `apps/daemon/tests/export-tool-token-nonloopback-authority.test.ts` / `tests/runtimes/agent-runtime-env.test.ts` | Bind the daemon to a real non-loopback interface, execute the real CLI, cover both configured API-token and run-token lanes plus invalid/expired/revoked/wrong-project/wrong-endpoint/wrong-operation cases, and prove the broad daemon token is not inherited by agents. |
| `apps/desktop/tests/main/base-href-precedence.test.ts` | Run both production document builders and actual Electron Chromium to prove the injected scoped base wins over an existing external `<base>` for CSS and image resolution. |

## Behavior matrix

| Scenario | Result |
| --- | --- |
| Spawned agent, valid token for exact Team project, no Workspace flags | Export succeeds |
| Valid token for a different project | Rejected with `FORBIDDEN` |
| Invalid or expired presented token on an otherwise unbound project | Rejected; no headerless downgrade |
| Valid token without the export capability | Rejected with `TOOL_ENDPOINT_DENIED` |
| Default export token used against inline project-file reads | Rejected; capability remains limited to screenshot export routes |
| Matching configured daemon API token on a screenshot export route | Stays on existing project authorization and succeeds |
| Valid run token over a real non-loopback peer | Passes the bounded outer guard, is re-authorized for exact project/capability in the route, and exports exact bytes |
| Invalid, expired, revoked, wrong-endpoint, or wrong-operation run token over non-loopback | Rejected at the outer guard with `API_TOKEN_REQUIRED` |
| Valid run token for the wrong project over non-loopback | Rejected by the route with `TOOL_PROJECT_MISMATCH` |
| Spawned-agent child environment | Receives `OD_DAEMON_URL` and `OD_TOOL_TOKEN`, but not inherited `OD_API_TOKEN` variants |
| Bound-project renderer loads relative CSS/image without a Bearer header | Exact bytes load through the project-bound preview scope |
| Project HTML already declares an external `<base>` | Both production desktop builders inject the scoped base first; Electron resolves `document.baseURI`, CSS, and images through the scoped preview URL |
| Renderer/exporter promise settles | Preview scope is revoked before output assembly/HTTP response completes |
| Explicit Workspace/member flags with no token | Existing behavior preserved |
| Headerless unbound local project with no token | Existing behavior preserved |

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — daemon-only authorization routing and regression coverage; no UI, public contract, new flag/env var, dependency, or extension surface

## Bug fix verification

- Test paths: `apps/daemon/tests/export-tool-token-authority.test.ts`, `apps/daemon/tests/export-tool-token-nonloopback-authority.test.ts`, and `apps/daemon/tests/runtimes/agent-runtime-env.test.ts`
- Red on the pre-fix branch: **yes** — a matching startup-configured `OD_API_TOKEN` returned `401 TOOL_TOKEN_INVALID` instead of `200` on `/api/projects/:id/export/image`.
- Green on this branch: **yes** — the same regression returns `200` with the exact PNG bytes, while invalid, expired, cross-project, endpoint-restricted, and inline-read cases remain fail-closed.
- The regression mutates `process.env.OD_API_TOKEN` after server startup and presents the original token, proving authorization uses the startup-captured credential rather than mutable process-global state.
- Renderer asset RED: a bound-project relative CSS GET resolved under `/raw/` and returned `400 WORKSPACE_CONTEXT_REQUIRED`, so the export returned `502` or could render with missing assets.
- Renderer asset GREEN: both the slide renderer and supported image fallback load the exact CSS and PNG bytes through an opaque project-bound preview scope, then return the exact output PNG.
- Lifecycle RED→GREEN: before the repair the scoped asset URL still returned `200` after the renderer promise settled; it now returns `404` before output file reading and HTTP response completion.
- Existing-`<base>` reviewer case: both production document builders were executed, their actual data URLs were loaded by Electron Chromium, and `document.baseURI`, relative stylesheet href, and relative image src all resolved under the scoped preview base. No production mutation was needed because injection already occurs immediately after the opening `<head>`, before existing head contents.
- Non-loopback outer-guard RED: the real CLI connected through an actual non-loopback interface with only `OD_TOOL_TOKEN` and received `401 API_TOKEN_REQUIRED` before the export route ran.
- Non-loopback GREEN: the same CLI request now writes the renderer's exact PNG bytes. The configured daemon API-token lane also remains green, while invalid/expired/revoked/wrong-endpoint/wrong-operation tokens fail at the outer guard and wrong-project tokens fail in the route.
- Runtime-env RED→GREEN: an inherited `OD_API_TOKEN` was visible to the spawned agent before this repair; uppercase and case-variant daemon-token keys are now removed while the run-scoped tool token remains available.

## Validation

- original feature RED before production edits: new regression had 5 failures; the happy path returned `WORKSPACE_CONTEXT_REQUIRED`, while invalid/expired tokens were ignored and downgraded to headerless export
- blocker regression RED: matching daemon API token returned `401 TOOL_TOKEN_INVALID`; GREEN: `200` plus exact PNG bytes
- renderer lifecycle RED: post-settlement scoped asset probe returned `200`; GREEN: immediate `404` while the HTTP response remained intentionally blocked
- artifact fallback RED: bearerless CSS GET returned `400 WORKSPACE_CONTEXT_REQUIRED`; GREEN: exact CSS/image bytes loaded before writing the PNG
- Node `24.13.1`: focused + adjacent authority/preview/non-loopback/runtime-env subset — `9` files, `162` tests passed after the final rebase
- Node `24.13.1`: real Electron existing-`<base>` regression — `2/2` passed for deck capture and artifact export
- full desktop suite — `326` passed, `1` skipped
- `pnpm --filter @open-design/daemon typecheck` / `build`
- `pnpm --filter @open-design/desktop typecheck` / `build`
- repository-wide `pnpm typecheck`
- `pnpm guard`
- `git diff --check`
- actual non-loopback HTTP integration: daemon bound to a non-loopback interface; real CLI + valid run token completed with exact PNG bytes, and the configured API-token lane completed independently
- stable patch-id `6122dcc239309392f23a18f1e13c38c64fc46c94` remained identical across the final rebase onto `0cab7ada8095055fc09587034a23ead6f9e9f98c`
- independent exact-diff five-lane review: `APPROVE`; no correctness, security, least-privilege, portability, cleanup, or flakiness blocker

The full daemon suite completed with `622` files / `8124` tests passing and `11` files / `16` tests failing outside the changed export-auth/runtime-env surfaces. Re-running the exact 11 failing files on both the candidate and a clean, normally built `origin/main` worktree produced the same 16 assertions, proving a zero-failure delta for this patch rather than misreporting the repository baseline as green.

## Screenshots / recordings

Not applicable; this changes daemon authorization behavior and has no UI surface.

## Checklist

- [x] I kept the patch scoped to spawned-agent screenshot exports, daemon API-token compatibility, and renderer-only asset authorization.
- [x] I added regression coverage for the affected behavior and adversarial authority cases.
- [x] I verified presented invalid credentials fail closed instead of falling back.
- [x] I verified adjacent manual Workspace and unbound local export behavior remains unchanged.
- [x] I ran the relevant type checks, build, repository guard, and focused tests.
- [x] I did not add dependencies, generated artifacts, credentials, co-author trailers, or unrelated changes.
