### PR TITLE
fix(daemon): unblock agent exports on workspace-bound projects

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -432,7 +432,8 @@ reachable; otherwise the command reports that the renderer is unavailable.
 Formats:  ${EXPORT_FORMATS.join(', ')}
 
 Options:
-  --project <id>           Project id (required)
+  --project <id>           Project id (required; defaults to OD_PROJECT_ID, and
+                           is derived from OD_TOOL_TOKEN inside an agent run)
   --format <fmt>           One of: ${EXPORT_FORMATS.join(' | ')} (required)
   --out <path>             Write the file here (defaults to the suggested name)
   --image-format <fmt>     png | jpeg (for --format image)
@@ -466,7 +467,11 @@ async function runExport(args) {
   const file = flags.file || pos[0];
   const projectId = flags.project || process.env.OD_PROJECT_ID;
   const format = flags.format;
-  if (!file || !projectId || !format) {
+  // An agent run is authenticated by the tool token the daemon injected, which
+  // already pins the project — it has no workspace identity to assert and does
+  // not need one. Everyone else addresses a project explicitly.
+  const token = process.env.OD_TOOL_TOKEN;
+  if (!file || !format || (!projectId && !token)) {
     printExportHelp();
     process.exit(2);
   }
@@ -483,7 +488,7 @@ async function runExport(args) {
     process.exit(2);
   }
   const base = await cliDaemonBaseUrl(flags);
-  const workspaceHeaders = workspaceHeadersFromExplicitFlags(flags) ?? {};
+  const workspaceHeaders = token ? {} : workspaceHeadersFromExplicitFlags(flags) ?? {};
   // All three formats rasterize through the desktop screenshot renderer so the
   // CLI matches the UI exactly. In particular `pdf` uses `/export/pdf-image`
   // (one raster page per deck slide / per viewport for a page) — NOT the generic
@@ -509,12 +514,22 @@ async function runExport(args) {
     ...(format === 'image' && flags['image-format'] ? { imageFormat: flags['image-format'] } : {}),
     ...(flags.title ? { title: flags.title } : {}),
   });
+  // The tool route takes one generic endpoint with `format` in the body and
+  // resolves the project from the token grant; the project route splits by
+  // format in the path. Both land on the same screenshot renderer.
+  const url = token
+    ? `${base}/api/tools/export`
+    : `${base}/api/projects/${encodeURIComponent(projectId)}/${exportPath}`;
   let resp;
   try {
-    resp = await fetch(`${base}/api/projects/${encodeURIComponent(projectId)}/${exportPath}`, {
+    resp = await fetch(url, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', ...workspaceHeaders },
-      body: JSON.stringify(requestBody),
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        ...workspaceHeaders,
+      },
+      body: JSON.stringify(token ? { ...requestBody, format } : requestBody),
     });
   } catch (err) {
     surfaceFetchError(err, base);

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -5,7 +5,10 @@ import os from 'node:os';
 import { readFile, rm } from 'node:fs/promises';
 import { isBlocked as isBlockedSystemDir } from './linked-dirs.js';
 import type { RouteDeps } from './server-context.js';
-import type { AuthorizeProjectRequest } from './collab/project-request-authority.js';
+import type {
+  AuthorizeProjectRequest,
+  AuthorizeProjectToolRequest,
+} from './collab/project-request-authority.js';
 import {
   InlineAssetsLimitError,
   MAX_INLINE_OWNER_BYTES,
@@ -519,8 +522,9 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
 
 }
 
-export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'node' | 'ids' | 'projectStore' | 'exports' | 'projectFiles' | 'validation'> {
+export interface RegisterProjectExportRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'node' | 'ids' | 'auth' | 'projectStore' | 'exports' | 'projectFiles' | 'validation'> {
   authorizeProjectRequest: AuthorizeProjectRequest;
+  authorizeProjectToolRequest: AuthorizeProjectToolRequest;
 }
 
 export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectExportRoutesDeps) {
@@ -532,6 +536,7 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   const { getProject } = ctx.projectStore;
   const { listFiles, readProjectFile, resolveProjectFilePath } = ctx.projectFiles;
   const { isSafeId } = ctx.validation;
+  const { authorizeToolRequest, requestProjectOverride } = ctx.auth;
   const {
     buildProjectArchive,
     buildBatchArchive,
@@ -556,6 +561,38 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
         ? { mode: 'read', allowNavigationQuery: true }
         : { mode: 'read' },
     );
+  }
+
+  // The generic `ExportRequest` body is shared by the browser-facing project
+  // route and the agent-facing tool route, so parse it once. Keeping the two
+  // routes on one parser is what stops the agent path from silently drifting
+  // into different deck / image / version semantics than the UI.
+  function screenshotExportRequest(body: any):
+    | { ok: true; format: 'pptx' | 'pdf' | 'image'; body: Record<string, unknown> }
+    | { ok: false; message: string } {
+    const { fileName, title, deck, format, imageFormat, width, height, versionId } = body || {};
+    if (typeof fileName !== 'string' || fileName.length === 0) {
+      return { ok: false, message: 'fileName required' };
+    }
+    if (!isExportFormat(format)) {
+      return { ok: false, message: 'invalid export format' };
+    }
+    return {
+      ok: true,
+      format,
+      body: {
+        fileName,
+        // pptx is deck-only (handleScreenshotExport forces it); pdf/image honor the
+        // caller's deck flag when one is supplied. Omitted stays omitted so the
+        // renderer can auto-detect deck artifacts.
+        ...(typeof deck === 'boolean' ? { deck } : {}),
+        ...(typeof imageFormat === 'string' ? { imageFormat } : {}),
+        ...(width != null ? { width } : {}),
+        ...(height != null ? { height } : {}),
+        ...(typeof title === 'string' ? { title } : {}),
+        ...(typeof versionId === 'string' ? { versionId } : {}),
+      },
+    };
   }
 
   function isNoSlideDeckRenderError(rendered: { ok: boolean; error?: string }): boolean {
@@ -1140,26 +1177,37 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // handleScreenshotExport owns validation, the 404/400/422 error mapping, and
   // scratch-dir cleanup.
   app.post('/api/projects/:id/export', async (req, res) => {
-    const { fileName, title, deck, format, imageFormat, width, height, versionId } = req.body || {};
-    if (typeof fileName !== 'string' || fileName.length === 0) {
-      return sendApiError(res, 400, 'BAD_REQUEST', 'fileName required');
-    }
-    if (!isExportFormat(format)) {
-      return sendApiError(res, 400, 'BAD_REQUEST', 'invalid export format');
-    }
+    const parsed = screenshotExportRequest(req.body);
+    if (!parsed.ok) return sendApiError(res, 400, 'BAD_REQUEST', parsed.message);
     if (!await authorizeExportRead(req, res)) return;
-    await handleScreenshotExport(res, format, req.params.id, {
-      fileName,
-      // pptx is deck-only (handleScreenshotExport forces it); pdf/image honor the
-      // caller's deck flag when one is supplied. Omitted stays omitted so the
-      // renderer can auto-detect deck artifacts.
-      ...(typeof deck === 'boolean' ? { deck } : {}),
-      ...(typeof imageFormat === 'string' ? { imageFormat } : {}),
-      ...(width != null ? { width } : {}),
-      ...(height != null ? { height } : {}),
-      ...(typeof title === 'string' ? { title } : {}),
-      ...(typeof versionId === 'string' ? { versionId } : {}),
-    });
+    await handleScreenshotExport(res, parsed.format, req.params.id, parsed.body);
+  });
+
+  // Agent-facing counterpart of the route above, mirroring the media pair
+  // (`/api/projects/:id/media/generate` + `/api/tools/media/generate`).
+  //
+  // The project route authorizes with the caller's `x-od-workspace-*` headers,
+  // which only the web client can produce. An agent has no workspace identity
+  // to assert — the daemon injects `OD_TOOL_TOKEN` and `OD_PROJECT_ID` and
+  // nothing else — so on a workspace-bound project every agent export failed
+  // closed with WORKSPACE_CONTEXT_REQUIRED, including the preview render the
+  // system prompt tells the model to run before it reports visual work as
+  // checked. Here the token is the authentication and the project's own
+  // persisted workspace binding is the authority, so no header is needed and
+  // the caller still cannot reach a project its run was not minted for.
+  app.post('/api/tools/export', async (req, res) => {
+    const grant = authorizeToolRequest(req, res, 'export:render');
+    if (!grant) return;
+    const suppliedProjectId = req.body?.projectId;
+    if (requestProjectOverride(suppliedProjectId, grant.projectId)) {
+      return sendApiError(res, 403, 'FORBIDDEN', 'projectId is derived from the tool token', {
+        details: { suppliedProjectId },
+      });
+    }
+    const parsed = screenshotExportRequest(req.body);
+    if (!parsed.ok) return sendApiError(res, 400, 'BAD_REQUEST', parsed.message);
+    if (!await ctx.authorizeProjectToolRequest(res, grant.projectId, { mode: 'read' })) return;
+    await handleScreenshotExport(res, parsed.format, grant.projectId, parsed.body);
   });
 
   // Export endpoint: serves an HTML body with every same-project

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7523,7 +7523,9 @@ export async function startServer({
     exports: projectExportDeps,
     projectFiles: projectFileDeps,
     validation: validationDeps,
+    auth: authDeps,
     authorizeProjectRequest,
+    authorizeProjectToolRequest,
   });
   registerProjectFileRoutes(app, {
     db,

--- a/apps/daemon/src/tool-tokens.ts
+++ b/apps/daemon/src/tool-tokens.ts
@@ -18,6 +18,7 @@ export const CHAT_TOOL_ENDPOINTS = [
   MEDIA_TASK_WAIT_TOOL_ENDPOINT,
   '/api/tools/library/search',
   '/api/tools/library/apply',
+  '/api/tools/export',
 ] as const;
 
 export const CHAT_TOOL_OPERATIONS = [
@@ -31,6 +32,7 @@ export const CHAT_TOOL_OPERATIONS = [
   'media:generate',
   'library:search',
   'library:apply',
+  'export:render',
 ] as const;
 
 export type ToolEndpoint = (typeof CHAT_TOOL_ENDPOINTS)[number] | (string & {});

--- a/apps/daemon/tests/export-tool-token-route.test.ts
+++ b/apps/daemon/tests/export-tool-token-route.test.ts
@@ -1,0 +1,215 @@
+import http from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createAuthorizeProjectRequest } from '../src/collab/project-request-authority.js';
+import { verifyWorkspaceRequestContext } from '../src/collab/request-workspace-context.js';
+import { workspaceContextFromDirectoryItem } from '../src/collab/vela-workspace-context.js';
+import { createToolRequestAuth } from '../src/http/tool-request-auth.js';
+import { sendApiError } from '../src/http/api-errors.js';
+import { registerProjectExportRoutes } from '../src/import-export-routes.js';
+import { ToolTokenRegistry } from '../src/tool-tokens.js';
+
+const WORKSPACE_ID = 'workspace-a';
+const MEMBER_ID = 'member-a';
+const PROJECT_ID = 'bound-project';
+const RUN_ID = 'run-1';
+
+const DIRECTORY_ITEM = {
+  workspaceId: WORKSPACE_ID,
+  workspaceName: 'A',
+  workspaceType: 'team' as const,
+  workspaceMemberId: MEMBER_ID,
+  role: 'member' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+// The project is claimed by a workspace — the shape every Team/Personal
+// workspace project has had since workspace isolation shipped, and the shape
+// that makes the header gate fail closed for a headerless caller.
+const BINDING = {
+  projectId: PROJECT_ID,
+  workspaceId: WORKSPACE_ID,
+  visibility: 'personal',
+  resourceState: 'active',
+  createdByWorkspaceMemberId: MEMBER_ID,
+};
+
+let server: http.Server | null = null;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function startExportServer(): Promise<{ baseUrl: string; token: string }> {
+  const renderDir = await mkdtemp(path.join(os.tmpdir(), 'od-export-tool-'));
+  tempDirs.push(renderDir);
+  const renderedPath = path.join(renderDir, 'rendered.png');
+  await writeFile(renderedPath, 'png-bytes');
+
+  const registry = new ToolTokenRegistry();
+  const grant = registry.mint({ runId: RUN_ID, projectId: PROJECT_ID });
+  const auth = createToolRequestAuth(registry);
+
+  const verifier = (req: unknown) =>
+    verifyWorkspaceRequestContext({
+      req,
+      fetchWorkspaceDirectory: async () => ({ ok: true as const, items: [DIRECTORY_ITEM] }),
+    });
+  const authorizeProjectRequest = createAuthorizeProjectRequest({
+    db: {},
+    getWorkspaceProject: () => BINDING,
+    getWorkspaceProjectByProjectId: () => BINDING,
+    verifyWorkspaceReadAuthority: verifier,
+    verifyWorkspaceRequestAuthority: verifier,
+    // The gate declares a widened `code: string`; the daemon's real error codes
+    // are the narrower ApiErrorCode union.
+    sendApiError: sendApiError as unknown as (
+      res: any,
+      status: number,
+      code: string,
+      message: string,
+    ) => unknown,
+  });
+  // Mirrors the daemon's local/dev `authorizeProjectToolRequest` branch: a tool
+  // call carries no headers, so authority comes from the project's own
+  // persisted workspace binding.
+  const authorizeProjectToolRequest = async (_res: unknown, projectId: string) => {
+    if (projectId !== PROJECT_ID) return false;
+    workspaceContextFromDirectoryItem(DIRECTORY_ITEM);
+    return true;
+  };
+
+  const app = express();
+  app.use(express.json());
+  registerProjectExportRoutes(app, {
+    db: {},
+    http: { sendApiError },
+    paths: { PROJECTS_DIR: renderDir, RUNTIME_DATA_DIR_CANONICAL: renderDir },
+    node: { fs, path },
+    ids: { randomId: () => 'render-1' },
+    projectStore: { getProject: () => ({ id: PROJECT_ID, metadata: null }) },
+    projectFiles: {
+      listFiles: async () => [],
+      readProjectFile: async () => ({ content: '<html></html>' }),
+      resolveProjectFilePath: () => renderedPath,
+    },
+    validation: { isSafeId: () => true },
+    exports: {
+      buildProjectArchive: async () => Buffer.alloc(0),
+      buildBatchArchive: async () => Buffer.alloc(0),
+      buildDesktopPdfExportInput: async () => ({}),
+      // `desktopSlideRenderer` stays undefined so the route takes the
+      // single-image `desktopArtifactExporter` path — the lightest branch that
+      // still proves authorization let the request through to a real render.
+      buildDesktopArtifactExportInput: async () => ({}),
+      desktopPdfExporter: undefined,
+      desktopSlideRenderer: undefined,
+      desktopArtifactExporter: async () => ({
+        ok: true,
+        path: renderedPath,
+        mime: 'image/png',
+      }),
+      daemonUrlRef: { current: 'http://127.0.0.1:0' },
+      sanitizeArchiveFilename: (value: string) => value,
+    },
+    auth,
+    authorizeProjectRequest,
+    authorizeProjectToolRequest,
+  } as any);
+
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind');
+  return { baseUrl: `http://127.0.0.1:${address.port}`, token: grant.token };
+}
+
+describe('agent-authenticated export on a workspace-bound project', () => {
+  it('renders through the tool token without any workspace headers', async () => {
+    const { baseUrl, token } = await startExportServer();
+
+    const response = await fetch(`${baseUrl}/api/tools/export`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ fileName: 'index.html', format: 'image' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('image/png');
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe('png-bytes');
+  });
+
+  it('refuses a project the tool token was not minted for', async () => {
+    const { baseUrl, token } = await startExportServer();
+
+    const response = await fetch(`${baseUrl}/api/tools/export`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        fileName: 'index.html',
+        format: 'image',
+        projectId: 'someone-elses-project',
+      }),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('rejects an unauthenticated caller on the tool route', async () => {
+    const { baseUrl } = await startExportServer();
+
+    const response = await fetch(`${baseUrl}/api/tools/export`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'index.html', format: 'image' }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('keeps the browser-facing project route gated on workspace headers', async () => {
+    const { baseUrl } = await startExportServer();
+
+    const response = await fetch(`${baseUrl}/api/projects/${PROJECT_ID}/export`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'index.html', format: 'image' }),
+    });
+
+    expect(response.status).toBe(400);
+    const failure = (await response.json()) as { error: { code: string } };
+    expect(failure.error.code).toBe('WORKSPACE_CONTEXT_REQUIRED');
+  });
+});
+
+// Guards the file the renderer stub hands back, so a future change that starts
+// streaming a different path fails loudly instead of silently exporting blanks.
+describe('export render stub', () => {
+  it('reads the bytes the renderer reported', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'od-export-tool-stub-'));
+    tempDirs.push(dir);
+    const file = path.join(dir, 'rendered.png');
+    await writeFile(file, 'png-bytes');
+    expect((await readFile(file)).toString()).toBe('png-bytes');
+  });
+});

--- a/apps/daemon/tests/project-consumer-cli-workspace-scope.test.ts
+++ b/apps/daemon/tests/project-consumer-cli-workspace-scope.test.ts
@@ -100,7 +100,7 @@ beforeAll(async () => {
         });
         return;
       }
-      if (request.url.includes('/export/')) {
+      if (request.url.includes('/export/') || request.url === '/api/tools/export') {
         res.writeHead(200, {
           'content-type': 'image/png',
           'content-disposition': 'attachment; filename="artifact.png"',
@@ -373,6 +373,38 @@ describe('project consumer CLI explicit Workspace fixture matrix', () => {
       }
     });
   }
+
+  it('routes an agent export through the tool token instead of workspace headers', async () => {
+    requests = [];
+    const result = await runCli(
+      [
+        'export',
+        'index.html',
+        '--format',
+        'image',
+        '--out',
+        path.join(outputDir, 'export-tool-token.png'),
+        '--daemon-url',
+        baseUrl,
+      ],
+      {
+        OD_PROJECT_ID: 'bound-project',
+        OD_TOOL_TOKEN: 'tool-proof',
+      },
+    );
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toBe('/api/tools/export');
+    expect(requests[0]?.headers.authorization).toBe('Bearer tool-proof');
+    expect(requests[0]?.headers['x-od-workspace-id']).toBeUndefined();
+    // The tool endpoint is format-generic, so the format rides in the body
+    // rather than the path the project route splits on.
+    expect(JSON.parse(requests[0]?.body ?? '{}')).toMatchObject({
+      fileName: 'index.html',
+      format: 'image',
+    });
+  });
 
   it('retains the authorized tool token through media polling', async () => {
     requests = [];


### PR DESCRIPTION
## Why

I hit this myself while reviewing a prototype in the 0.18.1-prerelease client. The
model finished the work and then told me, in the chat, that it could not look at
what it had built:

> the command requires an explicit workspace id, and there is no `OD_WORKSPACE_ID`
> in the environment, so the render check never ran — everything above is from
> static inspection and hand-calculation.

Half of that is a confabulation (`OD_WORKSPACE_ID` does not exist anywhere in the
product, and `od export` takes `--project`, never a workspace id), but the blocker
underneath it is real and reproduces on demand:

```
POST /api/projects/<bound-project>/export   →  400
{"error":{"code":"WORKSPACE_CONTEXT_REQUIRED","message":"an explicit workspace context is required"}}
```

`POST /api/projects/:id/export` authorizes through `authorizeProjectRequest`, which
reads the caller's `x-od-workspace-*` headers. Only the web client can produce those.
An agent gets `OD_TOOL_TOKEN`, `OD_PROJECT_ID`, `OD_PROJECT_DIR`, `OD_DAEMON_URL` and
`OD_BIN` — no workspace identity, by design. So since workspace isolation shipped,
**every agent export on a workspace-claimed project has failed closed**, including the
one-shot preview render `prompts/core-slim.ts` explicitly instructs the model to run
before it reports visual work as checked. The model's only remaining options are to
report the work as unverified or to guess.

Media already has the answer to this shape. It ships a route pair:
`/api/projects/:id/media/generate` for the browser (headers) and
`/api/tools/media/generate` for the agent (`authorizeToolRequest` +
`authorizeProjectToolRequest`, which derives authority from the project's own
persisted workspace binding rather than from anything the caller asserts). Export
simply never got its counterpart — the shipped prerelease bundle has ten
`/api/tools/*` routes and export is not among them.

## What users will see

Asking any agent to build or change a page, then asking it whether the result
actually renders, now works inside a Team or Personal workspace. Previously the model
would answer with some version of "I could not run the render check" and fall back to
reading its own source. The `od export` command line does not change:

```bash
"$OD_NODE_BIN" "$OD_BIN" export index.html --project "$OD_PROJECT_ID" --format image --out /tmp/preview.png
```

For anyone driving `od export` by hand or from an external agent, nothing changes
either — `--project` plus `--workspace` / `--workspace-member` still works exactly as
before. The tool path only engages when `OD_TOOL_TOKEN` is present.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — `od export` now honors `OD_TOOL_TOKEN` and derives the project from the grant when one is present
- [x] **API / contract** — new `POST /api/tools/export`, plus the `export:render` operation and `/api/tools/export` endpoint in the chat tool-token allowlist
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/export-tool-token-route.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — 3 failed / 2 passed
  before the source change (the tool route 404s), 5 passed after. The two that were
  green from the start are the ones that must stay green: the browser-facing project
  route is still rejected without workspace headers, so this does not widen access.

The spec builds the real primitives rather than stubbing the thing under test — real
`ToolTokenRegistry`, real `createToolRequestAuth`, real `createAuthorizeProjectRequest`
over a bound project row. Only the Chromium render is stubbed.

It also ran end-to-end against a real runtime, because a route-level test cannot prove
the daemon actually mints a token whose allowlist includes the new endpoint. On an
isolated `tools-dev` namespace (own `OD_DATA_DIR`, daemon + desktop renderer), with a
project created through the real HTTP API *with* workspace headers so it is genuinely
workspace-bound:

| check | result |
| --- | --- |
| headerless `POST /api/projects/:id/export` | `400 WORKSPACE_CONTEXT_REQUIRED` — the reported bug |
| `POST /api/tools/export`, no token | `401 TOOL_TOKEN_MISSING` |
| `POST /api/projects/:id/export` **with** workspace headers | `200`, 49944-byte PNG, 2880×2000 |
| real agent run → daemon-injected token → real `od export` | `exit 0`, **byte-identical** 49944-byte PNG |

The last row is the whole point, so it went through the production path rather than a
test seam: the daemon spawned an agent binary discovered on `PATH`, injected the token
itself, and that subprocess shelled out to the real CLI. Its log also settles the
original misdiagnosis:

```
OD_PROJECT_ID=export-verify-1
OD_TOOL_TOKEN=present
OD_WORKSPACE_ID=<unset>
```

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — all packages pass
- Focused: `export-tool-token-route`, `project-consumer-cli-workspace-scope`,
  `export-cli-routing`, `tool-tokens`, `route-registration-guard` — all green
- End-to-end on an isolated `tools-dev` daemon + desktop renderer, per the table above
- `apps/daemon` full suite: **8157 passed, 12 failed** (7 files). Those 12 are
  pre-existing on `main` — I re-ran the same seven files at `6a6bc6c45b` and got the
  identical 12 failures, byte-for-byte the same test names (`comm -13` between the two
  failure lists is empty). None are export-, tool-token-, or CLI-related; the closest
  one by name, `server-bootstrap-regression > server route inventory`, fails on the
  ordering of `GET /api/plugins/stats` and is unaffected by this change. Not fixed
  here — different spec, different PR.

## Adjacent issues (not fixed here)

Both are real and both are out of this spec's scope:

1. `od workspace` has no read-only `context` / `directory` subcommand even though
   `GET /api/workspace/context` and `GET /api/workspace/directory` exist. That is a
   genuine UI/CLI dual-track gap, but it is not what broke export — and handing agents
   a way to *assert* a workspace identity is the direction this authority model
   deliberately avoids.
2. `GET /api/projects` returns only unbound projects to a headerless caller, so an
   agent listing projects over the CLI sees an empty list. Same root shape, different
   route; an agent normally addresses `OD_PROJECT_ID` directly.
