### PR TITLE
fix(web): enter project immediately after Home send

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,7 +55,11 @@ import { AmrArtifactUpgradeGate } from './components/AmrArtifactUpgradeGate';
 import { AmrArtifactUpgradeHomeCard } from './components/AmrArtifactUpgradeHomeCard';
 import { TooltipLayer } from './components/TooltipLayer';
 import { UpdateDialog } from './components/UpdateDialog';
-import { openWorkspaceTab, WorkspaceTabsBar } from './components/WorkspaceTabsBar';
+import {
+  openWorkspaceTab,
+  removeWorkspaceProjectTabs,
+  WorkspaceTabsBar,
+} from './components/WorkspaceTabsBar';
 import {
   DesignSystemCreationFlow,
   DesignSystemDetailView,
@@ -2965,6 +2969,7 @@ function AppInner() {
         );
         if (optimisticProjectId) {
           clearLocalProject(optimisticProjectId);
+          removeWorkspaceProjectTabs(optimisticProjectId);
           setProjects((current) => current.filter((project) => project.id !== optimisticProjectId));
           setPendingProjectCreation((current) =>
             current?.projectId === optimisticProjectId ? null : current);
@@ -2998,184 +3003,205 @@ function AppInner() {
         );
         return false;
       }
-      const pendingFiles = Array.isArray(input.pendingFiles)
-        ? input.pendingFiles.filter((file): file is File => file instanceof File)
-        : [];
-      // Flip the project onto the user-picked working directory BEFORE
-      // uploading staged Home attachments. `replaceProjectWorkingDir` changes
-      // `metadata.baseDir`, so the project starts reading from the external
-      // folder. If we uploaded first, the staged files would land in the
-      // temporary managed `.od/projects/<id>` root and then silently vanish
-      // from Design Files and the first auto-send context once the working
-      // dir flips. Doing the handoff first means the initial upload lands in
-      // the final tree.
-      const userWorkingDir = metadata?.userWorkingDir;
-      let workingDirHandoffFailed = false;
-      if (userWorkingDir) {
-        try {
-          await replaceProjectWorkingDir(
-            result.project.id,
-            userWorkingDir,
-            input.userWorkingDirToken,
-            createWorkspaceContext,
-          );
-        } catch (err) {
-          // The desktop working-dir token is short-lived (~60s TTL); if the
-          // user lingered on Home or the POST was otherwise rejected, the
-          // handoff fails AFTER the project already exists. Do NOT swallow
-          // this and do NOT proceed: uploading staged attachments or
-          // auto-sending the first message would target the managed
-          // `.od/projects/<id>` root the user did not choose. Mark the
-          // handoff as failed so the upload + auto-send branches below are
-          // skipped, then surface a create-time error so the user can
-          // re-pick the working directory from inside the project.
-          console.warn('Failed to set working directory for new project', userWorkingDir, err);
-          workingDirHandoffFailed = true;
-          setWorkingDirError(
-            `Couldn't apply the chosen folder "${userWorkingDir}". The project was created in the default location — re-pick the working directory from the project before uploading files or sending a message.`,
-          );
-        }
-      }
-      let firstMessageAttachments: ChatAttachment[] = [];
-      if (!workingDirHandoffFailed && pendingFiles.length > 0) {
-        // Home composer attaches stay client-side until submit lands a
-        // project; the actual upload happens here. v2 doc wants one
-        // file_upload_result per surface — `page_name='home'` /
-        // `area='chat_composer'` so it's distinguishable from the
-        // file_manager Upload button and the chat_panel composer.
-        const cohort = deriveUploadCohort(pendingFiles);
-        const uploadResult = await uploadProjectFiles(
-          result.project.id,
-          pendingFiles,
-          undefined,
-          createWorkspaceContext,
-        );
-        firstMessageAttachments = uploadResult.uploaded;
-        const partial = uploadResult.failed.length > 0;
-        if (partial) {
-          console.warn('Some Home attachments failed to upload', uploadResult.failed);
-        }
-        trackFileUploadResult(analytics.track, {
-          page_name: 'home',
-          area: 'chat_composer',
-          project_id: result.project.id,
-          ...cohort,
-          result: partial ? 'failed' : 'success',
-          ...(partial && uploadResult.error
-            ? { error_code: uploadResult.error }
-            : {}),
-        });
-      }
-      trackProjectCreateResult(
-        analytics.track,
-        {
-          page_name: 'home',
-          area: 'new_project',
-          project_source: 'create_button',
-          project_id: result.project.id,
-          project_kind: projectKindFromMetadataToTracking(metadata),
-          fidelity,
-          ...(input.pluginId ? { plugin_id: input.pluginId } : {}),
-          ...(input.pluginType ? { plugin_type: input.pluginType } : {}),
-          result: 'success',
-        },
-        { requestId: input.requestId },
-      );
-      // PluginLoopHome flow: the user already typed (or accepted) the
-      // first message on Home. Mark this project so ProjectView fires
-      // sendMessage(pendingPrompt) once on mount instead of just
-      // pre-filling the composer. Scoped to sessionStorage so a page
-      // reload after the run has started does not refire.
-      if (
-        !workingDirHandoffFailed &&
-        input.autoSendFirstMessage &&
-        (derivedPendingPrompt !== undefined || firstMessageAttachments.length > 0)
-      ) {
-        try {
-          window.sessionStorage.setItem(
-            `od:auto-send-first:${result.project.id}`,
-            '1',
-          );
-          if (derivedPendingPrompt !== undefined) {
-            window.sessionStorage.setItem(
-              `od:auto-send-prompt:${result.project.id}`,
-              derivedPendingPrompt,
-            );
-          } else {
-            window.sessionStorage.removeItem(
-              `od:auto-send-prompt:${result.project.id}`,
-            );
-          }
-          if (input.amrGatePrecheckWitness) {
-            window.sessionStorage.setItem(
-              `od:auto-send-amr-gate-witness:${result.project.id}`,
-              JSON.stringify(input.amrGatePrecheckWitness),
-            );
-          } else {
-            window.sessionStorage.removeItem(
-              `od:auto-send-amr-gate-witness:${result.project.id}`,
-            );
-          }
-          window.sessionStorage.removeItem(
-            `od:auto-send-amr-gate-ok:${result.project.id}`,
-          );
-          if (firstMessageAttachments.length > 0) {
-            window.sessionStorage.setItem(
-              `od:auto-send-attachments:${result.project.id}`,
-              JSON.stringify(firstMessageAttachments),
-            );
-          } else {
-            window.sessionStorage.removeItem(
-              `od:auto-send-attachments:${result.project.id}`,
-            );
-          }
-          if (input.initialRunContext && Object.keys(input.initialRunContext).length > 0) {
-            window.sessionStorage.setItem(
-              `od:auto-send-context:${result.project.id}`,
-              JSON.stringify(input.initialRunContext),
-            );
-          } else {
-            window.sessionStorage.removeItem(
-              `od:auto-send-context:${result.project.id}`,
-            );
-          }
-        } catch {
-          /* sessionStorage may be unavailable (e.g. SSR / private mode); fall
-             back to manual send. */
-        }
-      }
-      // Home recommendation handoff: now that the project exists and its id is
-      // known, stash the onboarding entry keyed by that id. Studio consumes it
-      // by the same id on mount. Keying by id (instead of a single global slot
-      // written before create) removes the race where opening an unrelated
-      // project mid-create could steal the personalized funnel context, and
-      // means a failed/aborted create leaves nothing behind.
-      if (input.onboardingEntry) {
-        // Cache the prefilled seed prompt WITH the entry so the first-prompt
-        // funnel's `has_prefilled_prompt` comparison base survives a
-        // reopen-before-send (project.pendingPrompt is wiped on first mount).
-        stashOnboardingEntryForProject(result.project.id, {
-          ...input.onboardingEntry,
-          ...(derivedPendingPrompt
-            ? { seedPrompt: derivedPendingPrompt.trim() }
-            : {}),
-        });
-      }
       const project = result.appliedPluginSnapshotId
         ? {
             ...result.project,
             appliedPluginSnapshotId: result.appliedPluginSnapshotId,
           }
         : result.project;
-      rememberLocalProject(project.id);
-      flushSync(() => {
-        setProjects((curr) => [
-          project,
-          ...curr.filter((p) => p.id !== project.id),
-        ]);
+      if (optimisticProjectId) {
+        rememberLocalProject(project.id);
+        flushSync(() => {
+          setProjects((curr) => [
+            project,
+            ...curr.filter((candidate) => candidate.id !== project.id),
+          ]);
+        });
+      }
+      try {
+        const pendingFiles = Array.isArray(input.pendingFiles)
+          ? input.pendingFiles.filter((file): file is File => file instanceof File)
+          : [];
+        // Flip the project onto the user-picked working directory BEFORE
+        // uploading staged Home attachments. `replaceProjectWorkingDir` changes
+        // `metadata.baseDir`, so the project starts reading from the external
+        // folder. If we uploaded first, the staged files would land in the
+        // temporary managed `.od/projects/<id>` root and then silently vanish
+        // from Design Files and the first auto-send context once the working
+        // dir flips. Doing the handoff first means the initial upload lands in
+        // the final tree.
+        const userWorkingDir = metadata?.userWorkingDir;
+        let workingDirHandoffFailed = false;
+        if (userWorkingDir) {
+          try {
+            await replaceProjectWorkingDir(
+              result.project.id,
+              userWorkingDir,
+              input.userWorkingDirToken,
+              createWorkspaceContext,
+            );
+          } catch (err) {
+            // The desktop working-dir token is short-lived (~60s TTL); if the
+            // user lingered on Home or the POST was otherwise rejected, the
+            // handoff fails AFTER the project already exists. Do NOT swallow
+            // this and do NOT proceed: uploading staged attachments or
+            // auto-sending the first message would target the managed
+            // `.od/projects/<id>` root the user did not choose. Mark the
+            // handoff as failed so the upload + auto-send branches below are
+            // skipped, then surface a create-time error so the user can
+            // re-pick the working directory from inside the project.
+            console.warn('Failed to set working directory for new project', userWorkingDir, err);
+            workingDirHandoffFailed = true;
+            setWorkingDirError(
+              `Couldn't apply the chosen folder "${userWorkingDir}". The project was created in the default location — re-pick the working directory from the project before uploading files or sending a message.`,
+            );
+          }
+        }
+        let firstMessageAttachments: ChatAttachment[] = [];
+        if (!workingDirHandoffFailed && pendingFiles.length > 0) {
+          // Home composer attaches stay client-side until submit lands a
+          // project; the actual upload happens here. v2 doc wants one
+          // file_upload_result per surface — `page_name='home'` /
+          // `area='chat_composer'` so it's distinguishable from the
+          // file_manager Upload button and the chat_panel composer.
+          const cohort = deriveUploadCohort(pendingFiles);
+          const uploadResult = await uploadProjectFiles(
+            result.project.id,
+            pendingFiles,
+            undefined,
+            createWorkspaceContext,
+          );
+          firstMessageAttachments = uploadResult.uploaded;
+          const partial = uploadResult.failed.length > 0;
+          if (partial) {
+            console.warn('Some Home attachments failed to upload', uploadResult.failed);
+          }
+          trackFileUploadResult(analytics.track, {
+            page_name: 'home',
+            area: 'chat_composer',
+            project_id: result.project.id,
+            ...cohort,
+            result: partial ? 'failed' : 'success',
+            ...(partial && uploadResult.error
+              ? { error_code: uploadResult.error }
+              : {}),
+          });
+        }
+        trackProjectCreateResult(
+          analytics.track,
+          {
+            page_name: 'home',
+            area: 'new_project',
+            project_source: 'create_button',
+            project_id: result.project.id,
+            project_kind: projectKindFromMetadataToTracking(metadata),
+            fidelity,
+            ...(input.pluginId ? { plugin_id: input.pluginId } : {}),
+            ...(input.pluginType ? { plugin_type: input.pluginType } : {}),
+            result: 'success',
+          },
+          { requestId: input.requestId },
+        );
+        // PluginLoopHome flow: the user already typed (or accepted) the
+        // first message on Home. Mark this project so ProjectView fires
+        // sendMessage(pendingPrompt) once on mount instead of just
+        // pre-filling the composer. Scoped to sessionStorage so a page
+        // reload after the run has started does not refire.
+        if (
+          !workingDirHandoffFailed &&
+          input.autoSendFirstMessage &&
+          (derivedPendingPrompt !== undefined || firstMessageAttachments.length > 0)
+        ) {
+          try {
+            window.sessionStorage.setItem(
+              `od:auto-send-first:${result.project.id}`,
+              '1',
+            );
+            if (derivedPendingPrompt !== undefined) {
+              window.sessionStorage.setItem(
+                `od:auto-send-prompt:${result.project.id}`,
+                derivedPendingPrompt,
+              );
+            } else {
+              window.sessionStorage.removeItem(
+                `od:auto-send-prompt:${result.project.id}`,
+              );
+            }
+            if (input.amrGatePrecheckWitness) {
+              window.sessionStorage.setItem(
+                `od:auto-send-amr-gate-witness:${result.project.id}`,
+                JSON.stringify(input.amrGatePrecheckWitness),
+              );
+            } else {
+              window.sessionStorage.removeItem(
+                `od:auto-send-amr-gate-witness:${result.project.id}`,
+              );
+            }
+            window.sessionStorage.removeItem(
+              `od:auto-send-amr-gate-ok:${result.project.id}`,
+            );
+            if (firstMessageAttachments.length > 0) {
+              window.sessionStorage.setItem(
+                `od:auto-send-attachments:${result.project.id}`,
+                JSON.stringify(firstMessageAttachments),
+              );
+            } else {
+              window.sessionStorage.removeItem(
+                `od:auto-send-attachments:${result.project.id}`,
+              );
+            }
+            if (input.initialRunContext && Object.keys(input.initialRunContext).length > 0) {
+              window.sessionStorage.setItem(
+                `od:auto-send-context:${result.project.id}`,
+                JSON.stringify(input.initialRunContext),
+              );
+            } else {
+              window.sessionStorage.removeItem(
+                `od:auto-send-context:${result.project.id}`,
+              );
+            }
+          } catch {
+            /* sessionStorage may be unavailable (e.g. SSR / private mode); fall
+               back to manual send. */
+          }
+        }
+        // Home recommendation handoff: now that the project exists and its id is
+        // known, stash the onboarding entry keyed by that id. Studio consumes it
+        // by the same id on mount. Keying by id (instead of a single global slot
+        // written before create) removes the race where opening an unrelated
+        // project mid-create could steal the personalized funnel context, and
+        // means a failed/aborted create leaves nothing behind.
+        if (input.onboardingEntry) {
+          // Cache the prefilled seed prompt WITH the entry so the first-prompt
+          // funnel's `has_prefilled_prompt` comparison base survives a
+          // reopen-before-send (project.pendingPrompt is wiped on first mount).
+          stashOnboardingEntryForProject(result.project.id, {
+            ...input.onboardingEntry,
+            ...(derivedPendingPrompt
+              ? { seedPrompt: derivedPendingPrompt.trim() }
+              : {}),
+          });
+        }
+        if (!optimisticProjectId) {
+          rememberLocalProject(project.id);
+          flushSync(() => {
+            setProjects((curr) => [
+              project,
+              ...curr.filter((candidate) => candidate.id !== project.id),
+            ]);
+          });
+        }
+      } catch (err) {
+        if (!optimisticProjectId) throw err;
+        const errorCode =
+          err instanceof Error && err.message.trim() ? err.message : 'PROJECT_SETUP_FAILED';
+        console.warn('Failed to finish setting up new project', project.id, err);
+        setProjectCreateError(errorCode);
+      } finally {
         setPendingProjectCreation((current) =>
-          current?.projectId === optimisticProjectId ? null : current);
-      });
+          current?.projectId === optimisticProjectId ? null : current,
+        );
+      }
       const projectRoute = {
         kind: 'project',
         projectId: project.id,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,6 +50,7 @@ import {
   type ProjectRenameFenceToken,
   type ProjectNameAuthorityResolution,
 } from './components/ProjectView';
+import { ProjectCreationPendingView } from './components/ProjectCreationPendingView';
 import { AmrArtifactUpgradeGate } from './components/AmrArtifactUpgradeGate';
 import { AmrArtifactUpgradeHomeCard } from './components/AmrArtifactUpgradeHomeCard';
 import { TooltipLayer } from './components/TooltipLayer';
@@ -145,6 +146,7 @@ import {
 import { createSilentUpdatePreferenceWriter } from './state/silent-update-preference';
 import { applyAppearanceToDocument } from './state/appearance';
 import { isMacPlatform } from './utils/platform';
+import { randomUUID } from './utils/uuid';
 import { summarizeProjectNameFromPrompt } from './utils/projectName';
 import {
   amrArtifactUpgradeHomeMockOffer,
@@ -234,6 +236,11 @@ type AppCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   linkedDirs?: string[] | null;
   onboardingEntry?: OnboardingEntry;
 };
+
+interface PendingProjectCreation {
+  projectId: string;
+  prompt: string;
+}
 
 const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
 const AMR_AGENT_ID = 'amr';
@@ -937,6 +944,7 @@ function AppInner() {
   // this the failure was swallowed and the user believed their folder was in
   // effect while the project actually stayed in the managed root.
   const [workingDirError, setWorkingDirError] = useState<string | null>(null);
+  const [projectCreateError, setProjectCreateError] = useState<string | null>(null);
   const [projectOpenError, setProjectOpenError] = useState<string | null>(null);
   const [deepLinkResolutionFailure, setDeepLinkResolutionFailure] = useState<{
     projectId: string;
@@ -1002,6 +1010,8 @@ function AppInner() {
     Record<string, DesignSystemGenerationJob>
   >({});
   const [projects, setProjects] = useState<Project[]>([]);
+  const [pendingProjectCreation, setPendingProjectCreation] =
+    useState<PendingProjectCreation | null>(null);
   const [appliedProjectListWitness, setAppliedProjectListWitness] = useState<{
     scopeKey: string;
     generation: number;
@@ -2843,6 +2853,7 @@ function AppInner() {
       const creationSource: 'blank' | 'template' | 'zip' | 'folder' =
         kind === 'template' ? 'template' : 'blank';
       let createWorkspaceContext: WorkspaceCollabContext | null = null;
+      let optimisticProjectId: string | null = null;
       let result;
       try {
         const executionConfig = configRef.current;
@@ -2874,7 +2885,52 @@ function AppInner() {
         ) {
           throw new Error('AMR_WORKSPACE_GATE_STALE');
         }
+        // Home already accepted the run (including its balance gate), so move
+        // into the project frame immediately. The id is client-owned and the
+        // daemon already accepts that exact id for idempotent retries. Keep the
+        // real ProjectView unmounted until the response settles; the pending
+        // surface is deliberately read-free so an unpersisted project cannot
+        // fan out unauthorized conversation/file/presence requests.
+        if (input.autoSendFirstMessage) {
+          optimisticProjectId = randomUUID();
+          const now = Date.now();
+          const optimisticProject: Project = {
+            id: optimisticProjectId,
+            name: input.name.trim(),
+            skillId: input.skillId,
+            designSystemId: input.designSystemId,
+            createdAt: now,
+            updatedAt: now,
+            ...(derivedPendingPrompt ? { pendingPrompt: derivedPendingPrompt } : {}),
+            ...(metadata ? { metadata } : {}),
+            ...(input.appliedPluginSnapshotId
+              ? { appliedPluginSnapshotId: input.appliedPluginSnapshotId }
+              : {}),
+            ...(createWorkspaceContext?.workspaceId
+              ? { workspaceId: createWorkspaceContext.workspaceId }
+              : {}),
+          };
+          rememberLocalProject(optimisticProjectId);
+          flushSync(() => {
+            setPendingProjectCreation({
+              projectId: optimisticProjectId!,
+              prompt: derivedPendingPrompt ?? '',
+            });
+            setProjects((current) => [
+              optimisticProject,
+              ...current.filter((project) => project.id !== optimisticProjectId),
+            ]);
+          });
+          const optimisticRoute = {
+            kind: 'project',
+            projectId: optimisticProjectId,
+            fileName: null,
+          } as const;
+          openWorkspaceTab(optimisticRoute);
+          navigate(optimisticRoute);
+        }
         result = await createProject({
+          ...(optimisticProjectId ? { id: optimisticProjectId } : {}),
           name: input.name,
           skillId: input.skillId,
           designSystemId: input.designSystemId,
@@ -2907,6 +2963,20 @@ function AppInner() {
           },
           { requestId: input.requestId },
         );
+        if (optimisticProjectId) {
+          clearLocalProject(optimisticProjectId);
+          setProjects((current) => current.filter((project) => project.id !== optimisticProjectId));
+          setPendingProjectCreation((current) =>
+            current?.projectId === optimisticProjectId ? null : current);
+          if (
+            routeRef.current.kind === 'project'
+            && routeRef.current.projectId === optimisticProjectId
+          ) {
+            navigate({ kind: 'home', view: 'home' });
+          }
+          setProjectCreateError(errorCode);
+          return false;
+        }
         throw err;
       }
       if (!result) {
@@ -3103,17 +3173,25 @@ function AppInner() {
           project,
           ...curr.filter((p) => p.id !== project.id),
         ]);
+        setPendingProjectCreation((current) =>
+          current?.projectId === optimisticProjectId ? null : current);
       });
       const projectRoute = {
         kind: 'project',
         projectId: project.id,
         fileName: null,
       } as const;
-      openWorkspaceTab(projectRoute);
-      navigate(projectRoute);
+      // The Home auto-send path already owns this route from the optimistic
+      // handoff. Do not re-navigate after persistence: if the user deliberately
+      // backed out while creation finished, reopening the project would steal
+      // focus. Non-optimistic creation paths retain the existing navigation.
+      if (!optimisticProjectId) {
+        openWorkspaceTab(projectRoute);
+        navigate(projectRoute);
+      }
       return true;
     },
-    [analytics.track, rememberLocalProject],
+    [analytics.track, clearLocalProject, rememberLocalProject],
   );
 
   const handleCreateProjectFromDesignSystem = useCallback(
@@ -4848,6 +4926,10 @@ function AppInner() {
   } else if (route.kind === 'home' && route.view === 'settings') {
     appMain = renderSettingsSurface('page');
   } else if (route.kind === 'project') {
+    const pendingCreation =
+      activeProject && pendingProjectCreation?.projectId === activeProject.id
+        ? pendingProjectCreation
+        : null;
     const routeSurfaceState = projectRouteSurfaceState({
       projectsLoading,
       hasActiveProject: activeProject !== null,
@@ -4857,7 +4939,16 @@ function AppInner() {
           ? deepLinkResolutionFailure.failure
           : undefined,
     });
-    if (
+    if (pendingCreation && activeProject) {
+      appMain = (
+        <ProjectCreationPendingView
+          project={activeProject}
+          prompt={pendingCreation.prompt}
+          agentId={config.agentId}
+          onBack={handleBack}
+        />
+      );
+    } else if (
       routeSurfaceState === 'loading-projects'
       || routeSurfaceState === 'resolving-deep-link'
       || (
@@ -5178,6 +5269,14 @@ function AppInner() {
           message={workingDirError}
           role="alert"
           onDismiss={() => setWorkingDirError(null)}
+        />
+      ) : null}
+      {projectCreateError ? (
+        <Toast
+          message={projectCreateError}
+          role="alert"
+          tone="error"
+          onDismiss={() => setProjectCreateError(null)}
         />
       ) : null}
       {projectOpenError ? (

--- a/apps/web/src/components/ProjectCreationPendingView.module.css
+++ b/apps/web/src/components/ProjectCreationPendingView.module.css
@@ -1,0 +1,41 @@
+.split {
+  height: 100%;
+}
+
+.chatPane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--veil-panel);
+}
+
+.workspace {
+  grid-column: 3;
+}
+
+.addIcon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+}
+
+.workspaceBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 18px;
+  padding: 28px 24px;
+}
+
+.workspaceTitle {
+  color: var(--text-strong);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.workspaceEmpty {
+  color: var(--text-faint);
+  font-size: 13px;
+}

--- a/apps/web/src/components/ProjectCreationPendingView.tsx
+++ b/apps/web/src/components/ProjectCreationPendingView.tsx
@@ -1,0 +1,113 @@
+import { AgentIcon } from './AgentIcon';
+import { Icon } from './Icon';
+import { useI18n } from '../i18n';
+import { agentDisplayName, agentIconId } from '../utils/agentLabels';
+import type { Project } from '../types';
+import styles from './ProjectCreationPendingView.module.css';
+
+interface Props {
+  project: Project;
+  prompt: string;
+  agentId?: string | null;
+  onBack: () => void;
+}
+
+/**
+ * Immediate, read-free handoff shown while POST /api/projects is still
+ * settling. It deliberately mirrors the first ProjectView frame without
+ * mounting ProjectView itself: an optimistic project has not been authorized
+ * or persisted yet, so no project-owned API, SSE, file, or presence reads may
+ * start from this surface.
+ */
+export function ProjectCreationPendingView({
+  project,
+  prompt,
+  agentId,
+  onBack,
+}: Props) {
+  const { t } = useI18n();
+  const agentName = agentDisplayName(agentId) ?? t('assistant.role');
+  const iconId = agentIconId(agentId);
+
+  return (
+    <div className="app" data-testid="project-creation-pending-view">
+      <div className={`split ${styles.split}`}>
+        <div className="split-chat-slot">
+          <div className={`pane ${styles.chatPane}`}>
+            <div className="chat-project-header">
+              <button
+                type="button"
+                className="chat-project-back"
+                onClick={onBack}
+                title={t('project.backToProjects')}
+                aria-label={t('project.backToProjects')}
+              >
+                <Icon name="arrow-left" size={16} />
+              </button>
+              <span className="chat-project-header-title">
+                <span className="chat-project-title-line">
+                  <span className="title" data-testid="pending-project-title">
+                    {project.name}
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div className="chat-log-wrap">
+              <div className="chat-log" aria-busy="true">
+                {prompt ? (
+                  <div className="msg user">
+                    <div className="user-text-wrap">
+                      <div className="user-text user-bubble">{prompt}</div>
+                    </div>
+                  </div>
+                ) : null}
+                <div className="msg assistant">
+                  <div className="role">
+                    <AgentIcon id={iconId} size={20} className="role-agent-icon" />
+                    <span className="role-name">{agentName}</span>
+                  </div>
+                  <div className="assistant-flow">
+                    <div
+                      className="assistant-footer"
+                      data-streaming="true"
+                      data-last="true"
+                    >
+                      <span className="dot" data-active="true" />
+                      <span className="assistant-label shimmer-text shimmer-prepare">
+                        {t('assistant.statusPreparing')}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="split-resize-handle" aria-hidden="true" />
+        <section className={`workspace ${styles.workspace}`} aria-label={t('designFiles.title')}>
+          <div className="ws-tabs-shell">
+            <div className="ws-tabs-bar" role="tablist" aria-label={t('designFiles.title')}>
+              <div
+                className="ws-tab design-files-tab active"
+                role="tab"
+                aria-selected="true"
+              >
+                <span className="tab-icon" aria-hidden="true">
+                  <Icon name="grid" size={14} />
+                </span>
+                <span className="ws-tab-label">{t('designFiles.title')}</span>
+              </div>
+            </div>
+            <span className={styles.addIcon} aria-hidden="true">
+              <Icon name="plus" size={16} />
+            </span>
+          </div>
+          <div className={styles.workspaceBody}>
+            <span className={styles.workspaceTitle}>{t('designFiles.crumbs')}</span>
+            <span className={styles.workspaceEmpty}>{t('designFiles.empty')}</span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -114,6 +114,7 @@ interface Props {
 
 const STORAGE_KEY = 'open-design:workspace-tabs:v1';
 const OPEN_WORKSPACE_TAB_EVENT = 'open-design:workspace-tabs:open';
+const REMOVE_WORKSPACE_PROJECT_TABS_EVENT = 'open-design:workspace-tabs:remove-project';
 const MAX_PERSISTED_TAB_SCOPES = 12;
 const TAB_DRAG_HAPTIC_MS = 8;
 const TAB_DROP_HAPTIC_MS = 12;
@@ -132,6 +133,14 @@ export function openWorkspaceTab(route: Route): void {
   window.dispatchEvent(
     new CustomEvent<{ route: Route }>(OPEN_WORKSPACE_TAB_EVENT, {
       detail: { route },
+    }),
+  );
+}
+
+export function removeWorkspaceProjectTabs(projectId: string): void {
+  window.dispatchEvent(
+    new CustomEvent<{ projectId: string }>(REMOVE_WORKSPACE_PROJECT_TABS_EVENT, {
+      detail: { projectId },
     }),
   );
 }
@@ -1094,8 +1103,42 @@ export function WorkspaceTabsBar({
       });
     }
 
+    function onRemoveWorkspaceProjectTabs(event: Event) {
+      const detail = (event as CustomEvent<{ projectId?: string }>).detail;
+      const projectId = detail?.projectId;
+      if (!projectId) return;
+      setState((current) => {
+        const normalized = normalizeTabsState(current);
+        const nextTabs = normalized.tabs.filter(
+          (tab) => tab.kind !== 'project' || tab.projectId !== projectId,
+        );
+        if (nextTabs.length === normalized.tabs.length) return normalized;
+        const removedActiveTab = normalized.tabs.some(
+          (tab) => tab.id === normalized.activeTabId
+            && tab.kind === 'project'
+            && tab.projectId === projectId,
+        );
+        return normalizeTabsState({
+          tabs: nextTabs,
+          activeTabId: removedActiveTab
+            ? nextTabs.find((tab) => tab.kind === 'entry')?.id ?? ''
+            : normalized.activeTabId,
+        });
+      });
+    }
+
     window.addEventListener(OPEN_WORKSPACE_TAB_EVENT, onOpenWorkspaceTab);
-    return () => window.removeEventListener(OPEN_WORKSPACE_TAB_EVENT, onOpenWorkspaceTab);
+    window.addEventListener(
+      REMOVE_WORKSPACE_PROJECT_TABS_EVENT,
+      onRemoveWorkspaceProjectTabs,
+    );
+    return () => {
+      window.removeEventListener(OPEN_WORKSPACE_TAB_EVENT, onOpenWorkspaceTab);
+      window.removeEventListener(
+        REMOVE_WORKSPACE_PROJECT_TABS_EVENT,
+        onRemoveWorkspaceProjectTabs,
+      );
+    };
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -591,6 +591,8 @@ function isRetryableWorkspaceWriteFailure(status: number, retryable: boolean): b
 
 export async function createProject(
   input: {
+    /** Optional caller-minted id used for an optimistic route handoff. */
+    id?: string;
     name: string;
     projectLocationId?: string;
     skillId: string | null;
@@ -624,7 +626,7 @@ export async function createProject(
     // The id is minted ONCE and reused across retries: a retryable 503 fails
     // vela's authority check before any row is inserted, so replaying the same
     // client-provided id is idempotent, never a duplicate project.
-    const id = randomUUID();
+    const id = input.id ?? randomUUID();
     for (let attempt = 0; ; attempt += 1) {
       const resp = await fetch('/api/projects', {
         method: 'POST',

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -79,6 +79,10 @@ const projectViewRenameFenceHarness = vi.hoisted(() => ({
   token: null as ProjectRenameFenceToken | null,
 }));
 
+const workspaceTabsHarness = vi.hoisted(() => ({
+  projectIds: new Set<string>(),
+}));
+
 vi.mock('../../src/collab/workspace-events', () => ({
   useWorkspaceInvalidation: vi.fn((
     handlers: Record<string, (payload: any) => void>,
@@ -173,6 +177,7 @@ vi.mock('../../src/components/EntryView', () => ({
             skillId: null,
             designSystemId: null,
             pendingPrompt: 'Build the retained artifact prompt',
+            pendingFiles: [new File(['brief'], 'brief.txt', { type: 'text/plain' })],
             autoSendFirstMessage: true,
             metadata: { kind: 'prototype' },
           })).catch(() => {});
@@ -546,7 +551,14 @@ vi.mock('../../src/components/WorkspaceTabsBar', () => ({
       ))}
     </>
   ),
-  openWorkspaceTab: () => {},
+  openWorkspaceTab: (route: { kind: string; projectId?: string }) => {
+    if (route.kind === 'project' && route.projectId) {
+      workspaceTabsHarness.projectIds.add(route.projectId);
+    }
+  },
+  removeWorkspaceProjectTabs: (projectId: string) => {
+    workspaceTabsHarness.projectIds.delete(projectId);
+  },
 }));
 
 vi.mock('../../src/components/pet/PetOverlay', () => ({
@@ -765,6 +777,7 @@ describe('App project creation routing', () => {
     workspaceInvalidationHarness.handlers.length = 0;
     workspaceInvalidationHarness.onActive.length = 0;
     projectViewRenameFenceHarness.token = null;
+    workspaceTabsHarness.projectIds.clear();
     window.history.replaceState(null, '', '/');
     mockedDaemonIsLive.mockResolvedValue(true);
     mockedFetchAgentsStream.mockResolvedValue([]);
@@ -1262,6 +1275,7 @@ describe('App project creation routing', () => {
     render(<App />);
     fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
     await screen.findByTestId('project-creation-pending-view');
+    expect(workspaceTabsHarness.projectIds.has(requestedProjectId!)).toBe(true);
 
     creation.reject(new Error('Could not create project'));
 
@@ -1269,7 +1283,43 @@ describe('App project creation routing', () => {
     expect(window.location.pathname).toBe('/');
     expect(screen.queryByTestId('project-creation-pending-view')).toBeNull();
     expect(screen.queryByTestId(`entry-project-${requestedProjectId}`)).toBeNull();
+    expect(workspaceTabsHarness.projectIds.has(requestedProjectId!)).toBe(false);
     expect(screen.getByRole('alert').textContent).toContain('Could not create project');
+  });
+
+  it('releases a persisted project when attachment setup fails after creation', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    mockedUploadProjectFiles.mockRejectedValue(new Error('Attachment upload failed'));
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    let requestedProjectId: string | undefined;
+    mockedCreateProject.mockImplementation((input) => {
+      requestedProjectId = (input as typeof input & { id?: string }).id;
+      return creation.promise;
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+    await screen.findByTestId('project-creation-pending-view');
+
+    creation.resolve({
+      project: {
+        ...freshProject,
+        id: requestedProjectId!,
+        name: 'Persisted prompted project',
+        pendingPrompt: 'Build the retained artifact prompt',
+      },
+      conversationId: 'conv-new',
+    });
+
+    await screen.findByTestId('project-view');
+    expect(screen.getByTestId('project-title').textContent).toBe('Persisted prompted project');
+    expect(window.location.pathname).toBe(`/projects/${requestedProjectId}`);
+    expect(screen.queryByTestId('project-creation-pending-view')).toBeNull();
+    expect(workspaceTabsHarness.projectIds.has(requestedProjectId!)).toBe(true);
+    expect(screen.getByRole('alert').textContent).toContain('Attachment upload failed');
   });
 
   it('stores the plugin-share prompt before its prepared project projection can refresh', async () => {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -691,10 +691,12 @@ const existingProject: Project = {
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function workspaceContextPayload(
@@ -1206,6 +1208,68 @@ describe('App project creation routing', () => {
     expect(window.sessionStorage.getItem('od:auto-send-prompt:project-new')).toBe(
       'Build the retained artifact prompt',
     );
+  });
+
+  it('enters the project preparing surface before Home project creation settles', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    let requestedProjectId: string | undefined;
+    mockedCreateProject.mockImplementation((input) => {
+      requestedProjectId = (input as typeof input & { id?: string }).id;
+      return creation.promise;
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+
+    await screen.findByTestId('project-creation-pending-view');
+    expect(requestedProjectId).toBeTruthy();
+    expect(window.location.pathname).toBe(`/projects/${requestedProjectId}`);
+    expect(screen.getByText('Build the retained artifact prompt')).toBeTruthy();
+    expect(screen.getByText('Preparing...')).toBeTruthy();
+    expect(screen.queryByTestId('entry-home-surface')).toBeNull();
+    expect(screen.queryByTestId('project-view')).toBeNull();
+
+    creation.resolve({
+      project: {
+        ...freshProject,
+        id: requestedProjectId!,
+        name: 'Prompted project',
+        pendingPrompt: 'Build the retained artifact prompt',
+      },
+      conversationId: 'conv-new',
+    });
+
+    await screen.findByTestId('project-view');
+    expect(window.location.pathname).toBe(`/projects/${requestedProjectId}`);
+  });
+
+  it('rolls a failed optimistic Home creation back to the preserved Home surface', async () => {
+    mockedListProjects.mockResolvedValue([]);
+    const creation = deferred<{
+      project: Project;
+      conversationId: string;
+    }>();
+    let requestedProjectId: string | undefined;
+    mockedCreateProject.mockImplementation((input) => {
+      requestedProjectId = (input as typeof input & { id?: string }).id;
+      return creation.promise;
+    });
+
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Create prompted project' }));
+    await screen.findByTestId('project-creation-pending-view');
+
+    creation.reject(new Error('Could not create project'));
+
+    await screen.findByTestId('entry-home-surface');
+    expect(window.location.pathname).toBe('/');
+    expect(screen.queryByTestId('project-creation-pending-view')).toBeNull();
+    expect(screen.queryByTestId(`entry-project-${requestedProjectId}`)).toBeNull();
+    expect(screen.getByRole('alert').textContent).toContain('Could not create project');
   });
 
   it('stores the plugin-share prompt before its prepared project projection can refresh', async () => {

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   openWorkspaceTab,
+  removeWorkspaceProjectTabs,
   WorkspaceTabsBar,
 } from '../../src/components/WorkspaceTabsBar';
 import { navigate, type Route } from '../../src/router';
@@ -425,6 +426,27 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       expect(labels).toHaveLength(2);
       expect(labels.some((label) => label.includes('Home'))).toBe(true);
       expect(labels.some((label) => label.includes('Project Alpha'))).toBe(true);
+    });
+  });
+
+  it('removes a failed provisional project from live and persisted tab state', async () => {
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    openWorkspaceTab({ ...projectRoute });
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+
+    removeWorkspaceProjectTabs(project.id);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(1);
+      expect(labels.some((label) => label.includes('Project Alpha'))).toBe(false);
+      const stored = JSON.parse(
+        window.localStorage.getItem('open-design:workspace-tabs:v1') ?? '{}',
+      ) as { tabs?: Array<{ projectId?: string }> };
+      expect(stored.tabs?.some((tab) => tab.projectId === project.id)).toBe(false);
     });
   });
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -652,6 +652,33 @@ describe('createProject', () => {
     );
   });
 
+  it('uses a caller-minted project id for an optimistic route handoff', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { id: string };
+      return new Response(JSON.stringify({
+        project: { id: body.id },
+        conversationId: 'optimistic-conversation',
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const created = await createProject({
+      id: 'optimistic-project',
+      name: 'Optimistic project',
+      skillId: null,
+      designSystemId: null,
+    });
+
+    expect(created.project.id).toBe('optimistic-project');
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+    ) as { id: string };
+    expect(body.id).toBe('optimistic-project');
+  });
+
   it('fails closed while modern workspace authority is unresolved or unavailable', () => {
     expect(() => resolvedWorkspaceContextForWrite({
       context: null,


### PR DESCRIPTION
Fixes #6740

## Why

A Home submission currently keeps users on the entry surface with a spinning send button for roughly 2–3 seconds. The route transition is blocked because Home waits for project persistence, workspace setup, and attachment preparation to finish before navigating.

This change is based on a directly observed Home-to-project delay. The goal is to acknowledge an accepted submission immediately without allowing an unpersisted project to start project-owned API, SSE, file, or presence reads.

## What users will see

After Home accepts a prompt and completes its existing preflight gates, Open Design immediately enters the two-pane project Preparing surface. Project creation and setup continue in the background.

If project creation fails, the provisional project is removed, Home is restored, and the error is shown. Backing out during preparation is also respected instead of reopening the project after persistence finishes.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The original report included a Home spinner capture and a target Preparing-frame capture. They were supplied locally rather than as GitHub-hosted assets; copy them into this section before moving the Draft to Ready.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/App.project-create-race.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes**
- Additional state coverage: `apps/web/tests/state/projects.test.ts` verifies that the caller-minted project ID is preserved in the create request.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/App.project-create-race.test.tsx tests/state/projects.test.ts --maxWorkers=2` — 143 tests passed
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
