### PR TITLE
fix workspace deletion and extension installation failures

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -547,10 +547,13 @@ export function velaWorkspaceDirectoryIdentity(
 /**
  * One daemon-owned authority broker shared by idempotent reads and mutations.
  *
- * Successful authority reads seed a bounded display-read lease. Mutations
- * ignore that settled lease and always perform a fresh directory read, while
- * still sharing an already-unsettled request from the same Vela session. This
- * keeps the 5s status poll off the control plane without weakening mutation
+ * Successful authority reads seed a bounded display-read lease. General
+ * mutations ignore that settled lease and always perform a fresh directory
+ * read, while still sharing an already-unsettled request from the same Vela
+ * session. The cached-only accessor never starts I/O; its one production
+ * consumer may use a valid same-session lease for personal local-only project
+ * cleanup, then falls back to fresh authority on every miss. This keeps the 5s
+ * status poll off the control plane without weakening Team/hub mutation
  * freshness, and prevents a status/heartbeat boundary from launching duplicate
  * directory requests.
  */
@@ -560,6 +563,7 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   ttlMs?: number;
   now?: () => number;
 } = {}): {
+  cached: () => Promise<WorkspaceDirectoryFetchResult>;
   read: () => Promise<WorkspaceDirectoryFetchResult>;
   fresh: () => Promise<WorkspaceDirectoryFetchResult>;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
@@ -595,6 +599,15 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   };
 
   return {
+    cached: () => {
+      const identity = identityKey();
+      const cachedEntry = cached.get(identity);
+      if (cachedEntry && now() < cachedEntry.expiresAt) {
+        return Promise.resolve(cachedEntry.result);
+      }
+      cached.delete(identity);
+      return Promise.resolve({ ok: false, items: [] });
+    },
     read: () => {
       const identity = identityKey();
       const cachedEntry = cached.get(identity);

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -292,9 +292,20 @@ export function withLastKnownMembership(
 }
 
 export type WorkspaceResourceAccessInput = {
+  workspaceId?: string | null;
   visibility?: string | null;
   resourceState?: string | null;
   createdByWorkspaceMemberId?: string | null;
+  resourceHubResourceId?: string | null;
+  syncState?: string | null;
+};
+
+export type WorkspaceMutationAuthorityLease = {
+  verify: VerifyWorkspaceRequestAuthority;
+  allow: (
+    row: WorkspaceResourceAccessInput,
+    context: WorkspaceCollabContext,
+  ) => boolean;
 };
 
 export function headerValue(req: any, name: string): string | null {
@@ -615,17 +626,40 @@ export async function enforceVerifiedWorkspaceResourceMutation(
   resourceId: string,
   capability: WorkspaceResourceMutationCapability,
   verifyWorkspaceRequestAuthority: VerifyWorkspaceRequestAuthority | undefined,
+  options: { authorityLease?: WorkspaceMutationAuthorityLease } = {},
 ): Promise<boolean> {
   // No persisted Workspace binding means this is a genuine legacy/local
   // resource. Preserve that path without inventing a Workspace from ambient
   // navigation state.
-  if (!getWorkspaceResourceByResourceId(db, resourceId)) return true;
+  const persistedRow = getWorkspaceResourceByResourceId(db, resourceId);
+  if (!persistedRow) return true;
   if (!verifyWorkspaceRequestAuthority) {
     sendApiError(res, 400, 'WORKSPACE_CONTEXT_REQUIRED', 'an explicit workspace context is required');
     return false;
   }
 
-  const verified = await verifyWorkspaceRequestAuthorityForRequest(
+  let verified: Awaited<ReturnType<VerifyWorkspaceRequestAuthority>> | undefined;
+  if (options.authorityLease) {
+    const leased = await verifyWorkspaceRequestAuthorityForRequest(
+      req,
+      options.authorityLease.verify,
+    );
+    const leasedRow = leased.ok
+      ? getWorkspaceResource(
+          db,
+          leased.context.workspaceId,
+          resourceId,
+        )
+      : null;
+    if (
+      leased.ok
+      && leasedRow
+      && options.authorityLease.allow(leasedRow, leased.context)
+    ) {
+      verified = leased;
+    }
+  }
+  verified ??= await verifyWorkspaceRequestAuthorityForRequest(
     req,
     verifyWorkspaceRequestAuthority,
   );

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -153,16 +153,19 @@ export function classifyPluginInstallError(message: string): PluginInstallErrorC
   if (/cannot be replaced|owned by another workspace member|destination folder already exists/i.test(message)) {
     return 'CONFLICT';
   }
-  if (/fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
+  if (/network|fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
     return 'FETCH_FAILED';
   }
-  if (/archive|zip|symbolic|hard links?|path-traversal|integrity mismatch|extracted .* exceeds/i.test(message)) {
-    return 'INVALID_ARCHIVE';
+  if (/files? are required|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls|exceeds (?:size cap of )?\d+ (?:bytes|mib)|too large/i.test(message)) {
+    return 'BAD_REQUEST';
   }
   if (/manifest|plugin id|installable archive|re-parsing destination/i.test(message)) {
     return 'INVALID_MANIFEST';
   }
-  if (/files? are required|malformed github|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls/i.test(message)) {
+  if (/archive|zip|symbolic|hard links?|path-traversal|integrity mismatch/i.test(message)) {
+    return 'INVALID_ARCHIVE';
+  }
+  if (/malformed github/i.test(message)) {
     return 'BAD_REQUEST';
   }
   return 'INTERNAL_ERROR';
@@ -171,10 +174,20 @@ export function classifyPluginInstallError(message: string): PluginInstallErrorC
 async function* withStableInstallErrorCodes(
   events: AsyncIterable<InstallEvent>,
 ): AsyncGenerator<InstallEvent, void, void> {
-  for await (const event of events) {
-    yield event.kind === 'error' && !event.code
-      ? { ...event, code: classifyPluginInstallError(event.message) }
-      : event;
+  try {
+    for await (const event of events) {
+      yield event.kind === 'error' && !event.code
+        ? { ...event, code: classifyPluginInstallError(event.message) }
+        : event;
+    }
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    yield {
+      kind: 'error',
+      message,
+      warnings: [],
+      code: classifyPluginInstallError(message),
+    };
   }
 }
 

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -761,7 +761,12 @@ export async function* installFromLocalFolder(
   }, opts);
   const probe = await resolvePluginFolder(probeOptions);
   if (!probe.ok) {
-    yield { kind: 'error', message: probe.errors.join('; '), warnings: probe.warnings };
+    yield {
+      kind: 'error',
+      message: probe.errors.join('; '),
+      warnings: probe.warnings,
+      code: 'INVALID_MANIFEST',
+    };
     return;
   }
   warnings.push(...probe.warnings);
@@ -816,7 +821,12 @@ export async function* installFromLocalFolder(
   const parsed = await resolvePluginFolder(parsedOptions);
   if (!parsed.ok) {
     await fsp.rm(destFolder, { recursive: true, force: true }).catch(() => undefined);
-    yield { kind: 'error', message: parsed.errors.join('; '), warnings: [...warnings, ...parsed.warnings] };
+    yield {
+      kind: 'error',
+      message: parsed.errors.join('; '),
+      warnings: [...warnings, ...parsed.warnings],
+      code: 'INVALID_MANIFEST',
+    };
     return;
   }
   warnings.push(...parsed.warnings);

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -153,7 +153,7 @@ export function classifyPluginInstallError(message: string): PluginInstallErrorC
   if (/cannot be replaced|owned by another workspace member|destination folder already exists/i.test(message)) {
     return 'CONFLICT';
   }
-  if (/files? are required|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls|exceeds (?:size cap of )?\d+ (?:bytes|mib)|too large/i.test(message)) {
+  if (/files? are required|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls|invalid upload path|unsafe upload path|exceeds? (?:size cap of )?\d+ (?:bytes|mib)|too large/i.test(message)) {
     return 'BAD_REQUEST';
   }
   if (/network|fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -62,9 +62,18 @@ export interface InstallErrorEvent {
   kind: 'error';
   message: string;
   warnings: string[];
+  code?: PluginInstallErrorCode;
 }
 
 export type InstallEvent = InstallProgressEvent | InstallSuccessEvent | InstallErrorEvent;
+
+export type PluginInstallErrorCode =
+  | 'BAD_REQUEST'
+  | 'FETCH_FAILED'
+  | 'INVALID_ARCHIVE'
+  | 'INVALID_MANIFEST'
+  | 'CONFLICT'
+  | 'INTERNAL_ERROR';
 
 export interface InstallOptions {
   source: string;
@@ -139,6 +148,36 @@ interface GithubContentsBudget {
   maxBytes: number;
 }
 
+/** Keep installer diagnostics finite so SSE clients never use paths or URLs as analytics keys. */
+export function classifyPluginInstallError(message: string): PluginInstallErrorCode {
+  if (/cannot be replaced|owned by another workspace member|destination folder already exists/i.test(message)) {
+    return 'CONFLICT';
+  }
+  if (/fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
+    return 'FETCH_FAILED';
+  }
+  if (/archive|symbolic|hard links?|path-traversal|integrity mismatch|extracted .* exceeds/i.test(message)) {
+    return 'INVALID_ARCHIVE';
+  }
+  if (/manifest|plugin id|installable archive|re-parsing destination/i.test(message)) {
+    return 'INVALID_MANIFEST';
+  }
+  if (/malformed github|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls/i.test(message)) {
+    return 'BAD_REQUEST';
+  }
+  return 'INTERNAL_ERROR';
+}
+
+async function* withStableInstallErrorCodes(
+  events: AsyncIterable<InstallEvent>,
+): AsyncGenerator<InstallEvent, void, void> {
+  for await (const event of events) {
+    yield event.kind === 'error' && !event.code
+      ? { ...event, code: classifyPluginInstallError(event.message) }
+      : event;
+  }
+}
+
 // Top-level dispatcher. Picks the backend off the source string and yields
 // the same InstallEvent stream regardless of where the bytes came from.
 export async function* installPlugin(
@@ -147,21 +186,21 @@ export async function* installPlugin(
 ): AsyncGenerator<InstallEvent, void, void> {
   const browserGithub = resolveGithubRepositoryUrl(opts.source);
   if (browserGithub.kind === 'invalid') {
-    yield { kind: 'error', message: browserGithub.error, warnings: [] };
+    yield { kind: 'error', message: browserGithub.error, warnings: [], code: 'BAD_REQUEST' };
     return;
   }
   const normalizedOpts = browserGithub.kind === 'repository'
     ? { ...opts, source: browserGithub.source }
     : opts;
   if (normalizedOpts.source.startsWith('github:')) {
-    yield* installFromGithub(db, normalizedOpts);
+    yield* withStableInstallErrorCodes(installFromGithub(db, normalizedOpts));
     return;
   }
   if (HTTPS_SOURCE_RE.test(normalizedOpts.source)) {
-    yield* installFromHttpsArchive(db, normalizedOpts);
+    yield* withStableInstallErrorCodes(installFromHttpsArchive(db, normalizedOpts));
     return;
   }
-  yield* installFromLocalFolder(db, normalizedOpts);
+  yield* withStableInstallErrorCodes(installFromLocalFolder(db, normalizedOpts));
 }
 
 // `github:owner/repo[@ref][/subpath]` → codeload tarball.

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -153,13 +153,13 @@ export function classifyPluginInstallError(message: string): PluginInstallErrorC
   if (/cannot be replaced|owned by another workspace member|destination folder already exists/i.test(message)) {
     return 'CONFLICT';
   }
-  if (/network|fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
-    return 'FETCH_FAILED';
-  }
   if (/files? are required|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls|exceeds (?:size cap of )?\d+ (?:bytes|mib)|too large/i.test(message)) {
     return 'BAD_REQUEST';
   }
-  if (/manifest|plugin id|installable archive|re-parsing destination/i.test(message)) {
+  if (/network|fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
+    return 'FETCH_FAILED';
+  }
+  if (/manifest|plugin id|installable archive|re-parsing destination|contains no skill\.md/i.test(message)) {
     return 'INVALID_MANIFEST';
   }
   if (/archive|zip|symbolic|hard links?|path-traversal|integrity mismatch/i.test(message)) {

--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -156,13 +156,13 @@ export function classifyPluginInstallError(message: string): PluginInstallErrorC
   if (/fetch failed|download failed|private address|timed?\s*out|econn|enotfound/i.test(message)) {
     return 'FETCH_FAILED';
   }
-  if (/archive|symbolic|hard links?|path-traversal|integrity mismatch|extracted .* exceeds/i.test(message)) {
+  if (/archive|zip|symbolic|hard links?|path-traversal|integrity mismatch|extracted .* exceeds/i.test(message)) {
     return 'INVALID_ARCHIVE';
   }
   if (/manifest|plugin id|installable archive|re-parsing destination/i.test(message)) {
     return 'INVALID_MANIFEST';
   }
-  if (/malformed github|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls/i.test(message)) {
+  if (/files? are required|malformed github|only \.tar\.gz|only \.tgz|source folder not found|source path is not a directory|github repository urls/i.test(message)) {
     return 'BAD_REQUEST';
   }
   return 'INTERNAL_ERROR';

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -30,6 +30,24 @@ import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-
 import type { PluginShareAction } from '../../services/plugin-share-tasks.js';
 import type { AuthorizeProjectRequest } from '../../collab/project-request-authority.js';
 import { workspaceTeamPluginBindingResourceId } from '../../plugins/registry.js';
+import {
+  classifyPluginInstallError,
+  type PluginInstallErrorCode,
+} from '../../plugins/installer.js';
+
+function pluginUploadFailure(
+  cause: unknown,
+  errorCode?: PluginInstallErrorCode,
+) {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return {
+    ok: false,
+    warnings: [],
+    message,
+    errorCode: errorCode ?? classifyPluginInstallError(message),
+    log: [],
+  };
+}
 
 export interface RegisterPluginEventRoutesDeps {
   http: {
@@ -119,8 +137,8 @@ interface PluginRouteHelpers {
     array(field: string, maxCount?: number): RequestHandler;
   };
   pluginInstallation: {
-    stageUploadedPluginZip(buffer: Buffer, source: string): Promise<unknown>;
-    stageUploadedPluginFolder(files: Array<{ buffer: Buffer; originalname: string }>, rawPaths: unknown): Promise<unknown>;
+    stageUploadedPluginZip(buffer: Buffer, source: string): Promise<{ ok?: boolean }>;
+    stageUploadedPluginFolder(files: Array<{ buffer: Buffer; originalname: string }>, rawPaths: unknown): Promise<{ ok?: boolean }>;
   };
   connectorService: unknown;
   resolvedPortRef: { current: number | null | undefined };
@@ -449,8 +467,44 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     return helpers.handlePluginStats(res, installed, visibleSnapshots);
   });
   app.get('/api/plugins/:id', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; const plugin = await resolveRequestPlugin(req.params.id, authority); if (!plugin) return res.status(404).json({ error: 'plugin not found' }); res.json(plugin); } catch (err) { res.status(500).json({ error: String(err) }); } });
-  app.post('/api/plugins/upload-zip', (req, res) => helpers.pluginUpload.single('file')(req, res, async (err: unknown) => { if (err) return helpers.sendMulterError(res, err); try { const file = req.file; if (!file?.buffer) return res.status(400).json({ error: 'file is required' }); const result = await helpers.pluginInstallation.stageUploadedPluginZip(file.buffer, `upload:zip:${helpers.decodeMultipartFilename(file.originalname || 'plugin.zip')}`); res.status((result as { ok?: boolean }).ok ? 200 : 400).json(result); } catch (uploadErr: unknown) { res.status(400).json({ ok: false, warnings: [], message: uploadErr instanceof Error ? uploadErr.message : String(uploadErr), log: [] }); } }));
-  app.post('/api/plugins/upload-folder', (req, res) => helpers.pluginUpload.array('files', 500)(req, res, async (err: unknown) => { if (err) return helpers.sendMulterError(res, err); try { const files = Array.isArray(req.files) ? req.files as Array<{ buffer: Buffer; originalname: string }> : []; if (files.length === 0) return res.status(400).json({ error: 'files are required' }); const result = await helpers.pluginInstallation.stageUploadedPluginFolder(files, req.body?.paths); res.status((result as { ok?: boolean } | null)?.ok ? 200 : 400).json(result); } catch (uploadErr: unknown) { res.status(400).json({ ok: false, warnings: [], message: uploadErr instanceof Error ? uploadErr.message : String(uploadErr), log: [] }); } }));
+  app.post('/api/plugins/upload-zip', (req, res) => {
+    helpers.pluginUpload.single('file')(req, res, async (err: unknown) => {
+      if (err) return helpers.sendMulterError(res, err);
+      try {
+        const file = req.file;
+        if (!file?.buffer) {
+          return res.status(400).json(pluginUploadFailure('file is required', 'BAD_REQUEST'));
+        }
+        const result = await helpers.pluginInstallation.stageUploadedPluginZip(
+          file.buffer,
+          `upload:zip:${helpers.decodeMultipartFilename(file.originalname || 'plugin.zip')}`,
+        );
+        return res.status(result.ok ? 200 : 400).json(result);
+      } catch (cause) {
+        return res.status(400).json(pluginUploadFailure(cause));
+      }
+    });
+  });
+  app.post('/api/plugins/upload-folder', (req, res) => {
+    helpers.pluginUpload.array('files', 500)(req, res, async (err: unknown) => {
+      if (err) return helpers.sendMulterError(res, err);
+      try {
+        const files = Array.isArray(req.files)
+          ? req.files as Array<{ buffer: Buffer; originalname: string }>
+          : [];
+        if (files.length === 0) {
+          return res.status(400).json(pluginUploadFailure('files are required', 'BAD_REQUEST'));
+        }
+        const result = await helpers.pluginInstallation.stageUploadedPluginFolder(
+          files,
+          req.body?.paths,
+        );
+        return res.status(result.ok ? 200 : 400).json(result);
+      } catch (cause) {
+        return res.status(400).json(pluginUploadFailure(cause));
+      }
+    });
+  });
   app.post('/api/plugins/install', async (req, res) => {
     const authority = await resolveWorkspaceAuthority(req, res);
     if (authority === undefined) return;

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -134,6 +134,12 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
   verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
   /** Authoritative verifier for every Workspace-bound project mutation. */
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
+  /**
+   * Cached-only authority verifier for deleting a personal, local-only
+   * project. It must never start network I/O; all other mutations continue
+   * through `verifyWorkspaceRequestAuthority`.
+   */
+  verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority;
   /** Shared fresh exact authority gate for all project data-plane routes. */
   authorizeProjectRequest?: AuthorizeProjectRequest;
   /** Startup-hydrated O(1) quarantine lookup for stale Team mirrors. */
@@ -298,10 +304,11 @@ function projectAccess(
 
 /**
  * Build the project-flavored authoritative mutation gate. Every bound project
- * requires an exact Workspace/member pair and a fresh directory-backed
- * verifier result; request role/permission claims and daemon-global
- * active/current/last-known state are never authority. The exported factory is
- * shared with run/chat routes so all project mutations fail closed identically.
+ * requires an exact Workspace/member pair; request role/permission claims and
+ * daemon-global active/current/last-known state are never authority. Mutations
+ * use fresh directory authority except the narrow personal local-only delete
+ * lease below. The exported factory is shared with run/chat routes so all
+ * project mutations fail closed identically.
  */
 /**
  * The non-rejecting counterpart of `createEnforceWorkspaceProjectMutation`,
@@ -332,6 +339,7 @@ export function createWorkspaceProjectWriteAuthorityCheck(
 
 export function createEnforceWorkspaceProjectMutation(
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
+  verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority,
 ) {
   return async function enforceWorkspaceProjectMutation(
     req: any,
@@ -354,8 +362,37 @@ export function createEnforceWorkspaceProjectMutation(
       projectId,
       capability,
       verifyWorkspaceRequestAuthority,
+      capability === 'delete' && verifyPersonalProjectDeleteLeaseAuthority
+        ? {
+            authorityLease: {
+              verify: verifyPersonalProjectDeleteLeaseAuthority,
+              allow: personalLocalProjectDeleteLeaseAllowed,
+            },
+          }
+        : {},
     );
   };
+}
+
+/**
+ * A short-lived directory lease may authorize this one local-only cleanup.
+ * Hub-backed or Team resources, stale ownership, locked membership and every
+ * non-delete mutation still require a fresh control-plane read.
+ */
+export function personalLocalProjectDeleteLeaseAllowed(
+  row: WorkspaceProjectAccessInput,
+  context: WorkspaceCollabContext,
+): boolean {
+  return context.workspaceType === 'personal'
+    && context.memberStatus === 'active'
+    && context.lifecycleState === 'active'
+    && context.permissions.canWriteSyncedFiles
+    && row.workspaceId === context.workspaceId
+    && row.visibility === 'personal'
+    && row.resourceState === 'active'
+    && row.createdByWorkspaceMemberId === context.workspaceMemberId
+    && row.syncState === 'local_only'
+    && !row.resourceHubResourceId;
 }
 
 function projectDetailResolvedDir(
@@ -1699,6 +1736,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { collabSync, teamProjectCatalog, workspaceTypes } = ctx;
   const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
     ctx.verifyWorkspaceRequestAuthority,
+    ctx.verifyPersonalProjectDeleteLeaseAuthority,
   );
   const verifyWorkspaceProjectReadAuthority =
     ctx.verifyWorkspaceReadAuthority ?? ctx.verifyWorkspaceRequestAuthority;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3010,6 +3010,15 @@ export async function startServer({
     verifyExplicitWorkspaceRequestContext({ req }, { fresh: false });
   const verifyWorkspaceRequestAuthority = (req: unknown) =>
     verifyExplicitWorkspaceRequestContext({ req });
+  const verifyPersonalProjectDeleteLeaseAuthority =
+    process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela'
+      ? (req: unknown) => verifyWorkspaceRequestContext({
+          req,
+          // A miss is intentionally returned as unavailable. The project gate
+          // then falls through to the existing fresh authority verifier.
+          fetchWorkspaceDirectory: workspaceDirectoryAuthority.cached,
+        })
+      : undefined;
   const enforceAuthoritativeProjectMutation = createEnforceWorkspaceProjectMutation(
     verifyWorkspaceRequestAuthority,
   );
@@ -7023,6 +7032,7 @@ export async function startServer({
     // workspaceContext) — see the mutation-gate cross-check note above.
     verifyWorkspaceReadAuthority,
     verifyWorkspaceRequestAuthority,
+    verifyPersonalProjectDeleteLeaseAuthority,
     authorizeProjectRequest,
     isProjectRevoked: (projectId) =>
       revokedTeamProjectMirrors.has(projectId),

--- a/apps/daemon/src/services/plugin-installation.ts
+++ b/apps/daemon/src/services/plugin-installation.ts
@@ -2,6 +2,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import JSZip from 'jszip';
+import {
+  classifyPluginInstallError,
+  type PluginInstallErrorCode,
+} from '../plugins/installer.js';
+import type { RegistryRoots } from '../plugins/registry.js';
 
 export interface PluginInstallResult {
   ok: boolean;
@@ -9,12 +14,13 @@ export interface PluginInstallResult {
   warnings: unknown[];
   message: string;
   log: string[];
+  errorCode?: PluginInstallErrorCode;
 }
 
 export interface PluginInstallationHelpersDeps {
   db: PluginDbLike;
   installFromLocalFolder: (db: PluginDbLike, args: InstallFromLocalFolderArgs) => AsyncIterable<InstallFromLocalFolderEvent>;
-  PLUGIN_REGISTRY_ROOTS: string[];
+  PLUGIN_REGISTRY_ROOTS: RegistryRoots;
   PLUGIN_LOCKFILE_PATH: string;
   PLUGIN_UPLOAD_MAX_BYTES: number;
 }
@@ -34,7 +40,7 @@ interface InstalledPluginLike {
 
 interface InstallFromLocalFolderArgs {
   source: string;
-  roots: string[];
+  roots: RegistryRoots;
   _stagedFolder: string;
   _stagedSourceKind: string;
   lockfilePath: string;
@@ -45,6 +51,7 @@ interface InstallFromLocalFolderEvent {
   message?: string;
   warnings?: unknown[];
   plugin?: InstalledPluginLike;
+  code?: PluginInstallErrorCode;
 }
 
 export function normalizeProjectPluginFolderPath(input: unknown) {
@@ -128,11 +135,28 @@ export async function extractPluginZipToFolder(buffer: Buffer, stagedFolder: str
 }
 
 export function createPluginInstallationHelpers(deps: PluginInstallationHelpersDeps) {
+  function failedInstallResult(
+    cause: unknown,
+    warnings: unknown[] = [],
+    log: string[] = [],
+  ): PluginInstallResult {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return {
+      ok: false,
+      plugin: null,
+      warnings,
+      message,
+      log,
+      errorCode: classifyPluginInstallError(message),
+    };
+  }
+
   async function finishUploadedPluginInstall(stagedFolder: string, source: string): Promise<PluginInstallResult> {
     const warnings: unknown[] = [];
     const log: string[] = [];
     let plugin = null;
     let message = 'Install finished.';
+    let errorCode: PluginInstallErrorCode | undefined;
     try {
       const pluginRoot = await findUploadedPluginRoot(stagedFolder);
       for await (const ev of deps.installFromLocalFolder(deps.db, {
@@ -152,10 +176,21 @@ export function createPluginInstallationHelpers(deps: PluginInstallationHelpersD
         }
         if (ev.kind === 'error') {
           message = ev.message ?? 'Install failed.';
+          errorCode = ev.code ?? classifyPluginInstallError(message);
           break;
         }
       }
-      return { ok: Boolean(plugin), plugin, warnings, message, log };
+      const ok = Boolean(plugin);
+      return {
+        ok,
+        plugin,
+        warnings,
+        message,
+        log,
+        ...(!ok ? { errorCode: errorCode ?? classifyPluginInstallError(message) } : {}),
+      };
+    } catch (cause) {
+      return failedInstallResult(cause, warnings, log);
     } finally {
       await fs.promises.rm(stagedFolder, { recursive: true, force: true }).catch(() => undefined);
     }
@@ -163,14 +198,19 @@ export function createPluginInstallationHelpers(deps: PluginInstallationHelpersD
 
   async function stageUploadedPluginZip(buffer: Buffer, source: string) {
     const stagedFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'od-plugin-zip-'));
-    await extractPluginZipToFolder(buffer, stagedFolder, deps.PLUGIN_UPLOAD_MAX_BYTES);
-    return finishUploadedPluginInstall(stagedFolder, source);
+    try {
+      await extractPluginZipToFolder(buffer, stagedFolder, deps.PLUGIN_UPLOAD_MAX_BYTES);
+      return await finishUploadedPluginInstall(stagedFolder, source);
+    } catch (cause) {
+      await fs.promises.rm(stagedFolder, { recursive: true, force: true }).catch(() => undefined);
+      return failedInstallResult(cause);
+    }
   }
 
   async function stageUploadedPluginFolder(files: Array<{ buffer: Buffer; originalname: string }>, rawPaths: unknown) {
     const stagedFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'od-plugin-folder-'));
     try {
-      if (files.length === 0) return null;
+      if (files.length === 0) throw new Error('files are required');
       const paths = Array.isArray(rawPaths) ? rawPaths : rawPaths ? [rawPaths] : [];
       let totalBytes = 0;
       for (let i = 0; i < files.length; i += 1) {
@@ -183,9 +223,9 @@ export function createPluginInstallationHelpers(deps: PluginInstallationHelpersD
         await fs.promises.writeFile(dest, file.buffer);
       }
       return await finishUploadedPluginInstall(stagedFolder, 'upload:folder');
-    } catch (err) {
+    } catch (cause) {
       await fs.promises.rm(stagedFolder, { recursive: true, force: true }).catch(() => undefined);
-      throw err;
+      return failedInstallResult(cause);
     }
   }
 

--- a/apps/daemon/src/services/skill-installation.ts
+++ b/apps/daemon/src/services/skill-installation.ts
@@ -304,10 +304,13 @@ async function findSkillRoot(
     );
   }
   if (preferredSkillPath) {
-    const expected = preferredSkillPath.toLowerCase();
     const preferred = candidates.filter((candidate) => {
-      const relative = path.relative(extractRoot, candidate).split(path.sep).join('/').toLowerCase();
-      return relative === expected || relative.endsWith(`/${expected}`);
+      const archiveRelativeParts = path.relative(extractRoot, candidate).split(path.sep);
+      // GitHub codeload archives have exactly one repository wrapper directory
+      // (`repo-ref/`). The browser URL path is relative to the repository root,
+      // so discard only that wrapper and preserve GitHub's case-sensitive path.
+      const repositoryRelative = archiveRelativeParts.slice(1).join('/');
+      return repositoryRelative === preferredSkillPath;
     });
     if (preferred.length === 1) return preferred[0]!;
     if (preferred.length === 0) {

--- a/apps/daemon/src/services/skill-installation.ts
+++ b/apps/daemon/src/services/skill-installation.ts
@@ -24,6 +24,8 @@ const MAX_SKILL_SCAN_DEPTH = 6;
 const MAX_SKILL_SCAN_ENTRIES = 10_000;
 const GITHUB_SKILL_SOURCE_RE =
   /^github:([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9][A-Za-z0-9._-]*)$/;
+const GITHUB_SKILL_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const GITHUB_HOSTS = new Set(['github.com', 'www.github.com']);
 
 export type SkillInstallErrorCode =
   | 'BAD_REQUEST'
@@ -55,6 +57,7 @@ export interface SkillRemoteInstallOptions {
 interface ResolvedSkillSource {
   fetchUrl: string;
   preferredSkillDirectory?: string;
+  preferredSkillPath?: string;
 }
 
 function error(
@@ -64,7 +67,70 @@ function error(
   return { ok: false, code, error: message };
 }
 
+/**
+ * Resolve the browser URL users copy for one skill inside a multi-skill GitHub
+ * repository. Keep the grammar intentionally narrow: one unambiguous ref
+ * segment followed by a safe repository-relative folder path.
+ */
+function resolveGithubSkillTreeUrl(
+  rawSource: string,
+): ResolvedSkillSource | SkillRemoteInstallResult | null {
+  const source = rawSource.trim();
+  // URL parsing normalizes literal `..` segments before exposing pathname, so
+  // reject them from the original text instead of accidentally turning a
+  // traversal-looking selection into a different valid folder.
+  if (/\/(?:\.\.|%2e%2e)(?:\/|$)/i.test(source)) {
+    return error('BAD_REQUEST', 'GitHub skill tree URL contains an unsafe folder path');
+  }
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return null;
+  }
+  if (!GITHUB_HOSTS.has(url.hostname.toLowerCase())) return null;
+  if (
+    url.protocol !== 'https:'
+    || url.port
+    || url.username
+    || url.password
+    || url.search
+    || url.hash
+  ) {
+    return error('BAD_REQUEST', 'GitHub skill URLs must be public HTTPS URLs without query parameters');
+  }
+  const match = /^\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+?)\/?$/.exec(url.pathname);
+  if (!match) return null;
+  try {
+    const owner = decodeURIComponent(match[1]!);
+    const repo = decodeURIComponent(match[2]!).replace(/\.git$/i, '');
+    const ref = decodeURIComponent(match[3]!);
+    const skillPath = match[4]!
+      .split('/')
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment));
+    if (
+      !GITHUB_SKILL_SEGMENT_RE.test(owner)
+      || !GITHUB_SKILL_SEGMENT_RE.test(repo)
+      || !GITHUB_SKILL_SEGMENT_RE.test(ref)
+      || skillPath.length === 0
+      || skillPath.some((segment) => !GITHUB_SKILL_SEGMENT_RE.test(segment))
+    ) {
+      return error('BAD_REQUEST', 'GitHub skill tree URL contains an unsupported ref or folder path');
+    }
+    return {
+      fetchUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${encodeURIComponent(ref)}`,
+      preferredSkillDirectory: repo,
+      preferredSkillPath: skillPath.join('/'),
+    };
+  } catch {
+    return error('BAD_REQUEST', 'GitHub skill tree URL contains invalid encoding');
+  }
+}
+
 function resolveSkillSource(rawSource: string): ResolvedSkillSource | SkillRemoteInstallResult {
+  const browserTree = resolveGithubSkillTreeUrl(rawSource);
+  if (browserTree) return browserTree;
   const browserGithub = resolveGithubRepositoryUrl(rawSource);
   if (browserGithub.kind === 'invalid') {
     return error('BAD_REQUEST', browserGithub.error);
@@ -182,6 +248,7 @@ async function measureSafeTree(root: string, maxBytes: number): Promise<number> 
 async function findSkillRoot(
   extractRoot: string,
   preferredSkillDirectory?: string,
+  preferredSkillPath?: string,
 ): Promise<string | SkillRemoteInstallResult> {
   const rootManifest = path.join(extractRoot, 'SKILL.md');
   if (await lstat(rootManifest).then((stats) => stats.isFile()).catch(() => false)) {
@@ -216,6 +283,24 @@ async function findSkillRoot(
   }
   if (candidates.length === 0) {
     return error('INVALID_MANIFEST', 'Skill archive does not contain a SKILL.md file');
+  }
+  if (preferredSkillPath) {
+    const expected = preferredSkillPath.toLowerCase();
+    const preferred = candidates.filter((candidate) => {
+      const relative = path.relative(extractRoot, candidate).split(path.sep).join('/').toLowerCase();
+      return relative === expected || relative.endsWith(`/${expected}`);
+    });
+    if (preferred.length === 1) return preferred[0]!;
+    if (preferred.length === 0) {
+      return error(
+        'INVALID_MANIFEST',
+        `Skill repository does not contain SKILL.md at ${preferredSkillPath}`,
+      );
+    }
+    return error(
+      'INVALID_MANIFEST',
+      `Skill repository contains multiple matches for ${preferredSkillPath}`,
+    );
   }
   if (preferredSkillDirectory) {
     const expectedSuffix = `/skills/${preferredSkillDirectory.toLowerCase()}`;
@@ -367,6 +452,7 @@ export async function installSkillFromRemoteSource(
     const skillRoot = await findSkillRoot(
       extractRoot,
       resolved.preferredSkillDirectory,
+      resolved.preferredSkillPath,
     );
     if (typeof skillRoot !== 'string') return skillRoot;
     const identity = await readSkillIdentity(skillRoot);

--- a/apps/daemon/src/services/skill-installation.ts
+++ b/apps/daemon/src/services/skill-installation.ts
@@ -296,7 +296,12 @@ async function findSkillRoot(
     );
   }
   if (candidates.length === 0) {
-    return error('INVALID_MANIFEST', 'Skill archive does not contain a SKILL.md file');
+    return error(
+      'INVALID_MANIFEST',
+      preferredSkillPath
+        ? `Skill repository does not contain SKILL.md at ${preferredSkillPath}`
+        : 'Skill archive does not contain a SKILL.md file',
+    );
   }
   if (preferredSkillPath) {
     const expected = preferredSkillPath.toLowerCase();

--- a/apps/daemon/src/services/skill-installation.ts
+++ b/apps/daemon/src/services/skill-installation.ts
@@ -54,10 +54,14 @@ export interface SkillRemoteInstallOptions {
   allowInstallIdentity?: (identity: { id: string; slug: string }) => boolean | Promise<boolean>;
 }
 
-interface ResolvedSkillSource {
+interface SkillSourceCandidate {
   fetchUrl: string;
   preferredSkillDirectory?: string;
   preferredSkillPath?: string;
+}
+
+interface ResolvedSkillSource {
+  candidates: SkillSourceCandidate[];
 }
 
 function error(
@@ -69,8 +73,9 @@ function error(
 
 /**
  * Resolve the browser URL users copy for one skill inside a multi-skill GitHub
- * repository. Keep the grammar intentionally narrow: one unambiguous ref
- * segment followed by a safe repository-relative folder path.
+ * repository. GitHub does not delimit a slash-containing ref from the folder
+ * path, so return each safe split from shortest to longest ref. Installation
+ * tries them in order until an archive contains the explicitly selected skill.
  */
 function resolveGithubSkillTreeUrl(
   rawSource: string,
@@ -99,29 +104,32 @@ function resolveGithubSkillTreeUrl(
   ) {
     return error('BAD_REQUEST', 'GitHub skill URLs must be public HTTPS URLs without query parameters');
   }
-  const match = /^\/([^/]+)\/([^/]+)\/tree\/([^/]+)\/(.+?)\/?$/.exec(url.pathname);
+  const match = /^\/([^/]+)\/([^/]+)\/tree\/(.+?)\/?$/.exec(url.pathname);
   if (!match) return null;
   try {
     const owner = decodeURIComponent(match[1]!);
     const repo = decodeURIComponent(match[2]!).replace(/\.git$/i, '');
-    const ref = decodeURIComponent(match[3]!);
-    const skillPath = match[4]!
+    const treeParts = match[3]!
       .split('/')
       .filter(Boolean)
       .map((segment) => decodeURIComponent(segment));
     if (
       !GITHUB_SKILL_SEGMENT_RE.test(owner)
       || !GITHUB_SKILL_SEGMENT_RE.test(repo)
-      || !GITHUB_SKILL_SEGMENT_RE.test(ref)
-      || skillPath.length === 0
-      || skillPath.some((segment) => !GITHUB_SKILL_SEGMENT_RE.test(segment))
+      || treeParts.length < 2
+      || treeParts.some((segment) => !GITHUB_SKILL_SEGMENT_RE.test(segment))
     ) {
       return error('BAD_REQUEST', 'GitHub skill tree URL contains an unsupported ref or folder path');
     }
     return {
-      fetchUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${encodeURIComponent(ref)}`,
-      preferredSkillDirectory: repo,
-      preferredSkillPath: skillPath.join('/'),
+      candidates: treeParts.slice(0, -1).map((_, index) => {
+        const refParts = treeParts.slice(0, index + 1);
+        return {
+          fetchUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/${refParts.map(encodeURIComponent).join('/')}`,
+          preferredSkillDirectory: repo,
+          preferredSkillPath: treeParts.slice(index + 1).join('/'),
+        };
+      }),
     };
   } catch {
     return error('BAD_REQUEST', 'GitHub skill tree URL contains invalid encoding');
@@ -146,8 +154,10 @@ function resolveSkillSource(rawSource: string): ResolvedSkillSource | SkillRemot
       return error('BAD_REQUEST', 'Malformed GitHub source; expected github:owner/repo');
     }
     return {
-      fetchUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/HEAD`,
-      preferredSkillDirectory: repo,
+      candidates: [{
+        fetchUrl: `https://codeload.github.com/${owner}/${repo}/tar.gz/HEAD`,
+        preferredSkillDirectory: repo,
+      }],
     };
   }
   if (source.startsWith('github:')) {
@@ -172,7 +182,7 @@ function resolveSkillSource(rawSource: string): ResolvedSkillSource | SkillRemot
   if (!/\.(?:tar\.gz|tgz)$/i.test(url.pathname)) {
     return error('BAD_REQUEST', 'Only HTTPS .tar.gz or .tgz skill archives are supported');
   }
-  return { fetchUrl: url.toString() };
+  return { candidates: [{ fetchUrl: url.toString() }] };
 }
 
 /**
@@ -251,7 +261,10 @@ async function findSkillRoot(
   preferredSkillPath?: string,
 ): Promise<string | SkillRemoteInstallResult> {
   const rootManifest = path.join(extractRoot, 'SKILL.md');
-  if (await lstat(rootManifest).then((stats) => stats.isFile()).catch(() => false)) {
+  if (
+    !preferredSkillPath
+    && await lstat(rootManifest).then((stats) => stats.isFile()).catch(() => false)
+  ) {
     return extractRoot;
   }
   const candidates: string[] = [];
@@ -265,9 +278,10 @@ async function findSkillRoot(
         `Skill archive contains more than ${MAX_SKILL_SCAN_ENTRIES} entries while locating SKILL.md`,
       );
     }
-    if (entries.some((entry) => entry.isFile() && entry.name === 'SKILL.md')) {
+    const hasManifest = entries.some((entry) => entry.isFile() && entry.name === 'SKILL.md');
+    if (hasManifest) {
       candidates.push(dir);
-      return;
+      if (!preferredSkillPath) return;
     }
     for (const entry of entries) {
       if (entry.isDirectory()) await scan(path.join(dir, entry.name), depth + 1);
@@ -363,17 +377,11 @@ async function readSkillIdentity(
  * traversal and links and enforces the same 50 MiB default cap. Installation
  * is an atomic, fail-closed rename and never overwrites an existing skill.
  */
-export async function installSkillFromRemoteSource(
+async function installSkillSourceCandidate(
   userSkillsRoot: string,
-  rawSource: string,
+  resolved: SkillSourceCandidate,
   options: SkillRemoteInstallOptions = {},
 ): Promise<SkillRemoteInstallResult> {
-  if (typeof rawSource !== 'string' || !rawSource.trim()) {
-    return error('BAD_REQUEST', 'skill source is required');
-  }
-  const resolved = resolveSkillSource(rawSource);
-  if ('ok' in resolved) return resolved;
-
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
   const fetcher = options.fetcher ?? defaultFetcher;
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'od-skill-archive-'));
@@ -504,4 +512,34 @@ export async function installSkillFromRemoteSource(
       await rm(installStageRoot, { recursive: true, force: true }).catch(() => undefined);
     }
   }
+}
+
+function canTryNextSkillSourceCandidate(result: SkillRemoteInstallResult): boolean {
+  if (result.ok) return false;
+  return (
+    result.code === 'FETCH_FAILED' && /failed:\s*404(?:\s|$)/i.test(result.error)
+  ) || (
+    result.code === 'INVALID_MANIFEST'
+    && /does not contain SKILL\.md at/i.test(result.error)
+  );
+}
+
+export async function installSkillFromRemoteSource(
+  userSkillsRoot: string,
+  rawSource: string,
+  options: SkillRemoteInstallOptions = {},
+): Promise<SkillRemoteInstallResult> {
+  if (typeof rawSource !== 'string' || !rawSource.trim()) {
+    return error('BAD_REQUEST', 'skill source is required');
+  }
+  const resolved = resolveSkillSource(rawSource);
+  if ('ok' in resolved) return resolved;
+
+  let result: SkillRemoteInstallResult = error('BAD_REQUEST', 'skill source did not resolve');
+  for (let index = 0; index < resolved.candidates.length; index += 1) {
+    result = await installSkillSourceCandidate(userSkillsRoot, resolved.candidates[index]!, options);
+    if (result.ok || index === resolved.candidates.length - 1) return result;
+    if (!canTryNextSkillSourceCandidate(result)) return result;
+  }
+  return result;
 }

--- a/apps/daemon/tests/collab/project-delete-authority-lease.test.ts
+++ b/apps/daemon/tests/collab/project-delete-authority-lease.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { createEnforceWorkspaceProjectMutation } from '../../src/routes/project/index.js';
+import type { WorkspaceResourceAccessInput } from '../../src/collab/workspace-resource-mutation.js';
+
+function request() {
+  const headers: Record<string, string> = {
+    'x-od-workspace-id': 'workspace-personal',
+    'x-od-workspace-member-id': 'member-owner',
+  };
+  return {
+    get(name: string) {
+      return headers[name.toLowerCase()];
+    },
+  };
+}
+
+function personalContext(
+  overrides: Partial<WorkspaceCollabContext> = {},
+): WorkspaceCollabContext {
+  return {
+    workspaceId: 'workspace-personal',
+    workspaceName: 'Personal',
+    workspaceType: 'personal',
+    workspaceMemberId: 'member-owner',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: {
+      seatLimit: 1,
+      usedSeats: 1,
+      availableSeats: 0,
+      isSeatFull: true,
+    },
+    permissions: {
+      canManageMembers: true,
+      canManageBilling: true,
+      canInviteMembers: false,
+      canManageAutoRecharge: true,
+      canShareProjects: false,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: true,
+      canManageSharedResources: true,
+    },
+    ...overrides,
+  };
+}
+
+function localOnlyProject(
+  overrides: WorkspaceResourceAccessInput = {},
+): WorkspaceResourceAccessInput {
+  return {
+    workspaceId: 'workspace-personal',
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: 'member-owner',
+    resourceHubResourceId: null,
+    syncState: 'local_only',
+    ...overrides,
+  };
+}
+
+function lookups(row: WorkspaceResourceAccessInput) {
+  return {
+    exact: (_db: unknown, workspaceId: string) =>
+      row.workspaceId === workspaceId ? row : null,
+    any: () => row,
+  };
+}
+
+describe('personal local-only project delete authority lease', () => {
+  it('deletes from a warm personal lease without starting the fresh authority request', async () => {
+    const row = localOnlyProject();
+    const { exact, any } = lookups(row);
+    const fresh = vi.fn(async () => ({
+      ok: false as const,
+      status: 503 as const,
+      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+      message: 'fresh authority is unavailable',
+      retryable: true as const,
+    }));
+    const lease = vi.fn(async () => ({
+      ok: true as const,
+      context: personalContext(),
+    }));
+    const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
+
+    await expect(enforce(
+      request(),
+      {} as any,
+      vi.fn(),
+      exact,
+      any,
+      {},
+      'project-a',
+      'delete',
+    )).resolves.toBe(true);
+    expect(lease).toHaveBeenCalledTimes(1);
+    expect(fresh).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Team visibility', localOnlyProject({ visibility: 'team' }), personalContext()],
+    ['hub-backed project', localOnlyProject({ resourceHubResourceId: 'hub-1' }), personalContext()],
+    ['synced project', localOnlyProject({ syncState: 'synced' }), personalContext()],
+    ['different creator', localOnlyProject({ createdByWorkspaceMemberId: 'member-other' }), personalContext()],
+    ['locked membership', localOnlyProject(), personalContext({ lifecycleState: 'locked' })],
+    ['Team workspace', localOnlyProject(), personalContext({ workspaceType: 'team', teamId: 'workspace-personal' })],
+  ])('falls through to fresh authority for %s', async (_label, row, context) => {
+    const { exact, any } = lookups(row);
+    const fresh = vi.fn(async () => ({
+      ok: false as const,
+      status: 503 as const,
+      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+      message: 'fresh authority is unavailable',
+      retryable: true as const,
+    }));
+    const lease = vi.fn(async () => ({ ok: true as const, context }));
+    const sendApiError = vi.fn();
+    const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
+
+    await expect(enforce(
+      request(),
+      {} as any,
+      sendApiError,
+      exact,
+      any,
+      {},
+      'project-a',
+      'delete',
+    )).resolves.toBe(false);
+    expect(lease).toHaveBeenCalledTimes(1);
+    expect(fresh).toHaveBeenCalledTimes(1);
+    expect(sendApiError).toHaveBeenCalledWith(
+      expect.anything(),
+      503,
+      'WORKSPACE_AUTHORITY_UNAVAILABLE',
+      expect.any(String),
+    );
+  });
+
+  it('keeps non-delete mutations on fresh authority even when the lease is eligible', async () => {
+    const row = localOnlyProject();
+    const { exact, any } = lookups(row);
+    const fresh = vi.fn(async () => ({
+      ok: true as const,
+      context: personalContext(),
+    }));
+    const lease = vi.fn(async () => ({
+      ok: true as const,
+      context: personalContext(),
+    }));
+    const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
+
+    await expect(enforce(
+      request(),
+      {} as any,
+      vi.fn(),
+      exact,
+      any,
+      {},
+      'project-a',
+      'writeFiles',
+    )).resolves.toBe(true);
+    expect(fresh).toHaveBeenCalledTimes(1);
+    expect(lease).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -285,6 +285,9 @@ describe('plugin install diagnostics', () => {
     ['Only .tar.gz / .tgz archives are accepted from https sources (got https://example.com/plugin.zip)', 'BAD_REQUEST'],
     ['folder upload exceeds 50 MiB', 'BAD_REQUEST'],
     ['Plugin tree exceeds size cap of 1024 bytes', 'BAD_REQUEST'],
+    ['invalid upload path', 'BAD_REQUEST'],
+    ['unsafe upload path: ../outside', 'BAD_REQUEST'],
+    ['Downloaded GitHub contents exceed 52428800 bytes', 'BAD_REQUEST'],
   ] as const)('classifies %s as %s', (message, code) => {
     expect(classifyPluginInstallError(message)).toBe(code);
   });

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 import Database from 'better-sqlite3';
 import { migratePlugins } from '../src/plugins/persistence.js';
 import {
@@ -316,6 +317,47 @@ describe('plugin install diagnostics', () => {
       kind: 'error',
       message: 'network boom',
       code: 'FETCH_FAILED',
+    });
+  });
+
+  it('keeps a wrapped archive download limit in the bad-request bucket', async () => {
+    const events = [];
+    for await (const event of installPlugin(db, {
+      source: 'https://example.com/plugin.tgz',
+      roots: { userPluginsRoot: pluginsRoot },
+      maxBytes: 4,
+      fetcher: async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        body: Readable.from(Buffer.from('too large')),
+      }),
+    })) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      kind: 'error',
+      message: 'Archive download failed: Downloaded archive exceeds 4 bytes',
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('classifies a real README-only folder as an invalid manifest', async () => {
+    await rm(path.join(sourceFolder, 'open-design.json'));
+    await writeFile(path.join(sourceFolder, 'README.md'), '# Not a plugin\n');
+
+    const events = [];
+    for await (const event of installPlugin(db, {
+      source: sourceFolder,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      kind: 'error',
+      code: 'INVALID_MANIFEST',
     });
   });
 });

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -363,4 +363,33 @@ describe('plugin install diagnostics', () => {
       code: 'INVALID_MANIFEST',
     });
   });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['a missing required name', JSON.stringify({ version: '1.0.0' })],
+    ['an invalid repeat stage', JSON.stringify({
+      name: 'sample-plugin',
+      version: '1.0.0',
+      od: {
+        pipeline: {
+          stages: [{ id: 'critique', atoms: ['critique-theater'], repeat: true }],
+        },
+      },
+    })],
+  ])('classifies open-design.json with %s as an invalid manifest', async (_label, manifest) => {
+    await writeFile(path.join(sourceFolder, 'open-design.json'), manifest);
+
+    const events = [];
+    for await (const event of installPlugin(db, {
+      source: sourceFolder,
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      kind: 'error',
+      code: 'INVALID_MANIFEST',
+    });
+  });
 });

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -9,7 +9,12 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { migratePlugins } from '../src/plugins/persistence.js';
-import { installFromLocalFolder, installPlugin, uninstallPlugin } from '../src/plugins/installer.js';
+import {
+  classifyPluginInstallError,
+  installFromLocalFolder,
+  installPlugin,
+  uninstallPlugin,
+} from '../src/plugins/installer.js';
 import { listInstalledPlugins } from '../src/plugins/registry.js';
 import { addMarketplace, resolvePluginInMarketplaces } from '../src/plugins/marketplaces.js';
 import type { InstalledPluginRecord } from '@open-design/contracts';
@@ -265,5 +270,29 @@ describe('installFromLocalFolder', () => {
     const [row] = listInstalledPlugins(db);
     expect(row?.marketplaceTrust).toBe('restricted');
     expect(row?.trust).toBe('restricted');
+  });
+});
+
+describe('plugin install diagnostics', () => {
+  it.each([
+    ['Fetch failed: 404 Not Found for https://example.com/plugin.tgz', 'FETCH_FAILED'],
+    ['Archive extraction failed: invalid gzip data', 'INVALID_ARCHIVE'],
+    ['Plugin id is not a safe folder name', 'INVALID_MANIFEST'],
+    ['Bundled plugin "official" cannot be replaced', 'CONFLICT'],
+    ['Malformed github source', 'BAD_REQUEST'],
+  ] as const)('classifies %s as %s', (message, code) => {
+    expect(classifyPluginInstallError(message)).toBe(code);
+  });
+
+  it('adds a stable code to top-level install errors', async () => {
+    const events = [];
+    for await (const event of installPlugin(db, {
+      source: 'https://github.com/owner/repo/issues',
+      roots: { userPluginsRoot: pluginsRoot },
+    })) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({ kind: 'error', code: 'BAD_REQUEST' });
   });
 });

--- a/apps/daemon/tests/plugins-installer.test.ts
+++ b/apps/daemon/tests/plugins-installer.test.ts
@@ -276,10 +276,14 @@ describe('installFromLocalFolder', () => {
 describe('plugin install diagnostics', () => {
   it.each([
     ['Fetch failed: 404 Not Found for https://example.com/plugin.tgz', 'FETCH_FAILED'],
+    ['network boom', 'FETCH_FAILED'],
     ['Archive extraction failed: invalid gzip data', 'INVALID_ARCHIVE'],
     ['Plugin id is not a safe folder name', 'INVALID_MANIFEST'],
     ['Bundled plugin "official" cannot be replaced', 'CONFLICT'],
     ['Malformed github source', 'BAD_REQUEST'],
+    ['Only .tar.gz / .tgz archives are accepted from https sources (got https://example.com/plugin.zip)', 'BAD_REQUEST'],
+    ['folder upload exceeds 50 MiB', 'BAD_REQUEST'],
+    ['Plugin tree exceeds size cap of 1024 bytes', 'BAD_REQUEST'],
   ] as const)('classifies %s as %s', (message, code) => {
     expect(classifyPluginInstallError(message)).toBe(code);
   });
@@ -294,5 +298,24 @@ describe('plugin install diagnostics', () => {
     }
 
     expect(events.at(-1)).toMatchObject({ kind: 'error', code: 'BAD_REQUEST' });
+  });
+
+  it('turns a throwing fetch backend into a coded error event', async () => {
+    const events = [];
+    for await (const event of installPlugin(db, {
+      source: 'https://example.com/plugin.tgz',
+      roots: { userPluginsRoot: pluginsRoot },
+      fetcher: async () => {
+        throw new Error('network boom');
+      },
+    })) {
+      events.push(event);
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      kind: 'error',
+      message: 'network boom',
+      code: 'FETCH_FAILED',
+    });
   });
 });

--- a/apps/daemon/tests/services/plugin-installation.test.ts
+++ b/apps/daemon/tests/services/plugin-installation.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createPluginInstallationHelpers } from '../../src/services/plugin-installation.js';
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'od-plugin-upload-test-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function helpersWithError(message: string) {
+  return createPluginInstallationHelpers({
+    db: {
+      prepare: () => ({
+        all: () => [],
+        get: () => undefined,
+        run: () => undefined,
+      }),
+    },
+    installFromLocalFolder: async function* () {
+      yield { kind: 'error', message, warnings: [] };
+    },
+    PLUGIN_REGISTRY_ROOTS: { userPluginsRoot: '/tmp/unused-plugin-root' },
+    PLUGIN_LOCKFILE_PATH: '/tmp/unused-plugin-lock.json',
+    PLUGIN_UPLOAD_MAX_BYTES: 1024,
+  });
+}
+
+describe('plugin upload diagnostics', () => {
+  it.each([
+    ['Plugin manifest is missing', 'INVALID_MANIFEST'],
+    ['Destination folder already exists', 'CONFLICT'],
+  ] as const)('classifies local upload failure %s as %s', async (message, errorCode) => {
+    const stagedFolder = await tempRoot();
+    await mkdir(stagedFolder, { recursive: true });
+
+    await expect(
+      helpersWithError(message).finishUploadedPluginInstall(stagedFolder, 'upload:folder'),
+    ).resolves.toMatchObject({ ok: false, errorCode });
+  });
+
+  it('returns a structured archive code when ZIP extraction fails', async () => {
+    await expect(
+      helpersWithError('unused').stageUploadedPluginZip(
+        Buffer.from('not a zip archive'),
+        'upload:zip:broken.zip',
+      ),
+    ).resolves.toMatchObject({ ok: false, errorCode: 'INVALID_ARCHIVE' });
+  });
+});

--- a/apps/daemon/tests/skill-url-install.test.ts
+++ b/apps/daemon/tests/skill-url-install.test.ts
@@ -185,6 +185,47 @@ describe('installSkillFromRemoteSource', () => {
     ]);
   });
 
+  it('tries a longer GitHub ref when the shorter ref archive has no skill manifest', async () => {
+    const nonSkillArchive = await archiveFrom(async (root) => {
+      const repositoryRoot = path.join(root, 'collection-feature');
+      await mkdir(repositoryRoot, { recursive: true });
+      await writeFile(path.join(repositoryRoot, 'README.md'), '# Not a skill\n');
+    }, ['collection-feature']);
+    const skillArchive = await archiveFrom(async (root) => {
+      const skillRoot = path.join(root, 'collection-feature-foo', 'skills', 'beta-skill');
+      await mkdir(skillRoot, { recursive: true });
+      await writeFile(
+        path.join(skillRoot, 'SKILL.md'),
+        '---\nname: beta-skill\ndescription: fixture\n---\n\n# Beta workflow\n',
+      );
+    }, ['collection-feature-foo']);
+    const urls: string[] = [];
+
+    const result = await installSkillFromRemoteSource(
+      await tempRoot('od-user-skills-'),
+      'https://github.com/owner/collection/tree/feature/foo/skills/beta-skill',
+      {
+        fetcher: async (url) => {
+          urls.push(url);
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            body: Readable.from(
+              url.endsWith('/tar.gz/feature') ? nonSkillArchive : skillArchive,
+            ),
+          };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({ ok: true, id: 'beta-skill' });
+    expect(urls).toEqual([
+      'https://codeload.github.com/owner/collection/tar.gz/feature',
+      'https://codeload.github.com/owner/collection/tar.gz/feature/foo',
+    ]);
+  });
+
   it('finds an explicitly selected nested skill below a parent SKILL.md', async () => {
     const archive = await archiveFrom(async (root) => {
       const repositoryRoot = path.join(root, 'collection-main');

--- a/apps/daemon/tests/skill-url-install.test.ts
+++ b/apps/daemon/tests/skill-url-install.test.ts
@@ -250,6 +250,32 @@ describe('installSkillFromRemoteSource', () => {
     expect(result).toMatchObject({ ok: true, id: 'beta-skill' });
   });
 
+  it.each([
+    ['a nested suffix decoy', ['vendor', 'skills', 'beta-skill']],
+    ['a case-mismatched path', ['Skills', 'beta-skill']],
+  ] as const)('rejects %s for an explicit GitHub tree path', async (_label, decoyPath) => {
+    const archive = await archiveFrom(async (root) => {
+      const decoyRoot = path.join(root, 'collection-main', ...decoyPath);
+      await mkdir(decoyRoot, { recursive: true });
+      await writeFile(
+        path.join(decoyRoot, 'SKILL.md'),
+        '---\nname: decoy-skill\ndescription: fixture\n---\n\n# Decoy workflow\n',
+      );
+    }, ['collection-main']);
+
+    const result = await installSkillFromRemoteSource(
+      await tempRoot('od-user-skills-'),
+      'https://github.com/owner/collection/tree/main/skills/beta-skill',
+      { fetcher: archiveFetcher(archive) },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'INVALID_MANIFEST',
+      error: 'Skill repository does not contain SKILL.md at beta-skill',
+    });
+  });
+
   it('fails closed when a multi-skill repository has no unique repo-named default', async () => {
     const archive = await archiveFrom(async (root) => {
       for (const name of ['alpha-skill', 'beta-skill']) {

--- a/apps/daemon/tests/skill-url-install.test.ts
+++ b/apps/daemon/tests/skill-url-install.test.ts
@@ -143,6 +143,72 @@ describe('installSkillFromRemoteSource', () => {
     ]);
   });
 
+  it('tries slash-containing GitHub refs until the selected skill path resolves', async () => {
+    const archive = await archiveFrom(async (root) => {
+      const skillRoot = path.join(root, 'collection-feature-foo', 'skills', 'beta-skill');
+      await mkdir(skillRoot, { recursive: true });
+      await writeFile(
+        path.join(skillRoot, 'SKILL.md'),
+        '---\nname: beta-skill\ndescription: fixture\n---\n\n# Beta workflow\n',
+      );
+    }, ['collection-feature-foo']);
+    const urls: string[] = [];
+
+    const result = await installSkillFromRemoteSource(
+      await tempRoot('od-user-skills-'),
+      'https://github.com/owner/collection/tree/feature/foo/skills/beta-skill',
+      {
+        fetcher: async (url) => {
+          urls.push(url);
+          if (url.endsWith('/tar.gz/feature')) {
+            return {
+              ok: false,
+              status: 404,
+              statusText: 'Not Found',
+              body: null,
+            };
+          }
+          return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            body: Readable.from(archive),
+          };
+        },
+      },
+    );
+
+    expect(result).toMatchObject({ ok: true, id: 'beta-skill' });
+    expect(urls).toEqual([
+      'https://codeload.github.com/owner/collection/tar.gz/feature',
+      'https://codeload.github.com/owner/collection/tar.gz/feature/foo',
+    ]);
+  });
+
+  it('finds an explicitly selected nested skill below a parent SKILL.md', async () => {
+    const archive = await archiveFrom(async (root) => {
+      const repositoryRoot = path.join(root, 'collection-main');
+      const nestedSkillRoot = path.join(repositoryRoot, 'skills', 'beta-skill');
+      await mkdir(nestedSkillRoot, { recursive: true });
+      await writeFile(
+        path.join(repositoryRoot, 'SKILL.md'),
+        '---\nname: collection-root\ndescription: parent fixture\n---\n\n# Parent workflow\n',
+      );
+      await writeFile(
+        path.join(nestedSkillRoot, 'SKILL.md'),
+        '---\nname: beta-skill\ndescription: nested fixture\n---\n\n# Nested workflow\n',
+      );
+    }, ['collection-main']);
+
+    const result = await installSkillFromRemoteSource(
+      await tempRoot('od-user-skills-'),
+      'https://github.com/owner/collection/tree/main/skills/beta-skill',
+      { fetcher: archiveFetcher(archive) },
+    );
+
+    expect(result).toMatchObject({ ok: true, id: 'beta-skill' });
+  });
+
   it('fails closed when a multi-skill repository has no unique repo-named default', async () => {
     const archive = await archiveFrom(async (root) => {
       for (const name of ['alpha-skill', 'beta-skill']) {

--- a/apps/daemon/tests/skill-url-install.test.ts
+++ b/apps/daemon/tests/skill-url-install.test.ts
@@ -117,6 +117,32 @@ describe('installSkillFromRemoteSource', () => {
     ).resolves.toBe('default asset');
   });
 
+  it('installs a GitHub tree URL from the selected folder in a multi-skill repository', async () => {
+    const archive = await archiveFrom(async (root) => {
+      const repositoryRoot = path.join(root, 'collection-release');
+      for (const name of ['alpha-skill', 'beta-skill']) {
+        const skillRoot = path.join(repositoryRoot, 'skills', name);
+        await mkdir(skillRoot, { recursive: true });
+        await writeFile(
+          path.join(skillRoot, 'SKILL.md'),
+          `---\nname: ${name}\ndescription: fixture\n---\n\n# ${name}\n`,
+        );
+      }
+    }, ['collection-release']);
+    const urls: string[] = [];
+
+    const result = await installSkillFromRemoteSource(
+      await tempRoot('od-user-skills-'),
+      'https://github.com/owner/collection/tree/release/skills/beta-skill',
+      { fetcher: archiveFetcher(archive, urls) },
+    );
+
+    expect(result).toMatchObject({ ok: true, id: 'beta-skill' });
+    expect(urls).toEqual([
+      'https://codeload.github.com/owner/collection/tar.gz/release',
+    ]);
+  });
+
   it('fails closed when a multi-skill repository has no unique repo-named default', async () => {
     const archive = await archiveFrom(async (root) => {
       for (const name of ['alpha-skill', 'beta-skill']) {
@@ -159,6 +185,7 @@ describe('installSkillFromRemoteSource', () => {
     'https://downloads.example/skill.zip',
     'github:owner/../repo',
     'https://github.com/owner/repo/issues',
+    'https://github.com/owner/repo/tree/main/skills/../escape',
     'https://owner@github.com/owner/repo',
     'https://github.com/owner/repo?tab=readme',
     'https://github.com.evil/owner/repo',

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -275,6 +275,46 @@ describe('createFreshWorkspaceDirectoryFetcher', () => {
 });
 
 describe('createWorkspaceDirectoryAuthorityBroker', () => {
+  it('exposes a cached-only lease that never starts I/O and is partitioned by account identity and expiry', async () => {
+    let identity = 'account-a:config-a';
+    let now = 0;
+    const accepted = {
+      ok: true as const,
+      items: [{
+        workspaceId: 'ws-team-1',
+        workspaceName: 'Team',
+        workspaceType: 'team' as const,
+        workspaceMemberId: 'wm-1',
+        role: 'member' as const,
+        memberStatus: 'active' as const,
+        lifecycleState: 'active' as const,
+      }],
+    };
+    const fetchDirectory = vi.fn(async () => accepted);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => identity,
+      now: () => now,
+      ttlMs: 100,
+    });
+
+    await expect(authority.cached()).resolves.toEqual({ ok: false, items: [] });
+    expect(fetchDirectory).not.toHaveBeenCalled();
+
+    await authority.read();
+    await expect(authority.cached()).resolves.toEqual(accepted);
+    expect(fetchDirectory).toHaveBeenCalledTimes(1);
+
+    identity = 'account-b:config-b';
+    await expect(authority.cached()).resolves.toEqual({ ok: false, items: [] });
+    expect(fetchDirectory).toHaveBeenCalledTimes(1);
+
+    identity = 'account-a:config-a';
+    now = 100;
+    await expect(authority.cached()).resolves.toEqual({ ok: false, items: [] });
+    expect(fetchDirectory).toHaveBeenCalledTimes(1);
+  });
+
   it('single-flights shell and project bootstrap reads per account generation without caching failures', async () => {
     let identity = 'account-a:config-a';
     const fetchDirectory = vi.fn(async () => ({

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -1294,7 +1294,8 @@ export function ExtensionsMarketplace({
           setToast({ message: outcome.message || t('pluginsView.uploadFailed'), tone: 'error' });
           trackResourceResult({
             kind: 'expert_plugin', scope: 'personal', action: 'add', result: 'failed',
-            startedAt, errorCode: 'upload_failed',
+            startedAt,
+            errorCode: resourceActionAnalyticsErrorCode(outcome, 'upload_failed'),
           });
         }
         return;

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -3960,11 +3960,12 @@ function buildAvailablePlugins(
     return entries.flatMap((entry) => {
       const installedPlugin = installedByName.get(normalizePluginName(entry.name)) ?? null;
       if (installedPlugin && installedPlugin.sourceKind !== 'bundled') return [];
-      const installedRecord = installedPlugin && bundledPluginMatchesMarketplaceEntry(
-        installedPlugin,
-        marketplace,
-        entry,
-      )
+      // The daemon never permits a scoped install to replace a bundled plugin,
+      // regardless of which marketplace advertises the colliding entry. Treat
+      // the already-bundled record as installed whenever the normal lookup keys
+      // match, otherwise the UI offers an Install action that can only download,
+      // parse, and finally fail with "Bundled plugin cannot be replaced".
+      const installedRecord = installedPlugin?.sourceKind === 'bundled'
         ? installedPlugin
         : null;
       return [{
@@ -3975,16 +3976,6 @@ function buildAvailablePlugins(
       }];
     });
   });
-}
-
-function bundledPluginMatchesMarketplaceEntry(
-  plugin: InstalledPluginRecord,
-  marketplace: PluginMarketplace,
-  entry: PluginMarketplaceEntry,
-): boolean {
-  return plugin.sourceKind === 'bundled'
-    && plugin.sourceMarketplaceId === marketplace.id
-    && normalizePluginName(plugin.sourceMarketplaceEntryName ?? '') === normalizePluginName(entry.name);
 }
 
 function availablePluginTitle(entry: PluginMarketplaceEntry, locale?: string): string {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -965,6 +965,17 @@ export async function deleteProject(
       } catch {
         // Keep the stable HTTP fallback when a legacy daemon returns no JSON.
       }
+      // DELETE is idempotent for the web client. A second tab, a stale project
+      // list, or a retry whose first response was lost can legitimately reach
+      // the daemon after the project row is already gone. Only accept the
+      // daemon's structured PROJECT_NOT_FOUND response here — a generic 404
+      // can still mean the route itself is unavailable on an incompatible
+      // daemon and must remain visible as a failure.
+      if (resp.status === 404 && code === 'PROJECT_NOT_FOUND') {
+        removeCachedTabs(id, workspaceContext);
+        removeDesignBrowserProjectCache(id);
+        return true;
+      }
       throw new ProjectDeleteError(message, resp.status, code);
     }
     // Drop per-project browser caches once the project is gone server-side so

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -2174,7 +2174,7 @@ async function postPluginUpload(url: string, form: FormData): Promise<PluginInst
       body: form,
     });
     const json = (await resp.json()) as Partial<PluginInstallOutcome> & {
-      error?: string | { message?: string };
+      error?: string | { code?: unknown; message?: string };
     };
     if (resp.ok && json.ok) {
       return {
@@ -2189,10 +2189,15 @@ async function postPluginUpload(url: string, form: FormData): Promise<PluginInst
       json.message ??
       (typeof json.error === 'string' ? json.error : json.error?.message) ??
       resp.statusText;
+    const errorCode = boundedRequestErrorCode(
+      json.errorCode ?? (typeof json.error === 'object' ? json.error?.code : undefined),
+    );
     return {
       ok: false,
       warnings: json.warnings ?? [],
       message,
+      status: resp.status,
+      ...(errorCode ? { errorCode } : {}),
       log: json.log ?? [],
     };
   } catch (err) {
@@ -2200,6 +2205,7 @@ async function postPluginUpload(url: string, form: FormData): Promise<PluginInst
       ok: false,
       warnings: [],
       message: (err as Error).message,
+      errorCode: 'network_error',
       log: [],
     };
   }

--- a/apps/web/tests/components/ExtensionsMarketplace.card-actions.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.card-actions.test.tsx
@@ -21,9 +21,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { ExtensionsMarketplace } from '../../src/components/PluginsView';
 import { I18nProvider } from '../../src/i18n';
 
+const analyticsTrack = vi.hoisted(() => vi.fn());
+
 vi.mock('../../src/analytics/provider', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
-  return { ...actual, useAnalytics: () => ({ track: vi.fn() }) };
+  return { ...actual, useAnalytics: () => ({ track: analyticsTrack }) };
 });
 
 const TEAM_CONTEXT = {
@@ -101,6 +103,7 @@ let skills: Array<typeof USER_SKILL>;
 let installResolvers: Array<() => void>;
 let skillDetailFailuresRemaining: number;
 let skillDetailRequests: number;
+let uploadFolderFailureCode: string | null;
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -125,8 +128,19 @@ beforeEach(() => {
   installResolvers = [];
   skillDetailFailuresRemaining = 0;
   skillDetailRequests = 0;
+  uploadFolderFailureCode = null;
+  analyticsTrack.mockClear();
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString();
+    if (url === '/api/plugins/upload-folder' && uploadFolderFailureCode) {
+      return jsonResponse({
+        ok: false,
+        warnings: [],
+        message: 'Plugin manifest is missing.',
+        errorCode: uploadFolderFailureCode,
+        log: [],
+      }, 400);
+    }
     if (url.startsWith('/api/skills/import')) {
       const body = JSON.parse(String(init?.body ?? '{}')) as { name?: string };
       const imported = { ...USER_SKILL, id: body.name ?? 'imported', name: body.name ?? 'imported' };
@@ -380,6 +394,35 @@ describe('ExtensionsMarketplace card affordances', () => {
 });
 
 describe('ExtensionsMarketplace import', () => {
+  it('tracks the daemon error code when plugin folder upload fails', async () => {
+    uploadFolderFailureCode = 'INVALID_MANIFEST';
+    const { container } = renderMarketplace();
+    await waitFor(() => {
+      expect(container.querySelectorAll('.plugin-marketplace__item').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(container.querySelector('.plugin-marketplace__create')!);
+    const folderInput = await waitFor(() =>
+      container.querySelector<HTMLInputElement>('input[webkitdirectory]')!,
+    );
+    const folderFile = new File(['{}'], 'open-design.json', { type: 'application/json' });
+    fireEvent.change(folderInput, { target: { files: [folderFile] } });
+    fireEvent.click(screen.getByTestId('plugin-create-upload-folder'));
+
+    await waitFor(() => {
+      expect(analyticsTrack).toHaveBeenCalledWith(
+        'workspace_resource_action_result',
+        expect.objectContaining({
+          action: 'add',
+          resource_kind: 'expert_plugin',
+          result: 'failed',
+          error_code: 'INVALID_MANIFEST',
+        }),
+        undefined,
+      );
+    });
+  });
+
   it('#132 — a successful plugin URL import keeps workspace authority and reveals the result', async () => {
     workspaceContext = TEAM_CONTEXT;
     const { container } = renderMarketplace();

--- a/apps/web/tests/components/PluginsView.test.tsx
+++ b/apps/web/tests/components/PluginsView.test.tsx
@@ -286,7 +286,7 @@ describe('PluginsView', () => {
     expect(mockedInstallPluginSource).not.toHaveBeenCalled();
   });
 
-  it('installs restricted catalog entries that collide with bundled official plugin names', async () => {
+  it('uses bundled plugins instead of offering an install the daemon must reject', async () => {
     const onUsePlugin = vi.fn();
     mockedListMarketplaces.mockResolvedValue([
       {
@@ -316,16 +316,14 @@ describe('PluginsView', () => {
     expect(await screen.findByText('Team Official Plugin')).toBeTruthy();
 
     const install = screen.getByTestId('plugins-available-install-open-design/official-plugin');
-    expect(install.textContent).toBe('Install');
+    expect(install.textContent).toBe('Use');
     fireEvent.click(install);
 
-    await waitFor(() =>
-      expect(mockedInstallPluginSource).toHaveBeenCalledWith(
-        'open-design/official-plugin',
-        null,
-      ),
-    );
-    expect(onUsePlugin).not.toHaveBeenCalled();
+    expect(mockedInstallPluginSource).not.toHaveBeenCalled();
+    expect(onUsePlugin).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'official-plugin',
+      sourceKind: 'bundled',
+    }), 'use');
   });
 
   it('shows all installed plugins by default on the Plugins page', async () => {

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -29,6 +29,7 @@ import {
   publishGeneratedPluginToGitHub,
   resolvedWorkspaceContextForWrite,
   startGeneratedPluginShareTask,
+  uploadPluginFolder,
   waitGeneratedPluginShareTask,
   workspaceProjectMoveErrorCode,
 } from '../../src/state/projects';
@@ -2018,6 +2019,29 @@ describe('moveWorkspaceProject error surfaces (recvqzjnshIlOe)', () => {
       .toBe(true);
     expect(readProjectDisplaySnapshot(projectDisplaySnapshotKey(previousAccountScope))?.dirty)
       .toBe(false);
+  });
+});
+
+describe('plugin upload diagnostics', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves a bounded daemon error code on folder upload failure', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => Response.json({
+      ok: false,
+      warnings: [],
+      message: 'Plugin manifest is missing at /Users/example/private-plugin',
+      errorCode: 'INVALID_MANIFEST',
+      log: [],
+    }, { status: 400 })));
+
+    await expect(uploadPluginFolder([
+      new File(['readme'], 'README.md', { type: 'text/markdown' }),
+    ])).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'INVALID_MANIFEST',
+    });
   });
 });
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -899,6 +899,26 @@ describe('deleteProject', () => {
       message: 'workspace authority is temporarily unavailable',
     });
   });
+
+  it('treats a structured missing-project response as an idempotent success', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      error: {
+        code: 'PROJECT_NOT_FOUND',
+        message: 'not found',
+      },
+    }), { status: 404 })));
+
+    await expect(deleteProject('already-deleted', personalWorkspaceContext())).resolves.toBe(true);
+  });
+
+  it('does not hide an unstructured 404 from an incompatible daemon', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 404 })));
+
+    await expect(deleteProject('project-1', personalWorkspaceContext())).rejects.toMatchObject({
+      name: 'ProjectDeleteError',
+      status: 404,
+    });
+  });
 });
 
 // Same gap as deleteProject, found while auditing every client caller of a

--- a/e2e/lib/playwright/skill-fixture-cleanup.ts
+++ b/e2e/lib/playwright/skill-fixture-cleanup.ts
@@ -1,0 +1,22 @@
+interface CleanupResponse {
+  ok(): boolean;
+  status(): number;
+  statusText(): string;
+}
+
+interface CleanupOptions {
+  importCompleted: boolean;
+  skillName: string;
+}
+
+export async function cleanupSkillFixture(
+  deleteFixture: () => Promise<CleanupResponse>,
+  options: CleanupOptions,
+): Promise<void> {
+  const response = await deleteFixture();
+  if (response.ok()) return;
+  if (!options.importCompleted && response.status() === 404) return;
+  throw new Error(
+    `Skill fixture cleanup failed for ${options.skillName}: ${response.status()} ${response.statusText()}`,
+  );
+}

--- a/e2e/tests/skill-fixture-cleanup.test.ts
+++ b/e2e/tests/skill-fixture-cleanup.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cleanupSkillFixture } from '../lib/playwright/skill-fixture-cleanup.js';
+
+function response(status: number, statusText: string) {
+  return {
+    ok: () => status >= 200 && status < 300,
+    status: () => status,
+    statusText: () => statusText,
+  };
+}
+
+describe('cleanupSkillFixture', () => {
+  it('accepts a successful delete after import', async () => {
+    await expect(cleanupSkillFixture(
+      vi.fn().mockResolvedValue(response(204, 'No Content')),
+      { importCompleted: true, skillName: 'fixture' },
+    )).resolves.toBeUndefined();
+  });
+
+  it('rejects transport failures instead of hiding worker-state leakage', async () => {
+    await expect(cleanupSkillFixture(
+      vi.fn().mockRejectedValue(new Error('daemon unavailable')),
+      { importCompleted: true, skillName: 'fixture' },
+    )).rejects.toThrow('daemon unavailable');
+  });
+
+  it('rejects a failed delete after the fixture was imported', async () => {
+    await expect(cleanupSkillFixture(
+      vi.fn().mockResolvedValue(response(500, 'Internal Server Error')),
+      { importCompleted: true, skillName: 'fixture' },
+    )).rejects.toThrow('Skill fixture cleanup failed for fixture: 500 Internal Server Error');
+  });
+
+  it('accepts not-found only when import never completed', async () => {
+    await expect(cleanupSkillFixture(
+      vi.fn().mockResolvedValue(response(404, 'Not Found')),
+      { importCompleted: false, skillName: 'fixture' },
+    )).resolves.toBeUndefined();
+
+    await expect(cleanupSkillFixture(
+      vi.fn().mockResolvedValue(response(404, 'Not Found')),
+      { importCompleted: true, skillName: 'fixture' },
+    )).rejects.toThrow('Skill fixture cleanup failed for fixture: 404 Not Found');
+  });
+});

--- a/e2e/ui/plugin-folder-import.test.ts
+++ b/e2e/ui/plugin-folder-import.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { expect, test } from '@/playwright/suite';
 import { applyStandardMocks } from '@/playwright/mock-factory';
 import { ensureRailOpen } from '@/playwright/rail';
+import { cleanupSkillFixture } from '@/playwright/skill-fixture-cleanup';
 
 test.beforeEach(async ({ page }) => {
   await applyStandardMocks(page);
@@ -30,6 +31,9 @@ test('[P1] imports a valid local Skill folder through the running product', asyn
     ].join('\n'),
     'utf8',
   );
+  let importCompleted = false;
+  let importedSkillId: string | null = null;
+  let cleanupHeaders: Record<string, string> | undefined;
 
   try {
     await page.goto('/');
@@ -52,7 +56,18 @@ test('[P1] imports a valid local Skill folder through the running product', asyn
       && new URL(response.url()).pathname === '/api/skills/import',
     );
     await dialog.getByTestId('plugin-create-upload-folder').click();
-    expect((await imported).ok()).toBe(true);
+    const importResponse = await imported;
+    expect(importResponse.ok()).toBe(true);
+    importCompleted = true;
+    const importedPayload = await importResponse.json() as { skill?: { id?: unknown } };
+    const responseSkillId = importedPayload.skill?.id;
+    expect(typeof responseSkillId).toBe('string');
+    if (typeof responseSkillId !== 'string') throw new Error('Skill import response omitted skill.id');
+    importedSkillId = responseSkillId;
+    const importHeaders = await importResponse.request().allHeaders();
+    cleanupHeaders = Object.fromEntries(
+      Object.entries(importHeaders).filter(([name]) => name.startsWith('x-od-workspace-')),
+    );
 
     await expect(page.getByRole('status')).toContainText(skillName);
     await expect(plugins.getByText(skillName, { exact: true }).first()).toBeVisible();
@@ -60,8 +75,13 @@ test('[P1] imports a valid local Skill folder through the running product', asyn
     // The worker-scoped daemon/data root survives across UI files. Remove the
     // fixture even when an assertion fails so this browser witness cannot leak
     // state into a later test that happens to reuse the same worker.
-    await page.request
-      .delete(`/api/skills/${encodeURIComponent(skillName)}`)
-      .catch(() => undefined);
+    const cleanupSkillId = importedSkillId ?? skillName;
+    await cleanupSkillFixture(
+      () => page.request.delete(
+        `/api/skills/${encodeURIComponent(cleanupSkillId)}`,
+        cleanupHeaders ? { headers: cleanupHeaders } : undefined,
+      ),
+      { importCompleted, skillName: cleanupSkillId },
+    );
   }
 });

--- a/e2e/ui/plugin-folder-import.test.ts
+++ b/e2e/ui/plugin-folder-import.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from '@/playwright/suite';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+import { ensureRailOpen } from '@/playwright/rail';
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+});
+
+test('[P1] imports a valid local Skill folder through the running product', async ({
+  page,
+}, testInfo) => {
+  const skillName = `folder-import-${testInfo.workerIndex}-${Date.now()}`;
+  const skillDir = testInfo.outputPath(skillName);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    [
+      '---',
+      `name: ${skillName}`,
+      'description: Browser regression fixture for local folder import.',
+      '---',
+      '',
+      '# Folder import fixture',
+      '',
+      'Return `folder-import-ok` when invoked.',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  try {
+    await page.goto('/');
+    await ensureRailOpen(page);
+    await page.getByTestId('entry-nav-plugins').click();
+    await expect(page).toHaveURL(/\/plugins$/);
+
+    const plugins = page.getByTestId('entry-view-plugins');
+    await plugins.getByRole('button', { name: /Skills|技能/, exact: true }).click();
+    await plugins.getByRole('button', { name: /^(Add|新增)$/ }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    const folderInput = dialog.locator('input[webkitdirectory]');
+    await folderInput.setInputFiles(skillDir);
+    await expect(dialog.getByRole('button', { name: /1 file|1 个文件/ })).toBeVisible();
+
+    const imported = page.waitForResponse((response) =>
+      response.request().method() === 'POST'
+      && new URL(response.url()).pathname === '/api/skills/import',
+    );
+    await dialog.getByTestId('plugin-create-upload-folder').click();
+    expect((await imported).ok()).toBe(true);
+
+    await expect(page.getByRole('status')).toContainText(skillName);
+    await expect(plugins.getByText(skillName, { exact: true }).first()).toBeVisible();
+  } finally {
+    // The worker-scoped daemon/data root survives across UI files. Remove the
+    // fixture even when an assertion fails so this browser witness cannot leak
+    // state into a later test that happens to reuse the same worker.
+    await page.request
+      .delete(`/api/skills/${encodeURIComponent(skillName)}`)
+      .catch(() => undefined);
+  }
+});


### PR DESCRIPTION
## Why

Production diagnostics showed two release-risk clusters: project deletion failures were much slower than successful deletion, and plugin/Skill installation produced a high volume of failures without stable enough attribution. I investigated these paths to make personal local cleanup fast and deterministic while keeping team and remote-resource authorization fail-closed, and to turn the largest extension-installation failure modes into actionable behavior and diagnostics.

## What users will see

Personal, local-only projects delete without waiting on an avoidable remote workspace-directory round trip when the current session already has valid personal-workspace authority. Team, synced, Resource Hub-backed, locked, and cross-creator resources still require fresh verification. Repeated deletion of an already-absent project is treated as success.

Bundled plugins that are already available show the usable action instead of an install action that must collide. Skill imports accept GitHub `/tree/<ref>/<folder>` URLs, and plugin/Skill failures expose stable diagnostic codes for dashboard drill-down. Existing valid local-folder Skill imports remain supported and now have browser regression coverage.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No page layout or entry point changes. The conditional change is on existing plugin cards: bundled entries no longer present an install action that can only collide. The Plugins → Skills → Add folder-import path was exercised in a real Chrome session with the native macOS folder picker; the selected-file state, successful import message, and imported Skill card were verified.

## Bug fix verification

- Red-spec paths: `apps/web/tests/state/projects.test.ts`, `apps/web/tests/components/PluginsView.test.tsx`, `apps/daemon/tests/plugins-installer.test.ts`, `apps/daemon/tests/skill-url-install.test.ts`, `apps/daemon/tests/collab/project-delete-authority-lease.test.ts`, and `apps/daemon/tests/vela-workspace-context.test.ts`.
- The focused product tests were run against `origin/main` and failed before the source changes, then passed on this branch. The personal delete red proof failed because the authority broker had no cached-only lease and the eligible path invoked fresh verification.
- `e2e/ui/plugin-folder-import.test.ts` covers the valid local folder-import browser flow through the running daemon/web product and real `/api/skills/import` request.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- daemon workspace/delete focused suites: 41/41 passed
- daemon plugin installer + Skill URL suites: 37/37 passed
- web project state + Plugins view suites: 93/93 passed
- cached workspace-directory lease broker test passed
- `pnpm --filter @open-design/e2e typecheck`
- Playwright `e2e/ui/plugin-folder-import.test.ts`: 1/1 passed
- Local product UI E2E: real Chrome + native macOS folder picker + running local daemon/web; this validates the client and local `/api/skills/import` path, not Vela team authorization.
- Live test-Vela E2E (`VELA_PROFILE=test`): browser-approved CLI login; created a temporary Team workspace; created and shared a project through this branch daemon; verified `synced` in the Vela team catalog and present in the shared-resource index; deleted it through `DELETE /api/projects/:id` (HTTP 200, 3.48s); verified local GET 404, local directory absent, catalog entry absent, shared-resource entry absent, and published ref null.
- Live personal fast path: created a personal `local_only` project through the branch daemon, then deleted it against a warm same-session authority lease in 3.7ms (HTTP 200), with the local directory removed.
- Cleanup: the temporary Team workspace was soft-deleted in test Vela and the isolated local daemon data was moved to Trash. No production workspace or resource was touched.