### PR TITLE
open each Launch Week day at noon, not 08:00

### DIFF
--- a/apps/landing-page/app/pages/community/events/launch-week/index.astro
+++ b/apps/landing-page/app/pages/community/events/launch-week/index.astro
@@ -11,8 +11,9 @@ const meta = LW_META[locale] ?? LW_META.en;
 const launchWeekMain = LW_BODY[locale] ?? LW_BODY.en;
 
 /**
- * Drop schedule. Each day flips at 08:00 UTC+8, which is exactly 00:00 UTC —
- * and UTC+8 has no daylight saving, so a plain UTC timestamp is the whole story.
+ * Drop schedule. Each day flips at 12:00 UTC+8 (= 04:00 UTC) — ahead of the
+ * day's posts, so a link from one never lands on a card that is still sealed.
+ * UTC+8 has no daylight saving, so a plain UTC offset is the whole story.
  * Rendered per build; the inline script below re-resolves it in the visitor's
  * browser so a cached page still shows the right state.
  */
@@ -40,7 +41,7 @@ const jsonLd = {
   '@type': 'Event',
   name: title,
   description,
-  startDate: '2026-08-10T08:00:00+08:00',
+  startDate: '2026-08-10T12:00:00+08:00',
   endDate: '2026-08-14T23:59:00+08:00',
   eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
   eventStatus: 'https://schema.org/EventScheduled',
@@ -58,7 +59,7 @@ const jsonLd = {
     priceCurrency: 'USD',
     availability: 'https://schema.org/InStock',
     url: new URL(Astro.url.pathname, Astro.site ?? fallbackSite).toString(),
-    validFrom: '2026-08-10T08:00:00+08:00',
+    validFrom: '2026-08-10T12:00:00+08:00',
   },
 };
 ---
@@ -80,7 +81,7 @@ const jsonLd = {
   (() => {
     const now = Date.now();
     const stateFor = (iso) => {
-      const opens = Date.parse(iso + 'T00:00:00Z'); // 08:00 UTC+8
+      const opens = Date.parse(iso + 'T04:00:00Z'); // 12:00 UTC+8
       const closes = opens + 86400000;
       if (now < opens) return 'classified';
       return now < closes ? 'live' : 'released';
@@ -106,7 +107,7 @@ const jsonLd = {
       // Before the week opens, day 1 is the one we tease as next up.
       document.documentElement.dataset.launchWeek = Object.values(states).includes('live')
         ? 'running'
-        : now < Date.parse(DROPS[0].iso + 'T00:00:00Z')
+        : now < Date.parse(DROPS[0].iso + 'T04:00:00Z')
           ? 'before'
           : 'after';
     };

--- a/apps/landing-page/functions/launch-week/drops.ts
+++ b/apps/landing-page/functions/launch-week/drops.ts
@@ -7,8 +7,9 @@
  * days before each reveal. The sealed cards ship in the page; the revealed
  * markup lives here and is released on the hour, without needing a deploy.
  *
- * A day opens at 08:00 UTC+8, which is exactly 00:00 UTC. UTC+8 observes no
- * daylight saving, so a plain UTC timestamp is the whole calculation.
+ * A day opens at 12:00 UTC+8 — midday, a few hours ahead of when the day's
+ * posts go out, so the page is never the last thing to know. UTC+8 observes no
+ * daylight saving, so a plain UTC offset is the whole calculation.
  */
 import { LW_DROP_MARKUP } from '../../app/_partials/launch-week-drops';
 
@@ -19,13 +20,13 @@ type PagesFunctionContext<Env> = {
 
 type PagesFunction<Env> = (context: PagesFunctionContext<Env>) => Response | Promise<Response>;
 
-/** Day N opens at 2026-08-{09+N} 00:00 UTC. */
+/** Day N opens at 2026-08-{09+N} 04:00 UTC = 12:00 UTC+8. */
 const OPENS_AT = [
-  '2026-08-10T00:00:00Z',
-  '2026-08-11T00:00:00Z',
-  '2026-08-12T00:00:00Z',
-  '2026-08-13T00:00:00Z',
-  '2026-08-14T00:00:00Z',
+  '2026-08-10T04:00:00Z',
+  '2026-08-11T04:00:00Z',
+  '2026-08-12T04:00:00Z',
+  '2026-08-13T04:00:00Z',
+  '2026-08-14T04:00:00Z',
 ].map((iso) => Date.parse(iso));
 
 /**

--- a/apps/landing-page/tests/launch-week-drops.test.ts
+++ b/apps/landing-page/tests/launch-week-drops.test.ts
@@ -21,7 +21,7 @@ const at = (iso: string) => Date.parse(iso);
 const ENDPOINT = 'https://open-design.ai/launch-week/drops';
 
 test('an unopened day is never served', async () => {
-  const { body } = await call(ENDPOINT, at('2026-08-09T23:59:00Z'));
+  const { body } = await call(ENDPOINT, at('2026-08-10T03:59:00Z'));
   assert.deepEqual(body.drops, [], 'nothing is public before the week opens');
 
   const midweek = await call(ENDPOINT, at('2026-08-12T09:00:00Z'));
@@ -35,11 +35,11 @@ test('an unopened day is never served', async () => {
   assert.equal(after.body.drops.length, 5, 'the whole week stays up once it has run');
 });
 
-test('a day opens at 08:00 UTC+8 exactly', async () => {
-  const before = await call(ENDPOINT, at('2026-08-10T00:00:00Z') - 1);
+test('a day opens at 12:00 UTC+8 exactly', async () => {
+  const before = await call(ENDPOINT, at('2026-08-10T04:00:00Z') - 1);
   assert.equal(before.body.drops.length, 0);
 
-  const on = await call(ENDPOINT, at('2026-08-10T00:00:00Z'));
+  const on = await call(ENDPOINT, at('2026-08-10T04:00:00Z'));
   assert.equal(on.body.drops.length, 1);
 });
 
@@ -58,15 +58,15 @@ test('preview needs the key, and is never cached', async () => {
 });
 
 test('the edge stops caching a day at its boundary', async () => {
-  const { response } = await call(ENDPOINT, at('2026-08-10T23:00:00Z'));
+  const { response } = await call(ENDPOINT, at('2026-08-11T03:00:00Z'));
   const maxAge = Number(/s-maxage=(\d+)/.exec(response.headers.get('Cache-Control') ?? '')?.[1]);
   assert.ok(maxAge <= 3600, 'day 2 cannot be held back by a stale day-1 response');
 });
 
 test('every locale serves its own drops, and an unknown one falls back', async () => {
-  const zh = await call(`${ENDPOINT}?locale=zh`, at('2026-08-14T00:00:00Z'));
-  const en = await call(`${ENDPOINT}?locale=en`, at('2026-08-14T00:00:00Z'));
-  const bogus = await call(`${ENDPOINT}?locale=xx`, at('2026-08-14T00:00:00Z'));
+  const zh = await call(`${ENDPOINT}?locale=zh`, at('2026-08-14T04:00:00Z'));
+  const en = await call(`${ENDPOINT}?locale=en`, at('2026-08-14T04:00:00Z'));
+  const bogus = await call(`${ENDPOINT}?locale=xx`, at('2026-08-14T04:00:00Z'));
 
   assert.equal(zh.body.drops.length, 5);
   assert.notDeepEqual(zh.body.drops, en.body.drops, 'zh is translated, not the English copy');


### PR DESCRIPTION
## Why

The day's posts go out around 16:00–17:00 UTC+8, but the page flipped at 08:00.
That left it announcing a drop for eight or nine hours before anything existed
to read — and with the Launch Week entry about to appear on the homepage, that
window stops being hypothetical: a visitor arriving at 09:00 sees "The Creative
Slide Studio Is Live" with no post, no video, and nothing in the community.

## What users will see

Each day now opens at **12:00 UTC+8** instead of 08:00. Tomorrow's day 2 appears
at noon rather than breakfast.

The page still leads the posts, which it has to — the launch post links here, and
a link that lands on a sealed card is the worse failure by far. It now leads by
a few hours instead of most of a day, with enough slack that a post slipping to
the evening cannot invert the order.

Midday UTC+8 is 21:00 the previous day in San Francisco, so the drop is still
already live when the US audience wakes up — which is what the original 08:00
was chosen for, and is preserved.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `GET /launch-week/drops` releases each day four hours later
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the schedule visitors see shifts by four hours
- [ ] **None**

`startDate` and `offers.validFrom` in the Event structured data move with it.

### One hazard worth recording

**A later boundary can retract a day that has already opened.** Day 01 opened at
08:00 today; shipping this between 08:00 and 12:00 would have closed it again in
front of live traffic. Deploying after the new boundary has passed avoids that,
which is the case here. Anyone moving this again mid-week should check the same
thing first.

## Screenshots

No visual change.

## Bug fix verification

Not a bug fix in the red-spec sense — the schedule was working as specified; the
specification was wrong about when the content lands.

## Validation

- `pnpm --filter @open-design/landing-page test` — 134/134 pass, including the
  boundary case updated to 04:00 UTC (one millisecond before → 0 drops, on the
  tick → 1).
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors.
- Walked the whole week in UTC+8 against the real function:

```
2026-08-10 11:59 → 0 open      2026-08-12 11:59 → 2 open
2026-08-10 12:00 → 1 open      2026-08-12 12:00 → 3 open
2026-08-11 11:59 → 1 open      2026-08-14 12:00 → 5 open
2026-08-11 12:00 → 2 open
2026-08-11 16:30 → 2 open   (posting time — the page is already in place)
```
