### PR TITLE
count the Feishu joins on the Launch Week page

### DIFF
--- a/apps/landing-page/app/pages/community/events/launch-week/index.astro
+++ b/apps/landing-page/app/pages/community/events/launch-week/index.astro
@@ -163,6 +163,28 @@ const jsonLd = {
       });
   })();
 
+  // Count the Feishu joins. The site-wide tracker recognises `discord.gg/`
+  // and nothing else, so without this the page's only conversion is half
+  // measured — and Feishu is where the campaign's China-side community lives.
+  // Discord is deliberately left to the shared tracker rather than counted
+  // again here, which would double every click.
+  (() => {
+    // Listen on the document and resolve the tracker at click time. The shared
+    // `__odTrack` is defined by the analytics snippet in <head>, which is absent
+    // whenever PostHog has no key (CI and PR previews build without one) — a
+    // check at attach time would silently drop the listener for good.
+    document.addEventListener('click', (event) => {
+      const link = event.target.closest?.('a[href*="applink.feishu.cn"]');
+      if (!link || !link.closest('main.lw')) return;
+      if (typeof window.__odTrack !== 'function') return;
+      window.__odTrack('ui_click', {
+        element: 'join_feishu',
+        link_url: link.href,
+        link_text: (link.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 120),
+      });
+    });
+  })();
+
   // Scroll reveal. Lives here rather than in the partial so the markup stays
   // pure content; no-ops entirely when the visitor asks for reduced motion.
   (() => {


### PR DESCRIPTION
## Why

Joining the community is the only thing the Launch Week page asks anyone to do,
and half of that was unmeasured.

The site-wide PostHog tracker recognises `discord.gg/` and nothing else, and
autocapture is disabled site-wide, so a click on "Join Feishu group" left no
trace anywhere. I checked before writing this: **zero events referencing any
Feishu link across the whole site in the last 20 days**, in either PostHog or
GA4. Discord clicks, by contrast, are already counted (661 in the same window).

Feishu group growth is one of the campaign's stated goals, so the page's only
conversion could not be reported on for the half that matters most to it.

## What users will see

Nothing. This adds no UI and changes no behaviour — it only records a click the
page already handled.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — analytics instrumentation on one page

### Three decisions worth a reviewer's eye

**Scoped to this page, not the shared tracker.** Feishu links appear nowhere
else under `app/` — only the eleven Launch Week locale partials. Putting the
rule in the site-wide tracker would widen the blast radius of a campaign change
for no coverage gain.

**Discord is deliberately not counted here.** The shared tracker already emits
`join_discord` for it; emitting our own would double every click. The event
shape matches (`ui_click` + `element`), so both halves land in one table and the
join rate is a single query.

**The tracker is resolved at click time, not at attach time.** `__odTrack` comes
from the analytics snippet, which is absent whenever PostHog has no key — CI and
PR previews build without one. An attach-time guard would silently drop the
listener for the life of the page. This was not hypothetical: the first version
guarded at attach time and I caught it in the browser.

## Screenshots

No UI change.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/landing-page test` — 134/134 pass.
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors.
- Browser, patching the real `window.posthog.capture` and blocking the network
  so no test event reached production:
  - two Feishu clicks → exactly two `ui_click` / `join_feishu`, carrying
    `link_url` and `link_text`
  - two Discord clicks → two `ui_click` / `join_discord`, no duplicates
  - a Feishu link injected outside `main.lw` → no event
- Confirmed afterwards in PostHog that no `join_feishu` event reached the
  production project during testing.
