### PR TITLE
feat(web,daemon): add Kimi K3 to BYOK model picker

### DIFF
--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -8,6 +8,7 @@ export const kimiAgentDef = {
     versionArgs: ['--version'],
     fallbackModels: [
       DEFAULT_MODEL_OPTION,
+      { id: 'kimi-k3', label: 'kimi-k3' },
       { id: 'kimi-k2-turbo-preview', label: 'kimi-k2-turbo-preview' },
       { id: 'moonshot-v1-8k', label: 'moonshot-v1-8k' },
       { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k' },

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -608,9 +608,10 @@ fsTest('detectAgents keeps Kimi available when ACP model discovery fails', async
       assert.equal(kimi.available, true);
       assert.equal(kimi.version, 'kimi 0.6.0');
       assert.equal(kimi.models[0]?.id, 'default');
-      assert.equal(kimi.models[1]?.id, 'kimi-k2-turbo-preview');
-      assert.equal(kimi.models[2]?.id, 'moonshot-v1-8k');
-      assert.equal(kimi.models[3]?.id, 'moonshot-v1-32k');
+      assert.equal(kimi.models[1]?.id, 'kimi-k3');
+      assert.equal(kimi.models[2]?.id, 'kimi-k2-turbo-preview');
+      assert.equal(kimi.models[3]?.id, 'moonshot-v1-8k');
+      assert.equal(kimi.models[4]?.id, 'moonshot-v1-32k');
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -376,6 +376,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'openai',
     baseUrl: 'https://api.moonshot.cn/v1',
     preferredModels: [
+      'kimi-k3',
       'kimi-k2.6',
       'kimi-k2.7-code',
       'kimi-k2.7-code-highspeed',

--- a/apps/web/src/state/maxTokens.ts
+++ b/apps/web/src/state/maxTokens.ts
@@ -57,6 +57,7 @@ const OVERRIDES: Record<string, number> = {
   'kimi-k2:1t': 131072,
   'kimi-k2-thinking': 131072,
   'kimi-k2.5': 131072,
+  'kimi-k3': 131072,
   'kimi-k2.6': 131072,
   'kimi-k2.7-code': 131072,
   'minimax-m2': 131072,

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -46,7 +46,11 @@ describe('KNOWN_PROVIDERS', () => {
     const moonshot = KNOWN_PROVIDERS.find((provider) => provider.label === 'Moonshot');
     const moonshotPreset = BYOK_PROVIDER_PRESETS.find((preset) => preset.id === 'moonshot');
 
+    // kimi-k3 is the newest Kimi model and the recommended Moonshot default,
+    // so it holds the first-slot position that defaultKnownProviderModel() reads.
+    expect(moonshot?.preferredModels?.[0]).toBe('kimi-k3');
     expect(moonshot?.preferredModels).toEqual(expect.arrayContaining([
+      'kimi-k3',
       'kimi-k2.6',
       'kimi-k2.7-code',
     ]));
@@ -1028,11 +1032,13 @@ describe('loadConfig', () => {
 
     const config = loadConfig();
 
-    expect(config.model).toBe('kimi-k2.6');
-    expect(config.apiProtocolConfigs?.openai?.model).toBe('kimi-k2.6');
+    // kimi-k3 is the first-slot Moonshot preferred model, so retired ids
+    // (kimi-k2-0711-preview) migrate to it via defaultKnownProviderModel().
+    expect(config.model).toBe('kimi-k3');
+    expect(config.apiProtocolConfigs?.openai?.model).toBe('kimi-k3');
     expect(
       config.byokProviderConfigDrafts?.[`openai:${moonshotBaseUrl}`]?.apiConfig.model,
-    ).toBe('kimi-k2.6');
+    ).toBe('kimi-k3');
     expect(config.configMigrationVersion).toBe(3);
   });
 


### PR DESCRIPTION
## Why

Kimi K3 shipped on the Moonshot platform (https://platform.kimi.ai/docs/guide/kimi-k3-quickstart), but Open Design's curated model lists stop at the K2.7 family (`kimi-k2.6`, `kimi-k2.7-code`, `kimi-k2.7-code-highspeed`). Today, a user who wants to plug in a Moonshot API key and use K3 cannot find it in the BYOK model dropdown — they have to know the model ID `kimi-k3` in advance and type it as free-form text into the model search box. That is a discoverability gap: the newest Kimi model is invisible in the UI.

**My use case:** I tried to add my own Moonshot API key to use Kimi K3 and K3 simply was not selectable in the provider/model picker. The dropdown only offered K2.x and the legacy `moonshot-v1-*` models.

**Pain addressed:** K3 is OpenAI-compatible (same protocol and base URL as the existing K2 entries), so it already works end-to-end once the model ID is supplied — the only thing missing was a curated-list entry so users can pick it.

## What users will see

In **Settings → API Key (BYOK)**, after selecting the **Moonshot** provider, `kimi-k3` now appears at the **top** of the model dropdown — it is the recommended Moonshot model per the official K3 quickstart, so it takes the first-slot position. The inline model switcher surfaces the same entry. Selecting it works out of the box against the existing Moonshot preset (OpenAI-compatible protocol, `https://api.moonshot.cn/v1`). Users on Moonshot's international domain can still edit the Base URL to `https://api.moonshot.ai/v1` as before.

## Surface area

- [x] **UI** — `apps/web`: `kimi-k3` added to the Moonshot `preferredModels` list that feeds the BYOK Settings dialog and `InlineModelSwitcher`.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — `kimi-k3` is placed in the first slot of Moonshot `preferredModels`, which `defaultKnownProviderModel()` reads as the provider default. This is intentional: K3 is the recommended model. Existing users with an already-saved non-retired Moonshot model keep their selection; only retired ids (e.g. `kimi-k2-0711-preview`) migrate to the new default. The order-sensitive tests (`config.test.ts`, `env-and-detection.test.ts`) are updated accordingly.

A parallel one-line addition was made to the Kimi CLI runtime's fallback model list (`apps/daemon/src/runtimes/defs/kimi.ts`) so the `kimi` agent surfaces K3 when live ACP model discovery is unavailable.

## Screenshots

N/A for an isolated entry — the change adds one row to the existing BYOK model dropdown shown in the Moonshot provider section. The entry point (Settings → API Key → Moonshot) is unchanged; reviewers can confirm by opening the picker and seeing `kimi-k3` at the top of the list.

## Bug fix verification

N/A — this is a new model-list entry, not a bug fix.

## Validation

- `pnpm guard` — passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/web test` — passed (6324 tests, incl. `config.test.ts` migration + BYOK preset assertions)
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/env-and-detection.test.ts` — passed (63/63)

### Details

Model ID and protocol sourced from the official Kimi K3 quickstart:
- Model ID: `kimi-k3`
- Protocol: OpenAI-compatible (matches the existing Moonshot preset)
- Context window: 1M tokens; `max_completion_tokens` up to 1,048,576

The output cap is set to `131072`, matching the existing `kimi-k2.6` / `kimi-k2.7-code` entries. The UI hard-caps `MAX_MAX_TOKENS` at 200000 (`apps/web/src/state/maxTokens.ts`), so 131072 stays inside that envelope; the full 1M context window remains usable for input since this cap only bounds `max_tokens` output.

### Out of scope (deliberately not changed)

- **Moonshot base URL** kept as `https://api.moonshot.cn/v1`. The K3 doc uses `https://api.moonshot.ai/v1` (Moonshot's international domain), but the existing preset already works for the K2 family on `.cn`; changing the default would affect all current Kimi/Moonshot users. International-domain users can edit the Base URL in the same dialog.
- **`SUGGESTED_MODELS_BY_PROTOCOL`** in `apps/web/src/state/apiProtocols.ts` untouched — Kimi models do not appear there under `openai` today (they surface through `KNOWN_PROVIDERS`), so this change preserves existing behavior.