### PR TITLE
fix(entry): keep Home reachable where AMR has no Vela binary

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -593,13 +593,31 @@ export function EntryShell({
   // view from the route rather than keeping it in component state.
   const route = useRoute();
   const view: EntryViewKind = route.kind === 'home' ? route.view : 'home';
+  // Agent discovery reported AMR, and reported it unusable — the Vela binary
+  // this platform never shipped (Linux/Docker as of 0.18.1, upstream #5700 /
+  // #6567). Declared here, above the first consumer, because the identity-gate
+  // effect below reads it from its dependency array during render.
+  const amrRuntimeUnavailable =
+    !agentsLoading && agents.some((agent) => agent.id === 'amr' && !agent.available);
   useEffect(() => {
     // The entry shell is the authenticated Home surface. A definitive
     // signed-out result returns it to the Cloud identity gate while leaving
     // the saved model source untouched for passive reauthentication.
+    //
+    // That gate is only meaningful where signing in can actually succeed.
+    // Without a Vela binary `amrLoggedIn` is permanently false, so gating Home
+    // on it makes Home unreachable: every completed onboarding bounces back to
+    // a sign-in that always 500s. A local-CLI or BYOK runtime is a complete
+    // setup on its own, so those platforms keep Home without a cloud identity.
+    //
+    // Discovery has to finish before that can be judged. It streams, while the
+    // login status is a single request that resolves first, so deciding early
+    // means deciding on an agent list that has not yet mentioned AMR — and
+    // redirecting anyway, which is the bounce this guard exists to prevent.
+    if (agentsLoading || amrRuntimeUnavailable) return;
     if (amrLoggedIn !== false || view === 'onboarding') return;
     navigate({ kind: 'home', view: 'onboarding' }, { replace: true });
-  }, [amrLoggedIn, view]);
+  }, [agentsLoading, amrLoggedIn, amrRuntimeUnavailable, view]);
   // The one shared workspace context. Any non-null context is a real workspace
   // (personal or team); workspace surfaces gate on B's permission bits, not on
   // workspaceType.
@@ -612,6 +630,9 @@ export function EntryShell({
     workspaceContextState,
     amrLoggedIn,
   );
+  // `amrRuntimeUnavailable` (declared above) also suppresses the rail's
+  // sign-in card, which can only ever fail here: POST
+  // /api/integrations/vela/login → 500 "vela binary not found".
   const workspaceContextRef = useRef(workspaceContext);
   workspaceContextRef.current = workspaceContext;
   const workspaceBillingResponse = useWorkspaceBillingResponse();
@@ -1537,7 +1558,7 @@ export function EntryShell({
           footerNotice={
             accountFooterState === 'syncing'
               ? <RailAccountSyncTip />
-              : accountFooterState === 'sign-in'
+              : accountFooterState === 'sign-in' && !amrRuntimeUnavailable
                 ? <CloudSignInTip />
                 : null
           }
@@ -2088,6 +2109,21 @@ function OnboardingView({
   const availableCliAgents = agents.filter((agent) => agent.available && agent.id !== 'amr');
   const visibleAgents = availableCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
   const amrSignedIn = amrStatus?.loggedIn === true;
+  // Agent discovery reported AMR, and reported it unusable — the Vela binary
+  // this platform never shipped (Linux/Docker as of 0.18.1, upstream #5700 /
+  // #6567). Both AMR surfaces in this flow then dead-end on the same failing
+  // POST /api/integrations/vela/login: the step-0 cloud gate, whose only
+  // button starts that login, and the step-1 hosted card, which selects a
+  // runtime that cannot start. Skipping is decided at render time rather than
+  // in an effect on purpose — `onFinish()` navigates, and a navigation that
+  // can land back on this view turns an effect-driven skip into an infinite
+  // render loop (React #185).
+  const amrRuntimeUnavailable =
+    !agentsLoading && agents.some((agent) => agent.id === 'amr' && !agent.available);
+  // The hosted card is hidden when AMR is unavailable, so the 'amr' default
+  // must not survive into the selection either.
+  const effectiveModelSource: 'amr' | 'local' | 'byok' =
+    amrRuntimeUnavailable && modelSource === 'amr' ? 'local' : modelSource;
   const selectedAgent = visibleAgents.find((agent) => agent.id === config.agentId) ?? null;
   const selectedAgentChoice = selectedAgent ? (config.agentModels?.[selectedAgent.id] ?? {}) : {};
   const normalizedSelectedAgentChoice = effectiveAgentModelChoice(selectedAgent, selectedAgentChoice) ?? selectedAgentChoice;
@@ -2531,7 +2567,9 @@ function OnboardingView({
     event: ReactKeyboardEvent<HTMLButtonElement>,
     currentSource: 'amr' | 'local' | 'byok',
   ): void {
-    const sources = ['amr', 'local', 'byok'] as const;
+    const sources = (
+      amrRuntimeUnavailable ? ['local', 'byok'] : ['amr', 'local', 'byok']
+    ) as ReadonlyArray<'amr' | 'local' | 'byok'>;
     const currentIndex = sources.indexOf(currentSource);
     let nextIndex: number | null = null;
 
@@ -2554,7 +2592,7 @@ function OnboardingView({
   }
 
   function continueWithModelSource(): void {
-    if (modelSource === 'amr') {
+    if (effectiveModelSource === 'amr') {
       emitOnboardingClick('amr_cloud', 'select_runtime', {
         runtime_type: 'amr_cloud',
         is_recommended: true,
@@ -2566,7 +2604,7 @@ function OnboardingView({
       return;
     }
 
-    if (modelSource === 'local') {
+    if (effectiveModelSource === 'local') {
       emitOnboardingClick('local_coding_agent', 'select_runtime', {
         runtime_type: 'local_cli',
       });
@@ -3077,7 +3115,7 @@ function OnboardingView({
 
   // Step 1 is identity only: every user signs into Open Design Cloud before
   // choosing Hosted, Local, or BYOK on the next screen.
-  if (step === 0) {
+  if (step === 0 && !amrRuntimeUnavailable) {
     const cloudBusy = amrLoginPending;
     const amrStatusResolving = !amrStatusResolved;
     return (
@@ -3187,7 +3225,9 @@ function OnboardingView({
     );
   }
 
-  if (step === 1) {
+  // `step === 0` only reaches here when the cloud gate above was skipped as
+  // unusable; source selection becomes the first screen instead of a dead end.
+  if (step === 1 || step === 0) {
     return (
       <section
         className="onboarding-view onboarding-view--cloud"
@@ -3206,6 +3246,7 @@ function OnboardingView({
               role="radiogroup"
               aria-label={t('settings.onboardingExecutionTitle')}
             >
+              {amrRuntimeUnavailable ? null : (
               <Button
                 ref={(node) => {
                   modelSourceOptionRefs.current.amr = node;
@@ -3238,16 +3279,17 @@ function OnboardingView({
                 </span>
                 <span className={onboardingSourceStyles.radio} aria-hidden="true" />
               </Button>
+              )}
               <Button
                 ref={(node) => {
                   modelSourceOptionRefs.current.local = node;
                 }}
                 variant="subtle"
                 role="radio"
-                aria-checked={modelSource === 'local'}
-                tabIndex={modelSource === 'local' ? 0 : -1}
+                aria-checked={effectiveModelSource === 'local'}
+                tabIndex={effectiveModelSource === 'local' ? 0 : -1}
                 className={`${onboardingSourceStyles.option} ${
-                  modelSource === 'local' ? onboardingSourceStyles.optionActive : ''
+                  effectiveModelSource === 'local' ? onboardingSourceStyles.optionActive : ''
                 }`}
                 onClick={() => setModelSource('local')}
                 onKeyDown={(event) => handleModelSourceKeyDown(event, 'local')}
@@ -3271,10 +3313,10 @@ function OnboardingView({
                 }}
                 variant="subtle"
                 role="radio"
-                aria-checked={modelSource === 'byok'}
-                tabIndex={modelSource === 'byok' ? 0 : -1}
+                aria-checked={effectiveModelSource === 'byok'}
+                tabIndex={effectiveModelSource === 'byok' ? 0 : -1}
                 className={`${onboardingSourceStyles.option} ${
-                  modelSource === 'byok' ? onboardingSourceStyles.optionActive : ''
+                  effectiveModelSource === 'byok' ? onboardingSourceStyles.optionActive : ''
                 }`}
                 onClick={() => setModelSource('byok')}
                 onKeyDown={(event) => handleModelSourceKeyDown(event, 'byok')}

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -659,6 +659,49 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(props.onAgentChange).not.toHaveBeenCalled();
   });
 
+  it('keeps Home on platforms where discovery reports AMR as unavailable', async () => {
+    // No Vela binary ships for Linux, so `amrLoggedIn` is false forever and
+    // /api/integrations/vela/login always 500s. Gating Home on a sign-in that
+    // cannot succeed made a finished local-CLI setup bounce back to the gate
+    // on every attempt to reach Home.
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', configPath: '/x', user: null }),
+    ) as typeof fetch;
+    const config = baseConfig({
+      onboardingCompleted: true,
+      mode: 'daemon',
+      agentId: 'claude-code',
+      agentModels: { 'claude-code': { model: 'sonnet' } },
+    });
+    renderHome({
+      config,
+      amrLoggedIn: false,
+      agents: [cliAgent(), cliAgent({ id: 'amr', name: 'AMR', bin: 'vela', available: false })],
+    });
+
+    await waitFor(() => expect(window.location.pathname).toBe('/'));
+    expect(screen.queryByRole('heading', { name: 'Sign in to Open Design' })).toBeNull();
+  });
+
+  it('defers the identity gate until agent discovery has answered', async () => {
+    // Discovery streams; the login status is one request and lands first. A
+    // gate that decides on the first render therefore judges an agent list
+    // that has not yet mentioned AMR, and redirects before it could know.
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ loggedIn: false, profile: 'prod', configPath: '/x', user: null }),
+    ) as typeof fetch;
+    const config = baseConfig({
+      onboardingCompleted: true,
+      mode: 'daemon',
+      agentId: 'claude-code',
+      agentModels: { 'claude-code': { model: 'sonnet' } },
+    });
+    renderHome({ config, amrLoggedIn: false, agents: [], agentsLoading: true });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(window.location.pathname).toBe('/');
+  });
+
   it('shows the model-source chooser after Cloud sign-in without exposing legacy onboarding steps', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({


### PR DESCRIPTION
## Why

I hit this myself. I run Open Design via Docker Compose on Linux (Mint 22.3 / Ubuntu noble, amd64) with Claude Code mounted from the host, following `deploy/README.md` → "Linux: mounting host agent CLIs". Claude Code is detected and its connection test passes — but the app is unusable, because Home cannot be reached at all.

No `vela` binary ships for Linux (`@powerformer/vela-cli` only publishes `darwin-arm64`; see #6567, #5700). That makes `amrLoggedIn` permanently `false` and `POST /api/integrations/vela/login` permanently `500 vela binary not found`. Three surfaces treat cloud sign-in as mandatory anyway, so a fully configured local-CLI setup ends up in a loop:

1. Onboarding step 0 is a cloud gate whose only button starts that failing login. There is no way past it.
2. `EntryShell` gates Home on `amrLoggedIn !== false` and redirects to `/onboarding`. Completing onboarding navigates to Home, the gate immediately bounces it back — forever.
3. The step-1 "Open Design Hosted" card and the rail's sign-in card start the same failing login.

Symptom from the browser console, on every attempt:

```
[amr-login] startVelaLogin failed
{ ok: false, status: 500, error: "vela binary not found; install vela or configure VELA_BIN", authRoute: "proxy", fallbackUsed: true }
```

The daemon is healthy throughout and `/api/agents` correctly reports `amr → available: false` alongside `claude → available: true`, so this is purely a client-side gate.

## What users will see

On platforms where Vela does not resolve, Open Design becomes usable with a local CLI or BYOK:

- Onboarding opens on the model-source chooser instead of a sign-in screen that cannot succeed.
- "Open Design Hosted" is not offered, and the rail's cloud sign-in card is not shown.
- Finishing onboarding lands on Home and stays there, including across a reload.

Where Vela does resolve, nothing changes: discovery reports AMR as available and the gate behaves exactly as before.

## Surface area

- [x] **UI** — onboarding step 0 is skipped and two AMR entry points are hidden, on affected platforms only
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No new strings — this only changes which existing surfaces render.

## Bug fix verification

- Test path: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
  - `keeps Home on platforms where discovery reports AMR as unavailable`
  - `defers the identity gate until agent discovery has answered`
- Red on `main`, green on this branch: **yes**. Both fail on `main` with `expected '/onboarding' to be '/'`.

The second test covers the part that is easy to get wrong. Discovery streams, while the login status is a single request that resolves first, so a guard phrased as "AMR has not been reported unavailable yet" is still open at the moment `amrLoggedIn` flips to `false` — and the redirect fires anyway. I hit exactly this while developing the fix: the first version still bounced, roughly one second in. The gate now waits for discovery to finish before it judges.

One implementation note worth flagging for review: skipping step 0 is done at render time rather than from an effect. An effect-driven skip has to call `onFinish()`, which navigates, and a navigation that can land back on this view produces an infinite render loop (React #185) — also hit while developing this.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/` → **3787 passing**, 1 expected fail, 11 skipped. One file (`PluginDetailView.curated-layout.test.tsx`) errored in my container only, because `deploy/Dockerfile` copies `plugins/_official` but not `plugins/community`, so its `SKILL.md` fixture was absent — unrelated to this change.
- `pnpm --filter @open-design/web build` (via `deploy/Dockerfile`) — clean.
- End to end in Chromium against the Docker deployment, with Claude Code mounted from the host: onboarding completes, Home persists across a full reload, and no `vela/login` request is issued. Claude Code's connection test answers in ~3.5 s.

One harmless `500 GET /api/amr/models` remains in the console on affected platforms — the AMR catalog cannot exist without Vela. It is a background fetch and blocks nothing, so I left it out of scope rather than widen the diff.
