### PR TITLE
fix(ci): gate release cuts on main Windows smoke

### DIFF
--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -9,8 +9,10 @@ name: cut-patch-release
 #   2. A pre-flight guard: the current line's minor base X.Y.0 must be a PUBLISHED
 #      stable GitHub Release (tag open-design-vX.Y.0, isDraft=false, isPrerelease=false
 #      — i.e. release-stable ran `gh release edit --draft=false --latest`). If it is
-#      not published yet, do NOT cut a branch or build anything; instead post a
-#      Feishu notice that the patch cut was skipped, and stop.
+#      not published yet, do NOT cut a branch or launch a prerelease publication;
+#      instead post a Feishu notice that the patch cut was skipped, and stop. The
+#      independent Windows canary still runs first so every release-cut attempt
+#      leaves a current product-smoke signal.
 #   3. On the happy path it is otherwise identical to cut-release: create
 #      release/vX.Y.(Z+1), bump apps/packaged/package.json, push with the App token
 #      (which triggers notify-release-feishu -> prerelease build + Feishu card), and
@@ -39,14 +41,21 @@ on:
         default: false
 
 permissions:
-  contents: read               # actual writes go through the App token below
+  actions: write
+  contents: read               # branch/label writes still go through the App token below
 
 concurrency:
   group: cut-patch-release
   cancel-in-progress: false
 
 jobs:
+  prerelease_win_smoke:
+    if: github.repository == 'nexu-io/open-design'
+    uses: ./.github/workflows/main-prerelease-win-smoke.yml
+    secrets: inherit
+
   cut:
+    needs: prerelease_win_smoke
     if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +67,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: main            # always cut from main HEAD, even on a manual dispatch from another branch
+          # Cut the exact main commit that passed the Windows packaged smoke.
+          ref: ${{ needs.prerelease_win_smoke.outputs.commit }}
           fetch-depth: 0
           token: ${{ steps.app.outputs.token }}
 
@@ -136,7 +146,7 @@ jobs:
           echo "release $MINOR_TAG -> published=$published"
           echo "published=$published" >> "$GITHUB_OUTPUT"
 
-      # ---- Skip path: minor not published yet -> notify Feishu and stop ----
+      # ---- Skip path: minor not published yet -> no branch/release build; notify and stop ----
       # feishu-notice.ts imports only node:crypto (no workspace deps), so the
       # setup-node above is all it needs — no pnpm install, same as feishu.ts.
       - name: Notify Feishu that the patch cut was skipped

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,8 +1,9 @@
 name: cut-release
-# Every Tuesday 09:00 Asia/Shanghai, cut the next minor release branch from main HEAD:
-#   1. Compute version (highest release/vX.Y.Z -> bump minor -> X.(Y+1).0; e.g. 0.11.0 -> 0.12.0)
-#   2. Create release/vX.Y.Z, bump apps/packaged/package.json, push
-#   3. Create the "backport release/vX.Y.Z" label
+# Every Tuesday 09:00 Asia/Shanghai, cut the next minor release branch from main:
+#   1. Build + smoke main's Windows prerelease package and capture the passing SHA
+#   2. Compute version (highest release/vX.Y.Z -> bump minor -> X.(Y+1).0; e.g. 0.11.0 -> 0.12.0)
+#   3. Create release/vX.Y.Z from that SHA, bump apps/packaged/package.json, push
+#   4. Create the "backport release/vX.Y.Z" label
 # The push uses the App token (not GITHUB_TOKEN), so it triggers notify-release-feishu
 # -> builds a nightly package and posts the Feishu card.
 
@@ -17,10 +18,17 @@ on:
         default: ''
 
 permissions:
-  contents: read               # actual writes go through the App token below
+  actions: write
+  contents: read               # branch/label writes still go through the App token below
 
 jobs:
+  prerelease_win_smoke:
+    if: github.repository == 'nexu-io/open-design'
+    uses: ./.github/workflows/main-prerelease-win-smoke.yml
+    secrets: inherit
+
   cut:
+    needs: prerelease_win_smoke
     if: github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +40,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: main            # always cut from main HEAD, even on a manual dispatch from another branch
+          # Cut the exact main commit that passed the Windows packaged smoke.
+          ref: ${{ needs.prerelease_win_smoke.outputs.commit }}
           fetch-depth: 0
           token: ${{ steps.app.outputs.token }}
 

--- a/.github/workflows/main-prerelease-win-smoke.yml
+++ b/.github/workflows/main-prerelease-win-smoke.yml
@@ -1,0 +1,261 @@
+name: main-prerelease-win-smoke
+
+# Keep the Windows packaged prerelease path continuously exercised from main.
+# This intentionally does not prepare, reserve, or publish release metadata: a
+# stale workspace version must not prevent the product smoke from starting.
+on:
+  schedule:
+    - cron: "0 23 * * *" # 07:00 Asia/Shanghai, before the 09:00 release cuts
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      commit:
+        description: "The exact commit that passed the Windows packaged smoke."
+        value: ${{ jobs.smoke.outputs.commit }}
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: main-prerelease-win-smoke
+  cancel-in-progress: false
+
+env:
+  OPEN_DESIGN_AMR_PROFILE: prod
+  OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}
+  OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
+  POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+  POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+
+jobs:
+  smoke:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: windows-latest
+    outputs:
+      commit: ${{ steps.commit.outputs.commit }}
+    steps:
+      - name: Checkout main canary ref
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve canary commit
+        id: commit
+        shell: pwsh
+        run: |
+          "commit=$(git rev-parse HEAD)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Resolve canary version
+        id: version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $baseVersion = (Get-Content apps/packaged/package.json -Raw | ConvertFrom-Json).version
+          if ($baseVersion -notmatch '^\d+\.\d+\.\d+$') {
+            throw "main prerelease canary requires a stable packaged base version; got $baseVersion"
+          }
+          $version = "$baseVersion-prerelease.${{ github.run_number }}"
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "main prerelease Windows canary version: $version"
+
+      - name: Compute Windows tools-pack cache key
+        id: win_tools_pack_cache_key
+        shell: pwsh
+        env:
+          WIN_TOOLS_PACK_ORIGIN_KEY: ${{ hashFiles('package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'apps/daemon/**', 'apps/web/**', 'apps/desktop/**', 'apps/packaged/**', 'packages/agui-adapter/**', 'packages/contracts/**', 'packages/plugin-runtime/**', 'packages/sidecar-proto/**', 'packages/sidecar/**', 'packages/platform/**', 'tools/pack/bin/**', 'tools/pack/package.json', 'tools/pack/resources/**', 'tools/pack/src/**', 'tools/pack/tsconfig.json', 'assets/community-pets/**', 'assets/frames/**', 'craft/**', 'design-systems/**', 'design-templates/**', 'plugins/_official/**', 'plugins/registry/**', 'prompt-templates/**', 'skills/**', '.github/workflows/main-prerelease-win-smoke.yml', '.github/workflows/release-prerelease.yml', '.github/scripts/release/cache/win.ps1') }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WIN_TOOLS_PACK_ORIGIN_KEY)) {
+            throw "Windows tools-pack cache origin key is empty"
+          }
+          $prefix = "tools-pack-win-v1-prerelease-canary-$env:RUNNER_OS-"
+          "prefix=$prefix" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "key=$prefix$env:WIN_TOOLS_PACK_ORIGIN_KEY" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Restore Windows tools-pack cache
+        id: win_tools_pack_cache_restore
+        uses: actions/cache/restore@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}\tools-pack-cache
+          key: ${{ steps.win_tools_pack_cache_key.outputs.key }}
+          restore-keys: |
+            ${{ steps.win_tools_pack_cache_key.outputs.prefix }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup NSIS
+        shell: pwsh
+        run: |
+          function Test-Makensis {
+            [bool]((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe"))
+          }
+          if (Test-Makensis) { Write-Host "makensis already present"; exit 0 }
+          foreach ($attempt in 1..4) {
+            Write-Host "choco install nsis (attempt $attempt)"
+            choco install nsis -y --no-progress
+            if (Test-Makensis) { break }
+            Start-Sleep -Seconds (15 * $attempt)
+          }
+          if (-not (Test-Makensis)) {
+            Write-Error "NSIS install failed after 4 attempts"
+            exit 1
+          }
+
+      - name: Build prerelease Windows canary
+        id: win_tools_pack_build
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $toolsPackDir = "${{ runner.temp }}/tools-pack"
+          $cacheDir = "${{ runner.temp }}/tools-pack-cache"
+          $buildJsonPath = Join-Path $env:RUNNER_TEMP "release-build\win_x64\build.json"
+          New-Item -ItemType Directory -Force -Path (Split-Path -Parent $buildJsonPath) | Out-Null
+          pnpm.cmd exec tools-pack win cleanup --dir $toolsPackDir --namespace release-prerelease-canary-win --json
+          $buildArgs = @(
+            "exec", "tools-pack", "win", "build",
+            "--dir", $toolsPackDir,
+            "--cache-dir", $cacheDir,
+            "--namespace", "release-prerelease-canary-win",
+            "--portable",
+            "--app-version", "${{ steps.version.outputs.version }}",
+            "--to", "all",
+            "--require-vela-cli",
+            "--json"
+          )
+          $buildOutput = pnpm.cmd @buildArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows tools-pack cached canary build exited with code $LASTEXITCODE"
+          }
+          $buildOutput | Set-Content -Path $buildJsonPath -Encoding utf8
+          $build = $buildOutput | ConvertFrom-Json
+          pnpm.cmd exec tools-pack win validate-payload --namespace release-prerelease-canary-win --payload-path $build.payloadPath --expected-version "${{ steps.version.outputs.version }}" --json
+
+      - name: Retry prerelease Windows canary without restored cache
+        if: ${{ steps.win_tools_pack_build.outcome == 'failure' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $toolsPackDir = "${{ runner.temp }}/tools-pack"
+          $cacheDir = "${{ runner.temp }}/tools-pack-cache"
+          $buildJsonPath = Join-Path $env:RUNNER_TEMP "release-build\win_x64\build.json"
+          Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $cacheDir
+          pnpm.cmd exec tools-pack win cleanup --dir $toolsPackDir --namespace release-prerelease-canary-win --json
+          $buildOutput = pnpm.cmd exec tools-pack win build `
+            --dir $toolsPackDir `
+            --cache-dir $cacheDir `
+            --namespace release-prerelease-canary-win `
+            --portable `
+            --app-version "${{ steps.version.outputs.version }}" `
+            --to all `
+            --require-vela-cli `
+            --json
+          if ($LASTEXITCODE -ne 0) {
+            throw "Windows tools-pack uncached canary build exited with code $LASTEXITCODE"
+          }
+          $buildOutput | Set-Content -Path $buildJsonPath -Encoding utf8
+          $build = $buildOutput | ConvertFrom-Json
+          pnpm.cmd exec tools-pack win validate-payload --namespace release-prerelease-canary-win --payload-path $build.payloadPath --expected-version "${{ steps.version.outputs.version }}" --json
+
+      - name: Smoke prerelease Windows packaged runtime
+        working-directory: e2e
+        env:
+          OD_PACKAGED_E2E_BUILD_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\build.json
+          OD_PACKAGED_E2E_NAMESPACE: release-prerelease-canary-win
+          OD_PACKAGED_E2E_RELEASE_CHANNEL: prerelease
+          OD_PACKAGED_E2E_RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          OD_PACKAGED_E2E_REPORT_DIR: ${{ runner.temp }}\release-report\win_x64
+          OD_PACKAGED_E2E_TOOLS_PACK_DIR: ${{ runner.temp }}/tools-pack
+          OD_PACKAGED_E2E_WIN: "1"
+          OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core
+        run: pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts
+
+      - name: Write prerelease Windows canary report
+        if: ${{ always() }}
+        env:
+          BUILD_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\build.json
+          RELEASE_BUILD_TARGET: all
+          RELEASE_CHANNEL: prerelease
+          RELEASE_NAMESPACE: release-prerelease-canary-win
+          RELEASE_REPORT_DIR: ${{ runner.temp }}\release-report\win_x64
+          RELEASE_REPORT_JSON_PATH: ${{ runner.temp }}\release-report\win_x64\report.json
+          RELEASE_REPORT_SUMMARY_PATH: ${{ runner.temp }}\release-report\win_x64\summary.md
+          RELEASE_SMOKE_MODE: core
+          RELEASE_TARGET: win_x64
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          REPORT_TITLE: main prerelease win_x64 canary
+        run: pnpm exec tools-release write-report
+
+      - name: Publish canary report summary
+        if: ${{ always() }}
+        shell: pwsh
+        run: Get-Content "${{ runner.temp }}\release-report\win_x64\summary.md" | Add-Content $env:GITHUB_STEP_SUMMARY
+
+      - name: Upload Windows canary report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-main-prerelease-win-canary-report
+          path: ${{ runner.temp }}\release-report\win_x64
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Prune Windows tools-pack cache
+        if: ${{ success() }}
+        shell: pwsh
+        continue-on-error: true
+        run: .\.github\scripts\release\cache\win.ps1
+
+      - name: Save Windows tools-pack cache
+        if: ${{ success() && (steps.win_tools_pack_cache_restore.outputs.cache-hit != 'true' || steps.win_tools_pack_build.outcome == 'failure') }}
+        uses: actions/cache/save@v5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}\tools-pack-cache
+          key: ${{ steps.win_tools_pack_cache_key.outputs.key }}
+
+  notify_failure:
+    name: Notify Feishu on canary failure
+    needs: smoke
+    if: ${{ always() && needs.smoke.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout notifier
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Post prerelease Windows canary failure
+        env:
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+          NOTICE_TITLE: "🚨 main prerelease Windows smoke 失败"
+          NOTICE_TEMPLATE: "red"
+          NOTICE_BODY: |
+            main 的 Windows packaged prerelease canary 未通过。该 canary 不依赖 beta/prerelease 发布元数据，因此失败表示构建或产品 smoke 本身需要处理。
+
+            **目标 ref**: `main`
+
+            release cut 会被阻止，直到同一条 smoke 通过。
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node --experimental-strip-types tools/release/src/notifications/feishu-notice.ts

--- a/.github/workflows/notify-daily-feishu.yml
+++ b/.github/workflows/notify-daily-feishu.yml
@@ -122,3 +122,36 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: node --experimental-strip-types tools/release/src/notifications/feishu.ts
+
+  notify_failure:
+    name: Notify Feishu when daily beta fails
+    needs:
+      - resolve
+      - build
+    if: ${{ always() && needs.build.result == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted notifier
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Post daily beta failure card
+        env:
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_RELEASE_SIGN_SECRET }}
+          NOTICE_TITLE: "🚨 每日 beta 构建失败"
+          NOTICE_TEMPLATE: "red"
+          NOTICE_BODY: |
+            main 的每日 beta 构建未完成。失败可能发生在版本 / release metadata 校验阶段，因此即使尚未生成 beta_version，也必须立即处理。
+
+            **构建 ref**: `${{ needs.resolve.outputs.ref }}`
+
+            独立的 prerelease Windows canary 不受该 metadata 门禁影响；请结合两个 workflow 判断是发布状态问题还是产品 smoke 问题。
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node --experimental-strip-types tools/release/src/notifications/feishu-notice.ts

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -60,6 +60,12 @@ const releaseBetaWorkflowPath = join(workspaceRoot, ".github", "workflows", "rel
 const releaseBetaSelfHostedWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-beta-s.yml");
 const releasePreviewWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-preview.yml");
 const releasePrereleaseWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-prerelease.yml");
+const mainPrereleaseWinSmokeWorkflowPath = join(
+  workspaceRoot,
+  ".github",
+  "workflows",
+  "main-prerelease-win-smoke.yml",
+);
 const releaseStableWorkflowPath = join(workspaceRoot, ".github", "workflows", "release-stable.yml");
 const releaseStableNotesScriptPath = join(workspaceRoot, ".github", "scripts", "release", "github", "stable-notes.sh");
 const releasePreviewScriptPath = join(workspaceRoot, "tools", "release", "src", "metadata", "prepare-preview.ts");
@@ -1873,6 +1879,59 @@ process.stdin.on("end", () => {
     // Default path: an empty input builds main, never a release branch.
     expect(resolveJob).toContain('echo "ref=main" >> "$GITHUB_OUTPUT"');
     expect(resolveJob).not.toContain("refs/heads/release/v*");
+
+    // Metadata failures happen before beta_version exists, so the normal
+    // download-card job is skipped. Keep a separate failure-only notice or a
+    // stale main version can fail silently every day without reaching smoke.
+    expect(workflow).toContain("  notify_failure:");
+    expect(workflow).toContain("if: ${{ always() && needs.build.result == 'failure' }}");
+    expect(workflow).toContain("tools/release/src/notifications/feishu-notice.ts");
+  });
+
+  it("[P1] runs a metadata-independent prerelease Windows smoke before release cuts", async () => {
+    const [canary, minorCut, patchCut] = await Promise.all([
+      readFile(mainPrereleaseWinSmokeWorkflowPath, "utf8"),
+      readFile(cutReleaseWorkflowPath, "utf8"),
+      readFile(cutPatchReleaseWorkflowPath, "utf8"),
+    ]);
+
+    const trigger = sectionBetween(canary, "on:", "\npermissions:");
+    expect(trigger).toContain("schedule:");
+    expect(trigger).toContain("workflow_dispatch:");
+    expect(trigger).toContain("workflow_call:");
+    expect(canary).toContain("ref: main");
+    expect(canary).not.toContain("inputs.ref");
+    expect(canary).toContain("runs-on: windows-latest");
+    expect(canary).toContain("OPEN_DESIGN_AMR_PROFILE: prod");
+    expect(canary).toContain("OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}");
+    expect(canary).toContain("--namespace release-prerelease-canary-win");
+    expect(canary).toContain('OD_PACKAGED_E2E_RELEASE_CHANNEL: prerelease');
+    expect(canary).toContain('OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core');
+    expect(canary).toContain("pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts");
+    expect(canary).toContain("tools-pack win validate-payload");
+    expect(canary).toContain("tools/release/src/notifications/feishu-notice.ts");
+
+    // This lane is a product canary, not a beta/prerelease publication. In
+    // particular, a stale main package version must not prevent Windows from
+    // reaching the packaged smoke as happened while main was 0.16.2 and stable
+    // had already advanced to 0.18.1.
+    expect(canary).not.toContain("tools-release prepare");
+    expect(canary).not.toContain("tools-release check-storage");
+    expect(canary).not.toContain("uses: ./.github/workflows/release-beta.yml");
+    expect(canary).not.toContain("uses: ./.github/workflows/release-prerelease.yml");
+
+    for (const [label, workflow] of [
+      ["cut-release", minorCut],
+      ["cut-patch-release", patchCut],
+    ] as const) {
+      const smokeJob = sectionBetween(workflow, "  prerelease_win_smoke:", "\n  cut:");
+      expect(smokeJob, label).toContain("uses: ./.github/workflows/main-prerelease-win-smoke.yml");
+      expect(smokeJob, label).not.toContain("with:");
+      expect(smokeJob, label).toContain("secrets: inherit");
+      expect(workflow, label).toContain("permissions:\n  actions: write\n  contents: read");
+      expect(workflow, label).toContain("needs: prerelease_win_smoke");
+      expect(workflow, label).toContain("ref: ${{ needs.prerelease_win_smoke.outputs.commit }}");
+    }
   });
 
   it("[P2] gates the Thursday patch cut on the Tuesday minor being published", async () => {
@@ -1881,7 +1940,7 @@ process.stdin.on("end", () => {
     //   1. It fires Thursday and bumps patch (not minor) from the highest release branch.
     //   2. It only cuts when this line's minor base X.Y.0 is a PUBLISHED stable
     //      GitHub Release (non-draft, non-prerelease) — otherwise it must NOT create
-    //      a branch or build; it posts a Feishu notice and stops.
+    //      a branch or launch the prerelease publication; it posts a notice and stops.
     //   3. The happy path still cuts from main and pushes with the App token, so the
     //      existing notify-release-feishu push trigger produces the prerelease + card.
     const [workflow, notice] = await Promise.all([
@@ -1921,8 +1980,9 @@ process.stdin.on("end", () => {
       expect(workflow).toContain(`- name: ${step}\n        if: steps.guard.outputs.published == 'true'`);
     }
 
-    // Happy path keeps cut-release's mechanics: cut from main, App-token push.
-    expect(workflow).toContain("ref: main");
+    // Happy path keeps cut-release's mechanics: cut the exact main commit that
+    // passed the prerelease Windows canary, then push with the App token.
+    expect(workflow).toContain("ref: ${{ needs.prerelease_win_smoke.outputs.commit }}");
     expect(workflow).toContain("token: ${{ steps.app.outputs.token }}");
     expect(workflow).toContain('git push origin "$BRANCH"');
     // The version bump is a no-op whenever main already leads stable by this exact


### PR DESCRIPTION
## Why

The scheduled daily beta was expected to exercise the Windows packaged smoke from main, but its release metadata gate failed before any platform job started. On 2026-08-10 the checked-out main commit still carried packaged version 0.16.2 while stable was already 0.18.1, so Prepare beta metadata stopped the workflow and the Windows job was skipped. Because the normal Feishu job required a beta_version output, those metadata failures were silent.

This left the prerelease-only Windows path unexercised until a release branch was cut, which is why the authentication-first smoke regression was discovered late.

## What users will see

No product UI changes. Maintainers get:

- a daily 07:00 Asia/Shanghai Windows prerelease canary built from main;
- a Feishu failure card for both canary failures and daily-beta metadata failures;
- cut-release and cut-patch-release blocked until the exact main commit being cut passes the Windows packaged smoke.

The canary deliberately does not prepare, reserve, or publish release metadata, so a stale main version cannot prevent the product smoke from starting.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal CI/release automation and regression tests only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test path: e2e/tests/packaged-smoke-workflow.test.ts
- The new topology test went red before implementation because main-prerelease-win-smoke.yml did not exist, then went green after the workflow and release-cut gates were added.
- The daily-beta notification assertion also went red before the failure-only Feishu job was added, then green afterward.

## Validation

- PATH="/opt/homebrew/opt/python@3.13/libexec/bin:$PATH" pnpm --dir e2e exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts — 60 passed
- pnpm --dir tools/pack exec vitest run -c vitest.config.ts tests/release-workflows.test.ts — 5 passed
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color on all four changed workflow files
- pnpm guard
- pnpm typecheck
- git diff --check
