### PR TITLE
fix(web): recover stalled iframe preview refreshes

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -614,6 +614,7 @@ const htmlPreviewZoomState = new Map<string, { zoom: number; zoomMode: 'auto' | 
 // canvas-grow recovery in the auto-fit effect fires.
 const MAX_CACHED_PREVIEW_CONTENT_WIDTHS = 128;
 const PREVIEW_CONTENT_WIDTH_CACHE_VERSION = 2;
+const SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS = 1500;
 let previewContentMeasurementDocumentEpochSequence = 0;
 let previewContentMeasurementHostInstanceSequence = 0;
 let previewTransportGenerationSequence = 0;
@@ -10080,6 +10081,26 @@ function HtmlViewer({
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
+  const srcDocRecoveryAttemptedGenerationRef = useRef<string | null>(null);
+  const [srcDocRecoveryGeneration, setSrcDocRecoveryGeneration] = useState<string | null>(null);
+  const recoverUnacknowledgedSrcDocTransport = useCallback((generation: string) => {
+    if (
+      !workspaceActiveRef.current
+      || expectedSrcDocTransportGenerationRef.current !== generation
+    ) {
+      return;
+    }
+    const frame = srcDocPreviewIframeRef.current;
+    const ready = readySrcDocTransportRef.current;
+    if (frame && ready?.frame === frame && ready.generation === generation) return;
+    if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
+    srcDocRecoveryAttemptedGenerationRef.current = generation;
+    readySrcDocTransportRef.current = null;
+    activatedSrcDocTransportHtmlRef.current = null;
+    setSrcDocShellReady(false);
+    setSrcDocRecoveryGeneration(generation);
+    setSrcDocTransportResetKey((key) => key + 1);
+  }, []);
   // Sticky once the srcDoc iframe has materialized the real artifact for the
   // first time (i.e. the first entry into Mark/Edit/Comment/Inspect). Until
   // then the srcDoc iframe stays on the lazy shell — so passive preview never
@@ -10148,6 +10169,32 @@ function HtmlViewer({
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
   }, [replayPreviewBridgeModes, workspaceActive]);
+  // React can commit a fresh `srcdoc` attribute while Chromium aborts the
+  // corresponding about:srcdoc navigation. The host then believes the latest
+  // revision is applied, but the iframe stays on its old/empty document until
+  // Code -> Preview happens to remount it. Every real srcDoc carries an exact
+  // generation ACK; if the active frame never acknowledges that generation,
+  // retry through the small lazy shell automatically; Chromium can commit that
+  // shell even when it aborts a large direct srcDoc navigation, after which the
+  // existing ready handshake safely document.write's the latest HTML. One
+  // fallback per generation avoids a loop when an authored document is
+  // fundamentally unable to execute scripts.
+  useEffect(() => {
+    if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
+    const generation = srcDocTransportGeneration;
+    if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
+    const timeout = window.setTimeout(() => {
+      recoverUnacknowledgedSrcDocTransport(generation);
+    }, SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS);
+    return () => window.clearTimeout(timeout);
+  }, [
+    mode,
+    recoverUnacknowledgedSrcDocTransport,
+    srcDoc,
+    srcDocTransportGeneration,
+    useUrlLoadPreview,
+    workspaceActive,
+  ]);
   useEffect(() => {
     if (!workspaceActive) return;
     function onMessage(ev: MessageEvent) {
@@ -10172,7 +10219,8 @@ function HtmlViewer({
   // re-entering a mode is an instant visibility swap rather than a re-mount +
   // re-load. Direct-mount path (no #2361/#2791 postMessage race).
   const useLazySrcDocTransport =
-    !manualEditRequiresSrcDoc && !captureModeActive && useUrlLoadPreview && !srcDocMaterialized;
+    srcDocRecoveryGeneration === srcDocTransportGeneration
+    || (!manualEditRequiresSrcDoc && !captureModeActive && useUrlLoadPreview && !srcDocMaterialized);
   // Park on a static "loop detected" document once the guard reports a runaway
   // redirect. A self-redirecting artifact is forced onto the srcDoc iframe by
   // `needsRedirectGuard`, so swapping this content is the reliable stop — the
@@ -10318,6 +10366,25 @@ function HtmlViewer({
     }, '*');
     return true;
   }, [srcDoc, srcDocTransportGeneration]);
+  function verifyLoadedSrcDocTransport(target: HTMLIFrameElement | null) {
+    if (!target || target !== srcDocPreviewIframeRef.current) return;
+    const generation = srcDocTransportGeneration;
+    if (!useUrlLoadPreview && srcDoc) {
+      // `load` may belong to a provisional about:blank/about:srcdoc document.
+      // Drop any earlier ACK and require the document that actually completed
+      // this load to answer the generation probe. This closes the window where
+      // a provisional document announces from its head and is then aborted.
+      readySrcDocTransportRef.current = null;
+    }
+    target.contentWindow?.postMessage({
+      type: 'od:srcdoc-transport-ready-probe',
+      generation,
+    }, '*');
+    if (useUrlLoadPreview || !srcDoc) return;
+    window.setTimeout(() => {
+      recoverUnacknowledgedSrcDocTransport(generation);
+    }, SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS);
+  }
   useEffect(() => {
     if (useUrlLoadPreview) {
       activatedSrcDocTransportHtmlRef.current = null;
@@ -15590,10 +15657,7 @@ function HtmlViewer({
                           }
                           if (useLazySrcDocTransport) setSrcDocShellReady(true);
                           activateLoadedSrcDocTransport(frame);
-                          frame?.contentWindow?.postMessage({
-                            type: 'od:srcdoc-transport-ready-probe',
-                            generation: srcDocTransportGeneration,
-                          }, '*');
+                          verifyLoadedSrcDocTransport(frame);
                           dcViewportRestoreAtRef.current = Date.now();
                           frame?.contentWindow?.postMessage({
                             type: '__dc_set_viewport',

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -552,7 +552,13 @@ function injectSrcdocTransportActivationBridge(doc: string, generation: string):
   });
   announceReady();
 })();</script>`;
-  return injectBeforeBodyEnd(doc, script);
+  // Install the activation witness before authored styles/scripts. A srcDoc
+  // navigation can otherwise be healthy but spend seconds in a blocking
+  // external script before reaching a body-end bridge, which makes the host's
+  // missing-ACK recovery indistinguishable from a genuinely aborted
+  // `about:srcdoc` navigation. Placing the bridge first also runs it before an
+  // authored meta CSP can disable later inline scripts.
+  return injectAfterHeadOpen(doc, script);
 }
 
 function injectSnapshotBridge(doc: string): string {

--- a/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FileViewer } from '../../src/components/FileViewer';
+import type { ProjectFile } from '../../src/types';
+
+function htmlFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
+  return {
+    name: 'deepflow-landing.html',
+    path: 'deepflow-landing.html',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'html',
+      title: 'DeepFlow',
+      entry: 'deepflow-landing.html',
+      renderer: 'html',
+      exports: ['html'],
+    },
+    ...overrides,
+  };
+}
+
+function srcDocHtml(label: string): string {
+  // localStorage forces the same sandbox-shim/srcDoc transport used by the
+  // artifact in the reported diagnostics bundle.
+  return `<html><body><main>${label}</main><script>localStorage.setItem('deepflow', 'monthly')</script></body></html>`;
+}
+
+function transportGeneration(frame: HTMLIFrameElement): string {
+  const generation = frame.srcdoc.match(
+    /data-od-srcdoc-transport-activation>[\s\S]*?var generation = "([^"]+)";/,
+  )?.[1];
+  if (!generation) throw new Error('srcDoc transport generation missing');
+  return generation;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('FileViewer srcDoc file-watch refresh recovery', () => {
+  it('remounts once when a refreshed srcDoc revision never acknowledges activation', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    const { rerender } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('version-one')}
+      />,
+    );
+
+    const initialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(initialFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+
+    rerender(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile({ mtime: 1710000001, size: 1025 })}
+        filesRefreshKey={1}
+        liveHtml={srcDocHtml('version-two')}
+      />,
+    );
+
+    const refreshedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(refreshedFrame).toBe(initialFrame);
+    expect(refreshedFrame.srcdoc).toContain('version-two');
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(recoveredFrame).not.toBe(refreshedFrame);
+    expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+
+    const postMessage = vi.spyOn(recoveredFrame.contentWindow!, 'postMessage');
+    fireEvent.load(recoveredFrame);
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'od:srcdoc-transport-activate',
+        html: expect.stringContaining('version-two'),
+      }),
+      '*',
+    );
+  });
+
+  it('keeps the acknowledged refreshed srcDoc frame mounted', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    const { rerender } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('version-one')}
+      />,
+    );
+
+    rerender(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile({ mtime: 1710000001, size: 1025 })}
+        filesRefreshKey={1}
+        liveHtml={srcDocHtml('version-two')}
+      />,
+    );
+
+    const refreshedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    act(() => {
+      fireEvent.load(refreshedFrame);
+      window.dispatchEvent(new MessageEvent('message', {
+        source: refreshedFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: transportGeneration(refreshedFrame),
+        },
+      }));
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(refreshedFrame);
+  });
+
+  it('revalidates an early activation acknowledgement after the frame load completes', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    const { rerender } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('version-one')}
+      />,
+    );
+
+    rerender(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile({ mtime: 1710000001, size: 1025 })}
+        filesRefreshKey={1}
+        liveHtml={srcDocHtml('version-two')}
+      />,
+    );
+
+    const refreshedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: refreshedFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: transportGeneration(refreshedFrame),
+        },
+      }));
+    });
+
+    fireEvent.load(refreshedFrame);
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(recoveredFrame).not.toBe(refreshedFrame);
+    expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildLazySrcdocTransport,
+  buildSrcdoc,
   canActivateSrcDocTransport,
   type SrcDocActivationInputs,
 } from '../../src/runtime/srcdoc';
@@ -172,6 +173,20 @@ describe('buildLazySrcdocTransport (#2253)', () => {
     listener({ data: null });
     listener({ data: { type: 'unrelated' } });
     expect(writes).toEqual([]);
+  });
+});
+
+describe('srcDoc transport activation witness', () => {
+  it('runs before authored head scripts so slow boot code cannot cause a false recovery', () => {
+    const doc = buildSrcdoc(
+      '<html><head><script src="slow-app.js"></script></head><body>app</body></html>',
+      { transportActivationGeneration: 'generation-1' },
+    );
+
+    expect(doc.indexOf('data-od-srcdoc-transport-activation')).toBeGreaterThan(-1);
+    expect(doc.indexOf('data-od-srcdoc-transport-activation')).toBeLessThan(
+      doc.indexOf('src="slow-app.js"'),
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #6713

## Why

A teammate and community users reported that a generated artifact can update while the Project Preview stays blank or stale until they manually switch Code → Preview. I investigated the supplied desktop diagnostics and reproduced the failure against current main in the user's real Chrome.

The daemon watcher, file-change SSE, and authoritative file-list refresh all complete. The remaining failure is at the srcDoc transport boundary: Chromium can abort or replace an about:srcdoc navigation, while the host previously treated the React srcdoc attribute update as sufficient and had no recovery when the exact new generation never acknowledged activation.

## What users will see

When an HTML artifact changes while Preview is visible, the latest revision continues to refresh automatically. If the direct srcDoc navigation does not activate, Open Design now retries that revision once through the existing lightweight srcDoc shell. Users no longer need to toggle Code → Preview to recover a stale or blank preview.

Healthy previews keep the existing direct-mount path and do not remount.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Real-Chrome before/after evidence will be attached in a follow-up comment: current main stays on the injected stale document; Code → Preview displays the latest revision; this branch displays the latest revision automatically under the same fault injection.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — on main, the missing-ACK case expected an iframe remount but received the same stale frame; on this branch all three recovery/healthy-path cases pass.
- The source-level red spec is paired with a real-Chrome E2E reproduction using Open Browser Use. The same deterministic fault drops the new generation ACK and strands the iframe on `STUCK-OLD`: main remains stuck after 4 seconds and only recovers after Code → Preview; this branch automatically falls back to the lazy shell and renders `FIXED-PASS-V5` without a mode toggle.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx tests/components/FileViewer.srcdoc-reload.test.tsx tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx tests/runtime/srcdoc-transport.test.ts --maxWorkers=1` — 4 files, 283 tests passed
- `pnpm guard`
- `pnpm --filter @open-design/contracts build && pnpm typecheck`
- User's connected Chrome via Open Browser Use, old main reproduction and fixed-branch E2E; no Playwright
