### PR TITLE
fix desktop image export for runtime JSX

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/node": "24.12.2",
     "electron": "41.3.0",
+    "jsdom": "29.1.1",
     "typescript": "6.0.3",
     "vitest": "4.1.6"
   },

--- a/apps/desktop/src/main/artifact-export-readiness.ts
+++ b/apps/desktop/src/main/artifact-export-readiness.ts
@@ -1,0 +1,125 @@
+type ArtifactRenderTarget = {
+  executeJavaScriptInIsolatedWorld: (
+    worldId: number,
+    scripts: Array<{ code: string }>,
+    userGesture?: boolean,
+  ) => Promise<unknown>;
+};
+
+const DEFAULT_IMAGE_RENDER_TIMEOUT_MS = 30_000;
+const ARTIFACT_RENDER_WORLD_ID = 1001;
+
+function validatedTimeout(timeoutMs: number): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("Image render timeout must be a positive finite number");
+  }
+  return Math.ceil(timeoutMs);
+}
+
+export function artifactRenderReadinessScript(timeoutMs: number): string {
+  const timeout = validatedTimeout(timeoutMs);
+  return `(function() {
+    var runtimeJsx = document.querySelector('script[type="text/babel"], script[type="text/jsx"]');
+    if (!runtimeJsx) return Promise.resolve(true);
+
+    var ignoredTags = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'NOSCRIPT', 'TEMPLATE']);
+
+    function hasMountedChild(root) {
+      if (!root) return false;
+      return Array.from(root.childNodes).some(function(node) {
+        if (node.nodeType === 3) return Boolean(node.nodeValue && node.nodeValue.trim());
+        return node.nodeType === 1 && !ignoredTags.has(node.tagName);
+      });
+    }
+
+    function hasMountedContent() {
+      if (!document.body) return false;
+      var roots = Array.from(document.body.querySelectorAll(
+        '#root, #app, [data-reactroot], [data-v-app]'
+      ));
+      if (roots.length > 0) return roots.some(hasMountedChild);
+      return hasMountedChild(document.body);
+    }
+
+    return new Promise(function(resolve) {
+      var settled = false;
+      var settling = false;
+      var timer;
+      var observer = new MutationObserver(check);
+
+      function finish(ready) {
+        if (settled) return;
+        settled = true;
+        observer.disconnect();
+        clearTimeout(timer);
+        resolve(ready);
+      }
+
+      function check() {
+        if (settled || settling || !hasMountedContent()) return;
+        settling = true;
+        requestAnimationFrame(function() {
+          requestAnimationFrame(function() {
+            settling = false;
+            if (hasMountedContent()) finish(true);
+          });
+        });
+      }
+
+      observer.observe(document.documentElement, {
+        characterData: true,
+        childList: true,
+        subtree: true
+      });
+      timer = setTimeout(function() { finish(false); }, ${timeout});
+      check();
+    });
+  })()`;
+}
+
+export async function waitForRenderedArtifactContent(
+  target: ArtifactRenderTarget,
+  timeoutMs = DEFAULT_IMAGE_RENDER_TIMEOUT_MS,
+): Promise<void> {
+  const timeout = validatedTimeout(timeoutMs);
+  const ready = await target.executeJavaScriptInIsolatedWorld(
+    ARTIFACT_RENDER_WORLD_ID,
+    [{ code: artifactRenderReadinessScript(timeout) }],
+    false,
+  );
+  if (ready !== true) {
+    throw new Error(`Image export timed out waiting for runtime-rendered content (${timeout}ms)`);
+  }
+}
+
+export async function waitForArtifactResources(
+  operation: Promise<void>,
+  timeoutMs = DEFAULT_IMAGE_RENDER_TIMEOUT_MS,
+): Promise<void> {
+  const timeout = validatedTimeout(timeoutMs);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Image export timed out waiting for late resources (${timeout}ms)`)),
+      timeout,
+    );
+  });
+  try {
+    await Promise.race([operation, timedOut]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export async function waitForArtifactContent(
+  format: "image" | "pdf",
+  target: ArtifactRenderTarget,
+  settleResources: () => Promise<void>,
+): Promise<void> {
+  if (format === "pdf") {
+    await settleResources();
+    return;
+  }
+  await waitForRenderedArtifactContent(target);
+  await waitForArtifactResources(settleResources());
+}

--- a/apps/desktop/src/main/artifact-export-readiness.ts
+++ b/apps/desktop/src/main/artifact-export-readiness.ts
@@ -23,13 +23,22 @@ export function artifactRenderReadinessScript(timeoutMs: number): string {
     if (!runtimeJsx) return Promise.resolve(true);
 
     var ignoredTags = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'NOSCRIPT', 'TEMPLATE']);
-
-    function hasMountedChild(root) {
-      if (!root) return false;
-      return Array.from(root.childNodes).some(function(node) {
+    function meaningfulChildren(root) {
+      if (!root) return [];
+      return Array.from(root.childNodes).filter(function(node) {
         if (node.nodeType === 3) return Boolean(node.nodeValue && node.nodeValue.trim());
         return node.nodeType === 1 && !ignoredTags.has(node.tagName);
       });
+    }
+
+    function renderPlaceholder(root) {
+      var children = meaningfulChildren(root);
+      if (children.length !== 1 || children[0].nodeType !== 1) return null;
+      return children[0].classList.contains('ui-kit-loading') ? children[0] : null;
+    }
+
+    function hasMountedChild(root) {
+      return meaningfulChildren(root).length > 0;
     }
 
     function hasMountedContent() {
@@ -37,9 +46,23 @@ export function artifactRenderReadinessScript(timeoutMs: number): string {
       var roots = Array.from(document.body.querySelectorAll(
         '#root, #app, [data-reactroot], [data-v-app]'
       ));
-      if (roots.length > 0) return roots.some(hasMountedChild);
+      if (roots.length > 0) {
+        return roots.some(function(root) {
+          if (!hasMountedChild(root)) return false;
+          var initialPlaceholder = initialPlaceholders.get(root);
+          return initialPlaceholder === undefined || renderPlaceholder(root) !== initialPlaceholder;
+        });
+      }
       return hasMountedChild(document.body);
     }
+
+    var initialPlaceholders = new Map();
+    Array.from(document.body.querySelectorAll(
+      '#root, #app, [data-reactroot], [data-v-app]'
+    )).forEach(function(root) {
+      var placeholder = renderPlaceholder(root);
+      if (placeholder) initialPlaceholders.set(root, placeholder);
+    });
 
     return new Promise(function(resolve) {
       var settled = false;

--- a/apps/desktop/src/main/artifact-export.ts
+++ b/apps/desktop/src/main/artifact-export.ts
@@ -8,6 +8,7 @@ import type {
   DesktopExportArtifactResult,
 } from "@open-design/sidecar-proto";
 
+import { waitForArtifactContent, waitForArtifactResources } from "./artifact-export-readiness.js";
 import { DECK_PAGE_SIZE, DECK_PRINT_CSS, inferPageSize, waitForPrintableContent } from "./pdf-export.js";
 
 // Headless programmatic exporter for the `od export` CLI (PDF / image).
@@ -36,7 +37,7 @@ export async function exportArtifact(
     window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
     window.webContents.on("will-navigate", (event) => event.preventDefault());
     await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(buildDocument(input))}`);
-    await waitForPrintableContent(window);
+    await waitForArtifactContent(input.format, window.webContents, () => waitForPrintableContent(window));
 
     if (input.format === "pdf") return await renderPdf(window, input);
     return await renderImage(window, input);
@@ -81,7 +82,7 @@ async function renderImage(
       }
       const [w] = window.getContentSize();
       window.setContentSize(w, Math.ceil(contentHeight));
-      await waitForPrintableContent(window);
+      await waitForArtifactResources(waitForPrintableContent(window));
     }
   }
   const image = await window.webContents.capturePage();

--- a/apps/desktop/tests/main/artifact-export-readiness.test.ts
+++ b/apps/desktop/tests/main/artifact-export-readiness.test.ts
@@ -63,6 +63,58 @@ describe('artifact image render readiness', () => {
     await expect(ready).resolves.toBe(true);
   });
 
+  it('waits for an existing UI-kit placeholder to be replaced', async () => {
+    document.body.innerHTML = [
+      '<div id="root"><div class="ui-kit-loading">Loading Acme UI kit...</div></div>',
+      '<script type="text/babel"></script>',
+    ].join('');
+    let settled = false;
+    const ready = runReadinessScript(1_000).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(settled).toBe(false);
+
+    document.querySelector('#root')!.innerHTML = '<main>Mounted UI kit</main>';
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(ready).resolves.toBe(true);
+  });
+
+  it('accepts runtime JSX content that mounted before the readiness check', async () => {
+    document.body.innerHTML = '<div id="root"><main>Already mounted</main></div><script type="text/babel"></script>';
+    const ready = runReadinessScript(1_000);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(ready).resolves.toBe(true);
+  });
+
+  it('accepts a mounted loading subview after replacing the UI-kit placeholder', async () => {
+    document.body.innerHTML = [
+      '<div id="root"><div class="ui-kit-loading">Loading Acme UI kit...</div></div>',
+      '<script type="text/babel"></script>',
+    ].join('');
+    let settled = false;
+    const ready = runReadinessScript(1_000).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(settled).toBe(false);
+
+    document.querySelector('#root')!.innerHTML = [
+      '<main><h1>Mounted UI kit</h1>',
+      '<section aria-busy="true">Loading chart</section></main>',
+    ].join('');
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(ready).resolves.toBe(true);
+  });
+
   it('fails loudly when a runtime render root stays empty', async () => {
     document.body.innerHTML = '<div id="root"></div><script type="text/babel"></script>';
     const ready = runReadinessScript(250);

--- a/apps/desktop/tests/main/artifact-export-readiness.test.ts
+++ b/apps/desktop/tests/main/artifact-export-readiness.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  artifactRenderReadinessScript,
+  waitForArtifactContent,
+  waitForArtifactResources,
+  waitForRenderedArtifactContent,
+} from '../../src/main/artifact-export-readiness.js';
+
+function runReadinessScript(timeoutMs: number): Promise<boolean> {
+  return window.eval(artifactRenderReadinessScript(timeoutMs)) as Promise<boolean>;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.documentElement.innerHTML = '<head></head><body></body>';
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+    setTimeout(() => callback(performance.now()), 16),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('artifact image render readiness', () => {
+  it('runs in an isolated world without a user gesture', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn(async () => true);
+
+    await waitForRenderedArtifactContent({ executeJavaScriptInIsolatedWorld }, 1_250);
+
+    expect(executeJavaScriptInIsolatedWorld).toHaveBeenCalledWith(
+      1001,
+      [{ code: artifactRenderReadinessScript(1_250) }],
+      false,
+    );
+  });
+
+  it('does not delay documents that do not compile JSX at runtime', async () => {
+    document.body.innerHTML = '<canvas width="16" height="16"></canvas>';
+
+    await expect(runReadinessScript(1_000)).resolves.toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('waits for a runtime JSX render root to mount content', async () => {
+    document.body.innerHTML = '<div id="root"></div><script type="text/babel"></script>';
+    let settled = false;
+    const ready = runReadinessScript(1_000).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(settled).toBe(false);
+
+    document.querySelector('#root')!.innerHTML = '<p>Mounted content</p>';
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(ready).resolves.toBe(true);
+  });
+
+  it('fails loudly when a runtime render root stays empty', async () => {
+    document.body.innerHTML = '<div id="root"></div><script type="text/babel"></script>';
+    const ready = runReadinessScript(250);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(ready).resolves.toBe(false);
+  });
+
+  it('reports a runtime render timeout through the host boundary', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn(async () => false);
+
+    await expect(waitForRenderedArtifactContent({ executeJavaScriptInIsolatedWorld }, 1_250)).rejects.toThrow(
+      'Image export timed out waiting for runtime-rendered content (1250ms)',
+    );
+  });
+
+  it('bounds the late-resource settling pass', async () => {
+    const waiting = waitForArtifactResources(new Promise<void>(() => {}), 250);
+    const rejection = expect(waiting).rejects.toThrow(
+      'Image export timed out waiting for late resources (250ms)',
+    );
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    await rejection;
+  });
+
+  it('rejects invalid timeout values before running renderer code', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn(async () => true);
+
+    await expect(waitForRenderedArtifactContent({ executeJavaScriptInIsolatedWorld }, 0)).rejects.toThrow(
+      'Image render timeout must be a positive finite number',
+    );
+    expect(executeJavaScriptInIsolatedWorld).not.toHaveBeenCalled();
+  });
+
+  it('keeps runtime-render readiness out of the PDF path', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn(async () => true);
+    const settleResources = vi.fn(async () => {});
+
+    await waitForArtifactContent('pdf', { executeJavaScriptInIsolatedWorld }, settleResources);
+
+    expect(settleResources).toHaveBeenCalledOnce();
+    expect(executeJavaScriptInIsolatedWorld).not.toHaveBeenCalled();
+  });
+
+  it('runs render readiness and bounded resource settling for images', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn(async () => true);
+    const settleResources = vi.fn(async () => {});
+
+    await waitForArtifactContent('image', { executeJavaScriptInIsolatedWorld }, settleResources);
+
+    expect(executeJavaScriptInIsolatedWorld).toHaveBeenCalledOnce();
+    expect(settleResources).toHaveBeenCalledOnce();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       electron:
         specifier: 41.3.0
         version: 41.3.0
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
Fixes #6658

## Why

Issue #6658 reports that `od export` can save a blank PNG when a prototype uses Babel standalone to compile JSX in the browser. The existing export wait covers fonts and images, but it can finish before the runtime JSX app mounts. The command then reports success even though the captured page is still empty.

This follows up on the confirmed bug with a narrow readiness check for runtime JSX documents. Static HTML, CSS, and canvas exports keep the existing fast path.

## What users will see

Image export now waits for a runtime JSX app to mount before capture. If the app or late resources do not become ready within 30 seconds, export fails with a clear timeout instead of writing a blank image.

PDF export keeps its existing behavior.

## Surface area

- [ ] **UI**: new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut**: new or changed
- [ ] **CLI / env var**: new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract**: new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point**: new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys**: added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**: adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change**: changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None**: internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes the headless export path and does not add a UI entry point.

## Bug fix verification

- Test path: `apps/desktop/tests/main/artifact-export-readiness.test.ts`
- Red on `main`: not run as a separate checkout. The test covers the new readiness boundary, which does not exist on `main`; the current code moves from resource settling directly to capture.
- Green on this branch: yes. The tests cover delayed Babel/JSX mount, an empty render root, timeout errors, resource settling, image orchestration, and PDF isolation.

## Validation

- `pnpm guard`
- `pnpm typecheck`: the desktop package and other checked workspaces passed, but the root command stopped in `apps/web` because the local `three` module is not installed
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/desktop build`
- `./apps/desktop/node_modules/.bin/vitest run --root apps/desktop -c vitest.config.ts tests/main/artifact-export-readiness.test.ts tests/main/artifact-export-image-height.test.ts`: 10 tests passed
- `pnpm --filter @open-design/desktop test`: 185 tests passed; 13 existing Electron-dependent suites could not start because the local Electron binary is not installed
- `git diff --cached --check`
