### PR TITLE
fix Codex MCP preserving exact execution settings

### DIFF
--- a/apps/daemon/src/codex-config-normalize.ts
+++ b/apps/daemon/src/codex-config-normalize.ts
@@ -56,9 +56,19 @@ import { expandHomePath } from './runtimes/paths.js';
 export function resolveCodexConfigPath(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  const raw = env.CODEX_HOME?.trim();
-  const home = raw ? expandHomePath(raw) : path.join(os.homedir(), '.codex');
-  return path.join(home, 'config.toml');
+  return path.join(resolveCodexHomePath(env), 'config.toml');
+}
+
+export function resolveCodexHomePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = Object.entries(env).find(
+    ([key, value]) =>
+      key.toUpperCase() === 'CODEX_HOME'
+      && typeof value === 'string'
+      && value.trim().length > 0,
+  )?.[1]?.trim();
+  return raw ? expandHomePath(raw) : path.join(os.homedir(), '.codex');
 }
 
 /**

--- a/apps/daemon/src/codex-rollout-usage.ts
+++ b/apps/daemon/src/codex-rollout-usage.ts
@@ -15,11 +15,19 @@ import os from 'node:os';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
-interface CodexFirstCallUsage {
+export interface CodexFirstCallUsage {
   first_call_input_tokens: number;
   first_call_cache_read_input_tokens: number;
   first_call_cache_hit_ratio: number;
+  resolved_model_id?: string;
+  resolved_reasoning_effort?: string;
+  resolved_service_tier?: string;
 }
+
+type CodexTurnContextEvidence = Pick<
+  CodexFirstCallUsage,
+  'resolved_model_id' | 'resolved_reasoning_effort' | 'resolved_service_tier'
+>;
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -60,6 +68,8 @@ export function extractCodexLastTurnFirstCallUsage(
   rolloutJsonl: string,
 ): CodexFirstCallUsage | null {
   let firstCall: CodexFirstCallUsage | null = null;
+  let turnContext: CodexTurnContextEvidence | null = null;
+  let contextMayPrecedeTaskStart = false;
 
   for (const line of rolloutJsonl.split('\n')) {
     const trimmed = line.trim();
@@ -75,14 +85,33 @@ export function extractCodexLastTurnFirstCallUsage(
     const payload = asRecord(record.payload);
     const payloadType = payload?.type;
 
+    if (record.type === 'turn_context') {
+      firstCall = null;
+      const model = typeof payload?.model === 'string' ? payload.model.trim() : '';
+      const effort = typeof payload?.effort === 'string' ? payload.effort.trim() : '';
+      const serviceTier = typeof payload?.service_tier === 'string'
+        ? payload.service_tier.trim()
+        : '';
+      turnContext = {
+        ...(model ? { resolved_model_id: model } : {}),
+        ...(effort ? { resolved_reasoning_effort: effort } : {}),
+        ...(serviceTier ? { resolved_service_tier: serviceTier } : {}),
+      };
+      contextMayPrecedeTaskStart = true;
+      continue;
+    }
+
     if (payloadType === 'task_started') {
       // A new turn opens; reset so we capture THIS turn's opening call and let
       // the last turn in the file win.
       firstCall = null;
+      if (!contextMayPrecedeTaskStart) turnContext = null;
+      contextMayPrecedeTaskStart = false;
       continue;
     }
 
     if (payloadType !== 'token_count' || firstCall !== null) continue;
+    contextMayPrecedeTaskStart = false;
 
     const info = asRecord(payload?.info);
     const last = asRecord(info?.last_token_usage);
@@ -98,6 +127,7 @@ export function extractCodexLastTurnFirstCallUsage(
       first_call_input_tokens: input,
       first_call_cache_read_input_tokens: cached,
       first_call_cache_hit_ratio: cached / input,
+      ...(turnContext ?? {}),
     };
   }
 

--- a/apps/daemon/src/codex-rollout-usage.ts
+++ b/apps/daemon/src/codex-rollout-usage.ts
@@ -29,6 +29,22 @@ type CodexTurnContextEvidence = Pick<
   'resolved_model_id' | 'resolved_reasoning_effort' | 'resolved_service_tier'
 >;
 
+export function codexResolvedRunFinishedProperties(
+  evidence: Partial<CodexTurnContextEvidence> | null | undefined,
+): CodexTurnContextEvidence {
+  return {
+    ...(evidence?.resolved_model_id
+      ? { resolved_model_id: evidence.resolved_model_id }
+      : {}),
+    ...(evidence?.resolved_reasoning_effort
+      ? { resolved_reasoning_effort: evidence.resolved_reasoning_effort }
+      : {}),
+    ...(evidence?.resolved_service_tier
+      ? { resolved_service_tier: evidence.resolved_service_tier }
+      : {}),
+  };
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -828,7 +828,7 @@ export const TOOL_DEFS = [
   {
     name: 'list_agents',
     description:
-      'List the agent CLIs Open Design can run for start_run.agent. Returns only installed (available) agents by default — pass includeUnavailable:true to also see agents we know about but that are not on PATH (each carries an installUrl for the user). Each entry includes id, name, version, authoritative auth status when available, model-catalog source, and the complete compatibility catalog.',
+      'List the agent CLIs Open Design can run for start_run.agent. Returns only installed (available) agents by default — pass includeUnavailable:true to also see agents we know about but that are not on PATH (each carries an installUrl for the user). Codex entries use the separate ChatGPT-only readiness and complete live compatibility catalog; other agents retain a bounded model sample with modelsCount reporting the full total.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2422,18 +2422,30 @@ async function listPlugins(baseUrl: string): Promise<JsonObject> {
 // `available: true` (only installed CLIs) so the outer agent doesn't
 // pick an agent it can't actually run — the failure mode that left us
 // with zombie "running" runs whose inner Claude binary never spawned.
-// Compatibility is intentionally complete. Truncating this surface made a
-// valid exact model indistinguishable from an unsupported one.
+// Codex compatibility is intentionally complete because start_run validates
+// exact Local Codex settings against that same ChatGPT-only catalog. Other
+// adapters retain the historical bounded sample to control MCP payload size.
 async function listAgents(baseUrl: string, includeUnavailable: boolean): Promise<JsonObject> {
   const raw = await getJson<{ agents?: JsonObject[] }>(`${baseUrl}/api/agents`);
   const all = raw?.agents ?? [];
   const filtered = includeUnavailable
     ? all
     : all.filter((a) => a?.available === true);
+  const MAX_NON_CODEX_MODELS = 10;
   const agents = filtered.map((a) => {
-    const models = Array.isArray(a?.models) ? (a.models as unknown[]) : [];
+    const isCodex = a?.id === 'codex';
+    const completeModels = isCodex
+      ? Array.isArray(a?.chatgptModels)
+        ? (a.chatgptModels as unknown[])
+        : []
+      : Array.isArray(a?.models)
+        ? (a.models as unknown[])
+        : [];
+    const models = isCodex
+      ? completeModels
+      : completeModels.slice(0, MAX_NON_CODEX_MODELS);
     const usesAuthoritativeCodexAuth =
-      a?.id === 'codex' && typeof a?.chatgptAuthStatus === 'string';
+      isCodex && typeof a?.chatgptAuthStatus === 'string';
     const authStatus = usesAuthoritativeCodexAuth
       ? a?.chatgptAuthStatus
       : a?.authStatus;
@@ -2444,7 +2456,7 @@ async function listAgents(baseUrl: string, includeUnavailable: boolean): Promise
       id: a?.id,
       name: a?.name,
       models,
-      modelsCount: models.length,
+      modelsCount: completeModels.length,
     };
     if (typeof a?.version === 'string' && a.version.length > 0) out.version = a.version;
     if (typeof authStatus === 'string') out.authStatus = authStatus;
@@ -2455,7 +2467,20 @@ async function listAgents(baseUrl: string, includeUnavailable: boolean): Promise
     if (typeof a?.chatgptAuthMessage === 'string') {
       out.chatgptAuthMessage = a.chatgptAuthMessage;
     }
-    if (typeof a?.modelsSource === 'string') out.modelsSource = a.modelsSource;
+    const modelsSource = isCodex
+      ? typeof a?.chatgptModelsSource === 'string'
+        ? a.chatgptModelsSource
+        : 'unavailable'
+      : a?.modelsSource;
+    if (typeof modelsSource === 'string') out.modelsSource = modelsSource;
+    if (isCodex) {
+      out.ready = typeof a?.chatgptReady === 'boolean'
+        ? a.chatgptReady
+        : authStatus === 'ok' && modelsSource === 'live';
+      if (typeof a?.chatgptReadyMessage === 'string') {
+        out.readyMessage = a.chatgptReadyMessage;
+      }
+    }
     if (includeUnavailable) {
       out.available = Boolean(a?.available);
       if (typeof a?.installUrl === 'string') out.installUrl = a.installUrl;

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -127,18 +127,6 @@ const SAFE_MCP_DAEMON_RETRY_CALLS = new Set([
   'read_resource',
   'search_files',
 ]);
-const MCP_REASONING_OPTIONS = [
-  'default',
-  'none',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
-  'ultra',
-] as const;
-
 function normalizeDaemonUrl(value: string | URL): string {
   return String(value).replace(/\/$/, '');
 }
@@ -787,8 +775,7 @@ export const TOOL_DEFS = [
         },
         reasoning: {
           type: 'string',
-          enum: [...MCP_REASONING_OPTIONS],
-          description: 'Reasoning effort override for the selected model. Optional.',
+          description: 'Exact reasoning effort advertised by the selected model in the live agent catalog. Optional; the daemon validates it before spawn.',
         },
         serviceTier: {
           type: 'string',
@@ -841,7 +828,7 @@ export const TOOL_DEFS = [
   {
     name: 'list_agents',
     description:
-      'List the agent CLIs Open Design can run for start_run.agent. Returns only installed (available) agents by default — pass includeUnavailable:true to also see agents we know about but that are not on PATH (each carries an installUrl for the user). Each entry includes id, name, version, and up to 10 sample models (modelsCount carries the real total).',
+      'List the agent CLIs Open Design can run for start_run.agent. Returns only installed (available) agents by default — pass includeUnavailable:true to also see agents we know about but that are not on PATH (each carries an installUrl for the user). Each entry includes id, name, version, authoritative auth status when available, model-catalog source, and the complete compatibility catalog.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -2435,25 +2422,40 @@ async function listPlugins(baseUrl: string): Promise<JsonObject> {
 // `available: true` (only installed CLIs) so the outer agent doesn't
 // pick an agent it can't actually run — the failure mode that left us
 // with zombie "running" runs whose inner Claude binary never spawned.
-// Models are truncated to 10 with `modelsCount` carrying the full
-// total; that keeps the response token-economical even for agents
-// (e.g. opencode) that expose 100+ models.
+// Compatibility is intentionally complete. Truncating this surface made a
+// valid exact model indistinguishable from an unsupported one.
 async function listAgents(baseUrl: string, includeUnavailable: boolean): Promise<JsonObject> {
   const raw = await getJson<{ agents?: JsonObject[] }>(`${baseUrl}/api/agents`);
   const all = raw?.agents ?? [];
   const filtered = includeUnavailable
     ? all
     : all.filter((a) => a?.available === true);
-  const MAX_MODELS = 10;
   const agents = filtered.map((a) => {
     const models = Array.isArray(a?.models) ? (a.models as unknown[]) : [];
+    const usesAuthoritativeCodexAuth =
+      a?.id === 'codex' && typeof a?.chatgptAuthStatus === 'string';
+    const authStatus = usesAuthoritativeCodexAuth
+      ? a?.chatgptAuthStatus
+      : a?.authStatus;
+    const authMessage = usesAuthoritativeCodexAuth
+      ? a?.chatgptAuthMessage
+      : a?.authMessage;
     const out: JsonObject = {
       id: a?.id,
       name: a?.name,
-      models: models.slice(0, MAX_MODELS),
+      models,
       modelsCount: models.length,
     };
     if (typeof a?.version === 'string' && a.version.length > 0) out.version = a.version;
+    if (typeof authStatus === 'string') out.authStatus = authStatus;
+    if (typeof authMessage === 'string') out.authMessage = authMessage;
+    if (typeof a?.chatgptAuthStatus === 'string') {
+      out.chatgptAuthStatus = a.chatgptAuthStatus;
+    }
+    if (typeof a?.chatgptAuthMessage === 'string') {
+      out.chatgptAuthMessage = a.chatgptAuthMessage;
+    }
+    if (typeof a?.modelsSource === 'string') out.modelsSource = a.modelsSource;
     if (includeUnavailable) {
       out.available = Boolean(a?.available);
       if (typeof a?.installUrl === 'string') out.installUrl = a.installUrl;
@@ -2543,15 +2545,14 @@ async function startRun(
   if (Array.isArray(args.skills) && args.skills.length > 0) body.skillIds = args.skills;
   if (typeof args.plugin === 'string' && args.plugin.length > 0) body.pluginId = args.plugin;
   if (typeof args.agent === 'string' && args.agent.length > 0) body.agentId = args.agent;
+  // Every external-MCP Codex run is the official Local Codex route. The
+  // daemon enforces this only when the resolved runtime is Codex, so callers
+  // that omit agent and resolve to another local runtime remain unchanged.
+  body.codexAuthMode = 'chatgpt';
   if (typeof args.model === 'string' && args.model.length > 0) body.model = args.model;
   if (args.reasoning !== undefined) {
-    if (
-      typeof args.reasoning !== 'string'
-      || !MCP_REASONING_OPTIONS.includes(
-        args.reasoning as (typeof MCP_REASONING_OPTIONS)[number],
-      )
-    ) {
-      throw new Error('reasoning must be a supported reasoning effort');
+    if (typeof args.reasoning !== 'string') {
+      throw new Error('reasoning must be a string');
     }
     body.reasoning = args.reasoning;
   }

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -90,7 +90,7 @@ interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string;
 interface ActiveContext { active?: boolean; projectId?: string; projectName?: string | null; fileName?: string | null; ageMs?: number | null }
 type ResolvedProject = { id: string; name: string; source: 'uuid' | 'id' | 'exact' | 'slug' | 'substring' };
 interface ProjectListCache { baseUrl: string; t: number; list: ProjectSummary[] }
-interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown; prompt?: unknown; plugin?: unknown; inputs?: unknown; agent?: unknown; model?: unknown; serviceTier?: unknown; apiKey?: unknown; requestId?: unknown; resume?: unknown; runId?: unknown; id?: unknown; designSystem?: unknown; skill?: unknown; skills?: string[]; includeUnavailable?: unknown; artifactType?: unknown; projectTitle?: unknown; locale?: unknown; knownAnswers?: unknown; skip?: unknown; briefDraftId?: unknown; nonce?: unknown; answers?: unknown; externalPluginContext?: unknown; pluginWorkflowId?: unknown }
+interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown; prompt?: unknown; plugin?: unknown; inputs?: unknown; agent?: unknown; model?: unknown; reasoning?: unknown; serviceTier?: unknown; apiKey?: unknown; requestId?: unknown; resume?: unknown; runId?: unknown; id?: unknown; designSystem?: unknown; skill?: unknown; skills?: string[]; includeUnavailable?: unknown; artifactType?: unknown; projectTitle?: unknown; locale?: unknown; knownAnswers?: unknown; skip?: unknown; briefDraftId?: unknown; nonce?: unknown; answers?: unknown; externalPluginContext?: unknown; pluginWorkflowId?: unknown }
 interface ProjectFileBundleEntry { name: string; mime: string; size: number | null; content: string | null; binary: boolean }
 interface BundleInput { project: ProjectPayload | ProjectSummary; entry: string; files: ProjectFileBundleEntry[]; truncated: boolean; skippedFileCount?: number; active: ActiveContext | null; resolved?: ResolvedProject | null }
 interface ErrorWithCode { message?: string; code?: string; cause?: { code?: string } }
@@ -127,6 +127,17 @@ const SAFE_MCP_DAEMON_RETRY_CALLS = new Set([
   'read_resource',
   'search_files',
 ]);
+const MCP_REASONING_OPTIONS = [
+  'default',
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+] as const;
 
 function normalizeDaemonUrl(value: string | URL): string {
   return String(value).replace(/\/$/, '');
@@ -774,9 +785,14 @@ export const TOOL_DEFS = [
           type: 'string',
           description: 'Model id override for the run. Optional.',
         },
+        reasoning: {
+          type: 'string',
+          enum: [...MCP_REASONING_OPTIONS],
+          description: 'Reasoning effort override for the selected model. Optional.',
+        },
         serviceTier: {
           type: 'string',
-          description: "Service tier override for the selected model, e.g. 'priority' for Codex Fast. Optional.",
+          description: "Service tier override for the selected model, e.g. 'fast' for Codex Fast. Optional.",
         },
         requestId: {
           type: 'string',
@@ -2528,6 +2544,17 @@ async function startRun(
   if (typeof args.plugin === 'string' && args.plugin.length > 0) body.pluginId = args.plugin;
   if (typeof args.agent === 'string' && args.agent.length > 0) body.agentId = args.agent;
   if (typeof args.model === 'string' && args.model.length > 0) body.model = args.model;
+  if (args.reasoning !== undefined) {
+    if (
+      typeof args.reasoning !== 'string'
+      || !MCP_REASONING_OPTIONS.includes(
+        args.reasoning as (typeof MCP_REASONING_OPTIONS)[number],
+      )
+    ) {
+      throw new Error('reasoning must be a supported reasoning effort');
+    }
+    body.reasoning = args.reasoning;
+  }
   if (typeof args.serviceTier === 'string' && args.serviceTier.length > 0) {
     body.serviceTier = args.serviceTier;
   }

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -33,7 +33,10 @@ import {
 import { isSafeId as isSafeProjectId } from '../projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { proxyDispatcherRequestInit, validateUserProviderBaseUrl } from '../connectionTest.js';
-import { resolveModelForServiceTier } from '../runtimes/models.js';
+import {
+  isKnownReasoning,
+  resolveModelForServiceTier,
+} from '../runtimes/models.js';
 import { googleStreamGenerateContentUrl } from '../integrations/google-models.js';
 import { createRoleMarkerGuard } from '../role-marker-guard.js';
 import { authorizeReasoningEgress, sendReasoningEgressDenial } from '../reasoning-egress.js';
@@ -371,11 +374,14 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
           }
           const safeReasoning =
             def &&
-            typeof body.reasoning === 'string' &&
-            Array.isArray(def.reasoningOptions)
-              ? (def.reasoningOptions.find((r: any) => r.id === body.reasoning)?.id ?? undefined)
+            typeof body.reasoning === 'string'
+              ? def.id === 'codex'
+                ? body.reasoning
+                : Array.isArray(def.reasoningOptions)
+                  ? (def.reasoningOptions.find((r: any) => r.id === body.reasoning)?.id ?? undefined)
+                  : undefined
               : undefined;
-          safeModel = def
+          safeModel = def && def.id !== 'codex'
             ? resolveModelForServiceTier(
                 def,
                 safeModel,
@@ -388,6 +394,31 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
             isKnownServiceTier(def, safeModel, body.serviceTier)
               ? body.serviceTier
               : undefined;
+          const explicitCodexReasoningUnsupported =
+            def?.id === 'codex'
+            && typeof body.reasoning === 'string'
+            && body.reasoning.length > 0
+            && body.reasoning !== 'default'
+            && !isKnownReasoning(def, safeModel, body.reasoning);
+          const explicitCodexTierUnsupported =
+            def?.id === 'codex'
+            && typeof body.serviceTier === 'string'
+            && body.serviceTier.length > 0
+            && body.serviceTier !== 'default'
+            && !safeServiceTier;
+          if (explicitCodexReasoningUnsupported || explicitCodexTierUnsupported) {
+            const setting = explicitCodexReasoningUnsupported
+              ? `reasoning effort '${body.reasoning}'`
+              : `service tier '${body.serviceTier}'`;
+            return res.json({
+              ok: false,
+              kind: 'not_found_model',
+              latencyMs: Date.now() - testStart,
+              model: safeModel ?? 'default',
+              agentName: def.name,
+              detail: `The exact Codex model '${safeModel ?? 'default'}' does not advertise ${setting}. Select an exact compatible model and retry.`,
+            });
+          }
           const result = await testAgentConnection({
             agentId: body.agentId,
             model: safeModel ?? undefined,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -39,10 +39,12 @@ import {
   type WorkspaceResourceAccessInput,
 } from '../collab/workspace-resource-mutation.js';
 import {
+  codexResolvedRunFinishedProperties,
   codexSessionIdFromRunEvents,
   readCodexRolloutFirstCall,
   type CodexFirstCallUsage,
 } from '../codex-rollout-usage.js';
+import { resolveCodexHomePath } from '../codex-config-normalize.js';
 import type { ConnectorService } from '../connectors/service.js';
 import {
   conversationTurnIndexForRun,
@@ -917,14 +919,15 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     try {
       const sessionId = codexSessionIdFromRunEvents(run.events);
       const config = appConfig ?? await readAppConfig(RUNTIME_DATA_DIR);
-      const codexHome = spawnEnvForAgent(
+      const codexEnv = spawnEnvForAgent(
         'codex',
         { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
         agentCliEnvForAgent(
           (config as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
           'codex',
         ),
-      ).CODEX_HOME;
+      );
+      const codexHome = resolveCodexHomePath(codexEnv);
       return await readCodexRolloutFirstCall({ codexHome, sessionId });
     } catch {
       return null;
@@ -2484,6 +2487,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
                     typeof reqBody.reasoning === 'string' ? reqBody.reasoning : 'default',
                   requested_service_tier:
                     typeof reqBody.serviceTier === 'string' ? reqBody.serviceTier : 'default',
+                  ...codexResolvedRunFinishedProperties(firstCallUsage),
                 }
               : {}),
             artifact_count: artifactCount,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -41,6 +41,7 @@ import {
 import {
   codexSessionIdFromRunEvents,
   readCodexRolloutFirstCall,
+  type CodexFirstCallUsage,
 } from '../codex-rollout-usage.js';
 import type { ConnectorService } from '../connectors/service.js';
 import {
@@ -327,6 +328,12 @@ interface ChatRun {
   deliverableArtifactKind?: ChatRunStatusResponse['deliverableArtifactKind'];
   analyticsTelemetry?: RunTelemetryTimestamps;
   resolvedModelId?: string | null;
+  executedModelId?: string | null;
+  executedReasoning?: string | null;
+  executedServiceTier?: string | null;
+  executionEvidenceSource?: string | null;
+  reasoning?: string | null;
+  serviceTier?: string | null;
   preflightAgentCliVersion?: string | null;
   // E-lite root-cause telemetry read at run_finished. `stdinBackpressure`: the
   // prompt write to child stdin was queued (pipe buffer full). `lastAgentActivityAt`:
@@ -408,6 +415,12 @@ interface ChatRunService {
     insertId: string;
   }): void;
   markAnalyticsCompleted?(run: ChatRun): void;
+  setExecutionEvidence?(run: ChatRun, evidence: {
+    model?: string;
+    reasoning?: string;
+    serviceTier?: string;
+    source: 'codex_rollout_turn_context';
+  }): void;
   setDeliverableValidation?(
     run: ChatRun,
     result: RunDeliverableValidationResult,
@@ -895,6 +908,48 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     pinAssistantMessageOnRunCreate,
     reconcileAssistantMessageOnRunEnd,
   } = ctx.messages;
+
+  async function readCodexExecutionEvidence(
+    run: ChatRun,
+    appConfig?: Record<string, unknown>,
+  ): Promise<CodexFirstCallUsage | null> {
+    if (run.agentId !== 'codex') return null;
+    try {
+      const sessionId = codexSessionIdFromRunEvents(run.events);
+      const config = appConfig ?? await readAppConfig(RUNTIME_DATA_DIR);
+      const codexHome = spawnEnvForAgent(
+        'codex',
+        { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
+        agentCliEnvForAgent(
+          (config as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+          'codex',
+        ),
+      ).CODEX_HOME;
+      return await readCodexRolloutFirstCall({ codexHome, sessionId });
+    } catch {
+      return null;
+    }
+  }
+
+  function persistCodexExecutionEvidence(
+    run: ChatRun,
+    evidence: Pick<
+      CodexFirstCallUsage,
+      'resolved_model_id' | 'resolved_reasoning_effort' | 'resolved_service_tier'
+    > | null,
+  ): void {
+    if (!evidence) return;
+    design.runs.setExecutionEvidence?.(run, {
+      ...(evidence.resolved_model_id ? { model: evidence.resolved_model_id } : {}),
+      ...(evidence.resolved_reasoning_effort
+        ? { reasoning: evidence.resolved_reasoning_effort }
+        : {}),
+      ...(evidence.resolved_service_tier
+        ? { serviceTier: evidence.resolved_service_tier }
+        : {}),
+      source: 'codex_rollout_turn_context',
+    });
+  }
 
   /** Authorize every bound run mutation before plugin or snapshot resolution. */
   async function authorizeRunProjectBeforePluginResolution(
@@ -2223,22 +2278,19 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           first_call_cache_read_input_tokens?: number;
           first_call_cache_creation_input_tokens?: number;
           first_call_cache_hit_ratio?: number;
+          resolved_model_id?: string;
+          resolved_reasoning_effort?: string;
+          resolved_service_tier?: string;
         } | null> => {
           if (run.agentId === 'codex') {
             // Best-effort: a throw anywhere here (env resolution, rollout read)
             // must degrade to "no codex first-call fields", never bubble to the
             // outer run_finished .catch and drop the whole completion event.
             try {
-              const sessionId = codexSessionIdFromRunEvents(run.events);
-              const codexHome = spawnEnvForAgent(
-                'codex',
-                { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
-                agentCliEnvForAgent(
-                  (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
-                  'codex',
-                ),
-              ).CODEX_HOME;
-              const codexUsage = await readCodexRolloutFirstCall({ codexHome, sessionId });
+              const codexUsage = await readCodexExecutionEvidence(
+                run,
+                appCfgAtFinish as Record<string, unknown>,
+              );
               return codexUsage
                 ? {
                     ...codexUsage,
@@ -2276,6 +2328,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
               : {}),
           };
         })();
+        if (run.agentId === 'codex') {
+          persistCodexExecutionEvidence(run, firstCallUsage);
+        }
         const analyticsCapturedAt = Date.now();
         const timingAnalytics = summarizeRunTimingAnalytics({
           runCreatedAt: run.createdAt,
@@ -2365,11 +2420,13 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           firstTokenSeen: Boolean(run.analyticsTelemetry?.firstTokenAt),
           artifactWriteSeen: artifactCount > 0 || designSystemCreated || previewModuleCount > 0,
         });
-        const finishedModelId = hasExplicitRequestedModelForAnalytics(reqBody.model)
-          ? modelIdForTracking(reqBody.model)
-          : modelIdForTracking(
-              usageAnalytics.agent_reported_model ?? run.resolvedModelId,
-            );
+        const finishedModelId = run.agentId === 'codex'
+          ? firstCallUsage?.resolved_model_id ?? 'unconfirmed'
+          : hasExplicitRequestedModelForAnalytics(reqBody.model)
+            ? modelIdForTracking(reqBody.model)
+            : modelIdForTracking(
+                usageAnalytics.agent_reported_model ?? run.resolvedModelId,
+              );
         const runtimeVersions = getDetectedRuntimeVersions(run.agentId);
         const agentCliVersion =
           run.preflightAgentCliVersion ?? runtimeVersions?.agentCliVersion;
@@ -2415,6 +2472,20 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             result,
             ...(activationMilestones ? { $set_once: activationMilestones } : {}),
             model_id: finishedModelId,
+            ...(run.agentId === 'codex'
+              ? {
+                  model_evidence_source: firstCallUsage?.resolved_model_id
+                    ? 'codex_rollout_turn_context'
+                    : 'unconfirmed',
+                  requested_model_id: modelIdForTracking(
+                    typeof reqBody.model === 'string' ? reqBody.model : null,
+                  ),
+                  requested_reasoning_effort:
+                    typeof reqBody.reasoning === 'string' ? reqBody.reasoning : 'default',
+                  requested_service_tier:
+                    typeof reqBody.serviceTier === 'string' ? reqBody.serviceTier : 'default',
+                }
+              : {}),
             artifact_count: artifactCount,
             ...(run.externalPluginAnalytics
               ? {
@@ -2791,6 +2862,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     const run = design.runs.get(runId);
     if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
     if (!await authorizeRunProject(req, res, run, { mode: 'read' })) return;
+    if (design.runs.isTerminal(run.status) && run.agentId === 'codex') {
+      persistCodexExecutionEvidence(run, await readCodexExecutionEvidence(run));
+    }
     const status = design.runs.statusBody(run);
     if (!design.runs.isTerminal(run.status)) {
       res.json(status);

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -439,7 +439,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
 
     if (!wantsStream) {
       try {
-        const list = await detectAgents(agentCliEnv);
+        const list = await detectAgents(agentCliEnv, { effectiveCwd: PROJECT_ROOT });
         res.json({ agents: list });
       } catch (err: any) {
         res.status(500).json({ error: String(err) });
@@ -462,7 +462,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       aborted = true;
     });
     try {
-      for await (const agent of detectAgentsStream(agentCliEnv)) {
+      for await (const agent of detectAgentsStream(agentCliEnv, { effectiveCwd: PROJECT_ROOT })) {
         if (aborted) break;
         res.write(`event: agent\ndata: ${JSON.stringify(agent)}\n\n`);
       }

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -1,10 +1,17 @@
 import { execAgentFile } from './invocation.js';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import {
+  extractCodexProviderEnvKey,
   readCodexProviderEnvKey,
   resolveCodexConfigPath,
 } from '../codex-config-normalize.js';
-import { extractCodexRootModelConfig } from './codex-model-preflight.js';
+import {
+  extractCodexRootModelConfig,
+  findCodexProjectConfigPaths,
+  hasMacManagedConfigPreference,
+  resolveCodexManagedConfigPaths,
+  resolveCodexSystemConfigPath,
+} from './codex-model-preflight.js';
 import type { RuntimeAgentDef, RuntimeEnv } from './types.js';
 
 export type AgentAuthProbeResult = {
@@ -89,9 +96,14 @@ export function codexChatGptAuthGuidance(): string {
   return 'Local Codex through the official Open Design MCP route requires an existing ChatGPT/Codex login. Run `codex login`, confirm `codex login status` says `Logged in using ChatGPT`, then retry. API keys and custom providers are intentionally not accepted for this route.';
 }
 
+export function codexChatGptConfigInspectionGuidance(): string {
+  return 'Local Codex could not verify every effective Codex configuration layer. Repair permissions or remove the unreadable Codex configuration, then retry the official ChatGPT-backed route.';
+}
+
 export type CodexChatGptRoutePolicy = {
   allowed: boolean;
   providerEnvKey: string | null;
+  reason: 'custom_provider_not_allowed' | 'config_inspection_failed' | null;
 };
 
 /**
@@ -101,25 +113,54 @@ export type CodexChatGptRoutePolicy = {
  */
 export async function inspectCodexChatGptRoutePolicy(
   env: RuntimeEnv,
+  effectiveCwd?: string | null,
 ): Promise<CodexChatGptRoutePolicy> {
-  const providerEnvKey = await readCodexProviderEnvKey(env);
-  let hasUnverifiedProviderConfig = false;
-  try {
-    const config = await readFile(resolveCodexConfigPath(env), 'utf8');
+  const projectConfigPaths = await findCodexProjectConfigPaths(effectiveCwd);
+  if (projectConfigPaths === null) {
+    return { allowed: false, providerEnvKey: null, reason: 'config_inspection_failed' };
+  }
+  const managedPaths = resolveCodexManagedConfigPaths(env);
+  const configPaths = new Set([
+    resolveCodexConfigPath(env),
+    resolveCodexSystemConfigPath(env),
+    ...managedPaths.readable,
+    ...projectConfigPaths,
+  ]);
+  let providerEnvKey: string | null = null;
+  for (const configPath of configPaths) {
+    let config: string;
+    try {
+      config = await readFile(configPath, 'utf8');
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+      return { allowed: false, providerEnvKey, reason: 'config_inspection_failed' };
+    }
+    providerEnvKey ??= extractCodexProviderEnvKey(config);
     const configured = extractCodexRootModelConfig(config);
-    hasUnverifiedProviderConfig = Boolean(
+    if (
       (configured.modelProvider
         && configured.modelProvider.toLowerCase() !== 'openai')
-      || configured.hasCompatibilityOverlay,
-    );
-  } catch {
-    // Missing config is the normal ChatGPT-backed case. The login and live
-    // catalog probes remain authoritative for readiness.
+      || configured.hasCompatibilityOverlay
+    ) {
+      return { allowed: false, providerEnvKey, reason: 'custom_provider_not_allowed' };
+    }
   }
-  return {
-    allowed: !providerEnvKey && !hasUnverifiedProviderConfig,
-    providerEnvKey,
-  };
+  for (const configPath of managedPaths.opaque) {
+    try {
+      await stat(configPath);
+      return { allowed: false, providerEnvKey, reason: 'custom_provider_not_allowed' };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        return { allowed: false, providerEnvKey, reason: 'config_inspection_failed' };
+      }
+    }
+  }
+  if (await hasMacManagedConfigPreference(env)) {
+    return { allowed: false, providerEnvKey, reason: 'custom_provider_not_allowed' };
+  }
+  return { allowed: true, providerEnvKey, reason: null };
 }
 
 export function isCursorAuthFailureText(text: string): boolean {
@@ -484,6 +525,7 @@ export async function probeCodexChatGptAuthStatus(
   def: Pick<RuntimeAgentDef, 'id' | 'name' | 'authProbe'>,
   resolvedBin: string,
   env: RuntimeEnv,
+  effectiveCwd?: string | null,
 ): Promise<AgentAuthProbeResult | null> {
   if (def.id !== 'codex' || !def.authProbe) return null;
   try {
@@ -492,6 +534,7 @@ export async function probeCodexChatGptAuthStatus(
       def.authProbe.args,
       {
         env,
+        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
         timeout: def.authProbe.timeoutMs ?? 5000,
         maxBuffer: 1024 * 1024,
       },

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -80,6 +80,10 @@ export function claudeAuthGuidance(): string {
   return CLAUDE_AUTH_GUIDANCE;
 }
 
+export function codexChatGptAuthGuidance(): string {
+  return 'Local Codex through the official Open Design MCP route requires an existing ChatGPT/Codex login. Run `codex login`, confirm `codex login status` says `Logged in using ChatGPT`, then retry. API keys and custom providers are intentionally not accepted for this route.';
+}
+
 export function isCursorAuthFailureText(text: string): boolean {
   const value = String(text || '');
   if (!value.trim()) return false;
@@ -426,6 +430,69 @@ export async function probeAgentAuthStatus(
         message: `${def.name || def.id} authentication status could not be verified with \`${def.id} ${probe.args.join(' ')}\`.`,
         exitCode: numericExit,
         signal: childSignal,
+      },
+      stdoutText,
+      stderrText,
+    );
+  }
+}
+
+/**
+ * Probe the subscription-backed account path without honoring the generic
+ * Codex API-key/custom-provider shortcuts above. A successful process exit is
+ * insufficient: only the CLI's explicit ChatGPT status is authoritative.
+ */
+export async function probeCodexChatGptAuthStatus(
+  def: Pick<RuntimeAgentDef, 'id' | 'name' | 'authProbe'>,
+  resolvedBin: string,
+  env: RuntimeEnv,
+): Promise<AgentAuthProbeResult | null> {
+  if (def.id !== 'codex' || !def.authProbe) return null;
+  try {
+    const { stdout, stderr } = await execAgentFile(
+      resolvedBin,
+      def.authProbe.args,
+      {
+        env,
+        timeout: def.authProbe.timeoutMs ?? 5000,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    const stdoutText = typeof stdout === 'string' ? stdout : '';
+    const stderrText = typeof stderr === 'string' ? stderr : '';
+    const output = `${stdoutText}\n${stderrText}`;
+    if (/\bLogged in using ChatGPT\b/i.test(output)) {
+      return withProbeTails(
+        { status: 'ok', exitCode: 0, signal: null },
+        stdoutText,
+        stderrText,
+      );
+    }
+    return withProbeTails(
+      {
+        status: 'missing',
+        message: codexChatGptAuthGuidance(),
+        exitCode: 0,
+        signal: null,
+      },
+      stdoutText,
+      stderrText,
+    );
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & {
+      stdout?: unknown;
+      stderr?: unknown;
+      code?: string | number;
+      signal?: string;
+    };
+    const stdoutText = typeof err.stdout === 'string' ? err.stdout : '';
+    const stderrText = typeof err.stderr === 'string' ? err.stderr : '';
+    return withProbeTails(
+      {
+        status: 'missing',
+        message: codexChatGptAuthGuidance(),
+        exitCode: typeof err.code === 'number' ? err.code : null,
+        signal: typeof err.signal === 'string' ? err.signal : null,
       },
       stdoutText,
       stderrText,

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -1,5 +1,10 @@
 import { execAgentFile } from './invocation.js';
-import { readCodexProviderEnvKey } from '../codex-config-normalize.js';
+import { readFile } from 'node:fs/promises';
+import {
+  readCodexProviderEnvKey,
+  resolveCodexConfigPath,
+} from '../codex-config-normalize.js';
+import { extractCodexRootModelConfig } from './codex-model-preflight.js';
 import type { RuntimeAgentDef, RuntimeEnv } from './types.js';
 
 export type AgentAuthProbeResult = {
@@ -82,6 +87,39 @@ export function claudeAuthGuidance(): string {
 
 export function codexChatGptAuthGuidance(): string {
   return 'Local Codex through the official Open Design MCP route requires an existing ChatGPT/Codex login. Run `codex login`, confirm `codex login status` says `Logged in using ChatGPT`, then retry. API keys and custom providers are intentionally not accepted for this route.';
+}
+
+export type CodexChatGptRoutePolicy = {
+  allowed: boolean;
+  providerEnvKey: string | null;
+};
+
+/**
+ * Decide whether the current Codex config can be proven to use the official
+ * ChatGPT account path. Unknown provider/profile/endpoint overlays fail
+ * closed because the strict child cannot safely inherit them.
+ */
+export async function inspectCodexChatGptRoutePolicy(
+  env: RuntimeEnv,
+): Promise<CodexChatGptRoutePolicy> {
+  const providerEnvKey = await readCodexProviderEnvKey(env);
+  let hasUnverifiedProviderConfig = false;
+  try {
+    const config = await readFile(resolveCodexConfigPath(env), 'utf8');
+    const configured = extractCodexRootModelConfig(config);
+    hasUnverifiedProviderConfig = Boolean(
+      (configured.modelProvider
+        && configured.modelProvider.toLowerCase() !== 'openai')
+      || configured.hasCompatibilityOverlay,
+    );
+  } catch {
+    // Missing config is the normal ChatGPT-backed case. The login and live
+    // catalog probes remain authoritative for readiness.
+  }
+  return {
+    allowed: !providerEnvKey && !hasUnverifiedProviderConfig,
+    providerEnvKey,
+  };
 }
 
 export function isCursorAuthFailureText(text: string): boolean {

--- a/apps/daemon/src/runtimes/codex-model-preflight.ts
+++ b/apps/daemon/src/runtimes/codex-model-preflight.ts
@@ -223,15 +223,17 @@ async function pathState(filePath: string): Promise<'present' | 'missing' | 'unc
   }
 }
 
-async function projectConfigExists(projectCwd: string | null | undefined): Promise<boolean> {
-  if (!projectCwd) return false;
+export async function findCodexProjectConfigPaths(
+  projectCwd: string | null | undefined,
+): Promise<string[] | null> {
+  if (!projectCwd) return [];
   let start: string;
   try {
     // Node/Codex resolves the child cwd physically. Scan that same path so a
     // symlinked imported workspace cannot hide its real repository config.
     start = await realpath(path.resolve(projectCwd));
   } catch {
-    return true;
+    return null;
   }
   const ancestors: string[] = [];
   let current = start;
@@ -244,7 +246,7 @@ async function projectConfigExists(projectCwd: string | null | undefined): Promi
   while (true) {
     ancestors.push(current);
     const gitState = await pathState(path.join(current, '.git'));
-    if (gitState === 'uncertain') return true;
+    if (gitState === 'uncertain') return null;
     if (gitState === 'present') {
       gitRoot = current;
       break;
@@ -257,11 +259,19 @@ async function projectConfigExists(projectCwd: string | null | undefined): Promi
   const searchDirs = gitRoot
     ? ancestors.slice(0, ancestors.indexOf(gitRoot) + 1)
     : [start];
-  for (const dir of searchDirs) {
-    const configState = await pathState(path.join(dir, '.codex', 'config.toml'));
-    if (configState !== 'missing') return true;
+  const configPaths: string[] = [];
+  for (const dir of searchDirs.reverse()) {
+    const configPath = path.join(dir, '.codex', 'config.toml');
+    const configState = await pathState(configPath);
+    if (configState === 'uncertain') return null;
+    if (configState === 'present') configPaths.push(configPath);
   }
-  return false;
+  return configPaths;
+}
+
+async function projectConfigExists(projectCwd: string | null | undefined): Promise<boolean> {
+  const paths = await findCodexProjectConfigPaths(projectCwd);
+  return paths === null || paths.length > 0;
 }
 
 const AUTH_OR_ENDPOINT_ENV_KEYS = new Set([
@@ -296,10 +306,10 @@ function envValueCaseInsensitive(
   return matched?.trim() || null;
 }
 
-async function hasSystemConfigLayer(
+export function resolveCodexSystemConfigPath(
   env: NodeJS.ProcessEnv,
-): Promise<boolean> {
-  const configPath = process.platform === 'win32'
+): string {
+  return process.platform === 'win32'
     ? path.join(
         envValueCaseInsensitive(env, 'PROGRAMDATA') ?? 'C:\\ProgramData',
         'OpenAI',
@@ -307,10 +317,15 @@ async function hasSystemConfigLayer(
         'config.toml',
       )
     : '/etc/codex/config.toml';
-  return await pathState(configPath) !== 'missing';
 }
 
-async function hasMacManagedConfigPreference(
+async function hasSystemConfigLayer(
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  return await pathState(resolveCodexSystemConfigPath(env)) !== 'missing';
+}
+
+export async function hasMacManagedConfigPreference(
   env: NodeJS.ProcessEnv,
 ): Promise<boolean> {
   if (process.platform !== 'darwin') return false;
@@ -363,19 +378,29 @@ async function hasMacManagedConfigPreference(
   return macManagedConfigProbe;
 }
 
-async function hasManagedConfigLayer(env: NodeJS.ProcessEnv): Promise<boolean> {
+export function resolveCodexManagedConfigPaths(env: NodeJS.ProcessEnv): {
+  readable: string[];
+  opaque: string[];
+} {
   const configDir = path.dirname(resolveCodexConfigPath(env));
-  const candidates = [
+  const readable = [
     path.join(configDir, 'managed_config.toml'),
+  ];
+  const opaque = [
     // Codex stores fetched enterprise config bundles here. We do not parse the
     // signed payload or assume it is current; presence alone means a non-user
     // layer may affect the effective provider or endpoint, so fail open.
     path.join(configDir, 'cloud-config-bundle-cache.json'),
   ];
   if (process.platform !== 'win32') {
-    candidates.push('/etc/codex/managed_config.toml');
+    readable.push('/etc/codex/managed_config.toml');
   }
-  for (const candidate of candidates) {
+  return { readable, opaque };
+}
+
+async function hasManagedConfigLayer(env: NodeJS.ProcessEnv): Promise<boolean> {
+  const paths = resolveCodexManagedConfigPaths(env);
+  for (const candidate of [...paths.readable, ...paths.opaque]) {
     const state = await pathState(candidate);
     if (state !== 'missing') return true;
   }

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -137,33 +137,6 @@ const CODEX_5_6_REASONING_LEVELS = [
   'ultra',
 ];
 
-function assertCodexReasoningCompatibility(
-  modelId: string | null | undefined,
-  effort: string,
-): void {
-  const raw = String(modelId ?? '').trim();
-  const id = (raw.includes('/') ? raw.split('/').pop() : raw)?.toLowerCase() ?? '';
-  let supported: readonly string[] | null = null;
-  if (id.startsWith('gpt-5.6-')) {
-    supported = CODEX_5_6_REASONING_LEVELS;
-  } else if (
-    id.startsWith('gpt-5.2')
-    || id.startsWith('gpt-5.3')
-    || id.startsWith('gpt-5.4')
-    || id.startsWith('gpt-5.5')
-    || id === 'codex-auto-review'
-  ) {
-    supported = CODEX_CURRENT_REASONING_LEVELS;
-  } else if (id === 'gpt-5.1-codex-mini') {
-    supported = ['medium', 'high'];
-  } else if (id === 'gpt-5.1') {
-    supported = ['none', 'minimal', 'low', 'medium', 'high'];
-  }
-  if (supported && !supported.includes(effort)) {
-    throw new Error(`Codex model '${raw}' does not support reasoning effort '${effort}'`);
-  }
-}
-
 export function codexNeedsDangerFullAccessSandbox(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
@@ -325,7 +298,6 @@ export const codexAgentDef = {
         args.push('--model', options.model);
       }
       if (options.reasoning && options.reasoning !== 'default') {
-        assertCodexReasoningCompatibility(options.model, options.reasoning);
         // Codex accepts `-c key=value` config overrides; reasoning effort
         // is exposed as `model_reasoning_effort`.
         args.push('-c', `model_reasoning_effort="${options.reasoning}"`);

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MODEL_OPTION, clampCodexReasoning } from './shared.js';
+import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeModelOption } from '../types.js';
 import type { RuntimeAgentDef } from '../types.js';
 
@@ -8,6 +8,17 @@ function parseCodexStringList(raw: unknown): string[] | undefined {
     .map((value) => (typeof value === 'string' ? value.trim() : ''))
     .filter(Boolean);
   return values.length > 0 ? values : undefined;
+}
+
+function parseCodexReasoningLevels(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const levels = raw.map((value) => {
+    if (typeof value === 'string') return value.trim();
+    if (!value || typeof value !== 'object') return '';
+    const effort = (value as { effort?: unknown }).effort;
+    return typeof effort === 'string' ? effort.trim() : '';
+  }).filter(Boolean);
+  return levels.length > 0 ? [...new Set(levels)] : undefined;
 }
 
 function parseCodexServiceTiers(raw: unknown): RuntimeModelOption[] | undefined {
@@ -36,7 +47,7 @@ function parseCodexServiceTiers(raw: unknown): RuntimeModelOption[] | undefined 
 }
 
 const CODEX_SPEED_TIER_SERVICE_TIER_OPTIONS: Record<string, RuntimeModelOption> = {
-  fast: { id: 'priority', label: 'Fast' },
+  fast: { id: 'fast', label: 'Fast' },
 };
 
 function parseCodexServiceTiersFromSpeedTiers(
@@ -79,6 +90,7 @@ export function parseCodexDebugModels(stdout: string): RuntimeModelOption[] | nu
       visibility?: unknown;
       additional_speed_tiers?: unknown;
       service_tiers?: unknown;
+      supported_reasoning_levels?: unknown;
     };
     if (entry.visibility === 'hidden') continue;
     const id =
@@ -100,6 +112,12 @@ export function parseCodexDebugModels(stdout: string): RuntimeModelOption[] | nu
       entry.additional_speed_tiers,
     );
     if (additionalSpeedTiers) model.additionalSpeedTiers = additionalSpeedTiers;
+    const supportedReasoningLevels = parseCodexReasoningLevels(
+      entry.supported_reasoning_levels,
+    );
+    if (supportedReasoningLevels) {
+      model.supportedReasoningLevels = supportedReasoningLevels;
+    }
     const serviceTierOptions =
       parseCodexServiceTiers(entry.service_tiers) ??
       parseCodexServiceTiersFromSpeedTiers(additionalSpeedTiers);
@@ -109,9 +127,42 @@ export function parseCodexDebugModels(stdout: string): RuntimeModelOption[] | nu
   return out.length > 1 ? out : null;
 }
 
-const GPT_5_5_SERVICE_TIER_OPTIONS: RuntimeModelOption[] = [
-  { id: 'priority', label: 'Fast' },
+const CODEX_FAST_SERVICE_TIER_OPTIONS: RuntimeModelOption[] = [
+  { id: 'fast', label: 'Fast' },
 ];
+const CODEX_CURRENT_REASONING_LEVELS = ['low', 'medium', 'high', 'xhigh'];
+const CODEX_5_6_REASONING_LEVELS = [
+  ...CODEX_CURRENT_REASONING_LEVELS,
+  'max',
+  'ultra',
+];
+
+function assertCodexReasoningCompatibility(
+  modelId: string | null | undefined,
+  effort: string,
+): void {
+  const raw = String(modelId ?? '').trim();
+  const id = (raw.includes('/') ? raw.split('/').pop() : raw)?.toLowerCase() ?? '';
+  let supported: readonly string[] | null = null;
+  if (id.startsWith('gpt-5.6-')) {
+    supported = CODEX_5_6_REASONING_LEVELS;
+  } else if (
+    id.startsWith('gpt-5.2')
+    || id.startsWith('gpt-5.3')
+    || id.startsWith('gpt-5.4')
+    || id.startsWith('gpt-5.5')
+    || id === 'codex-auto-review'
+  ) {
+    supported = CODEX_CURRENT_REASONING_LEVELS;
+  } else if (id === 'gpt-5.1-codex-mini') {
+    supported = ['medium', 'high'];
+  } else if (id === 'gpt-5.1') {
+    supported = ['none', 'minimal', 'low', 'medium', 'high'];
+  }
+  if (supported && !supported.includes(effort)) {
+    throw new Error(`Codex model '${raw}' does not support reasoning effort '${effort}'`);
+  }
+}
 
 export function codexNeedsDangerFullAccessSandbox(
   platform: NodeJS.Platform = process.platform,
@@ -146,10 +197,25 @@ export const codexAgentDef = {
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
       {
+        id: 'gpt-5.6-sol',
+        label: 'gpt-5.6-sol',
+        additionalSpeedTiers: ['fast'],
+        supportedReasoningLevels: CODEX_5_6_REASONING_LEVELS,
+        serviceTierOptions: CODEX_FAST_SERVICE_TIER_OPTIONS,
+      },
+      {
+        id: 'gpt-5.6-terra',
+        label: 'gpt-5.6-terra',
+        additionalSpeedTiers: ['fast'],
+        supportedReasoningLevels: CODEX_5_6_REASONING_LEVELS,
+        serviceTierOptions: CODEX_FAST_SERVICE_TIER_OPTIONS,
+      },
+      {
         id: 'gpt-5.5',
         label: 'gpt-5.5',
         additionalSpeedTiers: ['fast'],
-        serviceTierOptions: GPT_5_5_SERVICE_TIER_OPTIONS,
+        supportedReasoningLevels: CODEX_CURRENT_REASONING_LEVELS,
+        serviceTierOptions: CODEX_FAST_SERVICE_TIER_OPTIONS,
       },
       { id: 'gpt-5.4', label: 'gpt-5.4' },
       { id: 'gpt-5.4-mini', label: 'gpt-5.4-mini' },
@@ -169,6 +235,8 @@ export const codexAgentDef = {
       { id: 'medium', label: 'Medium' },
       { id: 'high', label: 'High' },
       { id: 'xhigh', label: 'XHigh' },
+      { id: 'max', label: 'Max' },
+      { id: 'ultra', label: 'Ultra' },
     ],
     // Prompt is delivered via stdin pipe (gated by `promptViaStdin: true`
     // below) to avoid Windows `spawn ENAMETOOLONG` while keeping Codex on
@@ -257,10 +325,10 @@ export const codexAgentDef = {
         args.push('--model', options.model);
       }
       if (options.reasoning && options.reasoning !== 'default') {
-        const effort = clampCodexReasoning(options.model, options.reasoning);
+        assertCodexReasoningCompatibility(options.model, options.reasoning);
         // Codex accepts `-c key=value` config overrides; reasoning effort
         // is exposed as `model_reasoning_effort`.
-        args.push('-c', `model_reasoning_effort="${effort}"`);
+        args.push('-c', `model_reasoning_effort="${options.reasoning}"`);
       }
       if (options.serviceTier && options.serviceTier !== 'default') {
         args.push('-c', `service_tier="${options.serviceTier}"`);

--- a/apps/daemon/src/runtimes/defs/shared.ts
+++ b/apps/daemon/src/runtimes/defs/shared.ts
@@ -6,28 +6,6 @@ import type { RuntimeModelOption } from '../types.js';
 
 export { detectAcpModels, parsePiModels, execAgentFile, DEFAULT_MODEL_OPTION };
 
-export function clampCodexReasoning(
-  modelId: string | null | undefined,
-  effort: string | null | undefined,
-) {
-  if (!effort) return effort;
-  const raw = String(modelId ?? '').trim();
-  const id = raw.includes('/') ? raw.split('/').pop() : raw;
-  const isGpt5LateFamily =
-    !id ||
-    id === 'default' ||
-    id.startsWith('gpt-5.2') ||
-    id.startsWith('gpt-5.3') ||
-    id.startsWith('gpt-5.4') ||
-    id.startsWith('gpt-5.5');
-  if (isGpt5LateFamily && effort === 'minimal') return 'low';
-  if (id === 'gpt-5.1' && effort === 'xhigh') return 'high';
-  if (id === 'gpt-5.1-codex-mini') {
-    return effort === 'high' || effort === 'xhigh' ? 'high' : 'medium';
-  }
-  return effort;
-}
-
 // Parse one-id-per-line stdout from `<cli> models` and prepend the synthetic
 // default option. Used by opencode / cursor-agent.
 export function parseLineSeparatedModels(stdout: string): RuntimeModelOption[] {

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -1,6 +1,7 @@
 import { execAgentFile } from './invocation.js';
 import { AGENT_DEFS } from './registry.js';
 import {
+  CODEX_CHATGPT_MODEL_SCOPE,
   DEFAULT_MODEL_OPTION,
   clearRememberedLiveModels,
   getRememberedLiveModels,
@@ -10,6 +11,8 @@ import {
 import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
 import { spawnEnvForAgent } from './env.js';
 import {
+  codexChatGptAuthGuidance,
+  inspectCodexChatGptRoutePolicy,
   probeAgentAuthStatus,
   probeCodexChatGptAuthStatus,
 } from './auth.js';
@@ -286,25 +289,56 @@ async function probe(
   // so a single agent's detection wall is max(help, models, auth) ≈ 5s rather
   // than the sum ≈ 15s. `--help` capabilities are cached on `agentCapabilities`
   // for buildArgs to consult.
+  const chatgptPolicy = def.id === 'codex'
+    ? await inspectCodexChatGptRoutePolicy(probeEnv)
+    : null;
   const chatgptProbeEnv = def.id === 'codex'
-    ? spawnEnvForAgent(
-        'codex',
-        probeEnv,
-        {},
-        {},
-        { codexAuthMode: 'chatgpt' },
+    ? applyAgentLaunchEnv(
+        spawnEnvForAgent(
+          'codex',
+          probeEnv,
+          {},
+          {},
+          {
+            codexAuthMode: 'chatgpt',
+            codexProviderEnvKey: chatgptPolicy?.providerEnvKey ?? null,
+          },
+        ),
+        launch,
       )
     : probeEnv;
-  const [caps, modelResult, auth, chatgptAuth, amrOpenCodeVersion] = await Promise.all([
+  const unavailableChatGptModels = {
+    models: [] as RuntimeModelOption[],
+    source: 'unavailable' as const,
+  };
+  const [caps, modelResult, auth, chatgptAuth, chatgptModelResult, amrOpenCodeVersion] = await Promise.all([
     probeCapabilities(def, launch.launchPath, probeEnv),
     fetchModels(def, launch.launchPath, probeEnv),
     probeAgentAuthStatus(def, launch.launchPath, probeEnv),
     def.id === 'codex'
       ? probeCodexChatGptAuthStatus(def, launch.launchPath, chatgptProbeEnv)
       : Promise.resolve(null),
+    def.id === 'codex' && chatgptPolicy?.allowed
+      ? fetchModels(def, launch.launchPath, chatgptProbeEnv).then((result) =>
+          result.source === 'live'
+            ? { models: result.models, source: 'live' as const }
+            : unavailableChatGptModels,
+        )
+      : Promise.resolve(unavailableChatGptModels),
     probeAmrOpenCodeVersion(def, probeEnv),
   ]);
   const surfacedModelResult = withRememberedAmrModels(def, probeEnv, modelResult);
+  const chatgptReady = def.id === 'codex'
+    && chatgptPolicy?.allowed === true
+    && chatgptAuth?.status === 'ok'
+    && chatgptModelResult.source === 'live';
+  const chatgptReadyMessage = def.id !== 'codex' || chatgptReady
+    ? null
+    : chatgptPolicy?.allowed !== true
+      ? codexChatGptAuthGuidance()
+      : chatgptAuth?.status !== 'ok'
+        ? chatgptAuth?.message ?? codexChatGptAuthGuidance()
+        : 'The installed Codex CLI did not return a ChatGPT-only live model catalog. Refresh Local Codex agent discovery, then retry.';
   if (caps) {
     agentCapabilities.set(def.id, caps);
   }
@@ -339,6 +373,16 @@ async function probe(
           chatgptAuthStatus: chatgptAuth.status,
           ...(chatgptAuth.message
             ? { chatgptAuthMessage: chatgptAuth.message }
+            : {}),
+        }
+      : {}),
+    ...(def.id === 'codex'
+      ? {
+          chatgptModels: chatgptModelResult.models,
+          chatgptModelsSource: chatgptModelResult.source,
+          chatgptReady,
+          ...(chatgptReadyMessage
+            ? { chatgptReadyMessage }
             : {}),
         }
       : {}),
@@ -411,9 +455,19 @@ function rememberDetectedLiveModels(
     : null;
   if (def.id === 'codex' && agent.modelsSource !== 'live') {
     clearRememberedLiveModels(def.id, scope);
+  } else {
+    rememberLiveModels(agent.id, agent.models, scope);
+  }
+  if (def.id !== 'codex') return;
+  if (agent.chatgptModelsSource !== 'live') {
+    clearRememberedLiveModels(def.id, CODEX_CHATGPT_MODEL_SCOPE);
     return;
   }
-  rememberLiveModels(agent.id, agent.models, scope);
+  rememberLiveModels(
+    def.id,
+    agent.chatgptModels ?? [],
+    CODEX_CHATGPT_MODEL_SCOPE,
+  );
 }
 
 export async function detectAgents(

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -2,6 +2,7 @@ import { execAgentFile } from './invocation.js';
 import { AGENT_DEFS } from './registry.js';
 import {
   DEFAULT_MODEL_OPTION,
+  clearRememberedLiveModels,
   getRememberedLiveModels,
   mergeFallbackModelMetadata,
   rememberLiveModels,
@@ -86,7 +87,10 @@ async function fetchModels(
       if (!parsed || parsed.length === 0) {
         return { models: def.fallbackModels, source: 'fallback' };
       }
-      return { models: mergeFallbackModelMetadata(def, parsed), source: 'live' };
+      return {
+        models: def.id === 'codex' ? parsed : mergeFallbackModelMetadata(def, parsed),
+        source: 'live',
+      };
     } catch {
       return { models: def.fallbackModels, source: 'fallback' };
     }
@@ -110,7 +114,10 @@ async function fetchModels(
     if (!parsed || parsed.length === 0) {
       return { models: def.fallbackModels, source: 'fallback' };
     }
-    return { models: mergeFallbackModelMetadata(def, parsed), source: 'live' };
+    return {
+      models: def.id === 'codex' ? parsed : mergeFallbackModelMetadata(def, parsed),
+      source: 'live',
+    };
   } catch {
     return { models: def.fallbackModels, source: 'fallback' };
   }
@@ -379,6 +386,10 @@ function rememberDetectedLiveModels(
         ...configuredEnv,
       })
     : null;
+  if (def.id === 'codex' && agent.modelsSource !== 'live') {
+    clearRememberedLiveModels(def.id, scope);
+    return;
+  }
   rememberLiveModels(agent.id, agent.models, scope);
 }
 

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -12,6 +12,7 @@ import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
 import { spawnEnvForAgent } from './env.js';
 import {
   codexChatGptAuthGuidance,
+  codexChatGptConfigInspectionGuidance,
   inspectCodexChatGptRoutePolicy,
   probeAgentAuthStatus,
   probeCodexChatGptAuthStatus,
@@ -86,6 +87,7 @@ async function fetchModels(
   def: RuntimeAgentDef,
   resolvedBin: string,
   env: NodeJS.ProcessEnv,
+  effectiveCwd?: string | null,
 ): Promise<FetchedRuntimeModels> {
   if (typeof def.fetchModels === 'function') {
     try {
@@ -107,6 +109,7 @@ async function fetchModels(
   try {
     const { stdout } = await execAgentFile(resolvedBin, def.listModels.args, {
       env,
+      ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
       timeout: def.listModels.timeoutMs ?? 5000,
       // Models lists from popular CLIs (e.g. opencode) easily exceed the
       // default 1MB buffer once you include every openrouter model. Bump
@@ -251,6 +254,7 @@ async function probeCapabilities(
 async function probe(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string> = {},
+  effectiveCwd?: string | null,
 ): Promise<DetectedAgent> {
   detectedRuntimeVersions.delete(def.id);
   // Detection must probe the exact path the runtime will spawn, not just the
@@ -290,7 +294,7 @@ async function probe(
   // than the sum ≈ 15s. `--help` capabilities are cached on `agentCapabilities`
   // for buildArgs to consult.
   const chatgptPolicy = def.id === 'codex'
-    ? await inspectCodexChatGptRoutePolicy(probeEnv)
+    ? await inspectCodexChatGptRoutePolicy(probeEnv, effectiveCwd)
     : null;
   const chatgptProbeEnv = def.id === 'codex'
     ? applyAgentLaunchEnv(
@@ -316,10 +320,15 @@ async function probe(
     fetchModels(def, launch.launchPath, probeEnv),
     probeAgentAuthStatus(def, launch.launchPath, probeEnv),
     def.id === 'codex'
-      ? probeCodexChatGptAuthStatus(def, launch.launchPath, chatgptProbeEnv)
+      ? probeCodexChatGptAuthStatus(
+          def,
+          launch.launchPath,
+          chatgptProbeEnv,
+          effectiveCwd,
+        )
       : Promise.resolve(null),
     def.id === 'codex' && chatgptPolicy?.allowed
-      ? fetchModels(def, launch.launchPath, chatgptProbeEnv).then((result) =>
+      ? fetchModels(def, launch.launchPath, chatgptProbeEnv, effectiveCwd).then((result) =>
           result.source === 'live'
             ? { models: result.models, source: 'live' as const }
             : unavailableChatGptModels,
@@ -335,7 +344,9 @@ async function probe(
   const chatgptReadyMessage = def.id !== 'codex' || chatgptReady
     ? null
     : chatgptPolicy?.allowed !== true
-      ? codexChatGptAuthGuidance()
+      ? chatgptPolicy?.reason === 'config_inspection_failed'
+        ? codexChatGptConfigInspectionGuidance()
+        : codexChatGptAuthGuidance()
       : chatgptAuth?.status !== 'ok'
         ? chatgptAuth?.message ?? codexChatGptAuthGuidance()
         : 'The installed Codex CLI did not return a ChatGPT-only live model catalog. Refresh Local Codex agent discovery, then retry.';
@@ -425,9 +436,10 @@ function stripFns(
 async function safeProbe(
   def: RuntimeAgentDef,
   configuredEnv: Record<string, string> = {},
+  effectiveCwd?: string | null,
 ): Promise<DetectedAgent> {
   try {
-    return await probe(def, configuredEnv);
+    return await probe(def, configuredEnv, effectiveCwd);
   } catch {
     // Fault isolation (issue #2297): one adapter's probe blowing up
     // — e.g. a synchronous filesystem throw during PATH walking on a
@@ -472,9 +484,14 @@ function rememberDetectedLiveModels(
 
 export async function detectAgents(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
+  options: { effectiveCwd?: string | null } = {},
 ) {
   const results = await Promise.all(
-    AGENT_DEFS.map((def) => safeProbe(def, configuredEnvForAgent(configuredEnvByAgent, def.id))),
+    AGENT_DEFS.map((def) => safeProbe(
+      def,
+      configuredEnvForAgent(configuredEnvByAgent, def.id),
+      options.effectiveCwd,
+    )),
   );
   // Refresh the validation cache from whatever we just surfaced to the UI
   // so /api/chat can accept any model the user could have just picked,
@@ -495,9 +512,14 @@ export async function detectAgents(
 // that don't care about incremental delivery (cache warm, analytics, chat).
 export async function* detectAgentsStream(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
+  options: { effectiveCwd?: string | null } = {},
 ): AsyncGenerator<DetectedAgent> {
   const tagged = AGENT_DEFS.map((def, index) =>
-    safeProbe(def, configuredEnvForAgent(configuredEnvByAgent, def.id)).then((agent) => {
+    safeProbe(
+      def,
+      configuredEnvForAgent(configuredEnvByAgent, def.id),
+      options.effectiveCwd,
+    ).then((agent) => {
       rememberDetectedLiveModels(def, configuredEnvForAgent(configuredEnvByAgent, def.id), agent);
       return { index, agent };
     }),

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -9,7 +9,10 @@ import {
 } from './models.js';
 import { applyAgentLaunchEnv, resolveAgentLaunch } from './launch.js';
 import { spawnEnvForAgent } from './env.js';
-import { probeAgentAuthStatus } from './auth.js';
+import {
+  probeAgentAuthStatus,
+  probeCodexChatGptAuthStatus,
+} from './auth.js';
 import { agentCapabilities } from './capabilities.js';
 import { installMetaForAgent } from './metadata.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
@@ -283,10 +286,22 @@ async function probe(
   // so a single agent's detection wall is max(help, models, auth) ≈ 5s rather
   // than the sum ≈ 15s. `--help` capabilities are cached on `agentCapabilities`
   // for buildArgs to consult.
-  const [caps, modelResult, auth, amrOpenCodeVersion] = await Promise.all([
+  const chatgptProbeEnv = def.id === 'codex'
+    ? spawnEnvForAgent(
+        'codex',
+        probeEnv,
+        {},
+        {},
+        { codexAuthMode: 'chatgpt' },
+      )
+    : probeEnv;
+  const [caps, modelResult, auth, chatgptAuth, amrOpenCodeVersion] = await Promise.all([
     probeCapabilities(def, launch.launchPath, probeEnv),
     fetchModels(def, launch.launchPath, probeEnv),
     probeAgentAuthStatus(def, launch.launchPath, probeEnv),
+    def.id === 'codex'
+      ? probeCodexChatGptAuthStatus(def, launch.launchPath, chatgptProbeEnv)
+      : Promise.resolve(null),
     probeAmrOpenCodeVersion(def, probeEnv),
   ]);
   const surfacedModelResult = withRememberedAmrModels(def, probeEnv, modelResult);
@@ -317,6 +332,14 @@ async function probe(
       ? {
           authStatus: auth.status,
           ...(auth.message ? { authMessage: auth.message } : {}),
+        }
+      : {}),
+    ...(chatgptAuth
+      ? {
+          chatgptAuthStatus: chatgptAuth.status,
+          ...(chatgptAuth.message
+            ? { chatgptAuthMessage: chatgptAuth.message }
+            : {}),
         }
       : {}),
     ...(authDiagnostic ? { diagnostics: [authDiagnostic] } : {}),

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -19,6 +19,8 @@ import {
 type RuntimeEnvMap = NodeJS.ProcessEnv | Record<string, string>;
 type SpawnEnvOptions = {
   resolvedBin?: string | null;
+  codexAuthMode?: 'chatgpt';
+  codexProviderEnvKey?: string | null;
 };
 
 const RUNTIME_MODULE_PROJECT_ROOT = resolveProjectRootFromNestedModule(
@@ -73,7 +75,7 @@ export function spawnEnvForAgent(
   baseEnv: RuntimeEnvMap,
   configuredEnv: unknown = {},
   systemProxyEnv: RuntimeEnvMap = resolveSystemProxyEnv(),
-  _options: SpawnEnvOptions = {},
+  options: SpawnEnvOptions = {},
 ): NodeJS.ProcessEnv {
   const sandboxRuntime = sandboxRuntimeConfigForBaseEnv(baseEnv);
   const expandedConfiguredEnv = expandConfiguredEnv(configuredEnv);
@@ -135,6 +137,16 @@ export function spawnEnvForAgent(
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'codex') {
+    if (options.codexAuthMode === 'chatgpt') {
+      stripKeysCaseInsensitive(env, [
+        'OPENAI_API_KEY',
+        'CODEX_API_KEY',
+        'OPENAI_BASE_URL',
+        'OPENAI_API_BASE',
+        'CODEX_BASE_URL',
+        ...(options.codexProviderEnvKey ? [options.codexProviderEnvKey] : []),
+      ]);
+    }
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'opencode' || agentId === 'byok-opencode') {

--- a/apps/daemon/src/runtimes/models.ts
+++ b/apps/daemon/src/runtimes/models.ts
@@ -5,6 +5,9 @@ export const DEFAULT_MODEL_OPTION: RuntimeModelOption = {
   label: 'Default (CLI config)',
 };
 
+/** Isolated compatibility cache for the official ChatGPT-backed Codex route. */
+export const CODEX_CHATGPT_MODEL_SCOPE = 'chatgpt';
+
 // Daemon's /api/chat needs to validate the user's model pick against the
 // list we last surfaced to the UI. We keep a per-agent cache of the most
 // recent live list (refreshed every detectAgents() call) and additionally

--- a/apps/daemon/src/runtimes/models.ts
+++ b/apps/daemon/src/runtimes/models.ts
@@ -12,6 +12,7 @@ export const DEFAULT_MODEL_OPTION: RuntimeModelOption = {
 // gets rejected so a stale or hostile value can't smuggle arbitrary flags.
 const liveModelOrder = new Map<string, RuntimeModelOption[]>();
 const liveModelCache = new Map<string, Map<string, RuntimeModelOption>>();
+const availableLiveModelCatalogs = new Set<string>();
 
 function liveModelCacheKey(agentId: string, scope?: string | null): string {
   const trimmedScope = typeof scope === 'string' ? scope.trim() : '';
@@ -25,11 +26,26 @@ export function rememberLiveModels(agentId: string, models: RuntimeModelOption[]
       model != null && typeof model.id === 'string',
   );
   const key = liveModelCacheKey(agentId, scope);
+  availableLiveModelCatalogs.add(key);
   liveModelCache.set(
     key,
     new Map(remembered.map((model) => [model.id, model])),
   );
   liveModelOrder.set(key, remembered);
+}
+
+export function clearRememberedLiveModels(agentId: string, scope?: string | null): void {
+  const key = liveModelCacheKey(agentId, scope);
+  availableLiveModelCatalogs.delete(key);
+  liveModelCache.delete(key);
+  liveModelOrder.delete(key);
+}
+
+export function hasRememberedLiveModelCatalog(
+  agentId: string,
+  scope?: string | null,
+): boolean {
+  return availableLiveModelCatalogs.has(liveModelCacheKey(agentId, scope));
 }
 
 export function resolveDefaultModelFromOptions(
@@ -73,6 +89,7 @@ function mergeMissingFallbackModelMetadata(
 ): RuntimeModelOption {
   if (!fallback) return model;
   const fallbackSpeedTiers = fallback.additionalSpeedTiers;
+  const fallbackReasoningLevels = fallback.supportedReasoningLevels;
   const fallbackServiceTiers = fallback.serviceTierOptions;
   const needsSpeedTiers =
     (!model.additionalSpeedTiers || model.additionalSpeedTiers.length === 0) &&
@@ -82,7 +99,11 @@ function mergeMissingFallbackModelMetadata(
     (!model.serviceTierOptions || model.serviceTierOptions.length === 0) &&
     Array.isArray(fallbackServiceTiers) &&
     fallbackServiceTiers.length > 0;
-  if (!needsSpeedTiers && !needsServiceTiers) return model;
+  const needsReasoningLevels =
+    (!model.supportedReasoningLevels || model.supportedReasoningLevels.length === 0) &&
+    Array.isArray(fallbackReasoningLevels) &&
+    fallbackReasoningLevels.length > 0;
+  if (!needsSpeedTiers && !needsReasoningLevels && !needsServiceTiers) return model;
   return {
     ...model,
     ...(needsSpeedTiers
@@ -90,6 +111,9 @@ function mergeMissingFallbackModelMetadata(
       : {}),
     ...(needsServiceTiers
       ? { serviceTierOptions: cloneModelOptions(fallbackServiceTiers) }
+      : {}),
+    ...(needsReasoningLevels
+      ? { supportedReasoningLevels: cloneStringOptions(fallbackReasoningLevels) }
       : {}),
   };
 }
@@ -115,6 +139,7 @@ export function findKnownModel(
   const live = liveModelCache.get(liveModelCacheKey(def.id, scope));
   const liveModel = live?.get(modelId);
   const fallbackModel = findFallbackModel(def, modelId);
+  if (def.id === 'codex' && live) return liveModel ?? null;
   if (liveModel) {
     return mergeMissingFallbackModelMetadata(liveModel, fallbackModel);
   }
@@ -140,6 +165,17 @@ export function isKnownServiceTier(
   return Boolean(
     model?.serviceTierOptions?.some((tier) => tier.id === serviceTier),
   );
+}
+
+export function isKnownReasoning(
+  def: RuntimeAgentDef,
+  modelId: string | null | undefined,
+  reasoning: string | null | undefined,
+  scope?: string | null,
+) {
+  if (!reasoning || reasoning === 'default') return true;
+  const model = findKnownModel(def, modelId, scope);
+  return Boolean(model?.supportedReasoningLevels?.includes(reasoning));
 }
 
 export function resolveModelForServiceTier(

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -468,10 +468,16 @@ function buildExecutionDiagnostics(run) {
         : missingDiagnostic('provider_not_reported_by_runtime', 'agent-runtime'),
       requestedModel: run.model
         ? availableDiagnostic(run.model, 'requested model configuration', true, 'agent-runtime')
-        : missingDiagnostic('requested_model_not_recorded', 'agent-runtime'),
+        : missingDiagnostic(
+            run.agentId === 'codex' ? 'codex_cli_default_model' : 'requested_model_not_recorded',
+            'agent-runtime',
+          ),
       requestedReasoning: run.reasoning
         ? availableDiagnostic(run.reasoning, 'requested reasoning configuration', true, 'agent-runtime')
-        : missingDiagnostic('requested_reasoning_not_recorded', 'agent-runtime'),
+        : missingDiagnostic(
+            run.agentId === 'codex' ? 'codex_cli_default_reasoning' : 'requested_reasoning_not_recorded',
+            'agent-runtime',
+          ),
       requestedServiceTier: run.serviceTier
         ? availableDiagnostic(run.serviceTier, 'requested service tier configuration', true, 'agent-runtime')
         : missingDiagnostic('requested_service_tier_not_recorded', 'agent-runtime'),

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -469,12 +469,40 @@ function buildExecutionDiagnostics(run) {
       requestedModel: run.model
         ? availableDiagnostic(run.model, 'requested model configuration', true, 'agent-runtime')
         : missingDiagnostic('requested_model_not_recorded', 'agent-runtime'),
-      resolvedModel: run.resolvedModelId || assistantMessages.model
-        ? availableDiagnostic(run.resolvedModelId || assistantMessages.model, 'runtime-resolved model id', true, 'agent-runtime')
-        : missingDiagnostic('resolved_model_not_reported', 'agent-runtime'),
-      reasoning: run.reasoning
+      requestedReasoning: run.reasoning
         ? availableDiagnostic(run.reasoning, 'requested reasoning configuration', true, 'agent-runtime')
-        : missingDiagnostic('reasoning_configuration_not_recorded', 'agent-runtime'),
+        : missingDiagnostic('requested_reasoning_not_recorded', 'agent-runtime'),
+      requestedServiceTier: run.serviceTier
+        ? availableDiagnostic(run.serviceTier, 'requested service tier configuration', true, 'agent-runtime')
+        : missingDiagnostic('requested_service_tier_not_recorded', 'agent-runtime'),
+      resolvedModel: run.agentId === 'codex'
+        ? run.executedModelId
+          ? availableDiagnostic(run.executedModelId, 'model reported by Codex rollout turn_context', true, 'agent-runtime')
+          : missingDiagnostic('codex_rollout_model_unconfirmed', 'agent-runtime')
+        : run.resolvedModelId || assistantMessages.model
+          ? availableDiagnostic(run.resolvedModelId || assistantMessages.model, 'runtime-resolved model id', true, 'agent-runtime')
+          : missingDiagnostic('resolved_model_not_reported', 'agent-runtime'),
+      resolvedReasoning: run.agentId === 'codex'
+        ? run.executedReasoning
+          ? availableDiagnostic(run.executedReasoning, 'reasoning reported by Codex rollout turn_context', true, 'agent-runtime')
+          : missingDiagnostic('codex_rollout_reasoning_unconfirmed', 'agent-runtime')
+        : run.reasoning
+          ? availableDiagnostic(run.reasoning, 'runtime reasoning configuration', true, 'agent-runtime')
+          : missingDiagnostic('reasoning_configuration_not_recorded', 'agent-runtime'),
+      resolvedServiceTier: run.agentId === 'codex'
+        ? run.executedServiceTier
+          ? availableDiagnostic(run.executedServiceTier, 'service tier reported by Codex rollout turn_context', true, 'agent-runtime')
+          : missingDiagnostic('codex_rollout_service_tier_unconfirmed', 'agent-runtime')
+        : run.serviceTier
+          ? availableDiagnostic(run.serviceTier, 'runtime service tier configuration', true, 'agent-runtime')
+          : missingDiagnostic('service_tier_configuration_not_recorded', 'agent-runtime'),
+      reasoning: run.agentId === 'codex'
+        ? run.executedReasoning
+          ? availableDiagnostic(run.executedReasoning, 'reasoning reported by Codex rollout turn_context', true, 'agent-runtime')
+          : missingDiagnostic('codex_rollout_reasoning_unconfirmed', 'agent-runtime')
+        : run.reasoning
+          ? availableDiagnostic(run.reasoning, 'runtime reasoning configuration', true, 'agent-runtime')
+          : missingDiagnostic('reasoning_configuration_not_recorded', 'agent-runtime'),
       agentCliVersion: run.preflightAgentCliVersion
         ? availableDiagnostic(run.preflightAgentCliVersion, 'runtime CLI version observed during preflight', true, 'agent-runtime')
         : missingDiagnostic('agent_cli_version_not_recorded', 'agent-runtime'),
@@ -525,6 +553,13 @@ function durableRunState(run) {
       ? { preflightAgentCliVersion: run.preflightAgentCliVersion }
       : {}),
     ...(typeof run.reasoning === 'string' ? { reasoning: run.reasoning } : {}),
+    ...(typeof run.serviceTier === 'string' ? { serviceTier: run.serviceTier } : {}),
+    ...(typeof run.executedModelId === 'string' ? { executedModelId: run.executedModelId } : {}),
+    ...(typeof run.executedReasoning === 'string' ? { executedReasoning: run.executedReasoning } : {}),
+    ...(typeof run.executedServiceTier === 'string' ? { executedServiceTier: run.executedServiceTier } : {}),
+    ...(typeof run.executionEvidenceSource === 'string'
+      ? { executionEvidenceSource: run.executionEvidenceSource }
+      : {}),
     ...(typeof run.skillId === 'string' ? { skillId: run.skillId } : {}),
     ...(typeof run.designSystemId === 'string' ? { designSystemId: run.designSystemId } : {}),
     ...(typeof run.designSystemDigest === 'string' ? { designSystemDigest: run.designSystemDigest } : {}),
@@ -910,6 +945,15 @@ export function createChatRunService({
 
   const persistState = (run) => {
     if (run?.statePath) atomicWriteJson(run.statePath, durableRunState(run));
+  };
+
+  const setExecutionEvidence = (run, evidence) => {
+    if (!run || !evidence) return;
+    run.executedModelId = readString(evidence.model);
+    run.executedReasoning = readString(evidence.reasoning);
+    run.executedServiceTier = readString(evidence.serviceTier);
+    run.executionEvidenceSource = readString(evidence.source);
+    persistState(run);
   };
 
   const setAnalyticsRecovery = (run, recovery) => {
@@ -1540,6 +1584,7 @@ export function createChatRunService({
     wait,
     emit,
     persistState,
+    setExecutionEvidence,
     setAnalyticsRecovery,
     markAnalyticsCompleted,
     markLangfuseCompleted,

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -469,7 +469,9 @@ function buildExecutionDiagnostics(run) {
       requestedModel: run.model
         ? availableDiagnostic(run.model, 'requested model configuration', true, 'agent-runtime')
         : missingDiagnostic(
-            run.agentId === 'codex' ? 'codex_cli_default_model' : 'requested_model_not_recorded',
+            run.agentId === 'codex' && run.codexModelSelectionSource === 'cli_default'
+              ? 'codex_cli_default_model'
+              : 'requested_model_not_recorded',
             'agent-runtime',
           ),
       requestedReasoning: run.reasoning
@@ -552,6 +554,9 @@ function durableRunState(run) {
     endedWithUnfinishedWork: Boolean(run.endedWithUnfinishedWork),
     ...(typeof run.userPrompt === 'string' ? { userPrompt: run.userPrompt } : {}),
     ...(typeof run.model === 'string' ? { model: run.model } : {}),
+    ...(typeof run.codexModelSelectionSource === 'string'
+      ? { codexModelSelectionSource: run.codexModelSelectionSource }
+      : {}),
     ...(typeof run.resolvedModelId === 'string'
       ? { resolvedModelId: run.resolvedModelId }
       : {}),

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -296,6 +296,10 @@ export type DetectedAgent = Omit<
   authMessage?: string;
   chatgptAuthStatus?: 'ok' | 'missing' | 'unknown';
   chatgptAuthMessage?: string;
+  chatgptModels?: RuntimeModelOption[];
+  chatgptModelsSource?: 'live' | 'unavailable';
+  chatgptReady?: boolean;
+  chatgptReadyMessage?: string;
   path?: string;
   version?: string | null;
   diagnostics?: AgentDiagnostic[];

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -294,6 +294,8 @@ export type DetectedAgent = Omit<
   available: boolean;
   authStatus?: 'ok' | 'missing' | 'unknown';
   authMessage?: string;
+  chatgptAuthStatus?: 'ok' | 'missing' | 'unknown';
+  chatgptAuthMessage?: string;
   path?: string;
   version?: string | null;
   diagnostics?: AgentDiagnostic[];

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -14,6 +14,7 @@ export type RuntimeModelOption = {
   outputPriceUsdPerMillion?: number;
   metadata?: ModelMetadata;
   additionalSpeedTiers?: string[];
+  supportedReasoningLevels?: string[];
   serviceTierOptions?: RuntimeModelOption[];
 };
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -210,6 +210,8 @@ import {
 } from './agents.js';
 import {
   getRememberedLiveModels,
+  hasRememberedLiveModelCatalog,
+  isKnownReasoning,
   preferFreshLiveModels,
   rememberLiveModels,
   resolveDefaultModelFromOptions,
@@ -9573,6 +9575,56 @@ export async function startServer({
       typeof appConfigForRun?.agentModels?.[def.id]?.model === 'string'
         ? appConfigForRun.agentModels[def.id].model
         : null;
+    const hasExplicitRequestedModel =
+      typeof requestedRuntimeModel === 'string'
+      && requestedRuntimeModel.trim().length > 0
+      && requestedRuntimeModel.trim().toLowerCase() !== 'default';
+    const hasExplicitReasoning =
+      typeof reasoning === 'string' && reasoning.length > 0 && reasoning !== 'default';
+    const hasExplicitServiceTier =
+      typeof serviceTier === 'string' && serviceTier.length > 0 && serviceTier !== 'default';
+    if (
+      def.id === 'codex'
+      && (hasExplicitRequestedModel || hasExplicitReasoning || hasExplicitServiceTier)
+      && !hasRememberedLiveModelCatalog(def.id, requestedLiveModelScope)
+    ) {
+      run.failureCategory = 'model_unavailable';
+      run.failureDetail = 'model_not_supported';
+      run.failureAction = 'upgrade';
+      return design.runs.fail(
+        run,
+        'MODEL_UNAVAILABLE',
+        'The installed Codex CLI did not return a live model compatibility catalog. Upgrade or repair the managed Codex CLI, refresh Local Codex agent discovery, then retry the same settings.',
+        {
+          retryable: false,
+          details: {
+            failureCategory: 'model_unavailable',
+            failureDetail: 'model_not_supported',
+          },
+        },
+      );
+    }
+    if (
+      def.id === 'codex'
+      && hasExplicitRequestedModel
+      && !isKnownModel(def, requestedRuntimeModel, requestedLiveModelScope)
+    ) {
+      run.failureCategory = 'model_unavailable';
+      run.failureDetail = 'model_not_found';
+      run.failureAction = 'upgrade';
+      return design.runs.fail(
+        run,
+        'MODEL_UNAVAILABLE',
+        `The Codex model is unavailable: '${requestedRuntimeModel}' is not in the current model catalog.`,
+        {
+          retryable: false,
+          details: {
+            failureCategory: 'model_unavailable',
+            failureDetail: 'model_not_found',
+          },
+        },
+      );
+    }
     let safeModel = resolveModelForAgent(
       def,
       typeof requestedRuntimeModel === 'string'
@@ -9592,17 +9644,60 @@ export async function startServer({
       typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)
         ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
         : null;
-    safeModel = resolveModelForServiceTier(
-      def,
-      safeModel,
-      typeof serviceTier === 'string' ? serviceTier : null,
-      requestedLiveModelScope,
-    );
+    if (
+      def.id === 'codex'
+      && hasExplicitReasoning
+      && (
+        !safeReasoning
+        || !isKnownReasoning(def, safeModel, safeReasoning, requestedLiveModelScope)
+      )
+    ) {
+      run.failureCategory = 'model_unavailable';
+      run.failureDetail = 'model_not_supported';
+      run.failureAction = 'none';
+      return design.runs.fail(
+        run,
+        'MODEL_UNAVAILABLE',
+        `The Codex model is unsupported for this setting: '${safeModel ?? 'default'}' does not support reasoning level '${reasoning}'.`,
+        {
+          retryable: false,
+          details: {
+            failureCategory: 'model_unavailable',
+            failureDetail: 'model_not_supported',
+          },
+        },
+      );
+    }
+    if (def.id !== 'codex') {
+      safeModel = resolveModelForServiceTier(
+        def,
+        safeModel,
+        typeof serviceTier === 'string' ? serviceTier : null,
+        requestedLiveModelScope,
+      );
+    }
     const safeServiceTier =
       typeof serviceTier === 'string' &&
       isKnownServiceTier(def, safeModel, serviceTier, requestedLiveModelScope)
         ? serviceTier
         : null;
+    if (def.id === 'codex' && hasExplicitServiceTier && !safeServiceTier) {
+      run.failureCategory = 'model_unavailable';
+      run.failureDetail = 'model_not_supported';
+      run.failureAction = 'none';
+      return design.runs.fail(
+        run,
+        'MODEL_UNAVAILABLE',
+        `The Codex model is unsupported for this setting: '${safeModel ?? 'default'}' does not support service tier '${serviceTier}'.`,
+        {
+          retryable: false,
+          details: {
+            failureCategory: 'model_unavailable',
+            failureDetail: 'model_not_supported',
+          },
+        },
+      );
+    }
     const agentOptions = {
       model: safeModel,
       reasoning: safeReasoning,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -219,7 +219,14 @@ import {
   resolveModelForServiceTier,
 } from './runtimes/models.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
-import { preflightCodexDefaultModel } from './runtimes/codex-model-preflight.js';
+import {
+  extractCodexRootModelConfig,
+  preflightCodexDefaultModel,
+} from './runtimes/codex-model-preflight.js';
+import {
+  readCodexProviderEnvKey,
+  resolveCodexConfigPath,
+} from './codex-config-normalize.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js';
 import {
@@ -438,7 +445,9 @@ import {
   antigravityQuotaGuidance,
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
+  codexChatGptAuthGuidance,
   cursorAuthGuidance,
+  probeCodexChatGptAuthStatus,
 } from './runtimes/auth.js';
 import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
 import { createAgentStderrVisibilityFilter } from './amr-stderr-filter.js';
@@ -8890,6 +8899,7 @@ export async function startServer({
       model,
       reasoning,
       serviceTier,
+      codexAuthMode,
       locale,
       research,
       context,
@@ -9641,8 +9651,12 @@ export async function startServer({
       process.env[def.defaultModelEnvVar]?.trim(),
     );
     const safeReasoning =
-      typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)
-        ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
+      typeof reasoning === 'string'
+        ? def.id === 'codex'
+          ? reasoning
+          : Array.isArray(def.reasoningOptions)
+            ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
+            : null
         : null;
     if (
       def.id === 'codex'
@@ -9705,6 +9719,82 @@ export async function startServer({
     };
     const agentLaunch = resolveAgentLaunch(def, configuredAgentEnv);
     const resolvedBin = agentLaunch.selectedPath;
+    const requiresChatGptCodexAuth =
+      def.id === 'codex' && codexAuthMode === 'chatgpt';
+    let codexProviderEnvKey = null;
+    if (
+      requiresChatGptCodexAuth
+      && resolvedBin
+      && agentLaunch.launchPath
+    ) {
+      const codexBaseEnv = spawnEnvForAgent(
+        def.id,
+        {
+          ...process.env,
+          ...(def.env || {}),
+        },
+        configuredAgentEnv,
+        undefined,
+        { resolvedBin: agentLaunch.selectedPath },
+      );
+      codexProviderEnvKey = await readCodexProviderEnvKey(codexBaseEnv);
+      let hasUnverifiedCodexProviderConfig = false;
+      try {
+        const codexConfig = await fs.promises.readFile(
+          resolveCodexConfigPath(codexBaseEnv),
+          'utf8',
+        );
+        const configured = extractCodexRootModelConfig(codexConfig);
+        hasUnverifiedCodexProviderConfig = Boolean(
+          (configured.modelProvider
+            && configured.modelProvider.toLowerCase() !== 'openai')
+          || configured.hasCompatibilityOverlay,
+        );
+      } catch {
+        // A missing config is the normal ChatGPT-backed Codex case. The
+        // authoritative login probe below still decides whether it may run.
+      }
+      if (codexProviderEnvKey || hasUnverifiedCodexProviderConfig) {
+        run.failureCategory = 'auth';
+        run.failureDetail = 'custom_provider_not_allowed';
+        run.failureAction = 'relogin';
+        return design.runs.fail(
+          run,
+          'AGENT_AUTH_REQUIRED',
+          codexChatGptAuthGuidance(),
+          { retryable: false },
+        );
+      }
+      const strictProbeEnv = applyAgentLaunchEnv(
+        spawnEnvForAgent(
+          def.id,
+          codexBaseEnv,
+          {},
+          {},
+          {
+            resolvedBin: agentLaunch.selectedPath,
+            codexAuthMode: 'chatgpt',
+          },
+        ),
+        agentLaunch,
+      );
+      const chatgptAuth = await probeCodexChatGptAuthStatus(
+        def,
+        agentLaunch.launchPath,
+        strictProbeEnv,
+      );
+      if (chatgptAuth?.status !== 'ok') {
+        run.failureCategory = 'auth';
+        run.failureDetail = 'chatgpt_login_required';
+        run.failureAction = 'relogin';
+        return design.runs.fail(
+          run,
+          'AGENT_AUTH_REQUIRED',
+          chatgptAuth?.message ?? codexChatGptAuthGuidance(),
+          { retryable: false },
+        );
+      }
+    }
     if (def.id === 'amr' && resolvedBin && agentLaunch.launchPath) {
       // Concretize omitted/default AMR model requests to the live catalog
       // default before the resume guard. The AMR preflight below applies the
@@ -11399,7 +11489,15 @@ export async function startServer({
       },
       configuredAgentSpawnEnv,
       undefined,
-      { resolvedBin: agentLaunch.selectedPath },
+      {
+        resolvedBin: agentLaunch.selectedPath,
+        ...(requiresChatGptCodexAuth
+          ? {
+              codexAuthMode: 'chatgpt',
+              codexProviderEnvKey,
+            }
+          : {}),
+      },
     );
     if (def.id === 'amr') {
       const loginStatus = readVelaLoginStatus(agentSpawnEnv, configuredAgentSpawnEnv);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9716,6 +9716,14 @@ export async function startServer({
       process.env,
       requestedLiveModelScope,
     );
+    if (def.id === 'codex') {
+      run.codexModelSelectionSource = typeof requestedRuntimeModel === 'string'
+        ? 'request'
+        : safeModel
+          ? 'open_design_config'
+          : 'cli_default';
+      design.runs.persistState(run);
+    }
     const hasDefaultModelEnvOverride = Boolean(
       def.defaultModelEnvVar &&
       typeof process.env[def.defaultModelEnvVar] === 'string' &&

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -209,6 +209,7 @@ import {
   spawnEnvForAgent,
 } from './agents.js';
 import {
+  CODEX_CHATGPT_MODEL_SCOPE,
   getRememberedLiveModels,
   hasRememberedLiveModelCatalog,
   isKnownReasoning,
@@ -219,14 +220,7 @@ import {
   resolveModelForServiceTier,
 } from './runtimes/models.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
-import {
-  extractCodexRootModelConfig,
-  preflightCodexDefaultModel,
-} from './runtimes/codex-model-preflight.js';
-import {
-  readCodexProviderEnvKey,
-  resolveCodexConfigPath,
-} from './codex-config-normalize.js';
+import { preflightCodexDefaultModel } from './runtimes/codex-model-preflight.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js';
 import {
@@ -447,6 +441,7 @@ import {
   classifyAgentServiceFailure,
   codexChatGptAuthGuidance,
   cursorAuthGuidance,
+  inspectCodexChatGptRoutePolicy,
   probeCodexChatGptAuthStatus,
 } from './runtimes/auth.js';
 import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
@@ -8959,6 +8954,8 @@ export async function startServer({
         'AGENT_UNAVAILABLE',
         `unknown agent: ${agentId}`,
       );
+    const requiresChatGptCodexAuth =
+      def.id === 'codex' && codexAuthMode === 'chatgpt';
     if (!def.bin)
       return design.runs.fail(run, 'AGENT_UNAVAILABLE', 'agent has no binary');
     const byokOpenCodeProvider = def.id === 'byok-opencode'
@@ -9574,13 +9571,15 @@ export async function startServer({
     } catch {
       configuredAgentEnv = {};
     }
-    const requestedLiveModelScope = def.id === 'amr'
-      ? resolveAmrProfile({
-          ...process.env,
-          ...(def.env || {}),
-          ...configuredAgentEnv,
-        })
-      : null;
+    const requestedLiveModelScope = requiresChatGptCodexAuth
+      ? CODEX_CHATGPT_MODEL_SCOPE
+      : def.id === 'amr'
+        ? resolveAmrProfile({
+            ...process.env,
+            ...(def.env || {}),
+            ...configuredAgentEnv,
+          })
+        : null;
     const configuredModel =
       typeof appConfigForRun?.agentModels?.[def.id]?.model === 'string'
         ? appConfigForRun.agentModels[def.id].model
@@ -9719,8 +9718,6 @@ export async function startServer({
     };
     const agentLaunch = resolveAgentLaunch(def, configuredAgentEnv);
     const resolvedBin = agentLaunch.selectedPath;
-    const requiresChatGptCodexAuth =
-      def.id === 'codex' && codexAuthMode === 'chatgpt';
     let codexProviderEnvKey = null;
     if (
       requiresChatGptCodexAuth
@@ -9737,24 +9734,9 @@ export async function startServer({
         undefined,
         { resolvedBin: agentLaunch.selectedPath },
       );
-      codexProviderEnvKey = await readCodexProviderEnvKey(codexBaseEnv);
-      let hasUnverifiedCodexProviderConfig = false;
-      try {
-        const codexConfig = await fs.promises.readFile(
-          resolveCodexConfigPath(codexBaseEnv),
-          'utf8',
-        );
-        const configured = extractCodexRootModelConfig(codexConfig);
-        hasUnverifiedCodexProviderConfig = Boolean(
-          (configured.modelProvider
-            && configured.modelProvider.toLowerCase() !== 'openai')
-          || configured.hasCompatibilityOverlay,
-        );
-      } catch {
-        // A missing config is the normal ChatGPT-backed Codex case. The
-        // authoritative login probe below still decides whether it may run.
-      }
-      if (codexProviderEnvKey || hasUnverifiedCodexProviderConfig) {
+      const chatgptPolicy = await inspectCodexChatGptRoutePolicy(codexBaseEnv);
+      codexProviderEnvKey = chatgptPolicy.providerEnvKey;
+      if (!chatgptPolicy.allowed) {
         run.failureCategory = 'auth';
         run.failureDetail = 'custom_provider_not_allowed';
         run.failureAction = 'relogin';

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9640,6 +9640,10 @@ export async function startServer({
       typeof appConfigForRun?.agentModels?.[def.id]?.model === 'string'
         ? appConfigForRun.agentModels[def.id].model
         : null;
+    const configuredModelForRun =
+      requiresChatGptCodexAuth && typeof requestedRuntimeModel !== 'string'
+        ? null
+        : configuredModel;
     const explicitRequestedModel =
       typeof requestedRuntimeModel === 'string'
       && requestedRuntimeModel.trim().length > 0
@@ -9647,10 +9651,10 @@ export async function startServer({
         ? requestedRuntimeModel.trim()
         : null;
     const explicitConfiguredModel =
-      typeof configuredModel === 'string'
-      && configuredModel.trim().length > 0
-      && configuredModel.trim().toLowerCase() !== 'default'
-        ? configuredModel.trim()
+      typeof configuredModelForRun === 'string'
+      && configuredModelForRun.trim().length > 0
+      && configuredModelForRun.trim().toLowerCase() !== 'default'
+        ? configuredModelForRun.trim()
         : null;
     const effectiveCodexModel = explicitRequestedModel
       ?? (typeof requestedRuntimeModel === 'string' ? null : explicitConfiguredModel);
@@ -9708,7 +9712,7 @@ export async function startServer({
         ? isKnownModel(def, requestedRuntimeModel, requestedLiveModelScope)
           ? requestedRuntimeModel
           : sanitizeCustomModel(requestedRuntimeModel)
-        : configuredModel,
+        : configuredModelForRun,
       process.env,
       requestedLiveModelScope,
     );

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -440,6 +440,7 @@ import {
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
   codexChatGptAuthGuidance,
+  codexChatGptConfigInspectionGuidance,
   cursorAuthGuidance,
   inspectCodexChatGptRoutePolicy,
   probeCodexChatGptAuthStatus,
@@ -2381,6 +2382,7 @@ export interface StartServerResult {
   url: string;
   server: import('node:http').Server;
   shutdown: () => Promise<void> | void;
+  agentDiscoveryReady: Promise<void>;
   routeInventory: import('./route-registration-guard.js').RouteRegistration[];
 }
 
@@ -2877,12 +2879,14 @@ export async function startServer({
   // Warm agent-capability probes (e.g. whether the installed Claude Code
   // build advertises --include-partial-messages) so the first /api/chat
   // hits a populated cache even if /api/agents hasn't been called yet.
-  void readAppConfig(RUNTIME_DATA_DIR)
+  const agentDiscoveryReady = readAppConfig(RUNTIME_DATA_DIR)
     .then((config) => {
       orbitService.configure(config.orbit);
-      return detectAgents(config.agentCliEnv ?? {});
+      return detectAgents(config.agentCliEnv ?? {}, { effectiveCwd: PROJECT_ROOT });
     })
-    .catch(() => detectAgents().catch(() => {}));
+    .catch(() => detectAgents({}, { effectiveCwd: PROJECT_ROOT }).catch(() => []))
+    .then(() => {});
+  void agentDiscoveryReady;
 
   await recoverStaleLiveArtifactRefreshes({ projectsRoot: PROJECTS_DIR }).catch((error) => {
     console.warn('[od] Failed to recover stale live artifact refreshes:', error);
@@ -9571,6 +9575,58 @@ export async function startServer({
     } catch {
       configuredAgentEnv = {};
     }
+    const agentLaunch = resolveAgentLaunch(def, configuredAgentEnv);
+    const resolvedBin = agentLaunch.selectedPath;
+    let codexProviderEnvKey: string | null = null;
+    let strictCodexProbeEnv: NodeJS.ProcessEnv | null = null;
+    if (
+      requiresChatGptCodexAuth
+      && resolvedBin
+      && agentLaunch.launchPath
+    ) {
+      const codexBaseEnv = spawnEnvForAgent(
+        def.id,
+        {
+          ...process.env,
+          ...(def.env || {}),
+        },
+        configuredAgentEnv,
+        undefined,
+        { resolvedBin: agentLaunch.selectedPath },
+      );
+      const chatgptPolicy = await inspectCodexChatGptRoutePolicy(
+        codexBaseEnv,
+        effectiveCwd,
+      );
+      codexProviderEnvKey = chatgptPolicy.providerEnvKey;
+      if (!chatgptPolicy.allowed) {
+        const inspectionFailed = chatgptPolicy.reason === 'config_inspection_failed';
+        run.failureCategory = 'auth';
+        run.failureDetail = chatgptPolicy.reason ?? 'custom_provider_not_allowed';
+        run.failureAction = inspectionFailed ? 'repair' : 'relogin';
+        return design.runs.fail(
+          run,
+          'AGENT_AUTH_REQUIRED',
+          inspectionFailed
+            ? codexChatGptConfigInspectionGuidance()
+            : codexChatGptAuthGuidance(),
+          { retryable: false },
+        );
+      }
+      strictCodexProbeEnv = applyAgentLaunchEnv(
+        spawnEnvForAgent(
+          def.id,
+          codexBaseEnv,
+          {},
+          {},
+          {
+            resolvedBin: agentLaunch.selectedPath,
+            codexAuthMode: 'chatgpt',
+          },
+        ),
+        agentLaunch,
+      );
+    }
     const requestedLiveModelScope = requiresChatGptCodexAuth
       ? CODEX_CHATGPT_MODEL_SCOPE
       : def.id === 'amr'
@@ -9716,54 +9772,17 @@ export async function startServer({
       reasoning: safeReasoning,
       serviceTier: safeServiceTier,
     };
-    const agentLaunch = resolveAgentLaunch(def, configuredAgentEnv);
-    const resolvedBin = agentLaunch.selectedPath;
-    let codexProviderEnvKey = null;
     if (
       requiresChatGptCodexAuth
       && resolvedBin
       && agentLaunch.launchPath
+      && strictCodexProbeEnv
     ) {
-      const codexBaseEnv = spawnEnvForAgent(
-        def.id,
-        {
-          ...process.env,
-          ...(def.env || {}),
-        },
-        configuredAgentEnv,
-        undefined,
-        { resolvedBin: agentLaunch.selectedPath },
-      );
-      const chatgptPolicy = await inspectCodexChatGptRoutePolicy(codexBaseEnv);
-      codexProviderEnvKey = chatgptPolicy.providerEnvKey;
-      if (!chatgptPolicy.allowed) {
-        run.failureCategory = 'auth';
-        run.failureDetail = 'custom_provider_not_allowed';
-        run.failureAction = 'relogin';
-        return design.runs.fail(
-          run,
-          'AGENT_AUTH_REQUIRED',
-          codexChatGptAuthGuidance(),
-          { retryable: false },
-        );
-      }
-      const strictProbeEnv = applyAgentLaunchEnv(
-        spawnEnvForAgent(
-          def.id,
-          codexBaseEnv,
-          {},
-          {},
-          {
-            resolvedBin: agentLaunch.selectedPath,
-            codexAuthMode: 'chatgpt',
-          },
-        ),
-        agentLaunch,
-      );
       const chatgptAuth = await probeCodexChatGptAuthStatus(
         def,
         agentLaunch.launchPath,
-        strictProbeEnv,
+        strictCodexProbeEnv,
+        effectiveCwd,
       );
       if (chatgptAuth?.status !== 'ok') {
         run.failureCategory = 'auth';
@@ -14171,6 +14190,7 @@ export async function startServer({
           url,
           server,
           shutdown: shutdownDaemonRuns,
+          agentDiscoveryReady,
           routeInventory: getRouteRegistrationInventory(app),
         } : url);
       });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9640,17 +9640,29 @@ export async function startServer({
       typeof appConfigForRun?.agentModels?.[def.id]?.model === 'string'
         ? appConfigForRun.agentModels[def.id].model
         : null;
-    const hasExplicitRequestedModel =
+    const explicitRequestedModel =
       typeof requestedRuntimeModel === 'string'
       && requestedRuntimeModel.trim().length > 0
-      && requestedRuntimeModel.trim().toLowerCase() !== 'default';
+      && requestedRuntimeModel.trim().toLowerCase() !== 'default'
+        ? requestedRuntimeModel.trim()
+        : null;
+    const explicitConfiguredModel =
+      typeof configuredModel === 'string'
+      && configuredModel.trim().length > 0
+      && configuredModel.trim().toLowerCase() !== 'default'
+        ? configuredModel.trim()
+        : null;
+    const effectiveCodexModel = explicitRequestedModel
+      ?? (typeof requestedRuntimeModel === 'string' ? null : explicitConfiguredModel);
+    const hasExplicitCodexModel =
+      effectiveCodexModel !== null;
     const hasExplicitReasoning =
       typeof reasoning === 'string' && reasoning.length > 0 && reasoning !== 'default';
     const hasExplicitServiceTier =
       typeof serviceTier === 'string' && serviceTier.length > 0 && serviceTier !== 'default';
     if (
       def.id === 'codex'
-      && (hasExplicitRequestedModel || hasExplicitReasoning || hasExplicitServiceTier)
+      && (hasExplicitCodexModel || hasExplicitReasoning || hasExplicitServiceTier)
       && !hasRememberedLiveModelCatalog(def.id, requestedLiveModelScope)
     ) {
       run.failureCategory = 'model_unavailable';
@@ -9671,8 +9683,8 @@ export async function startServer({
     }
     if (
       def.id === 'codex'
-      && hasExplicitRequestedModel
-      && !isKnownModel(def, requestedRuntimeModel, requestedLiveModelScope)
+      && hasExplicitCodexModel
+      && !isKnownModel(def, effectiveCodexModel, requestedLiveModelScope)
     ) {
       run.failureCategory = 'model_unavailable';
       run.failureDetail = 'model_not_found';
@@ -9680,7 +9692,7 @@ export async function startServer({
       return design.runs.fail(
         run,
         'MODEL_UNAVAILABLE',
-        `The Codex model is unavailable: '${requestedRuntimeModel}' is not in the current model catalog.`,
+        `The Codex model is unavailable: '${effectiveCodexModel}' is not in the current model catalog.`,
         {
           retryable: false,
           details: {

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1081,7 +1081,7 @@ child.on('exit', (code, signal) => {
     }
   });
 
-  it('keeps service tier overrides when /api/runs omits model but settings has one', async () => {
+  it('keeps literal fast service tier when /api/runs omits model but settings has an exact model', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for service tier settings tests');
     }
@@ -1097,60 +1097,7 @@ child.on('exit', (code, signal) => {
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 if (args[0] === 'debug' && args[1] === 'models') {
-  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', service_tiers: [{ id: 'priority', label: 'Fast' }] }]));
-  process.exit(0);
-}
-if (args[0] === 'login' && args[1] === 'status') {
-  console.log('Logged in');
-  process.exit(0);
-}
-fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));
-console.log(JSON.stringify({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] }));
-process.exit(0);
-`,
-        async () => {
-          const createResponse = await fetch(`${baseUrl}/api/runs`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              agentId: 'codex',
-              message: 'hello',
-              serviceTier: 'priority',
-            }),
-          });
-          expect(createResponse.status).toBe(202);
-          const { runId } = await createResponse.json() as { runId: string };
-          await waitForRunStatus(baseUrl, runId);
-
-          const args = JSON.parse(readFileSync(argsPath, 'utf8')) as string[];
-          expect(args).toContain('--model');
-          expect(args).toContain('gpt-5.5');
-          expect(args).toContain('service_tier="priority"');
-        },
-      );
-    } finally {
-      rmSync(argsPath, { force: true });
-      await writeAppConfig(process.env.OD_DATA_DIR, {
-        agentModels: previousConfig.agentModels ?? null,
-      });
-    }
-  });
-
-  it('keeps service tier overrides when /api/runs omits model and settings has none', async () => {
-    if (!process.env.OD_DATA_DIR) {
-      throw new Error('OD_DATA_DIR is required for service tier settings tests');
-    }
-    const argsPath = join(tmpdir(), `od-codex-args-${randomUUID()}.json`);
-    const previousConfig = await readAppConfig(process.env.OD_DATA_DIR);
-    try {
-      await writeAppConfig(process.env.OD_DATA_DIR, { agentModels: null });
-      await withFakeAgent(
-        'codex',
-        `
-const fs = require('node:fs');
-const args = process.argv.slice(2);
-if (args[0] === 'debug' && args[1] === 'models') {
-  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', service_tiers: [{ id: 'priority', label: 'Fast' }] }]));
+  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', additional_speed_tiers: ['fast'] }]));
   process.exit(0);
 }
 if (args[0] === 'login' && args[1] === 'status') {
@@ -1169,7 +1116,7 @@ process.exit(0);
             body: JSON.stringify({
               agentId: 'codex',
               message: 'hello',
-              serviceTier: 'priority',
+              serviceTier: 'fast',
             }),
           });
           expect(createResponse.status).toBe(202);
@@ -1179,7 +1126,63 @@ process.exit(0);
           const args = JSON.parse(readFileSync(argsPath, 'utf8')) as string[];
           expect(args).toContain('--model');
           expect(args).toContain('gpt-5.5');
-          expect(args).toContain('service_tier="priority"');
+          expect(args).toContain('service_tier="fast"');
+        },
+      );
+    } finally {
+      rmSync(argsPath, { force: true });
+      await writeAppConfig(process.env.OD_DATA_DIR, {
+        agentModels: previousConfig.agentModels ?? null,
+      });
+    }
+  });
+
+  it('rejects an explicit Codex tier before spawn when no exact compatible model is selected', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for service tier settings tests');
+    }
+    const argsPath = join(tmpdir(), `od-codex-args-${randomUUID()}.json`);
+    const previousConfig = await readAppConfig(process.env.OD_DATA_DIR);
+    try {
+      await writeAppConfig(process.env.OD_DATA_DIR, { agentModels: null });
+      await withFakeAgent(
+        'codex',
+        `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === 'debug' && args[1] === 'models') {
+  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', additional_speed_tiers: ['fast'] }]));
+  process.exit(0);
+}
+if (args[0] === 'login' && args[1] === 'status') {
+  console.log('Logged in');
+  process.exit(0);
+}
+fs.writeFileSync(${JSON.stringify(argsPath)}, JSON.stringify(args));
+console.log(JSON.stringify({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] }));
+process.exit(0);
+`,
+        async () => {
+          await fetch(`${baseUrl}/api/agents`);
+          const createResponse = await fetch(`${baseUrl}/api/runs`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'codex',
+              message: 'hello',
+              serviceTier: 'fast',
+            }),
+          });
+          expect(createResponse.status).toBe(202);
+          const { runId } = await createResponse.json() as { runId: string };
+          const status = await waitForRunStatus(baseUrl, runId);
+
+          expect(status).toMatchObject({
+            status: 'failed',
+            errorCode: 'MODEL_UNAVAILABLE',
+          });
+          const probeArgs = JSON.parse(readFileSync(argsPath, 'utf8')) as string[];
+          expect(probeArgs).not.toContain('exec');
         },
       );
     } finally {

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1121,12 +1121,22 @@ process.exit(0);
           });
           expect(createResponse.status).toBe(202);
           const { runId } = await createResponse.json() as { runId: string };
-          await waitForRunStatus(baseUrl, runId);
+          const status = await waitForRunStatus(baseUrl, runId) as {
+            status: string;
+            executionDiagnostics?: {
+              environment: {
+                requestedModel: { missingReason?: string };
+              };
+            };
+          };
 
           const args = JSON.parse(readFileSync(argsPath, 'utf8')) as string[];
           expect(args).toContain('--model');
           expect(args).toContain('gpt-5.5');
           expect(args).toContain('service_tier="fast"');
+          expect(status.executionDiagnostics?.environment.requestedModel).toMatchObject({
+            missingReason: 'requested_model_not_recorded',
+          });
         },
       );
     } finally {

--- a/apps/daemon/tests/codex-config-normalize.test.ts
+++ b/apps/daemon/tests/codex-config-normalize.test.ts
@@ -392,6 +392,11 @@ describe('normalizeCodexConfigFile', () => {
     expect(normalize(p)).toBe(normalize('/custom/codex-home/config.toml'));
   });
 
+  it('resolves CODEX_HOME case-insensitively like a Windows child process', () => {
+    const p = resolveCodexConfigPath({ Codex_Home: '/custom/mixed-case-home' });
+    expect(normalize(p)).toBe(normalize('/custom/mixed-case-home/config.toml'));
+  });
+
   // -------------------------------------------------------------------------
   // BLOCKER 2 regression cases — atomic write and logged errors
   // -------------------------------------------------------------------------

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -188,6 +188,120 @@ describe('Codex configured-model capability preflight', () => {
     expect(args).not.toContain('gpt-5.5');
   });
 
+  it('launches a future model and effort only when both are advertised by the live catalog', async () => {
+    const fixture = await startCodexFixture();
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      {
+        id: 'gpt-future',
+        label: 'GPT Future',
+        supportedReasoningLevels: ['future-deep'],
+      },
+    ]);
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const finished = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-future',
+      reasoning: 'future-deep',
+    });
+
+    expect(finished.status).toBe('succeeded');
+    const args = JSON.parse(await readFile(fixture.spawnMarker, 'utf8')) as string[];
+    expect(args).toContain('gpt-future');
+    expect(args).toContain('model_reasoning_effort="future-deep"');
+  });
+
+  it('blocks ChatGPT-only Codex runs when an API key exists but ChatGPT login is absent', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-chatgpt-auth-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker, {
+      version: 'codex-cli 0.143.0',
+      spawnSucceeds: true,
+      loginStatus: 'Not logged in',
+      loginExitCode: 1,
+    });
+    await mkdir(codexHome, { recursive: true });
+    isolateExternalProcessEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: {
+        codex: {
+          ...codexTestEnv(fakeCodex, codexHome),
+          OPENAI_API_KEY: 'test-only-key',
+        },
+      },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
+    ]);
+
+    const { projectId, conversationId } = await createConversation(started.url);
+    const failed = await sendRunAndWait(started.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      codexAuthMode: 'chatgpt',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+    });
+    await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+
+  it('blocks ChatGPT-only Codex runs when a custom provider is selected', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-chatgpt-provider-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker, {
+      version: 'codex-cli 0.143.0',
+      spawnSucceeds: true,
+      loginStatus: 'Logged in using ChatGPT',
+    });
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'config.toml'),
+      [
+        'model_provider = "local-gateway"',
+        '',
+        '[model_providers.local-gateway]',
+        'base_url = "https://example.invalid/v1"',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    isolateExternalProcessEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: codexTestEnv(fakeCodex, codexHome) },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
+    ]);
+
+    const { projectId, conversationId } = await createConversation(started.url);
+    const failed = await sendRunAndWait(started.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      codexAuthMode: 'chatgpt',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+      failureDetail: 'custom_provider_not_allowed',
+    });
+    await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+
   it('continues to Codex exec at the known-compatible version without consulting a model catalog', async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-model-compatible-'));
     const codexHome = path.join(tempDir, 'codex-home');
@@ -354,6 +468,8 @@ async function writeFakeCodex(
     loginProbeMarker?: string;
     spawnSucceeds?: boolean;
     models?: Array<Record<string, unknown>>;
+    loginStatus?: string;
+    loginExitCode?: number;
   } = {},
 ): Promise<string> {
   const script = path.join(dir, 'fake-codex.cjs');
@@ -404,8 +520,8 @@ if (args.includes('--version')) {
   ${options.loginProbeMarker
     ? `fs.writeFileSync(${JSON.stringify(options.loginProbeMarker)}, '1');`
     : ''}
-  console.log('Logged in using ChatGPT');
-  process.exit(0);
+  console.log(${JSON.stringify(options.loginStatus ?? 'Logged in using ChatGPT')});
+  process.exit(${JSON.stringify(options.loginExitCode ?? 0)});
 } else {
   fs.writeFileSync(${JSON.stringify(spawnMarker)}, JSON.stringify(args));
   if (${JSON.stringify(options.spawnSucceeds === true)}) {
@@ -485,7 +601,7 @@ async function sendRunAndWait(
   url: string,
   projectId: string,
   conversationId: string,
-  options: { model?: string; reasoning?: string; serviceTier?: string } = {},
+  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt' } = {},
 ): Promise<RunStatus> {
   const runId = await startRun(url, projectId, conversationId, options);
   return await waitForRun(url, runId);
@@ -495,7 +611,7 @@ async function startRun(
   url: string,
   projectId: string,
   conversationId: string,
-  options: { model?: string; reasoning?: string; serviceTier?: string } = {},
+  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt' } = {},
 ): Promise<string> {
   const response = await fetch(`${url}/api/runs`, {
     method: 'POST',
@@ -509,6 +625,7 @@ async function startRun(
       model: options.model ?? 'default',
       ...(options.reasoning ? { reasoning: options.reasoning } : {}),
       ...(options.serviceTier ? { serviceTier: options.serviceTier } : {}),
+      ...(options.codexAuthMode ? { codexAuthMode: options.codexAuthMode } : {}),
       message: 'Create a small text artifact.',
       currentPrompt: 'Create a small text artifact.',
     }),

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -124,6 +124,25 @@ describe('Codex configured-model capability preflight', () => {
     await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
   });
 
+  it('rejects an unsupported persisted model when MCP omits the model field', async () => {
+    const fixture = await startCodexFixture();
+    await putConfig(fixture.url, {
+      agentModels: { codex: { model: 'persisted-unsupported-model' } },
+    });
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      codexAuthMode: 'chatgpt',
+      omitModel: true,
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+      failureCategory: 'model_unavailable',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
   it('fails closed when live compatibility cannot prove explicit Codex settings', async () => {
     const fixture = await startCodexFixture({ seedCatalog: false });
     const { projectId, conversationId } = await createConversation(fixture.url);
@@ -754,7 +773,7 @@ async function sendRunAndWait(
   url: string,
   projectId: string,
   conversationId: string,
-  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt' } = {},
+  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt'; omitModel?: boolean } = {},
 ): Promise<RunStatus> {
   const runId = await startRun(url, projectId, conversationId, options);
   return await waitForRun(url, runId);
@@ -764,7 +783,7 @@ async function startRun(
   url: string,
   projectId: string,
   conversationId: string,
-  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt' } = {},
+  options: { model?: string; reasoning?: string; serviceTier?: string; codexAuthMode?: 'chatgpt'; omitModel?: boolean } = {},
 ): Promise<string> {
   const response = await fetch(`${url}/api/runs`, {
     method: 'POST',
@@ -775,7 +794,7 @@ async function startRun(
       assistantMessageId: `assistant_codex_preflight_${randomUUID()}`,
       clientRequestId: `client_codex_preflight_${randomUUID()}`,
       agentId: 'codex',
-      model: options.model ?? 'default',
+      ...(!options.omitModel ? { model: options.model ?? 'default' } : {}),
       ...(options.reasoning ? { reasoning: options.reasoning } : {}),
       ...(options.serviceTier ? { serviceTier: options.serviceTier } : {}),
       ...(options.codexAuthMode ? { codexAuthMode: options.codexAuthMode } : {}),

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -28,6 +28,13 @@ type RunStatus = {
   failureCategory?: string | null;
   failureDetail?: string | null;
   failureAction?: string | null;
+  executionDiagnostics?: {
+    environment: {
+      requestedModel: { state: string; missingReason?: string };
+      requestedReasoning: { state: string; missingReason?: string };
+      resolvedModel: { state: string; missingReason?: string };
+    };
+  };
 };
 
 const CODEX_AUTH_OR_ENDPOINT_ENV_KEYS = [
@@ -124,23 +131,41 @@ describe('Codex configured-model capability preflight', () => {
     await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
   });
 
-  it('rejects an unsupported persisted model when MCP omits the model field', async () => {
+  it('uses the standalone Codex CLI default when strict MCP omits the model field', async () => {
     const fixture = await startCodexFixture();
     await putConfig(fixture.url, {
       agentModels: { codex: { model: 'persisted-unsupported-model' } },
     });
     const { projectId, conversationId } = await createConversation(fixture.url);
-    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+    const succeeded = await sendRunAndWait(fixture.url, projectId, conversationId, {
       codexAuthMode: 'chatgpt',
       omitModel: true,
     });
 
-    expect(failed).toMatchObject({
-      status: 'failed',
-      errorCode: 'MODEL_UNAVAILABLE',
-      failureCategory: 'model_unavailable',
+    expect(succeeded).toMatchObject({
+      status: 'succeeded',
+      errorCode: null,
+      executionDiagnostics: {
+        environment: {
+          requestedModel: {
+            state: 'not_collected',
+            missingReason: 'codex_cli_default_model',
+          },
+          requestedReasoning: {
+            state: 'not_collected',
+            missingReason: 'codex_cli_default_reasoning',
+          },
+          resolvedModel: {
+            state: 'not_collected',
+            missingReason: 'codex_rollout_model_unconfirmed',
+          },
+        },
+      },
     });
-    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+    const args = JSON.parse(await readFile(fixture.spawnMarker, 'utf8')) as string[];
+    expect(args).toContain('exec');
+    expect(args).not.toContain('--model');
+    expect(args).not.toContain('persisted-unsupported-model');
   });
 
   it('fails closed when live compatibility cannot prove explicit Codex settings', async () => {

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { writeAppConfig } from '../src/app-config.js';
 import { startServer } from '../src/server.js';
 import {
   clearRememberedLiveModels,
@@ -66,6 +67,7 @@ describe('Codex configured-model capability preflight', () => {
     }
     tempDir = null;
     clearRememberedLiveModels('codex');
+    clearRememberedLiveModels('codex', 'chatgpt');
     restoreEnv(originalEnv);
   });
 
@@ -210,6 +212,63 @@ describe('Codex configured-model capability preflight', () => {
     expect(args).toContain('model_reasoning_effort="future-deep"');
   });
 
+  it('validates ChatGPT-only runs against the strict catalog instead of the generic provider catalog', async () => {
+    const fixture = await startCodexFixture();
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'provider-only-model', label: 'Provider only' },
+    ]);
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      {
+        id: 'chatgpt-only-model',
+        label: 'ChatGPT only',
+        supportedReasoningLevels: ['future-deep'],
+      },
+    ], 'chatgpt');
+    const firstConversation = await createConversation(fixture.url);
+    const rejected = await sendRunAndWait(
+      fixture.url,
+      firstConversation.projectId,
+      firstConversation.conversationId,
+      {
+        model: 'provider-only-model',
+        codexAuthMode: 'chatgpt',
+      },
+    );
+
+    expect(rejected).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      {
+        id: 'chatgpt-only-model',
+        label: 'ChatGPT only',
+        supportedReasoningLevels: ['future-deep'],
+      },
+    ], 'chatgpt');
+    const secondConversation = await createConversation(fixture.url);
+    const finished = await sendRunAndWait(
+      fixture.url,
+      secondConversation.projectId,
+      secondConversation.conversationId,
+      {
+        model: 'chatgpt-only-model',
+        reasoning: 'future-deep',
+        codexAuthMode: 'chatgpt',
+      },
+    );
+
+    expect(finished.status).toBe('succeeded');
+    const args = JSON.parse(await readFile(fixture.spawnMarker, 'utf8')) as string[];
+    expect(args).toContain('chatgpt-only-model');
+    expect(args).toContain('model_reasoning_effort="future-deep"');
+  });
+
   it('blocks ChatGPT-only Codex runs when an API key exists but ChatGPT login is absent', async () => {
     tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-chatgpt-auth-'));
     const codexHome = path.join(tempDir, 'codex-home');
@@ -238,6 +297,10 @@ describe('Codex configured-model capability preflight', () => {
       { id: 'default', label: 'Default (CLI config)' },
       { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
     ]);
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
+    ], 'chatgpt');
 
     const { projectId, conversationId } = await createConversation(started.url);
     const failed = await sendRunAndWait(started.url, projectId, conversationId, {
@@ -286,6 +349,10 @@ describe('Codex configured-model capability preflight', () => {
       { id: 'default', label: 'Default (CLI config)' },
       { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
     ]);
+    rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'gpt-5.6-sol', label: 'gpt-5.6-sol', supportedReasoningLevels: ['xhigh'] },
+    ], 'chatgpt');
 
     const { projectId, conversationId } = await createConversation(started.url);
     const failed = await sendRunAndWait(started.url, projectId, conversationId, {
@@ -401,13 +468,18 @@ describe('Codex configured-model capability preflight', () => {
     });
     await mkdir(codexHome, { recursive: true });
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
-    await putConfig(started.url, {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for Codex preflight fixtures');
+    }
+    const configPatch = {
       agentId: 'codex',
       agentCliEnv: { codex: codexTestEnv(fakeCodex, codexHome) },
       telemetry: { metrics: false, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
-    });
+    };
+    await writeAppConfig(process.env.OD_DATA_DIR, configPatch);
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, configPatch);
     if (options.seedCatalog !== false) rememberLiveModels('codex', [
       { id: 'default', label: 'Default (CLI config)' },
       {

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -1,11 +1,15 @@
 import type { Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
-import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
+import {
+  clearRememberedLiveModels,
+  rememberLiveModels,
+} from '../src/runtimes/models.js';
 
 type StartedServer = {
   url: string;
@@ -21,6 +25,7 @@ type RunStatus = {
   exitCode?: number | null;
   failureCategory?: string | null;
   failureDetail?: string | null;
+  failureAction?: string | null;
 };
 
 const CODEX_AUTH_OR_ENDPOINT_ENV_KEYS = [
@@ -60,6 +65,7 @@ describe('Codex configured-model capability preflight', () => {
       await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
     }
     tempDir = null;
+    clearRememberedLiveModels('codex');
     restoreEnv(originalEnv);
   });
 
@@ -98,6 +104,88 @@ describe('Codex configured-model capability preflight', () => {
     expect(failed.failureDetail).toBe('cli_version_incompatible');
     expect(failed.exitCode).toBeNull();
     await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+
+  it('rejects an explicit model outside the Codex catalog before spawning', async () => {
+    const fixture = await startCodexFixture();
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-unsupported-future',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+      failureCategory: 'model_unavailable',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('fails closed when live compatibility cannot prove explicit Codex settings', async () => {
+    const fixture = await startCodexFixture({ seedCatalog: false });
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+      failureCategory: 'model_unavailable',
+      failureAction: 'upgrade',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('rejects an unsupported explicit reasoning level before spawning', async () => {
+    const fixture = await startCodexFixture();
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'minimal',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+      failureCategory: 'model_unavailable',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('rejects an unsupported tier without switching the explicit Codex model', async () => {
+    const fixture = await startCodexFixture();
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-5.1',
+      serviceTier: 'fast',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'MODEL_UNAVAILABLE',
+      failureCategory: 'model_unavailable',
+    });
+    expect(failed.error).toContain("'gpt-5.1'");
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('launches the exact live-catalog model, reasoning, and service tier unchanged', async () => {
+    const fixture = await startCodexFixture();
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    const finished = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
+    });
+
+    expect(finished.status).toBe('succeeded');
+    const args = JSON.parse(await readFile(fixture.spawnMarker, 'utf8')) as string[];
+    expect(args).toContain('gpt-5.6-sol');
+    expect(args).toContain('model_reasoning_effort="xhigh"');
+    expect(args).toContain('service_tier="fast"');
+    expect(args).not.toContain('gpt-5.5');
   });
 
   it('continues to Codex exec at the known-compatible version without consulting a model catalog', async () => {
@@ -186,6 +274,43 @@ describe('Codex configured-model capability preflight', () => {
     expect(canceled.exitCode).toBeNull();
     await expect(pathExists(spawnMarker)).resolves.toBe(false);
   });
+
+  async function startCodexFixture(
+    options: { seedCatalog?: boolean } = {},
+  ): Promise<StartedServer & { spawnMarker: string }> {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-selection-preflight-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker, {
+      version: 'codex-cli 0.143.0',
+      spawnSucceeds: true,
+    });
+    await mkdir(codexHome, { recursive: true });
+    isolateExternalProcessEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: codexTestEnv(fakeCodex, codexHome) },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+    if (options.seedCatalog !== false) rememberLiveModels('codex', [
+      { id: 'default', label: 'Default (CLI config)' },
+      {
+        id: 'gpt-5.6-sol',
+        label: 'gpt-5.6-sol',
+        supportedReasoningLevels: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+        serviceTierOptions: [{ id: 'fast', label: 'Fast' }],
+      },
+      {
+        id: 'gpt-5.1',
+        label: 'gpt-5.1',
+        supportedReasoningLevels: ['none', 'minimal', 'low', 'medium', 'high'],
+      },
+    ]);
+    else clearRememberedLiveModels('codex');
+    return { ...started, spawnMarker };
+  }
 });
 
 function snapshotEnv(): EnvSnapshot {
@@ -228,6 +353,7 @@ async function writeFakeCodex(
     versionProbeMarker?: string;
     loginProbeMarker?: string;
     spawnSucceeds?: boolean;
+    models?: Array<Record<string, unknown>>;
   } = {},
 ): Promise<string> {
   const script = path.join(dir, 'fake-codex.cjs');
@@ -244,6 +370,36 @@ if (args.includes('--version')) {
     console.log(${JSON.stringify(options.version ?? 'codex-cli 0.142.5')});
     process.exit(0);
   }, ${JSON.stringify(options.versionDelayMs ?? 0)});
+} else if (args[0] === 'debug' && args[1] === 'models') {
+  console.log(JSON.stringify({ models: ${JSON.stringify(options.models ?? [
+    {
+      slug: 'gpt-5.6-sol',
+      display_name: 'gpt-5.6-sol',
+      visibility: 'list',
+      supported_reasoning_levels: [
+        { effort: 'low' },
+        { effort: 'medium' },
+        { effort: 'high' },
+        { effort: 'xhigh' },
+        { effort: 'max' },
+        { effort: 'ultra' },
+      ],
+      additional_speed_tiers: ['fast'],
+    },
+    {
+      slug: 'gpt-5.1',
+      display_name: 'gpt-5.1',
+      visibility: 'list',
+      supported_reasoning_levels: [
+        { effort: 'none' },
+        { effort: 'minimal' },
+        { effort: 'low' },
+        { effort: 'medium' },
+        { effort: 'high' },
+      ],
+    },
+  ])} }));
+  process.exit(0);
 } else if (args[0] === 'login' && args[1] === 'status') {
   ${options.loginProbeMarker
     ? `fs.writeFileSync(${JSON.stringify(options.loginProbeMarker)}, '1');`
@@ -329,8 +485,9 @@ async function sendRunAndWait(
   url: string,
   projectId: string,
   conversationId: string,
+  options: { model?: string; reasoning?: string; serviceTier?: string } = {},
 ): Promise<RunStatus> {
-  const runId = await startRun(url, projectId, conversationId);
+  const runId = await startRun(url, projectId, conversationId, options);
   return await waitForRun(url, runId);
 }
 
@@ -338,6 +495,7 @@ async function startRun(
   url: string,
   projectId: string,
   conversationId: string,
+  options: { model?: string; reasoning?: string; serviceTier?: string } = {},
 ): Promise<string> {
   const response = await fetch(`${url}/api/runs`, {
     method: 'POST',
@@ -348,7 +506,9 @@ async function startRun(
       assistantMessageId: `assistant_codex_preflight_${randomUUID()}`,
       clientRequestId: `client_codex_preflight_${randomUUID()}`,
       agentId: 'codex',
-      model: 'default',
+      model: options.model ?? 'default',
+      ...(options.reasoning ? { reasoning: options.reasoning } : {}),
+      ...(options.serviceTier ? { serviceTier: options.serviceTier } : {}),
       message: 'Create a small text artifact.',
       currentPrompt: 'Create a small text artifact.',
     }),

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -16,6 +16,7 @@ type StartedServer = {
   url: string;
   server: Server;
   shutdown?: () => Promise<void> | void;
+  agentDiscoveryReady: Promise<void>;
 };
 
 type RunStatus = {
@@ -87,7 +88,7 @@ describe('Codex configured-model capability preflight', () => {
     // mixed-case inherited keys before starting the server.
     process.env.OpenAI_Api_Key = 'ambient-test-only';
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, {
       agentId: 'codex',
       agentCliEnv: {
@@ -281,7 +282,7 @@ describe('Codex configured-model capability preflight', () => {
     });
     await mkdir(codexHome, { recursive: true });
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, {
       agentId: 'codex',
       agentCliEnv: {
@@ -338,7 +339,7 @@ describe('Codex configured-model capability preflight', () => {
       'utf8',
     );
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, {
       agentId: 'codex',
       agentCliEnv: { codex: codexTestEnv(fakeCodex, codexHome) },
@@ -364,9 +365,80 @@ describe('Codex configured-model capability preflight', () => {
     expect(failed).toMatchObject({
       status: 'failed',
       errorCode: 'AGENT_AUTH_REQUIRED',
+      failureCategory: 'auth',
       failureDetail: 'custom_provider_not_allowed',
+      failureAction: 'relogin',
     });
     await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+
+  it.each([
+    ['custom provider', 'model_provider = "local-gateway"\n'],
+    ['custom endpoint', 'openai_base_url = "https://example.invalid/v1"\n'],
+  ])('blocks a project %s from the effective Codex child cwd', async (_label, content) => {
+    const fixture = await startCodexFixture({ seedCatalog: false });
+    const { projectId, conversationId } = await createConversation(fixture.url);
+    if (!process.env.OD_DATA_DIR) throw new Error('OD_DATA_DIR is required');
+    const projectRoot = path.join(process.env.OD_DATA_DIR, 'projects', projectId);
+    await mkdir(path.join(projectRoot, '.codex'), { recursive: true });
+    await writeFile(path.join(projectRoot, '.codex', 'config.toml'), content, 'utf8');
+
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      codexAuthMode: 'chatgpt',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+      failureCategory: 'auth',
+      failureDetail: 'custom_provider_not_allowed',
+      failureAction: 'relogin',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('uses the same custom-provider failure contract for a managed endpoint overlay', async () => {
+    const fixture = await startCodexFixture({ seedCatalog: false });
+    await writeFile(
+      path.join(fixture.codexHome, 'managed_config.toml'),
+      'chatgpt_base_url = "https://managed.example.invalid/backend-api/codex"\n',
+      'utf8',
+    );
+    const { projectId, conversationId } = await createConversation(fixture.url);
+
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      codexAuthMode: 'chatgpt',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+      failureCategory: 'auth',
+      failureDetail: 'custom_provider_not_allowed',
+      failureAction: 'relogin',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
+  });
+
+  it('fails deterministically when an effective Codex config layer is unreadable', async () => {
+    const fixture = await startCodexFixture({ seedCatalog: false });
+    await mkdir(path.join(fixture.codexHome, 'config.toml'), { recursive: true });
+    const { projectId, conversationId } = await createConversation(fixture.url);
+
+    const failed = await sendRunAndWait(fixture.url, projectId, conversationId, {
+      codexAuthMode: 'chatgpt',
+    });
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+      failureCategory: 'auth',
+      failureDetail: 'config_inspection_failed',
+      failureAction: 'repair',
+    });
+    await expect(pathExists(fixture.spawnMarker)).resolves.toBe(false);
   });
 
   it('continues to Codex exec at the known-compatible version without consulting a model catalog', async () => {
@@ -385,7 +457,7 @@ describe('Codex configured-model capability preflight', () => {
     );
 
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, {
       agentId: 'codex',
       agentCliEnv: {
@@ -422,7 +494,7 @@ describe('Codex configured-model capability preflight', () => {
     );
 
     isolateExternalProcessEnv();
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, {
       agentId: 'codex',
       agentCliEnv: {
@@ -458,7 +530,7 @@ describe('Codex configured-model capability preflight', () => {
 
   async function startCodexFixture(
     options: { seedCatalog?: boolean } = {},
-  ): Promise<StartedServer & { spawnMarker: string }> {
+  ): Promise<StartedServer & { codexHome: string; spawnMarker: string }> {
     tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-selection-preflight-'));
     const codexHome = path.join(tempDir, 'codex-home');
     const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
@@ -478,7 +550,7 @@ describe('Codex configured-model capability preflight', () => {
       privacyDecisionAt: Date.now(),
     };
     await writeAppConfig(process.env.OD_DATA_DIR, configPatch);
-    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    started = await startTestServer();
     await putConfig(started.url, configPatch);
     if (options.seedCatalog !== false) rememberLiveModels('codex', [
       { id: 'default', label: 'Default (CLI config)' },
@@ -494,10 +566,19 @@ describe('Codex configured-model capability preflight', () => {
         supportedReasoningLevels: ['none', 'minimal', 'low', 'medium', 'high'],
       },
     ]);
-    else clearRememberedLiveModels('codex');
-    return { ...started, spawnMarker };
+    else {
+      clearRememberedLiveModels('codex');
+      clearRememberedLiveModels('codex', 'chatgpt');
+    }
+    return { ...started, codexHome, spawnMarker };
   }
 });
+
+async function startTestServer(): Promise<StartedServer> {
+  const server = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+  await server.agentDiscoveryReady;
+  return server;
+}
 
 function snapshotEnv(): EnvSnapshot {
   return {

--- a/apps/daemon/tests/codex-rollout-usage.test.ts
+++ b/apps/daemon/tests/codex-rollout-usage.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  codexResolvedRunFinishedProperties,
   codexSessionIdFromRunEvents,
   extractCodexLastTurnFirstCallUsage,
   readCodexRolloutFirstCall,
@@ -195,5 +196,19 @@ describe('readCodexRolloutFirstCall', () => {
     await expect(
       readCodexRolloutFirstCall({ codexHome: '/nonexistent', sessionId: null }),
     ).resolves.toBeNull();
+  });
+});
+
+describe('Codex run-finished execution properties', () => {
+  it('maps authoritative turn-context settings into resolved analytics fields', () => {
+    expect(codexResolvedRunFinishedProperties({
+      resolved_model_id: 'gpt-5.6-sol',
+      resolved_reasoning_effort: 'xhigh',
+      resolved_service_tier: 'fast',
+    })).toEqual({
+      resolved_model_id: 'gpt-5.6-sol',
+      resolved_reasoning_effort: 'xhigh',
+      resolved_service_tier: 'fast',
+    });
   });
 });

--- a/apps/daemon/tests/codex-rollout-usage.test.ts
+++ b/apps/daemon/tests/codex-rollout-usage.test.ts
@@ -28,6 +28,16 @@ function tokenCount(input: number | null, cached: number | null): string {
     },
   });
 }
+function turnContext(model: string, effort: string, serviceTier?: string): string {
+  return JSON.stringify({
+    type: 'turn_context',
+    payload: {
+      model,
+      effort,
+      ...(serviceTier ? { service_tier: serviceTier } : {}),
+    },
+  });
+}
 
 describe('extractCodexLastTurnFirstCallUsage', () => {
   it('reports the first call of the LAST turn, not the whole-session aggregate', () => {
@@ -49,6 +59,26 @@ describe('extractCodexLastTurnFirstCallUsage', () => {
       first_call_input_tokens: 13342,
       first_call_cache_read_input_tokens: 12672,
       first_call_cache_hit_ratio: 12672 / 13342,
+    });
+  });
+
+  it('reports executed settings only from the LAST turn_context', () => {
+    const rollout = [
+      taskStarted(),
+      turnContext('gpt-5.5', 'high', 'flex'),
+      tokenCount(100, 25),
+      taskStarted(),
+      turnContext('gpt-5.6-sol', 'xhigh', 'fast'),
+      tokenCount(200, 100),
+    ].join('\n');
+
+    expect(extractCodexLastTurnFirstCallUsage(rollout)).toEqual({
+      first_call_input_tokens: 200,
+      first_call_cache_read_input_tokens: 100,
+      first_call_cache_hit_ratio: 0.5,
+      resolved_model_id: 'gpt-5.6-sol',
+      resolved_reasoning_effort: 'xhigh',
+      resolved_service_tier: 'fast',
     });
   });
 

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -2673,7 +2673,7 @@ setImmediate(() => process.exit(0));
     );
   });
 
-  it('keeps service tier overrides when connection tests omit model but settings has one', async () => {
+  it('keeps literal fast service tier when connection tests omit model but settings has an exact model', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for service tier settings tests');
     }
@@ -2689,7 +2689,7 @@ setImmediate(() => process.exit(0));
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 if (args[0] === 'debug' && args[1] === 'models') {
-  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', service_tiers: [{ id: 'priority', label: 'Fast' }] }]));
+  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', additional_speed_tiers: ['fast'] }]));
   process.exit(0);
 }
 if (args[0] === 'login' && args[1] === 'status') {
@@ -2707,7 +2707,7 @@ setImmediate(() => process.exit(0));
             body: JSON.stringify({
               mode: 'agent',
               agentId: 'codex',
-              serviceTier: 'priority',
+              serviceTier: 'fast',
             }),
           });
           expect(res.status).toBe(200);
@@ -2721,7 +2721,7 @@ setImmediate(() => process.exit(0));
           const args = JSON.parse(await fsp.readFile(argvFile, 'utf8')) as string[];
           expect(args).toContain('--model');
           expect(args).toContain('gpt-5.5');
-          expect(args).toContain('service_tier="priority"');
+          expect(args).toContain('service_tier="fast"');
         },
       );
     } finally {
@@ -2732,7 +2732,7 @@ setImmediate(() => process.exit(0));
     }
   });
 
-  it('keeps service tier overrides when connection tests omit model and settings has none', async () => {
+  it('rejects a Codex connection-test tier before spawn when no exact compatible model is selected', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for service tier settings tests');
     }
@@ -2746,7 +2746,7 @@ setImmediate(() => process.exit(0));
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 if (args[0] === 'debug' && args[1] === 'models') {
-  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', service_tiers: [{ id: 'priority', label: 'Fast' }] }]));
+  console.log(JSON.stringify([{ id: 'gpt-5.5', name: 'gpt-5.5', additional_speed_tiers: ['fast'] }]));
   process.exit(0);
 }
 if (args[0] === 'login' && args[1] === 'status') {
@@ -2765,21 +2765,18 @@ setImmediate(() => process.exit(0));
             body: JSON.stringify({
               mode: 'agent',
               agentId: 'codex',
-              serviceTier: 'priority',
+              serviceTier: 'fast',
             }),
           });
           expect(res.status).toBe(200);
           await expect(res.json()).resolves.toMatchObject({
-            ok: true,
-            kind: 'success',
+            ok: false,
+            kind: 'not_found_model',
             agentName: 'Codex CLI',
-            model: 'gpt-5.5',
+            model: 'default',
           });
-
-          const args = JSON.parse(await fsp.readFile(argvFile, 'utf8')) as string[];
-          expect(args).toContain('--model');
-          expect(args).toContain('gpt-5.5');
-          expect(args).toContain('service_tier="priority"');
+          const probeArgs = JSON.parse(await fsp.readFile(argvFile, 'utf8')) as string[];
+          expect(probeArgs).not.toContain('exec');
         },
       );
     } finally {
@@ -4262,7 +4259,7 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
     }
   });
 
-  it('drops invalid agent reasoning options before spawning an agent', async () => {
+  it('rejects unknown Codex reasoning before spawning an agent', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');
     try {
@@ -4286,15 +4283,12 @@ console.log(JSON.stringify({ type: 'item.completed', item: { type: 'agent_messag
           });
           expect(res.status).toBe(200);
           await expect(res.json()).resolves.toMatchObject({
-            ok: true,
-            kind: 'success',
+            ok: false,
+            kind: 'not_found_model',
             model: 'gpt-5',
           });
 
-          const args = JSON.parse(await fsp.readFile(argvFile, 'utf8')) as string[];
-          expect(args).toEqual(expect.arrayContaining(['--model', 'gpt-5']));
-          expect(args.some((arg) => arg.includes('model_reasoning_effort'))).toBe(false);
-          expect(args.some((arg) => arg.includes('totally-invalid-effort'))).toBe(false);
+          await expect(fsp.access(argvFile)).rejects.toThrow();
         },
       );
     } finally {

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -965,9 +965,12 @@ describe('public MCP discovery + generation tools', () => {
           promptInputFormat: 'text',
           streamFormat: 'codex-jsonl',
           authStatus: 'ok',
-          chatgptAuthStatus: 'missing',
-          chatgptAuthMessage: 'Run codex login.',
+          chatgptAuthStatus: 'ok',
           modelsSource: 'live',
+          chatgptModelsSource: 'unavailable',
+          chatgptModels: [],
+          chatgptReady: false,
+          chatgptReadyMessage: 'API keys and custom providers are intentionally not accepted.',
           models: [
             { id: 'default', label: 'Default' },
             { id: 'sonnet', label: 'Sonnet' },
@@ -995,17 +998,13 @@ describe('public MCP discovery + generation tools', () => {
       id: 'codex',
       name: 'Codex CLI',
       version: '2.1.153',
-      authStatus: 'missing',
-      authMessage: 'Run codex login.',
-      chatgptAuthStatus: 'missing',
-      chatgptAuthMessage: 'Run codex login.',
-      modelsSource: 'live',
-      models: [
-        { id: 'default', label: 'Default' },
-        { id: 'sonnet', label: 'Sonnet' },
-        { id: 'opus', label: 'Opus' },
-      ],
-      modelsCount: 3,
+      authStatus: 'ok',
+      chatgptAuthStatus: 'ok',
+      modelsSource: 'unavailable',
+      models: [],
+      modelsCount: 0,
+      ready: false,
+      readyMessage: 'API keys and custom providers are intentionally not accepted.',
     });
     // Protocol fields we don't want the agent reasoning about:
     expect(parsed.agents[0]).not.toHaveProperty('bin');
@@ -1013,7 +1012,33 @@ describe('public MCP discovery + generation tools', () => {
     expect(parsed.agents[0]).not.toHaveProperty('streamFormat');
   });
 
-  it('list_agents returns the complete live compatibility catalog', async () => {
+  it('list_agents returns the complete ChatGPT-strict Codex compatibility catalog', async () => {
+    const longModels = Array.from({ length: 165 }, (_, i) => ({ id: `m-${i}`, label: `M${i}` }));
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      agents: [{
+        id: 'codex',
+        name: 'Codex CLI',
+        available: true,
+        authStatus: 'ok',
+        chatgptAuthStatus: 'ok',
+        modelsSource: 'live',
+        models: [{ id: 'provider-only', label: 'Provider only' }],
+        chatgptModelsSource: 'live',
+        chatgptModels: longModels,
+      }],
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', {});
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.agents[0].models).toHaveLength(165);
+    expect(parsed.agents[0].models[164]).toEqual({ id: 'm-164', label: 'M164' });
+    expect(parsed.agents[0].modelsCount).toBe(165);
+    expect(parsed.agents[0]).toMatchObject({ modelsSource: 'live', ready: true });
+    expect(parsed.agents[0].models).not.toContainEqual({ id: 'provider-only', label: 'Provider only' });
+  });
+
+  it('list_agents keeps non-Codex model lists bounded while reporting the full count', async () => {
     const longModels = Array.from({ length: 165 }, (_, i) => ({ id: `m-${i}`, label: `M${i}` }));
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       agents: [{ id: 'opencode', name: 'OpenCode', available: true, models: longModels }],
@@ -1022,8 +1047,7 @@ describe('public MCP discovery + generation tools', () => {
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', {});
     const parsed = JSON.parse(firstText(result));
-    expect(parsed.agents[0].models).toHaveLength(165);
-    expect(parsed.agents[0].models[164]).toEqual({ id: 'm-164', label: 'M164' });
+    expect(parsed.agents[0].models).toHaveLength(10);
     expect(parsed.agents[0].modelsCount).toBe(165);
   });
 

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -107,6 +107,7 @@ describe('public MCP discovery + generation tools', () => {
       pluginId: 'pitch-deck',
       pluginInputs: { tone: 'bold' },
       agentId: 'codex',
+      codexAuthMode: 'chatgpt',
       model: 'gpt-5.6-sol',
       reasoning: 'xhigh',
       serviceTier: 'fast',
@@ -117,14 +118,31 @@ describe('public MCP discovery + generation tools', () => {
     });
   });
 
-  it('start_run exposes only supported reasoning values', () => {
+  it('start_run accepts future live-catalog reasoning values for daemon validation', async () => {
     const startRun = localMcpToolDefinitions().find((tool) => tool.name === 'start_run');
 
     expect(startRun?.inputSchema.properties.reasoning).toEqual({
       type: 'string',
-      enum: ['default', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
-      description: 'Reasoning effort override for the selected model. Optional.',
+      description: 'Exact reasoning effort advertised by the selected model in the live agent catalog. Optional; the daemon validates it before spawn.',
     });
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(JSON.stringify({ projects: [{ id: 'project-1', name: 'Demo' }] }), { status: 200 });
+      }
+      const body = JSON.parse(String(init?.body));
+      expect(body.reasoning).toBe('future/deep:v2');
+      return new Response(JSON.stringify({ runId: 'run-future' }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
+      project: 'Demo',
+      agent: 'codex',
+      model: 'gpt-future',
+      reasoning: 'future/deep:v2',
+    });
+    expect(result.isError).not.toBe(true);
   });
 
   it('start_run uses the active project when project is omitted', async () => {
@@ -935,17 +953,21 @@ describe('public MCP discovery + generation tools', () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       agents: [
         {
-          id: 'claude',
-          name: 'Claude Code',
-          bin: 'claude',
+          id: 'codex',
+          name: 'Codex CLI',
+          bin: 'codex',
           version: '2.1.153',
           available: true,
-          path: '/usr/local/bin/claude',
+          path: '/usr/local/bin/codex',
           installUrl: 'https://…',
           versionArgs: ['--version'],
           promptViaStdin: true,
-          promptInputFormat: 'stream-json',
-          streamFormat: 'claude-stream-json',
+          promptInputFormat: 'text',
+          streamFormat: 'codex-jsonl',
+          authStatus: 'ok',
+          chatgptAuthStatus: 'missing',
+          chatgptAuthMessage: 'Run codex login.',
+          modelsSource: 'live',
           models: [
             { id: 'default', label: 'Default' },
             { id: 'sonnet', label: 'Sonnet' },
@@ -970,9 +992,14 @@ describe('public MCP discovery + generation tools', () => {
     const parsed = JSON.parse(firstText(result));
     expect(parsed.agents).toHaveLength(1);
     expect(parsed.agents[0]).toEqual({
-      id: 'claude',
-      name: 'Claude Code',
+      id: 'codex',
+      name: 'Codex CLI',
       version: '2.1.153',
+      authStatus: 'missing',
+      authMessage: 'Run codex login.',
+      chatgptAuthStatus: 'missing',
+      chatgptAuthMessage: 'Run codex login.',
+      modelsSource: 'live',
       models: [
         { id: 'default', label: 'Default' },
         { id: 'sonnet', label: 'Sonnet' },
@@ -986,7 +1013,7 @@ describe('public MCP discovery + generation tools', () => {
     expect(parsed.agents[0]).not.toHaveProperty('streamFormat');
   });
 
-  it('list_agents truncates very long model lists but reports the real count', async () => {
+  it('list_agents returns the complete live compatibility catalog', async () => {
     const longModels = Array.from({ length: 165 }, (_, i) => ({ id: `m-${i}`, label: `M${i}` }));
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       agents: [{ id: 'opencode', name: 'OpenCode', available: true, models: longModels }],
@@ -995,7 +1022,8 @@ describe('public MCP discovery + generation tools', () => {
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', {});
     const parsed = JSON.parse(firstText(result));
-    expect(parsed.agents[0].models).toHaveLength(10);
+    expect(parsed.agents[0].models).toHaveLength(165);
+    expect(parsed.agents[0].models[164]).toEqual({ id: 'm-164', label: 'M164' });
     expect(parsed.agents[0].modelsCount).toBe(165);
   });
 

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -91,9 +91,10 @@ describe('public MCP discovery + generation tools', () => {
       prompt: 'A 5-slide seed pitch deck',
       plugin: 'pitch-deck',
       inputs: { tone: 'bold' },
-      agent: 'claude',
-      model: 'claude-opus-4-7',
-      serviceTier: 'priority',
+      agent: 'codex',
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
       requestId: 'brief-42-cloud',
     });
 
@@ -105,13 +106,24 @@ describe('public MCP discovery + generation tools', () => {
       currentPrompt: 'A 5-slide seed pitch deck',
       pluginId: 'pitch-deck',
       pluginInputs: { tone: 'bold' },
-      agentId: 'claude',
-      model: 'claude-opus-4-7',
-      serviceTier: 'priority',
+      agentId: 'codex',
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
     });
     expect(JSON.parse(firstText(result))).toMatchObject({
       runId: 'run-42',
       requestId: 'brief-42-cloud',
+    });
+  });
+
+  it('start_run exposes only supported reasoning values', () => {
+    const startRun = localMcpToolDefinitions().find((tool) => tool.name === 'start_run');
+
+    expect(startRun?.inputSchema.properties.reasoning).toEqual({
+      type: 'string',
+      enum: ['default', 'none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      description: 'Reasoning effort override for the selected model. Optional.',
     });
   });
 

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -790,52 +790,36 @@ test('kilo fetchModels falls back to fallbackModels when detection fails', async
   assert.equal(kilo.fallbackModels.length, 1);
 });
 
-// ---- reasoning-effort clamp ------------------------------------------------
-// Drives clampCodexReasoning through the public buildArgs surface so the
-// helper stays non-exported. The wire-level `-c model_reasoning_effort="..."`
-// flag is what the codex CLI (and ultimately OpenAI) actually sees.
+// ---- reasoning-effort compatibility ---------------------------------------
 
-test('codex buildArgs clamps reasoning effort per model', () => {
-  const cases: Array<[string | undefined, string, string]> = [
-    // [model, reasoning, expected wire-level effort]
-    // gpt-5.5 family (and unknown / 'default' which we treat as 5.5):
-    // minimal -> low, others pass through.
-    [undefined, 'minimal', 'low'],
-    ['default', 'minimal', 'low'],
-    ['gpt-5.2', 'minimal', 'low'],
-    ['gpt-5.3', 'minimal', 'low'],
-    ['gpt-5.4', 'minimal', 'low'],
-    ['gpt-5.5', 'minimal', 'low'],
-    ['gpt-5.5', 'low', 'low'],
-    ['gpt-5.5', 'medium', 'medium'],
-    ['gpt-5.5', 'high', 'high'],
-    ['vendor/gpt-5.5-foo', 'minimal', 'low'], // path-style id
-    // gpt-5.1: xhigh isn't supported, others pass through.
-    ['gpt-5.1', 'xhigh', 'high'],
-    ['gpt-5.1', 'high', 'high'],
-    // gpt-5.1-codex-mini: caps at medium / high only.
-    ['gpt-5.1-codex-mini', 'minimal', 'medium'],
-    ['gpt-5.1-codex-mini', 'low', 'medium'],
-    ['gpt-5.1-codex-mini', 'medium', 'medium'],
-    ['gpt-5.1-codex-mini', 'high', 'high'],
-    ['gpt-5.1-codex-mini', 'xhigh', 'high'],
-    // Unknown / future families: pass through; let the API surface its error
-    // as the signal a new rule belongs in clampCodexReasoning.
-    ['gpt-6', 'minimal', 'minimal'],
-  ];
-  for (const [model, reasoning, expected] of cases) {
+test('codex buildArgs preserves supported reasoning effort exactly', () => {
+  for (const reasoning of ['xhigh', 'max', 'ultra']) {
     const args = codex.buildArgs(
       '',
       [],
       [],
-      { ...(model === undefined ? {} : { model }), reasoning },
+      { model: 'gpt-5.6-sol', reasoning },
       { cwd: '/tmp/od-project' },
     );
-    assert.ok(
-      args.includes(`model_reasoning_effort="${expected}"`),
-      `(model=${model ?? '<none>'}, reasoning=${reasoning}) → expected ${expected}; args=${JSON.stringify(args)}`,
-    );
+    assert.ok(args.includes(`model_reasoning_effort="${reasoning}"`));
   }
+});
+
+test('codex buildArgs rejects unsupported effort instead of clamping it', () => {
+  assert.throws(() => codex.buildArgs(
+    '',
+    [],
+    [],
+    { model: 'gpt-5.1', reasoning: 'xhigh' },
+    { cwd: '/tmp/od-project' },
+  ), /does not support reasoning effort 'xhigh'/u);
+  assert.throws(() => codex.buildArgs(
+    '',
+    [],
+    [],
+    { model: 'gpt-5.5', reasoning: 'minimal' },
+    { cwd: '/tmp/od-project' },
+  ), /does not support reasoning effort 'minimal'/u);
 });
 
 test('codex buildArgs omits model_reasoning_effort when reasoning is "default"', () => {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -805,21 +805,18 @@ test('codex buildArgs preserves supported reasoning effort exactly', () => {
   }
 });
 
-test('codex buildArgs rejects unsupported effort instead of clamping it', () => {
-  assert.throws(() => codex.buildArgs(
+test('codex buildArgs preserves live-catalog effort without a stale adapter allowlist', () => {
+  const args = codex.buildArgs(
     '',
     [],
     [],
-    { model: 'gpt-5.1', reasoning: 'xhigh' },
+    { model: 'gpt-future', reasoning: 'simple' },
     { cwd: '/tmp/od-project' },
-  ), /does not support reasoning effort 'xhigh'/u);
-  assert.throws(() => codex.buildArgs(
-    '',
-    [],
-    [],
-    { model: 'gpt-5.5', reasoning: 'minimal' },
-    { cwd: '/tmp/od-project' },
-  ), /does not support reasoning effort 'minimal'/u);
+  );
+
+  assert.ok(args.includes('--model'));
+  assert.ok(args.includes('gpt-future'));
+  assert.ok(args.includes('model_reasoning_effort="simple"'));
 });
 
 test('codex buildArgs omits model_reasoning_effort when reasoning is "default"', () => {

--- a/apps/daemon/tests/runtimes/codex-chatgpt-policy.test.ts
+++ b/apps/daemon/tests/runtimes/codex-chatgpt-policy.test.ts
@@ -1,0 +1,85 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { inspectCodexChatGptRoutePolicy } from '../../src/runtimes/auth.js';
+
+type StrictPolicy = {
+  allowed: boolean;
+  providerEnvKey: string | null;
+  reason: 'custom_provider_not_allowed' | 'config_inspection_failed' | null;
+};
+
+const inspectPolicy = inspectCodexChatGptRoutePolicy as unknown as (
+  env: NodeJS.ProcessEnv,
+  effectiveCwd?: string | null,
+) => Promise<StrictPolicy>;
+
+describe('strict ChatGPT Codex config policy', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) =>
+      rm(dir, { recursive: true, force: true }),
+    ));
+  });
+
+  it.each([
+    ['custom provider', 'model_provider = "local-gateway"\n'],
+    ['custom endpoint', 'openai_base_url = "https://example.invalid/v1"\n'],
+  ])('rejects a project %s from the effective child cwd', async (_label, content) => {
+    const root = await makeTempDir();
+    const codexHome = path.join(root, 'codex-home');
+    const projectRoot = path.join(root, 'repo');
+    await mkdir(path.join(codexHome), { recursive: true });
+    await mkdir(path.join(projectRoot, '.git'), { recursive: true });
+    await mkdir(path.join(projectRoot, '.codex'), { recursive: true });
+    await writeFile(path.join(projectRoot, '.codex', 'config.toml'), content, 'utf8');
+
+    await expect(inspectPolicy(isolatedEnv(codexHome, root), projectRoot)).resolves.toMatchObject({
+      allowed: false,
+      reason: 'custom_provider_not_allowed',
+    });
+  });
+
+  it('rejects a managed endpoint overlay', async () => {
+    const root = await makeTempDir();
+    const codexHome = path.join(root, 'codex-home');
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'managed_config.toml'),
+      'chatgpt_base_url = "https://managed.example.invalid/backend-api/codex"\n',
+      'utf8',
+    );
+
+    await expect(inspectPolicy(isolatedEnv(codexHome, root))).resolves.toMatchObject({
+      allowed: false,
+      reason: 'custom_provider_not_allowed',
+    });
+  });
+
+  it('fails closed when an effective config layer cannot be read', async () => {
+    const root = await makeTempDir();
+    const codexHome = path.join(root, 'codex-home');
+    await mkdir(path.join(codexHome, 'config.toml'), { recursive: true });
+
+    await expect(inspectPolicy(isolatedEnv(codexHome, root))).resolves.toMatchObject({
+      allowed: false,
+      reason: 'config_inspection_failed',
+    });
+  });
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-chatgpt-policy-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+});
+
+function isolatedEnv(codexHome: string, root: string): NodeJS.ProcessEnv {
+  return {
+    CODEX_HOME: codexHome,
+    PROGRAMDATA: path.join(root, 'program-data'),
+  };
+}

--- a/apps/daemon/tests/runtimes/codex-chatgpt-policy.test.ts
+++ b/apps/daemon/tests/runtimes/codex-chatgpt-policy.test.ts
@@ -59,6 +59,25 @@ describe('strict ChatGPT Codex config policy', () => {
     });
   });
 
+  it('rejects a custom provider under a mixed-case Windows CODEX_HOME key', async () => {
+    const root = await makeTempDir();
+    const codexHome = path.join(root, 'codex-home');
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'config.toml'),
+      'model_provider = "local-gateway"\n',
+      'utf8',
+    );
+
+    await expect(inspectPolicy({
+      Codex_Home: codexHome,
+      PROGRAMDATA: path.join(root, 'program-data'),
+    })).resolves.toMatchObject({
+      allowed: false,
+      reason: 'custom_provider_not_allowed',
+    });
+  });
+
   it('fails closed when an effective config layer cannot be read', async () => {
     const root = await makeTempDir();
     const codexHome = path.join(root, 'codex-home');

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1388,6 +1388,35 @@ test('spawnEnvForAgent preserves configured Codex API keys', () => {
   assert.equal(env.PATH, '/usr/bin');
 });
 
+test('spawnEnvForAgent strips API credentials and custom endpoints for ChatGPT-only Codex runs', () => {
+  const env = spawnEnvForAgent(
+    'codex',
+    {
+      OPENAI_API_KEY: 'sk-inherited',
+      CODEX_API_KEY: 'sk-codex-inherited',
+      OPENAI_BASE_URL: 'https://proxy.example.test/v1',
+      AZURE_OPENAI_API_KEY: 'azure-inherited',
+      PATH: '/usr/bin',
+    },
+    {
+      OPENAI_API_KEY: 'sk-configured',
+      CODEX_API_KEY: 'sk-codex-configured',
+      OPENAI_BASE_URL: 'https://configured.example.test/v1',
+    },
+    {},
+    {
+      codexAuthMode: 'chatgpt',
+      codexProviderEnvKey: 'AZURE_OPENAI_API_KEY',
+    },
+  );
+
+  assert.equal(env.OPENAI_API_KEY, undefined);
+  assert.equal(env.CODEX_API_KEY, undefined);
+  assert.equal(env.OPENAI_BASE_URL, undefined);
+  assert.equal(env.AZURE_OPENAI_API_KEY, undefined);
+  assert.equal(env.PATH, '/usr/bin');
+});
+
 test('spawnEnvForAgent preserves Codex API keys for non-codex adapters', () => {
   for (const agentId of ['claude', 'opencode', 'devin']) {
     const env = spawnEnvForAgent(agentId, {

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -6,6 +6,44 @@ import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex
 import { isKnownServiceTier } from '../../src/runtimes/models.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
 
+interface CliFixtureResponse {
+  args: string[];
+  stdout?: string;
+  exitCode?: number;
+}
+
+function writeCliFixture(
+  dir: string,
+  name: string,
+  responses: CliFixtureResponse[],
+  defaultExitCode = 0,
+): string {
+  const scriptPath = join(dir, `${name}-fixture.cjs`);
+  writeFileSync(
+    scriptPath,
+    `const responses = ${JSON.stringify(responses)};\n`
+      + 'const args = process.argv.slice(2);\n'
+      + 'const response = responses.find((candidate) => candidate.args.length === args.length && candidate.args.every((value, index) => value === args[index]));\n'
+      + `if (!response) process.exit(${defaultExitCode});\n`
+      + "if (response.stdout) process.stdout.write(response.stdout.endsWith('\\n') ? response.stdout : `${response.stdout}\\n`);\n"
+      + 'process.exit(response.exitCode ?? 0);\n',
+  );
+  const launcherPath = join(dir, process.platform === 'win32' ? `${name}.cmd` : name);
+  if (process.platform === 'win32') {
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+    );
+  } else {
+    writeFileSync(
+      launcherPath,
+      `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`,
+    );
+    chmodSync(launcherPath, 0o755);
+  }
+  return launcherPath;
+}
+
 test('AGENT_DEFS ids are unique', () => {
   const ids = AGENT_DEFS.map((a) => a.id);
   const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
@@ -333,6 +371,8 @@ test('codex args keep plugins enabled when OD_CODEX_DISABLE_PLUGINS is not 1', (
 test('codex model picker includes current OpenAI choices in priority order', async () => {
   const expectedModels = [
     'default',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
     'gpt-5.5',
     'gpt-5.4',
     'gpt-5.4-mini',
@@ -348,7 +388,7 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   assert.deepEqual(codex.fallbackModels.map((m) => m.id), expectedModels);
   assert.deepEqual(
     codex.fallbackModels.find((m) => m.id === 'gpt-5.5')?.serviceTierOptions,
-    [{ id: 'priority', label: 'Fast' }],
+    [{ id: 'fast', label: 'Fast' }],
   );
   assert.ok(codex.reasoningOptions, 'codex must define reasoningOptions');
   assert.deepEqual(codex.reasoningOptions.map((o) => o.id), [
@@ -359,6 +399,8 @@ test('codex model picker includes current OpenAI choices in priority order', asy
     'medium',
     'high',
     'xhigh',
+    'max',
+    'ultra',
   ]);
 
   const args = codex.buildArgs(
@@ -376,23 +418,20 @@ test('codex model picker includes current OpenAI choices in priority order', asy
     '',
     [],
     [],
-    { model: 'gpt-5.5', serviceTier: 'priority' },
+    { model: 'gpt-5.5', serviceTier: 'fast' },
     { cwd: '/tmp/od-project' },
   );
-  assert.ok(fastArgs.includes('service_tier="priority"'));
+  assert.ok(fastArgs.includes('service_tier="fast"'));
 
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-models-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "codex 1.0.0"; exit 0; fi\nexit 0\n',
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex 1.0.0' },
+      ]);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
@@ -416,6 +455,10 @@ test('codex derives service tiers from live speed tiers when service_tiers is ab
         display_name: 'GPT 5.5',
         visibility: 'list',
         additional_speed_tiers: ['fast'],
+        supported_reasoning_levels: [
+          { effort: 'low' },
+          { effort: 'xhigh' },
+        ],
       },
     ],
   }));
@@ -426,7 +469,8 @@ test('codex derives service tiers from live speed tiers when service_tiers is ab
       id: 'gpt-5.5',
       label: 'GPT 5.5',
       additionalSpeedTiers: ['fast'],
-      serviceTierOptions: [{ id: 'priority', label: 'Fast' }],
+      serviceTierOptions: [{ id: 'fast', label: 'Fast' }],
+      supportedReasoningLevels: ['low', 'xhigh'],
     },
   ]);
 });
@@ -460,34 +504,28 @@ test('codex preserves explicit live service tiers from debug models JSON', () =>
   ]);
 });
 
-test('codex live model metadata falls back to static service tiers', async () => {
+test('codex live model metadata does not inherit an unreported static service tier', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-live-tier-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
-if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
-  printf '%s\\n' '{"models":[{"slug":"gpt-5.5","display_name":"GPT 5.5","visibility":"list"}]}'
-  exit 0
-fi
-if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
-exit 2
-`,
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex-cli 9.9.9' },
+        {
+          args: ['debug', 'models'],
+          stdout: '{"models":[{"slug":"gpt-5.5","display_name":"GPT 5.5","visibility":"list"}]}',
+        },
+        { args: ['login', 'status'], stdout: 'Logged in using ChatGPT' },
+      ], 2);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
       const model = detected?.models.find((m: { id: string }) => m.id === 'gpt-5.5');
 
-      assert.deepEqual(model?.serviceTierOptions, [{ id: 'priority', label: 'Fast' }]);
-      assert.equal(isKnownServiceTier(codex, 'gpt-5.5', 'priority'), true);
+      assert.equal(model?.serviceTierOptions, undefined);
+      assert.equal(isKnownServiceTier(codex, 'gpt-5.5', 'fast'), false);
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -503,20 +541,14 @@ test('claude probes auth status so rescans reflect CLI auth changes', async () =
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-claude-auth-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CLAUDE_BIN'], async () => {
-      const claudeBin = join(dir, 'claude');
-      writeFileSync(
-        claudeBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "2.1.168 (Claude Code)"; exit 0; fi
-if [ "$1" = "-p" ] && [ "$2" = "--help" ]; then echo "--include-partial-messages --add-dir"; exit 0; fi
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"authenticated":true,"source":"claude.ai"}'; exit 0; fi
-exit 0
-`,
-      );
-      chmodSync(claudeBin, 0o755);
+      const claudeBin = writeCliFixture(dir, 'claude', [
+        { args: ['--version'], stdout: '2.1.168 (Claude Code)' },
+        { args: ['-p', '--help'], stdout: '--include-partial-messages --add-dir' },
+        { args: ['auth', 'status'], stdout: '{"authenticated":true,"source":"claude.ai"}' },
+      ]);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CLAUDE_BIN;
+      process.env.CLAUDE_BIN = claudeBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'claude');
@@ -534,21 +566,15 @@ test('claude API key env satisfies auth probe without requiring local login', as
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-claude-api-key-auth-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CLAUDE_BIN', 'ANTHROPIC_API_KEY'], async () => {
-      const claudeBin = join(dir, 'claude');
-      writeFileSync(
-        claudeBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "2.1.168 (Claude Code)"; exit 0; fi
-if [ "$1" = "-p" ] && [ "$2" = "--help" ]; then echo "--include-partial-messages --add-dir"; exit 0; fi
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo '{"authenticated":false}'; exit 1; fi
-exit 0
-`,
-      );
-      chmodSync(claudeBin, 0o755);
+      const claudeBin = writeCliFixture(dir, 'claude', [
+        { args: ['--version'], stdout: '2.1.168 (Claude Code)' },
+        { args: ['-p', '--help'], stdout: '--include-partial-messages --add-dir' },
+        { args: ['auth', 'status'], stdout: '{"authenticated":false}', exitCode: 1 },
+      ]);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
       process.env.ANTHROPIC_API_KEY = 'sk-anthropic';
-      delete process.env.CLAUDE_BIN;
+      process.env.CLAUDE_BIN = claudeBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'claude');
@@ -571,19 +597,13 @@ test('codex probes login status so rescans reflect CLI auth changes', async () =
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-auth-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
-if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
-exit 0
-`,
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex-cli 9.9.9' },
+        { args: ['login', 'status'], stdout: 'Logged in using ChatGPT' },
+      ]);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
@@ -601,21 +621,15 @@ test('codex API key env satisfies auth probe without requiring local login', asy
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-api-key-auth-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN', 'CODEX_API_KEY'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
-if [ "$1" = "debug" ] && [ "$2" = "models" ]; then echo '{"models":[]}'; exit 0; fi
-if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Not logged in"; exit 1; fi
-exit 0
-`,
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex-cli 9.9.9' },
+        { args: ['debug', 'models'], stdout: '{"models":[]}' },
+        { args: ['login', 'status'], stdout: 'Not logged in', exitCode: 1 },
+      ]);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
       process.env.CODEX_API_KEY = 'sk-codex';
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
@@ -677,7 +691,7 @@ test('codex derives service tiers from live speed tiers when service_tiers is ab
       id: 'gpt-5.5',
       label: 'GPT-5.5',
       additionalSpeedTiers: ['fast'],
-      serviceTierOptions: [{ id: 'priority', label: 'Fast' }],
+      serviceTierOptions: [{ id: 'fast', label: 'Fast' }],
     },
   ]);
 });
@@ -736,23 +750,17 @@ test('codex detection surfaces live debug models separately from fallback models
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-live-models-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
-if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
-  printf '%s\\n' '{"models":[{"slug":"gpt-6-codex","display_name":"GPT-6 Codex","visibility":"list"}]}'
-  exit 0
-fi
-if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
-exit 2
-`,
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex-cli 9.9.9' },
+        {
+          args: ['debug', 'models'],
+          stdout: '{"models":[{"slug":"gpt-6-codex","display_name":"GPT-6 Codex","visibility":"list"}]}',
+        },
+        { args: ['login', 'status'], stdout: 'Logged in using ChatGPT' },
+      ], 2);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
@@ -770,26 +778,20 @@ exit 2
   }
 });
 
-test('codex detection enriches sparse live GPT-5.5 metadata from fallback tiers', async () => {
+test('codex detection does not invent missing live GPT-5.5 compatibility metadata', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-sparse-live-models-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
-      const codexBin = join(dir, 'codex');
-      writeFileSync(
-        codexBin,
-        `#!/bin/sh
-if [ "$1" = "--version" ]; then echo "codex-cli 9.9.9"; exit 0; fi
-if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
-  printf '%s\\n' '{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list"}]}'
-  exit 0
-fi
-exit 2
-`,
-      );
-      chmodSync(codexBin, 0o755);
+      const codexBin = writeCliFixture(dir, 'codex', [
+        { args: ['--version'], stdout: 'codex-cli 9.9.9' },
+        {
+          args: ['debug', 'models'],
+          stdout: '{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5","visibility":"list"}]}',
+        },
+      ], 2);
       process.env.OD_AGENT_HOME = dir;
       process.env.PATH = dir;
-      delete process.env.CODEX_BIN;
+      process.env.CODEX_BIN = codexBin;
 
       const agents = await detectAgents();
       const detected = agents.find((agent) => agent.id === 'codex');
@@ -801,10 +803,8 @@ exit 2
       assert.deepEqual(gpt55, {
         id: 'gpt-5.5',
         label: 'GPT-5.5',
-        additionalSpeedTiers: ['fast'],
-        serviceTierOptions: [{ id: 'priority', label: 'Fast' }],
       });
-      assert.equal(isKnownServiceTier(codex, 'gpt-5.5', 'priority'), true);
+      assert.equal(isKnownServiceTier(codex, 'gpt-5.5', 'fast'), false);
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -1,9 +1,14 @@
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, amp, assert, chmodSync, claude, codex, cursorAgent, detectAgents, grokBuild, join, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  AGENT_DEFS, amp, assert, chmodSync, claude, codex, cursorAgent, detectAgents, grokBuild, join, mkdirSync, mkdtempSync, rmSync, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex.js';
-import { isKnownServiceTier } from '../../src/runtimes/models.js';
+import {
+  clearRememberedLiveModels,
+  getRememberedLiveModels,
+  isKnownServiceTier,
+  rememberLiveModels,
+} from '../../src/runtimes/models.js';
 import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
 
 interface CliFixtureResponse {
@@ -29,6 +34,41 @@ function writeCliFixture(
       + 'process.exit(response.exitCode ?? 0);\n',
   );
   const launcherPath = join(dir, process.platform === 'win32' ? `${name}.cmd` : name);
+  if (process.platform === 'win32') {
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+    );
+  } else {
+    writeFileSync(
+      launcherPath,
+      `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`,
+    );
+    chmodSync(launcherPath, 0o755);
+  }
+  return launcherPath;
+}
+
+function writeEnvSensitiveCodexFixture(
+  dir: string,
+  signalEnvKey: string,
+  genericModel: string,
+  strictModel: string,
+): string {
+  const scriptPath = join(dir, 'codex-env-catalog-fixture.cjs');
+  writeFileSync(
+    scriptPath,
+    `const args = process.argv.slice(2);\n`
+      + `if (args.includes('--version')) { console.log('codex-cli 9.9.9'); process.exit(0); }\n`
+      + `if (args[0] === 'login' && args[1] === 'status') { console.log('Logged in using ChatGPT'); process.exit(0); }\n`
+      + `if (args[0] === 'debug' && args[1] === 'models') {\n`
+      + `  const slug = process.env[${JSON.stringify(signalEnvKey)}] ? ${JSON.stringify(genericModel)} : ${JSON.stringify(strictModel)};\n`
+      + `  console.log(JSON.stringify({ models: [{ slug, display_name: slug, visibility: 'list', supported_reasoning_levels: [{ effort: 'future-deep' }] }] }));\n`
+      + `  process.exit(0);\n`
+      + `}\n`
+      + `process.exit(0);\n`,
+  );
+  const launcherPath = join(dir, process.platform === 'win32' ? 'codex.cmd' : 'codex');
   if (process.platform === 'win32') {
     writeFileSync(
       launcherPath,
@@ -628,7 +668,7 @@ test('codex probes login status so rescans reflect CLI auth changes', async () =
   }
 });
 
-test('codex API key env satisfies auth probe without requiring local login', async () => {
+test('codex API key env satisfies generic auth but not the official ChatGPT route', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-api-key-auth-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN', 'CODEX_API_KEY'], async () => {
@@ -649,8 +689,123 @@ test('codex API key env satisfies auth probe without requiring local login', asy
       assert.equal(detected.available, true);
       assert.equal(detected.authStatus, 'ok');
       assert.equal(detected.chatgptAuthStatus, 'missing');
+      assert.equal(detected.chatgptReady, false);
     });
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex detection keeps generic and ChatGPT-strict live catalogs isolated', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-scoped-models-'));
+  const codexHome = join(dir, 'codex-home');
+  try {
+    mkdirSync(codexHome, { recursive: true });
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
+      const codexBin = writeEnvSensitiveCodexFixture(
+        dir,
+        'CODEX_API_KEY',
+        'provider-only-model',
+        'chatgpt-only-model',
+      );
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      process.env.CODEX_BIN = codexBin;
+      rememberLiveModels(
+        'codex',
+        [{ id: 'stale-chatgpt-model', label: 'Stale ChatGPT model' }],
+        'chatgpt',
+      );
+
+      const agents = await detectAgents({
+        codex: {
+          CODEX_HOME: codexHome,
+          CODEX_API_KEY: 'generic-provider-key',
+        },
+      });
+      const detected = agents.find((agent) => agent.id === 'codex') as any;
+
+      assert.deepEqual(detected.models.map((model: { id: string }) => model.id), [
+        'default',
+        'provider-only-model',
+      ]);
+      assert.deepEqual(
+        detected.chatgptModels.map((model: { id: string }) => model.id),
+        ['default', 'chatgpt-only-model'],
+      );
+      assert.equal(detected.chatgptModelsSource, 'live');
+      assert.equal(detected.chatgptReady, true);
+      assert.deepEqual(
+        getRememberedLiveModels('codex').map((model) => model.id),
+        ['default', 'provider-only-model'],
+      );
+      assert.deepEqual(
+        getRememberedLiveModels('codex', 'chatgpt').map((model) => model.id),
+        ['default', 'chatgpt-only-model'],
+      );
+    });
+  } finally {
+    clearRememberedLiveModels('codex');
+    clearRememberedLiveModels('codex', 'chatgpt');
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex detection does not mark a selected custom provider ready for ChatGPT runs', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-codex-custom-provider-'));
+  const codexHome = join(dir, 'codex-home');
+  try {
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(
+      join(codexHome, 'config.toml'),
+      [
+        'model_provider = "local-gateway"',
+        '',
+        '[model_providers.local-gateway]',
+        'base_url = "https://example.invalid/v1"',
+        'env_key = "LOCAL_PROVIDER_KEY"',
+        '',
+      ].join('\n'),
+    );
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'CODEX_BIN'], async () => {
+      const codexBin = writeEnvSensitiveCodexFixture(
+        dir,
+        'LOCAL_PROVIDER_KEY',
+        'provider-only-model',
+        'must-not-be-surfaced',
+      );
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+      process.env.CODEX_BIN = codexBin;
+      rememberLiveModels(
+        'codex',
+        [{ id: 'stale-chatgpt-model', label: 'Stale ChatGPT model' }],
+        'chatgpt',
+      );
+
+      const agents = await detectAgents({
+        codex: {
+          CODEX_HOME: codexHome,
+          LOCAL_PROVIDER_KEY: 'generic-provider-key',
+        },
+      });
+      const detected = agents.find((agent) => agent.id === 'codex') as any;
+
+      assert.equal(detected.authStatus, 'ok');
+      assert.deepEqual(detected.models.map((model: { id: string }) => model.id), [
+        'default',
+        'provider-only-model',
+      ]);
+      assert.equal(detected.chatgptAuthStatus, 'ok');
+      assert.deepEqual(detected.chatgptModels, []);
+      assert.equal(detected.chatgptModelsSource, 'unavailable');
+      assert.equal(detected.chatgptReady, false);
+      assert.match(detected.chatgptReadyMessage, /custom providers/i);
+      assert.deepEqual(getRememberedLiveModels('codex', 'chatgpt'), []);
+    });
+  } finally {
+    clearRememberedLiveModels('codex');
+    clearRememberedLiveModels('codex', 'chatgpt');
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -414,6 +414,16 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   assert.ok(args.includes('gpt-5.5'));
   assert.ok(args.includes('model_reasoning_effort="xhigh"'));
 
+  const futureArgs = codex.buildArgs(
+    '',
+    [],
+    [],
+    { model: 'gpt-future', reasoning: 'future-deep' },
+    { cwd: '/tmp/od-project' },
+  );
+  assert.ok(futureArgs.includes('gpt-future'));
+  assert.ok(futureArgs.includes('model_reasoning_effort="future-deep"'));
+
   const fastArgs = codex.buildArgs(
     '',
     [],
@@ -611,6 +621,7 @@ test('codex probes login status so rescans reflect CLI auth changes', async () =
       assert.ok(detected);
       assert.equal(detected.available, true);
       assert.equal(detected.authStatus, 'ok');
+      assert.equal(detected.chatgptAuthStatus, 'ok');
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -637,6 +648,7 @@ test('codex API key env satisfies auth probe without requiring local login', asy
       assert.ok(detected);
       assert.equal(detected.available, true);
       assert.equal(detected.authStatus, 'ok');
+      assert.equal(detected.chatgptAuthStatus, 'missing');
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -9,6 +9,41 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createChatRunService } from '../../src/runtimes/runs.js';
 
 describe('chat run service shutdown', () => {
+  it('keeps requested Codex settings separate from rollout-backed executed settings', () => {
+    const runs = createRuns();
+    const run = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      agentId: 'codex',
+    }) as any;
+    run.model = 'gpt-5.6-sol';
+    run.resolvedModelId = 'gpt-5.6-sol';
+    run.reasoning = 'xhigh';
+    run.serviceTier = 'fast';
+    runs.finish(run, 'succeeded', 0, null);
+
+    expect(runs.statusBody(run).executionDiagnostics?.environment).toMatchObject({
+      requestedModel: { state: 'available', value: 'gpt-5.6-sol' },
+      requestedReasoning: { state: 'available', value: 'xhigh' },
+      requestedServiceTier: { state: 'available', value: 'fast' },
+      resolvedModel: { state: 'not_collected', missingReason: 'codex_rollout_model_unconfirmed' },
+      resolvedReasoning: { state: 'not_collected', missingReason: 'codex_rollout_reasoning_unconfirmed' },
+      resolvedServiceTier: { state: 'not_collected', missingReason: 'codex_rollout_service_tier_unconfirmed' },
+    });
+
+    runs.setExecutionEvidence(run, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
+      source: 'codex_rollout_turn_context',
+    });
+    expect(runs.statusBody(run).executionDiagnostics?.environment).toMatchObject({
+      resolvedModel: { state: 'available', value: 'gpt-5.6-sol' },
+      resolvedReasoning: { state: 'available', value: 'xhigh' },
+      resolvedServiceTier: { state: 'available', value: 'fast' },
+    });
+  });
+
   it('exports terminal diagnostics without confusing a measured zero with missing data', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-04T00:00:00.000Z'));
@@ -1044,6 +1079,32 @@ describe('run event log persistence', () => {
       runsLogDir: runsLogDir as unknown as null,
     });
   }
+
+  it('persists rollout-backed Codex execution evidence across daemon restart', () => {
+    const beforeRestart = createRunsWithLog(tmpDir);
+    const run = beforeRestart.create({ agentId: 'codex', model: 'gpt-5.6-sol' }) as any;
+    beforeRestart.setExecutionEvidence(run, {
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
+      source: 'codex_rollout_turn_context',
+    });
+    beforeRestart.finish(run, 'succeeded', 0, null);
+
+    const afterRestart = createRunsWithLog(tmpDir);
+    const restored = afterRestart.get(run.id) as any;
+    expect(restored).toMatchObject({
+      executedModelId: 'gpt-5.6-sol',
+      executedReasoning: 'xhigh',
+      executedServiceTier: 'fast',
+      executionEvidenceSource: 'codex_rollout_turn_context',
+    });
+    expect(afterRestart.statusBody(restored).executionDiagnostics?.environment).toMatchObject({
+      resolvedModel: { state: 'available', value: 'gpt-5.6-sol' },
+      resolvedReasoning: { state: 'available', value: 'xhigh' },
+      resolvedServiceTier: { state: 'available', value: 'fast' },
+    });
+  });
 
   it('writes each emitted event as a JSONL line under runsLogDir/<runId>/events.jsonl', async () => {
     const runs = createRunsWithLog(tmpDir);

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -404,6 +404,13 @@ export interface RunCreatedProps extends RunTaskLineageProps {
 export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   area: 'chat_panel' | 'design_system_generation';
   result: TrackingRunResult;
+  model_evidence_source?: 'codex_rollout_turn_context' | 'unconfirmed';
+  requested_model_id?: string;
+  requested_reasoning_effort?: string;
+  requested_service_tier?: string;
+  resolved_model_id?: string;
+  resolved_reasoning_effort?: string;
+  resolved_service_tier?: string;
   error_code?: string;
   failure_category?: TrackingRunFailureCategory;
   failure_detail?: TrackingRunFailureDetail;

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -351,6 +351,7 @@ export interface McpRunCreateRequest {
   skillId?: string;
   pluginId?: string;
   model?: string;
+  reasoning?: string;
   serviceTier?: string;
   pluginInputs?: Record<string, unknown>;
   mediaExecution?: MediaExecutionPolicy;
@@ -602,7 +603,11 @@ export interface ChatRunExecutionDiagnostics {
     agentId: ChatRunDiagnosticValue<string>;
     provider: ChatRunDiagnosticValue<string>;
     requestedModel: ChatRunDiagnosticValue<string>;
+    requestedReasoning: ChatRunDiagnosticValue<string>;
+    requestedServiceTier: ChatRunDiagnosticValue<string>;
     resolvedModel: ChatRunDiagnosticValue<string>;
+    resolvedReasoning: ChatRunDiagnosticValue<string>;
+    resolvedServiceTier: ChatRunDiagnosticValue<string>;
     reasoning: ChatRunDiagnosticValue<string>;
     agentCliVersion: ChatRunDiagnosticValue<string>;
   };

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -100,6 +100,13 @@ export interface ChatRequest {
   reasoning?: string | null;
   serviceTier?: string | null;
   /**
+   * Opt-in Local Codex account-path policy. `chatgpt` requires an
+   * authoritative `codex login status` ChatGPT session and strips API-key or
+   * custom-endpoint credentials from the child. Omission preserves legacy
+   * Local CLI behavior for non-MCP callers.
+   */
+  codexAuthMode?: 'chatgpt';
+  /**
    * Run-scoped BYOK provider credentials for the daemon-backed OpenCode
    * adapter. The daemon must not persist this object; it is translated into
    * child env + OPENCODE_CONFIG_CONTENT for the current run only.
@@ -353,6 +360,7 @@ export interface McpRunCreateRequest {
   model?: string;
   reasoning?: string;
   serviceTier?: string;
+  codexAuthMode?: 'chatgpt';
   pluginInputs?: Record<string, unknown>;
   mediaExecution?: MediaExecutionPolicy;
   toolBundle?: RunScopedToolBundle;

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -108,6 +108,12 @@ export interface AgentInfo {
   /** Authoritative `codex login status` result for the ChatGPT account path. */
   chatgptAuthStatus?: 'ok' | 'missing' | 'unknown';
   chatgptAuthMessage?: string;
+  /** Live catalog probed without API-key/custom-provider credentials. */
+  chatgptModels?: AgentModelOption[];
+  chatgptModelsSource?: 'live' | 'unavailable';
+  /** Whether auth, provider policy, and the strict live catalog are all ready. */
+  chatgptReady?: boolean;
+  chatgptReadyMessage?: string;
   path?: string;
   version?: string | null;
   /**

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -105,6 +105,9 @@ export interface AgentInfo {
   available: boolean;
   authStatus?: 'ok' | 'missing' | 'unknown';
   authMessage?: string;
+  /** Authoritative `codex login status` result for the ChatGPT account path. */
+  chatgptAuthStatus?: 'ok' | 'missing' | 'unknown';
+  chatgptAuthMessage?: string;
   path?: string;
   version?: string | null;
   /**

--- a/packages/contracts/tests/mcp-run-contract.test.ts
+++ b/packages/contracts/tests/mcp-run-contract.test.ts
@@ -15,14 +15,16 @@ describe('McpRunCreateRequest contract', () => {
       projectId: 'proj-2',
       message: 'Build a pitch deck',
       agentId: 'claude',
-      model: 'gpt-5.5',
-      serviceTier: 'priority',
+      model: 'gpt-5.6-sol',
+      reasoning: 'xhigh',
+      serviceTier: 'fast',
     };
     expect(full.projectId).toBe('proj-2');
     expect(full.message).toBe('Build a pitch deck');
     expect(full.agentId).toBe('claude');
-    expect(full.model).toBe('gpt-5.5');
-    expect(full.serviceTier).toBe('priority');
+    expect(full.model).toBe('gpt-5.6-sol');
+    expect(full.reasoning).toBe('xhigh');
+    expect(full.serviceTier).toBe('fast');
   });
 
   it('accepts projectId + message with agentId omitted (daemon resolves default)', () => {


### PR DESCRIPTION
Fixes #6669

Related: #5402, #3147

## Why

The official external MCP Local Codex route currently loses run-scoped reasoning, relies on incomplete/static compatibility metadata, and can mix API-key or custom-provider state into what callers expect to be the user's ChatGPT-backed Codex execution. Explicit service tier can also select a different model. This makes an apparently selected model/effort impossible to prove at the actual child boundary.

## What users will see

Local Codex MCP runs preserve explicit model, reasoning, and service tier as independent settings. Unsupported combinations fail before generation instead of substituting a model, clamping effort, or changing tier. The official route requires the user's Codex ChatGPT login and cannot silently execute through an API key, custom provider, project endpoint, or managed endpoint overlay.

Existing web/API callers that omit the strict MCP-only auth mode keep their existing behavior.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — optional run/auth fields and MCP discovery diagnostics
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — official MCP Local Codex fails closed instead of substituting or falling back
- [ ] **None**

## Screenshots

Not applicable; no visible UI changes.

## Bug fix verification

- Focused RED covered dropped reasoning, static future-incompatible effort validation, truncated model discovery, API-key/custom-provider acceptance, generic/strict catalog contamination, tier-driven model substitution, missing terminal rollout evidence, project/managed config overlays, and warm-discovery cache races.
- The final combined MCP/registry/preflight command is green 92/92.
- Effective-config policy tests are green 4/4 and the project/provider/read-error integration surface is green 4/4.

## Validation

- Combined daemon affected files: 3 files, 92/92 tests passed.
- Contracts: 38 files, 270/270 tests passed.
- Daemon typecheck and build passed.
- Authenticated source smoke completed on `gpt-5.6-sol` with `xhigh`; terminal rollout `turn_context` identified the same model and effort. No `gpt-5.5` substitution and no reasoning downgrade occurred. Service tier was omitted in that host task and remains truthfully uncollected in the live smoke.
- `git diff --check` passed.
- Every cherry-picked commit has the same stable patch ID as the independently reviewed candidate; upstream drift since that base is one unrelated landing-page commit.

This is a draft because the corrected runtime is unpublished and Windows packaged clean-install acceptance remains blocked by the host's electron-builder symlink privilege. Source behavior is verified; installed/released acceptance is not claimed.