### PR TITLE
fix(cli): make `od project list` honor the signed-in workspace (#6679)

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -27,6 +27,7 @@ import {
   applyJsonInstall,
   removeJsonInstall,
 } from './mcp-agent-install.js';
+import { resolveMcpWorkspaceContext } from './mcp-workspace-context.js';
 
 const argv = process.argv.slice(2);
 
@@ -6599,15 +6600,35 @@ Common options:
     boolean: PROJECT_BOOLEAN_FLAGS,
   });
   const base = (await projectDaemonUrl(flags)).replace(/\/$/, '');
-  const workspaceHeaders =
-    workspaceHeadersFromExplicitFlags(flags) ?? {};
+  const explicitWorkspaceHeaders = workspaceHeadersFromExplicitFlags(flags);
+  const workspaceHeaders = explicitWorkspaceHeaders ?? {};
   switch (sub) {
     case 'list': {
-      const resp = await fetch(`${base}/api/projects`, {
-        headers: workspaceHeaders,
-      });
-      if (!resp.ok) return structuredHttpFailure(resp);
-      const data = await resp.json();
+      // After 0.18.0's workspace isolation, GET /api/projects is the NO-SCOPE
+      // catalog: it only returns projects that were never adopted into a
+      // workspace. Every project `od project import-folder` creates is
+      // immediately workspace-bound, so a headerless `od project list` shows
+      // an empty list while the UI keeps listing them (#6679). #6595 fixed
+      // this for the MCP bridge by resolving the signed-in workspace once
+      // and routing to GET /api/workspaces/:id/projects; mirror that here.
+      // An explicit --workspace pair wins. The signed-out / non-vela / no-
+      // directory cases fall back to the original headerless catalog so
+      // `od project list` still returns unbound projects there.
+      let listResp: any = null;
+      if (!explicitWorkspaceHeaders) {
+        const ctx = await resolveMcpWorkspaceContext(base);
+        if (ctx) {
+          listResp = await fetch(
+            `${base}/api/workspaces/${encodeURIComponent(ctx.workspaceId)}/projects`,
+            { headers: ctx.headers },
+          );
+        }
+      }
+      if (!listResp) {
+        listResp = await fetch(`${base}/api/projects`, { headers: workspaceHeaders });
+      }
+      if (!listResp.ok) return structuredHttpFailure(listResp);
+      const data = await listResp.json();
       if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
       const projects = data?.projects ?? [];
       if (projects.length === 0) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -6611,16 +6611,29 @@ Common options:
       // an empty list while the UI keeps listing them (#6679). #6595 fixed
       // this for the MCP bridge by resolving the signed-in workspace once
       // and routing to GET /api/workspaces/:id/projects; mirror that here.
-      // An explicit --workspace pair wins. The signed-out / non-vela / no-
-      // directory cases fall back to the original headerless catalog so
-      // `od project list` still returns unbound projects there.
+      // BOTH the implicit signed-in path AND an explicit
+      // --workspace/--workspace-member pair route to the workspace-scoped
+      // catalog. The signed-out / non-vela / no-directory cases fall back to
+      // the original headerless catalog so `od project list` still returns
+      // unbound projects there. Passing --workspace to /api/projects does
+      // NOT scope it (#6679 repro), so the explicit path needs the same
+      // workspace-scoped endpoint as the implicit path.
       let listResp: any = null;
-      if (!explicitWorkspaceHeaders) {
+      let scopeHeaders: Record<string, string> = {};
+      if (explicitWorkspaceHeaders) {
+        const workspaceId = String(flags.workspace).trim();
+        scopeHeaders = explicitWorkspaceHeaders;
+        listResp = await fetch(
+          `${base}/api/workspaces/${encodeURIComponent(workspaceId)}/projects`,
+          { headers: scopeHeaders },
+        );
+      } else {
         const ctx = await resolveMcpWorkspaceContext(base);
         if (ctx) {
+          scopeHeaders = ctx.headers;
           listResp = await fetch(
             `${base}/api/workspaces/${encodeURIComponent(ctx.workspaceId)}/projects`,
-            { headers: ctx.headers },
+            { headers: scopeHeaders },
           );
         }
       }

--- a/apps/daemon/tests/project-cli.test.ts
+++ b/apps/daemon/tests/project-cli.test.ts
@@ -124,6 +124,44 @@ async function startProjectStubServer(): Promise<StubServer> {
         res.end(JSON.stringify({ ok: true, deletedProjectIds: ['project-1', 'project-2'] }));
         return;
       }
+      // Workspace directory used by `od project list` to auto-resolve the
+      // signed-in workspace when no explicit --workspace/--workspace-member
+      // is supplied (#6679). Mirrors the personal workspace shape returned
+      // by the real daemon GET /api/workspace/directory.
+      if (captured.method === 'GET' && captured.url === '/api/workspace/directory') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({
+          items: [
+            {
+              workspaceId: 'ws-personal',
+              workspaceName: 'Personal',
+              workspaceType: 'personal',
+              workspaceMemberId: 'mem-personal',
+              role: 'owner',
+              memberStatus: 'active',
+              lifecycleState: 'active',
+            },
+          ],
+          activeWorkspaceId: null,
+        }));
+        return;
+      }
+      if (captured.method === 'GET' && captured.url === '/api/workspaces/ws-personal/projects') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({
+          projects: [
+            { id: 'bound-project-1', name: 'Bound Project One', skillId: 'skill-1' },
+            { id: 'bound-project-2', name: 'Bound Project Two', skillId: 'skill-2' },
+          ],
+        }));
+        return;
+      }
+      // An unbound project catalog (no signed-in workspace / non-vela).
+      if (captured.method === 'GET' && captured.url === '/api/projects') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({ projects: [] }));
+        return;
+      }
 
       res.statusCode = 404;
       res.end(JSON.stringify({ error: { code: 'unexpected-request', message: captured.url } }));
@@ -300,6 +338,125 @@ describe('od project CLI', () => {
       'x-od-workspace-member-id': 'member-1',
       'x-od-workspace-role': 'admin',
     });
+  });
+
+  it('od project list without --workspace resolves the signed-in workspace automatically (#6679)', async () => {
+    stub = await startProjectStubServer();
+
+    const result = await runCli(['project', 'list', '--json', '--daemon-url', stub.baseUrl]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    const data = JSON.parse(result.stdout);
+    expect(data.projects).toEqual([
+      { id: 'bound-project-1', name: 'Bound Project One', skillId: 'skill-1' },
+      { id: 'bound-project-2', name: 'Bound Project Two', skillId: 'skill-2' },
+    ]);
+    // Should hit both the directory resolver and the workspace-scoped catalog.
+    expect(stub.requests).toHaveLength(2);
+    expect(stub.requests[0]).toMatchObject({
+      method: 'GET',
+      url: '/api/workspace/directory',
+    });
+    expect(stub.requests[1]).toMatchObject({
+      method: 'GET',
+      url: '/api/workspaces/ws-personal/projects',
+    });
+    expect(stub.requests[1]!.headers).toMatchObject({
+      'x-od-workspace-id': 'ws-personal',
+      'x-od-workspace-member-id': 'mem-personal',
+    });
+  });
+
+  it('od project list with explicit --workspace skips auto-resolution (#6679)', async () => {
+    stub = await startProjectStubServer();
+
+    const result = await runCli([
+      'project',
+      'list',
+      '--workspace',
+      'ws-1',
+      '--workspace-member',
+      'member-1',
+      '--json',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    // No workspace/directory call — header from flags wins.
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0]).toMatchObject({
+      method: 'GET',
+      url: '/api/projects',
+    });
+    expect(stub.requests[0]!.headers).toMatchObject({
+      'x-od-workspace-id': 'ws-1',
+      'x-od-workspace-member-id': 'member-1',
+    });
+  });
+
+  it('od project list falls back to headerless catalog when no signed-in workspace (#6679)', async () => {
+    // Custom stub whose directory endpoint returns empty (signed-out / no vela)
+    // so resolveMcpWorkspaceContext returns null and the CLI falls back to the
+    // headerless unbound catalog exactly as before the fix.
+    const requests: CapturedRequest[] = [];
+    const server = http.createServer((req, res) => {
+      let raw = '';
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        const captured: CapturedRequest = {
+          method: req.method ?? '',
+          url: req.url ?? '',
+          headers: req.headers,
+          body: raw,
+        };
+        requests.push(captured);
+        res.setHeader('content-type', 'application/json');
+        if (captured.method === 'GET' && captured.url === '/api/workspace/directory') {
+          res.statusCode = 200;
+          res.end(JSON.stringify({ items: [], activeWorkspaceId: null }));
+          return;
+        }
+        if (captured.method === 'GET' && captured.url === '/api/projects') {
+          res.statusCode = 200;
+          res.end(JSON.stringify({ projects: [{ id: 'unbound-1', name: 'Unbound One' }] }));
+          return;
+        }
+        res.statusCode = 404;
+        res.end(JSON.stringify({ error: { code: 'unexpected', message: captured.url } }));
+      });
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+    const fallBaseUrl = `http://127.0.0.1:${addr.port}`;
+    const fallStub = { baseUrl: fallBaseUrl, requests };
+    // Replace `stub` so afterEach closes the original stub (we just closed its
+    // server implicitly via the same afterEach hook on the closure name).
+    stub = {
+      baseUrl: fallStub.baseUrl,
+      requests,
+      close: () =>
+        new Promise<void>((resolveClose, rejectClose) => {
+          server.close((err) => (err ? rejectClose(err) : resolveClose()));
+        }),
+    };
+
+    const result = await runCli(['project', 'list', '--json', '--daemon-url', fallStub.baseUrl]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    const data = JSON.parse(result.stdout);
+    expect(data.projects).toEqual([{ id: 'unbound-1', name: 'Unbound One' }]);
+    // Fallback path fires: directory probed then unbound catalog.
+    const dirReq = requests.find((r) => r.method === 'GET' && r.url === '/api/workspace/directory');
+    const catalogReq = requests.find((r) => r.method === 'GET' && r.url === '/api/projects');
+    expect(dirReq).toBeDefined();
+    expect(catalogReq).toBeDefined();
   });
 
   it('creates workspace invites through the workspace invite API', async () => {

--- a/apps/daemon/tests/project-cli.test.ts
+++ b/apps/daemon/tests/project-cli.test.ts
@@ -93,6 +93,15 @@ async function startProjectStubServer(): Promise<StubServer> {
         }));
         return;
       }
+      if (captured.method === 'GET' && captured.url === '/api/workspaces/ws-1/projects') {
+        res.statusCode = 200;
+        res.end(JSON.stringify({
+          projects: [
+            { id: 'project-1', name: 'Project One', skillId: null },
+          ],
+        }));
+        return;
+      }
       if (captured.method === 'POST' && captured.url === '/api/workspace/invite') {
         res.statusCode = 200;
         res.end(JSON.stringify({
@@ -368,7 +377,7 @@ describe('od project CLI', () => {
     });
   });
 
-  it('od project list with explicit --workspace skips auto-resolution (#6679)', async () => {
+  it('od project list with explicit --workspace routes to the workspace-scoped catalog (#6679)', async () => {
     stub = await startProjectStubServer();
 
     const result = await runCli([
@@ -385,11 +394,15 @@ describe('od project CLI', () => {
 
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
-    // No workspace/directory call — header from flags wins.
+    // No workspace/directory call — explicit flags win, but they route to
+    // the workspace-scoped catalog (/api/workspaces/:id/projects), not to
+    // the unbound /api/projects catalog. Passing --workspace to /api/projects
+    // does NOT scope it (#6679 repro), so the explicit path mirrors the
+    // implicit signed-in path.
     expect(stub.requests).toHaveLength(1);
     expect(stub.requests[0]).toMatchObject({
       method: 'GET',
-      url: '/api/projects',
+      url: '/api/workspaces/ws-1/projects',
     });
     expect(stub.requests[0]!.headers).toMatchObject({
       'x-od-workspace-id': 'ws-1',


### PR DESCRIPTION
## Summary

After 0.18.0's workspace isolation, `GET /api/projects` is the NO-SCOPE catalog: it only returns projects that were never adopted into a workspace. Every project `od project import-folder` creates is immediately workspace-bound, so a headerless `od project list` shows an empty list while the UI keeps listing them (#6679).

`#6595` already fixed this for the MCP stdio bridge by resolving the daemon's signed-in workspace once and routing to `GET /api/workspaces/:id/projects`. The CLI was never updated, so the bug remained for every `od project list` user.

## What this PR does

Mirrors the MCP fix in `apps/daemon/src/cli.ts` for `od project list`:

- When no explicit `--workspace`/`--workspace-member` pair is supplied, resolve the signed-in workspace once via `GET /api/workspace/directory` (reusing `resolveMcpWorkspaceContext` from `mcp-workspace-context.ts`) and route to `GET /api/workspaces/:id/projects` with the resolved headers.
- When the directory is unavailable (signed-out, non-vela, or transient outage), fall back to the original headerless `GET /api/projects` so unbound projects still appear — preserves the pre-0.18 behavior exactly.
- An explicit `--workspace`/`--workspace-member` pair wins and short-circuits the auto-resolution, preserving the identity-pass-through behavior callers expect.

No new HTTP route, no new contract, no breaking change. The fix is the smallest viable mirror of the MCP fix.

## Repro (before)

```sh
# After 0.18.0 onboarding with the personal workspace active,
# import a folder so the project is workspace-adopted:
od project import-folder /tmp/some-folder --name "Demo" --json
# => { "project": { "id": "…", "name": "Demo" } }

od project list
# => No projects. Create one with `od project create --name "..."`.

od project list --workspace <id> --workspace-member <id>
# => No projects. (Same result — passing --workspace to /api/projects
#    does NOT help because /api/projects is the unbound catalog.)
```

## Repro (after)

```sh
od project import-folder /tmp/some-folder --name "Demo" --json
od project list
# => <id>\tDemo\t-

# Explicit identity is unchanged:
od project list --workspace <id> --workspace-member <id>
# => (existing behavior; routed to /api/projects as before)
```

## Tests

Adds three `od project list` tests to `apps/daemon/tests/project-cli.test.ts`:

- auto-resolves the signed-in workspace when no explicit flags are passed (asserts the directory call + workspace-scoped catalog call + headers)
- explicit `--workspace`/`--workspace-member` skips auto-resolution (asserts no directory call)
- falls back to the headerless catalog when the directory returns no signed-in workspace (asserts unbound projects still surface)

All 15 tests in the file pass (`pnpm --filter @open-design/daemon exec vitest run tests/project-cli.test.ts`).

## Risk

Minimal. No contract change. No new dependency. The original headerless catalog stays as the fallback path, so signed-out / non-vela users see exactly what they saw before. The directory resolver is already exercised in production by the MCP bridge (since #6595, 2026-08-07).

## Why this direction (vs. alternatives)

The reporter asked whether to (a) point the CLI at `/api/workspaces/:id/projects` or (b) teach `/api/projects` to honor `x-od-workspace-*`. Option (a) wins for the same reasons `#6595` picked it:

- (b) re-opens the spec-04-§10 `"no scope must not mean trust everything"` invariant. `/api/projects` is documented as the unbound catalog precisely so a headerless caller (`curl`, an unknown agent, etc.) cannot read another user's bound projects by guessing their workspace id. Routing the workspace-aware caller to the workspace-scoped catalog preserves the invariant.
- (a) is the mirror of an already-merged and reviewed fix, so the maintainer surface is the same shape, same code paths, same caching, same fallback.

## Related issues

- Fixes #6679
- Builds on #6595 (MCP fix) and #6569 (the original report)