### PR TITLE
feat(web): report preview iframe failures to PostHog

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -3,6 +3,10 @@ import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import type { Express, Request, Response } from 'express';
 import {
+  PREVIEW_OBSERVABILITY_BRIDGE_MARKER,
+  buildPreviewObservabilityBridge,
+} from '@open-design/contracts/runtime/preview-observability';
+import {
   defaultScenarioPluginIdForProjectMetadata,
   type ChatSessionMode,
   type PluginManifest,
@@ -1266,6 +1270,10 @@ function wantsUrlPreviewSnapshotBridge(value: unknown): boolean {
   return previewBridgeTokens(value).some((token) => token === 'snapshot' || token === 'image' || token === 'capture');
 }
 
+function wantsUrlPreviewObservabilityBridge(value: unknown): boolean {
+  return previewBridgeTokens(value).some((token) => token === 'observability' || token === 'errors' || token === 'diagnostics');
+}
+
 function injectBeforeBodyClose(html: string, marker: string, injection: string): string {
   if (html.includes(marker)) return html;
   const bodyCloseIndex = html.search(/<\/body\s*>/i);
@@ -1275,7 +1283,25 @@ function injectBeforeBodyClose(html: string, marker: string, injection: string):
   return `${html}${injection}`;
 }
 
-function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | 'snapshot'): string {
+function injectAfterHeadOpen(html: string, marker: string, injection: string): string {
+  if (html.includes(marker)) return html;
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/<head[^>]*>/i, (match) => `${match}${injection}`);
+  }
+  if (/<html[^>]*>/i.test(html)) {
+    return html.replace(/<html[^>]*>/i, (match) => `${match}<head>${injection}</head>`);
+  }
+  return `${injection}${html}`;
+}
+
+function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | 'snapshot' | 'observability'): string {
+  if (bridge === 'observability') {
+    return injectAfterHeadOpen(
+      html,
+      PREVIEW_OBSERVABILITY_BRIDGE_MARKER,
+      buildPreviewObservabilityBridge(),
+    );
+  }
   if (bridge === 'scroll') {
     return injectBeforeBodyClose(html, 'data-od-url-scroll-bridge', URL_PREVIEW_SCROLL_BRIDGE);
   }
@@ -1294,7 +1320,8 @@ function applyUrlPreviewBridgesToHtml(
     !(
       wantsUrlPreviewScrollBridge(requestedBridge) ||
       wantsUrlPreviewSelectionBridge(requestedBridge) ||
-      wantsUrlPreviewSnapshotBridge(requestedBridge)
+      wantsUrlPreviewSnapshotBridge(requestedBridge) ||
+      wantsUrlPreviewObservabilityBridge(requestedBridge)
     ) ||
     !/^text\/html(?:;|$)/i.test(mime)
   ) {
@@ -1306,6 +1333,9 @@ function applyUrlPreviewBridgesToHtml(
   // filename. URL-load iframes cannot rely on the host rewriting the document
   // title after load, and powered previews are intentionally cross-origin.
   html = daemonSanitizeTitleInDoc(html);
+  if (wantsUrlPreviewObservabilityBridge(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'observability');
+  }
   if (wantsUrlPreviewScrollBridge(requestedBridge)) {
     html = injectUrlPreviewBridge(html, 'scroll');
   }

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -210,6 +210,10 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
       path.join(dir, 'snapshot-bridged.html'),
       Buffer.from('<html><body><script data-od-url-snapshot-bridge></script><main>Preview</main></body></html>'),
     );
+    await writeFile(
+      path.join(dir, 'observability-bridged.html'),
+      Buffer.from('<html><head><script data-od-preview-observability></script></head><body><main>Preview</main></body></html>'),
+    );
     await mkdir(path.join(dir, 'dist', 'assets'), { recursive: true });
     await writeFile(
       path.join(dir, 'vite-entry.html'),
@@ -334,7 +338,7 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
   });
 
   it('skips URL preview bridge injection for large HTML so first paint can stream', async () => {
-    const res = await fetch(`${rawUrl('large.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`, {
+    const res = await fetch(`${rawUrl('large.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability`, {
       headers: { Range: 'bytes=0-127' },
     });
     expect(res.status).toBe(206);
@@ -345,6 +349,7 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).not.toContain('data-od-url-scroll-bridge');
     expect(html).not.toContain('data-od-url-selection-bridge');
     expect(html).not.toContain('data-od-url-snapshot-bridge');
+    expect(html).not.toContain('data-od-preview-observability');
   });
 
   it('injects the URL preview scroll bridge only when requested', async () => {
@@ -399,6 +404,16 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain("type: 'od:snapshot:result'");
     expect(html).not.toContain('data-od-url-scroll-bridge');
     expect(html).not.toContain('data-od-url-selection-bridge');
+  });
+
+  it('injects URL preview observability before author scripts when requested', async () => {
+    const bridged = await fetch(`${rawUrl('body.html')}?odPreviewBridge=observability`);
+    expect(bridged.status).toBe(200);
+    const html = await bridged.text();
+    expect(html).toContain('data-od-preview-observability');
+    expect(html).toContain("send('runtime_error'");
+    expect(html).toContain("send('white_screen'");
+    expect(html.indexOf('data-od-preview-observability')).toBeLessThan(html.indexOf('<body>'));
   });
 
   it('serves built dist HTML for Vite dev entries so previews do not load /src from daemon root', async () => {
@@ -460,6 +475,16 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain('clientWidth: size && size.clientWidth');
   });
 
+  it('injects preview observability for powered previews when requested', async () => {
+    const bridged = await fetch(`${poweredUrl('page.html')}?odPreviewBridge=observability`);
+    expect(bridged.status).toBe(200);
+    expect(bridged.headers.get('document-isolation-policy')).toBe('isolate-and-credentialless');
+    const html = await bridged.text();
+    expect(html).toContain('data-od-preview-observability');
+    expect(html).toContain("send('runtime_error'");
+    expect(html).toContain("send('white_screen'");
+  });
+
   it('does not let the powered preview origin call normal daemon APIs', async () => {
     const origin = poweredOrigin();
     const poweredReferer = `${origin}/api/projects/${projectId}/powered/page.html`;
@@ -485,13 +510,15 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     });
   });
 
-  it('injects scroll and selection URL preview bridges together', async () => {
-    const bridged = await fetch(`${rawUrl('body.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`);
+  it('injects all URL preview bridges together', async () => {
+    const bridged = await fetch(`${rawUrl('body.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability`);
     expect(bridged.status).toBe(200);
     const html = await bridged.text();
     expect(html).toContain('data-od-url-scroll-bridge');
     expect(html).toContain('data-od-url-selection-bridge');
     expect(html).toContain('data-od-url-snapshot-bridge');
+    expect(html).toContain('data-od-preview-observability');
+    expect(html.indexOf('data-od-preview-observability')).toBeLessThan(html.indexOf('<body>'));
     expect(html.indexOf('data-od-url-scroll-bridge')).toBeLessThan(html.indexOf('</body>'));
     expect(html.indexOf('data-od-url-selection-bridge')).toBeLessThan(html.indexOf('</body>'));
     expect(html.indexOf('data-od-url-snapshot-bridge')).toBeLessThan(html.indexOf('</body>'));
@@ -516,6 +543,13 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(bridged.status).toBe(200);
     const html = await bridged.text();
     expect(html.match(/data-od-url-snapshot-bridge/g)?.length).toBe(1);
+  });
+
+  it('does not inject the URL preview observability bridge twice', async () => {
+    const bridged = await fetch(`${rawUrl('observability-bridged.html')}?odPreviewBridge=observability`);
+    expect(bridged.status).toBe(200);
+    const html = await bridged.text();
+    expect(html.match(/data-od-preview-observability/g)?.length).toBe(1);
   });
 
   it('returns 404 for a missing file', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -36,7 +36,11 @@ import {
 import { useAnalytics } from '../analytics/provider';
 import { exportErrorCode } from '../analytics/export-error-code';
 import { deployErrorCode } from '../analytics/deploy-error-code';
-import { trackIframeLoad } from '../observability/iframe-error';
+import {
+  reportPreviewIframeMessage,
+  subscribePreviewIframeMessages,
+  trackIframeLoad,
+} from '../observability/iframe-error';
 import {
   trackArtifactExportResult,
   trackArtifactDeployResult,
@@ -357,7 +361,7 @@ const POWERED_PREVIEW_SANDBOX =
   'allow-scripts allow-same-origin allow-downloads allow-popups allow-forms allow-modals allow-pointer-lock';
 const POWERED_PREVIEW_ALLOW =
   'accelerometer; autoplay; camera; cross-origin-isolated; fullscreen; gamepad; gyroscope; microphone; xr-spatial-tracking';
-const PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot';
+const PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability';
 // Generic runtime UI state carried across the URL-load -> srcDoc transport
 // switch. This preserves the current page of multi-page prototypes while
 // leaving artifact scripts and business state inside their sandboxed frames.
@@ -9695,6 +9699,26 @@ function HtmlViewer({
     setPreviewSrcUrl(effectiveBasePreviewSrcUrl);
     setUrlSelectionBridgeReady(false);
   }, [activeFilesRefreshPending, effectiveBasePreviewSrcUrl, previewSrcCarriesCurrentRefresh]);
+  const previewObservabilitySeenRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    previewObservabilitySeenRef.current = new Set();
+  }, [projectId, file.name, reloadKey]);
+  useEffect(() => {
+    if (mode !== 'preview') return undefined;
+    return subscribePreviewIframeMessages(({ source: messageSource, data }) => {
+      const activeFrame = useUrlLoadPreview
+        ? urlPreviewIframeRef.current
+        : srcDocPreviewIframeRef.current;
+      if (!activeFrame || messageSource !== activeFrame.contentWindow) return;
+      reportPreviewIframeMessage(data, {
+        surface: 'artifact_preview',
+        renderMode: useUrlLoadPreview ? 'url_load' : 'srcdoc',
+        artifactId: anonymizeArtifactId({ projectId, fileName: file.name }),
+        artifactKind: handoffArtifactKind ?? artifactKindToTracking({ fileKind: file.kind ?? null }),
+        projectId,
+      }, previewObservabilitySeenRef.current);
+    });
+  }, [file.kind, file.name, handoffArtifactKind, mode, projectId, useUrlLoadPreview]);
   useEffect(() => {
     const activeFrame = useUrlLoadPreview
       ? urlPreviewIframeRef.current

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -9937,6 +9937,7 @@ function HtmlViewer({
       editBridge: true,
       paletteBridge: false,
       previewFocusGuard: true,
+      previewObservability: true,
       // Embed the reload counter so the srcdoc string differs across reloads
       // even when the fetched HTML bytes are identical (issue #4650).
       reloadKey,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -9706,6 +9706,7 @@ function HtmlViewer({
   useEffect(() => {
     if (mode !== 'preview') return undefined;
     return subscribePreviewIframeMessages(({ source: messageSource, data }) => {
+      if (!workspaceActiveRef.current) return;
       const activeFrame = useUrlLoadPreview
         ? urlPreviewIframeRef.current
         : srcDocPreviewIframeRef.current;

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -65,8 +65,11 @@ export function installPreviewIframeMessageObserver(): () => void {
     const data = parsePreviewObservabilityMessage(event.data);
     if (!data) return;
     const message = { source: event.source, data, receivedAt: Date.now() };
-    previewMessageBuffer.push(message);
-    prunePreviewMessageBuffer();
+    if (previewMessageSubscribers.size === 0) {
+      previewMessageBuffer.push(message);
+      prunePreviewMessageBuffer();
+      return;
+    }
     for (const subscriber of previewMessageSubscribers) subscriber(message);
   };
   window.addEventListener('message', previewMessageListener);
@@ -85,7 +88,8 @@ export function subscribePreviewIframeMessages(
 ): () => void {
   previewMessageSubscribers.add(subscriber);
   prunePreviewMessageBuffer();
-  for (const message of previewMessageBuffer) subscriber(message);
+  const bufferedMessages = previewMessageBuffer.splice(0);
+  for (const message of bufferedMessages) subscriber(message);
   return () => previewMessageSubscribers.delete(subscriber);
 }
 

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -11,7 +11,12 @@
 // callback so the caller can remove instrumentation if the iframe is
 // reused for a different artifact.
 
+import {
+  parsePreviewObservabilityMessage,
+  type PreviewObservabilityMessage,
+} from '@open-design/contracts/runtime/preview-observability';
 import { reportSafetyEvent } from '../analytics/error-tracking';
+import { scrubFilePath } from '../analytics/scrub';
 
 const LOAD_TIMEOUT_MS = 15000;
 
@@ -23,6 +28,174 @@ interface TrackIframeOptions {
   // Surface label so dashboards can split file-viewer iframes from
   // deck-viewer iframes, comment-mode iframes, etc.
   surface: string;
+}
+
+export interface PreviewIframeReportOptions {
+  surface: string;
+  renderMode: 'url_load' | 'srcdoc';
+  artifactId?: string;
+  artifactKind?: string;
+  projectId?: string;
+}
+
+interface BufferedPreviewMessage {
+  source: MessageEventSource | null;
+  data: PreviewObservabilityMessage;
+  receivedAt: number;
+}
+
+type PreviewMessageSubscriber = (message: BufferedPreviewMessage) => void;
+
+const PREVIEW_MESSAGE_BUFFER_LIMIT = 30;
+const PREVIEW_MESSAGE_MAX_AGE_MS = 10_000;
+const PREVIEW_REPORT_LIMIT = 20;
+const previewMessageBuffer: BufferedPreviewMessage[] = [];
+const previewMessageSubscribers = new Set<PreviewMessageSubscriber>();
+let previewMessageObserverInstalled = false;
+let previewMessageListener: ((event: MessageEvent) => void) | null = null;
+
+// Installed at app boot, before FileViewer's iframes mount. This short buffer
+// closes the race where an author script throws synchronously while React is
+// still committing the iframe and before the component can subscribe.
+export function installPreviewIframeMessageObserver(): () => void {
+  if (previewMessageObserverInstalled) return () => undefined;
+  if (typeof window === 'undefined') return () => undefined;
+  previewMessageObserverInstalled = true;
+  previewMessageListener = (event: MessageEvent) => {
+    const data = parsePreviewObservabilityMessage(event.data);
+    if (!data) return;
+    const message = { source: event.source, data, receivedAt: Date.now() };
+    previewMessageBuffer.push(message);
+    prunePreviewMessageBuffer();
+    for (const subscriber of previewMessageSubscribers) subscriber(message);
+  };
+  window.addEventListener('message', previewMessageListener);
+
+  return () => {
+    if (previewMessageListener) window.removeEventListener('message', previewMessageListener);
+    previewMessageListener = null;
+    previewMessageObserverInstalled = false;
+    previewMessageBuffer.length = 0;
+    previewMessageSubscribers.clear();
+  };
+}
+
+export function subscribePreviewIframeMessages(
+  subscriber: PreviewMessageSubscriber,
+): () => void {
+  previewMessageSubscribers.add(subscriber);
+  prunePreviewMessageBuffer();
+  for (const message of previewMessageBuffer) subscriber(message);
+  return () => previewMessageSubscribers.delete(subscriber);
+}
+
+function prunePreviewMessageBuffer(): void {
+  const cutoff = Date.now() - PREVIEW_MESSAGE_MAX_AGE_MS;
+  while (
+    previewMessageBuffer.length > PREVIEW_MESSAGE_BUFFER_LIMIT ||
+    (previewMessageBuffer[0]?.receivedAt ?? Infinity) < cutoff
+  ) {
+    previewMessageBuffer.shift();
+  }
+}
+
+export function reportPreviewIframeMessage(
+  value: unknown,
+  options: PreviewIframeReportOptions,
+  seen: Set<string> = new Set(),
+): boolean {
+  const message = parsePreviewObservabilityMessage(value);
+  if (!message) return false;
+
+  const sanitizedMessage = sanitizePreviewText(message.message, 500);
+  const sanitizedSource = sanitizePreviewText(message.source, 2_000);
+  const sanitizedResourceUrl = sanitizePreviewUrl(message.resource_url);
+  const fingerprint = [
+    message.event,
+    message.name ?? '',
+    sanitizedMessage ?? '',
+    sanitizedSource ?? '',
+    sanitizedResourceUrl ?? '',
+  ].join('|');
+  if (seen.has(fingerprint) || seen.size >= PREVIEW_REPORT_LIMIT) return false;
+  seen.add(fingerprint);
+
+  const common: Record<string, unknown> = {
+    surface: options.surface,
+    render_mode: options.renderMode,
+    artifact_id: options.artifactId,
+    artifact_kind: options.artifactKind,
+    project_id: options.projectId,
+  };
+
+  if (message.event === 'white_screen') {
+    reportSafetyEvent('client_preview_white_screen', {
+      ...common,
+      reason: 'no_visible_paint_after_timeout',
+      ready_state: boundedText(message.ready_state, 32),
+      visibility_state: boundedText(message.visibility_state, 32),
+      body_child_count: boundedNumber(message.body_child_count),
+      visible_element_count: boundedNumber(message.visible_element_count),
+      viewport_width: boundedNumber(message.viewport_width),
+      viewport_height: boundedNumber(message.viewport_height),
+    });
+    return true;
+  }
+
+  if (message.event === 'resource_error') {
+    reportSafetyEvent('client_preview_resource_error', {
+      ...common,
+      resource_tag: boundedText(message.resource_tag, 32),
+      resource_url: sanitizedResourceUrl,
+    });
+    return true;
+  }
+
+  reportSafetyEvent('client_preview_runtime_error', {
+    ...common,
+    error_origin: message.event,
+    error_name: boundedText(message.name, 120),
+    error_message: sanitizedMessage,
+    error_source: sanitizedSource,
+    line: boundedNumber(message.line),
+    column: boundedNumber(message.column),
+  });
+  return true;
+}
+
+function boundedText(value: unknown, limit: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const next = value.trim();
+  return next ? next.slice(0, limit) : undefined;
+}
+
+function boundedNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(Math.round(value), 10_000_000));
+}
+
+function sanitizePreviewText(value: unknown, limit: number): string | undefined {
+  const bounded = boundedText(value, limit);
+  if (!bounded) return undefined;
+  const pathScrubbed = scrubFilePath(bounded);
+  if (typeof pathScrubbed !== 'string') return undefined;
+  return pathScrubbed
+    .replace(/\b(?:data|blob):[^\s)]+/gi, '[inline-url]')
+    .replace(/https?:\/\/[^\s)]+/gi, (raw) => sanitizePreviewUrl(raw) ?? '[url]')
+    .slice(0, limit);
+}
+
+function sanitizePreviewUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const raw = value.trim();
+  if (/^(?:data|blob):/i.test(raw)) return '[inline-url]';
+  try {
+    const parsed = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'http://localhost');
+    return `${parsed.origin}${parsed.pathname}`.slice(0, 500);
+  } catch {
+    const scrubbed = scrubFilePath(raw);
+    return typeof scrubbed === 'string' ? scrubbed.slice(0, 500) : undefined;
+  }
 }
 
 export function trackIframeLoad(options: TrackIframeOptions): () => void {

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -108,13 +108,15 @@ export function reportPreviewIframeMessage(
   if (!message) return false;
 
   const sanitizedMessage = sanitizePreviewText(message.message, 500);
-  const sanitizedSource = sanitizePreviewText(message.source, 2_000);
+  const sanitizedSourceUrl = sanitizePreviewUrl(message.source_url);
+  const sanitizedStack = sanitizePreviewText(message.stack, 2_000);
   const sanitizedResourceUrl = sanitizePreviewUrl(message.resource_url);
   const fingerprint = [
     message.event,
     message.name ?? '',
     sanitizedMessage ?? '',
-    sanitizedSource ?? '',
+    sanitizedSourceUrl ?? '',
+    sanitizedStack ?? '',
     sanitizedResourceUrl ?? '',
   ].join('|');
   if (seen.has(fingerprint) || seen.size >= PREVIEW_REPORT_LIMIT) return false;
@@ -156,7 +158,8 @@ export function reportPreviewIframeMessage(
     error_origin: message.event,
     error_name: boundedText(message.name, 120),
     error_message: sanitizedMessage,
-    error_source: sanitizedSource,
+    error_source_url: sanitizedSourceUrl,
+    error_stack: sanitizedStack,
     line: boundedNumber(message.line),
     column: boundedNumber(message.column),
   });

--- a/apps/web/src/observability/install.ts
+++ b/apps/web/src/observability/install.ts
@@ -16,6 +16,7 @@ import { installResourceErrorObserver } from './resource-error';
 import { installBootTimingObserver } from './boot-timing';
 import { installVisibilityObserver } from './visibility';
 import { installWhiteScreenDetector } from './white-screen';
+import { installPreviewIframeMessageObserver } from './iframe-error';
 
 let installed = false;
 
@@ -30,6 +31,7 @@ export function installWebObservability(): () => void {
     installBootTimingObserver(),
     installVisibilityObserver(),
     installWhiteScreenDetector(),
+    installPreviewIframeMessageObserver(),
   ];
 
   return () => {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -15,6 +15,7 @@
  * after every navigation so the host can render its own counter / dots.
  */
 import { injectDeckStageFallback } from '@open-design/contracts/runtime/deck-stage-fallback';
+import { buildPreviewObservabilityBridge } from '@open-design/contracts/runtime/preview-observability';
 
 import {
   buildManualEditBridge,
@@ -390,7 +391,10 @@ export function buildSrcdoc(
   // is inert on documents that never self-redirect. Injected right after the
   // sandbox shim so it is installed before any author script or meta refresh.
   const withRedirectGuard = injectPreviewRedirectGuard(withShim, { blockLoadTimeScriptRedirect });
-  const withKeydownRegistry = options.deck ? injectDeckKeydownRegistryHook(withRedirectGuard) : withRedirectGuard;
+  // Runtime errors stay in the iframe's Window and never bubble to the host.
+  // Install this before every author script so even boot failures are bridged.
+  const withObservability = injectAfterHeadOpen(withRedirectGuard, buildPreviewObservabilityBridge());
+  const withKeydownRegistry = options.deck ? injectDeckKeydownRegistryHook(withObservability) : withObservability;
   const withFocusGuard = options.previewFocusGuard
     ? injectPreviewFocusGuard(withKeydownRegistry)
     : withKeydownRegistry;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -38,6 +38,9 @@ export type SrcdocOptions = {
   paletteBridge?: boolean;
   initialPalette?: string | null;
   previewFocusGuard?: boolean;
+  /** Install the live-preview error and white-screen reporting bridge. Keep
+   * this disabled for exports, captures, thumbnails, and historical previews. */
+  previewObservability?: boolean;
   /**
    * Force every CSS animation/transition to complete instantly so the
    * document settles at its final visual state and stops repainting. Meant
@@ -392,8 +395,11 @@ export function buildSrcdoc(
   // sandbox shim so it is installed before any author script or meta refresh.
   const withRedirectGuard = injectPreviewRedirectGuard(withShim, { blockLoadTimeScriptRedirect });
   // Runtime errors stay in the iframe's Window and never bubble to the host.
-  // Install this before every author script so even boot failures are bridged.
-  const withObservability = injectAfterHeadOpen(withRedirectGuard, buildPreviewObservabilityBridge());
+  // Live previews opt in so exports and other off-screen srcdoc consumers do
+  // not emit diagnostics that no host observer is prepared to consume.
+  const withObservability = options.previewObservability
+    ? injectAfterHeadOpen(withRedirectGuard, buildPreviewObservabilityBridge())
+    : withRedirectGuard;
   const withKeydownRegistry = options.deck ? injectDeckKeydownRegistryHook(withObservability) : withObservability;
   const withFocusGuard = options.previewFocusGuard
     ? injectPreviewFocusGuard(withKeydownRegistry)

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -21,6 +21,10 @@ const { analyticsTrackMock } = vi.hoisted(() => ({
   analyticsTrackMock: vi.fn(),
 }));
 
+const { safetyEventMock } = vi.hoisted(() => ({
+  safetyEventMock: vi.fn(),
+}));
+
 vi.mock('../../src/analytics/provider', async () => {
   const actual = await vi.importActual<typeof import('../../src/analytics/provider')>(
     '../../src/analytics/provider',
@@ -39,6 +43,10 @@ vi.mock('../../src/analytics/provider', async () => {
     }),
   };
 });
+
+vi.mock('../../src/analytics/error-tracking', () => ({
+  reportSafetyEvent: safetyEventMock,
+}));
 
 vi.mock('../../src/state/projects', async () => {
   const actual = await vi.importActual<typeof import('../../src/state/projects')>(
@@ -84,6 +92,7 @@ import { I18nProvider } from '../../src/i18n';
 import type { Dict } from '../../src/i18n/types';
 import { emptyManualEditStyles } from '../../src/edit-mode/types';
 import { __resetPreviewIsolationCache } from '../../src/runtime/powered-preview';
+import { installPreviewIframeMessageObserver } from '../../src/observability/iframe-error';
 import { readExpandedIndexCss } from '../helpers/read-expanded-css';
 import { resetWorkspaceContextCache } from '../../src/collab/useWorkspaceContext';
 import {
@@ -176,6 +185,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   analyticsTrackMock.mockReset();
+  safetyEventMock.mockReset();
   Reflect.deleteProperty(navigator, 'clipboard');
   Reflect.deleteProperty(document, 'execCommand');
 });
@@ -1441,7 +1451,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(<Shell />);
 
     const firstFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    expect(firstFrame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=');
+    expect(firstFrame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=');
     const firstSrc = firstFrame.getAttribute('src');
 
     fireEvent.click(screen.getByRole('button', { name: 'Leave project' }));
@@ -1799,7 +1809,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="url-load"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="false"');
-    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0&amp;odPreviewBridge=scroll&amp;odPreviewBridge=selection&amp;odPreviewBridge=snapshot&amp;odPreviewEpoch=preview-document-');
+    expect(markup).toContain('src="/api/projects/project-1/raw/page.html?v=1710000000&amp;r=0&amp;odPreviewBridge=scroll&amp;odPreviewBridge=selection&amp;odPreviewBridge=snapshot&amp;odPreviewBridge=observability&amp;odPreviewEpoch=preview-document-');
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
@@ -1967,13 +1977,13 @@ describe('FileViewer SVG artifacts', () => {
     );
 
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    expect(frame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=');
+    expect(frame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=');
 
     fireEvent.click(screen.getByRole('button', { name: /reload preview/i }));
 
     const reloadedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(reloadedFrame).toBe(frame);
-    expect(reloadedFrame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=1&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=');
+    expect(reloadedFrame.getAttribute('src')).toContain('/api/projects/project-1/raw/page.html?v=1710000000&r=1&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=');
   });
 
   it('keeps raw file-watch refresh measurements on the refreshed document epoch', async () => {
@@ -2379,7 +2389,7 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
     const workerHtml = '<!doctype html><html><body><script>new Worker("worker.js")</script></body></html>';
-    const poweredSrc = 'http://localhost:43111/api/projects/project-1/powered/worker.html?v=1000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot';
+    const poweredSrc = 'http://localhost:43111/api/projects/project-1/powered/worker.html?v=1000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability';
 
     const { rerender } = render(
       <FileViewer
@@ -3802,7 +3812,7 @@ describe('FileViewer SVG artifacts', () => {
     const { container } = render(<Switcher />);
     const getFrame = () => container.querySelector<HTMLIFrameElement>('[data-testid="artifact-preview-frame"]');
     const initialFrame = getFrame();
-    expect(initialFrame?.getAttribute('src')).toContain('/api/projects/project-1/raw/first.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=');
+    expect(initialFrame?.getAttribute('src')).toContain('/api/projects/project-1/raw/first.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=');
 
     const observationsBeforeSwitch = observedCommittedSrcs.length;
     fireEvent.click(screen.getByRole('button', { name: 'Switch file' }));
@@ -3810,9 +3820,9 @@ describe('FileViewer SVG artifacts', () => {
     const nextFrame = getFrame();
     expect(nextFrame).toBeTruthy();
     expect(observedCommittedSrcs[observationsBeforeSwitch]).toContain(
-      '/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=',
+      '/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=',
     );
-    expect(nextFrame?.getAttribute('src')).toContain('/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewEpoch=');
+    expect(nextFrame?.getAttribute('src')).toContain('/api/projects/project-1/raw/second.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewEpoch=');
   });
 
   it('allows downloads in the in-tab HTML presentation iframe', { timeout: 10_000 }, async () => {
@@ -6931,6 +6941,56 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByPlaceholderText('Add a note for this mark')).toBeNull();
   });
 
+  it('reports diagnostics only from the active preview iframe', async () => {
+    const teardownObserver = installPreviewIframeMessageObserver();
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile()}
+          liveHtml='<html><body><main>Preview</main></body></html>'
+        />,
+      );
+
+      const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const inactiveFrame = screen.getByTestId('artifact-preview-frame-srcdoc') as HTMLIFrameElement;
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: activeFrame.contentWindow,
+          data: {
+            type: 'od:preview-observability',
+            version: 1,
+            event: 'runtime_error',
+            message: 'active preview failed',
+          },
+        }));
+        window.dispatchEvent(new MessageEvent('message', {
+          source: inactiveFrame.contentWindow,
+          data: {
+            type: 'od:preview-observability',
+            version: 1,
+            event: 'runtime_error',
+            message: 'hidden preview failed',
+          },
+        }));
+      });
+
+      await waitFor(() => {
+        expect(safetyEventMock).toHaveBeenCalledTimes(1);
+      });
+      expect(safetyEventMock).toHaveBeenCalledWith(
+        'client_preview_runtime_error',
+        expect.objectContaining({
+          render_mode: 'url_load',
+          error_message: 'active preview failed',
+        }),
+      );
+    } finally {
+      teardownObserver();
+    }
+  });
+
   it('keeps preview viewport selection scoped to each HTML file', async () => {
     const firstFile = htmlPreviewFile({ name: 'first.html', path: 'first.html' });
     const secondFile = htmlPreviewFile({ name: 'second.html', path: 'second.html' });
@@ -8188,7 +8248,7 @@ describe('FileViewer tweaks toolbar', () => {
       );
       expect(src.searchParams.get('v')).toBe('1710000000');
       expect(src.searchParams.get('r')).toBe('0');
-      expect(src.searchParams.getAll('odPreviewBridge')).toEqual(['scroll', 'selection', 'snapshot']);
+      expect(src.searchParams.getAll('odPreviewBridge')).toEqual(['scroll', 'selection', 'snapshot', 'observability']);
       expect(src.searchParams.get('odPreviewEpoch')).toMatch(/^preview-document-\d+$/);
     });
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -6941,10 +6941,10 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.queryByPlaceholderText('Add a note for this mark')).toBeNull();
   });
 
-  it('reports diagnostics only from the active preview iframe', async () => {
+  it('reports diagnostics only from the active viewer and preview iframe', async () => {
     const teardownObserver = installPreviewIframeMessageObserver();
     try {
-      render(
+      const { rerender } = render(
         <FileViewer
           projectId="project-1"
           projectKind="prototype"
@@ -6986,6 +6986,31 @@ describe('FileViewer tweaks toolbar', () => {
           error_message: 'active preview failed',
         }),
       );
+
+      rerender(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile()}
+          liveHtml='<html><body><main>Preview</main></body></html>'
+          workspaceActive={false}
+        />,
+      );
+      const retainedFrame = screen.getByTestId(
+        'artifact-preview-frame-retained-preview.html',
+      ) as HTMLIFrameElement;
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: retainedFrame.contentWindow,
+          data: {
+            type: 'od:preview-observability',
+            version: 1,
+            event: 'white_screen',
+            message: 'retained preview looks blank',
+          },
+        }));
+      });
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
     } finally {
       teardownObserver();
     }

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -28,7 +28,8 @@ describe('preview iframe observability', () => {
       event: 'runtime_error',
       name: 'TypeError',
       message: 'Failed at https://example.com/app.js?secret=token',
-      source: 'https://example.com/app.js?secret=token',
+      source_url: 'https://example.com/app.js?secret=token',
+      stack: 'TypeError: render failed at renderPreview',
       line: 12,
       column: 4,
     }, {
@@ -46,7 +47,8 @@ describe('preview iframe observability', () => {
       error_origin: 'runtime_error',
       error_name: 'TypeError',
       error_message: 'Failed at https://example.com/app.js',
-      error_source: 'https://example.com/app.js',
+      error_source_url: 'https://example.com/app.js',
+      error_stack: 'TypeError: render failed at renderPreview',
       line: 12,
       column: 4,
     }));

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -119,6 +119,36 @@ describe('preview iframe observability', () => {
     }));
 
     unsubscribe();
+    const laterSubscriber = vi.fn();
+    const unsubscribeLater = subscribePreviewIframeMessages(laterSubscriber);
+    expect(laterSubscriber).not.toHaveBeenCalled();
+
+    unsubscribeLater();
+    teardown();
+  });
+
+  it('does not replay messages delivered to a live subscriber', () => {
+    const teardown = installPreviewIframeMessageObserver();
+    const source = window;
+    const subscriber = vi.fn();
+    const unsubscribe = subscribePreviewIframeMessages(subscriber);
+    window.dispatchEvent(new MessageEvent('message', {
+      source,
+      data: {
+        type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+        version: 1,
+        event: 'runtime_error',
+        message: 'live failure',
+      },
+    }));
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    const replacementSubscriber = vi.fn();
+    const unsubscribeReplacement = subscribePreviewIframeMessages(replacementSubscriber);
+    expect(replacementSubscriber).not.toHaveBeenCalled();
+
+    unsubscribeReplacement();
     teardown();
   });
 });

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PREVIEW_OBSERVABILITY_MESSAGE_TYPE } from '@open-design/contracts/runtime/preview-observability';
+
+const { reportSafetyEvent } = vi.hoisted(() => ({
+  reportSafetyEvent: vi.fn(),
+}));
+
+vi.mock('../../src/analytics/error-tracking', () => ({ reportSafetyEvent }));
+
+import {
+  installPreviewIframeMessageObserver,
+  reportPreviewIframeMessage,
+  subscribePreviewIframeMessages,
+} from '../../src/observability/iframe-error';
+
+afterEach(() => {
+  reportSafetyEvent.mockReset();
+});
+
+describe('preview iframe observability', () => {
+  it('maps runtime failures to a scrubbed PostHog safety event', () => {
+    const seen = new Set<string>();
+    const reported = reportPreviewIframeMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'runtime_error',
+      name: 'TypeError',
+      message: 'Failed at https://example.com/app.js?secret=token',
+      source: 'https://example.com/app.js?secret=token',
+      line: 12,
+      column: 4,
+    }, {
+      surface: 'artifact_preview',
+      renderMode: 'url_load',
+      artifactId: 'anon-artifact',
+      artifactKind: 'prototype',
+      projectId: 'project-1',
+    }, seen);
+
+    expect(reported).toBe(true);
+    expect(reportSafetyEvent).toHaveBeenCalledWith('client_preview_runtime_error', expect.objectContaining({
+      surface: 'artifact_preview',
+      render_mode: 'url_load',
+      error_origin: 'runtime_error',
+      error_name: 'TypeError',
+      error_message: 'Failed at https://example.com/app.js',
+      error_source: 'https://example.com/app.js',
+      line: 12,
+      column: 4,
+    }));
+  });
+
+  it('reports resource failures and white screens without DOM text', () => {
+    reportPreviewIframeMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'resource_error',
+      resource_tag: 'script',
+      resource_url: 'https://cdn.example/app.js?token=secret',
+    }, { surface: 'artifact_preview', renderMode: 'srcdoc' });
+    reportPreviewIframeMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'white_screen',
+      ready_state: 'complete',
+      body_child_count: 1,
+      visible_element_count: 0,
+      viewport_width: 1440,
+      viewport_height: 900,
+    }, { surface: 'artifact_preview', renderMode: 'srcdoc' });
+
+    expect(reportSafetyEvent).toHaveBeenNthCalledWith(1, 'client_preview_resource_error', expect.objectContaining({
+      resource_tag: 'script',
+      resource_url: 'https://cdn.example/app.js',
+    }));
+    expect(reportSafetyEvent).toHaveBeenNthCalledWith(2, 'client_preview_white_screen', expect.objectContaining({
+      reason: 'no_visible_paint_after_timeout',
+      visible_element_count: 0,
+      viewport_width: 1440,
+    }));
+  });
+
+  it('deduplicates repeated failures from one preview', () => {
+    const seen = new Set<string>();
+    const message = {
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'console_error',
+      message: 'render failed',
+    } as const;
+
+    expect(reportPreviewIframeMessage(message, { surface: 'artifact_preview', renderMode: 'srcdoc' }, seen)).toBe(true);
+    expect(reportPreviewIframeMessage(message, { surface: 'artifact_preview', renderMode: 'srcdoc' }, seen)).toBe(false);
+    expect(reportSafetyEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('buffers boot-time iframe messages until FileViewer subscribes', () => {
+    const teardown = installPreviewIframeMessageObserver();
+    const source = window;
+    window.dispatchEvent(new MessageEvent('message', {
+      source,
+      data: {
+        type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+        version: 1,
+        event: 'runtime_error',
+        message: 'early boot failure',
+      },
+    }));
+
+    const subscriber = vi.fn();
+    const unsubscribe = subscribePreviewIframeMessages(subscriber);
+    expect(subscriber).toHaveBeenCalledWith(expect.objectContaining({
+      source,
+      data: expect.objectContaining({ message: 'early boot failure' }),
+    }));
+
+    unsubscribe();
+    teardown();
+  });
+});

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -94,6 +94,17 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain('foreignObject');
   });
 
+  it('injects preview observability before author scripts', () => {
+    const srcdoc = buildSrcdoc('<!doctype html><html><head><script>throw new Error("boot")</script></head><body></body></html>');
+
+    expect(srcdoc).toContain('data-od-preview-observability');
+    expect(srcdoc).toContain("send('runtime_error'");
+    expect(srcdoc).toContain("send('white_screen'");
+    expect(srcdoc.indexOf('data-od-preview-observability')).toBeLessThan(
+      srcdoc.indexOf('<script>throw new Error("boot")</script>'),
+    );
+  });
+
   it('paints an opaque background before drawing so empty rasters never flatten to black', () => {
     const srcdoc = buildSrcdoc('<main style="color:red">Hero</main>');
 

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -95,7 +95,8 @@ describe('buildSrcdoc', () => {
   });
 
   it('injects preview observability before author scripts', () => {
-    const srcdoc = buildSrcdoc('<!doctype html><html><head><script>throw new Error("boot")</script></head><body></body></html>');
+    const html = '<!doctype html><html><head><script>throw new Error("boot")</script></head><body></body></html>';
+    const srcdoc = buildSrcdoc(html, { previewObservability: true });
 
     expect(srcdoc).toContain('data-od-preview-observability');
     expect(srcdoc).toContain("send('runtime_error'");
@@ -103,6 +104,7 @@ describe('buildSrcdoc', () => {
     expect(srcdoc.indexOf('data-od-preview-observability')).toBeLessThan(
       srcdoc.indexOf('<script>throw new Error("boot")</script>'),
     );
+    expect(buildSrcdoc(html)).not.toContain('data-od-preview-observability');
   });
 
   it('paints an opaque background before drawing so empty rasters never flatten to black', () => {

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -15,6 +15,7 @@ await build({
     "./src/api/reasoningExecution.ts",
     "./src/api/research.ts",
     "./src/runtime/deck-stage-fallback.ts",
+    "./src/runtime/preview-observability.ts",
     "./src/design-systems/components-manifest.ts",
     "./src/design-systems/derived-token-outputs.ts",
     "./src/design-systems/token-schema.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/runtime/deck-stage-fallback.d.ts",
       "default": "./dist/runtime/deck-stage-fallback.mjs"
     },
+    "./runtime/preview-observability": {
+      "types": "./dist/runtime/preview-observability.d.ts",
+      "default": "./dist/runtime/preview-observability.mjs"
+    },
     "./design-systems/components-manifest": {
       "types": "./dist/design-systems/components-manifest.d.ts",
       "default": "./dist/design-systems/components-manifest.mjs"

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -50,6 +50,7 @@ export * from './examples.js';
 export * from './execution-profile.js';
 export * from './artifacts/od-card.js';
 export * from './runtime/deck-stage-fallback.js';
+export * from './runtime/preview-observability.js';
 export * from './design-systems/components-manifest.js';
 export * from './design-systems/derived-token-outputs.js';
 export * from './design-systems/token-schema.js';

--- a/packages/contracts/src/runtime/preview-observability.ts
+++ b/packages/contracts/src/runtime/preview-observability.ts
@@ -26,7 +26,8 @@ export interface PreviewObservabilityMessage {
   event: PreviewObservabilityEvent;
   message?: string;
   name?: string;
-  source?: string;
+  source_url?: string;
+  stack?: string;
   line?: number;
   column?: number;
   resource_tag?: string;
@@ -86,7 +87,7 @@ export function buildPreviewObservabilityBridge(): string {
       return {
         name: text(value.name, 120),
         message: text(value.message, 500),
-        source: text(value.stack, 2000)
+        stack: text(value.stack, 2000)
       };
     }
     return { message: text(String(value == null ? '' : value), 500) };
@@ -94,7 +95,7 @@ export function buildPreviewObservabilityBridge(): string {
   function send(event, detail){
     if (sentCount >= MAX_EVENTS) return;
     detail = detail || {};
-    var fingerprint = [event, detail.name || '', detail.message || '', detail.source || '', detail.resource_url || ''].join('|');
+    var fingerprint = [event, detail.name || '', detail.message || '', detail.source_url || '', detail.stack || '', detail.resource_url || ''].join('|');
     if (sent[fingerprint]) return;
     sent[fingerprint] = true;
     sentCount += 1;
@@ -115,7 +116,7 @@ export function buildPreviewObservabilityBridge(): string {
     }
     var detail = describe(event && event.error);
     if (!detail.message) detail.message = text(event && event.message || 'Uncaught preview error', 500);
-    detail.source = text(event && event.filename || detail.source, 2000);
+    detail.source_url = text(event && event.filename, 1000);
     detail.line = Number.isFinite(event && event.lineno) ? Number(event.lineno) : undefined;
     detail.column = Number.isFinite(event && event.colno) ? Number(event.colno) : undefined;
     send('runtime_error', detail);

--- a/packages/contracts/src/runtime/preview-observability.ts
+++ b/packages/contracts/src/runtime/preview-observability.ts
@@ -48,6 +48,46 @@ const EVENT_NAMES = new Set<PreviewObservabilityEvent>([
   'white_screen',
 ]);
 
+type PreviewStringField =
+  | 'message'
+  | 'name'
+  | 'source_url'
+  | 'stack'
+  | 'resource_tag'
+  | 'resource_url'
+  | 'ready_state'
+  | 'visibility_state';
+
+const STRING_FIELD_LIMITS: ReadonlyArray<readonly [PreviewStringField, number]> = [
+  ['message', 500],
+  ['name', 120],
+  ['source_url', 1_000],
+  ['stack', 2_000],
+  ['resource_tag', 32],
+  ['resource_url', 1_000],
+  ['ready_state', 32],
+  ['visibility_state', 32],
+];
+
+type PreviewNumberField =
+  | 'line'
+  | 'column'
+  | 'body_child_count'
+  | 'visible_element_count'
+  | 'viewport_width'
+  | 'viewport_height';
+
+const NUMBER_FIELDS: readonly PreviewNumberField[] = [
+  'line',
+  'column',
+  'body_child_count',
+  'visible_element_count',
+  'viewport_width',
+  'viewport_height',
+];
+
+const MAX_PREVIEW_OBSERVABILITY_NUMBER = 10_000_000;
+
 export function parsePreviewObservabilityMessage(
   value: unknown,
 ): PreviewObservabilityMessage | null {
@@ -58,7 +98,31 @@ export function parsePreviewObservabilityMessage(
   if (typeof candidate.event !== 'string' || !EVENT_NAMES.has(candidate.event as PreviewObservabilityEvent)) {
     return null;
   }
-  return candidate as unknown as PreviewObservabilityMessage;
+
+  // Construct a fresh, bounded payload before it can enter the host's message
+  // buffer. Generated artifacts are untrusted and may post arbitrary objects.
+  const normalized: Record<string, unknown> = {
+    type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+    version: PREVIEW_OBSERVABILITY_PROTOCOL_VERSION,
+    event: candidate.event,
+  };
+  for (const [field, limit] of STRING_FIELD_LIMITS) {
+    const value = candidate[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string') return null;
+    const text = value.replace(/\s+/g, ' ').trim().slice(0, limit);
+    if (text) normalized[field] = text;
+  }
+  for (const field of NUMBER_FIELDS) {
+    const value = candidate[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+    normalized[field] = Math.max(
+      0,
+      Math.min(Math.round(value), MAX_PREVIEW_OBSERVABILITY_NUMBER),
+    );
+  }
+  return normalized as unknown as PreviewObservabilityMessage;
 }
 
 /**

--- a/packages/contracts/src/runtime/preview-observability.ts
+++ b/packages/contracts/src/runtime/preview-observability.ts
@@ -1,0 +1,212 @@
+/**
+ * Cross-runtime protocol used by generated artifact previews to report
+ * failures to the Open Design host. The bridge runs inside both srcDoc and
+ * URL-loaded preview iframes; the host validates this narrow payload before it
+ * reaches analytics.
+ *
+ * Keep this module browser-API free. The browser code is serialized as a
+ * string so both the web and daemon runtimes inject exactly the same script.
+ */
+
+export const PREVIEW_OBSERVABILITY_MESSAGE_TYPE = 'od:preview-observability';
+export const PREVIEW_OBSERVABILITY_PROTOCOL_VERSION = 1;
+export const PREVIEW_OBSERVABILITY_BRIDGE_MARKER = 'data-od-preview-observability';
+export const PREVIEW_WHITE_SCREEN_TIMEOUT_MS = 5_000;
+
+export type PreviewObservabilityEvent =
+  | 'runtime_error'
+  | 'unhandled_rejection'
+  | 'console_error'
+  | 'resource_error'
+  | 'white_screen';
+
+export interface PreviewObservabilityMessage {
+  type: typeof PREVIEW_OBSERVABILITY_MESSAGE_TYPE;
+  version: typeof PREVIEW_OBSERVABILITY_PROTOCOL_VERSION;
+  event: PreviewObservabilityEvent;
+  message?: string;
+  name?: string;
+  source?: string;
+  line?: number;
+  column?: number;
+  resource_tag?: string;
+  resource_url?: string;
+  ready_state?: string;
+  visibility_state?: string;
+  body_child_count?: number;
+  visible_element_count?: number;
+  viewport_width?: number;
+  viewport_height?: number;
+}
+
+const EVENT_NAMES = new Set<PreviewObservabilityEvent>([
+  'runtime_error',
+  'unhandled_rejection',
+  'console_error',
+  'resource_error',
+  'white_screen',
+]);
+
+export function parsePreviewObservabilityMessage(
+  value: unknown,
+): PreviewObservabilityMessage | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type !== PREVIEW_OBSERVABILITY_MESSAGE_TYPE) return null;
+  if (candidate.version !== PREVIEW_OBSERVABILITY_PROTOCOL_VERSION) return null;
+  if (typeof candidate.event !== 'string' || !EVENT_NAMES.has(candidate.event as PreviewObservabilityEvent)) {
+    return null;
+  }
+  return candidate as unknown as PreviewObservabilityMessage;
+}
+
+/**
+ * Runs before author scripts and emits a bounded, deduplicated diagnostic
+ * stream. It deliberately does not serialize arbitrary objects or DOM text.
+ */
+export function buildPreviewObservabilityBridge(): string {
+  return `<script ${PREVIEW_OBSERVABILITY_BRIDGE_MARKER}>
+(function(){
+  if (window.__odPreviewObservability) return;
+  window.__odPreviewObservability = true;
+  var TYPE = ${JSON.stringify(PREVIEW_OBSERVABILITY_MESSAGE_TYPE)};
+  var VERSION = ${PREVIEW_OBSERVABILITY_PROTOCOL_VERSION};
+  var WHITE_SCREEN_TIMEOUT = ${PREVIEW_WHITE_SCREEN_TIMEOUT_MS};
+  var MAX_EVENTS = 12;
+  var sentCount = 0;
+  var sent = Object.create(null);
+  function text(value, limit){
+    if (typeof value !== 'string') return undefined;
+    var next = value.replace(/\\s+/g, ' ').trim();
+    if (!next) return undefined;
+    return next.slice(0, limit || 500);
+  }
+  function describe(value){
+    if (value && typeof value === 'object') {
+      return {
+        name: text(value.name, 120),
+        message: text(value.message, 500),
+        source: text(value.stack, 2000)
+      };
+    }
+    return { message: text(String(value == null ? '' : value), 500) };
+  }
+  function send(event, detail){
+    if (sentCount >= MAX_EVENTS) return;
+    detail = detail || {};
+    var fingerprint = [event, detail.name || '', detail.message || '', detail.source || '', detail.resource_url || ''].join('|');
+    if (sent[fingerprint]) return;
+    sent[fingerprint] = true;
+    sentCount += 1;
+    try {
+      window.parent.postMessage(Object.assign({ type: TYPE, version: VERSION, event: event }, detail), '*');
+    } catch (_) {}
+  }
+  window.addEventListener('error', function(event){
+    var target = event && event.target;
+    if (target && target !== window && target.tagName) {
+      var tag = String(target.tagName || '').toLowerCase();
+      var resourceUrl = target.currentSrc || target.src || target.href || '';
+      send('resource_error', {
+        resource_tag: text(tag, 32),
+        resource_url: text(String(resourceUrl || ''), 1000)
+      });
+      return;
+    }
+    var detail = describe(event && event.error);
+    if (!detail.message) detail.message = text(event && event.message || 'Uncaught preview error', 500);
+    detail.source = text(event && event.filename || detail.source, 2000);
+    detail.line = Number.isFinite(event && event.lineno) ? Number(event.lineno) : undefined;
+    detail.column = Number.isFinite(event && event.colno) ? Number(event.colno) : undefined;
+    send('runtime_error', detail);
+  }, true);
+  window.addEventListener('unhandledrejection', function(event){
+    send('unhandled_rejection', describe(event && event.reason));
+  });
+  if (window.console && typeof window.console.error === 'function') {
+    var originalConsoleError = window.console.error;
+    window.console.error = function(){
+      try {
+        var detail = null;
+        for (var i = 0; i < arguments.length; i += 1) {
+          var value = arguments[i];
+          if (value instanceof Error || typeof value === 'string') {
+            detail = describe(value);
+            break;
+          }
+        }
+        if (detail && detail.message) send('console_error', detail);
+      } catch (_) {}
+      return originalConsoleError.apply(this, arguments);
+    };
+  }
+  function nonBlankColor(value){
+    var normalized = String(value || '').replace(/\\s+/g, '').toLowerCase();
+    return !!normalized &&
+      normalized !== 'transparent' &&
+      normalized !== 'rgba(0,0,0,0)' &&
+      normalized !== 'rgb(255,255,255)' &&
+      normalized !== 'rgba(255,255,255,1)' &&
+      normalized !== '#fff' && normalized !== '#ffffff' && normalized !== 'white';
+  }
+  function intersectsViewport(rect){
+    return rect && rect.width > 1 && rect.height > 1 &&
+      rect.bottom > 0 && rect.right > 0 &&
+      rect.top < (window.innerHeight || 0) && rect.left < (window.innerWidth || 0);
+  }
+  function visiblyPaints(element){
+    var tag = String(element.tagName || '').toLowerCase();
+    if (tag === 'script' || tag === 'style' || tag === 'meta' || tag === 'link' || tag === 'template') return false;
+    var style;
+    var rect;
+    try {
+      style = window.getComputedStyle(element);
+      rect = element.getBoundingClientRect();
+    } catch (_) { return false; }
+    if (!intersectsViewport(rect) || style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity || 1) <= 0.01) return false;
+    if (tag === 'img' || tag === 'svg' || tag === 'canvas' || tag === 'video' || tag === 'picture' || tag === 'object') return true;
+    if (String(element.textContent || '').trim().length > 0) return true;
+    if (style.backgroundImage && style.backgroundImage !== 'none') return true;
+    if (nonBlankColor(style.backgroundColor)) return true;
+    return false;
+  }
+  function visiblePaintCount(){
+    if (!document.body) return 0;
+    var nodes = document.body.querySelectorAll('*');
+    var count = 0;
+    var limit = Math.min(nodes.length, 2000);
+    for (var i = 0; i < limit; i += 1) {
+      if (visiblyPaints(nodes[i])) {
+        count += 1;
+        if (count >= 3) break;
+      }
+    }
+    if (count === 0) {
+      try {
+        var bodyStyle = window.getComputedStyle(document.body);
+        if ((bodyStyle.backgroundImage && bodyStyle.backgroundImage !== 'none') || nonBlankColor(bodyStyle.backgroundColor)) count = 1;
+      } catch (_) {}
+    }
+    return count;
+  }
+  var whiteScreenChecked = false;
+  function checkWhiteScreen(){
+    if (whiteScreenChecked) return;
+    whiteScreenChecked = true;
+    var visible = visiblePaintCount();
+    if (visible > 0) return;
+    send('white_screen', {
+      ready_state: text(document.readyState, 32),
+      visibility_state: text(document.visibilityState, 32),
+      body_child_count: document.body ? document.body.children.length : 0,
+      visible_element_count: visible,
+      viewport_width: Math.max(0, Math.round(window.innerWidth || 0)),
+      viewport_height: Math.max(0, Math.round(window.innerHeight || 0))
+    });
+  }
+  if (document.readyState === 'complete') setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT);
+  else window.addEventListener('load', function(){ setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT); }, { once: true });
+  setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT * 2);
+})();
+</script>`;
+}

--- a/packages/contracts/tests/runtime/preview-observability.test.ts
+++ b/packages/contracts/tests/runtime/preview-observability.test.ts
@@ -42,4 +42,41 @@ describe('preview observability contract', () => {
       event: 'arbitrary_event',
     })).toBeNull();
   });
+
+  it('normalizes untrusted fields before returning a bounded payload', () => {
+    const parsed = parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'runtime_error',
+      message: `  ${'x'.repeat(600)}  `,
+      stack: 'line one\nline two',
+      line: 12.6,
+      viewport_width: 20_000_000,
+      ignored: 'not part of the protocol',
+    });
+
+    expect(parsed).toMatchObject({
+      event: 'runtime_error',
+      message: 'x'.repeat(500),
+      stack: 'line one line two',
+      line: 13,
+      viewport_width: 10_000_000,
+    });
+    expect(parsed).not.toHaveProperty('ignored');
+  });
+
+  it('rejects known fields with invalid types', () => {
+    expect(parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'runtime_error',
+      message: { nested: 'boom' },
+    })).toBeNull();
+    expect(parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'runtime_error',
+      line: '12',
+    })).toBeNull();
+  });
 });

--- a/packages/contracts/tests/runtime/preview-observability.test.ts
+++ b/packages/contracts/tests/runtime/preview-observability.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PREVIEW_OBSERVABILITY_BRIDGE_MARKER,
+  PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+  buildPreviewObservabilityBridge,
+  parsePreviewObservabilityMessage,
+} from '../../src/runtime/preview-observability.js';
+
+describe('preview observability contract', () => {
+  it('builds one bounded bridge for runtime, resource, console, and white-screen failures', () => {
+    const bridge = buildPreviewObservabilityBridge();
+
+    expect(bridge).toContain(PREVIEW_OBSERVABILITY_BRIDGE_MARKER);
+    expect(bridge).toContain(PREVIEW_OBSERVABILITY_MESSAGE_TYPE);
+    expect(bridge).toContain("send('runtime_error'");
+    expect(bridge).toContain("send('unhandled_rejection'");
+    expect(bridge).toContain("send('console_error'");
+    expect(bridge).toContain("send('resource_error'");
+    expect(bridge).toContain("send('white_screen'");
+    expect(bridge).toContain('var MAX_EVENTS = 12');
+    expect(bridge).not.toContain('JSON.stringify(arguments)');
+  });
+
+  it('accepts only the versioned preview observability wire shape', () => {
+    expect(parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'runtime_error',
+      message: 'boom',
+    })).toMatchObject({ event: 'runtime_error', message: 'boom' });
+
+    expect(parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 2,
+      event: 'runtime_error',
+    })).toBeNull();
+    expect(parsePreviewObservabilityMessage({
+      type: PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+      version: 1,
+      event: 'arbitrary_event',
+    })).toBeNull();
+  });
+});

--- a/packages/contracts/tests/runtime/preview-observability.test.ts
+++ b/packages/contracts/tests/runtime/preview-observability.test.ts
@@ -17,6 +17,8 @@ describe('preview observability contract', () => {
     expect(bridge).toContain("send('console_error'");
     expect(bridge).toContain("send('resource_error'");
     expect(bridge).toContain("send('white_screen'");
+    expect(bridge).toContain('stack: text(value.stack, 2000)');
+    expect(bridge).toContain('detail.source_url = text(event && event.filename, 1000)');
     expect(bridge).toContain('var MAX_EVENTS = 12');
     expect(bridge).not.toContain('JSON.stringify(arguments)');
   });


### PR DESCRIPTION
## Why

Community reports show generated HTML can remain blank or fail inside the artifact preview iframe while the host application stays healthy. A recent `0.16.2` diagnostics bundle also showed a successfully written HTML artifact followed by an aborted `about:srcdoc` subframe load; toggling Code → Preview rebuilt the preview and recovered it. The newer atomic refresh path reduces that race, but we still had no production signal to tell whether blank previews, child-script failures, or missing resources recur.

This adds bounded safety telemetry for both srcDoc and URL-loaded previews so maintainers can distinguish runtime errors, resource failures, and white-screen symptoms without collecting artifact HTML or arbitrary DOM text. Related reports: #1698 and #3868.

Operational dashboard: https://us.posthog.com/project/420348/dashboard/1976866

## What users will see

No visible UI changes. When an artifact preview fails, Open Design reports privacy-scrubbed diagnostics through the configured PostHog safety-event path and continues rendering normally. Hidden keep-alive iframes are ignored, so only the preview currently visible to the user is reported.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this change has no visible UI surface.

## Bug fix verification

- This is observability coverage rather than a direct white-screen root-cause fix. Focused tests verify early buffering, payload validation/scrubbing, deduplication, srcDoc and daemon-side injection, and active-iframe filtering. Existing latest-main file-watch/preview-epoch regression coverage remains intact after conflict resolution.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/contracts test` — 39 files, 272 tests passed
- `pnpm --filter @open-design/web exec vitest run tests/observability/iframe-error.test.ts tests/runtime/srcdoc.test.ts` — 40 tests passed
- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx` — 262 tests passed
- `pnpm --filter @open-design/daemon exec vitest run tests/project-file-range.test.ts` — 49 tests passed
- Real Chrome via Open Browser Use against a local PostHog-compatible collector: both `srcdoc` and `url_load` previews delivered runtime, console, unhandled-rejection, resource, and white-screen events.
