### PR TITLE
feat(skills): add Windows PowerShell execution guidance

### DIFF
--- a/apps/daemon/src/prompts/stable-sections.ts
+++ b/apps/daemon/src/prompts/stable-sections.ts
@@ -83,6 +83,7 @@ const SECTION_INPUTS = {
     'agentId',
     'includeCodexImagegenOverride',
     'promptCoreVariant',
+    'hostPlatform',
     'runtimeToolPrompt',
   ],
   'client-system': ['clientSystemPrompt'],

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -45,6 +45,7 @@ import {
 } from './media-contract.js';
 import { IMAGE_MODELS } from '../media/models.js';
 import { renderPanelPrompt } from './panel.js';
+import { WINDOWS_POWERSHELL_EXECUTION_CONTRACT } from './windows-powershell.js';
 import { defaultCritiqueConfig, type CritiqueConfig } from '@open-design/contracts/critique';
 import {
   executionProfileFromStreamFormat,
@@ -838,6 +839,10 @@ export interface ComposeInput {
   // `detectPlatformIntentSignal`). ORed with the metadata-based platform
   // gate for PLATFORM_CONTRACTS_BLOCK under slim; absent = metadata only.
   platformHintSignal?: boolean | undefined;
+  // Host OS selected by the daemon. Windows filesystem agents receive a
+  // compact PowerShell command contract; text-artifact/API runs do not have
+  // local command tools and therefore skip it.
+  hostPlatform?: string | undefined;
 }
 
 export function composeSystemPrompt({
@@ -880,6 +885,7 @@ export function composeSystemPrompt({
   promptCoreVariant,
   mediaHintSignal,
   platformHintSignal,
+  hostPlatform,
 }: ComposeInput): string {
   // Slim core collapses the discovery layer + designer charter + their tail
   // overrides into one charter document; the classic stack keeps the legacy
@@ -988,6 +994,10 @@ export function composeSystemPrompt({
     // Slim runs (charter head AND ask head) already composed this first.
     parts.push(API_MODE_OVERRIDE);
     parts.push('\n\n---\n\n');
+  }
+
+  if (hostPlatform === 'win32' && resolvedExecutionProfile === 'filesystem') {
+    parts.push(WINDOWS_POWERSHELL_EXECUTION_CONTRACT, '\n\n---\n\n');
   }
 
   // Ask mode (`chat`) is the deliberately bare conversation mode: the

--- a/apps/daemon/src/prompts/windows-powershell.ts
+++ b/apps/daemon/src/prompts/windows-powershell.ts
@@ -1,0 +1,20 @@
+/**
+ * Host-specific command contract for filesystem agents running on Windows.
+ * Keep this compact: the bundled skill supplies the detailed workflow and
+ * progressive references, while this remains a fail-safe if skill discovery
+ * or staging is unavailable.
+ */
+export const WINDOWS_POWERSHELL_SKILL_ID = 'windows-powershell';
+
+export function shouldComposeWindowsPowerShellSkill(input: {
+  hostPlatform: string | undefined;
+  executionProfile: string | undefined;
+}): boolean {
+  return input.hostPlatform === 'win32' && input.executionProfile === 'filesystem';
+}
+
+export const WINDOWS_POWERSHELL_EXECUTION_CONTRACT = `# Windows command execution — PowerShell
+
+This host is Windows. Every shell-tool command is parsed by PowerShell unless the tool explicitly says otherwise. The bundled \`windows-powershell\` host skill, when present below, is mandatory for shell work and routes detailed cases to progressive references.
+
+Fail-safe rules: do not paste Bash syntax; inspect \`$PSVersionTable\` before using version-specific syntax; use \`-LiteralPath\` and argument arrays instead of command strings; check cmdlet errors and native \`$LASTEXITCODE\`; classify failures before retrying; verify every mutation with a separate read-only command.`;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -38,6 +38,10 @@ import {
   serializeStableSections,
   type StableSectionHashes,
 } from './prompts/stable-sections.js';
+import {
+  shouldComposeWindowsPowerShellSkill,
+  WINDOWS_POWERSHELL_SKILL_ID,
+} from './prompts/windows-powershell.js';
 import { emittedRenderableQuestionForm } from './question-form-detect.js';
 import { resolveProjectRoot } from './project-root.js';
 import { OPEN_DESIGN_PLUGIN_ID } from './mcp-observability.js';
@@ -8389,6 +8393,40 @@ export async function startServer({
       }
     }
 
+    // Windows filesystem runs always receive the bundled PowerShell utility
+    // skill in addition to the user's selected design/functional skill. Do
+    // not register its mode, craft, or critique policy: it is a host execution
+    // contract and must not change the project's artifact surface. Registering
+    // only its directory ensures references and the Parser helper are staged
+    // into the project alongside any user-selected skill resources.
+    const executionProfile = executionProfileFromStreamFormat(streamFormat);
+    if (shouldComposeWindowsPowerShellSkill({
+      hostPlatform: process.platform,
+      executionProfile,
+    })) {
+      // Resolve from the bundled root directly. The normal combined registry
+      // intentionally lets user-managed skills shadow built-ins, but a
+      // machine-wide host execution contract must not be replaceable by a
+      // same-name user skill and silently affect every Windows run.
+      const bundledSkills = await listSkills(SKILLS_DIR);
+      const windowsPowerShellSkill = findSkillById(
+        bundledSkills,
+        WINDOWS_POWERSHELL_SKILL_ID,
+      );
+      if (windowsPowerShellSkill) {
+        const hostSkillBlock = [
+          `## Host execution skill — ${windowsPowerShellSkill.name}`,
+          '',
+          windowsPowerShellSkill.body.trim(),
+        ].join('\n');
+        skillBody = skillBody && skillBody.trim().length > 0
+          ? `${skillBody.trim()}\n\n---\n\n${hostSkillBlock}`
+          : hostSkillBlock;
+        skillName ??= windowsPowerShellSkill.name;
+        registerSkillDir(windowsPowerShellSkill.dir);
+      }
+    }
+
     let craftBody;
     let craftSections;
 
@@ -8736,13 +8774,14 @@ export async function startServer({
       mediaExecution,
       byokMediaDefaults,
       streamFormat,
-      executionProfile: executionProfileFromStreamFormat(streamFormat),
+      executionProfile,
       ...(pluginBlock ? { pluginBlock } : {}),
       ...(activeStageBlocks ? { activeStageBlocks } : {}),
       userInstructions,
       freeformDeckSignal,
       mediaHintSignal,
       platformHintSignal,
+      hostPlatform: process.platform,
       // VALIDATION DEFAULT — feat/system-prompt integration branch only.
       // Slim is the default here so packaged beta builds exercise the
       // rewritten charter without env plumbing (the packaged sidecar env

--- a/apps/daemon/tests/prompts/windows-powershell.test.ts
+++ b/apps/daemon/tests/prompts/windows-powershell.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { composeSystemPrompt } from '../../src/prompts/system.js';
+import { shouldComposeWindowsPowerShellSkill } from '../../src/prompts/windows-powershell.js';
+
+const HEADING = '# Windows command execution — PowerShell';
+
+describe('Windows PowerShell system-prompt contract', () => {
+  it.each(['classic', 'slim'] as const)(
+    'injects the execution contract for Windows filesystem agents with the %s core',
+    (promptCoreVariant) => {
+      const prompt = composeSystemPrompt({
+        agentId: 'qwen',
+        executionProfile: 'filesystem',
+        hostPlatform: 'win32',
+        promptCoreVariant,
+      });
+
+      expect(prompt).toContain(HEADING);
+      expect(prompt).toContain('Every shell-tool command is parsed by PowerShell');
+      expect(prompt).toContain('$PSVersionTable');
+      expect(prompt).toContain('-LiteralPath');
+      expect(prompt).toContain('$LASTEXITCODE');
+      expect(prompt).toContain('classify failures before retrying');
+      expect(prompt).toContain('verify every mutation with a separate read-only command');
+    },
+  );
+
+  it('does not inject the contract on non-Windows hosts', () => {
+    const prompt = composeSystemPrompt({
+      executionProfile: 'filesystem',
+      hostPlatform: 'linux',
+    });
+
+    expect(prompt).not.toContain(HEADING);
+  });
+
+  it('does not inject the contract into tool-less text-artifact runs', () => {
+    const prompt = composeSystemPrompt({
+      executionProfile: 'text_artifact',
+      hostPlatform: 'win32',
+      streamFormat: 'plain',
+    });
+
+    expect(prompt).not.toContain(HEADING);
+    expect(prompt).toContain('# API mode — no tools available');
+  });
+
+  it('composes the detailed host skill only for Windows filesystem runs', () => {
+    expect(shouldComposeWindowsPowerShellSkill({
+      hostPlatform: 'win32',
+      executionProfile: 'filesystem',
+    })).toBe(true);
+    expect(shouldComposeWindowsPowerShellSkill({
+      hostPlatform: 'linux',
+      executionProfile: 'filesystem',
+    })).toBe(false);
+    expect(shouldComposeWindowsPowerShellSkill({
+      hostPlatform: 'win32',
+      executionProfile: 'text_artifact',
+    })).toBe(false);
+  });
+});

--- a/e2e/tests/windows-powershell-skill.test.ts
+++ b/e2e/tests/windows-powershell-skill.test.ts
@@ -1,0 +1,84 @@
+import { readFile, stat } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const skillRoot = path.join(repoRoot, 'skills', 'windows-powershell');
+const checkerPath = path.join(skillRoot, 'scripts', 'Test-PowerShellSyntax.ps1');
+const testPath = path.join(skillRoot, 'tests', 'Test-PowerShellSyntax.Tests.ps1');
+
+const sideFiles = [
+  'references/quoting-and-parsing.md',
+  'references/native-commands.md',
+  'references/ps51-vs-pwsh7.md',
+  'references/encoding-and-json.md',
+  'references/failure-recovery.md',
+  'scripts/Test-PowerShellSyntax.ps1',
+  'tests/fixtures/valid-ps51.ps1',
+  'tests/fixtures/valid-ps7.ps1',
+  'tests/fixtures/invalid-parser.ps1',
+] as const;
+
+function availablePowerShellEngines(): string[] {
+  return ['pwsh', 'powershell.exe'].filter((engine) => {
+    const probe = spawnSync(
+      engine,
+      ['-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.ToString()'],
+      { encoding: 'utf8' },
+    );
+    return probe.status === 0;
+  });
+}
+
+describe('windows-powershell skill bundle', () => {
+  it('keeps the core contract compact and routes detailed topics to side files', async () => {
+    const skill = await readFile(path.join(skillRoot, 'SKILL.md'), 'utf8');
+
+    expect(skill).toContain('name: windows-powershell');
+    expect(skill).toContain('mode: utility');
+    expect(skill).toContain('$PSVersionTable.PSVersion');
+    expect(skill).toContain('$LASTEXITCODE');
+    expect(skill).toContain('Never build');
+    expect(skill).toContain('Invoke-Expression');
+    expect(skill).toContain('separate read-only command');
+    for (const sideFile of sideFiles) {
+      const info = await stat(path.join(skillRoot, sideFile));
+      expect(info.isFile(), `${sideFile} must be a regular file`).toBe(true);
+      if (sideFile.startsWith('references/') || sideFile.startsWith('scripts/')) {
+        expect(skill).toContain(sideFile);
+      }
+    }
+  });
+
+  it('uses the PowerShell Parser API without executing the inspected script', async () => {
+    const checker = await readFile(checkerPath, 'utf8');
+
+    expect(checker).toContain('System.Management.Automation.Language.Parser');
+    expect(checker).toContain('::ParseFile(');
+    expect(checker).not.toContain('Invoke-Expression');
+    expect(checker).not.toContain('Write-Error');
+    expect(checker).not.toMatch(/&\s+\$item\.FullName/);
+  });
+
+  const engines = availablePowerShellEngines();
+  it.skipIf(engines.length === 0)(
+    'accepts shared syntax and classifies version-specific parser failures in installed engines',
+    () => {
+      for (const engine of engines) {
+        const result = spawnSync(
+          engine,
+          ['-NoProfile', '-NonInteractive', '-File', testPath],
+          { encoding: 'utf8' },
+        );
+
+        expect(
+          { engine, status: result.status, stdout: result.stdout, stderr: result.stderr },
+          `${engine} syntax-check suite failed`,
+        ).toMatchObject({ status: 0 });
+      }
+    },
+  );
+});

--- a/skills/windows-powershell/SKILL.md
+++ b/skills/windows-powershell/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: windows-powershell
+en_name: "Windows PowerShell"
+zh_name: "Windows PowerShell 可靠执行"
+description: |
+  Execute, diagnose, and verify commands reliably in Windows PowerShell 5.1 or PowerShell 7. Use for Windows shell commands, .ps1 scripts, native CLI invocation, Bash-to-PowerShell translation, quoting or path failures, JSON and encoding work, and PowerShell failure recovery.
+en_description: "Execute, diagnose, and verify Windows PowerShell commands with version-aware syntax, safe argument passing, and explicit completion checks."
+zh_description: "通过版本感知语法、安全参数传递和明确的完成验证，可靠执行与诊断 Windows PowerShell 命令。"
+triggers:
+  - "Windows PowerShell"
+  - "powershell command"
+  - "pwsh"
+  - "Windows shell"
+  - ".ps1"
+  - "Bash to PowerShell"
+  - "PowerShell quoting"
+  - "PowerShell failed"
+  - "PowerShell 命令"
+  - "PowerShell 执行失败"
+od:
+  mode: utility
+  category: developer-tools
+  design_system:
+    requires: false
+  example_prompt: "Use Windows PowerShell to run this command, diagnose any failure, and verify the final state."
+  example_prompt_i18n:
+    zh-CN: "使用 Windows PowerShell 执行这项操作，诊断任何失败，并验证最终状态。"
+---
+
+# Windows PowerShell
+
+Execute PowerShell commands through a short inspect-run-verify loop. Prefer
+predictable commands over compressed one-liners.
+
+## Execution contract
+
+1. Identify the actual shell and runtime before relying on version-sensitive
+   behavior. Inspect `$PSVersionTable.PSVersion` and
+   `$PSVersionTable.PSEdition`; do not infer PowerShell 7 from a Windows host.
+2. Confirm the working directory with `Get-Location` when it affects the
+   result. Use the shell tool's working-directory option when available.
+3. Translate Unix command semantics into PowerShell. Do not paste Bash
+   heredocs, `export`, `source`, `VAR=value command`, backslash continuations,
+   or Bash-style command substitutions.
+4. Use `-LiteralPath` for discovered or user-supplied paths and `Join-Path`
+   when constructing paths. Invoke quoted executable paths with `&`.
+5. Pass dynamic native arguments as an array and splat the array. Never build
+   a command string for `Invoke-Expression`.
+6. Use `-ErrorAction Stop` or a narrowly scoped
+   `$ErrorActionPreference = 'Stop'` with `try/catch` for cmdlet failures that
+   must stop the step. Check `$LASTEXITCODE` after native commands.
+7. Keep simple operations inline. For complex multiline logic, write a `.ps1`
+   file, check it with `scripts/Test-PowerShellSyntax.ps1`, then run it with a
+   new PowerShell process using `-NoProfile -File`. Do not nest
+   `powershell -Command` calls without a concrete boundary reason.
+8. When a command fails, classify it before retrying: parser/quoting,
+   parameter binding, missing command/path, version/profile, permission or
+   sandbox, network/authentication, or native application exit. Fix the
+   classified cause instead of adding random escaping.
+9. Resolve and inspect targets before deletion, overwrite, move, install,
+   execution-policy, or permission changes. Do not bypass the host tool's
+   sandbox or approval boundary.
+10. After a mutation reports success, use a separate read-only command to
+    verify the intended state before reporting completion.
+
+## Progressive references
+
+Read only the references needed for the current failure or command:
+
+- For interpolation, metacharacters, here-strings, or nested quoting, read
+  `references/quoting-and-parsing.md`.
+- For executables, argument arrays, pipelines, stdout/stderr, or exit codes,
+  read `references/native-commands.md`.
+- For Windows PowerShell 5.1 versus PowerShell 7 behavior, read
+  `references/ps51-vs-pwsh7.md`.
+- For text encoding, JSON, or structured file edits, read
+  `references/encoding-and-json.md`.
+- After any failure or ambiguous partial success, read
+  `references/failure-recovery.md`.
+
+Resolve these paths from the skill root advertised above the skill body. Do
+not edit the staged skill copy as part of the user's task.
+
+## Command patterns
+
+Use an argument array for a native executable:
+
+```powershell
+$gitArgs = @('status', '--short', '--', $targetPath)
+& git @gitArgs
+if ($LASTEXITCODE -ne 0) { throw "git exited with code $LASTEXITCODE" }
+```
+
+Use terminating cmdlet errors for a failure-sensitive step:
+
+```powershell
+try {
+    Copy-Item -LiteralPath $source -Destination $destination -ErrorAction Stop
+} catch {
+    throw "Copy failed: $($_.Exception.Message)"
+}
+```
+
+Check a generated script without executing it:
+
+```powershell
+& powershell.exe -NoProfile -File '<skill-root>\scripts\Test-PowerShellSyntax.ps1' -Path '.\task.ps1'
+if ($LASTEXITCODE -ne 0) { throw 'PowerShell syntax check failed' }
+```
+
+Use `pwsh` instead of `powershell.exe` only after confirming it is available
+with `Get-Command pwsh -ErrorAction SilentlyContinue`.
+
+## Completion report
+
+Report the runtime used, the operation result, and the independent verification
+result. If verification is impossible, name the missing evidence and do not
+describe the task as completed.

--- a/skills/windows-powershell/agents/openai.yaml
+++ b/skills/windows-powershell/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Windows PowerShell"
+  short_description: "可靠执行、诊断和验证 Windows PowerShell 命令"
+  default_prompt: "Use $windows-powershell to execute and verify this task safely in Windows PowerShell."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/windows-powershell/references/encoding-and-json.md
+++ b/skills/windows-powershell/references/encoding-and-json.md
@@ -1,0 +1,49 @@
+# Encoding and JSON
+
+Use this reference when commands read or write text for another program, edit
+JSON, or cross the Windows PowerShell 5.1 / PowerShell 7 boundary.
+
+## Select encoding explicitly
+
+Default encodings vary by PowerShell version and cmdlet. For UTF-8 without a
+byte-order mark in both Windows PowerShell 5.1 and PowerShell 7, use .NET:
+
+```powershell
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($path, $text, $utf8NoBom)
+```
+
+For existing text, preserve the file's required encoding when known. Do not
+rewrite an entire file merely to change one value unless formatting and
+encoding changes are acceptable.
+
+## Modify JSON as data
+
+Parse JSON, change the object, and serialize it. Do not use regex replacement
+for structural JSON edits.
+
+```powershell
+$jsonText = [System.IO.File]::ReadAllText($path)
+$document = $jsonText | ConvertFrom-Json
+$document.enabled = $true
+$updated = $document | ConvertTo-Json -Depth 100
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($path, $updated + [Environment]::NewLine, $utf8NoBom)
+```
+
+Choose a sufficient `ConvertTo-Json -Depth`; shallow defaults can silently
+replace nested objects with abbreviated strings. After writing, parse the file
+again and assert the intended value.
+
+## Preserve arrays intentionally
+
+PowerShell unwraps single pipeline results. Wrap results with `@(...)` when the
+consumer requires an array even for zero or one item. When an API requires a
+JSON array, verify the serialized top-level shape rather than assuming it.
+
+## Console output is not file encoding
+
+`[Console]::OutputEncoding`, `$OutputEncoding`, and a file cmdlet's `-Encoding`
+control different boundaries. Change only the boundary involved in the
+failure, keep the change scoped, and restore process-wide settings if they
+must be modified.

--- a/skills/windows-powershell/references/failure-recovery.md
+++ b/skills/windows-powershell/references/failure-recovery.md
@@ -1,0 +1,48 @@
+# Failure recovery
+
+Use this reference after a failed command, a partial mutation, or an ambiguous
+result.
+
+## Capture evidence before changing the command
+
+Record:
+
+- the PowerShell version and edition;
+- the working directory;
+- the resolved command from `Get-Command`;
+- the exact parameter or argument array shape without secrets;
+- the PowerShell exception category and message;
+- `$LASTEXITCODE` for native programs;
+- the target state observed with `Test-Path -LiteralPath`, `Get-Item`, or a
+  domain-specific read-only check.
+
+Never print credentials, tokens, or full sensitive environment values while
+collecting evidence.
+
+## Classify one primary failure
+
+| Class | Typical evidence | Next action |
+| --- | --- | --- |
+| Parser or quoting | Parser error, unexpected token, unterminated string | Reduce quoting surface; run the Parser checker |
+| Parameter binding | Unknown/ambiguous parameter, wrong type | Inspect `Get-Command ... -Syntax` and object types |
+| Command or path resolution | Command not found, item absent | Use `Get-Command` or `Test-Path -LiteralPath` |
+| Runtime or profile | Works in one shell/profile only | Compare version/edition; retry with an explicit `-NoProfile` boundary |
+| Permission or sandbox | Access denied, blocked tool policy | Stop and request the required authority; do not bypass controls |
+| Network or authentication | HTTP/auth/TLS/proxy failure | Verify endpoint and credential presence without exposing secrets |
+| Native application exit | Nonzero `$LASTEXITCODE` | Interpret that program's exit contract and diagnostics |
+| Partial mutation | Some targets changed before failure | Inspect state, then choose a safe resume or rollback |
+
+## Retry rule
+
+Retry only after changing something tied to the classified cause. Do not keep
+adding quotes, backticks, `-Force`, administrator elevation, execution-policy
+changes, or alternate shells to see what happens.
+
+Before retrying a mutation, determine whether the first attempt already made a
+partial change. Prefer idempotent commands or an explicit resume point.
+
+## Completion rule
+
+Treat process success and task success separately. A zero exit code proves only
+the process contract. Run an independent, read-only check of the requested
+state. If the check cannot be performed, report the result as unverified.

--- a/skills/windows-powershell/references/native-commands.md
+++ b/skills/windows-powershell/references/native-commands.md
@@ -1,0 +1,55 @@
+# Native commands
+
+Use this reference for `.exe` files and cross-platform CLIs such as `git`,
+`node`, `pnpm`, `docker`, or `curl.exe`.
+
+## Resolve and invoke
+
+Probe uncertain commands before use:
+
+```powershell
+$command = Get-Command git -ErrorAction Stop
+$args = @('-C', $repoPath, 'status', '--short')
+& $command.Source @args
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) { throw "git failed with exit code $exitCode" }
+```
+
+Use `&` when the executable is stored in a variable or its path is quoted.
+Build dynamic arguments as an array. Do not flatten the array into a string.
+
+## Treat exit status as authoritative
+
+`$?` describes the success of the most recent PowerShell operation and can be
+overwritten by another expression. Capture `$LASTEXITCODE` immediately after a
+native process. Stdout does not prove success, and stderr does not necessarily
+prove failure.
+
+When output is needed, capture it without losing the exit code:
+
+```powershell
+$output = & $exe @args 2>&1
+$exitCode = $LASTEXITCODE
+if ($exitCode -ne 0) {
+    throw "Command failed ($exitCode): $($output -join [Environment]::NewLine)"
+}
+```
+
+Only merge stderr into stdout when combined diagnostic text is acceptable. If
+the streams have different meanings, redirect them to separate files or keep
+the tool's structured result.
+
+## Avoid pipeline shape surprises
+
+PowerShell pipelines pass objects between cmdlets, but native programs receive
+text. A cmdlet can emit zero, one, or many objects; normalize intentionally
+with `@(...)` when later code requires an array.
+
+Avoid formatting cmdlets such as `Format-Table` before filtering, exporting,
+or serializing. Formatting output is for display, not data processing.
+
+## Prefer explicit tools
+
+PowerShell aliases can differ by version and profile. In scripts, prefer full
+cmdlet names. On Windows PowerShell, `curl` may resolve to a PowerShell alias;
+use `curl.exe` when the native executable is specifically required.

--- a/skills/windows-powershell/references/ps51-vs-pwsh7.md
+++ b/skills/windows-powershell/references/ps51-vs-pwsh7.md
@@ -1,0 +1,52 @@
+# Windows PowerShell 5.1 and PowerShell 7
+
+Use this reference before relying on syntax or cmdlets that differ across the
+two runtimes.
+
+## Detect, do not guess
+
+```powershell
+$major = $PSVersionTable.PSVersion.Major
+$edition = $PSVersionTable.PSEdition
+$isPowerShell7 = $major -ge 7
+```
+
+Windows PowerShell 5.1 normally reports `Desktop`; PowerShell 7 reports `Core`.
+The host OS alone does not identify the runtime. `$IsWindows` is not available
+in Windows PowerShell 5.1, so do not use it in shared scripts without a guard.
+
+## Compatibility choices
+
+| Need | Shared 5.1/7 form | PowerShell 7-only convenience |
+| --- | --- | --- |
+| Run step B after A succeeds | Run A, test success/exit code, then run B | `A && B` |
+| Run fallback after failure | Use `try/catch` or explicit status branch | `A || B` |
+| Choose a value | Use `if (...) { ... } else { ... }` | Ternary `? :` |
+| Null fallback | Test `$null -eq $value` explicitly | `??` |
+| Parallel pipeline | Use an explicit job/runspace only when justified | `ForEach-Object -Parallel` |
+| Web request parsing | Inspect returned object and status explicitly | Newer cmdlet defaults/options |
+
+Do not use `&&`, `||`, `? :`, `??`, or other newer syntax until PowerShell 7
+has been confirmed. Parser failure occurs before a runtime guard can protect
+PowerShell 5.1 from unsupported syntax in the same file.
+
+## Starting a child process
+
+Prefer the current shell for simple commands. When a clean process boundary is
+needed, resolve the executable first:
+
+```powershell
+$pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+$engine = if ($pwsh) { $pwsh.Source } else { 'powershell.exe' }
+& $engine -NoProfile -File $scriptPath
+$exitCode = $LASTEXITCODE
+```
+
+Do not silently switch engines if the task requires a specific version.
+Report the missing runtime instead.
+
+## Encoding warning
+
+Windows PowerShell 5.1 and PowerShell 7 use different default encodings for
+several file cmdlets. Never rely on those defaults for files consumed by other
+tools. Read `references/encoding-and-json.md` and select an encoding explicitly.

--- a/skills/windows-powershell/references/quoting-and-parsing.md
+++ b/skills/windows-powershell/references/quoting-and-parsing.md
@@ -1,0 +1,64 @@
+# Quoting and parsing
+
+Use this reference when a command contains interpolation, metacharacters,
+here-strings, nested commands, or data that PowerShell could parse as syntax.
+
+## Choose the smallest quoting surface
+
+- Use single quotes for literal strings. A single quote inside a single-quoted
+  string is doubled: `'don''t'`.
+- Use double quotes only when `$variable`, `$($expression)`, or escape-sequence
+  expansion is intentional.
+- Use the format operator for mixed literal and dynamic text when interpolation
+  becomes hard to audit: `'File: {0}' -f $path`.
+- Quote URLs that contain `&`, `?`, or `#` so PowerShell does not interpret
+  metacharacters.
+- Do not add backslashes before quotes as if PowerShell used Bash or JSON
+  escaping. PowerShell's escape character is the backtick, but prefer changing
+  the quoting shape over stacking backticks.
+
+## Keep code and data separate
+
+Pass user or discovered values through variables and parameters. Do not splice
+them into a command string and do not call `Invoke-Expression`.
+
+```powershell
+$args = @('--output', $outputPath, '--name', $userValue)
+& $executable @args
+```
+
+For cmdlets, use named parameters directly:
+
+```powershell
+Get-ChildItem -LiteralPath $root -File -ErrorAction Stop
+```
+
+## Here-strings
+
+Use a here-string only for genuine multiline data. The opening marker must be
+the last token on its line, and the closing marker must begin at column 1.
+
+```powershell
+$literal = @'
+$name is not expanded here.
+'@
+
+$expanded = @"
+$name is expanded here.
+"@
+```
+
+Do not translate a Bash `<<EOF` heredoc token by token. For structured data,
+prefer an object plus a serializer. For a generated script, write a `.ps1`
+file with the file tool and run the Parser check before execution.
+
+## Native quoting boundary
+
+PowerShell first parses the command, then converts arguments for the native
+process. Avoid one large quoted command line. Keep each logical argument as one
+array element, especially paths with spaces, empty strings, wildcards, JSON,
+and values beginning with `-`.
+
+When invoking another shell is truly required, treat its command text as a new
+parser boundary and document why it is needed. Do not nest shells merely to
+reuse syntax from an example.

--- a/skills/windows-powershell/scripts/Test-PowerShellSyntax.ps1
+++ b/skills/windows-powershell/scripts/Test-PowerShellSyntax.ps1
@@ -1,0 +1,84 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [Alias('LiteralPath')]
+    [string] $Path,
+
+    [switch] $AsJson
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+try {
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.PSIsContainer) {
+        throw "Path is a directory, not a PowerShell script: $Path"
+    }
+
+    $tokens = $null
+    $parseErrors = $null
+    [void] [System.Management.Automation.Language.Parser]::ParseFile(
+        $item.FullName,
+        [ref] $tokens,
+        [ref] $parseErrors
+    )
+    $parseErrorItems = @($parseErrors)
+
+    $result = [pscustomobject]@{
+        valid = ($parseErrorItems.Count -eq 0)
+        path = $item.FullName
+        powershellVersion = $PSVersionTable.PSVersion.ToString()
+        powershellEdition = $PSVersionTable.PSEdition
+        errors = @(
+            $parseErrorItems | ForEach-Object {
+                [pscustomobject]@{
+                    message = $_.Message
+                    line = $_.Extent.StartLineNumber
+                    column = $_.Extent.StartColumnNumber
+                    text = $_.Extent.Text
+                }
+            }
+        )
+    }
+
+    if ($AsJson) {
+        $result | ConvertTo-Json -Depth 5 -Compress
+    } elseif ($result.valid) {
+        Write-Output "Syntax OK: $($result.path)"
+    } else {
+        foreach ($parseError in $result.errors) {
+            [Console]::Error.WriteLine(
+                '{0}:{1}:{2}: {3}' -f
+                $result.path,
+                $parseError.line,
+                $parseError.column,
+                $parseError.message
+            )
+        }
+    }
+
+    if (-not $result.valid) {
+        exit 1
+    }
+} catch {
+    if ($AsJson) {
+        [pscustomobject]@{
+            valid = $false
+            path = $Path
+            powershellVersion = $PSVersionTable.PSVersion.ToString()
+            powershellEdition = $PSVersionTable.PSEdition
+            errors = @(
+                [pscustomobject]@{
+                    message = $_.Exception.Message
+                    line = $null
+                    column = $null
+                    text = $null
+                }
+            )
+        } | ConvertTo-Json -Depth 5 -Compress
+    } else {
+        [Console]::Error.WriteLine($_.Exception.Message)
+    }
+    exit 2
+}

--- a/skills/windows-powershell/tests/Test-PowerShellSyntax.Tests.ps1
+++ b/skills/windows-powershell/tests/Test-PowerShellSyntax.Tests.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$skillRoot = Split-Path -Parent $PSScriptRoot
+$scripts = Join-Path $skillRoot 'scripts'
+$checker = Join-Path $scripts 'Test-PowerShellSyntax.ps1'
+$fixtures = Join-Path $PSScriptRoot 'fixtures'
+$engine = (Get-Process -Id $PID).Path
+
+function Invoke-SyntaxCheck {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Fixture
+    )
+
+    $fixturePath = Join-Path $fixtures $Fixture
+    $output = & $engine -NoProfile -File $checker -Path $fixturePath -AsJson 2>&1
+    [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output = ($output -join [Environment]::NewLine)
+    }
+}
+
+$shared = Invoke-SyntaxCheck -Fixture 'valid-ps51.ps1'
+if ($shared.ExitCode -ne 0) {
+    throw "Expected the PowerShell 5.1-compatible fixture to pass: $($shared.Output)"
+}
+
+$invalid = Invoke-SyntaxCheck -Fixture 'invalid-parser.ps1'
+if ($invalid.ExitCode -ne 1) {
+    throw "Expected the invalid fixture to fail parsing with exit code 1: $($invalid.Output)"
+}
+
+$powerShell7 = Invoke-SyntaxCheck -Fixture 'valid-ps7.ps1'
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+    if ($powerShell7.ExitCode -ne 0) {
+        throw "Expected the PowerShell 7 fixture to pass in PowerShell 7: $($powerShell7.Output)"
+    }
+} elseif ($powerShell7.ExitCode -ne 1) {
+    throw "Expected PowerShell 5.1 to reject PowerShell 7-only syntax: $($powerShell7.Output)"
+}
+
+Write-Output "PowerShell syntax checker tests passed on $($PSVersionTable.PSVersion)."

--- a/skills/windows-powershell/tests/fixtures/invalid-parser.ps1
+++ b/skills/windows-powershell/tests/fixtures/invalid-parser.ps1
@@ -1,0 +1,4 @@
+param(
+    [string] $Name
+
+Write-Output "Hello $Name"

--- a/skills/windows-powershell/tests/fixtures/valid-ps51.ps1
+++ b/skills/windows-powershell/tests/fixtures/valid-ps51.ps1
@@ -1,0 +1,8 @@
+[CmdletBinding()]
+param(
+    [string] $Name = 'world'
+)
+
+Set-StrictMode -Version 2.0
+$values = @('one', 'two')
+Write-Output ('Hello {0}: {1}' -f $Name, ($values -join ', '))

--- a/skills/windows-powershell/tests/fixtures/valid-ps7.ps1
+++ b/skills/windows-powershell/tests/fixtures/valid-ps7.ps1
@@ -1,0 +1,7 @@
+[CmdletBinding()]
+param(
+    [string] $Value
+)
+
+$resolved = $Value ?? 'PowerShell 7'
+Write-Output $resolved


### PR DESCRIPTION
## Why

Open Design can run local and open-source agents on native Windows, but smaller models frequently translate Unix examples token-by-token or mishandle PowerShell quoting, paths, native exit codes, and PowerShell 5.1 versus 7 syntax.

This adds a compact default execution floor plus progressively loaded detail so Windows command runs are more deterministic without loading a full PowerShell manual into every prompt.

## What users will see

On Windows filesystem-backed runs, agents automatically receive a concise PowerShell system contract and the bundled `windows-powershell` utility skill. The skill supplies focused references for quoting, native commands, runtime compatibility, encoding/JSON, and failure recovery, plus a Parser-only syntax checker.

The host skill is loaded from the bundled root, cannot be replaced by a same-name user shadow, and does not change the selected design skill, artifact mode, craft rules, or critique policy. Non-Windows and tool-less API runs are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — Windows filesystem agents receive the bundled execution contract automatically
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this change has no new UI surface.

## Bug fix verification

Not applicable; this is execution-reliability hardening rather than a regression fix.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/prompts/system.test.ts tests/prompts/core-slim.test.ts tests/prompts/stable-sections.test.ts tests/prompts/windows-powershell.test.ts` — 122 passed
- `pnpm exec vitest run -c vitest.config.ts tests/skills.test.ts` — 21 passed
- `pnpm test tests/windows-powershell-skill.test.ts tests/localized-content.test.ts` — 6 passed, 1 skipped because this macOS host has no `pwsh` or `powershell.exe`
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/e2e typecheck` — passed
- `pnpm typecheck` — passed
- `pnpm guard` — blocked by the pre-existing missing `apps/telemetry-worker/package.json`; daemon core boundary and cross-app import checks report `ENOENT`
