### PR TITLE
fix(collab): bound the two unbounded vela fan-outs

### DIFF
--- a/apps/daemon/src/collab/concurrency-gate.ts
+++ b/apps/daemon/src/collab/concurrency-gate.ts
@@ -25,6 +25,14 @@
  * only "fast" because it borrowed unboundedly from the machine and the hub.
  * 8 matches the bound the hub already puts on its own per-request fan-out
  * (MAX_BLOB_INSPECTION_CONCURRENCY), so neither side is the surprise.
+ *
+ * This is a per-SITE budget, and there are two sites: materializing shared
+ * resources (one gate at the composition root, shared by all three listing
+ * kinds) and publishing dirty projects (the scheduler's own). They stay
+ * separate because pulls and pushes run in opposite directions with different
+ * latency sensitivity — a big listing refresh should not delay a teammate's
+ * publish. The honest daemon-wide worst case from these two sites is therefore
+ * 8 pulls + 8 pushes, not 8 total.
  */
 export const COLLAB_VELA_FANOUT_CONCURRENCY = 8;
 

--- a/apps/daemon/src/collab/concurrency-gate.ts
+++ b/apps/daemon/src/collab/concurrency-gate.ts
@@ -16,10 +16,17 @@
  * How many `vela` child processes one collab fan-out may have in flight.
  *
  * Sized for transfer work rather than CPU: these operations are dominated by
- * network round-trips, so a handful in flight keeps the pipe busy without
- * turning one workspace into a load generator against the hub.
+ * network round-trips, so several in flight keep the pipe busy without turning
+ * one workspace into a load generator against the hub.
+ *
+ * The cap is a latency trade for a safety guarantee, and the trade is real: a
+ * 40-resource fan-out that used to run 40-wide now runs 8-wide, so it takes
+ * about five times as many rounds. That is the point — the old version was
+ * only "fast" because it borrowed unboundedly from the machine and the hub.
+ * 8 matches the bound the hub already puts on its own per-request fan-out
+ * (MAX_BLOB_INSPECTION_CONCURRENCY), so neither side is the surprise.
  */
-export const COLLAB_VELA_FANOUT_CONCURRENCY = 4;
+export const COLLAB_VELA_FANOUT_CONCURRENCY = 8;
 
 /**
  * Admits at most `capacity` operations at a time; the rest wait their turn.

--- a/apps/daemon/src/collab/concurrency-gate.ts
+++ b/apps/daemon/src/collab/concurrency-gate.ts
@@ -1,0 +1,123 @@
+// Bounded concurrency for the collab layer's vela fan-outs.
+//
+// Every collab fan-out ends in a `vela` child process — a pull per shared
+// resource, a push per dirty project. Those fan-outs are sized by user data
+// (how much a workspace shares, how many projects a run touched), so an
+// unbounded `Promise.all` over them makes the daemon's peak subprocess count a
+// property of the workspace: a member of a workspace with 200 shared design
+// systems spawns 200 concurrent transfers on one listing read, each holding a
+// socket locally and a connection at the far end.
+//
+// A gate turns that peak into a daemon-owned constant without changing what
+// eventually runs: every operation still runs, still exactly once, and still
+// propagates its own failure to its own caller.
+
+/**
+ * How many `vela` child processes one collab fan-out may have in flight.
+ *
+ * Sized for transfer work rather than CPU: these operations are dominated by
+ * network round-trips, so a handful in flight keeps the pipe busy without
+ * turning one workspace into a load generator against the hub.
+ */
+export const COLLAB_VELA_FANOUT_CONCURRENCY = 4;
+
+/**
+ * Admits at most `capacity` operations at a time; the rest wait their turn.
+ *
+ * FIFO by construction — waiters resume in arrival order — so a large fan-out
+ * queued ahead of a single later operation delays it by the queue, never
+ * starves it indefinitely.
+ */
+export class ConcurrencyGate {
+  private readonly capacity: number;
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error('ConcurrencyGate capacity must be a positive integer');
+    }
+    this.capacity = capacity;
+    this.available = capacity;
+  }
+
+  /** Operations admitted and not yet settled. */
+  get active(): number {
+    return this.capacity - this.available;
+  }
+
+  /** Operations waiting for a slot. */
+  get pending(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * Run `operation` once a slot is free, releasing the slot when it settles.
+   *
+   * An uncontended call starts the operation SYNCHRONOUSLY — no microtask hop
+   * between asking and starting. Callers that observe "the adapter was invoked
+   * by the time this returned" (a run-boundary flush, for one) keep behaving
+   * as they did before a gate existed; only a genuinely contended call waits.
+   *
+   * The slot is released on rejection too, so one failing transfer cannot
+   * permanently shrink the gate. The rejection itself is re-thrown to this
+   * caller unchanged — the gate schedules work, it does not police errors.
+   */
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.available > 0) {
+      this.available -= 1;
+      return this.settle(operation);
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    }).then(() => this.settle(operation));
+  }
+
+  /** Invoke the operation on an already-held slot and release it on settle. */
+  private settle<T>(operation: () => Promise<T>): Promise<T> {
+    let running: Promise<T>;
+    try {
+      running = operation();
+    } catch (error) {
+      // A synchronous throw never got to hold the slot's work.
+      this.release();
+      throw error;
+    }
+    return running.then(
+      (value) => {
+        this.release();
+        return value;
+      },
+      (error: unknown) => {
+        this.release();
+        throw error;
+      },
+    );
+  }
+
+  private release(): void {
+    const next = this.waiters.shift();
+    if (next) {
+      // Hand the slot straight to the next waiter instead of returning it to
+      // the pool, so a burst of releases cannot momentarily admit more than
+      // `capacity` operations.
+      next();
+      return;
+    }
+    this.available += 1;
+  }
+}
+
+/**
+ * `Promise.all(items.map(fn))` with at most `gate`'s capacity in flight.
+ *
+ * Results keep input order and a rejection propagates exactly as
+ * `Promise.all` would, so this is a drop-in for the unbounded form.
+ */
+export function mapWithGate<T, U>(
+  items: readonly T[],
+  gate: ConcurrencyGate,
+  fn: (item: T, index: number) => Promise<U>,
+): Promise<U[]> {
+  return Promise.all(items.map((item, index) => gate.run(() => fn(item, index))));
+}

--- a/apps/daemon/src/collab/publish-scheduler.ts
+++ b/apps/daemon/src/collab/publish-scheduler.ts
@@ -11,6 +11,7 @@
 // pull a version that is not yet durable. The adapter is expected to resolve only
 // on durable success (E's atomic write); this scheduler adds the coalescing.
 
+import { COLLAB_VELA_FANOUT_CONCURRENCY, ConcurrencyGate } from './concurrency-gate.js';
 import type { ResourceHubPrincipal } from './resource-principal.js';
 
 export interface ResourcePublishInput {
@@ -76,6 +77,12 @@ interface ProjectState {
   /** A change arrived while a publish was in flight → re-publish after it settles. */
   dirty: boolean;
   dirtyReason: string;
+  /**
+   * The publish has passed the fan-out gate and the adapter is reading the
+   * project. Until then the publish is only queued: it has not looked at the
+   * project yet, so a change arriving in that window needs no second publish.
+   */
+  admitted: boolean;
   /** Pending automatic retry of a failed publish (see {@link PUBLISH_RETRY_BACKOFF_MS}). */
   retryTimer: ReturnType<typeof setTimeout> | null;
   /** Consecutive failed publish attempts with no success or newer change in between. */
@@ -98,6 +105,12 @@ export class CollabPublishScheduler {
   private readonly onPublished?: CollabPublishSchedulerOptions['onPublished'];
   private readonly onError?: CollabPublishSchedulerOptions['onError'];
   private readonly projects = new Map<string, ProjectState>();
+  // Per-project re-entry is already blocked by `state.publishing`, but nothing
+  // bounded the fan-out ACROSS projects: a run boundary that dirties every
+  // project in a workspace, or a batch of debounce windows expiring in the
+  // same tick, spawned one concurrent `vela resource push` per project. The
+  // gate caps that peak; the queue behind it preserves every publish.
+  private readonly gate = new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY);
 
   constructor(options: CollabPublishSchedulerOptions) {
     this.adapter = options.adapter;
@@ -115,6 +128,10 @@ export class CollabPublishScheduler {
     state.consecutiveFailures = 0;
     this.clearRetryTimer(state);
     if (state.publishing) {
+      // Still queued behind the fan-out cap: the adapter has not read the
+      // project yet, so it will pick this change up when it is admitted.
+      // `state.reason` above is what it will publish under.
+      if (!state.admitted) return;
       // Don't interrupt an in-flight publish — mark dirty so a fresh one runs
       // after it settles (last-write-wins; the change is never lost).
       state.dirty = true;
@@ -139,6 +156,9 @@ export class CollabPublishScheduler {
       state.timer = null;
     }
     if (state.publishing) {
+      // Same queued-vs-reading split as notifyChanged: a publish still waiting
+      // for a fan-out slot will observe the end-of-run state on its own.
+      if (!state.admitted) return;
       state.dirty = true;
       state.dirtyReason = state.reason;
       return;
@@ -161,10 +181,18 @@ export class CollabPublishScheduler {
     state.timer = null;
     this.clearRetryTimer(state);
     state.publishing = true;
-    const reason = state.reason;
+    state.admitted = false;
+    // Resolved at admission, not at queueing: a change that lands while this
+    // publish waits for a slot updates `state.reason`, and that is the state
+    // the adapter is about to read.
+    let reason = state.reason;
     let failed = false;
     try {
-      const result = await this.adapter.publish({ projectId, reason });
+      const result = await this.gate.run(() => {
+        state.admitted = true;
+        reason = state.reason;
+        return this.adapter.publish({ projectId, reason });
+      });
       state.consecutiveFailures = 0;
       if (result) {
         this.onPublished?.({
@@ -179,6 +207,7 @@ export class CollabPublishScheduler {
       this.onError?.({ projectId, error });
     } finally {
       state.publishing = false;
+      state.admitted = false;
       if (state.dirty) {
         state.dirty = false;
         // A change landed during the publish — schedule a fresh one. That
@@ -224,6 +253,7 @@ export class CollabPublishScheduler {
         publishing: false,
         dirty: false,
         dirtyReason: 'change',
+        admitted: false,
         retryTimer: null,
         consecutiveFailures: 0,
       };

--- a/apps/daemon/src/collab/team-resource-list-cache.ts
+++ b/apps/daemon/src/collab/team-resource-list-cache.ts
@@ -1,4 +1,10 @@
-import type { TeamResourceRequestScope } from './team-resource-share.js';
+import { createSwrCache } from './swr-cache.js';
+import type {
+  TeamResourceRequestScope,
+  TeamResourceShareRecord,
+  TeamResourceSharedReadOptions,
+  TeamResourceShareService,
+} from './team-resource-share.js';
 
 export const TEAM_RESOURCE_LIST_KINDS = ['design_system', 'plugin', 'skill'] as const;
 
@@ -21,4 +27,91 @@ export function invalidateTeamResourceListingCaches(input: {
     input.providers[kind].invalidate(input.scope);
   }
   input.invalidateSharedCommand(input.scope.principal.teamId);
+}
+
+/** How long a listing stays fresh before the next read kicks a background refresh. */
+const TEAM_RESOURCE_LIST_FRESH_MS = 3000;
+
+/**
+ * Cache identity for a listing. Team resource visibility is a function of the
+ * whole principal — a role or lifecycle change can add or remove entries — so
+ * every field that the authority consults is part of the key.
+ */
+export const teamResourceScopeKey = (scope: TeamResourceRequestScope): string =>
+  JSON.stringify([
+    scope.principal.teamId,
+    scope.principal.memberId,
+    scope.principal.role,
+    scope.principal.lifecycleState,
+  ]);
+
+export interface TeamResourceListing {
+  ids: string[];
+  resources: TeamResourceShareRecord[];
+}
+
+export interface TeamResourceListCache {
+  (scope: TeamResourceRequestScope): Promise<TeamResourceListing>;
+  /** Bypass the cache and re-read from the authority (post-mutation reads). */
+  authoritative(scope: TeamResourceRequestScope): Promise<TeamResourceListing>;
+  invalidate(scope: TeamResourceRequestScope): void;
+}
+
+export interface TeamResourceListCacheOptions {
+  share: TeamResourceShareService;
+  /**
+   * Materialize one shared resource into the member's local copy. Optional:
+   * kinds with nothing to fetch pass nothing.
+   */
+  sync?: (
+    resource: TeamResourceShareRecord,
+    scope: TeamResourceRequestScope,
+  ) => Promise<void>;
+  /** Drops the `vela resource shared` command cache the listing was read through. */
+  invalidateSharedCommand: (workspaceId: string) => void;
+}
+
+/**
+ * SWR-cached "what has this workspace shared with me" listing, per principal,
+ * optionally materializing each entry as it lands.
+ */
+export function createTeamResourceListCache(
+  options: TeamResourceListCacheOptions,
+): TeamResourceListCache {
+  const { share, sync, invalidateSharedCommand } = options;
+  const listings = new Map<string, ReturnType<typeof createSwrCache<TeamResourceListing>>>();
+  const materialize = async (
+    scope: TeamResourceRequestScope,
+    readOptions?: TeamResourceSharedReadOptions,
+  ): Promise<TeamResourceListing> => {
+    const resources = await share.sharedResources(scope, readOptions);
+    if (sync) {
+      await Promise.all(resources.map((resource) => sync(resource, scope)));
+    }
+    return { ids: resources.map((resource) => resource.id), resources };
+  };
+  const read = async (scope: TeamResourceRequestScope): Promise<TeamResourceListing> => {
+    const key = teamResourceScopeKey(scope);
+    let listing = listings.get(key);
+    if (!listing) {
+      listing = createSwrCache(
+        () => materialize(scope),
+        () => key,
+        TEAM_RESOURCE_LIST_FRESH_MS,
+      );
+      listings.set(key, listing);
+    }
+    return listing();
+  };
+  return Object.assign(read, {
+    authoritative(scope: TeamResourceRequestScope) {
+      return materialize(scope, { authoritative: true });
+    },
+    invalidate(scope: TeamResourceRequestScope) {
+      const key = teamResourceScopeKey(scope);
+      listings.get(key)?.invalidate();
+      listings.delete(key);
+      invalidateSharedCommand(scope.principal.teamId);
+    },
+  });
 }

--- a/apps/daemon/src/collab/team-resource-list-cache.ts
+++ b/apps/daemon/src/collab/team-resource-list-cache.ts
@@ -33,6 +33,22 @@ export function invalidateTeamResourceListingCaches(input: {
 const TEAM_RESOURCE_LIST_FRESH_MS = 3000;
 
 /**
+ * How many `vela` child processes one collab fan-out may have in flight.
+ *
+ * Both collab fan-outs — materializing a workspace's shared resources, and
+ * publishing the projects that went dirty together — are sized by user data,
+ * not by the machine. Left unbounded, a workspace that shares 200 design
+ * systems spawns 200 concurrent `vela resource pull` processes on a single
+ * listing read, each holding a socket, a transfer buffer, and a connection at
+ * the far end. The cap makes the peak a property of the daemon.
+ *
+ * Sized for transfer work rather than CPU: these operations are dominated by
+ * network round-trips, so a handful in flight keeps the pipe busy without
+ * turning one workspace into a load generator against the hub.
+ */
+export const COLLAB_VELA_FANOUT_CONCURRENCY = 4;
+
+/**
  * Cache identity for a listing. Team resource visibility is a function of the
  * whole principal — a role or lifecycle change can add or remove entries — so
  * every field that the authority consults is part of the key.

--- a/apps/daemon/src/collab/team-resource-list-cache.ts
+++ b/apps/daemon/src/collab/team-resource-list-cache.ts
@@ -1,3 +1,8 @@
+import {
+  COLLAB_VELA_FANOUT_CONCURRENCY,
+  ConcurrencyGate,
+  mapWithGate,
+} from './concurrency-gate.js';
 import { createSwrCache } from './swr-cache.js';
 import type {
   TeamResourceRequestScope,
@@ -31,22 +36,6 @@ export function invalidateTeamResourceListingCaches(input: {
 
 /** How long a listing stays fresh before the next read kicks a background refresh. */
 const TEAM_RESOURCE_LIST_FRESH_MS = 3000;
-
-/**
- * How many `vela` child processes one collab fan-out may have in flight.
- *
- * Both collab fan-outs — materializing a workspace's shared resources, and
- * publishing the projects that went dirty together — are sized by user data,
- * not by the machine. Left unbounded, a workspace that shares 200 design
- * systems spawns 200 concurrent `vela resource pull` processes on a single
- * listing read, each holding a socket, a transfer buffer, and a connection at
- * the far end. The cap makes the peak a property of the daemon.
- *
- * Sized for transfer work rather than CPU: these operations are dominated by
- * network round-trips, so a handful in flight keeps the pipe busy without
- * turning one workspace into a load generator against the hub.
- */
-export const COLLAB_VELA_FANOUT_CONCURRENCY = 4;
 
 /**
  * Cache identity for a listing. Team resource visibility is a function of the
@@ -96,13 +85,18 @@ export function createTeamResourceListCache(
 ): TeamResourceListCache {
   const { share, sync, invalidateSharedCommand } = options;
   const listings = new Map<string, ReturnType<typeof createSwrCache<TeamResourceListing>>>();
+  // One gate per listing, shared across every principal reading it: the cap
+  // bounds this daemon's concurrent transfers for this resource kind, so two
+  // members of the same workspace refreshing at once must contend for the same
+  // slots rather than each getting a full fan-out of their own.
+  const gate = new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY);
   const materialize = async (
     scope: TeamResourceRequestScope,
     readOptions?: TeamResourceSharedReadOptions,
   ): Promise<TeamResourceListing> => {
     const resources = await share.sharedResources(scope, readOptions);
     if (sync) {
-      await Promise.all(resources.map((resource) => sync(resource, scope)));
+      await mapWithGate(resources, gate, (resource) => sync(resource, scope));
     }
     return { ids: resources.map((resource) => resource.id), resources };
   };

--- a/apps/daemon/src/collab/team-resource-list-cache.ts
+++ b/apps/daemon/src/collab/team-resource-list-cache.ts
@@ -1,8 +1,4 @@
-import {
-  COLLAB_VELA_FANOUT_CONCURRENCY,
-  ConcurrencyGate,
-  mapWithGate,
-} from './concurrency-gate.js';
+import { ConcurrencyGate, mapWithGate } from './concurrency-gate.js';
 import { createSwrCache } from './swr-cache.js';
 import type {
   TeamResourceRequestScope,
@@ -74,6 +70,17 @@ export interface TeamResourceListCacheOptions {
   ) => Promise<void>;
   /** Drops the `vela resource shared` command cache the listing was read through. */
   invalidateSharedCommand: (workspaceId: string) => void;
+  /**
+   * The materialization gate, owned by the composition root and SHARED by every
+   * resource kind.
+   *
+   * It has to be injected rather than built here. The three listing surfaces —
+   * design systems, plugins, skills — are separate caches that a single client
+   * poll refreshes together, so a gate built per cache bounds each kind
+   * independently and the daemon's real peak becomes the cap times the number
+   * of kinds. The bound only means anything if all three draw from one budget.
+   */
+  gate: ConcurrencyGate;
 }
 
 /**
@@ -83,13 +90,8 @@ export interface TeamResourceListCacheOptions {
 export function createTeamResourceListCache(
   options: TeamResourceListCacheOptions,
 ): TeamResourceListCache {
-  const { share, sync, invalidateSharedCommand } = options;
+  const { share, sync, invalidateSharedCommand, gate } = options;
   const listings = new Map<string, ReturnType<typeof createSwrCache<TeamResourceListing>>>();
-  // One gate per listing, shared across every principal reading it: the cap
-  // bounds this daemon's concurrent transfers for this resource kind, so two
-  // members of the same workspace refreshing at once must contend for the same
-  // slots rather than each getting a full fan-out of their own.
-  const gate = new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY);
   const materialize = async (
     scope: TeamResourceRequestScope,
     readOptions?: TeamResourceSharedReadOptions,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -813,7 +813,10 @@ import {
 } from './collab/sync-snapshot-store.js';
 import { createPersistentSyncCache } from './collab/persistent-sync-cache.js';
 import { createSwrCache } from './collab/swr-cache.js';
-import { invalidateTeamResourceListingCaches } from './collab/team-resource-list-cache.js';
+import {
+  createTeamResourceListCache,
+  invalidateTeamResourceListingCaches,
+} from './collab/team-resource-list-cache.js';
 import {
   createRememberedTeamResourceScopes,
   type RememberedTeamResourceScopeLease,
@@ -5730,62 +5733,19 @@ export async function startServer({
       },
     },
   );
-  const teamResourceScopeKey = (scope: TeamResourceRequestScope): string =>
-    JSON.stringify([
-      scope.principal.teamId,
-      scope.principal.memberId,
-      scope.principal.role,
-      scope.principal.lifecycleState,
-    ]);
   const cachedTeamResourceList = (
     share: TeamResourceShareService,
     sync?: (
       resource: TeamResourceShareRecord,
       scope: TeamResourceRequestScope,
     ) => Promise<void>,
-  ) => {
-    const listings = new Map<
-      string,
-      ReturnType<typeof createSwrCache<{
-        ids: string[];
-        resources: TeamResourceShareRecord[];
-      }>>
-    >();
-    const materialize = async (
-      scope: TeamResourceRequestScope,
-      readOptions?: TeamResourceSharedReadOptions,
-    ) => {
-      const resources = await share.sharedResources(scope, readOptions);
-      if (sync) {
-        await Promise.all(resources.map((resource) => sync(resource, scope)));
-      }
-      return { ids: resources.map((resource) => resource.id), resources };
-    };
-    const read = async (scope: TeamResourceRequestScope) => {
-      const key = teamResourceScopeKey(scope);
-      let listing = listings.get(key);
-      if (!listing) {
-        listing = createSwrCache(
-          () => materialize(scope),
-          () => key,
-          3000,
-        );
-        listings.set(key, listing);
-      }
-      return listing();
-    };
-    return Object.assign(read, {
-      authoritative(scope: TeamResourceRequestScope) {
-        return materialize(scope, { authoritative: true });
-      },
-      invalidate(scope: TeamResourceRequestScope) {
-        const key = teamResourceScopeKey(scope);
-        listings.get(key)?.invalidate();
-        listings.delete(key);
-        sharedTeamResourcesCommand.invalidate(scope.principal.teamId);
-      },
+  ) =>
+    createTeamResourceListCache({
+      share,
+      ...(sync ? { sync } : {}),
+      invalidateSharedCommand: (workspaceId) =>
+        sharedTeamResourcesCommand.invalidate(workspaceId),
     });
-  };
   const runTeamResourceCommand = async (
     args: string[],
     workspaceId?: string,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -814,6 +814,10 @@ import {
 import { createPersistentSyncCache } from './collab/persistent-sync-cache.js';
 import { createSwrCache } from './collab/swr-cache.js';
 import {
+  COLLAB_VELA_FANOUT_CONCURRENCY,
+  ConcurrencyGate,
+} from './collab/concurrency-gate.js';
+import {
   createTeamResourceListCache,
   invalidateTeamResourceListingCaches,
 } from './collab/team-resource-list-cache.js';
@@ -5733,6 +5737,15 @@ export async function startServer({
       },
     },
   );
+  // ONE materialization budget for the whole daemon, not one per resource kind.
+  // Design systems, plugins, and skills are three separate listing caches that
+  // a single client poll refreshes together, so a gate owned by each cache
+  // would bound each kind on its own and let the real peak reach the cap times
+  // three. The gate lives here, at the composition root, because here is the
+  // only place that can see all three.
+  const teamResourceMaterializationGate = new ConcurrencyGate(
+    COLLAB_VELA_FANOUT_CONCURRENCY,
+  );
   const cachedTeamResourceList = (
     share: TeamResourceShareService,
     sync?: (
@@ -5743,6 +5756,7 @@ export async function startServer({
     createTeamResourceListCache({
       share,
       ...(sync ? { sync } : {}),
+      gate: teamResourceMaterializationGate,
       invalidateSharedCommand: (workspaceId) =>
         sharedTeamResourcesCommand.invalidate(workspaceId),
     });

--- a/apps/daemon/tests/collab-concurrency-gate.test.ts
+++ b/apps/daemon/tests/collab-concurrency-gate.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { ConcurrencyGate, mapWithGate } from '../src/collab/concurrency-gate.js';
+
+/** A promise with its resolvers exposed, so a test can park an operation. */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ConcurrencyGate', () => {
+  it('rejects a capacity that cannot admit anything', () => {
+    expect(() => new ConcurrencyGate(0)).toThrow(/positive integer/);
+    expect(() => new ConcurrencyGate(-1)).toThrow(/positive integer/);
+    expect(() => new ConcurrencyGate(1.5)).toThrow(/positive integer/);
+  });
+
+  it('starts an uncontended operation synchronously', () => {
+    const gate = new ConcurrencyGate(2);
+    let started = false;
+    void gate.run(async () => {
+      started = true;
+    });
+    // No await: callers that relied on the pre-gate synchronous call still see it.
+    expect(started).toBe(true);
+  });
+
+  it('holds the extra operations at the cap and admits them as slots free', async () => {
+    const gate = new ConcurrencyGate(2);
+    const gates = [deferred(), deferred(), deferred()];
+    const started: number[] = [];
+
+    const runs = gates.map((parked, index) =>
+      gate.run(async () => {
+        started.push(index);
+        await parked.promise;
+      }),
+    );
+
+    expect(started).toEqual([0, 1]);
+    expect(gate.active).toBe(2);
+    expect(gate.pending).toBe(1);
+
+    gates[0]!.resolve();
+    await runs[0];
+    expect(started).toEqual([0, 1, 2]);
+
+    gates[1]!.resolve();
+    gates[2]!.resolve();
+    await Promise.all(runs);
+    expect(gate.active).toBe(0);
+    expect(gate.pending).toBe(0);
+  });
+
+  it('admits waiters in arrival order', async () => {
+    const gate = new ConcurrencyGate(1);
+    const blocker = deferred();
+    const order: string[] = [];
+
+    const first = gate.run(async () => {
+      order.push('first');
+      await blocker.promise;
+    });
+    const queued = ['a', 'b', 'c'].map((label) =>
+      gate.run(async () => {
+        order.push(label);
+      }),
+    );
+
+    blocker.resolve();
+    await Promise.all([first, ...queued]);
+    expect(order).toEqual(['first', 'a', 'b', 'c']);
+  });
+
+  it('releases the slot when an operation rejects, and re-throws unchanged', async () => {
+    const gate = new ConcurrencyGate(1);
+    const boom = new Error('transfer failed');
+
+    await expect(gate.run(async () => { throw boom; })).rejects.toBe(boom);
+    expect(gate.active).toBe(0);
+
+    // A failed operation must not permanently shrink the gate.
+    await expect(gate.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('releases the slot when an operation throws synchronously', async () => {
+    const gate = new ConcurrencyGate(1);
+    expect(() => gate.run((() => { throw new Error('sync boom'); }) as never)).toThrow('sync boom');
+    expect(gate.active).toBe(0);
+    await expect(gate.run(async () => 'ok')).resolves.toBe('ok');
+  });
+});
+
+describe('mapWithGate', () => {
+  it('keeps input order regardless of completion order', async () => {
+    const gate = new ConcurrencyGate(3);
+    const delays = [30, 0, 10, 20, 5];
+    const results = await mapWithGate(delays, gate, async (delay, index) => {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return index;
+    });
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('propagates the first rejection like Promise.all does', async () => {
+    const gate = new ConcurrencyGate(2);
+    await expect(
+      mapWithGate([1, 2, 3], gate, async (value) => {
+        if (value === 2) throw new Error('item 2 failed');
+        return value;
+      }),
+    ).rejects.toThrow('item 2 failed');
+    // Every admitted operation still released its slot.
+    await expect(gate.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('runs an empty fan-out without touching the gate', async () => {
+    const gate = new ConcurrencyGate(1);
+    await expect(mapWithGate([], gate, async () => 1)).resolves.toEqual([]);
+    expect(gate.active).toBe(0);
+  });
+});

--- a/apps/daemon/tests/collab-fanout-concurrency.test.ts
+++ b/apps/daemon/tests/collab-fanout-concurrency.test.ts
@@ -5,10 +5,8 @@
 // the workspace instead of the machine. These specs pin the peak.
 
 import { describe, expect, it, vi } from 'vitest';
-import {
-  COLLAB_VELA_FANOUT_CONCURRENCY,
-  createTeamResourceListCache,
-} from '../src/collab/team-resource-list-cache.js';
+import { COLLAB_VELA_FANOUT_CONCURRENCY } from '../src/collab/concurrency-gate.js';
+import { createTeamResourceListCache } from '../src/collab/team-resource-list-cache.js';
 import { CollabPublishScheduler } from '../src/collab/publish-scheduler.js';
 import type {
   TeamResourceRequestScope,
@@ -155,6 +153,83 @@ describe('cross-project publish fan-out', () => {
         await vi.advanceTimersByTimeAsync(0);
       }
       expect(probe.peak).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not stack a second publish for a change that arrives while queued', async () => {
+    vi.useFakeTimers();
+    try {
+      // Fill every slot with parked publishes, then queue one more project.
+      const blocker = concurrencyProbe();
+      const reasons: string[] = [];
+      const scheduler = new CollabPublishScheduler({
+        adapter: {
+          publish: async ({ projectId, reason }) => {
+            if (projectId !== 'queued') {
+              await blocker.run();
+              return { version: 1 };
+            }
+            reasons.push(reason);
+            return { version: 1 };
+          },
+        },
+        debounceMs: 10,
+      });
+
+      for (let index = 0; index < COLLAB_VELA_FANOUT_CONCURRENCY; index += 1) {
+        scheduler.notifyChanged(`blocker-${index}`);
+      }
+      scheduler.notifyChanged('queued', 'first');
+      await vi.advanceTimersByTimeAsync(10);
+      expect(reasons).toEqual([]); // still behind the cap
+
+      // The author keeps editing while the publish waits for a slot. The
+      // adapter has not read the project yet, so this must NOT become a
+      // second publish — it must become the reason of the queued one.
+      scheduler.notifyChanged('queued', 'second');
+      scheduler.notifyChanged('queued', 'third');
+
+      blocker.drain();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(reasons).toEqual(['third']);
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still re-publishes for a change that arrives after the adapter started reading', async () => {
+    vi.useFakeTimers();
+    try {
+      const inFlight = concurrencyProbe();
+      const reasons: string[] = [];
+      const scheduler = new CollabPublishScheduler({
+        adapter: {
+          publish: async ({ reason }) => {
+            reasons.push(reason);
+            await inFlight.run();
+            return { version: 1 };
+          },
+        },
+        debounceMs: 10,
+      });
+
+      scheduler.notifyChanged('p1', 'first');
+      await vi.advanceTimersByTimeAsync(10);
+      expect(reasons).toEqual(['first']); // admitted, adapter is reading
+
+      scheduler.notifyChanged('p1', 'second');
+      inFlight.drain();
+      await vi.advanceTimersByTimeAsync(10);
+      inFlight.drain();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(reasons).toEqual(['first', 'second']);
       scheduler.dispose();
     } finally {
       vi.useRealTimers();

--- a/apps/daemon/tests/collab-fanout-concurrency.test.ts
+++ b/apps/daemon/tests/collab-fanout-concurrency.test.ts
@@ -5,7 +5,10 @@
 // the workspace instead of the machine. These specs pin the peak.
 
 import { describe, expect, it, vi } from 'vitest';
-import { COLLAB_VELA_FANOUT_CONCURRENCY } from '../src/collab/concurrency-gate.js';
+import {
+  COLLAB_VELA_FANOUT_CONCURRENCY,
+  ConcurrencyGate,
+} from '../src/collab/concurrency-gate.js';
 import { createTeamResourceListCache } from '../src/collab/team-resource-list-cache.js';
 import { CollabPublishScheduler } from '../src/collab/publish-scheduler.js';
 import type {
@@ -67,6 +70,33 @@ async function settle(probe: ReturnType<typeof concurrencyProbe>, rounds: number
 }
 
 describe('shared team resource materialization fan-out', () => {
+  it('holds the cap across every resource kind refreshing together', async () => {
+    // The three listing surfaces are separate caches, and one client poll
+    // refreshes all of them. A gate owned per cache would bound each kind on
+    // its own and let the daemon's real peak reach cap x 3.
+    const probe = concurrencyProbe();
+    const gate = new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY);
+    const kinds = ['design_system', 'plugin', 'skill'].map(() =>
+      createTeamResourceListCache({
+        share: { sharedResources: async () => sharedResources(20) } as never,
+        sync: () => probe.run(),
+        gate,
+        invalidateSharedCommand: () => {},
+      }),
+    );
+
+    const reading = Promise.all(kinds.map((list) => list(SCOPE)));
+    for (let tick = 0; tick < 4; tick += 1) await Promise.resolve();
+
+    const peakBeforeAnySettles = probe.peak;
+    await settle(probe, 20 * kinds.length + 2);
+    const listings = await reading;
+
+    expect(listings.flatMap((listing) => listing.ids)).toHaveLength(60);
+    expect(peakBeforeAnySettles).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+    expect(probe.peak).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+  });
+
   it('never materializes more shared resources at once than the vela fan-out cap', async () => {
     const RESOURCE_COUNT = 60;
     const probe = concurrencyProbe();
@@ -75,6 +105,7 @@ describe('shared team resource materialization fan-out', () => {
         sharedResources: async () => sharedResources(RESOURCE_COUNT),
       } as never,
       sync: () => probe.run(),
+      gate: new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY),
       invalidateSharedCommand: () => {},
     });
 
@@ -102,6 +133,7 @@ describe('shared team resource materialization fan-out', () => {
       sync: async (resource) => {
         seen.push(resource.id);
       },
+      gate: new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY),
       invalidateSharedCommand: () => {},
     });
 
@@ -120,6 +152,7 @@ describe('shared team resource materialization fan-out', () => {
       sync: async (resource) => {
         if (resource.id === 'user:res-3') throw new Error('pull failed');
       },
+      gate: new ConcurrencyGate(COLLAB_VELA_FANOUT_CONCURRENCY),
       invalidateSharedCommand: () => {},
     });
 

--- a/apps/daemon/tests/collab-fanout-concurrency.test.ts
+++ b/apps/daemon/tests/collab-fanout-concurrency.test.ts
@@ -1,0 +1,192 @@
+// Every fan-out in the collab layer ends in a `vela` child process — one pull
+// per shared resource, one push per dirty project. Both fan-outs are sized by
+// user data (how much a workspace shares, how many projects a run touched), so
+// an unbounded fan-out makes the daemon's peak subprocess count a property of
+// the workspace instead of the machine. These specs pin the peak.
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  COLLAB_VELA_FANOUT_CONCURRENCY,
+  createTeamResourceListCache,
+} from '../src/collab/team-resource-list-cache.js';
+import { CollabPublishScheduler } from '../src/collab/publish-scheduler.js';
+import type {
+  TeamResourceRequestScope,
+  TeamResourceShareRecord,
+} from '../src/collab/team-resource-share.js';
+
+const SCOPE: TeamResourceRequestScope = {
+  principal: {
+    memberId: 'wm-1',
+    teamId: 'ws-1',
+    role: 'owner',
+    lifecycleState: 'active',
+    workspaceType: 'team',
+  },
+  canShare: true,
+};
+
+function sharedResources(count: number): TeamResourceShareRecord[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `user:res-${index}`,
+    ownerMemberId: 'wm-owner',
+  })) as TeamResourceShareRecord[];
+}
+
+/** Records the high-water mark of overlapping calls to the wrapped operation. */
+function concurrencyProbe() {
+  let active = 0;
+  let peak = 0;
+  const release: Array<() => void> = [];
+  return {
+    get peak() {
+      return peak;
+    },
+    get active() {
+      return active;
+    },
+    /** Settle every operation currently parked inside the probe. */
+    drain() {
+      const parked = release.splice(0, release.length);
+      for (const resolve of parked) resolve();
+    },
+    async run(): Promise<void> {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve) => release.push(resolve));
+      active -= 1;
+    },
+  };
+}
+
+/** Let parked operations settle and their continuations run. */
+async function settle(probe: ReturnType<typeof concurrencyProbe>, rounds: number) {
+  for (let round = 0; round < rounds; round += 1) {
+    probe.drain();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+describe('shared team resource materialization fan-out', () => {
+  it('never materializes more shared resources at once than the vela fan-out cap', async () => {
+    const RESOURCE_COUNT = 60;
+    const probe = concurrencyProbe();
+    const list = createTeamResourceListCache({
+      share: {
+        sharedResources: async () => sharedResources(RESOURCE_COUNT),
+      } as never,
+      sync: () => probe.run(),
+      invalidateSharedCommand: () => {},
+    });
+
+    const reading = list(SCOPE);
+    // Let the listing resolve and the fan-out schedule whatever it will.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const peakBeforeAnySettles = probe.peak;
+    await settle(probe, RESOURCE_COUNT + 2);
+    const listing = await reading;
+
+    expect(listing.ids).toHaveLength(RESOURCE_COUNT);
+    expect(peakBeforeAnySettles).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+    expect(probe.peak).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+  });
+
+  it('still materializes every shared resource exactly once', async () => {
+    const seen: string[] = [];
+    const list = createTeamResourceListCache({
+      share: {
+        sharedResources: async () => sharedResources(25),
+      } as never,
+      sync: async (resource) => {
+        seen.push(resource.id);
+      },
+      invalidateSharedCommand: () => {},
+    });
+
+    const listing = await list(SCOPE);
+
+    expect(seen).toHaveLength(25);
+    expect(new Set(seen).size).toBe(25);
+    expect(listing.ids).toEqual(seen.slice().sort((a, b) => seen.indexOf(a) - seen.indexOf(b)));
+  });
+
+  it('surfaces a failing materialization instead of swallowing it', async () => {
+    const list = createTeamResourceListCache({
+      share: {
+        sharedResources: async () => sharedResources(8),
+      } as never,
+      sync: async (resource) => {
+        if (resource.id === 'user:res-3') throw new Error('pull failed');
+      },
+      invalidateSharedCommand: () => {},
+    });
+
+    await expect(list(SCOPE)).rejects.toThrow('pull failed');
+  });
+});
+
+describe('cross-project publish fan-out', () => {
+  it('never publishes more projects at once than the vela fan-out cap', async () => {
+    vi.useFakeTimers();
+    try {
+      const PROJECT_COUNT = 40;
+      const probe = concurrencyProbe();
+      const scheduler = new CollabPublishScheduler({
+        adapter: { publish: () => probe.run().then(() => ({ version: 1 })) },
+        debounceMs: 10,
+      });
+
+      for (let index = 0; index < PROJECT_COUNT; index += 1) {
+        scheduler.notifyChanged(`p${index}`);
+      }
+      // Every project's debounce expires in the same tick — the worst case a
+      // run boundary or a workspace-wide reconcile produces.
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(probe.peak).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+
+      // Draining lets the queued projects through; the cap must hold there too.
+      for (let round = 0; round < PROJECT_COUNT + 2; round += 1) {
+        probe.drain();
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      expect(probe.peak).toBeLessThanOrEqual(COLLAB_VELA_FANOUT_CONCURRENCY);
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('publishes every dirty project once the queue drains', async () => {
+    vi.useFakeTimers();
+    try {
+      const PROJECT_COUNT = 20;
+      const published: string[] = [];
+      const scheduler = new CollabPublishScheduler({
+        adapter: {
+          publish: async ({ projectId }) => {
+            published.push(projectId);
+            return { version: 1 };
+          },
+        },
+        debounceMs: 10,
+      });
+
+      for (let index = 0; index < PROJECT_COUNT; index += 1) {
+        scheduler.notifyChanged(`p${index}`);
+      }
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(published).toHaveLength(PROJECT_COUNT);
+      expect(new Set(published).size).toBe(PROJECT_COUNT);
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Why

**My use case:** I was closing out the resource-hub reliability work (#6564, #6603, #6605 on this side; powerformer/vela#1445/#1466/#1471/#1472 on the backend) and went looking for what was still able to take the sync path down. Two fan-outs in the collab layer turned out to be sized by *user data* rather than by the machine.

**The pain:** every collab fan-out ends in a `vela` child process — a pull per shared resource, a push per dirty project — and both were unbounded `Promise.all`s.

- **Materializing shared resources.** One `vela resource pull` per shared design system / plugin / skill, all at once, on a single listing read. A member of a workspace that shares 200 resources spawned 200 concurrent transfers, each holding a socket locally and a connection at the far end.
- **Publishing dirty projects.** Per-project re-entry was guarded by `state.publishing`; *across* projects nothing was. A run boundary that dirties every project in a workspace, or a batch of debounce windows expiring in the same tick, spawned one concurrent `vela resource push` per project.

In both cases the workspace decided how many processes this daemon opened.

## What users will see

Nothing changes about what syncs — every shared resource still materializes, every dirty project still publishes, exactly once. What changes is the peak: at most 8 concurrent pulls and at most 8 concurrent pushes, instead of "as many as you happen to share."

*(Corrected after review: an earlier revision of this description claimed a flat peak of 8. The gate was being built per listing cache, and `server.ts` builds three of them, so the real peak was 24 — measured, not theorized. The gate now lives at the composition root and is shared by all three kinds. The publish scheduler keeps a separate gate on purpose, so the honest daemon-wide worst case from these two sites is 8 + 8.)*

**The trade is real and worth stating:** a large fan-out now takes longer in wall clock, because it runs 8-wide instead of all-at-once. Measured against real child processes, a 40-resource fan-out went from 457ms to 2152ms. The old number was only "fast" because it borrowed unboundedly from the machine and from the hub.

## Surface area

- [x] **None** — internal reliability change; no new UI, CLI, contract, or i18n surface

## Screenshots

Not a UI change. The runtime was still driven through a real browser as a regression check — see Validation.

## Bug fix verification

Red on the parent commit, green on this branch, in `apps/daemon/tests/collab-fanout-concurrency.test.ts`:

| Spec | Parent commit | This branch |
| --- | --- | --- |
| Shared-resource materialization peak | **60** (one per resource) | ≤ 8 |
| Cross-project publish peak | **40** (one per project) | ≤ 8 |

The three sibling specs — every resource materialized exactly once, a failing pull still surfacing, every dirty project eventually published — pass on **both** commits, so what went red is the cap and nothing else.

Mutation-tested: removing the queued-vs-reading early return puts the "no stacked publish" spec back to red; breaking FIFO handoff puts the arrival-order spec back to red.

## How it works

One `ConcurrencyGate` serves both sites. Every operation still runs, exactly once, and still propagates its own failure to its own caller — only the peak changes.

Two details worth a reviewer's eye:

1. **The uncontended path stays synchronous.** Callers that observe "the adapter was invoked by the time this returned" — the run-boundary flush, which has a spec asserting exactly that — behave as before. Only a genuinely contended call waits.

2. **The scheduler distinguishes queued from reading.** A publish waiting for a slot has not looked at the project yet, so a change arriving in that window updates the reason it will publish under rather than stacking a second publish behind it. Once the adapter *is* reading, the pre-existing dirty/re-publish path is untouched. Without this, adding the cap would have introduced redundant pushes on exactly the busy workspaces the cap exists to protect.

The first commit is a **pure move** — `cachedTeamResourceList` leaves the 11k-line `server.ts` closure for the module that already owns the listing caches — with no behavior change, so the behavior commit is readable on its own.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon build` — pass
- `pnpm --filter @open-design/daemon test` — **637 files / 8145 tests.** 7 files / 12 tests fail, and the *same* 7 files / 12 tests fail on `origin/main` — verified by running both the full suite and that exact file set on each commit. No new failures.
- **Real child processes, not promises:** a probe drives the real `createTeamResourceListCache` with a `sync` that spawns actual processes and counts them with `ps`. Pre-fix peak **40**; at cap=8, peak **8**; all 40 still materialized.
- **Real browser:** local runtime on this branch (isolated `OD_DATA_DIR`, namespace `fanout`), driven through Chrome — app boots, onboarding completes, home renders, and `/design-systems`, `/api/design-systems`, `/api/plugins`, `/api/skills` all return 200 with content.

**Coverage limit worth naming:** the browser pass ran in a personal workspace, so it exercises the refactored listing code path but not the *team* branch of it, which needs a signed-in cloud team workspace. The team path is covered by the unit specs above, not by the browser run.

## Related

Backend half: powerformer/vela#1513 (resource-hub pool isolation + bounded event publishes).

