### PR TITLE
reorder Launch Week days 2 to 4

### DIFF
--- a/apps/landing-page/app/_partials/launch-week-drops.ts
+++ b/apps/landing-page/app/_partials/launch-week-drops.ts
@@ -28,10 +28,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE IMAGE GENERATION &amp; EDITING</span>
-        <h3>The Campaign Engine Is Live.</h3>
-        <p class="proof">One brief in. A full campaign out—social creatives, animated assets, and landing pages. Ready for every channel.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">NATIVE SLIDE GENERATION &amp; EDITING</span>
+        <h3>The Creative Slide Studio Is Live.</h3>
+        <p class="proof">Stunning by default. Effortless to edit. Ready in minutes.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">WATCH THE DROP ↗</a>
       </div>
     </article>`,
@@ -43,10 +43,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>UP NEXT</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE VIDEO GENERATION &amp; EDITING</span>
-        <h3>The Product Film Studio Is Live.</h3>
-        <p class="proof">A campaign-ready product film—cinematic, polished, and built to perform.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">NATIVE IMAGE GENERATION &amp; EDITING</span>
+        <h3>The Campaign Engine Is Live.</h3>
+        <p class="proof">One brief in. A full campaign out—social creatives, animated assets, and landing pages. Ready for every channel.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">WATCH THE DROP ↗</a>
       </div>
     </article>`,
@@ -58,10 +58,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>UP NEXT</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE SLIDE GENERATION &amp; EDITING</span>
-        <h3>The Creative Slide Studio Is Live.</h3>
-        <p class="proof">Stunning by default. Effortless to edit. Ready in minutes.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">NATIVE VIDEO GENERATION &amp; EDITING</span>
+        <h3>The Product Film Studio Is Live.</h3>
+        <p class="proof">A campaign-ready product film—cinematic, polished, and built to perform.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">WATCH THE DROP ↗</a>
       </div>
     </article>`,
@@ -104,10 +104,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">原生图像生成与编辑</span>
-        <h3>营销物料引擎已上线。</h3>
-        <p class="proof">输入一份 brief，产出一整套 campaign——社媒素材、动态资源、落地页，每个渠道都能直接用。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">原生幻灯片生成与编辑</span>
+        <h3>创意幻灯片工作室已上线。</h3>
+        <p class="proof">默认就好看。改起来毫不费力。几分钟就能交付。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">观看当日发布 ↗</a>
       </div>
     </article>`,
@@ -119,10 +119,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>即将到来</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">原生视频生成与编辑</span>
-        <h3>产品影片工作室已上线。</h3>
-        <p class="proof">一支可直接投放的产品影片——有电影感、够精致、为效果而生。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">原生图像生成与编辑</span>
+        <h3>营销物料引擎已上线。</h3>
+        <p class="proof">输入一份 brief，产出一整套 campaign——社媒素材、动态资源、落地页，每个渠道都能直接用。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">观看当日发布 ↗</a>
       </div>
     </article>`,
@@ -134,10 +134,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>即将到来</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">原生幻灯片生成与编辑</span>
-        <h3>创意幻灯片工作室已上线。</h3>
-        <p class="proof">默认就好看。改起来毫不费力。几分钟就能交付。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">原生视频生成与编辑</span>
+        <h3>产品影片工作室已上线。</h3>
+        <p class="proof">一支可直接投放的产品影片——有电影感、够精致、为效果而生。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">观看当日发布 ↗</a>
       </div>
     </article>`,
@@ -180,10 +180,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">ネイティブ画像生成・編集</span>
-        <h3>キャンペーン・エンジン、公開。</h3>
-        <p class="proof">ブリーフをひとつ入れれば、キャンペーン一式が出てきます。SNS クリエイティブ、アニメーション素材、ランディングページ。どのチャネルにもそのまま使えます。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">ネイティブスライド生成・編集</span>
+        <h3>クリエイティブ・スライド・スタジオ、公開。</h3>
+        <p class="proof">はじめから美しく。編集は手間いらず。数分で仕上がります。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">ドロップを見る ↗</a>
       </div>
     </article>`,
@@ -195,10 +195,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>次回</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">ネイティブ動画生成・編集</span>
-        <h3>プロダクト・フィルム・スタジオ、公開。</h3>
-        <p class="proof">そのまま配信できるプロダクト映像。シネマティックで、磨かれていて、成果を出すために作られています。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">ネイティブ画像生成・編集</span>
+        <h3>キャンペーン・エンジン、公開。</h3>
+        <p class="proof">ブリーフをひとつ入れれば、キャンペーン一式が出てきます。SNS クリエイティブ、アニメーション素材、ランディングページ。どのチャネルにもそのまま使えます。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">ドロップを見る ↗</a>
       </div>
     </article>`,
@@ -210,10 +210,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>次回</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">ネイティブスライド生成・編集</span>
-        <h3>クリエイティブ・スライド・スタジオ、公開。</h3>
-        <p class="proof">はじめから美しく。編集は手間いらず。数分で仕上がります。</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">ネイティブ動画生成・編集</span>
+        <h3>プロダクト・フィルム・スタジオ、公開。</h3>
+        <p class="proof">そのまま配信できるプロダクト映像。シネマティックで、磨かれていて、成果を出すために作られています。</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">ドロップを見る ↗</a>
       </div>
     </article>`,
@@ -256,10 +256,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">네이티브 이미지 생성 및 편집</span>
-        <h3>캠페인 엔진이 공개되었습니다.</h3>
-        <p class="proof">브리프 하나를 넣으면 캠페인 전체가 나옵니다. 소셜 크리에이티브, 애니메이션 에셋, 랜딩 페이지까지 모든 채널에 바로 쓸 수 있습니다.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">네이티브 슬라이드 생성 및 편집</span>
+        <h3>크리에이티브 슬라이드 스튜디오가 공개되었습니다.</h3>
+        <p class="proof">기본부터 아름답게. 편집은 손쉽게. 몇 분이면 완성.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">드롭 보기 ↗</a>
       </div>
     </article>`,
@@ -271,10 +271,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>다음 차례</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">네이티브 비디오 생성 및 편집</span>
-        <h3>제품 필름 스튜디오가 공개되었습니다.</h3>
-        <p class="proof">바로 집행할 수 있는 제품 영상. 시네마틱하고, 정교하며, 성과를 내도록 만들어졌습니다.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">네이티브 이미지 생성 및 편집</span>
+        <h3>캠페인 엔진이 공개되었습니다.</h3>
+        <p class="proof">브리프 하나를 넣으면 캠페인 전체가 나옵니다. 소셜 크리에이티브, 애니메이션 에셋, 랜딩 페이지까지 모든 채널에 바로 쓸 수 있습니다.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">드롭 보기 ↗</a>
       </div>
     </article>`,
@@ -286,10 +286,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>다음 차례</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">네이티브 슬라이드 생성 및 편집</span>
-        <h3>크리에이티브 슬라이드 스튜디오가 공개되었습니다.</h3>
-        <p class="proof">기본부터 아름답게. 편집은 손쉽게. 몇 분이면 완성.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">네이티브 비디오 생성 및 편집</span>
+        <h3>제품 필름 스튜디오가 공개되었습니다.</h3>
+        <p class="proof">바로 집행할 수 있는 제품 영상. 시네마틱하고, 정교하며, 성과를 내도록 만들어졌습니다.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">드롭 보기 ↗</a>
       </div>
     </article>`,
@@ -332,10 +332,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE BILDERZEUGUNG &amp; -BEARBEITUNG</span>
-        <h3>Die Kampagnen-Engine ist live.</h3>
-        <p class="proof">Ein Briefing rein, eine komplette Kampagne raus — Social Creatives, animierte Assets und Landingpages. Bereit für jeden Kanal.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">NATIVE SLIDE-ERZEUGUNG &amp; -BEARBEITUNG</span>
+        <h3>Das Creative-Slide-Studio ist live.</h3>
+        <p class="proof">Von Haus aus beeindruckend. Mühelos zu bearbeiten. In Minuten fertig.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">DEN DROP ANSEHEN ↗</a>
       </div>
     </article>`,
@@ -347,10 +347,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>ALS NÄCHSTES</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE VIDEOERZEUGUNG &amp; -BEARBEITUNG</span>
-        <h3>Das Produktfilm-Studio ist live.</h3>
-        <p class="proof">Ein kampagnenfertiger Produktfilm — filmisch, ausgefeilt und auf Wirkung gebaut.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">NATIVE BILDERZEUGUNG &amp; -BEARBEITUNG</span>
+        <h3>Die Kampagnen-Engine ist live.</h3>
+        <p class="proof">Ein Briefing rein, eine komplette Kampagne raus — Social Creatives, animierte Assets und Landingpages. Bereit für jeden Kanal.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">DEN DROP ANSEHEN ↗</a>
       </div>
     </article>`,
@@ -362,10 +362,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>ALS NÄCHSTES</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">NATIVE SLIDE-ERZEUGUNG &amp; -BEARBEITUNG</span>
-        <h3>Das Creative-Slide-Studio ist live.</h3>
-        <p class="proof">Von Haus aus beeindruckend. Mühelos zu bearbeiten. In Minuten fertig.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">NATIVE VIDEOERZEUGUNG &amp; -BEARBEITUNG</span>
+        <h3>Das Produktfilm-Studio ist live.</h3>
+        <p class="proof">Ein kampagnenfertiger Produktfilm — filmisch, ausgefeilt und auf Wirkung gebaut.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">DEN DROP ANSEHEN ↗</a>
       </div>
     </article>`,
@@ -408,10 +408,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И РЕДАКТИРОВАНИЕ ИЗОБРАЖЕНИЙ</span>
-        <h3>Движок кампаний запущен.</h3>
-        <p class="proof">Один бриф на входе — целая кампания на выходе: креативы для соцсетей, анимированные ассеты и лендинги. Готово для любого канала.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И РЕДАКТИРОВАНИЕ СЛАЙДОВ</span>
+        <h3>Студия креативных слайдов запущена.</h3>
+        <p class="proof">Красиво по умолчанию. Редактируется без усилий. Готово за минуты.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">СМОТРЕТЬ ВЫПУСК ↗</a>
       </div>
     </article>`,
@@ -423,10 +423,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>ДАЛЕЕ</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И МОНТАЖ ВИДЕО</span>
-        <h3>Студия продуктовых роликов запущена.</h3>
-        <p class="proof">Продуктовый ролик, готовый к запуску: кинематографичный, отточенный и нацеленный на результат.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И РЕДАКТИРОВАНИЕ ИЗОБРАЖЕНИЙ</span>
+        <h3>Движок кампаний запущен.</h3>
+        <p class="proof">Один бриф на входе — целая кампания на выходе: креативы для соцсетей, анимированные ассеты и лендинги. Готово для любого канала.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">СМОТРЕТЬ ВЫПУСК ↗</a>
       </div>
     </article>`,
@@ -438,10 +438,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>ДАЛЕЕ</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И РЕДАКТИРОВАНИЕ СЛАЙДОВ</span>
-        <h3>Студия креативных слайдов запущена.</h3>
-        <p class="proof">Красиво по умолчанию. Редактируется без усилий. Готово за минуты.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">ВСТРОЕННАЯ ГЕНЕРАЦИЯ И МОНТАЖ ВИДЕО</span>
+        <h3>Студия продуктовых роликов запущена.</h3>
+        <p class="proof">Продуктовый ролик, готовый к запуску: кинематографичный, отточенный и нацеленный на результат.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">СМОТРЕТЬ ВЫПУСК ↗</a>
       </div>
     </article>`,
@@ -484,10 +484,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">GÉNÉRATION ET ÉDITION D'IMAGES NATIVES</span>
-        <h3>Le moteur de campagne est en ligne.</h3>
-        <p class="proof">Un brief en entrée, une campagne complète en sortie : créations sociales, assets animés et landing pages. Prêts pour chaque canal.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">GÉNÉRATION ET ÉDITION DE SLIDES NATIVES</span>
+        <h3>Le studio de slides créatives est en ligne.</h3>
+        <p class="proof">Superbes par défaut. Faciles à modifier. Prêtes en quelques minutes.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">VOIR LE DROP ↗</a>
       </div>
     </article>`,
@@ -499,10 +499,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>À VENIR</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GÉNÉRATION ET MONTAGE VIDÉO NATIFS</span>
-        <h3>Le studio de films produit est en ligne.</h3>
-        <p class="proof">Un film produit prêt pour la campagne — cinématographique, soigné et conçu pour performer.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">GÉNÉRATION ET ÉDITION D'IMAGES NATIVES</span>
+        <h3>Le moteur de campagne est en ligne.</h3>
+        <p class="proof">Un brief en entrée, une campagne complète en sortie : créations sociales, assets animés et landing pages. Prêts pour chaque canal.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">VOIR LE DROP ↗</a>
       </div>
     </article>`,
@@ -514,10 +514,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>À VENIR</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GÉNÉRATION ET ÉDITION DE SLIDES NATIVES</span>
-        <h3>Le studio de slides créatives est en ligne.</h3>
-        <p class="proof">Superbes par défaut. Faciles à modifier. Prêtes en quelques minutes.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">GÉNÉRATION ET MONTAGE VIDÉO NATIFS</span>
+        <h3>Le studio de films produit est en ligne.</h3>
+        <p class="proof">Un film produit prêt pour la campagne — cinématographique, soigné et conçu pour performer.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">VOIR LE DROP ↗</a>
       </div>
     </article>`,
@@ -560,10 +560,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERACIÓN Y EDICIÓN DE IMÁGENES NATIVAS</span>
-        <h3>El motor de campañas ya está disponible.</h3>
-        <p class="proof">Un brief a la entrada. Una campaña completa a la salida: creatividades sociales, recursos animados y landing pages. Listas para cada canal.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">GENERACIÓN Y EDICIÓN DE DIAPOSITIVAS NATIVAS</span>
+        <h3>El estudio de diapositivas creativas ya está disponible.</h3>
+        <p class="proof">Impresionantes por defecto. Fáciles de editar. Listas en minutos.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">VER EL DROP ↗</a>
       </div>
     </article>`,
@@ -575,10 +575,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>PRÓXIMAMENTE</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERACIÓN Y EDICIÓN DE VIDEO NATIVAS</span>
-        <h3>El estudio de películas de producto ya está disponible.</h3>
-        <p class="proof">Una película de producto lista para campaña: cinematográfica, pulida y hecha para rendir.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">GENERACIÓN Y EDICIÓN DE IMÁGENES NATIVAS</span>
+        <h3>El motor de campañas ya está disponible.</h3>
+        <p class="proof">Un brief a la entrada. Una campaña completa a la salida: creatividades sociales, recursos animados y landing pages. Listas para cada canal.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">VER EL DROP ↗</a>
       </div>
     </article>`,
@@ -590,10 +590,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>PRÓXIMAMENTE</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERACIÓN Y EDICIÓN DE DIAPOSITIVAS NATIVAS</span>
-        <h3>El estudio de diapositivas creativas ya está disponible.</h3>
-        <p class="proof">Impresionantes por defecto. Fáciles de editar. Listas en minutos.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">GENERACIÓN Y EDICIÓN DE VIDEO NATIVAS</span>
+        <h3>El estudio de películas de producto ya está disponible.</h3>
+        <p class="proof">Una película de producto lista para campaña: cinematográfica, pulida y hecha para rendir.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">VER EL DROP ↗</a>
       </div>
     </article>`,
@@ -636,10 +636,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE IMAGENS</span>
-        <h3>O motor de campanhas está no ar.</h3>
-        <p class="proof">Um briefing na entrada. Uma campanha completa na saída: criativos para redes sociais, recursos animados e landing pages. Prontos para cada canal.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE SLIDES</span>
+        <h3>O estúdio de slides criativos está no ar.</h3>
+        <p class="proof">Impressionantes por padrão. Fáceis de editar. Prontas em minutos.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">VER O DROP ↗</a>
       </div>
     </article>`,
@@ -651,10 +651,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>A SEGUIR</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE VÍDEO</span>
-        <h3>O estúdio de filmes de produto está no ar.</h3>
-        <p class="proof">Um filme de produto pronto para campanha: cinematográfico, refinado e feito para performar.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE IMAGENS</span>
+        <h3>O motor de campanhas está no ar.</h3>
+        <p class="proof">Um briefing na entrada. Uma campanha completa na saída: criativos para redes sociais, recursos animados e landing pages. Prontos para cada canal.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">VER O DROP ↗</a>
       </div>
     </article>`,
@@ -666,10 +666,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>A SEGUIR</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE SLIDES</span>
-        <h3>O estúdio de slides criativos está no ar.</h3>
-        <p class="proof">Impressionantes por padrão. Fáceis de editar. Prontas em minutos.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">GERAÇÃO E EDIÇÃO NATIVA DE VÍDEO</span>
+        <h3>O estúdio de filmes de produto está no ar.</h3>
+        <p class="proof">Um filme de produto pronto para campanha: cinematográfico, refinado e feito para performar.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">VER O DROP ↗</a>
       </div>
     </article>`,
@@ -712,10 +712,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERAZIONE E MODIFICA NATIVA DI IMMAGINI</span>
-        <h3>Il motore delle campagne è online.</h3>
-        <p class="proof">Un brief in ingresso. Una campagna completa in uscita: creatività social, asset animati e landing page. Pronte per ogni canale.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">GENERAZIONE E MODIFICA NATIVA DI SLIDE</span>
+        <h3>Lo studio di slide creative è online.</h3>
+        <p class="proof">Splendide di default. Facili da modificare. Pronte in pochi minuti.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">GUARDA IL DROP ↗</a>
       </div>
     </article>`,
@@ -727,10 +727,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>PROSSIMAMENTE</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERAZIONE E MONTAGGIO VIDEO NATIVI</span>
-        <h3>Lo studio di film di prodotto è online.</h3>
-        <p class="proof">Un film di prodotto pronto per la campagna: cinematografico, curato e costruito per rendere.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">GENERAZIONE E MODIFICA NATIVA DI IMMAGINI</span>
+        <h3>Il motore delle campagne è online.</h3>
+        <p class="proof">Un brief in ingresso. Una campagna completa in uscita: creatività social, asset animati e landing page. Pronte per ogni canale.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">GUARDA IL DROP ↗</a>
       </div>
     </article>`,
@@ -742,10 +742,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>PROSSIMAMENTE</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">GENERAZIONE E MODIFICA NATIVA DI SLIDE</span>
-        <h3>Lo studio di slide creative è online.</h3>
-        <p class="proof">Splendide di default. Facili da modificare. Pronte in pochi minuti.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">GENERAZIONE E MONTAGGIO VIDEO NATIVI</span>
+        <h3>Lo studio di film di prodotto è online.</h3>
+        <p class="proof">Un film di prodotto pronto per la campagna: cinematografico, curato e costruito per rendere.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">GUARDA IL DROP ↗</a>
       </div>
     </article>`,
@@ -788,10 +788,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <img class="live-stamp" src="/launch-week/stamp-live.svg" alt="Live now" loading="lazy" decoding="async">
       </div>
       <div class="drop-content">
-        <span class="drop-code">YERLEŞİK GÖRSEL ÜRETİMİ VE DÜZENLEME</span>
-        <h3>Kampanya motoru yayında.</h3>
-        <p class="proof">Bir brief girin, eksiksiz bir kampanya çıksın: sosyal görseller, animasyonlu içerikler ve açılış sayfaları. Her kanal için hazır.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
+        <span class="drop-code">YERLEŞİK SLAYT ÜRETİMİ VE DÜZENLEME</span>
+        <h3>Yaratıcı slayt stüdyosu yayında.</h3>
+        <p class="proof">Varsayılan olarak etkileyici. Düzenlemesi zahmetsiz. Dakikalar içinde hazır.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
         <a class="watch" href="#">DROP'U İZLE ↗</a>
       </div>
     </article>`,
@@ -803,10 +803,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>SIRADAKİ</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">YERLEŞİK VİDEO ÜRETİMİ VE DÜZENLEME</span>
-        <h3>Ürün filmi stüdyosu yayında.</h3>
-        <p class="proof">Kampanyaya hazır bir ürün filmi: sinematik, özenli ve sonuç almak için tasarlanmış.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
+        <span class="drop-code">YERLEŞİK GÖRSEL ÜRETİMİ VE DÜZENLEME</span>
+        <h3>Kampanya motoru yayında.</h3>
+        <p class="proof">Bir brief girin, eksiksiz bir kampanya çıksın: sosyal görseller, animasyonlu içerikler ve açılış sayfaları. Her kanal için hazır.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/canva-icon.png" alt="Canva" loading="lazy" decoding="async" width="24" height="24"> CANVA?</span></div>
         <a class="watch" href="#">DROP'U İZLE ↗</a>
       </div>
     </article>`,
@@ -818,10 +818,10 @@ export const LW_DROP_MARKUP: Record<string, string[]> = {
         <span data-status>SIRADAKİ</span>
       </div>
       <div class="drop-content">
-        <span class="drop-code">YERLEŞİK SLAYT ÜRETİMİ VE DÜZENLEME</span>
-        <h3>Yaratıcı slayt stüdyosu yayında.</h3>
-        <p class="proof">Varsayılan olarak etkileyici. Düzenlemesi zahmetsiz. Dakikalar içinde hazır.</p>
-        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/gamma-icon.png" alt="Gamma" loading="lazy" decoding="async" width="24" height="24"> GAMMA?</span></div>
+        <span class="drop-code">YERLEŞİK VİDEO ÜRETİMİ VE DÜZENLEME</span>
+        <h3>Ürün filmi stüdyosu yayında.</h3>
+        <p class="proof">Kampanyaya hazır bir ürün filmi: sinematik, özenli ve sonuç almak için tasarlanmış.</p>
+        <div class="killstrip">CAN IT KILL <span class="brand-target"><img src="/launch-week/higgsfield-icon.png" alt="Higgsfield" loading="lazy" decoding="async" width="24" height="24"> HIGGSFIELD?</span></div>
         <a class="watch" href="#">DROP'U İZLE ↗</a>
       </div>
     </article>`,


### PR DESCRIPTION
## Why

The running order was set from the original content calendar. Today's standup
re-sequenced it against what is actually ready to ship: slides and the image
drop are further along than video, so the week now leads with them.

This has a hard deadline — day 2 opens automatically at 08:00 UTC+8 tomorrow,
and the endpoint releases whatever is in `main` at that moment. There is no way
to hold a day back once the clock passes it, so this needs to be deployed to
production today.

## What users will see

Nothing until tomorrow morning, when day 2 opens as the slide studio instead of
the image drop.

| Day | Was | Now |
|---|---|---|
| 02 · Aug 11 | Native Image → Canva | **Native Slide → Gamma** |
| 03 · Aug 12 | Native Video → Higgsfield | **Native Image → Canva** |
| 04 · Aug 13 | Native Slide → Gamma | **Native Video → Higgsfield** |

Days 1 and 5 are untouched, and nothing about the unopened days is visible
before its date.

## Surface area

- [ ] **UI** — no layout, style or component change
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — the same reordering applied to all eleven locale variants
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

### What deliberately did not move

Only the `<div class="drop-content">` block moves between cards. Each card keeps
its day numeral, `DAY 0N/05`, date, `data-launch-day`, anchor id, per-day colour
and paint stroke.

That split is the point: the colours and strokes are chapter identity for a
position in the week, not branding for a product. Day 2 stays coral and simply
carries a different drop. Moving them too would have made the reorder look like
a redesign.

## Screenshots

No design change; the same card renders different copy. Verified visually that
day 2 now reads "The Creative Slide Studio Is Live. / CAN IT KILL GAMMA?" while
its numeral, date, colour and stroke are unchanged.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm --filter @open-design/landing-page test` — 134/134 pass.
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors.
- Browser, 11 locales at 1440px against the real endpoint: every locale returns
  the sequence `1:Figma 2:Gamma 3:Canva 4:Higgsfield 5:—`, five cards, no page
  errors, no horizontal overflow.
- Confirmed each card's day numeral and date stayed with its position
  (day 2 → `02` / AUG 11) in en, zh, ja and tr.
