### PR TITLE
feat(media): add OrcaRouter image provider

### DIFF
--- a/apps/daemon/src/media/config.ts
+++ b/apps/daemon/src/media/config.ts
@@ -92,6 +92,7 @@ const ENV_KEYS: Record<string, string[]> = {
   nanobanana: ['OD_NANOBANANA_API_KEY', 'GOOGLE_API_KEY', 'GEMINI_API_KEY'],
   imagerouter: ['OD_IMAGEROUTER_API_KEY', 'IMAGEROUTER_API_KEY'],
   openrouter: ['OD_OPENROUTER_API_KEY', 'OPENROUTER_API_KEY'],
+  orcarouter: ['OD_ORCAROUTER_API_KEY', 'ORCAROUTER_API_KEY'],
   'custom-image': ['OD_CUSTOM_IMAGE_API_KEY', 'CUSTOM_IMAGE_API_KEY'],
   bfl: ['OD_BFL_API_KEY', 'BFL_API_KEY'],
   fal: ['OD_FAL_KEY', 'FAL_KEY'],

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -179,6 +179,7 @@ const NANOBANANA_DEFAULT_BASE_URL = 'https://generativelanguage.googleapis.com';
 const NANOBANANA_DEFAULT_MODEL = 'gemini-3.1-flash-image-preview';
 const NANOBANANA_DEFAULT_IMAGE_SIZE = '1K';
 const IMAGEROUTER_DEFAULT_BASE_URL = 'https://api.imagerouter.io/v1/openai';
+const ORCAROUTER_DEFAULT_BASE_URL = 'https://api.orcarouter.ai/v1';
 const CUSTOM_IMAGE_MODEL_ID = 'custom-image';
 const CODEX_IMAGE_ORCHESTRATOR_MODEL = 'gpt-5.5';
 
@@ -711,6 +712,11 @@ export async function generateMedia(args: {
       suggestedExt = result.suggestedExt;
     } else if (def.provider === 'openrouter' && surface === 'video') {
       const result = await renderOpenRouterVideo(ctx, credentials, args.onProgress);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
+    } else if (def.provider === 'orcarouter' && surface === 'image') {
+      const result = await renderOrcaRouterImage(ctx, credentials);
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
@@ -1258,6 +1264,47 @@ async function renderImageRouterVideo(ctx: MediaContext, credentials: ProviderCo
     bytes,
     providerNote: `imagerouter/${wireModel} · ${imageRouterSizeFor(ctx.aspect, 'video')} · ${seconds === 'auto' ? 'auto' : `${seconds}s`} · ${bytes.length} bytes`,
     suggestedExt: '.mp4',
+  };
+}
+
+async function renderOrcaRouterImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      'no OrcaRouter API key — configure it in Settings or set ORCAROUTER_API_KEY',
+    );
+  }
+  const baseUrl = (credentials.baseUrl || ORCAROUTER_DEFAULT_BASE_URL).trim();
+  // Strip the `orcarouter/` catalogue prefix so the wire model name matches
+  // OrcaRouter's canonical vendor slug (e.g. `openai/gpt-image-2`).
+  const resolved = (credentials.model || ctx.wireModel).trim();
+  const wireModel = resolved.startsWith('orcarouter/')
+    ? resolved.slice('orcarouter/'.length)
+    : resolved;
+  const url = buildOpenAIImageUrl(baseUrl, false);
+  // openaiSizeFor keys off the bare model name (`gpt-image-` / `dall-e-`),
+  // so drop the vendor segment before sizing.
+  const sizeModel = wireModel.includes('/') ? wireModel.split('/').pop() || wireModel : wireModel;
+  const body: Record<string, unknown> = {
+    prompt: ctx.prompt || 'A high-quality reference image.',
+    model: wireModel,
+    n: 1,
+    size: openaiSizeFor(sizeModel, ctx.aspect),
+  };
+
+  const resp = await fetch(url, withMediaRequestInit(ctx, {
+    method: 'POST',
+    headers: {
+      'authorization': `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  }));
+  const data = await parseOpenAICompatibleJson(resp, 'orcarouter image');
+  const bytes = await bytesFromOpenAICompatibleData(data, 'orcarouter image', ctx.requestInit);
+  return {
+    bytes,
+    providerNote: `orcarouter/${wireModel} · ${body.size} · ${bytes.length} bytes`,
+    suggestedExt: sniffImageExt(bytes),
   };
 }
 

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -40,6 +40,7 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
   { id: 'nanobanana', label: 'Nano Banana', hint: 'Uses Google’s official API by default. You can also configure a custom gateway.', integrated: true, defaultBaseUrl: 'https://generativelanguage.googleapis.com', supportsCustomModel: true },
   { id: 'imagerouter', label: 'ImageRouter', hint: 'OpenAI-compatible image + video routing', integrated: true, defaultBaseUrl: 'https://api.imagerouter.io/v1/openai', docsUrl: 'https://docs.imagerouter.io/api-reference/image-generation/', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or xAI/grok-imagine-video' },
   { id: 'openrouter', label: 'OpenRouter', hint: 'Unified gateway for image + video models', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://openrouter.ai/api/v1', docsUrl: 'https://openrouter.ai/settings/keys' },
+  { id: 'orcarouter', label: 'OrcaRouter', hint: 'OpenAI-compatible image gateway', integrated: true, credentialsRequired: true, settingsVisible: true, defaultBaseUrl: 'https://api.orcarouter.ai/v1', docsUrl: 'https://www.orcarouter.ai', supportsCustomModel: true, customModelPlaceholder: 'openai/gpt-image-2 or google/gemini-2.5-flash-image' },
   { id: 'custom-image', label: 'Custom Image API', hint: 'OpenAI-compatible images/generations + images/edits (local or cloud)', integrated: true, docsUrl: 'https://platform.openai.com/docs/api-reference/images', supportsCustomModel: true, customModelPlaceholder: 'my-image-model' },
   { id: 'comfyui', label: 'ComfyUI', hint: 'Local JSON workflow server (planned adapter)', integrated: false, defaultBaseUrl: 'http://127.0.0.1:8188', docsUrl: 'https://docs.comfy.org/development/core-concepts/workflow' },
   { id: 'bfl', label: 'Black Forest Labs', hint: 'FLUX 1.1 Pro / FLUX Pro / Dev', integrated: false, defaultBaseUrl: 'https://api.bfl.ai' },
@@ -125,6 +126,10 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
+
+  { id: 'orcarouter/openai/gpt-image-2', label: 'openai/gpt-image-2 (OrcaRouter)', hint: 'OrcaRouter · routed GPT Image', provider: 'orcarouter', caps: ['t2i'] },
+  { id: 'orcarouter/google/gemini-2.5-flash-image', label: 'gemini-2.5-flash-image (OrcaRouter)', hint: 'OrcaRouter · Gemini', provider: 'orcarouter', caps: ['t2i'] },
+  { id: 'orcarouter/grok/grok-imagine-image', label: 'grok-imagine-image (OrcaRouter)', hint: 'OrcaRouter · xAI', provider: 'orcarouter', caps: ['t2i'] },
 
   { id: 'custom-image', label: 'custom-image', hint: 'Custom · OpenAI-compatible endpoint', provider: 'custom-image', caps: ['t2i', 'i2i'] },
 

--- a/apps/web/public/model-icons/orcarouter.svg
+++ b/apps/web/public/model-icons/orcarouter.svg
@@ -1,0 +1,1 @@
+<svg fill="#94A3B8" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>OrcaRouter</title><path d="M12 2.5 20.5 7v10L12 21.5 3.5 17V7L12 2.5Zm0 3.1L6 8.9v6.2l6 3.3 6-3.3V8.9l-6-3.3Zm0 3.9a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5Z"/></svg>

--- a/apps/web/src/components/modelProviderIcon.ts
+++ b/apps/web/src/components/modelProviderIcon.ts
@@ -41,5 +41,6 @@ export function modelProviderIconSrc(
   if (vendor.includes('doubao') || vendor.includes('bytedance'))
     return '/model-icons/bytedance.svg';
   if (vendor.includes('openrouter')) return '/model-icons/openrouter.svg';
+  if (vendor.includes('orcarouter')) return '/model-icons/orcarouter.svg';
   return null;
 }

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -37,6 +37,7 @@ export type MediaProviderId =
   | 'nanobanana'
   | 'imagerouter'
   | 'openrouter'
+  | 'orcarouter'
   | 'custom-image'
   | 'comfyui'
   | 'bfl'
@@ -162,6 +163,18 @@ export const MEDIA_PROVIDERS: MediaProvider[] = [
     settingsVisible: true,
     defaultBaseUrl: 'https://openrouter.ai/api/v1',
     docsUrl: 'https://openrouter.ai/settings/keys',
+  },
+  {
+    id: 'orcarouter',
+    label: 'OrcaRouter',
+    hint: 'OpenAI-compatible image gateway',
+    integrated: true,
+    credentialsRequired: true,
+    settingsVisible: true,
+    defaultBaseUrl: 'https://api.orcarouter.ai/v1',
+    docsUrl: 'https://www.orcarouter.ai',
+    supportsCustomModel: true,
+    customModelPlaceholder: 'openai/gpt-image-2 or google/gemini-2.5-flash-image',
   },
   {
     id: 'custom-image',
@@ -505,6 +518,12 @@ export const IMAGE_MODELS: MediaModel[] = [
   { id: 'openrouter/google/gemini-2.5-flash-image', label: 'gemini-flash-image (OR)', hint: 'OpenRouter · Gemini', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/black-forest-labs/flux-1.1-pro', label: 'flux-1.1-pro (OR)', hint: 'OpenRouter · BFL', provider: 'openrouter', caps: ['t2i'] },
   { id: 'openrouter/recraft/recraft-v3', label: 'recraft-v3 (OR)', hint: 'OpenRouter · Recraft', provider: 'openrouter', caps: ['t2i'] },
+
+  // OrcaRouter image models — routed through the gateway's OpenAI-compatible
+  // /v1/images/generations endpoint (same contract as OpenAI / ImageRouter).
+  { id: 'orcarouter/openai/gpt-image-2', label: 'openai/gpt-image-2 (OrcaRouter)', hint: 'OrcaRouter · routed GPT Image', provider: 'orcarouter', caps: ['t2i'] },
+  { id: 'orcarouter/google/gemini-2.5-flash-image', label: 'gemini-2.5-flash-image (OrcaRouter)', hint: 'OrcaRouter · Gemini', provider: 'orcarouter', caps: ['t2i'] },
+  { id: 'orcarouter/grok/grok-imagine-image', label: 'grok-imagine-image (OrcaRouter)', hint: 'OrcaRouter · xAI', provider: 'orcarouter', caps: ['t2i'] },
 
   // Custom OpenAI-compatible image generation + edit endpoints.
   {

--- a/apps/web/tests/components/modelProviderIcon.test.ts
+++ b/apps/web/tests/components/modelProviderIcon.test.ts
@@ -13,6 +13,9 @@ describe('modelProviderIconSrc', () => {
     expect(modelProviderIconSrc('openrouter/anthropic/claude-sonnet-4-5')).toBe(
       '/model-icons/openrouter.svg',
     );
+    expect(modelProviderIconSrc('orcarouter/openai/gpt-image-2')).toBe(
+      '/model-icons/orcarouter.svg',
+    );
   });
 
   it('matches on provider-name substrings so aliased prefixes still resolve', () => {


### PR DESCRIPTION
## Why

I use Open Design for quick image generation loops and recently wanted to route image generation through [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway that exposes 160+ models (OpenAI, Gemini, xAI, and more) behind a single key. Open Design already shipped a named `openrouter` provider, so an `orcarouter` provider is a natural addition — the same class of "one API key, many image models" gateway, wired through the same OpenAI-standard `/v1/images/generations` contract the daemon already speaks for OpenAI and ImageRouter.

The pain being addressed: users who hold an OrcaRouter key currently have no first-class surface in Settings or the model picker. They could work around it by hand-writing a custom OpenAI-compatible endpoint, but that loses the named provider UX (label, docs link, key hint, catalog models) every other integrated gateway gets.

I'm an engineer on the OrcaRouter team. OrcaRouter is a drop-in OpenAI-compatible API gateway — `https://api.orcarouter.ai/v1` with an `sk-orca-` key — that exposes 160+ models through one endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What users will see

- Settings → Media gains an **OrcaRouter** provider section (next to OpenRouter) with a base URL of `https://api.orcarouter.ai/v1`, a link to the key page, and a custom-model field.
- The new-project model picker lists OrcaRouter image models — `openai/gpt-image-2`, `google/gemini-2.5-flash-image`, and `grok/grok-imagine-image` (labeled "(OrcaRouter)") — with the OrcaRouter brand mark.
- Configuring a key via the new `ORCAROUTER_API_KEY` env var (or `OD_ORCAROUTER_API_KEY`, following the daemon's per-provider naming) lights up image generation through the gateway; the provider note on generated images reports `orcarouter/<wire-model>`.

The provider renders through the daemon's existing OpenAI-standard Images API path (`POST /v1/images/generations`), so it inherits the same size mapping, error surfacing, and output handling as the OpenAI/ImageRouter providers.

## Surface area

- [x] **UI** — new provider section in Settings → Media and new catalog entries in the model picker (`apps/web/src/media/models.ts`, `apps/web/public/model-icons/orcarouter.svg`)
- [ ] **Keyboard shortcut** — none
- [x] **CLI / env var** — new `OD_ORCAROUTER_API_KEY` / `ORCAROUTER_API_KEY` env vars (`apps/daemon/src/media/config.ts`)
- [ ] **API / contract** — none
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [ ] **Default behavior change** — none (opt-in provider; existing defaults untouched)
- [ ] **None**

## Screenshots

No UI screenshot attached — the change adds a provider entry in the existing Settings → Media list and model-picker rows; both render through the existing provider/model list components with no new layout.

## Bug fix verification

Not a bug fix — feature addition. The render path is anchored by the existing OpenAI-standard contract (verified live against the gateway: `POST /v1/images/generations` returns `data[0].b64_json`, and the dispatcher wrote a valid PNG through the repo's own `generateMedia` path).

## Validation

- `node scripts/verify-media-models.mjs` → OK (web/daemon registries in sync)
- `pnpm --filter @open-design/daemon typecheck` → pass
- `pnpm --filter @open-design/web typecheck` → pass
- `pnpm guard` → pass
- daemon: `media-adapters` (30), `media-generate-multi-image`, `media-generate-prompt-file`, `memory-media-provider-fallback` (7) → pass
- web: `modelProviderIcon` (5), `SettingsDialog.media`, `HomeView.media-options` → pass
- L3 live: `generateMedia({ surface: 'image', model: 'orcarouter/openai/gpt-image-2' })` with a real key → 907 KB PNG written, `providerNote: orcarouter/openai/gpt-image-2 · 1024x1024`
