### PR TITLE
fix(web): improve Workspace failure diagnostics

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3709,8 +3709,7 @@ function AppInner() {
     // visible, because this call sent no workspace headers at all).
     const mutationContext = workspaceContextRef.current;
     const mutationAccountGeneration = currentWorkspaceAccountGeneration();
-    const ok = await deleteProjectApi(id, mutationContext);
-    if (!ok) return false;
+    await deleteProjectApi(id, mutationContext);
     if (mutationContext) {
       removeProjectFromDisplaySnapshots({
         accountGeneration: mutationAccountGeneration,

--- a/apps/web/src/analytics/workspace.ts
+++ b/apps/web/src/analytics/workspace.ts
@@ -60,3 +60,26 @@ export function stableAnalyticsErrorCode(status?: number): string {
   if (status === 429) return 'rate_limited';
   return status >= 500 ? 'server_error' : 'request_failed';
 }
+
+/**
+ * Preserve a daemon-provided, bounded API error code when one is available,
+ * then fall back to the stable HTTP status buckets above. This deliberately
+ * refuses arbitrary messages so analytics cardinality cannot grow with paths,
+ * project names, or upstream error text.
+ */
+export function stableAnalyticsRequestErrorCode(
+  error: unknown,
+  fallback = 'request_failed',
+): string {
+  if (!error || typeof error !== 'object') return fallback;
+  const candidate = error as { code?: unknown; status?: unknown };
+  if (
+    typeof candidate.code === 'string'
+    && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(candidate.code)
+  ) {
+    return candidate.code;
+  }
+  return typeof candidate.status === 'number'
+    ? stableAnalyticsErrorCode(candidate.status)
+    : fallback;
+}

--- a/apps/web/src/analytics/workspace.ts
+++ b/apps/web/src/analytics/workspace.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { API_ERROR_CODES, type WorkspaceCollabContext } from '@open-design/contracts';
 import type {
   TrackingCountBucket,
   TrackingWorkspaceDimensions,
@@ -61,6 +61,34 @@ export function stableAnalyticsErrorCode(status?: number): string {
   return status >= 500 ? 'server_error' : 'request_failed';
 }
 
+const REQUEST_ERROR_CODES = new Set<string>([
+  ...API_ERROR_CODES,
+  // Client-side transport failures and HTTP fallbacks are already bounded
+  // analytics classes. Some call sites classify them before reaching this
+  // helper, so keep the same finite vocabulary accepted as input.
+  'network_error',
+  'unauthorized',
+  'forbidden',
+  'not_found',
+  'conflict',
+  'rate_limited',
+  'server_error',
+  'request_failed',
+  // The remote skill installer predates the shared ApiError envelope. Keep
+  // its operation-specific failure classes explicit and finite here;
+  // BAD_REQUEST, CONFLICT, and INTERNAL_ERROR already live in API_ERROR_CODES.
+  'FETCH_FAILED',
+  'INVALID_ARCHIVE',
+  'INVALID_MANIFEST',
+]);
+
+/** Accept only contract-owned or explicitly enumerated installer error codes. */
+export function boundedRequestErrorCode(value: unknown): string | undefined {
+  return typeof value === 'string' && REQUEST_ERROR_CODES.has(value)
+    ? value
+    : undefined;
+}
+
 /**
  * Preserve a daemon-provided, bounded API error code when one is available,
  * then fall back to the stable HTTP status buckets above. This deliberately
@@ -73,12 +101,8 @@ export function stableAnalyticsRequestErrorCode(
 ): string {
   if (!error || typeof error !== 'object') return fallback;
   const candidate = error as { code?: unknown; status?: unknown };
-  if (
-    typeof candidate.code === 'string'
-    && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(candidate.code)
-  ) {
-    return candidate.code;
-  }
+  const boundedCode = boundedRequestErrorCode(candidate.code);
+  if (boundedCode) return boundedCode;
   return typeof candidate.status === 'number'
     ? stableAnalyticsErrorCode(candidate.status)
     : fallback;

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -147,8 +147,10 @@ export function DesignsTab({
 		title: string;
 		message: string;
 		confirmLabel: string;
-		onConfirm: () => void;
+		onConfirm: () => Promise<boolean | void> | boolean | void;
 	} | null>(null);
+	const [confirmPending, setConfirmPending] = useState(false);
+	const [confirmError, setConfirmError] = useState<string | null>(null);
 	const [view, setView] = useState<ViewMode>(() => {
 		if (typeof window === "undefined") return "grid";
 		try {
@@ -418,23 +420,12 @@ export function DesignsTab({
 		setRenameInput("");
 	};
 	const handleDeleteProject = (project: Project) => {
+		setConfirmError(null);
 		setConfirmTarget({
 			title: t("designs.deleteTitle"),
 			message: t("designs.deleteConfirm", { name: project.name }),
 			confirmLabel: t("designs.menuDelete"),
-			onConfirm: async () => {
-				try {
-					const deleted = await onDelete(project.id);
-					if (deleted === false) throw new Error(t("ds.actionFailed"));
-				} catch (error) {
-					setDesignsToast({
-						id: (toastIdRef.current += 1),
-						message: error instanceof Error ? error.message : t("ds.actionFailed"),
-						role: "alert",
-						tone: "error",
-					});
-				}
-			},
+			onConfirm: () => onDelete(project.id),
 		});
 	};
 	const handleDuplicateProject = (project: Project) => {
@@ -451,6 +442,7 @@ export function DesignsTab({
 	const handleBatchDelete = () => {
 		const ids = Array.from(selected);
 		if (ids.length === 0) return;
+		setConfirmError(null);
 		setConfirmTarget({
 			title: t("designs.deleteTitle"),
 			message: t("designs.deleteSelectedConfirm", { n: ids.length }),
@@ -485,21 +477,42 @@ export function DesignsTab({
 		projectId: string,
 		artifact: LiveArtifactSummary,
 	) => {
+		setConfirmError(null);
 		setConfirmTarget({
 			title: t("common.delete"),
 			message: `${t("common.delete")} "${artifact.title}"?`,
 			confirmLabel: t("designs.menuDelete"),
 			onConfirm: async () => {
 				const ok = await deleteLiveArtifact(projectId, artifact.id, workspaceContext);
-				if (!ok) return;
+				if (!ok) return false;
 				setLiveArtifactsByProject((current) => ({
 					...current,
 					[projectId]: (current[projectId] ?? []).filter(
 						(candidate) => candidate.id !== artifact.id,
 					),
 				}));
+				return true;
 			},
 		});
+	};
+
+	const commitConfirmTarget = async () => {
+		if (!confirmTarget || confirmPending) return;
+		const target = confirmTarget;
+		setConfirmError(null);
+		setConfirmPending(true);
+		try {
+			const result = await target.onConfirm();
+			if (result === false) {
+				setConfirmError(t("ds.actionFailed"));
+				return;
+			}
+			setConfirmTarget((current) => current === target ? null : current);
+		} catch (error) {
+			setConfirmError(error instanceof Error ? error.message : t("ds.actionFailed"));
+		} finally {
+			setConfirmPending(false);
+		}
 	};
 
 	return (
@@ -1145,24 +1158,38 @@ export function DesignsTab({
 				<Dialog
 					className="modal-confirm"
 					role="alertdialog"
-					onClose={() => setConfirmTarget(null)}
+					onClose={() => {
+						if (confirmPending) return;
+						setConfirmTarget(null);
+						setConfirmError(null);
+					}}
+					closeOnBackdrop={!confirmPending}
 					ariaLabelledBy={confirmTitleId}
 				>
 					<DialogTitle id={confirmTitleId}>{confirmTarget.title}</DialogTitle>
 					<DialogDescription className="modal-confirm-message">{confirmTarget.message}</DialogDescription>
+					{confirmError ? (
+						<p className="modal-confirm-error" role="alert">
+							{confirmError}
+						</p>
+					) : null}
 					<DialogFooter className="row">
-						<button type="button" onClick={() => setConfirmTarget(null)}>
+						<button
+							type="button"
+							disabled={confirmPending}
+							onClick={() => {
+								setConfirmTarget(null);
+								setConfirmError(null);
+							}}
+						>
 							{t("designs.renameCancel")}
 						</button>
 						<button
 							type="button"
 							className="primary danger"
 							autoFocus
-							onClick={() => {
-								const run = confirmTarget.onConfirm;
-								setConfirmTarget(null);
-								run();
-							}}
+							disabled={confirmPending}
+							onClick={() => void commitConfirmTarget()}
 						>
 							{confirmTarget.confirmLabel}
 						</button>

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -422,7 +422,19 @@ export function DesignsTab({
 			title: t("designs.deleteTitle"),
 			message: t("designs.deleteConfirm", { name: project.name }),
 			confirmLabel: t("designs.menuDelete"),
-			onConfirm: () => onDelete(project.id),
+			onConfirm: async () => {
+				try {
+					const deleted = await onDelete(project.id);
+					if (deleted === false) throw new Error(t("ds.actionFailed"));
+				} catch (error) {
+					setDesignsToast({
+						id: (toastIdRef.current += 1),
+						message: error instanceof Error ? error.message : t("ds.actionFailed"),
+						role: "alert",
+						tone: "error",
+					});
+				}
+			},
 		});
 	};
 	const handleDuplicateProject = (project: Project) => {

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -44,7 +44,7 @@ import {
   trackWorkspaceResourceActionResult,
 } from '../analytics/events';
 import {
-  stableAnalyticsErrorCode,
+  stableAnalyticsRequestErrorCode,
   workspaceAnalyticsDimensions,
 } from '../analytics/workspace';
 import type { TrackingWorkspaceScope } from '@open-design/contracts/analytics';
@@ -228,10 +228,10 @@ function resourceActionAnalyticsErrorCode(
   error: { code?: string; errorCode?: string; status?: number },
   fallback: string,
 ): string {
-  if (error.errorCode) return error.errorCode;
-  if (error.code) return error.code;
-  if (error.status) return stableAnalyticsErrorCode(error.status);
-  return fallback;
+  return stableAnalyticsRequestErrorCode({
+    code: error.errorCode ?? error.code,
+    status: error.status,
+  }, fallback);
 }
 
 export function PluginsView({
@@ -3716,7 +3716,9 @@ function PluginImportModal({
           area: 'import_modal',
           import_source: kind,
           result: outcome.ok ? 'success' : 'failed',
-          ...(outcome.ok ? {} : { error_code: outcome.message ?? 'unknown' }),
+          ...(outcome.ok ? {} : {
+            error_code: resourceActionAnalyticsErrorCode(outcome, 'install_failed'),
+          }),
         });
       }
     } finally {

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -43,7 +43,10 @@ import {
   trackExtensionMarketplaceClick,
   trackWorkspaceResourceActionResult,
 } from '../analytics/events';
-import { workspaceAnalyticsDimensions } from '../analytics/workspace';
+import {
+  stableAnalyticsErrorCode,
+  workspaceAnalyticsDimensions,
+} from '../analytics/workspace';
 import type { TrackingWorkspaceScope } from '@open-design/contracts/analytics';
 import {
   addPluginMarketplace,
@@ -219,6 +222,16 @@ interface PluginsViewProps {
     action: PluginShareAction,
     locale?: string,
   ) => Promise<PluginShareProjectOutcome>;
+}
+
+function resourceActionAnalyticsErrorCode(
+  error: { code?: string; errorCode?: string; status?: number },
+  fallback: string,
+): string {
+  if (error.errorCode) return error.errorCode;
+  if (error.code) return error.code;
+  if (error.status) return stableAnalyticsErrorCode(error.status);
+  return fallback;
 }
 
 export function PluginsView({
@@ -1213,9 +1226,10 @@ export function ExtensionsMarketplace({
         if ('error' in result) {
           trackResourceResult({
             kind: 'skill', scope: 'personal', action: 'add', result: 'failed',
-            startedAt, errorCode: 'import_failed',
+            startedAt,
+            errorCode: resourceActionAnalyticsErrorCode(result.error, 'import_failed'),
           });
-          setToast({ message: result.error || t('pluginsView.importFailed'), tone: 'error' });
+          setToast({ message: result.error.message || t('pluginsView.importFailed'), tone: 'error' });
           return;
         }
         await refresh();
@@ -1250,7 +1264,8 @@ export function ExtensionsMarketplace({
         setToast({ message: outcome.message || t('pluginsView.importFailed'), tone: 'error' });
         trackResourceResult({
           kind: 'expert_plugin', scope: 'personal', action: 'add', result: 'failed',
-          startedAt, errorCode: 'import_failed',
+          startedAt,
+          errorCode: resourceActionAnalyticsErrorCode(outcome, 'import_failed'),
         });
       }
     } finally {
@@ -1303,7 +1318,8 @@ export function ExtensionsMarketplace({
       if ('error' in result) {
         trackResourceResult({
           kind: 'skill', scope: 'personal', action: 'add', result: 'failed',
-          startedAt, errorCode: 'import_failed',
+          startedAt,
+          errorCode: resourceActionAnalyticsErrorCode(result.error, 'import_failed'),
         });
         setToast({ message: result.error.message, tone: 'error' });
         return;
@@ -1766,7 +1782,7 @@ export function ExtensionsMarketplace({
           action: 'add',
           result: 'failed',
           startedAt,
-          errorCode: 'install_failed',
+          errorCode: resourceActionAnalyticsErrorCode(outcome, 'install_failed'),
         });
       }
     } catch {

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -2001,9 +2001,11 @@ export function RecentProjectsStrip({
           className="modal-confirm"
           role="alertdialog"
           onClose={() => {
+            if (deletePending) return;
             setConfirmTarget(null);
             setDeleteFailed(false);
           }}
+          closeOnBackdrop={!deletePending}
           ariaLabelledBy={confirmTitleId}
         >
           <DialogTitle id={confirmTitleId}>{t('designs.deleteTitle')}</DialogTitle>

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -64,7 +64,11 @@ import {
   trackWorkspaceProjectActionResult,
   trackWorkspaceSharedProjectOpenResult,
 } from '../analytics/events';
-import { countBucket, workspaceAnalyticsDimensions } from '../analytics/workspace';
+import {
+  countBucket,
+  stableAnalyticsRequestErrorCode,
+  workspaceAnalyticsDimensions,
+} from '../analytics/workspace';
 import type { ProjectCollectionClickProps } from '@open-design/contracts/analytics';
 
 /** Which project space this strip renders. Drives the per-card 共享 badge
@@ -480,6 +484,7 @@ export function RecentProjectsStrip({
   // that anything went wrong. Track failure so the dialog can stay open and
   // say so instead of silently doing nothing.
   const [deleteFailed, setDeleteFailed] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
   // Project → team-space sharing (the project card entry). The daemon gates on
   // `canShareProjects` (403 off-team / no rights), so we only badge on success.
   const [sharingId, setSharingId] = useState<string | null>(null);
@@ -1130,10 +1135,11 @@ export function RecentProjectsStrip({
   }
 
   async function commitDelete() {
-    if (!confirmTarget || !onDelete) return;
+    if (!confirmTarget || !onDelete || deletePending) return;
     const target = confirmTarget;
     const startedAt = performance.now();
     setDeleteFailed(false);
+    setDeletePending(true);
     try {
       const result = await onDelete(target.id);
       // A falsy result (false, or void from a caller that never resolves the
@@ -1180,9 +1186,11 @@ export function RecentProjectsStrip({
         succeeded_count: 0,
         failed_count: 1,
         duration_ms: Math.round(performance.now() - startedAt),
-        error_code: 'request_failed',
+        error_code: stableAnalyticsRequestErrorCode(err),
         ...workspaceDimensions,
       });
+    } finally {
+      setDeletePending(false);
     }
   }
 
@@ -2010,6 +2018,7 @@ export function RecentProjectsStrip({
           <DialogFooter className="row">
             <button
               type="button"
+              disabled={deletePending}
               onClick={() => {
                 setConfirmTarget(null);
                 setDeleteFailed(false);
@@ -2017,7 +2026,12 @@ export function RecentProjectsStrip({
             >
               {t('designs.renameCancel')}
             </button>
-            <button type="button" className="primary danger" onClick={() => void commitDelete()}>
+            <button
+              type="button"
+              className="primary danger"
+              disabled={deletePending}
+              onClick={() => void commitDelete()}
+            >
               {t('designs.menuDelete')}
             </button>
           </DialogFooter>

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -363,6 +363,35 @@ export interface SkillImportInput {
 export interface SkillImportError {
   code?: string;
   message: string;
+  status?: number;
+}
+
+async function readSkillOperationError(resp: Response): Promise<SkillImportError> {
+  try {
+    const payload = await resp.json() as {
+      error?: string | { code?: unknown; message?: unknown };
+      code?: unknown;
+      message?: unknown;
+    };
+    const envelope = payload.error && typeof payload.error === 'object'
+      ? payload.error
+      : null;
+    const rawCode = envelope?.code ?? payload.code;
+    const rawMessage = envelope?.message
+      ?? payload.message
+      ?? (typeof payload.error === 'string' ? payload.error : undefined);
+    return {
+      message: typeof rawMessage === 'string' && rawMessage.trim()
+        ? rawMessage
+        : `Request failed (${resp.status}).`,
+      ...(typeof rawCode === 'string' && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(rawCode)
+        ? { code: rawCode }
+        : {}),
+      status: resp.status,
+    };
+  } catch {
+    return { message: `Request failed (${resp.status}).`, status: resp.status };
+  }
 }
 
 // `workspaceContext`, when present, stamps the imported skill with the
@@ -384,20 +413,13 @@ export async function importSkill(
       body: JSON.stringify(input),
     });
     if (!resp.ok) {
-      const payload = (await resp.json().catch(() => null)) as
-        | { error?: SkillImportError }
-        | null;
-      return {
-        error: {
-          code: payload?.error?.code,
-          message: payload?.error?.message ?? `Import failed (${resp.status}).`,
-        },
-      };
+      return { error: await readSkillOperationError(resp) };
     }
     return (await resp.json()) as { skill: SkillSummary };
   } catch (err) {
     return {
       error: {
+        code: 'network_error',
         message: err instanceof Error ? err.message : 'Import request failed.',
       },
     };
@@ -3276,7 +3298,7 @@ function encodePluginAssetPath(relpath: string): string {
 export async function installSkill(
   input: InstallSkillRequest,
   workspaceContext?: WorkspaceCollabContext | null,
-): Promise<{ skill: SkillSummary } | { error: string }> {
+): Promise<{ skill: SkillSummary } | { error: SkillImportError }> {
   try {
     const resp = await fetch('/api/skills/install', {
       method: 'POST',
@@ -3286,11 +3308,11 @@ export async function installSkill(
       },
       body: JSON.stringify(input),
     });
+    if (!resp.ok) return { error: await readSkillOperationError(resp) };
     const json = await resp.json();
-    if (!resp.ok) return { error: json.error ?? 'Install failed' };
     return json as InstallSkillResponse;
   } catch {
-    return { error: 'Network error' };
+    return { error: { code: 'network_error', message: 'Network error' } };
   }
 }
 

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1,4 +1,5 @@
 import { workspaceContextHasTeamIdentity } from '@open-design/contracts';
+import { boundedRequestErrorCode } from '../analytics/workspace';
 import type {
   ConnectorAuthConfigPrepareResponse,
   ConnectorDetail,
@@ -377,6 +378,7 @@ async function readSkillOperationError(resp: Response): Promise<SkillImportError
       ? payload.error
       : null;
     const rawCode = envelope?.code ?? payload.code;
+    const boundedCode = boundedRequestErrorCode(rawCode);
     const rawMessage = envelope?.message
       ?? payload.message
       ?? (typeof payload.error === 'string' ? payload.error : undefined);
@@ -384,9 +386,7 @@ async function readSkillOperationError(resp: Response): Promise<SkillImportError
       message: typeof rawMessage === 'string' && rawMessage.trim()
         ? rawMessage
         : `Request failed (${resp.status}).`,
-      ...(typeof rawCode === 'string' && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(rawCode)
-        ? { code: rawCode }
-        : {}),
+      ...(boundedCode ? { code: boundedCode } : {}),
       status: resp.status,
     };
   } catch {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -179,6 +179,18 @@ export class WorkspaceProjectMoveError extends Error {
   }
 }
 
+/** A refused project delete with the daemon's stable status/code preserved. */
+export class ProjectDeleteError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | undefined,
+    readonly code: string | undefined,
+  ) {
+    super(message);
+    this.name = 'ProjectDeleteError';
+  }
+}
+
 /**
  * The contract error code a failed move carries, or null. Duck-typed on a
  * string `code` property (validated against `API_ERROR_CODES`) instead of
@@ -923,21 +935,54 @@ export async function patchProject(
 export async function deleteProject(
   id: string,
   workspaceContext?: WorkspaceCollabContext | null,
-): Promise<boolean> {
+): Promise<true> {
   try {
     const resp = await fetch(`/api/projects/${encodeURIComponent(id)}`, {
       method: 'DELETE',
       ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),
     });
+    if (!resp.ok) {
+      let message = `project delete failed with status ${resp.status}`;
+      let code: string | undefined;
+      try {
+        const payload = await resp.json() as {
+          error?: string | { code?: unknown; message?: unknown };
+          code?: unknown;
+          message?: unknown;
+        };
+        const envelope = payload.error && typeof payload.error === 'object'
+          ? payload.error
+          : null;
+        const rawCode = envelope?.code ?? payload.code;
+        const rawMessage = envelope?.message
+          ?? payload.message
+          ?? (typeof payload.error === 'string' ? payload.error : undefined);
+        if (
+          typeof rawCode === 'string'
+          && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(rawCode)
+        ) {
+          code = rawCode;
+        }
+        if (typeof rawMessage === 'string' && rawMessage.trim()) {
+          message = rawMessage;
+        }
+      } catch {
+        // Keep the stable HTTP fallback when a legacy daemon returns no JSON.
+      }
+      throw new ProjectDeleteError(message, resp.status, code);
+    }
     // Drop per-project browser caches once the project is gone server-side so
     // they do not accumulate in localStorage for the lifetime of the profile.
-    if (resp.ok) {
-      removeCachedTabs(id, workspaceContext);
-      removeDesignBrowserProjectCache(id);
-    }
-    return resp.ok;
-  } catch {
-    return false;
+    removeCachedTabs(id, workspaceContext);
+    removeDesignBrowserProjectCache(id);
+    return true;
+  } catch (error) {
+    if (error instanceof ProjectDeleteError) throw error;
+    throw new ProjectDeleteError(
+      error instanceof Error ? error.message : 'Project delete request failed.',
+      undefined,
+      'network_error',
+    );
   }
 }
 
@@ -1669,6 +1714,7 @@ interface PluginInstallEvent {
   kind?: 'progress' | 'success' | 'error';
   phase?: string;
   message?: string;
+  code?: string;
   plugin?: InstalledPluginRecord;
   warnings?: string[];
 }
@@ -1689,7 +1735,7 @@ export async function installPluginSource(
     });
     if (!resp.ok) {
       const message = await readErrorMessage(resp);
-      return { ok: false, warnings: [], message, log };
+      return { ok: false, warnings: [], message, status: resp.status, log };
     }
     if (!resp.body) {
       return {
@@ -1703,17 +1749,24 @@ export async function installPluginSource(
     let success: InstalledPluginRecord | undefined;
     let warnings: string[] = [];
     let errorMessage: string | undefined;
+    let errorCode: string | undefined;
     for await (const ev of readServerSentEvents(resp.body)) {
       if (ev.message) log.push(ev.message);
       if (ev.warnings) warnings = ev.warnings;
       if (ev.kind === 'success') success = ev.plugin;
-      if (ev.kind === 'error') errorMessage = ev.message ?? 'Install failed.';
+      if (ev.kind === 'error') {
+        errorMessage = ev.message ?? 'Install failed.';
+        if (ev.code && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(ev.code)) {
+          errorCode = ev.code;
+        }
+      }
     }
     return {
       ok: Boolean(success) && !errorMessage,
       plugin: success,
       warnings,
       message: errorMessage ?? (success ? `Installed ${success.title}.` : 'Install finished.'),
+      ...(errorCode ? { errorCode } : {}),
       log,
     };
   } catch (err) {
@@ -1721,6 +1774,7 @@ export async function installPluginSource(
       ok: false,
       warnings: [],
       message: (err as Error).message,
+      errorCode: 'network_error',
       log,
     };
   }

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -53,6 +53,7 @@ import type {
   ProjectTemplate,
 } from '../types';
 import { removeDesignBrowserProjectCache } from '../components/design-browser-storage';
+import { boundedRequestErrorCode } from '../analytics/workspace';
 
 export type { PluginInstallOutcome } from '@open-design/contracts';
 export type { PluginShareAction } from '@open-design/contracts';
@@ -957,12 +958,7 @@ export async function deleteProject(
         const rawMessage = envelope?.message
           ?? payload.message
           ?? (typeof payload.error === 'string' ? payload.error : undefined);
-        if (
-          typeof rawCode === 'string'
-          && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(rawCode)
-        ) {
-          code = rawCode;
-        }
+        code = boundedRequestErrorCode(rawCode);
         if (typeof rawMessage === 'string' && rawMessage.trim()) {
           message = rawMessage;
         }
@@ -1756,9 +1752,7 @@ export async function installPluginSource(
       if (ev.kind === 'success') success = ev.plugin;
       if (ev.kind === 'error') {
         errorMessage = ev.message ?? 'Install failed.';
-        if (ev.code && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(ev.code)) {
-          errorCode = ev.code;
-        }
+        errorCode = boundedRequestErrorCode(ev.code);
       }
     }
     return {

--- a/apps/web/tests/analytics/workspace.test.ts
+++ b/apps/web/tests/analytics/workspace.test.ts
@@ -43,11 +43,14 @@ describe('workspace analytics dimensions', () => {
     expect(stableAnalyticsErrorCode(403)).toBe('forbidden');
     expect(stableAnalyticsErrorCode(503)).toBe('server_error');
     expect(stableAnalyticsErrorCode()).toBe('network_error');
+    expect(stableAnalyticsRequestErrorCode({ code: 'network_error' })).toBe('network_error');
     expect(stableAnalyticsRequestErrorCode({ code: 'WORKSPACE_AUTHORITY_UNAVAILABLE', status: 503 }))
       .toBe('WORKSPACE_AUTHORITY_UNAVAILABLE');
     expect(stableAnalyticsRequestErrorCode({ status: 404 })).toBe('not_found');
     expect(stableAnalyticsRequestErrorCode({ code: 'bad code / project-name' }))
       .toBe('request_failed');
+    expect(stableAnalyticsRequestErrorCode({ code: 'UPSTREAM_abc123', status: 503 }))
+      .toBe('server_error');
   });
 
   it('does not treat unresolved seat state as available', () => {

--- a/apps/web/tests/analytics/workspace.test.ts
+++ b/apps/web/tests/analytics/workspace.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   countBucket,
   stableAnalyticsErrorCode,
+  stableAnalyticsRequestErrorCode,
   workspaceAnalyticsDimensions,
 } from '../../src/analytics/workspace';
 import { workspaceContextFixture } from '../helpers/workspace-context';
@@ -42,6 +43,11 @@ describe('workspace analytics dimensions', () => {
     expect(stableAnalyticsErrorCode(403)).toBe('forbidden');
     expect(stableAnalyticsErrorCode(503)).toBe('server_error');
     expect(stableAnalyticsErrorCode()).toBe('network_error');
+    expect(stableAnalyticsRequestErrorCode({ code: 'WORKSPACE_AUTHORITY_UNAVAILABLE', status: 503 }))
+      .toBe('WORKSPACE_AUTHORITY_UNAVAILABLE');
+    expect(stableAnalyticsRequestErrorCode({ status: 404 })).toBe('not_found');
+    expect(stableAnalyticsRequestErrorCode({ code: 'bad code / project-name' }))
+      .toBe('request_failed');
   });
 
   it('does not treat unresolved seat state as available', () => {

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -280,6 +280,42 @@ describe('DesignsTab select mode', () => {
     expect(screen.queryByRole('button', { name: 'Select' })).toBeNull();
   });
 
+  it('keeps a single-project delete confirmation open after refusal and allows retry', async () => {
+    const onDelete = vi.fn()
+      .mockRejectedValueOnce(new Error('Delete permission denied'))
+      .mockResolvedValueOnce(true);
+    render(
+      <DesignsTab
+        projects={[project]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={onDelete}
+        onRename={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    const dialog = screen.getByRole('alertdialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(1);
+      expect(within(dialog).getByRole('alert').textContent).toContain(
+        'Delete permission denied',
+      );
+    });
+    expect(screen.getByRole('alertdialog')).toBe(dialog);
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(2);
+      expect(screen.queryByRole('alertdialog')).toBeNull();
+    });
+  });
+
   it('exits select mode when switching to kanban view', () => {
     render(
       <DesignsTab

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -18,6 +18,12 @@ import {
   uploadPluginZip,
 } from '../../src/state/projects';
 
+const analyticsTrack = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({ track: analyticsTrack }),
+}));
+
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
 }));
@@ -98,6 +104,7 @@ const mockedUploadPluginFolder = vi.mocked(uploadPluginFolder);
 const mockedUploadPluginZip = vi.mocked(uploadPluginZip);
 
 beforeEach(() => {
+  analyticsTrack.mockClear();
   mockedListPlugins.mockResolvedValue([
     makePlugin('official-plugin', 'bundled', 'bundled'),
     makePlugin('user-plugin', 'github', 'restricted'),
@@ -403,6 +410,41 @@ describe('PluginsView', () => {
     expect(await screen.findByText('Installed New Plugin.')).toBeTruthy();
     expect(screen.getByTestId('plugins-tab-installed').getAttribute('aria-selected')).toBe('true');
     expect(screen.getAllByText('User Plugin').length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    { errorCode: 'FETCH_FAILED', expected: 'FETCH_FAILED' },
+    { errorCode: 'https://private.example/error//Users/alice', expected: 'install_failed' },
+  ])('reports a bounded code instead of a URL or local path from a failed import', async ({
+    errorCode,
+    expected,
+  }) => {
+    mockedInstallPluginSource.mockResolvedValueOnce({
+      ok: false,
+      warnings: [],
+      errorCode,
+      message: 'Could not fetch https://private.example/archive into /Users/alice/plugin',
+      log: [],
+    });
+    render(<PluginsView />);
+
+    fireEvent.click(await screen.findByTestId('plugins-import-button'));
+    fireEvent.change(screen.getByLabelText('GitHub, archive, or marketplace source'), {
+      target: { value: 'github:owner/private-plugin' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => {
+      const resultCall = analyticsTrack.mock.calls.find(
+        ([event]) => event === 'plugin_import_result',
+      );
+      expect(resultCall?.[1]).toMatchObject({
+        result: 'failed',
+        error_code: expected,
+      });
+      expect(JSON.stringify(resultCall?.[1])).not.toContain('private.example');
+      expect(JSON.stringify(resultCall?.[1])).not.toContain('/Users/alice');
+    });
   });
 
   it('installs an available marketplace entry by name', async () => {

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -414,6 +414,7 @@ describe('PluginsView', () => {
 
   it.each([
     { errorCode: 'FETCH_FAILED', expected: 'FETCH_FAILED' },
+    { errorCode: 'UPSTREAM_abc123', expected: 'install_failed' },
     { errorCode: 'https://private.example/error//Users/alice', expected: 'install_failed' },
   ])('reports a bounded code instead of a URL or local path from a failed import', async ({
     errorCode,

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -1321,4 +1321,33 @@ describe('recvqbh189zBY6 — single-card delete confirmation', () => {
     });
     expect(screen.queryByRole('alertdialog')).toBeNull();
   });
+
+  it('submits at most one delete while the request is pending', async () => {
+    let resolveDelete!: (value: true) => void;
+    const pendingDelete = new Promise<true>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const onDelete = vi.fn(() => pendingDelete);
+    render(
+      <RecentProjectsStrip
+        projects={[project({ id: 'project-1', name: 'My project' })]}
+        onOpen={() => {}}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+    const dialog = await screen.findByRole('alertdialog');
+    const deleteButton = within(dialog).getByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButton);
+    fireEvent.click(deleteButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => resolveDelete(true));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
 });

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -1346,6 +1346,9 @@ describe('recvqbh189zBY6 — single-card delete confirmation', () => {
 
     expect(onDelete).toHaveBeenCalledTimes(1);
     expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(dialog.parentElement as HTMLElement);
+    expect(screen.getByRole('alertdialog')).toBe(dialog);
+    expect(within(dialog).getByText(/My project/)).toBeTruthy();
 
     await act(async () => resolveDelete(true));
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -32,6 +32,8 @@ import {
   fetchLiveArtifacts,
   fetchSkillExample,
   invalidateProjectFilesCache,
+  importSkill,
+  installSkill,
   isDeployProviderId,
   openFolderDialog,
   patchPreviewCommentSortKey,
@@ -41,6 +43,42 @@ import {
   upsertPreviewComment,
   writeProjectTextFileDetailed,
 } from '../../src/providers/registry';
+
+describe('skill operation diagnostics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves the top-level remote-install error code and status', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: 'Skill download failed',
+      code: 'FETCH_FAILED',
+    }), { status: 502 })));
+
+    await expect(installSkill({ source: 'github:owner/repo' })).resolves.toEqual({
+      error: {
+        code: 'FETCH_FAILED',
+        message: 'Skill download failed',
+        status: 502,
+      },
+    });
+  });
+
+  it('preserves a nested import error envelope', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: { code: 'VALIDATION_FAILED', message: 'Invalid SKILL.md' },
+    }), { status: 400 })));
+
+    await expect(importSkill({ name: 'broken', body: 'broken' })).resolves.toEqual({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'Invalid SKILL.md',
+        status: 400,
+      },
+    });
+  });
+});
 
 function personalWorkspaceContext(): WorkspaceCollabContext {
   return {

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -78,6 +78,19 @@ describe('skill operation diagnostics', () => {
       },
     });
   });
+
+  it('drops a syntactically valid but unknown import error code', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: { code: 'UPSTREAM_abc123', message: 'Unknown upstream failure' },
+    }), { status: 503 })));
+
+    await expect(importSkill({ name: 'broken', body: 'broken' })).resolves.toEqual({
+      error: {
+        message: 'Unknown upstream failure',
+        status: 503,
+      },
+    });
+  });
 });
 
 function personalWorkspaceContext(): WorkspaceCollabContext {

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -15,6 +15,7 @@ import {
   importFolderProject,
   invalidateWorkspaceProjectLists,
   installGeneratedPluginFolder,
+  installPluginSource,
   listPlugins,
   listPluginsFresh,
   invalidatePluginCatalogCache,
@@ -1289,6 +1290,31 @@ describe('installGeneratedPluginFolder', () => {
       warnings: ['Missing open-design.json'],
       message: 'Plugin validation failed.',
       log: ['Validating generated-plugin'],
+    });
+  });
+});
+
+describe('installPluginSource diagnostics', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('drops a syntactically valid but unknown SSE error code', async () => {
+    const event = JSON.stringify({
+      kind: 'error',
+      code: 'UPSTREAM_abc123',
+      message: 'Unknown upstream failure',
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(`data: ${event}\n\n`, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })));
+
+    await expect(installPluginSource('github:owner/repo')).resolves.toEqual({
+      ok: false,
+      warnings: [],
+      message: 'Unknown upstream failure',
+      log: ['Unknown upstream failure'],
     });
   });
 });

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -768,7 +768,27 @@ describe('deleteProject', () => {
   it('reports failure when the daemon refuses the delete', async () => {
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 403 })));
 
-    await expect(deleteProject('someone-elses-project', personalWorkspaceContext())).resolves.toBe(false);
+    await expect(deleteProject('someone-elses-project', personalWorkspaceContext())).rejects.toMatchObject({
+      name: 'ProjectDeleteError',
+      status: 403,
+    });
+  });
+
+  it('preserves the daemon error code for analytics drill-down', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      error: {
+        code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+        message: 'workspace authority is temporarily unavailable',
+        retryable: true,
+      },
+    }), { status: 503 })));
+
+    await expect(deleteProject('project-1', personalWorkspaceContext())).rejects.toMatchObject({
+      name: 'ProjectDeleteError',
+      status: 503,
+      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+      message: 'workspace authority is temporarily unavailable',
+    });
   });
 });
 
@@ -1888,7 +1908,10 @@ describe('deleteProject local caches', () => {
   it('keeps tabs and Design Browser caches when the delete fails', async () => {
     const store = stubWindowStore();
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 500 })));
-    await expect(deleteProject('p1')).resolves.toBe(false);
+    await expect(deleteProject('p1')).rejects.toMatchObject({
+      name: 'ProjectDeleteError',
+      status: 500,
+    });
     expect(store.has(tabsKey)).toBe(true);
     expect(store.has(historyKey)).toBe(true);
     expect(store.has(viewportKey)).toBe(true);

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -97,8 +97,10 @@ export interface SpeakerNotesSaveResultProps {
 
 // Outcome of an actual import attempt from the plugin import modal. Fires
 // once per executed import (after the install/upload promise settles), not
-// for clicks that no-op. `error_code` carries the backend failure message —
-// the install pipeline has no structured codes (see PluginInstallOutcome).
+// for clicks that no-op. `error_code` carries a bounded machine-readable
+// backend code when available, with a stable HTTP/network fallback. Never put
+// the free-form install message here: it can contain URLs, paths, or upstream
+// response text and would create unbounded analytics cardinality.
 export interface PluginImportResultProps {
   page_name: 'plugins';
   area: 'import_modal';

--- a/packages/contracts/src/plugins/installed.ts
+++ b/packages/contracts/src/plugins/installed.ts
@@ -67,6 +67,10 @@ export const PluginInstallOutcomeSchema = z.object({
   plugin:   InstalledPluginRecordSchema.nullable().optional(),
   warnings: z.array(z.string()),
   message:  z.string().optional(),
+  /** Stable machine-readable failure class when the transport provides one. */
+  errorCode: z.string().optional(),
+  /** HTTP status for failures that occur before the install event stream. */
+  status:   z.number().int().optional(),
   log:      z.array(z.string()),
 });
 


### PR DESCRIPTION
## Why

While drilling into the Workspace PostHog dashboard, project and extension failures were collapsing into generic values such as `request_failed` and `import_failed`. That made a high failure count impossible to separate into permission, conflict, upstream, network, and server-side causes. The project delete flow also allowed a second confirmation click while the first request was still pending, creating avoidable duplicate requests.

This is a production-diagnostics follow-up: preserve the bounded machine-readable error data the daemon already returns, keep sensitive/free-form messages and stacks out of product analytics, and prevent duplicate delete submissions without changing successful mutation behavior.

## What users will see

Project deletion keeps its confirmation dialog open when the daemon refuses the request, disables both dialog actions while the request is pending, and shows the existing failure state instead of silently treating the project as deleted. Skill/plugin install and project-delete failures will be grouped by stable backend/HTTP/network error classes in Workspace diagnostics after deployment.

Existing PostHog history is not rewritten. New traffic will gradually populate the more specific `error_code` values.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No static screenshot: the only product UI change is a transient disabled state while an intentionally delayed delete request is in flight. It is covered by `RecentProjectsStrip.test.tsx`, which holds the request open and asserts that a second click cannot submit again.

Operational dashboard (updated separately from the repository): https://us.posthog.com/project/420348/dashboard/1976765

## Bug fix verification

- Red-spec paths: `apps/web/tests/analytics/workspace.test.ts`, `apps/web/tests/state/projects.test.ts`, `apps/web/tests/components/RecentProjectsStrip.test.tsx`, and `apps/web/tests/providers/registry.test.ts`.
- Verified red on `origin/main`: 7 failures / 177 tests (missing stable code helper, lost install status/code, project delete resolving `false`, and two delete submissions while pending).
- Verified green on this branch: 177 / 177 tests pass.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/contracts test` — 270 passed
- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/analytics/workspace.test.ts tests/state/projects.test.ts tests/components/RecentProjectsStrip.test.tsx tests/providers/registry.test.ts` (from `apps/web`) — 177 passed
- `git diff --check`
- Audited every `deleteProject`, `importSkill`, and `installSkill` caller for the typed failure-shape change.
- PostHog dashboard definitions verified in project 420348; tracking-document rows 168 and 172 updated and read back successfully.

Not exercised locally: destructive permission/upstream failures against a real team Workspace, and post-deployment live traffic using the new error classes. Those require the deployed build and will be checked in PostHog after rollout. Handled business failures intentionally do not send stacks; browser unhandled exceptions and fatal daemon exceptions retain the existing scrubbed stack telemetry.
