### PR TITLE
test(web): wait for project send readiness

### DIFF
--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -852,8 +852,11 @@ describe('a Home auto-send identifies its caller before the project scope resolv
           workspaceId: undefined,
         },
       });
-      const send = await waitFor(() => view.getByTestId('normal-send'));
-      expect(send).not.toBeDisabled();
+      const send = await waitFor(() => {
+        const candidate = view.getByTestId('normal-send');
+        expect(candidate).not.toBeDisabled();
+        return candidate;
+      });
       fireEvent.click(send);
 
       await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalled());


### PR DESCRIPTION
## Why

A main-derived merge-queue run failed in `ProjectView.run-workspace-identity.test.tsx` because the test waited only for the send button to be present, then asserted readiness immediately. During asynchronous chat-pane initialization the button can still be absent or disabled, so the test raced the existing readiness transition and blocked otherwise unrelated changes.

This PR encodes the actual completion signal: the normal send control must be mounted and enabled before the test clicks it. It does not add sleeps, increase timeouts, or change product behavior.

## What users will see

No user-visible behavior change. CI now waits for the existing project send action to become ready before exercising it.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a test-only synchronization fix.

## Bug fix verification

- Test path: `apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx`
- Red evidence: [merge-queue CI job 93358850518](https://github.com/nexu-io/open-design/actions/runs/31357113975/job/93358850518) failed both unbound normal-send cases because `normal-send` was still disabled.
- Did the test go red on `main` and green on this branch? Yes in the authoritative main-derived merge-queue run; one local baseline run on current `main` passed, confirming that the failure is intermittent. The first presence-only revision also reproduced the missing-button race locally. The final readiness wait passed 10 consecutive focused runs and the full file.

## Validation

- Focused unbound normal-send cases: 10 consecutive passes (2 tests per run)
- Full `ProjectView.run-workspace-identity.test.tsx`: 29/29 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`