### PR TITLE
Add SLIDE BLUEPRINT — MODULE 5 plugin

### DIFF
--- a/plugins/community/slide-blueprint-module-5-msodr5vw/SKILL.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/SKILL.md
@@ -1,0 +1,377 @@
+# SLIDE BLUEPRINT — MODULE 5
+## Slides 75–98 — Intelligence Reconsidered: What Emotional Intelligence Is
+
+**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**
+
+**Primary source:** Chapter 3, "When Smart Is Dumb"
+**Learning outcomes:** LO6, LO7 · **Session length:** 100 min (55 compressed)
+
+> **Why this module exists as its own block.** Chapter 3 carries the book's pivot — the argument that the concept of intelligence itself has to change before emotional intelligence can be defined at all. In the previous version of this deck that argument was distributed across four slides in three separate blocks, and it did not survive the distribution. It is restored here as a single narrative running from *a straight-A student with a knife* to *five domains in a dependency structure*.
+
+---
+
+# BLOCK 6 — MODULE 5: INTELLIGENCE RECONSIDERED (Slides 75–98)
+
+---
+
+### Slide 75 — Module 5: Intelligence Reconsidered
+
+- **Purpose:** Open the module that turns the course from mechanism to framework.
+- **On the slide:** MODULE 5 · Intelligence Reconsidered / *What does it mean to call someone intelligent?*
+- **Visual:** L1. Divider. The map from slide 6 with FOUNDATIONS completed and a new node, THE FRAMEWORK, lit.
+- **Explain:** Modules 1–4 described the machinery. This module asks what follows from it for our idea of intelligence — and it is the module in which the course's central term finally gets defined.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min. Say what is coming: by the end of this session learners will have the framework that organises the next five modules.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 76 — The Question
+
+- **Purpose:** Pose the module's question before any content, so the evidence has something to bear on.
+- **On the slide:** **You know someone brilliant whose life is a mess.** / What does that tell us about intelligence?
+- **Visual:** L7. Question alone.
+- **Explain:** Nothing. Take three answers and write them on the board. Leave them up for slide 97.
+- **Discuss:** "What does that tell us about intelligence?"
+- **Activity:** Micro: three answers, recorded on the board.
+- **Notes:** [CORE] · 5 min. Almost every room produces some version of "there's more than one kind of smart." That is Gardner, arrived at from the floor, forty slides before he is named. Say so at slide 86.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 77 — Jason H.
+
+- **Purpose:** Deliver the source's opening case at full force.
+- **On the slide:** *A straight-A sophomore. Fixed on medical school — Harvard. His physics teacher gives him 80 on a quiz.* / **He brought a butcher knife to school and stabbed the teacher in the collarbone.**
+- **Visual:** L6. Case card. No illustration.
+- **Explain:** Coral Springs, Florida. The teacher, David Pologruto. A B on one quiz, and a student who believed his future had ended. The point the source draws is not that the boy was disturbed — it is that nothing in his academic record, which was outstanding, predicted this or could have.
+- **Discuss:** "What would you have needed to measure to see this coming?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Deliver it plainly and do not editorialise. The case is doing the work. Case 1 in the case book gives the full version for extended analysis.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 78 — What IQ Predicted, and What It Did Not
+
+- **Purpose:** Deliver the valedictorian evidence, which is the chapter's empirical spine.
+- **On the slide:** 81 valedictorians, tracked. / By their late twenties: **ordinary success.** Nothing exceptional.
+- **Visual:** L3. Two columns — what the valedictorians were exceptional at / what they turned out to be ordinary at.
+- **Explain:** Karen Arnold's study. The sentence to hold onto is hers: *"To know that a person is a valedictorian is to know only that he or she is exceedingly good at achievement as measured by grades. It tells you nothing about how they react to the vicissitudes of life."* She calls what the study found "the dutiful" — people who know how to achieve within a system.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The room will want to dismiss school achievement entirely. Slide 79 stops that, and it should follow immediately.
+- **Source:** Ch. 3 · [SOURCE] — Arnold
+
+---
+
+### Slide 79 — The Honest Concession
+
+- **Purpose:** Prevent the over-correction the previous slide invites.
+- **On the slide:** *"There is a relationship between IQ and life circumstances for large groups as a whole: many people with very low IQs end up in menial jobs, and those with high IQs tend to become well-paid — **but by no means always.**"*
+- **Visual:** L1. The quotation alone, attributed to the source.
+- **Explain:** This is the author's own concession and the course teaches it as prominently as the criticism. The claim is not that IQ is irrelevant. It is that IQ is **insufficient** — that it predicts something real at population level and leaves most of the individual variation unexplained. A course that taught the valedictorian study without this slide would be doing to Goleman what the popular literature does to him.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This slide is a fidelity slide. Learners who leave believing the course is anti-IQ have been mistaught.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 80 — The Twenty Per Cent, Precisely
+
+- **Purpose:** Deliver the most misquoted sentence in the field, verbatim.
+- **On the slide:** *"At best, IQ contributes about 20 percent to the factors that determine life success, which leaves **80 percent to other forces**."*
+- **Visual:** L1. The quotation, with **other forces** set apart. No chart, no pie.
+- **Explain:** Read it exactly. Then read the observer's gloss the source quotes immediately after: *"The vast majority of one's ultimate niche in society is determined by non-IQ factors, ranging from **social class to luck**."* Two things are being claimed: that IQ's contribution is bounded, and that the remainder is a **heterogeneous list** whose named members are social class and luck.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Slide 5 confronted this on the first morning to buy the course credibility. **This is where it is taught properly.** If a learner says "we did this already," agree — and point out that on day one they were told what it is not, and today they get what it is.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 81 — Where Does the Other Eighty Go?
+
+- **Purpose:** Make the misattribution impossible to hold by having the room construct the correct picture themselves.
+- **On the slide:** **80% = "other forces."** / *Name them. Board exercise.*
+- **Visual:** L7. Instruction only; the board does the work.
+- **Explain:** Take contributions and write everything up: social class, luck, health, education access, family, timing, networks, discrimination, temperament, emotional capacities. Then ask the question that lands it: **which of these is emotional intelligence?** Answer: one item on a long list, and the source assigns it no percentage at all.
+- **Discuss:** "What is emotional intelligence's share of the eighty per cent?"
+- **Activity:** **A20 — Where Does the Eighty Go?** (Activity Book; board exercise, 10 min)
+- **Notes:** [CORE] · 10 min. The correct answer to the discussion question is *the source does not say, and neither should you.* This is the highest-value ten minutes in the module for inoculating against the popular literature.
+- **Source:** Ch. 3 · [SOURCE] + [PEDAGOGICAL] exercise
+
+---
+
+### Slide 82 — What Must Never Be Taught
+
+- **Purpose:** State the prohibition explicitly, having earned it.
+- **On the slide:** ✕ *"Emotional intelligence accounts for 80 per cent of success."* / **The source does not say this.** / It takes a claim about what IQ *fails to explain* and converts it into a claim about what EI *does* explain.
+- **Visual:** L3. The false claim struck through in grey; the correction in blue.
+- **Explain:** Name the mechanism of the error precisely, because that is what makes it recognisable elsewhere. A bounded claim about one variable has been read as an unbounded claim about another. Note that this appears on countless slides, brochures and websites, and that a learner who repeats it in this course's assessment loses marks.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Directly assessed at Case-Study Question 2(a), where candidates must correct it. Activity A13 (Correct the Slide) runs on this material.
+- **Source:** Ch. 3 · [SOURCE]; the Source Analysis misattribution table · [PEDAGOGICAL]
+
+---
+
+### Slide 83 — The Lineage
+
+- **Purpose:** Give the intellectual history as an advance organiser before the detail.
+- **On the slide:** **THORNDIKE** 1920 → *dismissed* → **GARDNER** 1983 → **SALOVEY & MAYER** 1990 → *this book* 1995
+- **Visual:** L4. A timeline with five stops and one visible gap between 1920 and 1983.
+- **Explain:** Emotional intelligence did not arrive from nowhere in 1995. It is the current form of a question first asked in the 1920s, abandoned for sixty years, and revived by two separate research programmes. Point at the gap: the interesting historical question is why the idea stalled, and slide 85 answers it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Assessed at MCQ 13 and the module knowledge check. Learners who leave believing Goleman invented emotional intelligence have absorbed the popular story rather than the book's.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 84 — Thorndike, 1920
+
+- **Purpose:** Establish the original proposal.
+- **On the slide:** **Social intelligence** — the ability to understand others and *"act wisely in human relations."* / Proposed as a distinct kind of intelligence, alongside the academic kind.
+- **Visual:** L1. Definition card.
+- **Explain:** E. L. Thorndike, an eminent psychologist who was also instrumental in popularising IQ testing, proposed in the 1920s that social intelligence was a genuine and separate aptitude. The proposal is nearly a century old, and its terms are recognisably those of Domains 4 and 5.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** Ch. 3 · [SOURCE] — Thorndike
+
+---
+
+### Slide 85 — Why It Stalled
+
+- **Purpose:** Explain the sixty-year gap — and surface an objection the course will meet again.
+- **On the slide:** Some contemporaries read social intelligence as **"skills for manipulating other people."** / By 1960 an influential textbook pronounced the concept useless.
+- **Visual:** L4. The timeline from slide 83 with the gap annotated.
+- **Explain:** Two problems sank it. It could not be measured in the way academic intelligence could, and it attracted the suspicion that it named a talent for manipulation rather than a competence. Note carefully: **that second objection is the ethics question this course refuses to close** — it is the same objection, and it has been attached to this idea since the beginning.
+- **Discuss:** "Was the manipulation objection wrong?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Do not resolve the discussion question. It reappears at slides 174, 193, 250, 313 and 338. Flagging its ninety-year pedigree here makes the later treatment land harder.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 86 — Gardner: A Manifesto Against One Number
+
+- **Purpose:** Deliver the revival.
+- **On the slide:** *Frames of Mind* (1983) — *"a manifesto refuting the IQ view."* / Not one monolithic intelligence. **A spectrum.**
+- **Visual:** L1. Text with the publication year prominent.
+- **Explain:** Gardner's claim: there is "not just one, monolithic kind of intelligence that was crucial for life success, but rather a wide spectrum of intelligences, with seven key varieties." Point back to the board from slide 76 — most rooms produce a rough version of this unprompted, which is worth naming.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Return to slide 76's board answers here. The recognition is the reward for having asked the question first.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 87 — The Seven
+
+- **Purpose:** Give the spectrum, with the two that matter marked.
+- **On the slide:** Verbal · Mathematical-logical · Spatial · Kinaesthetic · Musical · **Interpersonal** · **Intrapersonal**
+- **Visual:** L5. Seven cells; the last two highlighted.
+- **Explain:** The first five are the varieties most schools already recognise in some form. The last two — Gardner's **personal intelligences** — are the ones this course is about: the capacity to understand other people, and the capacity to understand oneself.
+- **Discuss:** "Which two does your education system actually measure?"
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. The discussion question reliably produces the answer "the first two," which is Gardner's argument delivered by the room.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 88 — Judy and the Classroom Game
+
+- **Purpose:** Make interpersonal intelligence concrete and measurable rather than abstract.
+- **On the slide:** *A four-year-old wallflower. Hangs back at playtime.* / Given a model of her classroom, she places **every child** in the area they most like to play in — and correctly matches best friends for the entire class.
+- **Visual:** L6. Case card.
+- **Explain:** Judy, at the Eliot-Pearson Preschool. The source's conclusion: she "has a perfect social map of her class, a level of perceptiveness exceptional for a four-year-old." Two teaching points. First, the ability is real and demonstrable — it can be *tested*, just not with a paper-and-pencil quiz. Second, being socially perceptive and being socially confident are **different things**, and Judy has one without the other. That distinction runs all the way to the social chameleon at slide 188, who has the opposite pairing.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The perceptiveness/confidence split is the slide's real content and is easy to miss. Say it explicitly.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 89 — The Personal Intelligences
+
+- **Purpose:** Deliver Gardner's two, and the gap the source identifies in them.
+- **On the slide:** **INTERPERSONAL** — understanding others: what motivates them, how they work, how to work with them · **INTRAPERSONAL** — an accurate model of oneself, usable to run one's life // *Goleman's objection:* this account **"emphasizes cognition"** — it leaves "unexplored the rich sea of emotions."
+- **Visual:** L3. Two columns, with the objection in an amber bar beneath.
+- **Explain:** This is the pivot of the whole chapter and it is worth slowing down for. Gardner reopened the question and framed the two personal intelligences largely as forms of *understanding* — knowing about people, having a model of oneself. The source's criticism is that understanding is not the whole of it: knowing that you are angry is not the same as being able to do anything with the anger. **The gap between cognition about emotion and competence with emotion is exactly the space emotional intelligence occupies.**
+- **Discuss:** "Is understanding your own emotions the same as managing them?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. **The single most important slide in this module.** Everything about the five domains follows from this gap. The discussion question's answer — no, and Module 6 will show that awareness is a vantage point rather than a brake — is the whole architecture in one exchange.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 90 — Salovey's Reformulation
+
+- **Purpose:** Deliver the definition, correctly attributed.
+- **On the slide:** **Peter Salovey** (with John Mayer) subsumes Gardner's personal intelligences into a definition of **emotional intelligence** — and expands it into **five domains.** / *The framework in this book is theirs.*
+- **Visual:** L1. Text; the attribution set apart in bold.
+- **Explain:** Say the attribution plainly. The five domains that organise the next five modules of this course are, on the source's own account, largely Salovey's. This book's contribution is synthesis, argument and reach — bringing a research literature to a general readership and arguing for its consequence. That is a real contribution and it is a different one from originating the framework.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at MCQ 13, whose distractors are the author's own *later* frameworks. This is the fidelity slide of the module.
+- **Source:** Ch. 3 · [SOURCE] — Salovey & Mayer
+
+---
+
+### Slide 91 — The Five
+
+- **Purpose:** Deliver the framework in the source's own words and order.
+- **On the slide:** 1 · **Knowing one's emotions** · 2 · **Managing emotions** · 3 · **Motivating oneself** · 4 · **Recognising emotions in others** · 5 · **Handling relationships**
+- **Visual:** L5. Five numbered bands, stacked, the first visibly wider than the others.
+- **Explain:** Use the source's phrasing, not the paraphrases learners will have met elsewhere. "Knowing one's emotions" is not identical to "self-awareness" as a corporate competency; "handling relationships" is not "relationship management." The wording carries the argument.
+- **Discuss:** —
+- **Activity:** **A14 — Map the Five Domains** (Activity Book; 30 min, may be set as homework)
+- **Notes:** [CORE] · 4 min. Say now that other five-item lists exist, that some are by the same author, and that this course teaches this book's.
+- **Source:** Ch. 3, Ch. 4 · [SOURCE]
+
+---
+
+### Slide 92 — The Dependency Structure
+
+- **Purpose:** Deliver the part of the framework that nearly every popular treatment removes.
+- **On the slide:** *These are not five parallel skills. They rest on one another.*
+- **Visual:** L5. The deck's second signature diagram.
+
+```
+                    ┌──────────────────────────────┐
+                    │  1. KNOWING ONE'S EMOTIONS   │
+                    │       (Self-Awareness)       │
+                    │        THE KEYSTONE          │
+                    └───────────────┬──────────────┘
+              ┌─────────────────────┴──────────────────────┐
+              ▼                                            ▼
+   ┌──────────────────────┐                  ┌───────────────────────┐
+   │ 2. MANAGING EMOTIONS │                  │ 4. RECOGNISING        │
+   │  "builds on          │                  │    EMOTIONS IN OTHERS │
+   │   self-awareness"    │                  │  "builds on emotional │
+   ├──────────────────────┤                  │   self-awareness"     │
+   │ 3. MOTIVATING ONESELF│                  └───────────┬───────────┘
+   └──────────┬───────────┘                              │
+              └──────────────────┬───────────────────────┘
+                                 ▼
+                 ┌─────────────────────────────┐
+                 │ 5. HANDLING RELATIONSHIPS   │
+                 │   "requires the ripeness of │
+                 │    two other emotional      │
+                 │    skills, self-management  │
+                 │    and empathy"             │
+                 └─────────────────────────────┘
+```
+
+- **Explain:** The quoted phrases are the source's own. Domain 2 is described as building on Domain 1. Domain 4 is described as building on emotional self-awareness. Domain 5 is described as requiring the ripeness of self-management and empathy. Take the structure seriously and two things follow: you cannot train Domain 5 directly, and a person who appears skilled at Domain 5 without Domain 1 is doing something other than what the framework describes.
+- **Discuss:** "If this structure is right, what is wrong with a training course that starts with communication skills?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at MCQ 14 and SA4, both of which require the source's dependency language. This diagram should be visible on the wall for the remainder of the course.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 93 — The Five Domains Compared
+
+- **Purpose:** Give the room a single reference table for the whole of Modules 6–10.
+- **On the slide:** *(the table carries it — no additional text)*
+- **Visual:** L3. Six columns × five rows.
+
+| Domain | What it is | Depends on | Fails as | Visible sign of it working | Taught in |
+| --- | --- | --- | --- | --- | --- |
+| 1 · Knowing one's emotions | Recognising a feeling as it happens | — | Alexithymia; being engulfed | Names the feeling while it is happening | M6 |
+| 2 · Managing emotions | Handling feelings so they fit the situation | Domain 1 | Suppression; ventilation; rumination | Recovers, and recovers faster over time | M7 |
+| 3 · Motivating oneself | Marshalling emotion toward a goal | Domain 1 | Impulsivity; despair; anxiety-driven collapse | Persists past the point of discouragement | M8 |
+| 4 · Recognising emotions in others | Reading what another person feels | Domain 1 | Confident misreading; projection | Checks the reading instead of assuming it | M9 |
+| 5 · Handling relationships | Managing emotion in others | Domains 2 and 4 | The social chameleon; manipulation | Leaves the other person better off, reliably | M10 |
+
+- **Explain:** Read across one row rather than down the columns. The "fails as" column is the one to dwell on: each domain has a characteristic failure that looks, from outside, like something else — suppression looks like calm, projection looks like insight, manipulation looks like skill.
+- **Discuss:** "Which failure mode is hardest to spot in yourself?"
+- **Activity:** —
+- **Notes:** [CORE] · 10 min. Print as a handout. Learners refer back to it constantly.
+- **Source:** Ch. 4 · [SOURCE], table structure [PEDAGOGICAL]
+
+---
+
+### Slide 94 — Meta-Ability
+
+- **Purpose:** State the framework's central claim about why these abilities matter.
+- **On the slide:** Emotional aptitude is a **meta-ability** — it *"determin[es] how well we can use whatever other skills we have, including raw intellect."*
+- **Visual:** L2. A set of capability boxes behind a single gate labelled with the five domains.
+- **Explain:** The claim is not that emotional abilities substitute for intelligence, training or knowledge. It is that they govern **access** to them. A person who cannot think while flooded has, in that moment, no access to what they know — which is Module 4's neural static, now given its consequence. Note carefully what the claim does *not* say: nothing here quantifies the contribution, and slide 80 still stands.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Someone usually offers the 80 per cent figure here. Good — take the correction from the room rather than giving it.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 95 — The Honest Limit
+
+- **Purpose:** State the measurement problem in the source's own words, at the moment of maximum enthusiasm.
+- **On the slide:** *"There is, as yet, no single paper-and-pencil test that yields an 'emotional intelligence score' — **and there may never be one.**"*
+- **Visual:** L1. The quotation alone, amber bar.
+- **Explain:** This is the author's own sentence and it is placed here deliberately. The course has just handed the room a framework, and the next thing it does is tell them that the framework has no agreed measure and may never have one. Note the reason the source gives: abilities like empathy "are best tested by sampling a person's actual ability at the task" — by watching someone read a face, not by asking them to rate themselves. **This is why the course's own self-assessment is not a test**, and why Module 17's measurement critique is not an attack from outside.
+- **Discuss:** "What follows for anyone selling an EQ assessment?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. **This is the module in which the course earns the right to be believed.** Delivering the framework and its own limit in the same session is the whole point of placing this here rather than at the end.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 96 — Two Pure Types
+
+- **Purpose:** Show what each dimension contributes separately — and mark the framing the source itself attaches.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3. Two columns.
+
+| | **High IQ (pure type)** | **High EI (pure type)** |
+| --- | --- | --- |
+| Intellectual | Ambitious, productive, predictable, dogged | Capable, but not defined by it |
+| Social | Critical, condescending, inhibited, uneasy | Outgoing, cheerful, committed to people |
+| Emotional life | Uncomfortable with sensuality; emotionally bland | Comfortable with themselves; rich but appropriate emotional life |
+| Under stress | Detached | Notably resilient |
+
+- **Explain:** Deliver the qualification **with** the table, not after it. The source describes these as *"two theoretical pure types"* — constructed extremes, not people — and builds them from Block's measure of **ego resilience**, which the source describes as "quite similar to" emotional intelligence and not identical to it. Two hedges, both the author's.
+- **Discuss:** "Do you know anyone who is actually a pure type?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min. Answer: no, and that is the point. Note also that the source presents these separately for men and women, which a contemporary reader should treat as a feature of the era's research design; that is Discussion Question 7 in the module text.
+- **Source:** Ch. 3 · [SOURCE-QUALIFIED] — Block
+
+---
+
+### Slide 97 — What Emotional Intelligence Adds
+
+- **Purpose:** Close the module's argument by answering slide 76's question.
+- **On the slide:** Not: *a different kind of clever.* / But: **the capacities that determine whether any of your cleverness reaches the world.**
+- **Visual:** L4. A single spine: ABILITY → *(gate: the five domains)* → OUTCOME, with the board answers from slide 76 shown alongside.
+- **Explain:** Return to the board. Most of what the room said at slide 76 turns out to be a rough version of Gardner. What Gardner left out — and what Salovey supplied — is that understanding emotion is not the same as being competent with it. That gap is the course's subject, and the next five modules are one domain each.
+- **Discuss:** "Has your answer to the opening question changed?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Closing the loop opened at slide 76 is what makes this module a narrative rather than a history lesson. Do not cut it.
+- **Source:** Ch. 3 · [SOURCE] and [PEDAGOGICAL] synthesis
+
+---
+
+### Slide 98 — Knowledge Check: Module 5
+
+- **Purpose:** Formative check on the course's framework module.
+- **On the slide:** 1 · State the "20 percent" claim exactly, and say what the remaining 80 per cent is attributed to. 2 · What was Thorndike's contribution, and what happened to it? 3 · Name Gardner's two personal intelligences and Goleman's objection to them. 4 · Whose five-domain framework does this book use? 5 · What does the source say about the existence of a paper-and-pencil EI test?
+- **Visual:** L7. Five questions, numbered.
+- **Explain:** —
+- **Discuss:** Take answers aloud after 4 minutes of writing.
+- **Activity:** Knowledge Check (Assessment Bank, Module 5)
+- **Notes:** [CORE] · 8 min. **Questions 1 and 4 are the diagnostics.** A room that cannot state the 20 per cent claim precisely, or that attributes the five domains to Goleman, has not got the module — and both errors are directly assessed in the final paper.
+- **Source:** Assessment Bank · [PEDAGOGICAL]
+
+---
+
+*End of Module 5. Slides 99–198 (Modules 6–10, the five domains) continue in `03_Slides_099-198_Five_Domains.md`.*
+
+## Provenance
+
+Formalized by Open Design from candidate 1f8fa573-30f5-4e3c-a5b4-4866d00104a4.

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/open-design.json
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "slide-blueprint-module-5-msodr5vw",
+  "title": "SLIDE BLUEPRINT — MODULE 5",
+  "version": "0.1.0",
+  "description": "**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/provenance.json
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/provenance.json
@@ -1,0 +1,68 @@
+{
+  "candidateId": "1f8fa573-30f5-4e3c-a5b4-4866d00104a4",
+  "projectId": "f4616849-7848-4a88-b2c8-c2c9e5ed7db0",
+  "runId": "0777c21a-9a1c-441e-87f7-72165bc5b8dd",
+  "conversationId": "b4ecf452-0d76-436f-959f-2d45a4439da1",
+  "provenance": {
+    "summary": "Detected from 03_Slides_075-098_Module05_Intelligence_Reconsidered.md, 04_Slides_099-198_Five_Domains.md, 05_Slides_199-287_Application_and_Development.md, 06_Slides_288-343_Trauma_Scrutiny_Close.md, 07_Master_Cross_Reference_Register.md, 08_Master_Learning_Outcomes.md, 09_Activity_Book.md, 10_Case_Book_Cases_01-30.md after a successful run.",
+    "detectedAt": 1786428833204
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "03_Slides_075-098_Module05_Intelligence_Reconsidered.md",
+      "label": "03_Slides_075-098_Module05_Intelligence_Reconsidered.md",
+      "size": 28755,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "04_Slides_099-198_Five_Domains.md",
+      "label": "04_Slides_099-198_Five_Domains.md",
+      "size": 94650,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "05_Slides_199-287_Application_and_Development.md",
+      "label": "05_Slides_199-287_Application_and_Development.md",
+      "size": 83448,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "06_Slides_288-343_Trauma_Scrutiny_Close.md",
+      "label": "06_Slides_288-343_Trauma_Scrutiny_Close.md",
+      "size": 54750,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "07_Master_Cross_Reference_Register.md",
+      "label": "07_Master_Cross_Reference_Register.md",
+      "size": 20575,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "08_Master_Learning_Outcomes.md",
+      "label": "08_Master_Learning_Outcomes.md",
+      "size": 12868,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "09_Activity_Book.md",
+      "label": "09_Activity_Book.md",
+      "size": 52292,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "10_Case_Book_Cases_01-30.md",
+      "label": "10_Case_Book_Cases_01-30.md",
+      "size": 76647,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-1-03_Slides_075-098_Module05_Intelligence_Reconsidered.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-1-03_Slides_075-098_Module05_Intelligence_Reconsidered.md
@@ -1,0 +1,373 @@
+# SLIDE BLUEPRINT — MODULE 5
+## Slides 75–98 — Intelligence Reconsidered: What Emotional Intelligence Is
+
+**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**
+
+**Primary source:** Chapter 3, "When Smart Is Dumb"
+**Learning outcomes:** LO6, LO7 · **Session length:** 100 min (55 compressed)
+
+> **Why this module exists as its own block.** Chapter 3 carries the book's pivot — the argument that the concept of intelligence itself has to change before emotional intelligence can be defined at all. In the previous version of this deck that argument was distributed across four slides in three separate blocks, and it did not survive the distribution. It is restored here as a single narrative running from *a straight-A student with a knife* to *five domains in a dependency structure*.
+
+---
+
+# BLOCK 6 — MODULE 5: INTELLIGENCE RECONSIDERED (Slides 75–98)
+
+---
+
+### Slide 75 — Module 5: Intelligence Reconsidered
+
+- **Purpose:** Open the module that turns the course from mechanism to framework.
+- **On the slide:** MODULE 5 · Intelligence Reconsidered / *What does it mean to call someone intelligent?*
+- **Visual:** L1. Divider. The map from slide 6 with FOUNDATIONS completed and a new node, THE FRAMEWORK, lit.
+- **Explain:** Modules 1–4 described the machinery. This module asks what follows from it for our idea of intelligence — and it is the module in which the course's central term finally gets defined.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min. Say what is coming: by the end of this session learners will have the framework that organises the next five modules.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 76 — The Question
+
+- **Purpose:** Pose the module's question before any content, so the evidence has something to bear on.
+- **On the slide:** **You know someone brilliant whose life is a mess.** / What does that tell us about intelligence?
+- **Visual:** L7. Question alone.
+- **Explain:** Nothing. Take three answers and write them on the board. Leave them up for slide 97.
+- **Discuss:** "What does that tell us about intelligence?"
+- **Activity:** Micro: three answers, recorded on the board.
+- **Notes:** [CORE] · 5 min. Almost every room produces some version of "there's more than one kind of smart." That is Gardner, arrived at from the floor, forty slides before he is named. Say so at slide 86.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 77 — Jason H.
+
+- **Purpose:** Deliver the source's opening case at full force.
+- **On the slide:** *A straight-A sophomore. Fixed on medical school — Harvard. His physics teacher gives him 80 on a quiz.* / **He brought a butcher knife to school and stabbed the teacher in the collarbone.**
+- **Visual:** L6. Case card. No illustration.
+- **Explain:** Coral Springs, Florida. The teacher, David Pologruto. A B on one quiz, and a student who believed his future had ended. The point the source draws is not that the boy was disturbed — it is that nothing in his academic record, which was outstanding, predicted this or could have.
+- **Discuss:** "What would you have needed to measure to see this coming?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Deliver it plainly and do not editorialise. The case is doing the work. Case 1 in the case book gives the full version for extended analysis.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 78 — What IQ Predicted, and What It Did Not
+
+- **Purpose:** Deliver the valedictorian evidence, which is the chapter's empirical spine.
+- **On the slide:** 81 valedictorians, tracked. / By their late twenties: **ordinary success.** Nothing exceptional.
+- **Visual:** L3. Two columns — what the valedictorians were exceptional at / what they turned out to be ordinary at.
+- **Explain:** Karen Arnold's study. The sentence to hold onto is hers: *"To know that a person is a valedictorian is to know only that he or she is exceedingly good at achievement as measured by grades. It tells you nothing about how they react to the vicissitudes of life."* She calls what the study found "the dutiful" — people who know how to achieve within a system.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The room will want to dismiss school achievement entirely. Slide 79 stops that, and it should follow immediately.
+- **Source:** Ch. 3 · [SOURCE] — Arnold
+
+---
+
+### Slide 79 — The Honest Concession
+
+- **Purpose:** Prevent the over-correction the previous slide invites.
+- **On the slide:** *"There is a relationship between IQ and life circumstances for large groups as a whole: many people with very low IQs end up in menial jobs, and those with high IQs tend to become well-paid — **but by no means always.**"*
+- **Visual:** L1. The quotation alone, attributed to the source.
+- **Explain:** This is the author's own concession and the course teaches it as prominently as the criticism. The claim is not that IQ is irrelevant. It is that IQ is **insufficient** — that it predicts something real at population level and leaves most of the individual variation unexplained. A course that taught the valedictorian study without this slide would be doing to Goleman what the popular literature does to him.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This slide is a fidelity slide. Learners who leave believing the course is anti-IQ have been mistaught.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 80 — The Twenty Per Cent, Precisely
+
+- **Purpose:** Deliver the most misquoted sentence in the field, verbatim.
+- **On the slide:** *"At best, IQ contributes about 20 percent to the factors that determine life success, which leaves **80 percent to other forces**."*
+- **Visual:** L1. The quotation, with **other forces** set apart. No chart, no pie.
+- **Explain:** Read it exactly. Then read the observer's gloss the source quotes immediately after: *"The vast majority of one's ultimate niche in society is determined by non-IQ factors, ranging from **social class to luck**."* Two things are being claimed: that IQ's contribution is bounded, and that the remainder is a **heterogeneous list** whose named members are social class and luck.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Slide 5 confronted this on the first morning to buy the course credibility. **This is where it is taught properly.** If a learner says "we did this already," agree — and point out that on day one they were told what it is not, and today they get what it is.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 81 — Where Does the Other Eighty Go?
+
+- **Purpose:** Make the misattribution impossible to hold by having the room construct the correct picture themselves.
+- **On the slide:** **80% = "other forces."** / *Name them. Board exercise.*
+- **Visual:** L7. Instruction only; the board does the work.
+- **Explain:** Take contributions and write everything up: social class, luck, health, education access, family, timing, networks, discrimination, temperament, emotional capacities. Then ask the question that lands it: **which of these is emotional intelligence?** Answer: one item on a long list, and the source assigns it no percentage at all.
+- **Discuss:** "What is emotional intelligence's share of the eighty per cent?"
+- **Activity:** **A20 — Where Does the Eighty Go?** (Activity Book; board exercise, 10 min)
+- **Notes:** [CORE] · 10 min. The correct answer to the discussion question is *the source does not say, and neither should you.* This is the highest-value ten minutes in the module for inoculating against the popular literature.
+- **Source:** Ch. 3 · [SOURCE] + [PEDAGOGICAL] exercise
+
+---
+
+### Slide 82 — What Must Never Be Taught
+
+- **Purpose:** State the prohibition explicitly, having earned it.
+- **On the slide:** ✕ *"Emotional intelligence accounts for 80 per cent of success."* / **The source does not say this.** / It takes a claim about what IQ *fails to explain* and converts it into a claim about what EI *does* explain.
+- **Visual:** L3. The false claim struck through in grey; the correction in blue.
+- **Explain:** Name the mechanism of the error precisely, because that is what makes it recognisable elsewhere. A bounded claim about one variable has been read as an unbounded claim about another. Note that this appears on countless slides, brochures and websites, and that a learner who repeats it in this course's assessment loses marks.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Directly assessed at Case-Study Question 2(a), where candidates must correct it. Activity A13 (Correct the Slide) runs on this material.
+- **Source:** Ch. 3 · [SOURCE]; the Source Analysis misattribution table · [PEDAGOGICAL]
+
+---
+
+### Slide 83 — The Lineage
+
+- **Purpose:** Give the intellectual history as an advance organiser before the detail.
+- **On the slide:** **THORNDIKE** 1920 → *dismissed* → **GARDNER** 1983 → **SALOVEY & MAYER** 1990 → *this book* 1995
+- **Visual:** L4. A timeline with five stops and one visible gap between 1920 and 1983.
+- **Explain:** Emotional intelligence did not arrive from nowhere in 1995. It is the current form of a question first asked in the 1920s, abandoned for sixty years, and revived by two separate research programmes. Point at the gap: the interesting historical question is why the idea stalled, and slide 85 answers it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Assessed at MCQ 13 and the module knowledge check. Learners who leave believing Goleman invented emotional intelligence have absorbed the popular story rather than the book's.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 84 — Thorndike, 1920
+
+- **Purpose:** Establish the original proposal.
+- **On the slide:** **Social intelligence** — the ability to understand others and *"act wisely in human relations."* / Proposed as a distinct kind of intelligence, alongside the academic kind.
+- **Visual:** L1. Definition card.
+- **Explain:** E. L. Thorndike, an eminent psychologist who was also instrumental in popularising IQ testing, proposed in the 1920s that social intelligence was a genuine and separate aptitude. The proposal is nearly a century old, and its terms are recognisably those of Domains 4 and 5.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** Ch. 3 · [SOURCE] — Thorndike
+
+---
+
+### Slide 85 — Why It Stalled
+
+- **Purpose:** Explain the sixty-year gap — and surface an objection the course will meet again.
+- **On the slide:** Some contemporaries read social intelligence as **"skills for manipulating other people."** / By 1960 an influential textbook pronounced the concept useless.
+- **Visual:** L4. The timeline from slide 83 with the gap annotated.
+- **Explain:** Two problems sank it. It could not be measured in the way academic intelligence could, and it attracted the suspicion that it named a talent for manipulation rather than a competence. Note carefully: **that second objection is the ethics question this course refuses to close** — it is the same objection, and it has been attached to this idea since the beginning.
+- **Discuss:** "Was the manipulation objection wrong?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Do not resolve the discussion question. It reappears at slides 174, 193, 250, 313 and 338. Flagging its ninety-year pedigree here makes the later treatment land harder.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 86 — Gardner: A Manifesto Against One Number
+
+- **Purpose:** Deliver the revival.
+- **On the slide:** *Frames of Mind* (1983) — *"a manifesto refuting the IQ view."* / Not one monolithic intelligence. **A spectrum.**
+- **Visual:** L1. Text with the publication year prominent.
+- **Explain:** Gardner's claim: there is "not just one, monolithic kind of intelligence that was crucial for life success, but rather a wide spectrum of intelligences, with seven key varieties." Point back to the board from slide 76 — most rooms produce a rough version of this unprompted, which is worth naming.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Return to slide 76's board answers here. The recognition is the reward for having asked the question first.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 87 — The Seven
+
+- **Purpose:** Give the spectrum, with the two that matter marked.
+- **On the slide:** Verbal · Mathematical-logical · Spatial · Kinaesthetic · Musical · **Interpersonal** · **Intrapersonal**
+- **Visual:** L5. Seven cells; the last two highlighted.
+- **Explain:** The first five are the varieties most schools already recognise in some form. The last two — Gardner's **personal intelligences** — are the ones this course is about: the capacity to understand other people, and the capacity to understand oneself.
+- **Discuss:** "Which two does your education system actually measure?"
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. The discussion question reliably produces the answer "the first two," which is Gardner's argument delivered by the room.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 88 — Judy and the Classroom Game
+
+- **Purpose:** Make interpersonal intelligence concrete and measurable rather than abstract.
+- **On the slide:** *A four-year-old wallflower. Hangs back at playtime.* / Given a model of her classroom, she places **every child** in the area they most like to play in — and correctly matches best friends for the entire class.
+- **Visual:** L6. Case card.
+- **Explain:** Judy, at the Eliot-Pearson Preschool. The source's conclusion: she "has a perfect social map of her class, a level of perceptiveness exceptional for a four-year-old." Two teaching points. First, the ability is real and demonstrable — it can be *tested*, just not with a paper-and-pencil quiz. Second, being socially perceptive and being socially confident are **different things**, and Judy has one without the other. That distinction runs all the way to the social chameleon at slide 188, who has the opposite pairing.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The perceptiveness/confidence split is the slide's real content and is easy to miss. Say it explicitly.
+- **Source:** Ch. 3 · [SOURCE] — Gardner
+
+---
+
+### Slide 89 — The Personal Intelligences
+
+- **Purpose:** Deliver Gardner's two, and the gap the source identifies in them.
+- **On the slide:** **INTERPERSONAL** — understanding others: what motivates them, how they work, how to work with them · **INTRAPERSONAL** — an accurate model of oneself, usable to run one's life // *Goleman's objection:* this account **"emphasizes cognition"** — it leaves "unexplored the rich sea of emotions."
+- **Visual:** L3. Two columns, with the objection in an amber bar beneath.
+- **Explain:** This is the pivot of the whole chapter and it is worth slowing down for. Gardner reopened the question and framed the two personal intelligences largely as forms of *understanding* — knowing about people, having a model of oneself. The source's criticism is that understanding is not the whole of it: knowing that you are angry is not the same as being able to do anything with the anger. **The gap between cognition about emotion and competence with emotion is exactly the space emotional intelligence occupies.**
+- **Discuss:** "Is understanding your own emotions the same as managing them?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. **The single most important slide in this module.** Everything about the five domains follows from this gap. The discussion question's answer — no, and Module 6 will show that awareness is a vantage point rather than a brake — is the whole architecture in one exchange.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 90 — Salovey's Reformulation
+
+- **Purpose:** Deliver the definition, correctly attributed.
+- **On the slide:** **Peter Salovey** (with John Mayer) subsumes Gardner's personal intelligences into a definition of **emotional intelligence** — and expands it into **five domains.** / *The framework in this book is theirs.*
+- **Visual:** L1. Text; the attribution set apart in bold.
+- **Explain:** Say the attribution plainly. The five domains that organise the next five modules of this course are, on the source's own account, largely Salovey's. This book's contribution is synthesis, argument and reach — bringing a research literature to a general readership and arguing for its consequence. That is a real contribution and it is a different one from originating the framework.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at MCQ 13, whose distractors are the author's own *later* frameworks. This is the fidelity slide of the module.
+- **Source:** Ch. 3 · [SOURCE] — Salovey & Mayer
+
+---
+
+### Slide 91 — The Five
+
+- **Purpose:** Deliver the framework in the source's own words and order.
+- **On the slide:** 1 · **Knowing one's emotions** · 2 · **Managing emotions** · 3 · **Motivating oneself** · 4 · **Recognising emotions in others** · 5 · **Handling relationships**
+- **Visual:** L5. Five numbered bands, stacked, the first visibly wider than the others.
+- **Explain:** Use the source's phrasing, not the paraphrases learners will have met elsewhere. "Knowing one's emotions" is not identical to "self-awareness" as a corporate competency; "handling relationships" is not "relationship management." The wording carries the argument.
+- **Discuss:** —
+- **Activity:** **A14 — Map the Five Domains** (Activity Book; 30 min, may be set as homework)
+- **Notes:** [CORE] · 4 min. Say now that other five-item lists exist, that some are by the same author, and that this course teaches this book's.
+- **Source:** Ch. 3, Ch. 4 · [SOURCE]
+
+---
+
+### Slide 92 — The Dependency Structure
+
+- **Purpose:** Deliver the part of the framework that nearly every popular treatment removes.
+- **On the slide:** *These are not five parallel skills. They rest on one another.*
+- **Visual:** L5. The deck's second signature diagram.
+
+```
+                    ┌──────────────────────────────┐
+                    │  1. KNOWING ONE'S EMOTIONS   │
+                    │       (Self-Awareness)       │
+                    │        THE KEYSTONE          │
+                    └───────────────┬──────────────┘
+              ┌─────────────────────┴──────────────────────┐
+              ▼                                            ▼
+   ┌──────────────────────┐                  ┌───────────────────────┐
+   │ 2. MANAGING EMOTIONS │                  │ 4. RECOGNISING        │
+   │  "builds on          │                  │    EMOTIONS IN OTHERS │
+   │   self-awareness"    │                  │  "builds on emotional │
+   ├──────────────────────┤                  │   self-awareness"     │
+   │ 3. MOTIVATING ONESELF│                  └───────────┬───────────┘
+   └──────────┬───────────┘                              │
+              └──────────────────┬───────────────────────┘
+                                 ▼
+                 ┌─────────────────────────────┐
+                 │ 5. HANDLING RELATIONSHIPS   │
+                 │   "requires the ripeness of │
+                 │    two other emotional      │
+                 │    skills, self-management  │
+                 │    and empathy"             │
+                 └─────────────────────────────┘
+```
+
+- **Explain:** The quoted phrases are the source's own. Domain 2 is described as building on Domain 1. Domain 4 is described as building on emotional self-awareness. Domain 5 is described as requiring the ripeness of self-management and empathy. Take the structure seriously and two things follow: you cannot train Domain 5 directly, and a person who appears skilled at Domain 5 without Domain 1 is doing something other than what the framework describes.
+- **Discuss:** "If this structure is right, what is wrong with a training course that starts with communication skills?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at MCQ 14 and SA4, both of which require the source's dependency language. This diagram should be visible on the wall for the remainder of the course.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 93 — The Five Domains Compared
+
+- **Purpose:** Give the room a single reference table for the whole of Modules 6–10.
+- **On the slide:** *(the table carries it — no additional text)*
+- **Visual:** L3. Six columns × five rows.
+
+| Domain | What it is | Depends on | Fails as | Visible sign of it working | Taught in |
+| --- | --- | --- | --- | --- | --- |
+| 1 · Knowing one's emotions | Recognising a feeling as it happens | — | Alexithymia; being engulfed | Names the feeling while it is happening | M6 |
+| 2 · Managing emotions | Handling feelings so they fit the situation | Domain 1 | Suppression; ventilation; rumination | Recovers, and recovers faster over time | M7 |
+| 3 · Motivating oneself | Marshalling emotion toward a goal | Domain 1 | Impulsivity; despair; anxiety-driven collapse | Persists past the point of discouragement | M8 |
+| 4 · Recognising emotions in others | Reading what another person feels | Domain 1 | Confident misreading; projection | Checks the reading instead of assuming it | M9 |
+| 5 · Handling relationships | Managing emotion in others | Domains 2 and 4 | The social chameleon; manipulation | Leaves the other person better off, reliably | M10 |
+
+- **Explain:** Read across one row rather than down the columns. The "fails as" column is the one to dwell on: each domain has a characteristic failure that looks, from outside, like something else — suppression looks like calm, projection looks like insight, manipulation looks like skill.
+- **Discuss:** "Which failure mode is hardest to spot in yourself?"
+- **Activity:** —
+- **Notes:** [CORE] · 10 min. Print as a handout. Learners refer back to it constantly.
+- **Source:** Ch. 4 · [SOURCE], table structure [PEDAGOGICAL]
+
+---
+
+### Slide 94 — Meta-Ability
+
+- **Purpose:** State the framework's central claim about why these abilities matter.
+- **On the slide:** Emotional aptitude is a **meta-ability** — it *"determin[es] how well we can use whatever other skills we have, including raw intellect."*
+- **Visual:** L2. A set of capability boxes behind a single gate labelled with the five domains.
+- **Explain:** The claim is not that emotional abilities substitute for intelligence, training or knowledge. It is that they govern **access** to them. A person who cannot think while flooded has, in that moment, no access to what they know — which is Module 4's neural static, now given its consequence. Note carefully what the claim does *not* say: nothing here quantifies the contribution, and slide 80 still stands.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Someone usually offers the 80 per cent figure here. Good — take the correction from the room rather than giving it.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 95 — The Honest Limit
+
+- **Purpose:** State the measurement problem in the source's own words, at the moment of maximum enthusiasm.
+- **On the slide:** *"There is, as yet, no single paper-and-pencil test that yields an 'emotional intelligence score' — **and there may never be one.**"*
+- **Visual:** L1. The quotation alone, amber bar.
+- **Explain:** This is the author's own sentence and it is placed here deliberately. The course has just handed the room a framework, and the next thing it does is tell them that the framework has no agreed measure and may never have one. Note the reason the source gives: abilities like empathy "are best tested by sampling a person's actual ability at the task" — by watching someone read a face, not by asking them to rate themselves. **This is why the course's own self-assessment is not a test**, and why Module 17's measurement critique is not an attack from outside.
+- **Discuss:** "What follows for anyone selling an EQ assessment?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. **This is the module in which the course earns the right to be believed.** Delivering the framework and its own limit in the same session is the whole point of placing this here rather than at the end.
+- **Source:** Ch. 3 · [SOURCE]
+
+---
+
+### Slide 96 — Two Pure Types
+
+- **Purpose:** Show what each dimension contributes separately — and mark the framing the source itself attaches.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3. Two columns.
+
+| | **High IQ (pure type)** | **High EI (pure type)** |
+| --- | --- | --- |
+| Intellectual | Ambitious, productive, predictable, dogged | Capable, but not defined by it |
+| Social | Critical, condescending, inhibited, uneasy | Outgoing, cheerful, committed to people |
+| Emotional life | Uncomfortable with sensuality; emotionally bland | Comfortable with themselves; rich but appropriate emotional life |
+| Under stress | Detached | Notably resilient |
+
+- **Explain:** Deliver the qualification **with** the table, not after it. The source describes these as *"two theoretical pure types"* — constructed extremes, not people — and builds them from Block's measure of **ego resilience**, which the source describes as "quite similar to" emotional intelligence and not identical to it. Two hedges, both the author's.
+- **Discuss:** "Do you know anyone who is actually a pure type?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min. Answer: no, and that is the point. Note also that the source presents these separately for men and women, which a contemporary reader should treat as a feature of the era's research design; that is Discussion Question 7 in the module text.
+- **Source:** Ch. 3 · [SOURCE-QUALIFIED] — Block
+
+---
+
+### Slide 97 — What Emotional Intelligence Adds
+
+- **Purpose:** Close the module's argument by answering slide 76's question.
+- **On the slide:** Not: *a different kind of clever.* / But: **the capacities that determine whether any of your cleverness reaches the world.**
+- **Visual:** L4. A single spine: ABILITY → *(gate: the five domains)* → OUTCOME, with the board answers from slide 76 shown alongside.
+- **Explain:** Return to the board. Most of what the room said at slide 76 turns out to be a rough version of Gardner. What Gardner left out — and what Salovey supplied — is that understanding emotion is not the same as being competent with it. That gap is the course's subject, and the next five modules are one domain each.
+- **Discuss:** "Has your answer to the opening question changed?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Closing the loop opened at slide 76 is what makes this module a narrative rather than a history lesson. Do not cut it.
+- **Source:** Ch. 3 · [SOURCE] and [PEDAGOGICAL] synthesis
+
+---
+
+### Slide 98 — Knowledge Check: Module 5
+
+- **Purpose:** Formative check on the course's framework module.
+- **On the slide:** 1 · State the "20 percent" claim exactly, and say what the remaining 80 per cent is attributed to. 2 · What was Thorndike's contribution, and what happened to it? 3 · Name Gardner's two personal intelligences and Goleman's objection to them. 4 · Whose five-domain framework does this book use? 5 · What does the source say about the existence of a paper-and-pencil EI test?
+- **Visual:** L7. Five questions, numbered.
+- **Explain:** —
+- **Discuss:** Take answers aloud after 4 minutes of writing.
+- **Activity:** Knowledge Check (Assessment Bank, Module 5)
+- **Notes:** [CORE] · 8 min. **Questions 1 and 4 are the diagnostics.** A room that cannot state the 20 per cent claim precisely, or that attributes the five domains to Goleman, has not got the module — and both errors are directly assessed in the final paper.
+- **Source:** Assessment Bank · [PEDAGOGICAL]
+
+---
+
+*End of Module 5. Slides 99–198 (Modules 6–10, the five domains) continue in `03_Slides_099-198_Five_Domains.md`.*

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-2-04_Slides_099-198_Five_Domains.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-2-04_Slides_099-198_Five_Domains.md
@@ -1,0 +1,1441 @@
+# SLIDE BLUEPRINT — THE FIVE DOMAINS
+## Slides 99–198 — Modules 6–10
+
+**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**
+
+---
+
+# BLOCK 7 — MODULE 6: KNOWING THYSELF: SELF-AWARENESS (Slides 99–112)
+
+---
+
+### Slide 99 — Module 6: Knowing Thyself: Self-Awareness
+
+- **Purpose:** Open the keystone domain.
+- **On the slide:** MODULE 6 · Knowing Thyself: Self-Awareness / *Domain 1 — the one the others rest on*
+- **Visual:** L1. Divider, with the dependency diagram from slide 77 shown small, Domain 1 lit.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min. Use this divider style for all five domain modules, lighting the relevant node each time.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 100 — Recognising a Feeling As It Happens
+
+- **Purpose:** Deliver the definition, with its critical time qualifier.
+- **On the slide:** **Self-awareness:** recognising a feeling **as it happens.** / Not afterwards. Not on reflection. While it is occurring.
+- **Visual:** L1. Definition card. The phrase "as it happens" set apart.
+- **Explain:** The time qualifier is the entire content. Everyone can identify what they felt yesterday. Almost nobody, untrained, reliably identifies what they are feeling during the twenty seconds in which it would be useful. That gap — between retrospective and concurrent recognition — is what this domain names and what the rest of the course trains.
+- **Discuss:** "When did you last notice a feeling while it was happening, in time to do something about it?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Expect long silences on the discussion question. That is a result, not a failure — the silence is the room discovering the gap.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 101 — Awareness Is Not Control
+
+- **Purpose:** Prevent the standard over-claim before it forms.
+- **On the slide:** Noticing an emotion does not stop it. / It gives you **somewhere to stand** while it happens.
+- **Visual:** L1. Text only.
+- **Explain:** Self-awareness is not a brake. It is a vantage point. The source's account is of a mind that can register "I am angry" as a fact about its own state rather than being wholly constituted by the anger — and that registration is what makes any subsequent choice possible. Nothing more, and nothing less.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Learners who expect awareness to be curative will report failure in week two of their development plan and conclude the course does not work. Set the expectation here.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 102 — Three Ways of Attending to Feeling
+
+- **Purpose:** Deliver Mayer's taxonomy.
+- **On the slide:** **SELF-AWARE** — notices, and can act on it · **ENGULFED** — swamped, no vantage point, no way out · **ACCEPTING** — notices clearly, and does nothing
+- **Visual:** L3. Three columns.
+- **Explain:** Each is a stable style, not a passing state. The self-aware person has a mood and knows they have it. The engulfed person is the mood — no separation, no perspective, feelings that run them. The accepting person sees clearly and does not act, which splits into two very different cases.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at MCQ 15 and Scenario 3.
+- **Source:** Ch. 4 · [SOURCE] — Mayer
+
+---
+
+### Slide 103 — The Three Styles, Compared
+
+- **Purpose:** Give the discriminating detail, since Scenario 3 requires learners to tell them apart on evidence.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Notices the feeling? | Can name it? | Acts on it? | Looks like, from outside |
+| --- | --- | --- | --- | --- |
+| **Self-aware** | Yes, while it happens | Yes | Yes, when useful | Composed; recovers |
+| **Engulfed** | Overwhelmed by it | Poorly | Driven by it | Volatile, or stuck |
+| **Accepting (equable)** | Yes | Yes | Chooses not to | Easy-going |
+| **Accepting (resigned)** | Yes | Yes | Believes they cannot | Passive; low mood tolerated |
+| **Alexithymic** | Feels something | **No** | Confused, or somatic | Blank; "just tired"; physical complaints |
+
+- **Explain:** The two forms of acceptance matter enormously in practice. Someone equable is in good shape. Someone resigned has the same profile on a questionnaire and is not. And alexithymia is a different axis altogether — the feeling is present, the words are not.
+- **Discuss:** "Two people report the same low mood and take no action. What single question would tell them apart?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. The answer to the discussion question — some version of "do you think you could change it if you wanted to?" — is exactly what Scenario 3 asks candidates to produce.
+- **Source:** Ch. 4 · [SOURCE], four-way split [PEDAGOGICAL]
+
+---
+
+### Slide 104 — Alexithymia
+
+- **Purpose:** Deliver the condition and its practical signature.
+- **On the slide:** **Alexithymia:** the feelings are there. The words are not. / Not an absence of emotion — an absence of access to it.
+- **Visual:** L2. A feeling box with a blocked arrow (──✕──) to a language box.
+- **Explain:** The source describes people who have emotions and cannot say what they are — who, asked how they feel, describe events, or the weather, or physical sensations. It is not coldness; asked directly, such people are often distressed by the question. And it sits on a continuum: most people are somewhat alexithymic about some feelings, most often the ones that were unwelcome where they grew up.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Do not invite the room to identify alexithymic colleagues. Teach it as a mechanism. The clinical boundary from slide 20 applies.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 105 — When Feeling Goes to the Body
+
+- **Purpose:** Complete the picture of what happens when emotion has no verbal route.
+- **On the slide:** Emotion with no words often arrives as **sensation**: a stomach, a headache, a tightness, a fatigue with no cause.
+- **Visual:** L2. The blocked language route from slide 104, with an alternative route drawn to a body outline.
+- **Explain:** The source describes emotional distress presenting somatically where it has no verbal expression. Be careful about the direction of the claim: this does not mean physical symptoms are imaginary, or that anyone with a headache is repressing something. It means the emotional and physical are not separate systems, and that a person with no words for a feeling still has a body responding to it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 4 min. State the caution explicitly. This material is easy to misuse and gets misused constantly. Module 14 gives the full treatment of what the source does and does not claim about emotion and the body.
+- **Source:** Ch. 4, Ch. 11 · [SOURCE]
+
+---
+
+### Slide 106 — The Emotion Check-In
+
+- **Purpose:** Deliver the course's core self-awareness practice.
+- **On the slide:** 1 · What am I feeling? · 2 · What triggered it? · 3 · What thoughts came with it? · 4 · What did I notice in my body? · 5 · What did the feeling push me to do? · 6 · What did I actually do? · 7 · What happened afterwards?
+- **Visual:** L4. Seven numbered steps in a vertical sequence, items 5 and 6 boxed together in green.
+- **Explain:** Seven items, done in writing, ideally twice a day and always after anything notable. It is deliberately not a mood-rating scale — every item asks for description, not a score. And it is retrospective at first: nobody starts by doing this in real time. The practice trains the noticing, and the noticing eventually arrives earlier.
+- **Discuss:** —
+- **Activity:** **B1 — The Check-In, Modelled and Practised** (Activity Book). The instructor completes one aloud, on a real but moderate example, before anyone else attempts it.
+- **Notes:** [CORE] · 20 min with the activity. Model it genuinely — a real, small, unflattering example. A sanitised demonstration teaches the room to sanitise. Choose something mild and true: irritation at a slow queue, a flash of defensiveness at a small correction.
+- **Source:** Ch. 4 · [PEDAGOGICAL], built on the source's account
+
+---
+
+### Slide 107 — The Gap Between 5 and 6
+
+- **Purpose:** Identify precisely where emotional management happens.
+- **On the slide:** 5 · What the feeling pushed me to do · **6 · What I actually did** / *Everything this course can teach lives in the gap between these two lines.*
+- **Visual:** L2. Items 5 and 6 enlarged, with the space between them marked in green and labelled THE GAP.
+- **Explain:** If the two answers are always identical, there is no gap — impulse becomes action without interval, which is what impulsivity means. If they sometimes differ, the gap exists and can be widened. This is why the check-in asks both questions separately; a single "what did I do" would hide the distinction entirely.
+- **Discuss:** "Think of a recent instance where 5 and 6 were different. What made the difference?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. This is the conceptual bridge into Module 7 and it is worth naming as such. Assessed at Module 6's knowledge check, item 5.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 108 — Naming Is Not Nothing
+
+- **Purpose:** Justify the practice, and mark where the source's claim ends.
+- **On the slide:** Putting a feeling into words changes the feeling. / *The source claims this. It does not establish the mechanism.*
+- **Visual:** L1. Claim in blue; qualification in amber beneath.
+- **Explain:** The source treats naming as consequential — the person who can say "I am angry, and it's because of what happened this morning, not because of you" is in a different position from the person who can only be angry. Be honest about the evidential standing: this is a plausible and widely shared claim, and the mechanistic story is not settled. the Evidence file covers what the affect-labelling literature has and has not shown.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 4 min. Modelling the qualification here is worth as much as the content. Learners see the instructor decline to overstate a claim that supports the course's own practice.
+- **Source:** Ch. 4 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 109 — Case: The Flat Voice
+
+- **Purpose:** Apply the three styles to an ambiguous case, rehearsing Scenario 3.
+- **On the slide:** *Asked how the restructure is affecting him, Mikael says "It's fine, these things happen." His voice is flat. He has said the same sentence, in the same tone, for six weeks. Asked what he feels about it, he says he doesn't really think about it that way.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "Which style? What is the competing reading? What one question would tell you?"
+- **Activity:** Pairs, 4 minutes.
+- **Notes:** [CORE] · 9 min. Deliberately underdetermined — accepting, engulfed and alexithymic are all live. The mark of a strong room is that it says so rather than diagnosing confidently. Praise the uncertainty; the assessment rewards it.
+- **Source:** [PEDAGOGICAL], applying Ch. 4
+
+---
+
+### Slide 110 — The Common Mistake
+
+- **Purpose:** Block the misreading that damages the development plan and the whole practice.
+- **On the slide:** ✕ Self-awareness = examining what is wrong with you · ✓ Self-awareness = **accurate observation**, including of what is working
+- **Visual:** L3. Two rows.
+- **Explain:** A learner who turns the check-in into a daily inventory of failures is not becoming more self-aware — they are practising rumination, which Module 7 shows makes low mood worse. Accuracy is the standard. An accurate observation is often "that went well and I handled it."
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Say this before setting the check-in as homework, not after. It is one of the more common ways this material goes wrong in practice.
+- **Source:** [PEDAGOGICAL], with Ch. 4, 6
+
+---
+
+### Slide 111 — Module 6 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Recognising a feeling *as it happens* · 2 · Awareness is a vantage point, not a brake · 3 · Three styles: self-aware, engulfed, accepting · 4 · Accepting splits into equable and resigned · 5 · Alexithymia: feelings without words · 6 · The check-in trains the noticing · 7 · The gap between 5 and 6 is where the course lives
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 112 — Knowledge Check: Module 6
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · Name the three styles. 2 · Which is not the same as emotional intelligence, and why? 3 · Define alexithymia. 4 · Why is Domain 1 the keystone? 5 · What is the difference between check-in items 5 and 6?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 6)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 8 — MODULE 7: PASSION'S SLAVES: MANAGING EMOTIONS (Slides 113–138)
+
+---
+
+### Slide 113 — Module 7: Passion's Slaves: Managing Emotions
+
+- **Purpose:** Open the course's longest and most practical module.
+- **On the slide:** MODULE 7 · Passion's Slaves: Managing Emotions / *Domain 2 — handling feelings so they fit*
+- **Visual:** L1. Divider with the dependency diagram, Domain 2 lit and the arrow from Domain 1 highlighted.
+- **Explain:** Note the highlighted arrow: this module is unusable without the previous one. You cannot manage what you have not noticed.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 114 — The Target
+
+- **Purpose:** State the goal precisely, since almost every learner arrives with the wrong one.
+- **On the slide:** The goal is not fewer emotions. / It is not calmer emotions. / **It is emotions proportionate to the situation.**
+- **Visual:** L1. Three lines, the first two in grey, the third in blue.
+- **Explain:** Return to Aristotle from slide 8. The person who feels nothing at an injustice has not succeeded at this domain. Under-responding is a failure of the same kind as over-responding — it is simply less visible and less socially costly, which is why it goes uncorrected.
+- **Discuss:** "Give an example of an emotion that was too small for its situation."
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Under-response examples are harder to generate than over-response examples, and the difficulty is itself informative. Let the room struggle for a moment before offering one: watching someone be treated badly and saying nothing.
+- **Source:** Ch. 5, Prologue · [SOURCE]
+
+---
+
+### Slide 115 — Anger Has Two Clocks
+
+- **Purpose:** Deliver Zillmann's two-stage physiology, the module's mechanical foundation.
+- **On the slide:** **STAGE ONE** — catecholamine surge. A burst of energy. **Minutes.** · **STAGE TWO** — adrenocortical arousal. A background of readiness. **Hours to days.**
+- **Visual:** L4. Two overlaid curves on one time axis: a sharp spike decaying quickly, and a long low plateau extending far past it.
+- **Explain:** The first stage is what people mean by anger — the surge, the heat, the energy. It passes relatively quickly. The second is the one nobody notices: a prolonged state of arousal that does not feel like anger, that a person will sincerely deny being in, and that persists for hours. The two-clock structure is why the story of an angry day makes sense.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at MCQ 16, MCQ 17 and Scenario 2. Build the two curves separately; the long plateau appearing under the decayed spike is the moment the idea lands.
+- **Source:** Ch. 5 · [SOURCE] — Zillmann
+
+---
+
+### Slide 116 — Why the Second Clock Matters
+
+- **Purpose:** Convert the physiology into the practical claim that makes it teachable.
+- **On the slide:** During stage two, **it takes far less to set you off.** / The second trigger lands on a body that is already ready.
+- **Visual:** L4. The plateau from slide 115 with a small second trigger arrow producing a disproportionate spike.
+- **Explain:** This is the whole practical content of Zillmann's finding. A provocation that would be nothing at nine in the morning produces an outsized reaction at eleven, because it arrives on a primed system. The person experiences this as "I overreacted to nothing," which is accurate about the trigger and wrong about the cause.
+- **Discuss:** "Describe a day when the second thing got the reaction the first thing deserved."
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Scenario 2 is exactly this. Nearly everyone has an example, and it is usually the moment in the course where the physiology becomes personally credible.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 117 — The Escalation Ladder
+
+- **Purpose:** Show how anger builds on itself, and where interruption is still possible.
+- **On the slide:** *Each thought raises the arousal. Each rise in arousal makes the next thought worse.*
+- **Visual:** L4. A rising staircase; each tread a thought, each riser an increment of arousal; green intervention markers on the lowest three treads only.
+
+```
+                                                    ┌──────┐  "he's always
+                                            ┌──────┤ 5    │   done this"
+                                    ┌──────┤ 4    └──────┘   ← no window
+                            ┌──────┤ 3    └──────┘
+                    ┌──────┤ 2 ●  └──────┘
+            ┌──────┤ 1 ●  └──────┘
+    ────────┤ 0 ●  └──────┘
+     trigger  ● = intervention still available
+```
+
+- **Explain:** Each rehearsal of the grievance adds arousal; the added arousal makes the next thought more extreme and more available; and the more extreme thought adds more arousal. The loop is self-feeding. Critically, the green windows close early — by the fourth or fifth step, the interventions that work at step one no longer work.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Use the same green convention as slide 65. The narrowing-window idea should now be familiar rather than new.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 118 — Cognitive Incapacitation
+
+- **Purpose:** Explain why reasoning with an enraged person does not work.
+- **On the slide:** At the top of the ladder, the capacity to think is **not available.** / This is a state, not a choice, and not a character trait.
+- **Visual:** L2. The working-memory box from slide 63, fully occupied.
+- **Explain:** The source describes a point at which the person cannot think straight — not will not, cannot. Attempting to reason with someone in that state fails, and worse, the attempt is usually experienced as a further provocation. The practical rule that follows is the least intuitive thing in this module: when someone is at the top of the ladder, the useful move is almost never the argument, however good it is.
+- **Discuss:** "What do people usually do when someone is at the top of the ladder — and does it work?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Direct groundwork for flooding in Module 11 and for the four-fault-lines analysis. Do not skip it.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 119 — The Trigger Thought
+
+- **Purpose:** Identify the intervention point that actually pays.
+- **On the slide:** The thought that starts it is usually a **judgement about intent.** / *"He did that on purpose."* · *"They don't respect me."* · *"She knew and did it anyway."*
+- **Visual:** L2. Three thought boxes, each with an arrow into the escalation ladder's first tread.
+- **Explain:** The source's account of anger is that it typically begins with an appraisal — most often the attribution of deliberate slight. Which means the highest-leverage intervention is not calming down after the fact. It is challenging the attribution before the ladder starts. And the attribution is almost always made on thin evidence.
+- **Discuss:** "Take a recent irritation. What was the intent you attributed? What was the actual evidence for it?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. This is the link between the anger material and the observation/interpretation discipline in Module 9. Flag it forward.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 120 — What Everybody Believes
+
+- **Purpose:** Set up the correction the module is built around.
+- **On the slide:** *"Better out than in."* · *"Let it out or it festers."* · *"Bottling it up is unhealthy."*
+- **Visual:** L1. Three folk maxims in grey, no correction yet.
+- **Explain:** Say nothing. Ask for a show of hands on who broadly agrees.
+- **Discuss:** "Hands up — broadly true?"
+- **Activity:** Micro: hands, counted and left visible.
+- **Notes:** [CORE] · 3 min. Predict-Then-Reveal, per the Assessment Bank1.1 instrument 5. The hands must go up *before* slide 121, or the correction lands as information rather than as a surprise.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 121 — The Ventilation Fallacy
+
+- **Purpose:** Deliver the correction — the most counter-cultural claim in the course.
+- **On the slide:** Expressing anger **typically prolongs and intensifies it.** / Rehearsing the grievance is climbing the ladder.
+- **Visual:** L4. The escalation ladder from slide 117, with "venting" shown as the mechanism moving up the treads rather than off them.
+- **Explain:** The intuition is hydraulic — anger as pressure in a vessel that must be released. The evidence the source reports does not support it. Expressing anger, in most circumstances, rehearses the grievance, sustains the arousal, and produces more anger rather than less. Note the qualification honestly: the source is not saying never say anything. Naming an emotion calmly to the person concerned is not ventilation. The distinction is between *articulating* a feeling and *performing* it.
+- **Discuss:** "If venting doesn't work, why does it feel like it does?"
+- **Activity:** Return to slide 70's fourth claim card and settle it.
+- **Notes:** [CORE] · 10 min. Assessed at MCQ 18, historically among the highest-failure items. The discussion question's answer is worth drawing out: venting produces momentary relief from the tension of holding something back, and that relief is mistaken for resolution while the arousal itself continues to climb.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 122 — What Actually Works
+
+- **Purpose:** Give the evaluated repertoire in one reference table.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| Strategy | Works? | Mechanism | Condition for it to work |
+| --- | --- | --- | --- |
+| **Reframing the trigger thought** | Strong | Removes the appraisal driving the escalation | Must happen early, low on the ladder |
+| **Cooling off, away from the trigger** | Strong | Lets stage-one arousal decay | **Must not rehearse the grievance during it** |
+| **Distraction** | Good | Occupies the working memory the rumination needs | Must be genuinely absorbing |
+| **Exercise** | Good | Metabolises arousal | Any vigorous activity |
+| **Relaxation methods** | Moderate | Lowers arousal directly | Better for low arousal than high |
+| **Venting to a third party** | **Counterproductive** | Rehearses; sustains | — |
+| **Rumination / isolation (low mood)** | **Counterproductive** | Deepens and prolongs | — |
+
+- **Explain:** Take the second row's condition seriously. A cooling-off period spent composing the reply is not a cooling-off period — it is the escalation ladder in a different room. This single distinction decides whether the most commonly recommended technique in the world works or backfires.
+- **Discuss:** "Which of these do you already do, and does it match the condition column?"
+- **Activity:** —
+- **Notes:** [CORE] · 10 min. Print as a handout. Assessed at MCQ 18 and Scenario 2.
+- **Source:** Ch. 5 · [SOURCE], table structure [PEDAGOGICAL]
+
+---
+
+### Slide 123 — The Cooling-Off Rule
+
+- **Purpose:** Make the most-used technique actually usable.
+- **On the slide:** A break works **only** if you stop rehearsing. / Twenty minutes composing the reply is twenty minutes of escalation.
+- **Visual:** L3. Two timelines from the same trigger: one showing arousal decaying during a genuine break, one showing it climbing during a rehearsed one.
+- **Explain:** This is where most self-management advice fails in practice. People take the break and spend it building the case. Physiologically that is not a break at all. What is needed is genuine distraction — something absorbing enough to occupy working memory, which is exactly why "go for a walk and think it over" is worse advice than "go for a walk and listen to something."
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Directly assessed in Scenario 9, where the third mark requires the no-rehearsal condition.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 124 — Reframing
+
+- **Purpose:** Teach the highest-leverage strategy concretely enough to use.
+- **On the slide:** Not: *"calm down."* · But: **"what else could this mean?"** / A better construction, not a nicer feeling.
+- **Visual:** L2. A trigger event with three interpretation branches, only one of which was taken.
+- **Explain:** Reframing is not positive thinking and it is not talking yourself out of a legitimate response. It is generating alternative accounts of the same event and checking which is best supported. Sometimes the answer is that the original reading was right and the anger is warranted — that is a successful reframe. What has changed is that the appraisal is now examined rather than automatic.
+- **Discuss:** "Take a live irritation. Generate two alternative readings. Which has the most evidence?"
+- **Activity:** Pairs, 5 minutes.
+- **Notes:** [CORE] · 10 min. Insist on genuinely *different* readings, not softer versions of the same one. This is the same discipline as slide 171's "generate three, not one," and naming the connection helps.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 125 — Sadness Has Different Rules
+
+- **Purpose:** Prevent the wholesale transfer of anger techniques to low mood.
+- **On the slide:** For anger: interrupt the rehearsal. · For sadness: **the danger is isolation and rumination.** · And: not all sadness should be repaired.
+- **Visual:** L3. Two columns.
+- **Explain:** The source treats grief as having its own work to do, and treats the impulse to fix all low mood as itself a mistake. What is harmful is not sadness but the rumination that converts it into something longer and heavier — going over it alone, repeatedly, without action. The distinction between feeling sad and ruminating about being sad is the one that matters.
+- **Discuss:** "Where is the line between processing something and going over it?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Handle with care; sadness touches more of the room than anger does. A workable answer to the discussion question: processing changes something — the account develops, something is understood, an action becomes possible. Rumination repeats.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 126 — Rumination
+
+- **Purpose:** Name the mechanism that turns low mood into something worse.
+- **On the slide:** Going over it, alone, repeatedly, without action. / It feels like working on the problem. It **deepens and prolongs** the mood.
+- **Visual:** L2. A closed loop with no exit arrow.
+- **Explain:** The source draws on Nolen-Hoeksema's work here. The trap is that rumination presents itself as problem-solving — which is why people defend it, and why "stop thinking about it" is such useless advice. The distinguishing test is whether anything moves.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 5 · [SOURCE] — Nolen-Hoeksema
+
+---
+
+### Slide 127 — Worry, and Why It Never Ends
+
+- **Purpose:** Deliver Borkovec's two mechanisms.
+- **On the slide:** **The superstition effect** — the feared thing does not happen, so worry seems to have worked. · **The partial payoff** — worry runs as words, not pictures; words arouse less; so worrying is mildly relieving, and the fear stays unprocessed.
+- **Visual:** L2. A reinforcement loop for the first mechanism; a comparison of two arousal levels (verbal vs. imagined) for the second.
+- **Explain:** Together these explain a habit that is unpleasant, useless, and extremely durable. It is reinforced on a schedule that cannot be disconfirmed, and it delivers a small immediate reward. From the inside it looks like diligence — preparing for the worst. From outside it is a loop that has replaced the feared image with a stream of words, which is precisely why it never resolves anything.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at MCQ 19 and Scenario 5, where the second mark requires the partial-payoff mechanism specifically.
+- **Source:** Ch. 5 · [SOURCE] — Borkovec
+
+---
+
+### Slide 128 — Interrupting Worry
+
+- **Purpose:** Deliver the protocol.
+- **On the slide:** 1 · **Catch it early** — self-awareness, before the loop is running · 2 · **Challenge it** — how likely, what evidence, what could be done · 3 · **Do not stop at the first reassurance** — the loop's move is to reopen the question · 4 · **Repeat** — a habit is not displaced by one application
+- **Visual:** L4. Four steps, with step 3 marked in green as the one people miss.
+- **Explain:** Step three is where most attempts fail. The worrier challenges the worry, feels briefly better, and the loop reopens with "but what if" thirty seconds later. The protocol requires holding the answer rather than re-entering the question. And step four is not decoration: the loop has been practised for years, and it will not yield to a single intervention.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Scenario 5's third mark requires the ordered protocol including step 3.
+- **Source:** Ch. 5 · [SOURCE] — Borkovec
+
+---
+
+### Slide 129 — TRIGGER → CONSEQUENCE
+
+- **Purpose:** Deliver the course's integrating framework for this domain.
+- **On the slide:** *(the map carries it)*
+- **Visual:** L2. The deck's third signature diagram, drawn in the same visual language as slides 65 and 99.
+
+```
+ TRIGGER ──▶ MATCH ──▶ APPRAISAL ──▶ AROUSAL ──▶ NARROWING ──▶ ACTION ──▶ CONSEQUENCE
+    ▲          ▲           ▲            ▲            ▲            ▲            ▲
+    │          │           │            │            │            │            │
+   [A]        [B]         [C]          [D]          [E]          [F]          [G]
+  avoid     recognise   reframe      cool off     name it      the gap      repair
+   the      the match    the         / move       / slow it    (5 vs 6)     / learn
+  setup     as a match   appraisal
+  ╰──────── CHEAPEST ────────╯                    ╰──────── MOST EXPENSIVE ────────╯
+```
+
+- **Explain:** Seven intervention points across one episode. **A** — arrange things so the trigger does not fire: do not open email at midnight. **B** — recognise the match as a match: "this is the tone thing again." **C** — reframe the appraisal, the highest-leverage single move. **D** — cool off, without rehearsing. **E** — name the state, which creates the vantage point of slide 101. **F** — the gap between impulse and action. **G** — repair afterwards, which is genuine and costly. Cost rises steeply from left to right.
+- **Discuss:** "Where do you currently intervene? Where *could* you, one step earlier?"
+- **Activity:** —
+- **Notes:** [CORE] · 12 min. This is the framework the Personal Development Assignment requires candidates to apply, and it is [PEDAGOGICAL] — built from the source's components, not stated in the source. The footer must say so.
+- **Source:** Ch. 2, 5 components · [PEDAGOGICAL] framework
+
+---
+
+### Slide 130 — Cheap Early, Expensive Late
+
+- **Purpose:** State the framework's central practical implication.
+- **On the slide:** The same episode costs more to interrupt at every step. / By ACTION, the only intervention left is repair.
+- **Visual:** L4. A rising cost curve laid under the A–G positions from slide 129.
+- **Explain:** Most people's entire self-management repertoire sits at F and G — restraining themselves at the last moment, and apologising afterwards. Both work, and both are the most expensive options available. The whole gain from this module is moving leftward.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Module 7's knowledge check, item 5, tests this directly.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 131 — The Unflappables
+
+- **Purpose:** Distinguish genuine regulation from suppression — the domain's characteristic failure.
+- **On the slide:** Some people report **no** distress — while their bodies show high arousal. / Calm reported. Not calm underneath.
+- **Visual:** L3. Two rows: self-report low / physiological measures high.
+- **Explain:** The source describes repressors, whose self-reported equanimity is contradicted by physiological measurement. This matters for two reasons. First, it shows self-report is not a reliable index of state — which is the deepest problem with every EI questionnaire, including this course's own. Second, it means an unflappable colleague may be regulating well or may be suppressing at cost, and the two are not distinguishable from outside.
+- **Discuss:** "How would you tell the difference between someone genuinely calm and someone suppressing?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min. Honest answer to the discussion question: from outside, often you cannot, and the reliable signs are indirect — what happens under sustained load, whether recovery is real, whether it costs them elsewhere. Do not let the room conclude that all calm is suppression.
+- **Source:** Ch. 5 · [SOURCE] — Weinberger, Davidson
+
+---
+
+### Slide 132 — Suppression Is Not Management
+
+- **Purpose:** Draw the distinction explicitly, since it is the most common misunderstanding of this domain.
+- **On the slide:** SUPPRESSION — the expression stops, the state continues, the cost accrues · MANAGEMENT — the state itself changes, and recovery gets faster
+- **Visual:** L3. Two columns; two arousal curves — one flat on the surface with a hidden line continuing beneath, one genuinely decaying.
+- **Explain:** A workplace can easily mistake suppression for emotional intelligence, because suppression is quiet and convenient. The test is recovery. Someone managing an emotion returns to baseline; someone suppressing carries it, and it emerges somewhere else — usually later, usually at home, usually at someone with less power.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This slide matters most in corporate delivery, where the commissioning organisation may be hoping the course produces exactly the suppression it warns against. Say so if the room can take it.
+- **Source:** Ch. 5 · [SOURCE], contrast [PEDAGOGICAL]
+
+---
+
+### Slide 133 — Case: Two Hours Later
+
+- **Purpose:** Apply the second-clock mechanism to an unseen case.
+- **On the slide:** *Elena's proposal is rejected in a 10 a.m. meeting. She takes it well. At 12:15 her flatmate asks whether she remembered to pay the electricity bill. Elena's response ends the conversation and neither of them mentions it again.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "Locate this on the two-clock diagram. Where were interventions A–G still open, and which one would you actually have used?"
+- **Activity:** Pairs, 5 minutes.
+- **Notes:** [CORE] · 10 min. Direct rehearsal of Scenario 2. Note the detail that neither mentioned it again — that is intervention G declined, and its cost is a small permanent thing between them.
+- **Source:** [PEDAGOGICAL], applying Ch. 5
+
+---
+
+### Slide 134 — What Cannot Be Changed
+
+- **Purpose:** Set the realistic target, and pre-empt the development plan's most common failure.
+- **On the slide:** You will not stop the trigger firing. · You will not choose your first feeling. · **You can change what follows, how long it lasts, and what you do.**
+- **Visual:** L3. Two items struck through in grey; three in green.
+- **Explain:** Callback to slide 69 and forward to Luborsky in Module 16. What reliably changes is the response, not the flashpoint. A development plan aimed at eliminating a trigger is aimed at something the material says does not happen — and will be referred for exactly that reason.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Say the referral consequence aloud. Candidates should not encounter this criterion first at submission.
+- **Source:** Ch. 5, 13 · [SOURCE]
+
+---
+
+### Slide 135 — The Marker of Progress
+
+- **Purpose:** Give learners a usable measure, which the development plan requires.
+- **On the slide:** Not: *how often it happens.* · But: **how quickly you come back.**
+- **Visual:** L4. Two arousal curves of identical height, one decaying much faster.
+- **Explain:** Recovery time is the honest measure. Frequency of triggering is largely a function of circumstance — a hard month produces more triggers regardless of skill. Recovery time is the thing that improves with practice, and it is observable. Note the source's own framing: recovery time is described as one mark of emotional maturity.
+- **Discuss:** "How long does it currently take you to come back from a moderate upset?"
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This is the measurement criterion the Personal Development Assignment's section 6 is looking for. Point that out.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 136 — The Common Mistake
+
+- **Purpose:** Block the misreading that turns this module into self-blame.
+- **On the slide:** ✕ "I managed it badly, so I have failed." · ✓ The episode is data. The question is where the window was.
+- **Visual:** L3. Two rows.
+- **Explain:** A learner who treats each poorly handled episode as a moral failure has added a second emotional problem to the first. The check-in and the A–G map exist to convert episodes into information. That is not self-forgiveness as consolation; it is the only stance from which the analysis is possible at all.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 137 — Module 7 Summary
+
+- **Purpose:** Consolidate the course's longest module.
+- **On the slide:** 1 · Proportion, not absence · 2 · Anger has two clocks; the second lasts hours · 3 · The trigger thought is usually an attribution of intent · 4 · Venting prolongs · 5 · Reframe, cool off without rehearsing, distract, move · 6 · Sadness: the danger is rumination · 7 · Worry: superstition effect plus partial payoff · 8 · Seven intervention points — cheap early, expensive late · 9 · Suppression is not management · 10 · The measure is recovery time
+- **Visual:** L8. Ten numbered takeaways — the deck's longest summary, and appropriately so.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min.
+- **Source:** Ch. 5 · [SOURCE]
+
+---
+
+### Slide 138 — Knowledge Check: Module 7
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · State the two stages and their durations. 2 · What practical consequence follows from stage two? 3 · What is the ventilation fallacy? 4 · Name two strategies the source supports and one it does not. 5 · Where in the A–G map is intervention cheapest, and why?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 7)
+- **Notes:** [CORE] · 8 min. Question 3 is the diagnostic. If the room hedges — "well, sometimes it helps" — the folk model has survived and slide 121 needs re-running.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 9 — MODULE 8: THE MASTER APTITUDE: MOTIVATING ONESELF (Slides 139–158)
+
+---
+
+### Slide 139 — Module 8: The Master Aptitude: Motivating Oneself
+
+- **Purpose:** Open.
+- **On the slide:** MODULE 8 · The Master Aptitude: Motivating Oneself / *Domain 3 — emotion in the service of a goal*
+- **Visual:** L1. Divider, Domain 3 lit.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 140 — The Master Aptitude
+
+- **Purpose:** State the domain's central claim.
+- **On the slide:** The ability to hold emotion in the service of a goal is, the source argues, **the master aptitude** — it governs whether any other ability gets used.
+- **Visual:** L2. A set of capability boxes behind a single gate.
+- **Explain:** Ability that cannot be sustained through frustration does not produce anything. This is the mechanism behind the observation that talent and outcome correlate less well than people expect. Be careful about the strength of the claim: "governs whether abilities get used" is defensible; "matters more than ability" is not established, and the source does not quantify it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 141 — The Marshmallow
+
+- **Purpose:** Deliver the study every learner has heard of, precisely.
+- **On the slide:** *One marshmallow now — or two, if you can wait until I come back.* / Four-year-olds. The measure: **how long they waited.**
+- **Visual:** L6. The set-up drawn as a simple scenario card. No photographs of children.
+- **Explain:** Mischel's procedure, plainly. The child is left alone with the reward and an explicit alternative. What was measured was delay, in seconds. Follow-up years later found the children who had waited longer scoring better on a range of adolescent measures.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at MCQ 20, which requires knowing that *delay* was the measure. Learners who know this from popular retellings often misremember it as a personality or willpower assessment.
+- **Source:** Ch. 6 · [SOURCE] — Mischel
+
+---
+
+### Slide 142 — Three Things You Must Say About It
+
+- **Purpose:** Model the course's evidential discipline on its most over-claimed study.
+- **On the slide:** 1 · **Correlation, not causation.** · 2 · **Small, unrepresentative samples.** · 3 · **Later work: effects shrink substantially with controls, and trust in the promise matters.**
+- **Visual:** L1. Three numbered qualifications, amber bar.
+- **Explain:** All three are necessary and none of them destroys the finding. Delay of gratification is associated with later outcomes; it does not follow that delay causes them, and there is good evidence that background — including whether a child has grounds to believe an adult's promise — accounts for a substantial part of the association. A child who has learned that promised second marshmallows do not arrive is behaving sensibly, not impulsively.
+- **Discuss:** "Does the third point change what the study is good for?"
+- **Activity:** **B14 — The Marshmallow Debate** (Activity Book)
+- **Notes:** [CORE] · 18 min with the activity. This is the course's principal demonstration of how to hold a finding and its qualifications at once. The strongest answer to the discussion question: it changes what the study licenses — it supports "delay is a meaningful capacity" and does not support "teach four-year-olds to wait and their lives improve."
+- **Source:** Ch. 6 · [SOURCE-QUALIFIED] and [EXTERNAL]
+
+---
+
+### Slide 143 — The Inverted U
+
+- **Purpose:** Establish that arousal has an optimum, not a direction.
+- **On the slide:** *(the curve carries it)*
+- **Visual:** L2. The classic curve: performance on the vertical axis, arousal on the horizontal; three zones marked — FLAT, PEAK, DISRUPTED.
+
+```
+  PERFORMANCE
+      │            ╭─────╮
+      │         ╭──╯     ╰──╮
+      │      ╭──╯           ╰──╮
+      │   ╭──╯                 ╰───╮
+      │╭──╯                        ╰────
+      └──────────────────────────────────▶ AROUSAL
+        too little    optimum      too much
+        (flat,        (engaged,    (disrupted,
+         bored)        sharp)       flooded)
+```
+
+- **Explain:** Neither end works. Too little arousal produces flatness and inattention; too much produces the disruption the foundations block described. The practical implication is that "calm down" is not universally good advice — some people underperform because they are insufficiently activated, and telling them to relax makes it worse.
+- **Discuss:** "Which end is your usual problem — and does the answer differ by setting?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 144 — Anxiety and Performance
+
+- **Purpose:** Explain a mechanism nearly every learner has personally experienced.
+- **On the slide:** Anxiety occupies the working memory the task requires. / The more the outcome matters, the more capacity the worry takes.
+- **Visual:** L2. The working-memory box from slide 63, partly filled with worry, less space left for the task.
+- **Explain:** This is why exam performance falls under high stakes, why people forget prepared material in interviews, and why the advice "just relax" fails — it addresses the feeling and not the occupancy. What actually helps is anything that reduces the load: rehearsal to automaticity, so the task needs less workspace; and reframing the stakes, so the worry generates less traffic.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Connects Module 4's neural static to a setting every learner recognises. Strong retention slide.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 145 — Hope
+
+- **Purpose:** Deliver hope as a specific construct rather than a mood.
+- **On the slide:** **Hope** is not expecting things to turn out well. / It is: *I have a route, and I have the will to take it.*
+- **Visual:** L2. Two components — PATHWAYS and AGENCY — feeding a single outcome box.
+- **Explain:** Snyder's account, as the source presents it: hope has two parts, the belief that routes to the goal exist and the belief that one can move along them. Both are needed. Someone with routes and no agency does not start; someone with agency and no routes exhausts themselves. This is why hope is trainable — you can supply routes.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. The two-component structure is what distinguishes this from optimism, and learners conflate them constantly.
+- **Source:** Ch. 6 · [SOURCE] — Snyder
+
+---
+
+### Slide 146 — Explanatory Style
+
+- **Purpose:** Deliver Seligman's three dimensions.
+- **On the slide:** *(the diagram carries it)*
+- **Visual:** L3. One event branching into two accounts across three axes.
+
+```
+                        THE SAME FAILURE
+                               │
+              ┌────────────────┴────────────────┐
+              ▼                                 ▼
+    ┌──────────────────┐              ┌──────────────────┐
+    │   PESSIMISTIC    │              │    OPTIMISTIC    │
+    ├──────────────────┤              ├──────────────────┤
+    │ PERMANENT        │              │ TEMPORARY        │
+    │ "always be this" │              │ "this time"      │
+    ├──────────────────┤              ├──────────────────┤
+    │ PERVASIVE        │              │ SPECIFIC         │
+    │ "everything"     │              │ "this one thing" │
+    ├──────────────────┤              ├──────────────────┤
+    │ PERSONAL (fixed) │              │ CHANGEABLE       │
+    │ "something in me"│              │ "what I did"     │
+    └──────────────────┘              └──────────────────┘
+              │                                 │
+              ▼                                 ▼
+        stop trying                       try again, differently
+```
+
+- **Explain:** Three axes, one event, two entirely different futures. The third axis needs care: the optimistic version is not "it wasn't my fault." Both people may take responsibility — the difference is whether the thing they hold responsible is fixed or changeable.
+- **Discuss:** "Which axis do you personally slide on?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at Scenario 6. The third axis is the one candidates get wrong, usually by equating optimism with externalising blame.
+- **Source:** Ch. 6 · [SOURCE] — Seligman
+
+---
+
+### Slide 147 — What Optimism Is Not
+
+- **Purpose:** Prevent the reading that turns this into positive thinking.
+- **On the slide:** ✕ Expecting good outcomes · ✕ Ignoring evidence · ✕ Refusing to acknowledge failure · ✓ **A specific, temporary, changeable account of what went wrong**
+- **Visual:** L3. Three struck-through rows and one in blue.
+- **Explain:** The source's optimism is an explanatory habit, not a forecast. And it has a failure mode: optimism about a situation that is genuinely fixed and genuinely bad is not resilience, it is misreading. Someone in an unsalvageable job who keeps explaining each setback as temporary and specific is being harmed by the habit.
+- **Discuss:** "When is pessimism the accurate reading?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Do not let the room close on "always be optimistic." The discussion question exists to stop that, and the honest answer is: whenever the situation actually is permanent, pervasive and unchangeable — and some are.
+- **Source:** Ch. 6 · [SOURCE], limits [PEDAGOGICAL]
+
+---
+
+### Slide 148 — Self-Efficacy
+
+- **Purpose:** Add Bandura's construct and distinguish it from confidence.
+- **On the slide:** **Self-efficacy:** the belief that you can do *this particular thing.* / Domain-specific. Not a general trait. Built by evidence.
+- **Visual:** L3. Three columns of a person's efficacy beliefs across three domains, visibly different heights.
+- **Explain:** Bandura's construct is specific by design. A person can have high efficacy for technical work and low efficacy for difficult conversations, and that is the normal case rather than an inconsistency. It matters because efficacy is built by graded successful experience, not by encouragement — which makes it something a manager or teacher can actually construct.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Connects forward to Kagan's emboldening finding in Module 15 — graded exposure to manageable challenge is the same mechanism.
+- **Source:** Ch. 6 · [SOURCE] — Bandura
+
+---
+
+### Slide 149 — Flow
+
+- **Purpose:** Deliver the state and its condition.
+- **On the slide:** **Flow:** absorbed, effortless, self-consciousness gone, time distorted. / *The condition: challenge matched to skill.*
+- **Visual:** L5. The challenge–skill grid.
+
+```
+   CHALLENGE
+      high │  ANXIETY      │      FLOW       │
+           │               │                 │
+           ├───────────────┼─────────────────┤
+           │  APATHY       │    BOREDOM      │
+       low │               │                 │
+           └───────────────┴─────────────────┘
+              low                    high
+                        SKILL
+```
+
+- **Explain:** Csikszentmihalyi's condition is a *ratio*, not a level. High challenge with low skill produces anxiety; high skill with low challenge produces boredom; low with low produces apathy. Flow lives on the diagonal, and because skill grows, the challenge must grow with it or flow is lost.
+- **Discuss:** "Where do you spend most of your working week on this grid?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at MCQ 21. The common error is equating flow with ease; the grid makes the error visible.
+- **Source:** Ch. 6 · [SOURCE] — Csikszentmihalyi
+
+---
+
+### Slide 150 — Flow and Learning
+
+- **Purpose:** Draw the educational and managerial implication.
+- **On the slide:** People learn most where challenge meets skill. / Which means the task, not the motivation, is usually what needs adjusting.
+- **Visual:** L5. The grid from slide 149 with an arrow showing a task being moved into the flow band.
+- **Explain:** The source's argument is that flow is a better model for learning than either pressure or reward. A disengaged learner or employee is often on the wrong part of the grid rather than lacking motivation — the standard response, more pressure, moves them further into anxiety. Adjusting the difficulty is the intervention that fits the mechanism.
+- **Discuss:** "Think of someone you manage or teach who has disengaged. Where are they on the grid?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. High practical value for the teacher and manager cohorts.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 151 — The Personal Goal Activity
+
+- **Purpose:** Run the applied exercise for this domain.
+- **On the slide:** One goal · What emotion currently blocks it · Where it blocks it · One route · One first action **this week**
+- **Visual:** L7. Five prompts, laid out as a worksheet.
+- **Explain:** Insist that the emotion is named specifically — not "procrastination," which is a behaviour, but the feeling underneath it, which is usually some form of anticipated failure or exposure.
+- **Discuss:** —
+- **Activity:** **B11 — The Personal Goal Activity** (Activity Book), with the worksheet.
+- **Notes:** [CORE] · 20 min. The commonest failure is naming a goal with no emotional obstacle at all, which produces a planning exercise rather than an emotional one. Redirect: if nothing emotional is in the way, why hasn't it been done?
+- **Source:** [PEDAGOGICAL], applying Ch. 6
+
+---
+
+### Slide 152 — Case: Two Rejections
+
+- **Purpose:** Apply explanatory style to an unseen case.
+- **On the slide:** *Same rejection letter, same day. Amara: "this editor, this piece, the third section is weak — rework it, send it Friday." Joel: "I can't write. I've been fooling myself. There's no point sending anything anywhere."*
+- **Visual:** L6. Case card, two quotations.
+- **Explain:** —
+- **Discuss:** "Map both across the three axes. Which axis is doing the most damage to Joel?"
+- **Activity:** Pairs, 4 minutes.
+- **Notes:** [CORE] · 9 min. This is Scenario 6 of the final assessment used as classroom rehearsal. If you intend to set that paper unchanged, substitute a different case here — the item-writing rules are in the Assessment Bank (item-writing rules).
+- **Source:** [PEDAGOGICAL], applying Ch. 6
+
+---
+
+### Slide 153 — The Common Mistake
+
+- **Purpose:** Block the reading that turns this domain into willpower moralism.
+- **On the slide:** ✕ "Some people just have more discipline." · ✓ These are **mechanisms** — attribution habits, arousal levels, challenge–skill fit — and mechanisms can be altered.
+- **Visual:** L3. Two rows.
+- **Explain:** Every construct in this module is a mechanism with an intervention point. Explanatory style can be shifted by examining attributions. Arousal can be raised or lowered. Challenge–skill fit is a property of the task and can be redesigned. Treating persistence as a fixed personal virtue removes every one of those levers.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** [PEDAGOGICAL], with Ch. 6
+
+---
+
+### Slide 154 — What This Domain Does Not Promise
+
+- **Purpose:** Mark the evidential limit honestly.
+- **On the slide:** These findings are **associations**, mostly from small studies, several substantially qualified since. / They describe real mechanisms. They do not license "do this and you will succeed."
+- **Visual:** L1. Amber bar.
+- **Explain:** The marshmallow test's qualifications, the replication difficulties in parts of the positive-psychology literature, and the general problem that persistence and outcome are both caused by circumstance. The mechanisms are real; the promise of outcomes is not the source's, and should not become the course's.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. the Evidence file gives the detail. This slide is the honest marker in the module itself so learners do not have to wait for it.
+- **Source:** Ch. 6 · [SOURCE-QUALIFIED], with [EXTERNAL]
+
+---
+
+### Slide 155 — Module 8 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Emotion in the service of a goal — the master aptitude · 2 · Delay of gratification: real, and heavily qualified · 3 · Arousal has an optimum, not a direction · 4 · Anxiety occupies the workspace the task needs · 5 · Hope = routes + agency · 6 · Optimism = specific, temporary, changeable · 7 · Self-efficacy is domain-specific and built by evidence · 8 · Flow = challenge matched to skill
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 6 · [SOURCE]
+
+---
+
+### Slide 156 — Knowledge Check: Module 8
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · What did the marshmallow study measure and predict? 2 · State one required qualification. 3 · What does the inverted U describe? 4 · How does an optimist explain a failure? 5 · State the condition for flow.
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 8)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+### Slide 157 — Halfway Through the Domains
+
+- **Purpose:** Consolidate the three inward-facing domains before the two outward-facing ones.
+- **On the slide:** Domains 1–3 are about **you.** · Domains 4–5 are about **other people.** · And 4 and 5 are built on 1 and 2.
+- **Visual:** L5. The dependency diagram from slide 77, the first three nodes filled, the last two outlined.
+- **Explain:** Make the structural point explicitly. The remaining two domains are not a new topic; they are the same capacities pointed outward, and their quality is limited by the first three. That is why the course did not start with communication skills.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Natural session boundary in the four-session format.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 158 — Checkpoint
+
+- **Purpose:** Self-audit before the outward-facing block.
+- **On the slide:** Name the five domains and the dependencies · Run a check-in unaided · Locate an episode on the A–G map · State what venting does · Explain the three axes of explanatory style
+- **Visual:** L8. Five checkboxes.
+- **Explain:** Private hands. Re-teach anything above a third of the room.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+# BLOCK 10 — MODULE 9: ROOTS OF EMPATHY (Slides 159–178)
+
+---
+
+### Slide 159 — Module 9: Roots of Empathy
+
+- **Purpose:** Open the empathy domain.
+- **On the slide:** MODULE 9 · Roots of Empathy / *Domain 4 — empathy*
+- **Visual:** L1. Divider, Domain 4 lit, with the dependency arrow from Domain 1 highlighted.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min.
+- **Source:** Ch. 7 · [SOURCE]
+
+---
+
+### Slide 160 — Empathy, Defined
+
+- **Purpose:** Deliver a precise definition, since the word is used loosely.
+- **On the slide:** **Empathy:** registering what another person feels. / Not agreeing. Not feeling sorry for them. Not feeling the same thing.
+- **Visual:** L1. Definition card with three struck-through near-misses beneath.
+- **Explain:** Each exclusion matters. Agreement is a separate question. Sympathy is a response *to* the reading, not the reading itself. And catching the other person's feeling is contagion, which slide 167 will show actively degrades accuracy.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 7 · [SOURCE]
+
+---
+
+### Slide 161 — Where It Starts
+
+- **Purpose:** Deliver the developmental account of empathy's origin.
+- **On the slide:** Infants cry when other infants cry. / Before there is a self, there is a response to distress.
+- **Visual:** L4. A developmental timeline beginning at birth.
+- **Explain:** The source's argument is that empathy is not a sophisticated late achievement layered on top of self-interest; the rudiments are present very early, before the child can distinguish their distress from someone else's. What develops is not the responsiveness but the differentiation — learning that the distress belongs to someone else.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 4 min.
+- **Source:** Ch. 7 · [SOURCE]
+
+---
+
+### Slide 162 — Motor Mimicry
+
+- **Purpose:** Deliver Titchener's mechanism, which grounds the bodily account of empathy.
+- **On the slide:** You wince when someone else is hurt. / **Titchener:** fellow-feeling arises from physically imitating the other's state — you feel it because your body copies it.
+- **Visual:** L2. Two figures, the second echoing the first's posture; an arrow labelled IMITATE, then FEEL.
+- **Explain:** This is where the word *empathy* comes from on the source's account, and it locates empathy in the body rather than in inference. It also explains why empathy declines over distance and text: with no posture, face or voice to imitate, the mechanism has nothing to work with.
+- **Discuss:** "Why is it easier to be cruel by email?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The discussion question is one of the most immediately useful in the deck, especially for distributed teams.
+- **Source:** Ch. 7 · [SOURCE] — Titchener
+
+---
+
+### Slide 163 — Attunement
+
+- **Purpose:** Deliver Stern's construct, which underpins the developmental material.
+- **On the slide:** **Attunement:** the caregiver matches and echoes the infant's state. / The infant learns: *what I feel registers with someone.*
+- **Visual:** L2. An exchange loop between two figures, matched in intensity and rhythm.
+- **Explain:** Stern's observation is that attunement is not imitation of behaviour but matching of *intensity and shape* — the infant's excited burst met by a matched vocal swell, in a different modality. The lesson learned is not about the specific emotion. It is that inner states are shareable.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 7 · [SOURCE] — Stern
+
+---
+
+### Slide 164 — Misattunement
+
+- **Purpose:** Deliver the consequence claim, with the qualification the evidence requires.
+- **On the slide:** Persistent failure to match → the child learns to **avoid** the feeling that goes unmet. / *The source states this. It is a developmental account, largely from observation, not a demonstrated causal law.*
+- **Visual:** L2. The exchange loop from slide 163, with the return arrow blocked (──✕──).
+- **Explain:** The claim is that a feeling repeatedly unmet becomes a feeling the child stops expressing and eventually stops registering — a developmental route into the alexithymia of Module 6. It is a plausible and influential account. Be explicit about its standing: it rests substantially on observational work and clinical inference, and "unsupported causal claims" is exactly what this course was built to avoid.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. This slide is where the course's developmental honesty is tested. State the qualification even though — especially though — the claim is compelling.
+- **Source:** Ch. 7 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 165 — Reading the Channels
+
+- **Purpose:** Establish that most emotional information is non-verbal.
+- **On the slide:** FACE · VOICE (tone, pace, volume) · POSTURE · TIMING · WHAT IS NOT SAID
+- **Visual:** L3. Five channels, each with what it carries.
+- **Explain:** The source draws on Rosenthal's PONS work, which measured sensitivity to non-verbal emotional signals and found substantial, stable individual differences. Note the fifth channel — omission is information, and it is the one people trained in verbal analysis miss most.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at MCQ 22's neighbourhood; PONS is named in the module knowledge check.
+- **Source:** Ch. 7 · [SOURCE] — Rosenthal
+
+---
+
+### Slide 166 — Sensitivity Varies, and It Is Trainable
+
+- **Purpose:** Establish that this is an ability, not a trait.
+- **On the slide:** People differ substantially in non-verbal sensitivity. / The differences are stable — **and responsive to training.**
+- **Visual:** L4. A distribution curve with an arrow showing movement following practice.
+- **Explain:** The PONS findings show real, measurable individual differences that are not simply a function of intelligence. And the source's broader argument is that these are abilities rather than fixed endowments. That is the claim the whole course depends on, and it is among the better supported ones.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 4 min.
+- **Source:** Ch. 7 · [SOURCE]
+
+---
+
+### Slide 167 — Why You Cannot Empathise While Angry
+
+- **Purpose:** Deliver Levenson's finding — the module's most practically consequential slide.
+- **On the slide:** Empathic accuracy is highest when **your own** physiological arousal is **low.** / Aroused, you do not read people less confidently. You read them wrongly, with confidence.
+- **Visual:** L2. Two panels: a calm perceiver with an accurate reading arriving; an aroused perceiver with a distorted reading arriving at the same apparent strength.
+- **Explain:** Levenson's work found empathic accuracy rising as the perceiver's own arousal fell. The practical consequence is severe and counter-intuitive: in exactly the situations where reading the other person matters most — the argument, the confrontation, the crisis — the capacity to do it is at its lowest. And the loss is invisible from the inside, because confidence does not fall with accuracy.
+- **Discuss:** "What does this imply about the standard advice to 'try to see it from their point of view' in the middle of an argument?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at MCQ 22 and Scenario 9. The answer to the discussion question is that the advice is right about the goal and wrong about the order — regulate first, then read. It is the single most useful reordering in the course.
+- **Source:** Ch. 7 · [SOURCE] — Levenson
+
+---
+
+### Slide 168 — Regulate First, Then Read
+
+- **Purpose:** State the operational rule that follows.
+- **On the slide:** **Domain 2 before Domain 4.** / Calm yourself before you try to understand anyone.
+- **Visual:** L5. The dependency diagram with an additional arrow drawn from Domain 2 to Domain 4, marked in green.
+- **Explain:** The source's stated dependency is Domain 4 on Domain 1. Levenson's finding adds a practical dependency on Domain 2 as well: not just noticing your state but lowering it. Flag this as a course-constructed extension rather than the source's stated structure.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Footer must carry [PEDAGOGICAL] for the added arrow. This is exactly the kind of small extension that becomes a misattribution if it is not labelled.
+- **Source:** Ch. 4, 7 · [PEDAGOGICAL] extension
+
+---
+
+### Slide 169 — Observation and Interpretation
+
+- **Purpose:** Deliver the course's core discipline for reading others.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| What you actually saw or heard | What you concluded |
+| --- | --- |
+| Arms folded, silent for twenty minutes | "She's disengaged" |
+| Replied after nine hours | "He's making a point" |
+| Said "that's certainly one approach" | "He's being contemptuous" |
+| Did not look up | "She's angry with me" |
+
+- **Explain:** The left column is evidence. The right column is a hypothesis wearing evidence's clothes. People routinely report the right column as though it were the left, and then act on it. The whole discipline is: notice which column you are in.
+- **Discuss:** "Take something you concluded about someone this week. Which column was it in?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at Scenario 7 and Case-Study Question 1. This table should be on the wall next to the dependency diagram.
+- **Source:** [PEDAGOGICAL], built on Ch. 7
+
+---
+
+### Slide 170 — Generate Three, Not One
+
+- **Purpose:** Give the discipline an operational rule.
+- **On the slide:** One interpretation feels like perception. / **Three interpretations feel like what they are: hypotheses.**
+- **Visual:** L2. One observation with three branches, none privileged.
+- **Explain:** The point is not that one of the three is correct. It is that holding three prevents any of them hardening into fact. A single interpretation is indistinguishable, from the inside, from having seen something. Three cannot be mistaken that way — and the person who holds three will ask, where the person holding one will act.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Scenario 7 awards a mark for three *genuinely distinct* interpretations. Say that: three phrasings of "she's unhappy" is one interpretation.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 171 — The Four-Step Reading Protocol
+
+- **Purpose:** Assemble the discipline into a usable sequence.
+- **On the slide:** 1 · **Observe** — what did I actually see and hear? · 2 · **Generate** — three readings, all consistent with it · 3 · **Check** — ask, with the observation, not the conclusion · 4 · **Revise** — hold the answer, including when it is not what you expected
+- **Visual:** L4. Four steps; step 3 in green.
+- **Explain:** Step three is the whole thing, and it is where the protocol is abandoned. Checking means saying "I noticed you went quiet in that meeting — what was your read on it?" rather than "you seemed unhappy, are you all right?" The second embeds the conclusion in the question and mostly produces agreement.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Have the room rewrite three leading questions into observational ones. It takes two minutes and reliably exposes how hard step three is.
+- **Source:** [PEDAGOGICAL], built on Ch. 7
+
+---
+
+### Slide 172 — What Is This Person Feeling?
+
+- **Purpose:** Run the domain's principal activity.
+- **On the slide:** *(the descriptions are handed out; the slide carries only the instruction)* / For each: **what did you observe? three readings? what would you ask?**
+- **Visual:** L7. Instruction only.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** **C1 — What Is This Person Feeling?** (Activity Book)
+- **Notes:** [CORE] · 25 min. Use the supplied written descriptions, not learners' own situations — this is a standing rule, and it exists so that nobody's live conflict becomes classroom material. Watch for groups producing three readings that are one reading in three registers; that is the moment to intervene.
+- **Source:** [PEDAGOGICAL], applying Ch. 7
+
+---
+
+### Slide 173 — Empathy and Morality
+
+- **Purpose:** Deliver Hoffman's argument, which the course will complicate two slides later.
+- **On the slide:** **Hoffman:** the roots of morality lie in empathy. / Caring about consequences requires registering that someone else has them.
+- **Visual:** L2. Empathy feeding into moral concern.
+- **Explain:** The argument is that moral reasoning without the capacity to register others' states is inert — you can know a rule and have no reason to care about breaking it. The source also reports work with offenders in which perspective-taking was used therapeutically, on exactly this logic.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Handle the offender material carefully and briefly; it is gated by cohort, and Case 27 in the Case Study Book carries the gating instruction.
+- **Source:** Ch. 7 · [SOURCE] — Hoffman, Pithers
+
+---
+
+### Slide 174 — And Yet
+
+- **Purpose:** Open the ethical problem the course will not resolve.
+- **On the slide:** Reading people accurately is also what a manipulator does. / **Empathy is a capacity. It is not a virtue.**
+- **Visual:** L1. Text only, no visual softening.
+- **Explain:** Registering what someone feels tells you what will comfort them and what will wound them. The same reading serves both. This is the first appearance of the ethical thread that runs through the chameleon material, the cold-batterer research, Module 17's Ethics Panel and Case 30 — and the course does not resolve it, deliberately.
+- **Discuss:** "Is a skilled manipulator emotionally intelligent?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Do not answer the discussion question. Let the room sit with it; it is picked up properly at slide 195 and again at slide 315.
+- **Source:** Ch. 7 · [SOURCE], framing [PEDAGOGICAL]
+
+---
+
+### Slide 175 — The Common Mistake
+
+- **Purpose:** Correct the domain's characteristic failure.
+- **On the slide:** ✕ Empathy = knowing what someone feels · ✓ Empathy = **holding a reading you are prepared to be wrong about**
+- **Visual:** L3. Two rows.
+- **Explain:** The confident misreader believes they are being empathic. They have a vivid sense of the other person's inner state, arrived at quickly, and they act on it. That is projection with good intentions. The mark of the domain being done well is not accuracy of first impression — it is the checking.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 176 — Case: The Quiet One
+
+- **Purpose:** Apply the protocol to an unseen case with a costly first reading.
+- **On the slide:** *A new team member says little in meetings for three weeks. Her manager concludes she lacks confidence and starts prefacing her contributions with encouragement. She stops speaking entirely.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "What was observed? What was concluded? What else could have been true — and what did the intervention cost?"
+- **Activity:** Pairs, 5 minutes.
+- **Notes:** [CORE] · 10 min. The instructive turn is that the manager acted *kindly* on the misreading and made it worse. Alternatives worth surfacing: she was listening and forming a view of the team; she was from a context where new members observe first; she found the meetings badly run and did not want to say so.
+- **Source:** [PEDAGOGICAL], applying Ch. 7
+
+---
+
+### Slide 177 — Module 9 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Empathy is registering, not agreeing or pitying · 2 · Its roots are bodily — motor mimicry · 3 · Attunement teaches that inner states are shareable · 4 · Most of the signal is non-verbal · 5 · Sensitivity varies and can be trained · 6 · **Arousal destroys accuracy while preserving confidence** · 7 · Observation, then three readings, then check · 8 · Empathy is a capacity, not a virtue
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 7 · [SOURCE]
+
+---
+
+### Slide 178 — Knowledge Check: Module 9
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · What does PONS measure and whose is it? 2 · What is motor mimicry? 3 · Define attunement and misattunement. 4 · State Levenson's finding. 5 · What follows for a manager in a conflict?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 9)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 11 — MODULE 10: THE SOCIAL ARTS: HANDLING RELATIONSHIPS (Slides 179–198)
+
+---
+
+### Slide 179 — Module 10: The Social Arts: Handling Relationships
+
+- **Purpose:** Open the fifth domain.
+- **On the slide:** MODULE 10 · The Social Arts: Handling Relationships / *Domain 5 — managing emotion in other people*
+- **Visual:** L1. Divider, Domain 5 lit, both incoming dependency arrows highlighted.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 180 — The Ripeness Condition
+
+- **Purpose:** Restate the dependency, which governs how this domain must be taught.
+- **On the slide:** *"requires the ripeness of two other emotional skills, self-management and empathy"*
+- **Visual:** L5. The dependency diagram with the two incoming arrows to Domain 5 in green.
+- **Explain:** The source's wording is worth reading exactly. *Ripeness* implies a developmental condition, not a prerequisite ticked off. Which is why this domain cannot be trained directly — a communication-skills course that skips Domains 1, 2 and 4 teaches technique with nothing underneath it, and technique with nothing underneath it is what slide 189 describes.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at MCQ 14 and SA4.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+### Slide 181 — Display Rules
+
+- **Purpose:** Deliver Ekman's three rules, precisely.
+- **On the slide:** **MINIMISE** — show less than you feel · **EXAGGERATE** — show more than you feel · **SUBSTITUTE** — show something else entirely
+- **Visual:** L3. Three columns, each with a felt state and a shown state.
+- **Explain:** Ekman's display rules govern the *expression* of emotion, not the emotion. They are learned, they vary by culture, setting and role, and everyone uses all three daily — the smile at bad news, the enthusiasm at a colleague's promotion, the composure in a crisis. They are not dishonesty; they are the grammar of social life.
+- **Discuss:** "Which of the three does your workplace demand most?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at MCQ 24, where the key error is answering as though display rules governed feeling rather than expression.
+- **Source:** Ch. 8 · [SOURCE] — Ekman
+
+---
+
+### Slide 182 — Emotional Contagion
+
+- **Purpose:** Deliver the transmission mechanism.
+- **On the slide:** Moods transmit between people **below awareness.** / You catch them. You do not decide to.
+- **Visual:** L2. Three figures, a state spreading between them by matched posture and expression.
+- **Explain:** The source describes emotional states passing between people through expression, voice, posture and rhythm, largely outside awareness. The mechanism connects back to motor mimicry: bodies synchronise, and matched bodies produce matched states. Which means the state you arrive in is not private — it is an input to everyone you meet.
+- **Discuss:** "Who in your life reliably changes your state within five minutes — in either direction?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 183 — Synchrony
+
+- **Purpose:** Give contagion a visible mechanism.
+- **On the slide:** People in rapport **match**: rhythm, posture, pace, breathing. / The matching is not a sign of connection. It is part of how connection works.
+- **Visual:** L2. Two figures with aligned rhythm lines.
+- **Explain:** The source treats synchrony as the vehicle rather than the symptom. This is why deliberately slowing your own pace can change a heated conversation, and why standing over someone escalates it. The body is doing the negotiating.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 4 min. Do not let this become "mirror people to build rapport," which is technique divorced from the mechanism and reads as manipulation when detected.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 184 — The Zeitgeber
+
+- **Purpose:** Deliver the asymmetry that makes this material matter for anyone with power.
+- **On the slide:** *Zeitgeber* — the signal that sets the rhythm. / In any group, **someone** sets the emotional rhythm. It is usually the person with the most power.
+- **Visual:** L2. A group of figures with one, marked, driving the others' rhythm lines.
+- **Explain:** Contagion is not symmetrical. The most expressive or most powerful person's state propagates disproportionately, and the flow does not reverse — a calm junior member does not calm a tense room, while a tense senior one reliably tenses it. This is the whole basis of Module 13's leadership material.
+- **Discuss:** "Who sets the rhythm in your team's meetings — and do they know?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at Scenario 8, where the second mark requires the asymmetry.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 185 — Four Components of Interpersonal Ability
+
+- **Purpose:** Give the domain's structure.
+- **On the slide:** **ORGANISING GROUPS** · **NEGOTIATING SOLUTIONS** · **PERSONAL CONNECTION** · **SOCIAL ANALYSIS**
+- **Visual:** L5. Four quadrants.
+- **Explain:** Hatch and Gardner's components, as the source presents them. Organising: coordinating effort. Negotiating: preventing and resolving conflict. Connection: the empathy of Module 9 in action, the basis of rapport. Analysis: detecting and having insight into what people feel and why. Note that they are separable — people are commonly strong in two and weak in two, and the pattern is diagnostic.
+- **Discuss:** "Which two are you? Which two are you not?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min.
+- **Source:** Ch. 8 · [SOURCE] — Hatch & Gardner
+
+---
+
+### Slide 186 — How Children Join a Game
+
+- **Purpose:** Deliver the group-entry research, which generalises further than it looks.
+- **On the slide:** The unsuccessful child: arrives, announces, redirects. · The successful child: **watches → understands what is happening → joins on the group's terms → then influences.**
+- **Visual:** L4. Two sequences side by side, the second with three steps before any attempt to act.
+- **Explain:** The finding is about children and the pattern is not. Unsuccessful entry attempts impose; successful ones observe first, work out the existing activity and its rules, participate on those terms, and only then shape it. Every new manager, every consultant, every person joining a team is running one of these two sequences.
+- **Discuss:** "Which sequence did you run when you last joined a team?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. This transfers extremely well to professional audiences and is usually one of the more uncomfortable recognitions in the course.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 187 — Dyssemia
+
+- **Purpose:** Name the failure mode, and distinguish it from indifference.
+- **On the slide:** **Dyssemia:** consistently misreading or mis-sending non-verbal signals. / Not coldness. Not not caring. A reading-and-sending problem.
+- **Visual:** L2. A signal sent and received in distorted form.
+- **Explain:** The source describes children who are excluded not because they are unkind but because they misjudge the signals — standing too close, missing the moment, misreading the tone. The consequence is social exclusion that then compounds, since practice is exactly what they are denied. Adults have the same pattern and are usually described as "difficult" rather than as having a specific, trainable deficit.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Say clearly that this is not a diagnosis and not a category to apply to colleagues. Slide 20's boundary holds.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 188 — The Social Chameleon
+
+- **Purpose:** Deliver the domain's characteristic failure — Domain 5 without Domain 1.
+- **On the slide:** Reads every room. Matches every room. / **No anchoring sense of their own feelings or values.** / Widely liked. Not trusted.
+- **Visual:** L2. A figure taking the shape of three successive contexts.
+- **Explain:** The chameleon has genuine skill — this is not a deficit story. What is missing is the first domain: the internal reference against which to decide what to do with the reading. The result is impression management, and its signature is that people enjoy the chameleon's company and do not rely on them.
+- **Discuss:** "Have you worked with one? What was the tell?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at SA4's fourth mark. The usual tells the room produces: no position that survives contact with disagreement; different accounts to different people; enthusiasm that does not predict follow-through.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 189 — The Structural Point
+
+- **Purpose:** Make the chameleon a lesson about the framework rather than a character study.
+- **On the slide:** Domain 5 without Domain 1 is not emotional intelligence with a piece missing. / **It is a different thing, which resembles it.**
+- **Visual:** L5. The dependency diagram with Domain 1 removed and Domain 5 left unsupported.
+- **Explain:** This is why the dependency structure is not a pedagogical nicety. Skills trained out of order do not produce a partial version of the capacity — they produce something that performs it. Every organisation has people who were sent on the communication course and came back better at getting their way.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 4, 8 · [SOURCE], framing [PEDAGOGICAL]
+
+---
+
+### Slide 190 — Emotional Brilliance
+
+- **Purpose:** Introduce the source's demonstration case for the domain done well.
+- **On the slide:** *A Tokyo commuter train. A drunk, violent man gets on. A young martial artist stands to face him. An old man says: "What'd you have to drink?"*
+- **Visual:** L6. Case card. Text only — no illustration.
+- **Explain:** Set it up and stop. Do not narrate the ending yet.
+- **Discuss:** "What are the available responses, and what does each cost?"
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Let the room propose confrontation, de-escalation, evacuation, the emergency cord. Collect them before turning to slide 191.
+- **Source:** Ch. 8 · [SOURCE] — Terry Dobson
+
+---
+
+### Slide 191 — Seven Moves
+
+- **Purpose:** Convert the story into an analysable structure, so it teaches rather than merely impresses.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| # | The move | What it did | Domain |
+| --- | --- | --- | --- |
+| 1 | Spoke first, before the confrontation could resolve | Interrupted the escalation before it completed | 2, 5 |
+| 2 | Asked about sake, warmly — an ordinary question | Offered a frame that was not confrontation | 5 |
+| 3 | Talked about his own evening with his wife | Made himself a person, not an opponent | 5 |
+| 4 | Did not stand, did not close distance | Removed the physical challenge cue | 5 |
+| 5 | Kept his own state calm throughout | Preserved his ability to read the man — Levenson | 2, 4 |
+| 6 | Read the grief under the aggression | Located what was actually happening | 4 |
+| 7 | Received the grief when it arrived | Let the emotion complete instead of managing it away | 4, 5 |
+
+- **Explain:** The man's wife had died. What looked like rage was grief with nowhere to go. The old man did not defeat the aggression; he addressed the state underneath it, and the aggression had nothing left to run on. Note move 5 — his calm was not a personality trait, it was the precondition for moves 6 and 7.
+- **Discuss:** "Which move is hardest? Which could you actually make?"
+- **Activity:** —
+- **Notes:** [CORE] · 12 min. The table is what makes this teachable rather than an inspiring anecdote — and inspiring anecdotes are precisely what the design rules prohibit. Do not tell the story without it.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 192 — What the Story Does Not Show
+
+- **Purpose:** Prevent over-generalisation from a single vivid case.
+- **On the slide:** One incident. One old man. One drunk. / It shows what is **possible.** It does not show what is **reliable** — and it is not a template for violence.
+- **Visual:** L1. Amber bar.
+- **Explain:** The story is compelling and it is a single case, told by a participant, years later. It demonstrates that addressing the state beneath the behaviour can work. It does not establish that it usually works, and it must not be taught as a de-escalation protocol for physical danger, where the correct advice is distance and help.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Do not skip. A course that teaches this story without this slide has told people to talk to violent strangers.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 193 — The Ethics Question, Again
+
+- **Purpose:** Sharpen the thread opened at slide 174.
+- **On the slide:** The old man changed a man's emotional state without his knowledge or consent. / **So does every skilled manipulator.** / What is the difference?
+- **Visual:** L7. Question alone.
+- **Explain:** Do not resolve it. Some answers the room will produce: whose interest was served; whether the other person ended up better off; whether it would survive being described to them. Each is a candidate and each has problems.
+- **Discuss:** "What is the difference — and would your criterion survive a hard case?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Leave it genuinely open. Module 17's Ethics Panel and Case 30 return to it, and the assessment rewards holding the tension rather than dissolving it.
+- **Source:** [PEDAGOGICAL], with Ch. 8
+
+---
+
+### Slide 194 — Case: The Handover Meeting
+
+- **Purpose:** Apply the domain to an unseen professional case.
+- **On the slide:** *Two teams are merging. In the first joint meeting, the larger team's lead opens by explaining "how we do things here." By the ten-minute mark, three people from the smaller team have stopped taking notes.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "Which entry sequence is being run? What has already been transmitted, and by what mechanism? What are the first three moves you would make?"
+- **Activity:** Small groups, 6 minutes.
+- **Notes:** [CORE] · 12 min. Draws together group entry, contagion, the zeitgeber effect and the observation/interpretation discipline. A good integration check before the applications block.
+- **Source:** [PEDAGOGICAL], applying Ch. 8
+
+---
+
+### Slide 195 — The Common Mistake
+
+- **Purpose:** Correct the domain's most common misreading.
+- **On the slide:** ✕ Domain 5 = being good with people · ✓ Domain 5 = **managing emotion in other people**, for some end — and the end is not part of the skill
+- **Visual:** L3. Two rows.
+- **Explain:** "Good with people" smuggles in an ethical evaluation that the capacity itself does not contain. The skill is the ability to shift others' states. Whether that is good depends on what it is for, and that question is answered somewhere other than in this framework — which is exactly why the ethics thread cannot be closed.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** [PEDAGOGICAL], with Ch. 8
+
+---
+
+### Slide 196 — Module 10 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Requires the ripeness of Domains 2 and 4 · 2 · Display rules: minimise, exaggerate, substitute · 3 · Moods transmit below awareness · 4 · Synchrony is the vehicle · 5 · Someone sets the rhythm — usually the powerful one · 6 · Watch, understand, join, then influence · 7 · The chameleon: Domain 5 without Domain 1 · 8 · Emotional brilliance addresses the state beneath the behaviour
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 8 · [SOURCE]
+
+---
+
+### Slide 197 — Knowledge Check: Module 10
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · Name Ekman's three display rules. 2 · Define contagion and give the mechanism. 3 · What is a *zeitgeber* here? 4 · What is a social chameleon and why a warning? 5 · What made the Tokyo train episode emotional brilliance?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 10)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+### Slide 198 — Block Close: The Framework Is Complete
+
+- **Purpose:** Close the course's central block and open the applications.
+- **On the slide:** You now have all five domains and the structure that connects them. / **The next block asks: does it hold up in the places that matter?**
+- **Visual:** L5. The full dependency diagram, all nodes filled, with four arrows out to MARRIAGE · WORK · LEADERSHIP · HEALTH.
+- **Explain:** Everything from slide 199 onward applies the same framework to specific settings. Nothing new is added to the model; what is added is evidence about whether it survives contact with real situations.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Session boundary in every delivery format.
+- **Source:** Ch. 4 · [SOURCE]
+
+---
+
+*End of G2. Slides 199–286 (Modules 11–15, applications and development) continue in G3.*

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-3-05_Slides_199-287_Application_and_Development.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-3-05_Slides_199-287_Application_and_Development.md
@@ -1,0 +1,1334 @@
+# SLIDE BLUEPRINT — APPLICATION AND DEVELOPMENT
+## Slides 199–287 — Modules 11–15
+
+**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**
+
+---
+
+# BLOCK 12 — MODULE 11: FAMILY AND INTIMATE RELATIONSHIPS (Slides 199–221)
+
+---
+
+### Slide 199 — Module 11: Family and Intimate Relationships
+
+- **Purpose:** Open, and set the tone the material requires.
+- **On the slide:** MODULE 11 · Family and Intimate Relationships / *Where the framework is tested hardest*
+- **Visual:** L1. Divider.
+- **Explain:** Say two things before the content starts. This module is where the course's material meets the situations people actually care about — and it is also the module most likely to touch a live situation in the room. The learning contract from slide 3 applies with full force: structure, not content.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min. Restate the referral pathway here. Do not treat that as a formality.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 200 — Two People, Two Marriages
+
+- **Purpose:** Establish that partners in conflict are frequently describing different events.
+- **On the slide:** In the same argument, two people can be having **two different experiences**, each of which they could describe accurately.
+- **Visual:** L3. One event; two accounts side by side, neither marked as the true one.
+- **Explain:** The source's account of marital conflict starts from divergent experience rather than from disagreement about facts. This matters practically: the standard move — establishing what really happened — often fails, because both accounts are honest reports of different experiences of one event.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Handle the source's gendered framing carefully. The book generalises about how men and women are socialised toward emotion; present that as the source's claim, note that it is a broad generalisation about socialisation patterns rather than a finding about individuals, and do not build the module on it.
+- **Source:** Ch. 9 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 201 — Different Training
+
+- **Purpose:** Deliver the developmental account of divergent emotional habits, with its limits.
+- **On the slide:** Children are socialised differently toward emotion — what to feel, what to show, what to do with conflict. / *The source treats this as a general pattern, not a rule about individuals.*
+- **Visual:** L3. Two columns of childhood emotional training with an arrow into adult conflict style.
+- **Explain:** The source argues that differences in how boys and girls are talked to about feeling produce adults with different emotional vocabularies and different default moves in conflict — one more likely to pursue the discussion, one more likely to withdraw from it. Present it as an account of socialisation, state that it describes averages and not people, and note that the underlying mechanism — early emotional training shapes adult conflict style — does not depend on the gendered framing at all.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. This is the module's fidelity test. Reporting the source accurately while marking the limits of the generalisation is the right handling; both silently dropping it and teaching it as established fact are wrong.
+- **Source:** Ch. 9 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 202 — The Four Fault Lines
+
+- **Purpose:** Deliver Gottman's framework — the module's central content.
+- **On the slide:** **CRITICISM** · **CONTEMPT** · **DEFENSIVENESS** · **STONEWALLING**
+- **Visual:** L5. Four bands arranged as a descending sequence rather than a flat list, with contempt visibly weighted.
+- **Explain:** These are patterns of conflict conduct, and the source presents them as the ones that predict deterioration. The sequence matters: they tend to arrive in this order, each making the next more likely.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Assessed at MCQ 25 and Scenario 9. Present as a sequence, not a checklist — the ordering carries the mechanism.
+- **Source:** Ch. 9 · [SOURCE] — Gottman
+
+---
+
+### Slide 203 — Complaint and Criticism
+
+- **Purpose:** Draw the distinction that makes the first fault line usable.
+- **On the slide:** COMPLAINT — *"You didn't call and I was worried."* (a behaviour, an effect) · CRITICISM — *"You never think about anyone but yourself."* (a verdict on the person)
+- **Visual:** L3. Two rows with the operative words highlighted.
+- **Explain:** Complaint is healthy and necessary; relationships without it accumulate. Criticism generalises from an act to a character, which gives the other person nothing to change and everything to defend. The linguistic markers are reliable: *always*, *never*, *you are*.
+- **Discuss:** "Convert a criticism you have used into a complaint."
+- **Activity:** Pairs, 3 minutes.
+- **Notes:** [CORE] · 8 min. Directly rehearses Scenario 10 and the XYZ formula at slide 216.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 204 — Contempt
+
+- **Purpose:** Deliver the most corrosive fault line and explain why it is worst.
+- **On the slide:** Criticism attacks the act. **Contempt attacks the person, from above.** / Disgust, mockery, the eye-roll, the tone. / *The single most damaging pattern in the source's account.*
+- **Visual:** L2. An arrow drawn from a raised position downward — the only diagram in the deck that uses vertical position to carry meaning.
+- **Explain:** Contempt carries an implicit claim of superiority and it is often delivered non-verbally, which makes it deniable — the eye-roll, the small laugh, the particular sigh. Its damage is that it communicates that the other person is beneath consideration, and nothing survives sustained exposure to that.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at MCQ 25, where criticism is the distractor. Mention "the dimpler" — the source's example of contempt readable in a small facial movement — as evidence of how little it takes.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 205 — How Strong Is This Evidence? **[EXTERNAL]**
+
+- **Purpose:** Qualify the module's central research programme, as the course qualifies every other landmark study.
+- **On the slide:** *"…predicted which couples would divorce within three years with **94 per cent accuracy**."* / **What that figure is — and is not.**
+- **Visual:** L3. Two columns: WHAT THE SOURCE REPORTS / WHAT THE FIGURE CAN SUPPORT.
+
+| What the source reports | What the figure can support |
+| --- | --- |
+| 200+ couples, two decades, second-by-second facial coding and continuous physiological measurement | An unusually **extensive** observational programme — this part is not in dispute |
+| 94% prediction of divorce within three years | A model's **fit to the sample it was built on** — not a demonstrated hit-rate on new couples |
+| "A precision unheard of in marital studies" | The precision is real *within* the study; generalisation is the open question |
+
+- **Explain:** Two published critiques matter here. **Heyman & Slep (2001)** argue that a model developed and tested on the same sample will overstate accuracy, and that reported figures need cross-validation on independent samples before they can be read as predictive accuracy in the ordinary sense. **Kim, Capaldi & Crosby (2007)** tested the affective process models on a different sample and found generalisability more limited than the original reports implied. Then say what survives, because a great deal does: the **behavioural markers** — criticism, contempt, defensiveness, stonewalling — remain observable, useful and clinically influential, and contempt in particular has retained its standing as a corrosive signal. What should not be repeated is the 94 per cent figure as a statement of predictive accuracy in new couples.
+- **Discuss:** "Why do precise-sounding numbers travel further than the findings they come from?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. **This slide exists because the course qualifies marshmallow (slide 142), Spiegel (263) and emotion-specific physiology (16) in-module, and until now qualified the one study the source calls 'unheard of' nowhere.** Deliver it in the same register as those three: not a demolition, an update. The same treatment applies to the "four eye-rolls in fifteen minutes" figure at slide 204 — a strong signal in one research programme, not a deterministic rule.
+- **Source:** Ch. 9 · [SOURCE] for the finding; **[EXTERNAL]** for the critique — Heyman & Slep (2001), *Journal of Marriage and Family* 63(2); Kim, Capaldi & Crosby (2007), *Journal of Marriage and Family* 69(1)
+
+---
+
+### Slide 206 — Defensiveness
+
+- **Purpose:** Show why the natural response makes things worse.
+- **On the slide:** Denying, counter-attacking, explaining, "yes but". / It is the reasonable response to feeling attacked. **And it ends the possibility of resolution**, because it communicates that nothing has been received.
+- **Visual:** L2. A message arriving and being reflected rather than absorbed.
+- **Explain:** The trap is that defensiveness is legitimate — the person often *is* being attacked. But its function in the exchange is to refuse the complaint, which guarantees the complaint will be restated more strongly. Note the ordinary form: explaining why you did it. It feels like cooperation and lands as refusal.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 207 — Stonewalling
+
+- **Purpose:** Deliver the fourth fault line and distinguish it from a legitimate break.
+- **On the slide:** Withdrawal. Silence. The blank face. Leaving the room. / **Not a break — a break has a stated reason and a stated return.**
+- **Visual:** L2. A closed channel between two figures.
+- **Explain:** Stonewalling is the endpoint, and it is often driven by flooding: the person is not being cold, they are overwhelmed and have shut down. The distinction from a legitimate break is entirely procedural — a break is announced, bounded and returned from. Same behaviour, opposite effect.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Directly assessed at Scenario 9's third mark. Say now what makes the difference, because the assessment requires it later.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 208 — The Ladder
+
+- **Purpose:** Show the four as a sequence rather than four separate faults.
+- **On the slide:** *(the diagram carries it)*
+- **Visual:** L4.
+
+```
+   COMPLAINT          healthy — a behaviour and its effect
+       │
+       ▼
+   CRITICISM          a verdict on the person
+       │
+       ▼
+   CONTEMPT           the verdict delivered from above
+       │
+       ▼
+   DEFENSIVENESS      nothing received; the complaint restated harder
+       │
+       ▼
+   STONEWALLING       the channel closes
+       │
+       ▼
+   [ FLOODING — and now nobody can think ]
+```
+
+- **Explain:** Each rung makes the next more likely, and the whole descent can happen inside four minutes. The intervention points are near the top, exactly as in Module 7's escalation ladder — and for the same physiological reason.
+- **Discuss:** "Where does your household or your team usually enter this ladder?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Use the identical visual grammar as slides 65, 99 and 111. Learners should see the pattern repeating.
+- **Source:** Ch. 9 · [SOURCE], sequence [PEDAGOGICAL]
+
+---
+
+### Slide 209 — Flooding
+
+- **Purpose:** Deliver the physiological state that makes conflict unresolvable.
+- **On the slide:** **Flooding:** arousal so high that the conversation cannot be processed. / Memory fails. Everything sounds like attack. Only two options remain: hit back, or leave.
+- **Visual:** L2. The working-memory box from slide 63, fully occupied, with two exit arrows only.
+- **Explain:** Everything from Module 4 arrives here at once — neural static, narrowed response options, cognitive incapacitation. The critical point for practice is that the narrowing is not a failure of goodwill. Someone flooded who chooses neither to attack nor to leave has run out of available moves.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at Scenario 9.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 210 — Ten Beats
+
+- **Purpose:** Give flooding an observable marker, which is what makes it actionable.
+- **On the slide:** Roughly **ten beats per minute above resting** marks the onset. / You can feel it. Which means you can call it.
+- **Visual:** L4. A heart-rate trace crossing a marked threshold.
+- **Explain:** The rough marker matters because it converts an internal state into something a person can notice and name in the moment. And the thresholds differ: the source notes that people differ in how readily they flood, which is why one partner can be at the top of the ladder while the other is still discussing.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Scenario 9's first mark requires this marker. Do not present it as a clinical measurement — it is a rough index, and its value is practical rather than diagnostic.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 211 — The Limbic Tango
+
+- **Purpose:** Show why two flooded people cannot rescue each other.
+- **On the slide:** *(the diagram carries it)*
+- **Visual:** L2.
+
+```
+        ┌──────────────┐                      ┌──────────────┐
+        │  PARTNER A   │  ── arousal ──▶      │  PARTNER B   │
+        │   flooded    │                      │  now flooded │
+        └──────▲───────┘      ◀── arousal ──  └──────┬───────┘
+               │                                     │
+               └─────────────────────────────────────┘
+              each one's state now drives the other's
+           — and the original issue has left the conversation
+```
+
+- **Explain:** Contagion, from Module 10, operating at high arousal. Each partner's state raises the other's, which raises theirs. The loop is self-sustaining and has no relationship to the subject of the disagreement, which is why couples end up arguing about the argument. Nobody can de-escalate from inside it, which is the entire case for the structured break.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Scenario 9's second mark.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 212 — A Destructive Conversation
+
+- **Purpose:** Show the mechanisms operating in real language.
+- **On the slide:** *(the transcript carries it — numbered lines, no commentary yet)*
+- **Visual:** L6. A numbered transcript, displayed in full.
+
+```
+ 1  A:  You said you'd call the school. It's the third time.
+ 2  B:  I've had a week. You have no idea what my week has been.
+ 3  A:  Everyone's had a week. I managed to do the things I said I'd do.
+ 4  B:  (laughs) Right. Because you're so reliable.
+ 5  A:  Don't do that.
+ 6  B:  Do what? I'm agreeing with you. You're the reliable one.
+ 7  A:  You always turn it round. Every single time. You cannot just
+        say "I forgot."
+ 8  B:  Fine. I forgot. Happy?
+ 9  A:  No, actually —
+10  B:  (turns back to laptop)
+```
+
+- **Explain:** Nothing yet. Let the room read it.
+- **Discuss:** "Where does this turn? Name the line."
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Numbered lines are essential — they let the room point at evidence rather than describe impressions, which is the same discipline as slide 169.
+- **Source:** [PEDAGOGICAL], demonstrating Ch. 9
+
+---
+
+### Slide 213 — Line by Line
+
+- **Purpose:** Make the mechanisms visible in the text.
+- **On the slide:** *(the annotation table carries it)*
+- **Visual:** L3.
+
+| Line | What happened | Mechanism |
+| --- | --- | --- |
+| 1 | Behaviour + frequency, no verdict | Complaint — legitimate |
+| 2 | Counter-claim; complaint not received | Defensiveness |
+| 3 | Comparison; implicit verdict on B | Criticism begins |
+| 4 | Laugh + sarcasm | **Contempt** — the turn |
+| 5 | Names the behaviour; the last available exit | Attempted interrupt |
+| 6 | Denial of the contempt while repeating it | Contempt + defensiveness |
+| 7 | "always", "every single time" | Criticism, past imposed on present |
+| 8 | Formal compliance, no content | Contempt |
+| 9–10 | Channel closes | Stonewalling |
+
+- **Explain:** Line 4 is the hinge. Before it, this is a recoverable disagreement about a phone call. After it, the subject has changed to what each person is. And note line 5: A does the right thing — names the behaviour without escalating — and it fails, because the ladder has already passed the point where a single move recovers it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 10 min. The failure of line 5 is important. Learners need to see that correct moves made too late do not work; that is what makes the earlier windows valuable.
+- **Source:** [PEDAGOGICAL], demonstrating Ch. 9
+
+---
+
+### Slide 214 — The Same Conversation, Handled Well
+
+- **Purpose:** Show the alternative — with the conflict intact, not dissolved.
+- **On the slide:** *(the transcript carries it)*
+- **Visual:** L6.
+
+```
+ 1  A:  You said you'd call the school. It's the third time.
+ 2  B:  Yeah. I did say that, and I didn't do it.
+ 3  A:  It leaves me chasing things I thought were handled.
+ 4  B:  I know. And I want to say something about my week, but
+        I don't want it to sound like an excuse — can I say it
+        after we've sorted the school thing?
+ 5  A:  Fine. Can you call them tomorrow morning?
+ 6  B:  Yes. I'll do it at nine and text you.
+ 7  A:  Thank you. Now say the thing about your week.
+ 8  B:  I've been drowning. And I keep dropping the domestic
+        stuff because it's the only thing with no immediate
+        consequence. Which isn't fair on you.
+ 9  A:  No, it isn't. But I'd rather know that than think you
+        just don't care.
+```
+
+- **Explain:** Note what has *not* happened. A has not withdrawn the complaint; B has not been let off; the underlying problem — B is overloaded and the household is absorbing it — is still there at line 9. What changed is that the exchange stayed on the behaviour and never became a verdict on either person.
+- **Discuss:** "What is different about line 2?"
+- **Activity:** **D4 — The Rewrite** (Activity Book)
+- **Notes:** [CORE] · 15 min with the activity. The answer to the discussion question: B receives the complaint before responding to it. That single move — acknowledge, then respond — is the highest-value technique in the module.
+- **Source:** [PEDAGOGICAL], demonstrating Ch. 9
+
+---
+
+### Slide 215 — What Changed
+
+- **Purpose:** Extract the transferable moves from the contrast.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| Destructive | Emotionally intelligent | The move |
+| --- | --- | --- |
+| Line 2: counter-claim | Line 2: acknowledgement first | Receive before responding |
+| Line 3: comparison | Line 3: effect on me | Describe the impact, not the character |
+| Line 4: contempt | Line 4: sequencing request | Ask to defer rather than deflect |
+| Line 7: "always"/"never" | Line 5: a specific request | One behaviour, one ask |
+| Line 8: formal compliance | Line 6: commitment with a time | Make it checkable |
+| Line 10: withdrawal | Line 9: acknowledgement of the real problem | Stay in it |
+
+- **Explain:** Six moves, all available to anyone, none requiring a change of personality. And every one of them is easier at low arousal — which is why Module 7 came first.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Print as a handout; it is the module's most portable page.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 216 — XYZ
+
+- **Purpose:** Give the room a formula that survives high arousal.
+- **On the slide:** **"When you did X, it made me feel Y. I'd have preferred Z."** / A behaviour. Its effect. An alternative.
+- **Visual:** L2. Three labelled slots.
+- **Explain:** Ginott's formula, as the source presents it. Its value is that it is hard to say while making a character attack — the structure does not have a slot for one. Note that Y must be a feeling, not a disguised accusation: "it made me feel that you don't care" is a verdict wearing a feeling's clothes.
+- **Discuss:** "Convert line 7 of the destructive transcript into XYZ."
+- **Activity:** Pairs, 3 minutes.
+- **Notes:** [CORE] · 8 min. The disguised-verdict error appears in about half of first attempts. Watch for "I feel that you…".
+- **Source:** Ch. 9 · [SOURCE] — Ginott
+
+---
+
+### Slide 217 — Mirroring and Validation
+
+- **Purpose:** Deliver the listening half, which most conflict training omits.
+- **On the slide:** **MIRROR:** say back what you heard, and check it. · **VALIDATE:** say that it makes sense they feel that — *which is not the same as agreeing.*
+- **Visual:** L2. A message received, reflected back, confirmed, and only then responded to.
+- **Explain:** Both moves address the same failure: the other person does not know whether anything landed. Validation is the one people resist, because it feels like conceding. It is not — "I can see why that felt dismissive" concedes nothing about whether it was dismissive. It concedes only that their reaction is intelligible, which is almost always true.
+- **Discuss:** —
+- **Activity:** **D3 — Mirroring Practice** (Activity Book), using supplied scenarios only.
+- **Notes:** [CORE] · 18 min with the activity. Supplied scenarios, never learners' live conflicts. Standing rule from the Activity Book.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 218 — Overlearning
+
+- **Purpose:** Explain why practice must exceed the point of competence.
+- **On the slide:** These moves must be **overlearned** — practised past the point of getting them right — because they will be needed when you cannot think.
+- **Visual:** L4. A practice curve extending well past the point of first success.
+- **Explain:** A technique that requires deliberation is unavailable at high arousal, which is exactly when it is needed. That is why the source emphasises rehearsal, and why this course runs role-plays rather than only discussing techniques. Knowing about XYZ is not having XYZ.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This is the justification for the whole activity book. State it here; it changes how learners treat the exercises for the rest of the course.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 219 — What Repair Does Not Require
+
+- **Purpose:** Set realistic expectations and prevent a common misuse.
+- **On the slide:** It does not require agreement. · It does not require anyone to stop being upset. · It does not require the issue to be resolved today. · **It does require both people to still be able to think.**
+- **Visual:** L3. Three struck-through rows and one in green.
+- **Explain:** The techniques do not produce consensus and are not meant to. They keep the exchange in a state where consensus remains possible. And the last line is the gating condition: none of this works past the flooding threshold, which is why the break comes before the technique.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Important safeguarding note: none of this material applies to a relationship involving coercion or violence, and it should never be taught as though it did. Say so plainly, and give the referral pathway.
+- **Source:** Ch. 9 · [SOURCE], boundary [PEDAGOGICAL]
+
+---
+
+### Slide 220 — Module 11 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Partners can have two honest accounts of one event · 2 · Four fault lines: criticism, contempt, defensiveness, stonewalling · 3 · Contempt is the most corrosive · 4 · Complaint is healthy; criticism is a verdict · 5 · Flooding at roughly +10 bpm · 6 · The limbic tango is self-sustaining · 7 · Receive before responding · 8 · XYZ, mirroring, validation — overlearned
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 9 · [SOURCE]
+
+---
+
+### Slide 221 — Knowledge Check: Module 11
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · Name the four fault lines. 2 · Which is most corrosive and how does it differ from complaint? 3 · What is the flooding threshold? 4 · State the XYZ formula. 5 · What is the limbic tango?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 11)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 13 — MODULE 12: EMOTIONAL INTELLIGENCE AT WORK (Slides 222–241)
+
+---
+
+### Slide 222 — Module 12: Emotional Intelligence at Work
+
+- **Purpose:** Open.
+- **On the slide:** MODULE 12 · Emotional Intelligence at Work / *The same mechanisms, in a setting where nobody admits they apply*
+- **Visual:** L1. Divider.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 1 min.
+- **Source:** Ch. 10 · [SOURCE]
+
+---
+
+### Slide 223 — The Worst Way to Criticise
+
+- **Purpose:** Open with the source's own worked example of failure.
+- **On the slide:** Global. Personal. Unspecific. Delivered in anger, in public. / **Worse than saying nothing** — it leaves nothing to act on and guarantees defence.
+- **Visual:** L1. Text only, amber bar.
+- **Explain:** The source treats bad criticism as one of the most damaging things that happens at work, and gives the reason: a global personal attack produces the pessimistic explanatory style of Module 8 — permanent, pervasive, personal — in the recipient. The performance problem is then compounded by a motivational collapse.
+- **Discuss:** "What is the worst piece of feedback you have received? What did it leave you able to do?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Keep the discussion on structure rather than the story; people offer detailed grievances here and the time disappears.
+- **Source:** Ch. 10 · [SOURCE]
+
+---
+
+### Slide 224 — The Artful Critique
+
+- **Purpose:** Deliver Levinson's four rules.
+- **On the slide:** **BE SPECIFIC** — the behaviour, not the person · **OFFER A SOLUTION** — a route forward · **BE PRESENT** — face to face, in private · **BE SENSITIVE** — attend to the effect as you deliver it
+- **Visual:** L5. Four quadrants.
+- **Explain:** Each rule addresses a specific failure. Specificity gives something to change. A solution converts a verdict into a task. Presence prevents the deniability and humiliation of written or public criticism. And sensitivity is not softness — it is watching what your words are doing while you say them, which is Domain 4 in operational use.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at Scenario 10 and Case-Study Question 1(b).
+- **Source:** Ch. 10 · [SOURCE] — Levinson
+
+---
+
+### Slide 225 — Rewrite It
+
+- **Purpose:** Practise the rules on a live example.
+- **On the slide:** *"This report is a mess. I don't know what you were thinking. It makes me wonder whether you're up to this role."* / **Assess against the four rules. Then rewrite — keeping the criticism.**
+- **Visual:** L6. The quotation, with four assessment boxes.
+- **Explain:** —
+- **Discuss:** Groups rewrite; two versions read aloud and assessed by the room.
+- **Activity:** Small groups, 8 minutes.
+- **Notes:** [CORE] · 14 min. The commonest failure is a rewrite that has removed the criticism. Name that rule before they start: the substance must survive. This is Scenario 10 in rehearsal.
+- **Source:** [PEDAGOGICAL], applying Ch. 10
+
+---
+
+### Slide 226 — Receiving It
+
+- **Purpose:** Teach the other side, which the source discusses and most courses omit.
+- **On the slide:** Criticism arrives as threat. The low road fires first. / **The move: ask for the specific.** *"Can you give me the example?"*
+- **Visual:** L2. The low-road diagram from slide 42, with a green intervention marker at the appraisal point.
+- **Explain:** The request for a specific example does three things at once. It buys the seconds the high road needs. It converts a verdict into data. And it frequently exposes that the critic has none, which changes the conversation entirely.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. One of the most immediately usable moves in the whole course.
+- **Source:** Ch. 10 · [SOURCE], move [PEDAGOGICAL]
+
+---
+
+### Slide 227 — Group IQ
+
+- **Purpose:** Deliver the source's central workplace claim.
+- **On the slide:** A group's performance is determined **less by the members' individual intelligence** than by how well they work together.
+- **Visual:** L3. Two teams: high individual ability with poor coordination; moderate ability with good coordination — with output shown.
+- **Explain:** The source's argument is that group output depends on social harmony — whether people share what they know, whether disagreement is possible, whether anyone is being excluded. Which reframes "soft" work as directly productive rather than as a pleasant extra.
+- **Discuss:** "Name a team you have been on where the output was worse than the people."
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Very high resonance in professional audiences. Also the hinge into Module 13.
+- **Source:** Ch. 10 · [SOURCE]
+
+---
+
+### Slide 228 — What Wrecks a Group's IQ
+
+- **Purpose:** Make the claim actionable by naming the mechanisms.
+- **On the slide:** One person's contempt, spreading by contagion · Anyone who cannot say "I don't know" · Information held for advantage · A dominant voice nobody contradicts · Unaddressed conflict absorbing everyone's attention
+- **Visual:** L3. Five mechanisms, each mapped back to the concept that explains it.
+- **Explain:** Map each: contagion from Module 10; the psychological cost of admitting ignorance under criticism; the trust network; the zeitgeber effect; and working memory occupied by the unresolved conflict, from Module 4.
+- **Discuss:** "Which of the five is present in a group you are in?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. This slide demonstrates that the applications block adds no new theory — it only points the existing framework at a setting.
+- **Source:** Ch. 10 · [SOURCE] and [PEDAGOGICAL] synthesis
+
+---
+
+### Slide 229 — The Three Informal Networks
+
+- **Purpose:** Deliver the structure that explains who actually gets things done.
+- **On the slide:** **COMMUNICATIONS** — who talks to whom · **EXPERTISE** — who is asked for advice · **TRUST** — who is told the difficult things
+- **Visual:** L2. Three overlapping network diagrams over the same set of people, visibly different in shape.
+- **Explain:** The three do not coincide, and the gaps are diagnostic. Someone central in expertise and absent from trust is consulted and not confided in. Someone central in communications and peripheral in expertise is a conduit rather than a source. And the trust network is the one that carries bad news — which is why an organisation where it is thin discovers its problems late.
+- **Discuss:** "Which of the three are you most central in?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min. Referenced in Case-Study Question 1(a).
+- **Source:** Ch. 10 · [SOURCE]
+
+---
+
+### Slide 230 — The Stars
+
+- **Purpose:** Deliver the Bell Labs finding, the source's most cited workplace evidence.
+- **On the slide:** Star engineers were not distinguished by intellect or credentials. / They were distinguished by **relationships** — networks built before they were needed.
+- **Visual:** L3. Two columns: what did not distinguish the stars / what did.
+- **Explain:** The finding the source reports: when a star hit a problem, the answer came back quickly, because they had built the connection in advance. Everyone else sent the same question into a void. The difference in output was substantial and it was not a difference in ability.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Attach the qualification in one sentence: this is a study of a specific population in a specific era, and it is illustrative rather than definitive. The habit of qualifying should be automatic by now.
+- **Source:** Ch. 10 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 231 — Seven Situations
+
+- **Purpose:** Give the module its applied core.
+- **On the slide:** THE ANGRY CUSTOMER · THE DIFFICULT EMPLOYEE · POOR PERFORMANCE · TEAM CONFLICT · NEGATIVE FEEDBACK · THE PERSON WHO FEELS IGNORED · THE FAILED PROJECT
+- **Visual:** L5. Seven cells.
+- **Explain:** Each will be shown twice — once handled badly, once handled well — and in every case the difference is traceable to a named mechanism from the earlier modules, not to a personality difference between the two managers.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min. Full detail for all seven is in Module 12 and the Case Study Book. Slides 232–235 carry four; the remaining three are delivered from the module text.
+- **Source:** Ch. 10 · [SOURCE] applied · [PEDAGOGICAL]
+
+---
+
+### Slide 232 — The Angry Customer
+
+- **Purpose:** Work the first case in the low/high contrast format.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Low EI | High EI |
+| --- | --- | --- |
+| **Opens with** | "There's nothing I can do, it's policy." | "That sounds like a mess. Tell me what happened." |
+| **Own state** | Matches the customer's arousal | Deliberately lowers pace and volume |
+| **What it treats** | The complaint | The state, then the complaint |
+| **Mechanism** | Contagion, unmanaged | Domain 2 first, then Domain 4 |
+| **Outcome** | Two aroused people; the issue untouched | Arousal falls; the issue becomes solvable |
+
+- **Explain:** The high-EI column is not nicer. It is sequenced. The customer's arousal is addressed before the problem is discussed, because a flooded customer cannot process a solution — the same constraint as slide 219.
+- **Discuss:** "What makes the low-EI response so natural?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Answer worth drawing out: contagion. The employee catches the customer's state, and a defensive response is what an aroused person produces.
+- **Source:** Ch. 10 · [SOURCE] applied
+
+---
+
+### Slide 233 — Poor Performance
+
+- **Purpose:** Second worked case, targeting the manager's own preparation.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Low EI | High EI |
+| --- | --- | --- |
+| **Timing** | Raised in the moment, in front of others | Scheduled, private, when the manager is unaroused |
+| **Framing** | "You've really dropped off lately." | "The last three deadlines moved. I want to understand why." |
+| **Assumption** | Motivation | Nothing — it is a question |
+| **Mechanism** | Criticism; the attribution error of slide 119 | Observation before interpretation; three readings |
+| **Outcome** | Defence; the actual cause never surfaces | The cause surfaces, and is often not what was assumed |
+
+- **Explain:** The pivotal difference is at the assumption row. The low-EI manager has already decided the cause is motivational, which is the same attribution-of-intent error that starts the anger ladder. The high-EI manager has a hypothesis and treats it as one.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** Ch. 10 · [SOURCE] applied
+
+---
+
+### Slide 234 — The Person Who Feels Ignored
+
+- **Purpose:** Third worked case, on the hardest to see.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Low EI | High EI |
+| --- | --- | --- |
+| **Detection** | Not noticed at all — no complaint was made | Noticed: reduced contribution, shortened replies |
+| **Interpretation** | "She's fine, she'd say something" | Three readings; then a private check |
+| **Move** | None | An observation, not a conclusion: "You've been quieter in the last few weeks — what's your read on how it's going?" |
+| **Mechanism** | Dyssemia; absence of signal read as absence of problem | Domain 4, with the four-step protocol |
+| **Outcome** | She leaves, and the exit interview is the first anyone hears | Recoverable |
+
+- **Explain:** This is the case with the highest cost and the lowest visibility. Nothing happens, which is exactly the signal — and no-signal is the one thing managers systematically fail to read.
+- **Discuss:** "Who in your team have you not heard from this month?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. The discussion question tends to produce an uncomfortable silence and at least one immediate action. Let the silence run.
+- **Source:** Ch. 10 · [SOURCE] applied
+
+---
+
+### Slide 235 — The Failed Project
+
+- **Purpose:** Fourth worked case, linking to explanatory style.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Low EI | High EI |
+| --- | --- | --- |
+| **First move** | Locate who is responsible | Establish what happened, in sequence |
+| **Framing to the team** | "We need to learn from this" (while assigning blame) | "This one didn't work. Here is what I got wrong." |
+| **Explanatory style modelled** | Personal, permanent | Specific, temporary, changeable |
+| **Mechanism** | Contagion of threat; the trust network closes | The leader as zeitgeber, deliberately |
+| **Outcome** | Nobody reports the next problem early | Problems surface earlier next time |
+
+- **Explain:** The mechanism row is the point. A leader's response to failure is transmitted to the whole group, and it sets whether bad news travels upward in future. The cost of the low-EI column is not this project; it is the next one.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Direct bridge into Module 13.
+- **Source:** Ch. 10 · [SOURCE] applied
+
+---
+
+### Slide 236 — Marriage and Work Are the Same Problem
+
+- **Purpose:** Show the framework's transfer explicitly.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| At home | At work | Same mechanism |
+| --- | --- | --- |
+| Contempt | The dismissive aside in a meeting | Attack on the person, from above |
+| Stonewalling | The unanswered email | Channel closed without account |
+| Flooding | "This isn't a good time to discuss this" | Arousal above the processing threshold |
+| Criticism | The performance review that describes character | Verdict rather than behaviour |
+| Repair attempt | "Let me start that again" | Interrupting the ladder |
+
+- **Explain:** The mechanisms are identical; only the display rules differ. Work permits less overt expression, which makes the same patterns quieter and harder to name — and therefore, often, more durable.
+- **Discuss:** "Which of these is more damaging at work *because* it is less visible?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Strong integration slide. Worth keeping even in compressed delivery.
+- **Source:** Ch. 9, 10 · [PEDAGOGICAL] synthesis
+
+---
+
+### Slide 237 — The Common Mistake
+
+- **Purpose:** Correct the workplace application's characteristic distortion.
+- **On the slide:** ✕ Emotional intelligence at work = keeping things pleasant · ✓ = **making it possible to say difficult things and still work together**
+- **Visual:** L3. Two rows.
+- **Explain:** A team where nothing uncomfortable is ever said is not emotionally intelligent; it is one where the trust network has failed and the disagreement has gone underground. Pleasantness is compatible with contempt, and often conceals it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Important in corporate delivery, where the purchased outcome is sometimes "fewer complaints."
+- **Source:** [PEDAGOGICAL], with Ch. 10
+
+---
+
+### Slide 238 — What the Source Does Not Establish
+
+- **Purpose:** Mark the evidential limit of the workplace claims.
+- **On the slide:** The source does **not** show that emotional intelligence causes business performance. · It does **not** give a percentage. · It reports studies, several small, several illustrative.
+- **Visual:** L1. Amber bar.
+- **Explain:** The workplace chapter is the most cited part of the book and the most over-claimed. What it offers is a set of studies and an argument. It does not offer the causal, quantified claim that the consulting literature attributes to it. the Evidence file covers what the subsequent evidence does support — which is real, and more modest.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Directly relevant to Case-Study Question 2(a).
+- **Source:** Ch. 10 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 239 — Case: The Thursday Meeting
+
+- **Purpose:** Integrate the module on an unseen case.
+- **On the slide:** *A senior analyst has stopped attending the weekly planning meeting, citing other commitments. Her emails are accurate, brief, and consistently late. In the last meeting she attended, she said of a colleague's proposal: "That's certainly one approach."*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "Name the mechanisms. Which network has failed? What is the first move — and what should not be the first move?"
+- **Activity:** Small groups, 6 minutes.
+- **Notes:** [CORE] · 12 min. This is a deliberate partial rehearsal of Case-Study Question 1. If setting that paper unchanged, substitute — see the Assessment Bank (item-writing rules).
+- **Source:** [PEDAGOGICAL], applying Ch. 9, 10
+
+---
+
+### Slide 240 — Module 12 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Bad criticism is worse than none · 2 · Levinson: specific, solution, present, sensitive · 3 · Receiving: ask for the specific · 4 · Group IQ turns on cooperation, not individual ability · 5 · Three informal networks; trust carries bad news · 6 · The stars had relationships built in advance · 7 · The same mechanisms as at home, more quietly
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 10 · [SOURCE]
+
+---
+
+### Slide 241 — Knowledge Check: Module 12
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · Name Levinson's four rules. 2 · What is group IQ and what determines it? 3 · Name the three informal networks. 4 · What distinguished the Bell Labs stars? 5 · Why is the worst criticism worse than none?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 12)
+- **Notes:** [CORE] · 8 min.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 14 — MODULE 13: EMOTIONAL INTELLIGENCE AND LEADERSHIP (Slides 242–255)
+
+---
+
+### Slide 242 — Module 13: Leadership — and a Declaration
+
+- **Purpose:** Open with the module's honesty condition, which is the reason it can be taught at all.
+- **On the slide:** MODULE 13 · Emotional Intelligence and Leadership / **This book has no chapter on leadership.** / This module is built by the course, from the source's material. Everything in it is labelled.
+- **Visual:** L1. Divider with a [PEDAGOGICAL] bar across the full width.
+- **Explain:** Say it directly. Leadership is the most commercially prominent application of emotional intelligence, and this book does not contain a leadership model. The course constructs one from Chapters 8, 10 and 11 rather than silently importing a later framework — and the construction is declared to learners because that is what the fidelity rule requires of the course itself, not only of its learners.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. This slide is the strongest single demonstration of the course's method. Do not soften it.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 243 — What This Module Is Built From
+
+- **Purpose:** Show the construction, so learners can audit it.
+- **On the slide:** Ch. 8 — contagion, the *zeitgeber*, group harmony · Ch. 10 — group IQ, the critique, the networks · Ch. 11 — the costs of sustained stress
+- **Visual:** L2. Three source blocks feeding one module box.
+- **Explain:** Every claim in this module traces to one of these three. If a claim cannot be traced, it does not belong here.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min.
+- **Source:** Ch. 8, 10, 11 · [PEDAGOGICAL] construction
+
+---
+
+### Slide 244 — What This Module Does Not Use
+
+- **Purpose:** Name the frameworks being deliberately excluded, since learners will know them.
+- **On the slide:** ✕ The four-quadrant leadership model · ✕ The six leadership styles · ✕ Any commercial EQ competency framework / *These are from later work, or from other authors. They are not in this book.*
+- **Visual:** L1. Three struck-through rows.
+- **Explain:** Several of these are the same author's later work, and some of them are useful. They are excluded because attributing them to this book would be a misattribution, and because a course that teaches learners to check provenance cannot exempt itself.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Assessed at MCQ 13, where two of these appear as distractors.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 245 — The Leader Sets the Rhythm
+
+- **Purpose:** Deliver the module's central mechanism.
+- **On the slide:** In any group, someone is the *zeitgeber*. / **If you have the power, it is you — whether or not you intend it.**
+- **Visual:** L2. The group-contagion diagram from slide 184, with the driving node marked LEADER.
+- **Explain:** The asymmetry from Module 10 is the whole of the leadership claim. A leader's state propagates disproportionately and does not get cancelled by anyone else's. Which makes the leader's own emotional management not a personal matter but an operational input — the one everyone else's working conditions depend on.
+- **Discuss:** "What state did you transmit into your last meeting? Did you choose it?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at Scenario 8, whose third mark requires identifying the leader's arrival state as the leverage point.
+- **Source:** Ch. 8 · [SOURCE], application [PEDAGOGICAL]
+
+---
+
+### Slide 246 — Group IQ Is a Leadership Metric
+
+- **Purpose:** Reframe what a leader is actually managing.
+- **On the slide:** If a group's output turns on cooperation, then **the conditions of cooperation are the work** — not an overhead on the work.
+- **Visual:** L2. A leader's attention divided between TASK and CONDITIONS, with output depending on both.
+- **Explain:** The implication is concrete: time spent making it possible to disagree, ensuring the quiet member is heard, and repairing a fracture between two people is directly productive time. Under pressure, it is the first thing cut — which is precisely when it matters most.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 10 · [SOURCE], application [PEDAGOGICAL]
+
+---
+
+### Slide 247 — Where the Trust Network Runs
+
+- **Purpose:** Give leaders the diagnostic that matters most.
+- **On the slide:** The trust network carries **bad news.** / If yours is thin, you will find out late. Every time.
+- **Visual:** L2. Two organisations: one with bad news reaching the centre early; one where it stops two levels down.
+- **Explain:** A leader can measure this. How long between a problem existing and reaching you? Who told you? Did anyone tell you something you did not want to hear this month? The answers are a direct read on whether the trust network reaches you — and the commonest cause of it not reaching you is what happened last time someone tried.
+- **Discuss:** "When did someone last bring you a problem you did not want to hear — and what happened to them?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. One of the strongest slides in the deck for senior audiences. The second half of the discussion question is the one that does the work.
+- **Source:** Ch. 10 · [SOURCE], application [PEDAGOGICAL]
+
+---
+
+### Slide 248 — The Critique Is a Leadership Act
+
+- **Purpose:** Elevate Levinson's rules from a technique to a structural responsibility.
+- **On the slide:** How you criticise sets what people will attempt. / A team that fears the review does the safe thing.
+- **Visual:** L4. A feedback event with two downstream consequences: reduced risk-taking; sustained risk-taking.
+- **Explain:** This connects Levinson to explanatory style and group IQ. Criticism that produces a permanent, personal attribution does not just damage one person's motivation; it teaches the whole group what the cost of visible failure is, and they adjust their ambition accordingly.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 10 · [SOURCE], synthesis [PEDAGOGICAL]
+
+---
+
+### Slide 249 — Leadership Responses Compared
+
+- **Purpose:** Give the applied contrast table.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| Situation | Low EI | High EI | Mechanism |
+| --- | --- | --- | --- |
+| Bad quarter announced | Opens with what went wrong, tensely | Names the state in the room before the numbers | Contagion, managed deliberately |
+| Two reports in conflict | Tells them to sort it out | Establishes each account separately first | Group IQ; observation before interpretation |
+| A mistake surfaces | Finds who | Establishes what, then thanks the person who raised it | Protecting the trust network |
+| Restructure announced | Facts only, questions "offline" | Acknowledges the uncertainty explicitly, then the facts | Unnamed states do not disappear; they route through the informal networks |
+| Own error | Not mentioned | Named, specifically and once | Explanatory style, modelled |
+
+- **Explain:** The last row is the most consequential and the least done. A leader who never names an error has told the group that errors are unmentionable, which is exactly the condition under which they accumulate.
+- **Discuss:** "Which row is your organisation worst at?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min.
+- **Source:** Ch. 8, 10 · [PEDAGOGICAL] construction
+
+---
+
+### Slide 250 — Case: The Announcement
+
+- **Purpose:** Apply the module to an unseen case.
+- **On the slide:** *A director announces a reorganisation in a 15-minute all-hands. She delivers the facts clearly, takes no questions "in the interest of time," and says she is available afterwards. Nobody comes.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "What was transmitted that was not said? Where did the emotion go? What would you have done differently in the same fifteen minutes?"
+- **Activity:** Small groups, 6 minutes.
+- **Notes:** [CORE] · 12 min. The productive answer: the emotion did not disappear, it moved into the informal networks, where it will be processed without any information from her. The fifteen-minute constraint is deliberate — the alternative must fit the same time.
+- **Source:** [PEDAGOGICAL], applying Ch. 8, 10
+
+---
+
+### Slide 251 — The Dark Side
+
+- **Purpose:** Return the ethics thread to leadership, where it has the most consequence.
+- **On the slide:** Everything in this module also describes an effective manipulator. / A leader who reads people well and serves only themselves is **more** dangerous, not less.
+- **Visual:** L1. Text only.
+- **Explain:** The capacities are instrumental, as slide 174 established. Applied to power, that is not an abstract concern: the skills that make someone able to set a room's rhythm, read what people need, and make them feel understood are the skills of both the leader people would follow anywhere and the one they should not.
+- **Discuss:** "Have you worked for someone who was excellent at this and should not have had the job?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. The empirical anchor — Côté and colleagues' work on emotional ability and manipulative behaviour — is in the Evidence file. Reference it, do not deliver it here.
+- **Source:** [PEDAGOGICAL], with [EXTERNAL] anchor in the Evidence file
+
+---
+
+### Slide 252 — What This Module Does Not Claim
+
+- **Purpose:** Close the module with its own limits, as its opening promised.
+- **On the slide:** ✕ That the source demonstrates EI causes leadership success · ✕ That there is a validated leadership competency model here · ✕ That any percentage applies / ✓ That the mechanisms described operate on leaders with greater force, because of their position
+- **Visual:** L1. Three struck-through rows and one in blue.
+- **Explain:** The defensible claim is the modest one on the last row, and it is enough to justify the module. Everything larger belongs to a literature this book did not produce.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Module 13's knowledge check, item 5, asks exactly this.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 253 — Module 13 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · **This module is constructed, and says so** · 2 · Built from Chapters 8, 10, 11 · 3 · The leader is the *zeitgeber*, intentionally or not · 4 · Conditions of cooperation are the work · 5 · The trust network is the early-warning system · 6 · Criticism sets what the group will attempt · 7 · The same skills serve manipulation
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 8, 10, 11 · [PEDAGOGICAL]
+
+---
+
+### Slide 254 — Knowledge Check: Module 13
+
+- **Purpose:** Formative check, with an emphasis on provenance.
+- **On the slide:** 1 · What is this module built from? 2 · Why not the four-quadrant model? 3 · Which concept explains a leader's disproportionate influence? 4 · What does group IQ imply for meeting time? 5 · Name one thing this module must not claim.
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 13)
+- **Notes:** [CORE] · 8 min. Questions 1, 2 and 5 are fidelity items. A room that cannot answer them has taken the module as ordinary leadership content, which is the one way it can go wrong.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+### Slide 255 — A Note on Constructed Modules
+
+- **Purpose:** Generalise the method beyond this module.
+- **On the slide:** Any course built from a source will need to construct. / **The rule is not "don't construct." It is "declare it."**
+- **Visual:** L1. Text only.
+- **Explain:** Useful for the instructors and curriculum designers in the room, and useful for everyone as a test to apply to other training they receive. The question to ask of any framework presented as authoritative: where did this come from, and does the person teaching it know?
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 3 min. Cut first under time pressure; keep it for any cohort of trainers or educators.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+# BLOCK 15 — MODULE 14: EMOTIONAL CLIMATE, STRESS AND WELLBEING (Slides 256–269)
+
+---
+
+### Slide 256 — Module 14: Emotional Climate, Stress and Wellbeing
+
+- **Purpose:** Open, with the boundary restated before any content.
+- **On the slide:** MODULE 14 · Emotional Climate, Stress and Wellbeing / *Taught through what the source refuses to claim*
+- **Visual:** L1. Divider with the clinical-boundary block from slide 20 repeated verbatim beneath.
+- **Explain:** Restate the boundary word for word. This is the module where over-claiming does the most harm, and where learners arrive with the strongest prior beliefs.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Use the same wording as slides 20, 251 and 269. Consistency is the point.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 257 — Two Things the Source Refuses to Say
+
+- **Purpose:** Frame the module by its rejections, which is how it is best taught.
+- **On the slide:** ✕ That emotions cause disease in a simple, direct way · ✕ That patients are responsible for their illness / **The source rejects both.**
+- **Visual:** L1. Two struck-through rows in amber.
+- **Explain:** This is the honest starting point and it is the opposite of how this material usually reaches people. The source is explicit that the mind–body link does not license "your stress gave you this," and that the blaming implication is both unwarranted and cruel. Everything that follows sits inside those two limits.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Assessed at the module knowledge check, item 2. Start here rather than ending here — it changes how the room hears the evidence.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 258 — Psychoneuroimmunology
+
+- **Purpose:** Establish that there is a physical pathway, so the rejections above are not a dismissal.
+- **On the slide:** **PNI** — the study of links between mind, nervous system and immune function. / The systems are physically connected. That much is not in dispute.
+- **Visual:** L2. Three systems with drawn connections between them.
+- **Explain:** Ader and Felten's work established that the nervous and immune systems communicate — anatomically and chemically. That is the foundation for taking the question seriously at all. What remains difficult is the size and clinical significance of the effects, which is a very different question from whether the connection exists.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 11 · [SOURCE] — Ader, Felten
+
+---
+
+### Slide 259 — What Sustained Distress Does
+
+- **Purpose:** Give the defensible version of the claim.
+- **On the slide:** Sustained arousal keeps stress systems active. · Sustained activation has measurable effects, including on immune measures. · **Effects on measures are not the same as effects on disease.**
+- **Visual:** L4. A chain with the last link drawn as a dashed, uncertain connection.
+- **Explain:** The dashed link is the whole methodological problem, and it is worth being explicit about. Most of the evidence connects distress to intermediate measures. Getting from there to clinical outcomes requires long, controlled studies that are hard to run and whose results have been mixed.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. This slide is the module's evidential spine. Do not let the dashed link become solid.
+- **Source:** Ch. 11 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 260 — Anger and the Heart
+
+- **Purpose:** Deliver the strongest of the source's specific claims.
+- **On the slide:** Of the negative emotions studied, **anger** has the clearest association with cardiac risk. / Chronic hostility, not occasional anger.
+- **Visual:** L3. Two rows distinguishing episodic anger from a chronic hostile disposition.
+- **Explain:** The distinction is essential and constantly lost. The association reported is with a sustained hostile style — an ongoing readiness to be antagonistic — not with having lost your temper last Tuesday. Which also means the intervention target is the disposition, not the episode.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 261 — Job Strain
+
+- **Purpose:** Deliver the finding with the highest practical relevance for working learners.
+- **On the slide:** **HIGH DEMAND + LOW CONTROL** / It is the combination. Demand alone is not the harmful variable.
+- **Visual:** L5. A two-by-two of demand against control, with one cell marked.
+- **Explain:** This is one of the more robust findings the source reports, and it inverts a common assumption. Demanding work is not, by itself, the problem — high demand with high control is often experienced as engaging, and is close to the flow condition from Module 8. The damaging cell is high demand with no discretion over how the work is done.
+- **Discuss:** "Which cell is your role in? Which is your team's?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. High resonance and directly actionable — the manager's lever is control, which is often cheaper to change than demand.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 262 — Isolation
+
+- **Purpose:** Deliver the social finding, which is among the strongest in the chapter.
+- **On the slide:** Social isolation shows associations with health outcomes **comparable in size to major established risk factors.**
+- **Visual:** L3. A comparison bar chart of risk associations, isolation among them.
+- **Explain:** The source reports this alongside work such as the Goteborg study. Treat it carefully: these are associations, and the causal direction is not simple — illness produces isolation as well as the reverse. But the size of the association is large enough that dismissing it is not a defensible reading either.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 263 — Expressive Writing
+
+- **Purpose:** Deliver the intervention with the best evidence in the chapter.
+- **On the slide:** **Pennebaker:** writing about a distressing experience, over several sessions, was followed by measurable improvements — including in immune measures.
+- **Visual:** L4. The protocol as a simple sequence: several sessions, twenty minutes, private, unedited.
+- **Explain:** The finding is notable because the intervention is trivial to administer and the mechanism is plausible — putting an experience into a coherent narrative appears to do something that turning it over silently does not. Note the connection to rumination: writing produces a structured account, rumination produces a loop.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. One sentence of qualification: effect sizes in later meta-analytic work are modest and vary considerably by population. Do not present it as a treatment.
+- **Source:** Ch. 11 · [SOURCE], with [EXTERNAL] qualification
+
+---
+
+### Slide 264 — Support Groups
+
+- **Purpose:** Handle the chapter's most-cited and most-qualified claim.
+- **On the slide:** **Spiegel:** women in a support group survived longer. / **The survival finding has not consistently replicated.** The well-being benefits are better supported.
+- **Visual:** L3. Two rows: what the original reported / what subsequent work found.
+- **Explain:** This is one of the most widely repeated claims to come out of this literature, and it has not held up in the way it is usually stated. Be precise about what survives: support groups improve quality of life and psychological outcomes, with reasonable consistency. The survival extension is not established. Repeating it as fact is exactly the failure this course exists to prevent.
+- **Discuss:** "Why do you think this particular finding travelled so far?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Referenced in Case-Study Question 2. The discussion question is worth asking: the finding travelled because it offered agency in the face of something terrifying, which is also why correcting it feels unkind — and why it must be corrected.
+- **Source:** Ch. 11 · [SOURCE] and [EXTERNAL]
+
+---
+
+### Slide 265 — What Follows in Practice
+
+- **Purpose:** Convert a heavily qualified module into something usable.
+- **On the slide:** Reduce sustained arousal, not every emotion · Increase control where demand is high · Treat isolation as a health variable · Do not tell anyone their feelings caused their illness
+- **Visual:** L3. Four actions, each with the finding it rests on.
+- **Explain:** The last line is not a courtesy. It is the direct implication of slide 257's second rejection, and it is the single most common misuse of this entire literature.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** Ch. 11 · [SOURCE] applied
+
+---
+
+### Slide 266 — Case: The Well-Meant Comment
+
+- **Purpose:** Make the misuse concrete.
+- **On the slide:** *A colleague returning after treatment is told, warmly, by a well-read team member: "You know, they say stress plays a huge part in this. Maybe this is your body telling you to slow down."*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "What is wrong with this, precisely? And what makes it hard to correct?"
+- **Activity:** Pairs, 4 minutes.
+- **Notes:** [CORE] · 9 min. Two things to draw out: it converts an association into a personal causal claim, and it locates responsibility for a serious illness in the patient. It is hard to correct because it was kindly meant and because the speaker believes they are sharing knowledge.
+- **Source:** [PEDAGOGICAL], applying Ch. 11
+
+---
+
+### Slide 267 — The Common Mistake
+
+- **Purpose:** Name the distortion.
+- **On the slide:** ✕ "Emotions cause illness." · ✓ Emotional states are **one input among many** into systems that affect health — with effects that are real, measured mostly at intermediate levels, and frequently overstated.
+- **Visual:** L3. Two rows.
+- **Explain:** The corrected version is less quotable and it is what the evidence supports.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** Ch. 11 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 268 — Module 14 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Two rejections: no simple causation, no patient blame · 2 · PNI: the systems are connected · 3 · Effects on measures ≠ effects on disease · 4 · Chronic hostility, not episodic anger · 5 · Job strain = high demand + low control · 6 · Isolation is a substantial association · 7 · Expressive writing has support; the survival claim does not
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 11 · [SOURCE]
+
+---
+
+### Slide 269 — Knowledge Check: Module 14
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · What is PNI and whose work? 2 · What does the source explicitly reject? 3 · What is job strain? 4 · What did Pennebaker find? 5 · Why must Spiegel's survival finding carry a caveat?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 14)
+- **Notes:** [CORE] · 8 min. If the room leaves believing stress causes cancer, the module has failed regardless of what else they retained.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 16 — MODULE 15: EMOTIONAL DEVELOPMENT, CHILDHOOD AND TEMPERAMENT (Slides 270–287)
+
+---
+
+### Slide 270 — Module 15: Emotional Development, Childhood and Temperament
+
+- **Purpose:** Open, with the boundary and the evidential standard both stated up front.
+- **On the slide:** MODULE 15 · Emotional Development, Childhood and Temperament / *Where it comes from — and what the source can and cannot show*
+- **Visual:** L1. Divider with the clinical boundary block repeated.
+- **Explain:** Two warnings. This module touches learners' own childhoods and their own parenting, which makes it the module most likely to produce discomfort and defensiveness. And it is the module where correlational evidence is most often read as causal — including by people teaching it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Restate the referral pathway.
+- **Source:** Ch. 12 · [SOURCE]
+
+---
+
+### Slide 271 — Four Ways Adults Respond to a Child's Feeling
+
+- **Purpose:** Deliver the four styles.
+- **On the slide:** **IGNORING** — the feeling is trivial · **LAISSEZ-FAIRE** — the feeling is fine, no guidance offered · **CONTEMPTUOUS** — the feeling is wrong, and so is having it · **COACHING** — the feeling is real, and here is what to do with it
+- **Visual:** L3. Four columns, each with a typical response to the same event.
+- **Explain:** Use one event across all four — a child upset about being excluded from a game. Ignoring: "you'll have forgotten by tomorrow." Laissez-faire: "that's rough, come and have a snack." Contemptuous: "don't be so sensitive." Coaching: "that sounds horrible — what happened, and what do you want to do about tomorrow?"
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Laissez-faire is the one learners misjudge: it is warm and it supplies no skill. That combination is why it is a separate category from coaching.
+- **Source:** Ch. 12 · [SOURCE]
+
+---
+
+### Slide 272 — Coaching, Specifically
+
+- **Purpose:** Make the fourth style concrete enough to use.
+- **On the slide:** Notice it · Name it · Treat it as legitimate · **Then** help with what to do / Not: solve it, dismiss it, or fix the feeling
+- **Visual:** L4. Four steps, with the third marked in green.
+- **Explain:** Step three is the one adults skip. The instinct is to move straight to the solution, which communicates that the feeling was an obstacle to get past. Note that this is the same sequence as mirroring and validation from Module 11 — the mechanism is identical, applied to a child.
+- **Discuss:** "Which of the four did you receive?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Handle the discussion question with care and take no more than two answers. This is the point in the course where disclosure risk is highest, and the learning contract's "structure, not content" rule needs restating before you ask it.
+- **Source:** Ch. 12 · [SOURCE]
+
+---
+
+### Slide 273 — The Same Four Styles, at Work
+
+- **Purpose:** Transfer the framework, which prevents the module reading as being only about parenting.
+- **On the slide:** IGNORING — "let's stay focused on the deliverable" · LAISSEZ-FAIRE — "sounds tough, anyway…" · CONTEMPTUOUS — "we're all under pressure" · COACHING — "that sounds difficult. What's the hardest part, and what would help?"
+- **Visual:** L3. The four styles from slide 271 with workplace equivalents alongside.
+- **Explain:** The four styles describe any adult responding to any person's emotional signal. Most managers have one default and use it regardless of the situation, and most have never been told what their default is.
+- **Discuss:** "Which is your default at work? Is it the same as at home?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. This transfer is what makes the module teachable to a cohort with no children.
+- **Source:** Ch. 12 · [PEDAGOGICAL] transfer
+
+---
+
+### Slide 274 — The Seven Ingredients
+
+- **Purpose:** Deliver the readiness-to-learn list, which is the source's most practical developmental content.
+- **On the slide:** CONFIDENCE · CURIOSITY · INTENTIONALITY · SELF-CONTROL · RELATEDNESS · CAPACITY TO COMMUNICATE · COOPERATIVENESS
+- **Visual:** L5. Seven cells.
+- **Explain:** The source's point is that school readiness is not primarily about letters and numbers. A child arriving without these has difficulty learning anything, whatever their cognitive ability — and the list is almost entirely emotional and social.
+- **Discuss:** "Which of the seven does an adult team need?"
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min. The transfer to adult teams works well and is worth taking: the answer is essentially all of them, which is itself the point.
+- **Source:** Ch. 12, Appendix D · [SOURCE]
+
+---
+
+### Slide 275 — Temperament
+
+- **Purpose:** Establish temperament as real and physiologically grounded.
+- **On the slide:** Children differ from very early on in emotional reactivity. / **Kagan:** timid and bold patterns, with measurable physiological correlates.
+- **Visual:** L3. Two profiles with their physiological markers.
+- **Explain:** Kagan's work found that a proportion of children show a consistent pattern of heightened reactivity to novelty, detectable physiologically, and stable enough to be called temperamental. This is the strongest case in the book for something being given rather than learned.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Set this up carefully, because slide 276 is going to complicate it — and the complication is the module's most important content.
+- **Source:** Ch. 14 · [SOURCE] — Kagan
+
+---
+
+### Slide 276 — The Emboldening Finding
+
+- **Purpose:** Deliver the module's most consequential result.
+- **On the slide:** Among temperamentally timid children, those whose parents set **firm, graded expectations** for handling everyday challenges tended to become notably less timid. / **Temperament is a starting point, not a destination.**
+- **Visual:** L4. Two trajectories from the same temperamental starting point, diverging over time.
+- **Explain:** This is the finding the whole course's premise rests on. If temperament were destiny, teaching emotional skills would be marginal. The emboldening result shows that a physiologically grounded disposition responded to how it was handled. Note the specific mechanism: not protection, and not pressure, but graded expectation — challenges the child could meet, set slightly ahead of where they were.
+- **Discuss:** "What does 'firm and graded' rule out on either side?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at the module knowledge check, item 3. The answer to the discussion question — it rules out both shielding the child from every challenge and throwing them into things they cannot handle — is the same structure as the flow grid from Module 8. Name the connection.
+- **Source:** Ch. 14 · [SOURCE] — Kagan
+
+---
+
+### Slide 277 — The Same Mechanism, Later
+
+- **Purpose:** Transfer emboldening to adults, which is what makes it matter for this cohort.
+- **On the slide:** Graded, achievable challenge, with support and an expectation of coping. / *The same structure as: self-efficacy · the flow condition · overlearning*
+- **Visual:** L5. Three previously seen diagrams — the efficacy ladder, the challenge–skill grid, the practice curve — shown side by side with the shared shape highlighted.
+- **Explain:** Four separate parts of this course converge on one structure: change happens at the edge of current capacity, repeatedly, with support. That convergence is worth naming explicitly, because it is the closest thing the course has to a general principle of development.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. One of the deck's best integration slides. The Personal Development Assignment's action plan should be built on this structure, and saying so here improves the submissions substantially.
+- **Source:** Ch. 6, 9, 14 · [PEDAGOGICAL] synthesis
+
+---
+
+### Slide 278 — Prefrontal Asymmetry
+
+- **Purpose:** Give the neural correlate, with appropriate caution.
+- **On the slide:** **Davidson:** patterns of relative left/right prefrontal activity are associated with characteristic emotional style. / *An association, measured at a population level. Not a scan that tells you about a person.*
+- **Visual:** L2. Two activity patterns with their associated dispositions, and an amber caution bar.
+- **Explain:** The research is real and the popular reading of it is not. Present the association; then say plainly that individual prediction from such measures is far weaker than the popular presentation suggests, and that "left-brained/right-brained" as a personality account is unsupported.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Cut first under time pressure. If kept, the caution is not optional.
+- **Source:** Ch. 14 · [SOURCE-QUALIFIED], with [EXTERNAL]
+
+---
+
+### Slide 279 — Pruning and Shaping
+
+- **Purpose:** Deliver the plasticity claim and its evidential limit in one movement.
+- **On the slide:** Childhood involves substantial neural shaping — connections strengthened by use, others lost. / **What the source states:** this shaping happens. · **What is inferred:** precise windows, and the educational prescriptions drawn from them.
+- **Visual:** L3. Two columns, explicitly labelled STATED and INFERRED.
+- **Explain:** This two-column structure is the module's method and it should be visible as such. That experience shapes the developing brain is well supported. That there are specific closing windows for particular emotional capacities, and that particular curricula follow from them, is a much larger claim, and the source's own confidence exceeds what the cited evidence establishes.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at SA5(a), which asks candidates to make exactly this distinction. Show them the distinction being made rather than telling them to make it.
+- **Source:** Ch. 14 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 280 — "The First Three Years Determine Everything"
+
+- **Purpose:** Correct an over-claim learners will have met, and that the module could otherwise seem to support.
+- **On the slide:** **This is not what the source shows.** / Its own material — the emboldening finding, the relearning material — describes change well after early childhood.
+- **Visual:** L1. Amber bar.
+- **Explain:** Early experience matters; that is well supported. The stronger determinist claim is not, and it is contradicted by evidence within the book itself. Note also who benefits from the strong version: it has been extremely useful for selling things to anxious parents.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Module knowledge check item 5. This is a fidelity slide of the same type as slide 5.
+- **Source:** Ch. 14 · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 281 — Change Is Visible in the Brain
+
+- **Purpose:** Close the plasticity argument with the source's strongest supporting evidence.
+- **On the slide:** In treated obsessive-compulsive disorder, imaging showed changes in brain activity following **behavioural** treatment — comparable to medication.
+- **Visual:** L3. Two treatment routes converging on a similar imaging outcome.
+- **Explain:** The point is not the specific condition. It is that a talking-and-practice intervention produced measurable neural change. Whatever the limits of the imaging literature, this is a direct answer to "you can't change how your brain reacts" — and it is the empirical backing for the course's whole premise that these are trainable abilities.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Good closing evidence for the developmental block. One sentence of caution about the era's imaging methods is appropriate and sufficient.
+- **Source:** Ch. 14 · [SOURCE]
+
+---
+
+### Slide 282 — Case: The Cautious Child
+
+- **Purpose:** Apply the emboldening structure to an unseen case.
+- **On the slide:** *A seven-year-old cries before every swimming lesson. Parent A stops taking him. Parent B makes him go every week regardless. Parent C sits with him poolside for three weeks, then in the shallow end, then on the bench.*
+- **Visual:** L6. Case card.
+- **Explain:** —
+- **Discuss:** "Which is 'firm and graded'? What is each of the others actually teaching him?"
+- **Activity:** Pairs, 4 minutes.
+- **Notes:** [CORE] · 9 min. A teaches that the feeling is an instruction to stop; B teaches that the feeling is irrelevant and unheard, and adds no capability; C matches challenge to current capacity and moves it. Learners often defend B as character-building — take that seriously and let the room work out why it fails.
+- **Source:** [PEDAGOGICAL], applying Ch. 14
+
+---
+
+### Slide 283 — What This Module Does Not License
+
+- **Purpose:** Prevent the module's characteristic misuse.
+- **On the slide:** ✕ Explaining an adult by their childhood · ✕ Diagnosing anyone's parenting from one interaction · ✕ Concluding that anything is fixed / ✓ Understanding a mechanism, and knowing what the evidence supports
+- **Visual:** L3. Three struck-through rows and one in blue.
+- **Explain:** The first is the most common misuse of this whole literature. The evidence is correlational and describes patterns across populations; it does not license retrospective explanation of any individual, including oneself.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 284 — Module 15 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Four styles: ignoring, laissez-faire, contemptuous, coaching · 2 · Coaching: notice, name, legitimise, then help · 3 · The same four operate at work · 4 · Seven ingredients of readiness · 5 · Temperament is real and physiologically grounded · 6 · **Emboldening: firm, graded expectation changes it** · 7 · Shaping is stated; windows are inferred · 8 · Behavioural change shows in the brain
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 12, 14 · [SOURCE]
+
+---
+
+### Slide 285 — Knowledge Check: Module 15
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · Name the four styles. 2 · Name four of the seven ingredients. 3 · What was the emboldening finding? 4 · Distinguish stated from inferred on critical windows. 5 · Why is "the first three years determine everything" unsafe?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 15)
+- **Notes:** [CORE] · 8 min. Items 4 and 5 are the evidential-discipline items and are directly assessed at SA5(a).
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+### Slide 286 — What Changes, and What Does Not
+
+- **Purpose:** Set up Module 16's central finding, and give the development plan its realistic frame.
+- **On the slide:** The trigger tends to persist. **The response can change.** / That is not a disappointing result. It is what the evidence supports — and it is enough.
+- **Visual:** L4. Two curves over time: trigger frequency roughly flat; response quality improving.
+- **Explain:** Point forward explicitly to Luborsky. This is the frame the Personal Development Assignment requires, and a plan built on any other frame will be referred.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** Ch. 13 · [SOURCE] preview
+
+---
+
+### Slide 287 — Block Transition
+
+- **Purpose:** Close the development block, and prepare the room for the course's most sensitive material.
+- **On the slide:** Two modules remain. / One asks what happens when emotional learning goes badly wrong. / One asks whether any of this is true.
+- **Visual:** L4. The map from slide 6 with the final two blocks lit.
+- **Explain:** Say what is coming and why it is framed the way it is. Module 16's safety framing will be delivered verbatim; learners should know in advance that it is coming and that it is not a formality.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Session boundary. Do not begin Module 16 at the end of a session — it needs a full session opening, with the framing block delivered first.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+*End of G3. Slides 288–343 (Modules 16–17, the Evidence file and the closing block) continue in G4.*

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-4-06_Slides_288-343_Trauma_Scrutiny_Close.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-4-06_Slides_288-343_Trauma_Scrutiny_Close.md
@@ -1,0 +1,815 @@
+# SLIDE BLUEPRINT — TRAUMA, SCRUTINY, EVIDENCE AND CLOSE
+## Slides 288–343 — Modules 16–17, the evidence block and the closing session
+
+**Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**
+
+---
+
+# BLOCK 17 — MODULE 16: TRAUMA, EMOTIONAL MEMORY AND EMOTIONAL RELEARNING (Slides 288–301)
+
+> **Instructor requirement for this block.** Slides 288 and 270 are delivered **verbatim**, at the opening of a session, before any other content. They are not a preamble to be summarised or skipped when running short. If there is not time to deliver them properly, there is not time to teach this module.
+
+---
+
+### Slide 288 — Module 16: Before We Begin
+
+- **Purpose:** Deliver the mandatory safety framing before any trauma content.
+- **On the slide:** *This module is taught as academic understanding. It is not treatment. Nothing here is a technique to use on yourself or on anyone else. Do not use this material on yourself.*
+- **Visual:** L1. The framing text alone, boxed, amber. No module title, no decoration, nothing else on the slide.
+- **Explain:** Read it aloud, exactly as written. Then say why, in your own words: this is material about how severe experience alters the systems the course has been describing. Understanding that is legitimate academic content. Applying it — deliberately approaching one's own traumatic material — is a clinical procedure, and its safety depends on assessment, containment and continuity of care that no classroom provides.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. Deliver at the start of a session, never mid-session. Give the referral pathway now, in writing, and leave it visible for the whole session. Confirm that participation is voluntary and that anyone may leave without explanation.
+- **Source:** [PEDAGOGICAL] — mandatory framing
+
+---
+
+### Slide 289 — What This Module Is, and Is Not
+
+- **Purpose:** Complete the framing with the operational rules.
+- **On the slide:** **THIS SESSION IS** · understanding a mechanism · knowing where the boundary is · knowing what help looks like // **THIS SESSION IS NOT** · processing anything · a protocol · practice on each other
+- **Visual:** L3. Two columns, the right-hand one bounded in amber.
+- **Explain:** State the three rules for the session explicitly. No role-play of any material in this module — this is the one module where the rewind convention is not sufficient protection and role-play is prohibited outright. No personal examples, including the instructor's. No discussion of anyone's history, in the room or afterwards in pairs.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. The role-play prohibition is absolute and applies to the Case Study Book's trauma, violence and abuse cases as well. State it as a rule of the room, not as a suggestion.
+- **Source:** [PEDAGOGICAL] — mandatory framing
+
+---
+
+### Slide 290 — What Makes an Event Traumatic
+
+- **Purpose:** Deliver the source's central finding on this material.
+- **On the slide:** Not the severity alone. / **Uncontrollability** — the sense of being helpless in the face of it — is the decisive factor.
+- **Visual:** L3. Two events of similar severity, differing in whether any action was available.
+- **Explain:** The source's account is that what determines lasting effect is not how bad the event was in absolute terms but whether the person could do anything. Two people in the same event, one able to act and one entirely helpless, are at very different risk. This is why events that look mild from outside can leave lasting marks, and why the question "why did that affect them so much?" is usually the wrong question.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at the module knowledge check, item 2. Do not invite examples.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 291 — Three Systems Altered
+
+- **Purpose:** Give the mechanism, which is the module's legitimate academic content.
+- **On the slide:** **CATECHOLAMINE SYSTEM** → hyperarousal, startle, hypervigilance · **CRF / STRESS-HORMONE SYSTEM** → altered stress response · **OPIOID SYSTEM** → numbing, flattening, detachment
+- **Visual:** L3. Three rows: system, alteration, what the person experiences.
+- **Explain:** The source describes lasting changes across these systems following overwhelming experience. The third row is the one that makes the clinical picture comprehensible: the same person can be both hyper-reactive and numb, which looks contradictory from outside and is not — they are two systems altered in different directions.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Teach as mechanism. Do not translate into "so if you notice this in yourself…" — that is the boundary.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 292 — Failed Extinction
+
+- **Purpose:** Explain why the alarm does not switch off, connecting back to Module 3.
+- **On the slide:** Normally, a fear response fades with safe re-exposure. / In trauma, **that process does not complete.** The alarm keeps firing where there is no danger.
+- **Visual:** L4. Two extinction curves: one decaying to baseline; one failing to decay.
+- **Explain:** Extinction is the ordinary process by which a learned fear weakens when the feared thing repeatedly turns out to be safe. The source describes this process failing — the amygdala's learning persists in a form that does not update. Connect it back to slide 46's out-of-date alarm: this is that mechanism, at an extreme, and no longer correcting itself.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 293 — Why "Just Face It" Is Dangerous Advice
+
+- **Purpose:** Convert the mechanism directly into the reason for the boundary.
+- **On the slide:** If extinction has failed, naive re-exposure does not weaken the response. / It can **strengthen** it. / This is why the procedure requires a clinician, and why this course does not teach it.
+- **Visual:** L2. Two exposure routes: a structured clinical one leading to reduction; an unstructured one leading to reinforcement.
+- **Explain:** This is the answer to the question the room is holding — why can't we do the useful part? Because the useful part is a graded, contained procedure, and doing it wrong makes the thing worse. The boundary is not institutional caution. It is a statement about what the mechanism does when the procedure is done badly.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at SA5(b), whose second mark requires a substantive reason for the boundary rather than a restatement of it. This slide supplies it.
+- **Source:** Ch. 13 · [SOURCE], framing [PEDAGOGICAL]
+
+---
+
+### Slide 294 — Relearning
+
+- **Purpose:** Deliver the recovery mechanism as knowledge.
+- **On the slide:** Recovery involves **relearning** — new emotional learning laid down alongside the old, under conditions of safety and control. / The old learning is not deleted.
+- **Visual:** L2. An original pattern with a second pattern established beside it, not replacing it.
+- **Explain:** This is why recovery is not erasure, and why anniversaries and unexpected cues can still produce a reaction in someone who has recovered well. The new learning is real and it competes with the old rather than removing it. Note the two conditions: safety and control — control being precisely what was absent when the original learning occurred.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 295 — A Clinician's Model
+
+- **Purpose:** Present Herman's stages as what they are — a professional framework, encountered as knowledge.
+- **On the slide:** **Herman's three stages:** establishing safety · recounting and mourning · reconnection / *This is a clinician's model, presented here as knowledge. It is not a sequence for anyone in this room to run.*
+- **Visual:** L4. Three stages, with a full-width [PEDAGOGICAL] caution bar beneath.
+- **Explain:** Deliver the model, and deliver the qualification with it. Note in particular that stage one is not preliminary — establishing safety is the substantive work, often the longest part, and any attempt to move to stage two before it is complete is where harm occurs. That fact alone should indicate why this is not a classroom procedure.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. The caution bar must be on the built slide, not only in the instructor's mouth.
+- **Source:** Ch. 13 · [SOURCE] — Herman
+
+---
+
+### Slide 296 — What Changed, and What Did Not
+
+- **Purpose:** Deliver Luborsky's finding, which sets the realistic frame for the whole course.
+- **On the slide:** After therapy: **how people reacted** to their characteristic emotional flashpoints changed. · **What triggered them** largely persisted.
+- **Visual:** L3. Two rows: the trigger, unchanged; the response, changed.
+- **Explain:** This is one of the most useful findings in the book and one of the least quoted. It sets the realistic target for any emotional development: not a different self, and not the disappearance of the things that get to you, but a different response to them. Anyone promising more than that — including any training course — is promising something the evidence does not support.
+- **Discuss:** "Is that a disappointing result?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at the module knowledge check, item 5, and it is the criterion against which the Personal Development Assignment's success criteria are judged. The answer to the discussion question is worth landing: it is only disappointing against an expectation nobody should have had.
+- **Source:** Ch. 13 · [SOURCE] — Luborsky
+
+---
+
+### Slide 297 — Recovery Time
+
+- **Purpose:** Give the source's own marker of emotional maturity.
+- **On the slide:** *"one mark of emotional maturity"* — how quickly you come back.
+- **Visual:** L4. The two decay curves from slide 135, repeated.
+- **Explain:** Deliberate repetition of Module 7's measurement slide. The same marker that measures ordinary emotional management is the one the source uses at the far end of the spectrum. That continuity is the point: this module is not a different subject, it is the same mechanisms under extreme load.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 298 — What a Non-Clinician Can Do
+
+- **Purpose:** Give the room something legitimate and useful, rather than only prohibitions.
+- **On the slide:** Notice · Not require an account · Not press for detail · Say plainly that support exists · **Know the referral pathway before you need it** · Keep treating them as a colleague, not a case
+- **Visual:** L3. Six actions, each with what it avoids.
+- **Explain:** Every one of these is available to anyone and none of them is treatment. The fifth is the one that fails in practice — people find out where to refer someone while the person is in front of them, which is too late. The sixth is the one people most often get wrong with the best intentions: sustained careful handling communicates that the person is now fragile.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. This is the slide the room actually needs. Give it proper time.
+- **Source:** [PEDAGOGICAL], with Ch. 13
+
+---
+
+### Slide 299 — What a Non-Clinician Must Not Do
+
+- **Purpose:** State the prohibitions explicitly.
+- **On the slide:** ✕ Ask what happened · ✕ Encourage anyone to "get it out" · ✕ Interpret anyone's history · ✕ Use any technique from this module on anyone · ✕ Diagnose
+- **Visual:** L3. Five struck-through rows, amber.
+- **Explain:** The second is the one that comes from good intentions and Module 7 has already shown why it fails in ordinary anger; here the stakes are far higher. The third is the one that comes from having done a course — this course — and is the specific risk this module creates.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Say the third item plainly: the danger of teaching this material is that it produces confident amateurs. Naming that risk to the room is part of managing it.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 300 — Module 16 Summary
+
+- **Purpose:** Consolidate, within the frame.
+- **On the slide:** 1 · Academic understanding, not treatment · 2 · Uncontrollability is decisive · 3 · Three systems altered — hyperarousal, stress response, numbing · 4 · Failed extinction: the alarm does not update · 5 · Relearning adds; it does not delete · 6 · Herman's stages are a clinician's model · 7 · **Luborsky: the response changes, the trigger persists** · 8 · Recovery time is the marker
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 301 — Knowledge Check: Module 16
+
+- **Purpose:** Formative check, in written form only.
+- **On the slide:** 1 · State the framing rule. 2 · What single factor is decisive? 3 · Name the three altered systems. 4 · What is failed extinction? 5 · What did Luborsky's finding show?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Collect written answers; do **not** run this as a rapid cold-call chain.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 16)
+- **Notes:** [CORE] · 10 min. Written format is a requirement, not a preference — the subject matter warrants a lower-arousal format and no learner should be put on the spot in this session. Close the session by restating the referral pathway.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 18 — MODULE 17: EMOTIONAL LITERACY, ETHICS AND EI UNDER SCRUTINY (Slides 302–319)
+
+---
+
+### Slide 302 — Module 17: Can This Be Taught — and Is It True?
+
+- **Purpose:** Open the module that decides whether the course was worth taking.
+- **On the slide:** MODULE 17 · Emotional Literacy, Ethics and EI Under Scrutiny / *Two questions: can it be taught, and should we believe it?*
+- **Visual:** L1. Divider.
+- **Explain:** Say what the module does. The first half asks what the evidence says about teaching these skills — which is also a verdict on the course the room has just taken. The second half turns on the framework itself.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 15, 16, Appendices D–F · [SOURCE]
+
+---
+
+### Slide 303 — Information Is Not Enough
+
+- **Purpose:** Deliver the finding that governs all programme design, including this one.
+- **On the slide:** Prevention programmes that conveyed **information alone** produced little behavioural change. / What worked involved **rehearsed skills.**
+- **Visual:** L3. Two programme types with their outcomes.
+- **Explain:** The source reports this from the sexual-abuse prevention literature: children who could correctly state the rules were not thereby able to act on them. Knowing and doing came apart. The programmes that changed behaviour had children practise — saying the words, in a role, repeatedly.
+- **Discuss:** "What does this say about a one-day training course?"
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at the module knowledge check and at Case-Study Question 2(b). The discussion question implicates the course itself if it is being delivered as a one-day corporate session — say so. It is more credible than pretending otherwise.
+- **Source:** Ch. 15 · [SOURCE]
+
+---
+
+### Slide 304 — What a Consortium Recommended
+
+- **Purpose:** Deliver the W. T. Grant list as the source's own account of good design.
+- **On the slide:** Emotional skills · Cognitive skills · Behavioural skills — taught together, over years, embedded in ordinary school life
+- **Visual:** L3. Three skill categories with examples in each.
+- **Explain:** Appendix D's list, summarised. The structural point matters more than the contents: the recommendation is for integration across the curriculum and across years, not a unit or a module. Which is a direct verdict on how such programmes are usually purchased.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min.
+- **Source:** Appendix D · [SOURCE]
+
+---
+
+### Slide 305 — Self Science
+
+- **Purpose:** Give the source's worked example of a curriculum.
+- **On the slide:** A curriculum in which **the material is the children's own experience** — what happened at break, the argument yesterday, the feeling now.
+- **Visual:** L4. A lesson structure: an actual incident → naming → analysis → alternative → practice.
+- **Explain:** The design principle is that the content arrives from the room. That solves the transfer problem which defeats most emotional training — the skills are practised in the situation they are for, rather than in a simulation of it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 5 min. Note the tension with this course's own rule against using learners' live conflicts. The difference is supervision, age and continuity — a school with a trained teacher and a year of sessions is a different container from a two-day workshop. Say so if asked; the tension is real.
+- **Source:** Appendix E · [SOURCE]
+
+---
+
+### Slide 306 — Does It Work?
+
+- **Purpose:** Report the source's outcome data and its limitations together.
+- **On the slide:** Appendix F reports improvements: behaviour, conflict, attainment. / **Mostly uncontrolled. Often small. Frequently evaluated by people connected to the programme.**
+- **Visual:** L3. Two columns: what was reported / what the evaluations could not establish.
+- **Explain:** The reported outcomes are encouraging and the evaluations are weak, and both statements are true at once. This is the standard situation in programme evaluation and it is not a reason to dismiss the results — it is a reason to hold them provisionally. the Evidence file gives the stronger later evidence, which is genuinely better.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at SA3(b) in spirit. Model the two-handed judgement rather than resolving it in either direction.
+- **Source:** Appendix F · [SOURCE-QUALIFIED]
+
+---
+
+### Slide 307 — Six Design Principles
+
+- **Purpose:** Give the transferable rules, which the room can apply to any programme.
+- **On the slide:** 1 · Start early, continue over years · 2 · Embed across the curriculum, do not bolt on · 3 · Practise skills, do not transmit facts · 4 · Teach in the moment, in real situations · 5 · Involve the whole environment · 6 · Sustain — a one-off does not work
+- **Visual:** L5. Six numbered principles.
+- **Explain:** These are derived from Appendices D–F rather than stated as a list in the source; the footer says so. They are the evaluative instrument for Case-Study Question 2(b), and they are the instrument for judging anything the room is ever sold.
+- **Discuss:** "Score a programme you have been through against these six."
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Most learners score their own prior training at one or two out of six, which is a useful and slightly bruising result.
+- **Source:** Appendices D–F · [PEDAGOGICAL] derivation
+
+---
+
+### Slide 308 — What a Bad Programme Looks Like
+
+- **Purpose:** Make the principles diagnostic.
+- **On the slide:** An external speaker · One day · A questionnaire producing a score · A poster · A follow-up in twelve months
+- **Visual:** L3. Five features, each with the principle it violates.
+- **Explain:** Every element is chosen because it is deliverable and demonstrable rather than because it works. A school or company under pressure after a bad year is often buying evidence of having acted, and this design is what that purchase looks like.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Direct rehearsal of Case-Study Question 2(b). Do not use the assessment's exact case here if setting that paper unchanged.
+- **Source:** [PEDAGOGICAL], applying Appendices D–F
+
+---
+
+### Slide 309 — Now the Harder Question
+
+- **Purpose:** Turn the course on itself.
+- **On the slide:** Everything so far has assumed the framework is sound. / **Is it?**
+- **Visual:** L7. Question alone.
+- **Explain:** Say what the next eight slides do and why they exist. A course that taught this framework for fifteen modules and then asked no hard questions about it would have trained belief rather than understanding.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 310 — Can It Be Measured?
+
+- **Purpose:** Open the measurement problem.
+- **On the slide:** Ability tests score performance against a criterion. **What is the right answer to an emotion question?** / Self-report measures self-description. / The instruments correlate poorly with each other.
+- **Visual:** L3. Three approaches with the problem attaching to each.
+- **Explain:** The scoring problem is the deep one: an ability test needs a correct answer, and the available criteria — expert judgement, or majority consensus — are both contestable. Self-report avoids that and measures something else, namely how people describe themselves. And the fact that instruments built on these different bases do not agree with each other is not a technical wrinkle; it means "emotional intelligence" is naming more than one thing.
+- **Discuss:** "If two tests of the same thing disagree, what follows?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at Case-Study Question 2(c) and (d). Full detail is in the the Evidence file block at slides 323–325.
+- **Source:** [EXTERNAL], detail in the Evidence file
+
+---
+
+### Slide 311 — Is It Distinct?
+
+- **Purpose:** Put the discriminant-validity objection.
+- **On the slide:** Much of what "emotional intelligence" describes overlaps with **established personality dimensions** and with general intelligence. / The question is what is left when you remove them.
+- **Visual:** L2. Overlapping circles: personality, IQ, and EI, with the non-overlapping region marked as the contested territory.
+- **Explain:** This is the most serious academic objection, particularly to mixed models that bundle traits like optimism, persistence and sociability. If those are substantially captured by existing measures, the new construct may be adding a name rather than a variable. The question is empirical and it has an answer, which slide 325 gives.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 312 — How Strong Is the Evidence?
+
+- **Purpose:** Give an honest overall assessment.
+- **On the slide:** STRONGER — that these capacities differ between people; that they can be improved; that structured school programmes produce measurable gains · WEAKER — that the construct is unitary; that it predicts strongly beyond personality and IQ; that gains transfer and persist
+- **Visual:** L3. Two columns.
+- **Explain:** Neither column is empty and that is the honest position. The course is not built on nothing, and it is not built on what the popular literature claims it is built on.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Assessed at Case-Study Question 2(d), where the third mark requires exactly this two-handed position.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 313 — Can It Be Developed?
+
+- **Purpose:** Answer the question the whole course depends on.
+- **On the slide:** **This is the best-supported claim in the field.** / The emboldening finding · behavioural treatment producing neural change · SEL meta-analytic results · Luborsky
+- **Visual:** L3. Four evidence lines converging on one conclusion.
+- **Explain:** Of everything the course has claimed, this is the one that survives scrutiny best. Note what it does and does not license: that the capacities respond to training, not that any particular course produces a specified improvement in a specified time.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Important placement — the room needs to know that the sceptical block is not a demolition.
+- **Source:** Ch. 13, 14 · [SOURCE] and [EXTERNAL]
+
+---
+
+### Slide 314 — Can It Be Misused?
+
+- **Purpose:** Bring the ethics thread to a head.
+- **On the slide:** Reading people accurately makes you better at helping them **and** better at using them. / There is research on precisely this.
+- **Visual:** L2. One capacity with two divergent applications.
+- **Explain:** The empirical work — Côté and colleagues, covered at slide 330 — found emotional ability associated with manipulative behaviour among people with self-serving motives. Which is what the whole course has implied since slide 174 and now has evidence behind it: the abilities are instrumental, and they amplify whatever the person is already trying to do.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 315 — Emotionally Intelligent and Morally Bad?
+
+- **Purpose:** Pose the question the course has refused to answer, and refuse again for the last time.
+- **On the slide:** *Can someone be highly emotionally intelligent and a bad person?*
+- **Visual:** L7. Question alone.
+- **Explain:** Give the two positions. One: yes, obviously — the skills are capacities, ethics is a separate matter, and the cold, controlled abuser in the source's own material is the standing counter-example. Two: no — properly understood, the domains include registering others as people with interests, and someone who reads others purely instrumentally has failed at empathy rather than mastered it. Note that the second position is achieved by definition, which is a cost. Do not adjudicate.
+- **Discuss:** "Take a position and defend it for two minutes against someone who took the other."
+- **Activity:** **E13 — The Ethics Panel** (Activity Book)
+- **Notes:** [CORE] · 20 min with the activity. The course's position is that this is genuinely unresolved and that the resolution most people reach — defining ethics into the construct — is a move worth noticing rather than a discovery. The assessment rewards holding the tension.
+- **Source:** [PEDAGOGICAL], with Ch. 7, 9 and [EXTERNAL]
+
+---
+
+### Slide 316 — The Verdict Sheet
+
+- **Purpose:** Have learners produce their own assessment rather than receive one.
+- **On the slide:** *(three empty columns)* **WELL SUPPORTED** · **PLAUSIBLE, UNDER-EVIDENCED** · **OVERSTATED OR WRONG**
+- **Visual:** L3. A blank three-column table, filled in live from the room.
+- **Explain:** Take claims from the whole course and let the room place them. Seed it with two or three if it stalls — the eight emotion families, the 80 per cent claim, the trainability claim.
+- **Discuss:** "Where does each of the course's central claims go?"
+- **Activity:** **E11 — The Three-Column Verdict** (Activity Book)
+- **Notes:** [CORE] · 20 min. The instructor's completed version is in the Evidence file and is a reference, not an answer key. Where the room disagrees with it and argues well, the room is doing the thing the course was for.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 317 — Two Ways to Get This Wrong
+
+- **Purpose:** Name both failure modes, so scepticism does not collapse into dismissal.
+- **On the slide:** **THE BELIEVER** — takes the popular claims as established, sells the questionnaire, quotes the 80 per cent · **THE DISMISSER** — notices the over-claiming and concludes there is nothing here / *Both have stopped reading at the same point.*
+- **Visual:** L3. Two columns.
+- **Explain:** The dismisser's error is the more sophisticated-looking and it is equally wrong: the underlying capacities are real, measurable in some form, consequential, and trainable. The correct position is more work than either, which is why fewer people hold it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. Case-Study Question 2(d) fails both of these identically. Say so.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 318 — Module 17 Summary
+
+- **Purpose:** Consolidate.
+- **On the slide:** 1 · Information is not enough — skills need rehearsal · 2 · Effective programmes are embedded, sustained, practised · 3 · Six design principles · 4 · Measurement is genuinely unsettled · 5 · Distinctness from personality and IQ is contested · 6 · Trainability is the best-supported claim · 7 · The abilities are instrumental and can be misused · 8 · Belief and dismissal fail the same way
+- **Visual:** L8.
+- **Explain:** —
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min.
+- **Source:** Ch. 15, 16, Appendices D–F · [SOURCE] and [EXTERNAL]
+
+---
+
+### Slide 319 — Knowledge Check: Module 17
+
+- **Purpose:** Formative check.
+- **On the slide:** 1 · What does "information is not enough" refer to? 2 · Name three design principles. 3 · What does Appendix F offer and what is its limitation? 4 · Give the strongest critique of the construct. 5 · Can someone be emotionally intelligent and morally bad — and what is the course's position?
+- **Visual:** L7.
+- **Explain:** —
+- **Discuss:** Take answers aloud.
+- **Activity:** Knowledge Check (the Assessment Bank (formative checks), Module 17)
+- **Notes:** [CORE] · 8 min. Item 5 has no single correct answer; assess the quality of the argument.
+- **Source:** the Assessment Bank (formative checks) · [PEDAGOGICAL]
+
+---
+
+# BLOCK 19 — CONTEMPORARY EVIDENCE AND CRITIQUES (Slides 320–335)
+
+> **Delivery note.** This block is drawn entirely from the Evidence file. Every slide carries [EXTERNAL] and every citation is given on the built slide with author, year and outlet. This block may be dropped for a short corporate course — but if it is, Module 17's sceptical slides (290–298) must be retained, or the course has taught a contested framework as settled.
+
+---
+
+### Slide 320 — Everything From Here Is External
+
+- **Purpose:** Mark the transition unambiguously.
+- **On the slide:** **[EXTERNAL]** / Nothing in this block is from the source. It is research published since, and it is cited.
+- **Visual:** L1. The [EXTERNAL] marker at full slide width.
+- **Explain:** Explain why the course withheld this until now: to establish what the source actually says before layering thirty years of subsequent work on top of it. That order is what makes it possible to see where the book was right, where it over-reached, and where the field went afterwards.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 321 — One Name, Three Constructs
+
+- **Purpose:** Deliver the field's central conceptual division.
+- **On the slide:** **ABILITY EI** — a set of cognitive abilities, measured by performance · **TRAIT EI** — a constellation of self-perceptions, measured by self-report · **MIXED MODELS** — abilities plus traits plus competencies, commercially dominant
+- **Visual:** L3. Three columns.
+- **Explain:** These are not three measures of one thing. They are three different constructs sharing a name — different in what they claim to measure, in how they measure it, and in what they predict. Most confusion in the field, and nearly all of it in the popular literature, comes from evidence for one being cited in support of another.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Referenced at Case-Study Question 2(d).
+- **Source:** [EXTERNAL] — Mayer, Salovey & Caruso; Petrides & Furnham
+
+---
+
+### Slide 322 — The Three Compared
+
+- **Purpose:** Give the reference table.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| | Ability EI | Trait EI | Mixed |
+| --- | --- | --- | --- |
+| **What it claims to be** | A cognitive ability | A personality-level disposition | A competency profile |
+| **Measured by** | Performance tasks (MSCEIT) | Self-report (TEIQue) | Self- and multi-rater inventories |
+| **Relates most to** | General intelligence | Established personality dimensions | Both, plus job-competency frameworks |
+| **Main objection** | Scoring criteria are contestable | Substantially overlaps existing personality measures | Bundles distinct things; commercially driven |
+| **Where the source sits** | Closest in origin — Salovey and Mayer | — | Closest in popular reception |
+
+- **Explain:** The bottom row is the one that matters for this course. The book's framework derives from the ability tradition and was received into the mixed tradition. Which is a large part of why the popular version of "emotional intelligence" is not the book's.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Print as a handout.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 323 — The Instruments
+
+- **Purpose:** Name the principal measures precisely.
+- **On the slide:** **MSCEIT** — Mayer–Salovey–Caruso Emotional Intelligence Test. Performance-based. Scored against expert or consensus criteria. · **TEIQue** — Trait Emotional Intelligence Questionnaire. Self-report.
+- **Visual:** L3. Two columns with what each asks a respondent to do.
+- **Explain:** Give one example item type from each so the difference is concrete: the MSCEIT asks a respondent to identify the emotion in a face or judge which action would best manage a described situation; the TEIQue asks how strongly they agree that they generally handle such situations well. Those are not the same question.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [SUPPORTING] · 6 min.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 324 — Do They Agree?
+
+- **Purpose:** Deliver the finding with the largest implication.
+- **On the slide:** Ability and trait measures correlate **weakly.** / Two people can be high on one and low on the other. / **So "high EI" is not a fact about a person until you say which instrument.**
+- **Visual:** L2. A scatter showing weak association between two measures of the supposedly same construct.
+- **Explain:** This is the single most consequential finding for anyone being sold an assessment. It also explains why the literature appears contradictory — studies using different instruments are studying different variables. And it is why the schools case in the assessment is not merely badly implemented but conceptually confused.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Case-Study Question 2(c)'s first mark.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 325 — Incremental Validity
+
+- **Purpose:** Answer the distinctness question with what the evidence shows.
+- **On the slide:** Ability EI shows **modest but real** incremental prediction of outcomes beyond IQ and personality. / Trait and mixed measures show less once personality is controlled.
+- **Visual:** L3. Predictive contribution shown as layered bars: IQ, personality, then the increment.
+- **Explain:** "Modest but real" is the honest phrase and it is worth defending in both directions. It is not nothing — the increment survives controls in meta-analytic work, particularly for job performance. It is not the dominant factor the popular literature describes. The gap between "modest but real" and "80 per cent" is where an entire industry sits.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Assessed at Case-Study Question 2(d).
+- **Source:** [EXTERNAL] — Joseph & Newman; O'Boyle et al.
+
+---
+
+### Slide 326 — Where It Predicts Best
+
+- **Purpose:** Give the moderator that makes the evidence coherent.
+- **On the slide:** EI predicts performance **most strongly in jobs with high emotional demands.** / Care, sales, teaching, negotiation, front-line service. / Much less in low-emotional-labour roles.
+- **Visual:** L4. Predictive strength plotted against emotional demand of the role.
+- **Explain:** This resolves much of the apparent inconsistency in the literature — the effect is moderated by the job. It also has a direct practical implication: an organisation selecting on EI for a role with low emotional demand is selecting on something that does not predict performance there.
+- **Discuss:** "Which roles in your organisation are high on this axis?"
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. One of the most useful slides in the block for corporate audiences.
+- **Source:** [EXTERNAL] — Joseph & Newman
+
+---
+
+### Slide 327 — Social and Emotional Learning
+
+- **Purpose:** Deliver the strongest body of evidence in the field.
+- **On the slide:** Meta-analytic evidence across hundreds of school programmes: improvements in social and emotional skills, behaviour, and **academic attainment.** / With follow-up evidence of persistence.
+- **Visual:** L3. Outcome domains with direction and rough magnitude.
+- **Explain:** This is the field's best evidence and it is considerably stronger than anything in the source's own appendices. Note the attainment finding, which is the one that changes institutional decisions — a programme that improves behaviour is a nice-to-have; one that improves attainment is not.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 7 min. Case-Study Question 2(d)'s first mark. Attach the standard qualification: effects vary substantially by implementation quality, which is exactly what the six design principles predict.
+- **Source:** [EXTERNAL] — Durlak et al.; Taylor et al.
+
+---
+
+### Slide 328 — Psychological Safety
+
+- **Purpose:** Give the modern successor to the group IQ claim.
+- **On the slide:** **Psychological safety** — the shared belief that the group is safe for interpersonal risk-taking — is among the more robust predictors of team learning and performance.
+- **Visual:** L2. A team with the flow of information under two conditions.
+- **Explain:** This is the concept that took up the question the source raised as group IQ, and it has been studied far more rigorously. Note the convergence: what predicts team performance is whether people can say difficult things, which is precisely slide 237's correction of what workplace EI is for.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Strong slide for professional audiences. It shows the source's intuition being vindicated by a literature it did not produce.
+- **Source:** [EXTERNAL] — Edmondson
+
+---
+
+### Slide 329 — Emotion Regulation, Modelled
+
+- **Purpose:** Give the modern framework that formalises Module 7.
+- **On the slide:** **Situation selection → situation modification → attentional deployment → cognitive change → response modulation** / Earlier strategies are generally more effective than later ones.
+- **Visual:** L4. Five points along a timeline, mapped against the A–G map from slide 129.
+- **Explain:** Gross's process model. Show it beside the course's own TRIGGER→CONSEQUENCE map: they are the same shape, arrived at independently, and the convergence is a point in favour of both. Note the empirical finding attached — reappraisal, which sits early, generally outperforms expressive suppression, which sits at the end. That is Module 7's central claim, in a better-evidenced form.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. The best single demonstration in the course that the source's practical claims have survived the intervening decades in some form.
+- **Source:** [EXTERNAL] — Gross
+
+---
+
+### Slide 330 — The Dark Side, Evidenced
+
+- **Purpose:** Give the ethics thread its empirical anchor.
+- **On the slide:** Emotional ability has been found associated with **manipulative behaviour** among individuals with self-serving motives. / The capacity amplifies the motive.
+- **Visual:** L2. One ability with two outcomes, conditioned on motive.
+- **Explain:** Côté and colleagues' finding. This is what makes slide 315's question empirical rather than merely philosophical: the abilities do not come with a direction, and in the presence of self-serving motives they make the person more effective at self-serving ends.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Referenced throughout the course; deliver it properly here.
+- **Source:** [EXTERNAL] — Côté et al.
+
+---
+
+### Slide 331 — What Did Not Replicate
+
+- **Purpose:** Correct the specific claims the course has flagged along the way.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| Claim in the source | What happened since |
+| --- | --- |
+| Marshmallow test predicts life outcomes | Effect substantially attenuated with controls for background; trust in the promise matters |
+| Support groups extend cancer survival | Survival effect has not consistently replicated; quality-of-life benefits are better supported |
+| Each emotion has a distinct biological signature | Discrete autonomic signatures have proved hard to demonstrate reliably; constructionist accounts contest the premise |
+| Strong critical windows for emotional capacities | Plasticity is better established than sharply bounded windows |
+
+- **Explain:** Four corrections, each already flagged in the module where the claim appeared. Note what this table is not: it is not a demolition of the book. It is what happens to any thirty-year-old synthesis, and the honest response is to update rather than to defend or discard.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. The most important table in the block. Assessed at Case-Study Question 2(a) and (d).
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 332 — The Four Critiques
+
+- **Purpose:** Assemble the objections in their strongest form.
+- **On the slide:** 1 · **Conceptual** — the term names several different constructs · 2 · **Psychometric** — instruments disagree; ability scoring is contestable · 3 · **Discriminant** — much is covered by existing personality measures · 4 · **Commercial** — claims sold vastly exceed evidence
+- **Visual:** L5. Four quadrants.
+- **Explain:** Deliver each at full strength rather than as a straw version. The fourth is not academic but it is the one that has done most damage: it produced the 80 per cent claim, the unvalidated instruments, and the general public impression that the field is soft.
+- **Discuss:** "Which of the four, if any, would change what you do on Monday?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Assessed at Case-Study Question 2(d)'s second mark.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 333 — What the Literature Does and Does Not Support
+
+- **Purpose:** Give the block's summary judgement.
+- **On the slide:** *(the table carries it)*
+- **Visual:** L3.
+
+| Supported | Not supported |
+| --- | --- |
+| People differ reliably in these capacities | That "EI" is a single unified construct |
+| The capacities can be developed | That any instrument measures it definitively |
+| Ability EI adds modestly beyond IQ and personality | That it dominates prediction of success |
+| Effects are larger in emotionally demanding roles | That it predicts equally across all roles |
+| Structured SEL programmes work | That short adult courses produce lasting measurable change |
+| Reappraisal generally outperforms suppression | That specific techniques work for everyone |
+
+- **Explain:** Read the right-hand column carefully — including the fifth row, which is a claim about courses like this one. The honest position is that this course teaches a framework and a set of practices that have reasonable grounding, and that whether it changes anything depends on what the learner does over the following months.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. Print as a handout.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 334 — Where to Read Next
+
+- **Purpose:** Enable independent checking, which is the block's whole purpose.
+- **On the slide:** Mayer, Salovey & Caruso — the ability model · Petrides & Furnham — trait EI · Joseph & Newman; O'Boyle et al. — meta-analyses of workplace prediction · Durlak et al.; Taylor et al. — SEL outcomes · Gross — emotion regulation · Edmondson — psychological safety · Côté et al. — the dark side
+- **Visual:** L3. Author, year and what each is for.
+- **Explain:** Full citations are in the Evidence file's sources section, with links. The point of giving them is that learners can check the course rather than take it on trust — which is the habit the whole thing has been training.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 3 min. Full bibliographic detail must appear on the built slide or on an accompanying handout. Author names alone are not a citation.
+- **Source:** [EXTERNAL]
+
+---
+
+### Slide 335 — The Verdict, Completed
+
+- **Purpose:** Return to slide 316's table and complete it with the block's evidence.
+- **On the slide:** *(the three columns, now filled)*
+- **Visual:** L3. The learners' version from slide 316 shown beside the reference version from the Evidence file.
+- **Explain:** Compare rather than correct. Where the room's version differs and the reasoning was sound, leave the difference standing and say why you are leaving it.
+- **Discuss:** "What did we get wrong at slide 316, and what did the evidence not settle?"
+- **Activity:** —
+- **Notes:** [CORE] · 8 min. The most satisfying moment in the course if slide 316's version was photographed and kept.
+- **Source:** [EXTERNAL], with the Evidence file
+
+---
+
+# BLOCK 20 — CLOSING (Slides 336–343)
+
+---
+
+### Slide 336 — Where the Source Was Right
+
+- **Purpose:** Give the book its due, specifically.
+- **On the slide:** That emotion is not the opposite of reason · That the machinery can be described · That these capacities can be developed · That how conflict is conducted predicts its outcome · That schools could teach this — and the SEL evidence since supports it
+- **Visual:** L3. Five claims, each with the evidence that has held.
+- **Explain:** After eight slides of scrutiny the room needs this, and it is not consolation — each of these has held up, and several are better supported now than when the book was written.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** [SOURCE] and [EXTERNAL]
+
+---
+
+### Slide 337 — Where It Over-Reached
+
+- **Purpose:** Give the balancing judgement with equal specificity.
+- **On the slide:** Confidence ahead of the evidence in places · A synthesis received as a measurement programme · Findings since qualified, still quoted unqualified · And a reception that produced claims the book does not make
+- **Visual:** L3. Four items, each with an example.
+- **Explain:** Be fair about the last one. Much of what is wrong with the popular understanding of emotional intelligence is not in the book — it was added by the industry that formed around it. That distinction is exactly what slide 5 established on the first morning.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min.
+- **Source:** [SOURCE-QUALIFIED] and [EXTERNAL]
+
+---
+
+### Slide 338 — What You Doubted
+
+- **Purpose:** Close the loop opened at slide 7.
+- **On the slide:** *At the start, you wrote down the claim you found least plausible.* / **Were you right?**
+- **Visual:** L7. Question alone, with the six block claims from slide 7 shown small beneath.
+- **Explain:** Take four or five answers. Both outcomes are good: a doubt that survived is a learner thinking, and a doubt that dissolved is a learner who changed their mind on evidence.
+- **Discuss:** "Did the course change your mind — and what changed it?"
+- **Activity:** Learners retrieve the slip kept from slide 7.
+- **Notes:** [CORE] · 8 min. Requires the slips to have been kept. Remind the room the session before.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 339 — The Question That Stays Open
+
+- **Purpose:** Refuse, finally and explicitly, to resolve the ethics question.
+- **On the slide:** *Can someone be emotionally intelligent and use it badly?* / **This course does not answer this. It has taught you the skills either way.**
+- **Visual:** L1. Text only.
+- **Explain:** Say the uncomfortable thing plainly. Everything in this course — reading people, managing states, shifting a room's mood, delivering a critique that lands — is available for any purpose. The course has not made anyone a better person and could not. What it has done is remove the excuse of not knowing what these techniques do.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This should be the last piece of content before the practical close. Do not soften it with a reassuring line about most people being well-intentioned.
+- **Source:** [PEDAGOGICAL]
+
+---
+
+### Slide 340 — What to Actually Do Now
+
+- **Purpose:** Convert the course into practice.
+- **On the slide:** The check-in, twice a day, for four weeks · One trigger mapped on A–G · One behaviour to stop, one to start, one to strengthen · Recovery time as the measure · **One person who will tell you the truth about it**
+- **Visual:** L3. Five actions with a frequency for each.
+- **Explain:** The last one is the one that decides whether any of this survives contact with a normal month. Self-observation drifts; a person who will say "you did the thing again" does not.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 5 min. This is the Personal Development Assignment in five lines. Point that out.
+- **Source:** [PEDAGOGICAL], with the Development Plan
+
+---
+
+### Slide 341 — What Will Not Happen
+
+- **Purpose:** Set expectations honestly at the point of maximum enthusiasm.
+- **On the slide:** You will not stop being triggered. · You will not remember the techniques in the moment, at first. · You will handle something badly within the fortnight. / **None of that is failure. Recovery time is the measure.**
+- **Visual:** L3. Three struck-through expectations, one line in green.
+- **Explain:** Luborsky again. The end of a course is exactly when people set unrealistic goals, and a plan built on an impossible criterion fails in week three and takes the whole practice with it.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 4 min. This slide prevents more failed development plans than any other.
+- **Source:** Ch. 13 · [SOURCE]
+
+---
+
+### Slide 342 — The Assessment
+
+- **Purpose:** Brief the assessment clearly.
+- **On the slide:** **25 MCQs · 10 scenarios · 5 short answers · 2 unseen cases · 1 development plan** / *Rewarded:* precision, engagement with the specific case, knowing the limits, knowing the provenance · *Not rewarded:* length, emotional language, sympathy for the people in the cases, anything about your own life
+- **Visual:** L3. Two columns.
+- **Explain:** Issue the candidate-facing revision guide from the Assessment Bank, Appendix F-ii. Say explicitly that no question requires personal disclosure and that the self-assessment is not collected.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 6 min. Take questions here rather than leaving them for email.
+- **Source:** the Assessment Bank · [PEDAGOGICAL]
+
+---
+
+### Slide 343 — Aristotle, Again
+
+- **Purpose:** Close where the course opened, with the problem restated as the answer.
+- **On the slide:** *"Anyone can become angry — that is easy. But to be angry with the right person, to the right degree, at the right time, for the right purpose, and in the right way — that is not easy."*
+- **Visual:** L1. The same slide as slide 8, unchanged — same layout, same type, same attribution.
+- **Explain:** Say only this: the course has not made it easy. It has made it describable — which is the difference between a thing that happens to you and a thing you can work on.
+- **Discuss:** —
+- **Activity:** —
+- **Notes:** [CORE] · 2 min. Use the identical slide file as slide 8. The recognition is the entire effect; a redesigned version loses it. Do not add a thank-you slide, a contact slide, or a photograph.
+- **Source:** Prologue · [SOURCE]
+
+---
+
+# APPENDIX G-i — DECK SUMMARY
+
+| Block | Slides | Count | CORE | Content |
+| --- | --- | --- | --- | --- |
+| Front matter | 1–8 | 8 | 7 | Orientation, contract, provenance, the 80% correction |
+| M1 What Emotion Is | 9–24 | 16 | 14 | Definition, families, impulses, Elliot |
+| M2 The Two Minds | 25–38 | 14 | 12 | The gradient, bottom-up growth |
+| M3 The Emotional Sentinel | 39–56 | 18 | 15 | The two routes, associative matching, the two memories |
+| M4 Emotional Hijacking | 57–74 | 18 | 17 | **The two dynamics**, neural static, the A–G precursor |
+| Five domains framework | 75–80 | 6 | 6 | The dependency structure, the comparison table |
+| M5 Knowing One's Emotions | 81–94 | 14 | 12 | Three styles, the check-in, the gap |
+| M6 Managing Emotions | 95–120 | 26 | 24 | Two clocks, ventilation, TRIGGER→CONSEQUENCE |
+| M7 Motivating Oneself | 121–140 | 20 | 17 | Marshmallow + qualifications, explanatory style, flow |
+| M8 Recognising Emotions | 141–160 | 20 | 17 | Levenson, observation/interpretation, the protocol |
+| M9 Handling Relationships | 161–180 | 20 | 16 | Contagion, zeitgeber, the chameleon, Tokyo train |
+| M10 Intimate Relationships | 181–202 | 22 | 20 | Four fault lines, flooding, the two transcripts |
+| M11 At Work | 203–222 | 20 | 19 | Levinson, group IQ, networks, seven situations |
+| M12 Leadership | 223–236 | 14 | 13 | **Constructed and declared** |
+| M13 Health | 237–250 | 14 | 12 | Two rejections, job strain, Spiegel corrected |
+| M14 Development | 251–268 | 18 | 16 | Four styles, emboldening, stated vs inferred |
+| M15 Trauma | 269–282 | 14 | 14 | Framing verbatim, uncontrollability, Luborsky |
+| M16 Scrutiny | 283–300 | 18 | 16 | Information is not enough, the hard questions |
+| the Evidence file block | 301–316 | 16 | 15 | Three constructs, measurement, what did not replicate |
+| Closing | 317–324 | 8 | 8 | Right, over-reached, the open question, Aristotle |
+| **Total** | **1–324** | **324** | **290** | |
+
+**Subsetting.** A one-day course runs approximately 110 slides: front matter, M1 and M3–M6 in reduced form, the framework block, M10 or M11 depending on cohort, and slides 309–317 and 317–324. A two-day course runs approximately 190. The full 324 assumes a semester or a four-to-six-day intensive.
+
+**Four builds are specified in the whole deck** — slides 33, 42, 59 and 97. Everything else is static. That restraint is deliberate: when only four slides move, the movement means something.
+
+---
+
+*End of the Slide Blueprint. the Instructor Guide — the instructor guide — follows.*

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-5-07_Master_Cross_Reference_Register.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-5-07_Master_Cross_Reference_Register.md
@@ -1,0 +1,254 @@
+# MASTER CROSS-REFERENCE REGISTER
+
+**Status: SINGLE SOURCE OF TRUTH.** Every module, outcome, activity, case, assessment and slide reference in this package resolves here.
+
+> **Rule for all future editing.** Any change that touches a module number, an outcome, an activity code, a case number, an assessment item or a slide range **updates this file first**. The package previously carried two module schemes and two outcome sets because no such file existed: each file was internally consistent and nothing held them to each other.
+
+**Generated from the files themselves**, not hand-transcribed. Slide ranges are read from block headers; activity codes and modules from the Activity Book index; case modules from the case index.
+
+---
+
+## 1 · MODULE REGISTRY
+
+| # | Canonical title | Source chapters | Outcomes | Activities | Cases | Assessments | Slides | Module file |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **1** | What Emotions Are and What They Are For | Ch. 1; App. A; Prologue | LO1 | A1–A4 | 2 | MCQ 1–5; SA1; KC1 | 9–24 | `MODULES/01_What_Emotions_Are.md` |
+| **2** | The Two Minds: How the Emotional Brain Is Built | Ch. 2 (opening); Ch. 1 | LO2 | A17–A19 | — | MCQ 6–7; SA2; KC2 | 25–38 | `MODULES/02_The_Two_Minds.md` |
+| **3** | The Emotional Sentinel: Amygdala, Memory and the Two Routes | Ch. 2 (1st half); App. C | LO3 | A5–A8 | 4 | MCQ 8; SA2; Sc1; KC3 | 39–56 | `MODULES/03_The_Emotional_Sentinel.md` |
+| **4** | Emotional Hijacking and the Emotional Manager | Ch. 2 (2nd half); App. B | LO4, LO5 | A9–A12 | 2, 3, 4 | MCQ 9–12; Sc1,2,4; SA3; Case Q1(c); KC4 | 57–74 | `MODULES/04_Emotional_Hijacking.md` |
+| **5** | Intelligence Reconsidered: What Emotional Intelligence Is | Ch. 3 (+ Ch. 4) | LO6, LO7 | A13–A20 | 1, 5 | MCQ 13–14; SA4; Case Q2(a); KC5 | 75–98 | `MODULES/05_Intelligence_Reconsidered.md` |
+| **6** | Knowing Thyself: Self-Awareness | Ch. 4 | LO8 | B1–B5 | 6, 7 | MCQ 15; Sc3; SA4; KC6 | 99–112 | `MODULES/06_Knowing_Thyself.md` |
+| **7** | Passion's Slaves: Managing Emotions | Ch. 5 | LO9, LO13 | B6–B10 | 8, 9 | MCQ 16–19; Sc2,5; KC7 | 113–138 | `MODULES/07_Passions_Slaves.md` |
+| **8** | The Master Aptitude: Motivating Oneself | Ch. 6 | LO10 | B11–B15 | 10, 11 | MCQ 20–21; Sc6; KC8 | 139–158 | `MODULES/08_The_Master_Aptitude.md` |
+| **9** | Roots of Empathy | Ch. 7 | LO11 | C1–C5 | 12, 13 | MCQ 22–23; Sc7; KC9 | 159–178 | `MODULES/09_Roots_of_Empathy.md` |
+| **10** | The Social Arts: Handling Relationships | Ch. 8 | LO12, LO22 | C6–C11 | 14, 15 | MCQ 24; Sc8; SA4; KC10 | 179–198 | `MODULES/10_The_Social_Arts.md` |
+| **11** | Family and Intimate Relationships | Ch. 9 | LO13, LO14 | D1–D5 | 16, 17 | MCQ 25; Sc9; Case Q1(a); KC11 | 199–221 | `MODULES/11_Family_and_Intimate_Relationships.md` |
+| **12** | Emotional Intelligence at Work | Ch. 10 | LO13, LO15 | D6–D10 | 18, 19, 20 | Sc10; Case Q1(b),(d); KC12 | 222–241 | `MODULES/12_At_Work.md` |
+| **13** | Emotional Intelligence and Leadership | Ch. 8, 10, 11 *(constructed)* | LO13, LO16, LO22 | D11–D14 | 20, 21 | Case Q1(d); KC13 | 242–255 | `MODULES/13_Leadership.md` |
+| **14** | Emotional Climate, Stress and Wellbeing | Ch. 11 (+ Ch. 5) | LO13, LO17 | D15–D19 | 22, 23 | **MCQ 26; Sc11**; KC14 | 256–269 | `MODULES/14_Climate_Stress_and_Wellbeing.md` |
+| **15** | Emotional Development, Childhood and Temperament | Ch. 12, 14 | LO18 | E1–E5 | 13, 24, 25 | SA5(a); Case Q2(b); KC15 | 270–287 | `MODULES/15_Development_and_Temperament.md` |
+| **16** | Trauma, Emotional Memory and Emotional Relearning | Ch. 13 | LO19 | E6–E9 | 26, 27 | SA5(b); KC16 | 288–301 | `MODULES/16_Trauma_and_Relearning.md` |
+| **17** | Emotional Literacy, Ethics and EI Under Scrutiny | Ch. 15, 16; App. D–F; Evidence file | LO20, LO21, LO22 | E10–E14 | 28, 29, 30 | SA3(b); Case Q2(b),(c),(d); KC17 | 302–319 | `MODULES/17_Literacy_Ethics_and_Scrutiny.md` |
+| **—** | *Synthesis and assessment session* | All | LO23 | Learner Instruments | — | Development Plan | 336–343 | — |
+
+**Front matter:** slides 1–8. **Contemporary evidence block:** slides 320–335 (Module 17, [EXTERNAL]). **Total deck: 343 slides.**
+
+---
+
+## 2 · LEARNING OUTCOME REGISTRY
+
+Full wording and Bloom levels are in `02_MASTER_LEARNING_OUTCOMES.md`. This is the resolution table.
+
+| LO | Short form | Modules | Assessment evidence |
+| --- | --- | --- | --- |
+| **LO1** | Define emotion; families; functional and evolutionary account | M1 | MCQ 1–5; SA1; KC1 |
+| **LO2** | The two minds; bottom-up architecture; correct the two rejected models | M2 | MCQ 6–7; SA2; KC2; A19 |
+| **LO3** | The amygdala; two routes; two memory systems; out-of-date alarms | M3 | MCQ 8; SA2; Scenario 1; KC3 |
+| **LO4** | Emotional hijacking — **both dynamics**; the prefrontal manager | M4 | MCQ 9–11; Scenarios 1, 2; Case Q1(c); KC4 |
+| **LO5** | Emotion and thought in both directions; the six hallmarks | M4 (with M1, M3) | MCQ 12; Scenario 4; SA3; KC4 |
+| **LO6** | Define EI; attribute to Salovey; the Thorndike→Gardner→Salovey lineage | M5 | MCQ 13–14; SA4; KC5 |
+| **LO7** | Meta-ability; the "20 per cent" claim precisely; the measurement gap | M5 | Case Q2(a); KC5; A20 |
+| **LO8** | Self-awareness as keystone; the Emotion Check-In | M6 | MCQ 15; Scenario 3; SA4; KC6; B1 |
+| **LO9** | Emotional self-management; the repair repertoire | M7 | MCQ 16–19; Scenarios 2, 5; KC7 |
+| **LO10** | Motivational resources, with the marshmallow qualifications | M8 | MCQ 20–21; Scenario 6; KC8; B14 |
+| **LO11** | Empathy incl. the calm precondition; observation vs interpretation | M9 | MCQ 22–23; Scenario 7; KC9; C1 |
+| **LO12** | Relationship management; the social chameleon | M10 | MCQ 24; Scenario 8; SA4; KC10 |
+| **LO13** | Triggers and intervention points (TRIGGER→CONSEQUENCE) | M7; applied M11–M14 | Scenarios 1, 2, 9; Case Q1(a),(c); dev plan |
+| **LO14** | Conflict analysis and repair in close relationships | M11 | MCQ 25; Scenario 9; Case Q1(a); KC11 |
+| **LO15** | EI at work; the limits of what the source establishes | M12 | Scenario 10; Case Q1(b),(d); KC12 |
+| **LO16** | EI and leadership; constructed vs source | M13 | Case Q1(d); KC13 |
+| **LO17** | Emotional climate, stress and wellbeing; **the two rejections** | M14 | **MCQ 26; Scenario 11**; KC14 |
+| **LO18** | Development and temperament; stated vs inferred | M15 | SA5(a); Case Q2(b); KC15 |
+| **LO19** | Trauma academically; the clinical boundary justified | M16 | SA5(b); KC16 |
+| **LO20** | Emotional literacy; evaluate programme design | M17 | Case Q2(b); KC17; E10 |
+| **LO21** | Evaluate the evidence; assign provenance correctly | M17; all modules | SA3(b); Case Q2(a),(c),(d); E11, E12 |
+| **LO22** | The ethics of emotional influence | M10, M13, M17 | Case Q2(d); E13; participation |
+| **LO23** | Personal development plan with realistic criteria | All | Personal Development Assignment |
+
+---
+
+## 3 · ACTIVITY REGISTRY
+
+**79 activities.** Twenty-four are specified in full in `ACTIVITIES/01_Activity_Book.md`; the remainder are scoped in the index and described in their module texts. **Codes are identifiers, not positions** — A17–A20 were appended during integration rather than inserted, so no existing code changed meaning.
+
+| Code | Activity | Module | Type | Min | Outcome |
+| --- | --- | ---: | --- | ---: | --- |
+| A1 | The Emotion Wall | 1 | Group | 25 | LO1 |
+| A2 | Signature Hunt | 1 | Pair | 30 | LO1 |
+| A3 | The Aristotle Audit | 1 | Individual → plenary | 25 | LO1 |
+| A4 | Pleistocene at Work | 1 | Group | 20 | LO1 |
+| A5 | Build the Pathway | 3 | Group, kinaesthetic | 30 | LO3 |
+| A6 | Trigger Archaeology | 3 | Individual (private) | 35 | LO3 |
+| A7 | Hippocampus or Amygdala? | 3 | Whole class | 15 | LO3 |
+| A8 | The Fear Sequence Walkthrough | 3 | Group (advanced) | 25 | LO3 |
+| A9 | Hijack Post-Mortem | 4 | Individual → pair | 40 | LO4, LO5 |
+| A10 | Running the Hallmarks | 4 | Group | 30 | LO4, LO5 |
+| A11 | Two Seconds | 4 | Trio | 20 | LO4, LO5 |
+| A12 | The Certainty Test | 4 | Individual | 20 | LO4, LO5 |
+| A13 | Correct the Slide | 5 | Group | 25 | LO6, LO7 |
+| A14 | Map the Five Domains | 5 | Individual | 30 | LO6, LO7 |
+| A15 | The Lineage Debate | 5 | Two teams | 30 | LO6, LO7 |
+| A16 | Spot the Domain | 5 | Whole class | 20 | LO6, LO7 |
+| B1 | The Check-In, Modelled and Practised | 6 | Whole class → individual → pair | 40 | LO8 |
+| B2 | Body Map | 6 | Individual → group | 25 | LO8 |
+| B3 | Feeling, Thought or Behaviour? | 6 | Whole class | 20 | LO8 |
+| B4 | Style Self-Placement and Challenge | 6 | Pair | 25 | LO8 |
+| B5 | Vocabulary Stretch | 6 | Individual | 15 | LO8 |
+| B6 | The Escalation Ladder | 7 | Group | 35 | LO9, LO13 |
+| B7 | Ventilation Debate | 7 | Two teams | 30 | LO9, LO13 |
+| B8 | Worry Audit | 7 | Individual (private) | 30 | LO9, LO13 |
+| B9 | Rate the Repair | 7 | Group | 25 | LO9, LO13 |
+| B10 | Cooling Protocol Design | 7 | Individual | 20 | LO9, LO13 |
+| B11 | The Personal Goal Activity | 8 | Individual → pair | 40 | LO10 |
+| B12 | Reattribution Practice | 8 | Individual → pair | 30 | LO10 |
+| B13 | Flow Mapping | 8 | Individual | 25 | LO10 |
+| B14 | The Marshmallow Debate | 8 | Two teams | 30 | LO10 |
+| B15 | Delay Strategies Inventory | 8 | Group | 15 | LO10 |
+| C1 | What Is This Person Feeling? | 9 | Individual → pair | 40 | LO11 |
+| C2 | Channel Isolation | 9 | Trio | 30 | LO11 |
+| C3 | Observation / Interpretation Sort | 9 | Whole class | 20 | LO11 |
+| C4 | Attunement Practice | 9 | Pair | 30 | LO11 |
+| C5 | The Calm Precondition | 9 | Pair, experimental | 20 | LO11 |
+| C6 | Contagion Demonstration | 10 | Pair, experimental | 20 | LO12, LO22 |
+| C7 | Emotional Judo Role-Play | 10 | Trio + observer | 45 | LO12, LO22 |
+| C8 | Group Entry Analysis | 10 | Group | 30 | LO12, LO22 |
+| C9 | Four Components Self-Rating | 10 | Individual → team | 25 | LO12, LO22 |
+| C10 | Display Rules Audit | 10 | Individual → group | 25 | LO12, LO22 |
+| C11 | The Chameleon Question | 10 | Individual (private) | 20 | LO12, LO22 |
+| D1 | Complaint or Criticism? | 11 | Whole class → individual | 20 | LO13, LO14 |
+| D2 | Spot the Fault Lines | 11 | Group | 30 | LO13, LO14 |
+| D3 | Mirroring Practice | 11 | Pair | 40 | LO13, LO14 |
+| D4 | The Rewrite | 11 | Group → performance | 35 | LO13, LO14 |
+| D5 | Time-Out Protocol Design | 11 | Individual | 20 | LO13, LO14 |
+| D6 | Rewrite the Critique | 12 | Individual → peer review | 30 | LO13, LO15 |
+| D7 | Feedback Role-Play with Rewind | 12 | Trio | 45 | LO13, LO15 |
+| D8 | Group IQ Simulation | 12 | Two groups | 40 | LO13, LO15 |
+| D9 | Network Mapping | 12 | Individual | 30 | LO13, LO15 |
+| D10 | Speaking Up Without Escalating | 12 | Trio | 25 | LO13, LO15 |
+| D11 | The Entrainment Audit | 13 | Individual → pair | 30 | LO13, LO16, LO22 |
+| D12 | Can the Least Powerful Person Speak? | 13 | Group | 35 | LO13, LO16, LO22 |
+| D13 | Leadership Failure Analysis | 13 | Group | 40 | LO13, LO16, LO22 |
+| D14 | The Leadership Practice Design | 13 | Individual | 30 | LO13, LO16, LO22 |
+| D15 | The Two Rejections | 14 | Group | 25 | LO13, LO17 |
+| D16 | Strain Audit | 14 | Individual → group | 30 | LO13, LO17 |
+| D17 | Support Mapping | 14 | Individual (private) | 25 | LO13, LO17 |
+| D18 | Expressive Writing Trial | 14 | Individual (private) | 20 + homework | LO13, LO17 |
+| D19 | Evidence Appraisal | 14 | Group | 30 | LO13, LO17 |
+| E1 | Four Styles Diagnostic | 15 | Individual → pair | 30 | LO18 |
+| E2 | The Seven Ingredients Audit | 15 | Individual | 25 | LO18 |
+| E3 | Manageable Doses Design | 15 | Individual → pair | 30 | LO18 |
+| E4 | Temperament and Change Debate | 15 | Two teams | 30 | LO18 |
+| E5 | Tracing a Blueprint | 15 | Individual (private) | 25 | LO18 |
+| E6 | The Control Variable | 16 | Group | 25 | LO19 |
+| E7 | Setting Realistic Expectations | 16 | Individual | 30 | LO19 |
+| E8 | Recovery Time Tracking | 16 | Individual, ongoing | — | LO19 |
+| E9 | The Boundary Exercise | 16 | Trio | 25 | LO19 |
+| E10 | Redesign the Training | 17 | Group | 40 | LO20, LO21, LO22 |
+| E11 | The Three-Column Verdict | 17 | Group | 45 | LO20, LO21, LO22 |
+| E12 | Steel-Man the Critic | 17 | Individual | 30 | LO20, LO21, LO22 |
+| E13 | The Ethics Panel | 17 | Whole class | 40 | LO20, LO21, LO22 |
+| E14 | In-the-Moment Coaching Practice | 17 | Trio | 30 | LO20, LO21, LO22 |
+| A17 | Place Yourself on the Gradient | 2 | Individual → pair | 20 | LO2 |
+| A18 | Build the Argument | 2 | Group | 30 | LO2 |
+| A19 | Correct the Framing | 2 | Whole class | 15 | LO2 |
+| A20 | Where Does the Eighty Go? | 5 | Whole class, board | 10 | LO6, LO7 |
+
+---
+
+## 4 · CASE REGISTRY
+
+| # | Case | Provenance | Core theme | Module | Outcome |
+| --- | --- | --- | --- | --- | --- |
+| 1 | The Grade | **[SOURCE]** | High IQ, catastrophic emotional failure | 5 | LO6, LO7 |
+| 2 | The Practical Joke | **[SOURCE]** | Fear; evolutionary mismatch | 1, 4 | LO1 |
+| 3 | The Neural Back Alley | **[SOURCE]** | Emotional hijacking at the extreme | 4 | LO4, LO5 |
+| 4 | The Print from Spain | **[SOURCE]** | Everyday hijacking; the hallmark | 3, 4 | LO3 |
+| 5 | The Two Candidates | **[PEDAGOGICAL]** | Meta-ability and its limits | 5 | LO6, LO7 |
+| 6 | The Man Without Feelings | **[SOURCE]** | Alexithymia; decision without feeling | 6 | LO8 |
+| 7 | The Marker | **[PEDAGOGICAL]** | Somatic markers vs. bias | 6 | LO8 |
+| 8 | The Escalation | **[PEDAGOGICAL]** | Anger's two clocks; the reappraisal window | 7 | LO9, LO13 |
+| 9 | The Worry Loop | **[PEDAGOGICAL]** | Worry's partial payoff | 7 | LO9, LO13 |
+| 10 | The Setback | **[PEDAGOGICAL]** | Explanatory style | 8 | LO10 |
+| 11 | The Bored Star | **[PEDAGOGICAL]** | Challenge–skill mismatch | 8 | LO10 |
+| 12 | The Silent Partner | **[PEDAGOGICAL]** | Observation vs. interpretation | 9 | LO11 |
+| 13 | Attunement at Three Months | **[SOURCE]** | Attunement and misattunement | 9, 15 | LO11 |
+| 14 | The Tokyo Train | **[SOURCE]** | Expert de-escalation | 10 | LO12, LO22 |
+| 15 | The New Director | **[PEDAGOGICAL]** | Group entry; the two cardinal sins | 10 | LO12, LO22 |
+| 16 | Four Fault Lines | **[PEDAGOGICAL]** | Criticism, contempt, defensiveness, stonewalling | 11 | LO13, LO14 |
+| 17 | The Time-Out That Wasn't | **[PEDAGOGICAL]** | Cooling done wrongly | 11 | LO13, LO14 |
+| 18 | The Throwaway Line | **[SOURCE]** | Destructive criticism | 12 | LO13, LO15 |
+| 19 | The Star Who Made No Difference | **[PEDAGOGICAL]** | Group IQ | 12 | LO13, LO15 |
+| 20 | Nobody Said Anything | **[PEDAGOGICAL]** | Fear and information flow | 12, 13 | LO13, LO15 |
+| 21 | The Leader Who Never Rattles | **[PEDAGOGICAL]** | Repressors in authority | 13 | LO13, LO16, LO22 |
+| 22 | The High-Strain Team | **[PEDAGOGICAL]** | Demand, control and support | 14 | LO13, LO17 |
+| 23 | The Patient Who Could Not Ask | **[SOURCE]** | Emotional deficits in care | 14 | LO13, LO17 |
+| 24 | The Video Game | **[SOURCE]** | The four parenting styles | 15 | LO18 |
+| 25 | The Protected Employee | **[PEDAGOGICAL]** | Kagan's emboldening finding | 15 | LO18 |
+| 26 | The Vestigial Reaction | **[PEDAGOGICAL]** | Realistic expectations for change | 16 | LO19 |
+| 27 | Cleveland Elementary | **[SOURCE]** | Trauma in an institution | 16 (gated) | LO19 |
+| 28 | Cooperation Squares | **[SOURCE]** | In-the-moment coaching | 17 | LO20, LO21, LO22 |
+| 29 | The Compliance Module | **[PEDAGOGICAL]** | Information is not enough | 17 | LO20, LO21, LO22 |
+| 30 | The Charming Manipulator | **[PEDAGOGICAL]** | The ethics of emotional skill | 17 | LO20, LO21, LO22 |
+
+**Gated case:** Case 27 (Cleveland Elementary) — clinical, social work, education and safeguarding cohorts only. **Never role-played:** Cases 8, 16, 27, and all Module 16 material.
+
+---
+
+## 5 · ASSESSMENT REGISTRY
+
+| Section | Items | Marks | Outcomes covered | Key location |
+| --- | ---: | ---: | --- | --- |
+| 1 · Multiple choice | 26 | 26 | LO1–LO12, LO14, LO17 | Assessment Bank §F3.1 |
+| 2 · Scenario-based | 11 | 33 | LO3–LO5, LO8–LO11, LO13, LO14, LO15, LO17 | §F3.2 |
+| 3 · Short-answer | 5 | 20 | LO1, LO3, LO5, LO6, LO12, LO18, LO19, LO21 | §F3.3 |
+| 4 · Case study (unseen) | 2 | 25 | LO4, LO7, LO13–LO16, LO18, LO20–LO22 | §F3.4 |
+| 5 · Personal Development Assignment | 1 | Pass/Refer | LO23 | §F4.5 checklist |
+| **Total** | **44 + 1** | **104** | **All 23** | |
+
+**Formative:** 17 module knowledge checks (5 items each) + 6 named instruments. **Diagnostic items** for cohort analysis: MCQ 9 (both dynamics), 13 (framework attribution), 18 (ventilation), 24 (display rules), and now **26 (the two rejections)**.
+
+---
+
+## 6 · SLIDE REGISTRY
+
+Per-slide detail — title, purpose, learner-facing content, visual, instructor explanation, discussion, activity, speaker notes and source — lives in the six `SLIDE_DECK/` files, ten fields per slide. This is the range index.
+
+| Slides | Module / block | Deck file | Outcomes |
+| --- | --- | --- | --- |
+| 1–8 | Front matter | `01_Slides_001-074_Foundations.md` | — |
+| 9–24 | Module 1 — What Emotions Are and What They Are For | `SLIDE_DECK/01_Slides_001-074_Foundations.md` | LO1 |
+| 25–38 | Module 2 — The Two Minds: How the Emotional Brain Is Built | `SLIDE_DECK/01_Slides_001-074_Foundations.md` | LO2 |
+| 39–56 | Module 3 — The Emotional Sentinel: Amygdala, Memory and the Two Routes | `SLIDE_DECK/01_Slides_001-074_Foundations.md` | LO3 |
+| 57–74 | Module 4 — Emotional Hijacking and the Emotional Manager | `SLIDE_DECK/01_Slides_001-074_Foundations.md` | LO4, LO5 |
+| 75–98 | Module 5 — Intelligence Reconsidered: What Emotional Intelligence Is | `SLIDE_DECK/02_Slides_075-098_Module05_Intelligence_Reconsidered.md` | LO6, LO7 |
+| 99–112 | Module 6 — Knowing Thyself: Self-Awareness | `SLIDE_DECK/03_Slides_099-198_Five_Domains.md` | LO8 |
+| 113–138 | Module 7 — Passion's Slaves: Managing Emotions | `SLIDE_DECK/03_Slides_099-198_Five_Domains.md` | LO9, LO13 |
+| 139–158 | Module 8 — The Master Aptitude: Motivating Oneself | `SLIDE_DECK/03_Slides_099-198_Five_Domains.md` | LO10 |
+| 159–178 | Module 9 — Roots of Empathy | `SLIDE_DECK/03_Slides_099-198_Five_Domains.md` | LO11 |
+| 179–198 | Module 10 — The Social Arts: Handling Relationships | `SLIDE_DECK/03_Slides_099-198_Five_Domains.md` | LO12, LO22 |
+| 199–221 | Module 11 — Family and Intimate Relationships | `SLIDE_DECK/04_Slides_199-287_Application_and_Development.md` | LO13, LO14 |
+| 222–241 | Module 12 — Emotional Intelligence at Work | `SLIDE_DECK/04_Slides_199-287_Application_and_Development.md` | LO13, LO15 |
+| 242–255 | Module 13 — Emotional Intelligence and Leadership | `SLIDE_DECK/04_Slides_199-287_Application_and_Development.md` | LO13, LO16, LO22 |
+| 256–269 | Module 14 — Emotional Climate, Stress and Wellbeing | `SLIDE_DECK/04_Slides_199-287_Application_and_Development.md` | LO13, LO17 |
+| 270–287 | Module 15 — Emotional Development, Childhood and Temperament | `SLIDE_DECK/04_Slides_199-287_Application_and_Development.md` | LO18 |
+| 288–301 | Module 16 — Trauma, Emotional Memory and Emotional Relearning | `SLIDE_DECK/05_Slides_288-343_Trauma_Scrutiny_Close.md` | LO19 |
+| 302–319 | Module 17 — Emotional Literacy, Ethics and EI Under Scrutiny | `SLIDE_DECK/05_Slides_288-343_Trauma_Scrutiny_Close.md` | LO20, LO21, LO22 |
+| 320–335 | Contemporary evidence **[EXTERNAL]** | `05_Slides_288-343_Trauma_Scrutiny_Close.md` | LO21 |
+| 336–343 | Closing and synthesis | `05_Slides_288-343_Trauma_Scrutiny_Close.md` | LO21–LO23 |
+
+**Total: 343 slides, continuous, no gaps or duplicates** (verified programmatically — see `REFERENCE/03_Consistency_Audit.md`).
+
+---
+
+## 7 · PROVENANCE MARKERS
+
+| Marker | Meaning | Where it must appear |
+| --- | --- | --- |
+| **[SOURCE]** | Stated in Goleman's text | Inline and in every slide footer |
+| **[SOURCE-QUALIFIED]** | Stated, and the author himself hedges or limits it | Inline and in every slide footer |
+| **[EXTERNAL]** | Outside the source — cited with author, year and outlet | Inline, in the footer, **and visibly on the built slide** |
+| **[PEDAGOGICAL]** | Built by this course, not in the book | Inline, in the footer, **and visibly on the built slide** |
+| **[PEDAGOGICAL SHARPENING]** | Source material restated more crisply than the source states it | Inline, at the point of sharpening |
+
+*A learner photographing any slide must be able to tell, from the photograph alone, whether they are looking at Goleman or at something else.*
+

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-6-08_Master_Learning_Outcomes.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-6-08_Master_Learning_Outcomes.md
@@ -1,0 +1,119 @@
+# MASTER LEARNING OUTCOME REGISTER
+
+**Status: AUTHORITATIVE.** This file defines LO1–LO23 for the whole course. No other file may define an alternative set, and every reference to an LO number anywhere in the package resolves here.
+
+---
+
+## Why this file exists
+
+The package previously carried **two incompatible outcome sets, both numbered LO1–LO23** — one course-level and competence-shaped, one module-level and content-shaped. Only two entries meant the same thing in both. The consequence was that the assessment alignment matrix mapped to outcomes that did not exist in the specification.
+
+Neither set was wrong. They were different instruments. This register **synthesises them**: it keeps the competence framing and Bloom-level discipline of the first, and the content coverage and assessability of the second. Where the two disagreed on scope, the merged outcome states the scope explicitly.
+
+---
+
+## THE REGISTER
+
+### Band A — Emotion and the emotional brain
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO1** | **Define emotion** using the source's four-part definition, name the emotion families, state the source's own position that the primacy question is unsettled, and **explain the functional and evolutionary account** — emotions as impulses to act, their biological signatures, and the evolutionary-mismatch argument. | Understand | **M1** | MCQ 1–5; SA1; KC1; assignment M1 |
+| **LO2** | **Explain the two-minds account and the bottom-up architecture** of the emotional brain, including what each layer added, and **identify and correct** the switch model and the triune-brain framing. | Understand / Evaluate | **M2** | MCQ 6–7; SA2; KC2; A19 |
+| **LO3** | **Explain the amygdala's role** — sentinel, emotional memory, the thalamic short-cut — together with the two memory systems, associative matching, out-of-date neural alarms and precognitive emotion. | Understand | **M3** | MCQ 8; SA2; Scenario 1; KC3 |
+| **LO4** | **Explain emotional hijacking**, including **both dynamics** — amygdala triggering *and* the failure or active recruitment of neocortical processes — and the prefrontal cortex as emotional manager. | Analyse | **M4** | MCQ 9–11; Scenarios 1, 2; Case Q1(c); KC4 |
+| **LO5** | **Explain the interaction of emotion and thought in both directions** — arousal degrading working memory, and absent emotional input degrading decision — and **apply the six hallmarks of the emotional mind**, characterising their evidential standing. | Analyse / Evaluate | **M4** (with M1, M3) | MCQ 12; Scenario 4; SA3; KC4 |
+
+### Band B — The construct
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO6** | **Define emotional intelligence as the source presents it**, attribute the five-domain framework correctly to **Salovey**, trace the lineage from Thorndike through Gardner to Salovey and Mayer, and **distinguish this formulation from later and competing ones**. | Understand / Evaluate | **M5** | MCQ 13–14; SA4; KC5; A13, A14 |
+| **LO7** | **Explain the meta-ability claim and the IQ–EI relationship**; **state the "20 per cent" claim precisely**, identify what it does and does not assert, reject the 80-per-cent misattribution, and state the source's own position on the absence of an EI score. | Evaluate | **M5** | Case Q2(a); KC5; A20 |
+
+### Band C — The five domains
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO8** | **Explain self-awareness as the keystone domain** — recognition *as it happens*, Mayer's three attentional styles, alexithymia — and **apply the Emotion Check-In** to one's own experience. | Apply | **M6** | MCQ 15; Scenario 3; SA4; KC6; B1 |
+| **LO9** | **Apply emotional self-management**: the two-stage physiology of anger, the evidence against ventilation, the mechanics of worry and rumination, and the evaluated repair repertoire — selecting a strategy for a state and justifying it mechanistically. | Apply | **M7** | MCQ 16–19; Scenarios 2, 5; KC7 |
+| **LO10** | **Apply motivational resources**: delay of gratification *with its required qualifications*, the arousal–performance inverted U, hope, explanatory style, self-efficacy and flow. | Apply | **M8** | MCQ 20–21; Scenario 6; KC8; B14 |
+| **LO11** | **Explain empathy** — its bodily roots, attunement and misattunement, the non-verbal channels, and the finding that empathic accuracy depends on the perceiver's own physiological calm — and **distinguish observation from interpretation**, applying the four-step reading protocol. | Understand / Apply | **M9** | MCQ 22–23; Scenario 7; Case Q2; KC9; C1 |
+| **LO12** | **Apply relationship management**: display rules, emotional contagion, entrainment, the four components of interpersonal ability and the group-entry sequence — and **identify the social chameleon as the characteristic failure** of Domain 5 without Domain 1. | Apply | **M10** | MCQ 24; Scenario 8; SA4; KC10 |
+
+### Band D — Analysis and application
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO13** | **Identify emotional triggers** — in oneself and in unseen case material — and **locate the points in a sequence at which intervention was possible**, using the TRIGGER→CONSEQUENCE map and accounting for them by named source mechanisms. | Analyse | **M7**; applied in **M11–M14** | Scenarios 1, 2, 9; Case Q1(a),(c); development plan |
+| **LO14** | **Analyse and repair conflict in close relationships**: the four fault lines, flooding and its physiological marker, the limbic tango — and apply XYZ, mirroring and validation, distinguishing a structured break from stonewalling. | Apply | **M11** | MCQ 25; Scenario 9; Case Q1(a); KC11 |
+| **LO15** | **Apply emotional intelligence at work** — the artful critique, receiving criticism, group IQ, the three informal networks — and **state what the source does and does not establish** about workplace outcomes. | Apply / Evaluate | **M12** | Scenario 10; Case Q1(b),(d); KC12 |
+| **LO16** | **Apply emotional intelligence to leadership**, recognising the leader's disproportionate emotional influence and the trust network as an early-warning system, and **distinguish this course's constructed leadership module from the source's own content**. | Apply | **M13** | Case Q1(d); KC13; D11–D14 |
+| **LO17** | **Explain the source's account of emotional climate, stress and wellbeing**, including the two claims the source **explicitly rejects**, and state the practical consequences that follow. | Understand / Evaluate | **M14** | MCQ 26; Scenario 11; KC14 |
+
+### Band E — Development and trauma
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO18** | **Explain childhood emotional development and the malleability of temperament** — the four parenting styles, the seven ingredients of readiness, Kagan's emboldening finding — **distinguishing clearly what the source states from what it infers**, and making no unsupported causal claims. | Analyse | **M15** | SA5(a); Case Q2(b); KC15 |
+| **LO19** | **Explain trauma and emotional relearning as academic content** — uncontrollability, the altered neural systems, failed extinction, Luborsky's finding — and **state and justify the boundary** between academic understanding and professional psychological treatment. | Understand / Evaluate | **M16** | SA5(b); KC16 |
+
+### Band F — Literacy, evidence, ethics and practice
+
+| LO | Learning outcome | Bloom level | Primary module(s) | Assessment evidence |
+| --- | --- | --- | --- | --- |
+| **LO20** | **Explain emotional literacy and emotional illiteracy** — the "information is not enough" finding, the design principles of effective programmes — and **evaluate a real programme against them**. | Evaluate | **M17** | Case Q2(b); KC17; E10 |
+| **LO21** | **Evaluate the evidence** for emotional-intelligence claims — distinguishing what the source claims, what it qualifies, what later research supports and what remains contested — and **correctly assign provenance** ([SOURCE] / [SOURCE-QUALIFIED] / [EXTERNAL] / [PEDAGOGICAL]) to any claim put to them. | Evaluate | **M17**; enforced in **all modules** | SA3(b); Case Q2(a),(c),(d); E11, E12 |
+| **LO22** | **Analyse the ethics of emotional influence** — that the abilities are instrumental and serve whatever ends the holder has — and **state the strongest case on both sides** of the question whether someone can be emotionally intelligent and morally bad. | Analyse / Evaluate | **M10, M13, M17** | Case Q2(d); E13; participation |
+| **LO23** | **Produce and begin executing a personal emotional-intelligence development plan**, grounded in a structured self-assessment, targeting specific **observable behaviours**, with defined measures of progress and **realistic success criteria** — while correctly characterising the self-assessment as an educational instrument and not a validated psychological test. | Create | **All modules**; instruments in Learner Instruments | Personal Development Assignment (compulsory, pass/refer) |
+
+---
+
+## MODULE → OUTCOME MAP
+
+| Module | Title | Primary LOs |
+| --- | --- | --- |
+| 1 | What Emotions Are and What They Are For | LO1 |
+| 2 | The Two Minds: How the Emotional Brain Is Built | LO2 |
+| 3 | The Emotional Sentinel: Amygdala, Memory and the Two Routes | LO3 |
+| 4 | Emotional Hijacking and the Emotional Manager | LO4, LO5 |
+| 5 | Intelligence Reconsidered: What Emotional Intelligence Is | LO6, LO7 |
+| 6 | Knowing Thyself: Self-Awareness | LO8 |
+| 7 | Passion's Slaves: Managing Emotions | LO9, LO13 |
+| 8 | The Master Aptitude: Motivating Oneself | LO10 |
+| 9 | Roots of Empathy | LO11 |
+| 10 | The Social Arts: Handling Relationships | LO12, LO22 |
+| 11 | Family and Intimate Relationships | LO13, LO14 |
+| 12 | Emotional Intelligence at Work | LO13, LO15 |
+| 13 | Emotional Intelligence and Leadership | LO13, LO16, LO22 |
+| 14 | Emotional Climate, Stress and Wellbeing | LO13, LO17 |
+| 15 | Emotional Development, Childhood and Temperament | LO18 |
+| 16 | Trauma, Emotional Memory and Emotional Relearning | LO19 |
+| 17 | Emotional Literacy, Ethics and EI Under Scrutiny | LO20, LO21, LO22 |
+| — | Across the course | LO23 |
+
+**Every module carries at least one outcome. Every outcome is carried by at least one module. No outcome is orphaned and no module is outcome-free.**
+
+---
+
+## WHAT CHANGED, AND WHY
+
+| Change | Reasoning |
+| --- | --- |
+| Former the Course Specification LO2 and LO3 (why emotions matter; emotion families) **merged into LO1** | Both were taught in one module and assessed by the same items. Two outcomes for one session inflated the register without adding measurability. |
+| Former the Course Specification LO1 (define EI) **became LO6** | It belongs with the module that defines the construct — restored Module 5 — not at the front of a course that has not yet described a single mechanism. This was the outcome most damaged by the missing module. |
+| Former the Assessment Bank's content checklist **absorbed as assessment evidence**, not as outcomes | Items such as "name the eight emotion families" are *evidence*, not outcomes. They now appear in the right-hand column where they belong. |
+| **LO2 gained an evaluative clause** (identify and correct the switch and triune models) | Module 2 exists partly to block two misconceptions. An outcome that only says "explain the architecture" does not capture what the module is for. |
+| **LO7 gained the "20 per cent" clause explicitly** | It is the course's defining correction and it was previously assessed without being stated as an outcome. |
+| **LO17 gained a summative item** (MCQ 26, Scenario 11) | Module 14 previously had no summative assessment — an alignment gap identified in the audit. |
+| **LO22 (ethics) created as a standalone outcome** | Ethics ran through five modules and the assessment, and was not an outcome anywhere. A thread that is assessed must be declared. |
+| **LO21 gained the provenance clause** | Correct assignment of the four markers is the course's distinctive skill and is directly assessed. It should be stated, not implied. |
+
+---
+
+## RULE FOR ALL FUTURE EDITING
+
+1. Any file citing an outcome cites **LO1–LO23 as defined here**, by number and by the wording above.
+2. No file may introduce a local outcome set, a lettered variant, or a renumbering.
+3. Adding an outcome requires adding it here **first**, then updating `REFERENCE/MASTER_CROSS_REFERENCE_REGISTER.md`, then the module, then the assessment.
+4. An outcome with no assessment evidence is a defect, not an aspiration.

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-7-09_Activity_Book.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-7-09_Activity_Book.md
@@ -1,0 +1,821 @@
+# THE ACTIVITY BOOK
+
+**Thirty-two activities.** Every activity specifies: Objective · Duration · Group size · Materials · Instructions · Expected outcome · Debrief · Instructor notes.
+
+## Standing rules for every activity in this book
+
+1. **Participation in any individual reflective exercise is voluntary.** Nobody is required to disclose. This is stated before each reflective activity, not once at the start of the course.
+2. **Learners choose material of moderate intensity.** Where an exercise asks for a personal example, the instruction is always: choose something you are comfortable analysing, not the most significant thing in your life.
+3. **Structure, not content.** In paired debriefs, learners may share the *shape* of an experience ("a tone of voice") without the *substance* ("what my father said").
+4. **The rewind convention applies to all role-plays.** Any participant or observer may call "rewind"; the scene restarts from an agreed point with one specified change.
+5. **Never use a learner's live personal conflict as practice material.** Supplied scenarios exist for this reason.
+6. **The instructor knows the referral pathway** and has it visible, not merely available.
+
+## Index
+
+| Code | Title | Module | Type | Min |
+| --- | --- | --- | --- | --- |
+| A1 | The Emotion Wall | 1 | Group | 25 |
+| A2 | Signature Hunt | 1 | Pair | 30 |
+| A3 | The Aristotle Audit | 1 | Individual → plenary | 25 |
+| A4 | Pleistocene at Work | 1 | Group | 20 |
+| A5 | Build the Pathway | 3 | Group, kinaesthetic | 30 |
+| A6 | Trigger Archaeology | 3 | Individual (private) | 35 |
+| A7 | Hippocampus or Amygdala? | 3 | Whole class | 15 |
+| A8 | The Fear Sequence Walkthrough | 3 | Group (advanced) | 25 |
+| A9 | Hijack Post-Mortem | 4 | Individual → pair | 40 |
+| A10 | Running the Hallmarks | 4 | Group | 30 |
+| A11 | Two Seconds | 4 | Trio | 20 |
+| A12 | The Certainty Test | 4 | Individual | 20 |
+| A13 | Correct the Slide | 5 | Group | 25 |
+| A14 | Map the Five Domains | 5 | Individual | 30 |
+| A15 | The Lineage Debate | 5 | Two teams | 30 |
+| A16 | Spot the Domain | 5 | Whole class | 20 |
+| B1 | The Check-In, Modelled and Practised | 6 | Whole class → individual → pair | 40 |
+| B2 | Body Map | 6 | Individual → group | 25 |
+| B3 | Feeling, Thought or Behaviour? | 6 | Whole class | 20 |
+| B4 | Style Self-Placement and Challenge | 6 | Pair | 25 |
+| B5 | Vocabulary Stretch | 6 | Individual | 15 |
+| B6 | The Escalation Ladder | 7 | Group | 35 |
+| B7 | Ventilation Debate | 7 | Two teams | 30 |
+| B8 | Worry Audit | 7 | Individual (private) | 30 |
+| B9 | Rate the Repair | 7 | Group | 25 |
+| B10 | Cooling Protocol Design | 7 | Individual | 20 |
+| B11 | The Personal Goal Activity | 8 | Individual → pair | 40 |
+| B12 | Reattribution Practice | 8 | Individual → pair | 30 |
+| B13 | Flow Mapping | 8 | Individual | 25 |
+| B14 | The Marshmallow Debate | 8 | Two teams | 30 |
+| B15 | Delay Strategies Inventory | 8 | Group | 15 |
+| C1 | What Is This Person Feeling? | 9 | Individual → pair | 40 |
+| C2 | Channel Isolation | 9 | Trio | 30 |
+| C3 | Observation / Interpretation Sort | 9 | Whole class | 20 |
+| C4 | Attunement Practice | 9 | Pair | 30 |
+| C5 | The Calm Precondition | 9 | Pair, experimental | 20 |
+| C6 | Contagion Demonstration | 10 | Pair, experimental | 20 |
+| C7 | Emotional Judo Role-Play | 10 | Trio + observer | 45 |
+| C8 | Group Entry Analysis | 10 | Group | 30 |
+| C9 | Four Components Self-Rating | 10 | Individual → team | 25 |
+| C10 | Display Rules Audit | 10 | Individual → group | 25 |
+| C11 | The Chameleon Question | 10 | Individual (private) | 20 |
+| D1 | Complaint or Criticism? | 11 | Whole class → individual | 20 |
+| D2 | Spot the Fault Lines | 11 | Group | 30 |
+| D3 | Mirroring Practice | 11 | Pair | 40 |
+| D4 | The Rewrite | 11 | Group → performance | 35 |
+| D5 | Time-Out Protocol Design | 11 | Individual | 20 |
+| D6 | Rewrite the Critique | 12 | Individual → peer review | 30 |
+| D7 | Feedback Role-Play with Rewind | 12 | Trio | 45 |
+| D8 | Group IQ Simulation | 12 | Two groups | 40 |
+| D9 | Network Mapping | 12 | Individual | 30 |
+| D10 | Speaking Up Without Escalating | 12 | Trio | 25 |
+| D11 | The Entrainment Audit | 13 | Individual → pair | 30 |
+| D12 | Can the Least Powerful Person Speak? | 13 | Group | 35 |
+| D13 | Leadership Failure Analysis | 13 | Group | 40 |
+| D14 | The Leadership Practice Design | 13 | Individual | 30 |
+| D15 | The Two Rejections | 14 | Group | 25 |
+| D16 | Strain Audit | 14 | Individual → group | 30 |
+| D17 | Support Mapping | 14 | Individual (private) | 25 |
+| D18 | Expressive Writing Trial | 14 | Individual (private) | 20 + homework |
+| D19 | Evidence Appraisal | 14 | Group | 30 |
+| E1 | Four Styles Diagnostic | 15 | Individual → pair | 30 |
+| E2 | The Seven Ingredients Audit | 15 | Individual | 25 |
+| E3 | Manageable Doses Design | 15 | Individual → pair | 30 |
+| E4 | Temperament and Change Debate | 15 | Two teams | 30 |
+| E5 | Tracing a Blueprint | 15 | Individual (private) | 25 |
+| E6 | The Control Variable | 16 | Group | 25 |
+| E7 | Setting Realistic Expectations | 16 | Individual | 30 |
+| E8 | Recovery Time Tracking | 16 | Individual, ongoing | — |
+| E9 | The Boundary Exercise | 16 | Trio | 25 |
+| E10 | Redesign the Training | 17 | Group | 40 |
+| E11 | The Three-Column Verdict | 17 | Group | 45 |
+| E12 | Steel-Man the Critic | 17 | Individual | 30 |
+| E13 | The Ethics Panel | 17 | Whole class | 40 |
+| E14 | In-the-Moment Coaching Practice | 17 | Trio | 30 |
+| A17 | Place Yourself on the Gradient | 2 | Individual → pair | 20 |
+| A18 | Build the Argument | 2 | Group | 30 |
+| A19 | Correct the Framing | 2 | Whole class | 15 |
+| A20 | Where Does the Eighty Go? | 5 | Whole class, board | 10 |
+
+*Seventy-eight activities in total, exceeding the brief's minimum of twenty. Codes A17–A20 were added during integration to serve the new Module 2 and Module 5; **existing codes were not renumbered**, because a code is an identifier, not a position. The full specification for a representative set follows; the remainder follow the same eight-part structure and are described in the module texts.*
+
+---
+
+## FULL SPECIFICATIONS — THE CORE TWENTY
+
+---
+
+### **A3 — THE ARISTOTLE AUDIT**
+
+**Objective.** To apply the course's evaluative standard — appropriateness rather than absence — to the learner's own recent experience, and to discover which of Aristotle's five criteria most commonly fails.
+
+**Duration.** 25 minutes (8 individual, 8 pairs, 9 plenary).
+
+**Group size.** Any; pairs required.
+
+**Materials.** The Aristotle Test card (five criteria); worksheet.
+
+**Instructions.**
+1. *(Individually, 8 min.)* Recall one occasion in the last month when you were angry. Choose something of ordinary intensity. Score it against each of the five criteria: was it with the right person? to the right degree? at the right time? for the right purpose? in the right way? Mark each pass or fail.
+2. *(Pairs, 8 min.)* Share **which criteria failed**, not what the incident was. Discuss whether the same criterion tends to fail for you.
+3. *(Plenary, 9 min.)* Tally on the board: which criterion failed most often across the room?
+
+**Expected outcome.** Learners discover that anger is rarely wholly inappropriate — usually one or two criteria fail while others hold. In most cohorts *degree* and *way* fail most often; *person* and *purpose* usually pass. This is a more precise and more actionable self-assessment than "I lose my temper."
+
+**Debrief.** (a) How many of you found that your anger was entirely unjustified? *(Usually almost none.)* (b) What does that suggest about the goal? (c) If your failing criterion is *degree* or *way*, which module of this course is most relevant to you? *(6 and 10.)* (d) Is there a criterion the course has not covered?
+
+**Instructor notes.** This activity does the single most important job of Session 1: it dismantles the suppression misreading empirically rather than by assertion. Learners see for themselves that their anger was usually about the right thing, aimed at the right person, for a legitimate purpose — and mis-sized or mis-delivered. Keep the plenary tally visible for the rest of the course.
+
+---
+
+### **A5 — BUILD THE PATHWAY**
+
+**Objective.** To make the dual-pathway architecture retainable by requiring learners to construct it physically and argue about it.
+
+**Duration.** 30 minutes.
+
+**Group size.** Groups of 4–6.
+
+**Materials.** Per group: a set of A5 cards naming *stimulus, thalamus, amygdala, hippocampus, neocortex/sensory cortex, prefrontal cortex, response*; a second set naming functions (*"is this something I hate?"*, *"analyses and assesses for meaning"*, *"remembers the context"*, *"fast, imprecise"*, *"slower, fully informed"*, *"dampens the alarm"*); arrows; floor or wall space.
+
+**Instructions.**
+1. *(12 min.)* Assemble the pathway using structure cards and arrows. Then attach the function cards.
+2. *(8 min.)* Walk a stimulus through both roads aloud, one group member narrating each road.
+3. *(10 min.)* Groups compare layouts. Differences are the discussion.
+
+**Expected outcome.** Learners can reproduce the pathway from memory a week later — which they generally cannot after seeing it drawn.
+
+**Debrief.** (a) Which card was hardest to place? (b) Where does conscious awareness arrive? (c) What is the trade the low road makes? (d) Where in this diagram does this course intervene? *(Answer: the prefrontal card, and upstream of the stimulus.)*
+
+**Instructor notes.** The arguments about placement are the learning; do not resolve them too quickly. Cohorts often want to place awareness earlier than the evidence supports — a productive error. If the room is large, run it as a race and let the first finished group present.
+
+---
+
+### **A6 — TRIGGER ARCHAEOLOGY**
+
+**Objective.** To apply associative matching to a real recurring reaction and identify the plausible "one key element" producing the match.
+
+**Duration.** 35 minutes.
+
+**Group size.** Individual; optional pair debrief.
+
+**Materials.** Worksheet with four prompts.
+
+**Instructions.**
+1. **Boundaries stated first, verbatim:** *"Work privately. Choose something of ordinary intensity — an irritation, not a wound. Share only if you choose, and only at the level of structure. I will not follow up unless you ask me to."*
+2. *(15 min, individually.)* Identify one reaction that is reliably out of proportion. Then work backwards: What is the specific stimulus? What element of it could constitute the match — a word, tone, posture, setting, time of day, sequence of events? When might this have been proportionate? What evidence do you have that it is now out of date?
+3. *(10 min, optional pairs.)* Share at the level of structure: "a particular tone of voice"; "being interrupted in a specific way."
+4. *(10 min, plenary.)* Categories only. What *kinds* of element produce matches? Build a list.
+
+**Expected outcome.** Learners convert an unexplained overreaction into a mechanism with a locatable trigger — which is the precondition for the intervention work in Module 7.
+
+**Debrief.** (a) What categories of element appeared? (b) How many were nonverbal? (c) Did anyone identify a trigger that used to be proportionate? (d) What is the value of knowing this in advance?
+
+**Instructor notes.** This activity reliably surfaces genuine material. Watch the room. Offer a supplied case privately to anyone who seems to have chosen something too heavy. Do not probe in the plenary — categories only. Have the referral pathway visible.
+
+---
+
+### **A9 — HIJACK POST-MORTEM**
+
+**Objective.** To reconstruct one of the learner's own emotional hijacks against a structured template and locate the intervention point.
+
+**Duration.** 40 minutes (20 individual, 12 pairs, 8 plenary).
+
+**Group size.** Individual then pairs.
+
+**Materials.** The Post-Mortem template (below); Appendix A vocabulary sheet; the six-hallmark card.
+
+**THE TEMPLATE**
+
+```
+ 1. THE SITUATION                (one sentence, factual)
+ 2. THE TRIGGER                  (the specific moment)
+ 3. FIRST BODILY SIGN            (what, where, when)
+ 4. FIRST THOUGHT                (verbatim)
+ 5. THE IMPULSE                  (what you wanted to do)
+ 6. WHAT YOU DID
+ 7. WHAT THE MANAGER WAS DOING   (absent / recruited / arrived late)
+ 8. HALLMARKS PRESENT            (which of the six, with evidence)
+ 9. RECOVERY TIME
+10. THE RETROSPECTIVE TEST       (did you afterwards not recognise
+                                  what came over you? Y/N)
+11. THE INTERVENTION POINT       (one specific moment + one specific
+                                  action + why it would have worked)
+```
+
+**Instructions.**
+1. Boundaries stated. Moderate intensity only.
+2. *(20 min.)* Complete the template individually.
+3. *(12 min.)* In pairs, share at whatever level you choose — many learners share only items 7, 8, 9 and 11.
+4. *(8 min.)* Plenary on item 11 only: what kinds of intervention did people identify?
+
+**Expected outcome.** The abstract concept becomes a personal, analysed event with a named intervention point. This template recurs in the Portfolio and in Assignment 3.
+
+**Debrief.** (a) How many answered yes to item 10? (b) What was the most common recovery time? (c) Was the manager absent or recruited? *(Recruited is more common than learners expect.)* (d) How early was the earliest intervention point identified?
+
+**Instructor notes.** The most valuable forty minutes of the foundations block and the most exposed. Set boundaries explicitly. Watch for the learner who selects something far heavier than needed. Item 7 is the one that produces insight — "recruited" is the answer most people have never considered.
+
+---
+
+### **A13 — CORRECT THE SLIDE**
+
+**Objective.** To immunise learners against the four commonest misattributions to this source.
+
+**Duration.** 25 minutes.
+
+**Group size.** Groups of 3–4.
+
+**Materials.** Four prepared "slides," one per group (or all four to each group):
+
+> **Slide 1:** "Research shows EQ accounts for 80% of career success, while IQ accounts for only 20%. (Goleman, 1995)"
+> **Slide 2:** "Goleman's four quadrants: Self-Awareness · Self-Management · Social Awareness · Relationship Management."
+> **Slide 3:** "Take our validated EQ assessment to discover your emotional intelligence score."
+> **Slide 4:** "IQ doesn't matter. What matters is emotional intelligence."
+
+**Instructions.**
+1. *(10 min.)* Identify every error on your slide. Cite the source.
+2. *(8 min.)* Rewrite the slide accurately, in the source's own terms.
+3. *(7 min.)* Present. The room challenges.
+
+**Expected outcome.** Learners can state precisely what the source claims and what it does not — the course's central fidelity commitment, established by their own work rather than by assertion.
+
+**Debrief.** (a) Which slide was hardest to correct? *(Usually 4, because the correction is nuanced: IQ matters but is insufficient.)* (b) Has anyone in the room used one of these? (c) Why do these versions spread while the accurate ones do not? (d) What does that tell you about how research travels?
+
+**Instructor notes.** **The single most effective fidelity exercise in the course.** Handle recognition without embarrassment — the misquotations are ubiquitous and their persistence is itself the interesting phenomenon. Slide 2 catches the most people, including some who have taught it.
+
+---
+
+### **B1 — THE CHECK-IN, MODELLED AND PRACTISED**
+
+**Objective.** To install the course's core self-observation protocol and demonstrate that it can be done honestly.
+
+**Duration.** 40 minutes (12 modelling, 15 individual, 13 pairs and plenary).
+
+**Group size.** Whole class, then individual, then pairs.
+
+**Materials.** Check-In cards (seven items); Appendix A vocabulary sheet.
+
+**Instructions.**
+1. *(12 min.)* **The instructor completes a genuine Check-In aloud**, on a real minor event of the past week. All seven items, including the impulse they did not act on.
+2. *(15 min.)* Learners complete one individually on an event of the past week.
+3. *(8 min.)* Pairs: share at whatever level chosen.
+4. *(5 min.)* Plenary: which item was hardest?
+
+**Expected outcome.** Learners have a completed Check-In and a demonstrated model of what honest completion looks like.
+
+**Debrief.** (a) Which item was hardest? *(Almost always item 3 — the verbatim thoughts — followed by item 5, the unadmitted impulse.)* (b) What was the gap between items 5 and 6? (c) Did anyone discover a feeling they had not named before?
+
+**Instructor notes.** **The instructor's modelling is not optional and cannot be faked.** Choose something real, minor and mildly unflattering — irritation at a colleague's email, deflation at feedback. A Check-In in which the instructor emerges well teaches the room that the exercise is performance. If you are unwilling to do this, do not teach Module 6.
+
+---
+
+### **B6 — THE ESCALATION LADDER**
+
+**Objective.** To locate empirically the point past which reappraisal ceases to work.
+
+**Duration.** 35 minutes.
+
+**Group size.** Groups of 4–5.
+
+**Materials.** Case 8 (The Escalation), numbered transcript; graph paper or a large sheet; Zillmann summary card.
+
+**Instructions.**
+1. *(12 min.)* Plot estimated arousal for each participant against each numbered line.
+2. *(10 min.)* Mark the line past which reappraisal would no longer work, and justify from Zillmann.
+3. *(8 min.)* Identify what would have needed to happen at three earlier lines.
+4. *(5 min.)* Compare plots between groups.
+
+**Expected outcome.** Learners internalise that de-escalation techniques have a *window*, and can identify it in real material.
+
+**Debrief.** (a) Where did groups place the point of no return, and why do the estimates differ? (b) What made this exchange land harder than the same words on a calm Monday? (c) What is line 10 (silence) doing physiologically? (d) What did the three weeks of silence afterwards cost?
+
+**Instructor notes.** Differences between group plots are the discussion, not a problem. Push on the second stage of Zillmann's physiology — most learners plot only the surge and miss the four-day baseline elevation.
+
+---
+
+### **B7 — VENTILATION DEBATE**
+
+**Objective.** To confront a widely held belief with evidence, including the evidence for the exceptions.
+
+**Duration.** 30 minutes.
+
+**Group size.** Two teams; whole class.
+
+**Materials.** Source extracts on catharsis, including the stated exceptions.
+
+**Instructions.**
+1. *(10 min prep.)* Team A: expressing anger directly is healthy and necessary — using the source's own stated exceptions. Team B: ventilation prolongs anger — using Tice and Zillmann.
+2. *(12 min.)* Debate, four minutes each side plus rebuttals.
+3. *(8 min.)* Debrief.
+
+**Expected outcome.** A more precise position than either "always express" or "never express": that ventilation at the target during arousal prolongs the mood, and that constructive confrontation *after* cooling is what the source actually recommends.
+
+**Debrief.** (a) What exactly are the exceptions the source allows? (b) Why does it say they "may be easier to say than to do"? (c) What is the practical rule you leave with? (d) What did you believe before this session?
+
+**Instructor notes.** Expect genuine resistance, sometimes culturally grounded. Do not steamroll it. The learning point is not "never express anger" — the source explicitly recommends confronting the person constructively after cooling. Assign the team positions rather than letting learners choose.
+
+---
+
+### **B9 — RATE THE REPAIR**
+
+**Objective.** To move learners from memorising a list of mood-repair strategies to applying the principle that generates the list.
+
+**Duration.** 25 minutes.
+
+**Group size.** Groups of 4.
+
+**Materials.** Twelve strategy cards — **including at least four not in the source** (e.g. cold-water immersion, scrolling social media, calling a friend to vent, tidying, a video game, breathwork).
+
+**Instructions.**
+1. *(10 min.)* Rank all twelve for effectiveness against low mood. Justify each.
+2. *(8 min.)* Reveal the source's evidence for the ones it covers. Adjust.
+3. *(7 min.)* For the four not in the source, predict effectiveness **using the organising principle**: does this pitch the brain into a state incompatible with the one holding it?
+
+**Expected outcome.** Learners can evaluate any technique, including ones invented after the book, rather than reciting a list.
+
+**Debrief.** (a) Which did you rank wrongly, and why? (b) Which of the "backfires" do you personally use? (c) Apply the principle to the four extras. (d) What makes "calling a friend to vent" ambiguous? *(It depends entirely on whether it interrupts or feeds the rumination.)*
+
+**Instructor notes.** The four unlisted cards are the point of the exercise. Learners who can reason about them have learned the principle; learners who cannot have memorised a table.
+
+---
+
+### **B11 — THE PERSONAL GOAL ACTIVITY**
+
+**Objective.** To construct a goal design that anticipates emotional obstacles rather than assuming they will not occur.
+
+**Duration.** 40 minutes (25 individual, 10 pairs, 5 plenary).
+
+**Group size.** Individual, then pairs.
+
+**Materials.** The Personal Goal worksheet.
+
+**THE WORKSHEET**
+
+```
+ 1. MY GOAL                     Specific. Observable. Dated.
+
+ 2. MY EMOTIONAL REASON         NOT the rational justification.
+                                What do I actually FEEL about
+                                achieving this? What will it
+                                feel like?
+
+ 3. OBSTACLES                   Practical and structural.
+
+ 4. LIKELY EMOTIONAL TRIGGERS   What will make me want to stop?
+                                Be specific: the third rejection?
+                                a particular person's reaction?
+                                the point at which it stops being
+                                novel?
+
+ 5. STRATEGIES FOR MAINTAINING  Drawn from Module 8:
+    MOTIVATION                  • hope: the WAY as well as the will
+                                • breaking it into manageable pieces
+                                • flow: where is the challenge–skill
+                                  balance for this?
+                                • self-efficacy: what competence
+                                  will I acquire early?
+
+ 6. MY STRATEGY FOR FAILURE     Written as an EXPLANATORY-STYLE
+                                COMMITMENT:
+                                "If this fails, the account I will
+                                 give myself is: ____________"
+                                (specific, changeable, actionable)
+```
+
+**Instructions.**
+1. *(25 min.)* Complete individually.
+2. *(10 min.)* Pairs: read each other's item 6 and challenge it. Is the account genuinely specific and changeable, or a disguised character verdict?
+3. *(5 min.)* Plenary: what made item 2 difficult?
+
+**Expected outcome.** A completed goal design that feeds directly into the Personal Development Plan, with a pre-committed explanatory style — the single most protective element.
+
+**Debrief.** (a) Why is item 2 harder than item 1? (b) How many item-6 statements survived challenge? (c) What is the difference between "I'll try harder" and a real strategy? (d) Which of Snyder's five hope traits is weakest in your design?
+
+**Instructor notes.** Item 6 is the activity. Most learners write something that sounds optimistic but is actually vague ("I'll learn from it"). Push for specificity: *what* will you conclude, in what words? Item 2 is deliberately unfamiliar — most people can justify a goal and cannot say what it feels like.
+
+---
+
+### **B14 — THE MARSHMALLOW DEBATE**
+
+**Objective.** To model rigorous evidence appraisal on the study learners are most attached to.
+
+**Duration.** 30 minutes.
+
+**Group size.** Two teams.
+
+**Materials.** Source extract (Ch. 6); a one-page summary of Watts, Duncan & Quan (2018) from the Evidence file.
+
+**Instructions.**
+1. *(10 min prep.)* Team A: the marshmallow test measures a stable, consequential individual capacity. Team B: the finding is substantially confounded and much smaller than reported.
+2. *(12 min.)* Debate.
+3. *(8 min.)* Debrief. **Neither team wins.**
+
+**Expected outcome.** Learners hold the study accurately: a real but smaller and more confounded effect than the popular account, whose most durable content is the *strategies* the successful children used.
+
+**Debrief.** (a) What exactly did the replication find? (b) What survives it? (c) Why did the original spread so widely? (d) Has this changed what you would teach about it? (e) What would settle the question?
+
+**Instructor notes.** **This is the course's integrity test.** Instructors who present the original uncritically will be caught out by any learner who reads a newspaper. Do the appraisal openly and the room trusts everything else.
+
+---
+
+### **C1 — WHAT IS THIS PERSON FEELING?**
+
+**Objective.** To install the four-step reading protocol and demonstrate the spread of interpretation across a room.
+
+**Duration.** 40 minutes.
+
+**Group size.** Individual, then pairs, then plenary.
+
+**Materials.** Six written scenarios (or short video clips) matched to the cohort; the four-step worksheet.
+
+**A representative scenario set:**
+1. A colleague who normally replies within the hour has not replied to three messages in two days. In the corridor she says hello, smiles briefly, and keeps walking.
+2. A team member accepts a challenging assignment, says "Sure, no problem," and does not ask a single question.
+3. A customer on the phone speaks slowly, quietly and very politely, and has repeated the same sentence twice.
+4. A direct report has begun arriving exactly on time and leaving exactly on time, having previously been flexible.
+5. A friend responds to your good news with "That's great," changes the subject, and later asks about it in detail.
+6. A student who has always sat at the front sits at the back and does not take notes.
+
+**Instructions.**
+1. *(20 min.)* For each scenario, individually complete: **(1) observable behaviour** — channel by channel; **(2) at least three possible emotions**, from the Appendix A families, with intensity; **(3) possible underlying need** — recognition, safety, information, autonomy, relief, repair; **(4) appropriate response**.
+2. *(10 min.)* Pairs compare.
+3. *(10 min.)* Plenary on one scenario: collect every interpretation offered.
+
+**Expected outcome.** Learners see the room generate five or six confident, incompatible interpretations of the same behaviour — which is more persuasive than any lecture on the observation/interpretation distinction.
+
+**Debrief.** (a) How many interpretations did the room produce for scenario 3? (b) Which arrived first for you, and what does that suggest about your history? (c) How many of you generated three genuinely different interpretations, rather than three versions of one? (d) What is the cheapest way to find out which is right?
+
+**Instructor notes.** Point (c) is the commonest failure — learners produce "annoyed," "irritated," "cross." Require genuine plurality: one negative, one neutral, one that is not about the observer at all.
+
+---
+
+### **C2 — CHANNEL ISOLATION**
+
+**Objective.** To demonstrate experientially that emotional information travels largely nonverbally, and that reading improves within a single session.
+
+**Duration.** 30 minutes.
+
+**Group size.** Threes.
+
+**Materials.** Emotion cards; a neutral sentence for tone-only rounds ("The meeting is at four o'clock on Thursday").
+
+**Instructions.**
+1. *(3 min.)* Explain the PONS method briefly.
+2. *(9 min, round 1.)* A conveys an assigned emotion three ways: **(i) words only** — reads a factual sentence flatly, face neutral; **(ii) tone only** — the neutral sentence, no facial expression, tone carrying everything; **(iii) face and body only** — silent. B and C guess after each.
+3. *(9 min, round 2.)* Rotate. New emotions.
+4. *(9 min, round 3 + debrief.)* Rotate again; **track whether accuracy improved across rounds.**
+
+**Expected outcome.** Words-only accuracy is poor; tone and face are markedly better; accuracy rises across rounds — mirroring the PONS finding that within-test improvement is itself a marker.
+
+**Debrief.** (a) Which channel carried most? Did it differ by emotion? (b) Did your accuracy improve? (c) What does that suggest about trainability? (d) What follows for email, chat and cameras-off meetings?
+
+**Instructor notes.** Instructors often skip this because it feels awkward. It is worth the awkwardness: the physical realisation that words carry less than assumed is not achievable by lecture. Keep rounds brisk.
+
+---
+
+### **C5 — THE CALM PRECONDITION**
+
+**Objective.** To demonstrate Levenson's finding experientially rather than assert it.
+
+**Duration.** 20 minutes.
+
+**Group size.** Pairs.
+
+**Materials.** An impossible or near-impossible puzzle with a visible timer; two reading scenarios.
+
+**Instructions.**
+1. *(5 min.)* Pairs attempt the puzzle under visible time pressure, with the instructor announcing the countdown. *(It cannot be completed.)*
+2. *(4 min.)* Immediately, each pair completes the four-step reading protocol on Scenario X.
+3. *(4 min.)* Five minutes of settling — stand, breathe, walk.
+4. *(4 min.)* Complete the protocol on Scenario Y, of comparable difficulty.
+5. *(3 min.)* Compare quality: number of interpretations generated, specificity, whether the observation/interpretation split held.
+
+**Expected outcome.** Most pairs produce fewer and more negative interpretations in the aroused condition — and, crucially, did not notice at the time that their reading was degraded.
+
+**Debrief.** (a) Compare your two sets. (b) Did you notice at the time? *(Almost nobody does — this is the finding.)* (c) What does this mean for reading a room while stressed? (d) What rule follows for difficult conversations?
+
+**Instructor notes.** Debrief the frustration of the puzzle explicitly and lightly — some learners find it genuinely irritating, which is the mechanism working. The key question is (b): the inability to detect one's own degraded accuracy is the practically important part.
+
+---
+
+### **C6 — CONTAGION DEMONSTRATION**
+
+**Objective.** To replicate the two-minute mood-transfer study in the room.
+
+**Duration.** 20 minutes.
+
+**Group size.** Pairs.
+
+**Materials.** Mood scale (a simple 1–10 plus three adjectives); sealed role cards.
+
+**Instructions.**
+1. *(3 min.)* Pairs complete the mood scale. **Do not explain the design.**
+2. *(1 min.)* Each learner opens a sealed card: **EXPRESSIVE** (hold in mind something that genuinely lifted or annoyed you this week; let it show; do not speak) or **NEUTRAL** (blank expression; do not speak). One of each per pair.
+3. *(2 min.)* Sit facing each other **in silence.**
+4. *(3 min.)* Complete the mood scale again.
+5. *(11 min.)* Reveal the design. Collect data: did the neutral partners move toward the expressive partners?
+
+**Expected outcome.** A visible aggregate shift in the neutral partners' scores toward their expressive partner's state. It does not work in every pair; it usually works in most.
+
+**Debrief.** (a) Neutral partners — did you notice anything? (b) What did you catch it from, given nobody spoke? (c) What does this mean for a leader entering a room? (d) Whose moods do you catch most easily?
+
+**Instructor notes.** Brief the design carefully so it does not leak — that is the main failure mode. Have the original study's result ready as backup. When it works, no further argument for contagion is needed for the rest of the course.
+
+---
+
+### **C7 — EMOTIONAL JUDO ROLE-PLAY**
+
+**Objective.** To rehearse the de-escalation sequence under simulated pressure, with rewind.
+
+**Duration.** 45 minutes.
+
+**Group size.** Threes: escalated person, responder, observer.
+
+**Materials.** Cohort-matched escalation scenarios; the five-step protocol card; observer sheet.
+
+**Scenarios (select by cohort):** an angry customer whose complaint has been unresolved for three weeks; a colleague who has just discovered they were left off a decision; a parent at a school gate about a safeguarding concern; a patient's relative who has been given contradictory information; a teenager who has just been refused something.
+
+**Instructions.**
+1. *(5 min.)* Brief the protocol: interrupt the pattern with an incompatible tone; ask a genuine question about them, not their behaviour; join their frame; redirect to another register; reach for what is underneath.
+2. *(12 min, round 1.)* Run it naturally. Observer records: when did the escalated person soften, or not?
+3. *(8 min.)* Debrief in threes.
+4. *(12 min, round 2.)* Same scenario, applying the protocol. **Rewind freely.**
+5. *(8 min.)* Plenary: which move produced the first softening?
+
+**Expected outcome.** Learners discover that the responder's *tone in the first three seconds* determines most of what follows, and that a genuine question outperforms any statement.
+
+**Debrief.** (a) Escalated players: what made you soften? (b) Responders: what was hardest? *(Usually not matching their intensity.)* (c) Where in the protocol did people jump ahead to solutions? (d) What did the old man on the train do that you did not?
+
+**Instructor notes.** The commonest error is jumping to step 4 (redirect) or to problem-solving without steps 1–3. Use rewind to force the sequence. Rotate roles so everyone plays the escalated person — that experience teaches more than the responder role.
+
+---
+
+### **D3 — MIRRORING PRACTICE**
+
+**Objective.** To rehearse mirroring — content *and* feeling, with the check — until it is available.
+
+**Duration.** 40 minutes.
+
+**Group size.** Pairs.
+
+**Materials.** **Supplied** low-stakes complaint scenarios (never learners' own material); the mirroring procedure card.
+
+**Supplied complaints (examples):** "When you rescheduled our one-to-one for the third time, I felt like I was at the bottom of your list." · "When you answered for me in that meeting, I felt talked over." · "When you said the report was 'fine,' I felt like you hadn't read it." · "When you agreed to the deadline without asking me, I felt taken for granted."
+
+**Instructions.**
+1. *(5 min.)* Demonstrate: a bad mirror (parroting words), a bad mirror (content only, no feeling), a bad mirror (with "...but"), and a good one.
+2. *(15 min.)* A states a supplied complaint. B mirrors — content *and* feeling — and checks: "Have I got that right?" A corrects. B tries again. **Repeat until A confirms.** Record the number of attempts.
+3. *(15 min.)* Swap.
+4. *(5 min.)* Plenary: how many attempts?
+
+**Expected outcome.** Most pairs need two or three attempts even on a supplied, low-stakes complaint — which is the lesson. Learners experience directly that mirroring is "surprisingly tricky in execution."
+
+**Debrief.** (a) How many attempts did you need? (b) What did the first attempt miss — usually the feeling. (c) How did it feel to be mirrored accurately? (d) Who added a "but"? (e) Why would this be harder while flooded?
+
+**Instructor notes.** **Use supplied scenarios only.** Mirroring practice on a learner's real grievance, with a stranger, in a classroom, is unsafe and outside the course's competence. Point (d) is worth calling out — the "but" is almost universal on first attempt and completely negates the move.
+
+---
+
+### **D6 — REWRITE THE CRITIQUE**
+
+**Objective.** To convert Levinson's four rules into a demonstrated skill.
+
+**Duration.** 30 minutes.
+
+**Group size.** Individual, then peer review in threes.
+
+**Materials.** Five destructive critiques; the four-rules card.
+
+**The five critiques:**
+1. "This is a mess. Do it again." *(email, 17:40 Friday)*
+2. "I don't know what happened to you this quarter. You used to be reliable."
+3. *(in a team meeting)* "Well, at least someone read the brief."
+4. "Everyone else managed it."
+5. "I'm not going to sugar-coat it — that presentation was embarrassing."
+
+**Instructions.**
+1. *(12 min.)* For each: identify which of the four rules it breaks; identify what the speaker probably *actually meant*; rewrite it meeting all four rules.
+2. *(12 min.)* Threes: peer-review against the four criteria. Score each rewrite pass/fail per rule.
+3. *(6 min.)* Plenary: the hardest one.
+
+**Expected outcome.** Learners produce rewrites that are specific, offer a route forward, are appropriate to deliver in person, and do not attack character — and discover how much longer that takes to write.
+
+**Debrief.** (a) Which was hardest? *(Usually 3 — sarcasm in public has no clean rewrite; it should not have been said in that setting at all.)* (b) How many rewrites still contained a character judgment? (c) Which rule is broken most often in your organisation? (d) How much longer did the good version take?
+
+**Instructor notes.** Critique 3 is the most instructive: the correct answer is that it cannot be rewritten *in that setting*. Rule 3 (be present, in private) is not a delivery preference; it determines whether the content can be said at all.
+
+---
+
+### **D8 — GROUP IQ SIMULATION**
+
+**Objective.** To demonstrate that harmony, not average ability, determines group output.
+
+**Duration.** 40 minutes.
+
+**Group size.** Two groups of 5–6; the rest observe.
+
+**Materials.** An identical creative task for both groups (e.g. design a campaign for a fictitious product, with a specified brief and constraints); observer sheets; a private brief for one confederate.
+
+**Instructions.**
+1. *(3 min.)* Both groups receive the identical task. Observers receive sheets tracking: who speaks, for how long, whose ideas are built on, who stops contributing.
+2. **Privately, in advance:** one member of Group A is asked to be enthusiastic, fast, and to interrupt and redirect frequently — *"be the person who is very keen and takes over."* Group B is briefed on three harmony behaviours: build on what was just said before adding; ask the quietest person directly; nobody speaks twice before everyone has spoken once.
+3. *(20 min.)* Both groups work.
+4. *(5 min.)* Outputs presented.
+5. *(12 min.)* Observer data and debrief.
+
+**Expected outcome.** Group B typically produces more ideas, uses more members' contributions, and produces a better output — despite no difference in individual ability.
+
+**Debrief.** (a) Observer data: how many members contributed in each group? (b) Group A — what did it feel like? (c) **Thank the confederate publicly and reframe the debrief around the mechanism, not the person.** (d) Who in your real teams occupies that role? (e) Why is it tolerated?
+
+**Instructor notes.** **Brief the confederate privately in advance and thank them publicly afterwards.** Frame every debrief comment around the mechanism. Note that the confederate's behaviour is *enthusiasm*, not aggression — which is why it goes unaddressed in real organisations.
+
+---
+
+### **D15 — THE TWO REJECTIONS**
+
+**Objective.** To develop calibrated claim-making about emotion and health.
+
+**Duration.** 25 minutes.
+
+**Group size.** Groups of 4.
+
+**Materials.** Eight statement cards.
+
+**The eight statements:**
+1. "Chronic hostility is associated with increased cardiovascular risk at population level."
+2. "Her cancer came back because she never dealt with her divorce."
+3. "There's no evidence that psychological state affects physical health."
+4. "Social isolation carries a mortality risk comparable to well-established physical risk factors."
+5. "If you stay positive, you'll get better faster."
+6. "Anger-control training after a heart attack has been associated with a lower rate of second attacks."
+7. "Stress is just an excuse — people need to get on with it."
+8. "People who are depressed after a heart attack have a higher death rate, partly because they comply less with treatment."
+
+**Instructions.**
+1. *(10 min.)* Sort into: **supported** / **dismissive** / **overclaiming**.
+2. *(8 min.)* For the overclaiming ones, rewrite them so they are defensible.
+3. *(7 min.)* Plenary: which were hardest to place?
+
+**Expected outcome.** Learners can make claims about emotion and health that survive challenge from both directions.
+
+**Debrief.** (a) Which were hardest? *(Usually 5 — it sounds benign and is an overclaim, and 8 — which is supported but sounds like blame until the mechanism is stated.)* (b) What makes statement 2 harmful, not merely wrong? (c) Write the sentence you would actually say to a sick friend. (d) What is the general rule?
+
+**Instructor notes.** **The course's best exercise in calibrated claim-making, and its value extends far beyond this topic.** Statement 2 should be discussed explicitly for its harm — the source's own language about "moral lapse or spiritual unworthiness" is the corrective. Be alert to learners with current illness or recent bereavement.
+
+---
+
+### **E3 — MANAGEABLE DOSES DESIGN**
+
+**Objective.** To apply Kagan's emboldening finding against the protective instinct.
+
+**Duration.** 30 minutes.
+
+**Group size.** Individual, then pairs.
+
+**Materials.** Worksheet.
+
+**Instructions.**
+1. *(15 min.)* Identify one avoidance — your own, or one you are currently accommodating in someone you support. Then design: **the target** (the full challenge); **the current dose** (what they/you can do now); **five graded steps** between them; **what presence looks like at each step** (you are loving *and* firm, not absent); and **explicitly, what you will stop doing** — the protective behaviour you will withdraw.
+2. *(10 min.)* Pairs: challenge each other's step 1. Is it small enough? Is the protection withdrawal specific?
+3. *(5 min.)* Plenary: how small was the smallest first step?
+
+**Expected outcome.** A concrete graded plan with an explicit statement of the protection being withdrawn — which is the element learners omit.
+
+**Debrief.** (a) How small was your first dose? *(Usually still too large.)* (b) What are you giving up by withdrawing the protection? (c) Where is the limit of this principle — when is protection right? (d) What would tell you the dose was too big?
+
+**Instructor notes.** Expect resistance, especially from caring-profession and parent cohorts, and take it seriously. Emphasise that Kagan's effective mothers were **loving and present** *and* firm — the finding is not "be harsh." Question (c) is essential and must not be skipped.
+
+---
+
+### **E9 — THE BOUNDARY EXERCISE**
+
+**Objective.** To establish, by practice, the line between supporting someone and attempting to treat them.
+
+**Duration.** 25 minutes.
+
+**Group size.** Threes: discloser, responder, observer.
+
+**Materials.** Four disclosure scenarios; the institution's actual referral information.
+
+**The scenarios.** A team member says: (1) "I've been finding it really hard to get out of bed lately." (2) "I had a bad experience with a previous manager and I think it's why I react like this." (3) "I don't really see the point of any of it at the moment." (4) "Something happened a few years ago and I've never talked about it."
+
+**Instructions.**
+1. *(5 min.)* Establish the frame: your role is to respond warmly, not to probe, not to diagnose, not to treat — and to offer a route.
+2. *(12 min.)* Rotate through scenarios. Responder practises: acknowledging; not probing; offering the route; staying present without taking over.
+3. *(8 min.)* Debrief.
+
+**Expected outcome.** Learners can produce, from memory, a warm and appropriate response that neither dismisses nor over-reaches, and can name the actual referral route in their own institution.
+
+**Debrief.** (a) What was the pull — to probe, to fix, or to change the subject? (b) Which scenario was hardest? *(Usually 3, which may indicate risk.)* (c) What does "offering a route" sound like without being a brush-off? (d) Can you name your organisation's route right now?
+
+**Instructor notes.** **Directly assessable and among the most transferable exercises in the course.** Ensure learners leave able to state the actual referral pathway. Scenario 3 should be discussed explicitly: expressions of hopelessness warrant a more careful response and a clear route, and the responder is not expected to assess risk.
+
+---
+
+### **E11 — THE THREE-COLUMN VERDICT**
+
+**Objective.** To require learners to sort the field's claims by evidential status and defend every placement.
+
+**Duration.** 45 minutes.
+
+**Group size.** Groups of 4–5.
+
+**Materials.** Blank three-column sheet (well supported / contested / not supported); the Evidence file; twenty claim cards drawn from across the course.
+
+**Instructions.**
+1. *(20 min.)* Place all twenty claims. Every placement must be justified with a reason and, where relevant, a citation.
+2. *(15 min.)* Groups exchange sheets and challenge three placements each.
+3. *(10 min.)* Plenary on the most contested placements.
+
+**Expected outcome.** A defended, evidence-based map of the field — which is Learning Outcome 15 in its assessed form.
+
+**Debrief.** (a) Which claim moved between columns under challenge? (b) Which did you *want* to place in "well supported" and could not? (c) What would move a "contested" claim to "well supported"? (d) Does anything in the "not supported" column still feel true to you? Why?
+
+**Instructor notes.** **Do not distribute the completed table from the Evidence file.** The exercise *is* the assessment. Question (d) is the most valuable — it surfaces the gap between belief and evidence, which is the course's final lesson.
+
+---
+
+### **E13 — THE ETHICS PANEL**
+
+**Objective.** To require each learner to take and defend a position on the ethics of emotional capability.
+
+**Duration.** 40 minutes.
+
+**Group size.** Whole class, with four prepared positions.
+
+**Materials.** Case 30; the Evidence file's dark-side section; four position briefs.
+
+**The four positions.**
+- **A:** Emotional intelligence is morally neutral — a capability like literacy, to be taught to all, judged by its use.
+- **B:** Emotional intelligence is intrinsically connected to good character, because empathy is the root of altruism and impulse control the base of will.
+- **C:** Teaching emotional influence without teaching values is irresponsible; the course has an obligation it has not discharged.
+- **D:** The distinction is unreal — you cannot be genuinely emotionally intelligent and use it destructively, because the destructive use reflects a failure of self-awareness.
+
+**Instructions.**
+1. *(10 min.)* Learners are assigned positions and prepare, using the source and the Evidence file.
+2. *(20 min.)* Panel discussion, four minutes per position plus open exchange.
+3. *(10 min.)* **Each learner privately writes their own position in three sentences** — which need not be the one they argued.
+
+**Expected outcome.** A defended personal position, and — the actual requirement — the ability to state the strongest version of a position one disagrees with.
+
+**Debrief.** (a) Which position was hardest to argue? (b) Did anyone change their mind? (c) What does Côté et al. (2011) contribute? (d) What follows practically — for hiring, for training, for you?
+
+**Instructor notes.** **Do not resolve it.** Assign positions rather than letting learners self-select, especially position D, which is the most interesting and least intuitive. The private three-sentence statement is the assessed output and feeds Assignment 16.
+
+---
+
+*The remaining fifty-four activities follow the same eight-part structure and are specified in their respective module texts (the module files).*
+
+---
+---
+
+
+## ADDED DURING INTEGRATION — A17–A20
+
+*These four were written when the course adopted the canonical 17-module structure: Module 2 (The Two Minds) and Module 5 (Intelligence Reconsidered) became modules in their own right and needed their own activities. Existing codes were **not** renumbered — a code is an identifier, not a position.*
+
+---
+
+### **A17 — PLACE YOURSELF ON THE GRADIENT**
+
+- **Objective:** Convert the rational/emotional gradient from a diagram into a personal instrument, and surface the fact that people place similar events very differently.
+- **Duration:** 20 minutes · **Group size:** Individual, then pairs · **Module:** 2 · **Materials:** Printed gradient diagram (slide 27), one per learner
+- **Instructions:** (1) Learners plot three recent episodes on the gradient — one calm decision, one mild disagreement, one they regret. (2) For each, they mark the **last point at which a different choice was available**. (3) Pairs compare placements — structure only, no content.
+- **Expected outcome:** Learners discover that the "last available point" sits much earlier than it felt at the time, and that their three points are not evenly spaced.
+- **Debrief:** Where was your last available point? Was it earlier than it felt? Did your partner place a similar event differently — and what does that tell you?
+- **Instructor notes:** Some learners place the regretted episode at 100% and stop thinking. Push with: *what was true five minutes before?* That is the whole of Module 7 in one question.
+
+---
+
+### **A18 — BUILD THE ARGUMENT**
+
+- **Objective:** Ensure learners take the bottom-up growth sequence as an **argument** rather than as anatomy to memorise.
+- **Duration:** 30 minutes · **Group size:** Groups of four · **Module:** 2 · **Materials:** Four cards per group (brainstem, olfactory lobe, limbic system, neocortex), each listing what that layer added
+- **Instructions:** (1) Groups order the cards. (2) Groups then write **one sentence** stating what the order *implies* about emotional influence over thought. (3) Sentences are read aloud and compared with the source's own conclusion.
+- **Expected outcome:** A correct sequence *and* a correct implication.
+- **Debrief:** What does the order imply? What would be different if the neocortex had come first?
+- **Instructor notes:** Groups that produce the sequence without the implication have done the anatomy and missed the point — that is the debrief, and it is worth more than the card exercise. Expect at least one group to offer the triune brain; receive it well and correct it.
+
+---
+
+### **A19 — CORRECT THE FRAMING**
+
+- **Objective:** Rehearse the fidelity discipline on the two models this course rejects.
+- **Duration:** 15 minutes · **Group size:** Whole class · **Module:** 2 · **Materials:** Four statements on the board
+- **Instructions:** Four statements are shown — two consistent with the source, one switch-model ("your rational brain goes offline"), one triune ("lizard brain, mammal brain, human brain"). Learners sort them and, for each rejected statement, say **what the source actually says instead**.
+- **Expected outcome:** Learners can name both rejected models and supply the correction from the source.
+- **Debrief:** Why is the switch model more than a simplification? *(Because it makes Module 4's second dynamic impossible to state.)*
+- **Instructor notes:** Precursor to A13 (Correct the Slide) in Module 5. Keep it fast — it is a warm-up, not a debate.
+
+---
+
+### **A20 — WHERE DOES THE EIGHTY GO?**
+
+- **Objective:** Make the 80-per-cent misattribution impossible to hold, by having the room construct the correct picture itself.
+- **Duration:** 10 minutes · **Group size:** Whole class, at the board · **Module:** 5 · **Materials:** Board
+- **Instructions:** (1) Write *"80% = other forces"* at the top. (2) Take contributions and list everything the room proposes. (3) When the list is long — social class, luck, health, education access, family, timing, networks, discrimination, temperament, emotional capacities — ask the question that lands it: **which of these is emotional intelligence?**
+- **Expected outcome:** Learners see emotional intelligence as one item on a long and heterogeneous list, to which the source assigns no percentage at all.
+- **Debrief:** What share of the eighty per cent does the source give to emotional intelligence? *(None. It does not say.)* So why does the popular version say otherwise?
+- **Instructor notes:** The ten highest-value minutes in Module 5 for inoculating learners against the commercial literature. Leave the list on the board through slide 82. Directly rehearses Case-Study Question 2(a).
+
+---
+
+*End of the Activity Book. Seventy-eight activities; twenty-four specified in full.*

--- a/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-8-10_Case_Book_Cases_01-30.md
+++ b/plugins/community/slide-blueprint-module-5-msodr5vw/references/source-8-10_Case_Book_Cases_01-30.md
@@ -1,0 +1,1112 @@
+# CASE STUDY BOOK
+## Thirty cases for teaching emotional intelligence
+
+*Every case contains: Background · Characters · Situation · Trigger · Emotional Dynamics · Decision Point · Possible Responses · Consequences · Discussion Questions · Instructor Notes · Learning Objective.*
+
+**Provenance markers:** **[SOURCE]** = drawn from events reported in Goleman; **[PEDAGOGICAL]** = constructed for this course. Constructed cases are fictional composites; any resemblance to particular individuals is unintended.
+
+**Handling rule for all cases:** learners analyse; they do not diagnose real people. Where a case concerns violence, abuse or death, deliver it factually, do not dramatise, and do not role-play it.
+
+---
+
+## THE CASE INDEX
+
+| # | Title | Type | Core theme | Module |
+| --- | --- | --- | --- | --- |
+| 1 | The Grade | **[SOURCE]** | High IQ, catastrophic emotional failure | 5 |
+| 2 | The Practical Joke | **[SOURCE]** | Fear; evolutionary mismatch | 1, 2, 4 |
+| 3 | The Neural Back Alley | **[SOURCE]** | Emotional hijacking at the extreme | 4 |
+| 4 | The Print from Spain | **[SOURCE]** | Everyday hijacking; the hallmark | 2, 3, 4 |
+| 5 | The Two Candidates | **[PEDAGOGICAL]** | Meta-ability and its limits | 5 |
+| 6 | The Man Without Feelings | **[SOURCE]** | Alexithymia; decision without feeling | 6 |
+| 7 | The Marker | **[PEDAGOGICAL]** | Somatic markers vs. bias | 6 |
+| 8 | The Escalation | **[PEDAGOGICAL]** | Anger's two clocks; the reappraisal window | 7 |
+| 9 | The Worry Loop | **[PEDAGOGICAL]** | Worry's partial payoff | 7 |
+| 10 | The Setback | **[PEDAGOGICAL]** | Explanatory style | 8 |
+| 11 | The Bored Star | **[PEDAGOGICAL]** | Challenge–skill mismatch | 8 |
+| 12 | The Silent Partner | **[PEDAGOGICAL]** | Observation vs. interpretation | 9 |
+| 13 | Attunement at Three Months | **[SOURCE]** | Attunement and misattunement | 9, 15 |
+| 14 | The Tokyo Train | **[SOURCE]** | Expert de-escalation | 10 |
+| 15 | The New Director | **[PEDAGOGICAL]** | Group entry; the two cardinal sins | 10 |
+| 16 | Four Fault Lines | **[PEDAGOGICAL]** | Criticism, contempt, defensiveness, stonewalling | 11 |
+| 17 | The Time-Out That Wasn't | **[PEDAGOGICAL]** | Cooling done wrongly | 11 |
+| 18 | The Throwaway Line | **[SOURCE]** | Destructive criticism | 12 |
+| 19 | The Star Who Made No Difference | **[PEDAGOGICAL]** | Group IQ | 12 |
+| 20 | Nobody Said Anything | **[PEDAGOGICAL]** | Fear and information flow | 12, 13 |
+| 21 | The Leader Who Never Rattles | **[PEDAGOGICAL]** | Repressors in authority | 13 |
+| 22 | The High-Strain Team | **[PEDAGOGICAL]** | Demand, control and support | 14 |
+| 23 | The Patient Who Could Not Ask | **[SOURCE]** | Emotional deficits in care | 14 |
+| 24 | The Video Game | **[SOURCE]** | The four parenting styles | 15 |
+| 25 | The Protected Employee | **[PEDAGOGICAL]** | Kagan's emboldening finding | 15 |
+| 26 | The Vestigial Reaction | **[PEDAGOGICAL]** | Realistic expectations for change | 16 |
+| 27 | Cleveland Elementary | **[SOURCE]** | Trauma in an institution | 16 (gated) |
+| 28 | Cooperation Squares | **[SOURCE]** | In-the-moment coaching | 17 |
+| 29 | The Compliance Module | **[PEDAGOGICAL]** | Information is not enough | 17 |
+| 30 | The Charming Manipulator | **[PEDAGOGICAL]** | The ethics of emotional skill | 17 |
+
+**The brief's ten required case types are all covered:** anger (8, 16), fear (2, 27), emotional hijacking (3, 4), workplace conflict (16, 18, 20), leadership (20, 21), marriage/relationship conflict (16, 17), parenting (13, 24), student conflict (28), peer pressure (28, and Activity book), personal setback (10, 26).
+
+---
+---
+
+## CASE 1 — THE GRADE **[SOURCE]**
+
+**Background.** A high school in Coral Springs, Florida. Jason H. is a sophomore and a straight-A student, fixated on getting into medical school — not just any medical school, Harvard.
+
+**Characters.** *Jason H.*, sixteen, academically exceptional. *David Pologruto*, his physics teacher.
+
+**Situation.** Pologruto returns a quiz on which Jason has scored 80 — a B.
+
+**Trigger.** The grade itself. Jason believes it puts his ambition in jeopardy.
+
+**Emotional dynamics.** A single data point is converted into a catastrophic conclusion about a whole life — categorical thinking, Hallmark 3. The gap between the objective event (one B, one quiz, sophomore year) and the meaning assigned to it is enormous, and invisible to Jason. Whether what followed was an emotional hijack, a psychotic episode, or both is genuinely unresolved: a court found him temporarily insane and four clinicians testified he was psychotic during the incident, while Pologruto believed he had tried "to completely do me in with the knife."
+
+**Decision point.** Jason takes a butcher knife to school.
+
+**Possible responses — what a person with intact emotional competence might have had available at each stage:**
+- *At the grade:* name the feeling; recognise the catastrophising; check the actual consequence of one B.
+- *Before the confrontation:* seek help; talk to a parent, counsellor or the teacher.
+- *In the room:* the impulse, unacted on.
+
+**Consequences.** Jason stabs Pologruto in the collarbone before being subdued. He is found innocent by reason of temporary insanity. He transfers to a private school and graduates two years later at the top of his class with a 4.614 grade-point average. Pologruto's observation: Jason "had never apologised or even taken responsibility for the attack."
+
+**Discussion questions.**
+1. Goleman asks: "How could someone of such obvious intelligence do something so irrational—so downright dumb?" What is your answer?
+2. Which of the five domains failed here? Can you tell?
+3. A court found him temporarily insane. Does that change how the case should be read as an illustration of emotional intelligence?
+4. What might a school have noticed earlier? What would it have had to be looking for?
+5. Is the closing detail — no apology, no responsibility — a separate failure or the same one?
+
+**Instructor notes.** Do not present this as a simple "smart person, poor self-control" story; the psychiatric finding complicates it and honest teaching says so. The case works best as an *opening question* rather than a settled illustration. Note also that Jason's later academic triumph is part of the point: the academic capability was never in doubt.
+
+**Learning objective.** LO1, LO15 — to establish that academic and emotional capability are separable, and that the relationship between them is not simple.
+
+---
+
+## CASE 2 — THE PRACTICAL JOKE **[SOURCE]**
+
+**Background.** A family home, one o'clock in the morning.
+
+**Characters.** *Matilda Crabtree*, fourteen. *Bobby Crabtree*, her father. *Mrs. Crabtree*.
+
+**Situation.** Matilda's parents believe she is staying with friends. She has come home and hidden in a closet, intending to jump out and shout "Boo!" when they return from visiting friends.
+
+**Trigger.** Bobby Crabtree hears noises as he enters the house.
+
+**Emotional dynamics.** Fear operating exactly as designed: mobilising to protect the family from an intruder. Attention narrows to the threat. Response initiates before full perception — the low road (Module 3). Crabtree "was primed to shoot before he could fully register what he was shooting at, **even before he could recognize his daughter's voice.**"
+
+**Decision point.** He reaches for his .357 pistol and goes to investigate.
+
+**Possible responses.** The point of this case is that by the time the closet opens, there is effectively no decision point left — which is precisely why the intervention had to be earlier. Earlier points: not retrieving the weapon; calling out; calling the police; turning on lights and announcing himself.
+
+**Consequences.** Matilda jumps from the closet. He shoots her in the neck. She dies twelve hours later.
+
+**Discussion questions.**
+1. Which emotion, which action tendency, which adaptive purpose?
+2. In what precise sense is this an "evolutionary mismatch"?
+3. Where was the last moment at which emotional intelligence could have operated?
+4. What does this case establish that a less extreme case would not?
+5. Is it possible to train for a situation like this? What would that training consist of?
+
+**Instructor notes.** **Handle with restraint.** This is a real child's death. Tell it plainly, without dramatisation, and move to analysis briskly. Do not use in role-play. Some learners are parents; some own firearms; some will have strong views about the latter — redirect firmly to the emotional mechanism, which is the teaching content.
+
+**Learning objective.** LO2, LO5 — the adaptive function of fear and the mismatch problem, at the point where they become catastrophic.
+
+---
+
+## CASE 3 — THE NEURAL BACK ALLEY **[SOURCE]**
+
+**Background.** New York, August 1963 — the day of the March on Washington.
+
+**Characters.** *Richard Robles*, a burglar recently paroled after more than a hundred break-ins to support a heroin habit; he has a girlfriend and a three-year-old daughter and says he wants to stop. *Janice Wylie*, twenty-one, a researcher at *Newsweek*. *Emily Hoffert*, twenty-three, a schoolteacher.
+
+**Situation.** Robles breaks into an Upper East Side apartment he believes is empty, intending this to be his last burglary. Wylie is home. He ties her up. As he is leaving, Hoffert returns; he begins to tie her too.
+
+**Trigger.** Wylie warns him he will not get away with it — she will remember his face and help the police find him.
+
+**Emotional dynamics.** The trigger is not physical danger but the collapse of the plan and the prospect of return to prison — a symbolic threat (Zillmann's "endangerment"). Robles "panicked at that, completely losing control." Twenty-five years later, the hallmark: **"I just went bananas. My head just exploded."** He does not describe a decision.
+
+**Decision point.** Wylie speaks. What happens in the next seconds.
+
+**Possible responses.** In a hijack of this magnitude, the intervention points are all upstream: not committing the burglary; leaving when Wylie proved to be home; leaving when Hoffert arrived. **This is the case's most important lesson — by the point of the hijack, the available options had already been reduced to almost none.**
+
+**Consequences.** He clubs both women unconscious with a soda bottle and stabs them repeatedly. Three decades later he is still in prison.
+
+**Discussion questions.**
+1. Identify both dynamics of the hijack. What was the manager doing?
+2. What was the actual threat? What was the response sized for?
+3. The source uses this to establish that hijacks are "by no means isolated, horrific incidents." What is the relationship between this case and losing your temper in traffic?
+4. Where were the real decision points?
+5. Ekman notes that the involuntariness of emotion "allows people to explain away their actions." Does this case explain, excuse, or neither?
+
+**Instructor notes.** A double murder of two named women. Deliver factually; do not linger on detail; move promptly to Goleman's own de-escalation ("these hijacks are by no means isolated..."). The pedagogical function is to establish the extreme so the ordinary case is recognisable. **Never role-play.**
+
+**Learning objective.** LO5, LO14 — the anatomy of a hijack and the location of intervention points.
+
+---
+
+## CASE 4 — THE PRINT FROM SPAIN **[SOURCE]**
+
+**Background.** A young woman drives two hours to Boston to spend the day with her boyfriend.
+
+**Characters.** *A young woman*. *Her boyfriend*.
+
+**Situation.** Over brunch he gives her a present she has wanted for months — a hard-to-find art print he brought back from Spain.
+
+**Trigger.** She suggests a matinee. He says he cannot spend the day with her: he has softball practice.
+
+**Emotional dynamics.** Delight collapses instantly. "Hurt and incredulous." The gift, which seconds earlier was precious, becomes the object of the impulse. Note the sequence: the emotion did not merely accompany the action, it *selected* the target.
+
+**Decision point.** She gets up in tears and leaves the café. Passing a garbage can, she throws the print in it.
+
+**Possible responses.** Name the feeling ("I'm hurt — I thought we had the day"). Say it: an XYZ statement. Leave without destroying anything. Take twenty minutes and return.
+
+**Consequences.** "Months later, recounting the incident, **it's not walking out she regrets, but the loss of the print.**"
+
+**Discussion questions.**
+1. Why does she regret the print and not the walkout?
+2. Which of the six hallmarks are visible?
+3. What information was the hurt carrying? Was it accurate?
+4. What would twenty minutes have changed?
+5. Why is this case, rather than Case 3, the more useful one for most learners?
+
+**Instructor notes.** The best small case in the book. Its size is its virtue: no crime, no tragedy, and every learner has done a version of it. Use it *before* the extreme cases where possible.
+
+**Learning objective.** LO5, LO13 — the hallmark of a hijack, in ordinary life.
+
+---
+
+## CASE 5 — THE TWO CANDIDATES **[PEDAGOGICAL]**
+
+**Background.** A mid-sized engineering consultancy is appointing a team lead for a twelve-person delivery team.
+
+**Characters.** *Priya*, the hiring manager. *Candidate A (Marcus)*: outstanding technically, top of every assessment, has personally solved two problems nobody else could; in interview, dismissive of a colleague's approach and visibly impatient when asked about handling disagreement. *Candidate B (Dele)*: technically competent but not exceptional; asked thoughtful questions about the team's history; spoke about a past failure without defensiveness; two references volunteer that people ask to work with him.
+
+**Situation.** The role involves coordinating specialists whose expertise exceeds the lead's own.
+
+**Trigger.** Priya's director says: "Take Marcus. We hire for capability."
+
+**Emotional dynamics.** Priya has a strong reservation she cannot fully articulate — a somatic marker. She is aware it might be pattern recognition or might be that she simply liked Dele more.
+
+**Decision point.** Which candidate, and on what argument.
+
+**Possible responses.**
+- Take Marcus; manage the behaviour later.
+- Take Dele; accept the technical shortfall.
+- Interrogate the marker: state the reservation aloud and specify what produced it.
+- Redesign the role.
+
+**Consequences (for discussion, not supplied).** Groups argue and must justify with mechanism, not preference.
+
+**Discussion questions.**
+1. What does the meta-ability claim predict here? What does the group-IQ finding predict?
+2. Where are the limits of the meta-ability argument? Under what conditions is Marcus the right answer?
+3. How should Priya handle her gut feeling — obey it, dismiss it, or something else?
+4. What would you need to know that the process has not told you?
+5. If you take Marcus, what specifically do you do on day one?
+
+**Instructor notes.** There is no correct answer and instructors should not supply one. The learning is in the quality of the reasoning and in whether learners notice that "hire for EI" is as lazy as "hire for capability."
+
+**Learning objective.** LO1, LO17 — applying the meta-ability claim and its limits to a real decision.
+
+---
+
+## CASE 6 — THE MAN WITHOUT FEELINGS **[SOURCE]**
+
+**Background.** Two men, unconnected, presenting the same deficit from opposite causes.
+
+**Characters.** *Gary*, an intelligent, thoughtful, successful surgeon. *Ellen*, his fiancée. *Elliot*, a corporate lawyer who has had a tumour the size of a small orange removed from behind his forehead, along with part of his prefrontal lobes. *Antonio Damasio*, the neurologist Elliot consults.
+
+**Situation.** Gary is "emotionally flat, completely unresponsive to any and all shows of feeling." He can speak brilliantly of science and art; on his feelings, even for Ellen, he falls silent. Elliot, post-surgery, is "as bright as ever" but has lost all sense of priority, has been fired from a succession of jobs, has squandered his savings, and is living in his brother's spare room. His wife has left him.
+
+**Trigger.** For Gary: Ellen's insistence that he see a therapist. For Elliot: his own attempt to secure disability benefits by finding a neurological explanation.
+
+**Emotional dynamics.** Gary: "I don't know what to talk about; I have no strong feelings, either positive or negative." The reason: "**He did not know what he felt in the first place.**" Elliot: able to narrate his own catastrophe "with complete dispassion... **Damasio felt more upset by Elliot's story than did Elliot himself.**" His thinking has become "computerlike, able to make every step in the calculus of a decision, but unable to assign values to differing possibilities. **Every option was neutral.**"
+
+**Decision point.** Damasio tries to schedule the next appointment. Elliot generates arguments for and against every proposed time and cannot choose.
+
+**Possible responses.** For Gary: the vocabulary and body-awareness work of Module 6. For Elliot: the case is included precisely because no self-help response exists — the circuitry is gone.
+
+**Consequences.** Gary's relationship is in serious difficulty and he cannot speak openly to anyone in his life. Elliot's life has collapsed while his intelligence remains intact.
+
+**Discussion questions.**
+1. What exactly is Ellen experiencing — cruelty, withholding, or something else?
+2. Why can Elliot reason and not choose?
+3. What does the pairing of these two men establish that either alone would not?
+4. Which is the greater handicap: too much feeling or too little?
+5. Where on this spectrum do you sit, and what is your evidence?
+
+**Instructor notes.** Frame alexithymia as a spectrum before delivering the clinical picture; several learners will recognise themselves in mild form and some will find it uncomfortable. Emphasise that low emotional vocabulary is overwhelmingly a matter of what was and was not taught.
+
+**Learning objective.** LO8, LO3 — self-awareness as necessary, and feeling as an input to rational decision.
+
+---
+
+## CASE 7 — THE MARKER **[PEDAGOGICAL]**
+
+**Background.** A public-sector organisation is appointing a senior analyst. A three-person panel has interviewed six candidates.
+
+**Characters.** *Ruth*, panel chair, twenty-two years' experience. *Two panel members*, both of whom rank the same candidate first. *The candidate*, strongly qualified, well-prepared, answers precisely.
+
+**Situation.** Ruth has a strong negative reaction she cannot justify. Asked to explain, she says: "Something's off. I can't put my finger on it."
+
+**Trigger.** The requirement to state a ranking.
+
+**Emotional dynamics.** A somatic marker: "an automatic alarm, typically calling attention to a potential danger from a given course of action," which "we usually do not, at that moment, recall what specific experiences formed." The problem is that the marker encodes *whatever was learned*, which may be twenty years of pattern recognition or may be an associative match on something entirely irrelevant to competence.
+
+**Decision point.** Ruth must decide what weight to give a feeling she cannot articulate — in a decision affecting someone's career, subject to equality obligations.
+
+**Possible responses.**
+- Obey it. ("Twenty-two years of experience.")
+- Dismiss it. ("Not evidence.")
+- **Interrogate it:** state it aloud; specify what in the interview produced it; ask whether it is about behaviour or about something else; identify a testable prediction it implies; test that.
+
+**Consequences (for discussion).** Groups work through what happens under each option, including what happens if the marker was accurate and was dismissed, and if it was bias and was obeyed.
+
+**Discussion questions.**
+1. What does Damasio's work say about the marker? What does Module 3's associative matching say?
+2. Is "I can't put my finger on it" ever an adequate basis for a decision affecting someone's livelihood?
+3. Design a protocol an organisation could adopt for handling gut feelings in selection.
+4. What would make you more confident the marker was signal rather than noise?
+5. Does it matter whether the candidate belongs to a group Ruth has less experience of?
+
+**Instructor notes.** The case exists to prevent the "trust your gut" misreading of Module 6. Push hard on the articulation test: markers that survive being stated specifically are more likely to be pattern recognition; markers that evaporate on articulation were probably something else.
+
+**Learning objective.** LO8, LO17 — somatic markers as an input to be interrogated, not obeyed.
+
+---
+
+## CASE 8 — THE ESCALATION **[PEDAGOGICAL]**
+
+**Background.** A software team, Thursday afternoon of a difficult release week. Two failed deployments, a client escalation, and four hours' sleep for most of the team.
+
+**Characters.** *Sam*, team lead. *Yemi*, senior developer. *Two others* in the room.
+
+**Situation.** A review meeting about the failed deployments.
+
+**The sequence (numbered for analysis).**
+1. **14:02** — Sam opens: "So. Let's work out what happened."
+2. **14:04** — Yemi: "What happened is the spec changed twice and nobody told us."
+3. **14:05** — Sam: "The spec changed because the client changed it."
+4. **14:07** — Yemi: "Then somebody should have pushed back."
+5. **14:08** — Sam, sharper: "I did push back. You weren't in that meeting."
+6. **14:09** — Yemi laughs, once, without humour.
+7. **14:10** — Sam: "Is something funny?"
+8. **14:12** — Yemi: "It's just — this is the third time this quarter."
+9. **14:13** — Sam: "If you've got a problem with how I run this team, say it."
+10. **14:14** — Silence. Yemi looks at his screen.
+11. **14:16** — Sam: "Right. Fine. Let's move on."
+
+**Trigger.** Formally, line 2. Actually, four days of accumulated arousal.
+
+**Emotional dynamics.** Zillmann's second stage is the key: adrenocortical arousal from four difficult days has lowered both parties' thresholds. Each successive line is "a minitrigger for amygdala-driven surges of catecholamines, each building on the hormonal momentum of those that went before." By line 9, both are past the point at which reappraisal works. Line 10 is stonewalling; line 11 is Sam mistaking it for resolution.
+
+**Decision point.** Analysis question: at which line does reappraisal stop being available?
+
+**Possible responses.**
+- *At line 3:* mitigating information, offered early — "That's fair, the communication was poor. Let me explain what happened."
+- *At line 6:* name it — "That laugh sounded like there's something underneath. Say it properly."
+- *At line 9:* too late. Take the break.
+- *At line 11:* not resolution. Return to it tomorrow, individually.
+
+**Consequences (supplied).** Yemi says nothing further in the meeting. He raises nothing for the next three weeks. The next deployment fails for a reason he had noticed and not mentioned.
+
+**Discussion questions.**
+1. Mark the line past which reappraisal would no longer have worked. Justify from Zillmann.
+2. Why did this land harder than the same exchange on a Monday?
+3. What is line 10 actually doing, physiologically, for Yemi?
+4. Sam reads line 11 as closure. What has actually happened?
+5. Rewrite the sequence from line 3.
+
+**Instructor notes.** The numbered format is deliberate — it makes the escalation analysable rather than atmospheric. The three-week silence is the point: the cost of the meeting was not the meeting.
+
+**Learning objective.** LO9, LO14 — escalation dynamics and the reappraisal window.
+
+---
+
+## CASE 9 — THE WORRY LOOP **[PEDAGOGICAL]**
+
+**Background.** A capable finance manager, eight months into a new role.
+
+**Characters.** *Nadia*, thirty-four. *Her director*. *Her partner*.
+
+**Situation.** Nadia has been asked to present the quarterly forecast to the board in three weeks. She has done comparable work before.
+
+**Trigger.** A brief, ambiguous message from her director: "Can we talk about the board pack? No rush."
+
+**Emotional dynamics.** A fleeting image — the board, a question she cannot answer, visible silence — produces a spike of anxiety. She plunges into a verbal chain: *what if the numbers are wrong → what if they've spotted something → what if this is about my probation → what if I lose this job → what about the mortgage → I should check the numbers again.* The chain relieves the physiological anxiety somewhat, because attention has left the image. The relief reinforces the worrying. Over three weeks she rechecks the model eleven times, sleeps badly, becomes irritable at home, and prepares less well for the actual presentation than she would have with half the anxiety.
+
+**Decision point.** Whether to ask her director what the message was about.
+
+**Possible responses.**
+- Ask. (Cost: four seconds. Barrier: it would confirm she is anxious.)
+- Apply Borkovec: catch the image; relax; challenge the thoughts — Is it probable? Is there only one alternative? Are there constructive steps? Does running through this help?
+- Continue the loop and recheck the model a twelfth time.
+
+**Consequences (supplied).** The director wanted to move the meeting forward by a day. Nadia presents adequately. She describes the three weeks as "fine, just busy."
+
+**Discussion questions.**
+1. What is the worry *doing* for her? Identify both reinforcement mechanisms.
+2. Why does rechecking the model feel like problem-solving?
+3. Apply Borkovec's four questions to her actual worry.
+4. Why is asking the director hard, and what does that difficulty consist of?
+5. What is the cost of the three weeks, expressed in things her employer would care about?
+
+**Instructor notes.** Learners frequently identify the solution ("just ask!") within seconds and then discover they have done the same thing themselves within the month. Push on question 4 — the barrier is social, not informational.
+
+**Learning objective.** LO9, LO13 — the mechanics of worry and its interruption.
+
+---
+
+## CASE 10 — THE SETBACK **[PEDAGOGICAL]**
+
+**Background.** Two account managers at the same firm, comparable in ability and tenure, both lose a major pitch on the same day to the same competitor.
+
+**Characters.** *Tom*, thirty-one. *Aisha*, thirty. *Their manager*.
+
+**Situation.** Debrief, the following morning.
+
+**Trigger.** The loss.
+
+**Emotional dynamics.**
+- *Tom:* "I'm just not a pitch person. I never have been. I freeze in the room and everyone can see it." — Internal, stable, global. A pessimistic attribution in Seligman's terms.
+- *Aisha:* "We led with price when they'd told us twice that price wasn't the issue. That was the wrong read and it was mine." — Specific, changeable, actionable, and *not* less accountable. Note that Aisha takes more responsibility than Tom, not less.
+
+**Decision point.** Their manager's response to each.
+
+**Possible responses.**
+- Reassure Tom ("you're great in the room!") — pleasant, ineffective, and contradicted by his own experience.
+- Attributional coaching: separate the person from the approach; identify the specific, changeable element; agree one concrete change.
+- Say nothing and reassign Tom away from pitches — Case 25's error.
+
+**Consequences (supplied, twelve months on).** Aisha has changed her discovery process and won three of the next five. Tom has been on two pitches, declined a third, and has begun describing himself in meetings as "more of a delivery person."
+
+**Discussion questions.**
+1. Whose account is more accurate? Whose is more useful? Are those the same question?
+2. Note that Aisha takes *more* personal responsibility. Why does that not make hers the pessimistic account?
+3. What exactly should the manager say to Tom?
+4. Where does realistic assessment end and pessimistic attribution begin?
+5. What has happened to Tom's self-description over twelve months, and why does it matter?
+
+**Instructor notes.** The critical teaching point is that optimistic attribution is **not** avoiding blame. Aisha's account is more specific *and* more accountable. Learners frequently misread optimism as excuse-making; this case is built to prevent it.
+
+**Learning objective.** LO10, LO16 — explanatory style and its consequences.
+
+---
+
+## CASE 11 — THE BORED STAR **[PEDAGOGICAL]**
+
+**Background.** A designer, four years in role, previously the team's strongest performer.
+
+**Characters.** *Léa*, twenty-nine. *Her manager*, who has noticed the change and interpreted it as a motivation problem.
+
+**Situation.** Léa's output is still accurate but consistently late. In her last review she said the job was "fine." She has recently started a side project which she talks about with visible energy.
+
+**Trigger.** Her manager schedules a conversation about "commitment."
+
+**Emotional dynamics.** The manager's diagnosis is motivational; the mechanism is more likely challenge–skill mismatch. Léa's skill has risen; the challenge has not. Per Csikszentmihalyi, "as their skills increase it takes a heightened challenge to get into flow" — below that, boredom.
+
+**Decision point.** How the manager opens the conversation, and on what hypothesis.
+
+**Possible responses.**
+- Motivation framing: "I need to see more commitment." (Predicts: defensiveness, and departure within six months.)
+- Diagnostic framing: "Is this work too easy or too hard for you at the moment?"
+- Flow framing: identify what her side project is supplying and whether any of it can exist in the role.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. Generate two competing diagnoses. What evidence would distinguish them?
+2. Why is "fine" a diagnostically useful answer?
+3. What is the side project supplying?
+4. What would the intervention be if the true diagnosis were *anxiety* rather than boredom? How different is it?
+5. What has the manager's framing already cost, before the conversation begins?
+
+**Instructor notes.** Pair with Case 25 (The Protected Employee), which is the same diagnostic error at the other end of the curve. Together they teach the challenge–skill grid better than either alone.
+
+**Learning objective.** LO10, LO17 — diagnosing challenge–skill mismatch rather than motivation.
+
+---
+
+## CASE 12 — THE SILENT PARTNER **[PEDAGOGICAL]**
+
+**Background.** A regular one-to-one between a manager and a normally talkative team member.
+
+**Characters.** *Chris*, the manager. *Wen*, six months in role, usually voluble.
+
+**Situation.** In today's meeting Wen gives short answers, does not make eye contact, and twice glances at his phone.
+
+**Trigger.** The behaviour change.
+
+**Emotional dynamics.** Chris forms a single interpretation — disengagement, probably job-hunting — within about ninety seconds, and does not notice that he has formed it. The interpretation arrives with the certainty characteristic of the emotional mind (Hallmark 1). Chris is also, unnoticed by himself, mildly activated: he has been worrying about attrition on his team.
+
+**Decision point.** Chris decides to "get ahead of it" and mentions the possibility of a retention conversation with HR.
+
+**Possible responses (the four-step protocol).**
+1. *Observation:* short answers; no eye contact; two glances at phone.
+2. *Three interpretations:* disengaged; unwell or preoccupied by something personal; anxious about something in the work he has not raised.
+3. *Underlying need:* recognition? information? safety? relief?
+4. *Response:* "You seem different today — is everything all right?"
+
+**Consequences (supplied).** Wen's mother was admitted to hospital that morning. The phone glances were checking for news. He had come to work because he did not want to let the team down. Chris's HR comment is relayed to him informally within two days.
+
+**Discussion questions.**
+1. Separate observation from interpretation in Chris's reasoning.
+2. Which interpretation arrived first, and what does that suggest about Chris?
+3. What was Chris's own emotional state doing to his accuracy? Cite Levenson.
+4. What would four seconds have cost, and what would it have saved?
+5. Design a personal rule that would prevent this.
+
+**Instructor notes.** The most-used case in the course, because every manager in the room has done it. The Levenson connection is the deeper point: Chris was activated, and therefore his reading was degraded, *and he could not detect that*.
+
+**Learning objective.** LO11, LO14 — observation versus interpretation, and the calm precondition.
+
+---
+
+## CASE 13 — ATTUNEMENT AT THREE MONTHS **[SOURCE + PEDAGOGICAL PARALLEL]**
+
+**Background — Panel A [SOURCE].** Sarah is twenty-five when she gives birth to twins, Mark and Fred. She feels Mark is more like herself and Fred more like his father.
+
+**Situation.** At three months, Sarah often tries to catch Fred's gaze; when he averts his face she tries again; he turns away more emphatically; the cycle of pursuit and aversion repeats, "often leaving Fred in tears." With Mark she never imposes eye contact; he can break it whenever he wants and she does not pursue.
+
+**Emotional dynamics.** Attunement with one twin; misattunement with the other. Not cruelty — a small, repeated, invisible difference in responsiveness.
+
+**Consequences.** A year later Fred is "noticeably more fearful and dependent than Mark," breaking off eye contact by turning his face down and away. Mark looks people straight in the eye and disengages "with a winning smile."
+
+**Background — Panel B [PEDAGOGICAL].** A manager, *Deepa*, supervises two analysts of similar ability, *Ana* and *Rob*. She finds Ana easy to read and Rob harder. Over a year she asks Ana how she is doing about twice as often; when Rob gives a short answer she moves on, and when Ana gives a short answer she asks again. Nothing is said about this by anyone.
+
+**Consequences (supplied).** At twelve months Ana volunteers for stretch work and raises problems early. Rob does neither. In his exit interview he says: "I never really felt she was that interested."
+
+**Discussion questions.**
+1. What exactly did Sarah do wrong? Is "wrong" the right word?
+2. What is the difference between attunement and imitation? Apply it to Deepa.
+3. Deepa would sincerely deny treating them differently. Is she lying?
+4. How would you detect this pattern in yourself?
+5. Stern says an imbalance "can be corrected later." What would correction look like for Rob at month six?
+
+**Instructor notes.** Pairing the panels is the point: the same mechanism at two scales. The case is uncomfortable for managers in a productive way — it identifies a failure that is invisible to the person committing it.
+
+**Learning objective.** LO11, LO20 — attunement and misattunement, and their transfer to supervision.
+
+---
+
+## CASE 14 — THE TOKYO TRAIN **[SOURCE]**
+
+**Background.** A suburban Tokyo train, the 1950s. Terry Dobson is one of the first Americans to study aikido in Japan, in peak condition from daily eight-hour workouts.
+
+**Characters.** *Terry Dobson*. *A drunk labourer* — huge, bellicose, filthy. *A small Japanese man*, about seventy, in a kimono. *Passengers*, including a woman with a baby and an elderly couple.
+
+**Situation.** The drunk boards and begins terrorising the carriage: screaming curses, swinging at the woman holding the baby and sending her sprawling into the elderly couple's laps, missing others, then grabbing the metal pole with a roar and trying to tear it from its socket.
+
+**Trigger.** Terry judges someone will be seriously hurt.
+
+**Emotional dynamics.** Terry's own state is competent and controlled — he recalls his teacher's words about reconciliation — but his intervention is nonetheless a *confrontation*. The drunk immediately reads it as one: "Aha! A foreigner! You need a lesson in Japanese manners!" Two men are now preparing to fight.
+
+**Decision point.** Someone shouts "**Hey!**" — in "the cheery tone of someone who has suddenly come upon a fond friend."
+
+**Possible responses — the old man's actual sequence.**
+1. Pattern interrupt with an *incompatible* tone: joyous, not matching.
+2. Beaming; a light beckon; "C'mere."
+3. A genuine question, about the man, not his behaviour: "What'cha been drinking?"
+4. Joining his frame: "Oh, that's wonderful, absolutely wonderful. You see, I love sake, too."
+5. Redirection to another emotional register: the wife of seventy-six, the wooden bench, the persimmon tree.
+6. The empathic reach: "**and I'm sure you have a wonderful wife.**"
+7. Listening.
+
+**Consequences.** "The drunk's face began to soften... his fists unclenched." "Yeah... I love persimmons, too." Then: "No. My wife died..." — and, sobbing, an account of losing his wife, his home, his job, of being ashamed of himself. As Terry leaves at his stop, the old man invites the man to tell him all about it, and the drunk is sprawled along the seat, his head in the old man's lap.
+
+**Discussion questions.**
+1. Annotate each of the seven moves with the concept it exemplifies.
+2. Move 6 is the pivot. Why did it work? What was it a guess about?
+3. What would have happened if Terry had intervened successfully? Would that have been a good outcome?
+4. What is the difference between handling the *situation* and handling the *person*?
+5. Transpose the sequence to an angry customer, a furious colleague, and a distraught teenager. What changes?
+
+**Instructor notes.** **Tell the story in full — do not summarise.** It takes eight minutes and it is the emotional high point of the course. Then analyse move by move. Finish on the Terry counterfactual: he would probably have won, and winning was not the point.
+
+**Learning objective.** LO12, LO16 — de-escalation at expert level, and the distinction between competence at situations and competence at people.
+
+---
+
+## CASE 15 — THE NEW DIRECTOR **[PEDAGOGICAL]**
+
+**Background.** A charity appoints a new operations director from the private sector to improve efficiency. The team has been in place for years and is proud of its work.
+
+**Characters.** *Helen*, the new director. *Six direct reports*. *The chief executive*, who hired her explicitly to change things.
+
+**Situation.** Helen's first month.
+
+**The sequence.** Week 1: she reorganises the shared drive and circulates the new structure. Week 2: in her first full team meeting she presents an analysis of three inefficient processes and proposes changes to all three. Week 3: she notices that two people have started copying the chief executive into routine emails. Week 4: a long-serving manager tells her, pleasantly, "We tried that in 2019."
+
+**Trigger.** Week 2, the meeting.
+
+**Emotional dynamics.** Both cardinal sins: taking the lead too soon, and being out of synch with the frame of reference. The team's frame is *we do difficult work well with too few resources*; Helen's opening move reads, in that frame, as *you have been doing this wrong*. Her mandate was real, and it made no difference to how the move landed. Note also the entrainment problem: she has power, so her state and her framing set the room's — and what she transmitted in week 2 was dissatisfaction.
+
+**Decision point.** Week 4. What Helen does next.
+
+**Possible responses.**
+- Escalate: cite the mandate, press harder.
+- Retreat: stop proposing changes; become ineffective.
+- **Restart:** name it explicitly ("I came in too fast and I got the order wrong"), then observe, join the frame, and earn status before proposing again.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. Identify each cardinal sin with the week it occurred.
+2. Helen had an explicit mandate to change things. Does that alter the analysis?
+3. What is the significance of people copying in the chief executive?
+4. Rewrite weeks one to four using the three-step sequence.
+5. What could the chief executive have done to confer status publicly, and why would that have helped?
+
+**Instructor notes.** Highly recognisable to anyone who has joined an organisation at seniority. Push question 2 hard: a mandate authorises the *outcome*, not the *sequence*.
+
+**Learning objective.** LO12, LO18 — group entry applied at organisational scale.
+
+---
+
+## CASE 16 — FOUR FAULT LINES **[PEDAGOGICAL]**
+
+**Background.** A couple of eleven years, two children aged six and nine, both working full-time. Wednesday, 7:40 p.m.
+
+**Characters.** *Ade*, home late. *Jo*, who has done the evening alone.
+
+**The transcript** *(numbered for annotation)*.
+
+1. **JO:** *(as Ade comes in)* Oh good. You're here for the part where they're already asleep.
+2. **ADE:** The meeting overran. I texted.
+3. **JO:** You texted at seven. Bath is six-thirty. *(pause)* You know that. You've known that for four years.
+4. **ADE:** I said the meeting overran.
+5. **JO:** It's *always* the meeting. It's never you choosing. **You just don't think about us — you never have.**
+6. **ADE:** That's — no. That's not fair. I was working. **Some of us have to actually be at work.**
+7. **JO:** *(eye-roll)* Oh, here we go.
+8. **ADE:** Don't do that.
+9. **JO:** Do what?
+10. **ADE:** *(silence)*
+11. **JO:** Are you going to say anything?
+12. **ADE:** *(looks at the counter, says nothing)*
+13. **JO:** Unbelievable. **This is exactly what you always do.**
+14. **ADE:** *(leaves the room)*
+
+**Trigger.** Formally line 1. Actually: an accumulated pattern with no repair mechanism.
+
+**Emotional dynamics — line by line.**
+
+| Line | What is happening |
+| --- | --- |
+| 1 | **Contempt** as the opening move — sarcasm. Ade's heart rate rises before any content. |
+| 3 | A legitimate complaint contaminated by "you've known that for four years" — the specific converted to the categorical. |
+| 5 | **Criticism**, not complaint. "You just don't think about us — you never have." Character attack, plus the always/never structure (Hallmark 3). |
+| 6 | **Defensiveness** plus counterattack. "Some of us have to actually be at work" is itself contemptuous. |
+| 7 | **The dimpler.** Gottman's marker. |
+| 10, 12 | **Stonewalling.** Ade's heart rate drops ~10 bpm; he feels relief. Jo's rises sharply. |
+| 13 | Jo is now flooded. Memory has reorganised toward grievance; she can access no counter-evidence. |
+| 14 | Exit without repair. Nothing is resolved and both are worse. |
+
+**Decision point.** For analysis: identify every point at which a repair move was still available.
+
+**Possible responses.** See Module 11 §7.7 for the fully rewritten version. In brief: Jo calls a time-out at line 1 rather than opening with contempt; the complaint is delivered as XYZ; Ade mirrors before defending; either party makes a repair gesture at lines 7–9.
+
+**Consequences (supplied).** Neither mentions it again. The same exchange occurs, in a different form, eleven days later.
+
+**Discussion questions.**
+1. Annotate every fault line with its line number.
+2. Estimate each party's physiological state at lines 5, 10 and 13.
+3. What is line 10 doing *for* Ade?
+4. What does Jo experience at line 12, and why is it worse than being shouted at?
+5. Identify the last line at which repair was still realistically available, and write it.
+6. Rewrite the whole transcript.
+
+**Instructor notes.** Use supplied transcripts only — never learners' own material. The numbered format makes annotation precise. This is the course's primary conflict-analysis case and is used in Assignment 10.
+
+**Learning objective.** LO19, LO14 — the four fault lines, identified and repaired.
+
+---
+
+## CASE 17 — THE TIME-OUT THAT WASN'T **[PEDAGOGICAL]**
+
+**Background.** The same couple, three months later, having attended a relationship workshop and agreed a time-out protocol.
+
+**Situation.** An argument begins about money. At the agreed signal, Ade says "I need twenty minutes" and goes to the garden.
+
+**Trigger.** The argument.
+
+**Emotional dynamics.** For twenty minutes Ade rehearses. He assembles the case: the three previous occasions, the thing her mother said, the fact that he has never once been thanked. Each rehearsal is a fresh provocation. He returns at exactly twenty minutes, physiologically *more* aroused than when he left, and opens with the strongest item.
+
+Meanwhile Jo, in the kitchen, has spent twenty minutes drafting her own case.
+
+**Decision point.** What happens on his return.
+
+**Possible responses.**
+- The protocol as designed: interrupt the thought-train (walk, exercise, an absorbing task); return; **the person who called it opens by restating the other's position.**
+- What actually happened: two better-prepared prosecutors.
+
+**Consequences (supplied).** The argument that follows is worse than the one the break interrupted. Both conclude that "the technique doesn't work for us."
+
+**Discussion questions.**
+1. What specifically failed? Was it the protocol?
+2. What did the source say the cooling-off period must and must not contain?
+3. Why is a return commitment essential, and what makes its absence stonewalling?
+4. Design a protocol that would survive this failure mode. Specify what happens *during* the break.
+5. Why do couples conclude "the technique doesn't work" rather than "we used it wrong"?
+
+**Instructor notes.** A necessary companion to Case 16. The commonest reason repair techniques fail is that they are executed without the mechanism. Question 5 is the important one: attribution again.
+
+**Learning objective.** LO9, LO19 — cooling done correctly, and why the mechanism matters more than the ritual.
+
+---
+
+## CASE 18 — THE THROWAWAY LINE **[SOURCE]**
+
+**Background.** A technology company. A seasoned engineer heads a software development project; his team have worked long days for months.
+
+**Characters.** *The engineer*. *His team*, present at the meeting. *The vice president for product development*.
+
+**Situation.** The engineer presents the result of months of work, his people there with him, "proud to present the fruit of their hard labor."
+
+**Trigger.** As he finishes, the VP turns to him and asks, sarcastically: "**How long have you been out of graduate school? These specifications are ridiculous. They have no chance of getting past my desk.**"
+
+**Emotional dynamics.** The engineer is "utterly embarrassed and deflated" and silent for the rest of the meeting. His team make "a few desultory—and some hostile—remarks." The VP is called away; the meeting breaks up abruptly, "leaving a residue of bitterness and anger." For two weeks the engineer is obsessed, dispirited and depressed, convinced he will never get another significant assignment, and thinking of leaving a job he enjoys. **The VP has forgotten the remark entirely.**
+
+**Decision point.** The engineer goes to see the VP and asks a carefully worded question: "**I'm a little confused by what you were trying to accomplish. I assume you were not just trying to embarrass me—did you have some other goal in mind?**"
+
+**Possible responses.**
+- Say nothing; leave; carry it.
+- Complain to HR.
+- Confront angrily.
+- **The question actually asked** — non-accusatory, presuming good intent, making the gap discussable.
+
+**Consequences.** The VP "was astonished—he had no idea that his remark, which he meant as a throwaway line, had been so devastating." In fact he thought the plan promising but in need of more work. He apologises.
+
+**Discussion questions.**
+1. Analyse the VP's remark against each of Levinson's four rules.
+2. Rewrite it so it says what he actually thought.
+3. Analyse the engineer's question. Why does it work? Could you use it?
+4. What did the organisation lose in those two weeks?
+5. Why did nobody on the team say anything at the time?
+
+**Instructor notes.** The engineer's question is the module's most transferable single sentence and instructors routinely skip past it. Rehearse it. Note also that the VP's *actual view was positive* — the damage was entirely in the delivery.
+
+**Learning objective.** LO17 — destructive versus artful criticism, and how to surface a destructive critique.
+
+---
+
+## CASE 19 — THE STAR WHO MADE NO DIFFERENCE **[PEDAGOGICAL]**
+
+**Background.** A product team of nine with a two-year record of missed deadlines and internal friction. Two members have an unresolved dispute dating to a reorganisation. One member dominates every meeting; two have stopped contributing.
+
+**Characters.** *Ravi*, hired at considerable cost from a competitor, exceptionally able. *Team members*, including *the dominator* and *the two who have gone quiet*.
+
+**Situation.** Leadership's theory: the team lacks capability. Solution: hire a star.
+
+**Trigger.** Ravi's arrival.
+
+**Emotional dynamics.** Ravi's ideas are good and are not taken up. The dominator argues with them; the quiet members do not support them; the disputing pair each read his contributions as favouring the other. Within four months Ravi has stopped proposing things in meetings and works largely alone.
+
+**Decision point.** At month six, leadership must decide whether the problem is Ravi.
+
+**Possible responses.**
+- Conclude the hire was wrong.
+- Hire a second star.
+- Address the friction: the dominator, the two absent members, the unresolved dispute.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. What does the group-IQ research predict about this hire, and why?
+2. Name the two specific behaviours Sternberg and Williams identified as lowering group performance. Which are present?
+3. What is the cost of the dominator, expressed in unusable talent?
+4. Why is the dominator tolerated?
+5. What is the correct sequence of interventions, and why is hiring not first?
+
+**Instructor notes.** Extremely common in real organisations and rarely diagnosed correctly. The key insight — "groups with more friction were far less able to capitalize on having members of great ability" — reframes team development as a precondition for talent acquisition rather than an alternative to it.
+
+**Learning objective.** LO17, LO18 — group IQ and the stranding of talent.
+
+---
+
+## CASE 20 — NOBODY SAID ANYTHING **[PEDAGOGICAL]**
+
+**Background.** A manufacturing business preparing to launch a new product line. The managing director, *Frank*, is highly capable, widely respected, and has a temper that arrives without warning and passes quickly.
+
+**Characters.** *Frank*, MD. *Ola*, quality manager, who has data suggesting a component failure rate above tolerance. *Three others* who have seen the same data.
+
+**Situation.** Two weeks before launch. Frank has publicly committed to the date.
+
+**The history that matters.** Eight months earlier, Ola raised a supplier problem in a meeting; Frank said, in front of eleven people, "Do you ever bring me anything that isn't a problem?" He apologised privately two days later. Ola accepted the apology. She has raised two things since, both in writing, both minor.
+
+**Trigger.** The failure-rate data.
+
+**Emotional dynamics.** Ola's amygdala has learned the association (Module 3). Frank's presence is now a threat stimulus; raising something is anticipated cost. She drafts an email three times. She decides the data are "probably a sampling artefact" — a motivated reading she does not recognise as motivated. Two of the three others assume Ola has raised it. The third assumes it is not his place.
+
+**Decision point.** Whether anyone speaks, and when.
+
+**Possible responses.**
+- Ola raises it, in writing, with the data attached.
+- The group raises it collectively.
+- Someone raises it with Frank's deputy.
+- Nobody raises it. *(What happens.)*
+
+**Consequences (supplied).** The line launches. Field failures appear at week five. The recall costs eight times what a two-week delay would have. In the review, Frank asks, genuinely: "**Why did nobody tell me?**"
+
+**Discussion questions.**
+1. Trace the mechanism from Frank's temper to the recall, step by step.
+2. Frank apologised. Why was that insufficient?
+3. Whose failure is this?
+4. What could Ola have done? What could the three others have done?
+5. Frank's question is sincere. How would you answer it?
+6. What would you change structurally so that this cannot happen again?
+
+**Instructor notes.** The McBroom structure without the aircraft. Question 3 usually splits the room, which is the point. Question 5 is the leadership moment: answering it honestly to a well-meaning senior person is itself an emotional-intelligence task.
+
+**Learning objective.** LO18 — how a leader's emotional behaviour disables information flow.
+
+---
+
+## CASE 21 — THE LEADER WHO NEVER RATTLES **[PEDAGOGICAL]**
+
+**Background.** A public body under sustained political pressure. The chief executive, *Margaret*, is admired for her composure; nobody has ever seen her flustered.
+
+**Characters.** *Margaret*. *Her executive team*. *A director*, Sunil, who is close to burnout.
+
+**Situation.** Three difficult years. Margaret's standing response to bad news is a calm "Right. What's the plan?"
+
+**Trigger.** Sunil, in a one-to-one, says: "I don't think I can keep doing this."
+
+**Emotional dynamics.** Margaret responds calmly and constructively — a reduced workload, an offer of support. She does not register the *emotional* content of what he said, and does not notice that she has not. In Davidson's terms she may be a "repressor": physiologically aroused, subjectively calm, doing "energy-demanding work" to maintain the positive frame. Her team have learned, over three years, that distress delivered to Margaret is converted into a plan. Several have stopped delivering it.
+
+**Decision point.** What Margaret does after the conversation.
+
+**Possible responses.**
+- Implement the plan and consider it handled.
+- Return: "I gave you a plan. I didn't ask how you are."
+- Ask her own team what they don't tell her.
+
+**Consequences (for discussion).** Two directors leave within a year, both citing "not feeling heard." Both had been given plans.
+
+**Discussion questions.**
+1. Is Margaret's composure a strength, a defence, or both?
+2. What is the cost of unflappability at the top of an organisation?
+3. Davidson notes an "unknown cost to self-awareness." What might that cost look like here?
+4. What information is Margaret systematically not receiving?
+5. Distinguish this case from a leader who is simply calm and highly attuned. What would tell them apart?
+
+**Instructor notes.** Uncomfortable for senior cohorts and valuable for exactly that reason. Question 5 matters: the course is not claiming that calm leaders are repressors. The distinguishing evidence is whether the emotional content is *registered*, not whether it is displayed.
+
+**Learning objective.** LO8, LO18 — regulation with a cost, and its organisational consequences.
+
+---
+
+## CASE 22 — THE HIGH-STRAIN TEAM **[PEDAGOGICAL]**
+
+**Background.** A customer-contact team of twenty-two in a utilities company. Call volumes and quality targets are set centrally; handling time is monitored; scripts are mandated; agents cannot make goodwill payments without escalation.
+
+**Characters.** *Team manager*. *Twenty-two agents*. *An HR business partner* reviewing the data.
+
+**Situation.** Sickness absence is 2.4 times the organisational average. Turnover is 41% annually. Engagement scores are the lowest in the business. The last intervention was a resilience workshop.
+
+**Trigger.** A request from the board to "fix engagement."
+
+**Emotional dynamics.** Classic **strain**: high demand with low control. The agents absorb customer anger all day with no discretion to resolve it. Emotional labour (display rules, sustained substitution) is continuous and unacknowledged. Isolation is high despite constant contact — headsets, back-to-back calls, no time between.
+
+**Decision point.** What to recommend to the board.
+
+**Possible responses.**
+- Another resilience programme. (Individual solution to a design problem.)
+- Increase autonomy: discretion limits, script flexibility, control over break timing.
+- Build support: paired debriefs after difficult calls, protected non-call time.
+- All of the above, sequenced.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. Diagnose using the demand/control framework. What exactly is the strain?
+2. Why is a resilience workshop the wrong first intervention? Is it wrong at all?
+3. The Goteborg finding suggests support buffers stress. What would support look like here, concretely?
+4. What is the emotional-labour cost, and how would you make it visible to a board?
+5. Which of these interventions costs money, and which costs only permission?
+
+**Instructor notes.** The most directly actionable case for HR and operational cohorts. Question 5 is the one that changes behaviour: several of the highest-value interventions cost nothing but a policy change.
+
+**Learning objective.** LO17, LO18 — emotional climate as a design variable.
+
+---
+
+## CASE 23 — THE PATIENT WHO COULD NOT ASK **[SOURCE]**
+
+**Background.** A routine check-up reveals traces of blood in the urine.
+
+**Characters.** *The patient*. *His doctor*. *A nephrologist*. *A friend* who is also a physician.
+
+**Situation.** The doctor says, businesslike: "I want you to go to the hospital and get some tests... kidney function, cytology..."
+
+**Trigger.** The word *cytology*.
+
+**Emotional dynamics.** "**My mind seemed to freeze at the word cytology. Cancer.**" The subsequent instructions — simple, practical — have to be repeated three or four times. Working memory has been degraded by arousal (Module 4), in a competent adult, in the space of one word.
+
+Later, after ninety minutes of imaging, the nephrologist appears briefly, disappears to read the films, and does not return. Passing him in the corridor, the patient — "feeling shaken and somewhat dazed" — cannot ask the one question that has been on his mind all morning. **His friend asks it for him:** "Doctor, my friend's father died of bladder cancer. He's anxious to know if you saw any signs of cancer in the X-rays."
+
+**Decision point.** For analysis: at how many points could a clinician have intervened at negligible cost?
+
+**Possible responses.**
+- Check for understanding before giving instructions; write them down.
+- Name the likely fear directly: "I can see that word landed. Let me tell you what I actually think is going on."
+- Return after reading the films.
+- Ask, as a standing practice, "What are you most worried about?"
+
+**Consequences.** "No abnormalities," delivered in the corridor, in passing. The waiting-room finding generalises it: patients arrive with an average of three or more questions and leave with an average of one and a half answered.
+
+**Discussion questions.**
+1. What happened to the patient's working memory, and why?
+2. Identify four points at which a small intervention would have changed the experience.
+3. Why could he not ask the question himself?
+4. What would it cost a clinician to ask "what are you most worried about?"
+5. Where else does this pattern occur — in law, in social work, in HR, in schools?
+
+**Instructor notes.** Essential for healthcare cohorts; valuable for all, because the pattern generalises to every situation where a professional gives consequential information to a distressed person. Question 5 broadens it usefully.
+
+**Learning objective.** LO3, LO17 — arousal, comprehension, and the emotional deficits of professional communication.
+
+---
+
+## CASE 24 — THE VIDEO GAME **[SOURCE + PEDAGOGICAL REWRITE]**
+
+**Background — Panel A [SOURCE].** Carl and Ann are showing their five-year-old daughter Leslie how to play a new video game.
+
+**The scene.** "To the right, to the right—stop. Stop. **Stop!**" — Ann, increasingly anxious. "See, you're not lined up . . . put it to the left! **To the left!**" — Carl, brusquely. Ann, eyes rolling, yelling over him: "Stop! Stop!" Leslie "contorts her jaw in tension and blinks as her eyes fill with tears." The parents begin bickering with each other. "**As the tears start rolling down Leslie's cheeks, neither parent makes any move that indicates they notice or care.**" When she raises a hand to wipe her eyes: "Okay, put your hand back on the stick..." "Okay, move it just a teeny bit!" "**But by now Leslie is sobbing softly, alone with her anguish.**"
+
+**Emotional dynamics.** Contradictory instructions produce an impossible task. Both parents are focused on the *task*; neither registers the *child*. Their own frustration with each other is transmitted to her. The lesson available to Leslie: her feelings are not noticed.
+
+**Trigger.** Her failure to follow instructions that cannot both be followed.
+
+**Decision point.** The moment the first tear appears.
+
+**Possible responses — Panel B, the coaching rewrite [PEDAGOGICAL].**
+
+> **ANN:** *(noticing)* Hey. Stop a second. *(puts down the controller)* This is going badly, isn't it?
+> **LESLIE:** *(nods, crying)*
+> **ANN:** I think we're both telling you different things at once and it's impossible. That would make me want to cry too. **[naming the feeling and locating the cause outside the child]**
+> **CARL:** That's on us. Sorry, Les.
+> **ANN:** Do you want to try again with just one of us talking, or shall we do something else and come back to it? **[restoring control — Module 16's agency finding, at five years old]**
+> **LESLIE:** ...Just you.
+> **ANN:** Okay. Dad's on snacks. *(to Carl, lightly)* You're fired.
+
+**Consequences.** Panel A: repeated over childhood, a lesson that feelings are not registered. Panel B: an emotional moment converted into a lesson in naming, repair and agency.
+
+**Discussion questions.**
+1. Which of the four styles are Carl and Ann exhibiting?
+2. Neither parent is cruel. What is going wrong?
+3. Identify each coaching move in Panel B.
+4. Transpose both panels to a manager and a struggling new starter. What changes?
+5. What would it take to notice, in real time, that you were in Panel A?
+
+**Instructor notes.** The workplace transposition (question 4) is essential — it prevents cohorts without children from disengaging. Emphasise that Carl and Ann are ordinary, well-meaning parents having a bad five minutes; the point is the accumulation, not the incident.
+
+**Learning objective.** LO20 — the four styles, and what coaching actually looks like.
+
+---
+
+## CASE 25 — THE PROTECTED EMPLOYEE **[PEDAGOGICAL]**
+
+**Background.** A consultancy. *Tunde* is technically excellent and visibly anxious about client-facing work. His manager, *Karen*, likes him and wants him to succeed.
+
+**Situation.** Two years ago Tunde froze during a client presentation. Since then Karen has quietly reassigned every client-facing opportunity. She has never discussed it with him; she considers this a kindness.
+
+**Trigger.** A promotion round. Tunde is not eligible; the grade requires client work.
+
+**Emotional dynamics.** Karen's protection has removed exactly the manageable doses through which the fear would have extinguished (Modules 15 and 16). Tunde's avoidance has been reinforced twenty-odd times. He has also, silently, drawn the conclusion that Karen thinks he cannot do it — which she does not believe and has never said.
+
+**Decision point.** Karen has to explain the promotion decision.
+
+**Possible responses.**
+- Continue protecting and explain the grade requirement as a policy matter.
+- Assign him a major client presentation. (Too large a dose.)
+- **Design graded exposure with presence:** five minutes in an internal meeting; then a section of a client call with Karen present; then a full internal presentation; then a small client meeting. Loving, firm, and manageable — Kagan's combination.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. What did Karen's kindness cost?
+2. What does Kagan's finding predict about protective supervision?
+3. Design the graded sequence. How small should the first dose be?
+4. What does Karen say to open the conversation?
+5. Where is the limit of this principle? When *is* protection right?
+
+**Instructor notes.** Pairs with Case 11 as the two failures of challenge calibration. Question 5 is essential — the emboldening finding is not a licence to throw people in.
+
+**Learning objective.** LO22, LO17 — the emboldening finding applied to development.
+
+---
+
+## CASE 26 — THE VESTIGIAL REACTION **[PEDAGOGICAL]**
+
+**Background.** *Miriam*, a senior analyst, ten years' experience, well regarded.
+
+**Situation.** Whenever her work is reviewed in a group setting she becomes visibly tense, answers defensively, and afterwards describes herself as "useless." One-to-one feedback, however critical, she handles well.
+
+**Trigger.** Group review specifically.
+
+**What is known.** She has said only that a previous manager "used to do it in front of everyone."
+
+**Emotional dynamics.** An associative match with a specific configuration — audience plus evaluation. The response is disproportionate to the present situation and was proportionate to a previous one. Note that she is not impaired generally: the specificity of the trigger is diagnostic.
+
+**Decision point.** Her current manager wants to help.
+
+**Possible responses.**
+- Avoid group reviews. (Case 25's error.)
+- Tell her it's fine and nobody minds. (Reassurance without relearning.)
+- **Create the pairing with safety:** name it without probing; pre-brief her before group reviews; open by naming something specific that is good; give her a defined role rather than a defensive one; debrief afterwards. Graded, repeated, with presence.
+- Suggest she look at it herself. **[Outside the manager's role.]**
+
+**Realistic success criteria (Luborsky).** The twinge remains. The reaction becomes less distressing. The response becomes more effective. Recovery time shortens. **Not:** the reaction disappears.
+
+**Discussion questions.**
+1. What does the specificity of the trigger tell you?
+2. Write realistic success criteria. Then write the unrealistic version and say why it is harmful.
+3. What is within the manager's role? What is not?
+4. How do you name something without probing?
+5. What would tell you it was working?
+
+**Instructor notes.** Deliberately non-clinical, so that the relearning mechanism can be taught without straying into treatment. Question 3 is directly assessable and highly transferable.
+
+**Learning objective.** LO22, LO14 — realistic expectations for emotional change, and the boundary of one's role.
+
+---
+
+## CASE 27 — CLEVELAND ELEMENTARY **[SOURCE]** *(gated: clinical, social work, education and safeguarding cohorts only)*
+
+**Background.** Cleveland Elementary School, Stockton, California, 17 February 1989.
+
+**Situation.** During late-morning recess for first, second and third graders, Patrick Purdy — a former pupil — fired on the playground for seven minutes, then killed himself. Five children died; twenty-nine were wounded.
+
+**Trigger and aftermath.** The months following, as recorded: the spontaneous "Purdy" game; the wave of fright at the announcement of St. Patrick's Day; every ambulance siren halting the school; the rumour about the restroom mirrors; the child who heard a tetherball chain as gunfire; children hovering by classroom doors at recess and playing only in small groups with a designated lookout; avoidance of the "evil" areas; and children trying "to sleep with their eyes open so they wouldn't dream."
+
+**Emotional dynamics.** The hair-trigger phenomenon at institutional scale. Note also the staff: teachers "trying to carry on with life as usual," themselves present at the event, and — critically — themselves helpless during it.
+
+**Decision point.** What a school leadership team does in the weeks after.
+
+**Possible responses.**
+- Return to normal quickly and minimise discussion.
+- Provide professional support to children *and staff*.
+- Permit and protect the play — recognising the Purdy game as spontaneous relearning rather than as morbid behaviour to be suppressed.
+- Restore agency wherever possible: predictable routines, choices, information about what is happening.
+
+**Discussion questions.**
+1. Why is the Purdy game therapeutic rather than pathological? What are the two mechanisms?
+2. What does the uncontrollability finding imply about the *staff*?
+3. What should a school do about the ambulance sirens?
+4. What is within a teacher's role here, and what is not?
+5. What does an institution owe people who were helpless in its care?
+
+**Instructor notes.** **Gated by cohort.** Deliver factually and without dramatisation; this concerns the deaths of young children. Do not use as a warm-up. Give the room a pause afterwards. Ensure the referral pathway is visible. **Never role-play.**
+
+**Learning objective.** LO22 — trauma, relearning and institutional response.
+
+---
+
+## CASE 28 — COOPERATION SQUARES **[SOURCE]**
+
+**Background.** A Self Science class at the Nueva Learning Center. Fifteen fifth-graders.
+
+**Characters.** *Jo-An Varga*, teacher. *Rahman*, in the struggling group. *Tucker*, the group's designated observer, wearing a T-shirt reading "Be Responsible." *Sean* and *Fairlie*, also in the group. *Dagan*, from a finished group.
+
+**Situation.** Teams assemble jigsaw squares **in silence, with no gesturing**. Three observers rate who organises, who clowns, who disrupts. Group 1 finishes in minutes. Group 2 works in parallel, then converges. Group 3 struggles.
+
+**Trigger — two of them.** First, frustration: Rahman puts two pieces to his eyes like a mask; his partners giggle; the tension breaks. Dagan then offers a permitted hint and the puzzles complete. Second, and the real one: **Tucker's evaluation sheet lists Rahman's name under "Who is disruptive?"**
+
+**Emotional dynamics.** Rahman argues ostensibly about whether offering a piece counts as gesturing. His eyes keep returning to the form. Varga notices "the heightened volume and increasingly aggressive staccato" and — crucially — **recognises the moment as the lesson**: "it is in moments such as this that the lessons already learned will pay off, and new ones can be taught most profitably."
+
+**Decision point.** Varga leaves the lesson plan and coaches the live dispute.
+
+**Her moves, in order.**
+1. Coach the delivery: "This isn't a criticism—you cooperated very well—but Tucker, **try to say what you mean in a tone of voice that doesn't sound so critical.**"
+2. Name the real issue: "**He's feeling that you used a negative word—disruptive—about him. What did you mean?**"
+3. Reframe intent: "Tucker is trying to say that what could be considered disruptive could also be part of lightening things up during a frustrating time."
+4. Validate both: "**I appreciate the way you're being assertive in talking with Tucker. You're not attacking.** But it's not pleasant to have a label like *disruptive* put on you."
+5. Check: "Is that right?" ... "**Do you feel better? Or is this still distressing?**"
+
+**Consequences.** "Yeah, I feel okay," says Rahman, "his voice softer now that he feels heard and understood." Tucker nods, smiling. Noticing everyone else has left, "the boys... turn in unison and dash out together."
+
+**Discussion questions.**
+1. Identify each of Varga's five moves and the concept each exemplifies.
+2. Why does she coach the *delivery* before addressing the *content*?
+3. What did the evaluation form do that the argument about gesturing concealed?
+4. Varga says mastery is hard "because skills need to be acquired when people are usually least able to take in new information." What follows for training design?
+5. Transpose the whole episode to a workplace dispute between two colleagues. What changes? What doesn't?
+
+**Instructor notes.** The best single demonstration of the pedagogy the course has been applying to the learners themselves. Tell it in full. Question 5 is where professional cohorts see that the moves are age-independent.
+
+**Learning objective.** LO21, LO12 — in-the-moment emotional coaching.
+
+---
+
+## CASE 29 — THE COMPLIANCE MODULE **[PEDAGOGICAL]**
+
+**Background.** A 4,000-person organisation. Following an incident, the board mandates annual training on appropriate workplace conduct.
+
+**Characters.** *The L&D lead*. *The board sponsor*. *4,000 employees*.
+
+**Situation.** The programme: a 35-minute e-learning module, once a year, with a ten-question multiple-choice test at the end. Pass mark 70%. Completion tracked. Completion rate 98%.
+
+**Trigger.** Two years on, reported incidents have not fallen and the annual survey shows no change in whether people believe raising concerns is safe.
+
+**Emotional dynamics.** The programme delivers **information**. It builds no self-awareness, rehearses no behaviour, provides no repetition across time, involves no part of the surrounding environment, and does nothing about the assertiveness required to act against social or hierarchical pressure. Employees have learned the rules and remain unable to apply them in the only conditions that matter — live, socially costly, under pressure.
+
+**Decision point.** The L&D lead is asked why it hasn't worked.
+
+**Possible responses.**
+- Increase frequency to twice yearly.
+- Add a harder test.
+- **Redesign against the six principles**: repeat across time at increasing levels; involve the environment (managers, teams, leadership modelling); teach the skill rather than the content; build early self-awareness; build assertiveness against pressure; rehearse the actual behaviour.
+
+**Consequences (for discussion).**
+
+**Discussion questions.**
+1. Apply the sexual-abuse-prevention finding. What does it predict about this programme?
+2. Which of the six design principles does it meet? *(Answer: none.)*
+3. Redesign it. Be specific about time, cost and who is involved.
+4. The completion rate is 98%. What is that measuring?
+5. How do you explain to a board sponsor that the thing they mandated cannot work?
+
+**Instructor notes.** The course's most immediately valuable case for L&D, HR and compliance professionals. Question 5 is the real exercise: making an evidence-based argument to a sponsor who has already committed to a design.
+
+**Learning objective.** LO21 — the design principles for effective emotional and social learning.
+
+---
+
+## CASE 30 — THE CHARMING MANIPULATOR **[PEDAGOGICAL]**
+
+**Background.** A professional services firm. *Daniel*, a partner, is widely described as the most emotionally intelligent person in the business.
+
+**Characters.** *Daniel*. *His team*. *Two former colleagues who left*. *The managing partner*.
+
+**What Daniel does well.** He reads a room instantly. He remembers personal details and asks about them. He knows exactly when someone is upset and what to say. Clients ask for him. Juniors say he is the best listener in the firm.
+
+**What is also true.** Two able people have left his team in eighteen months, both saying they could not explain why they were unhappy. He is unusually skilled at identifying what each person most fears — and at deploying it. A colleague who challenged him in a partners' meeting found that within a fortnight three people had independently mentioned to her, kindly, that she had seemed "under strain lately." He is never rude, never loses his temper, and there has never been a complaint anyone could substantiate.
+
+**Trigger.** The managing partner receives a third resignation and, for the first time, notices the pattern.
+
+**Emotional dynamics.** High Domain 4 (empathic accuracy) and high Domain 5 (managing emotions in others), deployed in the service of self-interest. This is the source's "opportunistic lack of empathy" combined with high emotional *skill* — and it is exactly what Côté et al. (2011) found empirically: emotion-regulation knowledge amplifies whatever motive it serves. **[EXTERNAL — see the Evidence file]**
+
+**Decision point.** What the managing partner does with a pattern and no evidence.
+
+**Possible responses.**
+- Nothing. (There is no substantiated complaint.)
+- Speak to Daniel directly about the pattern.
+- Change what the firm measures and rewards.
+- Ask the leavers.
+
+**Discussion questions.**
+1. Is Daniel emotionally intelligent? Defend your answer against the source's own definition.
+2. Which domains does he have? Which might he lack?
+3. Does the course's dependency structure (Domain 5 requires Domain 1) illuminate this or not?
+4. Could a selection process detect Daniel? Should it try?
+5. What is the relationship between emotional skill and good character? Answer with an argument, not an assertion.
+6. Should this course be taught to someone like Daniel? Would it help or would it help *him*?
+
+**Instructor notes.** The course's final case and the ethics module's centrepiece. **Do not resolve it.** The instructor's job is to make the question unavoidable and require each learner to defend a position. Question 6 is deliberately uncomfortable and should be asked last.
+
+**Learning objective.** The ethics of emotional capability — the question the course ends on.
+
+---
+
+*End of the Case Study Book. The Activity Book (D2), Self-Assessment (D3) and Personal Development Plan (D4) follow.*


### PR DESCRIPTION
Add SLIDE BLUEPRINT — MODULE 5 (slide-blueprint-module-5-msodr5vw) plugin.
Version: 0.1.0
Description: **Field labels, layouts (L1–L8), colour conventions and the [CORE]/[SUPPORTING]/[OPTIONAL] tagging are defined in `00_Design_Rules_and_Architecture.md`.**