### PR TITLE
fix(daemon): retry Azure alias token parameter

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -54,6 +54,7 @@ import {
   buildLegacyMaxTokensParam,
   buildMaxCompletionTokensParam,
   buildOpenAIChatTokenParam,
+  isAzureOpenAIHostname,
   isUnsupportedMaxTokensError,
 } from './integrations/openai-chat-token-params.js';
 import { aihubmixHeaders } from './integrations/aihubmix.js';
@@ -1192,6 +1193,8 @@ function openAIChatCompletionsProviderCall(
   apiKey: string,
   model: string,
 ): ProviderCallShape {
+  const messages = [{ role: 'user', content: SMOKE_PROMPT }];
+  const isAzureHosted = isAzureOpenAIHostname(new URL(baseUrl).hostname);
   return {
     url: appendVersionedApiPath(baseUrl, '/chat/completions'),
     headers: {
@@ -1205,9 +1208,17 @@ function openAIChatCompletionsProviderCall(
     body: {
       model,
       ...buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS),
-      messages: [{ role: 'user', content: SMOKE_PROMPT }],
+      messages,
       stream: false,
     },
+    ...(isAzureHosted ? {
+      retryBodyOnUnsupportedMaxTokens: {
+        model,
+        ...buildMaxCompletionTokensParam(PROVIDER_MAX_TOKENS),
+        messages,
+        stream: false,
+      },
+    } : {}),
     extractText: extractOpenAIMessageText,
   };
 }

--- a/apps/daemon/src/integrations/openai-chat-token-params.ts
+++ b/apps/daemon/src/integrations/openai-chat-token-params.ts
@@ -33,6 +33,17 @@ export function buildMaxCompletionTokensParam(
   return { max_completion_tokens: maxTokens };
 }
 
+const AZURE_OPENAI_HOST_SUFFIXES = [
+  '.openai.azure.com',
+  '.services.ai.azure.com',
+  '.cognitiveservices.azure.com',
+] as const;
+
+export function isAzureOpenAIHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, '');
+  return AZURE_OPENAI_HOST_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
 export function isUnsupportedMaxTokensError(detail: string): boolean {
   const normalized = detail.toLowerCase();
   return (

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -5,6 +5,7 @@ import {
   buildLegacyMaxTokensParam,
   buildMaxCompletionTokensParam,
   buildOpenAIChatTokenParam,
+  isAzureOpenAIHostname,
   isUnsupportedMaxTokensError,
 } from '../integrations/openai-chat-token-params.js';
 import {
@@ -1069,15 +1070,23 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       payloadMessages.unshift({ role: 'system', content: systemPrompt });
     }
 
+    const effectiveMaxTokens =
+      typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192;
     const payload: any = {
       model,
       messages: payloadMessages,
-      ...buildOpenAIChatTokenParam(
-        model,
-        typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192,
-      ),
+      ...buildOpenAIChatTokenParam(model, effectiveMaxTokens),
       stream: true,
     };
+    const retryPayload = {
+      model,
+      messages: payloadMessages,
+      ...buildMaxCompletionTokensParam(effectiveMaxTokens),
+      stream: true,
+    };
+    const canRetryUnsupportedMaxTokens = isAzureOpenAIHostname(
+      validated.parsed!.hostname,
+    );
 
     const sse = createSseResponse(res);
     let proxyDispatcher: ReturnType<typeof proxyDispatcherRequestInit> | null = null;
@@ -1085,7 +1094,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       proxyDispatcher = proxyDispatcherRequestInit();
       const signal = clientDisconnectSignal(res);
       sse.send('start', { model });
-      const response = await fetch(url, {
+      const requestInit = {
         ...proxyDispatcher.requestInit,
         signal,
         method: 'POST',
@@ -1097,21 +1106,40 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
             'X-Title': 'Open Design',
           } : {}),
         },
+        redirect: 'error' as const,
+      };
+      let response = await fetch(url, {
+        ...requestInit,
         body: JSON.stringify(payload),
-        redirect: 'error',
       });
 
       if (!response.ok) {
-        const errorText = await response.text();
-        console.error(
-          `[proxy:openai] upstream error: ${response.status} ${redactAuthTokens(errorText)}`,
-        );
-        sendProxyError(sse, `Upstream error: ${response.status}`, {
-          code: proxyErrorCode(response.status),
-          details: errorText,
-          retryable: response.status === 429 || response.status >= 500,
-        });
-        return sse.end();
+        let errorText = await response.text();
+        if (
+          canRetryUnsupportedMaxTokens &&
+          response.status === 400 &&
+          isUnsupportedMaxTokensError(errorText)
+        ) {
+          console.warn(
+            `[proxy:openai] retrying Azure-hosted request with max_completion_tokens model=${model}`,
+          );
+          response = await fetch(url, {
+            ...requestInit,
+            body: JSON.stringify(retryPayload),
+          });
+          errorText = response.ok ? '' : await response.text();
+        }
+        if (!response.ok) {
+          console.error(
+            `[proxy:openai] upstream error: ${response.status} ${redactAuthTokens(errorText)}`,
+          );
+          sendProxyError(sse, `Upstream error: ${response.status}`, {
+            code: proxyErrorCode(response.status),
+            details: errorText,
+            retryable: response.status === 429 || response.status >= 500,
+          });
+          return sse.end();
+        }
       }
 
       let ended = false;

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -1508,6 +1508,63 @@ describe('POST /api/test/connection provider mode', () => {
     expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
+  it('retries Azure-hosted OpenAI protocol alias connection tests when max_tokens is rejected', async () => {
+    const fetchMock = passThroughOrUpstream((url, init) => {
+      if (url.endsWith('/models')) {
+        return jsonResponse({
+          data: [{ id: 'gpt-chat-latest', object: 'model' }],
+        });
+      }
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return jsonResponse({
+          error: {
+            message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+            type: 'invalid_request_error',
+            param: 'max_tokens',
+            code: 'unsupported_parameter',
+          },
+        }, { status: 400 });
+      }
+      return jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/test/connection`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mode: 'provider',
+        protocol: 'openai',
+        baseUrl: 'https://resource.services.ai.azure.com/api/projects/project/openai/v1',
+        apiKey: 'azure-key',
+        model: 'gpt-chat-latest',
+      }),
+    });
+
+    const responseBody = (await res.json()) as Record<string, unknown>;
+    expect(responseBody.ok).toBe(true);
+    const chatCalls = fetchMock.mock.calls.filter(
+      ([input]) => String(input).endsWith('/chat/completions'),
+    );
+    expect(chatCalls).toHaveLength(2);
+    const firstBody = JSON.parse(String(chatCalls[0]![1]?.body));
+    const secondBody = JSON.parse(String(chatCalls[1]![1]?.body));
+    expect(firstBody).toMatchObject({
+      model: 'gpt-chat-latest',
+      max_tokens: 100,
+      stream: false,
+    });
+    expect(secondBody).toMatchObject({
+      model: 'gpt-chat-latest',
+      max_completion_tokens: 100,
+      stream: false,
+    });
+    expect(secondBody).not.toHaveProperty('max_tokens');
+  });
+
   it('retries Azure deployment-mode connection tests with max_completion_tokens when max_tokens is rejected', async () => {
     const fetchMock = passThroughOrUpstream((_url, init) => {
       const body = JSON.parse(String(init?.body)) as Record<string, unknown>;

--- a/apps/daemon/tests/openai-chat-token-params.test.ts
+++ b/apps/daemon/tests/openai-chat-token-params.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isAzureOpenAIHostname } from '../src/integrations/openai-chat-token-params.js';
+
+describe('isAzureOpenAIHostname', () => {
+  it.each([
+    'resource.openai.azure.com',
+    'resource.services.ai.azure.com',
+    'resource.cognitiveservices.azure.com',
+    'RESOURCE.SERVICES.AI.AZURE.COM.',
+  ])('recognizes Azure OpenAI-compatible host %s', (hostname) => {
+    expect(isAzureOpenAIHostname(hostname)).toBe(true);
+  });
+
+  it.each([
+    'api.openai.com',
+    'services.ai.azure.com.evil.example',
+    'notservices.ai.azure.com',
+  ])('rejects non-Azure host %s', (hostname) => {
+    expect(isAzureOpenAIHostname(hostname)).toBe(false);
+  });
+});

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -638,6 +638,66 @@ describe('API proxy routes', () => {
     expect(secondBody).not.toHaveProperty('max_tokens');
   });
 
+  it('retries Azure-hosted OpenAI protocol alias requests when max_tokens is rejected', async () => {
+    const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) return realFetch(input, init);
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      if ('max_tokens' in body) {
+        return Promise.resolve(new Response(
+          JSON.stringify({
+            error: {
+              message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+              type: 'invalid_request_error',
+              param: 'max_tokens',
+              code: 'unsupported_parameter',
+            },
+          }),
+          { status: 400, headers: { 'content-type': 'application/json' } },
+        ));
+      }
+      return Promise.resolve(sseResponse('data: [DONE]\n\n'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await realFetch(`${baseUrl}/api/proxy/openai/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseUrl: 'https://resource.services.ai.azure.com/api/projects/project/openai/v1',
+        apiKey: 'azure-key',
+        model: 'gpt-chat-latest',
+        maxTokens: 1234,
+        messages: [{ role: 'user', content: 'hello' }],
+      }),
+    });
+
+    await expect(res.text()).resolves.toContain('event: end');
+    const upstreamCalls = fetchMock.mock.calls.filter(
+      ([input]) => !String(input).startsWith(baseUrl),
+    );
+    expect(upstreamCalls).toHaveLength(2);
+    expect(String(upstreamCalls[0]![0])).toBe(
+      'https://resource.services.ai.azure.com/api/projects/project/openai/v1/chat/completions',
+    );
+    expect(upstreamCalls[0]![1]?.headers).toMatchObject({
+      Authorization: 'Bearer azure-key',
+    });
+    const firstBody = JSON.parse(String(upstreamCalls[0]![1]?.body));
+    const secondBody = JSON.parse(String(upstreamCalls[1]![1]?.body));
+    expect(firstBody).toMatchObject({
+      model: 'gpt-chat-latest',
+      max_tokens: 1234,
+      stream: true,
+    });
+    expect(secondBody).toMatchObject({
+      model: 'gpt-chat-latest',
+      max_completion_tokens: 1234,
+      stream: true,
+    });
+    expect(secondBody).not.toHaveProperty('max_tokens');
+  });
+
   it('retries Azure deployment-mode requests with max_completion_tokens when max_tokens is rejected', async () => {
     const fetchMock = vi.fn((input: FetchInput, init?: FetchInit) => {
       const url = String(input);


### PR DESCRIPTION
Fixes #2024

## Why

I picked this up from the open P1 provider-compatibility issue after reproducing it against the generic OpenAI-protocol path. Azure AI Foundry can expose deployments through an OpenAI-compatible /openai/v1 URL and a deployment alias whose name does not identify the underlying GPT family. Open Design therefore sent max_tokens, received Azure's structured 400 asking for max_completion_tokens, and stopped. The same configuration failed both normal chat streaming and Settings connection testing even though the dedicated Azure protocol already handled this compatibility response.

## What users will see

Custom providers configured with protocol OpenAI and an Azure OpenAI or Azure AI Foundry host now recover automatically when Azure rejects max_tokens and requests max_completion_tokens. The retry applies to both chat streaming and connection tests. Other OpenAI-compatible hosts keep their current behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see TRANSLATIONS.md for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root package.json (dependencies or devDependencies); workspace-package package.json files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see CONTRIBUTING.md → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test paths: apps/daemon/tests/proxy-routes.test.ts, apps/daemon/tests/connection-test.test.ts, and apps/daemon/tests/openai-chat-token-params.test.ts.
- Yes. The two entry-point regressions failed on upstream main because the first structured Azure 400 was returned directly; they pass after the fix with two requests and max_completion_tokens only on the retry.
- The hostname unit coverage also verifies that lookalike suffixes such as services.ai.azure.com.evil.example are not treated as Azure.

## Validation

- pnpm --filter @open-design/daemon exec vitest run tests/openai-chat-token-params.test.ts tests/proxy-routes.test.ts tests/connection-test.test.ts (244 passed)
- pnpm --filter @open-design/daemon typecheck
- pnpm --filter @open-design/daemon build
- pnpm guard
- pnpm typecheck

The full tests were run with inherited HTTP(S)/ALL proxy variables removed so the repository's malformed-proxy test cases were isolated from the contributor machine's proxy configuration.
