### PR TITLE
fix(web): make project conversation forks reliable

### DIFF
--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -119,6 +119,16 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
       && typeof req.body.forkFallbackMessage.content === 'string'
         ? req.body.forkFallbackMessage
         : null;
+    const rawForkFallbackPredecessorMessageId = req.body?.forkFallbackPredecessorMessageId;
+    let clientForkFallbackPredecessorMessageId: string | null | undefined;
+    if (rawForkFallbackPredecessorMessageId === null) {
+      clientForkFallbackPredecessorMessageId = null;
+    } else if (
+      typeof rawForkFallbackPredecessorMessageId === 'string'
+      && rawForkFallbackPredecessorMessageId
+    ) {
+      clientForkFallbackPredecessorMessageId = rawForkFallbackPredecessorMessageId;
+    }
     let seedMessages: any[] = [];
     if (clientSeedMessages && clientSeedMessages.length > 0) {
       seedMessages = clientSeedMessages;
@@ -137,6 +147,20 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
         if (forkIndex < 0) {
           if (clientForkFallbackMessage?.id !== requestedForkMessageId) {
             return res.status(404).json({ error: 'fork message not found' });
+          }
+          if (clientForkFallbackPredecessorMessageId === undefined) {
+            return res.status(400).json({ error: 'fork fallback predecessor is required' });
+          }
+          if (clientForkFallbackPredecessorMessageId === null) {
+            seedMessages = [];
+          } else {
+            const predecessorIndex = seedMessages.findIndex(
+              (message) => message.id === clientForkFallbackPredecessorMessageId,
+            );
+            if (predecessorIndex < 0) {
+              return res.status(404).json({ error: 'fork fallback predecessor not found' });
+            }
+            seedMessages = seedMessages.slice(0, predecessorIndex + 1);
           }
           seedMessages.push(clientForkFallbackMessage);
         } else {

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -104,17 +104,21 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
       typeof seedFromConversationId === 'string' && seedFromConversationId
         ? getRoutableConversation(req.params.id, seedFromConversationId)
         : null;
-    // Client-supplied fork snapshot. The chat "Fork" action sends the exact
-    // messages the user is looking at (up to the fork point). We prefer it over
-    // reading the source conversation from the DB so a fork point that was
-    // never persisted — e.g. an assistant turn whose run errored / had its
-    // connection reset before reaching the database — still forks instead of
-    // 404ing on `forkAfterMessageId`.
+    // Keep accepting full snapshots from older clients. Current clients copy
+    // persisted history first and retry with one compact fallback message only
+    // when an in-memory fork point never reached the database.
     const clientSeedMessages = Array.isArray(req.body?.seedMessages)
       ? (req.body.seedMessages as any[]).filter(
           (message) => message && typeof message.role === 'string',
         )
       : null;
+    const clientForkFallbackMessage =
+      req.body?.forkFallbackMessage
+      && typeof req.body.forkFallbackMessage.id === 'string'
+      && typeof req.body.forkFallbackMessage.role === 'string'
+      && typeof req.body.forkFallbackMessage.content === 'string'
+        ? req.body.forkFallbackMessage
+        : null;
     let seedMessages: any[] = [];
     if (clientSeedMessages && clientSeedMessages.length > 0) {
       seedMessages = clientSeedMessages;
@@ -131,9 +135,13 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
       if (requestedForkMessageId) {
         const forkIndex = seedMessages.findIndex((message) => message.id === requestedForkMessageId);
         if (forkIndex < 0) {
-          return res.status(404).json({ error: 'fork message not found' });
+          if (clientForkFallbackMessage?.id !== requestedForkMessageId) {
+            return res.status(404).json({ error: 'fork message not found' });
+          }
+          seedMessages.push(clientForkFallbackMessage);
+        } else {
+          seedMessages = seedMessages.slice(0, forkIndex + 1);
         }
-        seedMessages = seedMessages.slice(0, forkIndex + 1);
       }
     } else if (requestedForkMessageId) {
       return res.status(404).json({ error: 'fork source conversation not found' });

--- a/apps/daemon/tests/routes/projects.test.ts
+++ b/apps/daemon/tests/routes/projects.test.ts
@@ -378,6 +378,80 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(forkMessages[1]?.lastRunEventId).toBeUndefined();
   });
 
+  it('appends one client fallback message when the fork point was never persisted', async () => {
+    const projectId = `proj-conv-fork-fallback-${Date.now()}`;
+    const createProjectResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Conversation fork fallback fixture',
+        skillId: null,
+        designSystemId: null,
+      }),
+    });
+    expect(createProjectResp.status).toBe(200);
+
+    const sourceResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Source', sessionMode: 'chat' }),
+    });
+    expect(sourceResp.status).toBe(200);
+    const sourceId = (
+      (await sourceResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    const saveUserResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${sourceId}/messages/fallback-user-1`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: 'fallback-user-1',
+          role: 'user',
+          content: 'Continue from this request',
+        }),
+      },
+    );
+    expect(saveUserResp.status).toBe(200);
+
+    const forkResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Recovered fork',
+        sessionMode: 'chat',
+        seedFromConversationId: sourceId,
+        forkAfterMessageId: 'fallback-assistant-1',
+        forkFallbackMessage: {
+          id: 'fallback-assistant-1',
+          role: 'assistant',
+          content: 'Unpersisted answer',
+        },
+      }),
+    });
+    expect(forkResp.status).toBe(200);
+    const forkId = (
+      (await forkResp.json()) as { conversation: { id: string } }
+    ).conversation.id;
+
+    const forkMessagesResp = await fetch(
+      `${baseUrl}/api/projects/${projectId}/conversations/${forkId}/messages`,
+    );
+    expect(forkMessagesResp.status).toBe(200);
+    const forkMessages = (
+      (await forkMessagesResp.json()) as {
+        messages: Array<{ id: string; role: string; content: string }>;
+      }
+    ).messages;
+    expect(forkMessages.map((message) => message.content)).toEqual([
+      'Continue from this request',
+      'Unpersisted answer',
+    ]);
+    expect(forkMessages.map((message) => message.id)).not.toContain('fallback-assistant-1');
+  });
+
   it('serves project files through raw and files path routes', async () => {
     const projectId = `proj-raw-route-${Date.now()}`;
     const createResp = await fetch(`${baseUrl}/api/projects`, {

--- a/apps/daemon/tests/routes/projects.test.ts
+++ b/apps/daemon/tests/routes/projects.test.ts
@@ -378,7 +378,7 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(forkMessages[1]?.lastRunEventId).toBeUndefined();
   });
 
-  it('appends one client fallback message when the fork point was never persisted', async () => {
+  it('cuts persisted history at the fallback predecessor before appending the missing fork point', async () => {
     const projectId = `proj-conv-fork-fallback-${Date.now()}`;
     const createProjectResp = await fetch(`${baseUrl}/api/projects`, {
       method: 'POST',
@@ -416,6 +416,29 @@ describe('GET /api/projects/:id resolvedDir', () => {
     );
     expect(saveUserResp.status).toBe(200);
 
+    for (const message of [
+      {
+        id: 'fallback-user-2',
+        role: 'user',
+        content: 'Later persisted request that must be excluded',
+      },
+      {
+        id: 'fallback-assistant-2',
+        role: 'assistant',
+        content: 'Later persisted answer that must be excluded',
+      },
+    ]) {
+      const saveLaterResp = await fetch(
+        `${baseUrl}/api/projects/${projectId}/conversations/${sourceId}/messages/${message.id}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(message),
+        },
+      );
+      expect(saveLaterResp.status).toBe(200);
+    }
+
     const forkResp = await fetch(`${baseUrl}/api/projects/${projectId}/conversations`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -424,6 +447,7 @@ describe('GET /api/projects/:id resolvedDir', () => {
         sessionMode: 'chat',
         seedFromConversationId: sourceId,
         forkAfterMessageId: 'fallback-assistant-1',
+        forkFallbackPredecessorMessageId: 'fallback-user-1',
         forkFallbackMessage: {
           id: 'fallback-assistant-1',
           role: 'assistant',

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2712,7 +2712,7 @@ export function ChatPane({
                 nextStepSkills={skills}
                 toolboxSkillNames={featuredToolboxSkillNames}
                 nextStepVariant={nextStepVariant}
-                onForkFromMessage={onForkFromMessage}
+                onForkFromMessage={viewerOnly ? undefined : onForkFromMessage}
                 onAssistantFeedback={onAssistantFeedback}
                 forkingMessageId={forkingMessageId}
                 t={t}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -8922,11 +8922,17 @@ export function ProjectView({
         const forkTitle = sourceTitle
           ? t('chat.forkedConversationTitle', { title: sourceTitle })
           : undefined;
+        const forkIndex = messages.findIndex((message) => message.id === assistantMessage.id);
+        const forkFallbackPredecessorMessageId = forkIndex < 0
+          ? undefined
+          : (messages[forkIndex - 1]?.id ?? null);
         const fresh = await createConversation(project.id, forkTitle, {
           seedFromConversationId: activeConversationId,
           forkAfterMessageId: assistantMessage.id,
           sessionMode: activeSessionMode,
-          forkFallbackMessage: assistantMessage,
+          forkFallbackMessage:
+            forkFallbackPredecessorMessageId === undefined ? undefined : assistantMessage,
+          forkFallbackPredecessorMessageId,
           workspaceContext: projectRunWorkspaceContext,
           throwOnError: true,
         });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -8914,7 +8914,7 @@ export function ProjectView({
 
   const handleForkFromMessage = useCallback(
     async (assistantMessage: ChatMessage) => {
-      if (!activeConversationId || forkingMessageId) return;
+      if (!activeConversationId || forkingMessageId || projectCollab.viewerOnly) return;
       setForkingMessageId(assistantMessage.id);
       setConversationLoadError(null);
       try {
@@ -8922,21 +8922,13 @@ export function ProjectView({
         const forkTitle = sourceTitle
           ? t('chat.forkedConversationTitle', { title: sourceTitle })
           : undefined;
-        // Seed the fork from the messages the user is actually looking at,
-        // up to and including the fork point. A run that errored or had its
-        // connection reset before its assistant message was persisted leaves
-        // that message in memory only; copying from the database by id would
-        // 404 and silently drop the fork. Sending the in-memory snapshot makes
-        // the fork resilient to that gap.
-        const forkIndex = messages.findIndex((m) => m.id === assistantMessage.id);
-        const seedMessages =
-          forkIndex >= 0 ? messages.slice(0, forkIndex + 1) : [...messages, assistantMessage];
         const fresh = await createConversation(project.id, forkTitle, {
           seedFromConversationId: activeConversationId,
           forkAfterMessageId: assistantMessage.id,
           sessionMode: activeSessionMode,
-          seedMessages,
+          forkFallbackMessage: assistantMessage,
           workspaceContext: projectRunWorkspaceContext,
+          throwOnError: true,
         });
         if (!fresh) throw new Error(t('chat.forkConversationFailed'));
         setMessages([]);
@@ -8981,6 +8973,7 @@ export function ProjectView({
       onProjectsRefresh,
       openTabsState.active,
       project.id,
+      projectCollab.viewerOnly,
       t,
     ],
   );
@@ -10667,7 +10660,9 @@ export function ProjectView({
               onAssistantFeedback={handleAssistantFeedback}
               onArtifactShare={handleArtifactShare}
               onArtifactDownload={handleArtifactDownload}
-              onForkFromMessage={handleForkFromMessage}
+              onForkFromMessage={
+                projectCollab.viewerOnly ? undefined : handleForkFromMessage
+              }
               forkingMessageId={forkingMessageId}
               onNewConversation={handleNewConversation}
               newConversationDisabled={newConversationDisabled}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -959,6 +959,7 @@ type CreateConversationOptions = {
   sessionMode?: ChatSessionMode;
   // The one in-memory fork point to retry with when it never reached the DB.
   forkFallbackMessage?: ChatMessage;
+  forkFallbackPredecessorMessageId?: string | null;
   workspaceContext?: WorkspaceCollabContext | null;
   throwOnError?: boolean;
 };
@@ -1031,7 +1032,11 @@ export async function createConversation(
       if (resp.status === 404 && message === 'fork message not found' && fallbackMessage) {
         resp = await postConversation(
           projectId,
-          { ...body, forkFallbackMessage: fallbackMessage },
+          {
+            ...body,
+            forkFallbackMessage: fallbackMessage,
+            forkFallbackPredecessorMessageId: opts?.forkFallbackPredecessorMessageId,
+          },
           opts?.workspaceContext,
         );
       } else {
@@ -1072,7 +1077,7 @@ function compactForkFallbackMessage(
   opts: CreateConversationOptions | undefined,
 ): ChatMessage | null {
   const forkMessage = opts?.forkFallbackMessage;
-  if (!forkMessage) return null;
+  if (!forkMessage || opts?.forkFallbackPredecessorMessageId === undefined) return null;
   return {
     id: forkMessage.id,
     role: forkMessage.role,

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -944,11 +944,24 @@ export async function deleteProject(
 // ---------- conversations ----------
 
 export class ProjectConversationsHttpError extends Error {
-  constructor(readonly status: number) {
-    super(`conversations ${status}`);
+  constructor(
+    readonly status: number,
+    message = `conversations ${status}`,
+  ) {
+    super(message);
     this.name = 'ProjectConversationsHttpError';
   }
 }
+
+type CreateConversationOptions = {
+  seedFromConversationId?: string | null;
+  forkAfterMessageId?: string | null;
+  sessionMode?: ChatSessionMode;
+  // The one in-memory fork point to retry with when it never reached the DB.
+  forkFallbackMessage?: ChatMessage;
+  workspaceContext?: WorkspaceCollabContext | null;
+  throwOnError?: boolean;
+};
 
 export async function listConversations(
   projectId: string,
@@ -998,17 +1011,7 @@ export async function createConversation(
   // Side Chat: seed the new conversation with another conversation's context
   // by copying its messages. `forkAfterMessageId` narrows that copy to a
   // specific point in the source history.
-  opts?: {
-    seedFromConversationId?: string | null;
-    forkAfterMessageId?: string | null;
-    sessionMode?: ChatSessionMode;
-    // Fork snapshot: the exact in-memory messages to copy (up to the fork
-    // point). Lets the daemon fork from what the user sees even when the fork
-    // point was never persisted (e.g. a run that errored before its assistant
-    // message reached the database).
-    seedMessages?: ChatMessage[];
-    workspaceContext?: WorkspaceCollabContext | null;
-  },
+  opts?: CreateConversationOptions,
 ): Promise<Conversation | null> {
   try {
     const body: CreateConversationRequest = { title };
@@ -1021,29 +1024,60 @@ export async function createConversation(
     if (opts?.forkAfterMessageId) {
       body.forkAfterMessageId = opts.forkAfterMessageId;
     }
-    if (opts?.seedMessages && opts.seedMessages.length > 0) {
-      body.seedMessages = opts.seedMessages;
+    let resp = await postConversation(projectId, body, opts?.workspaceContext);
+    if (!resp.ok) {
+      const message = await readErrorMessage(resp);
+      const fallbackMessage = compactForkFallbackMessage(opts);
+      if (resp.status === 404 && message === 'fork message not found' && fallbackMessage) {
+        resp = await postConversation(
+          projectId,
+          { ...body, forkFallbackMessage: fallbackMessage },
+          opts?.workspaceContext,
+        );
+      } else {
+        throw new ProjectConversationsHttpError(resp.status, message);
+      }
     }
-    const resp = await fetch(
-      `/api/projects/${encodeURIComponent(projectId)}/conversations`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(opts?.workspaceContext
-            ? workspaceProjectHeaders(opts.workspaceContext)
-            : {}),
-        },
-        body: JSON.stringify(body),
-      },
-    );
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      throw new ProjectConversationsHttpError(resp.status, await readErrorMessage(resp));
+    }
     const json = (await resp.json()) as { conversation: Conversation };
     evictConversationsRead(projectId, opts?.workspaceContext);
     return json.conversation;
-  } catch {
+  } catch (error) {
+    if (opts?.throwOnError) throw error;
     return null;
   }
+}
+
+function postConversation(
+  projectId: string,
+  body: CreateConversationRequest,
+  workspaceContext?: WorkspaceCollabContext | null,
+): Promise<Response> {
+  return fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/conversations`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(workspaceContext ? workspaceProjectHeaders(workspaceContext) : {}),
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function compactForkFallbackMessage(
+  opts: CreateConversationOptions | undefined,
+): ChatMessage | null {
+  const forkMessage = opts?.forkFallbackMessage;
+  if (!forkMessage) return null;
+  return {
+    id: forkMessage.id,
+    role: forkMessage.role,
+    content: forkMessage.content,
+  };
 }
 
 export async function patchConversation(

--- a/apps/web/tests/components/chat-feedback.test.tsx
+++ b/apps/web/tests/components/chat-feedback.test.tsx
@@ -100,6 +100,8 @@ function renderChatPane({
   streaming = false,
   onAssistantFeedback = vi.fn(),
   hasActiveDesignSystem = false,
+  onForkFromMessage,
+  viewerOnly = false,
 }: {
   messages: ChatMessage[];
   streaming?: boolean;
@@ -108,6 +110,8 @@ function renderChatPane({
     change: ChatMessageFeedbackChange,
   ) => void;
   hasActiveDesignSystem?: boolean;
+  onForkFromMessage?: (message: ChatMessage) => void;
+  viewerOnly?: boolean;
 }) {
   return {
     onAssistantFeedback,
@@ -128,6 +132,8 @@ function renderChatPane({
         onSelectConversation={() => {}}
         onDeleteConversation={() => {}}
         onAssistantFeedback={onAssistantFeedback}
+        onForkFromMessage={onForkFromMessage}
+        viewerOnly={viewerOnly}
       />,
     ),
   };
@@ -151,6 +157,16 @@ describe('chat assistant feedback', () => {
     });
 
     expect(screen.getByRole('group', { name: 'Feedback' })).toBeTruthy();
+  });
+
+  it('hides conversation fork actions from read-only project viewers', () => {
+    renderChatPane({
+      messages: [completedAssistant()],
+      onForkFromMessage: vi.fn(),
+      viewerOnly: true,
+    });
+
+    expect(screen.queryByRole('button', { name: 'Fork from here' })).toBeNull();
   });
 
   it('collects positive and negative feedback on completed artifact results', () => {

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -3,6 +3,7 @@ import {
   applyPlugin,
   cacheTabsLocally,
   contributeGeneratedPluginToOpenDesign,
+  createConversation,
   createDesignSystemProjectFromProject,
   createProject,
   createPluginShareProject,
@@ -78,6 +79,110 @@ function teamWorkspaceContext(
     ...overrides,
   };
 }
+
+describe('createConversation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps a persisted conversation fork request compact', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({
+      conversation: {
+        id: 'fork-1',
+        projectId: 'project-1',
+        title: 'Fork',
+        createdAt: 2,
+        updatedAt: 2,
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createConversation('project-1', 'Fork', {
+      seedFromConversationId: 'source-1',
+      forkAfterMessageId: 'assistant-1',
+      forkFallbackMessage: {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Done',
+        events: [{ kind: 'raw', line: 'large diagnostic payload' }],
+      },
+    })).resolves.toMatchObject({ id: 'fork-1' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      seedFromConversationId: 'source-1',
+      forkAfterMessageId: 'assistant-1',
+    });
+    expect(body.seedMessages).toBeUndefined();
+    expect(body.forkFallbackMessage).toBeUndefined();
+  });
+
+  it('retries an unpersisted fork point with one compact fallback message', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if (fetchMock.mock.calls.length === 1) {
+        expect(body.seedMessages).toBeUndefined();
+        expect(body.forkFallbackMessage).toBeUndefined();
+        return Response.json({ error: 'fork message not found' }, { status: 404 });
+      }
+      return Response.json({
+        conversation: {
+          id: 'fork-recovered',
+          projectId: 'project-1',
+          title: 'Fork',
+          createdAt: 2,
+          updatedAt: 2,
+        },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createConversation('project-1', 'Fork', {
+      seedFromConversationId: 'source-1',
+      forkAfterMessageId: 'assistant-missing',
+      forkFallbackMessage: {
+        id: 'assistant-missing',
+        role: 'assistant',
+        content: 'Partial answer',
+        runId: 'failed-run',
+        runStatus: 'failed',
+        events: [{ kind: 'raw', line: 'large diagnostic payload' }],
+        producedFiles: [],
+      },
+    })).resolves.toMatchObject({ id: 'fork-recovered' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const retryBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
+      seedMessages?: unknown;
+      forkFallbackMessage?: Record<string, unknown>;
+    };
+    expect(retryBody.seedMessages).toBeUndefined();
+    expect(retryBody.forkFallbackMessage).toEqual({
+      id: 'assistant-missing',
+      role: 'assistant',
+      content: 'Partial answer',
+    });
+  });
+
+  it('surfaces the daemon error for an interactive conversation write', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => Response.json({
+      error: {
+        code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
+        message: 'workspace project mutation is not allowed',
+      },
+    }, { status: 403 })));
+
+    await expect(createConversation('project-1', 'Fork', {
+      seedFromConversationId: 'source-1',
+      forkAfterMessageId: 'assistant-1',
+      throwOnError: true,
+    })).rejects.toMatchObject({
+      message: 'workspace project mutation is not allowed',
+      status: 403,
+    });
+  });
+});
 
 describe('project detail reads', () => {
   afterEach(() => {

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -141,6 +141,7 @@ describe('createConversation', () => {
     await expect(createConversation('project-1', 'Fork', {
       seedFromConversationId: 'source-1',
       forkAfterMessageId: 'assistant-missing',
+      forkFallbackPredecessorMessageId: 'user-before-missing',
       forkFallbackMessage: {
         id: 'assistant-missing',
         role: 'assistant',
@@ -156,6 +157,7 @@ describe('createConversation', () => {
     const retryBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
       seedMessages?: unknown;
       forkFallbackMessage?: Record<string, unknown>;
+      forkFallbackPredecessorMessageId?: string;
     };
     expect(retryBody.seedMessages).toBeUndefined();
     expect(retryBody.forkFallbackMessage).toEqual({
@@ -163,6 +165,7 @@ describe('createConversation', () => {
       role: 'assistant',
       content: 'Partial answer',
     });
+    expect(retryBody.forkFallbackPredecessorMessageId).toBe('user-before-missing');
   });
 
   it('surfaces the daemon error for an interactive conversation write', async () => {

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -2857,18 +2857,117 @@ test('[P1] project detail assistant completion actions support copy, fork, and f
   const forkBody = forkRequest.postDataJSON() as {
     forkAfterMessageId?: string;
     seedFromConversationId?: string;
-    seedMessages?: Array<{ id?: string; role?: string }>;
+    seedMessages?: unknown;
   };
   expect(forkBody.seedFromConversationId).toBe(conversationId);
   expect(forkBody.forkAfterMessageId).toBe(assistantMessageId);
-  expect(
-    forkBody.seedMessages?.some((message) => {
-      return message.id === assistantMessageId && message.role === 'assistant';
-    }),
-  ).toBe(true);
+  expect(forkBody.seedMessages).toBeUndefined();
   await expect
     .poll(() => getProjectContextFromUrl(page).conversationId)
     .not.toBe(conversationId);
+});
+
+test('[P1] project detail forks histories larger than the daemon JSON body limit', async ({ page }) => {
+  test.setTimeout(T.xlong);
+  const { projectId, conversationId, expectedContents } =
+    await seedProjectWithLargeAssistantHistory(page);
+
+  await page.goto(`/projects/${projectId}/conversations/${conversationId}`);
+  await expectWorkspaceReady(page);
+  await expect(page.getByTestId('assistant-fork-button')).toHaveCount(3, {
+    timeout: T.long,
+  });
+
+  const forkResponsePromise = page.waitForResponse((response) => {
+    return response.request().method() === 'POST'
+      && response.url().endsWith(`/api/projects/${projectId}/conversations`);
+  });
+  await page.getByTestId('assistant-fork-button').last().click();
+  const forkResponse = await forkResponsePromise;
+  expect(
+    forkResponse.ok(),
+    `fork large conversation: ${await forkResponse.text()}`,
+  ).toBe(true);
+  const forkRequestBody = forkResponse.request().postDataJSON() as {
+    seedMessages?: unknown;
+  };
+  expect(forkRequestBody.seedMessages).toBeUndefined();
+
+  await expect
+    .poll(() => getProjectContextFromUrl(page).conversationId)
+    .not.toBe(conversationId);
+  const forkConversationId = getProjectContextFromUrl(page).conversationId;
+  expect(forkConversationId).toBeTruthy();
+  const forkRequestHeaders = forkResponse.request().headers();
+  const workspaceHeaders = Object.fromEntries(
+    ['x-od-workspace-id', 'x-od-workspace-member-id']
+      .map((name) => [name, forkRequestHeaders[name]] as const)
+      .filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+  const forkMessagesResponse = await page.request.get(
+    `/api/projects/${projectId}/conversations/${forkConversationId}/messages`,
+    { headers: workspaceHeaders },
+  );
+  expect(
+    forkMessagesResponse.ok(),
+    `load forked messages: ${await forkMessagesResponse.text()}`,
+  ).toBe(true);
+  const forkMessagesBody = (await forkMessagesResponse.json()) as {
+    messages: Array<{ content: string }>;
+  };
+  expect(forkMessagesBody.messages.map((message) => message.content)).toEqual(expectedContents);
+});
+
+test('[P1] read-only project viewers do not see conversation fork actions', async ({ page }) => {
+  const { projectId, conversationId } = await seedProjectWithAssistantCompletion(page);
+  const readonlyTeamContext = {
+    ...AMR_PERSONAL_WORKSPACE_CONTEXT,
+    workspaceId: 'workspace-readonly-fork',
+    workspaceType: 'team',
+    workspaceMemberId: 'member-readonly-fork',
+    role: 'member',
+    teamId: 'team-readonly-fork',
+    permissions: {
+      ...AMR_PERSONAL_WORKSPACE_CONTEXT.permissions,
+      canWriteSyncedFiles: false,
+    },
+  };
+  await page.route(`**/api/projects/${projectId}/workspace-scope`, async (route) => {
+    await route.fulfill({
+      json: {
+        scope: {
+          kind: 'team',
+          projectId,
+          workspaceId: readonlyTeamContext.workspaceId,
+          visibility: 'team',
+          context: readonlyTeamContext,
+        },
+      },
+    });
+  });
+  await page.route(`**/api/projects/${projectId}/collab/status`, async (route) => {
+    await route.fulfill({
+      json: {
+        publishedVersion: 1,
+        materializedVersion: 1,
+        syncState: 'synced',
+        ownerMemberId: 'member-project-owner',
+      },
+    });
+  });
+
+  await page.goto(`/projects/${projectId}/conversations/${conversationId}`);
+  await page
+    .getByText('Loading Open Design…')
+    .waitFor({ state: 'hidden', timeout: T.long })
+    .catch(() => {});
+  const expandConversation = page.getByRole('button', { name: 'Expand the conversation pane' });
+  if (await expandConversation.isVisible()) {
+    await expandConversation.click();
+  }
+  await expect(page.getByTestId('chat-composer-input')).toBeVisible({ timeout: T.long });
+  await expect(page.getByTestId('chat-composer-input')).toHaveAttribute('aria-readonly', 'true');
+  await expect(page.getByTestId('assistant-fork-button')).toHaveCount(0);
 });
 
 test('[P1] project detail conversations menu supports new chat, search, counts, and run duration metadata', async ({ page }) => {
@@ -3786,6 +3885,72 @@ async function seedProjectWithAssistantCompletion(
   expect(assistantResponse.ok(), `seed assistant message: ${await assistantResponse.text()}`).toBeTruthy();
 
   return { projectId, conversationId, assistantMessageId, assistantText };
+}
+
+async function seedProjectWithLargeAssistantHistory(
+  page: Page,
+): Promise<{
+  projectId: string;
+  conversationId: string;
+  expectedContents: string[];
+}> {
+  const projectId = `assistant-large-fork-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const projectResponse = await page.request.post('/api/projects', {
+    data: {
+      id: projectId,
+      name: 'Large Conversation Fork',
+      skillId: null,
+      designSystemId: null,
+      metadata: {
+        kind: 'prototype',
+        nameSource: 'user',
+      },
+    },
+  });
+  expect(projectResponse.ok(), `create project: ${await projectResponse.text()}`).toBeTruthy();
+  const { conversationId } = (await projectResponse.json()) as { conversationId: string };
+  const expectedContents: string[] = [];
+
+  for (let index = 1; index <= 3; index += 1) {
+    const userMessageId = `large-user-${index}`;
+    const userContent = `Large fork request ${index}`;
+    const userResponse = await page.request.put(
+      `/api/projects/${projectId}/conversations/${conversationId}/messages/${userMessageId}`,
+      {
+        data: {
+          id: userMessageId,
+          role: 'user',
+          content: userContent,
+          createdAt: Date.now() + index * 2,
+        },
+      },
+    );
+    expect(userResponse.ok(), `seed user ${index}: ${await userResponse.text()}`).toBeTruthy();
+    expectedContents.push(userContent);
+
+    const assistantMessageId = `large-assistant-${index}`;
+    const assistantContent = `Large fork point ${index}`;
+    const assistantResponse = await page.request.put(
+      `/api/projects/${projectId}/conversations/${conversationId}/messages/${assistantMessageId}`,
+      {
+        data: {
+          id: assistantMessageId,
+          role: 'assistant',
+          content: assistantContent,
+          runStatus: 'succeeded',
+          events: [{ kind: 'raw', line: 'x'.repeat(1_500_000) }],
+          createdAt: Date.now() + index * 2 + 1,
+        },
+      },
+    );
+    expect(
+      assistantResponse.ok(),
+      `seed assistant ${index}: ${await assistantResponse.text()}`,
+    ).toBeTruthy();
+    expectedContents.push(assistantContent);
+  }
+
+  return { projectId, conversationId, expectedContents };
 }
 
 type ConversationHistoryFixture = {

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -635,6 +635,13 @@ export interface CreateConversationRequest {
    */
   forkFallbackMessage?: ChatMessage;
   /**
+   * The persisted message immediately before `forkFallbackMessage`, or null
+   * when the fallback is the first message. The daemon cuts persisted history
+   * at this boundary before appending the fallback, so later turns cannot leak
+   * into a fork from an older unpersisted assistant message.
+   */
+  forkFallbackPredecessorMessageId?: string | null;
+  /**
    * Client-supplied snapshot of the messages to seed the fork with, in order,
    * up to and including the fork point. When present, the daemon copies these
    * instead of reading the source conversation from the database by id. This

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -628,6 +628,13 @@ export interface CreateConversationRequest {
    */
   forkAfterMessageId?: string | null;
   /**
+   * One compact client-side message used only when `forkAfterMessageId` is not
+   * present in the source conversation's persisted history. The daemon appends
+   * it to the persisted prefix, which preserves an errored/unpersisted final
+   * assistant turn without making normal forks upload the entire transcript.
+   */
+  forkFallbackMessage?: ChatMessage;
+  /**
    * Client-supplied snapshot of the messages to seed the fork with, in order,
    * up to and including the fork point. When present, the daemon copies these
    * instead of reading the source conversation from the database by id. This
@@ -636,6 +643,10 @@ export interface CreateConversationRequest {
    * message reached the database. Without it, such a fork would 404 on
    * `forkAfterMessageId` and silently fail. When absent, the daemon falls back
    * to copying from `seedFromConversationId` (the original Side Chat path).
+   *
+   * @deprecated Retained for older clients. New clients should first fork from
+   * persisted history and use `forkFallbackMessage` only after a missing fork
+   * point response.
    */
   seedMessages?: ChatMessage[];
 }


### PR DESCRIPTION
Fixes #6672

## Why

Project chat users can hit a silent fork failure when a visible conversation serializes beyond the daemon 4 MB JSON body limit. The web client was sending the entire transcript as seedMessages, and createConversation converted HTTP errors into null. Read-only shared-project viewers also saw a fork action that the daemon correctly rejected.

The 4 MB global limit is intentionally retained: unbounded JSON parsing would expose the local daemon to large memory spikes, event-loop stalls, and denial-of-service behavior. The fix removes the oversized request instead of weakening that boundary.

## What users will see

Forking a project conversation now works for long histories because persisted messages are copied server-side. If the selected final assistant message has not been persisted, the client retries with only that compact message. Interactive failures surface their daemon error, and read-only viewers no longer see the fork action.

## Surface area

- [x] **UI** — project chat fork availability and failure behavior
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [x] **API / contract** — adds the compact forkFallbackMessage request field while retaining legacy seedMessages compatibility
- [ ] **Extension point** — skills, design systems, templates, craft, or protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root package dependency change
- [x] **Default behavior change** — fork requests are compact and read-only viewers cannot invoke them
- [ ] **None** — internal-only change

## Screenshots

The UI change removes an invalid action rather than adding a new surface. Writable and read-only states were exercised and captured through the Playwright project-detail fixture; the committed browser assertion verifies one writable fork path and zero fork actions in the read-only state.

## Bug fix verification

- Test paths: apps/web/tests/state/projects.test.ts, apps/web/tests/components/chat-feedback.test.tsx, apps/daemon/tests/routes/projects.test.ts, and e2e/ui/project-management-flows.test.ts
- Did the tests go red on main and green on this branch? yes
- Main failures reproduced: oversized history returned HTTP 413, missing persisted fork point returned 404, interactive errors were swallowed, and read-only UI exposed one fork button. All corresponding tests pass on this branch.

## Validation

- pnpm guard
- pnpm typecheck
- pnpm --filter @open-design/web test: 608 files, 6307 passed, 1 expected failure, 11 skipped
- focused daemon project-route suite: 49 passed
- pnpm --filter @open-design/web build
- pnpm --filter @open-design/daemon build
- pnpm --filter @open-design/contracts build
- Playwright project fork coverage: 3 passed, including a roughly 4.5 MB persisted history and read-only permissions
- Full daemon suite baseline audit: 12 deterministic failures reproduced unchanged on clean origin/main; two additional full-run timeouts passed in isolated reruns. No new daemon-suite failure was introduced by this branch.