### PR TITLE
fix(web): auto-open generated media previews

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -3263,6 +3263,21 @@ export function FileWorkspace({
     return liveArtifactEntries.find((entry) => entry.tabId === activeTab) ?? null;
   }, [activeTab, liveArtifactEntries]);
 
+  const activeTabHasRenderableSurface =
+    (activeTab === DESIGN_SYSTEM_TAB && Boolean(designSystemProject))
+    || (isBrowserTabId(activeTab) && browserTabs.some((tab) => tab.id === activeTab))
+    || isTerminalTabId(activeTab)
+    || (isSideChatTabId(activeTab) && Boolean(chatConfig) && Boolean(chatAgentsById))
+    || activeLiveArtifact !== null
+    || activeFile !== null;
+  // A persisted file tab can outlive its file. The tab strip hides that stale
+  // entry, so keeping it as the visual active target would leave the fixed
+  // Design Files tab as the only visible tab while the body tells the user to
+  // open Design Files. Treat the root as the display fallback without erasing
+  // persisted state: an in-flight file refresh may still restore the target.
+  const designFilesTabActive =
+    activeTab === DESIGN_FILES_TAB || !activeTabHasRenderableSurface;
+
   // Identity-stable props for the memoized FileViewer. Without these, every
   // FileWorkspace state change (closing an adjacent tab, drag hover, launcher
   // toggles) would hand FileViewer fresh object/function identities and drag
@@ -3359,7 +3374,7 @@ export function FileWorkspace({
         tabId: activeTab,
       };
     }
-    if (activeTab === DESIGN_FILES_TAB) {
+    if (designFilesTabActive) {
       // Nothing to reference yet — don't auto-stage an empty "Design files" chip.
       if (designFilesTabIsEmpty) return null;
       const trimmedDir = uploadDir.trim();
@@ -3368,7 +3383,7 @@ export function FileWorkspace({
         id: trimmedDir ? `folder:${trimmedDir}` : 'workspace:design-files',
         kind: trimmedDir ? 'folder' : 'design-files',
         label,
-        tabId: activeTab,
+        tabId: DESIGN_FILES_TAB,
         ...(trimmedDir ? { path: trimmedDir } : {}),
         ...(resolvedDir ? { absolutePath: joinDisplayPath(resolvedDir, trimmedDir) } : {}),
       };
@@ -3434,6 +3449,7 @@ export function FileWorkspace({
     browserTabs,
     conversations,
     designFilesTabIsEmpty,
+    designFilesTabActive,
     designSystemProject,
     resolvedDir,
     t,
@@ -3912,9 +3928,9 @@ export function FileWorkspace({
           ) : null}
           <button
             type="button"
-            className={`ws-tab design-files-tab ${activeTab === DESIGN_FILES_TAB ? 'active' : ''}`}
+            className={`ws-tab design-files-tab ${designFilesTabActive ? 'active' : ''}`}
             role="tab"
-            aria-selected={activeTab === DESIGN_FILES_TAB}
+            aria-selected={designFilesTabActive}
             aria-label={designFilesTabTitle}
             tabIndex={0}
             data-testid="design-files-tab"
@@ -4196,7 +4212,7 @@ export function FileWorkspace({
             onConnectRepo={onConnectRepo}
             githubConnected={githubConnected}
           />
-        ) : activeTab === DESIGN_FILES_TAB ? (
+        ) : designFilesTabActive ? (
           <DesignFilesPanel
             key={projectId}
             projectId={projectId}

--- a/apps/web/src/components/auto-open-file.ts
+++ b/apps/web/src/components/auto-open-file.ts
@@ -112,15 +112,20 @@ function isMarkdownPreviewFile(file: CandidateFile): boolean {
   return /\.(md|markdown)$/i.test(path);
 }
 
+function isMediaPreviewFile(file: CandidateFile): boolean {
+  return file.kind === 'image' || file.kind === 'video' || file.kind === 'audio';
+}
+
 // Auto-open priority for a turn's produced files. Higher wins. HTML is the
 // primary visual deliverable, so when a turn writes both an HTML page and a
 // markdown note (e.g. index.html + README.md) the page takes focus; markdown
-// is the next-best previewable artifact; everything else (decks, images, raw
-// text) has no in-place reshape preview worth stealing focus for and is left
-// for the user to open from the produced-files chips.
+// is the next-best previewable artifact. Image, video, and audio files are the
+// fallback for media-only turns; non-previewable outputs such as decks and raw
+// text are left for the user to open from the produced-files chips.
 function autoOpenPreviewRank(file: CandidateFile): number {
-  if (isHtmlPreviewFile(file)) return 2;
-  if (isMarkdownPreviewFile(file)) return 1;
+  if (isHtmlPreviewFile(file)) return 3;
+  if (isMarkdownPreviewFile(file)) return 2;
+  if (isMediaPreviewFile(file)) return 1;
   return 0;
 }
 

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -2480,6 +2480,26 @@ describe('FileWorkspace launcher tab creation', () => {
     });
   });
 
+  it('shows Design Files when the persisted active file no longer exists', () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: ['missing.png'], active: 'missing.png' }}
+        onTabsStateChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('design-files-empty')).toBeTruthy();
+    expect(screen.queryByText(/Open a file from/i)).toBeNull();
+    expect(renderedTabLabels()).toEqual(['Design Files']);
+  });
+
   it('hides terminal creation while keeping browser creation available', () => {
     render(
       <FileWorkspace

--- a/apps/web/tests/components/auto-open-file.test.ts
+++ b/apps/web/tests/components/auto-open-file.test.ts
@@ -182,6 +182,36 @@ describe('selectAutoOpenProducedArtifact', () => {
     expect(result).toBe('index.html');
   });
 
+  it.each([
+    ['image', 'hero.png'],
+    ['video', 'launch.mp4'],
+    ['audio', 'narration.mp3'],
+  ] as const)('auto-opens a produced %s file when the turn contains only media', (kind, name) => {
+    const result = selectAutoOpenProducedArtifact([
+      { name, path: name, kind, mtime: 30 },
+    ]);
+
+    expect(result).toBe(name);
+  });
+
+  it('prefers html over a newer media file', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'index.html', path: 'index.html', kind: 'html', mtime: 10 },
+      { name: 'hero.png', path: 'hero.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('index.html');
+  });
+
+  it('opens the newest file when a turn produces multiple media files', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'hero.png', path: 'hero.png', kind: 'image', mtime: 10 },
+      { name: 'launch.mp4', path: 'launch.mp4', kind: 'video', mtime: 30 },
+    ]);
+
+    expect(result).toBe('launch.mp4');
+  });
+
   it('leaves a plain .txt file alone (text kind is shared with markdown)', () => {
     // `.md` and `.txt` both arrive as kind: 'text'; only markdown should open.
     const result = selectAutoOpenProducedArtifact([

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -192,6 +192,10 @@ async function emitRun(promptText) {
     await emitPlanArtifactGenerateRun();
     return;
   }
+  if (promptText.includes('Create a deterministic media-only artifact')) {
+    await emitMediaOnlyRun();
+    return;
+  }
   if (promptText.includes('Create a deterministic plan document')) {
     await emitPlanDocumentRun();
     return;
@@ -319,6 +323,17 @@ async function emitPlanDocumentRun() {
     'utf8',
   );
   emitSuccess('Created plan.md with a deterministic planning outline.', false, false);
+  process.exitCode = 0;
+  exitSoon(0);
+}
+
+async function emitMediaOnlyRun() {
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
+    'base64',
+  );
+  await writeFileFs(join(projectDir(), 'media-only.png'), png);
+  emitSuccess('Created media-only.png as the only file produced by this turn.', false, false);
   process.exitCode = 0;
   exitSoon(0);
 }

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -25,6 +25,7 @@ const DELAYED_HEADING = 'Delayed Daemon Smoke';
 const SLOW_RELOAD_FILE = 'slow-reload-daemon-smoke.html';
 const SLOW_RELOAD_HEADING = 'Slow Reload Daemon Smoke';
 const FOLLOW_UP_FILE = 'follow-up-daemon-smoke.html';
+const MEDIA_ONLY_FILE = 'media-only.png';
 let fakeRuntimes: Awaited<ReturnType<typeof createFakeAgentRuntimes>>;
 
 function artifactPreview(page: Page) {
@@ -260,6 +261,34 @@ test('[P1] Plan mode daemon run creates, opens, and restores an editable markdow
   await expect(page.getByRole('textbox', { name: /markdown editor/i })).toHaveValue(/Deterministic Plan/);
   await expect(page.getByLabel(/markdown preview/i)).toContainText('Keep the plan editable');
   await expect(page.getByTestId('chat-composer')).toBeVisible();
+});
+
+test('[P1] media-only turn auto-opens the generated image file', async ({ page }) => {
+  await createProject(page, 'Media-only auto-open smoke');
+  await expectWorkspaceReady(page);
+
+  // Establish an already-active project file first. Otherwise the workspace's
+  // one-time initial-primary-file fallback can open the first project file and
+  // mask whether turn-end media selection actually works.
+  await sendPrompt(page, 'Create a deterministic plan document');
+  const workspace = page.getByTestId('file-workspace');
+  await expect(workspace.getByRole('tab', { name: /plan\.md/i })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+
+  await sendPrompt(page, 'Create a deterministic media-only artifact');
+
+  const mediaTab = workspace.getByRole('tab', { name: /media-only\.png/i });
+  await expect(mediaTab).toBeVisible({ timeout: T.medium });
+  await expect(mediaTab).toHaveAttribute('aria-selected', 'true');
+  await expect(workspace.getByRole('img', { name: MEDIA_ONLY_FILE })).toBeVisible();
+
+  const rawHref = await workspace.getByRole('link', { name: 'Open' }).getAttribute('href');
+  if (!rawHref) throw new Error('media preview did not expose its raw file URL');
+  const rawResponse = await page.request.get(rawHref);
+  expect(rawResponse.ok(), await rawResponse.text()).toBeTruthy();
+  expect(rawResponse.headers()['content-type']).toContain('image/png');
 });
 
 // Red spec for "Plan 模式生成 HTML 后没有自动打开生成的文件": after the user


### PR DESCRIPTION
## Why

A teammate using the latest `origin/main` found that image artifacts generated by a multimodal agent stayed hidden in Design Files instead of opening automatically. A stale persisted file tab could also leave the fixed Design Files tab looking selected while the workspace showed the contradictory “Open a file from Design Files” fallback.

Generated visual output should surface immediately without changing the established preference for authored HTML and Markdown previews.

## What users will see

- Generated artifacts now auto-open in this priority order: HTML, Markdown, then image/video/audio.
- When a turn produces media only, the newest media artifact opens automatically.
- If the persisted active file no longer exists, the workspace visually falls back to the selected Design Files empty state instead of showing “Open a file from Design Files”.
- Existing HTML and Markdown auto-open behavior remains unchanged.

## Surface area

- [x] UI
- [ ] CLI
- [ ] HTTP API / contracts
- [ ] Agent runtime / prompts
- [ ] Desktop / packaged runtime
- [ ] Skills
- [ ] Design systems
- [ ] Design templates
- [ ] Craft
- [ ] i18n
- [ ] Environment variables
- [ ] Root dependencies
- [x] Default behavior change

## Screenshots

The original reproduction is the Design Files workspace showing “Open a file from Design Files” after a generated image failed to become active. The fixed state was verified in real Chrome against an isolated local daemon/web service: a media-only turn selected and rendered the generated PNG automatically, and deleting the selected file returned to the normal Design Files empty state.

## Bug fix verification

- Red spec: `e2e/ui/real-daemon-run.test.ts` — `[P1] media-only turn auto-opens the generated image file`.
- Confirmed the same automated scenario failed against the old `origin/main` selection logic because no media tab appeared, then passed on this branch.
- Component red/green coverage:
  - `apps/web/tests/components/auto-open-file.test.ts` covers image, video, audio, newest-media selection, and HTML-over-media priority.
  - `apps/web/tests/components/FileWorkspace.test.tsx` covers stale active-tab fallback to the Design Files empty state.
- Old source with the new component specs: 5 failed, 129 passed, 3 skipped.
- Current branch with the same specs: 134 passed, 3 skipped.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm -C apps/web exec vitest run tests/components/auto-open-file.test.ts tests/components/FileWorkspace.test.tsx`
- `pnpm -C e2e typecheck`
- `pnpm -C e2e exec playwright test ui/real-daemon-run.test.ts --grep "media-only turn" --workers=1`
- Manual real-Chrome validation with Open Browser Use and isolated local services:
  - media-only PNG generation auto-opened without a file-list click;
  - deleting the selected PNG showed the normal Design Files empty state;
  - a turn producing both PNG and HTML opened only the HTML preview.
