### PR TITLE
fix(web): hide stale run recovery cards after success

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1464,10 +1464,23 @@ export function ChatPane({
     !!retryAssistant?.resumable &&
     !!retryAssistant?.agentId &&
     retryAssistant.agentId === config?.agentId;
+  // `error` is a shared escape hatch for both run failures and unrelated
+  // pane errors (conversation load, audio, artifact persistence). A run error
+  // also lives durably on its assistant message. Once a later turn succeeds,
+  // the old global string can race or survive long enough to otherwise render
+  // a stale recovery card at the bottom of the conversation. Treat a global
+  // error that is already owned by an older assistant message as history; keep
+  // genuinely current non-run errors visible. When the latest run itself
+  // failed, its persisted event is the authoritative raw diagnostic.
+  const historicalRunError = useMemo(
+    () => !retryAssistant && isPersistedAssistantRunError(displayMessages, error),
+    [displayMessages, error, retryAssistant],
+  );
+  const currentGlobalError = historicalRunError ? null : error;
   // Prefer a case-specific message (AMR auth / balance) over the raw upstream
-  // string; fall back to the live global error (also covers conversation-load
-  // / audio errors) then the persisted run error so a reload still shows it.
-  const rawError = error ?? failedRunErrorEvent?.detail ?? null;
+  // string; fall back to a current pane-level error when the failed message has
+  // no persisted error event of its own.
+  const rawError = failedRunErrorEvent?.detail ?? currentGlobalError ?? null;
   // Friendly agent name for {agent} interpolation in failure copy (e.g. the
   // sign-in messages). Falls back to a neutral word when unreadable, never null.
   const failedAgentLabel =
@@ -4447,6 +4460,24 @@ export function retryableAssistantMessage(
   if (!last || last.role !== 'assistant') return null;
   if (last.id !== lastAssistantId) return null;
   return isRetryableAssistantTerminalFailure(last) ? last : null;
+}
+
+function isPersistedAssistantRunError(
+  messages: ChatMessage[],
+  error: string | null,
+): boolean {
+  const target = error?.trim();
+  if (!target) return false;
+  return messages.some(
+    (message) =>
+      message.role === 'assistant' &&
+      (message.events ?? []).some(
+        (event) =>
+          event.kind === 'status' &&
+          event.label === 'error' &&
+          event.detail?.trim() === target,
+      ),
+  );
 }
 
 export function isAssistantMessageStreaming(

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -520,6 +520,10 @@ interface Props {
   streaming: boolean;
   loading?: boolean;
   error: string | null;
+  // Identifies a pane-level error produced by an assistant run. This lets the
+  // pane distinguish a stale run error from a later failure with identical
+  // canonical text; non-run errors leave the source undefined.
+  errorSourceAssistantId?: string | null;
   projectId: string | null;
   sessionMode?: ChatSessionMode;
   onSessionModeChange?: (mode: ChatSessionMode) => void;
@@ -875,6 +879,7 @@ export function ChatPane({
   viewerOnly = false,
   queuedItems = [],
   error,
+  errorSourceAssistantId,
   projectId,
   sessionMode = 'design',
   onSessionModeChange,
@@ -1464,17 +1469,20 @@ export function ChatPane({
     !!retryAssistant?.resumable &&
     !!retryAssistant?.agentId &&
     retryAssistant.agentId === config?.agentId;
-  // `error` is a shared escape hatch for both run failures and unrelated
-  // pane errors (conversation load, audio, artifact persistence). A run error
-  // also lives durably on its assistant message. Once a later turn succeeds,
-  // the old global string can race or survive long enough to otherwise render
-  // a stale recovery card at the bottom of the conversation. Treat a global
-  // error that is already owned by an older assistant message as history; keep
-  // genuinely current non-run errors visible. When the latest run itself
-  // failed, its persisted event is the authoritative raw diagnostic.
+  // `error` is a shared escape hatch for both run failures and unrelated pane
+  // errors. A run error also lives durably on its assistant message. Suppress
+  // it only when its exact source assistant owns the persisted diagnostic and
+  // a later assistant has succeeded; canonical error text alone cannot prove
+  // ownership because a new run can fail with the same detail.
   const historicalRunError = useMemo(
-    () => !retryAssistant && isPersistedAssistantRunError(displayMessages, error),
-    [displayMessages, error, retryAssistant],
+    () =>
+      !retryAssistant &&
+      isRecoveredAssistantRunError(
+        displayMessages,
+        error,
+        errorSourceAssistantId,
+      ),
+    [displayMessages, error, errorSourceAssistantId, retryAssistant],
   );
   const currentGlobalError = historicalRunError ? null : error;
   // Prefer a case-specific message (AMR auth / balance) over the raw upstream
@@ -4462,21 +4470,28 @@ export function retryableAssistantMessage(
   return isRetryableAssistantTerminalFailure(last) ? last : null;
 }
 
-function isPersistedAssistantRunError(
+function isRecoveredAssistantRunError(
   messages: ChatMessage[],
   error: string | null,
+  sourceAssistantId: string | null | undefined,
 ): boolean {
   const target = error?.trim();
-  if (!target) return false;
-  return messages.some(
+  if (!target || !sourceAssistantId) return false;
+  const sourceIndex = messages.findIndex(
     (message) =>
-      message.role === 'assistant' &&
-      (message.events ?? []).some(
-        (event) =>
-          event.kind === 'status' &&
-          event.label === 'error' &&
-          event.detail?.trim() === target,
-      ),
+      message.role === 'assistant' && message.id === sourceAssistantId,
+  );
+  if (sourceIndex < 0) return false;
+  const source = messages[sourceIndex]!;
+  const ownsPersistedError = (source.events ?? []).some(
+    (event) =>
+      event.kind === 'status' &&
+      event.label === 'error' &&
+      event.detail?.trim() === target,
+  );
+  if (!ownsPersistedError) return false;
+  return messages.slice(sourceIndex + 1).some(
+    (message) => message.role === 'assistant' && message.runStatus === 'succeeded',
   );
 }
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1486,9 +1486,9 @@ export function ChatPane({
   );
   const currentGlobalError = historicalRunError ? null : error;
   // Prefer a case-specific message (AMR auth / balance) over the raw upstream
-  // string; fall back to a current pane-level error when the failed message has
-  // no persisted error event of its own.
-  const rawError = failedRunErrorEvent?.detail ?? currentGlobalError ?? null;
+  // string; otherwise keep a current pane-level error ahead of the persisted
+  // failed-run detail. Historical run errors were already removed above.
+  const rawError = currentGlobalError ?? failedRunErrorEvent?.detail ?? null;
   // Friendly agent name for {agent} interpolation in failure copy (e.g. the
   // sign-in messages). Falls back to a neutral word when unreadable, never null.
   const failedAgentLabel =

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -2192,7 +2192,29 @@ export function ProjectView({
   useEffect(() => {
     if (!streaming) setLiveToolInput((prev) => (Object.keys(prev).length ? {} : prev));
   }, [streaming]);
-  const [error, setError] = useState<string | null>(null);
+  const [paneError, setPaneError] = useState<{
+    message: string;
+    sourceAssistantId: string | null;
+  } | null>(null);
+  const error = paneError?.message ?? null;
+  const errorSourceAssistantId = paneError?.sourceAssistantId ?? null;
+  const setError = useCallback((next: SetStateAction<string | null>) => {
+    setPaneError((current) => {
+      const currentMessage = current?.message ?? null;
+      const message = typeof next === 'function' ? next(currentMessage) : next;
+      if (message == null) return null;
+      return {
+        message,
+        sourceAssistantId:
+          typeof next === 'function' && message === currentMessage
+            ? current?.sourceAssistantId ?? null
+            : null,
+      };
+    });
+  }, []);
+  const setRunError = useCallback((message: string, sourceAssistantId: string) => {
+    setPaneError({ message, sourceAssistantId });
+  }, []);
   const [artifact, setArtifact] = useState<Artifact | null>(null);
   const [filesRefresh, setFilesRefresh] = useState(0);
   const filesRefreshRequestKeyRef = useRef(0);
@@ -5698,7 +5720,7 @@ export function ProjectView({
               textBuffer.cancel();
               unregisterTextBuffer();
               if (runMayFinalize) {
-                setError(err.message);
+                setRunError(err.message, message.id);
                 appendAssistantErrorEvent(message.id, err.message, errorCode, failure);
                 updateMessageById(
                   message.id,
@@ -6006,7 +6028,7 @@ export function ProjectView({
               !supersededRunsRef.current.has(controller);
             if ((err as Error).name !== 'AbortError' && runMayFinalize) {
               const msg = err instanceof Error ? err.message : String(err);
-              setError(msg);
+              setRunError(msg, message.id);
               appendAssistantErrorEvent(message.id, msg);
               updateMessageById(
                 message.id,
@@ -7360,7 +7382,7 @@ export function ProjectView({
           textBuffer.cancel();
           cancelSendTextBuffer();
           if (runMayFinalize) {
-            setError(err.message);
+            setRunError(err.message, assistantId);
             appendAssistantErrorEvent(assistantId, err.message, errorCode, failure);
             updateAssistant((prev) => ({
               ...prev,
@@ -9263,6 +9285,8 @@ export function ProjectView({
 	            sendDisabled: currentConversationSendDisabled,
             queuedItems: currentConversationQueuedItems,
             error: conversationLoadError ?? error,
+            errorSourceAssistantId:
+              conversationLoadError ? null : errorSourceAssistantId,
             onSend: handleComposerSend,
             onRetry: handleRetry,
             onStop: handleStop,
@@ -9282,6 +9306,7 @@ export function ProjectView({
 	      currentConversationLoading,
 	      currentConversationControlStreaming,
       error,
+      errorSourceAssistantId,
       handleAssistantFeedback,
       handleRetry,
       handleComposerSend,
@@ -10729,6 +10754,9 @@ export function ProjectView({
               }
               queuedItems={currentConversationQueuedItems}
               error={conversationLoadError ?? error}
+              errorSourceAssistantId={
+                conversationLoadError ? null : errorSourceAssistantId
+              }
               projectId={project.id}
               sessionMode={activeSessionMode}
               onSessionModeChange={handleActiveConversationSessionModeChange}

--- a/apps/web/src/components/workspace/SideChatTab.tsx
+++ b/apps/web/src/components/workspace/SideChatTab.tsx
@@ -29,6 +29,7 @@ export interface ActiveConversationChatState {
     commentAttachments?: ChatCommentAttachment[];
   }>;
   error: string | null;
+  errorSourceAssistantId?: string | null;
   onSend: (
     prompt: string,
     attachments: ChatAttachment[],
@@ -152,6 +153,7 @@ export function SideChatTab({
           onReorderQueuedSends={controlledChat?.onReorderQueuedSends}
           onSendQueuedNow={controlledChat?.onSendQueuedNow}
           error={controlledChat ? controlledChat.error : chat.error}
+          errorSourceAssistantId={controlledChat?.errorSourceAssistantId}
           projectId={projectId}
           sessionMode={sessionMode}
           onSessionModeChange={(mode) => onSessionModeChange?.(conversationId, mode)}

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -485,6 +485,54 @@ describe('ChatPane streaming state', () => {
     expect(container.querySelector('[data-user-action-card="run-recovery"]')).toBeTruthy();
   });
 
+  it('prefers a current non-run error over the latest failed-run detail', () => {
+    const currentError = 'Could not load the conversation.';
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Build the report', createdAt: 0 },
+      {
+        id: 'assistant-failed',
+        role: 'assistant',
+        content: 'I started the report.',
+        createdAt: 1,
+        endedAt: 2,
+        runStatus: 'failed',
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'Run interrupted because the daemon restarted.',
+            code: 'DAEMON_RESTARTED',
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={messages}
+        streaming={false}
+        error={currentError}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    const recoveryCard = container.querySelector<HTMLElement>(
+      '[data-user-action-card="run-recovery"]',
+    );
+    expect(recoveryCard).toBeTruthy();
+    expect(within(recoveryCard!).getByText(currentError)).toBeTruthy();
+  });
+
   it.each(['no_result', 'delivery_failed'] as const)(
     'exposes retry for a %s delivery failure',
     (resultDeliveryState) => {

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -378,6 +378,7 @@ describe('ChatPane streaming state', () => {
         messages={messages}
         streaming={false}
         error={restartError}
+        errorSourceAssistantId="assistant-failed"
         projectId="project-1"
         projectFiles={[]}
         onEnsureProject={async () => 'project-1'}
@@ -392,6 +393,61 @@ describe('ChatPane streaming state', () => {
     );
 
     expect(container.querySelector('[data-user-action-card="run-recovery"]')).toBeNull();
+  });
+
+  it('keeps a repeated current daemon-restart error visible before its failure is persisted', () => {
+    const restartError = 'Run interrupted because the daemon restarted.';
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Build the report', createdAt: 0 },
+      {
+        id: 'assistant-failed',
+        role: 'assistant',
+        content: 'I started the report.',
+        createdAt: 1,
+        endedAt: 2,
+        runStatus: 'failed',
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: restartError,
+            code: 'DAEMON_RESTARTED',
+          },
+        ],
+      },
+      { id: 'user-2', role: 'user', content: 'Continue', createdAt: 3 },
+      {
+        id: 'assistant-succeeded',
+        role: 'assistant',
+        content: 'The report is complete.',
+        createdAt: 4,
+        endedAt: 5,
+        runStatus: 'succeeded',
+      },
+      { id: 'user-3', role: 'user', content: 'Make one more change', createdAt: 6 },
+    ];
+
+    const { container } = render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={messages}
+        streaming={false}
+        error={restartError}
+        errorSourceAssistantId="assistant-current"
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    expect(container.querySelector('[data-user-action-card="run-recovery"]')).toBeTruthy();
   });
 
   it('keeps a current non-run error visible after an assistant run succeeds', () => {

--- a/apps/web/tests/components/ChatPane.streaming.test.tsx
+++ b/apps/web/tests/components/ChatPane.streaming.test.tsx
@@ -341,6 +341,94 @@ describe('ChatPane streaming state', () => {
       .toBeNull();
   });
 
+  it('hides a stale run-recovery card after a later assistant run succeeds', () => {
+    const restartError = 'Run interrupted because the daemon restarted.';
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Build the report', createdAt: 0 },
+      {
+        id: 'assistant-failed',
+        role: 'assistant',
+        content: 'I started the report.',
+        createdAt: 1,
+        endedAt: 2,
+        runStatus: 'failed',
+        events: [
+          {
+            kind: 'status',
+            label: 'error',
+            detail: restartError,
+            code: 'DAEMON_RESTARTED',
+          },
+        ],
+      },
+      { id: 'user-2', role: 'user', content: 'Continue', createdAt: 3 },
+      {
+        id: 'assistant-succeeded',
+        role: 'assistant',
+        content: 'The report is complete.',
+        createdAt: 4,
+        endedAt: 5,
+        runStatus: 'succeeded',
+      },
+    ];
+
+    const { container } = render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={messages}
+        streaming={false}
+        error={restartError}
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    expect(container.querySelector('[data-user-action-card="run-recovery"]')).toBeNull();
+  });
+
+  it('keeps a current non-run error visible after an assistant run succeeds', () => {
+    const messages: ChatMessage[] = [
+      { id: 'user-1', role: 'user', content: 'Build the report', createdAt: 0 },
+      {
+        id: 'assistant-succeeded',
+        role: 'assistant',
+        content: 'The report is complete.',
+        createdAt: 1,
+        endedAt: 2,
+        runStatus: 'succeeded',
+      },
+    ];
+
+    const { container } = render(
+      <ChatPane
+        projectKindForTracking="prototype"
+        messages={messages}
+        streaming={false}
+        error="Could not load the conversation."
+        projectId="project-1"
+        projectFiles={[]}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+        conversations={conversations}
+        activeConversationId="conv-1"
+        onSelectConversation={vi.fn()}
+        onDeleteConversation={vi.fn()}
+        projectMetadata={projectMetadata}
+      />,
+    );
+
+    expect(container.querySelector('[data-user-action-card="run-recovery"]')).toBeTruthy();
+  });
+
   it.each(['no_result', 'delivery_failed'] as const)(
     'exposes retry for a %s delivery failure',
     (resultDeliveryState) => {


### PR DESCRIPTION
## Why

A daemon restart can interrupt an early assistant run and persist its failure on that assistant message. After later runs succeed, the shared pane-level `error` string can still retain the old daemon-restart text, causing the large “Task execution failed” recovery card to remain at the bottom of an otherwise recovered conversation.

This makes a historical interruption look like the current conversation still needs recovery.

## What users will see

After a later assistant run succeeds, a recovery card owned by an older failed run no longer remains at the bottom of the conversation. The historical inline error record remains available in the failed turn, while genuinely current non-run errors such as conversation-load failures still render normally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the user-reported conversation retained the large run-recovery card after later successful work.

After: the stale card is intentionally absent. The regression test asserts that `[data-user-action-card="run-recovery"]` is not rendered for this recovered transcript shape.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatPane.streaming.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** Before the source change, the new test received the stale `run-recovery` section; after the change it passes.
- Companion coverage verifies that a current non-run error remains visible after a successful assistant run.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatPane.streaming.test.tsx tests/components/AssistantMessage.error-pill.test.tsx` — 31 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
