### PR TITLE
fix(web): keep sibling assets working when presenting in a new tab

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -184,6 +184,7 @@ import {
   htmlNeedsRedirectGuard,
   htmlNeedsSandboxShim,
   parseForceInline,
+  presentUrlLoadDecision,
   shouldUrlLoadHtmlPreview,
   type UrlLoadDecision,
 } from './file-viewer-render-mode';
@@ -12311,9 +12312,20 @@ function HtmlViewer({
     // and `<base href>` cannot carry the required query string (URL resolution
     // discards it), so `./styles.css` 400s and the page renders unstyled.
     // Load the daemon URL instead — it rewrites relative references as it
-    // serves. Decks keep the inlined path because they depend on slide-state
-    // options that only exist when the document is composed here.
-    if (!effectiveDeck && !manualEditFrozenSource) {
+    // serves.
+    //
+    // Reuse the viewer's own URL-vs-srcDoc gate rather than a bespoke
+    // condition, so Present inherits every render-safety rule the inline
+    // preview already enforces: sandbox-shim artifacts that throw
+    // SecurityError at an opaque origin, self-redirecting documents that need
+    // buildSrcdoc's redirect guard (#710), and root-relative asset refs that
+    // only resolve after the srcDoc rewrite. A file with unsaved manual edits
+    // also stays inlined, since the daemon would serve the version on disk.
+    const presentViaUrl =
+      !manualEditFrozenSource
+      && !manualEditRequiresSrcDoc
+      && shouldUrlLoadHtmlPreview(presentUrlLoadDecision(urlLoadDecision));
+    if (presentViaUrl) {
       openSandboxedPreviewUrlInNewTab(
         projectRawUrl(projectId, file.name, workspaceContext),
         exportTitle,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -143,6 +143,7 @@ import {
   imageDataUrlToBlob,
   isOpenDesignHostAvailable,
   openSandboxedPreviewInNewTab,
+  openSandboxedPreviewUrlInNewTab,
   prepareImageExportTarget,
   planDeckImageCapture,
   requestPreviewSnapshot,
@@ -12305,6 +12306,20 @@ function HtmlViewer({
 
   function openInNewTab() {
     if (!source) return;
+    // A multi-file artifact cannot survive being inlined into a srcdoc: its
+    // sibling assets are reachable only through workspace-scoped daemon URLs,
+    // and `<base href>` cannot carry the required query string (URL resolution
+    // discards it), so `./styles.css` 400s and the page renders unstyled.
+    // Load the daemon URL instead — it rewrites relative references as it
+    // serves. Decks keep the inlined path because they depend on slide-state
+    // options that only exist when the document is composed here.
+    if (!effectiveDeck && !manualEditFrozenSource) {
+      openSandboxedPreviewUrlInNewTab(
+        projectRawUrl(projectId, file.name, workspaceContext),
+        exportTitle,
+      );
+      return;
+    }
     openSandboxedPreviewInNewTab(source, exportTitle, {
       deck: effectiveDeck,
       baseHref: srcDocBaseHref,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12308,11 +12308,22 @@ function HtmlViewer({
   function openInNewTab() {
     if (!source) return;
     // A multi-file artifact cannot survive being inlined into a srcdoc: its
-    // sibling assets are reachable only through workspace-scoped daemon URLs,
-    // and `<base href>` cannot carry the required query string (URL resolution
-    // discards it), so `./styles.css` 400s and the page renders unstyled.
-    // Load the daemon URL instead — it rewrites relative references as it
-    // serves.
+    // siblings are reachable only through scoped daemon URLs, and `<base href>`
+    // cannot carry the query that scope lives in (URL resolution discards a
+    // base's query), so `./styles.css` 400s and the page renders unstyled.
+    //
+    // Ask the daemon for the same containment document the inline preview
+    // uses. Presence of `odPreviewBridge` makes it mint a preview scope and
+    // inject a path-scoped `<base href=".../preview/<token>/">` with no query
+    // to lose, so rewritten attributes AND a runtime `fetch('./data.json')`
+    // both resolve. An empty value asks for the base without any bridge
+    // scripts, which Present has no parent listener for.
+    //
+    // Two paths that look right and are not: serving `/raw/` plain fixes only
+    // attributes, because the daemon cannot rewrite a URL inside a script, so
+    // a data fetch silently falls back to whatever the artifact embeds; and
+    // navigating to the `/preview/<token>/` document directly is served with
+    // `connect-src 'none'`, which blocks every fetch outright.
     //
     // Reuse the viewer's own URL-vs-srcDoc gate rather than a bespoke
     // condition, so Present inherits every render-safety rule the inline
@@ -12327,7 +12338,10 @@ function HtmlViewer({
       && shouldUrlLoadHtmlPreview(presentUrlLoadDecision(urlLoadDecision));
     if (presentViaUrl) {
       openSandboxedPreviewUrlInNewTab(
-        projectRawUrl(projectId, file.name, workspaceContext),
+        appendResourceQuery(
+          projectRawUrl(projectId, file.name, workspaceContext),
+          'odPreviewBridge=',
+        ),
         exportTitle,
       );
       return;

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -124,6 +124,31 @@ export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
   return true;
 }
 
+/**
+ * Narrow a viewer decision to the one Present makes.
+ *
+ * Present renders the artifact and nothing else: no comment, inspect, edit,
+ * palette, tweaks, or draw affordance is reachable from a presented tab, so
+ * the bridges those modes need are irrelevant and must not drag Present onto
+ * the inline path. Everything else is inherited deliberately — in particular
+ * `forceInline` (sandbox shim), `needsFocusGuard`, `needsRedirectGuard`, and
+ * `projectRootAssetRefs`, which are render-safety signals rather than editor
+ * plumbing. Those documents are unsafe to serve raw whatever surface asks for
+ * them, so Present keeps the guarded srcDoc path for them too.
+ */
+export function presentUrlLoadDecision(d: UrlLoadDecision): UrlLoadDecision {
+  return {
+    ...d,
+    mode: 'preview',
+    commentMode: false,
+    inspectMode: false,
+    editMode: false,
+    paletteActive: false,
+    tweaksBridge: false,
+    drawMode: false,
+  };
+}
+
 export function hasUrlModeBridge(source: string | null | undefined): boolean {
   if (!source) return false;
   return /<script\b[^>]*\bsrc\s*=\s*["'][^"']*\bod-direct-edit\.js\b[^"']*["'][^>]*>/i.test(source);

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1268,6 +1268,59 @@ export function buildSandboxedPreviewDocument(
 </html>`;
 }
 
+// Same sandbox contract as `buildSandboxedPreviewDocument`, but the child
+// loads a real daemon URL instead of inlined source.
+//
+// Inlining cannot preserve sibling assets. The only handle a srcdoc child has
+// on its origin is `<base href>`, and the daemon's raw URLs are workspace
+// scoped — `/api/projects/<id>/raw/?workspaceId=…&workspaceMemberId=…`. URL
+// resolution drops a base's query string, so `./styles.css` resolves without
+// those parameters and the endpoint answers 400. The artifact then renders as
+// unstyled markup, with any inline `<svg>` blown up to full size because
+// nothing is left to size it.
+//
+// Loading the raw URL directly avoids this: the daemon rewrites every relative
+// reference to a fully scoped URL as it serves the file. The child still has an
+// opaque origin, so untrusted artifact code cannot reach the daemon session.
+export function buildSandboxedPreviewUrlDocument(
+  src: string,
+  title: string,
+  opts?: { allowModals?: boolean },
+): string {
+  const safeTitle = escapeHtmlAttribute(title || 'Preview');
+  const sandbox = opts?.allowModals ? 'allow-scripts allow-modals' : 'allow-scripts';
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${safeTitle}</title>
+  <style>html,body,iframe{margin:0;width:100%;height:100%;border:0}body{overflow:hidden;background:#fff}</style>
+</head>
+<body>
+  <iframe title="${safeTitle}" sandbox="${sandbox}" src="${escapeHtmlAttribute(src)}"></iframe>
+</body>
+</html>`;
+}
+
+export function openSandboxedPreviewUrlInNewTab(src: string, title: string): void {
+  // The wrapper is served from a Blob URL, and a Blob URL is not hierarchical:
+  // a root-relative `/api/...` src has nothing to resolve against and the frame
+  // stays blank. Absolutise against the app origin before embedding.
+  const absolute = (() => {
+    try {
+      return new URL(src, window.location.origin).href;
+    } catch {
+      return src;
+    }
+  })();
+  const doc = buildSandboxedPreviewUrlDocument(absolute, title);
+  const blob = new Blob([doc], { type: 'text/html;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  window.open(url, '_blank', 'noopener,noreferrer');
+  setTimeout(() => URL.revokeObjectURL(url), 60_000);
+}
+
 function currentOriginBaseHref(): string | undefined {
   if (typeof window !== 'undefined' && typeof window.location?.origin === 'string') {
     return `${window.location.origin.replace(/\/+$/, '')}/`;

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -8,6 +8,7 @@ import {
   htmlNeedsRedirectGuard,
   htmlNeedsSandboxShim,
   parseForceInline,
+  presentUrlLoadDecision,
   shouldUrlLoadHtmlPreview,
 } from '../../src/components/file-viewer-render-mode';
 
@@ -94,6 +95,54 @@ describe('shouldUrlLoadHtmlPreview', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, tweaksBridge: true, forceInline: true })).toBe(false);
     expect(shouldUrlLoadHtmlPreview({ ...base, commentMode: true, urlModeBridge: true, inspectMode: true })).toBe(false);
     expect(shouldUrlLoadHtmlPreview({ ...base, drawMode: true, urlSnapshotBridge: true, inspectMode: true })).toBe(false);
+  });
+});
+
+describe('presentUrlLoadDecision', () => {
+  const base = { mode: 'preview' as const, isDeck: false, commentMode: false, forceInline: false };
+
+  it('URL-loads a plain artifact so its sibling assets resolve', () => {
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision(base))).toBe(true);
+  });
+
+  it('ignores editor bridges the presented tab cannot reach', () => {
+    for (const mode of [
+      { commentMode: true },
+      { inspectMode: true },
+      { editMode: true },
+      { paletteActive: true },
+      { tweaksBridge: true },
+      { drawMode: true },
+    ]) {
+      expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, ...mode }))).toBe(true);
+    }
+  });
+
+  it('keeps srcDoc for a sandbox-shim artifact, which throws at an opaque origin', () => {
+    // e.g. localStorage / sessionStorage touched at mount — URL-loading it
+    // under sandbox="allow-scripts" raises SecurityError and blanks the tab.
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, forceInline: true })))
+      .toBe(false);
+  });
+
+  it('keeps srcDoc for a self-redirecting artifact so the guard survives', () => {
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, needsRedirectGuard: true })))
+      .toBe(false);
+  });
+
+  it('keeps srcDoc for focus-stealing and root-relative-asset artifacts', () => {
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, needsFocusGuard: true })))
+      .toBe(false);
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, projectRootAssetRefs: true })))
+      .toBe(false);
+  });
+
+  it('presents the rendered artifact even when the viewer is on the source tab', () => {
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, mode: 'source' }))).toBe(true);
+  });
+
+  it('keeps srcDoc for a deck, which needs slide state composed host-side', () => {
+    expect(shouldUrlLoadHtmlPreview(presentUrlLoadDecision({ ...base, isDeck: true }))).toBe(false);
   });
 });
 

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -7,6 +7,7 @@ import {
   buildDesignManifestContent,
   downloadImageDataUrl,
   buildSandboxedPreviewDocument,
+  buildSandboxedPreviewUrlDocument,
   downloadDesignSystemArchive,
   downloadProjectArchive,
   exportAsImage,
@@ -1174,6 +1175,25 @@ describe('sandboxed preview Blob exports', () => {
     });
 
     expect(wrapper).toContain('sandbox="allow-scripts allow-modals"');
+    expect(wrapper).not.toContain('allow-same-origin');
+  });
+
+  it('loads a URL wrapper by src so sibling assets keep their workspace query', () => {
+    // A workspace-scoped raw URL carries the query that authorises the
+    // request. Inlining the document and pointing `<base href>` at that URL
+    // loses it, because URL resolution drops a base's query string, so
+    // `./styles.css` requests an unauthorised path and 400s. Referencing the
+    // URL with `src` keeps the daemon's own link rewriting in play.
+    const wrapper = buildSandboxedPreviewUrlDocument(
+      '/api/projects/p1/raw/index.html?workspaceId=w1&workspaceMemberId=m1',
+      'Preview',
+    );
+
+    expect(wrapper).toContain(
+      'src="/api/projects/p1/raw/index.html?workspaceId=w1&amp;workspaceMemberId=m1"',
+    );
+    expect(wrapper).not.toContain('srcdoc=');
+    expect(wrapper).toContain('sandbox="allow-scripts"');
     expect(wrapper).not.toContain('allow-same-origin');
   });
 


### PR DESCRIPTION
Fixes #6664

## Why

Hit this while building Frontend Mentor solutions on top of OD: the agent produced `index.html` + `styles.css`, the inline preview looked right, and **Present → New tab** showed unstyled markup with one inline `<svg>` blown up to full viewport size. My first assumption was that the artifact was broken — it wasn't.

`openInNewTab()` inlines the source into a sandboxed `srcdoc` and gives the child a `<base href>` pointing at the file's directory. That directory is a workspace-scoped daemon URL carrying `?workspaceId=…&workspaceMemberId=…`, and **URL resolution discards a base's query string**, so `./styles.css` requests a path without those parameters and the endpoint answers `400`:

```
GET /api/projects/<id>/raw/styles.css                                  → 400
GET /api/projects/<id>/raw/styles.css?workspaceId=…&workspaceMemberId=…    → 200
```

`<base href>` cannot express this — a base contributes scheme, host, and path, never a query. So no amount of fixing the base value repairs the inlined path for a multi-file artifact.

## What users will see

**Present → New tab** now renders an artifact with separate stylesheets or asset files exactly as the inline preview and Fullscreen already do. Previously it showed unstyled markup. Single-file artifacts are unaffected; decks are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — Present → New tab now loads the daemon URL instead of an inlined copy. For a file with unsaved manual edits this would have meant presenting the version on disk, so that case keeps the old inlined path.
- [ ] **None**

No new UI surface — the existing menu item simply works.

## Screenshots

Same artifact, same menu item, before and after. Both are `Present → New tab` on an `index.html` + `styles.css` project.

**Before** — unstyled, with the Reaction icon `<svg>` filling the page:

> serif headings, no layout, giant black lightning glyph

**After** — identical to the inline preview:

> the intended two-column card, correct palette and type

(Screenshots are of a local Frontend Mentor artifact; happy to attach images if useful — the reproduction above is deterministic with any two-file artifact.)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/exports.test.ts` → `loads a URL wrapper by src so sibling assets keep their workspace query`
- Did the test go red on `main` and green on this branch? **yes**

Red on `main` (source files checked out from `main`, test kept):

```
FAIL  tests/runtime/exports.test.ts > sandboxed preview Blob exports > loads a URL wrapper by src so sibling assets keep their workspace query
TypeError: buildSandboxedPreviewUrlDocument is not a function
 Tests  1 failed | 90 passed (91)
```

Green on this branch:

```
 Test Files  1 passed (1)
      Tests  91 passed (91)
```

Also verified by hand in a browser: the same artifact that previously rendered unstyled through New tab now matches the inline preview.

## Validation

- `pnpm guard` — passed
- `pnpm --filter @open-design/web typecheck` — passed
- `npx vitest run -c vitest.config.ts tests/runtime/exports.test.ts` — 91 passed

## Implementation notes

- `apps/web/src/runtime/exports.ts` — new `buildSandboxedPreviewUrlDocument()` / `openSandboxedPreviewUrlInNewTab()`: an iframe with `src` rather than `srcdoc`. The daemon already rewrites relative references to fully scoped URLs as it serves the file, so siblings resolve. Sandbox stays `allow-scripts` with no `allow-same-origin`, so untrusted artifact code still runs at an opaque origin and cannot reach the daemon session — the contract in `docs/architecture.md` is unchanged.
- `apps/web/src/components/FileViewer.tsx` — `openInNewTab()` takes the URL path for ordinary HTML files. **Decks keep the inlined path**, since they depend on slide-state options composed client-side, and so does a file with unsaved manual edits.
- One trap worth recording: the URL must be absolutised against `window.location.origin` first. A root-relative `/api/...` src inside a Blob-URL wrapper leaves the frame blank, because a Blob URL is not hierarchical and a leading `/` has nothing to resolve against. That cost me one wrong iteration.