### PR TITLE
fix packaged runs surviving MCP reconnects

### DIFF
--- a/apps/daemon/src/mcp-bootstrap.ts
+++ b/apps/daemon/src/mcp-bootstrap.ts
@@ -12,6 +12,7 @@ import { resolveDaemonUrl as resolveDaemonUrlDefault } from "./daemon-url.js";
 
 const DEFAULT_BOOTSTRAP_TIMEOUT_MS = 60_000;
 const DEFAULT_BOOTSTRAP_POLL_MS = 250;
+const inFlightBootstraps = new Map<string, Promise<string>>();
 
 export type McpDaemonBootstrapPlan =
   | {
@@ -131,22 +132,41 @@ export async function ensureMcpDaemonUrl(
     );
   }
 
-  await spawnBootstrap(plan);
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await sleep(DEFAULT_BOOTSTRAP_POLL_MS);
-    daemonUrl = registeredBootstrapTarget
-      ? await discoverTargetDaemonUrl(env, 300)
-      : await resolveDaemonUrl({
-          env,
-          flagUrl: null,
-          timeoutMs: 300,
-        });
-    if (daemonUrl != null && await probeDaemon(daemonUrl)) return daemonUrl;
+  const bootstrapKey = JSON.stringify([
+    plan.command,
+    plan.args,
+    env[SIDECAR_ENV.IPC_PATH] ?? null,
+    env.OD_DATA_DIR ?? null,
+  ]);
+  const existingBootstrap = inFlightBootstraps.get(bootstrapKey);
+  if (existingBootstrap) return await existingBootstrap;
+
+  const bootstrap = (async (): Promise<string> => {
+    await spawnBootstrap(plan);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      await sleep(DEFAULT_BOOTSTRAP_POLL_MS);
+      daemonUrl = registeredBootstrapTarget
+        ? await discoverTargetDaemonUrl(env, 300)
+        : await resolveDaemonUrl({
+            env,
+            flagUrl: null,
+            timeoutMs: 300,
+          });
+      if (daemonUrl != null && await probeDaemon(daemonUrl)) return daemonUrl;
+    }
+    throw new Error(
+      `Open Design was launched headlessly but its daemon did not become ready within ${timeoutMs}ms.`,
+    );
+  })();
+  inFlightBootstraps.set(bootstrapKey, bootstrap);
+  try {
+    return await bootstrap;
+  } finally {
+    if (inFlightBootstraps.get(bootstrapKey) === bootstrap) {
+      inFlightBootstraps.delete(bootstrapKey);
+    }
   }
-  throw new Error(
-    `Open Design was launched headlessly but its daemon did not become ready within ${timeoutMs}ms.`,
-  );
 }
 
 async function discoverDaemonUrlFromRegisteredIpc(

--- a/apps/daemon/src/mcp-routes.ts
+++ b/apps/daemon/src/mcp-routes.ts
@@ -66,6 +66,10 @@ export function registerMcpRoutes(app: Express, ctx: RegisterMcpRoutesDeps) {
     if (mcpBootstrapArgs != null && mcpBootstrapArgs.length > 0) {
       sidecarEnv.OD_MCP_BOOTSTRAP_ARGS = mcpBootstrapArgs;
     }
+    const codexBin = process.env.CODEX_BIN;
+    if (codexBin != null && codexBin.length > 0) {
+      sidecarEnv.CODEX_BIN = codexBin;
+    }
     // tools-dev / packaged launchers export OD_WEB_PORT so the daemon
     // knows where the browser-facing Open Design studio is running.
     // CLI-only / headless launches set neither and webBaseUrl falls

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -22,6 +22,9 @@ import {
 } from './run-restart-recovery.js';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+export const DAEMON_SHUTDOWN_ERROR_CODE = 'DAEMON_SHUTDOWN';
+export const DAEMON_SHUTDOWN_ERROR_MESSAGE =
+  'Run interrupted because the Open Design daemon is shutting down.';
 
 const RUN_STATE_SCHEMA_VERSION = 1;
 
@@ -1453,7 +1456,11 @@ export function createChatRunService({
   const shutdownActive = async ({ graceMs = shutdownGraceMs } = {}) => {
     const activeRuns = Array.from(runs.values()).filter((run) => !TERMINAL_RUN_STATUSES.has(run.status));
     await Promise.all(activeRuns.map(async (run) => {
-      run.cancelRequested = true;
+      run.cancelRequested = false;
+      run.failureCategory = 'process_exit';
+      run.failureDetail = 'interrupted';
+      run.failureAction = 'retry';
+      run.resumable = true;
       run.updatedAt = Date.now();
       clearPendingRetryRestart(run);
       closeRunStdin(run);
@@ -1464,8 +1471,13 @@ export function createChatRunService({
           // Process signals below are the shutdown fallback.
         }
       }
+      emit(run, 'error', createSseErrorPayload(
+        DAEMON_SHUTDOWN_ERROR_CODE,
+        DAEMON_SHUTDOWN_ERROR_MESSAGE,
+        { retryable: true },
+      ));
+      finish(run, 'failed', 1, null);
       killChild(run, 'SIGTERM');
-      finish(run, 'canceled', null, 'SIGTERM');
       if (run.child && !(await waitForChildExit(run.child, graceMs))) {
         killChild(run, 'SIGKILL');
         await waitForChildExit(run.child, 500);

--- a/apps/daemon/tests/mcp-bootstrap.test.ts
+++ b/apps/daemon/tests/mcp-bootstrap.test.ts
@@ -82,6 +82,38 @@ describe("planMcpDaemonBootstrap", () => {
 });
 
 describe("ensureMcpDaemonUrl", () => {
+  it("single-flights concurrent MCP bootstrap calls and adopts the same daemon", async () => {
+    const spawnBootstrap = vi.fn(async () => undefined);
+    const resolveDaemonUrl = vi.fn(async () => {
+      return resolveDaemonUrl.mock.calls.length <= 2
+        ? "http://127.0.0.1:1"
+        : "http://127.0.0.1:61234";
+    });
+    const probeDaemon = vi.fn(async (url: string) => url.endsWith(":61234"));
+    const options = {
+      env: {
+        OD_MCP_BOOTSTRAP_COMMAND: "/usr/bin/open",
+        OD_MCP_BOOTSTRAP_ARGS:
+          '["-g","-j","/Applications/Open Design.app","--args","--headless"]',
+      },
+      probeDaemon,
+      resolveDaemonUrl,
+      sleep: async () => undefined,
+      spawnBootstrap,
+      timeoutMs: 1_000,
+    };
+
+    await expect(Promise.all([
+      ensureMcpDaemonUrl(options),
+      ensureMcpDaemonUrl(options),
+    ])).resolves.toEqual([
+      "http://127.0.0.1:61234",
+      "http://127.0.0.1:61234",
+    ]);
+
+    expect(spawnBootstrap).toHaveBeenCalledTimes(1);
+  });
+
   it("does not substitute an unrelated tools-dev daemon for the registered packaged IPC", async () => {
     const spawnBootstrap = vi.fn(async () => undefined);
     const discoverTargetDaemonUrl = vi

--- a/apps/daemon/tests/mcp-install-info.test.ts
+++ b/apps/daemon/tests/mcp-install-info.test.ts
@@ -87,6 +87,7 @@ function makeInstallInfoApp({ cliPath, port, env = {}, dataDir }: InstallInfoOpt
     for (const key of [
       'OD_MCP_BOOTSTRAP_COMMAND',
       'OD_MCP_BOOTSTRAP_ARGS',
+      'CODEX_BIN',
     ] as const) {
       const value = env[key];
       if (value != null && value.length > 0) sidecarEnv[key] = value;
@@ -324,6 +325,7 @@ describe('GET /api/mcp/install-info', () => {
           '/tmp/open-design/ipc/default/daemon.sock',
         OD_MCP_BOOTSTRAP_COMMAND: '/usr/bin/open',
         OD_MCP_BOOTSTRAP_ARGS: bootstrapArgs,
+        CODEX_BIN: '/opt/codex/bin/codex',
       },
       dataDir,
     );
@@ -338,6 +340,7 @@ describe('GET /api/mcp/install-info', () => {
           '/tmp/open-design/ipc/default/daemon.sock',
         OD_MCP_BOOTSTRAP_COMMAND: '/usr/bin/open',
         OD_MCP_BOOTSTRAP_ARGS: bootstrapArgs,
+        CODEX_BIN: '/opt/codex/bin/codex',
       });
     } finally {
       await new Promise<void>((done) => server?.close(() => done()));

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -801,7 +801,7 @@ describe('chat run service shutdown', () => {
     expect(JSON.stringify(status)).not.toContain('server.js');
   });
 
-  it('cancels active runs and terminates their child process during daemon shutdown', async () => {
+  it('fails active runs with a daemon-shutdown diagnostic and terminates their child', async () => {
     const runs = createRuns();
     const child = new FakeChildProcess({ closeOn: 'SIGTERM' });
     const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1' });
@@ -812,13 +812,28 @@ describe('chat run service shutdown', () => {
     await runs.shutdownActive({ graceMs: 10 });
 
     expect(child.signals).toEqual(['SIGTERM']);
-    expect(run.status).toBe('canceled');
-    expect(run.cancelRequested).toBe(true);
-    expect(run.signal).toBe('SIGTERM');
-    await expect(wait).resolves.toMatchObject({ status: 'canceled', signal: 'SIGTERM' });
+    expect(run.status).toBe('failed');
+    expect(run.cancelRequested).toBe(false);
+    await expect(wait).resolves.toMatchObject({
+      status: 'failed',
+      signal: null,
+      errorCode: 'DAEMON_SHUTDOWN',
+      failureCategory: 'process_exit',
+      failureDetail: 'interrupted',
+      failureAction: 'retry',
+    });
+    expect(run.events.at(-2)).toMatchObject({
+      event: 'error',
+      data: { error: { code: 'DAEMON_SHUTDOWN' } },
+    });
     expect(run.events.at(-1)).toMatchObject({
       event: 'end',
-      data: { status: 'canceled', signal: 'SIGTERM' },
+      data: {
+        status: 'failed',
+        signal: null,
+        failureCategory: 'process_exit',
+        failureDetail: 'interrupted',
+      },
     });
   });
 
@@ -832,7 +847,8 @@ describe('chat run service shutdown', () => {
     await runs.shutdownActive({ graceMs: 1 });
 
     expect(child.signals).toEqual(['SIGTERM', 'SIGKILL']);
-    expect(run.status).toBe('canceled');
+    expect(run.status).toBe('failed');
+    expect(run.cancelRequested).toBe(false);
   });
 
   it('uses adapter abort before process signals for ACP-style runs', async () => {
@@ -848,7 +864,8 @@ describe('chat run service shutdown', () => {
 
     expect(abort).toHaveBeenCalledTimes(1);
     expect(child.signals).toEqual(['SIGTERM']);
-    expect(run.status).toBe('canceled');
+    expect(run.status).toBe('failed');
+    expect(run.cancelRequested).toBe(false);
   });
 
   it('closes child stdin for active runs during shutdown before signaling them', async () => {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json --emitDeclarationOnly",
+    "pretest": "pnpm --filter @open-design/daemon build",
     "test": "vitest run -c vitest.config.ts",
     "typecheck": "pnpm --filter @open-design/desktop build && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "node ./esbuild.config.mjs && tsc -p tsconfig.json --emitDeclarationOnly",
-    "pretest": "pnpm --filter @open-design/daemon build",
+    "pretest": "pnpm --filter @open-design/daemon build && pnpm --filter @open-design/web build:sidecar && pnpm build",
     "test": "vitest run -c vitest.config.ts",
     "typecheck": "pnpm --filter @open-design/desktop build && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -407,6 +407,12 @@ interface LiveOwnerCodexRunnerResult {
   stdout: string;
 }
 
+interface ExistingCodexMcpRegistration {
+  args: string[];
+  command: string;
+  env: Record<string, string>;
+}
+
 export interface RepairCodexMcpRegistrationOptions {
   fetchImpl?: typeof fetch;
   run?: (
@@ -441,6 +447,70 @@ function parseLiveOwnerMcpInstallPayload(value: unknown): LiveOwnerMcpInstallPay
     command: payload.command,
     env: payload.env,
   };
+}
+
+function parseExistingCodexMcpRegistration(
+  stdout: string,
+): ExistingCodexMcpRegistration {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    throw new Error("codex mcp get returned invalid JSON for open-design");
+  }
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("codex mcp get returned an invalid open-design registration");
+  }
+  const transport = (value as { transport?: unknown }).transport;
+  if (transport == null || typeof transport !== "object" || Array.isArray(transport)) {
+    throw new Error("codex mcp get returned an incomplete open-design registration");
+  }
+  const candidate = transport as {
+    type?: unknown;
+    command?: unknown;
+    args?: unknown;
+    env?: unknown;
+  };
+  if (
+    candidate.type !== "stdio"
+    || typeof candidate.command !== "string"
+    || candidate.command.length === 0
+    || !Array.isArray(candidate.args)
+    || !candidate.args.every((entry) => typeof entry === "string")
+    || !isStringRecord(candidate.env)
+  ) {
+    throw new Error("codex mcp get returned an unsupported open-design registration");
+  }
+  return {
+    args: candidate.args,
+    command: candidate.command,
+    env: candidate.env,
+  };
+}
+
+function codexMcpAddArgs(
+  registration: ExistingCodexMcpRegistration,
+): string[] {
+  const args = ["mcp", "add", "open-design"];
+  for (const [key, value] of Object.entries(registration.env)) {
+    args.push("--env", `${key}=${value}`);
+  }
+  args.push("--", registration.command, ...registration.args);
+  return args;
+}
+
+function codexMcpFailureDetail(result: LiveOwnerCodexRunnerResult): string {
+  return result.stderr.trim()
+    || result.stdout.trim()
+    || `exit ${result.exitCode}`;
+}
+
+function codexMcpRegistrationIsMissing(
+  result: LiveOwnerCodexRunnerResult,
+): boolean {
+  return /no mcp server named .* found|mcp server .* not found/iu.test(
+    `${result.stderr}\n${result.stdout}`,
+  );
 }
 
 async function runCodexMcpRepair(
@@ -505,18 +575,39 @@ export async function repairCodexMcpRegistrationViaLiveOwner(
     );
   }
   const payload = parseLiveOwnerMcpInstallPayload(await response.json());
-  const registrationEnv = { ...payload.env, CODEX_BIN: codexBin };
-  const args = ["mcp", "add", "open-design"];
-  for (const [key, value] of Object.entries(registrationEnv)) {
-    args.push("--env", `${key}=${value}`);
+  const run = options.run ?? runCodexMcpRepair;
+  const current = await run(codexBin, ["mcp", "get", "open-design", "--json"]);
+  if (current.exitCode !== 0 && !codexMcpRegistrationIsMissing(current)) {
+    throw new Error(`codex mcp get failed: ${codexMcpFailureDetail(current)}`);
   }
-  args.push("--", payload.command, ...payload.args);
-  const result = await (options.run ?? runCodexMcpRepair)(codexBin, args);
+  const previous = current.exitCode === 0
+    ? parseExistingCodexMcpRegistration(current.stdout)
+    : null;
+  if (previous) {
+    const removed = await run(codexBin, ["mcp", "remove", "open-design"]);
+    if (removed.exitCode !== 0) {
+      throw new Error(`codex mcp remove failed: ${codexMcpFailureDetail(removed)}`);
+    }
+  }
+
+  const replacement: ExistingCodexMcpRegistration = {
+    args: payload.args,
+    command: payload.command,
+    env: { ...payload.env, CODEX_BIN: codexBin },
+  };
+  const result = await run(codexBin, codexMcpAddArgs(replacement));
   if (result.exitCode !== 0) {
-    const detail = result.stderr.trim()
-      || result.stdout.trim()
-      || `exit ${result.exitCode}`;
-    throw new Error(`codex mcp add failed: ${detail}`);
+    if (previous) {
+      await run(codexBin, ["mcp", "remove", "open-design"]);
+      const restored = await run(codexBin, codexMcpAddArgs(previous));
+      if (restored.exitCode !== 0) {
+        throw new Error(
+          `codex mcp add failed: ${codexMcpFailureDetail(result)}; `
+          + `restoring the prior registration also failed: ${codexMcpFailureDetail(restored)}`,
+        );
+      }
+    }
+    throw new Error(`codex mcp add failed: ${codexMcpFailureDetail(result)}`);
   }
   process.stdout.write(" Open Design MCP repaired through the running owner\n");
 }

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -471,20 +471,21 @@ function parseExistingCodexMcpRegistration(
     args?: unknown;
     env?: unknown;
   };
+  const env = candidate.env == null ? {} : candidate.env;
   if (
     candidate.type !== "stdio"
     || typeof candidate.command !== "string"
     || candidate.command.length === 0
     || !Array.isArray(candidate.args)
     || !candidate.args.every((entry) => typeof entry === "string")
-    || !isStringRecord(candidate.env)
+    || !isStringRecord(env)
   ) {
     throw new Error("codex mcp get returned an unsupported open-design registration");
   }
   return {
     args: candidate.args,
     command: candidate.command,
-    env: candidate.env,
+    env,
   };
 }
 

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -119,7 +119,7 @@ export async function acquirePackagedHeadlessStartup(
 
   try {
     ipcServer = await dependencies.createIpcServer({
-      currentWebUrl: () => webUrl,
+      currentWebUrl: () => sidecars?.currentWebUrl() || webUrl,
       shutdown,
     });
     identity = await dependencies.writeIdentity();

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 
 import {
@@ -90,6 +91,7 @@ export interface ExistingPackagedHeadlessOwner {
 
 export interface AcquireOrAdoptPackagedHeadlessOptions {
   inspectExistingOwner(): Promise<ExistingPackagedHeadlessOwner | null>;
+  repairAdoptedOwner?(webUrl: string): Promise<void>;
   sleep?: (milliseconds: number) => Promise<void>;
   timeoutMs?: number;
 }
@@ -147,9 +149,13 @@ export async function acquireOrAdoptPackagedHeadlessStartup(
   dependencies: PackagedHeadlessStartupDependencies,
   options: AcquireOrAdoptPackagedHeadlessOptions,
 ): Promise<PackagedHeadlessStartupHandle | AdoptedPackagedHeadlessStartupHandle> {
+  const adopt = async (webUrl: string): Promise<AdoptedPackagedHeadlessStartupHandle> => {
+    await options.repairAdoptedOwner?.(webUrl);
+    return { ownership: "adopted", webUrl };
+  };
   const existing = await options.inspectExistingOwner();
   if (existing?.state === "running" && existing.webUrl) {
-    return { ownership: "adopted", webUrl: existing.webUrl };
+    return await adopt(existing.webUrl);
   }
 
   try {
@@ -163,7 +169,7 @@ export async function acquireOrAdoptPackagedHeadlessStartup(
     while (Date.now() < deadline) {
       const owner = await options.inspectExistingOwner();
       if (owner?.state === "running" && owner.webUrl) {
-        return { ownership: "adopted", webUrl: owner.webUrl };
+        return await adopt(owner.webUrl);
       }
       await sleep(100);
     }
@@ -338,6 +344,18 @@ export async function runPackagedHeadless(
         return null;
       }
     },
+    ...(request.mcpInstallAgent === "codex"
+      ? {
+          repairAdoptedOwner: async (webUrl: string) => {
+            const codexBin = process.env.CODEX_BIN?.trim();
+            if (codexBin) {
+              await repairCodexMcpRegistrationViaLiveOwner(webUrl, codexBin);
+              return;
+            }
+            await installCodexMcp(webUrl);
+          },
+        }
+      : {}),
   });
 
   const { webUrl } = startup;
@@ -375,4 +393,130 @@ async function installCodexMcp(daemonUrl: string | null): Promise<void> {
     );
   }
   process.stdout.write(" Open Design MCP installed for Codex\n");
+}
+
+interface LiveOwnerMcpInstallPayload {
+  args: string[];
+  command: string;
+  env: Record<string, string>;
+}
+
+interface LiveOwnerCodexRunnerResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+export interface RepairCodexMcpRegistrationOptions {
+  fetchImpl?: typeof fetch;
+  run?: (
+    command: string,
+    args: string[],
+  ) => Promise<LiveOwnerCodexRunnerResult>;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return value != null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function parseLiveOwnerMcpInstallPayload(value: unknown): LiveOwnerMcpInstallPayload {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("live Open Design owner returned invalid MCP install info");
+  }
+  const payload = value as Partial<LiveOwnerMcpInstallPayload>;
+  if (
+    typeof payload.command !== "string"
+    || payload.command.length === 0
+    || !Array.isArray(payload.args)
+    || !payload.args.every((entry) => typeof entry === "string")
+    || !isStringRecord(payload.env)
+  ) {
+    throw new Error("live Open Design owner returned incomplete MCP install info");
+  }
+  return {
+    args: payload.args,
+    command: payload.command,
+    env: payload.env,
+  };
+}
+
+async function runCodexMcpRepair(
+  command: string,
+  args: string[],
+): Promise<LiveOwnerCodexRunnerResult> {
+  return await new Promise<LiveOwnerCodexRunnerResult>((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const finish = (
+      callback: () => void,
+    ): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(() => reject(new Error("codex MCP registration timed out after 30s")));
+    }, 30_000);
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("error", (error) => {
+      finish(() => reject(error));
+    });
+    child.once("close", (code) => {
+      finish(() => resolve({ exitCode: code ?? -1, stderr, stdout }));
+    });
+  });
+}
+
+export async function repairCodexMcpRegistrationViaLiveOwner(
+  webUrl: string,
+  codexBin: string,
+  options: RepairCodexMcpRegistrationOptions = {},
+): Promise<void> {
+  const ownerUrl = new URL(webUrl);
+  if (
+    ownerUrl.protocol !== "http:"
+    || !["127.0.0.1", "localhost", "[::1]"].includes(ownerUrl.hostname)
+  ) {
+    throw new Error("live Open Design owner must use a loopback HTTP URL");
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const installInfoUrl = `${webUrl.replace(/\/$/u, "")}/api/mcp/install-info`;
+  const response = await fetchImpl(installInfoUrl);
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText);
+    throw new Error(
+      `live Open Design MCP install info failed (${response.status}): ${detail}`,
+    );
+  }
+  const payload = parseLiveOwnerMcpInstallPayload(await response.json());
+  const registrationEnv = { ...payload.env, CODEX_BIN: codexBin };
+  const args = ["mcp", "add", "open-design"];
+  for (const [key, value] of Object.entries(registrationEnv)) {
+    args.push("--env", `${key}=${value}`);
+  }
+  args.push("--", payload.command, ...payload.args);
+  const result = await (options.run ?? runCodexMcpRepair)(codexBin, args);
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim()
+      || result.stdout.trim()
+      || `exit ${result.exitCode}`;
+    throw new Error(`codex mcp add failed: ${detail}`);
+  }
+  process.stdout.write(" Open Design MCP repaired through the running owner\n");
 }

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -7,9 +7,15 @@ import {
   SIDECAR_MODES,
   SIDECAR_SOURCES,
   normalizeDesktopSidecarMessage,
+  type DesktopStatusSnapshot,
   type SidecarStamp,
 } from "@open-design/sidecar-proto";
-import { bootstrapSidecarRuntime, createJsonIpcServer, resolveAppIpcPath } from "@open-design/sidecar";
+import {
+  bootstrapSidecarRuntime,
+  createJsonIpcServer,
+  requestJsonIpc,
+  resolveAppIpcPath,
+} from "@open-design/sidecar";
 import type { JsonIpcServerHandle } from "@open-design/sidecar";
 
 import type { PackagedConfig } from "./config.js";
@@ -56,8 +62,8 @@ export interface RunPackagedHeadlessOptions {
 export interface PackagedHeadlessStartupDependencies {
   confirmRuntime(): Promise<void>;
   createIpcServer(options: {
+    currentWebUrl(): string | null;
     shutdown(): Promise<void>;
-    webUrl: string;
   }): Promise<JsonIpcServerHandle>;
   exit(code: number): void;
   installMcp(daemonUrl: string | null): Promise<void>;
@@ -67,8 +73,25 @@ export interface PackagedHeadlessStartupDependencies {
 }
 
 export interface PackagedHeadlessStartupHandle {
+  ownership: "owner";
   shutdown(): Promise<void>;
   webUrl: string;
+}
+
+export interface AdoptedPackagedHeadlessStartupHandle {
+  ownership: "adopted";
+  webUrl: string;
+}
+
+export interface ExistingPackagedHeadlessOwner {
+  state: "starting" | "running";
+  webUrl: string | null;
+}
+
+export interface AcquireOrAdoptPackagedHeadlessOptions {
+  inspectExistingOwner(): Promise<ExistingPackagedHeadlessOwner | null>;
+  sleep?: (milliseconds: number) => Promise<void>;
+  timeoutMs?: number;
 }
 
 export async function acquirePackagedHeadlessStartup(
@@ -77,6 +100,7 @@ export async function acquirePackagedHeadlessStartup(
   let identity: PackagedDesktopIdentityHandle | null = null;
   let sidecars: PackagedSidecarHandle | null = null;
   let ipcServer: JsonIpcServerHandle | null = null;
+  let webUrl: string | null = null;
   let closed = false;
 
   const close = async (): Promise<void> => {
@@ -92,21 +116,57 @@ export async function acquirePackagedHeadlessStartup(
   };
 
   try {
+    ipcServer = await dependencies.createIpcServer({
+      currentWebUrl: () => webUrl,
+      shutdown,
+    });
     identity = await dependencies.writeIdentity();
     sidecars = await dependencies.startSidecars();
-    const webUrl = sidecars.web.url;
+    webUrl = sidecars.web.url;
     if (!webUrl) {
       throw new Error(
         "web sidecar failed to produce URL — check logs/desktop/latest.log",
       );
     }
     await dependencies.installMcp(sidecars.daemon.url);
-    ipcServer = await dependencies.createIpcServer({ shutdown, webUrl });
     await dependencies.writeWebIdentity(webUrl);
     await dependencies.confirmRuntime();
-    return { shutdown, webUrl };
+    return { ownership: "owner", shutdown, webUrl };
   } catch (error) {
     await close();
+    throw error;
+  }
+}
+
+function isPackagedHeadlessOwnershipConflict(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return code === "EADDRINUSE" || code === "EACCES" || code === "EPERM";
+}
+
+export async function acquireOrAdoptPackagedHeadlessStartup(
+  dependencies: PackagedHeadlessStartupDependencies,
+  options: AcquireOrAdoptPackagedHeadlessOptions,
+): Promise<PackagedHeadlessStartupHandle | AdoptedPackagedHeadlessStartupHandle> {
+  const existing = await options.inspectExistingOwner();
+  if (existing?.state === "running" && existing.webUrl) {
+    return { ownership: "adopted", webUrl: existing.webUrl };
+  }
+
+  try {
+    return await acquirePackagedHeadlessStartup(dependencies);
+  } catch (error) {
+    if (!isPackagedHeadlessOwnershipConflict(error)) throw error;
+    const deadline = Date.now() + (options.timeoutMs ?? 60_000);
+    const sleep = options.sleep ?? (async (milliseconds: number) => {
+      await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+    });
+    while (Date.now() < deadline) {
+      const owner = await options.inspectExistingOwner();
+      if (owner?.state === "running" && owner.webUrl) {
+        return { ownership: "adopted", webUrl: owner.webUrl };
+      }
+      await sleep(100);
+    }
     throw error;
   }
 }
@@ -189,18 +249,19 @@ export async function runPackagedHeadless(
     contract: OPEN_DESIGN_SIDECAR_CONTRACT,
   });
 
-  const { shutdown, webUrl } = await acquirePackagedHeadlessStartup({
+  const startup = await acquireOrAdoptPackagedHeadlessStartup({
     confirmRuntime: async () => await confirmPackagedLauncherRuntime(launcherRuntime),
-    createIpcServer: async ({ shutdown: stop, webUrl: activeWebUrl }) =>
+    createIpcServer: async ({ currentWebUrl, shutdown: stop }) =>
       await createJsonIpcServer({
         socketPath: stamp.ipc,
         handler: async (message: unknown) => {
           const normalized = normalizeDesktopSidecarMessage(message);
           switch (normalized.type) {
             case SIDECAR_MESSAGES.STATUS:
+              const activeWebUrl = currentWebUrl();
               return {
                 pid: process.pid,
-                state: "running",
+                state: activeWebUrl ? "running" : "idle",
                 updatedAt: new Date().toISOString(),
                 url: activeWebUrl,
                 windowVisible: false,
@@ -261,7 +322,31 @@ export async function runPackagedHeadless(
         pid: process.pid,
         url: activeWebUrl,
       }),
+  }, {
+    inspectExistingOwner: async () => {
+      try {
+        const status = await requestJsonIpc<DesktopStatusSnapshot>(
+          stamp.ipc,
+          { type: SIDECAR_MESSAGES.STATUS },
+          { timeoutMs: 800 },
+        );
+        return {
+          state: status.state === "running" ? "running" : "starting",
+          webUrl: status.url ?? null,
+        };
+      } catch {
+        return null;
+      }
+    },
   });
+
+  const { webUrl } = startup;
+  if (startup.ownership === "adopted") {
+    process.stdout.write(`\n Open Design is already running\n\n`);
+    process.stdout.write(` ➜ ${colorize(webUrl)}\n\n`);
+    return;
+  }
+  const { shutdown } = startup;
 
   process.stdout.write(`\n Open Design is running\n\n`);
   process.stdout.write(` ➜ ${colorize(webUrl)}\n\n`);

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -36,6 +36,18 @@ function resolveHeadlessAmrProfile(): PackagedConfig["amrProfile"] {
   return resolvePackagedAmrProfile(process.env.OPEN_DESIGN_AMR_PROFILE);
 }
 
+function resolveHeadlessWebOutputMode(): PackagedConfig["webOutputMode"] {
+  const configured = process.env.OD_WEB_OUTPUT_MODE?.trim();
+  if (configured == null || configured.length === 0) return "server";
+  if (configured === "server" || configured === "standalone") return configured;
+  throw new Error(`unsupported packaged web output mode: ${configured}`);
+}
+
+function resolveHeadlessWebStandaloneRoot(): string | null {
+  const configured = process.env.OD_WEB_STANDALONE_ROOT?.trim();
+  return configured ? resolve(configured) : null;
+}
+
 function resolveHeadlessConfig(): PackagedConfig {
   const namespace = OPEN_DESIGN_SIDECAR_CONTRACT.normalizeNamespace(
     process.env[PACKAGED_NAMESPACE_ENV] ?? SIDECAR_DEFAULTS.namespace,
@@ -65,8 +77,8 @@ function resolveHeadlessConfig(): PackagedConfig {
     posthogHost: process.env.POSTHOG_HOST?.trim() || null,
     velaWebUrl: process.env.OD_VELA_WEB_URL?.trim() || null,
     webSidecarEntry: null,
-    webStandaloneRoot: null,
-    webOutputMode: "server",
+    webStandaloneRoot: resolveHeadlessWebStandaloneRoot(),
+    webOutputMode: resolveHeadlessWebOutputMode(),
   };
 }
 

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -43,6 +43,7 @@ import { workspaceTeamTransportEnv } from "./workspace-team.js";
 
 const require = createRequire(import.meta.url);
 const PACKAGED_CHILD_ENV_ALLOWLIST = [
+  "CODEX_BIN",
   "CODEX_HOME",
   "HOME",
   "HTTP_PROXY",

--- a/apps/packaged/tests/headless-mcp-reconnect.integration.test.ts
+++ b/apps/packaged/tests/headless-mcp-reconnect.integration.test.ts
@@ -1,0 +1,360 @@
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_ENV,
+  SIDECAR_MESSAGES,
+  type DesktopStatusSnapshot,
+} from "@open-design/sidecar-proto";
+import {
+  createJsonIpcServer,
+  requestJsonIpc,
+  resolveAppIpcPath,
+} from "@open-design/sidecar";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { acquireOrAdoptPackagedHeadlessStartup } from "../src/headless-runtime.js";
+
+type JsonRpcResponse = {
+  error?: { code: number; message: string };
+  id: number;
+  result?: unknown;
+};
+
+class McpClient {
+  readonly child: ChildProcessWithoutNullStreams;
+  private readonly pending = new Map<number, {
+    reject(error: Error): void;
+    resolve(value: unknown): void;
+  }>();
+  private nextId = 1;
+  private stdout = "";
+  private stderr = "";
+
+  constructor(entry: string, env: NodeJS.ProcessEnv) {
+    this.child = spawn(process.execPath, [entry, "mcp"], {
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.child.stdout.setEncoding("utf8");
+    this.child.stderr.setEncoding("utf8");
+    this.child.stdout.on("data", (chunk: string) => {
+      this.stdout += chunk;
+      while (true) {
+        const newline = this.stdout.indexOf("\n");
+        if (newline < 0) break;
+        const line = this.stdout.slice(0, newline).trim();
+        this.stdout = this.stdout.slice(newline + 1);
+        if (!line) continue;
+        const message = JSON.parse(line) as JsonRpcResponse;
+        if (typeof message.id !== "number") continue;
+        const waiter = this.pending.get(message.id);
+        if (!waiter) continue;
+        this.pending.delete(message.id);
+        if (message.error) waiter.reject(new Error(message.error.message));
+        else waiter.resolve(message.result);
+      }
+    });
+    this.child.stderr.on("data", (chunk: string) => {
+      this.stderr += chunk;
+    });
+    this.child.once("exit", (code, signal) => {
+      const error = new Error(
+        `MCP child exited code=${code ?? "null"} signal=${signal ?? "none"}: ${this.stderr}`,
+      );
+      for (const waiter of this.pending.values()) waiter.reject(error);
+      this.pending.clear();
+    });
+  }
+
+  async initialize(): Promise<void> {
+    await this.request("initialize", {
+      capabilities: {},
+      clientInfo: { name: "packaged-reconnect-test", version: "1" },
+      protocolVersion: "2025-03-26",
+    });
+    this.child.stdin.write(`${JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    })}\n`);
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const result = await this.request("tools/call", {
+      arguments: args,
+      name,
+    }) as { content?: Array<{ text?: string }> };
+    const text = result.content?.find((entry) => typeof entry.text === "string")?.text;
+    if (!text) throw new Error(`MCP ${name} returned no text payload`);
+    return JSON.parse(text) as Record<string, unknown>;
+  }
+
+  async close(): Promise<void> {
+    if (this.child.exitCode !== null) return;
+    this.child.stdin.end();
+    await Promise.race([
+      new Promise<void>((resolveExit) => this.child.once("exit", () => resolveExit())),
+      new Promise<void>((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
+    ]);
+    if (this.child.exitCode === null) this.child.kill("SIGKILL");
+  }
+
+  private async request(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    const response = new Promise<unknown>((resolveResponse, rejectResponse) => {
+      this.pending.set(id, { reject: rejectResponse, resolve: resolveResponse });
+    });
+    this.child.stdin.write(`${JSON.stringify({
+      id,
+      jsonrpc: "2.0",
+      method,
+      params,
+    })}\n`);
+    return await Promise.race([
+      response,
+      new Promise<never>((_resolve, rejectTimeout) => {
+        setTimeout(() => rejectTimeout(new Error(`MCP request ${method} timed out`)), 10_000);
+      }),
+    ]);
+  }
+}
+
+function sendJson(response: import("node:http").ServerResponse, body: unknown): void {
+  response.writeHead(200, { "Content-Type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+describe("packaged headless MCP reconnect lifecycle", () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const close of cleanup.splice(0).reverse()) await close();
+  });
+
+  it("keeps one owner and one real child alive across separate MCP clients", async () => {
+    const workspaceRoot = resolve(import.meta.dirname, "..", "..", "..");
+    const daemonCli = join(workspaceRoot, "apps", "daemon", "dist", "cli.js");
+    expect(existsSync(daemonCli), "packaged pretest must build the daemon MCP entry").toBe(true);
+
+    const tempRoot = await mkdtemp(join(tmpdir(), "od-packaged-mcp-reconnect-"));
+    cleanup.push(async () => await rm(tempRoot, { force: true, recursive: true }));
+    const signalLog = join(tempRoot, "worker-signals.log");
+    const runId = "run-packaged-reconnect";
+    const projectId = "project-packaged-reconnect";
+    let runCreationCount = 0;
+    let runStatus: "running" | "succeeded" = "running";
+    let workerSignal: NodeJS.Signals | null = null;
+    let worker: ChildProcess | null = null;
+
+    const httpServer: Server = createServer((request, response) => {
+      const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+      if (requestUrl.pathname === "/api/health") {
+        sendJson(response, { ok: true });
+        return;
+      }
+      if (request.method === "GET" && requestUrl.pathname === "/api/projects") {
+        sendJson(response, { projects: [{ id: projectId, name: "Reconnect project" }] });
+        return;
+      }
+      if (request.method === "POST" && requestUrl.pathname === "/api/runs") {
+        runCreationCount++;
+        if (worker == null) {
+          const spawnedWorker = spawn(process.execPath, ["-e", [
+            "const fs=require('node:fs');",
+            `const log=${JSON.stringify(signalLog)};`,
+            "process.on('SIGTERM',()=>{fs.appendFileSync(log,'SIGTERM\\n');process.exit(143);});",
+            "setTimeout(()=>process.exit(0),700);",
+          ].join("")], {
+            stdio: ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+          });
+          worker = spawnedWorker;
+          spawnedWorker.once("exit", (code, signal) => {
+            workerSignal = signal;
+            if (code === 0 && signal == null) runStatus = "succeeded";
+          });
+        }
+        sendJson(response, {
+          conversationId: "conversation-packaged-reconnect",
+          id: runId,
+          projectId,
+          runId,
+          status: runStatus,
+        });
+        return;
+      }
+      if (request.method === "GET" && requestUrl.pathname === `/api/runs/${runId}`) {
+        sendJson(response, {
+          artifactCount: 0,
+          cancelRequested: false,
+          conversationId: "conversation-packaged-reconnect",
+          deliverableEntryFile: null,
+          deliverableValid: false,
+          deliverableValidation: "none",
+          error: null,
+          exitCode: runStatus === "succeeded" ? 0 : null,
+          id: runId,
+          projectId,
+          signal: workerSignal,
+          status: runStatus,
+        });
+        return;
+      }
+      if (request.method === "GET" && requestUrl.pathname === `/api/runs/${runId}/events`) {
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.end("event: agent\ndata: {\"type\":\"text_delta\",\"delta\":\"done\"}\n\n");
+        return;
+      }
+      if (request.method === "GET" && requestUrl.pathname === "/api/mcp/install-info") {
+        sendJson(response, { webBaseUrl: null });
+        return;
+      }
+      sendJson(response, {});
+    });
+    await new Promise<void>((resolveListen) => httpServer.listen(0, "127.0.0.1", resolveListen));
+    cleanup.push(async () => await new Promise<void>((resolveClose) => httpServer.close(() => resolveClose())));
+    const address = httpServer.address();
+    if (address == null || typeof address === "string") throw new Error("fake daemon did not bind TCP");
+    const daemonUrl = `http://127.0.0.1:${address.port}`;
+
+    const namespace = `reconnect-${randomUUID()}`;
+    const daemonIpc = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      namespace,
+    });
+    const desktopIpc = resolveAppIpcPath({
+      app: APP_KEYS.DESKTOP,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      namespace,
+    });
+    const daemonIpcServer = await createJsonIpcServer({
+      socketPath: daemonIpc,
+      handler: async () => ({
+        desktopAuthGateActive: false,
+        pid: process.pid,
+        state: "running",
+        updatedAt: new Date().toISOString(),
+        url: daemonUrl,
+      }),
+    });
+    cleanup.push(async () => await daemonIpcServer.close());
+
+    let ownerStartCount = 0;
+    const dependencies = {
+      confirmRuntime: async () => undefined,
+      createIpcServer: async ({
+        currentWebUrl,
+        shutdown,
+      }: {
+        currentWebUrl(): string | null;
+        shutdown(): Promise<void>;
+      }) => await createJsonIpcServer({
+        socketPath: desktopIpc,
+        handler: async (message: unknown) => {
+          const type = (message as { type?: unknown })?.type;
+          if (type === SIDECAR_MESSAGES.SHUTDOWN) {
+            setImmediate(() => void shutdown());
+            return { accepted: true };
+          }
+          const url = currentWebUrl();
+          return {
+            pid: process.pid,
+            state: url ? "running" : "idle",
+            updatedAt: new Date().toISOString(),
+            url,
+            windowVisible: false,
+          } satisfies DesktopStatusSnapshot;
+        },
+      }),
+      exit: () => undefined,
+      installMcp: async () => undefined,
+      startSidecars: async () => {
+        ownerStartCount++;
+        return {
+          close: async () => undefined,
+          currentWebUrl: () => daemonUrl,
+          daemon: {
+            desktopAuthGateActive: false,
+            state: "running" as const,
+            url: daemonUrl,
+          },
+          web: { state: "running" as const, url: daemonUrl },
+        };
+      },
+      writeIdentity: async () => ({ close: async () => undefined, identity: {} as never }),
+      writeWebIdentity: async () => undefined,
+    };
+    const inspectExistingOwner = async () => {
+      try {
+        const status = await requestJsonIpc<DesktopStatusSnapshot>(
+          desktopIpc,
+          { type: SIDECAR_MESSAGES.STATUS },
+          { timeoutMs: 300 },
+        );
+        return {
+          state: status.state === "running" ? "running" as const : "starting" as const,
+          webUrl: status.url ?? null,
+        };
+      } catch {
+        return null;
+      }
+    };
+    const owner = await acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner });
+    expect(owner.ownership).toBe("owner");
+    if (owner.ownership !== "owner") throw new Error("first packaged runtime did not own lifecycle");
+    cleanup.push(async () => await owner.shutdown());
+
+    const clientEnv = {
+      ...process.env,
+      [SIDECAR_ENV.IPC_PATH]: daemonIpc,
+      OD_DATA_DIR: tempRoot,
+    };
+    const firstClient = new McpClient(daemonCli, clientEnv);
+    await firstClient.initialize();
+    const started = await firstClient.callTool("start_run", {
+      project: projectId,
+      prompt: "complete after the initiating MCP client disconnects",
+      requestId: "request-packaged-reconnect",
+    });
+    expect(started.runId).toBe(runId);
+    expect(runStatus).toBe("running");
+    await firstClient.close();
+
+    const adopted = await acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner });
+    expect(adopted).toEqual({ ownership: "adopted", webUrl: daemonUrl });
+    expect(ownerStartCount).toBe(1);
+
+    const secondClient = new McpClient(daemonCli, clientEnv);
+    cleanup.push(async () => await secondClient.close());
+    await secondClient.initialize();
+    let terminal: Record<string, unknown> | null = null;
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      terminal = await secondClient.callTool("get_run", { runId });
+      expect(terminal.id).toBe(runId);
+      if (terminal.status === "succeeded") break;
+      await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 40));
+    }
+
+    expect(terminal).toMatchObject({
+      cancelRequested: false,
+      exitCode: 0,
+      id: runId,
+      signal: null,
+      status: "succeeded",
+    });
+    expect(runCreationCount).toBe(1);
+    expect(ownerStartCount).toBe(1);
+    expect(workerSignal).toBeNull();
+    expect(existsSync(signalLog)).toBe(false);
+  }, 30_000);
+});

--- a/apps/packaged/tests/headless-mcp-reconnect.integration.test.ts
+++ b/apps/packaged/tests/headless-mcp-reconnect.integration.test.ts
@@ -1,26 +1,21 @@
-import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
+  type DaemonStatusSnapshot,
   type DesktopStatusSnapshot,
 } from "@open-design/sidecar-proto";
-import {
-  createJsonIpcServer,
-  requestJsonIpc,
-  resolveAppIpcPath,
-} from "@open-design/sidecar";
+import { requestJsonIpc, resolveAppIpcPath } from "@open-design/sidecar";
 import { afterEach, describe, expect, it } from "vitest";
-
-import { acquireOrAdoptPackagedHeadlessStartup } from "../src/headless-runtime.js";
 
 type JsonRpcResponse = {
   error?: { code: number; message: string };
@@ -80,7 +75,7 @@ class McpClient {
       capabilities: {},
       clientInfo: { name: "packaged-reconnect-test", version: "1" },
       protocolVersion: "2025-03-26",
-    });
+    }, 60_000);
     this.child.stdin.write(`${JSON.stringify({
       jsonrpc: "2.0",
       method: "notifications/initialized",
@@ -91,9 +86,10 @@ class McpClient {
     const result = await this.request("tools/call", {
       arguments: args,
       name,
-    }) as { content?: Array<{ text?: string }> };
+    }, 30_000) as { content?: Array<{ text?: string }>; isError?: boolean };
     const text = result.content?.find((entry) => typeof entry.text === "string")?.text;
     if (!text) throw new Error(`MCP ${name} returned no text payload`);
+    if (result.isError === true) throw new Error(`MCP ${name} failed: ${text}`);
     return JSON.parse(text) as Record<string, unknown>;
   }
 
@@ -107,10 +103,15 @@ class McpClient {
     if (this.child.exitCode === null) this.child.kill("SIGKILL");
   }
 
-  private async request(method: string, params: unknown): Promise<unknown> {
+  private async request(method: string, params: unknown, timeoutMs: number): Promise<unknown> {
     const id = this.nextId++;
+    let timeout: NodeJS.Timeout | undefined;
     const response = new Promise<unknown>((resolveResponse, rejectResponse) => {
       this.pending.set(id, { reject: rejectResponse, resolve: resolveResponse });
+      timeout = setTimeout(() => {
+        this.pending.delete(id);
+        rejectResponse(new Error(`MCP request ${method} timed out after ${timeoutMs}ms: ${this.stderr}`));
+      }, timeoutMs);
     });
     this.child.stdin.write(`${JSON.stringify({
       id,
@@ -118,18 +119,118 @@ class McpClient {
       method,
       params,
     })}\n`);
-    return await Promise.race([
-      response,
-      new Promise<never>((_resolve, rejectTimeout) => {
-        setTimeout(() => rejectTimeout(new Error(`MCP request ${method} timed out`)), 10_000);
-      }),
-    ]);
+    try {
+      return await response;
+    } finally {
+      if (timeout != null) clearTimeout(timeout);
+    }
   }
 }
 
-function sendJson(response: import("node:http").ServerResponse, body: unknown): void {
-  response.writeHead(200, { "Content-Type": "application/json" });
-  response.end(JSON.stringify(body));
+async function waitFor<T>(
+  inspect: () => Promise<T | null>,
+  description: string,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await inspect();
+      if (value != null) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 50));
+  }
+  throw new Error(
+    `timed out waiting for ${description}${
+      lastError instanceof Error ? `: ${lastError.message}` : ""
+    }`,
+  );
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeFakeCodex(options: {
+  completeMarker: string;
+  invocationLog: string;
+  releaseMarker: string;
+  signalLog: string;
+  startMarker: string;
+  tempRoot: string;
+}): Promise<string> {
+  const script = join(options.tempRoot, "fake-codex.cjs");
+  await writeFile(script, `
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args.includes("--version")) {
+  console.log("codex-cli 0.142.5");
+  process.exit(0);
+}
+if (args[0] === "debug" && args[1] === "models") {
+  console.log(JSON.stringify({ models: [] }));
+  process.exit(0);
+}
+if (args[0] === "login" && args[1] === "status") {
+  console.log("Logged in using ChatGPT");
+  process.exit(0);
+}
+fs.appendFileSync(${JSON.stringify(options.invocationLog)}, JSON.stringify({ args, pid: process.pid }) + "\\n");
+fs.writeFileSync(${JSON.stringify(options.startMarker)}, String(process.pid));
+process.on("SIGTERM", () => {
+  fs.appendFileSync(${JSON.stringify(options.signalLog)}, "SIGTERM\\n");
+  process.exit(143);
+});
+console.log(JSON.stringify({ type: "thread.started", thread_id: "019f-packaged-reconnect" }));
+console.log(JSON.stringify({ type: "turn.started" }));
+const deadline = Date.now() + 15000;
+const timer = setInterval(() => {
+  if (fs.existsSync(${JSON.stringify(options.releaseMarker)})) {
+    clearInterval(timer);
+    console.log(JSON.stringify({
+      type: "item.completed",
+      item: { id: "item-1", type: "agent_message", text: "Reconnect completed." },
+    }));
+    console.log(JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
+    }));
+    fs.writeFileSync(${JSON.stringify(options.completeMarker)}, "complete");
+    setTimeout(() => process.exit(0), 20);
+    return;
+  }
+  if (Date.now() >= deadline) {
+    clearInterval(timer);
+    process.stderr.write("timed out waiting for reconnect release\\n");
+    process.exit(2);
+  }
+}, 25);
+`, "utf8");
+
+  const bin = join(options.tempRoot, process.platform === "win32" ? "fake-codex.cmd" : "fake-codex");
+  if (process.platform === "win32") {
+    await writeFile(
+      bin,
+      `@echo off\r\n"${process.execPath}" "${script}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+      "utf8",
+    );
+  } else {
+    await writeFile(
+      bin,
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(script)} "$@"\n`,
+      "utf8",
+    );
+    await chmod(bin, 0o755);
+  }
+  return bin;
 }
 
 describe("packaged headless MCP reconnect lifecycle", () => {
@@ -139,91 +240,56 @@ describe("packaged headless MCP reconnect lifecycle", () => {
     for (const close of cleanup.splice(0).reverse()) await close();
   });
 
-  it("keeps one owner and one real child alive across separate MCP clients", async () => {
+  it("keeps the daemon-owned run alive while a separate MCP client reconnects", async () => {
     const workspaceRoot = resolve(import.meta.dirname, "..", "..", "..");
     const daemonCli = join(workspaceRoot, "apps", "daemon", "dist", "cli.js");
+    const packagedHeadless = join(workspaceRoot, "apps", "packaged", "dist", "headless.mjs");
+    const webSidecar = join(workspaceRoot, "apps", "web", "dist", "sidecar", "index.js");
     expect(existsSync(daemonCli), "packaged pretest must build the daemon MCP entry").toBe(true);
+    expect(existsSync(packagedHeadless), "packaged pretest must build the headless entry").toBe(true);
+    expect(existsSync(webSidecar), "packaged pretest must build the web sidecar entry").toBe(true);
 
     const tempRoot = await mkdtemp(join(tmpdir(), "od-packaged-mcp-reconnect-"));
-    cleanup.push(async () => await rm(tempRoot, { force: true, recursive: true }));
-    const signalLog = join(tempRoot, "worker-signals.log");
-    const runId = "run-packaged-reconnect";
-    const projectId = "project-packaged-reconnect";
-    let runCreationCount = 0;
-    let runStatus: "running" | "succeeded" = "running";
-    let workerSignal: NodeJS.Signals | null = null;
-    let worker: ChildProcess | null = null;
-
-    const httpServer: Server = createServer((request, response) => {
-      const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
-      if (requestUrl.pathname === "/api/health") {
-        sendJson(response, { ok: true });
-        return;
-      }
-      if (request.method === "GET" && requestUrl.pathname === "/api/projects") {
-        sendJson(response, { projects: [{ id: projectId, name: "Reconnect project" }] });
-        return;
-      }
-      if (request.method === "POST" && requestUrl.pathname === "/api/runs") {
-        runCreationCount++;
-        if (worker == null) {
-          const spawnedWorker = spawn(process.execPath, ["-e", [
-            "const fs=require('node:fs');",
-            `const log=${JSON.stringify(signalLog)};`,
-            "process.on('SIGTERM',()=>{fs.appendFileSync(log,'SIGTERM\\n');process.exit(143);});",
-            "setTimeout(()=>process.exit(0),700);",
-          ].join("")], {
-            stdio: ["ignore", "pipe", "pipe"],
-            windowsHide: true,
-          });
-          worker = spawnedWorker;
-          spawnedWorker.once("exit", (code, signal) => {
-            workerSignal = signal;
-            if (code === 0 && signal == null) runStatus = "succeeded";
-          });
-        }
-        sendJson(response, {
-          conversationId: "conversation-packaged-reconnect",
-          id: runId,
-          projectId,
-          runId,
-          status: runStatus,
-        });
-        return;
-      }
-      if (request.method === "GET" && requestUrl.pathname === `/api/runs/${runId}`) {
-        sendJson(response, {
-          artifactCount: 0,
-          cancelRequested: false,
-          conversationId: "conversation-packaged-reconnect",
-          deliverableEntryFile: null,
-          deliverableValid: false,
-          deliverableValidation: "none",
-          error: null,
-          exitCode: runStatus === "succeeded" ? 0 : null,
-          id: runId,
-          projectId,
-          signal: workerSignal,
-          status: runStatus,
-        });
-        return;
-      }
-      if (request.method === "GET" && requestUrl.pathname === `/api/runs/${runId}/events`) {
-        response.writeHead(200, { "Content-Type": "text/event-stream" });
-        response.end("event: agent\ndata: {\"type\":\"text_delta\",\"delta\":\"done\"}\n\n");
-        return;
-      }
-      if (request.method === "GET" && requestUrl.pathname === "/api/mcp/install-info") {
-        sendJson(response, { webBaseUrl: null });
-        return;
-      }
-      sendJson(response, {});
+    cleanup.push(async () => await rm(tempRoot, {
+      force: true,
+      maxRetries: 20,
+      recursive: true,
+      retryDelay: 100,
+    }));
+    const bootstrapLog = join(tempRoot, "bootstrap.log");
+    const completeMarker = join(tempRoot, "codex-complete");
+    const invocationLog = join(tempRoot, "codex-invocations.jsonl");
+    const releaseMarker = join(tempRoot, "release-codex");
+    const signalLog = join(tempRoot, "codex-signals.log");
+    const startMarker = join(tempRoot, "codex-started");
+    const webStartedMarker = join(tempRoot, "standalone-web-started");
+    const fakeCodex = await writeFakeCodex({
+      completeMarker,
+      invocationLog,
+      releaseMarker,
+      signalLog,
+      startMarker,
+      tempRoot,
     });
-    await new Promise<void>((resolveListen) => httpServer.listen(0, "127.0.0.1", resolveListen));
-    cleanup.push(async () => await new Promise<void>((resolveClose) => httpServer.close(() => resolveClose())));
-    const address = httpServer.address();
-    if (address == null || typeof address === "string") throw new Error("fake daemon did not bind TCP");
-    const daemonUrl = `http://127.0.0.1:${address.port}`;
+
+    const standaloneRoot = join(tempRoot, "web-standalone");
+    const standaloneWebRoot = join(standaloneRoot, "apps", "web");
+    await mkdir(standaloneWebRoot, { recursive: true });
+    await writeFile(join(standaloneWebRoot, "server.js"), `
+const fs = require("node:fs");
+const http = require("node:http");
+const server = http.createServer((_request, response) => response.end("ok"));
+server.listen(Number(process.env.PORT), process.env.HOSTNAME, () => {
+  fs.writeFileSync(${JSON.stringify(webStartedMarker)}, String(process.pid));
+});
+`, "utf8");
+
+    const bootstrapWrapper = join(tempRoot, "bootstrap-wrapper.mjs");
+    await writeFile(bootstrapWrapper, `
+import { appendFileSync } from "node:fs";
+appendFileSync(${JSON.stringify(bootstrapLog)}, String(process.pid) + "\\n");
+await import(${JSON.stringify(pathToFileURL(packagedHeadless).href)});
+`, "utf8");
 
     const namespace = `reconnect-${randomUUID()}`;
     const daemonIpc = resolveAppIpcPath({
@@ -236,114 +302,99 @@ describe("packaged headless MCP reconnect lifecycle", () => {
       contract: OPEN_DESIGN_SIDECAR_CONTRACT,
       namespace,
     });
-    const daemonIpcServer = await createJsonIpcServer({
-      socketPath: daemonIpc,
-      handler: async () => ({
-        desktopAuthGateActive: false,
-        pid: process.pid,
-        state: "running",
-        updatedAt: new Date().toISOString(),
-        url: daemonUrl,
-      }),
-    });
-    cleanup.push(async () => await daemonIpcServer.close());
-
-    let ownerStartCount = 0;
-    const dependencies = {
-      confirmRuntime: async () => undefined,
-      createIpcServer: async ({
-        currentWebUrl,
-        shutdown,
-      }: {
-        currentWebUrl(): string | null;
-        shutdown(): Promise<void>;
-      }) => await createJsonIpcServer({
-        socketPath: desktopIpc,
-        handler: async (message: unknown) => {
-          const type = (message as { type?: unknown })?.type;
-          if (type === SIDECAR_MESSAGES.SHUTDOWN) {
-            setImmediate(() => void shutdown());
-            return { accepted: true };
-          }
-          const url = currentWebUrl();
-          return {
-            pid: process.pid,
-            state: url ? "running" : "idle",
-            updatedAt: new Date().toISOString(),
-            url,
-            windowVisible: false,
-          } satisfies DesktopStatusSnapshot;
-        },
-      }),
-      exit: () => undefined,
-      installMcp: async () => undefined,
-      startSidecars: async () => {
-        ownerStartCount++;
-        return {
-          close: async () => undefined,
-          currentWebUrl: () => daemonUrl,
-          daemon: {
-            desktopAuthGateActive: false,
-            state: "running" as const,
-            url: daemonUrl,
-          },
-          web: { state: "running" as const, url: daemonUrl },
-        };
-      },
-      writeIdentity: async () => ({ close: async () => undefined, identity: {} as never }),
-      writeWebIdentity: async () => undefined,
-    };
-    const inspectExistingOwner = async () => {
-      try {
-        const status = await requestJsonIpc<DesktopStatusSnapshot>(
-          desktopIpc,
-          { type: SIDECAR_MESSAGES.STATUS },
-          { timeoutMs: 300 },
-        );
-        return {
-          state: status.state === "running" ? "running" as const : "starting" as const,
-          webUrl: status.url ?? null,
-        };
-      } catch {
-        return null;
+    let ownerPid: number | null = null;
+    cleanup.push(async () => {
+      await requestJsonIpc(
+        desktopIpc,
+        { type: SIDECAR_MESSAGES.SHUTDOWN },
+        { timeoutMs: 1_000 },
+      ).catch(() => undefined);
+      if (ownerPid != null) {
+        const closingPid = ownerPid;
+        await waitFor(
+          async () => isProcessAlive(closingPid) ? null : true,
+          "packaged owner process exit",
+          15_000,
+        ).catch(() => undefined);
       }
-    };
-    const owner = await acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner });
-    expect(owner.ownership).toBe("owner");
-    if (owner.ownership !== "owner") throw new Error("first packaged runtime did not own lifecycle");
-    cleanup.push(async () => await owner.shutdown());
+    });
 
     const clientEnv = {
       ...process.env,
       [SIDECAR_ENV.IPC_PATH]: daemonIpc,
+      CODEX_BIN: fakeCodex,
+      CODEX_HOME: join(tempRoot, "codex-home"),
       OD_DATA_DIR: tempRoot,
-    };
-    const firstClient = new McpClient(daemonCli, clientEnv);
-    await firstClient.initialize();
-    const started = await firstClient.callTool("start_run", {
-      project: projectId,
-      prompt: "complete after the initiating MCP client disconnects",
-      requestId: "request-packaged-reconnect",
-    });
-    expect(started.runId).toBe(runId);
-    expect(runStatus).toBe("running");
-    await firstClient.close();
+      OD_MCP_BOOTSTRAP_ARGS: JSON.stringify([bootstrapWrapper, "--headless"]),
+      OD_MCP_BOOTSTRAP_COMMAND: process.execPath,
+      OD_PACKAGED_NAMESPACE: namespace,
+      OD_RESOURCE_ROOT: workspaceRoot,
+      OD_WEB_OUTPUT_MODE: "standalone",
+      OD_WEB_STANDALONE_ROOT: standaloneRoot,
+    } satisfies NodeJS.ProcessEnv;
 
-    const adopted = await acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner });
-    expect(adopted).toEqual({ ownership: "adopted", webUrl: daemonUrl });
-    expect(ownerStartCount).toBe(1);
+    const firstClient = new McpClient(daemonCli, clientEnv);
+    cleanup.push(async () => await firstClient.close());
+    await firstClient.initialize();
+
+    const ownerBefore = await waitFor(async () => {
+      const status = await requestJsonIpc<DesktopStatusSnapshot>(
+        desktopIpc,
+        { type: SIDECAR_MESSAGES.STATUS },
+        { timeoutMs: 500 },
+      );
+      return status.state === "running" && status.url ? status : null;
+    }, "packaged headless owner");
+    if (typeof ownerBefore.pid !== "number") throw new Error("packaged owner status omitted pid");
+    ownerPid = ownerBefore.pid;
+    const daemonBefore = await requestJsonIpc<DaemonStatusSnapshot>(
+      daemonIpc,
+      { type: SIDECAR_MESSAGES.STATUS },
+      { timeoutMs: 500 },
+    );
+    expect(existsSync(webStartedMarker), "headless bootstrap must honor standalone web configuration").toBe(true);
+
+    const projectId = `reconnect-${randomUUID()}`;
+    const project = await firstClient.callTool("create_project", {
+      id: projectId,
+      name: "Packaged MCP reconnect lifecycle",
+    });
+    expect(project).toMatchObject({ project: { id: projectId } });
+    const started = await firstClient.callTool("start_run", {
+      agent: "codex",
+      project: projectId,
+      prompt: "Remain alive until the replacement MCP client reconnects.",
+      requestId: randomUUID(),
+    });
+    const runId = String(started.runId ?? started.id ?? "");
+    expect(runId).not.toBe("");
+    await waitFor(async () => existsSync(startMarker) ? true : null, "daemon-owned Codex child");
+    expect(existsSync(completeMarker)).toBe(false);
+
+    await firstClient.close();
+    const ownerAfterDisconnect = await requestJsonIpc<DesktopStatusSnapshot>(
+      desktopIpc,
+      { type: SIDECAR_MESSAGES.STATUS },
+      { timeoutMs: 500 },
+    );
+    expect(ownerAfterDisconnect.pid).toBe(ownerBefore.pid);
 
     const secondClient = new McpClient(daemonCli, clientEnv);
     cleanup.push(async () => await secondClient.close());
     await secondClient.initialize();
-    let terminal: Record<string, unknown> | null = null;
-    const deadline = Date.now() + 5_000;
-    while (Date.now() < deadline) {
-      terminal = await secondClient.callTool("get_run", { runId });
-      expect(terminal.id).toBe(runId);
-      if (terminal.status === "succeeded") break;
-      await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 40));
-    }
+    const daemonAfterReconnect = await requestJsonIpc<DaemonStatusSnapshot>(
+      daemonIpc,
+      { type: SIDECAR_MESSAGES.STATUS },
+      { timeoutMs: 500 },
+    );
+    expect(daemonAfterReconnect.pid).toBe(daemonBefore.pid);
+
+    await writeFile(releaseMarker, "release", "utf8");
+    const terminal = await waitFor(async () => {
+      const status = await secondClient.callTool("get_run", { runId });
+      expect(status.id).toBe(runId);
+      return status.status === "succeeded" ? status : null;
+    }, "same run to reach terminal success", 20_000);
 
     expect(terminal).toMatchObject({
       cancelRequested: false,
@@ -352,9 +403,16 @@ describe("packaged headless MCP reconnect lifecycle", () => {
       signal: null,
       status: "succeeded",
     });
-    expect(runCreationCount).toBe(1);
-    expect(ownerStartCount).toBe(1);
-    expect(workerSignal).toBeNull();
+    expect(existsSync(completeMarker)).toBe(true);
     expect(existsSync(signalLog)).toBe(false);
-  }, 30_000);
+    const invocations = (await readFile(invocationLog, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { args: string[]; pid: number });
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]?.args).toContain("exec");
+    const bootstraps = (await readFile(bootstrapLog, "utf8")).trim().split("\n").filter(Boolean);
+    expect(bootstraps).toEqual([String(ownerBefore.pid)]);
+  }, 90_000);
 });

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   acquireOrAdoptPackagedHeadlessStartup,
   acquirePackagedHeadlessStartup,
   parsePackagedHeadlessRequest,
+  type PackagedHeadlessStartupDependencies,
   repairCodexMcpRegistrationViaLiveOwner,
   resolvePackagedMcpBootstrapLaunch,
 } from "../src/headless-runtime.js";
@@ -61,34 +62,40 @@ describe("resolvePackagedMcpBootstrapLaunch", () => {
 });
 
 describe("acquirePackagedHeadlessStartup", () => {
-  function createDependencies(failAt: "mcp" | "web-identity") {
+  function createDependencies(failAt: "mcp" | "web-identity" | null) {
     const closed: string[] = [];
     const exit = vi.fn();
+    const createIpcServer = vi.fn<
+      PackagedHeadlessStartupDependencies["createIpcServer"]
+    >(async () => ({
+      close: async () => {
+        closed.push("ipc");
+      },
+    }));
+    const startSidecars = vi.fn<
+      PackagedHeadlessStartupDependencies["startSidecars"]
+    >(async () => ({
+      close: async () => {
+        closed.push("sidecars");
+      },
+      currentWebUrl: () => "http://127.0.0.1:7456",
+      daemon: {
+        desktopAuthGateActive: false,
+        state: "running" as const,
+        url: "http://127.0.0.1:7457",
+      },
+      web: { state: "running" as const, url: "http://127.0.0.1:7456" },
+    }));
     return {
       closed,
       dependencies: {
         confirmRuntime: vi.fn(async () => undefined),
-        createIpcServer: vi.fn(async () => ({
-          close: async () => {
-            closed.push("ipc");
-          },
-        })),
+        createIpcServer,
         exit,
         installMcp: vi.fn(async () => {
           if (failAt === "mcp") throw new Error("MCP install failed");
         }),
-        startSidecars: vi.fn(async () => ({
-          close: async () => {
-            closed.push("sidecars");
-          },
-          currentWebUrl: () => "http://127.0.0.1:7456",
-          daemon: {
-            desktopAuthGateActive: false,
-            state: "running" as const,
-            url: "http://127.0.0.1:7457",
-          },
-          web: { state: "running" as const, url: "http://127.0.0.1:7456" },
-        })),
+        startSidecars,
         writeIdentity: vi.fn(async () => ({
           close: async () => {
             closed.push("identity");
@@ -213,6 +220,39 @@ describe("acquirePackagedHeadlessStartup", () => {
     expect(repairAdoptedOwner).toHaveBeenCalledOnce();
     expect(repairAdoptedOwner).toHaveBeenCalledWith('http://127.0.0.1:7456');
     expect(dependencies.startSidecars).not.toHaveBeenCalled();
+  });
+
+  it('publishes a respawned web URL so adoption repairs through the live listener', async () => {
+    const { dependencies } = createDependencies(null);
+    let liveWebUrl = 'http://127.0.0.1:7456';
+    let publishedWebUrl: (() => string | null) | null = null;
+    dependencies.createIpcServer.mockImplementation(async ({ currentWebUrl }) => {
+      publishedWebUrl = currentWebUrl;
+      return { close: async () => undefined };
+    });
+    dependencies.startSidecars.mockImplementation(async () => ({
+      close: async () => undefined,
+      currentWebUrl: () => liveWebUrl,
+      daemon: {
+        desktopAuthGateActive: false,
+        state: 'running' as const,
+        url: 'http://127.0.0.1:7457',
+      },
+      web: { state: 'running' as const, url: liveWebUrl },
+    }));
+
+    await acquirePackagedHeadlessStartup(dependencies);
+    liveWebUrl = 'http://127.0.0.1:8465';
+    const repairAdoptedOwner = vi.fn(async () => undefined);
+    await acquireOrAdoptPackagedHeadlessStartup(dependencies, {
+      inspectExistingOwner: async () => ({
+        state: 'running',
+        webUrl: publishedWebUrl?.() ?? null,
+      }),
+      repairAdoptedOwner,
+    });
+
+    expect(repairAdoptedOwner).toHaveBeenCalledWith('http://127.0.0.1:8465');
   });
 });
 

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -303,7 +303,7 @@ describe('repairCodexMcpRegistrationViaLiveOwner', () => {
               type: 'stdio',
               command: 'C:\\Old Open Design\\Open Design.exe',
               args: ['C:\\Old Open Design\\daemon-cli.mjs', 'mcp'],
-              env: { CODEX_BIN: 'C:\\stale\\codex.exe' },
+              env: null,
             },
           }),
           stderr: '',
@@ -366,7 +366,7 @@ describe('repairCodexMcpRegistrationViaLiveOwner', () => {
               type: 'stdio',
               command: oldCommand,
               args: oldArgs,
-              env: { CODEX_BIN: 'C:\\stale\\codex.exe' },
+              env: null,
             },
           }),
           stderr: '',
@@ -398,8 +398,14 @@ describe('repairCodexMcpRegistrationViaLiveOwner', () => {
     expect(run).toHaveBeenCalledTimes(5);
     expect(run.mock.calls[3]?.[1]).toEqual(['mcp', 'remove', 'open-design']);
     const restoreArgs = run.mock.calls[4]?.[1] ?? [];
-    expect(restoreArgs).toContain('CODEX_BIN=C:\\stale\\codex.exe');
-    expect(restoreArgs.slice(-3)).toEqual([oldCommand, ...oldArgs]);
+    expect(restoreArgs).toEqual([
+      'mcp',
+      'add',
+      'open-design',
+      '--',
+      oldCommand,
+      ...oldArgs,
+    ]);
   });
 
   it('fails closed when the existing registration cannot be inspected', async () => {

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -217,12 +217,60 @@ describe("acquirePackagedHeadlessStartup", () => {
 });
 
 describe('repairCodexMcpRegistrationViaLiveOwner', () => {
-  it('rebuilds the live owner registration with the current exact CODEX_BIN', async () => {
-    const run = vi.fn(async (_command: string, _args: string[]) => ({
-      exitCode: 0,
-      stdout: '',
-      stderr: '',
+  it('adds the registration directly when no previous entry exists', async () => {
+    const run = vi.fn(async (_command: string, args: string[]) => (
+      args[1] === 'get'
+        ? {
+            exitCode: 1,
+            stdout: '',
+            stderr: "Error: No MCP server named 'open-design' found.",
+          }
+        : { exitCode: 0, stdout: '', stderr: '' }
+    ));
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+      args: ['C:\\Program Files\\Open Design\\daemon-cli.mjs', 'mcp'],
+      env: {},
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
     }));
+
+    await repairCodexMcpRegistrationViaLiveOwner(
+      'http://127.0.0.1:7456',
+      'C:\\RR-ESW\\bin\\codex.exe',
+      { fetchImpl, run },
+    );
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[1]?.slice(0, 4)).toEqual([
+      'mcp',
+      'add',
+      'open-design',
+      '--env',
+    ]);
+  });
+
+  it('rebuilds the live owner registration with the current exact CODEX_BIN', async () => {
+    const run = vi.fn(async (_command: string, args: string[]) => {
+      if (args[1] === 'get') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            name: 'open-design',
+            enabled: true,
+            transport: {
+              type: 'stdio',
+              command: 'C:\\Old Open Design\\Open Design.exe',
+              args: ['C:\\Old Open Design\\daemon-cli.mjs', 'mcp'],
+              env: { CODEX_BIN: 'C:\\stale\\codex.exe' },
+            },
+          }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
       command: 'C:\\Program Files\\Open Design\\Open Design.exe',
       args: [
@@ -249,8 +297,10 @@ describe('repairCodexMcpRegistrationViaLiveOwner', () => {
     expect(fetchImpl).toHaveBeenCalledWith(
       'http://127.0.0.1:7456/api/mcp/install-info',
     );
-    expect(run).toHaveBeenCalledOnce();
-    const [command, args] = run.mock.calls[0] ?? [];
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run.mock.calls[0]?.[1]).toEqual(['mcp', 'get', 'open-design', '--json']);
+    expect(run.mock.calls[1]?.[1]).toEqual(['mcp', 'remove', 'open-design']);
+    const [command, args] = run.mock.calls[2] ?? [];
     expect(command).toBe('C:\\RR-ESW\\bin\\codex.exe');
     expect(args).toContain('CODEX_BIN=C:\\RR-ESW\\bin\\codex.exe');
     expect(args).not.toContain('CODEX_BIN=C:\\stale\\codex.exe');
@@ -259,5 +309,80 @@ describe('repairCodexMcpRegistrationViaLiveOwner', () => {
       'C:\\Program Files\\Open Design\\resources\\app\\prebundled\\daemon\\daemon-cli.mjs',
       'mcp',
     ]);
+  });
+
+  it('restores the previous registration when replacement add fails', async () => {
+    const oldCommand = 'C:\\Old Open Design\\Open Design.exe';
+    const oldArgs = ['C:\\Old Open Design\\daemon-cli.mjs', 'mcp'];
+    let addAttempt = 0;
+    const run = vi.fn(async (_command: string, args: string[]) => {
+      if (args[1] === 'get') {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            name: 'open-design',
+            enabled: true,
+            transport: {
+              type: 'stdio',
+              command: oldCommand,
+              args: oldArgs,
+              env: { CODEX_BIN: 'C:\\stale\\codex.exe' },
+            },
+          }),
+          stderr: '',
+        };
+      }
+      if (args[1] === 'add') {
+        addAttempt += 1;
+        if (addAttempt === 1) {
+          return { exitCode: 1, stdout: '', stderr: 'replacement rejected' };
+        }
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+      args: ['C:\\Program Files\\Open Design\\daemon-cli.mjs', 'mcp'],
+      env: { CODEX_BIN: 'C:\\stale\\codex.exe' },
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    }));
+
+    await expect(repairCodexMcpRegistrationViaLiveOwner(
+      'http://127.0.0.1:7456',
+      'C:\\RR-ESW\\bin\\codex.exe',
+      { fetchImpl, run },
+    )).rejects.toThrow(/replacement rejected/);
+
+    expect(run).toHaveBeenCalledTimes(5);
+    expect(run.mock.calls[3]?.[1]).toEqual(['mcp', 'remove', 'open-design']);
+    const restoreArgs = run.mock.calls[4]?.[1] ?? [];
+    expect(restoreArgs).toContain('CODEX_BIN=C:\\stale\\codex.exe');
+    expect(restoreArgs.slice(-3)).toEqual([oldCommand, ...oldArgs]);
+  });
+
+  it('fails closed when the existing registration cannot be inspected', async () => {
+    const run = vi.fn(async () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'permission denied',
+    }));
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+      args: ['C:\\Program Files\\Open Design\\daemon-cli.mjs', 'mcp'],
+      env: {},
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    }));
+
+    await expect(repairCodexMcpRegistrationViaLiveOwner(
+      'http://127.0.0.1:7456',
+      'C:\\RR-ESW\\bin\\codex.exe',
+      { fetchImpl, run },
+    )).rejects.toThrow(/mcp get failed.*permission denied/i);
+
+    expect(run).toHaveBeenCalledOnce();
   });
 });

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  acquireOrAdoptPackagedHeadlessStartup,
   acquirePackagedHeadlessStartup,
   parsePackagedHeadlessRequest,
   resolvePackagedMcpBootstrapLaunch,
@@ -110,7 +111,7 @@ describe("acquirePackagedHeadlessStartup", () => {
       "MCP install failed",
     );
 
-    expect(closed).toEqual(["sidecars", "identity"]);
+    expect(closed).toEqual(["ipc", "sidecars", "identity"]);
     expect(exit).not.toHaveBeenCalled();
   });
 
@@ -123,5 +124,72 @@ describe("acquirePackagedHeadlessStartup", () => {
 
     expect(closed).toEqual(["ipc", "sidecars", "identity"]);
     expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('claims desktop IPC before starting sidecars so concurrent bootstrap has one owner', async () => {
+    const { dependencies } = createDependencies('mcp');
+    const order: string[] = [];
+    dependencies.createIpcServer.mockImplementation(async () => {
+      order.push('ipc');
+      return { close: async () => undefined };
+    });
+    dependencies.startSidecars.mockImplementation(async () => {
+      order.push('sidecars');
+      throw new Error('stop after ownership order');
+    });
+
+    await expect(acquirePackagedHeadlessStartup(dependencies)).rejects.toThrow(
+      'stop after ownership order',
+    );
+
+    expect(order).toEqual(['ipc', 'sidecars']);
+  });
+
+  it('adopts a concurrent owner without restarting its active run', async () => {
+    const { dependencies } = createDependencies('web-identity');
+    let ipcClaimed = false;
+    let activeRunState: 'running' | 'completed' = 'running';
+    const childSignals: string[] = [];
+    dependencies.createIpcServer.mockImplementation(async () => {
+      if (ipcClaimed) {
+        const error = new Error('desktop IPC is already owned') as NodeJS.ErrnoException;
+        error.code = 'EADDRINUSE';
+        throw error;
+      }
+      ipcClaimed = true;
+      return {
+        close: async () => {
+          ipcClaimed = false;
+          childSignals.push('SIGTERM');
+        },
+      };
+    });
+    dependencies.writeWebIdentity.mockResolvedValue(undefined);
+    dependencies.startSidecars.mockImplementation(async () => ({
+      close: async () => {
+        childSignals.push('SIGTERM');
+      },
+      currentWebUrl: () => 'http://127.0.0.1:7456',
+      daemon: {
+        desktopAuthGateActive: false,
+        state: 'running' as const,
+        url: 'http://127.0.0.1:7457',
+      },
+      web: { state: 'running' as const, url: 'http://127.0.0.1:7456' },
+    }));
+    const inspectExistingOwner = vi.fn(async () => ipcClaimed
+      ? { state: 'running' as const, webUrl: 'http://127.0.0.1:7456' }
+      : null);
+
+    const [first, second] = await Promise.all([
+      acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner }),
+      acquireOrAdoptPackagedHeadlessStartup(dependencies, { inspectExistingOwner }),
+    ]);
+
+    activeRunState = 'completed';
+    expect([first.ownership, second.ownership].sort()).toEqual(['adopted', 'owner']);
+    expect(dependencies.startSidecars).toHaveBeenCalledTimes(1);
+    expect(activeRunState).toBe('completed');
+    expect(childSignals).toEqual([]);
   });
 });

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   acquireOrAdoptPackagedHeadlessStartup,
   acquirePackagedHeadlessStartup,
   parsePackagedHeadlessRequest,
+  repairCodexMcpRegistrationViaLiveOwner,
   resolvePackagedMcpBootstrapLaunch,
 } from "../src/headless-runtime.js";
 
@@ -191,5 +192,72 @@ describe("acquirePackagedHeadlessStartup", () => {
     expect(dependencies.startSidecars).toHaveBeenCalledTimes(1);
     expect(activeRunState).toBe('completed');
     expect(childSignals).toEqual([]);
+  });
+
+  it('repairs stale MCP registration through a healthy owner before adopting it', async () => {
+    const { dependencies } = createDependencies('web-identity');
+    const repairAdoptedOwner = vi.fn(async () => undefined);
+
+    const adopted = await acquireOrAdoptPackagedHeadlessStartup(dependencies, {
+      inspectExistingOwner: async () => ({
+        state: 'running',
+        webUrl: 'http://127.0.0.1:7456',
+      }),
+      repairAdoptedOwner,
+    });
+
+    expect(adopted).toEqual({
+      ownership: 'adopted',
+      webUrl: 'http://127.0.0.1:7456',
+    });
+    expect(repairAdoptedOwner).toHaveBeenCalledOnce();
+    expect(repairAdoptedOwner).toHaveBeenCalledWith('http://127.0.0.1:7456');
+    expect(dependencies.startSidecars).not.toHaveBeenCalled();
+  });
+});
+
+describe('repairCodexMcpRegistrationViaLiveOwner', () => {
+  it('rebuilds the live owner registration with the current exact CODEX_BIN', async () => {
+    const run = vi.fn(async (_command: string, _args: string[]) => ({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    }));
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      command: 'C:\\Program Files\\Open Design\\Open Design.exe',
+      args: [
+        'C:\\Program Files\\Open Design\\resources\\app\\prebundled\\daemon\\daemon-cli.mjs',
+        'mcp',
+      ],
+      env: {
+        ELECTRON_RUN_AS_NODE: '1',
+        CODEX_BIN: 'C:\\stale\\codex.exe',
+        OD_DATA_DIR: 'C:\\OpenDesignData',
+        OD_SIDECAR_IPC_PATH: '\\\\.\\pipe\\open-design-daemon',
+      },
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    }));
+
+    await repairCodexMcpRegistrationViaLiveOwner(
+      'http://127.0.0.1:7456',
+      'C:\\RR-ESW\\bin\\codex.exe',
+      { fetchImpl, run },
+    );
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:7456/api/mcp/install-info',
+    );
+    expect(run).toHaveBeenCalledOnce();
+    const [command, args] = run.mock.calls[0] ?? [];
+    expect(command).toBe('C:\\RR-ESW\\bin\\codex.exe');
+    expect(args).toContain('CODEX_BIN=C:\\RR-ESW\\bin\\codex.exe');
+    expect(args).not.toContain('CODEX_BIN=C:\\stale\\codex.exe');
+    expect(args.slice(-3)).toEqual([
+      'C:\\Program Files\\Open Design\\Open Design.exe',
+      'C:\\Program Files\\Open Design\\resources\\app\\prebundled\\daemon\\daemon-cli.mjs',
+      'mcp',
+    ]);
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -148,6 +148,17 @@ describe('packaged child Vite+ environment forwarding', () => {
     expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
   });
 
+  it('forwards CODEX_BIN so a packaged headless daemon keeps the selected Codex executable', () => {
+    const env = resolvePackagedChildBaseEnv({
+      CODEX_BIN: '/opt/codex/bin/codex',
+      HOME: '/Users/tester',
+      RANDOM_INTERNAL_FLAG: 'drop-me',
+    });
+
+    expect(env.CODEX_BIN).toBe('/opt/codex/bin/codex');
+    expect(env.RANDOM_INTERNAL_FLAG).toBeUndefined();
+  });
+
   it('keeps VP_HOME in the packaged child base env without forwarding unrelated variables', () => {
     const env = resolvePackagedChildBaseEnv({
       HOME: '/Users/tester',


### PR DESCRIPTION
Fixes #6667

## Why

A Local Codex design run can outlive the MCP stdio client that started it, but the packaged headless owner currently treats transient client lifecycle as process ownership. That can terminate the active child or bootstrap a second owner when the next tool-call connection arrives. The same adoption path prevents a stale Codex MCP registration from being repaired during an upgrade while a healthy owner is running.

## What users will see

Long-running Local Codex runs continue after the initiating MCP connection closes. A later client reconnects to the same daemon and polls the same run instead of starting a duplicate. Codex MCP registration can also be repaired without restarting a healthy packaged owner.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — packaged install-info/registration data
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — packaged headless lifetime and MCP registration adoption
- [ ] **None**

## Screenshots

Not applicable; no visible UI changes.

## Bug fix verification

- Tests: `apps/packaged/tests/headless-mcp-reconnect.integration.test.ts`, `apps/packaged/tests/headless-runtime.test.ts`, `apps/daemon/tests/mcp-bootstrap.test.ts`, and `apps/daemon/tests/mcp-install-info.test.ts`.
- The reconnect and adopted-owner assertions were red before the production corrections and green after them.
- The real-boundary integration boots the production MCP stdio entrypoint, built packaged headless owner, production daemon/web sidecars, and real daemon run service; it closes client 1 before client 2 polls the same run.

## Validation

- Packaged affected surface: 83/83 tests passed.
- Daemon MCP bootstrap/stdio-idle surface: 10/10 tests passed.
- Packaged build and typecheck passed.
- Contracts suite: 270/270 passed.
- `git diff --check` passed.
- Each cherry-picked patch has the same stable patch ID as the independently reviewed candidate; upstream drift since that base is one unrelated landing-page commit.

This is a draft because the Windows packaged clean-install acceptance is still blocked by the host's symlink privilege while extracting electron-builder's winCodeSign payload. Source verification is green; installed/released acceptance is not claimed.