### PR TITLE
fix(web): prevent duplicate queued chat submissions

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -402,6 +402,10 @@ export interface ChatComposerHandle {
 }
 
 export interface ChatSendMeta {
+  /** Stable identity for one confirmed user submission. Queueing and the
+   *  eventual daemon run reuse it so retries of the same UI action are
+   *  idempotent without collapsing separate sends that share the same text. */
+  clientRequestId?: string;
   queueOnly?: boolean;
   research?: ResearchOptions;
   context?: RunContextSelection;
@@ -506,6 +510,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     // by handleEditorChange (the editor is the single source for typing) and by
     // the programmatic-set paths below.
     const draftRef = useRef(draft);
+    // Submission admission can cross asynchronous gates before the composer
+    // is cleared. Keep a synchronous latch so a second Enter/click in that
+    // window cannot enqueue the same still-visible payload again.
+    const composedSendPendingRef = useRef(false);
     const previousSessionModeRef = useRef(sessionMode);
 
     useEffect(() => {
@@ -1346,7 +1354,24 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
             pendingSessionModeRef.current = pendingMetadata.sessionMode;
           }
         },
-      );
+      ).finally(() => {
+        composedSendPendingRef.current = false;
+      });
+    }
+
+    function beginComposedSend(
+      send: () => ChatSendOutcome | Promise<ChatSendOutcome>,
+      pendingMetadata?: { entryFrom: ChatSendMeta['entryFrom'] | null; sessionMode: ChatSessionMode | null },
+    ): boolean {
+      if (composedSendPendingRef.current) return false;
+      composedSendPendingRef.current = true;
+      try {
+        finishComposedSend(send(), pendingMetadata);
+        return true;
+      } catch (error) {
+        composedSendPendingRef.current = false;
+        throw error;
+      }
     }
 
     function sendComposedTurn(
@@ -1381,11 +1406,10 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       };
       const effectiveMeta =
         Object.keys(effectiveMetaShape).length > 0 ? effectiveMetaShape : undefined;
-      finishComposedSend(
-        onSend(prompt, nextAttachments, nextCommentAttachments, effectiveMeta),
+      return beginComposedSend(
+        () => onSend(prompt, nextAttachments, nextCommentAttachments, effectiveMeta),
         { entryFrom: pendingEntryFrom, sessionMode: pendingSessionMode },
       );
-      return true;
     }
 
     function queueMeta(meta?: ChatSendMeta): ChatSendMeta {
@@ -2628,15 +2652,15 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       if (hatched) {
         if (streaming) return;
         setStreamingAnnotationSendPending(false);
-        finishComposedSend(onSend(hatched, staged, nextCommentAttachments, contextMeta));
+        beginComposedSend(() => onSend(hatched, staged, nextCommentAttachments, contextMeta));
         return;
       }
       const search = researchAvailable ? expandSearchCommand(prompt) : null;
       if (search) {
         if (streaming) return;
         setStreamingAnnotationSendPending(false);
-        finishComposedSend(
-          onSend(search.prompt, staged, nextCommentAttachments, {
+        beginComposedSend(
+          () => onSend(search.prompt, staged, nextCommentAttachments, {
             ...contextMeta,
             research: { enabled: true, query: search.query },
           }),

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6241,8 +6241,12 @@ export function ProjectView({
   }, [project.id]);
 
   const enqueueChatSend = useCallback((item: QueuedChatSend) => {
+    if (queuedChatSendsRef.current.some((candidate) => candidate.id === item.id)) {
+      return false;
+    }
     const next = [...queuedChatSendsRef.current, item];
     commitQueuedChatSends(next);
+    return true;
   }, [commitQueuedChatSends]);
 
   const removeQueuedChatSend = useCallback((id: string) => {
@@ -6306,9 +6310,13 @@ export function ProjectView({
     meta?: ProjectChatSendMeta;
     prompt: string;
   }) => {
-    const queuedMeta = stripQueueOnlyFromMeta(input.meta);
-    enqueueChatSend({
-      id: randomUUID(),
+    const clientRequestId = input.meta?.clientRequestId ?? randomUUID();
+    const queuedMeta = stripQueueOnlyFromMeta({
+      ...(input.meta ?? {}),
+      clientRequestId,
+    });
+    const enqueued = enqueueChatSend({
+      id: clientRequestId,
       conversationId: input.conversationId,
       prompt: input.prompt,
       attachments: input.attachments,
@@ -6316,6 +6324,7 @@ export function ProjectView({
       ...(queuedMeta === undefined ? {} : { meta: queuedMeta }),
       createdAt: Date.now(),
     });
+    if (!enqueued) return;
     if (input.commentAttachments.length > 0) {
       const reservedCommentIds = new Set(
         input.commentAttachments
@@ -6358,6 +6367,11 @@ export function ProjectView({
     ) => {
       if (!activeConversationId) return false;
       if (messagesConversationIdRef.current !== activeConversationId) return false;
+      const clientRequestId = meta?.clientRequestId ?? randomUUID();
+      meta = {
+        ...(meta ?? {}),
+        clientRequestId,
+      };
       const runSessionMode = meta?.sessionMode ?? activeSessionMode;
       const retryTarget = meta?.retryOfAssistantId
         ? resolveRetryTarget(messages, meta.retryOfAssistantId)
@@ -7644,7 +7658,7 @@ export function ProjectView({
           conversationId: runConversationId,
           userMessageId: userMsg.id,
           assistantMessageId: assistantId,
-          clientRequestId: randomUUID(),
+          clientRequestId,
           skillId: project.skillId ?? null,
           skillIds: Array.isArray(meta?.skillIds) ? meta.skillIds : [],
           context: runContext,
@@ -7819,7 +7833,7 @@ export function ProjectView({
           conversationId: runConversationId,
           userMessageId: userMsg.id,
           assistantMessageId: assistantId,
-          clientRequestId: randomUUID(),
+          clientRequestId,
           skillId: project.skillId ?? null,
           skillIds: Array.isArray(meta?.skillIds) ? meta.skillIds : [],
           context: runContext,
@@ -11555,7 +11569,15 @@ function loadQueuedChatSends(projectId: string): QueuedChatSend[] {
     const raw = window.localStorage.getItem(queuedChatSendsStorageKey(projectId));
     const parsed = raw ? JSON.parse(raw) : [];
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isQueuedChatSend).slice(0, 100);
+    const seenIds = new Set<string>();
+    return parsed
+      .filter(isQueuedChatSend)
+      .filter((item) => {
+        if (seenIds.has(item.id)) return false;
+        seenIds.add(item.id);
+        return true;
+      })
+      .slice(0, 100);
   } catch {
     return [];
   }

--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -392,6 +392,13 @@ function KeyboardPlugin({
             e.preventDefault();
             return true;
           }
+          // A held Enter key produces repeated keydown events. Sending is a
+          // one-shot action, so only the initial keydown may submit or choose
+          // a popover item. Shift+Enter remains repeatable for line breaks.
+          if (e?.repeat) {
+            e.preventDefault();
+            return true;
+          }
           // Cmd/Ctrl+Enter force-sends even with a popover open.
           if (e?.metaKey || e?.ctrlKey) {
             e.preventDefault();

--- a/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
+++ b/apps/web/tests/components/ChatComposer.infinite-render.test.tsx
@@ -130,6 +130,31 @@ describe('ChatComposer infinite re-render regression (#2097)', () => {
     expect(composerText()).toBe('keep this exact prompt');
   });
 
+  it('accepts only one submit while the current send decision is pending', async () => {
+    let resolveFirstSend!: () => void;
+    const firstSend = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const onSend = vi.fn()
+      .mockReturnValueOnce(firstSend)
+      .mockResolvedValueOnce(undefined);
+    renderComposer({ onSend });
+    await flushMounts();
+
+    await typeAndSettle('send this once');
+    pressEnter();
+    pressEnter();
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveFirstSend());
+    await waitFor(() => expect(composerText().trim()).toBe(''));
+
+    await typeAndSettle('send a later turn');
+    pressEnter();
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2));
+  });
+
   it('does not enter an infinite update loop on rapid plain-text typing', async () => {
     // #2097 surfaced as "Maximum update depth exceeded" from a feedback loop
     // between the input and a layout effect. The Lexical editor owns its own

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -579,6 +579,21 @@ vi.mock('../../src/components/ChatPane', () => ({
         >
           send with context
         </button>
+        <button
+          type="button"
+          data-testid="send-message-stable-request"
+          onClick={() =>
+            onSend(
+              'hello from stable request',
+              [],
+              [],
+              { clientRequestId: 'submission-1' },
+            )
+          }
+          disabled={sendDisabled}
+        >
+          send stable request
+        </button>
         <button type="button" data-testid="new-conversation" onClick={onNewConversation}>
           new
         </button>
@@ -2029,6 +2044,48 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('attached-comment-count').textContent).toBe('0');
   });
 
+  it('queues a logical submission only once when its stable request id is retried', async () => {
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    fireEvent.click(screen.getByTestId('send-message-stable-request'));
+    fireEvent.click(screen.getByTestId('send-message-stable-request'));
+
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+    expect(screen.queryByTestId('send-queued-1')).toBeNull();
+  });
+
+  it('reuses a queued submission request id when the daemon run starts', async () => {
+    let finishReattach: (() => void) | null = null;
+    let reattachHandlers: { onDone: () => void } | null = null;
+    reattachDaemonRun.mockImplementation(async (input: unknown) => {
+      reattachHandlers = (input as { handlers: { onDone: () => void } }).handlers;
+      return new Promise<void>((resolve) => {
+        finishReattach = resolve;
+      });
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    fireEvent.click(screen.getByTestId('send-message-stable-request'));
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+
+    await act(async () => {
+      reattachHandlers?.onDone();
+      finishReattach?.();
+    });
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
+      clientRequestId: 'submission-1',
+    }));
+  });
+
   it('keeps newer attached comments when a queued send flushes older comment attachments', async () => {
     let finishReattach: (() => void) | null = null;
     let reattachHandlers: { onDone: () => void } | null = null;
@@ -2540,6 +2597,28 @@ describe('ProjectView conversation run isolation', () => {
 
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
     await waitFor(() => expect(screen.getByTestId('send-queued-0').textContent).toBe('hello from b'));
+  });
+
+  it('restores only one queued send for each stable request id', async () => {
+    reattachDaemonRun.mockImplementation(async () => new Promise<void>(() => {}));
+    const duplicateQueuedSend = {
+      id: 'submission-1',
+      conversationId: 'conv-a',
+      prompt: 'hello from stable request',
+      attachments: [],
+      commentAttachments: [],
+      meta: { clientRequestId: 'submission-1' },
+      createdAt: 1,
+    };
+    window.localStorage.setItem(
+      'od:chat-queued-sends:project-1:v1',
+      JSON.stringify([duplicateQueuedSend, duplicateQueuedSend]),
+    );
+
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
+    expect(screen.queryByTestId('send-queued-1')).toBeNull();
   });
 
   it('surfaces conversation message load errors and keeps sends disabled until messages load', async () => {

--- a/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
+++ b/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
@@ -426,4 +426,27 @@ describe('LexicalComposerInput', () => {
     });
     await waitFor(() => expect(onEnterSend).toHaveBeenCalledTimes(1));
   });
+
+  it('does not send when the browser repeats a held Enter key', async () => {
+    const { onEnterSend, getByTestId } = setup({ draft: 'hi' });
+    const editable = getByTestId('chat-composer-input') as HTMLElement & {
+      __lexicalEditor?: import('lexical').LexicalEditor;
+    };
+    const editor = editable.__lexicalEditor;
+    expect(editor).toBeTruthy();
+
+    act(() => {
+      editor?.dispatchCommand(KEY_ENTER_COMMAND, {
+        key: 'Enter',
+        shiftKey: false,
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        repeat: true,
+        preventDefault() {},
+      } as unknown as KeyboardEvent);
+    });
+
+    await waitFor(() => expect(onEnterSend).not.toHaveBeenCalled());
+  });
 });


### PR DESCRIPTION
## Why

A user pressed Enter roughly three times in the chat composer and the pending queue expanded to 58 copies of the same task. The browser's repeated keydown events were treated as independent sends, the composer remained actionable while asynchronous admission was pending, and queued sends received a fresh random identity instead of preserving one logical submission identity.

This made a small input gesture fan out into many visible queued tasks and could let the queue drain them as separate runs.

## What users will see

Holding or rapidly pressing Enter now submits the current composer payload once while that submission is being admitted. Queueing and the eventual daemon run reuse one stable client request ID, so retries of the same logical submission are idempotent. Intentionally sending the same prompt again remains a separate submission.

Persisted queues are also deduplicated by stable request ID when a project is reopened.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — repeated submission gestures no longer enqueue duplicate tasks
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this is a behavior-only fix with no visual layout or entry-point change. The reported symptom was the existing queue counter and repeated rows growing from one logical submission.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/composer/LexicalComposerInput.test.tsx`
  - `apps/web/tests/components/ChatComposer.infinite-render.test.tsx`
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx`
- Red on `main`, green on this branch: yes
  - repeated Enter dispatched a send
  - two submits were admitted while the first async decision was pending
  - the same stable request ID produced two queue entries
  - queued submissions received a new ID when the daemon run started
  - duplicate persisted queue entries were restored twice

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/composer/LexicalComposerInput.test.tsx tests/components/ChatComposer.infinite-render.test.tsx tests/components/ProjectView.run-isolation.test.tsx` — 100 passed, 1 skipped
- `corepack pnpm exec vitest run -c vitest.config.ts tests/run-request-idempotency.test.ts` in `apps/daemon` — 6 passed
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check`