### PR TITLE
Complete Windows standalone delivery parity

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1371,7 +1371,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "immutable Windows Shell resolution failed with exit code $LASTEXITCODE" }
 
       - name: Setup NSIS
-        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' }}
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' || (inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '') }}
         shell: pwsh
         run: |
           if ((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -321,6 +321,8 @@ env:
   CLOSURE_MIN_SHELL_VERSION: 0.19.0-beta.4
   LEGACY_MAC_ARM64_DIGEST: sha256:6d9c2fea2106fc0207acd4ee78bc8d08f9563f967121dbffd399b8d510d0c37f
   LEGACY_MAC_ARM64_VERSION: 0.16.2-beta.155
+  LEGACY_WIN_X64_DIGEST: sha256:a0c2ef5d8b0da1ef7f93d375211fff396aa73d90b2cc3c591c27268fe6966330
+  LEGACY_WIN_X64_VERSION: 0.16.2-beta.155
   OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
   # `publish` governs distribution metadata only. Build inputs must remain
   # identical between publish=false QA and the final publish=true lane so the
@@ -1293,6 +1295,7 @@ jobs:
     if: ${{ inputs.enable_win_x64 }}
     runs-on: windows-latest
     env:
+      OD_UPDATE_METADATA_URL: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/beta/latest/metadata.json
       RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
     steps:
       - name: Checkout
@@ -1339,7 +1342,36 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve immutable win_x64 Electron Shell
+        id: win_x64_shell_resolution
+        shell: pwsh
+        env:
+          OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}
+          RELEASE_CHANNEL: beta
+          RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_SHELL_BUILD_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\build.json
+          RELEASE_SHELL_PLAN_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\shell-plan.json
+          RELEASE_SHELL_SMOKE_ACCEPTANCE_DIGEST: sha256:${{ hashFiles('.github/workflows/release-beta.yml', 'e2e/specs/win.spec.ts', 'e2e/scripts/release-smoke.ts', 'e2e/lib/vitest/packaged-smoke-plan.ts', 'e2e/lib/vitest/packaged-closure-fixture.ts', 'e2e/lib/vitest/tools-serve-updater-fixture.ts', 'e2e/lib/vitest/win-installer-log.ts', 'tools/pack/src/win/custom-installer.ts', 'tools/serve/src/index.ts', 'tools/serve/src/updater-fixture.ts') }}
+          RELEASE_SHELL_SMOKE_MATRIX: win-shell-v1
+          RELEASE_STANDALONE_PROTOCOL_VERSION: "1"
+          RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
+          RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
+          RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
+          RELEASE_STORAGE_REGION: auto
+          RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force -Path "${{ runner.temp }}\release-build\win_x64" | Out-Null
+          $identityArgs = @("exec", "tools-pack", "win", "identity", "--dir", "${{ runner.temp }}\tools-pack", "--cache-dir", "${{ runner.temp }}\tools-pack-cache", "--namespace", "release-beta-win", "--portable", "--release-version", "${{ needs.metadata.outputs.beta_version }}", "--shell-version", "${{ needs.metadata.outputs.shell_version }}", "--to", "${{ inputs.win_x64_target }}", "--json")
+          if ("${{ inputs.win_x64_sign_mode }}" -eq "on") { $identityArgs += "--signed" }
+          $identityOutput = pnpm.cmd @identityArgs
+          if ($LASTEXITCODE -ne 0) { throw "tools-pack win identity failed with exit code $LASTEXITCODE" }
+          $identityOutput | Set-Content -Path $env:RELEASE_SHELL_PLAN_JSON_PATH -Encoding utf8
+          pnpm.cmd exec tools-release resolve-shell-build
+          if ($LASTEXITCODE -ne 0) { throw "immutable Windows Shell resolution failed with exit code $LASTEXITCODE" }
+
       - name: Setup NSIS
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' }}
         shell: pwsh
         run: |
           if ((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {
@@ -1349,11 +1381,13 @@ jobs:
 
       - name: Probe Windows signing capability
         id: sign_probe
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' }}
         shell: pwsh
         run: .\.github\scripts\release\probe-win-signing.ps1 -SignMode "${{ inputs.win_x64_sign_mode }}"
 
       - name: Build beta win_x64
         id: win_tools_pack_build
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' }}
         continue-on-error: true
         shell: pwsh
         env:
@@ -1390,7 +1424,7 @@ jobs:
 
       - name: Retry beta win_x64 without restored cache
         id: win_tools_pack_build_retry
-        if: ${{ steps.win_tools_pack_build.outcome == 'failure' }}
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' && steps.win_tools_pack_build.outcome == 'failure' }}
         shell: pwsh
         env:
           OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}
@@ -1406,6 +1440,20 @@ jobs:
           $buildOutput | Set-Content -Path "${{ runner.temp }}\release-build\win_x64\build.json" -Encoding utf8
           $build = $buildOutput | ConvertFrom-Json
           pnpm.cmd exec tools-pack win validate-payload --namespace release-beta-win --payload-path $build.payloadPath --expected-version "${{ needs.metadata.outputs.beta_version }}" --json
+
+      - name: Register verified immutable win_x64 Electron Shell
+        if: ${{ steps.win_x64_shell_resolution.outputs.state == 'miss' }}
+        env:
+          RELEASE_CHANNEL: beta
+          RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_SHELL_BUILD_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\build.json
+          RELEASE_SHELL_PLAN_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\shell-plan.json
+          RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
+          RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
+          RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
+          RELEASE_STORAGE_REGION: auto
+          RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+        run: pnpm exec tools-release register-shell-build
 
       - name: Build beta win_x64 Standalone Closure
         shell: pwsh
@@ -1479,7 +1527,7 @@ jobs:
           "deletedFailedCacheKey=$matchedKey count=$($caches.Count)"
 
       - name: Build beta win_x64 update fixture
-        if: ${{ inputs.win_x64_smoke_mode == 'full' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' }}
+        if: ${{ inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' }}
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -1494,6 +1542,26 @@ jobs:
           $updateBuild = $updateOutput | ConvertFrom-Json
           pnpm.cmd exec tools-pack win validate-payload --namespace release-beta-win --payload-path $updateBuild.payloadPath --expected-version $updateVersion --json
 
+      - name: Materialize legacy win_x64 migration fixture
+        id: win_x64_legacy_fixture
+        if: ${{ inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit' }}
+        shell: pwsh
+        env:
+          RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $fixtureDir = "${{ runner.temp }}\release-work\win_x64\legacy-migration"
+          $installerPath = Join-Path $fixtureDir "open-design-$env:LEGACY_WIN_X64_VERSION-win-x64-setup.exe"
+          $url = "$env:RELEASE_PUBLIC_ORIGIN/beta/versions/$env:LEGACY_WIN_X64_VERSION.unsigned/open-design-$env:LEGACY_WIN_X64_VERSION.unsigned-win-x64-setup.exe"
+          New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
+          Invoke-WebRequest -Uri $url -OutFile $installerPath -MaximumRetryCount 3 -RetryIntervalSec 2
+          $actualDigest = "sha256:$((Get-FileHash -Algorithm SHA256 -LiteralPath $installerPath).Hash.ToLowerInvariant())"
+          if ($actualDigest -ne $env:LEGACY_WIN_X64_DIGEST) {
+            throw "legacy Windows installer digest mismatch: expected $env:LEGACY_WIN_X64_DIGEST, got $actualDigest"
+          }
+          "installer_path=$installerPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "version=$env:LEGACY_WIN_X64_VERSION" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       - name: Smoke beta win_x64 packaged runtime
         if: ${{ inputs.win_x64_smoke_mode != 'skip' }}
         working-directory: e2e
@@ -1506,11 +1574,35 @@ jobs:
           OD_PACKAGED_E2E_REPORT_DIR: ${{ runner.temp }}\release-report\win_x64
           OD_PACKAGED_E2E_TOOLS_PACK_DIR: ${{ runner.temp }}\tools-pack
           OD_PACKAGED_E2E_WIN: "1"
+          OD_PACKAGED_E2E_WIN_LEGACY_INSTALLER_PATH: ${{ steps.win_x64_legacy_fixture.outputs.installer_path }}
+          OD_PACKAGED_E2E_WIN_LEGACY_VERSION: ${{ steps.win_x64_legacy_fixture.outputs.version }}
+          OD_PACKAGED_E2E_WIN_MIN_SHELL_VERSION: ${{ env.CLOSURE_MIN_SHELL_VERSION }}
+          OD_PACKAGED_E2E_WIN_SMOKE_LANES: ${{ inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof == 'hit' && 'standalone' || '' }}
           OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: ${{ inputs.win_x64_smoke_mode }}
           OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE: ${{ inputs.win_x64_smoke_mode == 'full' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' && 'tools-serve' || '' }}
           OD_PACKAGED_E2E_WIN_UPDATE_METADATA_URL: ${{ inputs.win_x64_update_metadata_url }}
           OD_PACKAGED_E2E_WIN_UPDATE_VERSION: ${{ inputs.win_x64_update_target_version }}
+          OD_PACKAGED_E2E_SHELL_SMOKE_PROOF: ${{ steps.win_x64_shell_resolution.outputs.smoke_proof }}
+          OD_PACKAGED_E2E_SHELL_VERSION: ${{ steps.win_x64_shell_resolution.outputs.shell_version != '' && steps.win_x64_shell_resolution.outputs.shell_version || needs.metadata.outputs.shell_version }}
         run: pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts
+
+      - name: Register win_x64 Electron Shell full-smoke proof
+        if: ${{ inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '' }}
+        env:
+          RELEASE_CHANNEL: beta
+          RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_SHELL_BUILD_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\build.json
+          RELEASE_SHELL_PLAN_JSON_PATH: ${{ runner.temp }}\release-build\win_x64\shell-plan.json
+          RELEASE_SHELL_SMOKE_ACCEPTANCE_DIGEST: sha256:${{ hashFiles('.github/workflows/release-beta.yml', 'e2e/specs/win.spec.ts', 'e2e/scripts/release-smoke.ts', 'e2e/lib/vitest/packaged-smoke-plan.ts', 'e2e/lib/vitest/packaged-closure-fixture.ts', 'e2e/lib/vitest/tools-serve-updater-fixture.ts', 'e2e/lib/vitest/win-installer-log.ts', 'tools/pack/src/win/custom-installer.ts', 'tools/serve/src/index.ts', 'tools/serve/src/updater-fixture.ts') }}
+          RELEASE_SHELL_SMOKE_MATRIX: win-shell-v1
+          RELEASE_SHELL_SMOKE_SUMMARY_PATH: ${{ runner.temp }}\release-report\win_x64\summary.json
+          RELEASE_STANDALONE_PROTOCOL_VERSION: "1"
+          RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
+          RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
+          RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
+          RELEASE_STORAGE_REGION: auto
+          RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+        run: pnpm exec tools-release register-shell-smoke
 
       - name: Write win_x64 release report
         if: ${{ always() }}
@@ -1611,7 +1703,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish beta metadata
+    name: Stage beta metadata
     needs:
       - metadata
       - build_mac_arm64
@@ -1697,7 +1789,7 @@ jobs:
           pnpm exec tools-release publish-release-note
           pnpm exec tools-release verify-release-note
 
-      - name: Publish beta metadata
+      - name: Publish immutable beta metadata
         env:
           BASE_VERSION: ${{ needs.metadata.outputs.base_version }}
           ENABLE_MAC_ARM64: ${{ inputs.enable_mac_arm64 }}
@@ -1706,6 +1798,7 @@ jobs:
           MAC_ARM64_RESULT: ${{ needs.build_mac_arm64.result }}
           MAC_X64_RESULT: ${{ needs.build_mac_x64.result }}
           RELEASE_ASSET_SUFFIX: ${{ needs.metadata.outputs.asset_version_suffix }}
+          RELEASE_ACTIVATE_LATEST: ${{ inputs.enable_win_x64 && 'false' || 'true' }}
           RELEASE_CHANNEL: beta
           RELEASE_CLOSURE_REQUIRED: "true"
           RELEASE_SHELL_REQUIRED: "true"
@@ -1713,12 +1806,13 @@ jobs:
           RELEASE_LAUNCHER_VERSION_MIN_STABLE: ${{ vars.RELEASE_LAUNCHER_VERSION_MIN_STABLE }}
           RELEASE_LAUNCHER_VERSION_MIN_URL_BETA: ${{ vars.RELEASE_LAUNCHER_VERSION_MIN_URL_BETA }}
           RELEASE_LAUNCHER_VERSION_MIN_URL_STABLE: ${{ vars.RELEASE_LAUNCHER_VERSION_MIN_URL_STABLE }}
+          RELEASE_LATEST_CAS_REQUIRED: "true"
           RELEASE_MANIFEST_DIR: ${{ runner.temp }}/release-platform-manifests
           RELEASE_METADATA_DIR: ${{ runner.temp }}/release-metadata
           RELEASE_NOTE_MANIFEST_PATH: ${{ runner.temp }}/release-metadata/release-note-publication.json
           RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-metadata/outputs.json
           RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
-          RELEASE_SIGNED: "true"
+          RELEASE_SIGNED: ${{ !inputs.enable_win_x64 && 'true' || 'false' }}
           RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
           RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
           RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
@@ -1758,8 +1852,8 @@ jobs:
           WIN_X64_RESULT: ${{ needs.build_win_x64.result }}
         run: pnpm exec tools-release verify-metadata
 
-      - name: Observe published beta public feed
-        continue-on-error: true
+      - name: Observe directly activated beta public feed
+        if: ${{ !inputs.enable_win_x64 }}
         env:
           RELEASE_LATEST_METADATA_URL: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/beta/latest/metadata.json
           RELEASE_METADATA_URL: ${{ steps.outputs.outputs.version_metadata_url }}
@@ -1779,7 +1873,177 @@ jobs:
         run: cat "${{ runner.temp }}/release-metadata/summary.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup workflow artifacts
-        if: ${{ success() && steps.outputs.outputs.release_state == 'complete' }}
+        if: ${{ success() && !inputs.enable_win_x64 && steps.outputs.outputs.release_state == 'complete' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/release/github/cleanup-artifacts.sh
+
+  public_win_x64_acceptance:
+    name: Accept public win_x64 beta artifacts
+    needs:
+      - metadata
+      - publish
+    if: >-
+      ${{
+        !cancelled() &&
+        inputs.publish &&
+        inputs.enable_win_x64 &&
+        needs.metadata.result == 'success' &&
+        needs.publish.result == 'success' &&
+        needs.publish.outputs.release_state == 'complete'
+      }}
+    runs-on: windows-latest
+    env:
+      GITHUB_SHA: ${{ needs.metadata.outputs.commit }}
+      RELEASE_COMMIT: ${{ needs.metadata.outputs.commit }}
+      RELEASE_NAMESPACE: release-beta-win
+      RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+      RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
+    steps:
+      - name: Checkout accepted commit
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.metadata.outputs.commit }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Re-download immutable public win_x64 artifacts
+        env:
+          RELEASE_METADATA_URL: ${{ needs.publish.outputs.version_metadata_url }}
+          RELEASE_PUBLIC_ACCEPTANCE_BUILD_JSON_PATH: ${{ runner.temp }}\public-feedback\build.json
+          RELEASE_PUBLIC_ACCEPTANCE_DOWNLOAD_DIR: ${{ runner.temp }}\public-feedback\tools-pack\out\win\namespaces\release-beta-win\builder
+          RELEASE_PUBLIC_ACCEPTANCE_PLAN_PATH: ${{ runner.temp }}\public-feedback\plan.json
+        run: pnpm exec tools-release prepare-public-acceptance
+
+      - name: Smoke immutable public win_x64 install and online Closure cold start
+        working-directory: e2e
+        env:
+          OD_PACKAGED_E2E_BUILD_JSON_PATH: ${{ runner.temp }}\public-feedback\build.json
+          OD_PACKAGED_E2E_NAMESPACE: release-beta-win
+          OD_PACKAGED_E2E_RELEASE_CHANNEL: beta
+          OD_PACKAGED_E2E_RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
+          OD_PACKAGED_E2E_REPORT_DIR: ${{ runner.temp }}\public-feedback\report
+          OD_PACKAGED_E2E_SHELL_SMOKE_PROOF: public-immutable-artifacts
+          OD_PACKAGED_E2E_TOOLS_PACK_DIR: ${{ runner.temp }}\public-feedback\tools-pack
+          OD_PACKAGED_E2E_WIN: "1"
+          OD_PACKAGED_E2E_WIN_SMOKE_LANES: shell
+          OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core
+          OD_UPDATE_METADATA_URL: ${{ needs.publish.outputs.version_metadata_url }}
+        run: pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts
+
+      - name: Issue public win_x64 acceptance credential
+        env:
+          RELEASE_PUBLIC_ACCEPTANCE_CREDENTIAL_PATH: ${{ runner.temp }}\public-feedback\win_x64.json
+          RELEASE_PUBLIC_ACCEPTANCE_PLAN_PATH: ${{ runner.temp }}\public-feedback\plan.json
+          RELEASE_PUBLIC_ACCEPTANCE_SMOKE_SUMMARY_PATH: ${{ runner.temp }}\public-feedback\report\summary.json
+          RELEASE_PUBLIC_ACCEPTANCE_SUITE_RESULT_PATH: ${{ runner.temp }}\public-feedback\report\suite-result.json
+        run: pnpm exec tools-release issue-public-acceptance
+
+      - name: Upload public win_x64 acceptance credential
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-beta-win-x64-public-acceptance
+          path: ${{ runner.temp }}\public-feedback\win_x64.json
+          if-no-files-found: error
+
+      - name: Upload public win_x64 acceptance evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: open-design-beta-win-x64-public-acceptance-evidence
+          path: |
+            ${{ runner.temp }}\public-feedback\build.json
+            ${{ runner.temp }}\public-feedback\plan.json
+            ${{ runner.temp }}\public-feedback\report
+          if-no-files-found: warn
+
+  activate:
+    name: Activate accepted beta release
+    needs:
+      - metadata
+      - publish
+      - public_win_x64_acceptance
+    if: >-
+      ${{
+        !cancelled() &&
+        inputs.publish &&
+        inputs.enable_win_x64 &&
+        needs.metadata.result == 'success' &&
+        needs.publish.result == 'success' &&
+        needs.public_win_x64_acceptance.result == 'success'
+      }}
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_PUBLIC_ORIGIN: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+      RELEASE_VERSION: ${{ needs.metadata.outputs.beta_version }}
+    steps:
+      - name: Checkout accepted commit
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ needs.metadata.outputs.commit }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download public win_x64 acceptance credential
+        uses: actions/download-artifact@v8
+        with:
+          name: open-design-beta-win-x64-public-acceptance
+          path: ${{ runner.temp }}/public-acceptance
+
+      - name: Activate accepted immutable beta metadata with CAS
+        env:
+          RELEASE_ACTIVATION_WORK_DIR: ${{ runner.temp }}/release-activation
+          RELEASE_OUTPUTS_PATH: ${{ runner.temp }}/release-activation/outputs.json
+          RELEASE_PUBLIC_ACCEPTANCE_CREDENTIAL_PATH: ${{ runner.temp }}/public-acceptance/win_x64.json
+          RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
+          RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
+          RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
+          RELEASE_STORAGE_REGION: auto
+          RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+        run: pnpm exec tools-release activate-public-release
+
+      - name: Read back activated beta public feed
+        env:
+          RELEASE_LATEST_METADATA_URL: ${{ env.RELEASE_PUBLIC_ORIGIN }}/beta/latest/metadata.json
+          RELEASE_METADATA_URL: ${{ needs.publish.outputs.version_metadata_url }}
+          RELEASE_PUBLIC_FEED_REPORT_PATH: ${{ runner.temp }}/release-activation/public-feed-observation.json
+        run: pnpm exec tools-release observe-public-feed
+
+      - name: Publish activation summary
+        run: |
+          echo "## Accepted beta activation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- version: \`${{ needs.metadata.outputs.beta_version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- commit: \`${{ needs.metadata.outputs.commit }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Windows artifact smoke: \`success\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- latest CAS and public readback: \`success\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup workflow artifacts
+        if: ${{ success() }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: bash .github/scripts/release/github/cleanup-artifacts.sh

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -2035,12 +2035,14 @@ jobs:
 
       - name: Publish activation summary
         run: |
-          echo "## Accepted beta activation" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- version: \`${{ needs.metadata.outputs.beta_version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- commit: \`${{ needs.metadata.outputs.commit }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Windows artifact smoke: \`success\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- latest CAS and public readback: \`success\`" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Accepted beta activation"
+            echo ""
+            echo "- version: \`${{ needs.metadata.outputs.beta_version }}\`"
+            echo "- commit: \`${{ needs.metadata.outputs.commit }}\`"
+            echo "- Windows artifact smoke: \`success\`"
+            echo "- latest CAS and public readback: \`success\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup workflow artifacts
         if: ${{ success() }}

--- a/docs/testing/updater-lifecycle.md
+++ b/docs/testing/updater-lifecycle.md
@@ -53,7 +53,7 @@ spec (`e2e/specs/mac.spec.ts` / `win.spec.ts` via `release-smoke.ts`),
 | Stale relaunch freeze scrub after rollback (installResult.activeVersion > running) | U, P | desktop unit stale-freeze spec; exercised by the spec's self-heal phase |
 | Exact desktop identity, cold-start reconvergence | P, F | specs; real-feed loop |
 | Historical-outer handoff bridge (prepared→armed→confirmed) | U, partial P | daemon handoff unit; win spec legacy-executable path |
-| Full historical-outer migration with a real legacy binary | P | release-beta mac full spec pins `0.16.2-beta.155` from the public immutable feed, proves installer-required against the candidate metadata, replaces the DMG, and reopens persisted product data |
+| Full historical-outer migration with a real legacy binary | P | release-beta mac and win full specs pin `0.16.2-beta.155` from the public immutable feed, prove installer-required against candidate metadata, replace the outer, and reopen persisted product data |
 | Obsolete outer retirement (mac/win) | U | packaged `obsolete-installed-outer.test.ts` |
 | Reinstalled newer outer resets runtime (bound > active) | U | packaged `launcher-runtime.test.ts` supersede case |
 | Reinstalled older outer delegates (bound < active) | P | spec recovery segment precondition |
@@ -79,7 +79,8 @@ spec (`e2e/specs/mac.spec.ts` / `win.spec.ts` via `release-smoke.ts`),
 
 | Node | Coverage | Owning tests |
 | --- | --- | --- |
-| metadata.json composition + CAS latest publish | U | tools-serve `release-metadata-publish.test.ts` |
+| metadata.json composition + CAS latest publish | U, P, F | tools-release publication/public-acceptance tests; staged release-beta activation and blocking public readback |
+| Public immutable Windows installer + online Closure feedback | P, F | release-beta `public_win_x64_acceptance`; exact commit/release/artifact/Closure/smoke credential |
 | Launcher version floor channel policy (vars pairs, stable fallback, validation) | U | tools-release `launcher-version-floor.test.ts`; publish integration |
 | Workflow env passthrough (no YAML fallback) | U | tools-pack `release-workflows.test.ts` floor passthrough test |
 | verify-metadata / summary-metadata wiring | U | publish integration test |
@@ -89,6 +90,6 @@ spec (`e2e/specs/mac.spec.ts` / `win.spec.ts` via `release-smoke.ts`),
 
 - Interactive installer UIs (mac drag, NSIS wizard) stay human-verified.
 - Windows full historical-outer migration remains a dedicated Windows-machine
-  acceptance item; the daemon bridge is unit-tested and the win spec covers
-  the legacy-executable identity variant.
+  release lane and is required by the saturation matrix in
+  `windows-standalone-acceptance.md`.
 - Linux ships no packaged auto-update (AppImage manual) by design.

--- a/docs/testing/windows-standalone-acceptance.md
+++ b/docs/testing/windows-standalone-acceptance.md
@@ -1,0 +1,82 @@
+# Windows Standalone saturation acceptance matrix
+
+This is the release gate for the Windows Electron Shell + independently
+versioned Standalone Closure architecture. It deliberately separates local
+proof, packaged platform proof, and proof made from public immutable bytes.
+
+## Fixed release policy
+
+- A first launch requires network access. The installer must not contain an
+  initial Closure archive or extracted Closure payload.
+- Windows artifacts are unsigned for this phase. `signed=false` is expected in
+  both the `win_x64` platform manifest and combined metadata when Windows is an
+  enabled target.
+- `opendesign://` is the stable OS registration and wake-up boundary. Electron
+  owns the internal `od://` proxy, which remains channel, namespace, and
+  generation isolated.
+- A Closure-only iteration must reuse the immutable Electron Shell and its
+  registered full-smoke proof. It must not rebuild Electron and must not run a
+  Shell smoke lane.
+- A native NSIS overwrite is failure-atomic. It either commits the candidate or
+  restores the prior install. It refuses mutation if owned namespace processes
+  cannot be stopped.
+- Public activation is staged: immutable objects first, public Windows smoke
+  second, immutable acceptance credential third, `latest/metadata.json` CAS
+  fourth, blocking public readback last.
+
+## Saturation matrix
+
+| ID | Boundary | Required proof | Automated owner | Release gate |
+| --- | --- | --- | --- | --- |
+| WIN-ARC-01 | Shell/Closure split | Installer inventory has no Closure; Shell resolves Closure only through channel metadata | tools-pack builder/identity tests; packaged spec | local |
+| WIN-ARC-02 | Closure-only iteration | Same Shell version/source digest/build bytes and registered Shell proof are reused; selected smoke lane is only `standalone` | tools-release shell-build tests; release workflow topology tests | local + release-beta |
+| WIN-ARC-03 | sidecar contract | Daemon and Web sidecars start through the committed Closure and expose the expected health/IPC contract | Closure/store unit tests; packaged shell and standalone lanes | local |
+| WIN-ARC-04 | long Windows paths | A deeply nested Store generation launches Daemon and in-process Next through a verified generation/digest-bound junction | tools-pack Closure test; packaged historical migration | local + release-beta full |
+| WIN-COLD-01 | first online boot | A clean install downloads, verifies, commits, and starts the public Closure without a seeded fixture | public `core + shell` acceptance job | release-beta publish=true |
+| WIN-COLD-02 | first offline boot | With no committed Closure and no network, startup fails closed and does not synthesize a payload | Closure update/store tests; standalone packaged lane | local |
+| WIN-COLD-03 | integrity | Wrong archive digest, size, inventory, identity, platform, channel, or Shell floor never becomes committed | closure-proto/store/update/tools-pack tests | local |
+| WIN-COLD-04 | restart | Cold protocol launch reuses the exact committed generation, reaches a healthy renderer or Cloud identity gate, and preserves the persisted onboarding state | packaged shell lane | local + public smoke |
+| WIN-INS-01 | unsigned NSIS | Installer builds and installs successfully with no signing step; manifests truthfully report unsigned | tools-pack identity/builder tests; workflow topology | local + release-beta |
+| WIN-INS-02 | install identity | Install directory, display name, uninstall entry, namespace token, and executable identity agree | tools-pack identity tests; packaged shell lane | local |
+| WIN-INS-03 | shortcuts | Fresh silent install creates desktop and Start Menu shortcuts; update/repair preserves the prior desktop shortcut presence/absence | custom NSIS tests; packaged full lane | local + release-beta full |
+| WIN-INS-04 | registry | Uninstall keys and stable `opendesign://` command point to the installed outer executable, never a generation payload | custom NSIS/identity tests; packaged shell lane | local + public smoke |
+| WIN-INS-05 | overwrite transaction | Candidate is staged, prior install is backed up, commit is logged, and any failed replacement restores the prior bytes | custom NSIS tests; packaged rollback/reinstall scenarios | local + release-beta full |
+| WIN-INS-06 | process guard | Install/uninstall stops only owned namespace processes and refuses filesystem/registry mutation if any remain | lifecycle/custom NSIS tests; packaged full lane | local + release-beta full |
+| WIN-INS-07 | long-path cleanup | Transaction backup/staging and uninstall remove owned long paths without broad deletion | custom NSIS tests; packaged migration/uninstall | local + release-beta full |
+| WIN-RUN-01 | installed lifecycle | install → start → health/eval → PTY → screenshot → stop/uninstall succeeds | packaged shell lane | local + public smoke |
+| WIN-RUN-02 | protocol delivery | Hot delivery keeps the process; cold delivery starts a new process; continuation reaches the daemon | packaged shell lane | local + public smoke |
+| WIN-RUN-03 | `od://` isolation | Electron proxy resolves only the selected channel/namespace/generation runtime | Electron boundary tests; packaged lanes | local |
+| WIN-RUN-04 | data ownership | Product data persists across update/repair; remove-data uninstall clears only exact Open Design product state | packaged migration/shell lanes | local + release-beta full |
+| WIN-UPD-01 | Closure successor | Valid successor commits without rebuilding Shell; damaged successor rolls back/fails closed | standalone packaged lane | local + release-beta |
+| WIN-UPD-02 | silent payload | Shell IPC downloads the payload independently of renderer sign-in state; the payload applies on next cold start when allowed | packaged full shell lane | local + release-beta full |
+| WIN-UPD-03 | Shell/outer floor | An outer below the published minimum routes through installer reinstall, including running-process and same-version repair | updater unit tests; packaged full/migration lanes | local + release-beta full |
+| WIN-UPD-04 | historical migration | Public `0.16.2-beta.155` installs, preserves seeded project/PPTX data, transitions to the standalone architecture, cold-starts, and uninstalls cleanly | packaged migration lane | local + release-beta full |
+| WIN-UPD-05 | crash recovery | Crashing payload rolls back to last-successful and a later valid update self-heals | packaged rollback lane | local + release-beta full |
+| WIN-UN-01 | native uninstall | Native uninstaller removes executable, uninstaller, shortcuts, protocol and uninstall registry entries | packaged shell lane | local + public smoke |
+| WIN-UN-02 | residue observation | No owned process, registry residue, shortcut, executable, uninstaller, or selected product-data root remains | tools-pack uninstall result assertions | local + public smoke |
+| WIN-PUB-01 | immutable stage | Platform assets/manifests and combined version metadata publish without changing latest when Windows is enabled | tools-release publication tests; workflow topology | release-beta publish=true |
+| WIN-PUB-02 | public re-download | Acceptance runner downloads the installer from its immutable public URL and rechecks exact digest/size | tools-release public-acceptance tests/job | release-beta publish=true |
+| WIN-PUB-03 | public Closure feedback | Public installer performs a real online first boot; smoke summary records the committed Closure digest/version/platform/namespace | packaged shell lane + credential issuer | release-beta publish=true |
+| WIN-PUB-04 | credential | Credential binds full commit, release version, metadata, platform manifest, installer, Closure, and smoke summary digests | tools-release public-acceptance tests | release-beta publish=true |
+| WIN-PUB-05 | least privilege | Windows acceptance job has no storage write credential; only activation job can publish credential/latest objects | workflow topology test | local |
+| WIN-PUB-06 | activation | Support objects are prepared and counted beta latest moves through an ETag CAS that refuses rollback | latest-publication tests/integration | release-beta publish=true |
+| WIN-PUB-07 | readback | Latest metadata is byte-equivalent to immutable version metadata and every public file URL responds successfully | blocking `observe-public-feed` | release-beta publish=true |
+
+## Execution order
+
+1. Run typechecks and unit/integration suites for closure-store,
+   closure-update, tools-pack, tools-release, Electron and e2e topology.
+2. Build the Windows Shell/NSIS once with `tools-pack`; run the full shell,
+   standalone, rollback, migration, protocol, data and uninstall lanes against
+   local fixtures. Preserve the Shell build and its full-smoke proof.
+3. Rebuild only Closure and prove the Shell build and every Shell smoke lane are
+   skipped. Run the standalone-bound proof against the new Closure.
+4. Dispatch `release-beta` with `publish=true`, `enable_win_x64=true`,
+   `win_x64_sign_mode=off`, `win_x64_target=all`, and full local build smoke.
+5. The workflow stages immutable objects, re-downloads the public installer,
+   runs the online cold-start smoke, issues the acceptance credential, performs
+   CAS activation, and blocks on public readback.
+
+Any failed row keeps `beta/latest/metadata.json` unchanged. Immutable staged
+objects and workflow evidence remain available for diagnosis; they are not a
+successful release until WIN-PUB-07 passes.

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -90,8 +90,9 @@ export function asPackagedAppShellSnapshot(value: unknown): PackagedAppShellSnap
 /**
  * A surface the packaged app can legitimately come to rest on.
  *
- * `home` is the signed-in/seeded main shell. `onboarding-landing` is the cloud
- * sign-in landing a first run stops at.
+ * `home` is the signed-in main shell. `onboarding-landing` is the cloud
+ * identity gate shown both on a genuine first run and when a previously
+ * completed user is definitively signed out.
  */
 export type PackagedAppShellState = 'home' | 'onboarding-landing';
 
@@ -335,27 +336,27 @@ export type PackagedAppShellPolicyInput = {
 /**
  * Which terminal states this run may settle on.
  *
- * Derived from the daemon's own `onboardingCompleted`, never from the smoke
- * profile, so a run's setup and its accepted terminal state cannot disagree.
- * The smoke seeds `onboardingCompleted: true` before start; if the daemon
- * confirms it, the renderer must honour it and home is the only acceptable
- * outcome — that is what keeps a broken completed-onboarding boot path
- * detectable on the core release lane. Only a run whose daemon reports
- * onboarding as *not* completed is a genuine first run, and only then is the
- * cloud sign-in landing a legitimate place to stop.
+ * The daemon's own `onboardingCompleted` remains the authority for whether a
+ * seed survived a relaunch. It is not, however, an authentication fact: the
+ * current EntryShell deliberately returns a completed-but-signed-out user to
+ * the Cloud identity gate. A retained completed seed may therefore settle on
+ * either Home (signed in) or the positively identified Cloud landing (signed
+ * out). `assertSeededOnboardingRetained` still fails before this policy can
+ * absorb a missing or false seed.
  *
- * `coreProfile` still narrows it: the full profile goes on to drive the entry
- * rail, which `clickUpdaterRailExpression` refuses while onboarding is up, so
- * it needs home either way.
+ * `coreProfile` only narrows a genuinely fresh, unseeded launch. Full release
+ * acceptance controls the Shell updater through the Shell IPC plane, so it is
+ * intentionally independent of the Closure route and Cloud login state.
  */
 export function packagedAppShellPolicy(
   input: PackagedAppShellPolicyInput,
 ): { readonly acceptOnboardingLanding: boolean } {
-  // A run that seeded completion and saw the daemon confirm it may never accept
-  // the landing, whatever a later reading says. Losing the seed across a
-  // relaunch is a regression, not a downgrade to "genuine first run" — see
-  // `assertSeededOnboardingRetained`, which is what turns that loss into a
-  // named failure rather than merely a stricter expectation here.
+  // Exact true means the persisted completion fact survived. The renderer may
+  // still choose the identity gate when Cloud reports signed out.
+  if (input.daemonOnboardingCompleted === true) return { acceptOnboardingLanding: true };
+  // A seeded run that no longer reads true is a regression, not a genuine
+  // first run. `assertSeededOnboardingRetained` raises the named error before
+  // settling; keep this direction closed as a second line of defence.
   if (input.seededOnboardingCompleted !== false) return { acceptOnboardingLanding: false };
   // Only an explicit `false` — a daemon that positively said "not completed" —
   // buys permission. Testing for truthiness instead would let any non-boolean
@@ -449,8 +450,9 @@ export function assertSeededOnboardingRetained(input: {
  * `shouldRouteToFirstRunOnboarding` (apps/web/src/App.tsx) keys purely on
  * `onboardingCompleted`, and `connectStepRuntimeReady` (EntryShell.tsx) lets
  * onboarding complete through cloud sign-in *or* a local CLI *or* a verified
- * BYOK key. So "completed setup, currently signed out -> home" and "never
- * completed -> cloud sign-in landing" are both correct.
+ * BYOK key. In addition, EntryShell's Cloud identity effect means "completed
+ * setup, currently signed out -> cloud sign-in landing" is also correct; the
+ * daemon config and rendered identity surface are separate assertions.
  */
 export type PackagedLaunchScenario = 'completed-user' | 'first-run';
 

--- a/e2e/lib/vitest/packaged-smoke-plan.ts
+++ b/e2e/lib/vitest/packaged-smoke-plan.ts
@@ -49,6 +49,43 @@ export const MAC_SHELL_PROOF_SCENARIO_IDS = Object.values(MAC_PACKAGED_SMOKE_SCE
   .filter((scenario) => scenario.lane === 'shell' || scenario.lane === 'migration')
   .map((scenario) => scenario.id);
 
+export const WIN_PACKAGED_SMOKE_SCENARIOS = {
+  shellLifecycle: {
+    domains: ['shell', 'standalone', 'contract', 'distribution'],
+    id: 'win-shell-lifecycle',
+    lane: 'shell',
+    title: '[P2] installs, starts, inspects with eval and screenshot, stops, and uninstalls the built windows artifact',
+  },
+  shellSilentUpdate: {
+    domains: ['shell', 'contract'],
+    id: 'win-shell-silent-update',
+    lane: 'shell',
+    title: 'applies a downloaded payload silently on the next cold start',
+  },
+  shellRollback: {
+    domains: ['shell', 'contract'],
+    id: 'win-shell-rollback',
+    lane: 'shell',
+    title: 'rolls back a crashing payload and self-heals on the next good update',
+  },
+  standaloneClosure: {
+    domains: ['standalone', 'contract'],
+    id: 'win-standalone-closure',
+    lane: 'standalone',
+    title: '[P0] attaches a release Closure across cold start and reinstall, then rolls a damaged successor back',
+  },
+  legacyMigration: {
+    domains: ['migration', 'distribution', 'contract'],
+    id: 'win-legacy-migration',
+    lane: 'migration',
+    title: '[P0] routes the last packaged Windows beta through the installer and preserves product data in the new architecture',
+  },
+} as const satisfies Record<string, PackagedSmokeScenario>;
+
+export const WIN_SHELL_PROOF_SCENARIO_IDS = Object.values(WIN_PACKAGED_SMOKE_SCENARIOS)
+  .filter((scenario) => scenario.lane === 'shell' || scenario.lane === 'migration')
+  .map((scenario) => scenario.id);
+
 export function resolvePackagedSmokeLanes(
   profile: PackagedSmokeProfile,
   raw: string | undefined | null,

--- a/e2e/lib/vitest/win-installer-log.ts
+++ b/e2e/lib/vitest/win-installer-log.ts
@@ -9,16 +9,8 @@ const WORKING_OVERWRITE_MARKERS: InstallerLogMarker[] = [
     pattern: /existing installation found; silent install will overwrite it/,
   },
   {
-    label: 'install directory exists before removal',
-    pattern: /event=install_dir_before_remove .* exists=1/,
-  },
-  {
-    label: 'install directory removal succeeds',
-    pattern: /install dir remove exit=0/,
-  },
-  {
-    label: 'install directory is absent after removal',
-    pattern: /event=install_dir_after_remove .* exists=0/,
+    label: 'existing shortcut state is captured',
+    pattern: /install transaction captured existing=1 desktopShortcut=[01]/,
   },
   {
     label: 'base payload extraction succeeds',
@@ -29,12 +21,20 @@ const WORKING_OVERWRITE_MARKERS: InstallerLogMarker[] = [
     pattern: /payload overlay extraction exit=0/,
   },
   {
-    label: 'install directory exists after extraction',
-    pattern: /event=install_dir_after_extract .* exists=1/,
+    label: 'staging directory exists after extraction',
+    pattern: /event=install_staging_after_extract .* exists=1/,
   },
   {
-    label: 'installed executable exists after extraction',
-    pattern: /event=installed_exe_after_extract .* exists=1/,
+    label: 'staged executable exists after extraction',
+    pattern: /event=staged_exe_after_extract .* exists=1/,
+  },
+  {
+    label: 'previous install is quarantined',
+    pattern: /event=install_dir_after_quarantine .* exists=1/,
+  },
+  {
+    label: 'staged install is committed',
+    pattern: /event=install_dir_after_commit .* exists=1/,
   },
   {
     label: 'launcher runtime sync succeeds',
@@ -43,6 +43,10 @@ const WORKING_OVERWRITE_MARKERS: InstallerLogMarker[] = [
   {
     label: 'launcher runtime pointer is written',
     pattern: /event=launcher_runtime_after_write path=\S+/,
+  },
+  {
+    label: 'install transaction commits',
+    pattern: /install transaction committed/,
   },
   {
     label: 'install section completes',

--- a/e2e/scripts/release-smoke.ts
+++ b/e2e/scripts/release-smoke.ts
@@ -9,6 +9,7 @@ import {
   MAC_PACKAGED_SMOKE_SCENARIOS,
   resolvePackagedSmokeLanes,
   type PackagedSmokeScenario,
+  WIN_PACKAGED_SMOKE_SCENARIOS,
 } from '../lib/vitest/packaged-smoke-plan.ts';
 import { resolvePackagedSmokeProfile } from '../lib/vitest/packaged-smoke-profile.ts';
 
@@ -31,9 +32,12 @@ async function main(): Promise<void> {
       ? process.env.OD_PACKAGED_E2E_MAC_SMOKE_PROFILE
       : process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE,
   );
-  const selectedLanes = platform === 'mac'
-    ? resolvePackagedSmokeLanes(smokeProfile, process.env.OD_PACKAGED_E2E_MAC_SMOKE_LANES)
-    : [];
+  const selectedLanes = resolvePackagedSmokeLanes(
+    smokeProfile,
+    platform === 'mac'
+      ? process.env.OD_PACKAGED_E2E_MAC_SMOKE_LANES
+      : process.env.OD_PACKAGED_E2E_WIN_SMOKE_LANES,
+  );
 
   process.env.OD_PACKAGED_E2E_REPORT_DIR = report.root;
 
@@ -167,9 +171,11 @@ async function resolveSmokeSummary(input: {
   shellProof: string | null;
   vitestResultPath: string;
 }): Promise<Record<string, unknown>> {
-  const scenarios = input.platform === 'mac'
-    ? Object.values(MAC_PACKAGED_SMOKE_SCENARIOS)
-    : [];
+  const scenarios = Object.values(
+    input.platform === 'mac'
+      ? MAC_PACKAGED_SMOKE_SCENARIOS
+      : WIN_PACKAGED_SMOKE_SCENARIOS,
+  );
   const byTitle = new Map<string, PackagedSmokeScenario>(
     scenarios.map((scenario) => [scenario.title, scenario]),
   );
@@ -203,7 +209,7 @@ async function resolveSmokeSummary(input: {
       shellProof: input.shellProof,
     },
     schemaVersion: 1,
-    ...(input.platform === 'mac' ? { timings } : {}),
+    timings,
   };
 }
 

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -384,6 +384,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
       expectPathInside(install.dmgPath, join(outputNamespaceRoot, 'dmg'));
       expectPathInside(install.installedAppPath, join(outputNamespaceRoot, 'install', 'Applications'));
       await assertMacInviteProtocolRegistration(install.installedAppPath);
+      await registerMacAppWithLaunchServices(install.installedAppPath);
 
       await seedPackagedOnboardingComplete();
       if (!shellAbsorbsStandaloneAcceptance) await seedConfiguredPackagedClosure();
@@ -487,6 +488,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
         expect(reinstallStop.remainingPids).toEqual([]);
         const reinstall = await runToolsPackJson<MacInstallResult>('install');
         expect(reinstall.installedAppPath).toBe(install.installedAppPath);
+        await registerMacAppWithLaunchServices(reinstall.installedAppPath);
         const reinstallStart = await runToolsPackJson<MacStartResult>('start');
         started = true;
         expect(reinstallStart.pid).not.toBe(start.pid);
@@ -3369,6 +3371,16 @@ async function assertMacInviteProtocolRegistration(installedAppPath: string): Pr
     (entry) => entry.CFBundleURLSchemes ?? [],
   );
   expect(schemes).toContain('opendesign');
+}
+
+async function registerMacAppWithLaunchServices(installedAppPath: string): Promise<void> {
+  // A real Finder drag-install registers the copied bundle. The tools-pack
+  // harness uses `ditto` into an isolated Applications directory, so perform
+  // that missing OS step explicitly before testing cold protocol delivery.
+  await execFileAsync(
+    '/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister',
+    ['-f', installedAppPath],
+  );
 }
 
 async function invokeMacInviteDeeplink(

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -509,7 +509,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
         expect(protocolStop.status).not.toBe('partial');
         expect(protocolStop.remainingPids).toEqual([]);
 
-        await invokeMacInviteDeeplink(install.installedAppPath);
+        await invokeMacInviteDeeplink(install.installedAppPath, { forceNewInstance: true });
         started = true;
         const protocolColdInspect = await waitForHealthyDesktop();
         expect(protocolColdInspect.status?.state).toBe('running');
@@ -3351,10 +3351,22 @@ async function assertMacInviteProtocolRegistration(installedAppPath: string): Pr
   expect(schemes).toContain('opendesign');
 }
 
-async function invokeMacInviteDeeplink(installedAppPath: string): Promise<void> {
+async function invokeMacInviteDeeplink(
+  installedAppPath: string,
+  options: { forceNewInstance?: boolean } = {},
+): Promise<void> {
   // `-a` pins delivery to this namespace's installed test bundle instead of a
   // developer's stable Open Design app that may own the same global scheme.
-  await execFileAsync('/usr/bin/open', ['-a', installedAppPath, packagedInviteDeeplink]);
+  // LaunchServices may briefly retain the connection to a just-terminated app
+  // after tools-pack has proved that all of its PIDs are gone. For the cold
+  // assertion, `-n` requires a new application process while still delivering
+  // the URL through the installed bundle's OS protocol entry.
+  await execFileAsync('/usr/bin/open', [
+    ...(options.forceNewInstance === true ? ['-n'] : []),
+    '-a',
+    installedAppPath,
+    packagedInviteDeeplink,
+  ]);
 }
 
 async function pathExists(filePath: string): Promise<boolean> {

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -511,7 +511,13 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
 
         await invokeMacInviteDeeplink(install.installedAppPath, { forceNewInstance: true });
         started = true;
-        const protocolColdInspect = await waitForHealthyDesktop();
+        const protocolColdInspect = await waitForHealthyDesktop(releaseVersion, async () => {
+          // LaunchServices can accept `open -n` while it is still retiring the
+          // just-stopped application record, without creating a new process.
+          // Retry the same OS-protocol launch; never fall back to starting the
+          // executable directly, so a healthy PID still proves cold routing.
+          await invokeMacInviteDeeplink(install.installedAppPath, { forceNewInstance: true });
+        });
         expect(protocolColdInspect.status?.state).toBe('running');
         expect(protocolColdInspect.status?.pid).not.toBe(protocolHotPid);
       }
@@ -2844,9 +2850,12 @@ async function readDesktopLocalCliSnapshot(
 
 async function waitForHealthyDesktop(
   releaseVersionOverride: string | null | undefined = releaseVersion,
+  retryUnavailableLaunch?: () => Promise<void>,
 ): Promise<MacInspectResult> {
   const timeoutMs = 90_000;
+  const launchRetryIntervalMs = 5_000;
   const startedAt = Date.now();
+  let lastLaunchRetryAt = startedAt;
   let lastResult: unknown = null;
 
   while (Date.now() - startedAt < timeoutMs) {
@@ -2866,6 +2875,17 @@ async function waitForHealthyDesktop(
       }
     } catch (error) {
       lastResult = error;
+    }
+    if (
+      retryUnavailableLaunch != null
+      && Date.now() - lastLaunchRetryAt >= launchRetryIntervalMs
+    ) {
+      try {
+        await retryUnavailableLaunch();
+      } catch (error) {
+        lastResult = error;
+      }
+      lastLaunchRetryAt = Date.now();
     }
     await delay(1000);
   }

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -383,7 +383,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
       expect(install.detached).toBe(true);
       expectPathInside(install.dmgPath, join(outputNamespaceRoot, 'dmg'));
       expectPathInside(install.installedAppPath, join(outputNamespaceRoot, 'install', 'Applications'));
-      await assertMacInviteProtocolRegistration(install.installedAppPath);
+      const protocolBundleIdentifier = await assertMacInviteProtocolRegistration(install.installedAppPath);
       await registerMacAppWithLaunchServices(install.installedAppPath);
 
       await seedPackagedOnboardingComplete();
@@ -488,6 +488,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
         expect(reinstallStop.remainingPids).toEqual([]);
         const reinstall = await runToolsPackJson<MacInstallResult>('install');
         expect(reinstall.installedAppPath).toBe(install.installedAppPath);
+        expect(await assertMacInviteProtocolRegistration(reinstall.installedAppPath)).toBe(protocolBundleIdentifier);
         await registerMacAppWithLaunchServices(reinstall.installedAppPath);
         const reinstallStart = await runToolsPackJson<MacStartResult>('start');
         started = true;
@@ -501,7 +502,7 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
       }
 
       const protocolHotPid = protocolBaseInspect.status?.pid ?? start.pid;
-      await invokeMacInviteDeeplink(install.installedAppPath);
+      await invokeMacInviteDeeplink(protocolBundleIdentifier);
       const protocolHotInspect = await waitForHealthyDesktop();
       expect(protocolHotInspect.status?.pid).toBe(protocolHotPid);
 
@@ -511,14 +512,14 @@ macShellDescribe('packaged mac Shell runtime smoke', () => {
         expect(protocolStop.status).not.toBe('partial');
         expect(protocolStop.remainingPids).toEqual([]);
 
-        await invokeMacInviteDeeplink(install.installedAppPath, { forceNewInstance: true });
+        await invokeMacInviteDeeplink(protocolBundleIdentifier, { forceNewInstance: true });
         started = true;
         const protocolColdInspect = await waitForHealthyDesktop(releaseVersion, async () => {
           // LaunchServices can accept `open -n` while it is still retiring the
           // just-stopped application record, without creating a new process.
           // Retry the same OS-protocol launch; never fall back to starting the
           // executable directly, so a healthy PID still proves cold routing.
-          await invokeMacInviteDeeplink(install.installedAppPath, { forceNewInstance: true });
+          await invokeMacInviteDeeplink(protocolBundleIdentifier, { forceNewInstance: true });
         });
         expect(protocolColdInspect.status?.state).toBe('running');
         expect(protocolColdInspect.status?.pid).not.toBe(protocolHotPid);
@@ -3355,7 +3356,7 @@ function expectPathInside(filePath: string, expectedRoot: string): void {
   ).toBe(true);
 }
 
-async function assertMacInviteProtocolRegistration(installedAppPath: string): Promise<void> {
+async function assertMacInviteProtocolRegistration(installedAppPath: string): Promise<string> {
   const plistPath = join(installedAppPath, 'Contents', 'Info.plist');
   const { stdout } = await execFileAsync('/usr/bin/plutil', [
     '-convert',
@@ -3365,12 +3366,15 @@ async function assertMacInviteProtocolRegistration(installedAppPath: string): Pr
     plistPath,
   ]);
   const plist = JSON.parse(stdout) as {
+    CFBundleIdentifier?: string;
     CFBundleURLTypes?: Array<{ CFBundleURLSchemes?: string[] }>;
   };
   const schemes = (plist.CFBundleURLTypes ?? []).flatMap(
     (entry) => entry.CFBundleURLSchemes ?? [],
   );
   expect(schemes).toContain('opendesign');
+  expect(plist.CFBundleIdentifier).toEqual(expect.any(String));
+  return plist.CFBundleIdentifier!;
 }
 
 async function registerMacAppWithLaunchServices(installedAppPath: string): Promise<void> {
@@ -3384,19 +3388,20 @@ async function registerMacAppWithLaunchServices(installedAppPath: string): Promi
 }
 
 async function invokeMacInviteDeeplink(
-  installedAppPath: string,
+  bundleIdentifier: string,
   options: { forceNewInstance?: boolean } = {},
 ): Promise<void> {
-  // `-a` pins delivery to this namespace's installed test bundle instead of a
-  // developer's stable Open Design app that may own the same global scheme.
+  // `-b` routes through the registered bundle identity instead of interpreting
+  // a nested .app path as an application name. The channel-specific bundle ID
+  // also avoids a developer's stable Open Design app that owns the same scheme.
   // LaunchServices may briefly retain the connection to a just-terminated app
   // after tools-pack has proved that all of its PIDs are gone. For the cold
   // assertion, `-n` requires a new application process while still delivering
   // the URL through the installed bundle's OS protocol entry.
   await execFileAsync('/usr/bin/open', [
     ...(options.forceNewInstance === true ? ['-n'] : []),
-    '-a',
-    installedAppPath,
+    '-b',
+    bundleIdentifier,
     packagedInviteDeeplink,
   ]);
 }

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -735,8 +735,8 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(pty.exitCode, JSON.stringify(pty, null, 2)).toBe(0);
       expect(pty.cleanup.terminalStatus).toBe(200);
       expect(pty.cleanup.projectStatus).toBe(200);
-      assertLauncherPointer(inspect.launcher.active, updateScenario.expectedInstalledShellVersion, 0, 'initial active');
-      assertLauncherPointer(inspect.launcher.lastSuccessful, updateScenario.expectedInstalledShellVersion, 0, 'initial lastSuccessful');
+      assertLauncherPointer(inspect.launcher.active, updateScenario.expectedCurrentVersion, 0, 'initial active');
+      assertLauncherPointer(inspect.launcher.lastSuccessful, updateScenario.expectedCurrentVersion, 0, 'initial lastSuccessful');
 
       // The seed's postcondition, asserted where it must hold: this process was
       // started by `tools-pack win start`, which points the packaged runtime at
@@ -1232,7 +1232,7 @@ winDescribe('packaged windows runtime smoke', () => {
         lastSuccessful?: { generation?: number; version?: string };
       };
       expect(strandedRuntime.active?.version).toBe(targetVersion);
-      expect(strandedRuntime.lastSuccessful?.version).toBe(updateScenario.expectedInstalledShellVersion);
+      expect(strandedRuntime.lastSuccessful?.version).toBe(updateScenario.expectedCurrentVersion);
       expect(strandedAttempt.generation).toBe(strandedRuntime.active?.generation);
 
       // Cold start rolls back: the installed outer sees the unconfirmed
@@ -1246,7 +1246,7 @@ winDescribe('packaged windows runtime smoke', () => {
         start.pid,
         false,
       );
-      expect(rolledBack.launcher.lastSuccessful?.version).toBe(updateScenario.expectedInstalledShellVersion);
+      expect(rolledBack.launcher.lastSuccessful?.version).toBe(updateScenario.expectedCurrentVersion);
       // Degraded steady state: the broken pointer stays active with its
       // attempt as evidence until a healthy release replaces it.
       expect(rolledBack.launcher.active?.version).toBe(targetVersion);

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -4,6 +4,7 @@ import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { copyFile, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -90,6 +91,14 @@ const installIdentity = resolvePackagedWinInstallIdentity({ namespace, releaseVe
 
 const outputNamespaceRoot = join(toolsPackDir, 'out', 'win', 'namespaces', namespace);
 const runtimeNamespaceRoot = join(toolsPackDir, 'runtime', 'win', 'namespaces', namespace);
+const portableNsisLogPath = join(
+  tmpdir(),
+  'Open Design',
+  'installer-logs',
+  'namespaces',
+  namespace.replace(/[^A-Za-z0-9._-]+/g, '-'),
+  'nsis.log',
+);
 const launcherNamespaceRoot = join(
   toolsPackDir,
   'runtime',
@@ -1492,6 +1501,7 @@ winLegacyMigrationDescribe('packaged Windows historical outer migration acceptan
         expectedVersion: targetReleaseVersion,
         fixture: migrationFixture,
         installDir,
+        nsisLogPath: portableNsisLogPath,
         persistedProjectId: seeded.projectId,
       });
       expect(migration.downloaded.reinstall).toEqual({
@@ -1965,6 +1975,7 @@ async function runInstallerFallbackAcceptance(options: {
   expectedVersion: string | null;
   fixture: ToolsServeUpdaterFixture | null;
   installDir: string;
+  nsisLogPath?: string;
   persistedProjectId: string | null;
 }): Promise<InstallerFallbackSummary> {
   if (options.fixture == null) throw new Error('installer fallback requires a tools-serve fixture');
@@ -1989,7 +2000,7 @@ async function runInstallerFallbackAcceptance(options: {
   const install = await runDirectInstaller(
     downloadPath,
     options.installDir,
-    join(fixtureNamespaceRoot, 'logs', 'nsis.log'),
+    options.nsisLogPath ?? join(fixtureNamespaceRoot, 'logs', 'nsis.log'),
   );
   expect(install.code).toBe(0);
   assertWorkingWinInstallerOverwriteLog(install.nsisLogTail);

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -2904,7 +2904,10 @@ function expectPathInside(filePath: string, expectedRoot: string): void {
 }
 
 function expectWindowsPackagedAppUrl(value: string | null | undefined): void {
-  expect(value).toEqual(expect.stringMatching(/^od:\/\/app\/$/));
+  // The health probe races the SPA's first-run redirect. Both the app root and
+  // its dedicated onboarding route are Shell-owned `od://` surfaces; pinning
+  // only the pre-redirect root makes a healthy cold start nondeterministic.
+  expect(value).toEqual(expect.stringMatching(/^od:\/\/app\/(?:onboarding)?$/));
 }
 
 function expectWindowsHealthyRendererUrl(value: string | null | undefined): void {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -19,6 +19,11 @@ import {
   type PackagedAppShellState,
 } from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
+import {
+  hasPackagedSmokeLane,
+  resolvePackagedSmokeLanes,
+  WIN_PACKAGED_SMOKE_SCENARIOS,
+} from '@/vitest/packaged-smoke-plan';
 import { resolvePackagedSmokeProfile } from '@/vitest/packaged-smoke-profile';
 import {
   assertPackagedPtySmokeResult,
@@ -30,9 +35,12 @@ import {
 } from '@/vitest/packaged-update-scenario';
 import {
   activateBrokenClosureSuccessor,
+  readCommittedPackagedClosureFixture,
+  readPackagedClosureBuildFixture,
   readPackagedClosureFixtureRuntime,
   resetPackagedClosureFixture,
   seedPackagedClosureFixture,
+  type PackagedClosureFixture,
 } from '@/vitest/packaged-closure-fixture';
 import { releaseAppVersionArgs, resolvePackagedWinInstallIdentity } from '@/vitest/packaged-win-identity';
 import { resolvePackagedSmokeNamespace } from '@/vitest/suite';
@@ -46,13 +54,17 @@ const toolsPackDir = resolveFromWorkspace(process.env.OD_PACKAGED_E2E_TOOLS_PACK
 const namespace = resolvePackagedSmokeNamespace('win');
 const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
+const maxStartDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_START_MS ?? '300000', 10);
 // `??` would keep an EMPTY value, and the release workflows can hand one down
 // — see `resolvePackagedSmokeProfile` for why all three layers have to agree
 // that empty means unset. An empty value surviving here reads as "not core"
 // and silently selects the updater path.
 const smokeProfile = resolvePackagedSmokeProfile(process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE);
+const smokeLanes = resolvePackagedSmokeLanes(
+  smokeProfile,
+  process.env.OD_PACKAGED_E2E_WIN_SMOKE_LANES,
+);
 const verifyCoreOnly = smokeProfile === 'core';
-const verifyReinstallWhileRunning = !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
 const verifyUpgradePersistence =
   !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_UPGRADE_PERSISTENCE === '1';
 const updateMetadataUrl = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_METADATA_URL);
@@ -63,13 +75,17 @@ const intermediateUpdateBuildJsonPath = normalizeOptionalEnv(
 );
 const updateFixture = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE);
 const closureBuildJsonPath = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_CLOSURE_BUILD_JSON_PATH);
+const legacyInstallerPath = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_LEGACY_INSTALLER_PATH);
+const legacyVersion = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_LEGACY_VERSION);
+const minimumShellVersion = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_MIN_SHELL_VERSION);
 const updateFixturePort = resolveOptionalFixturePort(process.env.OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE_PORT);
 const updateFixtureMode = resolveUpdateFixtureMode(process.env.OD_PACKAGED_E2E_WIN_UPDATE_MODE);
 const releaseChannel = process.env.OD_PACKAGED_E2E_RELEASE_CHANNEL;
 const releaseVersion = process.env.OD_PACKAGED_E2E_RELEASE_VERSION;
+const shellVersion = process.env.OD_PACKAGED_E2E_SHELL_VERSION;
 const packagedInviteDeeplink =
   'opendesign://workspace/invite/continue?workspace_id=packaged-smoke-workspace&member_id=packaged-smoke-member&invite_id=packaged-smoke-invite&nonce=packaged-smoke-nonce';
-const updateScenario = resolvePackagedUpdateScenario({ releaseChannel, releaseVersion });
+const updateScenario = resolvePackagedUpdateScenario({ releaseChannel, releaseVersion, shellVersion });
 const installIdentity = resolvePackagedWinInstallIdentity({ namespace, releaseVersion });
 
 const outputNamespaceRoot = join(toolsPackDir, 'out', 'win', 'namespaces', namespace);
@@ -202,57 +218,6 @@ function existingProjectPptxExportExpression(projectId: string): string {
     })()
   `;
 }
-const updaterPopupExpression = `
-  (() => {
-    const popup = document.querySelector('[data-testid="updater-popup"]');
-    const button = document.querySelector('[data-testid="updater-install-button"]');
-    const reinstallLink = document.querySelector('[data-testid="updater-reinstall-learn-more"]');
-    return {
-      installButtonVisible: button instanceof HTMLButtonElement && !button.disabled,
-      reinstallLinkVisible: reinstallLink instanceof HTMLElement,
-      text: popup?.textContent?.trim() ?? null,
-      title: popup?.querySelector('h2')?.textContent?.trim() ?? null,
-      visible: popup instanceof HTMLElement,
-    };
-  })()
-`;
-const clickUpdaterInstallExpression = `
-  (() => {
-    const button = document.querySelector('[data-testid="updater-install-button"]');
-    if (!(button instanceof HTMLButtonElement)) return { clicked: false, reason: 'missing-install-button' };
-    if (button.disabled) return { clicked: false, reason: 'install-button-disabled' };
-    button.click();
-    return { clicked: true };
-  })()
-`;
-const clickUpdaterRailExpression = `
-  (async () => {
-    const onboarding = document.querySelector('.entry-shell--onboarding, .entry-onboarding-modal');
-    if (onboarding instanceof HTMLElement) return { clicked: false, reason: 'onboarding-visible' };
-    const host = window.__od__;
-    let hostStatus = null;
-    if (host?.updater?.status instanceof Function) {
-      hostStatus = await host.updater.status({ payload: { source: 'e2e-open-ready-updater-prompt' } });
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    const button = document.querySelector('[data-testid="entry-nav-updater"]');
-    if (!(button instanceof HTMLButtonElement)) {
-      const candidates = Array.from(document.querySelectorAll('button,[role="button"],a'))
-        .map((element) => ({
-          aria: element.getAttribute('aria-label'),
-          disabled: element instanceof HTMLButtonElement ? element.disabled : element.getAttribute('aria-disabled'),
-          testid: element.getAttribute('data-testid'),
-          text: element.textContent?.trim() ?? '',
-        }))
-        .filter((candidate) => candidate.testid != null || /update|install|restart|更新|安装|重启/i.test([candidate.aria, candidate.text].join(' ')))
-        .slice(0, 40);
-      return { candidates, clicked: false, hostStatus, reason: 'missing-updater-rail' };
-    }
-    if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, hostStatus, reason: 'updater-rail-disabled' };
-    button.click();
-    return { clicked: true, hostStatus };
-  })()
-`;
 const packagedOnboardingExpression = `
   (() => {
     const onboardingShell = document.querySelector('.entry-shell--onboarding');
@@ -481,20 +446,13 @@ type DesktopIdentityMarker = {
     scope?: { channel?: string; generation?: number; namespace?: string };
     standalonePid?: number;
   };
+  stamp?: {
+    app?: string;
+    mode?: string;
+    namespace?: string;
+    source?: string;
+  };
   version: number;
-};
-
-type UpdaterPopupEvalValue = {
-  installButtonVisible: boolean;
-  reinstallLinkVisible: boolean;
-  text: string | null;
-  title: string | null;
-  visible: boolean;
-};
-
-type UpdaterClickEvalValue = {
-  clicked: boolean;
-  reason?: string;
 };
 
 type PackagedOnboardingEvalValue = {
@@ -518,8 +476,23 @@ type DirectInstallerResult = {
 type UpdateFixtureMode = 'installer' | 'payload';
 
 const shouldRunPackagedWinSmoke = process.platform === 'win32' && process.env.OD_PACKAGED_E2E_WIN === '1';
-const winDescribe = shouldRunPackagedWinSmoke ? describe : describe.skip;
-const winClosureDescribe = shouldRunPackagedWinSmoke && closureBuildJsonPath != null
+const winDescribe = shouldRunPackagedWinSmoke && hasPackagedSmokeLane(smokeLanes, 'shell')
+  ? describe
+  : describe.skip;
+const shellAbsorbsStandaloneAcceptance = hasPackagedSmokeLane(smokeLanes, 'shell')
+  && hasPackagedSmokeLane(smokeLanes, 'standalone')
+  && !verifyCoreOnly
+  && updateFixture === 'tools-serve'
+  && closureBuildJsonPath != null;
+const winClosureDescribe = shouldRunPackagedWinSmoke
+  && hasPackagedSmokeLane(smokeLanes, 'standalone')
+  && closureBuildJsonPath != null
+  && !shellAbsorbsStandaloneAcceptance
+  ? describe
+  : describe.skip;
+const winLegacyMigrationDescribe = shouldRunPackagedWinSmoke
+  && hasPackagedSmokeLane(smokeLanes, 'migration')
+  && !verifyCoreOnly
   ? describe
   : describe.skip;
 const shouldRunPackagedWinOnboardingSmoke =
@@ -530,7 +503,7 @@ winDescribe('packaged windows runtime smoke', () => {
   let installed = false;
   let started = false;
 
-  test('[P2] installs, starts, inspects with eval and screenshot, stops, and uninstalls the built windows artifact', async () => {
+  test(WIN_PACKAGED_SMOKE_SCENARIOS.shellLifecycle.title, async () => {
     const report = await createPackagedSmokeReport('win');
     let passed = false;
     const timings: SmokeTiming[] = [];
@@ -541,12 +514,14 @@ winDescribe('packaged windows runtime smoke', () => {
     let intermediatePayloadUpdate: PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let payloadUpdate: InstallerFallbackSummary | PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let updaterRecovery: UpdaterRecoverySummary | { skipped: true } = { skipped: true };
-    let reinstall: DirectInstallerResult | { skipped: true } = { skipped: true };
     let logs: LogsResult | { skipped: true } = { skipped: true };
     let stop: WinStopResult | { skipped: true } = { skipped: true };
     let postUpdateHealth: HealthEvalValue | { skipped: true } = { skipped: true };
     let upgradePersistence: UpgradePersistenceSeed | { skipped: true } = { skipped: true };
     let payloadFixture: ToolsServeUpdaterFixture | null = null;
+    let closureAcceptance: PackagedClosureFixture | null = null;
+    let expectedClosureReleaseVersion = updateScenario.expectedCurrentVersion;
+    let expectedStandaloneVersion = updateScenario.expectedCurrentVersion;
     let intermediateUpdateFixture: Awaited<ReturnType<typeof resolveLocalUpdateFixture>> | null = null;
     let localUpdateFixture: Awaited<ReturnType<typeof resolveLocalUpdateFixture>> | null = null;
     const updateEnv = captureUpdateEnv();
@@ -557,6 +532,11 @@ winDescribe('packaged windows runtime smoke', () => {
       await measureSmokeStep(timings, 'pre-clean uninstall', async () => {
         await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => null);
         await resetPackagedUpdaterNamespaceRoots();
+        await resetPackagedClosureFixture({
+          channel: updateScenario.channel,
+          installationRoot: join(toolsPackDir, 'runtime', 'win'),
+          namespace,
+        });
       });
 
       const install = await measureSmokeStep(timings, 'install', async () => runToolsPackJson<WinInstallResult>('install'));
@@ -575,7 +555,7 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(JSON.stringify(install.registryEntries)).toContain(installIdentity.displayName);
       expect(JSON.stringify(install.registryEntries)).toContain(`Open Design-${installIdentity.namespaceToken}`);
       await assertWindowsInviteProtocolRegistration(install.installDir);
-      await seedConfiguredPackagedClosure();
+      if (!shellAbsorbsStandaloneAcceptance) await seedConfiguredPackagedClosure();
       expect(install.installPayload.fileCount).toBeGreaterThan(0);
       expect(install.installPayload.totalBytes).toBeGreaterThan(0);
       expect(install.installPayload.topLevel.length).toBeGreaterThan(0);
@@ -660,11 +640,21 @@ winDescribe('packaged windows runtime smoke', () => {
           }
           const initialUpdateFixture = intermediateUpdateFixture ?? localUpdateFixture;
           expectedPayloadUpdateVersion = initialUpdateFixture.targetVersion;
+          const closureBuild = shellAbsorbsStandaloneAcceptance
+            ? await readPackagedClosureBuildFixture({
+                buildJsonPath: closureBuildJsonPath!,
+                channel: updateScenario.channel,
+                expectedPlatform: 'win32-x64',
+                workspaceRoot,
+              })
+            : null;
           payloadFixture = await startToolsServeUpdaterFixture({
             artifactPath: initialUpdateFixture.installerPath,
             channel: updateScenario.channel,
+            ...(closureBuild == null ? {} : { closureManifestPath: closureBuild.manifestPath }),
             ...(updateFixtureMode === 'payload' ? { payloadPath: initialUpdateFixture.payloadPath } : {}),
             platform: 'win',
+            ...(closureBuild == null ? {} : { rebaseClosureUrl: true }),
             ...(updateFixturePort == null ? {} : { port: updateFixturePort }),
             version: initialUpdateFixture.targetVersion,
             workspaceRoot,
@@ -681,6 +671,19 @@ winDescribe('packaged windows runtime smoke', () => {
       expectPathInside(start.logPath, join(runtimeNamespaceRoot, 'logs', 'desktop'));
       expect(start.pid).toBeGreaterThan(0);
 
+      if (shellAbsorbsStandaloneAcceptance) {
+        closureAcceptance = await measureSmokeStep(timings, 'wait online Closure commit', async () =>
+          waitForCommittedPackagedClosureFixture({
+            buildJsonPath: closureBuildJsonPath!,
+            channel: updateScenario.channel,
+            expectedPlatform: 'win32-x64',
+            installationRoot: join(toolsPackDir, 'runtime', 'win'),
+            namespace,
+            workspaceRoot,
+          }),
+        );
+      }
+
       const inspect = await measureSmokeStep(timings, 'wait healthy inspect eval', async () => waitForHealthyDesktop());
       expect(inspect.status?.state).toBe('running');
       if (inspect.desktopIpcUnavailable) expectWindowsFallbackWebUrl(inspect.status?.url);
@@ -693,6 +696,21 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(value.health.ok).toBe(true);
       if (releaseVersion != null && releaseVersion !== '') expect(value.health.version).toBe(releaseVersion);
       else expect(value.health.version).toEqual(expect.any(String));
+      if (shellAbsorbsStandaloneAcceptance) {
+        if (closureAcceptance == null) throw new Error('Windows Shell did not commit the expected Closure fixture');
+        const closureRuntime = await readPackagedClosureFixtureRuntime(closureAcceptance);
+        expectedStandaloneVersion = closureAcceptance.manifest.identity.version;
+        const committedClosureReleaseVersion = closureRuntime.committed?.releaseVersion;
+        if (committedClosureReleaseVersion == null) {
+          throw new Error('Windows Shell did not commit a Closure release version');
+        }
+        expectedClosureReleaseVersion = committedClosureReleaseVersion;
+        assertClosureDesktopIdentity(
+          await readDesktopIdentityMarker(),
+          expectedStandaloneVersion,
+          expectedClosureReleaseVersion,
+        );
+      }
       const ptyInspect = await measureSmokeStep(timings, 'packaged PTY capability', async () =>
         runToolsPackJson<WinInspectResult>('inspect', [
           '--expr',
@@ -708,8 +726,8 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(pty.exitCode, JSON.stringify(pty, null, 2)).toBe(0);
       expect(pty.cleanup.terminalStatus).toBe(200);
       expect(pty.cleanup.projectStatus).toBe(200);
-      assertLauncherPointer(inspect.launcher.active, updateScenario.expectedCurrentVersion, 0, 'initial active');
-      assertLauncherPointer(inspect.launcher.lastSuccessful, updateScenario.expectedCurrentVersion, 0, 'initial lastSuccessful');
+      assertLauncherPointer(inspect.launcher.active, updateScenario.expectedInstalledShellVersion, 0, 'initial active');
+      assertLauncherPointer(inspect.launcher.lastSuccessful, updateScenario.expectedInstalledShellVersion, 0, 'initial lastSuccessful');
 
       // The seed's postcondition, asserted where it must hold: this process was
       // started by `tools-pack win start`, which points the packaged runtime at
@@ -774,13 +792,14 @@ winDescribe('packaged windows runtime smoke', () => {
         // protocol handler, and that cold start carries none of this process's
         // environment — so it is a different daemon, and only it can say what
         // config the surface being asserted on is actually running under.
-        // Phase 2 — the completed user. The seed must have been confirmed before
-        // this point; anything else means the run never established the fact
-        // this phase depends on.
+        // Phase 2 — the completed user's persisted data plus the current
+        // identity surface. The seed must have been confirmed before this
+        // point; Cloud sign-out may still render the identity gate, which is a
+        // separate product fact from onboarding completion.
         if (seededOnboardingCompleted !== true) {
           throw new Error('reached the completed-user app-shell check without a confirmed seeded onboarding state');
         }
-        const completedUser = await measureSmokeStep(timings, 'ensure completed-user app shell', async () =>
+        const completedUser = await measureSmokeStep(timings, 'ensure completed-user identity surface', async () =>
           runPackagedAppShellPhase({
             coreProfile: verifyCoreOnly,
             describeLast: formatUnknown,
@@ -791,7 +810,7 @@ winDescribe('packaged windows runtime smoke', () => {
         );
         onboardingCompleted = completedUser.onboardingCompleted;
         appShell = completedUser.appShell;
-        expect(appShell).toBe('home');
+        expect(['home', 'onboarding-landing']).toContain(appShell);
 
         if (verifyUpgradePersistence) {
           const seedInspect = await measureSmokeStep(timings, 'seed pre-update persistence project', async () =>
@@ -816,12 +835,15 @@ winDescribe('packaged windows runtime smoke', () => {
         payloadUpdate = await measureSmokeStep(timings, `${updateFixtureMode} update acceptance`, async () =>
           updateFixtureMode === 'installer'
             ? runInstallerFallbackAcceptance({
+                expectedStandaloneVersion,
                 expectedVersion: expectedPayloadUpdateVersion,
                 fixture: payloadFixture,
                 installDir: install.installDir,
                 persistedProjectId,
               })
             : runPayloadUpdateAcceptance({
+                expectedClosureReleaseVersion,
+                expectedStandaloneVersion,
                 expectedVersion: expectedPayloadUpdateVersion,
                 ...(intermediateUpdateFixture == null
                   ? {}
@@ -861,12 +883,14 @@ winDescribe('packaged windows runtime smoke', () => {
           start = await startDesktop('restart with target update fixture');
           expect(start.source).toBe('installed');
           await measureSmokeStep(timings, 'wait healthy after target fixture restart', async () =>
-            waitForHealthyDesktopVersion(intermediateVersion, intermediateIdentityPid),
+            waitForHealthyDesktopShellVersion(intermediateVersion, expectedStandaloneVersion, intermediateIdentityPid),
           );
           expectedPayloadUpdateVersion = targetVersion;
           payloadUpdate = await measureSmokeStep(timings, 'target payload update acceptance', async () =>
             runPayloadUpdateAcceptance({
+              expectedClosureReleaseVersion,
               expectedCurrentVersion: intermediateVersion,
+              expectedStandaloneVersion,
               expectedVersion: targetVersion,
               persistedProjectId,
             }),
@@ -903,7 +927,8 @@ winDescribe('packaged windows runtime smoke', () => {
           const recoveryTargetVersion = expectedPayloadUpdateVersion;
           updaterRecovery = await measureSmokeStep(timings, 'same-version reinstall and clear-cache recovery', async () =>
             runSameVersionUpdaterRecoveryAcceptance({
-              expectedInstalledVersion: updateScenario.expectedCurrentVersion,
+              expectedInstalledVersion: updateScenario.expectedInstalledShellVersion,
+              expectedStandaloneVersion,
               fixture: recoveryFixture,
               installDir: install.installDir,
               persistedProjectId,
@@ -912,31 +937,6 @@ winDescribe('packaged windows runtime smoke', () => {
           );
           postUpdateHealth = updaterRecovery.installer.health;
         }
-      }
-
-      if (verifyReinstallWhileRunning && verifyCoreOnly) {
-        reinstall = await measureSmokeStep(timings, 'direct reinstall while running', async () =>
-          runDirectInstaller(install.installerPath, install.installDir),
-        );
-        started = false;
-        expect(reinstall.code).toBe(0);
-        assertWorkingWinInstallerOverwriteLog(reinstall.nsisLogTail);
-        expect(reinstall.nsisLogTail.join('\n')).toContain('running instances detected before silent install');
-        expect(reinstall.nsisLogTail.join('\n')).toMatch(/running instances close via (?:pwsh|powershell)\.exe exit=0/);
-
-        start = await measureSmokeStep(timings, 'restart after direct reinstall', async () =>
-          runToolsPackJson<WinStartResult>('start'),
-        );
-        started = true;
-        expect(start.namespace).toBe(namespace);
-        expect(start.source).toBe('installed');
-        expectPathInside(start.executablePath, install.installDir);
-
-        const postReinstallInspect = await measureSmokeStep(timings, 'wait healthy inspect after reinstall', async () =>
-          waitForHealthyDesktop(),
-        );
-        expect(postReinstallInspect.status?.state).toBe('running');
-        expectWindowsPackagedAppUrl(postReinstallInspect.status?.url);
       }
 
       if (!inspect.desktopIpcUnavailable) {
@@ -960,6 +960,12 @@ winDescribe('packaged windows runtime smoke', () => {
         expect(stop.remainingPids).toEqual([]);
       }
 
+      // Bind the public acceptance proof to the exact Closure committed by
+      // the installed Shell before uninstall removes the namespace state.
+      // Local release smoke records the same fact, so this is evidence rather
+      // than a workflow-only behavior branch.
+      const closureBinding = await readPackagedClosureBinding();
+
       const uninstall = await measureSmokeStep(timings, 'uninstall remove data', async () =>
         runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']),
       );
@@ -976,6 +982,7 @@ winDescribe('packaged windows runtime smoke', () => {
       await assertWindowsInviteProtocolRemoved();
       await report.saveSummary({
         appShell,
+        closureBinding,
         onboarding: {
           afterSeed: seededOnboardingCompleted,
           atAppShell: onboardingCompleted,
@@ -1000,7 +1007,6 @@ winDescribe('packaged windows runtime smoke', () => {
         payloadUpdate,
         pty,
         updaterRecovery,
-        reinstall,
         screenshot: inspect.desktopIpcUnavailable ? null : report.screenshotRelpath,
         screenshots: inspect.desktopIpcUnavailable
           ? { afterUpdate: null, beforeUpdate: null }
@@ -1062,7 +1068,7 @@ winDescribe('packaged windows runtime smoke', () => {
   // without any user-facing updater action.
   const silentUpdateTest =
     !verifyCoreOnly && updateFixture === 'tools-serve' && updateFixtureMode === 'payload' ? test : test.skip;
-  silentUpdateTest('applies a downloaded payload silently on the next cold start', async () => {
+  silentUpdateTest(WIN_PACKAGED_SMOKE_SCENARIOS.shellSilentUpdate.title, async () => {
     const updateEnv = captureUpdateEnv();
     let payloadFixtureLocal: ToolsServeUpdaterFixture | null = null;
     let cleanupStarted = false;
@@ -1118,7 +1124,11 @@ winDescribe('packaged windows runtime smoke', () => {
       const coldStart = await runToolsPackJson<WinStartResult>('start');
       cleanupStarted = true;
       expect(coldStart.source).toBe('installed');
-      const silent = await waitForHealthyDesktopVersion(targetVersion, start.pid);
+      const silent = await waitForHealthyDesktopShellVersion(
+        targetVersion,
+        updateScenario.expectedCurrentVersion,
+        start.pid,
+      );
       expect(settledLauncherGeneration(silent.launcher, targetVersion)).not.toBeNull();
       expect(silent.launcher.active?.version).toBe(targetVersion);
       expect(silent.launcher.lastSuccessful?.version).toBe(targetVersion);
@@ -1150,7 +1160,7 @@ winDescribe('packaged windows runtime smoke', () => {
   // version, and a version-bumped healthy release self-heals.
   const rollbackTest =
     !verifyCoreOnly && updateFixture === 'tools-serve' && updateFixtureMode === 'payload' ? test : test.skip;
-  rollbackTest('rolls back a crashing payload and self-heals on the next good update', async () => {
+  rollbackTest(WIN_PACKAGED_SMOKE_SCENARIOS.shellRollback.title, async () => {
     const updateEnv = captureUpdateEnv();
     let corruptFixture: ToolsServeUpdaterFixture | null = null;
     let goodFixture: ToolsServeUpdaterFixture | null = null;
@@ -1193,10 +1203,9 @@ winDescribe('packaged windows runtime smoke', () => {
       const launcherRuntimePath = readyUpdate.launcher.runtimePath;
       const launcherAttemptsPath = readyUpdate.launcher.attemptsPath;
 
-      const popup = await openReadyUpdaterPrompt(targetVersion);
-      expect(popup.installButtonVisible).toBe(true);
-      const clickInstall = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterInstallExpression]);
-      expect(assertUpdaterClickEvalValue(clickInstall.eval?.value).clicked).toBe(true);
+      const installControl = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'install']);
+      expect(installControl.update?.state).toBe('downloaded');
+      expect(installControl.update?.installResult?.dryRun).toBe(false);
 
       // The app quits for the relaunch; the corrupted payload stub then exits
       // before any launcher bookkeeping. Wait for the desktop to disappear.
@@ -1214,7 +1223,7 @@ winDescribe('packaged windows runtime smoke', () => {
         lastSuccessful?: { generation?: number; version?: string };
       };
       expect(strandedRuntime.active?.version).toBe(targetVersion);
-      expect(strandedRuntime.lastSuccessful?.version).toBe(updateScenario.expectedCurrentVersion);
+      expect(strandedRuntime.lastSuccessful?.version).toBe(updateScenario.expectedInstalledShellVersion);
       expect(strandedAttempt.generation).toBe(strandedRuntime.active?.generation);
 
       // Cold start rolls back: the installed outer sees the unconfirmed
@@ -1222,8 +1231,13 @@ winDescribe('packaged windows runtime smoke', () => {
       const rollbackStart = await runToolsPackJson<WinStartResult>('start');
       cleanupStarted = true;
       expect(rollbackStart.source).toBe('installed');
-      const rolledBack = await waitForHealthyDesktopVersion(updateScenario.expectedCurrentVersion, start.pid, false);
-      expect(rolledBack.launcher.lastSuccessful?.version).toBe(updateScenario.expectedCurrentVersion);
+      const rolledBack = await waitForHealthyDesktopShellVersion(
+        updateScenario.expectedInstalledShellVersion,
+        updateScenario.expectedCurrentVersion,
+        start.pid,
+        false,
+      );
+      expect(rolledBack.launcher.lastSuccessful?.version).toBe(updateScenario.expectedInstalledShellVersion);
       // Degraded steady state: the broken pointer stays active with its
       // attempt as evidence until a healthy release replaces it.
       expect(rolledBack.launcher.active?.version).toBe(targetVersion);
@@ -1256,11 +1270,15 @@ winDescribe('packaged windows runtime smoke', () => {
       const healStart = await runToolsPackJson<WinStartResult>('start');
       cleanupStarted = true;
       expect(healStart.source).toBe('installed');
-      await waitForDownloadedUpdater(healedVersion, 'payload', 120_000, updateScenario.expectedCurrentVersion);
-      await openReadyUpdaterPrompt(healedVersion);
-      const healClick = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterInstallExpression]);
-      expect(assertUpdaterClickEvalValue(healClick.eval?.value).clicked).toBe(true);
-      const healed = await waitForHealthyDesktopVersion(healedVersion, rollbackStart.pid);
+      await waitForDownloadedUpdater(healedVersion, 'payload', 120_000, updateScenario.expectedInstalledShellVersion);
+      const healControl = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'install']);
+      expect(healControl.update?.state).toBe('downloaded');
+      expect(healControl.update?.installResult?.dryRun).toBe(false);
+      const healed = await waitForHealthyDesktopShellVersion(
+        healedVersion,
+        updateScenario.expectedCurrentVersion,
+        rollbackStart.pid,
+      );
       expect(settledLauncherGeneration(healed.launcher, healedVersion)).not.toBeNull();
       expect(healed.launcher.active?.version).toBe(healedVersion);
       expect(healed.launcher.lastSuccessful?.version).toBe(healedVersion);
@@ -1289,7 +1307,7 @@ winDescribe('packaged windows runtime smoke', () => {
 });
 
 winClosureDescribe('packaged Windows Standalone Closure release acceptance', () => {
-  test('[P0] attaches a release Closure across cold start and reinstall, then rolls a damaged successor back', async () => {
+  test(WIN_PACKAGED_SMOKE_SCENARIOS.standaloneClosure.title, async () => {
     const installationRoot = join(toolsPackDir, 'runtime', 'win');
     let installed = false;
     let started = false;
@@ -1333,7 +1351,19 @@ winClosureDescribe('packaged Windows Standalone Closure release acceptance', () 
       started = false;
       expect(faultStop.remainingPids).toEqual([]);
       const broken = await activateBrokenClosureSuccessor(fixture);
-      await expect(runToolsPackJson<WinStartResult>('start')).rejects.toThrow(/Standalone|standalone/u);
+      // Windows `tools-pack start` has a bounded best-effort status probe and
+      // returns `status:null` when the spawned app exits during that window;
+      // unlike the macOS launch command it does not surface the child exit as
+      // a rejected command. Prove the actual fail-closed postconditions: no
+      // healthy desktop, no identity confirmation, an exited process, and the
+      // immutable-verification failure in the Shell log.
+      const brokenStart = await runToolsPackJson<WinStartResult>('start');
+      expect(brokenStart.status).toBeNull();
+      await waitForDesktopGone('damaged Closure never became the desktop');
+      await expect(readDesktopIdentityMarker()).rejects.toThrow();
+      const brokenDesktopLog = await readFile(join(runtimeNamespaceRoot, 'logs', 'desktop', 'latest.log'), 'utf8');
+      expect(brokenDesktopLog).toContain('Committed Standalone failed immutable Store verification');
+      expect(brokenDesktopLog).toContain('"code":1');
       expect((await readPackagedClosureFixtureRuntime(fixture)).committed?.standalone).toEqual(broken.pointer);
 
       await resetPackagedClosureFixture({
@@ -1356,6 +1386,159 @@ winClosureDescribe('packaged Windows Standalone Closure release acceptance', () 
       expect((await readPackagedClosureFixtureRuntime(recovered)).committed?.standalone).toEqual(recovered.pointer);
     } finally {
       if (started) await runToolsPackJson<WinStopResult>('stop').catch(() => undefined);
+      if (installed) {
+        await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => undefined);
+      }
+      await resetPackagedClosureFixture({
+        channel: updateScenario.channel,
+        installationRoot,
+        namespace,
+      }).catch(() => undefined);
+    }
+  }, 720_000);
+});
+
+winLegacyMigrationDescribe('packaged Windows historical outer migration acceptance', () => {
+  test(WIN_PACKAGED_SMOKE_SCENARIOS.legacyMigration.title, async () => {
+    const report = await createPackagedSmokeReport('win');
+    const updateEnv = captureUpdateEnv();
+    const legacyFixturePath = requireMigrationInput(
+      'OD_PACKAGED_E2E_WIN_LEGACY_INSTALLER_PATH',
+      legacyInstallerPath,
+    );
+    const legacyFixtureVersion = requireMigrationInput(
+      'OD_PACKAGED_E2E_WIN_LEGACY_VERSION',
+      legacyVersion,
+    );
+    const requiredShellVersion = requireMigrationInput(
+      'OD_PACKAGED_E2E_WIN_MIN_SHELL_VERSION',
+      minimumShellVersion,
+    );
+    const targetReleaseVersion = requireMigrationInput(
+      'OD_PACKAGED_E2E_RELEASE_VERSION',
+      releaseVersion,
+    );
+    const buildJsonPath = requireMigrationInput(
+      'OD_PACKAGED_E2E_CLOSURE_BUILD_JSON_PATH',
+      closureBuildJsonPath,
+    );
+    const installationRoot = join(toolsPackDir, 'runtime', 'win');
+    const installDir = join(runtimeNamespaceRoot, 'install', 'Open Design');
+    let installed = false;
+    let started = false;
+    let migrationFixture: ToolsServeUpdaterFixture | null = null;
+
+    try {
+      await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => null);
+      await resetPackagedUpdaterNamespaceRoots();
+      await resetPackagedClosureFixture({
+        channel: updateScenario.channel,
+        installationRoot,
+        namespace,
+      });
+
+      const legacyInstall = await runDirectInstaller(resolveFromWorkspace(legacyFixturePath), installDir);
+      expect(legacyInstall.code).toBe(0);
+      installed = true;
+      expect(await fileSizeBytes(join(installDir, 'Open Design.exe'))).toBeGreaterThan(0);
+      await seedPackagedOnboardingComplete();
+
+      const currentInstallerPath = await resolveMainBuildInstallerPath();
+      const closureBuild = await readPackagedClosureBuildFixture({
+        buildJsonPath,
+        channel: updateScenario.channel,
+        expectedPlatform: 'win32-x64',
+        workspaceRoot,
+      });
+      migrationFixture = await startToolsServeUpdaterFixture({
+        artifactPath: currentInstallerPath,
+        channel: updateScenario.channel,
+        closureManifestPath: closureBuild.manifestPath,
+        controlLauncherVersionMin: requiredShellVersion,
+        controlLauncherVersionUrl: 'https://open-design.ai/download',
+        platform: 'win',
+        rebaseClosureUrl: true,
+        version: targetReleaseVersion,
+        workspaceRoot,
+      });
+      applyPackagedUpdateEnv(
+        process.env,
+        resolvePackagedUpdateScenario({
+          releaseChannel: updateScenario.channel,
+          releaseVersion: legacyFixtureVersion,
+          shellVersion: legacyFixtureVersion,
+        }),
+        migrationFixture.info.metadataUrl,
+      );
+
+      const legacyStart = await runToolsPackJsonForVersion<WinStartResult>('start', legacyFixtureVersion);
+      started = true;
+      expect(legacyStart.source).toBe('installed');
+      const legacyInspect = await waitForHealthyDesktopVersion(legacyFixtureVersion, null, false);
+      const legacyHealth = assertHealthEvalValue(legacyInspect.eval?.value);
+      expect(legacyHealth.health.version).toBe(legacyFixtureVersion);
+      const seedInspect = await runToolsPackJsonForVersion<WinInspectResult>(
+        'inspect',
+        legacyFixtureVersion,
+        ['--expr', upgradePersistenceSeedExpression],
+      );
+      if (seedInspect.eval?.ok !== true) {
+        throw new Error(`legacy Windows project seed eval failed: ${formatUnknown(seedInspect)}`);
+      }
+      const seeded = assertUpgradePersistenceSeed(seedInspect.eval.value);
+
+      const migration = await runInstallerFallbackAcceptance({
+        expectedCurrentVersion: legacyFixtureVersion,
+        expectedVersion: targetReleaseVersion,
+        fixture: migrationFixture,
+        installDir,
+        persistedProjectId: seeded.projectId,
+      });
+      expect(migration.downloaded.reinstall).toEqual({
+        installedVersion: legacyFixtureVersion,
+        minVersion: requiredShellVersion,
+        reason: 'outer-below-min',
+        url: 'https://open-design.ai/download',
+      });
+      expect(migration.coldStart.start.pid).not.toBe(legacyStart.pid);
+      await assertWindowsInviteProtocolRegistration(installDir);
+
+      const committedClosure = await readCommittedPackagedClosureFixture({
+        buildJsonPath,
+        channel: updateScenario.channel,
+        expectedPlatform: 'win32-x64',
+        installationRoot,
+        namespace,
+        workspaceRoot,
+      });
+      assertClosureDesktopIdentity(
+        await readDesktopIdentityMarker(),
+        committedClosure.manifest.identity.version,
+      );
+      const coldPptx = assertPptxExportEvalValue((await runToolsPackJson<WinInspectResult>(
+        'inspect',
+        ['--expr', existingProjectPptxExportExpression(seeded.projectId)],
+      )).eval?.value);
+      expect(coldPptx.projectId).toBe(seeded.projectId);
+
+      await report.report.json('historical-outer-migration.json', {
+        closure: committedClosure.pointer,
+        coldPptx,
+        legacyHealth,
+        migration,
+        versions: {
+          legacy: legacyFixtureVersion,
+          minimumShell: requiredShellVersion,
+          release: targetReleaseVersion,
+        },
+      });
+    } finally {
+      restoreUpdateEnv(updateEnv);
+      await migrationFixture?.close().catch(() => undefined);
+      if (started) {
+        await runToolsPackJson<WinStopResult>('stop').catch(() => undefined);
+        await runToolsPackJsonForVersion<WinStopResult>('stop', legacyVersion).catch(() => undefined);
+      }
       if (installed) {
         await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => undefined);
       }
@@ -1529,8 +1712,8 @@ type PayloadUpdateSummary = {
   downloaded: NonNullable<WinInspectResult['update']>;
   health: HealthEvalValue;
   identity: DesktopIdentityMarker;
+  installControl: NonNullable<WinInspectResult['update']>;
   launcherAfterConfirm: LauncherSnapshot;
-  popup: UpdaterPopupEvalValue;
   pptx: PptxExportEvalValue | { skipped: true };
   terminal: NonNullable<WinInspectResult['update']>;
   targetVersion: string;
@@ -1556,12 +1739,12 @@ type UpdaterRecoverySummary = {
   cleared: NonNullable<WinInspectResult['update']>;
   downloadedBeforeClear: NonNullable<WinInspectResult['update']>;
   installer: InstallerFallbackSummary;
-  popup: UpdaterPopupEvalValue;
   terminal: NonNullable<WinInspectResult['update']>;
 };
 
 async function runSameVersionUpdaterRecoveryAcceptance(options: {
   expectedInstalledVersion: string;
+  expectedStandaloneVersion: string;
   fixture: ToolsServeUpdaterFixture;
   installDir: string;
   persistedProjectId: string | null;
@@ -1572,7 +1755,11 @@ async function runSameVersionUpdaterRecoveryAcceptance(options: {
   expect(stop.remainingPids).toEqual([]);
   const start = await runToolsPackJson<WinStartResult>('start');
   expect(start.source).toBe('installed');
-  const running = await waitForHealthyDesktopVersion(options.targetVersion, null);
+  const running = await waitForHealthyDesktopShellVersion(
+    options.targetVersion,
+    options.expectedStandaloneVersion,
+    null,
+  );
 
   const downloadedInspect = await waitForDownloadedUpdater(
     options.targetVersion,
@@ -1591,11 +1778,6 @@ async function runSameVersionUpdaterRecoveryAcceptance(options: {
   });
   expect(downloadedInspect.status?.pid).toBe(running.status?.pid);
 
-  const popup = await openReadyUpdaterPrompt(options.targetVersion);
-  expect(popup.visible).toBe(true);
-  expect(popup.installButtonVisible).toBe(true);
-  expect(popup.reinstallLinkVisible).toBe(true);
-
   const clearedInspect = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'clear-cache']);
   if (clearedInspect.update == null) throw new Error('clear-cache did not return updater status');
   expect(clearedInspect.update.state).toBe('idle');
@@ -1607,6 +1789,7 @@ async function runSameVersionUpdaterRecoveryAcceptance(options: {
 
   const installer = await runInstallerFallbackAcceptance({
     expectedCurrentVersion: options.targetVersion,
+    expectedStandaloneVersion: options.expectedStandaloneVersion,
     expectedVersion: options.targetVersion,
     fixture: options.fixture,
     installDir: options.installDir,
@@ -1625,13 +1808,14 @@ async function runSameVersionUpdaterRecoveryAcceptance(options: {
     cleared: clearedInspect.update,
     downloadedBeforeClear: downloadedInspect.update,
     installer,
-    popup,
     terminal: terminalInspect.update,
   };
 }
 
 async function runPayloadUpdateAcceptance(options: {
+  expectedClosureReleaseVersion: string;
   expectedCurrentVersion?: string;
+  expectedStandaloneVersion: string;
   expectedVersion: string | null;
   legacyInstalledExecutablePath?: string;
   persistedProjectId: string | null;
@@ -1651,25 +1835,28 @@ async function runPayloadUpdateAcceptance(options: {
   expect(downloadedInspect.update.artifact?.type).toBe('payload');
   expectPathInside(downloadedInspect.update.downloadPath ?? '', join(runtimeNamespaceRoot, 'updates'));
 
-  const popup = await openReadyUpdaterPrompt(targetVersion);
-  expect(popup.visible).toBe(true);
-  expect(popup.installButtonVisible).toBe(true);
-  expect(popup.text ?? '').toContain(targetVersion);
-  expect(popup.text ?? '').not.toMatch(/installer|安装器/i);
-
   const previousPid = downloadedInspect.status?.pid;
-  const clickInstall = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterInstallExpression]);
-  const clickValue = assertUpdaterClickEvalValue(clickInstall.eval?.value);
-  expect(clickValue.clicked).toBe(true);
+  // The updater belongs to the immutable Electron Shell. Exercise its IPC
+  // capability directly so Cloud identity state and the selected Closure route
+  // cannot become prerequisites for a Shell update.
+  const installInspect = await runToolsPackJson<WinInspectResult>('inspect', ['--update-action', 'install']);
+  if (installInspect.update == null) throw new Error('payload update install control result is missing');
+  expect(installInspect.update.state).toBe('downloaded');
+  expect(installInspect.update.installResult?.dryRun).toBe(false);
 
-  const postUpdateInspect = await waitForHealthyDesktopVersion(targetVersion, previousPid);
+  const postUpdateInspect = await waitForHealthyDesktopShellVersion(
+    targetVersion,
+    options.expectedStandaloneVersion,
+    previousPid,
+  );
   expect(postUpdateInspect.status?.state).toBe('running');
   expectWindowsPackagedAppUrl(postUpdateInspect.status?.url);
   const health = assertHealthEvalValue(postUpdateInspect.eval?.value);
-  expectWindowsPackagedAppUrl(health.href);
+  expectWindowsHealthyRendererUrl(health.href);
   expect(health.status).toBe(200);
   expect(health.health.ok).toBe(true);
-  expect(health.health.version).toBe(targetVersion);
+  expect(health.health.version).toBe(options.expectedStandaloneVersion);
+  expect(packagedOnboardingCompletedFromProbe(await readPackagedOnboardingConfig())).toBe(true);
   const confirmedGeneration = settledLauncherGeneration(postUpdateInspect.launcher, targetVersion);
   if (confirmedGeneration == null) throw new Error('post-update launcher did not settle on the target version');
   assertLauncherPointer(postUpdateInspect.launcher.active, targetVersion, confirmedGeneration, 'post-relaunch active');
@@ -1682,10 +1869,18 @@ async function runPayloadUpdateAcceptance(options: {
   expect(postUpdateInspect.launcher.attempt).toBeNull();
   assertSettledDesktopHandoff(postUpdateInspect.launcher.handoff);
   const identity = await readDesktopIdentityMarker();
+  expect(identity.stamp).toMatchObject({
+    app: 'desktop',
+    mode: 'runtime',
+    namespace,
+    source: 'packaged',
+  });
   await assertPayloadDesktopIdentity(
     identity,
     postUpdateInspect.launcher,
     targetVersion,
+    options.expectedStandaloneVersion,
+    options.expectedClosureReleaseVersion,
     options.legacyInstalledExecutablePath,
   );
 
@@ -1706,12 +1901,17 @@ async function runPayloadUpdateAcceptance(options: {
   expect(stop.remainingPids).toEqual([]);
   const start = await runToolsPackJson<WinStartResult>('start');
   expect(start.source).toBe('installed');
-  const coldInspect = await waitForHealthyDesktopVersion(targetVersion, identity.pid);
+  const coldInspect = await waitForHealthyDesktopShellVersion(
+    targetVersion,
+    options.expectedStandaloneVersion,
+    identity.pid,
+  );
   const coldHealth = assertHealthEvalValue(coldInspect.eval?.value);
-  expectWindowsPackagedAppUrl(coldHealth.href);
+  expectWindowsHealthyRendererUrl(coldHealth.href);
   expect(coldHealth.status).toBe(200);
   expect(coldHealth.health.ok).toBe(true);
-  expect(coldHealth.health.version).toBe(targetVersion);
+  expect(coldHealth.health.version).toBe(options.expectedStandaloneVersion);
+  expect(packagedOnboardingCompletedFromProbe(await readPackagedOnboardingConfig())).toBe(true);
   const coldGeneration = settledLauncherGeneration(coldInspect.launcher, targetVersion);
   if (coldGeneration == null) throw new Error('cold-start launcher did not settle on the target version');
   expect(coldGeneration).toBeGreaterThanOrEqual(confirmedGeneration);
@@ -1725,10 +1925,18 @@ async function runPayloadUpdateAcceptance(options: {
   expect(coldInspect.launcher.attempt).toBeNull();
   assertSettledDesktopHandoff(coldInspect.launcher.handoff);
   const coldIdentity = await readDesktopIdentityMarker();
+  expect(coldIdentity.stamp).toMatchObject({
+    app: 'desktop',
+    mode: 'runtime',
+    namespace,
+    source: 'tools-pack',
+  });
   await assertPayloadDesktopIdentity(
     coldIdentity,
     coldInspect.launcher,
     targetVersion,
+    options.expectedStandaloneVersion,
+    options.expectedClosureReleaseVersion,
     options.legacyInstalledExecutablePath,
   );
   expect(coldIdentity.pid).not.toBe(identity.pid);
@@ -1743,8 +1951,8 @@ async function runPayloadUpdateAcceptance(options: {
     downloaded: downloadedInspect.update,
     health,
     identity,
+    installControl: installInspect.update,
     launcherAfterConfirm: postUpdateInspect.launcher,
-    popup,
     pptx,
     terminal: terminal.update,
     targetVersion,
@@ -1753,6 +1961,7 @@ async function runPayloadUpdateAcceptance(options: {
 
 async function runInstallerFallbackAcceptance(options: {
   expectedCurrentVersion?: string;
+  expectedStandaloneVersion?: string;
   expectedVersion: string | null;
   fixture: ToolsServeUpdaterFixture | null;
   installDir: string;
@@ -1793,11 +2002,17 @@ async function runInstallerFallbackAcceptance(options: {
   // desktop while replacing the physical outer. Verify continuity here; the
   // explicit full stop + installed-outer cold start below owns the stronger
   // process-generation assertion.
-  const postInstallInspect = await waitForHealthyDesktopVersion(targetVersion, null, false);
+  const standaloneVersion = options.expectedStandaloneVersion ?? targetVersion;
+  const postInstallInspect = await waitForHealthyDesktopShellVersion(
+    targetVersion,
+    standaloneVersion,
+    null,
+    false,
+  );
   const health = assertHealthEvalValue(postInstallInspect.eval?.value);
   expect(health.status).toBe(200);
   expect(health.health.ok).toBe(true);
-  expect(health.health.version).toBe(targetVersion);
+  expect(health.health.version).toBe(standaloneVersion);
 
   const list = await runToolsPackJsonForVersion<WinListResult>('list', targetVersion);
   expect(list.current.installedExeExists).toBe(true);
@@ -1820,11 +2035,16 @@ async function runInstallerFallbackAcceptance(options: {
   expect(stop.status).not.toBe('partial');
   expect(stop.remainingPids).toEqual([]);
   const coldStart = await runToolsPackJsonForVersion<WinStartResult>('start', targetVersion);
-  const coldInspect = await waitForHealthyDesktopVersion(targetVersion, postInstallInspect.status?.pid, false);
+  const coldInspect = await waitForHealthyDesktopShellVersion(
+    targetVersion,
+    standaloneVersion,
+    postInstallInspect.status?.pid,
+    false,
+  );
   const coldHealth = assertHealthEvalValue(coldInspect.eval?.value);
   expect(coldHealth.status).toBe(200);
   expect(coldHealth.health.ok).toBe(true);
-  expect(coldHealth.health.version).toBe(targetVersion);
+  expect(coldHealth.health.version).toBe(standaloneVersion);
   return {
     coldStart: { health: coldHealth, start: coldStart, stop },
     downloaded: downloadedInspect.update,
@@ -1885,10 +2105,10 @@ async function runToolsPackJsonForVersion<T>(
 }
 
 function assertWorkingWinInstallerOverwriteLog(lines: string[]): void {
-  // #6008 deliberately restored this working replace flow after the
-  // transactional installer failed fresh installs. Keep the full release
-  // smoke aligned with the generated installer until a transactional redesign
-  // lands together with real installer coverage.
+  // The custom installer stages and validates the successor before moving the
+  // old install aside, then rolls back both filesystem and launcher state on
+  // any failure. Keep real packaged smoke aligned with those transaction
+  // boundaries instead of accepting a successful process exit alone.
   expect(missingWorkingWinInstallerOverwriteMarkers(lines)).toEqual([]);
 }
 
@@ -1908,7 +2128,7 @@ async function runDirectInstaller(
             '-ExecutionPolicy',
             'Bypass',
             '-Command',
-            "& { $process = Start-Process -FilePath $env:OD_TEST_INSTALLER_PATH -ArgumentList '/S', $env:OD_TEST_INSTALL_DIR_ARG -Wait -PassThru; exit $process.ExitCode }",
+            "& { $process = Start-Process -FilePath $env:OD_TEST_INSTALLER_PATH -ArgumentList '/S', $env:OD_TEST_INSTALL_DIR_ARG -Wait -PassThru -WindowStyle Hidden; exit $process.ExitCode }",
           ],
           {
             cwd: dirname(installerPath),
@@ -1978,11 +2198,25 @@ async function resolveLocalUpdateFixture(
   };
 }
 
+async function resolveMainBuildInstallerPath(): Promise<string> {
+  const buildJsonPath = requireMigrationInput(
+    'OD_PACKAGED_E2E_BUILD_JSON_PATH',
+    normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_BUILD_JSON_PATH),
+  );
+  const build = JSON.parse(stripUtf8Bom(await readFile(resolveFromWorkspace(buildJsonPath), 'utf8'))) as {
+    installerPath?: unknown;
+  };
+  if (typeof build.installerPath !== 'string' || build.installerPath.length === 0) {
+    throw new Error(`Windows build metadata missing installerPath: ${buildJsonPath}`);
+  }
+  return resolveFromWorkspace(build.installerPath);
+}
+
 async function waitForDownloadedUpdater(
   expectedVersion: string | null,
   expectedArtifactType: UpdateFixtureMode,
   timeoutMs = 120_000,
-  expectedCurrentVersion = updateScenario.expectedCurrentVersion,
+  expectedCurrentVersion = updateScenario.expectedInstalledShellVersion,
 ): Promise<WinInspectResult> {
   const startedAt = Date.now();
   let lastResult: unknown = null;
@@ -2135,6 +2369,24 @@ async function waitForHealthyDesktop(): Promise<WinInspectResult> {
   throw new Error(`packaged windows runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
+async function waitForCommittedPackagedClosureFixture(
+  input: Parameters<typeof readCommittedPackagedClosureFixture>[0],
+): Promise<PackagedClosureFixture> {
+  const startedAt = Date.now();
+  let lastError: unknown = null;
+
+  while (Date.now() - startedAt < maxStartDurationMs) {
+    try {
+      return await readCommittedPackagedClosureFixture(input);
+    } catch (error) {
+      lastError = error;
+      await delay(1000);
+    }
+  }
+
+  throw new Error(`packaged windows runtime did not commit Closure: ${formatUnknown(lastError)}`);
+}
+
 async function maybeCoreHealthFallback(inspect: WinInspectResult): Promise<WinInspectResult | null> {
   if (!verifyCoreOnly) return null;
   if (inspect.status != null) return null;
@@ -2222,7 +2474,21 @@ async function waitForHealthyDesktopVersion(
   previousPid: number | null | undefined,
   requireSettledLauncher = true,
 ): Promise<WinInspectResult> {
-  const timeoutMs = 120_000;
+  return await waitForHealthyDesktopShellVersion(
+    expectedVersion,
+    expectedVersion,
+    previousPid,
+    requireSettledLauncher,
+  );
+}
+
+async function waitForHealthyDesktopShellVersion(
+  expectedShellVersion: string,
+  expectedStandaloneVersion: string,
+  previousPid: number | null | undefined,
+  requireSettledLauncher = true,
+): Promise<WinInspectResult> {
+  const timeoutMs = maxStartDurationMs;
   const startedAt = Date.now();
   let lastResult: unknown = null;
 
@@ -2249,9 +2515,9 @@ async function waitForHealthyDesktopVersion(
         if (
           value?.status === 200 &&
           value.health.ok === true &&
-          value.health.version === expectedVersion &&
+          value.health.version === expectedStandaloneVersion &&
           (previousPid == null || inspect.status?.pid !== previousPid) &&
-          (!requireSettledLauncher || settledLauncherGeneration(inspect.launcher, expectedVersion) != null)
+          (!requireSettledLauncher || settledLauncherGeneration(inspect.launcher, expectedShellVersion) != null)
         ) {
           return inspect;
         }
@@ -2262,7 +2528,9 @@ async function waitForHealthyDesktopVersion(
     await delay(1000);
   }
 
-  throw new Error(`packaged windows runtime did not relaunch healthy on ${expectedVersion}: ${formatUnknown(lastResult)}`);
+  throw new Error(
+    `packaged Windows Shell ${expectedShellVersion} did not relaunch with Standalone ${expectedStandaloneVersion}: ${formatUnknown(lastResult)}`,
+  );
 }
 
 async function waitForPackagedOnboarding(
@@ -2411,56 +2679,6 @@ async function waitForTerminalUpdateState(expectedVersion: string): Promise<WinI
   throw new Error(`packaged windows updater did not reach terminal no-update state: ${formatUnknown(lastResult)}`);
 }
 
-async function openReadyUpdaterPrompt(version: string): Promise<UpdaterPopupEvalValue> {
-  await clickUpdaterRailButton('open ready updater prompt');
-  return await waitForUpdaterPopupMatching(
-    (popup) => popup.visible && popup.installButtonVisible && (popup.text ?? '').includes(version),
-    'ready updater prompt',
-  );
-}
-
-async function clickUpdaterRailButton(label: string, timeoutMs = 90_000): Promise<void> {
-  const startedAt = Date.now();
-  let lastResult: unknown = null;
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const click = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', clickUpdaterRailExpression]);
-      const value = assertUpdaterClickEvalValue(click.eval?.value);
-      lastResult = value;
-      if (value.clicked) return;
-    } catch (error) {
-      lastResult = error;
-    }
-    await delay(750);
-  }
-  throw new Error(`${label}: updater rail did not become clickable: ${formatUnknown(lastResult)}`);
-}
-
-async function waitForUpdaterPopupMatching(
-  predicate: (value: UpdaterPopupEvalValue) => boolean,
-  label: string,
-  timeoutMs = 90_000,
-): Promise<UpdaterPopupEvalValue> {
-  const startedAt = Date.now();
-  let lastResult: unknown = null;
-
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', updaterPopupExpression]);
-      lastResult = inspect;
-      if (inspect.status?.state === 'running' && inspect.eval?.ok === true) {
-        const value = asUpdaterPopupEvalValue(inspect.eval.value);
-        if (value != null && predicate(value)) return value;
-      }
-    } catch (error) {
-      lastResult = error;
-    }
-    await delay(1000);
-  }
-
-  throw new Error(`${label}: updater popup timed out: ${formatUnknown(lastResult)}`);
-}
-
 function assertLogPathsAndContent(result: LogsResult): void {
   expect(result.namespace).toBe(namespace);
   for (const app of ['desktop', 'web', 'daemon']) {
@@ -2537,13 +2755,17 @@ async function readDesktopIdentityMarker(): Promise<DesktopIdentityMarker> {
   return value as DesktopIdentityMarker;
 }
 
-function assertClosureDesktopIdentity(identity: DesktopIdentityMarker, version: string): void {
-  if (identity.runtime?.descriptor?.standalone?.version !== version) {
+function assertClosureDesktopIdentity(
+  identity: DesktopIdentityMarker,
+  standaloneVersion: string,
+  releaseVersion: string = standaloneVersion,
+): void {
+  if (identity.runtime?.descriptor?.standalone?.version !== standaloneVersion) {
     throw new Error(`packaged Windows did not attach the seeded Closure: ${formatUnknown(identity.runtime)}`);
   }
   expect(identity.runtime.descriptor).toMatchObject({
-    release: { version },
-    standalone: { protocolVersion: 1, version },
+    release: { version: releaseVersion },
+    standalone: { protocolVersion: 1, version: standaloneVersion },
   });
   expect(identity.runtime.descriptor).not.toHaveProperty('shell');
   expect(identity.runtime.descriptor.standalone?.digest).toMatch(/^sha256:[a-f0-9]{64}$/);
@@ -2556,11 +2778,18 @@ function assertClosureDesktopIdentity(identity: DesktopIdentityMarker, version: 
 async function assertPayloadDesktopIdentity(
   identity: DesktopIdentityMarker,
   launcher: LauncherSnapshot,
-  version: string,
+  shellVersion: string,
+  standaloneVersion: string,
+  releaseVersion: string,
   legacyInstalledExecutablePath?: string,
 ): Promise<void> {
-  const payloadRoot = join(launcher.versionsRoot, version, 'payload');
+  const payloadRoot = join(launcher.versionsRoot, shellVersion, 'payload');
   expect(identity.pid).toBeGreaterThan(0);
+  expect(identity.runtime?.descriptor).toMatchObject({
+    release: { version: releaseVersion },
+    standalone: { protocolVersion: 1, version: standaloneVersion },
+  });
+  expect(identity.runtime?.descriptor).not.toHaveProperty('shell');
   if (isPathInside(identity.executablePath, payloadRoot)) return;
 
   if (legacyInstalledExecutablePath == null) {
@@ -2637,23 +2866,6 @@ function assertHealthEvalValue(value: unknown): HealthEvalValue {
   return normalized;
 }
 
-function assertUpdaterClickEvalValue(value: unknown): UpdaterClickEvalValue {
-  if (!isRecord(value) || typeof value.clicked !== 'boolean') {
-    throw new Error(`unexpected updater click eval value: ${formatUnknown(value)}`);
-  }
-  return value as UpdaterClickEvalValue;
-}
-
-function asUpdaterPopupEvalValue(value: unknown): UpdaterPopupEvalValue | null {
-  if (!isRecord(value)) return null;
-  if (typeof value.visible !== 'boolean') return null;
-  if (typeof value.installButtonVisible !== 'boolean') return null;
-  if (typeof value.reinstallLinkVisible !== 'boolean') return null;
-  if (value.text != null && typeof value.text !== 'string') return null;
-  if (value.title != null && typeof value.title !== 'string') return null;
-  return value as UpdaterPopupEvalValue;
-}
-
 function asHealthEvalValue(value: unknown): HealthEvalValue | null {
   if (!isRecord(value)) return null;
   if (typeof value.href !== 'string' || typeof value.status !== 'number' || typeof value.title !== 'string') return null;
@@ -2684,6 +2896,10 @@ function expectWindowsPackagedAppUrl(value: string | null | undefined): void {
   expect(value).toEqual(expect.stringMatching(/^od:\/\/app\/$/));
 }
 
+function expectWindowsHealthyRendererUrl(value: string | null | undefined): void {
+  expect(value).toEqual(expect.stringMatching(/^od:\/\/app\/(?:onboarding)?$/));
+}
+
 function expectWindowsFallbackWebUrl(value: string | null | undefined): void {
   expect(value).toEqual(expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/?$/));
 }
@@ -2698,10 +2914,9 @@ async function assertWindowsInviteProtocolRegistration(installDir: string): Prom
     'HKCU\\Software\\Classes\\opendesign\\shell\\open\\command',
     '/ve',
   ]);
-  const normalized = stdout.toLowerCase();
-  expect(normalized).toContain(installDir.toLowerCase());
-  expect(normalized).toContain('%1');
-  expect(normalized).not.toContain('\\versions\\');
+  const command = stdout.match(/REG_SZ\s+(.+)$/mi)?.[1]?.trim();
+  expect(command).toBe(`"${join(installDir, 'Open Design.exe')}" "%1"`);
+  expect(command?.toLowerCase()).not.toContain('\\versions\\');
 }
 
 async function invokeWindowsInviteDeeplink(): Promise<void> {
@@ -2824,6 +3039,26 @@ async function seedConfiguredPackagedClosure(): Promise<void> {
   });
 }
 
+async function readPackagedClosureBinding(): Promise<Record<string, unknown>> {
+  const bindingPath = join(
+    toolsPackDir,
+    'runtime',
+    'win',
+    'closure',
+    'channels',
+    updateScenario.channel,
+    'namespaces',
+    namespace,
+    'state',
+    'binding.json',
+  );
+  const value = JSON.parse(stripUtf8Bom(await readFile(bindingPath, 'utf8'))) as unknown;
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`packaged Windows Closure binding is invalid: ${bindingPath}`);
+  }
+  return value as Record<string, unknown>;
+}
+
 function isPathInside(filePath: string, expectedRoot: string): boolean {
   const normalizedPath = normalizePathForComparison(resolve(filePath));
   const normalizedRoot = normalizePathForComparison(resolve(expectedRoot));
@@ -2924,6 +3159,11 @@ function formatUnknown(value: unknown): string {
 function normalizeOptionalEnv(value: string | undefined): string | null {
   const normalized = value?.trim();
   return normalized == null || normalized.length === 0 ? null : normalized;
+}
+
+function requireMigrationInput(name: string, value: string | null | undefined): string {
+  if (value != null && value.length > 0) return value;
+  throw new Error(`full historical migration acceptance requires ${name}`);
 }
 
 function resolveOptionalFixturePort(value: string | undefined): number | null {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -333,6 +333,7 @@ type WinInspectResult = {
     ok: boolean;
     value?: unknown;
   };
+  managedProcessPids?: number[];
   screenshot?: {
     path: string;
   };
@@ -2659,12 +2660,16 @@ async function waitForDesktopGone(label: string, timeoutMs = 120_000): Promise<v
   let lastResult: unknown = null;
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const inspect = await runToolsPackJson<WinInspectResult>('inspect');
+      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--include-managed-processes']);
       lastResult = inspect;
-      if (inspect.status == null || inspect.status.state !== 'running') return;
-    } catch {
-      // A dead desktop IPC socket is exactly the expected terminal state.
-      return;
+      if (
+        (inspect.status == null || inspect.status.state !== 'running')
+        && inspect.managedProcessPids?.length === 0
+      ) return;
+    } catch (error) {
+      // An inspect failure does not prove process death; retain it as timeout
+      // evidence and keep polling the read-only process oracle.
+      lastResult = error;
     }
     await delay(1000);
   }

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -96,6 +96,14 @@ const releaseBetaPlatformPublishScriptPath = join(
   "storage",
   "publish-platform.ts",
 );
+const releaseLatestPublicationScriptPath = join(
+  workspaceRoot,
+  "tools",
+  "release",
+  "src",
+  "storage",
+  "latest-publication.ts",
+);
 
 function sectionBetween(content: string, start: string, end: string): string {
   const startIndex = content.indexOf(start);
@@ -1595,6 +1603,20 @@ process.stdin.on("end", () => {
     expect(betaWinJob).toContain("uses: actions/cache/restore@v5");
     expect(betaWinJob).toContain("uses: actions/cache/save@v5");
     expect(betaWinJob).toContain("tools-pack-win-v1-beta-$env:RUNNER_OS-");
+    expect(betaWinJob).toContain("OD_UPDATE_METADATA_URL: ${{ inputs.release_public_origin != '' && inputs.release_public_origin || vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}/beta/latest/metadata.json");
+    expect(betaWinJob).toContain("Resolve immutable win_x64 Electron Shell");
+    expect(betaWinJob).toContain("RELEASE_SHELL_SMOKE_MATRIX: win-shell-v1");
+    expect(betaWinJob.match(/hashFiles\('\.github\/workflows\/release-beta\.yml'/gu)).toHaveLength(2);
+    expect(betaWinJob).toContain(
+      `RELEASE_STANDALONE_PROTOCOL_VERSION: "${STANDALONE_PROTOCOL_VERSION}"`,
+    );
+    expect(betaWinJob).toContain("steps.win_x64_shell_resolution.outputs.state == 'miss'");
+    expect(betaWinJob).toContain("steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit'");
+    expect(betaWinJob).toContain("OD_PACKAGED_E2E_WIN_SMOKE_LANES: ${{ inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof == 'hit' && 'standalone' || '' }}");
+    expect(betaWinJob).toContain("OD_PACKAGED_E2E_SHELL_SMOKE_PROOF: ${{ steps.win_x64_shell_resolution.outputs.smoke_proof }}");
+    expect(betaWinJob).toContain("Materialize legacy win_x64 migration fixture");
+    expect(betaWinJob).toContain("Register win_x64 Electron Shell full-smoke proof");
+    expect(betaWinJob).toContain("RELEASE_SHELL_SMOKE_SUMMARY_PATH: ${{ runner.temp }}\\release-report\\win_x64\\summary.json");
     expect(betaWinJob).toContain('"tools-pack", "win", "build"');
     expect(betaWinJob).toContain("tools-pack win validate-payload");
     expect(betaWinJob).toContain("pnpm exec tsx scripts/release-smoke.ts win specs/win.spec.ts");
@@ -2163,9 +2185,13 @@ process.stdin.on("end", () => {
     const workflow = await readFile(releaseBetaWorkflowPath, "utf8");
     const macJob = sectionBetween(workflow, "  build_mac_arm64:", "  build_mac_x64:");
     const winJob = sectionBetween(workflow, "  build_win_x64:", "  publish:");
-    const publishStart = workflow.indexOf("\n  publish:");
-    expect(publishStart).toBeGreaterThan(0);
-    const publishJob = workflow.slice(publishStart);
+    const publishJob = sectionBetween(workflow, "  publish:", "  public_win_x64_acceptance:");
+    const publicAcceptanceJob = sectionBetween(
+      workflow,
+      "  public_win_x64_acceptance:",
+      "  activate:",
+    );
+    const activationJob = workflow.slice(workflow.indexOf("\n  activate:"));
 
     expect(workflow).toContain("CLOSURE_MIN_SHELL_VERSION: 0.19.0-beta.4");
     expect(workflow).toContain("OPEN_DESIGN_POSTINSTALL_CONCURRENCY: 2");
@@ -2203,6 +2229,11 @@ process.stdin.on("end", () => {
     expect(macJob).toContain("RELEASE_SHELL_BUILD_JSON_PATH:");
     expect(macJob).toContain("DOGFOOD_BUILD_JSON_KEYS: archivePath,inventoryPath,manifestPath,provenancePath");
     expect(winJob).toContain("Build beta win_x64 Standalone Closure");
+    expect(winJob).toContain("Resolve immutable win_x64 Electron Shell");
+    expect(winJob).toContain('"tools-pack", "win", "identity"');
+    expect(winJob).toContain("tools-release resolve-shell-build");
+    expect(winJob).toContain("Register verified immutable win_x64 Electron Shell");
+    expect(winJob).toContain("tools-release register-shell-build");
     expect(winJob).toContain("tools-pack closure build");
     expect(winJob).toContain("--platform win32-x64");
     expect(winJob).toContain('--cache-dir "${{ runner.temp }}\\tools-pack-cache"');
@@ -2220,11 +2251,33 @@ process.stdin.on("end", () => {
     expect(publishJob).toContain('RELEASE_SHELL_REQUIRED: "true"');
     expect(workflow).toContain("Validate checkout ref shape");
     expect(workflow).toContain("full 40-character commit SHA; abbreviated SHA");
-    expect(publishJob).toContain("Observe published beta public feed");
-    expect(publishJob).toContain("continue-on-error: true");
+    expect(publishJob).toContain("RELEASE_ACTIVATE_LATEST: ${{ inputs.enable_win_x64 && 'false' || 'true' }}");
+    expect(publishJob).toContain('RELEASE_LATEST_CAS_REQUIRED: "true"');
+    expect(publishJob).toContain("RELEASE_SIGNED: ${{ !inputs.enable_win_x64 && 'true' || 'false' }}");
+    expect(publishJob).toContain("Observe directly activated beta public feed");
+    expect(publishJob).toContain("if: ${{ !inputs.enable_win_x64 }}");
+    expect(sectionBetween(
+      publishJob,
+      "      - name: Observe directly activated beta public feed",
+      "      - name: Write beta metadata summary",
+    )).not.toContain("continue-on-error");
     expect(publishJob).toContain("tools-release observe-public-feed");
     expect(publishJob).toContain("mac_arm64_closure_url:");
     expect(publishJob).toContain("win_x64_closure_url:");
+    expect(publicAcceptanceJob).toContain("runs-on: windows-latest");
+    expect(publicAcceptanceJob).toContain("tools-release prepare-public-acceptance");
+    expect(publicAcceptanceJob).toContain("tools-release issue-public-acceptance");
+    expect(publicAcceptanceJob).toContain("OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core");
+    expect(publicAcceptanceJob).toContain("OD_PACKAGED_E2E_WIN_SMOKE_LANES: shell");
+    expect(publicAcceptanceJob).toContain("OD_UPDATE_METADATA_URL: ${{ needs.publish.outputs.version_metadata_url }}");
+    expect(publicAcceptanceJob).not.toContain("OD_PACKAGED_E2E_CLOSURE_BUILD_JSON_PATH");
+    expect(publicAcceptanceJob).not.toContain("RELEASE_STORAGE_SECRET_ACCESS_KEY");
+    expect(activationJob).toContain("needs.public_win_x64_acceptance.result == 'success'");
+    expect(activationJob).toContain("tools-release activate-public-release");
+    expect(activationJob).toContain("Activate accepted immutable beta metadata with CAS");
+    expect(activationJob).toContain("Read back activated beta public feed");
+    expect(activationJob).toContain("tools-release observe-public-feed");
+    expect(activationJob).not.toContain("continue-on-error");
   });
 
   it("publishes release-betas mac_x64 payloads while preserving the zip feed", async () => {
@@ -2239,12 +2292,13 @@ process.stdin.on("end", () => {
   });
 
   it("keeps the self-hosted beta lane metadata-driven with reusable platform publish scripts", async () => {
-    const [workflow, posixBuildScript, windowsBuildScript, platformPublishScript, publishMetadataScript] = await Promise.all([
+    const [workflow, posixBuildScript, windowsBuildScript, platformPublishScript, publishMetadataScript, latestPublicationScript] = await Promise.all([
       readFile(releaseBetaSelfHostedWorkflowPath, "utf8"),
       readFile(releaseBetaPosixBuildScriptPath, "utf8"),
       readFile(releaseBetaWindowsBuildScriptPath, "utf8"),
       readFile(releaseBetaPlatformPublishScriptPath, "utf8"),
       readFile(releasePublishMetadataScriptPath, "utf8"),
+      readFile(releaseLatestPublicationScriptPath, "utf8"),
     ]);
 
     expect(workflow).toContain("enable_win_x64:");
@@ -2366,7 +2420,7 @@ process.stdin.on("end", () => {
     expect(publishMetadataScript).toContain("manifest.r2.versionPrefix.includes(`/versions/${releaseVersion}`)");
     expect(publishMetadataScript).toContain('if (assetVersionSuffix === "auto")');
     expect(publishMetadataScript).toContain('assetVersionSuffix = allReadyTargetsSigned ? ".signed" : ".unsigned";');
-    expect(publishMetadataScript).toContain("const feedVersionPrefix = manifest.r2?.artifactPrefix ?? manifest.r2?.versionPrefix;");
+    expect(latestPublicationScript).toContain("const feedVersionPrefix = platform.manifest.r2?.artifactPrefix ?? platform.manifest.r2?.versionPrefix;");
     expect(publishMetadataScript).toContain("refusing stale ${def.target} platform manifest");
     expect(publishMetadataScript).toContain("publishLatestPlatformObjects");
     expect(platformPublishScript).not.toContain("await upload(join(releaseAssetsDir, name), `${latestPrefix}/${name}`");
@@ -2615,8 +2669,8 @@ process.stdin.on("end", () => {
 
       expect(fixture.uploadedObjectKeys()).toEqual([
         "beta/versions/1.2.3-beta.4/metadata.json",
-        "beta/latest/metadata.json",
         "beta/latest/platforms/mac_arm64.json",
+        "beta/latest/metadata.json",
       ]);
     } finally {
       await fixture.close();
@@ -2705,9 +2759,9 @@ process.stdin.on("end", () => {
       expect(metadata.releaseTargets.win_x64.r2.versionPrefix).toBe("beta/versions/1.2.3-beta.4.unsigned");
       expect(fixture.uploadedObjectKeys()).toEqual([
         "beta/versions/1.2.3-beta.4.unsigned/metadata.json",
-        "beta/latest/metadata.json",
         "beta/latest/platforms/win_x64.json",
         "beta/latest/latest.yml",
+        "beta/latest/metadata.json",
       ]);
     } finally {
       await fixture.close();
@@ -2850,10 +2904,10 @@ process.stdin.on("end", () => {
       expect(outputs.win_x64_payload_url).toBe(metadata.platforms.win.artifacts?.payload?.url);
       expect(fixture.uploadedObjectKeys()).toEqual([
         "beta/versions/1.2.3-beta.4.unsigned/metadata.json",
-        "beta/latest/metadata.json",
         "beta/latest/platforms/mac_arm64.json",
         "beta/latest/platforms/win_x64.json",
         "beta/latest/latest.yml",
+        "beta/latest/metadata.json",
       ]);
     } finally {
       await fixture.close();
@@ -2924,7 +2978,11 @@ function expectWindowsUpdaterSmokeContract(workflow: string, channel: "beta" | "
     expect(workflow).toContain(`Build ${channel} win_x64 update fixture`);
     expect(workflow).toContain(`full Windows smoke requires a counted ${channel} version`);
   }
-  expect(workflow).not.toContain("OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core");
+  if (channel === "beta") {
+    expect(workflow.match(/OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core/gu)).toHaveLength(1);
+  } else {
+    expect(workflow).not.toContain("OD_PACKAGED_E2E_WIN_SMOKE_PROFILE: core");
+  }
 }
 
 function expectCountedReleaseWorkflowCallContract(workflow: string, channel: "preview" | "prerelease"): void {

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -90,7 +90,7 @@ function probe(document: PackagedAppShellProbeDocument): PackagedAppShellSnapsho
   return snapshot;
 }
 
-// The surface a signed-in or onboarding-seeded packaged app comes up on.
+// The surface a signed-in packaged app comes up on.
 const HOME_SHELL: readonly FixtureNode[] = [
   { classes: ['entry-shell'] },
   { attributes: { 'data-testid': 'entry-nav-home' }, classes: ['entry-nav__item'] },
@@ -235,13 +235,13 @@ describe('packaged app-shell terminal state', () => {
 // fact, so the policy reads the daemon's own `onboardingCompleted` (served from
 // `readAppConfig(RUNTIME_DATA_DIR)`) rather than the smoke profile.
 describe('packaged app-shell policy', () => {
-  it('requires home once the daemon confirms onboarding is completed', () => {
+  it('accepts the signed-out identity gate once completion is retained', () => {
     expect(
       packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true, seededOnboardingCompleted: false }),
-    ).toEqual({ acceptOnboardingLanding: false });
+    ).toEqual({ acceptOnboardingLanding: true });
     expect(
       packagedAppShellPolicy({ coreProfile: false, daemonOnboardingCompleted: true, seededOnboardingCompleted: false }),
-    ).toEqual({ acceptOnboardingLanding: false });
+    ).toEqual({ acceptOnboardingLanding: true });
   });
 
   it('accepts the landing only when the daemon reports onboarding is not completed', () => {
@@ -250,12 +250,11 @@ describe('packaged app-shell policy', () => {
     ).toEqual({ acceptOnboardingLanding: true });
   });
 
-  it('keeps a seeded run failing when the app ignores completed onboarding', () => {
+  it('lets a completed but signed-out user settle on the identity gate', () => {
     const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
     const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true, seededOnboardingCompleted: false });
 
-    expect(packagedAppShellSettled(landing, policy)).toBe(false);
-    expect(packagedAppShellFailureReason(landing, policy)).toContain('needs home');
+    expect(packagedAppShellSettled(landing, policy)).toBe(true);
   });
 
   // Swept alongside the probe fix: both of these read their input for
@@ -566,20 +565,20 @@ describe('packaged launch scenarios', () => {
     expect(result).toEqual({ appShell: 'home', onboardingCompleted: true });
   });
 
-  it('fails a completed user that lands on onboarding instead of home', async () => {
+  it('settles a completed but signed-out user on the cloud identity gate', async () => {
     const clock = virtualClock();
     const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
 
-    await expect(
-      runPackagedAppShellPhase({
-        coreProfile: true,
-        now: clock.now,
-        observe: async () => landing,
-        readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: true, status: 200 }),
-        scenario: 'completed-user',
-        sleep: clock.sleep,
-      }),
-    ).rejects.toThrow(/needs home/);
+    const result = await runPackagedAppShellPhase({
+      coreProfile: true,
+      now: clock.now,
+      observe: async () => landing,
+      readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: true, status: 200 }),
+      scenario: 'completed-user',
+      sleep: clock.sleep,
+    });
+
+    expect(result).toEqual({ appShell: 'onboarding-landing', onboardingCompleted: true });
   });
 
   it('fails a completed user whose seeded state was lost across the relaunch', async () => {

--- a/e2e/tests/packaged/smoke-plan.test.ts
+++ b/e2e/tests/packaged/smoke-plan.test.ts
@@ -5,6 +5,8 @@ import {
   MAC_SHELL_PROOF_SCENARIO_IDS,
   resolvePackagedSmokeLanes,
   type PackagedSmokeDomain,
+  WIN_PACKAGED_SMOKE_SCENARIOS,
+  WIN_SHELL_PROOF_SCENARIO_IDS,
 } from '@/vitest/packaged-smoke-plan';
 
 describe('packaged smoke plan', () => {
@@ -44,5 +46,20 @@ describe('packaged smoke plan', () => {
       (scenario.domains as readonly PackagedSmokeDomain[]).includes('standalone'))).toBe(true);
     expect(scenarios.some((scenario) =>
       (scenario.domains as readonly PackagedSmokeDomain[]).includes('distribution'))).toBe(true);
+  });
+
+  it('keeps Windows installer lifecycle and migration outside Closure-only reruns', () => {
+    const scenarios = Object.values(WIN_PACKAGED_SMOKE_SCENARIOS);
+    expect(WIN_SHELL_PROOF_SCENARIO_IDS).toEqual([
+      'win-shell-lifecycle',
+      'win-shell-silent-update',
+      'win-shell-rollback',
+      'win-legacy-migration',
+    ]);
+    expect(scenarios
+      .filter((scenario) => scenario.lane === 'shell' || scenario.lane === 'migration')
+      .map((scenario) => scenario.id))
+      .toEqual(WIN_SHELL_PROOF_SCENARIO_IDS);
+    expect(scenarios.find((scenario) => scenario.id === 'win-standalone-closure')?.lane).toBe('standalone');
   });
 });

--- a/e2e/tests/win-installer-log.test.ts
+++ b/e2e/tests/win-installer-log.test.ts
@@ -3,42 +3,44 @@ import { describe, expect, it } from 'vitest';
 import { missingWorkingWinInstallerOverwriteMarkers } from '@/vitest/win-installer-log';
 
 describe('working Windows installer overwrite log contract', () => {
-  it('accepts the current remove, extract, and launcher-runtime sync lifecycle', () => {
+  it('accepts the stage, switch, and launcher-runtime sync lifecycle', () => {
     const lines = [
       'existing installation found; silent install will overwrite it',
-      'event=install_dir_before_remove target=C:\\Open Design exists=1',
-      'install dir remove exit=0',
-      'event=install_dir_after_remove target=C:\\Open Design exists=0',
+      'install transaction captured existing=1 desktopShortcut=0',
       'payload base extraction exit=0',
       'payload overlay extraction exit=0',
-      'event=install_dir_after_extract target=C:\\Open Design exists=1',
-      'event=installed_exe_after_extract target=C:\\Open Design\\Open Design.exe exists=1',
+      'event=install_staging_after_extract target=C:\\Open Design.__od_staging exists=1',
+      'event=staged_exe_after_extract target=C:\\Open Design.__od_staging\\Open Design.exe exists=1',
+      'event=install_dir_after_quarantine target=C:\\Open Design.__od_backup exists=1',
+      'event=install_dir_after_commit target=C:\\Open Design exists=1',
       'launcher runtime sync exit=0',
       'event=launcher_runtime_after_write path=C:\\launcher\\runtime.json',
+      'install transaction committed',
       'install section done',
     ];
 
     expect(missingWorkingWinInstallerOverwriteMarkers(lines)).toEqual([]);
   });
 
-  it('reports lifecycle gaps without requiring the reverted transactional markers', () => {
+  it('reports lifecycle gaps when a direct-remove overwrite log is supplied', () => {
     const lines = [
       'existing installation found; silent install will overwrite it',
-      'event=install_dir_after_quarantine target=C:\\Open Design.back exists=1',
-      'event=install_dir_after_commit target=C:\\Open Design exists=1',
-      'install transaction cleanup exit=0',
+      'event=install_dir_before_remove target=C:\\Open Design exists=1',
+      'install dir remove exit=0',
+      'event=install_dir_after_remove target=C:\\Open Design exists=0',
     ];
 
     expect(missingWorkingWinInstallerOverwriteMarkers(lines)).toEqual([
-      'install directory exists before removal',
-      'install directory removal succeeds',
-      'install directory is absent after removal',
+      'existing shortcut state is captured',
       'base payload extraction succeeds',
       'overlay payload extraction succeeds',
-      'install directory exists after extraction',
-      'installed executable exists after extraction',
+      'staging directory exists after extraction',
+      'staged executable exists after extraction',
+      'previous install is quarantined',
+      'staged install is committed',
       'launcher runtime sync succeeds',
       'launcher runtime pointer is written',
+      'install transaction commits',
       'install section completes',
     ]);
   });

--- a/packages/closure-store/src/index.ts
+++ b/packages/closure-store/src/index.ts
@@ -295,29 +295,74 @@ function compareName(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-async function collectPayloadFiles(
-  root: string,
-  current = root,
-): Promise<ClosureFileInventory["files"]> {
-  const entries = await readdir(current, { withFileTypes: true }).catch((error) => {
-    throw new ClosureStoreError(`Closure payload is missing or unreadable at ${current}: ${
-      error instanceof Error ? error.message : String(error)
-    }`);
-  });
-  const files: ClosureFileInventory["files"] = [];
-  for (const entry of entries.sort((left, right) => compareName(left.name, right.name))) {
-    const absolutePath = join(current, entry.name);
-    const metadata = await lstat(absolutePath);
-    const archivePath = relative(root, absolutePath).split(sep).join("/");
-    if (metadata.isSymbolicLink()) throw new ClosureStoreError(`Closure payload contains a symlink: ${archivePath}`);
-    if (metadata.isDirectory()) {
-      files.push(...await collectPayloadFiles(root, absolutePath));
-      continue;
+const CLOSURE_VERIFY_IO_CONCURRENCY = 16;
+
+async function collectPayloadFiles(root: string): Promise<ClosureFileInventory["files"]> {
+  const directories = [root];
+  const discovered: Array<{ absolutePath: string; archivePath: string }> = [];
+
+  // Traverse in bounded batches: Windows Closure payloads contain thousands
+  // of directories, so serial readdir/lstat turns Defender latency into a
+  // multi-minute cold start. Dirent still rejects links and special files; the
+  // queue only changes I/O scheduling, not the verified inventory contract.
+  while (directories.length > 0) {
+    const batch = directories.splice(0, CLOSURE_VERIFY_IO_CONCURRENCY);
+    const batches = await Promise.all(batch.map(async (current) => {
+      const entries = await readdir(current, { withFileTypes: true }).catch((error) => {
+        throw new ClosureStoreError(`Closure payload is missing or unreadable at ${current}: ${
+          error instanceof Error ? error.message : String(error)
+        }`);
+      });
+      return { current, entries: entries.sort((left, right) => compareName(left.name, right.name)) };
+    }));
+    for (const { current, entries } of batches) {
+      for (const entry of entries) {
+        const absolutePath = join(current, entry.name);
+        const archivePath = relative(root, absolutePath).split(sep).join("/");
+        if (entry.isSymbolicLink()) {
+          throw new ClosureStoreError(`Closure payload contains a symlink: ${archivePath}`);
+        }
+        if (entry.isDirectory()) {
+          directories.push(absolutePath);
+          continue;
+        }
+        if (!entry.isFile()) {
+          const metadata = await lstat(absolutePath);
+          if (metadata.isSymbolicLink()) {
+            throw new ClosureStoreError(`Closure payload contains a symlink: ${archivePath}`);
+          }
+          if (metadata.isDirectory()) {
+            directories.push(absolutePath);
+            continue;
+          }
+          if (!metadata.isFile()) {
+            throw new ClosureStoreError(`Closure payload contains an unsupported entry: ${archivePath}`);
+          }
+        }
+        discovered.push({ absolutePath, archivePath });
+      }
     }
-    if (!metadata.isFile()) throw new ClosureStoreError(`Closure payload contains an unsupported entry: ${archivePath}`);
-    const identity = await digestFile(absolutePath);
-    files.push({ digest: identity.digest as `sha256:${string}`, path: archivePath, size: identity.size });
   }
+
+  discovered.sort((left, right) => compareName(left.archivePath, right.archivePath));
+  const files = new Array<ClosureFileInventory["files"][number]>(discovered.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(CLOSURE_VERIFY_IO_CONCURRENCY, discovered.length) },
+    async () => {
+      while (nextIndex < discovered.length) {
+        const index = nextIndex++;
+        const file = discovered[index]!;
+        const identity = await digestFile(file.absolutePath);
+        files[index] = {
+          digest: identity.digest as `sha256:${string}`,
+          path: file.archivePath,
+          size: identity.size,
+        };
+      }
+    },
+  );
+  await Promise.all(workers);
   return files;
 }
 
@@ -421,9 +466,40 @@ export async function commitStoredClosureCandidate(
   verification: StoredClosureVerification;
 }> {
   const verification = await verifyStoredClosureCandidate(paths, binding);
+  return await commitVerifiedStoredClosureCandidate(paths, verification, releaseVersion);
+}
+
+/**
+ * Commit a candidate whose exact materialized bytes were already verified.
+ *
+ * Fresh update staging verifies every inventory entry before an atomic rename
+ * into the Store. Carrying that proof across the rename avoids hashing a large
+ * Windows Closure two more times while preserving the one full byte-level
+ * verification before the binding becomes visible.
+ */
+export async function commitVerifiedStoredClosureCandidate(
+  paths: ClosureStorePaths,
+  verification: StoredClosureVerification,
+  releaseVersion: string,
+): Promise<{
+  committed: CommittedClosureBinding;
+  descriptor: ClosureBindingDescriptor;
+  verification: StoredClosureVerification;
+}> {
+  const binding = validateClosureBindingIdentity(verification.binding, paths);
+  const expectedPaths = resolveClosureStoreVersionPaths(paths, binding);
+  if (
+    verification.paths.versionRoot !== expectedPaths.versionRoot
+    || verification.paths.archivePath !== expectedPaths.archivePath
+    || verification.paths.inventoryPath !== expectedPaths.inventoryPath
+    || verification.paths.manifestPath !== expectedPaths.manifestPath
+    || verification.paths.payloadRoot !== expectedPaths.payloadRoot
+  ) {
+    throw new ClosureStoreError("verified Closure paths do not match the committed Store location");
+  }
   const current = await readClosureBindingDescriptor(paths);
   const generation = current.nextGeneration;
-  const pointer: ClosureRuntimePointer = { ...verification.binding, generation };
+  const pointer: ClosureRuntimePointer = { ...binding, generation };
   const committed: CommittedClosureBinding = {
     releaseVersion: normalizeReleaseVersion(releaseVersion),
     standalone: pointer,

--- a/packages/closure-store/tests/index.test.ts
+++ b/packages/closure-store/tests/index.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   commitStoredClosureCandidate,
+  commitVerifiedStoredClosureCandidate,
   readClosureBindingDescriptor,
   resolveClosureStorePaths,
   resolveClosureStoreVersionPaths,
@@ -190,6 +191,20 @@ describe("Closure committed binding", () => {
     });
     expect(await readClosureBindingDescriptor(paths)).toEqual(result.descriptor);
     expect(paths.bindingPath).toMatch(/binding\.json$/u);
+  });
+
+  it("commits an atomically promoted candidate from its existing verification proof", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const verification = await verifyStoredClosureCandidate(paths, binding);
+
+    const result = await commitVerifiedStoredClosureCandidate(paths, verification, "0.19.0-beta.1");
+
+    expect(result.committed.standalone).toEqual({ ...binding, generation: 0 });
+    await expect(commitVerifiedStoredClosureCandidate(paths, {
+      ...verification,
+      paths: { ...verification.paths, versionRoot: join(paths.stagingRoot, "candidate") },
+    }, "0.19.0-beta.1")).rejects.toThrow(/verified Closure paths/u);
   });
 
   it("replaces the committed binding without retaining launch history", async () => {

--- a/packages/closure-update/src/index.ts
+++ b/packages/closure-update/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from "@open-design/closure-proto";
 import type { ClosureBindingDescriptor } from "@open-design/closure-store";
 import {
-  commitStoredClosureCandidate,
+  commitVerifiedStoredClosureCandidate,
   readClosureBindingDescriptor,
   resolveClosureStoreVersionPaths,
   verifyMaterializedClosureCandidate,
@@ -25,6 +25,7 @@ import {
   type ClosureRuntimePointer,
   type ClosureStorePaths,
   type ClosureStoreVersionPaths,
+  type StoredClosureVerification,
 } from "@open-design/closure-store";
 import { downloadCopyAndClear } from "@open-design/download";
 import { isProcessAlive } from "@open-design/platform";
@@ -477,14 +478,13 @@ async function ensureCandidateMaterialized(input: {
   descriptor: ClosureBindingDescriptor;
   fetchImpl: typeof globalThis.fetch;
   paths: ClosureStorePaths;
-}): Promise<ReturnType<typeof bindClosureCandidateIdentity>> {
+}): Promise<StoredClosureVerification> {
   const binding = bindClosureCandidateIdentity(input.candidate.manifest.identity, input.paths.namespace);
   const finalPaths = resolveClosureStoreVersionPaths(input.paths, binding);
   const existing = await stat(finalPaths.versionRoot).catch(() => null);
   if (existing != null) {
     try {
-      await verifyStoredClosureCandidate(input.paths, binding);
-      return binding;
+      return await verifyStoredClosureCandidate(input.paths, binding);
     } catch (error) {
       if (candidateIsReferenced(input.descriptor, binding)) throw error;
       await rm(finalPaths.versionRoot, { force: true, recursive: true });
@@ -518,16 +518,15 @@ async function ensureCandidateMaterialized(input: {
       }),
     ]);
     await extractZip(stagePaths.archivePath, { dir: stagePaths.payloadRoot });
-    await verifyMaterializedClosureCandidate(input.paths, binding, stagePaths);
+    const stagedVerification = await verifyMaterializedClosureCandidate(input.paths, binding, stagePaths);
     await mkdir(dirname(finalPaths.versionRoot), { recursive: true });
     try {
       await rename(stageRoot, finalPaths.versionRoot);
     } catch (error) {
       if (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY") throw error;
-      await verifyStoredClosureCandidate(input.paths, binding);
+      return await verifyStoredClosureCandidate(input.paths, binding);
     }
-    await verifyStoredClosureCandidate(input.paths, binding);
-    return binding;
+    return { ...stagedVerification, paths: finalPaths };
   } finally {
     await rm(stageRoot, { force: true, recursive: true }).catch(() => undefined);
   }
@@ -555,7 +554,7 @@ export async function applyClosureUpdate(input: {
     if (decision.action === "retain") {
       return { candidate: input.candidate, reason: decision.reason, state: "retained" };
     }
-    const binding = await ensureCandidateMaterialized({
+    const verification = await ensureCandidateMaterialized({
       candidate: input.candidate,
       descriptor,
       fetchImpl: input.fetch ?? globalThis.fetch,
@@ -572,9 +571,9 @@ export async function applyClosureUpdate(input: {
     if (currentDecision.action === "retain") {
       return { candidate: input.candidate, reason: currentDecision.reason, state: "retained" };
     }
-    const committed = await commitStoredClosureCandidate(
+    const committed = await commitVerifiedStoredClosureCandidate(
       input.paths,
-      binding,
+      verification,
       input.candidate.releaseVersion,
     );
     return {

--- a/packages/sidecar/src/control/controller.ts
+++ b/packages/sidecar/src/control/controller.ts
@@ -132,6 +132,8 @@ async function waitForLaunchedClient<TMethods>(input: {
 
   return await new Promise<SidecarControlClient<TMethods>>((resolveReady, rejectReady) => {
     let checking = false;
+    let checkAgain = false;
+    let poll: NodeJS.Timeout | null = null;
     let settled = false;
     let timeout: NodeJS.Timeout | null = null;
     let watcher: FSWatcher | null = null;
@@ -139,11 +141,16 @@ async function waitForLaunchedClient<TMethods>(input: {
       if (settled) return;
       settled = true;
       if (timeout != null) clearTimeout(timeout);
+      if (poll != null) clearInterval(poll);
       watcher?.close();
       callback();
     };
     const check = async () => {
-      if (settled || checking) return;
+      if (settled) return;
+      if (checking) {
+        checkAgain = true;
+        return;
+      }
       checking = true;
       try {
         const descriptor = await readCurrentDescriptor(
@@ -160,16 +167,26 @@ async function waitForLaunchedClient<TMethods>(input: {
         // filesystem event, child exit, or the deadline gives the next signal.
       } finally {
         checking = false;
+        if (checkAgain && !settled) {
+          checkAgain = false;
+          void check();
+        }
       }
     };
     watcher = watch(descriptorRoot, () => void check());
     watcher.once("error", (error) => settle(() => rejectReady(error)));
+    // fs.watch can coalesce or drop a Windows directory event while an async
+    // descriptor probe is already in flight. The coalesced retry above closes
+    // that window; this bounded poll is the backstop for an event the OS never
+    // delivers at all. Both paths still require an exact fenced descriptor and
+    // a successful peer probe before readiness resolves.
+    poll = setInterval(() => void check(), 100);
     timeout = setTimeout(() => {
       settle(() =>
         rejectReady(
           new SidecarControlError(
             "peer-unavailable",
-            `sidecar launch readiness timed out after ${input.timeoutMs}ms`,
+            `sidecar ${input.descriptor.identity.service} launch readiness timed out after ${input.timeoutMs}ms`,
           ),
         ),
       );

--- a/shells/electron/src/index.ts
+++ b/shells/electron/src/index.ts
@@ -218,6 +218,12 @@ async function main(): Promise<void> {
   if (!claimPackagedSingleInstanceLock(app, (argv) => {
     secondInstanceHandoff.handle(findPackagedDeeplinkArg(argv));
   })) return;
+  // A normal tools-pack launch already carries this projection, but a real
+  // Windows protocol/shortcut cold start does not. Standalone sidecars inherit
+  // process.env while the bootloader handoff is running, so establish their
+  // namespace/base/stamp before entering Closure rather than only after it has
+  // somehow become healthy.
+  applyLaunchEnv(paths.runtimeRoot, stamp);
   await app.whenReady();
 
   const splash = createSplashWindow();
@@ -250,7 +256,6 @@ async function main(): Promise<void> {
     shellDigest: await digestElectronShellEntry(import.meta.url),
     shellVersion,
   });
-  applyLaunchEnv(paths.runtimeRoot, stamp);
   const desktopControl = bootstrapSidecarRuntime(stamp, process.env, {
     app: APP_KEYS.DESKTOP,
     base: paths.runtimeRoot,

--- a/shells/electron/src/launcher-after-quit.ts
+++ b/shells/electron/src/launcher-after-quit.ts
@@ -200,20 +200,32 @@ export async function inspectExistingDesktopForLauncher(
     return { action: "continue", reason: "not-running" };
   }
 
-  const staleSidecars: AppKey[] = [];
-  for (const app of [APP_KEYS.DAEMON, APP_KEYS.WEB]) {
-    const sidecarIpcPath = resolveAppIpcPath({
-      app,
-      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-      namespace,
-    });
-    const sidecarStatus = await requestIpc<{ url?: unknown }>(
-      sidecarIpcPath,
-      { type: SIDECAR_MESSAGES.STATUS },
-      { timeoutMs: 350 },
-    ).catch(() => null);
-    if (typeof sidecarStatus?.url !== "string" || sidecarStatus.url.length === 0) {
-      staleSidecars.push(app);
+  const staleSidecars: Array<AppKey | "standalone"> = [];
+  if (status.standalone != null || status.standaloneStatusError != null) {
+    // The standalone Closure owns daemon/web behind generation-bound control
+    // endpoints. Their historical namespace pipes are deliberately absent, so
+    // probing those paths would classify every healthy standalone desktop as
+    // stale and kill it when a stable outer proxies an opendesign:// launch.
+    // The desktop's attached standalone handle is the authoritative aggregate
+    // readiness signal for this architecture.
+    if (status.standalone?.state !== "running") staleSidecars.push("standalone");
+  } else {
+    // Backward compatibility for historical embedded Shells that do not expose
+    // the standalone status field and still own fixed daemon/web sidecars.
+    for (const app of [APP_KEYS.DAEMON, APP_KEYS.WEB]) {
+      const sidecarIpcPath = resolveAppIpcPath({
+        app,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        namespace,
+      });
+      const sidecarStatus = await requestIpc<{ url?: unknown }>(
+        sidecarIpcPath,
+        { type: SIDECAR_MESSAGES.STATUS },
+        { timeoutMs: 350 },
+      ).catch(() => null);
+      if (typeof sidecarStatus?.url !== "string" || sidecarStatus.url.length === 0) {
+        staleSidecars.push(app);
+      }
     }
   }
 

--- a/shells/electron/src/main/updater.ts
+++ b/shells/electron/src/main/updater.ts
@@ -23,10 +23,16 @@ import {
 import {
   LAUNCHER_SCHEMA_VERSION,
 } from "@open-design/launcher-proto";
+import { createProcessStampArgs } from "@open-design/platform";
+import { resolveAppIpcPath } from "@open-design/sidecar";
 import {
+  APP_KEYS,
   DESKTOP_UPDATE_ACTIONS,
   DESKTOP_UPDATE_MODES,
   DESKTOP_UPDATE_STATES,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
   type DesktopUpdateAction,
   type DesktopUpdateCacheLifecycleSummary,
   type DesktopUpdateChecksumSnapshot,
@@ -1095,6 +1101,8 @@ export function createDesktopUpdater(
   ): Promise<DeferredLaunchResult & { launchPath?: string }> {
     if (config.openDryRun) return {};
     if (config.platform !== "darwin" && config.platform !== "win32") return {};
+    const namespace = config.namespace?.trim();
+    if (!namespace) return { error: "launcher payload relaunch requires a namespace" };
     try {
       await access(launchPath);
       const launcherTarget = await lstat(launchPath);
@@ -1109,6 +1117,17 @@ export function createDesktopUpdater(
       cwd: config.runtimeBase,
       ...(delegated == null ? {} : { delegated }),
       launchPath,
+      processStampArgs: createProcessStampArgs({
+        app: APP_KEYS.DESKTOP,
+        ipc: resolveAppIpcPath({
+          app: APP_KEYS.DESKTOP,
+          contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+          namespace,
+        }),
+        mode: SIDECAR_MODES.RUNTIME,
+        namespace,
+        source: SIDECAR_SOURCES.PACKAGED,
+      }, OPEN_DESIGN_SIDECAR_CONTRACT),
       root: updateRoot,
       timeoutMs: DEFERRED_INSTALLER_TIMEOUT_MS,
     });

--- a/shells/electron/src/main/updater/deferred-launch.ts
+++ b/shells/electron/src/main/updater/deferred-launch.ts
@@ -46,6 +46,8 @@ export type DeferredAppLaunchInput = {
    */
   delegated?: { generation: number; version: string };
   launchPath: string;
+  /** Process-ownership stamp inherited by tools-pack/native lifecycle guards. */
+  processStampArgs: readonly string[];
   root: string;
   timeoutMs: number;
 };
@@ -275,6 +277,7 @@ export async function launchPayloadAppAfterQuit(
       [
         ...buildLauncherAfterQuitArgs({ targetPid: input.appPid, timeoutMs: input.timeoutMs }),
         ...(input.delegated == null ? [] : buildLauncherDelegatedArgs(input.delegated)),
+        ...input.processStampArgs,
       ],
       { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
     );

--- a/shells/electron/tests/launch.test.ts
+++ b/shells/electron/tests/launch.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -56,6 +56,18 @@ describe("stabilizePackagedWorkingDirectory", () => {
     } finally {
       cwd.mockRestore();
     }
+  });
+});
+
+describe("packaged startup ordering", () => {
+  it("projects the sidecar namespace before entering Standalone Closure", () => {
+    const source = readFileSync(join(__dirname, "..", "src", "index.ts"), "utf8");
+    const projectEnvironment = source.indexOf("applyLaunchEnv(paths.runtimeRoot, stamp);");
+    const enterStandalone = source.indexOf("withStandaloneBootstrapEnvironment({");
+
+    expect(projectEnvironment).toBeGreaterThanOrEqual(0);
+    expect(enterStandalone).toBeGreaterThan(projectEnvironment);
+    expect(source.match(/applyLaunchEnv\(paths\.runtimeRoot, stamp\);/gu)).toHaveLength(1);
   });
 });
 

--- a/shells/electron/tests/launcher-after-quit.test.ts
+++ b/shells/electron/tests/launcher-after-quit.test.ts
@@ -228,6 +228,82 @@ describe("inspectExistingDesktopForLauncher", () => {
     }
   });
 
+  it("focuses a healthy standalone desktop without probing retired daemon/web pipes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-inspect-standalone-focus-"));
+    const requests: Array<{ ipcPath: string; message: unknown }> = [];
+    try {
+      const paths = fakePaths(root);
+
+      const result = await inspectExistingDesktopForLauncher("release-beta-win", {
+        deeplinkUrl: "opendesign://workspace/invite/continue?nonce=standalone-hot",
+        incomingVersion: "0.19.0-beta.4",
+        paths,
+        requestIpc: (async (ipcPath: string, message: unknown) => {
+          requests.push({ ipcPath, message });
+          if ((message as { type?: string }).type === SIDECAR_MESSAGES.STATUS) {
+            return {
+              pid: 1234,
+              standalone: { state: "running" },
+              state: "running",
+              update: { currentVersion: "0.19.0-beta.4" },
+              updatedAt: new Date().toISOString(),
+              windowVisible: true,
+            };
+          }
+          return { accepted: true };
+        }) as typeof import("@open-design/sidecar").requestJsonIpc,
+      });
+
+      expect(result).toEqual({ action: "exit", reason: "existing-focused" });
+      expect(requests).toHaveLength(2);
+      expect(requests.every(({ ipcPath }) => ipcPath.includes("desktop"))).toBe(true);
+      expect(requests.map(({ message }) => message)).toEqual([
+        { type: SIDECAR_MESSAGES.STATUS },
+        {
+          input: { deeplinkUrl: "opendesign://workspace/invite/continue?nonce=standalone-hot" },
+          type: SIDECAR_MESSAGES.SHOW,
+        },
+      ]);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("restarts a desktop whose attached standalone runtime is no longer running", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-inspect-standalone-stale-"));
+    const requests: unknown[] = [];
+    try {
+      const paths = fakePaths(root);
+
+      const result = await inspectExistingDesktopForLauncher("release-beta-win", {
+        paths,
+        requestIpc: (async (_ipcPath: string, message: unknown) => {
+          requests.push(message);
+          if ((message as { type?: string }).type === SIDECAR_MESSAGES.STATUS) {
+            return {
+              pid: 1234,
+              standalone: { state: "failed" },
+              state: "running",
+              updatedAt: new Date().toISOString(),
+            };
+          }
+          return { accepted: true };
+        }) as typeof import("@open-design/sidecar").requestJsonIpc,
+        waitForExit: (async (pid: number) => pid === 1234) as typeof import("@open-design/platform").waitForProcessExit,
+      });
+
+      expect(result).toEqual({ action: "continue", reason: "stale-sidecar" });
+      expect(requests).toEqual([
+        { type: SIDECAR_MESSAGES.STATUS },
+        { type: SIDECAR_MESSAGES.SHUTDOWN },
+      ]);
+      const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
+      expect(log).toContain("action=restart reason=stale-sidecar apps=standalone pid=1234");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("replaces a healthy standalone owner before opening the desktop window", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-launcher-inspect-standalone-"));
     const requests: unknown[] = [];

--- a/shells/electron/tests/main/updater.test.ts
+++ b/shells/electron/tests/main/updater.test.ts
@@ -14,9 +14,13 @@ import {
   LAUNCHER_SCHEMA_VERSION,
   resolveLauncherPaths,
 } from "@open-design/launcher-proto";
+import { readProcessStamp } from "@open-design/platform";
 import {
+  APP_KEYS,
   DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_STATES,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MODES,
   SIDECAR_SOURCES,
 } from "@open-design/sidecar-proto";
 import type { ReleaseChannel } from "@open-design/release";
@@ -2284,6 +2288,13 @@ describe("desktop updater", () => {
         LAUNCHER_AFTER_QUIT_TIMEOUT_MS_ARG,
         "600000",
       ]));
+      expect(readProcessStamp(args, OPEN_DESIGN_SIDECAR_CONTRACT)).toEqual({
+        app: APP_KEYS.DESKTOP,
+        ipc: "\\\\.\\pipe\\open-design-release-beta-win-desktop",
+        mode: SIDECAR_MODES.RUNTIME,
+        namespace: "release-beta-win",
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/shells/electron/tests/main/updater.test.ts
+++ b/shells/electron/tests/main/updater.test.ts
@@ -15,6 +15,7 @@ import {
   resolveLauncherPaths,
 } from "@open-design/launcher-proto";
 import { readProcessStamp } from "@open-design/platform";
+import { resolveAppIpcPath } from "@open-design/sidecar";
 import {
   APP_KEYS,
   DESKTOP_UPDATE_CHANNELS,
@@ -2290,7 +2291,11 @@ describe("desktop updater", () => {
       ]));
       expect(readProcessStamp(args, OPEN_DESIGN_SIDECAR_CONTRACT)).toEqual({
         app: APP_KEYS.DESKTOP,
-        ipc: "\\\\.\\pipe\\open-design-release-beta-win-desktop",
+        ipc: resolveAppIpcPath({
+          app: APP_KEYS.DESKTOP,
+          contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+          namespace: "release-beta-win",
+        }),
         mode: SIDECAR_MODES.RUNTIME,
         namespace: "release-beta-win",
         source: SIDECAR_SOURCES.PACKAGED,

--- a/shells/electron/tests/standalone-handoff.test.ts
+++ b/shells/electron/tests/standalone-handoff.test.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from "node:url";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -105,7 +107,7 @@ describe("Electron Shell Standalone handoff", () => {
     ]);
 
     expect(importBootloader).toHaveBeenCalledOnce();
-    expect(importBootloader).toHaveBeenCalledWith("file:///open-design/standalone/bootloader.mjs");
+    expect(importBootloader).toHaveBeenCalledWith(pathToFileURL(binding().bootloaderPath).href);
     expect(handoff).toHaveBeenCalledOnce();
     expect(first).toBe(second);
   });

--- a/tools/pack/src/closure.ts
+++ b/tools/pack/src/closure.ts
@@ -444,6 +444,7 @@ export default handoff;
 
 export function standaloneBodySource(): string {
   return `import { existsSync } from "node:fs";
+import { mkdir, realpath, symlink, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -451,8 +452,42 @@ import { startSidecarStandalone } from "@open-design/standalone";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 
-export function resolveOpenDesignClosureLayout() {
-  const standaloneRoot = join(root, "web", "standalone");
+function sameWindowsPath(left, right) {
+  const normalize = (value) => value.replaceAll("/", "\\\\").replace(/[\\\\]+$/, "").toLowerCase();
+  return normalize(left) === normalize(right);
+}
+
+/**
+ * Node's Windows chdir still rejects paths beyond MAX_PATH even when file I/O
+ * and the Electron manifest are long-path aware. Enter the verified Closure
+ * through a generation-bound junction under the namespace runtime root so the
+ * Next standalone server and native module resolution stay below that limit.
+ */
+export async function resolveOpenDesignClosureRuntimeRoot(request) {
+  if (process.platform !== "win32") return root;
+  const scope = request.handoff.scope;
+  const digest = request.handoff.descriptor.standalone.digest.slice("sha256:".length, "sha256:".length + 16);
+  const aliasParent = join(request.paths.runtimeRoot, "closure-aliases");
+  const aliasRoot = join(aliasParent, [scope.channel, "g" + String(scope.generation), digest].join("-"));
+  await mkdir(aliasParent, { recursive: true });
+  const expectedRoot = await realpath(root);
+  const currentRoot = await realpath(aliasRoot).catch(() => null);
+  if (currentRoot != null && sameWindowsPath(currentRoot, expectedRoot)) return aliasRoot;
+  if (currentRoot != null) await unlink(aliasRoot);
+  await symlink(expectedRoot, aliasRoot, "junction").catch(async (error) => {
+    const racedRoot = await realpath(aliasRoot).catch(() => null);
+    if (racedRoot != null && sameWindowsPath(racedRoot, expectedRoot)) return;
+    throw error;
+  });
+  const linkedRoot = await realpath(aliasRoot);
+  if (!sameWindowsPath(linkedRoot, expectedRoot)) {
+    throw new Error("Closure runtime alias does not resolve to the selected generation");
+  }
+  return aliasRoot;
+}
+
+export function resolveOpenDesignClosureLayout(runtimeRoot = root) {
+  const standaloneRoot = join(runtimeRoot, "web", "standalone");
   const serverCandidates = [
     join(standaloneRoot, "apps", "web", "server.js"),
     join(standaloneRoot, "server.js"),
@@ -460,19 +495,24 @@ export function resolveOpenDesignClosureLayout() {
   const webServerEntry = serverCandidates.find((candidate) => existsSync(candidate));
   if (webServerEntry == null) throw new Error("Closure Web standalone entry is missing");
   return Object.freeze({
-    daemonCliEntry: join(root, "daemon", "daemon-cli.mjs"),
-    daemonSidecarEntry: join(root, "daemon", "daemon-sidecar.mjs"),
-    daemonStandaloneSidecarEntry: join(root, "daemon", "daemon-standalone-sidecar.mjs"),
-    resourceRoot: join(root, "resources", "open-design"),
+    daemonCliEntry: join(runtimeRoot, "daemon", "daemon-cli.mjs"),
+    daemonSidecarEntry: join(runtimeRoot, "daemon", "daemon-sidecar.mjs"),
+    daemonStandaloneSidecarEntry: join(runtimeRoot, "daemon", "daemon-standalone-sidecar.mjs"),
+    resourceRoot: join(runtimeRoot, "resources", "open-design"),
     webServerEntry,
-    webSidecarEntry: join(root, "web", "web-sidecar.mjs"),
-    webStandaloneSidecarEntry: join(root, "web", "web-standalone-sidecar.mjs"),
+    webSidecarEntry: join(runtimeRoot, "web", "web-sidecar.mjs"),
+    webStandaloneSidecarEntry: join(runtimeRoot, "web", "web-standalone-sidecar.mjs"),
     webStandaloneRoot: standaloneRoot,
   });
 }
 
 export async function startStandaloneBody(request) {
-  const layout = resolveOpenDesignClosureLayout();
+  const layout = resolveOpenDesignClosureLayout(await resolveOpenDesignClosureRuntimeRoot(request));
+  // Windows can spend more than the control plane's generic five-second
+  // default loading a freshly materialized Electron-as-Node sidecar while
+  // Defender scans its Closure tree. Keep readiness event-driven, but give the
+  // child a bounded platform allowance before declaring it unavailable.
+  const sidecarReadyTimeoutMs = process.platform === "win32" ? 120_000 : undefined;
   const childEnv = {
     ...process.env,
     OD_DAEMON_CLI_PATH: layout.daemonCliEntry,
@@ -486,6 +526,7 @@ export async function startStandaloneBody(request) {
       env: childEnv,
       executable: process.execPath,
       output: "inherit",
+      readyTimeoutMs: sidecarReadyTimeoutMs,
     },
     web: {
       args: [layout.webStandaloneSidecarEntry],
@@ -496,6 +537,7 @@ export async function startStandaloneBody(request) {
       },
       executable: process.execPath,
       output: "inherit",
+      readyTimeoutMs: sidecarReadyTimeoutMs,
     },
   });
 }

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -34,6 +34,7 @@ export type ToolPackCliOptions = {
   diagnoseAttempts?: string | number;
   expectedVersion?: string;
   expr?: string;
+  includeManagedProcesses?: boolean;
   json?: boolean;
   macCompression?: string;
   minShellVersion?: string;

--- a/tools/pack/src/index.ts
+++ b/tools/pack/src/index.ts
@@ -57,6 +57,7 @@ function addSharedOptions(command: CacCommand) {
     .option("--json", "print JSON")
     .option("--namespace <name>", "runtime namespace")
     .option("--expr <expression>", "desktop inspect eval expression")
+    .option("--include-managed-processes", "inspect: enumerate processes owned by this namespace")
     .option("--path <path>", "desktop inspect screenshot path")
     .option("--shell <shell>", "launcher shell (default: electron)")
     .option("--status-poll-count <count>", "inspect: poll the shell-owned runtime status projection this many times")

--- a/tools/pack/src/win/builder.ts
+++ b/tools/pack/src/win/builder.ts
@@ -603,6 +603,7 @@ export async function runElectronBuilder(
       webStandaloneHookAuditPath: (await pathExists(paths.webStandaloneHookAuditPath)) ? paths.webStandaloneHookAuditPath : null,
     });
   });
+  const packagedConfig = await hashPath(paths.packagedConfigPath);
   if (shouldBuildWinNsisInstaller(config.to) || shouldBuildWinPortableZip(config.to)) {
     const signingCacheKey = resolveWinSigningCacheKey(config);
     const nsisInstallerImplementation = shouldBuildWinNsisInstaller(config.to)
@@ -665,6 +666,7 @@ export async function runElectronBuilder(
         archiveCacheVersion: WIN_ARCHIVE_CACHE_VERSION,
         key,
         namespace: config.namespace,
+        packagedConfig,
         packagedVersion,
         signing: signingCacheKey,
         target: "nsis-payload-overlay",

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, win32 } from "node:path";
 import { promisify } from "node:util";
 
 import type { ToolPackConfig } from "../config.js";
@@ -93,26 +93,20 @@ function createNsisLangString(
     .join("\n");
 }
 
-function createLauncherRuntimeSyncScript(
-  config: ToolPackConfig,
+export function createLauncherRuntimeSyncNsisScript(
+  channel: string,
+  namespace: string,
   runtimePath: string,
   attemptsPath: string,
   cleanupPath: string,
   helperScriptPath: string,
 ): string {
-  if (config.portable) {
-    return `
-Function SyncLauncherRuntime
-  StrCpy $LauncherRuntimeSyncExitCode "0"
-FunctionEnd
-`;
-  }
   const helperFileName = escapeNsisString(helperScriptPath.split(/[\\/]/).at(-1) ?? "sync-launcher-runtime.ps1");
   const escapedRuntimePath = escapeNsisString(runtimePath);
   const escapedAttemptsPath = escapeNsisString(attemptsPath);
   const escapedCleanupPath = escapeNsisString(cleanupPath);
-  const escapedChannel = escapeNsisString(resolveToolPackLauncherLayout(config).channel);
-  const escapedNamespace = escapeNsisString(config.namespace);
+  const escapedChannel = escapeNsisString(channel);
+  const escapedNamespace = escapeNsisString(namespace);
 
   return `
 Function SyncLauncherRuntime
@@ -135,6 +129,38 @@ done:
   Pop $0
 FunctionEnd
 `;
+}
+
+export function rebasePortableLauncherInstallerPath(
+  launcherRoot: string,
+  targetPath: string,
+): string {
+  const relativePath = win32.relative(launcherRoot, targetPath);
+  if (
+    relativePath.length === 0
+    || relativePath === ".."
+    || relativePath.startsWith(`..${win32.sep}`)
+    || win32.isAbsolute(relativePath)
+  ) {
+    throw new Error(`portable launcher path escapes launcher root: ${targetPath}`);
+  }
+  return win32.join("$APPDATA", PRODUCT_NAME, relativePath);
+}
+
+export function resolveWinInstallerLogPath(
+  portable: boolean,
+  namespace: string,
+  buildLogPath: string,
+): string {
+  if (!portable) return buildLogPath;
+  return win32.join(
+    "$TEMP",
+    PRODUCT_NAME,
+    "installer-logs",
+    "namespaces",
+    sanitizeNamespace(namespace),
+    "nsis.log",
+  );
 }
 
 export function createLauncherRuntimeSyncPowerShellScript(): string {
@@ -414,6 +440,13 @@ if ($ids) {
 async function writeInstallerScript(config: ToolPackConfig, paths: WinPaths, packagedVersion: string): Promise<void> {
   const identity = resolveWinInstallIdentity(config);
   const launcher = resolveToolPackLauncherLayout(config);
+  const launcherRuntimePaths = config.portable
+    ? {
+        attemptsPath: rebasePortableLauncherInstallerPath(launcher.root, launcher.paths.attemptsPath),
+        cleanupPath: rebasePortableLauncherInstallerPath(launcher.root, launcher.paths.cleanupPath),
+        runtimePath: rebasePortableLauncherInstallerPath(launcher.root, launcher.paths.runtimePath),
+      }
+    : launcher.paths;
   const productName = escapeNsisString(identity.displayName);
   const exeName = escapeNsisString(identity.exeName);
   const uninstallerName = escapeNsisString(identity.uninstallerName);
@@ -427,7 +460,9 @@ async function writeInstallerScript(config: ToolPackConfig, paths: WinPaths, pac
   const localUpdateDownloadsRoot = `${localDataRoot}\\updates\\downloads`;
   const localUpdateReleasesRoot = `${localDataRoot}\\updates\\releases`;
   const localUpdateStagingRoot = `${localDataRoot}\\updates\\staging`;
-  const nsisLogPath = escapeNsisString(paths.nsisLogPath);
+  const installerLogPath = resolveWinInstallerLogPath(config.portable, config.namespace, paths.nsisLogPath);
+  const nsisLogDirectory = escapeNsisString(win32.dirname(installerLogPath));
+  const nsisLogPath = escapeNsisString(installerLogPath);
   const runningInstancesScriptPath = join(dirname(paths.installerScriptPath), "running-instances.ps1");
   const launcherRuntimeSyncScriptPath = join(dirname(paths.installerScriptPath), "sync-launcher-runtime.ps1");
 
@@ -547,7 +582,7 @@ Var LX
 Function LogInstallerEvent
   Exch $0
   Push $1
-  CreateDirectory "${escapeNsisString(dirname(paths.nsisLogPath))}"
+  CreateDirectory "${nsisLogDirectory}"
   FileOpen $1 "${nsisLogPath}" a
   IfErrors done
   FileSeek $1 0 END
@@ -585,18 +620,19 @@ Function RemoveInstallTree
   Pop $2
 FunctionEnd
 
-${createLauncherRuntimeSyncScript(
-  config,
-  launcher.paths.runtimePath,
-  launcher.paths.attemptsPath,
-  launcher.paths.cleanupPath,
+${createLauncherRuntimeSyncNsisScript(
+  launcher.channel,
+  config.namespace,
+  launcherRuntimePaths.runtimePath,
+  launcherRuntimePaths.attemptsPath,
+  launcherRuntimePaths.cleanupPath,
   launcherRuntimeSyncScriptPath,
 )}
 
 Function un.LogInstallerEvent
   Exch $0
   Push $1
-  CreateDirectory "${escapeNsisString(dirname(paths.nsisLogPath))}"
+  CreateDirectory "${nsisLogDirectory}"
   FileOpen $1 "${nsisLogPath}" a
   IfErrors done
   FileSeek $1 0 END

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -103,6 +103,7 @@ function createLauncherRuntimeSyncScript(
   if (config.portable) {
     return `
 Function SyncLauncherRuntime
+  StrCpy $LauncherRuntimeSyncExitCode "0"
 FunctionEnd
 `;
   }
@@ -116,18 +117,21 @@ FunctionEnd
   return `
 Function SyncLauncherRuntime
   Push $0
+  StrCpy $LauncherRuntimeSyncExitCode "1"
   InitPluginsDir
   File "/oname=$PLUGINSDIR\\${helperFileName}" "${escapeNsisString(helperScriptPath)}"
   nsExec::ExecToLog 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\${helperFileName}" -RuntimePath "${escapedRuntimePath}" -AttemptsPath "${escapedAttemptsPath}" -CleanupPath "${escapedCleanupPath}" -Channel "${escapedChannel}" -Namespace "${escapedNamespace}" -Version "\${APP_VERSION}"'
   Pop $0
+  StrCpy $LauncherRuntimeSyncExitCode $0
   Push "launcher runtime sync exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
     DetailPrint "launcher runtime sync failed with exit code $0"
-    Abort
+    Goto done
   \${EndIf}
   Push "event=launcher_runtime_after_write path=${escapedRuntimePath}"
   Call LogInstallerEvent
+done:
   Pop $0
 FunctionEnd
 `;
@@ -518,6 +522,12 @@ Var RemoveLocalDataState
 Var RunningInstancesOutput
 Var ExistingInstallLocation
 Var RunningInstancesInstallRoot
+Var InstallStagingDir
+Var InstallBackupDir
+Var ExistingInstallWasPresent
+Var InstallBackupWasCreated
+Var DesktopShortcutWasPresent
+Var LauncherRuntimeSyncExitCode
 Var LE
 Var LT
 Var LX
@@ -561,6 +571,20 @@ write:
   Call LogInstallerEvent
 FunctionEnd
 
+Function RemoveInstallTree
+  Exch $2
+  Push $0
+  Push $1
+  nsExec::ExecToStack 'cmd.exe /d /s /c if exist "$2" rmdir /s /q "\\\\?\\$2"'
+  Pop $0
+  Pop $1
+  Push "install transaction remove tree exit=$0 target=$2 output=$1"
+  Call LogInstallerEvent
+  Pop $1
+  Pop $0
+  Pop $2
+FunctionEnd
+
 ${createLauncherRuntimeSyncScript(
   config,
   launcher.paths.runtimePath,
@@ -597,9 +621,12 @@ write:
 FunctionEnd
 
 Function un.onInit
+  SetShellVarContext current
   StrCpy $RemoveDesktopShortcutState "\${BST_CHECKED}"
   StrCpy $RemoveCacheDataState "\${BST_CHECKED}"
   StrCpy $RemoveLocalDataState 0
+  StrCpy $ExistingInstallLocation "$INSTDIR"
+  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
 FunctionEnd
 
 Function DetectRunningInstances
@@ -687,6 +714,77 @@ done:
   Pop $2
   Pop $1
   Pop $0
+FunctionEnd
+
+Function un.DetectRunningInstances
+  Push $0
+  Push $1
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\\running-instances.ps1" "\${RUNNING_INSTANCES_PS1}"
+
+  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  Pop $0
+  Pop $1
+  \${If} $0 == "0"
+    StrCpy $RunningInstancesOutput $1
+    Goto done
+  \${EndIf}
+
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  Pop $0
+  Pop $1
+  \${If} $0 == "0"
+    StrCpy $RunningInstancesOutput $1
+    Goto done
+  \${EndIf}
+
+  StrCpy $RunningInstancesOutput "__detection_failed__"
+  Push "uninstall running instance detection failed: last exit=$0 output=$1"
+  Call un.LogInstallerEvent
+done:
+  Pop $1
+  Pop $0
+FunctionEnd
+
+Function un.CloseRunningInstances
+  Push $0
+  Push $1
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\\running-instances.ps1" "\${RUNNING_INSTANCES_PS1}"
+
+  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  Pop $0
+  Pop $1
+  \${If} $0 == "0"
+    Push "uninstall running instances close via pwsh.exe exit=$0 output=$1"
+    Call un.LogInstallerEvent
+    Goto done
+  \${EndIf}
+
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  Pop $0
+  Pop $1
+  Push "uninstall running instances close via powershell.exe exit=$0 output=$1"
+  Call un.LogInstallerEvent
+done:
+  Pop $1
+  Pop $0
+FunctionEnd
+
+Function un.GuardRunningInstancesBeforeUninstall
+  Call un.DetectRunningInstances
+  \${If} $RunningInstancesOutput == ""
+    Return
+  \${EndIf}
+  Push "running instances detected before uninstall: $RunningInstancesOutput"
+  Call un.LogInstallerEvent
+  Call un.CloseRunningInstances
+  Call un.DetectRunningInstances
+  \${If} $RunningInstancesOutput != ""
+    Push "uninstall aborted: running instances still detected before file changes: $RunningInstancesOutput"
+    Call un.LogInstallerEvent
+    Abort "$(RunningInstancesCloseFailed)"
+  \${EndIf}
 FunctionEnd
 
 Function .onInit
@@ -817,15 +915,97 @@ Function CreateDesktopShortcut
   !insertmacro LOG_PATH_STATE "desktop_shortcut_after_create" "$DESKTOP\\${shortcutName}"
 FunctionEnd
 
-Function RemoveInstallDir
-  !insertmacro LOG_PATH_STATE "install_dir_before_remove" "$INSTDIR"
-  Push $0
-  nsExec::ExecToLog 'cmd.exe /d /s /c if exist "$INSTDIR" rmdir /s /q "\\\\?\\$INSTDIR"'
-  Pop $0
-  Push "install dir remove exit=$0"
+Function InitializeInstallTransaction
+  StrCpy $InstallStagingDir "$INSTDIR.__od_staging"
+  StrCpy $InstallBackupDir "$INSTDIR.__od_backup"
+  StrCpy $InstallBackupWasCreated 0
+FunctionEnd
+
+Function RecoverInterruptedInstallTransaction
+  IfFileExists "$InstallBackupDir\\${exeName}" 0 clear_stale_backup
+  Push "install transaction recovery start backup=$InstallBackupDir"
   Call LogInstallerEvent
-  Pop $0
-  !insertmacro LOG_PATH_STATE "install_dir_after_remove" "$INSTDIR"
+  Push "$INSTDIR"
+  Call RemoveInstallTree
+  ClearErrors
+  Rename "$InstallBackupDir" "$INSTDIR"
+  IfErrors recovery_failed recovery_done
+recovery_failed:
+  Push "install transaction recovery failed backup=$InstallBackupDir"
+  Call LogInstallerEvent
+  Abort
+recovery_done:
+  Push "install transaction recovery restored previous install"
+  Call LogInstallerEvent
+  Goto clear_staging
+clear_stale_backup:
+  Push "$InstallBackupDir"
+  Call RemoveInstallTree
+clear_staging:
+  Push "$InstallStagingDir"
+  Call RemoveInstallTree
+FunctionEnd
+
+Function CaptureInstallState
+  StrCpy $ExistingInstallWasPresent 0
+  StrCpy $DesktopShortcutWasPresent 0
+  IfFileExists "$INSTDIR\\${exeName}" 0 capture_shortcut
+  StrCpy $ExistingInstallWasPresent 1
+capture_shortcut:
+  IfFileExists "$DESKTOP\\${shortcutName}" 0 done
+  StrCpy $DesktopShortcutWasPresent 1
+done:
+  Push "install transaction captured existing=$ExistingInstallWasPresent desktopShortcut=$DesktopShortcutWasPresent"
+  Call LogInstallerEvent
+FunctionEnd
+
+Function RollbackInstallTransaction
+  Push "install transaction rollback start"
+  Call LogInstallerEvent
+  Push "$INSTDIR"
+  Call RemoveInstallTree
+  \${If} $InstallBackupWasCreated == 1
+    ClearErrors
+    Rename "$InstallBackupDir" "$INSTDIR"
+    IfErrors rollback_failed rollback_done
+  \${EndIf}
+  Goto rollback_done
+rollback_failed:
+  Push "install transaction rollback failed backup=$InstallBackupDir"
+  Call LogInstallerEvent
+  Goto cleanup_staging
+rollback_done:
+  Push "install transaction rollback restored previous install"
+  Call LogInstallerEvent
+cleanup_staging:
+  Push "$InstallStagingDir"
+  Call RemoveInstallTree
+FunctionEnd
+
+Function CommitInstallTransaction
+  Push "$InstallBackupDir"
+  Call RemoveInstallTree
+  IfFileExists "$INSTDIR\*.*" 0 promote_staging
+  ClearErrors
+  Rename "$INSTDIR" "$InstallBackupDir"
+  IfErrors quarantine_failed 0
+  StrCpy $InstallBackupWasCreated 1
+  !insertmacro LOG_PATH_STATE "install_dir_after_quarantine" "$InstallBackupDir"
+promote_staging:
+  ClearErrors
+  Rename "$InstallStagingDir" "$INSTDIR"
+  IfErrors promote_failed 0
+  !insertmacro LOG_PATH_STATE "install_dir_after_commit" "$INSTDIR"
+  Return
+quarantine_failed:
+  Push "install transaction quarantine failed"
+  Call LogInstallerEvent
+  Abort
+promote_failed:
+  Push "install transaction promote failed"
+  Call LogInstallerEvent
+  Call RollbackInstallTransaction
+  Abort
 FunctionEnd
 
 Function un.UninstallOptionsPage
@@ -925,13 +1105,12 @@ Section "Install"
   Push "install section start"
   Call LogInstallerEvent
   Call GuardRunningInstancesBeforeInstall
+  Call InitializeInstallTransaction
+  Call RecoverInterruptedInstallTransaction
+  Call CaptureInstallState
   !insertmacro LOG_PATH_STATE "install_dir_before_install" "$INSTDIR"
   !insertmacro LOG_PATH_STATE "installed_exe_before_install" "$INSTDIR\\${exeName}"
 
-  IfFileExists "$INSTDIR\\${exeName}" 0 prepare_install_dir
-  Call RemoveInstallDir
-
-prepare_install_dir:
   InitPluginsDir
   SetOutPath "$PLUGINSDIR"
   File "/oname=$PLUGINSDIR\\payload-base.7z" "\${PAYLOAD_BASE_7Z}"
@@ -939,38 +1118,64 @@ prepare_install_dir:
   File "/oname=$PLUGINSDIR\\7z.exe" "\${SEVEN_Z_EXE}"
   File "/oname=$PLUGINSDIR\\7z.dll" "\${SEVEN_Z_DLL}"
 
-  CreateDirectory "$INSTDIR"
+  CreateDirectory "$InstallStagingDir"
   Push "payload base extraction start"
   Call LogInstallerEvent
-  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-base.7z" "-o$INSTDIR"'
+  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-base.7z" "-o$InstallStagingDir"'
   Pop $0
   Push "payload base extraction exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
     DetailPrint "base payload extraction failed with exit code $0"
+    Push "$InstallStagingDir"
+    Call RemoveInstallTree
     Abort
   \${EndIf}
 
   Push "payload overlay extraction start"
   Call LogInstallerEvent
-  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-overlay.7z" "-o$INSTDIR"'
+  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-overlay.7z" "-o$InstallStagingDir"'
   Pop $0
   Push "payload overlay extraction exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
     DetailPrint "overlay payload extraction failed with exit code $0"
+    Push "$InstallStagingDir"
+    Call RemoveInstallTree
     Abort
   \${EndIf}
 
-  !insertmacro LOG_PATH_STATE "install_dir_after_extract" "$INSTDIR"
-  !insertmacro LOG_PATH_STATE "installed_exe_after_extract" "$INSTDIR\\${exeName}"
-  WriteUninstaller "$INSTDIR\\${uninstallerName}"
-  !insertmacro LOG_PATH_STATE "uninstaller_after_write" "$INSTDIR\\${uninstallerName}"
+  !insertmacro LOG_PATH_STATE "install_staging_after_extract" "$InstallStagingDir"
+  !insertmacro LOG_PATH_STATE "staged_exe_after_extract" "$InstallStagingDir\\${exeName}"
+  IfFileExists "$InstallStagingDir\\${exeName}" 0 invalid_staging
+  IfFileExists "$InstallStagingDir\\resources\\app\\package.json" 0 invalid_staging
+  IfFileExists "$InstallStagingDir\\resources\\open-design-config.json" 0 invalid_staging
+  WriteUninstaller "$InstallStagingDir\\${uninstallerName}"
+  !insertmacro LOG_PATH_STATE "staged_uninstaller_after_write" "$InstallStagingDir\\${uninstallerName}"
+  Call CommitInstallTransaction
+  Call SyncLauncherRuntime
+  \${If} $LauncherRuntimeSyncExitCode != "0"
+    Call RollbackInstallTransaction
+    Abort
+  \${EndIf}
+  Push "$InstallBackupDir"
+  Call RemoveInstallTree
+  IfFileExists "$InstallBackupDir\\*.*" transaction_cleanup_failed transaction_cleanup_done
+transaction_cleanup_failed:
+  Push "install transaction cleanup failed backup=$InstallBackupDir"
+  Call LogInstallerEvent
+  Call RollbackInstallTransaction
+  Abort
+transaction_cleanup_done:
+  Push "install transaction committed"
+  Call LogInstallerEvent
   SetOutPath "$INSTDIR"
   IfSilent 0 skip_silent_desktop_shortcut
-  !insertmacro LOG_PATH_STATE "desktop_shortcut_before_create" "$DESKTOP\\${shortcutName}"
-  CreateShortCut "$DESKTOP\\${shortcutName}" "$INSTDIR\\${exeName}" "" "$INSTDIR\\${exeName}" 0
-  !insertmacro LOG_PATH_STATE "desktop_shortcut_after_create" "$DESKTOP\\${shortcutName}"
+  \${If} $ExistingInstallWasPresent == 0
+    Call CreateDesktopShortcut
+  \${ElseIf} $DesktopShortcutWasPresent == 1
+    Call CreateDesktopShortcut
+  \${EndIf}
 skip_silent_desktop_shortcut:
   !insertmacro LOG_PATH_STATE "start_menu_shortcut_before_create" "$SMPROGRAMS\\${shortcutName}"
   CreateShortCut "$SMPROGRAMS\\${shortcutName}" "$INSTDIR\\${exeName}" "" "$INSTDIR\\${exeName}" 0
@@ -985,18 +1190,26 @@ skip_silent_desktop_shortcut:
   WriteRegStr HKCU "${inviteProtocolKey}" "" "URL:Open Design Invite Protocol"
   WriteRegStr HKCU "${inviteProtocolKey}" "URL Protocol" ""
   WriteRegStr HKCU "${inviteProtocolKey}\\DefaultIcon" "" "$INSTDIR\\${exeName},0"
-  WriteRegStr HKCU "${inviteProtocolKey}\\shell\\open\\command" "" '$\"$INSTDIR\\${exeName}$\" $\"%1$\"'
+  WriteRegStr HKCU "${inviteProtocolKey}\\shell\\open\\command" "" '$\\"$INSTDIR\\${exeName}$\\" $\\"%1$\\"'
   Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"
   Call LogInstallerEvent
-  Call SyncLauncherRuntime
   Push "install section done"
   Call LogInstallerEvent
+  Goto install_done
+invalid_staging:
+  Push "install transaction staged payload validation failed"
+  Call LogInstallerEvent
+  Push "$InstallStagingDir"
+  Call RemoveInstallTree
+  Abort
+install_done:
 SectionEnd
 
 Section "Uninstall"
   SetShellVarContext current
   Push "uninstall section start"
   Call un.LogInstallerEvent
+  Call un.GuardRunningInstancesBeforeUninstall
   IfSilent delete_desktop_shortcut check_desktop_shortcut_state
 check_desktop_shortcut_state:
   \${If} $RemoveDesktopShortcutState == \${BST_CHECKED}
@@ -1012,7 +1225,7 @@ after_desktop_shortcut:
   DeleteRegKey HKCU "${registryKey}"
   DeleteRegKey HKCU "${appPathsKey}"
   ReadRegStr $0 HKCU "${inviteProtocolKey}\\shell\\open\\command" ""
-  StrCmp $0 '$\"$INSTDIR\\${exeName}$\" $\"%1$\"' 0 preserve_invite_protocol
+  StrCmp $0 '$\\"$INSTDIR\\${exeName}$\\" $\\"%1$\\"' 0 preserve_invite_protocol
   DeleteRegKey HKCU "${inviteProtocolKey}"
 preserve_invite_protocol:
   Push "event=registry_after_delete key=${registryKey} appPathsKey=${appPathsKey}"

--- a/tools/pack/src/win/lifecycle.ts
+++ b/tools/pack/src/win/lifecycle.ts
@@ -171,6 +171,35 @@ async function observeWinResidues(config: ToolPackConfig, paths = resolveWinPath
   };
 }
 
+async function waitForNativeUninstallSettlement(
+  config: ToolPackConfig,
+  paths: WinPaths,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  let pending: string[] = [];
+  do {
+    const [publicDesktop, registryEntries, startMenu, userDesktop] = await Promise.all([
+      pathExists(paths.publicDesktopShortcutPath),
+      queryWinRegistryEntries(paths, config),
+      pathExists(paths.startMenuShortcutPath),
+      pathExists(paths.userDesktopShortcutPath),
+    ]);
+    pending = [
+      ...(publicDesktop ? [paths.publicDesktopShortcutPath] : []),
+      ...registryEntries.map((entry) => entry.keyPath),
+      ...(startMenu ? [paths.startMenuShortcutPath] : []),
+      ...(userDesktop ? [paths.userDesktopShortcutPath] : []),
+    ];
+    if (pending.length === 0) return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  } while (Date.now() - startedAt < timeoutMs);
+
+  throw new Error(
+    `native Windows uninstaller returned before its lifecycle mutations settled: ${pending.join(", ")}`,
+  );
+}
+
 export async function installPackedWinApp(config: ToolPackConfig): Promise<WinInstallResult> {
   const lifecycleTimings: WinLifecycleTiming[] = [];
   const paths = resolveWinPaths(config);
@@ -357,6 +386,13 @@ export async function uninstallPackedWinApp(config: ToolPackConfig): Promise<Win
     await measureLifecycleStep(lifecycleTimings, "nsis uninstall", async () => runTimed(paths.uninstallTimingPath, "uninstall", async () => {
       await invokeNsis(paths, registeredPaths.uninstallerPath, config.silent ? ["/S"] : [], "uninstall");
     }));
+    // NSIS first launches a temporary self-copy. On Windows the original
+    // uninstaller process can return while that child is still deleting
+    // shortcuts and registry keys. Do not let callers observe that transient
+    // state as the result of a completed uninstall.
+    await measureLifecycleStep(lifecycleTimings, "wait for native uninstall settlement", async () => {
+      await waitForNativeUninstallSettlement(config, registeredPaths);
+    });
   }
   await measureLifecycleStep(lifecycleTimings, "remove install dir", async () => removeTree(registeredPaths.installDir));
   const registryResiduesRemoved = await measureLifecycleStep(lifecycleTimings, "cleanup registry residues", async () => cleanupWinRegistryResidues(registeredPaths, config));
@@ -496,7 +532,11 @@ async function requestDesktopEval(
     return await requestJsonIpc<DesktopEvalResult>(
       ipc,
       { input: { expression }, type: SIDECAR_MESSAGES.EVAL },
-      { timeoutMs: 5000 },
+      // Packaged acceptance uses eval for intentionally expensive first-use
+      // operations (project creation and PPTX export). The desktop capability
+      // contract already allows ten minutes; keep the CLI probe below that
+      // ceiling while avoiding a false sidecar failure on a cold Windows disk.
+      { timeoutMs: 120_000 },
     );
   } catch (error) {
     return {

--- a/tools/pack/src/win/lifecycle.ts
+++ b/tools/pack/src/win/lifecycle.ts
@@ -599,13 +599,16 @@ async function pollWinInspectStatus(config: ToolPackConfig, count: number, inter
 
 export async function inspectPackedWinApp(
   config: ToolPackConfig,
-  options: { expr?: string; path?: string; statusPollCount?: string | number; statusPollIntervalMs?: string | number; updateAction?: string },
+  options: { expr?: string; includeManagedProcesses?: boolean; path?: string; statusPollCount?: string | number; statusPollIntervalMs?: string | number; updateAction?: string },
 ): Promise<WinInspectResult> {
   const stamp = desktopStamp(config);
-  const [desktopSnapshot, daemonSnapshot, webSnapshot] = await Promise.all([
+  const [desktopSnapshot, daemonSnapshot, webSnapshot, managedProcessPids] = await Promise.all([
     requestStatusSnapshot<DesktopStatusSnapshot>(stamp.ipc),
     requestStatusSnapshot<DaemonStatusSnapshot>(appIpcPath(config, APP_KEYS.DAEMON)),
     requestStatusSnapshot<WebStatusSnapshot>(appIpcPath(config, APP_KEYS.WEB)),
+    options.includeManagedProcesses === true
+      ? findManagedDesktopProcessTree(config)
+      : Promise.resolve(null),
   ]);
   const updateAction = resolveUpdateAction(options.updateAction);
   const statusPollCount = resolveOptionalPositiveInteger(options.statusPollCount, "--status-poll-count");
@@ -624,6 +627,7 @@ export async function inspectPackedWinApp(
       note: "launcher snapshot is read from the tools-pack runtime root; user-installed launcher state is reported by the running desktop status and its AppData paths",
       root: launcher.root,
     },
+    ...(managedProcessPids == null ? {} : { managedProcessPids }),
     updateCache,
     updateCacheSource: {
       kind: "tools-pack-runtime",

--- a/tools/pack/src/win/types.ts
+++ b/tools/pack/src/win/types.ts
@@ -375,6 +375,7 @@ export type WinInspectResult = {
     note: string;
     root: string;
   };
+  managedProcessPids?: number[];
   screenshot?: DesktopScreenshotResult;
   status: DesktopStatusSnapshot | null;
   statusError?: string;

--- a/tools/pack/tests/closure.test.ts
+++ b/tools/pack/tests/closure.test.ts
@@ -97,10 +97,16 @@ describe("tools-pack Closure archive", () => {
     expect(inner).not.toContain("resolveRegisteredBootloader");
 
     expect(body).toContain("resolveOpenDesignClosureLayout");
+    expect(body).toContain("resolveOpenDesignClosureRuntimeRoot");
+    expect(body).toContain('join(request.paths.runtimeRoot, "closure-aliases")');
+    expect(body).toContain('symlink(expectedRoot, aliasRoot, "junction")');
+    expect(body).toContain("Closure runtime alias does not resolve to the selected generation");
     expect(body).toContain("daemonStandaloneSidecarEntry");
     expect(body).toContain("webStandaloneSidecarEntry");
     expect(body).toContain("OD_DAEMON_CLI_PATH");
     expect(body).toContain("OD_RESOURCE_TRUST_ROOT: request.paths.installationRoot");
+    expect(body).toContain('process.platform === "win32" ? 120_000 : undefined');
+    expect(body.match(/readyTimeoutMs: sidecarReadyTimeoutMs/gu)).toHaveLength(2);
     expect(body.match(/output: "inherit"/gu)).toHaveLength(2);
     for (const source of [root, inner, body]) {
       expect(source).not.toContain("payload-desktop-handoff");

--- a/tools/pack/tests/node-pty-runtime.test.ts
+++ b/tools/pack/tests/node-pty-runtime.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../src/node-pty-runtime.js";
 
 describe("node-pty packaged runtime closure", () => {
-  it("repairs and validates the target macOS prebuild", async () => {
+  it.skipIf(process.platform === "win32")("repairs and validates the target macOS prebuild", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-node-pty-runtime-"));
     const prebuildRoot = join(root, "node_modules", "node-pty", "prebuilds", "darwin-arm64");
 

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -104,12 +104,12 @@ describe("release workflows", () => {
     expect(mac).toContain("OD_PACKAGED_E2E_MAC_LEGACY_DMG_PATH: ${{ steps.mac_arm64_legacy_fixture.outputs.dmg_path }}");
     expect(mac).toContain("OD_PACKAGED_E2E_MAC_MIN_SHELL_VERSION: ${{ env.CLOSURE_MIN_SHELL_VERSION }}");
     expect(mac).toContain("OD_PACKAGED_E2E_MAC_UPDATE_BUILD_JSON_PATH: ${{ steps.mac_arm64_update_fixture.outputs.update_build_json_path }}");
-    expect(mac).toContain("RELEASE_SHELL_SMOKE_MATRIX: mac-shell-v2");
+    expect(mac).toContain("RELEASE_SHELL_SMOKE_MATRIX: mac-shell-v3");
     expect(mac).toContain("RELEASE_SHELL_SMOKE_ACCEPTANCE_DIGEST: sha256:${{ hashFiles(");
     expect(mac).toContain('RELEASE_STANDALONE_PROTOCOL_VERSION: "1"');
     expect(mac).toMatch(/Build beta mac_arm64 update fixture[\s\S]*?--to app/);
     expect(mac).toContain("steps.mac_arm64_shell_resolution.outputs.smoke_proof != 'hit'");
-    expect(mac).toContain("OD_PACKAGED_E2E_MAC_SMOKE_LANES: ${{ inputs.mac_arm64_smoke_mode == 'full' && steps.mac_arm64_shell_resolution.outputs.smoke_proof == 'hit' && 'standalone,migration' || '' }}");
+    expect(mac).toContain("OD_PACKAGED_E2E_MAC_SMOKE_LANES: ${{ inputs.mac_arm64_smoke_mode == 'full' && steps.mac_arm64_shell_resolution.outputs.smoke_proof == 'hit' && 'standalone' || '' }}");
     expect(mac).toContain("OD_PACKAGED_E2E_SHELL_SMOKE_PROOF: ${{ steps.mac_arm64_shell_resolution.outputs.smoke_proof }}");
     expect(mac).toContain("Register mac_arm64 Electron Shell full-smoke proof");
     expect(mac).toContain("run: pnpm exec tools-release register-shell-smoke");
@@ -155,8 +155,11 @@ describe("release workflows", () => {
     expect(beta).toContain("tools-release verify-metadata");
     expect(beta).toContain("Validate checkout ref shape");
     expect(beta).toContain("full 40-character commit SHA; abbreviated SHA");
-    expect(betaPublish).toContain("Observe published beta public feed");
-    expect(betaPublish).toContain("continue-on-error: true");
+    expect(betaPublish).toContain("Observe directly activated beta public feed");
+    expect(betaPublish).toContain("Read back activated beta public feed");
+    expect(betaPublish).toContain("tools-release prepare-public-acceptance");
+    expect(betaPublish).toContain("tools-release issue-public-acceptance");
+    expect(betaPublish).toContain("tools-release activate-public-release");
     expect(betaPublish).toContain("tools-release observe-public-feed");
     expect(beta).toContain("tools-release summary-metadata");
     for (const workflow of [beta, betaSelfHosted, preview, prerelease, stable]) {

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -173,6 +173,9 @@ describe("release workflows", () => {
     expect(win).toContain("uses: actions/cache/restore@v5");
     expect(win).toContain("uses: actions/cache/save@v5");
     expect(win).toContain("tools-pack-win-v1-beta-$env:RUNNER_OS-");
+    expect(win).toContain(
+      "steps.win_x64_shell_resolution.outputs.state == 'miss' || (inputs.win_x64_smoke_mode == 'full' && steps.win_x64_shell_resolution.outputs.smoke_proof != 'hit' && inputs.win_x64_update_metadata_url == '' && inputs.win_x64_update_target_version == '')",
+    );
     expect(win).toContain('pnpm.cmd exec tools-pack win cleanup --dir "${{ runner.temp }}\\tools-pack" --namespace release-beta-win --json');
     expect(win).toContain('"tools-pack", "win", "build"');
     expect(buildWin).toContain('$buildArgs += "--require-vela-cli"');

--- a/tools/pack/tests/win-builder.test.ts
+++ b/tools/pack/tests/win-builder.test.ts
@@ -185,6 +185,17 @@ describe("Windows pack artifact boundaries", () => {
     expect(source).toContain("nsisInstallerImplementation");
     expect(source.indexOf("nsisInstallerImplementation")).toBeLessThan(source.indexOf('target: "nsis-installer"'));
   });
+
+  it("invalidates the NSIS overlay and installer when packaged config changes", async () => {
+    const source = await readFile(new URL("../src/win/builder.ts", import.meta.url), "utf8");
+    expect(source).toContain("const packagedConfig = await hashPath(paths.packagedConfigPath)");
+    expect(source.indexOf("await writePackagedConfig(config, paths")).toBeLessThan(
+      source.indexOf("const packagedConfig = await hashPath(paths.packagedConfigPath)"),
+    );
+    const overlayNode = source.slice(source.indexOf("const createNsisOverlayPayloadNode"), source.indexOf("const nsisBasePayloadNode"));
+    expect(overlayNode).toContain("packagedConfig,");
+    expect(overlayNode.indexOf("packagedConfig,")).toBeLessThan(overlayNode.indexOf('target: "nsis-payload-overlay"'));
+  });
 });
 
 describe("launcher runtime sync helper", () => {

--- a/tools/pack/tests/win-builder.test.ts
+++ b/tools/pack/tests/win-builder.test.ts
@@ -8,7 +8,12 @@ import { NtExecutable, NtExecutableResource, Resource } from "resedit";
 import { describe, expect, it } from "vitest";
 
 import { materializeCachedUnpackedForInstaller } from "../src/win/builder.js";
-import { createLauncherRuntimeSyncPowerShellScript } from "../src/win/custom-installer.js";
+import {
+  createLauncherRuntimeSyncNsisScript,
+  createLauncherRuntimeSyncPowerShellScript,
+  rebasePortableLauncherInstallerPath,
+  resolveWinInstallerLogPath,
+} from "../src/win/custom-installer.js";
 import type { WinPaths } from "../src/win/types.js";
 import { readWinExecutableVersionSnapshot } from "../src/win/version-resource.js";
 
@@ -199,6 +204,53 @@ describe("Windows pack artifact boundaries", () => {
 });
 
 describe("launcher runtime sync helper", () => {
+  it("writes portable installer logs outside build and removable product-data roots", () => {
+    const buildLogPath = "D:\\a\\_temp\\tools-pack\\out\\win\\namespaces\\release-beta-win\\logs\\nsis.log";
+
+    expect(resolveWinInstallerLogPath(true, "release beta/win", buildLogPath)).toBe(
+      "$TEMP\\Open Design\\installer-logs\\namespaces\\release-beta-win\\nsis.log",
+    );
+    expect(resolveWinInstallerLogPath(false, "release beta/win", buildLogPath)).toBe(buildLogPath);
+  });
+
+  it("rebases release installer launcher state into the end-user AppData root", () => {
+    const launcherRoot = "D:\\a\\_temp\\tools-pack\\runtime\\win";
+    const runtimePath = rebasePortableLauncherInstallerPath(
+      launcherRoot,
+      `${launcherRoot}\\launcher\\channels\\beta\\namespaces\\release-beta-win\\runtime.json`,
+    );
+    const attemptsPath = rebasePortableLauncherInstallerPath(
+      launcherRoot,
+      `${launcherRoot}\\launcher\\channels\\beta\\namespaces\\release-beta-win\\state\\attempt.json`,
+    );
+    const cleanupPath = rebasePortableLauncherInstallerPath(
+      launcherRoot,
+      `${launcherRoot}\\launcher\\channels\\beta\\namespaces\\release-beta-win\\state\\cleanup.json`,
+    );
+
+    expect(runtimePath).toBe("$APPDATA\\Open Design\\launcher\\channels\\beta\\namespaces\\release-beta-win\\runtime.json");
+    expect(attemptsPath).toBe("$APPDATA\\Open Design\\launcher\\channels\\beta\\namespaces\\release-beta-win\\state\\attempt.json");
+    expect(cleanupPath).toBe("$APPDATA\\Open Design\\launcher\\channels\\beta\\namespaces\\release-beta-win\\state\\cleanup.json");
+    const nsis = createLauncherRuntimeSyncNsisScript(
+      "beta",
+      "release-beta-win",
+      runtimePath,
+      attemptsPath,
+      cleanupPath,
+      "D:\\build\\sync-launcher-runtime.ps1",
+    );
+    expect(nsis).toContain('Push "launcher runtime sync exit=$0"');
+    expect(nsis).toContain('Push "event=launcher_runtime_after_write path=$APPDATA\\Open Design\\launcher');
+    expect(nsis).not.toContain(launcherRoot);
+  });
+
+  it("refuses to rebase a portable launcher path outside its build root", () => {
+    expect(() => rebasePortableLauncherInstallerPath(
+      "D:\\a\\_temp\\tools-pack\\runtime\\win",
+      "D:\\a\\_temp\\outside\\runtime.json",
+    )).toThrow(/escapes launcher root/);
+  });
+
   it.runIf(process.platform === "win32")("writes cleanup.json for superseded launcher runtime pointers", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-launcher-sync-"));
     const runtimePath = join(root, "runtime.json");

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -95,7 +95,7 @@ describe("resolveWinInstallIdentity", () => {
       'ReadRegStr $0 HKCU "${inviteProtocolKey}\\\\shell\\\\open\\\\command" ""',
     );
     expect(source).toContain(
-      "StrCmp $0 '$\\\"$INSTDIR\\\\${exeName}$\\\" $\\\"%1$\\\"' 0 preserve_invite_protocol",
+      "StrCmp $0 '$\\\\\"$INSTDIR\\\\${exeName}$\\\\\" $\\\\\"%1$\\\\\"' 0 preserve_invite_protocol",
     );
     expect(source).toContain('DeleteRegKey HKCU "${inviteProtocolKey}"');
     expect(source).toContain("preserve_invite_protocol:");
@@ -126,10 +126,49 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).toContain("older-than-bound-package");
     expect(source).toContain("[System.IO.File]::WriteAllText($CleanupPath");
     expect(source).toContain('Push "event=launcher_runtime_after_write path=${escapedRuntimePath}"');
-    expect(source.indexOf('Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"')).toBeLessThan(
-      source.indexOf("Call SyncLauncherRuntime"),
+    expect(source.indexOf("Call CommitInstallTransaction")).toBeLessThan(source.indexOf("Call SyncLauncherRuntime"));
+    expect(source.indexOf("Call SyncLauncherRuntime")).toBeLessThan(
+      source.indexOf('Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"'),
     );
-    expect(source.indexOf("Call SyncLauncherRuntime")).toBeLessThan(source.indexOf('Push "install section done"'));
+    expect(source.indexOf('Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"')).toBeLessThan(
+      source.indexOf('Push "install section done"'),
+    );
+  });
+
+  it("stages and validates a replacement before atomically switching the install directory", async () => {
+    const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    expect(source).toContain('StrCpy $InstallStagingDir "$INSTDIR.__od_staging"');
+    expect(source).toContain('StrCpy $InstallBackupDir "$INSTDIR.__od_backup"');
+    expect(source).toContain('IfFileExists "$InstallStagingDir\\\\resources\\\\open-design-config.json" 0 invalid_staging');
+    expect(source).toContain('Rename "$INSTDIR" "$InstallBackupDir"');
+    expect(source).toContain('Rename "$InstallStagingDir" "$INSTDIR"');
+    expect(source).toContain("Function RemoveInstallTree");
+    expect(source).toContain('rmdir /s /q "\\\\\\\\?\\\\$2"');
+    expect(source).not.toContain('RMDir /r "$InstallBackupDir"');
+    expect(source).not.toContain('RMDir /r "$InstallStagingDir"');
+    expect(source).toContain("Call RollbackInstallTransaction");
+    expect(source.indexOf('Rename "$INSTDIR" "$InstallBackupDir"')).toBeLessThan(
+      source.indexOf('Rename "$InstallStagingDir" "$INSTDIR"'),
+    );
+  });
+
+  it("preserves desktop shortcut absence on silent repair while creating one for a fresh install", async () => {
+    const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    expect(source).toContain("StrCpy $ExistingInstallWasPresent 0");
+    expect(source).toContain("StrCpy $DesktopShortcutWasPresent 0");
+    expect(source).toContain("\${If} $ExistingInstallWasPresent == 0");
+    expect(source).toContain("\${ElseIf} $DesktopShortcutWasPresent == 1");
+  });
+
+  it("makes the generated uninstaller stop namespace processes before changing files", async () => {
+    const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    const uninstallSection = source.slice(source.indexOf('Section "Uninstall"'));
+    expect(source).toContain("Function un.GuardRunningInstancesBeforeUninstall");
+    expect(source).toContain("Call un.CloseRunningInstances");
+    expect(source).toContain("uninstall aborted: running instances still detected before file changes");
+    expect(uninstallSection.indexOf("Call un.GuardRunningInstancesBeforeUninstall")).toBeLessThan(
+      uninstallSection.indexOf('Delete "$DESKTOP'),
+    );
   });
 
   it.skipIf(process.platform !== "win32")("writes cleanup metadata when installer runtime sync supersedes an older runtime", async () => {

--- a/tools/pack/tests/win-lifecycle.test.ts
+++ b/tools/pack/tests/win-lifecycle.test.ts
@@ -60,7 +60,7 @@ vi.mock("../src/win/registry.js", async () => {
   };
 });
 
-const { diagnosePackedWinIpc, inspectPackedWinApp, installPackedWinApp, stopPackedWinApp } = await import(
+const { diagnosePackedWinIpc, inspectPackedWinApp, installPackedWinApp, stopPackedWinApp, uninstallPackedWinApp } = await import(
   "../src/win/lifecycle.js"
 );
 const { resolveWinPaths } = await import("../src/win/paths.js");
@@ -128,6 +128,51 @@ describe("installPackedWinApp", () => {
 
       expect(result.installDir).toBe(paths.installDir);
       expect(result.lifecycleTimings.map(({ step }) => step)).toContain("ensure install directory");
+      expect(invokeNsis).toHaveBeenCalledOnce();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("uninstallPackedWinApp", () => {
+  it("waits for the NSIS self-copy to finish deleting shortcuts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-lifecycle-"));
+    const config = createConfig(root);
+    const paths = resolveWinPaths(config);
+
+    try {
+      await Promise.all([
+        mkdir(dirname(paths.uninstallerPath), { recursive: true }),
+        mkdir(dirname(paths.startMenuShortcutPath), { recursive: true }),
+        mkdir(dirname(paths.userDesktopShortcutPath), { recursive: true }),
+      ]);
+      await Promise.all([
+        writeFile(paths.uninstallerPath, "", "utf8"),
+        writeFile(paths.startMenuShortcutPath, "", "utf8"),
+        writeFile(paths.userDesktopShortcutPath, "", "utf8"),
+      ]);
+      requestJsonIpc.mockReset();
+      requestJsonIpc.mockRejectedValue(new Error("not running"));
+      listProcessSnapshots.mockReset();
+      listProcessSnapshots.mockResolvedValue([]);
+      queryWinRegistryEntries.mockReset();
+      queryWinRegistryEntries.mockResolvedValue([]);
+      invokeNsis.mockReset();
+      invokeNsis.mockImplementation(async () => {
+        setTimeout(() => {
+          void Promise.all([
+            rm(paths.startMenuShortcutPath, { force: true }),
+            rm(paths.userDesktopShortcutPath, { force: true }),
+          ]);
+        }, 25);
+      });
+
+      const result = await uninstallPackedWinApp(config);
+
+      expect(result.lifecycleTimings.map(({ step }) => step)).toContain("wait for native uninstall settlement");
+      expect(result.residueObservation.startMenuShortcutExists).toBe(false);
+      expect(result.residueObservation.userDesktopShortcutExists).toBe(false);
       expect(invokeNsis).toHaveBeenCalledOnce();
     } finally {
       await rm(root, { force: true, recursive: true });

--- a/tools/pack/tests/win-lifecycle.test.ts
+++ b/tools/pack/tests/win-lifecycle.test.ts
@@ -273,6 +273,35 @@ describe("inspectPackedWinApp", () => {
     }
   });
 
+  it("reports namespace-owned processes only when explicitly requested", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-lifecycle-"));
+    const config = createConfig(root);
+    const payloadDesktop = { command: "payload-desktop --od-namespace=test", pid: 4242, ppid: 1 };
+
+    try {
+      requestJsonIpc.mockReset();
+      requestJsonIpc.mockRejectedValue(new Error("not running"));
+      listProcessSnapshots.mockReset();
+      listProcessSnapshots.mockResolvedValue([payloadDesktop]);
+      matchesStampedProcess.mockReset();
+      matchesStampedProcess.mockImplementation((processInfo, criteria) => (
+        processInfo.command === payloadDesktop.command
+        && (criteria as { namespace?: string }).namespace === config.namespace
+      ));
+
+      const result = await inspectPackedWinApp(config, { includeManagedProcesses: true });
+
+      expect(result.managedProcessPids).toEqual([payloadDesktop.pid]);
+      expect(listProcessSnapshots).toHaveBeenCalledOnce();
+    } finally {
+      listProcessSnapshots.mockReset();
+      listProcessSnapshots.mockResolvedValue([]);
+      matchesStampedProcess.mockReset();
+      matchesStampedProcess.mockReturnValue(false);
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("diagnoses Windows IPC by polling status during repeated fresh starts", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-win-lifecycle-"));
     const config = createConfig(root);

--- a/tools/release/src/index.ts
+++ b/tools/release/src/index.ts
@@ -120,6 +120,24 @@ cli
   });
 
 cli
+  .command("prepare-public-acceptance", "Download and bind public Windows release artifacts for smoke")
+  .action(async () => {
+    await import("./storage/prepare-public-acceptance.ts");
+  });
+
+cli
+  .command("issue-public-acceptance", "Issue a digest-bound credential for a successful public Windows smoke")
+  .action(async () => {
+    await import("./storage/issue-public-acceptance.ts");
+  });
+
+cli
+  .command("activate-public-release", "Activate an accepted public release with a latest metadata CAS")
+  .action(async () => {
+    await import("./storage/activate-public-release.ts");
+  });
+
+cli
   .command("summary-metadata", "Write a release metadata summary")
   .action(async () => {
     await import("./storage/summary-metadata.ts");

--- a/tools/release/src/storage/activate-public-release.ts
+++ b/tools/release/src/storage/activate-public-release.ts
@@ -1,0 +1,12 @@
+import { required, storageConfigFromEnv, writeJson } from "./common.ts";
+import { activateAcceptedPublicRelease } from "./public-acceptance.ts";
+
+const outputsPath = required("RELEASE_OUTPUTS_PATH");
+const result = await activateAcceptedPublicRelease({
+  credentialPath: required("RELEASE_PUBLIC_ACCEPTANCE_CREDENTIAL_PATH"),
+  publicOrigin: required("RELEASE_PUBLIC_ORIGIN"),
+  storage: storageConfigFromEnv(),
+  workDir: required("RELEASE_ACTIVATION_WORK_DIR"),
+});
+writeJson(outputsPath, result);
+console.log(JSON.stringify(result, null, 2));

--- a/tools/release/src/storage/issue-public-acceptance.ts
+++ b/tools/release/src/storage/issue-public-acceptance.ts
@@ -1,0 +1,11 @@
+import { required } from "./common.ts";
+import { issuePublicWindowsAcceptance } from "./public-acceptance.ts";
+
+const result = await issuePublicWindowsAcceptance({
+  credentialPath: required("RELEASE_PUBLIC_ACCEPTANCE_CREDENTIAL_PATH"),
+  planPath: required("RELEASE_PUBLIC_ACCEPTANCE_PLAN_PATH"),
+  smokeSummaryPath: required("RELEASE_PUBLIC_ACCEPTANCE_SMOKE_SUMMARY_PATH"),
+  suiteResultPath: required("RELEASE_PUBLIC_ACCEPTANCE_SUITE_RESULT_PATH"),
+});
+
+console.log(JSON.stringify(result, null, 2));

--- a/tools/release/src/storage/latest-publication.ts
+++ b/tools/release/src/storage/latest-publication.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  parseCountedReleaseVersion,
+  parseReleaseBaseVersion,
+  type CountedReleaseChannel,
+  type ReleaseChannel,
+} from "@open-design/release";
+
+import { contentType } from "./common.ts";
+import {
+  getStorageObject,
+  putStorageObject,
+  putStorageObjectWithStatus,
+  type StorageConfig,
+} from "./s3-upload.ts";
+
+export type LatestPlatformManifest = {
+  feed?: {
+    name?: string;
+  } | null;
+  r2?: {
+    artifactPrefix?: string;
+    versionPrefix?: string;
+  };
+};
+
+type LatestPlatformInput = {
+  manifest: LatestPlatformManifest;
+  path: string;
+};
+
+function parseCountedVersion(
+  value: string,
+  channel: CountedReleaseChannel,
+): { base: [number, number, number]; releaseNumber: number } | null {
+  const parsed = parseCountedReleaseVersion(value, channel);
+  if (parsed == null) return null;
+  const base = parseReleaseBaseVersion(parsed.baseVersion);
+  if (base == null) return null;
+  return { base: [...base], releaseNumber: parsed.number };
+}
+
+export function compareCountedReleaseVersions(
+  left: string,
+  right: string,
+  channel: CountedReleaseChannel,
+): number {
+  const parsedLeft = parseCountedVersion(left, channel);
+  const parsedRight = parseCountedVersion(right, channel);
+  if (parsedLeft == null || parsedRight == null) {
+    throw new Error(`invalid ${channel} version comparison: ${left} vs ${right}`);
+  }
+  for (let index = 0; index < parsedLeft.base.length; index += 1) {
+    if (parsedLeft.base[index] > parsedRight.base[index]) return 1;
+    if (parsedLeft.base[index] < parsedRight.base[index]) return -1;
+  }
+  if (parsedLeft.releaseNumber > parsedRight.releaseNumber) return 1;
+  if (parsedLeft.releaseNumber < parsedRight.releaseNumber) return -1;
+  return 0;
+}
+
+async function latestReleaseVersion(input: {
+  channel: CountedReleaseChannel;
+  storage: StorageConfig;
+}): Promise<string | null> {
+  const latest = await getStorageObject({
+    ...input.storage,
+    objectKey: `${input.channel}/latest/metadata.json`,
+  });
+  if (latest == null) return null;
+  try {
+    const parsed = JSON.parse(latest.text.replace(/^\uFEFF/u, "")) as { releaseVersion?: unknown };
+    if (typeof parsed.releaseVersion !== "string" || parsed.releaseVersion.length === 0) {
+      throw new Error("releaseVersion is missing");
+    }
+    return parsed.releaseVersion;
+  } catch (error) {
+    throw new Error(`latest metadata is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function assertLatestReleaseCanAdvance(input: {
+  channel: CountedReleaseChannel;
+  releaseVersion: string;
+  storage: StorageConfig;
+}): Promise<void> {
+  const current = await latestReleaseVersion(input);
+  if (
+    current != null
+    && compareCountedReleaseVersions(current, input.releaseVersion, input.channel) > 0
+  ) {
+    throw new Error(
+      `refusing to move ${input.channel} latest backward from ${current} to ${input.releaseVersion}`,
+    );
+  }
+}
+
+async function upload(
+  storage: StorageConfig,
+  path: string,
+  objectKey: string,
+  cacheControl: string,
+  type = "application/json; charset=utf-8",
+): Promise<void> {
+  await putStorageObject({
+    ...storage,
+    bodyPath: path,
+    cacheControl,
+    contentType: type,
+    objectKey,
+  });
+}
+
+export async function publishLatestMetadataWithCas(input: {
+  channel: CountedReleaseChannel;
+  metadataPath: string;
+  releaseVersion: string;
+  storage: StorageConfig;
+}): Promise<void> {
+  const objectKey = `${input.channel}/latest/metadata.json`;
+  if (parseCountedVersion(input.releaseVersion, input.channel) == null) {
+    throw new Error(`invalid ${input.channel} version for latest CAS: ${input.releaseVersion}`);
+  }
+
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const latest = await getStorageObject({ ...input.storage, objectKey });
+    const headers: Record<string, string> = {};
+    if (latest == null) {
+      headers["if-none-match"] = "*";
+    } else {
+      let latestReleaseVersion = "";
+      try {
+        const parsed = JSON.parse(latest.text.replace(/^\uFEFF/u, "")) as { releaseVersion?: unknown };
+        latestReleaseVersion = typeof parsed.releaseVersion === "string" ? parsed.releaseVersion : "";
+      } catch (error) {
+        throw new Error(`latest metadata is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      if (
+        latestReleaseVersion.length > 0
+        && compareCountedReleaseVersions(latestReleaseVersion, input.releaseVersion, input.channel) > 0
+      ) {
+        throw new Error(
+          `refusing to move ${input.channel} latest backward from ${latestReleaseVersion} to ${input.releaseVersion}`,
+        );
+      }
+      if (latest.etag.length === 0) {
+        throw new Error("latest metadata GET did not return an ETag for CAS update");
+      }
+      headers["if-match"] = latest.etag;
+    }
+
+    const result = await putStorageObjectWithStatus({
+      ...input.storage,
+      bodyPath: input.metadataPath,
+      cacheControl: "public, max-age=60, must-revalidate",
+      contentType: "application/json; charset=utf-8",
+      headers,
+      objectKey,
+    });
+    if (result.ok) return;
+    if (result.status !== 412) {
+      throw new Error(
+        `latest metadata CAS PUT ${objectKey} failed with HTTP ${result.status}`
+        + `${result.body.length > 0 ? `: ${result.body}` : ""}`,
+      );
+    }
+    console.log(`latest metadata CAS conflict on attempt ${attempt}; retrying`);
+  }
+
+  throw new Error(`failed to update latest metadata with CAS after 5 attempts: ${objectKey}`);
+}
+
+export async function publishLatestPlatformObjects(input: {
+  channel: ReleaseChannel;
+  metadataDir: string;
+  platforms: Record<string, LatestPlatformInput>;
+  storage: StorageConfig;
+}): Promise<void> {
+  const latestPrefix = `${input.channel}/latest`;
+  for (const [target, platform] of Object.entries(input.platforms)) {
+    await upload(
+      input.storage,
+      platform.path,
+      `${latestPrefix}/platforms/${target}.json`,
+      "public, max-age=60, must-revalidate",
+    );
+
+    const feedName = platform.manifest.feed?.name;
+    if (feedName == null || feedName.length === 0) continue;
+    const feedVersionPrefix = platform.manifest.r2?.artifactPrefix ?? platform.manifest.r2?.versionPrefix;
+    if (feedVersionPrefix == null || feedVersionPrefix.length === 0) {
+      throw new Error(`published ${target} platform manifest is missing r2.versionPrefix for ${feedName}`);
+    }
+    const versionFeed = await getStorageObject({
+      ...input.storage,
+      objectKey: `${feedVersionPrefix}/${feedName}`,
+    });
+    if (versionFeed == null) {
+      throw new Error(`expected versioned feed object not found: ${feedVersionPrefix}/${feedName}`);
+    }
+    const feedPath = join(input.metadataDir, "latest-feeds", feedName);
+    mkdirSync(join(input.metadataDir, "latest-feeds"), { recursive: true });
+    writeFileSync(feedPath, versionFeed.bytes);
+    await upload(
+      input.storage,
+      feedPath,
+      `${latestPrefix}/${feedName}`,
+      "public, max-age=60, must-revalidate",
+      contentType(feedName),
+    );
+  }
+}
+
+export async function publishLatestRelease(input: {
+  channel: CountedReleaseChannel;
+  metadataDir: string;
+  metadataPath: string;
+  platforms: Record<string, LatestPlatformInput>;
+  releaseVersion: string;
+  storage: StorageConfig;
+}): Promise<void> {
+  // Reject an already-newer latest before touching compatibility objects. The
+  // workflow-level release concurrency serializes the remaining support-object
+  // preparation and metadata CAS window; the CAS still detects any external
+  // writer that ignores that serialization.
+  await assertLatestReleaseCanAdvance(input);
+  // Materialize support objects first. The metadata CAS below is the only
+  // activation point consumers use to discover this release.
+  await publishLatestPlatformObjects(input);
+  await publishLatestMetadataWithCas(input);
+}
+
+export function sha256Digest(bytes: Buffer | string): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}

--- a/tools/release/src/storage/prepare-public-acceptance.ts
+++ b/tools/release/src/storage/prepare-public-acceptance.ts
@@ -1,0 +1,15 @@
+import { required } from "./common.ts";
+import { preparePublicWindowsAcceptance } from "./public-acceptance.ts";
+
+const result = await preparePublicWindowsAcceptance({
+  buildJsonPath: required("RELEASE_PUBLIC_ACCEPTANCE_BUILD_JSON_PATH"),
+  commit: required("RELEASE_COMMIT"),
+  downloadDir: required("RELEASE_PUBLIC_ACCEPTANCE_DOWNLOAD_DIR"),
+  metadataUrl: required("RELEASE_METADATA_URL"),
+  namespace: required("RELEASE_NAMESPACE"),
+  planPath: required("RELEASE_PUBLIC_ACCEPTANCE_PLAN_PATH"),
+  publicOrigin: required("RELEASE_PUBLIC_ORIGIN"),
+  releaseVersion: required("RELEASE_VERSION"),
+});
+
+console.log(JSON.stringify(result, null, 2));

--- a/tools/release/src/storage/public-acceptance.ts
+++ b/tools/release/src/storage/public-acceptance.ts
@@ -1,0 +1,672 @@
+import { createHash } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { Readable, Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { isDeepStrictEqual } from "node:util";
+
+import { putStorageObjectWithStatus, getStorageObject, type StorageConfig } from "./s3-upload.ts";
+import { normalizePublicUrl, writeJson } from "./common.ts";
+import { publishLatestRelease, sha256Digest } from "./latest-publication.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+export type PublicArtifactBinding = {
+  digest: string;
+  size: number;
+  url: string;
+};
+
+export type PublicAcceptancePlan = {
+  closure: PublicArtifactBinding & {
+    channel: "beta";
+    platform: "win32-x64";
+    version: string;
+  };
+  commit: string;
+  installer: PublicArtifactBinding & { path: string };
+  metadata: PublicArtifactBinding & { path: string };
+  namespace: string;
+  platformManifest: PublicArtifactBinding & { path: string };
+  releaseVersion: string;
+  schemaVersion: 1;
+  target: "win_x64";
+};
+
+export type PublicAcceptanceCredential = {
+  acceptedAt: string;
+  closure: PublicAcceptancePlan["closure"];
+  commit: string;
+  installer: PublicArtifactBinding;
+  metadata: PublicArtifactBinding;
+  namespace: string;
+  platformManifest: PublicArtifactBinding;
+  releaseVersion: string;
+  schemaVersion: 1;
+  smoke: {
+    profile: string;
+    selectedLanes: string[];
+    status: "success";
+    summaryDigest: string;
+  };
+  status: "accepted";
+  target: "win_x64";
+};
+
+function assertRecord(value: unknown, label: string): asserts value is JsonRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+}
+
+function stringField(record: JsonRecord, name: string, label: string): string {
+  const value = record[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label}.${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function numberField(record: JsonRecord, name: string, label: string): number {
+  const value = record[name];
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label}.${name} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function assertDigest(value: string, label: string): void {
+  if (!/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new Error(`${label} must be a lowercase sha256 digest`);
+  }
+}
+
+function artifactBinding(value: unknown, label: string): PublicArtifactBinding {
+  assertRecord(value, label);
+  const binding = {
+    digest: stringField(value, "digest", label),
+    size: numberField(value, "size", label),
+    url: normalizePublicUrl(stringField(value, "url", label)),
+  };
+  assertDigest(binding.digest, `${label}.digest`);
+  return binding;
+}
+
+function childRecord(record: JsonRecord, name: string, label: string): JsonRecord {
+  const child = record[name];
+  assertRecord(child, `${label}.${name}`);
+  return child;
+}
+
+function assertPublicImmutableUrl(url: string, publicOrigin: string, label: string): void {
+  const parsed = new URL(normalizePublicUrl(url));
+  const origin = new URL(normalizePublicUrl(publicOrigin));
+  if (parsed.origin !== origin.origin || !parsed.pathname.startsWith(origin.pathname.replace(/\/$/u, ""))) {
+    throw new Error(`${label} must be under the configured public origin`);
+  }
+  if (!parsed.pathname.includes("/versions/") || parsed.pathname.includes("/latest/")) {
+    throw new Error(`${label} must identify an immutable version object`);
+  }
+}
+
+function assertIdentity(input: {
+  commit: string;
+  metadata: JsonRecord;
+  platform: JsonRecord;
+  releaseVersion: string;
+}): void {
+  if (stringField(input.metadata, "releaseVersion", "metadata") !== input.releaseVersion) {
+    throw new Error("public metadata releaseVersion mismatch");
+  }
+  if (stringField(input.metadata, "releaseState", "metadata") !== "complete") {
+    throw new Error("public metadata must be complete before acceptance");
+  }
+  const metadataGithub = childRecord(input.metadata, "github", "metadata");
+  if (stringField(metadataGithub, "commit", "metadata.github") !== input.commit) {
+    throw new Error("public metadata commit mismatch");
+  }
+  if (stringField(input.platform, "releaseVersion", "platform") !== input.releaseVersion) {
+    throw new Error("public Windows platform releaseVersion mismatch");
+  }
+  if (stringField(input.platform, "platformKey", "platform") !== "win_x64") {
+    throw new Error("public Windows platform target mismatch");
+  }
+  if (stringField(input.platform, "status", "platform") !== "published") {
+    throw new Error("public Windows platform must be published");
+  }
+  const platformGithub = childRecord(input.platform, "github", "platform");
+  if (stringField(platformGithub, "commit", "platform.github") !== input.commit) {
+    throw new Error("public Windows platform commit mismatch");
+  }
+}
+
+function parseJsonBytes(bytes: Buffer, label: string): JsonRecord {
+  let value: unknown;
+  try {
+    value = JSON.parse(bytes.toString("utf8").replace(/^\uFEFF/u, "")) as unknown;
+  } catch (error) {
+    throw new Error(`${label} is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  assertRecord(value, label);
+  return value;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchPublic(url: string, fetchImpl: typeof fetch): Promise<Response> {
+  let lastStatus = 0;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, { redirect: "follow" });
+      lastStatus = response.status;
+      if (response.ok) return response;
+      await response.body?.cancel().catch(() => undefined);
+      if (response.status !== 404 && response.status !== 429 && response.status < 500) {
+        throw new Error(`public object returned HTTP ${response.status}: ${url}`);
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < 5) await delay(Math.min(8_000, 500 * 2 ** (attempt - 1)));
+  }
+  const cause = lastError instanceof Error ? lastError.message : `HTTP ${lastStatus}`;
+  throw new Error(`public object did not become readable after 5 attempts: ${url} (${cause})`);
+}
+
+async function fetchBytes(url: string, fetchImpl: typeof fetch): Promise<Buffer> {
+  const response = await fetchPublic(url, fetchImpl);
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function downloadBoundArtifact(input: {
+  binding: PublicArtifactBinding;
+  fetchImpl: typeof fetch;
+  path: string;
+}): Promise<void> {
+  await mkdir(dirname(input.path), { recursive: true });
+  const response = await fetchPublic(input.binding.url, input.fetchImpl);
+  if (response.body == null) throw new Error(`public artifact response has no body: ${input.binding.url}`);
+  const hash = createHash("sha256");
+  let size = 0;
+  const observer = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      hash.update(chunk);
+      size += chunk.byteLength;
+      callback(null, chunk);
+    },
+  });
+  await pipeline(
+    Readable.from(response.body as AsyncIterable<Uint8Array>),
+    observer,
+    createWriteStream(input.path, { flags: "wx" }),
+  );
+  const digest = `sha256:${hash.digest("hex")}`;
+  if (size !== input.binding.size || digest !== input.binding.digest) {
+    throw new Error(
+      `downloaded public artifact mismatch for ${input.binding.url}: `
+      + `expected ${input.binding.digest}/${input.binding.size}, got ${digest}/${size}`,
+    );
+  }
+}
+
+async function describeFile(path: string): Promise<{ digest: string; size: number }> {
+  const hash = createHash("sha256");
+  const stream = createReadStream(path);
+  for await (const chunk of stream) hash.update(chunk);
+  return {
+    digest: `sha256:${hash.digest("hex")}`,
+    size: (await stat(path)).size,
+  };
+}
+
+function assertFileBinding(
+  actual: { digest: string; size: number },
+  expected: PublicArtifactBinding,
+  label: string,
+): void {
+  if (actual.digest !== expected.digest || actual.size !== expected.size) {
+    throw new Error(
+      `${label} no longer matches public binding: expected ${expected.digest}/${expected.size}, `
+      + `got ${actual.digest}/${actual.size}`,
+    );
+  }
+}
+
+export async function preparePublicWindowsAcceptance(input: {
+  buildJsonPath: string;
+  commit: string;
+  downloadDir: string;
+  fetchImpl?: typeof fetch;
+  metadataUrl: string;
+  namespace: string;
+  planPath: string;
+  publicOrigin: string;
+  releaseVersion: string;
+}): Promise<PublicAcceptancePlan> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const metadataUrl = normalizePublicUrl(input.metadataUrl);
+  assertPublicImmutableUrl(metadataUrl, input.publicOrigin, "metadata URL");
+  const metadataBytes = await fetchBytes(metadataUrl, fetchImpl);
+  const metadata = parseJsonBytes(metadataBytes, "public metadata");
+  const releaseTargets = childRecord(metadata, "releaseTargets", "metadata");
+  const embeddedPlatform = childRecord(releaseTargets, "win_x64", "metadata.releaseTargets");
+  const platformR2 = childRecord(embeddedPlatform, "r2", "metadata.releaseTargets.win_x64");
+  const platformUrl = normalizePublicUrl(stringField(platformR2, "versionManifestUrl", "platform.r2"));
+  assertPublicImmutableUrl(platformUrl, input.publicOrigin, "Windows platform manifest URL");
+  const platformBytes = await fetchBytes(platformUrl, fetchImpl);
+  const platform = parseJsonBytes(platformBytes, "public Windows platform manifest");
+  assertIdentity({
+    commit: input.commit,
+    metadata,
+    platform,
+    releaseVersion: input.releaseVersion,
+  });
+  if (!isDeepStrictEqual(embeddedPlatform, platform)) {
+    throw new Error("combined metadata Windows target differs from its immutable platform manifest");
+  }
+
+  const artifacts = childRecord(platform, "artifacts", "platform");
+  const installer = artifactBinding(artifacts.installer, "platform.artifacts.installer");
+  const closure = childRecord(platform, "closure", "platform");
+  const closureAssets = childRecord(closure, "assets", "platform.closure");
+  const closureArchive = artifactBinding(closureAssets.archive, "platform.closure.assets.archive");
+  const closureManifest = childRecord(closure, "manifest", "platform.closure");
+  const closureIdentity = childRecord(closureManifest, "identity", "platform.closure.manifest");
+  const closureVersion = stringField(closureIdentity, "version", "closure.identity");
+  if (
+    stringField(closureIdentity, "channel", "closure.identity") !== "beta"
+    || stringField(closureIdentity, "platform", "closure.identity") !== "win32-x64"
+  ) {
+    throw new Error("public Windows Closure identity mismatch");
+  }
+  if (stringField(closureIdentity, "digest", "closure.identity") !== closureArchive.digest) {
+    throw new Error("public Windows Closure identity digest mismatch");
+  }
+  const closureArtifact = artifactBinding(closureManifest.artifact, "platform.closure.manifest.artifact");
+  if (!isDeepStrictEqual(closureArchive, closureArtifact)) {
+    throw new Error("public Windows Closure archive differs from its candidate manifest artifact");
+  }
+  for (const [label, binding] of [
+    ["installer URL", installer],
+    ["Closure archive URL", closureArchive],
+  ] as const) {
+    assertPublicImmutableUrl(binding.url, input.publicOrigin, label);
+  }
+
+  const installerName = decodeURIComponent(basename(new URL(installer.url).pathname));
+  const installerPath = join(input.downloadDir, installerName);
+  await downloadBoundArtifact({ binding: installer, fetchImpl, path: installerPath });
+  const metadataPath = join(input.downloadDir, "public-metadata.json");
+  const platformPath = join(input.downloadDir, "public-win_x64.json");
+  await mkdir(input.downloadDir, { recursive: true });
+  await Promise.all([
+    writeFile(metadataPath, metadataBytes, { flag: "wx" }),
+    writeFile(platformPath, platformBytes, { flag: "wx" }),
+  ]);
+
+  const plan: PublicAcceptancePlan = {
+    closure: {
+      ...closureArchive,
+      channel: "beta",
+      platform: "win32-x64",
+      version: closureVersion,
+    },
+    commit: input.commit,
+    installer: { ...installer, path: installerPath },
+    metadata: {
+      digest: sha256Digest(metadataBytes),
+      path: metadataPath,
+      size: metadataBytes.byteLength,
+      url: metadataUrl,
+    },
+    namespace: input.namespace,
+    platformManifest: {
+      digest: sha256Digest(platformBytes),
+      path: platformPath,
+      size: platformBytes.byteLength,
+      url: platformUrl,
+    },
+    releaseVersion: input.releaseVersion,
+    schemaVersion: 1,
+    target: "win_x64",
+  };
+  writeJson(input.buildJsonPath, { installerPath });
+  writeJson(input.planPath, plan);
+  return plan;
+}
+
+function parsePlan(value: unknown): PublicAcceptancePlan {
+  assertRecord(value, "public acceptance plan");
+  if (value.schemaVersion !== 1 || value.target !== "win_x64") {
+    throw new Error("unsupported public acceptance plan identity");
+  }
+  return value as PublicAcceptancePlan;
+}
+
+function parseCredential(value: unknown): PublicAcceptanceCredential {
+  assertRecord(value, "public acceptance credential");
+  if (value.schemaVersion !== 1 || value.target !== "win_x64" || value.status !== "accepted") {
+    throw new Error("unsupported public acceptance credential identity");
+  }
+  const closureRecord = childRecord(value, "closure", "public acceptance credential");
+  const closureArtifact = artifactBinding(closureRecord, "public acceptance credential.closure");
+  const closureChannel = stringField(closureRecord, "channel", "credential.closure");
+  const closurePlatform = stringField(closureRecord, "platform", "credential.closure");
+  if (closureChannel !== "beta" || closurePlatform !== "win32-x64") {
+    throw new Error("public acceptance credential Closure identity mismatch");
+  }
+  const smoke = childRecord(value, "smoke", "public acceptance credential");
+  if (
+    smoke.status !== "success"
+    || smoke.profile !== "core"
+    || !Array.isArray(smoke.selectedLanes)
+    || smoke.selectedLanes.length !== 1
+    || smoke.selectedLanes[0] !== "shell"
+  ) {
+    throw new Error("public acceptance credential smoke proof is invalid");
+  }
+  const summaryDigest = stringField(smoke, "summaryDigest", "credential.smoke");
+  assertDigest(summaryDigest, "credential.smoke.summaryDigest");
+  const releaseVersion = stringField(value, "releaseVersion", "credential");
+  const commit = stringField(value, "commit", "credential");
+  if (!/^[0-9a-f]{40}$/u.test(commit)) throw new Error("public acceptance credential commit must be a full SHA");
+  return {
+    acceptedAt: stringField(value, "acceptedAt", "credential"),
+    closure: {
+      ...closureArtifact,
+      channel: "beta",
+      platform: "win32-x64",
+      version: stringField(closureRecord, "version", "credential.closure"),
+    },
+    commit,
+    installer: artifactBinding(value.installer, "public acceptance credential.installer"),
+    metadata: artifactBinding(value.metadata, "public acceptance credential.metadata"),
+    namespace: stringField(value, "namespace", "credential"),
+    platformManifest: artifactBinding(
+      value.platformManifest,
+      "public acceptance credential.platformManifest",
+    ),
+    releaseVersion,
+    schemaVersion: 1,
+    smoke: {
+      profile: "core",
+      selectedLanes: ["shell"],
+      status: "success",
+      summaryDigest,
+    },
+    status: "accepted",
+    target: "win_x64",
+  };
+}
+
+export async function issuePublicWindowsAcceptance(input: {
+  credentialPath: string;
+  planPath: string;
+  smokeSummaryPath: string;
+  suiteResultPath: string;
+}): Promise<PublicAcceptanceCredential> {
+  const [planBytes, summaryBytes, suiteResultBytes] = await Promise.all([
+    readFile(input.planPath),
+    readFile(input.smokeSummaryPath),
+    readFile(input.suiteResultPath),
+  ]);
+  const plan = parsePlan(parseJsonBytes(planBytes, "public acceptance plan"));
+  const summary = parseJsonBytes(summaryBytes, "public smoke summary");
+  const suiteResult = parseJsonBytes(suiteResultBytes, "public smoke suite result");
+  if (suiteResult.status !== "success" || suiteResult.exitCode !== 0) {
+    throw new Error("public Windows smoke suite did not succeed");
+  }
+  const planSummary = childRecord(summary, "plan", "smoke summary");
+  const profile = stringField(planSummary, "profile", "smoke summary.plan");
+  const selectedLanes = planSummary.selectedLanes;
+  if (profile !== "core" || !Array.isArray(selectedLanes) || selectedLanes.length !== 1 || selectedLanes[0] !== "shell") {
+    throw new Error("public Windows acceptance requires the core shell smoke plan");
+  }
+  if (!Array.isArray(summary.timings)) throw new Error("public smoke summary timings are required");
+  const lifecycle = summary.timings.find((entry) => {
+    return entry != null && typeof entry === "object" && (entry as JsonRecord).step === "win-shell-lifecycle";
+  });
+  assertRecord(lifecycle, "public shell lifecycle timing");
+  if (lifecycle.status !== "success") throw new Error("public Windows shell lifecycle did not succeed");
+
+  const closureBinding = childRecord(summary, "closureBinding", "smoke summary");
+  const committed = childRecord(closureBinding, "committed", "smoke summary.closureBinding");
+  if (stringField(committed, "releaseVersion", "closure committed") !== plan.releaseVersion) {
+    throw new Error("public smoke committed Closure releaseVersion mismatch");
+  }
+  const standalone = childRecord(committed, "standalone", "closure committed");
+  for (const [name, expected] of [
+    ["channel", plan.closure.channel],
+    ["digest", plan.closure.digest],
+    ["platform", plan.closure.platform],
+    ["version", plan.closure.version],
+    ["namespace", plan.namespace],
+  ] as const) {
+    if (standalone[name] !== expected) {
+      throw new Error(`public smoke committed Closure ${name} mismatch`);
+    }
+  }
+
+  const [metadataFile, platformFile, installerFile] = await Promise.all([
+    describeFile(plan.metadata.path),
+    describeFile(plan.platformManifest.path),
+    describeFile(plan.installer.path),
+  ]);
+  assertFileBinding(metadataFile, plan.metadata, "public metadata");
+  assertFileBinding(platformFile, plan.platformManifest, "public Windows platform manifest");
+  assertFileBinding(installerFile, plan.installer, "public Windows installer");
+
+  const credential: PublicAcceptanceCredential = {
+    acceptedAt: new Date().toISOString(),
+    closure: plan.closure,
+    commit: plan.commit,
+    installer: {
+      digest: plan.installer.digest,
+      size: plan.installer.size,
+      url: plan.installer.url,
+    },
+    metadata: {
+      digest: plan.metadata.digest,
+      size: plan.metadata.size,
+      url: plan.metadata.url,
+    },
+    namespace: plan.namespace,
+    platformManifest: {
+      digest: plan.platformManifest.digest,
+      size: plan.platformManifest.size,
+      url: plan.platformManifest.url,
+    },
+    releaseVersion: plan.releaseVersion,
+    schemaVersion: 1,
+    smoke: {
+      profile,
+      selectedLanes: ["shell"],
+      status: "success",
+      summaryDigest: sha256Digest(summaryBytes),
+    },
+    status: "accepted",
+    target: "win_x64",
+  };
+  writeJson(input.credentialPath, credential);
+  return credential;
+}
+
+function objectKeyFromPublicUrl(url: string, publicOrigin: string): string {
+  const parsed = new URL(normalizePublicUrl(url));
+  const origin = new URL(normalizePublicUrl(publicOrigin));
+  const originPath = origin.pathname.replace(/\/+$/u, "");
+  if (parsed.origin !== origin.origin || !parsed.pathname.startsWith(`${originPath}/`)) {
+    throw new Error(`public URL is outside the configured origin: ${url}`);
+  }
+  return decodeURIComponent(parsed.pathname.slice(originPath.length + 1));
+}
+
+async function uploadImmutableCredential(input: {
+  credentialBytes: Buffer;
+  credentialPath: string;
+  objectKey: string;
+  storage: StorageConfig;
+}): Promise<void> {
+  const result = await putStorageObjectWithStatus({
+    ...input.storage,
+    bodyPath: input.credentialPath,
+    cacheControl: "public, max-age=31536000, immutable",
+    contentType: "application/json; charset=utf-8",
+    headers: { "if-none-match": "*" },
+    objectKey: input.objectKey,
+  });
+  if (result.ok) return;
+  if (result.status !== 412) {
+    throw new Error(`acceptance credential PUT failed with HTTP ${result.status}: ${result.body}`);
+  }
+  const existing = await getStorageObject({ ...input.storage, objectKey: input.objectKey });
+  if (existing == null || !existing.bytes.equals(input.credentialBytes)) {
+    throw new Error(`immutable acceptance credential conflict: ${input.objectKey}`);
+  }
+}
+
+export async function activateAcceptedPublicRelease(input: {
+  credentialPath: string;
+  fetchImpl?: typeof fetch;
+  publicOrigin: string;
+  storage: StorageConfig;
+  workDir: string;
+}): Promise<{ acceptanceUrl: string; latestMetadataUrl: string }> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const credentialBytes = await readFile(input.credentialPath);
+  const credential = parseCredential(parseJsonBytes(credentialBytes, "public acceptance credential"));
+  for (const [label, binding] of [
+    ["credential metadata URL", credential.metadata],
+    ["credential Windows platform manifest URL", credential.platformManifest],
+    ["credential installer URL", credential.installer],
+    ["credential Closure URL", credential.closure],
+  ] as const) {
+    assertPublicImmutableUrl(binding.url, input.publicOrigin, label);
+  }
+  const [metadataBytes, winPlatformBytes] = await Promise.all([
+    fetchBytes(credential.metadata.url, fetchImpl),
+    fetchBytes(credential.platformManifest.url, fetchImpl),
+  ]);
+  assertFileBinding(
+    { digest: sha256Digest(metadataBytes), size: metadataBytes.byteLength },
+    credential.metadata,
+    "public metadata",
+  );
+  assertFileBinding(
+    { digest: sha256Digest(winPlatformBytes), size: winPlatformBytes.byteLength },
+    credential.platformManifest,
+    "public Windows platform manifest",
+  );
+  const metadata = parseJsonBytes(metadataBytes, "public metadata");
+  const winPlatform = parseJsonBytes(winPlatformBytes, "public Windows platform manifest");
+  assertIdentity({
+    commit: credential.commit,
+    metadata,
+    platform: winPlatform,
+    releaseVersion: credential.releaseVersion,
+  });
+  const metadataR2 = childRecord(metadata, "r2", "metadata");
+  if (stringField(metadataR2, "versionMetadataUrl", "metadata.r2") !== credential.metadata.url) {
+    throw new Error("accepted metadata URL no longer matches its public metadata identity");
+  }
+  const embeddedWindows = childRecord(
+    childRecord(metadata, "releaseTargets", "metadata"),
+    "win_x64",
+    "metadata.releaseTargets",
+  );
+  const embeddedWindowsR2 = childRecord(embeddedWindows, "r2", "metadata.releaseTargets.win_x64");
+  if (
+    stringField(embeddedWindowsR2, "versionManifestUrl", "win_x64.r2")
+    !== credential.platformManifest.url
+  ) {
+    throw new Error("accepted Windows platform URL no longer matches public metadata");
+  }
+  const publicInstaller = artifactBinding(
+    childRecord(winPlatform, "artifacts", "platform").installer,
+    "platform.artifacts.installer",
+  );
+  if (!isDeepStrictEqual(publicInstaller, credential.installer)) {
+    throw new Error("accepted installer binding no longer matches public Windows metadata");
+  }
+  const publicClosure = childRecord(winPlatform, "closure", "platform");
+  const publicClosureArchive = artifactBinding(
+    childRecord(publicClosure, "assets", "platform.closure").archive,
+    "platform.closure.assets.archive",
+  );
+  const publicClosureIdentity = childRecord(
+    childRecord(publicClosure, "manifest", "platform.closure"),
+    "identity",
+    "platform.closure.manifest",
+  );
+  if (
+    !isDeepStrictEqual(publicClosureArchive, {
+      digest: credential.closure.digest,
+      size: credential.closure.size,
+      url: credential.closure.url,
+    })
+    || publicClosureIdentity.channel !== credential.closure.channel
+    || publicClosureIdentity.digest !== credential.closure.digest
+    || publicClosureIdentity.platform !== credential.closure.platform
+    || publicClosureIdentity.version !== credential.closure.version
+  ) {
+    throw new Error("accepted Closure binding no longer matches public Windows metadata");
+  }
+
+  const releaseTargets = childRecord(metadata, "releaseTargets", "metadata");
+  const platformInputs: Record<string, { manifest: JsonRecord; path: string }> = {};
+  await mkdir(input.workDir, { recursive: true });
+  for (const [target, embedded] of Object.entries(releaseTargets)) {
+    assertRecord(embedded, `metadata.releaseTargets.${target}`);
+    if (embedded.status !== "published") continue;
+    const r2 = childRecord(embedded, "r2", `metadata.releaseTargets.${target}`);
+    const url = normalizePublicUrl(stringField(r2, "versionManifestUrl", `${target}.r2`));
+    assertPublicImmutableUrl(url, input.publicOrigin, `${target} platform manifest URL`);
+    const bytes = target === "win_x64" ? winPlatformBytes : await fetchBytes(url, fetchImpl);
+    const manifest = parseJsonBytes(bytes, `${target} public platform manifest`);
+    if (!isDeepStrictEqual(embedded, manifest)) {
+      throw new Error(`combined metadata ${target} differs from its immutable platform manifest`);
+    }
+    const path = join(input.workDir, `${target}.json`);
+    await writeFile(path, bytes);
+    platformInputs[target] = { manifest, path };
+  }
+  if (platformInputs.win_x64 == null) throw new Error("accepted release no longer publishes win_x64");
+
+  const versionPrefix = stringField(metadataR2, "versionPrefix", "metadata.r2");
+  if (versionPrefix !== `beta/versions/${credential.releaseVersion}`) {
+    throw new Error(`accepted metadata has unexpected version prefix: ${versionPrefix}`);
+  }
+  const credentialKey = `${versionPrefix}/acceptance/win_x64.json`;
+  await uploadImmutableCredential({
+    credentialBytes,
+    credentialPath: input.credentialPath,
+    objectKey: credentialKey,
+    storage: input.storage,
+  });
+  const metadataPath = join(input.workDir, "metadata.json");
+  await writeFile(metadataPath, metadataBytes);
+  await publishLatestRelease({
+    channel: "beta",
+    metadataDir: input.workDir,
+    metadataPath,
+    platforms: platformInputs,
+    releaseVersion: credential.releaseVersion,
+    storage: input.storage,
+  });
+  return {
+    acceptanceUrl: normalizePublicUrl(`${input.publicOrigin.replace(/\/+$/u, "")}/${credentialKey}`),
+    latestMetadataUrl: normalizePublicUrl(`${input.publicOrigin.replace(/\/+$/u, "")}/beta/latest/metadata.json`),
+  };
+}
+
+export const publicAcceptanceInternals = {
+  artifactBinding,
+  assertPublicImmutableUrl,
+  objectKeyFromPublicUrl,
+  parseCredential,
+  parsePlan,
+};

--- a/tools/release/src/storage/publish-metadata.ts
+++ b/tools/release/src/storage/publish-metadata.ts
@@ -1,7 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-  contentType,
   githubInfo,
   optional,
   publicUrl,
@@ -10,18 +9,16 @@ import {
   writeJson,
 } from "./common.ts";
 import { assertCurrentVersionReservation, versionLockObjectKey } from "./beta-version-reservation.ts";
-import { getStorageObject, putStorageObject, putStorageObjectWithStatus } from "./s3-upload.ts";
+import { putStorageObject } from "./s3-upload.ts";
+import { publishLatestPlatformObjects, publishLatestRelease } from "./latest-publication.ts";
 import {
   assertLauncherVersionFloorSatisfiable,
   resolveLauncherVersionFloor,
 } from "./launcher-version-floor.ts";
 import {
-  parseCountedReleaseVersion,
-  parseReleaseBaseVersion,
   parseReleaseVersion,
   releaseChannelDescriptor,
   releaseMetadataVersionFields,
-  type CountedReleaseChannel,
 } from "@open-design/release";
 import {
   parseReleaseNotePublication,
@@ -96,6 +93,7 @@ const versionLockKey = optional(
   countedReleaseChannel == null ? "" : versionLockObjectKey(releaseVersion, countedReleaseChannel),
 );
 const latestCasRequired = process.env.RELEASE_LATEST_CAS_REQUIRED === "true";
+const latestActivationEnabled = optional("RELEASE_ACTIVATE_LATEST", "true") !== "false";
 const closureRequired = process.env.RELEASE_CLOSURE_REQUIRED === "true";
 const shellRequired = process.env.RELEASE_SHELL_REQUIRED === "true";
 const storage = publishSideEffectsEnabled || versionLockRequired ? storageConfigFromEnv() : null;
@@ -175,30 +173,6 @@ function releaseMetadataFields(): Record<string, unknown> {
   };
 }
 
-function parseCountedVersionForChannel(value: string, channel: CountedReleaseChannel): { base: [number, number, number]; releaseNumber: number } | null {
-  const parsed = parseCountedReleaseVersion(value, channel);
-  if (parsed == null) return null;
-  const base = parseReleaseBaseVersion(parsed.baseVersion);
-  if (base == null) return null;
-  return { base: [...base], releaseNumber: parsed.number };
-}
-
-function compareReleaseVersions(left: string, right: string): number {
-  if (releaseChannel === "stable") throw new Error("stable latest CAS does not compare counted release versions");
-  const parsedLeft = parseCountedVersionForChannel(left, releaseChannel);
-  const parsedRight = parseCountedVersionForChannel(right, releaseChannel);
-  if (parsedLeft == null || parsedRight == null) {
-    throw new Error(`invalid ${releaseChannel} version comparison: ${left} vs ${right}`);
-  }
-  for (let index = 0; index < parsedLeft.base.length; index += 1) {
-    if (parsedLeft.base[index] > parsedRight.base[index]) return 1;
-    if (parsedLeft.base[index] < parsedRight.base[index]) return -1;
-  }
-  if (parsedLeft.releaseNumber > parsedRight.releaseNumber) return 1;
-  if (parsedLeft.releaseNumber < parsedRight.releaseNumber) return -1;
-  return 0;
-}
-
 async function upload(path: string, objectKey: string, cacheControl: string, type = "application/json; charset=utf-8"): Promise<void> {
   if (!publishSideEffectsEnabled) {
     console.log(`[dry-run:${dryRunMode || "plan"}] would upload ${path} to ${objectKey}`);
@@ -212,84 +186,6 @@ async function upload(path: string, objectKey: string, cacheControl: string, typ
     contentType: type,
     objectKey,
   });
-}
-
-async function uploadLatestMetadataWithCas(path: string, objectKey: string): Promise<void> {
-  if (storage == null) throw new Error("storage config is required to publish latest metadata");
-  if (!latestCasRequired) {
-    await upload(path, objectKey, "public, max-age=60, must-revalidate");
-    return;
-  }
-
-  if (releaseChannel === "stable") {
-    throw new Error("latest metadata CAS is only supported for counted releases");
-  }
-  if (parseCountedVersionForChannel(releaseVersion, releaseChannel) == null) {
-    throw new Error(`invalid ${releaseChannel} version for latest CAS: ${releaseVersion}`);
-  }
-
-  for (let attempt = 1; attempt <= 5; attempt += 1) {
-    const latest = await getStorageObject({ ...storage, objectKey });
-    const headers: Record<string, string> = {};
-    if (latest == null) {
-      headers["if-none-match"] = "*";
-    } else {
-      let latestReleaseVersion = "";
-      try {
-        const parsed = JSON.parse(latest.text.replace(/^\uFEFF/u, "")) as { releaseVersion?: unknown };
-        latestReleaseVersion = typeof parsed.releaseVersion === "string" ? parsed.releaseVersion : "";
-      } catch (error) {
-        throw new Error(`latest metadata is invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
-      }
-      if (latestReleaseVersion.length > 0 && compareReleaseVersions(latestReleaseVersion, releaseVersion) > 0) {
-        throw new Error(`refusing to move ${releaseChannel} latest backward from ${latestReleaseVersion} to ${releaseVersion}`);
-      }
-      if (latest.etag.length === 0) {
-        throw new Error("latest metadata GET did not return an ETag for CAS update");
-      }
-      headers["if-match"] = latest.etag;
-    }
-
-    const result = await putStorageObjectWithStatus({
-      ...storage,
-      bodyPath: path,
-      cacheControl: "public, max-age=60, must-revalidate",
-      contentType: "application/json; charset=utf-8",
-      headers,
-      objectKey,
-    });
-    if (result.ok) return;
-    if (result.status !== 412) {
-      throw new Error(`latest metadata CAS PUT ${objectKey} failed with HTTP ${result.status}${result.body.length > 0 ? `: ${result.body}` : ""}`);
-    }
-    console.log(`latest metadata CAS conflict on attempt ${attempt}; retrying`);
-  }
-
-  throw new Error(`failed to update latest metadata with CAS after 5 attempts: ${objectKey}`);
-}
-
-async function publishLatestPlatformObjects(manifests: Record<string, PlatformManifest>): Promise<void> {
-  if (storage == null) throw new Error("storage config is required to publish latest platform objects");
-  for (const [target, manifest] of Object.entries(manifests)) {
-    const manifestPath = join(manifestDir, `${target}.json`);
-    await upload(manifestPath, `${latestPrefix}/platforms/${target}.json`, "public, max-age=60, must-revalidate");
-
-    const feedName = manifest.feed?.name;
-    if (feedName == null || feedName.length === 0) continue;
-
-    const feedVersionPrefix = manifest.r2?.artifactPrefix ?? manifest.r2?.versionPrefix;
-    if (feedVersionPrefix == null || feedVersionPrefix.length === 0) {
-      throw new Error(`published ${target} platform manifest is missing r2.versionPrefix for ${feedName}`);
-    }
-    const versionFeed = await getStorageObject({ ...storage, objectKey: `${feedVersionPrefix}/${feedName}` });
-    if (versionFeed == null) {
-      throw new Error(`expected versioned feed object not found: ${feedVersionPrefix}/${feedName}`);
-    }
-    const feedPath = join(metadataDir, "latest-feeds", feedName);
-    mkdirSync(join(metadataDir, "latest-feeds"), { recursive: true });
-    writeFileSync(feedPath, versionFeed.text, "utf8");
-    await upload(feedPath, `${latestPrefix}/${feedName}`, "public, max-age=60, must-revalidate", contentType(feedName));
-  }
 }
 
 function enabled(name: string): boolean {
@@ -457,9 +353,32 @@ mkdirSync(metadataDir, { recursive: true });
 const metadataPath = join(metadataDir, "metadata.json");
 writeJson(metadataPath, metadata);
 await upload(metadataPath, `${versionPrefix}/metadata.json`, "public, max-age=31536000, immutable");
-if (latestMetadataUpdated && publishSideEffectsEnabled) {
-  await uploadLatestMetadataWithCas(metadataPath, `${latestPrefix}/metadata.json`);
-  await publishLatestPlatformObjects(releaseTargets);
+if (latestMetadataUpdated && latestActivationEnabled && publishSideEffectsEnabled) {
+  if (storage == null) throw new Error("storage config is required to publish latest metadata");
+  const latestPlatforms = Object.fromEntries(readyTargets.map((target) => [target, {
+    manifest: releaseTargets[target],
+    path: join(manifestDir, `${target}.json`),
+  }]));
+  if (releaseChannel === "stable" || !latestCasRequired) {
+    await publishLatestPlatformObjects({
+      channel: releaseChannel,
+      metadataDir,
+      platforms: latestPlatforms,
+      storage,
+    });
+    await upload(metadataPath, `${latestPrefix}/metadata.json`, "public, max-age=60, must-revalidate");
+  } else {
+    await publishLatestRelease({
+      channel: releaseChannel,
+      metadataDir,
+      metadataPath,
+      platforms: latestPlatforms,
+      releaseVersion,
+      storage,
+    });
+  }
+} else if (latestMetadataUpdated && !latestActivationEnabled) {
+  console.log(`staged ${metadata.r2.versionMetadataUrl}; left ${metadata.r2.latestMetadataUrl} unchanged pending public acceptance`);
 } else if (latestMetadataUpdated) {
   console.log(`[dry-run:${dryRunMode || "plan"}] left ${metadata.r2.latestMetadataUrl} unchanged`);
 } else {
@@ -468,6 +387,7 @@ if (latestMetadataUpdated && publishSideEffectsEnabled) {
 
 const outputs: Record<string, string> = {
   latest_metadata_updated: String(latestMetadataUpdated),
+  latest_metadata_activated: String(latestMetadataUpdated && latestActivationEnabled),
   metadata_url: metadata.r2.latestMetadataUrl,
   release_state: releaseState,
   report_url: metadata.r2.reportUrl,

--- a/tools/release/src/storage/publish-platform.ts
+++ b/tools/release/src/storage/publish-platform.ts
@@ -19,7 +19,7 @@ import {
   writeJson,
 } from "./common.ts";
 import { assertCurrentVersionReservation, versionLockObjectKey } from "./beta-version-reservation.ts";
-import { putStorageObject } from "./s3-upload.ts";
+import { getStorageObject, putStorageObject, putStorageObjectWithStatus } from "./s3-upload.ts";
 import { parseReleaseVersion, releaseChannelDescriptor } from "@open-design/release";
 
 type AssetEntry = {
@@ -44,6 +44,7 @@ type ShellBuildReport = {
   artifacts: Record<string, ShellBuildArtifact | null>;
   resolution?: {
     artifacts: Record<string, ShellRemoteArtifact>;
+    createdAt: string;
     recordUrl: string;
     state: "registered" | "reused";
   };
@@ -135,6 +136,10 @@ function readShellBuildReport(): ShellBuildReport | null {
     if (report.resolution.artifacts == null || typeof report.resolution.artifacts !== "object") {
       throw new Error("Shell build report resolution artifacts are required");
     }
+    if (
+      typeof report.resolution.createdAt !== "string"
+      || !Number.isFinite(Date.parse(report.resolution.createdAt))
+    ) throw new Error("Shell build report resolution createdAt is required");
   }
   return report as ShellBuildReport;
 }
@@ -324,6 +329,29 @@ async function upload(path: string, objectKey: string, cacheControl: string): Pr
   });
 }
 
+async function uploadImmutable(path: string, objectKey: string): Promise<void> {
+  if (!publishSideEffectsEnabled) {
+    console.log(`[dry-run:${dryRunMode || "plan"}] would upload immutable ${path} to ${objectKey}`);
+    return;
+  }
+  if (storage == null) throw new Error("storage config is required to upload immutable release assets");
+  const result = await putStorageObjectWithStatus({
+    ...storage,
+    bodyPath: path,
+    cacheControl: "public, max-age=31536000, immutable",
+    contentType: contentType(path),
+    headers: { "if-none-match": "*" },
+    objectKey,
+  });
+  if (result.ok) return;
+  if (result.status !== 412) throw new Error(`immutable release PUT failed with HTTP ${result.status}: ${result.body}`);
+  const existing = await getStorageObject({ ...storage, objectKey });
+  if (existing == null) throw new Error(`immutable release object disappeared after conflict: ${objectKey}`);
+  if (sha256Digest(path) !== `sha256:${createHash("sha256").update(existing.bytes).digest("hex")}`) {
+    throw new Error(`immutable release object conflicts: ${objectKey}`);
+  }
+}
+
 async function uploadReport(reportDirectory: string): Promise<Record<string, unknown> | null> {
   if (reportRoot.length === 0) return null;
   const files = listFiles(reportRoot);
@@ -434,6 +462,7 @@ function targetConfig(): TargetConfig {
 
 const config = targetConfig();
 const closure = closurePublication();
+const preparedShellArtifacts = { ...config.artifacts };
 if (shellBuild != null) {
   for (const [name, artifact] of Object.entries(config.artifacts)) {
     const built = shellBuild.artifacts[name];
@@ -464,12 +493,39 @@ if (shellBuild != null) {
     }
   }
 }
+
+function prepareResolvedShellFeed(): void {
+  if (shellBuild?.resolution == null || config.feed == null) return;
+  const kind = config.platform === "mac" ? "zip" : "installer";
+  const prepared = preparedShellArtifacts[kind];
+  const remote = config.artifacts[kind];
+  if (prepared == null || remote == null) throw new Error(`resolved Shell updater feed requires ${kind}`);
+  const path = join(releaseAssetsDir, prepared.name);
+  const sha512 = createHash("sha512").update(readFileSync(path)).digest("base64");
+  const quoted = (value: string): string => JSON.stringify(value);
+  writeFileSync(join(releaseAssetsDir, config.feed.name), [
+    `version: ${quoted(shellBuild.shell.version)}`,
+    "files:",
+    `  - url: ${quoted(remote.url)}`,
+    `    sha512: ${quoted(sha512)}`,
+    `    size: ${remote.size}`,
+    `path: ${quoted(remote.url)}`,
+    `sha512: ${quoted(sha512)}`,
+    `releaseDate: ${quoted(shellBuild.resolution.createdAt)}`,
+    `releaseNotes: ${quoted(`Open Design Shell ${shellBuild.shell.version}`)}`,
+  ].join("\n") + "\n", "utf8");
+}
+
+prepareResolvedShellFeed();
 if (shellBuild?.resolution == null) {
   for (const name of config.assetNames) {
     await upload(join(releaseAssetsDir, name), `${artifactPrefix}/${name}`, "public, max-age=31536000, immutable");
   }
 } else if (config.feed != null) {
-  throw new Error("resolved immutable Shell publication does not yet support updater feed artifacts");
+  await uploadImmutable(
+    join(releaseAssetsDir, config.feed.name),
+    `${artifactPrefix}/${config.feed.name}`,
+  );
 }
 if (closure != null) {
   for (const name of closure.assetNames) {

--- a/tools/release/src/storage/shell-build.ts
+++ b/tools/release/src/storage/shell-build.ts
@@ -134,6 +134,14 @@ function requiredShellSmokeScenarioEntries(matrix: string): Array<{ lane: "migra
       { lane: "migration", step: "mac-legacy-migration" },
     ];
   }
+  if (matrix === "win-shell-v1") {
+    return [
+      { lane: "shell", step: "win-shell-lifecycle" },
+      { lane: "shell", step: "win-shell-silent-update" },
+      { lane: "shell", step: "win-shell-rollback" },
+      { lane: "migration", step: "win-legacy-migration" },
+    ];
+  }
   throw new Error(`unsupported Shell smoke matrix: ${matrix}`);
 }
 

--- a/tools/release/src/storage/shell-build.ts
+++ b/tools/release/src/storage/shell-build.ts
@@ -302,6 +302,7 @@ function createReusedBuildReport(
     releaseVersion: plan.releaseVersion,
     resolution: {
       artifacts: record.artifacts,
+      createdAt: record.createdAt,
       recordUrl: publicUrl(
         required("RELEASE_PUBLIC_ORIGIN"),
         "",
@@ -586,6 +587,7 @@ export async function registerShellBuild(): Promise<void> {
     ...build,
     resolution: {
       artifacts: committedRecord.artifacts,
+      createdAt: committedRecord.createdAt,
       recordUrl: publicUrl(publicOrigin, "", indexKey),
       state: "registered",
     },

--- a/tools/release/tests/closure-publication.test.ts
+++ b/tools/release/tests/closure-publication.test.ts
@@ -112,6 +112,7 @@ async function writeFixture(root: string, options: { closureVersion?: string } =
           url: "https://releases.open-design.test/beta/shells/electron/versions/0.18.0-beta.3/darwin-arm64/Open%20Design-release-beta-payload.zip",
         },
       },
+      createdAt: "2026-08-01T02:03:04.000Z",
       recordUrl: "https://releases.open-design.test/beta/shells/electron/builds/source/artifacts/darwin-arm64.json",
       state: "reused",
     },
@@ -145,11 +146,115 @@ function platformEnv(
   };
 }
 
+async function writeResolvedWindowsShellFixture(root: string): Promise<{
+  assetsRoot: string;
+  manifestRoot: string;
+  shellBuildJsonPath: string;
+}> {
+  const assetsRoot = join(root, "assets");
+  const manifestRoot = join(root, "manifests");
+  const shellBuildJsonPath = join(root, "shell-build.json");
+  const releaseVersion = "0.18.0-beta.4";
+  const shellVersion = "0.18.0-beta.3";
+  const suffix = ".unsigned";
+  const installerName = `open-design-${releaseVersion}${suffix}-win-x64-setup.exe`;
+  const payloadName = `open-design-${releaseVersion}${suffix}-win-x64-payload.7z`;
+  const portableZipName = `open-design-${releaseVersion}${suffix}-win-x64-portable.zip`;
+  const bytes = {
+    installer: Buffer.from("immutable installer"),
+    payload: Buffer.from("immutable payload"),
+    portableZip: Buffer.from("immutable portable zip"),
+  };
+  const prefix = `beta/shells/electron/versions/${shellVersion}/win32-x64`;
+  const remote = (kind: keyof typeof bytes, name: string, contentType: string) => ({
+    contentType,
+    digest: digest(bytes[kind]),
+    name,
+    objectKey: `${prefix}/${name}`,
+    size: bytes[kind].byteLength,
+    url: `https://releases.open-design.test/${prefix}/${name}`,
+  });
+  await mkdir(assetsRoot, { recursive: true });
+  await Promise.all([
+    writeFile(join(assetsRoot, installerName), bytes.installer),
+    writeFile(join(assetsRoot, `${installerName}.sha256`), "fixture\n"),
+    writeFile(join(assetsRoot, payloadName), bytes.payload),
+    writeFile(join(assetsRoot, `${payloadName}.sha256`), "fixture\n"),
+    writeFile(join(assetsRoot, portableZipName), bytes.portableZip),
+    writeFile(join(assetsRoot, `${portableZipName}.sha256`), "fixture\n"),
+    writeFile(join(assetsRoot, "latest.yml"), "stale release-scoped updater feed\n"),
+  ]);
+  await writeFile(shellBuildJsonPath, `${JSON.stringify({
+    artifacts: {
+      installer: { digest: digest(bytes.installer), path: "/fixture/setup.exe", size: bytes.installer.byteLength },
+      payload: { digest: digest(bytes.payload), path: "/fixture/payload.7z", size: bytes.payload.byteLength },
+      portableZip: { digest: digest(bytes.portableZip), path: "/fixture/portable.zip", size: bytes.portableZip.byteLength },
+    },
+    releaseVersion,
+    resolution: {
+      artifacts: {
+        installer: remote("installer", "Open Design-release-beta-win-setup.exe", "application/vnd.microsoft.portable-executable"),
+        payload: remote("payload", "Open Design-release-beta-win-payload.7z", "application/x-7z-compressed"),
+        portableZip: remote("portableZip", "Open Design-release-beta-win-portable.zip", "application/zip"),
+      },
+      createdAt: "2026-08-01T02:03:04.000Z",
+      recordUrl: "https://releases.open-design.test/beta/shells/electron/builds/source/artifacts/win32-x64.json",
+      state: "reused",
+    },
+    shell: { sourceDigest: digest("electron shell source"), type: "electron", version: shellVersion },
+  }, null, 2)}\n`);
+  return { assetsRoot, manifestRoot, shellBuildJsonPath };
+}
+
 afterEach(async () => {
   await Promise.all(temporaryRoots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
 });
 
 describe("Standalone Closure release publication", () => {
+  it("publishes a resolved Windows Shell feed against the immutable Shell identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-shell-feed-independent-"));
+    temporaryRoots.push(root);
+    const fixture = await writeResolvedWindowsShellFixture(root);
+
+    const publication = await execFileAsync(process.execPath, ["--experimental-strip-types", publishPlatformPath], {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        RELEASE_ASSET_SUFFIX: ".unsigned",
+        RELEASE_ASSETS_DIR: fixture.assetsRoot,
+        RELEASE_CHANNEL: "beta",
+        RELEASE_CLOSURE_ENABLED: "false",
+        RELEASE_MANIFEST_DIR: fixture.manifestRoot,
+        RELEASE_OUTPUTS_PATH: join(fixture.manifestRoot, "outputs.json"),
+        RELEASE_PUBLIC_ORIGIN: "https://releases.open-design.test",
+        RELEASE_PUBLISH_SIDE_EFFECTS: "false",
+        RELEASE_SHELL_BUILD_JSON_PATH: fixture.shellBuildJsonPath,
+        RELEASE_SHELL_ENABLED: "true",
+        RELEASE_SIGNED: "false",
+        RELEASE_TARGET: "win_x64",
+        RELEASE_VERSION: "0.18.0-beta.4",
+        WIN_INCLUDE_ZIP: "true",
+      },
+    });
+
+    expect(publication.stdout).toContain("would upload immutable");
+    expect(publication.stdout).toContain("/latest.yml");
+    expect(publication.stdout).not.toContain("open-design-0.18.0-beta.4.unsigned-win-x64-setup.exe to");
+    const feed = await readFile(join(fixture.assetsRoot, "latest.yml"), "utf8");
+    expect(feed).toContain('version: "0.18.0-beta.3"');
+    expect(feed).toContain("/beta/shells/electron/versions/0.18.0-beta.3/win32-x64/Open Design-release-beta-win-setup.exe");
+    expect(feed).toContain('releaseDate: "2026-08-01T02:03:04.000Z"');
+    expect(feed).not.toContain("0.18.0-beta.4");
+
+    const platform = JSON.parse(await readFile(join(fixture.manifestRoot, "win_x64.json"), "utf8"));
+    expect(platform.releaseVersion).toBe("0.18.0-beta.4");
+    expect(platform.shell.version).toBe("0.18.0-beta.3");
+    expect(platform.artifacts.installer.url).toContain("/beta/shells/electron/versions/0.18.0-beta.3/");
+    expect(platform.feed.url).toBe(
+      "https://releases.open-design.test/beta/shells/electron/versions/0.18.0-beta.3/win32-x64/latest.yml",
+    );
+  });
+
   it("binds an independently versioned Shell artifact and its two digests to the release", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-shell-release-independent-"));
     temporaryRoots.push(root);

--- a/tools/release/tests/public-acceptance.test.ts
+++ b/tools/release/tests/public-acceptance.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compareCountedReleaseVersions, sha256Digest } from "../src/storage/latest-publication.js";
+import {
+  issuePublicWindowsAcceptance,
+  preparePublicWindowsAcceptance,
+  publicAcceptanceInternals,
+} from "../src/storage/public-acceptance.js";
+
+const publicOrigin = "https://releases.example";
+const releaseVersion = "0.19.0-beta.27";
+const closureVersion = "0.19.0-beta.31";
+const commit = "0123456789abcdef0123456789abcdef01234567";
+const namespace = "release-beta-win";
+const temporaryRoots: string[] = [];
+
+function fixture() {
+  const installerBytes = Buffer.from("unsigned public NSIS installer");
+  const closureBytes = Buffer.from("public Closure archive");
+  const installerUrl = `${publicOrigin}/beta/shells/electron/versions/0.19.0-beta.4/win32-x64/Open%20Design.exe`;
+  const closureUrl = `${publicOrigin}/beta/closure/win32-x64/versions/${closureVersion}/closure.zip`;
+  const platformUrl = `${publicOrigin}/beta/versions/${releaseVersion}.unsigned/platforms/win_x64.json`;
+  const metadataUrl = `${publicOrigin}/beta/versions/${releaseVersion}/metadata.json`;
+  const closureArtifact = {
+    digest: sha256Digest(closureBytes),
+    size: closureBytes.byteLength,
+    url: closureUrl,
+  };
+  const platform = {
+    artifacts: {
+      installer: {
+        digest: sha256Digest(installerBytes),
+        size: installerBytes.byteLength,
+        url: installerUrl,
+      },
+    },
+    channel: "beta",
+    closure: {
+      assets: { archive: closureArtifact },
+      manifest: {
+        artifact: closureArtifact,
+        identity: {
+          channel: "beta",
+          digest: closureArtifact.digest,
+          platform: "win32-x64",
+          protocolVersion: 1,
+          version: closureVersion,
+        },
+      },
+    },
+    enabled: true,
+    github: { commit },
+    platformKey: "win_x64",
+    r2: {
+      versionManifestUrl: platformUrl,
+      versionPrefix: `beta/versions/${releaseVersion}.unsigned`,
+    },
+    releaseVersion,
+    status: "published",
+  };
+  const metadata = {
+    github: { commit },
+    r2: { versionPrefix: `beta/versions/${releaseVersion}` },
+    releaseState: "complete",
+    releaseTargets: { win_x64: platform },
+    releaseVersion,
+  };
+  const metadataBytes = Buffer.from(`${JSON.stringify(metadata, null, 2)}\n`);
+  const platformBytes = Buffer.from(`${JSON.stringify(platform, null, 2)}\n`);
+  const responses = new Map<string, Buffer>([
+    [metadataUrl, metadataBytes],
+    [platformUrl, platformBytes],
+    [installerUrl, installerBytes],
+  ]);
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const bytes = responses.get(String(input));
+    return bytes == null ? new Response(null, { status: 404 }) : new Response(Uint8Array.from(bytes));
+  });
+  return { closureArtifact, fetchImpl, installerBytes, metadataUrl };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+describe("public Windows release acceptance", () => {
+  it("downloads immutable public installer bytes and issues an exact Closure-bound smoke credential", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-public-acceptance-"));
+    temporaryRoots.push(root);
+    const source = fixture();
+    const planPath = join(root, "plan.json");
+    const buildJsonPath = join(root, "build.json");
+    const plan = await preparePublicWindowsAcceptance({
+      buildJsonPath,
+      commit,
+      downloadDir: join(root, "download"),
+      fetchImpl: source.fetchImpl,
+      metadataUrl: source.metadataUrl,
+      namespace,
+      planPath,
+      publicOrigin,
+      releaseVersion,
+    });
+    expect(await readFile(plan.installer.path)).toEqual(source.installerBytes);
+    expect(JSON.parse(await readFile(buildJsonPath, "utf8"))).toEqual({ installerPath: plan.installer.path });
+
+    const summaryPath = join(root, "summary.json");
+    const suiteResultPath = join(root, "suite-result.json");
+    await writeFile(summaryPath, `${JSON.stringify({
+      closureBinding: {
+        committed: {
+          releaseVersion,
+          standalone: {
+            channel: "beta",
+            digest: source.closureArtifact.digest,
+            generation: 0,
+            namespace,
+            platform: "win32-x64",
+            protocolVersion: 1,
+            version: closureVersion,
+          },
+        },
+      },
+      plan: { profile: "core", selectedLanes: ["shell"] },
+      timings: [{ status: "success", step: "win-shell-lifecycle" }],
+    }, null, 2)}\n`);
+    await writeFile(suiteResultPath, `${JSON.stringify({ exitCode: 0, status: "success" })}\n`);
+
+    const credentialPath = join(root, "credential.json");
+    const credential = await issuePublicWindowsAcceptance({
+      credentialPath,
+      planPath,
+      smokeSummaryPath: summaryPath,
+      suiteResultPath,
+    });
+    expect(credential).toMatchObject({
+      closure: {
+        digest: source.closureArtifact.digest,
+        platform: "win32-x64",
+        version: closureVersion,
+      },
+      commit,
+      releaseVersion,
+      smoke: { profile: "core", selectedLanes: ["shell"], status: "success" },
+      status: "accepted",
+      target: "win_x64",
+    });
+  });
+
+  it("refuses to issue a credential after downloaded installer bytes change", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-public-acceptance-tamper-"));
+    temporaryRoots.push(root);
+    const source = fixture();
+    const planPath = join(root, "plan.json");
+    const plan = await preparePublicWindowsAcceptance({
+      buildJsonPath: join(root, "build.json"),
+      commit,
+      downloadDir: join(root, "download"),
+      fetchImpl: source.fetchImpl,
+      metadataUrl: source.metadataUrl,
+      namespace,
+      planPath,
+      publicOrigin,
+      releaseVersion,
+    });
+    await writeFile(plan.installer.path, "tampered");
+    const summaryPath = join(root, "summary.json");
+    await writeFile(summaryPath, `${JSON.stringify({
+      closureBinding: {
+        committed: {
+          releaseVersion,
+          standalone: {
+            channel: "beta",
+            digest: source.closureArtifact.digest,
+            namespace,
+            platform: "win32-x64",
+            version: closureVersion,
+          },
+        },
+      },
+      plan: { profile: "core", selectedLanes: ["shell"] },
+      timings: [{ status: "success", step: "win-shell-lifecycle" }],
+    })}\n`);
+    const suiteResultPath = join(root, "suite-result.json");
+    await writeFile(suiteResultPath, `${JSON.stringify({ exitCode: 0, status: "success" })}\n`);
+
+    await expect(issuePublicWindowsAcceptance({
+      credentialPath: join(root, "credential.json"),
+      planPath,
+      smokeSummaryPath: summaryPath,
+      suiteResultPath,
+    })).rejects.toThrow(/installer no longer matches public binding/);
+  });
+
+  it("rejects mutable latest URLs and prevents counted latest rollback", () => {
+    expect(() => publicAcceptanceInternals.assertPublicImmutableUrl(
+      `${publicOrigin}/beta/latest/metadata.json`,
+      publicOrigin,
+      "metadata URL",
+    )).toThrow(/immutable version object/);
+    expect(compareCountedReleaseVersions("0.19.0-beta.28", "0.19.0-beta.27", "beta")).toBeGreaterThan(0);
+    expect(compareCountedReleaseVersions("0.19.0-beta.27", "0.19.0-beta.28", "beta")).toBeLessThan(0);
+  });
+});

--- a/tools/release/tests/shell-build.test.ts
+++ b/tools/release/tests/shell-build.test.ts
@@ -209,6 +209,7 @@ describe("immutable Shell build storage", () => {
         await registerShellBuild();
         const registered = JSON.parse(await readFile(buildPath, "utf8"));
         expect(registered.resolution.state).toBe("registered");
+        expect(Date.parse(registered.resolution.createdAt)).not.toBeNaN();
         expect(registered.resolution.artifacts.dmg.url).toBe(
           "https://releases.example/beta/shells/electron/versions/0.19.0-beta.2/darwin-arm64/Open%20Design-release-beta.dmg",
         );
@@ -226,6 +227,7 @@ describe("immutable Shell build storage", () => {
         expect(reused.releaseVersion).toBe("0.19.0-beta.3");
         expect(reused.shell.version).toBe("0.19.0-beta.2");
         expect(reused.resolution.artifacts).toEqual(registered.resolution.artifacts);
+        expect(reused.resolution.createdAt).toBe(registered.resolution.createdAt);
         expect(reused.timings).toHaveLength(1);
         expect(reused.timings[0].phase).toBe("remote-shell-materialize");
         expect(reused.timings[0].durationMs).toBeGreaterThan(0);

--- a/tools/release/tests/shell-build.test.ts
+++ b/tools/release/tests/shell-build.test.ts
@@ -97,6 +97,36 @@ describe("immutable Shell build storage", () => {
     }, plan, "beta")).toThrow(/identity/);
   });
 
+  it("binds the Windows Shell proof to lifecycle, update, rollback, and migration", () => {
+    const windowsPlan = { ...plan, target: "win32-x64" as const };
+    const proof = validateShellSmokeProofRecord({
+      acceptanceDigest,
+      channel: "beta",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      matrix: "win-shell-v1",
+      profileDigest: windowsPlan.profileDigest,
+      provenance: {},
+      releaseVersion: "0.19.0-beta.2",
+      scenarios: [
+        "win-shell-lifecycle",
+        "win-shell-silent-update",
+        "win-shell-rollback",
+        "win-legacy-migration",
+      ],
+      schemaVersion: 2,
+      shell: windowsPlan.shell,
+      standaloneProtocolVersion: 1,
+      target: "win32-x64",
+    }, windowsPlan, "beta", "win-shell-v1", acceptanceDigest, 1);
+
+    expect(proof.scenarios).toEqual([
+      "win-shell-lifecycle",
+      "win-shell-silent-update",
+      "win-shell-rollback",
+      "win-legacy-migration",
+    ]);
+  });
+
   it("registers once and materializes the same verified bytes for a later release", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-shell-build-storage-"));
     temporaryRoots.push(root);


### PR DESCRIPTION
## Why

Windows still shipped the pre-standalone lifecycle while macOS had already split the stable Electron Shell from the independently downloadable Closure. This completes the Windows side so Closure-only iterations can reuse a proven Shell and skip Electron rebuild plus Shell smoke.

## What users will see

- A fresh Windows install contains the Shell only and downloads its first Closure on first online launch.
- Closure updates, damaged-install recovery, repair installs, shortcuts, registry protocol ownership, and uninstall cleanup follow explicit Windows lifecycle rules.
- `opendesign://` remains the OS-facing protocol; Electron proxies internal `od://` traffic into the selected Closure generation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `shells/electron` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed.

## Bug fix verification

- Test paths: `shells/electron/tests/launcher-after-quit.test.ts` and `e2e/specs/win.spec.ts` encode the deferred payload ownership-stamp race found during packaged lifecycle saturation.
- The packaged scenario failed before the stamp fix because stop returned while the Electron root was still exiting; it passes with distinct `packaged` and `tools-pack` launch identities after the fix.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- actionlint 1.7.12 and release-beta YAML parse
- closure-store: 11 passed
- closure-update: 10 passed
- sidecar: 21 passed
- tools-release: 62 passed
- tools-pack: 232 passed, 5 skipped
- Electron: 576 passed, 3 skipped
- packaged e2e support tests: 57 passed
- Local Windows packaged saturation: core, standalone damage/recovery, historical `0.16.2-beta.155` migration, online first Closure, payload update/cold start, silent apply, corrupted payload rollback, bumped-version self-heal, same-version NSIS repair, and cleanup; 3 scenarios passed, 3 intentionally skipped
- Exact `feat/standalone-closure` → head Plumb boundary: clean, no paths outside the declared claim
