### PR TITLE
fix: update explicitly named chat artifacts in place

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3494,14 +3494,21 @@ export function ProjectView({
       const artifactToPersist = persistedHtml === art.html ? art : { ...art, html: persistedHtml };
       const baseName = artifactBaseNameFor(art);
       const ext = artifactExtensionFor(art);
-      // Pick a name that doesn't collide with an existing project file.
-      // The first run uses `<base>.<ext>`; subsequent runs append `-2`, `-3`…
-      // so prior artifacts aren't silently overwritten.
       const currentProjectFiles = projectFilesSnapshot ?? projectFilesRef.current;
       const existing = new Set(currentProjectFiles.map((f) => f.name));
       let fileName = `${baseName}${ext}`;
+      // A non-empty identifier is stable artifact identity: when its canonical
+      // filename already exists, update that file in place. Title- and
+      // fallback-derived names still suffix collisions so new artifacts cannot
+      // silently replace unrelated project files.
+      const updatesExplicitlyIdentifiedFile =
+        Boolean(art.identifier?.trim()) && existing.has(fileName);
       let n = 2;
-      while (existing.has(fileName) && savedArtifactRef.current !== fileName) {
+      while (
+        existing.has(fileName) &&
+        savedArtifactRef.current !== fileName &&
+        !updatesExplicitlyIdentifiedFile
+      ) {
         fileName = `${baseName}-${n}${ext}`;
         n += 1;
       }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3503,15 +3503,16 @@ export function ProjectView({
       // silently replace unrelated project files.
       const updatesExplicitlyIdentifiedFile =
         Boolean(art.identifier?.trim()) && existing.has(fileName);
+      let collisionFileName = fileName;
       let n = 2;
       while (
-        existing.has(fileName) &&
-        savedArtifactRef.current !== fileName &&
-        !updatesExplicitlyIdentifiedFile
+        existing.has(collisionFileName) &&
+        savedArtifactRef.current !== collisionFileName
       ) {
-        fileName = `${baseName}-${n}${ext}`;
+        collisionFileName = `${baseName}-${n}${ext}`;
         n += 1;
       }
+      if (!updatesExplicitlyIdentifiedFile) fileName = collisionFileName;
       if (ext === '.html') {
         const pointerProjectFiles = filterProjectFilesByMinMtime(
           currentProjectFiles,
@@ -3519,7 +3520,7 @@ export function ProjectView({
         );
         const pointerTarget = resolveHtmlPointerArtifactTarget({
           content: artifactToPersist.html,
-          candidateFileName: fileName,
+          candidateFileName: collisionFileName,
           projectFiles: pointerProjectFiles,
         });
         if (pointerTarget) {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -711,17 +711,150 @@ describe('ProjectView API empty response handling', () => {
       expect(hasSavedAssistantMessage((message) => message.runStatus === 'succeeded')).toBe(true);
     });
     await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalled());
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('landing-page.html');
+    await waitFor(() => {
+      expect(screen.getByTestId('file-workspace').dataset.openRequestName).toBe(
+        'landing-page.html',
+      );
+    });
     await waitFor(() => expect(mockedPlaySound).toHaveBeenCalledWith('success-sound'));
     expect(mockedPlaySound).not.toHaveBeenCalledWith('failure-sound');
     expect(screen.queryByText(/provider ended the request/i)).toBeNull();
     expect(screen.queryByText('empty_response:deepseek-chat')).toBeNull();
   });
 
-  it('marks a generated artifact as failed when project persistence does not deliver it', async () => {
+  it('updates an existing project file when a chat artifact explicitly identifies it', async () => {
+    const existingIndex = {
+      name: 'index.html',
+      path: 'index.html',
+      kind: 'html',
+      mime: 'text/html',
+      size: 100,
+      mtime: 1,
+    };
+    const updatedHtml =
+      '<!doctype html><html><head><title>Updated</title></head><body><main><h1>Updated home page</h1><p>Complete replacement content for the existing project entry.</p></main></body></html>';
+    mockedFetchProjectFiles.mockResolvedValue([existingIndex] as never);
+    mockedWriteProjectTextFile.mockImplementation(
+      async (_projectId, fileName) =>
+        ({
+          ...existingIndex,
+          name: fileName,
+          path: fileName,
+          mtime: 2,
+        }) as never,
+    );
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const artifact =
+        '<artifact identifier="index" type="text/html" title="Updated Home">' +
+        updatedHtml +
+        '</artifact>';
+      options.handlers.onDelta(artifact);
+      options.handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1));
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.slice(0, 3)).toEqual([
+      'project-1',
+      'index.html',
+      updatedHtml,
+    ]);
+    await waitFor(() => {
+      expect(screen.getByTestId('file-workspace').dataset.openRequestName).toBe('index.html');
+    });
+  });
+
+  it('suffixes a title-derived artifact that collides with an existing project file', async () => {
+    const existingLandingPage = {
+      name: 'landing-page.html',
+      path: 'landing-page.html',
+      kind: 'html',
+      mime: 'text/html',
+      size: 100,
+      mtime: 1,
+    };
+    const generatedHtml =
+      '<!doctype html><html><head><title>Landing</title></head><body><main><h1>New landing page</h1><p>Complete content for a distinct generated project artifact.</p></main></body></html>';
+    mockedFetchProjectFiles.mockResolvedValue([existingLandingPage] as never);
+    mockedWriteProjectTextFile.mockImplementation(
+      async (_projectId, fileName) =>
+        ({
+          ...existingLandingPage,
+          name: fileName,
+          path: fileName,
+          mtime: 2,
+        }) as never,
+    );
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const artifact =
+        '<artifact type="text/html" title="Landing Page">' +
+        generatedHtml +
+        '</artifact>';
+      options.handlers.onDelta(artifact);
+      options.handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1));
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.slice(0, 3)).toEqual([
+      'project-1',
+      'landing-page-2.html',
+      generatedHtml,
+    ]);
+    await waitFor(() => {
+      expect(screen.getByTestId('file-workspace').dataset.openRequestName).toBe(
+        'landing-page-2.html',
+      );
+    });
+  });
+
+  it('refuses invalid HTML instead of overwriting an explicitly identified project file', async () => {
+    mockedFetchProjectFiles.mockResolvedValue([
+      {
+        name: 'index.html',
+        path: 'index.html',
+        kind: 'html',
+        mime: 'text/html',
+        size: 100,
+        mtime: 1,
+      },
+    ] as never);
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      options.handlers.onDelta(
+        '<artifact identifier="index" type="text/html" title="Updated Home">Summary only.</artifact>',
+      );
+      options.handlers.onDone('');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Refused to save artifact "index"/i).length).toBeGreaterThan(0);
+    });
+    expect(mockedWriteProjectTextFile).not.toHaveBeenCalled();
+  });
+
+  it('marks an explicitly identified overwrite as failed when persistence does not deliver it', async () => {
     const artifact =
-      '<artifact identifier="landing-page" type="text/html" title="Landing Page">' +
+      '<artifact identifier="index" type="text/html" title="Updated Home">' +
       '<!doctype html><html><head><title>Landing</title></head><body><main><h1>Landing page</h1><p>Generated design artifact with enough structure to persist.</p></main></body></html>' +
       '</artifact>';
+    mockedFetchProjectFiles.mockResolvedValue([
+      {
+        name: 'index.html',
+        path: 'index.html',
+        kind: 'html',
+        mime: 'text/html',
+        size: 100,
+        mtime: 1,
+      },
+    ] as never);
     mockedWriteProjectTextFile.mockResolvedValueOnce(null);
     mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
       options.handlers.onDelta(artifact);
@@ -746,6 +879,7 @@ describe('ProjectView API empty response handling', () => {
         ),
       ).toBe(true);
     });
+    expect(mockedWriteProjectTextFile.mock.calls[0]?.[1]).toBe('index.html');
     expect(screen.getAllByText(/couldn't save artifact/i).length).toBeGreaterThan(0);
     await waitFor(() => expect(mockedPlaySound).toHaveBeenCalledWith('failure-sound'));
     expect(mockedPlaySound).not.toHaveBeenCalledWith('success-sound');


### PR DESCRIPTION
Fixes #

## Why

Refine `persistArtifact`'s filename decision so a non-empty artifact identifier that canonically resolves to an existing project filename is treated as stable artifact identity and is written back to that same file. Preserve collision suffixing when the name comes only from a title or fallback, so genuinely new artifacts do not silently replace unrelated project files, and leave HTML pointer resolution, validation, manifest generation, refresh, and auto-open behavior intact. Cover the real API/chat completion flow with an existing `index.html`, asserting that persistence and the opened tab retain `index.html`; also retain coverage for a title-derived collision to prove the safety behavior still creates a suffixed file.

Chat-requested edits to an existing HTML artifact such as `index.html` currently pass through `ProjectView`'s artifact persistence fallback. That fallback always avoids a pre-existing filename unless it was already saved during the mounted session, so an explicitly named `index` artifact becomes `index-2.html`, then later versions, while the original remains unchanged. Each version is opened as a new workspace tab and relative links that still target `index.html` continue to show stale content. The reporter confirmed the chat route, and the current collision loop in `ProjectView.tsx` provides a concrete repository-verifiable cause.

Closes #5238

## What users will see

Not applicable to this change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No user-visible surface changes in this PR, so there is nothing to show.

## Bug fix verification

-

## Validation

Existing `index.html` plus a completed chat artifact with explicit identifier `index` writes the new complete HTML to `index.html`, never requests `index-2.html`, and opens the existing `index.html` tab.
The same explicitly identified artifact in a project without `index.html` continues to create and open `index.html` normally.
An artifact whose candidate name is derived only from its title or fallback and collides with an unrelated existing file still receives the next available numeric suffix rather than overwriting that file.
Invalid HTML and failed writes continue through the existing refusal/delivery-failure paths without treating an overwrite candidate as successfully persisted.

AI was used for assistance.
