### PR TITLE
fix(web): load custom skill files after create

### DIFF
--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -511,6 +511,19 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }:
     setCreating(false);
     setDraft(EMPTY_DRAFT);
     setDraftIdentity(null);
+    setFilesLoadingId(updated.id);
+    try {
+      const files = await fetchSkillFiles(updated.id, issuedContext);
+      if (
+        currentWorkspaceAccountGeneration() !== issuedGeneration
+        || workspaceCatalogIdentityRef.current !== issuedIdentity
+      ) return;
+      setFilesById((cur) => ({ ...cur, [updated.id]: files }));
+    } finally {
+      if (workspaceCatalogIdentityRef.current === issuedIdentity) {
+        setFilesLoadingId((cur) => (cur === updated.id ? null : cur));
+      }
+    }
     onSkillsChanged?.(updated.id);
   }, [
     draft,

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -48,27 +48,37 @@ function renderSkillsSection(
     locale?: 'en' | 'zh-CN';
     onSkillsRefresh?: () => void | Promise<void>;
     onSkillsChanged?: (id?: string) => void;
+    filesById?: Record<string, Array<{ path: string; kind: 'file' | 'directory'; size: number | null }>>;
   },
 ) {
   const setCfg = vi.fn();
   const onSkillsRefresh = options?.onSkillsRefresh;
   const onSkillsChanged = options?.onSkillsChanged;
+  let catalog = [...skills];
+  const filesById = options?.filesById ?? {};
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = input.toString();
     if (url === '/api/skills' && (!init || init.method === undefined)) {
-      return new Response(JSON.stringify({ skills }), {
+      return new Response(JSON.stringify({ skills: catalog }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
     }
     if (url === '/api/skills/import' && init?.method === 'POST') {
+      const payload = init.body
+        ? (JSON.parse(init.body as string) as { name?: string; description?: string; body?: string; triggers?: string[] })
+        : {};
+      const skill = makeSkill({
+        id: 'new-skill',
+        name: payload.name ?? 'New skill',
+        description: payload.description ?? '',
+        triggers: payload.triggers ?? [],
+        source: 'user',
+      });
+      catalog = [skill, ...catalog];
       return new Response(
         JSON.stringify({
-          skill: makeSkill({
-            id: 'new-skill',
-            name: 'New skill',
-            source: 'user',
-          }),
+          skill,
         }),
         {
           status: 200,
@@ -100,7 +110,8 @@ function renderSkillsSection(
       });
     }
     if (url.match(/^\/api\/skills\/[^/]+\/files$/) && (!init || init.method === undefined)) {
-      return new Response(JSON.stringify({ files: [] }), {
+      const id = decodeURIComponent(url.split('/').at(-2) ?? '');
+      return new Response(JSON.stringify({ files: filesById[id] ?? [] }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -375,6 +386,38 @@ describe('SkillsSection', () => {
           url.toString() === '/api/skills/import' && init?.method === 'POST',
       ),
     ).toBe(true);
+  });
+
+  it('loads the file tree for a newly created skill when its row is expanded automatically', async () => {
+    const { fetchMock } = renderSkillsSection([], {
+      filesById: {
+        'new-skill': [{ path: 'SKILL.md', kind: 'file', size: 28 }],
+      },
+    });
+
+    fireEvent.click(await screen.findByTestId('skills-new'));
+    const form = await screen.findByTestId('skills-create-form');
+    fireEvent.change(within(form).getByPlaceholderText('my-skill'), {
+      target: { value: 'New skill' },
+    });
+    fireEvent.change(within(form).getAllByRole('textbox').at(-1)!, {
+      target: { value: '# New skill\n\nDo the thing.' },
+    });
+    fireEvent.click(within(form).getByTestId('skills-save'));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(
+          ([url, init]) =>
+            url.toString() === '/api/skills/new-skill/files' && init?.method === undefined,
+        ),
+      ).toBe(true);
+    });
+    const row = await screen.findByTestId('skill-row-new-skill');
+    const fileTree = row.querySelector('.skills-file-tree');
+    expect(fileTree).toBeTruthy();
+    expect(within(fileTree as HTMLElement).getByText('SKILL.md')).toBeTruthy();
+    expect(within(row).queryByText(en['settings.skillsNoFiles'])).toBeNull();
   });
 
   // Regression for the mrcfps follow-up on PR #2190: when a user edits


### PR DESCRIPTION
Fixes #2974

## Why

I am opening this PR to fix the custom-skill creation dead end tracked in #2974.

The pain being addressed is that a newly saved custom skill can immediately expand into an empty-looking file section even though the daemon has written `SKILL.md`. That makes the skill authoring flow look broken right after save.

## What users will see

After creating or saving a custom skill in Settings → Skills, the automatically expanded skill row now loads and shows its file tree, including `SKILL.md`, instead of showing the “no files” empty state.

## Surface area

- [x] **UI** — Settings → Skills custom skill create/save detail row
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a state-loading fix covered by component regression tests.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SkillsSection.test.tsx`
- Did the test go red on `main` and green on this branch? yes; the new regression fails before the fix because `/api/skills/new-skill/files` is never requested after automatic expansion, and passes after the fix.
- Root cause: `submitDraft()` set `expandedId` directly after save, bypassing `toggleExpanded()` and therefore never calling `ensureFiles()` for the newly created skill row.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/SkillsSection.test.tsx`
- `pnpm --filter @open-design/web exec vitest run tests/components/SkillsSection.test.tsx tests/components/SkillsSection.workspace-scope.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm typecheck`
- `git diff --check`
- `pnpm guard` fails on existing workspace hygiene issues unrelated to this PR: missing `apps/telemetry-worker/package.json` and disallowed `tools/.DS_Store` top-level entry.

Note: local commands warn that this machine is running Node `v22.14.0` while the repo wants Node `~24`.
