### PR TITLE
ci: gate configured contributors on maintainer check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,7 +669,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # The needs-validation gate below produces a `handoff/comment` artifact when it ejects a
+      # The merge-blocking label gate below produces a `handoff/comment` artifact when it ejects a
       # queued PR, and that production goes through `.github/scripts/handoff.py` (the only
       # sanctioned source of handoff names and layout). Only the merge_group context can eject,
       # so pull_request runs skip the checkout entirely.
@@ -721,12 +721,12 @@ jobs:
             exit 1
           fi
 
-      - name: Block merge while the needs-validation label is present
-        id: needs_validation_gate
-        # Hard gate: a PR that still carries `needs-validation` must not merge. Enforced ONLY in
-        # the merge_group (merge-queue) context — never on pull_request. main requires the merge
-        # queue, so every merge passes through merge_group; a needs-validation entry fails this
-        # step there and is ejected from the queue, so it can never land.
+      - name: Block merge while a merge-blocking label is present
+        id: merge_blocking_label_gate
+        # Hard gate: a PR that still carries `needs-validation` or `needs-maintainer-check` must
+        # not merge. Enforced ONLY in the merge_group (merge-queue) context — never on
+        # pull_request. main requires the merge queue, so every merge passes through merge_group;
+        # a labeled entry fails this step there and is ejected from the queue, so it can never land.
         #
         # Why not also fail on pull_request: that turns the PR's own required `Validate workspace`
         # check red, and a deliberately-red required check is indistinguishable from a real CI
@@ -736,7 +736,8 @@ jobs:
         # forever). The merge_group run executes on the queue's transient ref, so this failure does
         # NOT appear in the PR head's status rollup; the PR stays green until the label is cleared.
         # Fails closed: any label-lookup error blocks rather than silently waving the merge through.
-        # Respects skip-validation implicitly (that override means needs-validation is never added).
+        # `skip-validation` continues to override only the `needs-validation` producer; it has no
+        # effect on the independent maintainer-check policy.
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -752,7 +753,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" != "merge_group" ]; then
-            echo "needs-validation is gated at merge time in the merge_group context; nothing to enforce on $EVENT_NAME (PR check stays green)."
+            echo "Merge-blocking labels are gated in the merge_group context; nothing to enforce on $EVENT_NAME (PR check stays green)."
           else
             # An ejection is invisible from the PR: this failure runs on the queue's transient
             # ref, the PR's own checks stay green, and `mergeQueueEntry` just goes null. Leave a
@@ -761,25 +762,41 @@ jobs:
             # completes. Best-effort: a handoff failure must never soften the block itself.
             emit_ejection_notice() {
               local pr="$1"
-              local pr_json pr_head pr_base handoff_id handoff_root handoff_dir marker
+              local blocking_label="$2"
+              local pr_json pr_head pr_base handoff_id handoff_root handoff_dir marker next_step
               pr_json="$(gh api "repos/$REPO/pulls/$pr")"
               pr_head="$(jq -r '.head.sha' <<< "$pr_json")"
               pr_base="$(jq -r '.base.sha' <<< "$pr_json")"
-              handoff_id="needs-validation-pr-$pr"
+              case "$blocking_label" in
+                needs-validation)
+                  handoff_id="needs-validation-pr-$pr"
+                  marker="<!-- merge-queue-needs-validation -->"
+                  # Markdown code spans are intentional literal text.
+                  # shellcheck disable=SC2016
+                  next_step='To land this PR: complete the QA pass the label is tracking, remove the `needs-validation` label, then add the PR back to the merge queue.'
+                  ;;
+                needs-maintainer-check)
+                  handoff_id="needs-maintainer-check-pr-$pr"
+                  marker="<!-- merge-queue-needs-maintainer-check -->"
+                  # Markdown code spans are intentional literal text.
+                  # shellcheck disable=SC2016
+                  next_step='To land this PR: have a maintainer complete the check, remove the `needs-maintainer-check` label, then add the PR back to the merge queue.'
+                  ;;
+                *)
+                  echo "Unsupported merge-blocking label: $blocking_label" >&2
+                  return 1
+                  ;;
+              esac
               handoff_root="$RUNNER_TEMP/handoff-comment-$handoff_id"
               handoff_dir="$(python3 .github/scripts/handoff.py dir comment "$handoff_id" --root "$handoff_root")"
               mkdir -p "$handoff_dir"
-              marker="<!-- merge-queue-needs-validation -->"
               # Markdown code spans are intentionally literal in these single-quoted strings.
               # shellcheck disable=SC2016
               {
                 printf '%s\n' "$marker"
-                # Markdown code spans are intentional literal text.
-                # shellcheck disable=SC2016
-                printf 'Ejected from the merge queue: this PR still carries the `needs-validation` label.\n\n'
+                printf 'Ejected from the merge queue: this PR still carries the `%s` label.\n\n' "$blocking_label"
                 printf 'The merge queue gate ([run %s](%s/%s/actions/runs/%s)) blocked the queued group because of the label. That failure runs on the queue'"'"'s transient ref, so it never appears in this PR'"'"'s own checks — they stay green, and this notice is the only visible trace on the PR.\n\n' "$RUN_ID" "$GITHUB_SERVER_URL" "$REPO" "$RUN_ID"
-                # shellcheck disable=SC2016
-                printf 'To land this PR: complete the QA pass the label is tracking, remove the `needs-validation` label, then add the PR back to the merge queue.\n'
+                printf '%s\n' "$next_step"
               } > "$handoff_dir/body.md"
               jq -n \
                 --arg kind "comment" \
@@ -843,31 +860,37 @@ jobs:
                 fi
                 covered=1
                 case " $checked " in *" $pr "*) ;; *) checked="$checked $pr";; esac
-                if printf '%s\n' "$labels" | grep -qx 'needs-validation'; then
-                  echo "::error::PR #$pr still has 'needs-validation' — blocking merge."
+                blocking_label=""
+                if printf '%s\n' "$labels" | grep -qx 'needs-maintainer-check'; then
+                  blocking_label="needs-maintainer-check"
+                elif printf '%s\n' "$labels" | grep -qx 'needs-validation'; then
+                  blocking_label="needs-validation"
+                fi
+                if [ -n "$blocking_label" ]; then
+                  echo "::error::PR #$pr still has '$blocking_label' — blocking merge."
                   # Fail-fast keeps this per-run notice on the FIRST labeled PR found; every
                   # labeled entry also fails its own queue run, so each still gets its own notice.
-                  emit_ejection_notice "$pr" || echo "::warning::could not produce the ejection-notice handoff for PR #$pr; the block itself still stands."
+                  emit_ejection_notice "$pr" "$blocking_label" || echo "::warning::could not produce the ejection-notice handoff for PR #$pr; the block itself still stands."
                   exit 1
                 fi
-                echo "PR #$pr: no needs-validation label."
+                echo "PR #$pr: no merge-blocking label."
               done
               if [ "$covered" -eq 0 ]; then
-                echo "::error::merge-group commit $sha resolved to no pull request (candidates: ${candidates:-none}) — cannot verify needs-validation; blocking merge (fail closed)."
+                echo "::error::merge-group commit $sha resolved to no pull request (candidates: ${candidates:-none}) — cannot verify merge-blocking labels; blocking merge (fail closed)."
                 exit 1
               fi
             done
-            echo "No 'needs-validation' label in the queued group ($checked ) — clear to merge."
+            echo "No merge-blocking label in the queued group ($checked ) — clear to merge."
           fi
 
       # `failure()` is required: the gate exits 1 on the very path that produces the handoff,
       # and the default `success()` condition would skip this upload exactly when it matters.
       - name: Upload merge-queue ejection notice handoff
-        if: ${{ failure() && steps.needs_validation_gate.outputs.comment_created == 'true' }}
+        if: ${{ failure() && steps.merge_blocking_label_gate.outputs.comment_created == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.needs_validation_gate.outputs.comment_name }}
-          path: ${{ steps.needs_validation_gate.outputs.comment_path }}
+          name: ${{ steps.merge_blocking_label_gate.outputs.comment_name }}
+          path: ${{ steps.merge_blocking_label_gate.outputs.comment_path }}
 
   runtime_summary:
     name: Runtime summary

--- a/.github/workflows/contributor-maintainer-check.yml
+++ b/.github/workflows/contributor-maintainer-check.yml
@@ -1,0 +1,44 @@
+name: Contributor maintainer check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: contributor-maintainer-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  route:
+    if: github.repository == 'nexu-io/open-design'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Require maintainer check for configured contributors
+        uses: actions/github-script@v8
+        env:
+          NEEDS_MAINTAINER_CHECK_USER_IDS: ${{ secrets.NEEDS_MAINTAINER_CHECK_USER_IDS }}
+        with:
+          script: |
+            const rawIds = process.env.NEEDS_MAINTAINER_CHECK_USER_IDS?.trim();
+            const configuredIds = rawIds ? JSON.parse(rawIds) : [];
+            if (!Array.isArray(configuredIds) || !configuredIds.every((id) => Number.isSafeInteger(id) && id > 0)) {
+              core.setFailed('NEEDS_MAINTAINER_CHECK_USER_IDS must be a JSON array of positive integer GitHub user IDs.');
+              return;
+            }
+
+            const authorId = context.payload.pull_request?.user?.id;
+            if (!Number.isSafeInteger(authorId) || !configuredIds.includes(authorId)) {
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['needs-maintainer-check'],
+            });

--- a/.github/workflows/pr-author-inactivity.yml
+++ b/.github/workflows/pr-author-inactivity.yml
@@ -70,6 +70,7 @@ jobs:
               'exempt-from-stale',
               'looper:worker-ready',
               'needs-design-review',
+              'needs-maintainer-check',
               'needs-maintainer-merge',
               'needs-qa',
               'needs-qa-validation',

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -34,6 +34,13 @@ const playwrightConfigPath = join(e2eRoot, "playwright.config.ts");
 const commentWorkflowPath = join(workspaceRoot, ".github", "workflows", "comment.atom.yml");
 const autofixWorkflowPath = join(workspaceRoot, ".github", "workflows", "autofix.atom.yml");
 const reportWorkflowPath = join(workspaceRoot, ".github", "workflows", "report.atom.yml");
+const contributorMaintainerCheckWorkflowPath = join(
+  workspaceRoot,
+  ".github",
+  "workflows",
+  "contributor-maintainer-check.yml",
+);
+const prAuthorInactivityWorkflowPath = join(workspaceRoot, ".github", "workflows", "pr-author-inactivity.yml");
 const rerunWorkflowPath = join(workspaceRoot, ".github", "workflows", "rerun.atom.yml");
 const rerunInfraCancelScriptPath = join(workspaceRoot, ".github", "scripts", "rerun_infra_cancel.py");
 const bakePluginPreviewsWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews.yml");
@@ -172,7 +179,7 @@ function extractValidateGateJqPrograms(workflow: string): { failures: string; re
   const needsCheck = sectionBetween(
     validate,
     "      - name: Check workspace validation jobs",
-    "      - name: Block merge while the needs-validation label is present",
+    "      - name: Block merge while a merge-blocking label is present",
   );
   const programs = [...needsCheck.matchAll(/jq -r '([\s\S]*?)'/g)].map((match) => match[1] ?? "");
   expect(programs).toHaveLength(2);
@@ -527,7 +534,7 @@ describe("packaged smoke workflow", () => {
     expect(ciWorkflow).toContain("<!-- merge-queue-needs-validation -->");
     expect(ciWorkflow).toContain("emit_ejection_notice");
     expect(ciWorkflow).toContain(
-      "if: ${{ failure() && steps.needs_validation_gate.outputs.comment_created == 'true' }}",
+      "if: ${{ failure() && steps.merge_blocking_label_gate.outputs.comment_created == 'true' }}",
     );
 
     // Consumer: a merge_group run's head_sha is the queue's synthetic merge commit, so the atom
@@ -536,6 +543,35 @@ describe("packaged smoke workflow", () => {
     expect(commentWorkflow).toContain('"$RUN_EVENT" = "merge_group"');
     expect(commentWorkflow).toContain('"$artifact_run_id" != "$RUN_ID"');
     expect(commentWorkflow).toContain('[ "$RUN_EVENT" != "merge_group" ] && [ "$current_base" != "$base_sha" ]');
+  });
+
+  it("[P1] routes configured contributors into an independent maintainer merge block", async () => {
+    const [routingWorkflow, ciWorkflow, inactivityWorkflow] = await Promise.all([
+      readFile(contributorMaintainerCheckWorkflowPath, "utf8"),
+      readFile(ciWorkflowPath, "utf8"),
+      readFile(prAuthorInactivityWorkflowPath, "utf8"),
+    ]);
+    const trigger = sectionBetween(routingWorkflow, "on:", "\npermissions:");
+
+    expect(trigger).toContain("pull_request_target:");
+    expect(trigger).toContain("types: [opened, reopened, synchronize]");
+    expect(trigger).not.toContain("unlabeled");
+    expect(routingWorkflow).toContain("permissions:\n  issues: write");
+    expect(routingWorkflow).toContain("actions/github-script@v8");
+    expect(routingWorkflow).toContain("secrets.NEEDS_MAINTAINER_CHECK_USER_IDS");
+    expect(routingWorkflow).toContain("rawIds ? JSON.parse(rawIds) : []");
+    expect(routingWorkflow).toContain("Number.isSafeInteger(id) && id > 0");
+    expect(routingWorkflow).toContain("context.payload.pull_request?.user?.id");
+    expect(routingWorkflow).toContain("configuredIds.includes(authorId)");
+    expect(routingWorkflow).toContain("github.rest.issues.addLabels");
+    expect(routingWorkflow).toContain("labels: ['needs-maintainer-check']");
+    expect(routingWorkflow).not.toContain("actions/checkout");
+
+    expect(ciWorkflow).toContain("Block merge while a merge-blocking label is present");
+    expect(ciWorkflow).toContain("grep -qx 'needs-maintainer-check'");
+    expect(ciWorkflow).toContain("<!-- merge-queue-needs-maintainer-check -->");
+    expect(ciWorkflow).toContain("needs-maintainer-check-pr-$pr");
+    expect(inactivityWorkflow).toContain("'needs-maintainer-check'");
   });
 
   it("[P2] gates the backport auto-merge follow-up as a trusted workflow_run consumer", async () => {


### PR DESCRIPTION
## Why

We need an internal policy route for contributions that require explicit maintainer review, without overloading `needs-validation` or exposing contributor configuration in the repository. Reusing the QA label would couple unrelated states and create a long-term semantic burden.

This PR establishes a dedicated, fail-closed merge-queue gate while keeping the configured contributor IDs in a repository Secret.

## What users will see

Configured PR authors receive a `needs-maintainer-check` label when a PR is opened, reopened, or updated. Their PR head checks remain green, but the PR cannot merge until a maintainer completes the check and removes the label. If the merge queue ejects the PR, the existing comment handoff posts the required next step.

There is no product UI or runtime behavior change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing product users experience without opting in
- [x] **None** — internal CI and repository automation only

## Screenshots

Not applicable; this change has no UI surface.

## Bug fix verification

Not a bug fix. The new policy topology is covered directly in `e2e/tests/packaged-smoke-workflow.test.ts`.

## Validation

- `python3 .github/scripts/handoff.py self-check`
- `actionlint -color`
- `git diff --check`
- Targeted topology tests for merge-queue handoff and contributor routing: 2 passed
- Full topology file attempted in the isolated Concord member: 61 passed; 11 environment failures from unavailable workspace package links and the host Python version, with no failure in the new assertions
- `pnpm guard` and `pnpm typecheck` attempted; the isolated member lacks workspace-level dependencies (`jszip` and `astro`), so CI remains the complete repository-level verification

Operational setup is separate from Git history: the label and repository Secret have been provisioned without exposing configured IDs here.
