### PR TITLE
feat(daemon): reuse negotiated ACP sessions

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -110,12 +110,16 @@ const ACP_SESSION_LOAD_MISS_KINDS = new Set([
   'session_not_found',
 ]);
 const ACP_SESSION_NOT_FOUND_ERROR_CODE = -32002;
+const ACP_SESSION_SUBJECT_MISSING_PATTERN =
+  /\bsession(?:\s+id)?\s+(?:(?:is|was)\s+)?(?:not found|missing|does not exist|unknown)\b/u;
+const ACP_MISSING_SESSION_SUBJECT_PATTERN =
+  /\b(?:(?:missing|unknown)\s+session|no such session)(?:\s+id)?\b/u;
 
 function sessionMissingMessage(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   const normalized = value.trim().toLowerCase();
-  return /(?:session.{0,40}(?:not found|missing|does not exist|unknown)|(?:not found|missing|unknown).{0,40}session)/u
-    .test(normalized);
+  return ACP_SESSION_SUBJECT_MISSING_PATTERN.test(normalized)
+    || ACP_MISSING_SESSION_SUBJECT_PATTERN.test(normalized);
 }
 
 function isSessionLoadMiss(errorCode: unknown, errorMessage: unknown, details: unknown): boolean {

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -104,6 +104,19 @@ export interface AttachAcpSessionOptions {
   onSessionInit?: () => void;
   onPromptComplete?: () => void;
 }
+
+const ACP_SESSION_LOAD_MISS_KINDS = new Set([
+  'resume_failed',
+  'session_not_found',
+]);
+
+function isStructuredSessionLoadMiss(details: unknown): boolean {
+  const value = asObject(details);
+  if (!value) return false;
+  const kind = typeof value.kind === 'string' ? value.kind.trim().toLowerCase() : '';
+  const code = typeof value.code === 'string' ? value.code.trim().toLowerCase() : '';
+  return ACP_SESSION_LOAD_MISS_KINDS.has(kind) || ACP_SESSION_LOAD_MISS_KINDS.has(code);
+}
 /**
  * Attaches an ACP protocol session to an already-spawned child process and
  * drives the full JSON-RPC conversation from handshake to prompt completion.
@@ -152,6 +165,10 @@ export function attachAcpSession({
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
   const effectiveCwd = path.resolve(cwd || process.cwd());
+  const sessionSetupParams = buildAcpSessionNewParams(
+    effectiveCwd,
+    mcpServers ? { mcpServers, envFormat } : { envFormat },
+  );
   if (!child.stdin || !child.stdout) {
     throw new Error('ACP child process must expose stdin and stdout streams');
   }
@@ -160,6 +177,7 @@ export function attachAcpSession({
   let expectedId = 1;
   let nextId = 2;
   let promptRequestId: JsonRpcId | null = null;
+  let sessionLoadRequestId: JsonRpcId | null = null;
   let setModelRequestId: JsonRpcId | null = null;
   let sessionId: string | null = null;
   let supportsSessionLoad = false;
@@ -695,11 +713,10 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
-      if (obj.id === expectedId && expectedId === 2 && resumeSessionId) {
-        // The outstanding id=2 request is session/load on a resume turn. Keep
-        // this protocol fact on the controller instead of trying to recognize
-        // every adapter's error prose in server.ts; the caller uses it to clear
-        // the stale handle and transparently re-seed the full transcript.
+      if (obj.id === sessionLoadRequestId && isStructuredSessionLoadMiss(details)) {
+        // Only a structured missing-session signal authorizes the caller to
+        // discard the durable handle. Auth, MCP, configuration, and transient
+        // load failures must preserve it and surface their original error.
         resumeFailed = true;
       }
       const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);
@@ -720,6 +737,11 @@ export function attachAcpSession({
     }
     const update = asObject(params?.update);
     if (obj.method === 'session/update' && update) {
+      // Standard ACP session/load replays the existing conversation before it
+      // resolves. Those notifications reconstruct client UI state; they are not
+      // output from the new Open Design turn and must not enter its transcript,
+      // artifact accounting, or tool telemetry.
+      if (sessionLoadRequestId !== null) return;
       if (modelUnavailableErrorCode) {
         const promotedPayload = promotedAmrRetryStatusPayload(update);
         if (promotedPayload) {
@@ -923,10 +945,16 @@ export function attachAcpSession({
       }
       return;
     }
-    if (obj.id !== expectedId || !result) {
+    if (obj.id !== expectedId) {
+      return;
+    }
+    const isSessionLoadResponse =
+      sessionLoadRequestId !== null && obj.id === sessionLoadRequestId;
+    if (!result && !(isSessionLoadResponse && obj.result === null)) {
       return;
     }
     if (expectedId === 1) {
+      if (!result) return;
       const initializeCapabilities =
         asObject(result.agentCapabilities) ?? asObject(result.capabilities);
       supportsSessionLoad = initializeCapabilities?.loadSession === true;
@@ -946,20 +974,18 @@ export function attachAcpSession({
       }
       if (resumeSessionId) {
         // Resume the prior upstream session instead of creating a fresh one.
+        sessionLoadRequestId = nextId;
         writeRpc(
           nextId,
           'session/load',
-          { sessionId: resumeSessionId, cwd: effectiveCwd },
+          { ...sessionSetupParams, sessionId: resumeSessionId },
           'session/load',
         );
       } else {
         writeRpc(
           nextId,
           'session/new',
-          buildAcpSessionNewParams(
-            effectiveCwd,
-            mcpServers ? { mcpServers, envFormat } : { envFormat },
-          ),
+          sessionSetupParams,
           'session/new',
         );
       }
@@ -967,24 +993,26 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 2) {
+      const sessionResult = result ?? {};
+      sessionLoadRequestId = null;
       sessionId =
-        typeof result.sessionId === 'string'
-          ? result.sessionId
+        typeof sessionResult.sessionId === 'string'
+          ? sessionResult.sessionId
           : resumeSessionId
             ? resumeSessionId
             : null;
       // The durable handle for resuming this session on the next turn.
       durableSessionId =
-        typeof result.openCodeSessionId === 'string'
-          ? result.openCodeSessionId
+        typeof sessionResult.openCodeSessionId === 'string'
+          ? sessionResult.openCodeSessionId
           : supportsSessionLoad
             ? sessionId
             : null;
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
-      const modelConfig = findModelConfigOption(result.configOptions);
+      const modelConfig = findModelConfigOption(sessionResult.configOptions);
       modelConfigId = modelConfig?.configId ?? null;
-      activeModel = currentModelFromSessionResult(result);
+      activeModel = currentModelFromSessionResult(sessionResult);
       if (sessionId && activeModel) {
         send('agent', { type: 'status', label: 'model', model: activeModel });
       }
@@ -1011,6 +1039,7 @@ export function attachAcpSession({
       sendPrompt();
       return;
     }
+    if (!result) return;
     if (promptRequestId !== null && obj.id === promptRequestId) {
       // Flush still-open tools before AMR no-output classification. A successful
       // session/prompt may omit a terminal tool_call_update; clean-closing those

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -122,7 +122,12 @@ function sessionMissingMessage(value: unknown): boolean {
     || ACP_MISSING_SESSION_SUBJECT_PATTERN.test(normalized);
 }
 
-function isSessionLoadMiss(errorCode: unknown, errorMessage: unknown, details: unknown): boolean {
+function isSessionLoadMiss(
+  errorCode: unknown,
+  errorMessage: unknown,
+  details: unknown,
+  requestedSessionId: string | null | undefined,
+): boolean {
   const value = asObject(details);
   const kind = typeof value?.kind === 'string' ? value.kind.trim().toLowerCase() : '';
   const code = typeof value?.code === 'string' ? value.code.trim().toLowerCase() : value?.code;
@@ -145,6 +150,9 @@ function isSessionLoadMiss(errorCode: unknown, errorMessage: unknown, details: u
   ].filter((entry): entry is string => typeof entry === 'string');
   if (resourceFields.length > 0) {
     return resourceFields.some((entry) => entry.trim().toLowerCase() === 'session');
+  }
+  if (typeof value?.uri === 'string' && value.uri === requestedSessionId) {
+    return true;
   }
   return sessionMissingMessage(errorMessage) || sessionMissingMessage(value?.message);
 }
@@ -746,7 +754,7 @@ export function attachAcpSession({
       const details = rpcErrorData(obj);
       if (
         obj.id === sessionLoadRequestId
-        && isSessionLoadMiss(error?.code, error?.message, details)
+        && isSessionLoadMiss(error?.code, error?.message, details, resumeSessionId)
       ) {
         // Only an explicit adapter signal or a generic resource-not-found code
         // that identifies the session authorizes discarding the durable handle.

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -111,15 +111,38 @@ const ACP_SESSION_LOAD_MISS_KINDS = new Set([
 ]);
 const ACP_SESSION_NOT_FOUND_ERROR_CODE = -32002;
 
-function isSessionLoadMiss(errorCode: unknown, details: unknown): boolean {
-  if (errorCode === ACP_SESSION_NOT_FOUND_ERROR_CODE) return true;
+function sessionMissingMessage(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim().toLowerCase();
+  return /(?:session.{0,40}(?:not found|missing|does not exist|unknown)|(?:not found|missing|unknown).{0,40}session)/u
+    .test(normalized);
+}
+
+function isSessionLoadMiss(errorCode: unknown, errorMessage: unknown, details: unknown): boolean {
   const value = asObject(details);
-  if (!value) return false;
-  const kind = typeof value.kind === 'string' ? value.kind.trim().toLowerCase() : '';
-  const code = typeof value.code === 'string' ? value.code.trim().toLowerCase() : value.code;
-  return ACP_SESSION_LOAD_MISS_KINDS.has(kind)
-    || ACP_SESSION_LOAD_MISS_KINDS.has(String(code))
-    || code === ACP_SESSION_NOT_FOUND_ERROR_CODE;
+  const kind = typeof value?.kind === 'string' ? value.kind.trim().toLowerCase() : '';
+  const code = typeof value?.code === 'string' ? value.code.trim().toLowerCase() : value?.code;
+  if (ACP_SESSION_LOAD_MISS_KINDS.has(kind) || ACP_SESSION_LOAD_MISS_KINDS.has(String(code))) {
+    return true;
+  }
+  const hasResourceNotFoundCode =
+    errorCode === ACP_SESSION_NOT_FOUND_ERROR_CODE
+    || code === ACP_SESSION_NOT_FOUND_ERROR_CODE
+    || code === String(ACP_SESSION_NOT_FOUND_ERROR_CODE);
+  if (!hasResourceNotFoundCode) return false;
+
+  const resourceFields = [
+    value?.resource,
+    value?.resourceType,
+    value?.entity,
+    value?.entityType,
+    value?.target,
+    value?.targetType,
+  ].filter((entry): entry is string => typeof entry === 'string');
+  if (resourceFields.length > 0) {
+    return resourceFields.some((entry) => entry.trim().toLowerCase() === 'session');
+  }
+  return sessionMissingMessage(errorMessage) || sessionMissingMessage(value?.message);
 }
 /**
  * Attaches an ACP protocol session to an already-spawned child process and
@@ -717,10 +740,13 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
-      if (obj.id === sessionLoadRequestId && isSessionLoadMiss(error?.code, details)) {
-        // Only the standard ACP missing-session code or an adapter's structured
-        // missing-session signal authorizes the caller to discard the durable
-        // handle. Auth, MCP, configuration, and transient failures preserve it.
+      if (
+        obj.id === sessionLoadRequestId
+        && isSessionLoadMiss(error?.code, error?.message, details)
+      ) {
+        // Only an explicit adapter signal or a generic resource-not-found code
+        // that identifies the session authorizes discarding the durable handle.
+        // Auth, MCP, configuration, and transient failures preserve it.
         resumeFailed = true;
       }
       const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -109,13 +109,17 @@ const ACP_SESSION_LOAD_MISS_KINDS = new Set([
   'resume_failed',
   'session_not_found',
 ]);
+const ACP_SESSION_NOT_FOUND_ERROR_CODE = -32002;
 
-function isStructuredSessionLoadMiss(details: unknown): boolean {
+function isSessionLoadMiss(errorCode: unknown, details: unknown): boolean {
+  if (errorCode === ACP_SESSION_NOT_FOUND_ERROR_CODE) return true;
   const value = asObject(details);
   if (!value) return false;
   const kind = typeof value.kind === 'string' ? value.kind.trim().toLowerCase() : '';
-  const code = typeof value.code === 'string' ? value.code.trim().toLowerCase() : '';
-  return ACP_SESSION_LOAD_MISS_KINDS.has(kind) || ACP_SESSION_LOAD_MISS_KINDS.has(code);
+  const code = typeof value.code === 'string' ? value.code.trim().toLowerCase() : value.code;
+  return ACP_SESSION_LOAD_MISS_KINDS.has(kind)
+    || ACP_SESSION_LOAD_MISS_KINDS.has(String(code))
+    || code === ACP_SESSION_NOT_FOUND_ERROR_CODE;
 }
 /**
  * Attaches an ACP protocol session to an already-spawned child process and
@@ -713,10 +717,10 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
-      if (obj.id === sessionLoadRequestId && isStructuredSessionLoadMiss(details)) {
-        // Only a structured missing-session signal authorizes the caller to
-        // discard the durable handle. Auth, MCP, configuration, and transient
-        // load failures must preserve it and surface their original error.
+      if (obj.id === sessionLoadRequestId && isSessionLoadMiss(error?.code, details)) {
+        // Only the standard ACP missing-session code or an adapter's structured
+        // missing-session signal authorizes the caller to discard the durable
+        // handle. Auth, MCP, configuration, and transient failures preserve it.
         resumeFailed = true;
       }
       const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -89,6 +89,11 @@ export interface AttachAcpSessionOptions {
   // `session/new`. The agent verifies the session and, if it is gone, returns a
   // structured `resume_failed` error the caller maps to its reseed path.
   resumeSessionId?: string | null;
+  // AMR/vela shipped its durable `openCodeSessionId` + `session/load` extension
+  // before it advertised the standard ACP loadSession capability. Keep that
+  // established compatibility path explicit; every standard ACP adapter must
+  // negotiate load support during initialize.
+  allowUnadvertisedSessionLoad?: boolean;
   // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
   // `onCliReady` fires once on the first well-formed ACP JSON-RPC message
   // (the CLI is up and speaking the protocol); `onSessionInit` fires once when
@@ -140,6 +145,7 @@ export function attachAcpSession({
   modelUnavailableErrorCode,
   completePromptOnTurnEnd = false,
   resumeSessionId,
+  allowUnadvertisedSessionLoad = false,
   onCliReady,
   onSessionInit,
   onPromptComplete,
@@ -156,10 +162,12 @@ export function attachAcpSession({
   let promptRequestId: JsonRpcId | null = null;
   let setModelRequestId: JsonRpcId | null = null;
   let sessionId: string | null = null;
+  let supportsSessionLoad = false;
+  let resumeFailed = false;
   // The durable upstream session handle reported by the agent on session/new or
-  // session/load (vela's `openCodeSessionId`). The caller stores it per
-  // conversation to resume next turn. Distinct from `sessionId`, which is the
-  // ACP wrapper id ("vela-opencode-1").
+  // session/load. Standard ACP agents reuse `sessionId`; AMR/vela reports its
+  // underlying OpenCode handle as `openCodeSessionId` while `sessionId` remains
+  // the wrapper id ("vela-opencode-1").
   let durableSessionId: string | null = null;
   let activeModel: string | null = null;
   let modelConfigId: string | null = null;
@@ -687,6 +695,13 @@ export function attachAcpSession({
         return;
       }
       const details = rpcErrorData(obj);
+      if (obj.id === expectedId && expectedId === 2 && resumeSessionId) {
+        // The outstanding id=2 request is session/load on a resume turn. Keep
+        // this protocol fact on the controller instead of trying to recognize
+        // every adapter's error prose in server.ts; the caller uses it to clear
+        // the stale handle and transparently re-seed the full transcript.
+        resumeFailed = true;
+      }
       const promotedPayload = promotedOpenCodeSessionErrorPayload(details, rpcErr);
       if (promotedPayload) {
         failWithPayload(promotedPayload);
@@ -912,7 +927,23 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 1) {
+      const initializeCapabilities =
+        asObject(result.agentCapabilities) ?? asObject(result.capabilities);
+      supportsSessionLoad = initializeCapabilities?.loadSession === true;
       expectedId = nextId;
+      const canLoadSession = supportsSessionLoad || allowUnadvertisedSessionLoad;
+      if (resumeSessionId && !canLoadSession) {
+        // Prompt composition already omitted the stored transcript because the
+        // daemon expected session/load to restore it. Opening session/new in
+        // this child would therefore lose history. Report a recoverable resume
+        // failure so the daemon restarts fresh and recomposes the full prompt.
+        resumeFailed = true;
+        fail('The ACP agent no longer advertises session/load support.', {
+          details: { kind: 'resume_failed', reason: 'load_session_unsupported' },
+          retryable: true,
+        });
+        return;
+      }
       if (resumeSessionId) {
         // Resume the prior upstream session instead of creating a fresh one.
         writeRpc(
@@ -936,10 +967,19 @@ export function attachAcpSession({
       return;
     }
     if (expectedId === 2) {
-      sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
+      sessionId =
+        typeof result.sessionId === 'string'
+          ? result.sessionId
+          : resumeSessionId
+            ? resumeSessionId
+            : null;
       // The durable handle for resuming this session on the next turn.
       durableSessionId =
-        typeof result.openCodeSessionId === 'string' ? result.openCodeSessionId : null;
+        typeof result.openCodeSessionId === 'string'
+          ? result.openCodeSessionId
+          : supportsSessionLoad
+            ? sessionId
+            : null;
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
       const modelConfig = findModelConfigOption(result.configOptions);
@@ -1045,6 +1085,10 @@ export function attachAcpSession({
     /** Returns `true` when the session ended with a fatal protocol or transport error, allowing the caller to surface the failure. */
     hasFatalError() {
       return fatal;
+    },
+    /** Returns `true` when a requested session/load could not be attempted or was rejected. */
+    resumeFailed() {
+      return resumeFailed;
     },
     // The durable upstream session handle to persist for resume, or null when
     // none was reported (older agents, or a handshake that never established a

--- a/apps/daemon/src/runtimes/defs/devin.ts
+++ b/apps/daemon/src/runtimes/defs/devin.ts
@@ -42,5 +42,6 @@ export const devinAgentDef = {
       'acp',
     ],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/hermes.ts
+++ b/apps/daemon/src/runtimes/defs/hermes.ts
@@ -47,6 +47,7 @@ export const hermesAgentDef = {
     ],
     buildArgs: () => ['acp', '--accept-hooks'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kilo.ts
+++ b/apps/daemon/src/runtimes/defs/kilo.ts
@@ -17,5 +17,6 @@ export const kiloAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -22,6 +22,7 @@ export const kimiAgentDef = {
       }),
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kiro.ts
+++ b/apps/daemon/src/runtimes/defs/kiro.ts
@@ -17,6 +17,7 @@ export const kiroAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     acpTurnEndCompletesPrompt: true,
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/reasonix.ts
+++ b/apps/daemon/src/runtimes/defs/reasonix.ts
@@ -59,6 +59,7 @@ export const reasonixAgentDef = {
       }),
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
     acpMcpEnvFormat: 'map',

--- a/apps/daemon/src/runtimes/defs/trae-cli.ts
+++ b/apps/daemon/src/runtimes/defs/trae-cli.ts
@@ -18,6 +18,7 @@ export const traeCliAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp', 'serve', '--yolo'],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/vibe.ts
+++ b/apps/daemon/src/runtimes/defs/vibe.ts
@@ -17,5 +17,6 @@ export const vibeAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => [],
     streamFormat: 'acp-json-rpc',
+    resumesSessionViaAcpLoad: true,
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -204,10 +204,10 @@ export type RuntimeAgentDef = {
   // path and `agent-cli-session-resume.md`.
   capturesSessionIdFromStream?: boolean;
   // ACP-runtime analogue of capture-style resume: the agent talks `acp-json-rpc`
-  // (today only AMR/vela) and supports resuming via `session/load`. The daemon
-  // captures the durable upstream session handle from the ACP session
+  // and can advertise `loadSession` during initialize. The daemon captures the
+  // durable upstream session handle from the ACP session
   // (`getDurableSessionId()`) and persists THAT, drives `session/load` on a
-  // resume turn, and maps the agent's structured `resume_failed` error onto the
+  // resume turn, and maps a rejected/unsupported load onto the transparent
   // reseed path. Kept distinct from `resumesSessionViaCli` /
   // `capturesSessionIdFromStream` because the capture + resume transport is the
   // ACP result, not a `--session-id` flag or a stream `status` event.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11367,6 +11367,8 @@ export async function startServer({
 
     let child;
     let acpSession = null;
+    const acpResumeFailed = () =>
+      typeof acpSession?.resumeFailed === 'function' && acpSession.resumeFailed();
     let writePromptToChildStdin = false;
     let spawnedAgentEnv = null;
     let agentStdoutTail = '';
@@ -12228,7 +12230,7 @@ export async function startServer({
             (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
             agentResumeCtx.isResuming &&
             !run.resumeAutoReseeded &&
-            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+            (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
@@ -12408,6 +12410,7 @@ export async function startServer({
         ...(def.resumesSessionViaAcpLoad === true && agentResumeCtx.isResuming && agentResumeCtx.resumeSessionId
           ? { resumeSessionId: agentResumeCtx.resumeSessionId }
           : {}),
+        ...(def.id === 'amr' ? { allowUnadvertisedSessionLoad: true } : {}),
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
         onPromptComplete: () => clearFirstOutputWatchdog(),
@@ -12467,7 +12470,7 @@ export async function startServer({
             agentResumeCtx.isResuming &&
             agentResumeCtx.resumeSessionId &&
             !run.resumeAutoReseeded &&
-            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+            (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
@@ -12615,7 +12618,7 @@ export async function startServer({
         (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
         agentResumeCtx.isResuming &&
         run.conversationId &&
-        isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+        (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
       ) {
         // The resumed upstream session is gone (expired / pruned). Clear the dead
         // handle and TRANSPARENTLY re-run this same turn with a fresh session +

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11367,12 +11367,30 @@ export async function startServer({
 
     let child;
     let acpSession = null;
-    const acpResumeFailed = () =>
+    const acpSessionResumeFailed = () =>
       typeof acpSession?.resumeFailed === 'function' && acpSession.resumeFailed();
     let writePromptToChildStdin = false;
     let spawnedAgentEnv = null;
     let agentStdoutTail = '';
     let agentStderrTail = '';
+    const agentResumeFailed = () => {
+      if (def.resumesSessionViaAcpLoad === true) {
+        // Standard ACP adapters have an authoritative JSON-RPC session/load
+        // result. Do not let generic stderr phrases fall through to the legacy
+        // Claude detector and clear a valid durable session. AMR predates the
+        // negotiated loadSession contract and can still report its established
+        // structured resume_failed marker on the prompt response.
+        return (
+          acpSessionResumeFailed() ||
+          (def.id === 'amr' &&
+            isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
+        );
+      }
+      return (
+        def.resumesSessionViaCli === true &&
+        isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail)
+      );
+    };
     const agentStderrFilter = createAgentStderrVisibilityFilter(agentId);
     const emitVisibleAgentStderr = (chunk: unknown) => {
       const visibleChunk = agentStderrFilter.write(chunk);
@@ -12230,7 +12248,7 @@ export async function startServer({
             (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
             agentResumeCtx.isResuming &&
             !run.resumeAutoReseeded &&
-            (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
+            agentResumeFailed()
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
@@ -12470,7 +12488,7 @@ export async function startServer({
             agentResumeCtx.isResuming &&
             agentResumeCtx.resumeSessionId &&
             !run.resumeAutoReseeded &&
-            (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
+            agentResumeFailed()
           ) {
             design.runs.emit(run, 'diagnostic', {
               type: 'agent_resume_failed_suppressed',
@@ -12618,7 +12636,7 @@ export async function startServer({
         (def.resumesSessionViaCli === true || def.resumesSessionViaAcpLoad === true) &&
         agentResumeCtx.isResuming &&
         run.conversationId &&
-        (acpResumeFailed() || isAgentResumeFailure(def.id, agentStderrTail, agentStdoutTail))
+        agentResumeFailed()
       ) {
         // The resumed upstream session is gone (expired / pruned). Clear the dead
         // handle and TRANSPARENTLY re-run this same turn with a fresh session +

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2958,6 +2958,28 @@ test('attachAcpSession preserves a session for a generic ACP resource-not-found 
   assert.equal(session.hasFatalError(), true);
 });
 
+test('attachAcpSession preserves a session when a missing resource name contains session', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32002,
+    message: 'MCP resource not found: session-template',
+  });
+
+  assert.equal(session.resumeFailed(), false);
+  assert.equal(session.hasFatalError(), true);
+});
+
 test('attachAcpSession preserves a session after a non-missing load error', () => {
   const child = new FakeAcpChild();
   const errors: unknown[] = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2980,6 +2980,52 @@ test('attachAcpSession preserves a session when a missing resource name contains
   assert.equal(session.hasFatalError(), true);
 });
 
+test('attachAcpSession recognizes an ACP missing-resource URI for the requested session', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'dead-session-123',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32002,
+    message: 'Resource not found: dead-session-123',
+    data: { uri: 'dead-session-123' },
+  });
+
+  assert.equal(session.resumeFailed(), true);
+  assert.equal(session.hasFatalError(), true);
+});
+
+test('attachAcpSession preserves the requested session when a different URI is missing', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32002,
+    message: 'Resource not found: dead-session-123',
+    data: { uri: 'dead-session-123' },
+  });
+
+  assert.equal(session.resumeFailed(), false);
+  assert.equal(session.hasFatalError(), true);
+});
+
 test('attachAcpSession preserves a session after a non-missing load error', () => {
   const child = new FakeAcpChild();
   const errors: unknown[] = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2914,6 +2914,28 @@ test('attachAcpSession marks a rejected session/load for transparent reseeding',
   assert.equal(session.hasFatalError(), true);
 });
 
+test('attachAcpSession recognizes the standard ACP missing-session error without data', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32002,
+    message: 'Session not found',
+  });
+
+  assert.equal(session.resumeFailed(), true);
+  assert.equal(session.hasFatalError(), true);
+});
+
 test('attachAcpSession preserves a session after a non-missing load error', () => {
   const child = new FakeAcpChild();
   const errors: unknown[] = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2936,6 +2936,28 @@ test('attachAcpSession recognizes the standard ACP missing-session error without
   assert.equal(session.hasFatalError(), true);
 });
 
+test('attachAcpSession preserves a session for a generic ACP resource-not-found error', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32002,
+    message: 'MCP resource not found',
+  });
+
+  assert.equal(session.resumeFailed(), false);
+  assert.equal(session.hasFatalError(), true);
+});
+
 test('attachAcpSession preserves a session after a non-missing load error', () => {
   const child = new FakeAcpChild();
   const errors: unknown[] = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2816,7 +2816,9 @@ test('attachAcpSession resumes via session/load when resumeSessionId is set', ()
     send: () => {},
   });
 
-  writeAcpResult(child, 1, {}); // initialize ack -> drives the resume handshake
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  }); // initialize ack -> drives the resume handshake
 
   const requests = parseRpcWrites(writes);
   const loadReq = requests.find((entry) => entry.method === 'session/load');
@@ -2826,6 +2828,56 @@ test('attachAcpSession resumes via session/load when resumeSessionId is set', ()
     cwd: path.resolve('/tmp/od-project'),
   });
   assert.equal(requests.some((entry) => entry.method === 'session/new'), false);
+});
+
+test('attachAcpSession rejects resume when loadSession is not advertised so the caller can reseed', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const errors: unknown[] = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: (event, payload) => {
+      if (event === 'error') errors.push(payload);
+    },
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: false },
+  });
+
+  const requests = parseRpcWrites(writes);
+  assert.equal(requests.some((entry) => entry.method === 'session/load'), false);
+  assert.equal(requests.some((entry) => entry.method === 'session/new'), false);
+  assert.equal(session.resumeFailed(), true);
+  assert.equal(session.hasFatalError(), true);
+  assert.equal(errors.length, 1);
+});
+
+test('attachAcpSession marks a rejected session/load for transparent reseeding', () => {
+  const child = new FakeAcpChild();
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: () => {},
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32000,
+    message: 'Session not found',
+  });
+
+  assert.equal(session.resumeFailed(), true);
+  assert.equal(session.hasFatalError(), true);
 });
 
 test('attachAcpSession captures the durable session handle from the result', () => {
@@ -2841,6 +2893,34 @@ test('attachAcpSession captures the durable session handle from the result', () 
   writeAcpResult(child, 2, { sessionId: 'vela-opencode-1', openCodeSessionId: 'oc-handle' });
 
   assert.equal(session.getDurableSessionId(), 'oc-handle');
+});
+
+test('attachAcpSession captures the standard ACP session id only when loadSession is supported', () => {
+  const supportedChild = new FakeAcpChild();
+  const supported = attachAcpSession({
+    child: supportedChild as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    send: () => {},
+  });
+  writeAcpResult(supportedChild, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpResult(supportedChild, 2, { sessionId: 'standard-session' });
+  assert.equal(supported.getDurableSessionId(), 'standard-session');
+
+  const unsupportedChild = new FakeAcpChild();
+  const unsupported = attachAcpSession({
+    child: unsupportedChild as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    send: () => {},
+  });
+  writeAcpResult(unsupportedChild, 1, {
+    agentCapabilities: { loadSession: false },
+  });
+  writeAcpResult(unsupportedChild, 2, { sessionId: 'transient-session' });
+  assert.equal(unsupported.getDurableSessionId(), null);
 });
 
 test('createJsonLineStream replays absorbed complete frames when a value-position aggregate turns invalid', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2803,9 +2803,10 @@ test('attachAcpSession marks OpenCode upstream idle session errors retryable', (
   assert.deepEqual(payload.error?.details, details);
 });
 
-test('attachAcpSession resumes via session/load when resumeSessionId is set', () => {
+test('attachAcpSession loads with MCP servers, suppresses replay, and accepts a null result', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
   child.stdin.on('data', (chunk) => writes.push(String(chunk)));
 
   attachAcpSession({
@@ -2813,7 +2814,15 @@ test('attachAcpSession resumes via session/load when resumeSessionId is set', ()
     prompt: 'hello',
     cwd: '/tmp/od-project',
     resumeSessionId: 'oc-prev',
-    send: () => {},
+    mcpServers: [
+      {
+        type: 'stdio',
+        name: 'open-design-live-artifacts',
+        command: 'od',
+        args: ['mcp', 'live-artifacts'],
+      },
+    ],
+    send: (event, payload) => events.push({ event, payload }),
   });
 
   writeAcpResult(child, 1, {
@@ -2826,8 +2835,32 @@ test('attachAcpSession resumes via session/load when resumeSessionId is set', ()
   assert.deepEqual(loadReq?.params, {
     sessionId: 'oc-prev',
     cwd: path.resolve('/tmp/od-project'),
+    mcpServers: [
+      {
+        type: 'stdio',
+        name: 'open-design-live-artifacts',
+        command: 'od',
+        args: ['mcp', 'live-artifacts'],
+        env: [],
+      },
+    ],
   });
   assert.equal(requests.some((entry) => entry.method === 'session/new'), false);
+
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'historical replay' },
+  });
+  assert.equal(events.some((entry) => entry.event === 'agent'), false);
+  assert.equal(parseRpcWrites(writes).some((entry) => entry.method === 'session/prompt'), false);
+
+  writeAcpResult(child, 2, null);
+  const promptReq = parseRpcWrites(writes).find((entry) => entry.method === 'session/prompt');
+  assert.ok(promptReq, 'expected session/prompt after the load response');
+  assert.deepEqual(promptReq.params, {
+    sessionId: 'oc-prev',
+    prompt: [{ type: 'text', text: 'hello' }],
+  });
 });
 
 test('attachAcpSession rejects resume when loadSession is not advertised so the caller can reseed', () => {
@@ -2873,11 +2906,39 @@ test('attachAcpSession marks a rejected session/load for transparent reseeding',
   });
   writeAcpError(child, 2, {
     code: -32000,
-    message: 'Session not found',
+    message: 'The resumed session could not be loaded',
+    data: { kind: 'session_not_found', phase: 'session_load', retryable: true },
   });
 
   assert.equal(session.resumeFailed(), true);
   assert.equal(session.hasFatalError(), true);
+});
+
+test('attachAcpSession preserves a session after a non-missing load error', () => {
+  const child = new FakeAcpChild();
+  const errors: unknown[] = [];
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    resumeSessionId: 'stored-session',
+    send: (event, payload) => {
+      if (event === 'error') errors.push(payload);
+    },
+  });
+
+  writeAcpResult(child, 1, {
+    agentCapabilities: { loadSession: true },
+  });
+  writeAcpError(child, 2, {
+    code: -32000,
+    message: 'MCP server failed to reconnect',
+    data: { kind: 'mcp_connection_failed', retryable: true },
+  });
+
+  assert.equal(session.resumeFailed(), false);
+  assert.equal(session.hasFatalError(), true);
+  assert.equal(errors.length, 1);
 });
 
 test('attachAcpSession captures the durable session handle from the result', () => {

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -720,6 +720,7 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
         model: 'deepseek-v3.2',
         // A stored durable handle drives session/load instead of session/new.
         resumeSessionId: 'oc-prev-handle',
+        allowUnadvertisedSessionLoad: true,
         mcpServers: [],
         send: () => {},
       });
@@ -744,6 +745,7 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
         cwd: process.cwd(),
         model: 'deepseek-v3.2',
         resumeSessionId: 'oc-gone',
+        allowUnadvertisedSessionLoad: true,
         mcpServers: [],
         send: (event, payload) => events.push({ event, payload }),
       });

--- a/apps/daemon/tests/fixtures/fake-standard-acp.ts
+++ b/apps/daemon/tests/fixtures/fake-standard-acp.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Minimal standard ACP executable for session/load integration tests.
+ *
+ * This stays TypeScript-first even though the daemon launches it as a CLI: the
+ * test wrapper runs it with Node 24's type stripping. Its first session/load
+ * can emit a non-session JSON-RPC failure plus deliberately misleading stderr,
+ * allowing the full daemon close path to prove it trusts the ACP protocol over
+ * generic CLI text.
+ */
+import { appendFileSync, readFileSync } from 'node:fs';
+import { argv, env, exit, stdin, stderr, stdout } from 'node:process';
+
+type JsonObject = Record<string, unknown>;
+
+const SESSION_ID = 'standard-acp-session-1';
+const invocationLog = env.FAKE_STANDARD_ACP_INVOCATION_LOG ?? '';
+let modelDetectionProbe = false;
+
+function asObject(value: unknown): JsonObject | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : null;
+}
+
+function writeMessage(value: JsonObject): void {
+  stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function writeResult(id: unknown, result: JsonObject): void {
+  writeMessage({ jsonrpc: '2.0', id, result });
+}
+
+function logInvocation(method: 'new' | 'load'): void {
+  if (!invocationLog) return;
+  appendFileSync(invocationLog, `${JSON.stringify({ method })}\n`);
+}
+
+function priorLoadCount(): number {
+  if (!invocationLog) return 0;
+  try {
+    return readFileSync(invocationLog, 'utf8')
+      .split('\n')
+      .filter((line) => line.includes('"method":"load"'))
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+function handleRequest(value: unknown): void {
+  const request = asObject(value);
+  if (!request || typeof request.method !== 'string') return;
+  const params = asObject(request.params);
+
+  switch (request.method) {
+    case 'initialize':
+      modelDetectionProbe =
+        asObject(params?.clientInfo)?.name === 'open-design-detect';
+      writeResult(request.id, {
+        protocolVersion: 1,
+        agentCapabilities: { loadSession: true },
+      });
+      return;
+    case 'session/new':
+      // Runtime model discovery also opens a disposable ACP session. It is not
+      // part of the conversation resume path under test, so keep it out of the
+      // causal invocation trace.
+      if (!modelDetectionProbe) logInvocation('new');
+      writeResult(request.id, { sessionId: SESSION_ID });
+      return;
+    case 'session/load': {
+      const loadsBeforeThisRequest = priorLoadCount();
+      logInvocation('load');
+      if (
+        env.FAKE_STANDARD_ACP_FAIL_FIRST_LOAD === '1'
+        && loadsBeforeThisRequest === 0
+      ) {
+        // This phrase matches the legacy Claude detector, but the authoritative
+        // ACP response says the failure belongs to MCP setup, not session
+        // identity. The daemon must preserve the stored session handle.
+        stderr.write('No session found while reconnecting an MCP helper\n');
+        writeMessage({
+          jsonrpc: '2.0',
+          id: request.id,
+          error: {
+            code: -32000,
+            message: 'MCP server failed to reconnect',
+            data: { kind: 'mcp_connection_failed', retryable: true },
+          },
+        });
+        return;
+      }
+      const requestedSessionId =
+        typeof params?.sessionId === 'string' ? params.sessionId : SESSION_ID;
+      writeResult(request.id, { sessionId: requestedSessionId });
+      return;
+    }
+    case 'session/prompt': {
+      const sessionId =
+        typeof params?.sessionId === 'string' ? params.sessionId : SESSION_ID;
+      writeMessage({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Hello from standard ACP.' },
+          },
+        },
+      });
+      writeResult(request.id, {
+        stopReason: 'end_turn',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+      return;
+    }
+    case 'session/cancel':
+      return;
+    default:
+      writeMessage({
+        jsonrpc: '2.0',
+        id: request.id,
+        error: { code: -32601, message: `unknown method: ${request.method}` },
+      });
+  }
+}
+
+if (argv.includes('--version')) {
+  stdout.write('fake-standard-acp 1.0.0\n');
+  exit(0);
+}
+
+let buffer = '';
+stdin.setEncoding('utf8');
+stdin.on('data', (chunk: string) => {
+  buffer += chunk;
+  const lines = buffer.split('\n');
+  buffer = lines.pop() ?? '';
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    try {
+      handleRequest(JSON.parse(line));
+    } catch (error) {
+      stderr.write(`invalid JSON: ${error instanceof Error ? error.message : String(error)}\n`);
+    }
+  }
+});
+
+stdin.on('end', () => {
+  stdout.end();
+  exit(0);
+});

--- a/apps/daemon/tests/fixtures/fake-standard-acp.ts
+++ b/apps/daemon/tests/fixtures/fake-standard-acp.ts
@@ -43,8 +43,16 @@ function priorLoadCount(): number {
       .split('\n')
       .filter((line) => line.includes('"method":"load"'))
       .length;
-  } catch {
-    return 0;
+  } catch (error) {
+    if (
+      error !== null
+      && typeof error === 'object'
+      && 'code' in error
+      && error.code === 'ENOENT'
+    ) {
+      return 0;
+    }
+    throw error;
   }
 }
 

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -778,6 +778,18 @@ test('kimi args leave model selection to the ACP session', () => {
   assert.deepEqual(args, ['acp']);
 });
 
+test('all ACP runtime definitions opt into negotiated session/load reuse', () => {
+  const acpDefs = AGENT_DEFS.filter((def) => def.streamFormat === 'acp-json-rpc');
+  assert.ok(acpDefs.length > 1, 'expected multiple ACP adapters');
+  for (const def of acpDefs) {
+    assert.equal(
+      def.resumesSessionViaAcpLoad,
+      true,
+      `${def.id} must reuse sessions when the ACP agent advertises loadSession`,
+    );
+  }
+});
+
 test('kilo fetchModels falls back to fallbackModels when detection fails', async () => {
   assert.ok(kilo.fetchModels, 'kilo must define fetchModels');
   const result = await kilo.fetchModels('/nonexistent/kilo', {}).catch(() => null);

--- a/apps/daemon/tests/standard-acp-session-resume.test.ts
+++ b/apps/daemon/tests/standard-acp-session-resume.test.ts
@@ -1,0 +1,222 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+};
+
+type RunIdentity = {
+  projectId: string;
+  conversationId: string;
+  workspaceId: string;
+  workspaceMemberId: string;
+};
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FAKE_STANDARD_ACP = path.join(HERE, 'fixtures', 'fake-standard-acp.ts');
+
+describe('standard ACP session resume — full server cycle', () => {
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+  });
+
+  it('retains the stored session when non-stale ACP load failure stderr resembles a Claude resume miss', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-standard-acp-resume-'));
+    const invocationLog = path.join(binDir, 'invocations.jsonl');
+    const bin = await writeAgentWrapper(binDir, invocationLog);
+
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, bin);
+    const identity = await createConversation(started.url);
+
+    const first = await sendRunAndWait(started.url, identity, 'first request');
+    expect(first.status).toBe('succeeded');
+
+    // The structured load error is MCP-specific and therefore does not
+    // authorize clearing the session. The generic stderr phrase deliberately
+    // resembles Claude's missing-session output and must not override ACP.
+    const second = await sendRunAndWait(started.url, identity, 'second request');
+    expect(second.status).toBe('succeeded');
+
+    // The retry proves the durable handle survived the failed load: it retries
+    // session/load and succeeds. Incorrect stale-session classification clears
+    // the handle and produces new -> load -> new instead.
+    expect(await readInvocations(invocationLog)).toEqual(['new', 'load', 'load']);
+  });
+});
+
+async function writeAgentWrapper(dir: string, invocationLog: string): Promise<string> {
+  const bin = path.join(dir, 'hermes');
+  const lines = [
+    '#!/bin/sh',
+    `export FAKE_STANDARD_ACP_INVOCATION_LOG=${JSON.stringify(invocationLog)}`,
+    'export FAKE_STANDARD_ACP_FAIL_FIRST_LOAD=1',
+    `exec ${JSON.stringify(process.execPath)} --experimental-strip-types ${JSON.stringify(FAKE_STANDARD_ACP)} "$@"`,
+    '',
+  ];
+  await writeFile(bin, lines.join('\n'), 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function readInvocations(logPath: string): Promise<string[]> {
+  const raw = await readFile(logPath, 'utf8');
+  const methods: string[] = [];
+  for (const line of raw.trim().split('\n').filter(Boolean)) {
+    const value: unknown = JSON.parse(line);
+    if (
+      value !== null
+      && typeof value === 'object'
+      && 'method' in value
+      && typeof value.method === 'string'
+    ) {
+      methods.push(value.method);
+    }
+  }
+  return methods;
+}
+
+async function putConfig(url: string, hermesBin: string): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      agentId: 'hermes',
+      agentCliEnv: { hermes: { HERMES_BIN: hermesBin } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    }),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createConversation(url: string): Promise<RunIdentity> {
+  const projectId = `standard_acp_resume_${randomUUID()}`;
+  const workspaceId = `standard_acp_workspace_${projectId}`;
+  const workspaceMemberId = `standard_acp_owner_${projectId}`;
+  const response = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-workspace-id': workspaceId,
+      'x-od-workspace-type': 'personal',
+      'x-od-workspace-member-id': workspaceMemberId,
+      'x-od-workspace-role': 'owner',
+    },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Standard ACP resume smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(response.status).toBe(200);
+  const value: unknown = await response.json();
+  if (
+    value === null
+    || typeof value !== 'object'
+    || !('conversationId' in value)
+    || typeof value.conversationId !== 'string'
+  ) {
+    throw new Error('project response did not include conversationId');
+  }
+  return { projectId, conversationId: value.conversationId, workspaceId, workspaceMemberId };
+}
+
+async function sendRunAndWait(
+  url: string,
+  identity: RunIdentity,
+  message: string,
+): Promise<RunStatus> {
+  const headers = {
+    'content-type': 'application/json',
+    'x-od-analytics-device-id': 'standard-acp-resume-test',
+    'x-od-analytics-session-id': 'standard-acp-resume-session',
+    'x-od-analytics-client-type': 'web',
+    'x-od-workspace-id': identity.workspaceId,
+    'x-od-workspace-type': 'personal',
+    'x-od-workspace-member-id': identity.workspaceMemberId,
+    'x-od-workspace-role': 'owner',
+  };
+  const response = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      projectId: identity.projectId,
+      conversationId: identity.conversationId,
+      assistantMessageId: `assistant_standard_acp_${randomUUID()}`,
+      clientRequestId: `client_standard_acp_${randomUUID()}`,
+      agentId: 'hermes',
+      message,
+      currentPrompt: message,
+    }),
+  });
+  const value: unknown = await response.json();
+  expect(response.status, JSON.stringify(value)).toBe(202);
+  if (
+    value === null
+    || typeof value !== 'object'
+    || !('runId' in value)
+    || typeof value.runId !== 'string'
+  ) {
+    throw new Error('run response did not include runId');
+  }
+  return await waitForRun(url, value.runId, headers);
+}
+
+async function waitForRun(
+  url: string,
+  runId: string,
+  headers: Record<string, string>,
+): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 15_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`, { headers });
+    expect(response.status).toBe(200);
+    const value: unknown = await response.json();
+    if (
+      value !== null
+      && typeof value === 'object'
+      && 'id' in value
+      && typeof value.id === 'string'
+      && 'status' in value
+      && typeof value.status === 'string'
+    ) {
+      if (value.status === 'failed' || value.status === 'succeeded' || value.status === 'canceled') {
+        return {
+          id: value.id,
+          status: value.status,
+          error: 'error' in value && typeof value.error === 'string' ? value.error : null,
+          errorCode: 'errorCode' in value && typeof value.errorCode === 'string' ? value.errorCode : null,
+        };
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${runId} did not finish`);
+}


### PR DESCRIPTION
Fixes #730

## Why

I picked this up from the issue's agreed Phase 1 scope: keep a fresh ACP child process per turn, but reuse the upstream agent session through the standard ACP `session/load` capability. Before this change, Open Design always created a new ACP session, resent the full transcript, and discarded the session id when the child exited. That made follow-up turns slower and prevented ACP agents from retaining their native conversational state.

The daemon already had conversation-scoped session persistence and transparent stale-session reseeding for AMR/vela. This PR closes the remaining gap by making that lifecycle available to every ACP runtime through capability negotiation, while retaining AMR's older unadvertised extension as an explicit compatibility path.

## What users will see

Follow-up turns with Devin, Hermes, Kilo, Kimi, Kiro, Reasonix, Trae CLI, and Vibe reuse the agent's prior ACP session when that agent advertises `loadSession`. The process remains fresh for every turn, but the upstream agent keeps its conversation state and Open Design sends only the incremental turn context.

If an agent stops advertising load support or rejects a stored session, Open Design silently clears the stale handle, starts a fresh session, and re-injects the complete transcript in the same user turn. Switching model, project/cwd, agent, or conversation continues to invalidate reuse through the existing identity guard.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — ACP follow-up turns now reuse negotiated upstream sessions
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes the daemon's ACP session lifecycle and adds no UI.

## Bug fix verification

- Red specs: `apps/daemon/tests/acp.test.ts` and `apps/daemon/tests/runtimes/agent-args.test.ts`.
- The new assertions went red before the source changes: standard ACP session ids were not captured, capability-aware resume fallback did not exist, and non-AMR ACP runtime definitions did not opt into session reuse.
- The same specs are green on this branch, including rejected-load and no-longer-advertised capability paths.

## Validation

- `pnpm guard`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/daemon exec vitest run tests/acp.test.ts tests/amr-acp-integration.test.ts tests/runtimes/agent-args.test.ts tests/amr-session-resume.test.ts tests/native-session-recovery.test.ts` — 180 passed
- Full daemon suite was also attempted. Its ACP compatibility failure was fixed and is included in the 180-test focused pass above; the remaining observed failures were unrelated existing suites (`brand-routes`, `collab-sync-routes`, workspace-gate/bootstrap/owner-conflict tests), so the long-running full invocation was stopped after those failures were recorded.
