### PR TITLE
fix(daemon): report missing vela runtime as unavailable

### DIFF
--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -508,6 +508,12 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
     try {
       const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
       const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      const amrDef = getAgentDef('amr');
+      const amrLaunch = amrDef ? resolveAgentLaunch(amrDef, configuredEnv) : null;
+      if (!(amrLaunch?.launchPath ?? amrLaunch?.selectedPath)) {
+        res.status(503).json({ error: 'amr-runtime-unavailable' });
+        return;
+      }
       const refresh = _req.query.refresh === '1' || _req.query.refresh === 'true';
       const status = readVelaLoginStatus(mergeVelaEnv(env, configuredEnv));
       // Reported on every response, signed in or not: the client builds console

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -638,6 +638,60 @@ describe('GET /api/integrations/vela/wallet', () => {
 });
 
 describe('GET /api/integrations/vela/status', () => {
+  it('reports AMR runtime unavailable instead of signed out when the vela binary cannot be resolved', async () => {
+    const previousPath = process.env.PATH;
+    const previousAgentHome = process.env.OD_AGENT_HOME;
+    const previousResourceRoot = process.env.OD_RESOURCE_ROOT;
+    const previousVelaBin = process.env.VELA_BIN;
+    const previousVelaOpenCodeBin = process.env.VELA_OPENCODE_BIN;
+    process.env.PATH = '';
+    process.env.OD_AGENT_HOME = tmpHome;
+    delete process.env.OD_RESOURCE_ROOT;
+    delete process.env.VELA_BIN;
+    delete process.env.VELA_OPENCODE_BIN;
+
+    const isolatedApp = express();
+    isolatedApp.use(express.json());
+    registerVelaRoutes(isolatedApp, {
+      paths: { RUNTIME_DATA_DIR: tmpHome },
+      appConfig: {
+        readAppConfig: async () => ({ agentCliEnv: {} }),
+      },
+      http: {},
+      env: {
+        HOME: tmpHome,
+        OPEN_DESIGN_AMR_PROFILE: 'local',
+        PATH: '',
+      },
+    });
+    const isolatedServer = createServer(isolatedApp);
+    await new Promise<void>((resolve) => isolatedServer.listen(0, '127.0.0.1', resolve));
+    const isolatedAddress = isolatedServer.address() as AddressInfo;
+    const isolatedUrl = `http://127.0.0.1:${isolatedAddress.port}`;
+
+    try {
+      const { status, body } = await getJson<{ error?: string; loggedIn?: boolean }>(
+        `${isolatedUrl}/api/integrations/vela/status`,
+      );
+
+      expect(status).toBe(503);
+      expect(body.error).toBe('amr-runtime-unavailable');
+      expect(body.loggedIn).toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve) => isolatedServer.close(() => resolve()));
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      if (previousAgentHome === undefined) delete process.env.OD_AGENT_HOME;
+      else process.env.OD_AGENT_HOME = previousAgentHome;
+      if (previousResourceRoot === undefined) delete process.env.OD_RESOURCE_ROOT;
+      else process.env.OD_RESOURCE_ROOT = previousResourceRoot;
+      if (previousVelaBin === undefined) delete process.env.VELA_BIN;
+      else process.env.VELA_BIN = previousVelaBin;
+      if (previousVelaOpenCodeBin === undefined) delete process.env.VELA_OPENCODE_BIN;
+      else process.env.VELA_OPENCODE_BIN = previousVelaOpenCodeBin;
+    }
+  });
+
   it('reports loggedIn=false when ~/.amr/config.json is absent', async () => {
     const { status, body } = await getJson<{
       loggedIn: boolean;

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -50,6 +50,10 @@ export function clearAnonymousState(storage: Storage): void {
 
 export async function isAmrLoggedIn(): Promise<boolean> {
   const response = await fetch('/api/integrations/vela/status', { cache: 'no-store' });
+  if (response.status === 503) {
+    const payload = (await response.clone().json().catch(() => null)) as { error?: string } | null;
+    if (payload?.error === 'amr-runtime-unavailable') return false;
+  }
   if (!response.ok) throw new Error(`AMR status failed: ${response.status}`);
   const payload = (await response.json()) as { loggedIn?: boolean };
   return payload.loggedIn === true;

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -87,6 +87,23 @@ describe('MessageCenter', () => {
     expect(String(anonymousPull?.[0])).not.toContain('startedAt=');
   });
 
+  it('falls back to the public feed when the AMR runtime is unavailable', async () => {
+    mockFetch({
+      onStatus: async () => Response.json({ error: 'amr-runtime-unavailable' }, { status: 503 }),
+    });
+
+    renderMessageCenter();
+    const dialog = await openCenter();
+
+    expect(within(dialog).getByText('Open Design 0.14 is available')).toBeTruthy();
+    expect(
+      vi.mocked(fetch).mock.calls.some(([url]) =>
+        String(url).includes('/api/integrations/vela/message-center-public/messages?'),
+      ),
+    ).toBe(true);
+    expect(screen.queryByText('Check failed. Please retry.')).toBeNull();
+  });
+
   it('keeps anonymous read state locally and restores it', async () => {
     renderMessageCenter();
     await openCenter();


### PR DESCRIPTION
Fixes #6728

## Why

I picked this up from #6728 after confirming the Home lockout path is caused by the daemon reporting an unchecked AMR login state as a definitive signed-out state.

Source builds without a resolvable `vela` binary cannot complete the Open Design Cloud sign-in flow, but `/api/integrations/vela/status` returned `loggedIn: false` anyway. `EntryShell` treats that as authoritative and redirects Home, Projects, and Design Systems to the identity gate, locking out local-CLI users.

## What users will see

Source builds without `vela` no longer get bounced to the cloud sign-in gate just because the AMR login state cannot be checked. AMR-specific surfaces can still treat the runtime as unavailable, while Home can render through the existing client `null` status path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — changed existing `/api/integrations/vela/status` failure semantics when AMR cannot be launched
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — missing AMR runtime is now reported as unavailable instead of signed out
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — daemon API behavior only.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/integrations/vela.routes.test.ts`
- Did the test go red on `main` and green on this branch? yes. The focused test failed before the route change with `expected 200 to be 503`, then passed after the fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/integrations/vela.routes.test.ts -t "reports AMR runtime unavailable"`
- `pnpm --filter @open-design/daemon exec vitest run tests/integrations/vela.routes.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm typecheck`
- `git diff --check`
- `pnpm guard` fails on pre-existing unrelated repository state: missing `apps/telemetry-worker/package.json` and disallowed `tools/.DS_Store` top-level entry.

Note: local commands warn that this machine is running Node v22.14.0 while the repo expects Node `~24`.
