### PR TITLE
fix(daemon): avoid false Antigravity auth errors

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -46,6 +46,7 @@ import {
   antigravityQuotaGuidance,
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
+  classifySilentAntigravityFailure,
   cursorAuthGuidance,
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
@@ -2638,40 +2639,33 @@ async function testAgentConnectionInternal(
           });
         }
       }
-      // Antigravity print-mode empty-output guard. agy exits cleanly
-      // (code 0) with no assistant text for BOTH missing-auth and
-      // quota-exhausted failures, so without this the connection test
-      // collapses every such failure into a useless `unknown` / "Test
-      // failed: exit 0" (#4281). Mirror the chat-run guard in
-      // server.ts: fold agy's `--log-file` tail into the classifier
-      // input and route to the specific auth / quota result so Settings
-      // can show actionable re-authentication or quota guidance. Only
-      // runs when agy produced no visible text — a healthy `ok` reply
-      // returns above before reaching here.
+      // Antigravity print-mode empty-output guard. Use direct stdout/stderr for
+      // auth, while allowing the diagnostic log to contribute quota/upstream
+      // signals. agy's background polling writes auth-looking noise even for
+      // authenticated sessions, so log-only text cannot prove missing auth
+      // (#4121). A healthy visible reply returns above before reaching here.
       if (input.agentId === 'antigravity' && !visibleText) {
-        let combinedDetail = `${stderrTail}\n${rawStdoutTail}`;
+        const directDetail = `${stderrTail}\n${rawStdoutTail}`;
+        let diagnosticDetail = directDetail;
         if (antigravityLogFilePath) {
           try {
             const logContent = await fsp.readFile(antigravityLogFilePath, 'utf8');
-            // Keep the last 8 KB — quota / auth lines land near the tail,
-            // after the spawn / model-config preamble.
-            combinedDetail = `${combinedDetail}\n${logContent.slice(-8192)}`;
+            // Keep the last 8 KB — quota / upstream lines land near the tail,
+            // after the spawn / model-config preamble. Auth remains direct-only.
+            diagnosticDetail = `${diagnosticDetail}\n${logContent.slice(-8192)}`;
           } catch {
             // Missing log file (agy never wrote it, read-only tmp, etc.)
-            // is fine — fall through to the clean-exit auth fallback below.
+            // is fine — fall through to the generic exit detail below.
           }
         }
-        const antigravityAuth = classifyAgentAuthFailure('antigravity', combinedDetail);
-        const serviceFailure = classifyAgentServiceFailure(combinedDetail);
-        // Empirically a silent agy print-mode exit almost always means
-        // missing OAuth; quota is the only other silent path and it is
-        // caught by the log-file grep above. Apply the auth fallback only
-        // on a clean exit so a genuine crash still reports as a spawn
-        // failure with its exit code.
+        const { authFailure: antigravityAuth, serviceFailure } =
+          classifySilentAntigravityFailure({
+            directText: directDetail,
+            diagnosticText: diagnosticDetail,
+          });
         const isAuth =
           antigravityAuth?.status === 'missing' ||
-          serviceFailure === 'AGENT_AUTH_REQUIRED' ||
-          (!antigravityAuth && !serviceFailure && exitedCleanly);
+          serviceFailure === 'AGENT_AUTH_REQUIRED';
         if (isAuth) {
           console.warn(
             `[test:agent] ${def.name} → auth_required (silent exit ${winner.code ?? 'null'})`,

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -266,6 +266,34 @@ export function classifyAgentServiceFailure(
   return null;
 }
 
+/**
+ * Classifies a silent Antigravity run without allowing background diagnostic
+ * polling to establish authentication state. `directText` is child
+ * stdout/stderr; `diagnosticText` may additionally contain agy's default or
+ * per-run log tail. Quota and upstream signals remain useful from either
+ * source, while auth requires evidence on the run's own process channels.
+ */
+export function classifySilentAntigravityFailure(input: {
+  directText: string;
+  diagnosticText?: string;
+}): {
+  authFailure: AgentAuthProbeResult | null;
+  serviceFailure: AgentServiceFailureCode | null;
+} {
+  const directText = String(input.directText || '');
+  const diagnosticText = String(input.diagnosticText ?? directText);
+  const authFailure = classifyAgentAuthFailure('antigravity', directText);
+  const directServiceFailure = classifyAgentServiceFailure(directText);
+  const diagnosticServiceFailure = classifyAgentServiceFailure(diagnosticText);
+  return {
+    authFailure,
+    serviceFailure:
+      diagnosticServiceFailure === 'AGENT_AUTH_REQUIRED'
+        ? directServiceFailure
+        : diagnosticServiceFailure,
+  };
+}
+
 // Tail length matches the smoke-test sink so the diagnostics block
 // stays compact when it folds probe output back into its overrides.
 const PROBE_TAIL_BYTES = 400;

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -214,6 +214,10 @@ export type AgentServiceFailureCode =
   | 'AGENT_AUTH_REQUIRED'
   | 'RATE_LIMITED'
   | 'UPSTREAM_UNAVAILABLE';
+type AgentNonAuthServiceFailureCode = Exclude<
+  AgentServiceFailureCode,
+  'AGENT_AUTH_REQUIRED'
+>;
 
 // A bare HTTP status number (`500`, `429`, …) is too noisy to trust on its own
 // — agent stderr is full of unrelated numbers (`line 500`, `read 502 bytes`,
@@ -250,6 +254,16 @@ const AGENT_UPSTREAM_FAILURE_RE = new RegExp(
   'i',
 );
 
+function classifyAgentNonAuthServiceFailure(
+  text: string,
+): AgentNonAuthServiceFailureCode | null {
+  const value = String(text || '');
+  if (!value.trim()) return null;
+  if (AGENT_RATE_FAILURE_RE.test(value)) return 'RATE_LIMITED';
+  if (AGENT_UPSTREAM_FAILURE_RE.test(value)) return 'UPSTREAM_UNAVAILABLE';
+  return null;
+}
+
 // Returns the model-service failure class implied by an agent's combined
 // stdout/stderr/error text, or null when the text looks like an ordinary
 // process failure. Auth is checked before rate/upstream so a `401` is never
@@ -261,9 +275,7 @@ export function classifyAgentServiceFailure(
   const value = String(text || '');
   if (!value.trim()) return null;
   if (AGENT_AUTH_FAILURE_RE.test(value)) return 'AGENT_AUTH_REQUIRED';
-  if (AGENT_RATE_FAILURE_RE.test(value)) return 'RATE_LIMITED';
-  if (AGENT_UPSTREAM_FAILURE_RE.test(value)) return 'UPSTREAM_UNAVAILABLE';
-  return null;
+  return classifyAgentNonAuthServiceFailure(value);
 }
 
 /**
@@ -284,13 +296,11 @@ export function classifySilentAntigravityFailure(input: {
   const diagnosticText = String(input.diagnosticText ?? directText);
   const authFailure = classifyAgentAuthFailure('antigravity', directText);
   const directServiceFailure = classifyAgentServiceFailure(directText);
-  const diagnosticServiceFailure = classifyAgentServiceFailure(diagnosticText);
+  const diagnosticNonAuthServiceFailure =
+    classifyAgentNonAuthServiceFailure(diagnosticText);
   return {
     authFailure,
-    serviceFailure:
-      diagnosticServiceFailure === 'AGENT_AUTH_REQUIRED'
-        ? directServiceFailure
-        : diagnosticServiceFailure,
+    serviceFailure: directServiceFailure ?? diagnosticNonAuthServiceFailure,
   };
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12804,7 +12804,7 @@ export async function startServer({
           ? authFailure.message ?? `${def.name} authentication expired. Please re-authenticate and retry.`
           : isAntigravityQuota
             ? antigravityQuotaGuidance()
-            : `${def.name} returned an empty response. Check the agent logs for an upstream, quota, or permission error, then retry.`;
+            : `${def.name} returned an empty response. Check the agent logs for details, then retry.`;
         send('error', createSseErrorPayload(
           errorCode,
           msg,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -432,10 +432,10 @@ import { narrowProjectCritiqueOverride } from './critique/spawn-inputs.js';
 import { createCopilotStreamHandler } from './copilot-stream.js';
 import { createJsonEventStreamHandler } from './runtimes/json-event-stream.js';
 import {
-  antigravityAuthGuidance,
   antigravityQuotaGuidance,
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
+  classifySilentAntigravityFailure,
   cursorAuthGuidance,
 } from './runtimes/auth.js';
 import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
@@ -12756,14 +12756,11 @@ export async function startServer({
         }
       }
       // Plain-stream empty-output guard: plain agents send raw stdout
-      // chunks without structured event tracking. Detect auth failures
-      // and quota / upstream errors when exit 0 but no stdout was
-      // seen. agy in print mode is silent on stdout/stderr for both
-      // missing-auth AND quota-exhausted failures; the daemon piped
-      // agy's `--log-file` to `agentLogFilePath` precisely so this
-      // guard can grep the upstream error code (RESOURCE_EXHAUSTED 429
-      // for quota, "not logged into Antigravity" for auth) and route
-      // to the right user-facing guidance.
+      // chunks without structured event tracking. Detect direct auth evidence
+      // plus quota/upstream failures when exit 0 but no stdout was seen. agy's
+      // default log is diagnostic-only: background polling can write "not
+      // logged into Antigravity" during an otherwise authenticated session, so
+      // log-only text must never establish the run's auth state (#4121).
       if (
         code === 0 &&
         !run.cancelRequested &&
@@ -12771,34 +12768,34 @@ export async function startServer({
         !childStdoutSeen
       ) {
         markRpcCloseReason('empty_output');
-        let combinedDetail = `${agentStderrTail}\n${agentStdoutTail}`;
+        const directDetail = `${agentStderrTail}\n${agentStdoutTail}`;
+        let diagnosticDetail = directDetail;
         if (def.id === 'antigravity' && agentLogFilePath) {
           try {
             const logContent = await fs.promises.readFile(agentLogFilePath, 'utf8');
-            // Keep the last 8 KB — quota / auth lines all land near the
-            // tail (after the spawn / model-config preamble).
-            combinedDetail = `${combinedDetail}\n${logContent.slice(-8192)}`;
+            // Keep the last 8 KB — quota / upstream lines land near the tail
+            // (after the spawn / model-config preamble). Auth remains direct-only.
+            diagnosticDetail = `${diagnosticDetail}\n${logContent.slice(-8192)}`;
           } catch {
             // Missing log file (agy didn't write it, mounted tmpfs is
             // read-only, etc.) is fine — fall through to the generic
             // empty-output message.
           }
         }
-        const authFailure = classifyAgentAuthFailure(agentId, combinedDetail);
-        const serviceFailure = !authFailure
-          ? classifyAgentServiceFailure(combinedDetail)
-          : null;
+        const { authFailure, serviceFailure } =
+          def.id === 'antigravity'
+            ? classifySilentAntigravityFailure({
+                directText: directDetail,
+                diagnosticText: diagnosticDetail,
+              })
+            : {
+                authFailure: classifyAgentAuthFailure(agentId, directDetail),
+                serviceFailure: classifyAgentServiceFailure(diagnosticDetail),
+              };
         const isAntigravityQuota =
           def.id === 'antigravity' && serviceFailure === 'RATE_LIMITED';
-        // Antigravity-only fallback: if neither classifier matched but
-        // the run was silent, lean on the empirical observation that
-        // an empty agy print-mode exit almost always means
-        // missing-OAuth (the only other silent path is quota, which
-        // the log-file check above already caught).
-        const useAntigravityAuthFallback =
-          !authFailure && !serviceFailure && def.id === 'antigravity';
         const errorCode =
-          authFailure || useAntigravityAuthFallback
+          authFailure || serviceFailure === 'AGENT_AUTH_REQUIRED'
             ? 'AGENT_AUTH_REQUIRED'
             : isAntigravityQuota
               ? 'RATE_LIMITED'
@@ -12807,9 +12804,7 @@ export async function startServer({
           ? authFailure.message ?? `${def.name} authentication expired. Please re-authenticate and retry.`
           : isAntigravityQuota
             ? antigravityQuotaGuidance()
-            : useAntigravityAuthFallback
-              ? antigravityAuthGuidance()
-              : `${def.name} returned an empty response. This may indicate an expired session — try re-authenticating the agent.`;
+            : `${def.name} returned an empty response. Check the agent logs for an upstream, quota, or permission error, then retry.`;
         send('error', createSseErrorPayload(
           errorCode,
           msg,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2588,7 +2588,7 @@ process.exit(0);
         const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
           signal: eventsController.signal,
         });
-        const eventsBody = await readSseUntil(eventsResponse, 'returned an empty response');
+        const eventsBody = await readSseUntil(eventsResponse, 'event: end');
         eventsController.abort();
         const statusBody = await waitForRunStatus(baseUrl, runId);
 
@@ -2596,6 +2596,13 @@ process.exit(0);
         expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
         expect(eventsBody).not.toContain('AGENT_AUTH_REQUIRED');
         expect(eventsBody).not.toContain('needs to sign in');
+        expect(eventsBody).toContain('event: run_retry_finished');
+        expect(eventsBody).toContain('"failure_category":"empty_output"');
+        expect(eventsBody).toContain('"failure_detail":"empty_output"');
+        expect(eventsBody).not.toContain('"retry_suppressed_reason":"hard_quota"');
+        expect(eventsBody).toContain('event: end');
+        expect(eventsBody).toContain('"failureCategory":"empty_output"');
+        expect(eventsBody).toContain('"failureDetail":"empty_output"');
         expect(statusBody.status).toBe('failed');
       },
     );

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2601,6 +2601,56 @@ process.exit(0);
     );
   });
 
+  it('preserves Antigravity quota errors mixed with background auth noise', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+const logIndex = args.indexOf('--log-file');
+if (logIndex !== -1) {
+  fs.writeFileSync(
+    args[logIndex + 1],
+    [
+      'Authentication required while polling ListExperiments',
+      'upstream error: code = 429 RESOURCE_EXHAUSTED: Individual quota reached',
+    ].join('\\n'),
+  );
+}
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'RATE_LIMITED');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('RATE_LIMITED');
+        expect(eventsBody).not.toContain('AGENT_AUTH_REQUIRED');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('parses successful Antigravity Gemini JSONL output instead of forwarding raw stdout', async () => {
     await withFakeAgent(
       'agy',

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -2553,6 +2553,54 @@ process.exit(0);
     );
   });
 
+  it('does not classify Antigravity background-poll log noise as missing auth', async () => {
+    await withFakeAgent(
+      'agy',
+      `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.107.0-test');
+  process.exit(0);
+}
+const logIndex = args.indexOf('--log-file');
+if (logIndex !== -1) {
+  fs.writeFileSync(
+    args[logIndex + 1],
+    'Failed to poll ListExperiments: error getting token source: You are not logged into Antigravity',
+  );
+}
+process.exit(0);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'antigravity',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'returned an empty response');
+        eventsController.abort();
+        const statusBody = await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('event: error');
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).not.toContain('AGENT_AUTH_REQUIRED');
+        expect(eventsBody).not.toContain('needs to sign in');
+        expect(statusBody.status).toBe('failed');
+      },
+    );
+  });
+
   it('parses successful Antigravity Gemini JSONL output instead of forwarding raw stdout', async () => {
     await withFakeAgent(
       'agy',

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3951,7 +3951,7 @@ console.log(JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: {
   // The fake agy writes the caller-supplied log body to whatever
   // `--log-file` path the daemon passes, then exits 0 with no stdout —
   // exactly the not-logged-in / quota shape captured from the real CLI.
-  const fakeAgyScript = (logBody: string) => `
+  const fakeAgyScript = (logBody: string, stderrBody = '') => `
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 if (args[0] === '--version') {
@@ -3968,19 +3968,19 @@ process.stdin.on('end', () => {
   if (logPath && body) {
     try { fs.writeFileSync(logPath, body); } catch {}
   }
+  const stderr = ${JSON.stringify(stderrBody)};
+  if (stderr) process.stderr.write(stderr);
   // Silent clean exit — no assistant text on stdout, matching agy's
   // real print-mode behavior when it cannot establish a connection.
   process.exit(0);
 });
 `;
 
-  it('surfaces antigravity missing-auth as agent_auth_required instead of "exit 0" (#4281)', async () => {
+  it('surfaces direct antigravity missing-auth evidence despite noisy background polling logs', async () => {
     await withFakeAntigravity(
       fakeAgyScript(
-        [
-          'Propagating selected model override to backend: label="Gemini 3.1 Pro (High)"',
-          'error getting token source: You are not logged into Antigravity',
-        ].join('\n'),
+        'Failed to poll ListExperiments: error getting token source: You are not logged into Antigravity',
+        'Authentication required. Please visit the URL to log in: https://accounts.google.com/o/oauth2/auth?client_id=test&redirect_uri=antigravity\n',
       ),
       async () => {
         const result = await testAgentConnection({ agentId: 'antigravity' });
@@ -3990,6 +3990,20 @@ process.stdin.on('end', () => {
         // The old bug surfaced the bare process-exit line as the detail.
         expect(result.detail).not.toBe('exit 0');
         expect(result.detail).toContain('sign in');
+      },
+    );
+  });
+
+  it('does not treat antigravity background-poll auth noise as session auth failure', async () => {
+    await withFakeAntigravity(
+      fakeAgyScript(
+        'Failed to poll ListExperiments: error getting token source: You are not logged into Antigravity',
+      ),
+      async () => {
+        const result = await testAgentConnection({ agentId: 'antigravity' });
+        expect(result.ok).toBe(false);
+        expect(result.kind).toBe('unknown');
+        expect(result.detail).not.toContain('sign in');
       },
     );
   });
@@ -4011,14 +4025,12 @@ process.stdin.on('end', () => {
     );
   });
 
-  it('falls back to agent_auth_required when antigravity exits silently with no log signal (#4281)', async () => {
+  it('reports an unknown failure when antigravity exits silently with no auth evidence', async () => {
     await withFakeAntigravity(fakeAgyScript(''), async () => {
       const result = await testAgentConnection({ agentId: 'antigravity' });
       expect(result.ok).toBe(false);
-      // A silent clean exit almost always means missing OAuth; it must
-      // never regress back to the opaque `unknown` / "exit 0" result.
-      expect(result.kind).toBe('agent_auth_required');
-      expect(result.kind).not.toBe('unknown');
+      expect(result.kind).toBe('unknown');
+      expect(result.detail).not.toContain('sign in');
     });
   });
 

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -4012,6 +4012,7 @@ process.stdin.on('end', () => {
     await withFakeAntigravity(
       fakeAgyScript(
         [
+          'Authentication required while polling ListExperiments',
           'Propagating selected model override to backend: label="Gemini 3.1 Pro (High)"',
           'upstream error: code = 429 RESOURCE_EXHAUSTED: Individual quota reached',
         ].join('\n'),

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1253,6 +1253,8 @@ test('antigravity auth matcher covers agy print-mode + log-file auth signals', a
   // current run lacks credentials.
   const pollNoise =
     'Failed to poll ListExperiments: error getting token source: You are not logged into Antigravity';
+  const classifiedPollAuthNoise =
+    `${pollNoise}\nAuthentication required while polling ListExperiments`;
   assert.deepEqual(
     classifySilentAntigravityFailure({ directText: '', diagnosticText: pollNoise }),
     { authFailure: null, serviceFailure: null },
@@ -1260,10 +1262,23 @@ test('antigravity auth matcher covers agy print-mode + log-file auth signals', a
   assert.equal(
     classifySilentAntigravityFailure({
       directText: '',
-      diagnosticText: `${pollNoise}\nRESOURCE_EXHAUSTED: Individual quota reached`,
+      diagnosticText: `${classifiedPollAuthNoise}\nRESOURCE_EXHAUSTED: Individual quota reached`,
     }).serviceFailure,
     'RATE_LIMITED',
   );
+  assert.equal(
+    classifySilentAntigravityFailure({
+      directText: '',
+      diagnosticText: `${classifiedPollAuthNoise}\n503 Service temporarily unavailable`,
+    }).serviceFailure,
+    'UPSTREAM_UNAVAILABLE',
+  );
+  const directAuthWithDiagnosticQuota = classifySilentAntigravityFailure({
+    directText: 'Authentication required. Please visit the URL to log in: https://example',
+    diagnosticText: `${classifiedPollAuthNoise}\nRESOURCE_EXHAUSTED: Individual quota reached`,
+  });
+  assert.equal(directAuthWithDiagnosticQuota.authFailure?.status, 'missing');
+  assert.equal(directAuthWithDiagnosticQuota.serviceFailure, 'AGENT_AUTH_REQUIRED');
   assert.equal(
     classifySilentAntigravityFailure({
       directText: 'Authentication required. Please visit the URL to log in: https://example',

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -1188,7 +1188,12 @@ test('Cursor auth matcher covers current unauthenticated Cursor error records', 
 // paste the auth code into). The matcher converts each shape into
 // AGENT_AUTH_REQUIRED with actionable guidance.
 test('antigravity auth matcher covers agy print-mode + log-file auth signals', async () => {
-  const { isAntigravityAuthFailureText, antigravityAuthGuidance, classifyAgentAuthFailure } =
+  const {
+    isAntigravityAuthFailureText,
+    antigravityAuthGuidance,
+    classifyAgentAuthFailure,
+    classifySilentAntigravityFailure,
+  } =
     await import('../../src/runtimes/auth.js');
 
   // print-mode stdout shape — user-visible
@@ -1241,6 +1246,30 @@ test('antigravity auth matcher covers agy print-mode + log-file auth signals', a
   assert.equal(
     classifyAgentAuthFailure('antigravity', 'rate limit exceeded'),
     null,
+  );
+
+  // The raw matcher still recognizes the phrase, but silent-run classification
+  // is source-aware: agy's background experiment poll cannot prove that the
+  // current run lacks credentials.
+  const pollNoise =
+    'Failed to poll ListExperiments: error getting token source: You are not logged into Antigravity';
+  assert.deepEqual(
+    classifySilentAntigravityFailure({ directText: '', diagnosticText: pollNoise }),
+    { authFailure: null, serviceFailure: null },
+  );
+  assert.equal(
+    classifySilentAntigravityFailure({
+      directText: '',
+      diagnosticText: `${pollNoise}\nRESOURCE_EXHAUSTED: Individual quota reached`,
+    }).serviceFailure,
+    'RATE_LIMITED',
+  );
+  assert.equal(
+    classifySilentAntigravityFailure({
+      directText: 'Authentication required. Please visit the URL to log in: https://example',
+      diagnosticText: pollNoise,
+    }).authFailure?.status,
+    'missing',
   );
 });
 


### PR DESCRIPTION
Fixes #4121

## Why

The issue investigation identified a remaining Open Design-side false diagnosis: agy's background `ListExperiments` polling can write `You are not logged into Antigravity` into its diagnostic log even while the current session is authenticated. When a run later exits without assistant output for an unrelated reason, Open Design combines that log with the child process output and reports `AGENT_AUTH_REQUIRED`.

That sends authenticated users toward a sign-in flow that cannot fix the actual failure and hides useful categories such as quota, upstream, or headless permission errors. This PR makes authentication evidence source-aware while preserving the existing actionable message for real OAuth prompts.

## What users will see

An Antigravity run or Settings connection test now shows sign-in guidance only when the run's own stdout/stderr contains direct authentication evidence. A diagnostic-log-only background polling message no longer produces a false “Antigravity needs to sign in” error.

Quota and upstream signals from agy's diagnostic log are still used. A completely silent exit with no reliable category is reported as an empty/unknown execution failure rather than guessed to be an authentication failure.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — silent Antigravity failures are no longer assumed to mean missing authentication
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes daemon and connection-test failure classification without adding UI.

## Bug fix verification

- Red specs: `apps/daemon/tests/chat-route.test.ts` and `apps/daemon/tests/connection-test.test.ts`.
- The tests went red on current `main`: both diagnostic-log noise and a fully silent exit returned `agent_auth_required`, and the chat run emitted `AGENT_AUTH_REQUIRED`.
- They are green on this branch. Additional unit coverage in `apps/daemon/tests/runtimes/env-and-detection.test.ts` verifies all three boundaries: log-only auth noise is ignored, log-derived quota remains `RATE_LIMITED`, and direct OAuth evidence remains missing-auth.

## Validation

- `pnpm guard`
- `ASTRO_TELEMETRY_DISABLED=1 pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/daemon exec vitest run tests/connection-test.test.ts tests/chat-route.test.ts` — 238 passed
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/env-and-detection.test.ts` — 63 passed
- Post-refactor focused passes: 4 Antigravity connection tests and 8 Antigravity chat-route tests passed
