### PR TITLE
fix(pack): remove owned Windows protocol on uninstall

### DIFF
--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -1012,7 +1012,13 @@ after_desktop_shortcut:
   DeleteRegKey HKCU "${registryKey}"
   DeleteRegKey HKCU "${appPathsKey}"
   ReadRegStr $0 HKCU "${inviteProtocolKey}\\shell\\open\\command" ""
-  StrCmp $0 '$\"$INSTDIR\\${exeName}$\" $\"%1$\"' 0 preserve_invite_protocol
+  ; Electron refreshes the protocol command when the app starts and may change
+  ; its trailing arguments. Compare only the exact quoted executable prefix so
+  ; this install can remove its registration without touching another owner.
+  StrCpy $1 '$\"$INSTDIR\\${exeName}$\"'
+  StrLen $2 $1
+  StrCpy $3 $0 $2
+  StrCmp $3 $1 0 preserve_invite_protocol
   DeleteRegKey HKCU "${inviteProtocolKey}"
 preserve_invite_protocol:
   Push "event=registry_after_delete key=${registryKey} appPathsKey=${appPathsKey}"

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -83,7 +83,7 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).not.toContain('"DisplayName" "${productName} \\${APP_VERSION}"');
   });
 
-  it("registers the invite protocol and removes it on uninstall only while this install owns it", async () => {
+  it("removes an Electron-refreshed invite protocol while this install still owns it", async () => {
     const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
     expect(source).toContain('const inviteProtocolKey = "Software\\\\Classes\\\\opendesign"');
     expect(source).toContain('WriteRegStr HKCU "${inviteProtocolKey}" "URL Protocol" ""');
@@ -94,12 +94,16 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).toContain(
       'ReadRegStr $0 HKCU "${inviteProtocolKey}\\\\shell\\\\open\\\\command" ""',
     );
-    expect(source).toContain(
+    expect(source).toContain("StrCpy $1 '$\\\"$INSTDIR\\\\${exeName}$\\\"'");
+    expect(source).toContain("StrLen $2 $1");
+    expect(source).toContain("StrCpy $3 $0 $2");
+    expect(source).toContain("StrCmp $3 $1 0 preserve_invite_protocol");
+    expect(source).not.toContain(
       "StrCmp $0 '$\\\"$INSTDIR\\\\${exeName}$\\\" $\\\"%1$\\\"' 0 preserve_invite_protocol",
     );
     expect(source).toContain('DeleteRegKey HKCU "${inviteProtocolKey}"');
     expect(source).toContain("preserve_invite_protocol:");
-    expect(source.indexOf("StrCmp $0")).toBeLessThan(
+    expect(source.indexOf("StrCmp $3 $1")).toBeLessThan(
       source.indexOf('DeleteRegKey HKCU "${inviteProtocolKey}"'),
     );
     expect(source.indexOf('DeleteRegKey HKCU "${inviteProtocolKey}"')).toBeLessThan(


### PR DESCRIPTION
## Why

The Windows prerelease smoke in run 31373495790 built the installer successfully but failed after uninstall because `HKCU\Software\Classes\opendesign` remained registered. That blocked Windows platform publication and the final prerelease release.

The installer removed the protocol only when the full registry command exactly matched the text it originally wrote. Electron refreshes that command at runtime, so an installation could still own the registered executable while differing in trailing command text.

## What users will see

Uninstalling Open Design on Windows removes the `opendesign://` protocol registration when it still points to that installation. A protocol registration owned by another installation remains untouched.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes Windows installer cleanup behavior and has no UI surface.

## Bug fix verification

- Test path: `tools/pack/tests/win-identity.test.ts`
- The regression assertion failed on `main` before the installer change and passes on this branch.
- The original end-to-end red evidence is the Windows prerelease smoke failure in run 31373495790. Full Windows installer validation remains delegated to PR CI because the local machine is macOS.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/win-identity.test.ts`
- `pnpm --filter @open-design/tools-pack test` — 274 passed, 8 skipped
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
