### PR TITLE
fix(daemon): persist run events lost to a transient event-log stream failure

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -867,6 +867,10 @@ export function createChatRunService({
       // Set once finish() has closed the log stream, so a late post-finish emit
       // can't lazily re-open a stream nothing will ever close (FD leak).
       eventsLogClosed: false,
+      // Set when the log stream errors, meaning a record queued on the broken
+      // stream may have been dropped from events.jsonl; the next emit / finish
+      // reconciles the file from the in-memory ring (#5292).
+      eventsLogReplayNeeded: false,
       cleanupGeneration: 0,
       manualResumeAttemptCount: 0,
       rechargeWaitDurationMs: 0,
@@ -1016,6 +1020,7 @@ export function createChatRunService({
     run.stdinOpen = false;
     run.eventsLogStream = null;
     run.eventsLogClosed = false;
+    run.eventsLogReplayNeeded = false;
     run.manualResumeAttemptCount = (run.manualResumeAttemptCount ?? 0) + 1;
     run.rechargeWaitDurationMs =
       (run.rechargeWaitDurationMs ?? 0) + rechargeWaitDurationMs;
@@ -1054,6 +1059,11 @@ export function createChatRunService({
       run.eventsLogStream.on('error', () => {
         try { run.eventsLogStream?.destroy(); } catch { /* ignore */ }
         run.eventsLogStream = null;
+        // The write that triggered this error (and any writes already queued
+        // on the broken stream) were dropped from events.jsonl. Flag the run
+        // so the next emit / finish repairs the file from the in-memory ring
+        // before new writes land (#5292).
+        run.eventsLogReplayNeeded = true;
       });
       return run.eventsLogStream;
     } catch {
@@ -1061,7 +1071,55 @@ export function createChatRunService({
     }
   };
 
+  // Repair events.jsonl after a transient log-stream failure. The stream's
+  // on('error') nulled the broken stream and flagged the run; a record queued
+  // on that stream was dropped from the file, so re-append every in-memory
+  // record whose id is missing, keeping the file self-consistent ("end"
+  // present implies every earlier record present). Everything here is
+  // synchronous + best-effort: it opens/closes its own fd via appendFileSync,
+  // so it never depends on the (possibly nulled) stream, and a hard-disk
+  // failure must never crash the run or block emit.
+  const reconcileEventLog = (run) => {
+    if (!run.eventsLogPath || run.eventsLogReplayNeeded !== true) return;
+    try {
+      let content = '';
+      try {
+        content = fs.readFileSync(run.eventsLogPath, 'utf8');
+      } catch {
+        // No file yet (the stream never opened successfully) — treat as empty
+        // so every in-memory record is re-appended below.
+      }
+      // A torn partial trailing line (a write cut mid-record) would corrupt
+      // later reads; truncate the file back to the last complete line first.
+      const lastNewline = content.lastIndexOf('\n');
+      if (lastNewline >= 0 && lastNewline < content.length - 1) {
+        const completeBytes = Buffer.byteLength(content.slice(0, lastNewline + 1), 'utf8');
+        fs.truncateSync(run.eventsLogPath, completeBytes);
+        content = content.slice(0, lastNewline + 1);
+      }
+      const present = new Set();
+      for (const line of content.split('\n')) {
+        if (!line) continue;
+        try {
+          const record = JSON.parse(line);
+          if (record && Number.isFinite(record.id)) present.add(record.id);
+        } catch { /* skip malformed line */ }
+      }
+      for (const record of run.events) {
+        if (!present.has(record.id)) {
+          fs.appendFileSync(run.eventsLogPath, JSON.stringify(record) + '\n', 'utf8');
+          present.add(record.id);
+        }
+      }
+    } catch {
+      // Hard-disk failure: keep the run alive; the memory ring + SSE still work.
+    } finally {
+      run.eventsLogReplayNeeded = false;
+    }
+  };
+
   const emit = (run, event, data) => {
+    if (run.eventsLogReplayNeeded) reconcileEventLog(run);
     if (event === 'error') {
       const details = extractErrorDetails(data);
       if (details.error) run.error = details.error;
@@ -1207,6 +1265,10 @@ export function createChatRunService({
     run.clients.clear();
     for (const waiter of run.waiters) waiter(statusBody(run));
     run.waiters.clear();
+    // If the last emit(s) hit a broken stream, repair the log from the
+    // in-memory ring BEFORE closing it, so 'end' and every earlier record are
+    // on disk for tail/grep even when the final write failed (#5292).
+    if (run.eventsLogReplayNeeded) reconcileEventLog(run);
     // Close the event log stream now that no more events will be
     // emitted for this run. The file stays on disk for tail/grep.
     try { run.eventsLogStream?.end(); } catch { /* ignore */ }

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1442,8 +1442,13 @@ export function createChatRunService({
       }
       // A torn partial trailing line (a write cut mid-record) would corrupt
       // later reads; truncate the file back to the last complete line first.
+      // With no newline anywhere the whole file is one torn first record, so
+      // it goes back to byte zero instead of growing a valid line after it.
       const lastNewline = content.lastIndexOf('\n');
-      if (lastNewline >= 0 && lastNewline < content.length - 1) {
+      if (content && lastNewline < 0) {
+        fs.truncateSync(run.eventsLogPath, 0);
+        content = '';
+      } else if (lastNewline >= 0 && lastNewline < content.length - 1) {
         const completeBytes = Buffer.byteLength(content.slice(0, lastNewline + 1), 'utf8');
         fs.truncateSync(run.eventsLogPath, completeBytes);
         content = content.slice(0, lastNewline + 1);
@@ -1462,10 +1467,12 @@ export function createChatRunService({
           present.add(record.id);
         }
       }
+      // Cleared only once the file is self-consistent again: a failed read,
+      // truncate, or append above leaves the flag set so the next emit or
+      // finish retries the reconciliation.
+      run.eventsLogReplayNeeded = false;
     } catch {
       // Hard-disk failure: keep the run alive; the memory ring + SSE still work.
-    } finally {
-      run.eventsLogReplayNeeded = false;
     }
   };
 

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1032,6 +1032,10 @@ export function createChatRunService({
       // Set once finish() has closed the log stream, so a late post-finish emit
       // can't lazily re-open a stream nothing will ever close (FD leak).
       eventsLogClosed: false,
+      // Set when the log stream errors, meaning a record queued on the broken
+      // stream may have been dropped from events.jsonl; the next emit / finish
+      // reconciles the file from the in-memory ring (#5292).
+      eventsLogReplayNeeded: false,
       cleanupGeneration: 0,
       cumulativeRetryAttemptCount: 0,
       manualResumeAttemptCount: 0,
@@ -1352,6 +1356,7 @@ export function createChatRunService({
     run.stdinOpen = false;
     run.eventsLogStream = null;
     run.eventsLogClosed = false;
+    run.eventsLogReplayNeeded = false;
     run.runtimeGenerationId = null;
     run.terminalIntegrity = null;
     run.terminalLifecycle = undefined;
@@ -1405,6 +1410,11 @@ export function createChatRunService({
       run.eventsLogStream.on('error', () => {
         try { run.eventsLogStream?.destroy(); } catch { /* ignore */ }
         run.eventsLogStream = null;
+        // The write that triggered this error (and any writes already queued
+        // on the broken stream) were dropped from events.jsonl. Flag the run
+        // so the next emit / finish repairs the file from the in-memory ring
+        // before new writes land (#5292).
+        run.eventsLogReplayNeeded = true;
       });
       return run.eventsLogStream;
     } catch {
@@ -1412,7 +1422,55 @@ export function createChatRunService({
     }
   };
 
+  // Repair events.jsonl after a transient log-stream failure. The stream's
+  // on('error') nulled the broken stream and flagged the run; a record queued
+  // on that stream was dropped from the file, so re-append every in-memory
+  // record whose id is missing, keeping the file self-consistent ("end"
+  // present implies every earlier record present). Everything here is
+  // synchronous + best-effort: it opens/closes its own fd via appendFileSync,
+  // so it never depends on the (possibly nulled) stream, and a hard-disk
+  // failure must never crash the run or block emit.
+  const reconcileEventLog = (run) => {
+    if (!run.eventsLogPath || run.eventsLogReplayNeeded !== true) return;
+    try {
+      let content = '';
+      try {
+        content = fs.readFileSync(run.eventsLogPath, 'utf8');
+      } catch {
+        // No file yet (the stream never opened successfully) — treat as empty
+        // so every in-memory record is re-appended below.
+      }
+      // A torn partial trailing line (a write cut mid-record) would corrupt
+      // later reads; truncate the file back to the last complete line first.
+      const lastNewline = content.lastIndexOf('\n');
+      if (lastNewline >= 0 && lastNewline < content.length - 1) {
+        const completeBytes = Buffer.byteLength(content.slice(0, lastNewline + 1), 'utf8');
+        fs.truncateSync(run.eventsLogPath, completeBytes);
+        content = content.slice(0, lastNewline + 1);
+      }
+      const present = new Set();
+      for (const line of content.split('\n')) {
+        if (!line) continue;
+        try {
+          const record = JSON.parse(line);
+          if (record && Number.isFinite(record.id)) present.add(record.id);
+        } catch { /* skip malformed line */ }
+      }
+      for (const record of run.events) {
+        if (!present.has(record.id)) {
+          fs.appendFileSync(run.eventsLogPath, JSON.stringify(record) + '\n', 'utf8');
+          present.add(record.id);
+        }
+      }
+    } catch {
+      // Hard-disk failure: keep the run alive; the memory ring + SSE still work.
+    } finally {
+      run.eventsLogReplayNeeded = false;
+    }
+  };
+
   const emit = (run, event, data, timestamp = Date.now(), persistLifecycle = true) => {
+    if (run.eventsLogReplayNeeded) reconcileEventLog(run);
     // Once a terminal verdict is waiting only on process-tree quiescence, the
     // attempt no longer owns transcript or error state. Shutdown bytes and
     // duplicate child callbacks must not overwrite the classified verdict
@@ -1656,6 +1714,10 @@ export function createChatRunService({
     run.clients.clear();
     for (const waiter of run.waiters) waiter(statusBody(run));
     run.waiters.clear();
+    // If the last emit(s) hit a broken stream, repair the log from the
+    // in-memory ring BEFORE closing it, so 'end' and every earlier record are
+    // on disk for tail/grep even when the final write failed (#5292).
+    if (run.eventsLogReplayNeeded) reconcileEventLog(run);
     // Close the event log stream now that no more events will be
     // emitted for this run. The file stays on disk for tail/grep.
     try { run.eventsLogStream?.end(); } catch { /* ignore */ }

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -1418,4 +1418,70 @@ describe('run event log persistence', () => {
     expect(after - before).toBeLessThan(15);
     expect(kept.length).toBe(ITER);
   });
+
+  it('recovers a run event that was lost to a transient log-stream failure', async () => {
+    // Regression for #5292: a write to a destroyed fs.WriteStream does not
+    // throw synchronously — it returns false and surfaces the failure as an
+    // async 'error'. The on('error') handler (runs.ts) destroys + nulls the
+    // stream, so EVERY record emitted while the stream is broken is silently
+    // dropped from events.jsonl even though the run later reaches a terminal
+    // status with its `end` record persisted on a freshly-reopened stream.
+    // The run's in-memory ring retains the lost records; the fix reconciles the
+    // file from the ring on the next emit so "end present on disk" implies
+    // every earlier record is present too. We drop TWO records in one burst
+    // (a second 'start' plus the retry telemetry that follows it) to pin the
+    // id-diff reconcile: a fix that only replays the single most-recent record
+    // would restore the retry telemetry but leave the second 'start' missing.
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' }) as any;
+
+    runs.emit(run, 'start', { model: 'x' }); // lazily opens the write stream
+    expect(run.eventsLogStream).toBeDefined();
+    // Wait until the underlying fd is actually open so the destroy below is a
+    // clean destroy of an OPEN stream (deterministic 'error' emission) rather
+    // than a race with the stream's async open().
+    await new Promise<void>((resolve) => run.eventsLogStream.once('open', resolve));
+
+    // Simulate a transient fs failure: destroy the stream with an error.
+    // write() on the destroyed stream returns false + surfaces an async error
+    // instead of throwing, so every record emitted while it is broken is
+    // silently lost from the file (but stays in run.events).
+    const broken = run.eventsLogStream;
+    broken.destroy(new Error('simulated io failure'));
+
+    runs.emit(run, 'start', { model: 'y' }); // on the buggy code this write is LOST
+    runs.emit(run, 'run_retry_attempted', { retry_attempt_index: 1 }); // …and this one too
+    // Wait for destroy()'s async fs.close to complete so the run's on('error')
+    // handler has nulled the broken stream (and, on the fix, set
+    // eventsLogReplayNeeded) before the next emit re-opens a fresh stream.
+    await new Promise<void>((resolve) => broken.once('close', resolve));
+    runs.finish(run, 'succeeded', 0, null);
+
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    let lines: string[] = [];
+    for (let i = 0; i < 150; i++) {
+      if (fs.existsSync(logPath)) {
+        const text = fs.readFileSync(logPath, 'utf8').trim();
+        lines = text ? text.split('\n') : [];
+        if (lines.some((line) => {
+          try { return JSON.parse(line).event === 'end'; } catch { return false; }
+        })) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    const events = lines.map((line) => JSON.parse(line));
+    const starts = events.filter((event) => event.event === 'start');
+    const retries = events.filter((event) => event.event === 'run_retry_attempted');
+    const ends = events.filter((event) => event.event === 'end');
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toMatchObject({ event: 'end', data: { status: 'succeeded' } });
+    expect(retries).toHaveLength(1);
+    expect(retries[0]).toMatchObject({
+      event: 'run_retry_attempted',
+      data: { retry_attempt_index: 1 },
+    });
+    expect(starts).toHaveLength(2);
+    expect(new Set(starts.map((event) => event.id)).size).toBe(2);
+  });
 });

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -2048,6 +2048,72 @@ describe('run event log persistence', () => {
     expect(after - before).toBeLessThan(15);
     expect(kept.length).toBe(ITER);
   });
+
+  it('recovers a run event that was lost to a transient log-stream failure', async () => {
+    // Regression for #5292: a write to a destroyed fs.WriteStream does not
+    // throw synchronously — it returns false and surfaces the failure as an
+    // async 'error'. The on('error') handler (runs.ts) destroys + nulls the
+    // stream, so EVERY record emitted while the stream is broken is silently
+    // dropped from events.jsonl even though the run later reaches a terminal
+    // status with its `end` record persisted on a freshly-reopened stream.
+    // The run's in-memory ring retains the lost records; the fix reconciles the
+    // file from the ring on the next emit so "end present on disk" implies
+    // every earlier record is present too. We drop TWO records in one burst
+    // (a second 'start' plus the retry telemetry that follows it) to pin the
+    // id-diff reconcile: a fix that only replays the single most-recent record
+    // would restore the retry telemetry but leave the second 'start' missing.
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' }) as any;
+
+    runs.emit(run, 'start', { model: 'x' }); // lazily opens the write stream
+    expect(run.eventsLogStream).toBeDefined();
+    // Wait until the underlying fd is actually open so the destroy below is a
+    // clean destroy of an OPEN stream (deterministic 'error' emission) rather
+    // than a race with the stream's async open().
+    await new Promise<void>((resolve) => run.eventsLogStream.once('open', resolve));
+
+    // Simulate a transient fs failure: destroy the stream with an error.
+    // write() on the destroyed stream returns false + surfaces an async error
+    // instead of throwing, so every record emitted while it is broken is
+    // silently lost from the file (but stays in run.events).
+    const broken = run.eventsLogStream;
+    broken.destroy(new Error('simulated io failure'));
+
+    runs.emit(run, 'start', { model: 'y' }); // on the buggy code this write is LOST
+    runs.emit(run, 'run_retry_attempted', { retry_attempt_index: 1 }); // …and this one too
+    // Wait for destroy()'s async fs.close to complete so the run's on('error')
+    // handler has nulled the broken stream (and, on the fix, set
+    // eventsLogReplayNeeded) before the next emit re-opens a fresh stream.
+    await new Promise<void>((resolve) => broken.once('close', resolve));
+    runs.finish(run, 'succeeded', 0, null);
+
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    let lines: string[] = [];
+    for (let i = 0; i < 150; i++) {
+      if (fs.existsSync(logPath)) {
+        const text = fs.readFileSync(logPath, 'utf8').trim();
+        lines = text ? text.split('\n') : [];
+        if (lines.some((line) => {
+          try { return JSON.parse(line).event === 'end'; } catch { return false; }
+        })) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    const events = lines.map((line) => JSON.parse(line));
+    const starts = events.filter((event) => event.event === 'start');
+    const retries = events.filter((event) => event.event === 'run_retry_attempted');
+    const ends = events.filter((event) => event.event === 'end');
+    expect(ends).toHaveLength(1);
+    expect(ends[0]).toMatchObject({ event: 'end', data: { status: 'succeeded' } });
+    expect(retries).toHaveLength(1);
+    expect(retries[0]).toMatchObject({
+      event: 'run_retry_attempted',
+      data: { retry_attempt_index: 1 },
+    });
+    expect(starts).toHaveLength(2);
+    expect(new Set(starts.map((event) => event.id)).size).toBe(2);
+  });
 });
 
 describe('work completeness vs a settled OD Next verdict', () => {

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -2114,6 +2114,139 @@ describe('run event log persistence', () => {
     expect(starts).toHaveLength(2);
     expect(new Set(starts.map((event) => event.id)).size).toBe(2);
   });
+
+  async function waitForLogLines(logPath: string, count: number) {
+    for (let i = 0; i < 150; i++) {
+      if (fs.existsSync(logPath)) {
+        const lines = fs.readFileSync(logPath, 'utf8').split('\n').filter(Boolean);
+        if (lines.length >= count) return lines;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return [];
+  }
+
+  // Every line must stay parseable and every in-memory record must be on disk;
+  // a log that only *looks* complete (malformed first line, no matching ids)
+  // returns empty so the caller's assertion fails instead of silently passing.
+  async function waitForCompleteLog(logPath: string, ids: number[]) {
+    for (let i = 0; i < 150; i++) {
+      if (fs.existsSync(logPath)) {
+        const lines = fs.readFileSync(logPath, 'utf8').split('\n').filter(Boolean);
+        const parsed: any[] = [];
+        let valid = true;
+        for (const line of lines) {
+          try { parsed.push(JSON.parse(line)); } catch { valid = false; break; }
+        }
+        if (valid && ids.every((id) => parsed.some((event) => event.id === id))) {
+          return lines;
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return [];
+  }
+
+  it('retries the reconciliation when the first repair append fails', async () => {
+    // Regression for the #6726 review: the replay flag used to be cleared in a
+    // finally, so an append that failed while the stream was broken consumed
+    // the only recovery attempt and the dropped records were never written
+    // back, letting a later `end` land on a log that was still incomplete.
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' }) as any;
+
+    runs.emit(run, 'start', { model: 'x' });
+    await new Promise<void>((resolve) => run.eventsLogStream.once('open', resolve));
+
+    const broken = run.eventsLogStream;
+    broken.destroy(new Error('simulated io failure'));
+    runs.emit(run, 'start', { model: 'y' }); // dropped from events.jsonl
+    await new Promise<void>((resolve) => broken.once('close', resolve));
+    expect(run.eventsLogReplayNeeded).toBe(true);
+
+    // Clear what the reopened stream flushed (same inode, so its fd stays
+    // valid) so the next reconciliation has a record to append and the
+    // injected failure is actually exercised.
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    fs.writeFileSync(logPath, '', 'utf8');
+
+    const append = vi.spyOn(fs, 'appendFileSync').mockImplementationOnce(() => {
+      throw new Error('simulated disk failure');
+    });
+    runs.emit(run, 'run_retry_attempted', { retry_attempt_index: 1 });
+    append.mockRestore();
+    // The failed repair stays pending instead of being dropped with the flag.
+    expect(run.eventsLogReplayNeeded).toBe(true);
+
+    // Let the record the reopened stream just took land before the next
+    // reconciliation reads the file back, so it repairs instead of re-appends.
+    const streamedId = run.events[run.events.length - 1].id;
+    expect((await waitForCompleteLog(logPath, [streamedId])).length).toBeGreaterThan(0);
+
+    runs.emit(run, 'heartbeat', {});
+    expect(run.eventsLogReplayNeeded).toBe(false);
+    runs.finish(run, 'succeeded', 0, null);
+
+    const lines = await waitForCompleteLog(logPath, run.events.map((event: any) => event.id));
+    expect(lines.length).toBeGreaterThan(0);
+    const events = lines.map((line) => JSON.parse(line));
+    const starts = events.filter((event) => event.event === 'start');
+    expect(starts).toHaveLength(2);
+    expect(new Set(starts.map((event) => event.id)).size).toBe(2);
+    expect(events.filter((event) => event.event === 'run_retry_attempted')).toHaveLength(1);
+    expect(events.filter((event) => event.event === 'heartbeat')).toHaveLength(1);
+    expect(events.filter((event) => event.event === 'end')).toHaveLength(1);
+  });
+
+  it('truncates a torn first record before replaying the recovered log', async () => {
+    // Regression for the #6726 review: a fragment with no newline anywhere
+    // leaves lastNewline at -1, so the old truncation skipped it and replayed
+    // the recovered records after the fragment, keeping the first line
+    // unparseable and its event unreadable.
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' }) as any;
+
+    runs.emit(run, 'start', { model: 'x' });
+    runs.emit(run, 'start', { model: 'y' });
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    expect((await waitForLogLines(logPath, 2)).length).toBe(2);
+
+    fs.writeFileSync(logPath, '{"id":0,"event":"sta', 'utf8');
+
+    run.eventsLogReplayNeeded = true;
+    runs.emit(run, 'heartbeat', {});
+    expect(run.eventsLogReplayNeeded).toBe(false);
+
+    const lines = await waitForCompleteLog(logPath, run.events.map((event: any) => event.id));
+    expect(lines.length).toBeGreaterThan(0);
+    const events = lines.map((line) => JSON.parse(line));
+    expect(events.filter((event) => event.event === 'start')).toHaveLength(2);
+    expect(events.filter((event) => event.event === 'heartbeat')).toHaveLength(1);
+    runs.finish(run, 'succeeded', 0, null);
+  });
+
+  it('truncates a torn trailing record before replaying the recovered log', async () => {
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({ projectId: 'p1', conversationId: 'c1' }) as any;
+
+    runs.emit(run, 'start', { model: 'x' });
+    runs.emit(run, 'start', { model: 'y' });
+    const logPath = path.join(tmpDir, run.id, 'events.jsonl');
+    expect((await waitForLogLines(logPath, 2)).length).toBe(2);
+
+    fs.appendFileSync(logPath, '{"id":99,"event":"hear', 'utf8');
+
+    run.eventsLogReplayNeeded = true;
+    runs.emit(run, 'heartbeat', {});
+    expect(run.eventsLogReplayNeeded).toBe(false);
+
+    const lines = await waitForCompleteLog(logPath, run.events.map((event: any) => event.id));
+    expect(lines.length).toBeGreaterThan(0);
+    const events = lines.map((line) => JSON.parse(line));
+    expect(events.some((event) => event.id === 99)).toBe(false);
+    expect(events.filter((event) => event.event === 'heartbeat')).toHaveLength(1);
+    runs.finish(run, 'succeeded', 0, null);
+  });
 });
 
 describe('work completeness vs a settled OD Next verdict', () => {


### PR DESCRIPTION
Fixes #5292

## Why

A same-run retry can end `succeeded` with only one `start` persisted in its event log: records are written fire-and-forget to a lazily-opened `fs.WriteStream`, and a transient stream error silently drops the queued record while later emits re-open a fresh stream. The in-memory event ring keeps the full history, but the file projection ends up with a hole, so a tailed `events.jsonl` can reach `end` with earlier records missing. This is the intermittent persisted-event flake on main seen in the QA records of #6598 and #6600.

The fix reconciles the file from the in-memory ring: when the stream errors the run is flagged, and the next emit / finish re-appends any record missing from the file.

## What users will see

Nothing in the UI. After a transient log-stream failure the run event log (`events.jsonl`) is repaired from the in-memory ring on the next emit or finish, instead of the affected records being silently dropped from the file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A (no UI).

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/runs.test.ts` → "recovers a run event that was lost to a transient log-stream failure".
- Red on main: `expected [ { id: 1, event: 'start', ... } ] to have a length of 2 but got 1` — the same assertion the issue reports, reproduced deterministically with an injected stream failure; a weaker "replay only the last record" variant also stays red.
- Green on branch: 46/46 `runs.test.ts`, 11/11 `run-retry-runtime.test.ts`, 37/37 adjacent bundle (`run-retry-runtime` + `headless-runs` + `tool-tokens` + `plugins-tool-token-gate`).

## Validation

```
pnpm --dir apps/daemon exec vitest run tests/runtimes/runs.test.ts --reporter=dot  (46 passed)
pnpm --dir apps/daemon exec vitest run tests/run-retry-runtime.test.ts --reporter=dot  (11 passed)
pnpm --dir apps/daemon exec vitest run tests/run-retry-runtime.test.ts tests/headless-runs.test.ts tests/tool-tokens.test.ts tests/plugins-tool-token-gate.test.ts --reporter=dot --pool=forks --maxWorkers=1  (37 passed)
git diff --check  (clean)
```

