### PR TITLE
feat(analytics): observe conversation fork outcomes

### DIFF
--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -184,6 +184,12 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
       createdAt: now,
       updatedAt: now,
     });
+    // TODO(native-session-clone): Add a runtime-capability-gated adapter contract
+    // that forks the source agent session at this exact message and persists the
+    // clone's independent handle for `conv.id`. Never copy/reuse the source
+    // `agent_sessions.session_id`, because branch turns could then advance the
+    // original conversation. Unsupported runtimes, historical fork-point
+    // mismatches, and clone failures must keep today's transcript-reseed path.
     // Side Chat: inherit the source conversation's context by copying its
     // messages into the fresh conversation. Be defensive — a missing or
     // cross-project source id silently yields an empty conversation.

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -110,6 +110,7 @@ import type {
   AssistantFeedbackClickProps,
   AssistantFeedbackReasonClickProps,
   AssistantFeedbackReasonSubmitClickProps,
+  ConversationForkClickProps,
   AssistantFeedbackReasonSubmitProps,
   AssistantFeedbackReasonViewProps,
   SettingsSidebarClickProps,
@@ -139,6 +140,7 @@ import type {
   SketchSaveResultProps,
   SketchExportResultProps,
   FeedbackSubmitResultProps,
+  ConversationForkResultProps,
   SettingsViewProps,
   SettingsCliTestResultProps,
   SettingsByokModelsFetchResultProps,
@@ -991,6 +993,14 @@ export function trackAssistantFeedbackButtonClick(
   send(track, 'ui_click', props);
 }
 
+export function trackConversationForkClick(
+  track: Track,
+  props: ConversationForkClickProps,
+  options?: { requestId?: string },
+): void {
+  send(track, 'ui_click', props, options);
+}
+
 export function trackAssistantFeedbackReasonSubmitClick(
   track: Track,
   props: AssistantFeedbackReasonSubmitClickProps,
@@ -1178,6 +1188,14 @@ export function trackFeedbackSubmitResult(
   options?: { requestId?: string },
 ): void {
   send(track, 'feedback_submit_result', props, options);
+}
+
+export function trackConversationForkResult(
+  track: Track,
+  props: ConversationForkResultProps,
+  options?: { requestId?: string },
+): void {
+  send(track, 'conversation_fork_result', props, options);
 }
 
 // ---- Settings view + test/auth result events -----------------------------

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -73,9 +73,12 @@ import {
   executionModeToTracking,
   projectKindFromMetadataToTracking,
   projectKindToTracking,
+  sessionModeToTracking,
 } from '@open-design/contracts/analytics';
 import type {
   TrackingArtifactKind,
+  TrackingConversationForkErrorCode,
+  TrackingConversationForkPoint,
   TrackingDesignSystemApplyTargetKind,
   TrackingDesignSystemOrigin,
   TrackingDesignSystemStatusValue,
@@ -85,6 +88,8 @@ import { useAnalytics } from '../analytics/provider';
 import {
   trackByokPreflightBlocked,
   trackComposerBarClick,
+  trackConversationForkClick,
+  trackConversationForkResult,
   trackDesignSystemApplyResult,
   trackDesignSystemEnrichClick,
   trackPageView,
@@ -387,6 +392,33 @@ export function mergeSavedPreviewComment(current: PreviewComment[], saved: Previ
 
 function wait(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function conversationForkErrorCode(error: unknown): TrackingConversationForkErrorCode {
+  if (error instanceof ProjectConversationsHttpError) {
+    if (error.status === 400) return 'bad_request';
+    if (error.status === 401 || error.status === 403) return 'permission_denied';
+    if (error.status === 404) return 'fork_source_not_found';
+    if (error.status === 413) return 'payload_too_large';
+    if (error.status >= 500) return 'server_error';
+    return 'http_error';
+  }
+  if (error instanceof TypeError) return 'network_error';
+  return 'unknown_error';
+}
+
+function conversationForkPoint(
+  messages: ChatMessage[],
+  assistantMessageId: string,
+  forkIndex: number,
+): TrackingConversationForkPoint {
+  if (forkIndex < 0) return 'unknown';
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== 'assistant') continue;
+    return message.id === assistantMessageId ? 'latest' : 'historical';
+  }
+  return 'unknown';
 }
 
 export async function listConversationsWithRetry(
@@ -8983,14 +9015,36 @@ export function ProjectView({
   const handleForkFromMessage = useCallback(
     async (assistantMessage: ChatMessage) => {
       if (!activeConversationId || forkingMessageId || projectCollab.viewerOnly) return;
+      const requestId = analytics.newRequestId();
+      const startedAt = Date.now();
+      const forkIndex = messages.findIndex((message) => message.id === assistantMessage.id);
+      const forkContext = {
+        page_name: 'chat_panel' as const,
+        area: 'chat_panel' as const,
+        element: 'assistant_fork_button' as const,
+        action: 'fork_conversation' as const,
+        project_id: project.id,
+        project_kind: projectKindFromMetadataToTracking(project.metadata),
+        conversation_id: activeConversationId,
+        assistant_message_id: assistantMessage.id,
+        source_run_id: assistantMessage.runId ?? null,
+        source_agent_id: assistantMessage.agentId ?? 'unknown',
+        agent_provider_id: runAgentProviderId(assistantMessage.agentId ?? 'unknown'),
+        session_mode: sessionModeToTracking(activeSessionMode),
+        fork_point: conversationForkPoint(messages, assistantMessage.id, forkIndex),
+        seed_message_count: forkIndex < 0 ? null : forkIndex + 1,
+        conversation_message_count: messages.length,
+        messages_after_fork_count: forkIndex < 0 ? null : messages.length - forkIndex - 1,
+      };
+      trackConversationForkClick(analytics.track, forkContext, { requestId });
       setForkingMessageId(assistantMessage.id);
       setConversationLoadError(null);
+      let emptyResponse = false;
       try {
         const sourceTitle = activeConversation?.title?.trim();
         const forkTitle = sourceTitle
           ? t('chat.forkedConversationTitle', { title: sourceTitle })
           : undefined;
-        const forkIndex = messages.findIndex((message) => message.id === assistantMessage.id);
         const forkFallbackPredecessorMessageId = forkIndex < 0
           ? undefined
           : (messages[forkIndex - 1]?.id ?? null);
@@ -9004,7 +9058,20 @@ export function ProjectView({
           workspaceContext: projectRunWorkspaceContext,
           throwOnError: true,
         });
-        if (!fresh) throw new Error(t('chat.forkConversationFailed'));
+        if (!fresh) {
+          emptyResponse = true;
+          throw new Error(t('chat.forkConversationFailed'));
+        }
+        trackConversationForkResult(
+          analytics.track,
+          {
+            ...forkContext,
+            target_conversation_id: fresh.id,
+            result: 'success',
+            duration_ms: Math.max(0, Date.now() - startedAt),
+          },
+          { requestId },
+        );
         setMessages([]);
         commitPreviewComments([]);
         setAttachedComments([]);
@@ -9029,6 +9096,17 @@ export function ProjectView({
         onProjectsRefresh();
         setError(null);
       } catch (err) {
+        trackConversationForkResult(
+          analytics.track,
+          {
+            ...forkContext,
+            target_conversation_id: null,
+            result: 'failed',
+            error_code: emptyResponse ? 'empty_response' : conversationForkErrorCode(err),
+            duration_ms: Math.max(0, Date.now() - startedAt),
+          },
+          { requestId },
+        );
         const message = err instanceof Error ? err.message : t('chat.forkConversationFailed');
         setConversationLoadError(message);
         setError(message);
@@ -9040,6 +9118,7 @@ export function ProjectView({
       activeConversationId,
       activeConversation?.title,
       activeSessionMode,
+      analytics,
       commitPreviewComments,
       forkingMessageId,
       messages,
@@ -9047,6 +9126,7 @@ export function ProjectView({
       onProjectsRefresh,
       openTabsState.active,
       project.id,
+      project.metadata,
       projectCollab.viewerOnly,
       t,
     ],

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -4,6 +4,13 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView } from '../../src/components/ProjectView';
 import type { QuestionForm } from '../../src/artifacts/question-form';
+import type { ChatMessage } from '../../src/types';
+import { ProjectConversationsHttpError } from '../../src/state/projects';
+
+const analyticsMocks = vi.hoisted(() => ({
+  newRequestId: vi.fn(() => 'fork-request-1'),
+  track: vi.fn(),
+}));
 
 const listConversations = vi.fn();
 const listMessages = vi.fn();
@@ -32,10 +39,12 @@ const saveTabs = vi.fn();
 // regression we want to pin).
 const chatPaneProps: {
   onDeleteConversation?: (id: string) => Promise<void> | void;
+  onForkFromMessage?: (message: ChatMessage) => Promise<void> | void;
   onSubmitQuestionForm?: (text: string) => void;
   questionFormSubmitDisabled?: boolean;
   activeConversationId?: string | null;
   conversations?: Array<{ id: string; title?: string | null }>;
+  messages?: ChatMessage[];
 } = {};
 
 const fileWorkspaceProps: {
@@ -53,6 +62,16 @@ vi.mock('../../src/i18n', () => ({
 
 vi.mock('../../src/providers/anthropic', () => ({
   streamMessage: vi.fn(),
+}));
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({
+    newRequestId: analyticsMocks.newRequestId,
+    setConfigureGlobals: vi.fn(),
+    setConsent: vi.fn(),
+    setIdentity: vi.fn(),
+    track: analyticsMocks.track,
+  }),
 }));
 
 vi.mock('../../src/providers/daemon', () => ({
@@ -81,6 +100,11 @@ vi.mock('../../src/router', () => ({
 }));
 
 vi.mock('../../src/state/projects', () => ({
+  ProjectConversationsHttpError: class ProjectConversationsHttpError extends Error {
+    constructor(readonly status: number, message = `conversations ${status}`) {
+      super(message);
+    }
+  },
   createConversation: (...args: unknown[]) => createConversation(...args),
   deleteConversation: (...args: unknown[]) => deleteConversation(...args),
   getTemplate: (...args: unknown[]) => getTemplate(...args),
@@ -104,16 +128,20 @@ vi.mock('../../src/components/AvatarMenu', () => ({
 vi.mock('../../src/components/ChatPane', () => ({
   ChatPane: (props: {
     onDeleteConversation?: (id: string) => Promise<void> | void;
+    onForkFromMessage?: (message: ChatMessage) => Promise<void> | void;
     onSubmitQuestionForm?: (text: string) => void;
     questionFormSubmitDisabled?: boolean;
     activeConversationId?: string | null;
     conversations?: Array<{ id: string; title?: string | null }>;
+    messages?: ChatMessage[];
   }) => {
     chatPaneProps.onDeleteConversation = props.onDeleteConversation;
+    chatPaneProps.onForkFromMessage = props.onForkFromMessage;
     chatPaneProps.onSubmitQuestionForm = props.onSubmitQuestionForm;
     chatPaneProps.questionFormSubmitDisabled = props.questionFormSubmitDisabled;
     chatPaneProps.activeConversationId = props.activeConversationId;
     chatPaneProps.conversations = props.conversations;
+    chatPaneProps.messages = props.messages;
     return null;
   },
 }));
@@ -165,11 +193,14 @@ describe('ProjectView conversation delete', () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    analyticsMocks.newRequestId.mockReturnValue('fork-request-1');
     chatPaneProps.onDeleteConversation = undefined;
+    chatPaneProps.onForkFromMessage = undefined;
     chatPaneProps.onSubmitQuestionForm = undefined;
     chatPaneProps.questionFormSubmitDisabled = undefined;
     chatPaneProps.activeConversationId = undefined;
     chatPaneProps.conversations = undefined;
+    chatPaneProps.messages = undefined;
     fileWorkspaceProps.questionForm = undefined;
   });
 
@@ -364,5 +395,152 @@ describe('ProjectView conversation delete', () => {
     await waitFor(() => expect(chatPaneProps.onSubmitQuestionForm).toBeDefined());
     await waitFor(() => expect(chatPaneProps.questionFormSubmitDisabled).toBe(false));
     expect(fileWorkspaceProps.questionForm).toBeUndefined();
+  });
+});
+
+describe('ProjectView conversation fork analytics', () => {
+  const sourceMessages: ChatMessage[] = [
+    { id: 'user-1', role: 'user', content: 'First request' },
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'First response',
+      agentId: 'claude',
+      runId: 'run-1',
+      runStatus: 'succeeded',
+    },
+    { id: 'user-2', role: 'user', content: 'Second request' },
+    {
+      id: 'assistant-2',
+      role: 'assistant',
+      content: 'Second response',
+      agentId: 'claude',
+      runId: 'run-2',
+      runStatus: 'succeeded',
+    },
+  ];
+
+  beforeEach(() => {
+    analyticsMocks.newRequestId.mockReturnValue('fork-request-1');
+    analyticsMocks.track.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    chatPaneProps.onForkFromMessage = undefined;
+    chatPaneProps.messages = undefined;
+  });
+
+  function prepareForkHarness() {
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation 1' }]);
+    listMessages.mockResolvedValue(sourceMessages);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    listProjectRuns.mockResolvedValue([]);
+    reattachDaemonRun.mockResolvedValue(undefined);
+  }
+
+  it('tracks the fork click and successful result with one request id', async () => {
+    prepareForkHarness();
+    createConversation.mockResolvedValue({ id: 'conv-fork', title: 'Conversation 1 fork' });
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.messages).toEqual(sourceMessages));
+    await act(async () => {
+      await chatPaneProps.onForkFromMessage?.(sourceMessages[1]!);
+    });
+
+    expect(analyticsMocks.newRequestId).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.track).toHaveBeenCalledWith(
+      'ui_click',
+      expect.objectContaining({
+        page_name: 'chat_panel',
+        area: 'chat_panel',
+        element: 'assistant_fork_button',
+        action: 'fork_conversation',
+        project_id: 'project-1',
+        conversation_id: 'conv-1',
+        assistant_message_id: 'assistant-1',
+        source_run_id: 'run-1',
+        source_agent_id: 'claude',
+        agent_provider_id: 'claude_code',
+        fork_point: 'historical',
+        seed_message_count: 2,
+        conversation_message_count: 4,
+        messages_after_fork_count: 2,
+        session_mode: 'design',
+      }),
+      { requestId: 'fork-request-1' },
+    );
+    expect(analyticsMocks.track).toHaveBeenCalledWith(
+      'conversation_fork_result',
+      expect.objectContaining({
+        result: 'success',
+        target_conversation_id: 'conv-fork',
+        duration_ms: expect.any(Number),
+      }),
+      { requestId: 'fork-request-1' },
+    );
+  });
+
+  it('tracks a failed fork result without reporting success', async () => {
+    prepareForkHarness();
+    createConversation.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.messages).toEqual(sourceMessages));
+    await act(async () => {
+      await chatPaneProps.onForkFromMessage?.(sourceMessages[3]!);
+    });
+
+    expect(analyticsMocks.track).toHaveBeenCalledWith(
+      'conversation_fork_result',
+      expect.objectContaining({
+        fork_point: 'latest',
+        seed_message_count: 4,
+        messages_after_fork_count: 0,
+        result: 'failed',
+        target_conversation_id: null,
+        error_code: 'network_error',
+        duration_ms: expect.any(Number),
+      }),
+      { requestId: 'fork-request-1' },
+    );
+    expect(
+      analyticsMocks.track.mock.calls.filter(([event]) => event === 'conversation_fork_result'),
+    ).toHaveLength(1);
+  });
+
+  it('classifies daemon body-limit failures for rollout monitoring', async () => {
+    prepareForkHarness();
+    createConversation.mockRejectedValue(
+      new ProjectConversationsHttpError(413, 'request body too large'),
+    );
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.messages).toEqual(sourceMessages));
+    await act(async () => {
+      await chatPaneProps.onForkFromMessage?.(sourceMessages[3]!);
+    });
+
+    expect(analyticsMocks.track).toHaveBeenCalledWith(
+      'conversation_fork_result',
+      expect.objectContaining({
+        result: 'failed',
+        error_code: 'payload_too_large',
+      }),
+      { requestId: 'fork-request-1' },
+    );
   });
 });

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -2867,6 +2867,90 @@ test('[P1] project detail assistant completion actions support copy, fork, and f
     .not.toBe(conversationId);
 });
 
+test('[P1] project detail fork emits correlated click and result analytics', async ({ page }) => {
+  const analyticsBodies: string[] = [];
+  await page.unroute('**/api/app-config').catch(() => {});
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'default',
+        agentId: 'codex',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        privacyDecisionAt: 1,
+        telemetry: { metrics: true, content: false, artifactManifest: false },
+        agentModels: { codex: { model: 'default' } },
+      }),
+    );
+  }, STORAGE_KEY);
+  await page.route('**/api/app-config', async (route) => {
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          privacyDecisionAt: 1,
+          telemetry: { metrics: true, content: false, artifactManifest: false },
+          mode: 'daemon',
+          agentId: 'codex',
+          skillId: null,
+          designSystemId: null,
+          agentModels: { codex: { model: 'default' } },
+          agentCliEnv: {},
+        },
+      },
+    });
+  });
+  await page.route('**/api/analytics/config', async (route) => {
+    await route.fulfill({
+      json: {
+        enabled: true,
+        env: 'e2e',
+        key: 'phc_e2e',
+        host: 'https://analytics.open-design.test',
+        installationId: 'e2e-installation',
+      },
+    });
+  });
+  await page.route('https://analytics.open-design.test/**', async (route) => {
+    analyticsBodies.push(route.request().postData() ?? '');
+    await route.fulfill({ status: 200, json: { status: 1 } });
+  });
+
+  const { projectId, conversationId } = await seedProjectWithAssistantCompletion(page);
+  await page.goto(`/projects/${projectId}/conversations/${conversationId}`);
+  await expectWorkspaceReady(page);
+
+  const forkResponsePromise = page.waitForResponse((response) => {
+    return response.request().method() === 'POST'
+      && response.url().endsWith(`/api/projects/${projectId}/conversations`);
+  });
+  await page.getByTestId('assistant-fork-button').click();
+  expect((await forkResponsePromise).ok()).toBe(true);
+
+  await expect
+    .poll(() => analyticsBodies.join('\n'), { timeout: T.medium })
+    .toContain('conversation_fork_result');
+  const raw = analyticsBodies.join('\n');
+  expect(raw).toContain('assistant_fork_button');
+  expect(raw).toContain('fork_conversation');
+  expect(raw).toContain('"result":"success"');
+  expect(raw).toContain('"fork_point":"latest"');
+  expect(raw).toContain(projectId);
+  expect(raw).toContain(conversationId);
+  const requestIdCounts = new Map<string, number>();
+  for (const match of raw.matchAll(/"request_id":"([^"]+)"/g)) {
+    const requestId = match[1];
+    if (!requestId) continue;
+    requestIdCounts.set(requestId, (requestIdCounts.get(requestId) ?? 0) + 1);
+  }
+  expect([...requestIdCounts.values()].some((count) => count >= 2)).toBe(true);
+});
+
 test('[P1] project detail forks histories larger than the daemon JSON body limit', async ({ page }) => {
   test.setTimeout(T.xlong);
   const { projectId, conversationId, expectedContents } =
@@ -2961,6 +3045,10 @@ test('[P1] read-only project viewers do not see conversation fork actions', asyn
     .getByText('Loading Open Design…')
     .waitFor({ state: 'hidden', timeout: T.long })
     .catch(() => {});
+  const showChat = page.getByTestId('workspace-focus-toggle');
+  if (await showChat.isVisible()) {
+    await showChat.click();
+  }
   const expandConversation = page.getByRole('button', { name: 'Expand the conversation pane' });
   if (await expandConversation.isVisible()) {
     await expandConversation.click();

--- a/packages/contracts/src/analytics/events/event-names.ts
+++ b/packages/contracts/src/analytics/events/event-names.ts
@@ -53,6 +53,9 @@ export type AnalyticsEventName =
   | 'workspace_shared_project_open_result'
   | 'workspace_resource_action_result'
   | 'project_comment_create_result'
+  // Message-level conversation forking. Entry clicks stay on `ui_click`;
+  // this result event records whether the new conversation was created.
+  | 'conversation_fork_result'
   // Feedback
   | 'feedback_submit_result'
   | 'assistant_feedback_click'

--- a/packages/contracts/src/analytics/events/event-payload.ts
+++ b/packages/contracts/src/analytics/events/event-payload.ts
@@ -7,7 +7,7 @@ import type { AmrAuthStageProps } from './amr-auth.js';
 import type { DesignSystemApplyResultProps, DesignSystemCreateResultProps, DesignSystemEnrichResultProps, DesignSystemReviewResultProps, DesignSystemSourceIngestResultProps, DesignSystemStatusResultProps } from './design-systems.js';
 import type { OnboardingCompletedProps, OnboardingCompleteResultProps, OnboardingFirstGenerationCompletedProps, OnboardingFirstPromptSentProps, OnboardingPromptPrefilledProps, OnboardingRuntimeScanResultProps } from './onboarding.js';
 import type { PageViewProps } from './page-view.js';
-import type { ArtifactDeployResultProps, ArtifactExportResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ByokPreflightBlockedProps, ContextLinkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, MediaGenerationResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateCheckResultProps, UpdateInstallResultProps } from './result-events.js';
+import type { ArtifactDeployResultProps, ArtifactExportResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ByokPreflightBlockedProps, ContextLinkResultProps, ConversationForkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, MediaGenerationResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateCheckResultProps, UpdateInstallResultProps } from './result-events.js';
 import type { SurfaceViewProps } from './surface-view.js';
 import type { AmrAuthResultProps, UiClickProps } from './ui-click.js';
 import type {
@@ -52,6 +52,7 @@ export type AnalyticsEventPayload =
   | { event: 'workspace_shared_project_open_result'; props: WorkspaceSharedProjectOpenResultProps }
   | { event: 'workspace_resource_action_result'; props: WorkspaceResourceActionResultProps }
   | { event: 'project_comment_create_result'; props: ProjectCommentCreateResultProps }
+  | { event: 'conversation_fork_result'; props: ConversationForkResultProps }
   | { event: 'feedback_submit_result'; props: FeedbackSubmitResultProps }
   | { event: 'assistant_feedback_click'; props: AssistantFeedbackClickProps }
   | {

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -15,7 +15,7 @@ import type { ArtifactOriginEntrySurface, ArtifactOriginStatus } from '../../api
 import type { TrackingDesignSystemEditSurface, TrackingDesignSystemKind, TrackingDesignSystemLengthBucket, TrackingDesignSystemOrigin, TrackingDesignSystemRunEntryFrom } from './design-systems.js';
 import type { TrackingSettingsPage } from './event-names.js';
 import type { TrackingAmrOpenCodeErrorPhase, TrackingAmrOpenCodeLastEventType, TrackingAmrOpenCodeLastToolKind, TrackingAmrOpenCodeLastToolStatus, TrackingArtifactKind, TrackingArtifactWriteSource, TrackingArtifactWriteStatus, TrackingByokPreflightBlockReason, TrackingByokProviderId, TrackingCliProviderId, TrackingDesignSystemSource, TrackingExecutionMode, TrackingExportFormat, TrackingExportResult, TrackingFeedbackAction, TrackingFeedbackProviderId, TrackingFeedbackRating, TrackingFeedbackRatingWithNone, TrackingFeedbackReasonCode, TrackingFidelity, TrackingFileSizeBucket, TrackingFileType, TrackingFirstModelEventType, TrackingLangfuseDeliveryStatus, TrackingLangfuseDropReason, TrackingLangfuseReportResult, TrackingLangfuseReportSkipReason, TrackingProjectKind, TrackingProjectSource, TrackingResult, TrackingRunCloseReason, TrackingRunDiagnosticSource, TrackingRunFailureCategory, TrackingRunFailureDetail, TrackingRunFailureStage, TrackingRunFailureUserAction, TrackingRunLifecyclePhase, TrackingRunPhaseTimingStatus, TrackingRunResult, TrackingRunRetryFinalResult, TrackingRunRetryStrategy, TrackingRunRetrySuppressedReason, TrackingStderrLineCountBucket, TrackingTestResult, TrackingTokenCountSource } from './shared-enums.js';
-import type { TrackingFileVersionSource, TrackingPluginImportSource, TrackingSessionMode, TrackingSettingsArea } from './ui-click.js';
+import type { ConversationForkAnalyticsContext, TrackingFileVersionSource, TrackingPluginImportSource, TrackingSessionMode, TrackingSettingsArea } from './ui-click.js';
 // ---- Result events -------------------------------------------------------
 
 // Final outcome for the paid provider submission. Keep this envelope free of
@@ -837,6 +837,24 @@ export interface FeedbackSubmitResultProps {
   has_custom_reason: boolean;
   custom_reason?: string;
   result: TrackingResult;
+}
+
+export type TrackingConversationForkErrorCode =
+  | 'bad_request'
+  | 'permission_denied'
+  | 'fork_source_not_found'
+  | 'payload_too_large'
+  | 'server_error'
+  | 'http_error'
+  | 'network_error'
+  | 'empty_response'
+  | 'unknown_error';
+
+export interface ConversationForkResultProps extends ConversationForkAnalyticsContext {
+  target_conversation_id: string | null;
+  result: TrackingResult;
+  error_code?: TrackingConversationForkErrorCode;
+  duration_ms: number;
 }
 
 interface AssistantFeedbackBase {

--- a/packages/contracts/src/analytics/events/ui-click.ts
+++ b/packages/contracts/src/analytics/events/ui-click.ts
@@ -1431,6 +1431,32 @@ export interface AssistantFeedbackReasonSubmitClickProps {
   custom_reason?: string;
 }
 
+// CONVERSATION FORK funnel. The click and result events share this context so
+// analysts can compare historical-vs-latest forks without joining prompts or
+// other user-authored content into PostHog.
+export type TrackingConversationForkPoint = 'latest' | 'historical' | 'unknown';
+
+export interface ConversationForkAnalyticsContext {
+  page_name: 'chat_panel';
+  area: 'chat_panel';
+  element: 'assistant_fork_button';
+  action: 'fork_conversation';
+  project_id: string;
+  project_kind: TrackingProjectKind | null;
+  conversation_id: string;
+  assistant_message_id: string;
+  source_run_id: string | null;
+  source_agent_id: string;
+  agent_provider_id: string;
+  session_mode: TrackingSessionMode;
+  fork_point: TrackingConversationForkPoint;
+  seed_message_count: number | null;
+  conversation_message_count: number;
+  messages_after_fork_count: number | null;
+}
+
+export type ConversationForkClickProps = ConversationForkAnalyticsContext;
+
 // SETTINGS clicks
 export type TrackingSettingsArea =
   | 'configure_execution_mode'
@@ -1670,6 +1696,7 @@ export type UiClickProps =
   | DeckViewerClickProps
   | ShareOptionPopoverClickProps
   | FileVersionModalClickProps
+  | ConversationForkClickProps
   | AssistantFeedbackButtonClickProps
   | AssistantFeedbackReasonSubmitClickProps
   | SettingsSidebarClickProps


### PR DESCRIPTION
## Why

A reported project-chat fork failure exposed that we cannot currently answer two basic production questions: how often people use message-level fork, and whether the request succeeds or fails. That makes it risky to prioritize or roll out deeper session-fork work because failures, payload-limit regressions, permission blocks, and adoption are invisible.

This PR adds content-free, correlated fork telemetry and locks the current behavior down with red/green browser coverage. It also records native coding-agent session cloning as an explicit follow-up without changing the existing transcript-reseed fallback.

## What users will see

No visible UI change. Writable project members still see the assistant-message Fork action, read-only viewers do not, and a successful fork still opens a new conversation seeded through the selected assistant message.

When metrics telemetry is enabled, Open Design now records a correlated fork click and success/failure result with bounded operational metadata. Prompt text, assistant content, file contents, titles, and credentials are not captured.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this is observability and test coverage only; it does not change the rendered fork entry point or result UI.

## Bug fix verification

- Red spec: `e2e/ui/project-management-flows.test.ts` — `project detail fork emits correlated click and result analytics`.
- On unmodified `main`, the spec timed out waiting for `conversation_fork_result`; it passes on this branch.
- The focused browser group also verifies normal fork, histories larger than the daemon JSON-body limit, and read-only users having no fork action.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 610 files passed; 6,340 tests passed, 1 expected failure, 11 skipped
- `pnpm --filter @open-design/e2e exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts --grep 'assistant completion actions support copy, fork, and feedback|fork emits correlated click and result analytics|forks histories larger than the daemon JSON body limit|read-only project viewers do not see conversation fork actions'` — 4 passed
- Contracts test suite — 274 passed
- Real local CLI matrix through the Web UI: Claude Code, Codex, OpenCode, Grok Build, and Vela/AMR each completed `real first turn -> UI Fork -> real branch turn`; every source and branch run succeeded, forked history grew from 2 to 4 messages, and copied runtime pointers were absent.

## Follow-up

`TODO(native-session-clone)` documents the fail-closed design boundary for a future runtime-capability-gated native session clone. This PR deliberately keeps the current fresh-session transcript reseed so unsupported runtimes or clone failures cannot regress the main fork path.
