### PR TITLE
fix(pack): preserve NSIS protocol command quotes

### DIFF
--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -40,6 +40,12 @@ function escapeNsisString(value: string): string {
   return value.replace(/\$/g, "$$").replace(/"/g, '$\\"').replace(/\r?\n/g, "$\\r$\\n");
 }
 
+export function createNsisQuotedCommandLiteral(args: readonly string[]): string {
+  // NSIS accepts single-quoted string literals, so embedded command quotes do
+  // not need a second escape layer that JavaScript templates can consume.
+  return `'${args.map((arg) => `"${arg}"`).join(" ")}'`;
+}
+
 function normalizeArchivePath(relativePath: string): string {
   return relativePath.split("/").join("\\");
 }
@@ -417,6 +423,8 @@ async function writeInstallerScript(config: ToolPackConfig, paths: WinPaths, pac
   const registryKey = escapeNsisString(identity.registryKey);
   const appPathsKey = escapeNsisString(identity.appPathsKey);
   const inviteProtocolKey = "Software\\Classes\\opendesign";
+  const inviteProtocolCommand = createNsisQuotedCommandLiteral([`$INSTDIR\\${exeName}`, "%1"]);
+  const inviteProtocolExecutablePrefix = createNsisQuotedCommandLiteral([`$INSTDIR\\${exeName}`]);
   const namespace = escapeNsisString(config.namespace);
   const localDataRoot = `$APPDATA\\${escapeNsisString(PRODUCT_NAME)}\\namespaces\\${escapeNsisString(sanitizeNamespace(config.namespace))}`;
   const localCacheRoot = `${localDataRoot}\\cache`;
@@ -985,7 +993,7 @@ skip_silent_desktop_shortcut:
   WriteRegStr HKCU "${inviteProtocolKey}" "" "URL:Open Design Invite Protocol"
   WriteRegStr HKCU "${inviteProtocolKey}" "URL Protocol" ""
   WriteRegStr HKCU "${inviteProtocolKey}\\DefaultIcon" "" "$INSTDIR\\${exeName},0"
-  WriteRegStr HKCU "${inviteProtocolKey}\\shell\\open\\command" "" '$\"$INSTDIR\\${exeName}$\" $\"%1$\"'
+  WriteRegStr HKCU "${inviteProtocolKey}\\shell\\open\\command" "" ${inviteProtocolCommand}
   Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"
   Call LogInstallerEvent
   Call SyncLauncherRuntime
@@ -1015,7 +1023,7 @@ after_desktop_shortcut:
   ; Electron refreshes the protocol command when the app starts and may change
   ; its trailing arguments. Compare only the exact quoted executable prefix so
   ; this install can remove its registration without touching another owner.
-  StrCpy $1 '$\"$INSTDIR\\${exeName}$\"'
+  StrCpy $1 ${inviteProtocolExecutablePrefix}
   StrLen $2 $1
   StrCpy $3 $0 $2
   StrCmp $3 $1 0 preserve_invite_protocol

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -6,7 +6,10 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import { createLauncherRuntimeSyncPowerShellScript } from "../src/win/custom-installer.js";
+import {
+  createLauncherRuntimeSyncPowerShellScript,
+  createNsisQuotedCommandLiteral,
+} from "../src/win/custom-installer.js";
 import { resolveWinInstallIdentity } from "../src/win/identity.js";
 
 const execFileAsync = promisify(execFile);
@@ -83,23 +86,35 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).not.toContain('"DisplayName" "${productName} \\${APP_VERSION}"');
   });
 
+  it("emits a valid NSIS command literal for executable paths containing spaces", () => {
+    expect(createNsisQuotedCommandLiteral(["$INSTDIR\\Open Design.exe", "%1"])).toBe(
+      `'"$INSTDIR\\Open Design.exe" "%1"'`,
+    );
+    expect(createNsisQuotedCommandLiteral(["$INSTDIR\\Open Design.exe"])).toBe(
+      `'"$INSTDIR\\Open Design.exe"'`,
+    );
+  });
+
   it("removes an Electron-refreshed invite protocol while this install still owns it", async () => {
     const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
     expect(source).toContain('const inviteProtocolKey = "Software\\\\Classes\\\\opendesign"');
     expect(source).toContain('WriteRegStr HKCU "${inviteProtocolKey}" "URL Protocol" ""');
     expect(source).toContain(
-      'WriteRegStr HKCU "${inviteProtocolKey}\\\\shell\\\\open\\\\command" ""',
+      'WriteRegStr HKCU "${inviteProtocolKey}\\\\shell\\\\open\\\\command" "" ${inviteProtocolCommand}',
     );
     expect(source).toContain('$INSTDIR\\\\${exeName}');
     expect(source).toContain(
       'ReadRegStr $0 HKCU "${inviteProtocolKey}\\\\shell\\\\open\\\\command" ""',
     );
-    expect(source).toContain("StrCpy $1 '$\\\"$INSTDIR\\\\${exeName}$\\\"'");
+    expect(source).toContain(
+      "const inviteProtocolExecutablePrefix = createNsisQuotedCommandLiteral([`$INSTDIR\\\\${exeName}`])",
+    );
+    expect(source).toContain("StrCpy $1 ${inviteProtocolExecutablePrefix}");
     expect(source).toContain("StrLen $2 $1");
     expect(source).toContain("StrCpy $3 $0 $2");
     expect(source).toContain("StrCmp $3 $1 0 preserve_invite_protocol");
     expect(source).not.toContain(
-      "StrCmp $0 '$\\\"$INSTDIR\\\\${exeName}$\\\" $\\\"%1$\\\"' 0 preserve_invite_protocol",
+      "StrCmp $0 ${inviteProtocolCommand} 0 preserve_invite_protocol",
     );
     expect(source).toContain('DeleteRegKey HKCU "${inviteProtocolKey}"');
     expect(source).toContain("preserve_invite_protocol:");


### PR DESCRIPTION
## Why

A Windows installer QA rerun for PR #6694 still left `HKCU\\Software\\Classes\\opendesign` behind after uninstall. The generated NSIS script contained `$"` sequences because JavaScript consumed the intended backslash before NSIS compiled the template; `makensis` warned that the executable path was an unknown variable/constant, so the ownership comparison never matched.

This follow-up unblocks the prerelease Windows smoke and keeps uninstall cleanup safe: the protocol key is removed only when its command still points at the current installation.

## What users will see

Uninstalling Open Design on Windows removes the `opendesign://` protocol registration when that installation still owns it. A registration owned by another installation remains untouched.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — Windows uninstall now removes its owned invite protocol registration
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI changes.

## Bug fix verification

- Test path: `tools/pack/tests/win-identity.test.ts`
- The generated NSIS command-literal spec went red on `main` and green on this branch.
- End-to-end red evidence: [QA Windows installer uninstall smoke run 31381120115](https://github.com/nexu-io/open-design/actions/runs/31381120115/job/93431296296).

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/win-identity.test.ts`
- `pnpm --filter @open-design/tools-pack test` — 37 files passed; 275 passed, 8 skipped
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- [Windows prerelease canary run 31383218068](https://github.com/nexu-io/open-design/actions/runs/31383218068) — full build passed without retry; packaged runtime smoke passed installation, hot/cold invite protocol delivery, uninstall, and registry cleanup; no NSIS warning 6000 / unknown variable warning remained.
