### PR TITLE
chore(pack): bump bundled vela-cli to 0.0.32

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-LZeGYpjxKgDwqbY/1XZLiaHBawIZM68i9oUju7XU6PI=";
-  webHash = "sha256-+kvUsQ9gNVaGIO2aF0z3dSPrNi4Nbp2z/B4gkWUZXyo=";
+  daemonHash = "sha256-5n0A3EWwM20HiAkJWOcL/x+9QnJ3xiaykJ8q+VTTWaA=";
+  webHash = "sha256-nukdJv4wMn02Xc9oOBUtqkcoW3v3cGm9VQQOElzRQPI=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.31
-        version: 0.0.31
+        specifier: 0.0.32
+        version: 0.0.32
 
   tools/release:
     dependencies:
@@ -2053,33 +2053,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.31':
-    resolution: {integrity: sha512-Qp2E++ELUhs4W7nJ9RlAHbGO1X3rkdrkZ1ru/G4rg3gZP/MIiZLgzSAsrmF2cp7esy64QODsq2uhU9UsHz/I9w==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.32':
+    resolution: {integrity: sha512-58VGcSqrMWjSUqIYRiBoIMjaoUfFZCQBEZ74QEAkqf1PLxT9j8gFDrejORjUFPrULdm4B4zhk7hJuKDPuS0eJw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.31':
-    resolution: {integrity: sha512-rSqPd253JXXJIcr7S/hGXwn+jKW2tj2tsul3vMSICO/iYek5RrNZ76fmNL2lacVzWoQkVShIbLcmkiu2NcUfnA==}
+  '@powerformer/vela-cli-darwin-x64@0.0.32':
+    resolution: {integrity: sha512-Zwx9Xznp6+OZnUYtEjZXgiMqYIoOreF5I4ysY2qoMxUskjvmx9ONQlPtKf0Y+aROcTD79NcdDh9kv0aSeMbkbQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.31':
-    resolution: {integrity: sha512-/JMbdZii+JyJGC5cZBM69XMqvQyg58TlmMgVLKwnflflVtPOqO+qQcjcKFa/6Y9bdlAdXGFN9r7GQ6e82/5xZA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.32':
+    resolution: {integrity: sha512-J8bBa9bZt3+MTCNKJCYcsSQFJWJlZVdhgEh+LsdNA4S5hB72oH082x5pm+NEciYKw1SimO05BEyowhtpmzyJrw==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.31':
-    resolution: {integrity: sha512-/OK19sB6vVzRx/buH9ALyqBrponkIB6jf9oxNZDktHU5xIYtGBe/47wguZEPkMrfn8xHSkaMDb31ZFqC4aeGrQ==}
+  '@powerformer/vela-cli-linux-x64@0.0.32':
+    resolution: {integrity: sha512-dvxd9qQCHXhExqC0mkw+/XT17KiTps1cSJm94ScdOzxTEer7dNLZJaSnij72hZKCuyb/j4I0cjTI8y2jVi1gxQ==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.31':
-    resolution: {integrity: sha512-9B9Y0nzD/TAEur94EqpDKNqjbbAKkKV0X65Y9ANcj8KJ1UFATFdsvJb1tesgCssxFBU40zjt/p+HQoqdBy6sfg==}
+  '@powerformer/vela-cli-win32-x64@0.0.32':
+    resolution: {integrity: sha512-1lCHlyETx/tXv4iB9SNtxSAJFeUcGnZM0pNBQSiQwamT6lZc5StzZsFOr3cIDoKK3vFDWVYPiQpvQopINBTFfg==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.31':
-    resolution: {integrity: sha512-/mMa/IwR//BJ+ClWhQf+bbYNUf+Op3CUPlOQX6IwSk7PdRjlFcD8mMourwTfP2JDTny123nw/UW9mMD5GyBbVg==}
+  '@powerformer/vela-cli@0.0.32':
+    resolution: {integrity: sha512-hcW1/aCRS0bosgguF9+pSm05x/t53JNP0L06cgMsErNPMO7UsLjfkKPkBIKqVKGyNKc2j6PRIj88BNFoVS1EHw==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7911,28 +7911,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.31':
+  '@powerformer/vela-cli-darwin-arm64@0.0.32':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.31':
+  '@powerformer/vela-cli-darwin-x64@0.0.32':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.31':
+  '@powerformer/vela-cli-linux-arm64@0.0.32':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.31':
+  '@powerformer/vela-cli-linux-x64@0.0.32':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.31':
+  '@powerformer/vela-cli-win32-x64@0.0.32':
     optional: true
 
-  '@powerformer/vela-cli@0.0.31':
+  '@powerformer/vela-cli@0.0.32':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.31
-      '@powerformer/vela-cli-darwin-x64': 0.0.31
-      '@powerformer/vela-cli-linux-arm64': 0.0.31
-      '@powerformer/vela-cli-linux-x64': 0.0.31
-      '@powerformer/vela-cli-win32-x64': 0.0.31
+      '@powerformer/vela-cli-darwin-arm64': 0.0.32
+      '@powerformer/vela-cli-darwin-x64': 0.0.32
+      '@powerformer/vela-cli-linux-arm64': 0.0.32
+      '@powerformer/vela-cli-linux-x64': 0.0.32
+      '@powerformer/vela-cli-win32-x64': 0.0.32
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.31"
+    "@powerformer/vela-cli": "0.0.32"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Routine maintenance on my side: I wanted the packaged runtime to ship the current Vela CLI, so I bumped the `tools-pack` optional pin to `0.0.32`.

The pain it addresses is plain version drift. `main` moved the pin to `0.0.31` and, in the same change, made the staged-pull capability gate accept both the `<stageDir>` and `[stageDir]` usage spellings that Vela started emitting once `--authorize-only` made the positional optional. That work already covers 0.0.32, so this PR is only the pin and the lockfile — no guard changes needed.

## What users will see

Nothing changes in the UI or the CLI surface. Packaged builds (mac / win / linux) bundle Vela CLI 0.0.32 instead of 0.0.31; users pick it up on their next packaged install or update.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency** — the pin lives in `tools/pack/package.json`, not root, and it is a version bump of an existing entry
- [ ] **Default behavior change**
- [x] **None** — dependency bump only

## Screenshots

n/a — no UI surface.

## Bug fix verification

Not a bug fix.

Capability surface verified directly against the installed 0.0.32 darwin-arm64 binary, since packaging's `--require-vela-cli` gate depends on it:

- `vela --version` → `0.0.32`
- `vela team-projects pull --help` → `pull <projectId> [stageDir]`, plus `--expected-version`, `--live-dir`, `--ref`, `--json` (and `--authorize-only`)
- `vela billing workspace-snapshot --help` → `workspace-snapshot`, `--workspace-id`, `--format`

`copies the installed Vela CLI through the default npm resolver` exercises that gate against the real installed binary and is green on this branch.

## Validation

- `pnpm install` (lockfile refreshed for all five `@powerformer/vela-cli-*` platform packages)
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/tools-pack test` — 37 files, 273 passed / 8 skipped

All four re-run after rebasing onto `main` (`d07e2070f`).

Not run: the full `@open-design/daemon` suite. `apps/daemon/src` has no reference to `@powerformer/vela-cli`, `resolveVelaCliBin`, or `OPEN_DESIGN_VELA_CLI_BIN` — it resolves the binary from packaged resources at runtime — so the pin change does not reach it. CI covers it either way.
