### PR TITLE
fix(daemon): cache workspace authority reads safely

### DIFF
--- a/apps/daemon/src/collab/hub-events-subscriber.ts
+++ b/apps/daemon/src/collab/hub-events-subscriber.ts
@@ -21,6 +21,7 @@
 import type { WorkspaceBillingRevisionClock } from '@open-design/contracts';
 
 export type HubResourceStatus = 'shared' | 'retracted';
+export type HubWorkspaceMemberChange = 'added' | 'removed' | 'updated';
 export type HubListenerHealth = 'starting' | 'healthy' | 'reconnecting' | 'stopped';
 
 export interface HubListenerStatus {
@@ -36,6 +37,10 @@ export interface HubReadyFrame {
 }
 
 const BILLING_REVISION_CLOCKS_CAPABILITY = 'billing-revision-clocks-v1';
+export const WORKSPACE_MEMBER_EVENTS_CAPABILITY =
+  'workspace-member-events-v1';
+const WORKSPACE_EVENT_LISTENER_STATUS_CAPABILITY =
+  'workspace-event-listener-status-v1';
 export const AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY =
   'authoritative-project-presence-v1';
 const MAX_HANDLED_SOURCE_GAP_EPOCHS = 64;
@@ -46,6 +51,7 @@ export interface HubWorkspaceEvent {
     | 'comment-changed'
     | 'presence-changed'
     | 'workspace-context-changed'
+    | 'workspace-members-changed'
     | 'billing-changed'
     | 'billing-subscription-changed'
     | 'wallet-balance-changed'
@@ -54,6 +60,10 @@ export interface HubWorkspaceEvent {
     | 'team-resources-changed';
   workspaceId?: string;
   workspaceMemberId?: string;
+  /** Subject of a workspace-members-changed event. This is distinct from the
+   * authenticated workspaceMemberId carried by private billing events. */
+  memberId?: string;
+  memberChange?: HubWorkspaceMemberChange;
   revision?: string;
   revisionClock?: WorkspaceBillingRevisionClock;
   projectId?: string;
@@ -78,6 +88,7 @@ const HUB_EVENT_TYPES = new Set<HubWorkspaceEvent['type']>([
   'comment-changed',
   'presence-changed',
   'workspace-context-changed',
+  'workspace-members-changed',
   'billing-changed',
   'billing-subscription-changed',
   'wallet-balance-changed',
@@ -87,6 +98,11 @@ const HUB_EVENT_TYPES = new Set<HubWorkspaceEvent['type']>([
 ]);
 
 const HUB_RESOURCE_STATUSES = new Set<HubResourceStatus>(['shared', 'retracted']);
+const HUB_WORKSPACE_MEMBER_CHANGES = new Set<HubWorkspaceMemberChange>([
+  'added',
+  'removed',
+  'updated',
+]);
 
 export function parseHubWorkspaceEvent(data: string): HubWorkspaceEvent | null {
   try {
@@ -98,6 +114,15 @@ export function parseHubWorkspaceEvent(data: string): HubWorkspaceEvent | null {
     if (typeof parsed.workspaceId === 'string') event.workspaceId = parsed.workspaceId;
     if (typeof parsed.workspaceMemberId === 'string') {
       event.workspaceMemberId = parsed.workspaceMemberId;
+    }
+    if (typeof parsed.memberId === 'string') event.memberId = parsed.memberId;
+    if (
+      typeof parsed.memberChange === 'string'
+      && HUB_WORKSPACE_MEMBER_CHANGES.has(
+        parsed.memberChange as HubWorkspaceMemberChange,
+      )
+    ) {
+      event.memberChange = parsed.memberChange as HubWorkspaceMemberChange;
     }
     if (typeof parsed.revision === 'string') event.revision = parsed.revision;
     const revisionClock = parseRevisionClock(parsed.revisionClock);
@@ -206,8 +231,23 @@ export interface HubEventsSubscriberOptions {
    */
   resolveEndpoint: () => Promise<HubEventsEndpoint | null>;
   onEvent: (event: HubWorkspaceEvent) => void;
+  /** Terminal authorization signal emitted immediately before Vela closes a
+   * revoked member's verified stream. */
+  onAccessRevoked?: (revocation: {
+    workspaceId?: string;
+    reason?: string;
+  }) => void;
   /** Channel health transitions — drives poll-cadence switching. */
   onStateChange?: (state: 'connected' | 'disconnected') => void;
+  /** Strict authority health for adaptive polling. `healthy` is true only
+   * after exact-scope verification, required roster/listener capabilities,
+   * and a healthy gap-free producer status are all present. */
+  onAuthorityHealthChange?: (health: {
+    workspaceId?: string;
+    healthy: boolean;
+    capabilities: readonly string[];
+    listenerStatus: HubListenerStatus | null;
+  }) => void;
   /** Fired after a `ready` frame verifies the stream workspace. Unlike
    *  `onReconnect`, this includes the first successful connection. */
   onConnect?: (connection: {
@@ -280,9 +320,43 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
       };
     });
 
-  async function consumeStream(endpoint: HubEventsEndpoint): Promise<void> {
+  async function consumeStream(
+    endpoint: HubEventsEndpoint,
+  ): Promise<'closed' | 'rejected' | 'revoked'> {
     abortController = new AbortController();
     let watchdog: NodeJS.Timeout | null = null;
+    let scopeVerified = false;
+    let verifiedWorkspaceId: string | undefined;
+    let verifiedCapabilities: readonly string[] = [];
+    let lastListenerStatus: HubListenerStatus | null = null;
+    let lastAuthorityHealthy: boolean | null = null;
+    const publishAuthorityHealth = (
+      status: HubListenerStatus | null,
+      forceUnhealthy = false,
+    ) => {
+      lastListenerStatus = status;
+      const healthy =
+        !forceUnhealthy &&
+        scopeVerified &&
+        verifiedCapabilities.includes(WORKSPACE_MEMBER_EVENTS_CAPABILITY) &&
+        verifiedCapabilities.includes(
+          WORKSPACE_EVENT_LISTENER_STATUS_CAPABILITY,
+        ) &&
+        status?.listenerHealth === 'healthy' &&
+        status.sourceGap === false;
+      if (lastAuthorityHealthy === healthy) return;
+      lastAuthorityHealthy = healthy;
+      try {
+        options.onAuthorityHealthChange?.({
+          ...(verifiedWorkspaceId ? { workspaceId: verifiedWorkspaceId } : {}),
+          healthy,
+          capabilities: [...verifiedCapabilities],
+          listenerStatus: status,
+        });
+      } catch (error) {
+        options.onError?.(error);
+      }
+    };
     const armWatchdog = () => {
       if (watchdog) clearTimeout(watchdog);
       watchdog = setTimeout(() => abortController?.abort(), heartbeatTimeoutMs);
@@ -297,18 +371,14 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
       if (!response.ok || !response.body) {
         throw new Error(`hub events stream ${response.status}`);
       }
-      // Transport-connected. Content catch-up remains gated on the server's
-      // `ready` frame proving the expected workspace below.
-      backoffMs = backoffMinMs;
-      setConnected(true);
+      // Transport-connected. Do not publish a connected state until the
+      // server's `ready` frame proves the exact expected workspace below.
       armWatchdog();
 
       const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
-      let scopeVerified = false;
       let connectionNotified = false;
-      let verifiedWorkspaceId: string | undefined;
       let revisionClocksEnabled = false;
       const reportSourceGap = (
         status: HubListenerStatus | null,
@@ -388,7 +458,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
                   : {}),
               });
               abortController?.abort();
-              return;
+              return 'rejected';
             }
             const actualWorkspaceId = ready.workspaceId;
             if (endpoint.workspaceId && actualWorkspaceId !== endpoint.workspaceId) {
@@ -399,10 +469,16 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
                 actualWorkspaceId,
               });
               abortController?.abort();
-              return;
+              return 'rejected';
             }
             scopeVerified = true;
             verifiedWorkspaceId = actualWorkspaceId;
+            verifiedCapabilities = [...ready.capabilities];
+            // A verified connection has recovered from prior transport
+            // failures. Terminal revocation below deliberately overrides this
+            // with the maximum retry delay.
+            backoffMs = backoffMinMs;
+            setConnected(true);
             revisionClocksEnabled = ready.capabilities.includes(
               BILLING_REVISION_CLOCKS_CAPABILITY,
             );
@@ -412,11 +488,52 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
             // catch-up. A first connection has no such callback, so a healthy
             // producer-side gap reported in ready must trigger it here.
             reportSourceGap(ready.listenerStatus, reconnect);
+            // `ready` verifies the stream scope and capabilities, but Vela
+            // emits it before its post-subscribe membership revalidation has
+            // completed. Keep the authority path conservative until the first
+            // healthy post-ready status/heartbeat proves that catch-up crossed
+            // that boundary.
+            publishAuthorityHealth(ready.listenerStatus, true);
             continue;
           }
           if (eventName === 'source-status' || eventName === 'heartbeat') {
-            if (scopeVerified) reportSourceGap(parseHubListenerStatus(data));
+            if (scopeVerified) {
+              const status = parseHubListenerStatus(data);
+              reportSourceGap(status);
+              publishAuthorityHealth(status);
+            }
             continue;
+          }
+          if (eventName === 'access-revoked') {
+            if (!scopeVerified) {
+              options.onDrop?.({
+                reason: 'unverified-scope',
+                eventName,
+                ...(endpoint.workspaceId
+                  ? { expectedWorkspaceId: endpoint.workspaceId }
+                  : {}),
+              });
+              continue;
+            }
+            const parsed = parseJsonRecord(data);
+            const reason =
+              typeof parsed?.reason === 'string' && parsed.reason.trim()
+                ? parsed.reason.trim()
+                : undefined;
+            try {
+              options.onAccessRevoked?.({
+                ...(verifiedWorkspaceId
+                  ? { workspaceId: verifiedWorkspaceId }
+                  : {}),
+                ...(reason ? { reason } : {}),
+              });
+            } catch (error) {
+              options.onError?.(error);
+            }
+            publishAuthorityHealth(lastListenerStatus, true);
+            setConnected(false);
+            abortController?.abort();
+            return 'revoked';
           }
           if (eventName !== 'workspace-event') continue;
           if (!scopeVerified) {
@@ -455,9 +572,11 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
           }
         }
       }
+      return 'closed';
     } finally {
       if (watchdog) clearTimeout(watchdog);
       abortController = null;
+      if (scopeVerified) publishAuthorityHealth(lastListenerStatus, true);
       setConnected(false);
     }
   }
@@ -476,13 +595,16 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
           await sleep(backoffMaxMs);
           continue;
         }
-        await consumeStream(endpoint);
+        const outcome = await consumeStream(endpoint);
         if (generation !== endpointGeneration) {
           backoffMs = backoffMinMs;
           continue;
         }
-        // Server closed cleanly (deploy/restart) — reconnect promptly.
-        backoffMs = backoffMinMs;
+        // Server closed cleanly (deploy/restart) — reconnect promptly. A
+        // terminal revocation or untrusted ready frame must not become a
+        // one-request-per-second loop; probe only at the bounded maximum until
+        // membership, deployment, or scope changes.
+        backoffMs = outcome === 'closed' ? backoffMinMs : backoffMaxMs;
       } catch (error) {
         // Deliberately aborting the old workspace stream is not a transport
         // failure and must not surface a misleading reconnect warning.

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -562,11 +562,25 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   identityKey?: () => string;
   ttlMs?: number;
   now?: () => number;
+  onDecision?: (input: {
+    source: 'cache' | 'directory';
+    reason: 'cold' | 'lease_hit' | 'lease_expired' | 'in_flight' | 'fresh';
+    outcome: 'allow' | 'deny' | 'unavailable' | 'fallback';
+    ageMs?: number;
+  }) => void;
+  onSuppressedRequest?: (input: {
+    source: 'directory';
+    reason: 'lease_hit' | 'in_flight';
+  }) => void;
+  onInvalidation?: (input: {
+    source: 'cache';
+    reason: 'mutation' | 'event_dirty' | 'auth_reject' | 'catch_up';
+  }) => void;
 } = {}): {
   cached: () => Promise<WorkspaceDirectoryFetchResult>;
   read: () => Promise<WorkspaceDirectoryFetchResult>;
   fresh: () => Promise<WorkspaceDirectoryFetchResult>;
-  invalidate: () => void;
+  invalidate: (reason?: 'event_dirty' | 'auth_reject' | 'catch_up') => void;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
 } {
   const fetchDirectory =
@@ -599,12 +613,22 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     cached.delete(identity);
   };
 
+  const recordDecision = (
+    input: Parameters<NonNullable<typeof options.onDecision>>[0],
+  ): void => {
+    options.onDecision?.(input);
+  };
+
   const start = (
     identity: string,
+    reason: 'cold' | 'lease_expired' | 'fresh',
   ): Promise<WorkspaceDirectoryFetchResult> => {
     const generation = generationFor(identity);
     const pending = inFlight.get(identity);
-    if (pending?.generation === generation) return pending.request;
+    if (pending?.generation === generation) {
+      options.onSuppressedRequest?.({ source: 'directory', reason: 'in_flight' });
+      return pending.request;
+    }
     const request = fetchDirectory()
       .then((result) => {
         if (result.ok && generationFor(identity) === generation) {
@@ -614,7 +638,20 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
             result,
           });
         }
+        recordDecision({
+          source: 'directory',
+          reason,
+          outcome: result.ok ? 'allow' : 'unavailable',
+        });
         return result;
+      })
+      .catch((error) => {
+        recordDecision({
+          source: 'directory',
+          reason,
+          outcome: 'unavailable',
+        });
+        throw error;
       })
       .finally(() => {
         if (inFlight.get(identity)?.request === request) {
@@ -634,9 +671,19 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
         && cachedEntry.generation === generationFor(identity)
         && now() < cachedEntry.expiresAt
       ) {
+        const ageMs = Math.max(0, ttlMs - (cachedEntry.expiresAt - now()));
+        recordDecision({
+          source: 'cache',
+          reason: 'lease_hit',
+          outcome: 'allow',
+          ageMs,
+        });
+        options.onSuppressedRequest?.({ source: 'directory', reason: 'lease_hit' });
         return Promise.resolve(cachedEntry.result);
       }
+      const reason = cachedEntry ? 'lease_expired' : 'cold';
       cached.delete(identity);
+      recordDecision({ source: 'cache', reason, outcome: 'fallback' });
       return Promise.resolve({ ok: false, items: [] });
     },
     read: () => {
@@ -647,12 +694,25 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
         && cachedEntry.generation === generationFor(identity)
         && now() < cachedEntry.expiresAt
       ) {
+        const ageMs = Math.max(0, ttlMs - (cachedEntry.expiresAt - now()));
+        recordDecision({
+          source: 'cache',
+          reason: 'lease_hit',
+          outcome: 'allow',
+          ageMs,
+        });
+        options.onSuppressedRequest?.({ source: 'directory', reason: 'lease_hit' });
         return Promise.resolve(cachedEntry.result);
       }
-      return start(identity);
+      const reason = cachedEntry ? 'lease_expired' : 'cold';
+      cached.delete(identity);
+      return start(identity, reason);
     },
-    fresh: () => start(identityKey()),
-    invalidate: () => invalidateIdentity(identityKey()),
+    fresh: () => start(identityKey(), 'fresh'),
+    invalidate: (reason = 'event_dirty') => {
+      invalidateIdentity(identityKey());
+      options.onInvalidation?.({ source: 'cache', reason });
+    },
     refreshAfterMutation: async () => {
       // A read that started before the remote mutation can still be in flight
       // after the mutation commits. Drain it, then deliberately start another
@@ -661,7 +721,8 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
       const pending = inFlight.get(identity)?.request;
       if (pending) await pending.catch(() => undefined);
       invalidateIdentity(identity);
-      return start(identityKey());
+      options.onInvalidation?.({ source: 'cache', reason: 'mutation' });
+      return start(identityKey(), 'fresh');
     },
   };
 }

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -566,6 +566,7 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   cached: () => Promise<WorkspaceDirectoryFetchResult>;
   read: () => Promise<WorkspaceDirectoryFetchResult>;
   fresh: () => Promise<WorkspaceDirectoryFetchResult>;
+  invalidate: () => void;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
 } {
   const fetchDirectory =
@@ -575,26 +576,52 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   const now = options.now ?? Date.now;
   const cached = new Map<
     string,
-    { expiresAt: number; result: WorkspaceDirectoryFetchResult }
+    {
+      generation: number;
+      expiresAt: number;
+      result: WorkspaceDirectoryFetchResult;
+    }
   >();
-  const inFlight = new Map<string, Promise<WorkspaceDirectoryFetchResult>>();
+  const inFlight = new Map<
+    string,
+    {
+      generation: number;
+      request: Promise<WorkspaceDirectoryFetchResult>;
+    }
+  >();
+  const generations = new Map<string, number>();
+
+  const generationFor = (identity: string): number =>
+    generations.get(identity) ?? 0;
+
+  const invalidateIdentity = (identity: string): void => {
+    generations.set(identity, generationFor(identity) + 1);
+    cached.delete(identity);
+  };
 
   const start = (
     identity: string,
   ): Promise<WorkspaceDirectoryFetchResult> => {
+    const generation = generationFor(identity);
     const pending = inFlight.get(identity);
-    if (pending) return pending;
+    if (pending?.generation === generation) return pending.request;
     const request = fetchDirectory()
       .then((result) => {
-        if (result.ok) {
-          cached.set(identity, { expiresAt: now() + ttlMs, result });
+        if (result.ok && generationFor(identity) === generation) {
+          cached.set(identity, {
+            generation,
+            expiresAt: now() + ttlMs,
+            result,
+          });
         }
         return result;
       })
       .finally(() => {
-        if (inFlight.get(identity) === request) inFlight.delete(identity);
+        if (inFlight.get(identity)?.request === request) {
+          inFlight.delete(identity);
+        }
       });
-    inFlight.set(identity, request);
+    inFlight.set(identity, { generation, request });
     return request;
   };
 
@@ -602,7 +629,11 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     cached: () => {
       const identity = identityKey();
       const cachedEntry = cached.get(identity);
-      if (cachedEntry && now() < cachedEntry.expiresAt) {
+      if (
+        cachedEntry
+        && cachedEntry.generation === generationFor(identity)
+        && now() < cachedEntry.expiresAt
+      ) {
         return Promise.resolve(cachedEntry.result);
       }
       cached.delete(identity);
@@ -611,20 +642,25 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     read: () => {
       const identity = identityKey();
       const cachedEntry = cached.get(identity);
-      if (cachedEntry && now() < cachedEntry.expiresAt) {
+      if (
+        cachedEntry
+        && cachedEntry.generation === generationFor(identity)
+        && now() < cachedEntry.expiresAt
+      ) {
         return Promise.resolve(cachedEntry.result);
       }
       return start(identity);
     },
     fresh: () => start(identityKey()),
+    invalidate: () => invalidateIdentity(identityKey()),
     refreshAfterMutation: async () => {
       // A read that started before the remote mutation can still be in flight
       // after the mutation commits. Drain it, then deliberately start another
       // fetch so the settled lease is based on post-mutation authority.
       const identity = identityKey();
-      const pending = inFlight.get(identity);
+      const pending = inFlight.get(identity)?.request;
       if (pending) await pending.catch(() => undefined);
-      cached.delete(identity);
+      invalidateIdentity(identity);
       return start(identityKey());
     },
   };

--- a/apps/daemon/src/collab/workspace-authority-health.ts
+++ b/apps/daemon/src/collab/workspace-authority-health.ts
@@ -1,0 +1,67 @@
+export type WorkspaceAuthorityCacheMode = 'legacy' | 'observe' | 'adaptive';
+
+export function resolveWorkspaceAuthorityCacheMode(
+  value: string | undefined,
+): WorkspaceAuthorityCacheMode {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === 'observe' || normalized === 'adaptive'
+    ? normalized
+    : 'legacy';
+}
+
+export interface WorkspaceAuthorityHealthCoordinatorOptions {
+  mode: WorkspaceAuthorityCacheMode;
+  catchUp(workspaceId: string): Promise<void>;
+  setDirectoryPollingHealthy(workspaceId: string, healthy: boolean): void;
+  setBillingPollingHealthy(workspaceId: string, healthy: boolean): void;
+  setContextCachingHealthy?(workspaceId: string, healthy: boolean): void;
+  onError?: (error: unknown) => void;
+}
+
+export interface WorkspaceAuthorityHealthCoordinator {
+  update(input: { workspaceId?: string; healthy: boolean }): Promise<void>;
+}
+
+/**
+ * Converts strict upstream health into permission to suppress legacy polls.
+ * A healthy frame is only a candidate: adaptive mode remains on legacy
+ * cadence until one exact-workspace catch-up completes. Generation fencing
+ * prevents a late catch-up from re-enabling suppression after a disconnect.
+ */
+export function createWorkspaceAuthorityHealthCoordinator(
+  options: WorkspaceAuthorityHealthCoordinatorOptions,
+): WorkspaceAuthorityHealthCoordinator {
+  const generations = new Map<string, number>();
+
+  const setHealthy = (workspaceId: string, healthy: boolean): void => {
+    options.setDirectoryPollingHealthy(workspaceId, healthy);
+    options.setBillingPollingHealthy(workspaceId, healthy);
+    options.setContextCachingHealthy?.(workspaceId, healthy);
+  };
+
+  return {
+    async update(input): Promise<void> {
+      const workspaceId = input.workspaceId?.trim() ?? '';
+      if (!workspaceId) return;
+      const generation = (generations.get(workspaceId) ?? 0) + 1;
+      generations.set(workspaceId, generation);
+
+      if (options.mode !== 'adaptive' || !input.healthy) {
+        setHealthy(workspaceId, false);
+        return;
+      }
+
+      // Keep legacy cadence through the catch-up window. Only a completed
+      // catch-up in the still-current health generation may enable the floor.
+      setHealthy(workspaceId, false);
+      try {
+        await options.catchUp(workspaceId);
+      } catch (error) {
+        options.onError?.(error);
+        return;
+      }
+      if (generations.get(workspaceId) !== generation) return;
+      setHealthy(workspaceId, true);
+    },
+  };
+}

--- a/apps/daemon/src/collab/workspace-authority-health.ts
+++ b/apps/daemon/src/collab/workspace-authority-health.ts
@@ -15,6 +15,11 @@ export interface WorkspaceAuthorityHealthCoordinatorOptions {
   setDirectoryPollingHealthy(workspaceId: string, healthy: boolean): void;
   setBillingPollingHealthy(workspaceId: string, healthy: boolean): void;
   setContextCachingHealthy?(workspaceId: string, healthy: boolean): void;
+  onDecision?: (input: {
+    source: 'sse';
+    reason: 'mode_disabled' | 'unhealthy' | 'catch_up' | 'healthy';
+    outcome: 'allow' | 'unavailable' | 'fallback';
+  }) => void;
   onError?: (error: unknown) => void;
 }
 
@@ -48,6 +53,11 @@ export function createWorkspaceAuthorityHealthCoordinator(
 
       if (options.mode !== 'adaptive' || !input.healthy) {
         setHealthy(workspaceId, false);
+        options.onDecision?.({
+          source: 'sse',
+          reason: input.healthy ? 'mode_disabled' : 'unhealthy',
+          outcome: 'fallback',
+        });
         return;
       }
 
@@ -57,11 +67,21 @@ export function createWorkspaceAuthorityHealthCoordinator(
       try {
         await options.catchUp(workspaceId);
       } catch (error) {
+        options.onDecision?.({
+          source: 'sse',
+          reason: 'catch_up',
+          outcome: 'unavailable',
+        });
         options.onError?.(error);
         return;
       }
       if (generations.get(workspaceId) !== generation) return;
       setHealthy(workspaceId, true);
+      options.onDecision?.({
+        source: 'sse',
+        reason: 'healthy',
+        outcome: 'allow',
+      });
     },
   };
 }

--- a/apps/daemon/src/collab/workspace-authority-health.ts
+++ b/apps/daemon/src/collab/workspace-authority-health.ts
@@ -13,6 +13,8 @@ export function resolveWorkspaceAuthorityCacheMode(
 export interface WorkspaceAuthorityHealthCoordinatorOptions {
   mode: WorkspaceAuthorityCacheMode;
   catchUp(workspaceId: string): Promise<void>;
+  /** Bounded-cadence retry after a transient catch-up failure. */
+  catchUpRetryMs?: number;
   setDirectoryPollingHealthy(workspaceId: string, healthy: boolean): void;
   setBillingPollingHealthy(workspaceId: string, healthy: boolean): void;
   setContextCachingHealthy?(workspaceId: string, healthy: boolean): void;
@@ -38,6 +40,8 @@ export function createWorkspaceAuthorityHealthCoordinator(
   options: WorkspaceAuthorityHealthCoordinatorOptions,
 ): WorkspaceAuthorityHealthCoordinator {
   const generations = new Map<string, number>();
+  const retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const catchUpRetryMs = Math.max(1, options.catchUpRetryMs ?? 30_000);
 
   const setHealthy = (workspaceId: string, healthy: boolean): void => {
     options.setDirectoryPollingHealthy(workspaceId, healthy);
@@ -45,44 +49,70 @@ export function createWorkspaceAuthorityHealthCoordinator(
     options.setContextCachingHealthy?.(workspaceId, healthy);
   };
 
-  return {
-    async update(input): Promise<void> {
-      const workspaceId = input.workspaceId?.trim() ?? '';
-      if (!workspaceId) return;
-      const generation = (generations.get(workspaceId) ?? 0) + 1;
-      generations.set(workspaceId, generation);
+  function clearRetry(workspaceId: string): void {
+    const timer = retryTimers.get(workspaceId);
+    if (!timer) return;
+    clearTimeout(timer);
+    retryTimers.delete(workspaceId);
+  }
 
-      if (options.mode !== 'adaptive' || !input.healthy) {
-        setHealthy(workspaceId, false);
-        options.onDecision?.({
-          source: 'sse',
-          reason: input.healthy ? 'mode_disabled' : 'unhealthy',
-          outcome: 'fallback',
-        });
-        return;
-      }
+  async function update(input: {
+    workspaceId?: string;
+    healthy: boolean;
+  }): Promise<void> {
+    const workspaceId = input.workspaceId?.trim() ?? '';
+    if (!workspaceId) return;
+    clearRetry(workspaceId);
+    const generation = (generations.get(workspaceId) ?? 0) + 1;
+    generations.set(workspaceId, generation);
 
-      // Keep legacy cadence through the catch-up window. Only a completed
-      // catch-up in the still-current health generation may enable the floor.
+    if (options.mode !== 'adaptive' || !input.healthy) {
       setHealthy(workspaceId, false);
-      try {
-        await options.catchUp(workspaceId);
-      } catch (error) {
-        options.onDecision?.({
-          source: 'sse',
-          reason: 'catch_up',
-          outcome: 'unavailable',
-        });
-        options.onError?.(error);
-        return;
-      }
-      if (generations.get(workspaceId) !== generation) return;
-      setHealthy(workspaceId, true);
       options.onDecision?.({
         source: 'sse',
-        reason: 'healthy',
-        outcome: 'allow',
+        reason: input.healthy ? 'mode_disabled' : 'unhealthy',
+        outcome: 'fallback',
       });
-    },
+      return;
+    }
+
+    // Keep legacy cadence through the catch-up window. Only a completed
+    // catch-up in the still-current health generation may enable the floor.
+    setHealthy(workspaceId, false);
+    try {
+      await options.catchUp(workspaceId);
+    } catch (error) {
+      options.onDecision?.({
+        source: 'sse',
+        reason: 'catch_up',
+        outcome: 'unavailable',
+      });
+      options.onError?.(error);
+      // The hub edge-publishes health, so another healthy heartbeat will not
+      // re-notify us after a transient catch-up failure. Retry locally at a
+      // bounded cadence; a disconnect/unhealthy update advances the generation
+      // and cancels this recovery before it can re-enable suppression.
+      if (generations.get(workspaceId) === generation) {
+        const timer = setTimeout(() => {
+          retryTimers.delete(workspaceId);
+          if (generations.get(workspaceId) !== generation) return;
+          void update({ workspaceId, healthy: true });
+        }, catchUpRetryMs);
+        timer.unref?.();
+        retryTimers.set(workspaceId, timer);
+      }
+      return;
+    }
+    if (generations.get(workspaceId) !== generation) return;
+    setHealthy(workspaceId, true);
+    options.onDecision?.({
+      source: 'sse',
+      reason: 'healthy',
+      outcome: 'allow',
+    });
+  }
+
+  return {
+    update,
   };
 }

--- a/apps/daemon/src/collab/workspace-authority-health.ts
+++ b/apps/daemon/src/collab/workspace-authority-health.ts
@@ -3,7 +3,8 @@ export type WorkspaceAuthorityCacheMode = 'legacy' | 'observe' | 'adaptive';
 export function resolveWorkspaceAuthorityCacheMode(
   value: string | undefined,
 ): WorkspaceAuthorityCacheMode {
-  const normalized = value?.trim().toLowerCase();
+  if (value == null || value.trim() === '') return 'adaptive';
+  const normalized = value.trim().toLowerCase();
   return normalized === 'observe' || normalized === 'adaptive'
     ? normalized
     : 'legacy';

--- a/apps/daemon/src/collab/workspace-billing-runtime.ts
+++ b/apps/daemon/src/collab/workspace-billing-runtime.ts
@@ -7,6 +7,7 @@ import type {
 import type { VelaWorkspaceBillingProjection } from '../integrations/vela-billing.js';
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_REALTIME_POLL_FLOOR_MS = 5 * 60_000;
 const DEFAULT_RETRY_DELAYS_MS = [5_000, 15_000, 30_000] as const;
 const DEFAULT_INTEREST_LEASE_MS = 60_000;
 const DEFAULT_INTEREST_SWEEP_INTERVAL_MS = 5_000;
@@ -76,8 +77,13 @@ export interface WorkspaceBillingRuntimeCoordinatorOptions {
   fetchProjection(key: WorkspaceBillingRuntimeKey): Promise<VelaWorkspaceBillingProjection>;
   scheduler?: WorkspaceBillingRuntimeScheduler;
   pollIntervalMs?: number;
+  realtimePollFloorMs?: number;
   retryDelaysMs?: readonly number[];
   onStateChange?: (state: WorkspaceBillingRuntimeState) => void;
+  onAccessRevoked?: (
+    key: WorkspaceBillingRuntimeKey,
+    error: unknown,
+  ) => void;
   interestLeaseMs?: number;
   interestSweepIntervalMs?: number;
   entryRetentionMs?: number;
@@ -183,6 +189,8 @@ export class WorkspaceBillingRuntimeCoordinator {
   private readonly maxEntries: number;
   private readonly softTtlMs: number;
   private readonly hardTtlMs: number;
+  private readonly realtimePollFloorMs: number;
+  private readonly realtimeHealthyWorkspaces = new Set<string>();
   private readonly maxConcurrentRefreshes: number;
   private readonly maxRefreshStartsPerWindow: number;
   private readonly refreshStartWindowMs: number;
@@ -212,6 +220,10 @@ export class WorkspaceBillingRuntimeCoordinator {
     this.hardTtlMs = Math.max(
       this.softTtlMs,
       options.hardTtlMs ?? this.softTtlMs * DEFAULT_HARD_TTL_MULTIPLIER,
+    );
+    this.realtimePollFloorMs = Math.max(
+      this.softTtlMs,
+      options.realtimePollFloorMs ?? DEFAULT_REALTIME_POLL_FLOOR_MS,
     );
     this.maxConcurrentRefreshes = Math.max(
       1,
@@ -348,10 +360,11 @@ export class WorkspaceBillingRuntimeCoordinator {
     const entry = this.entryFor(key);
     const forceForInterest = this.acceptClientInterest(entry, options);
     const requireFresh = options.requireFresh === true;
+    const softTtlMs = this.effectiveSoftTtlMs(entry);
     if (
       entry.status === 'fresh' &&
       entry.observedAt != null &&
-      this.scheduler.now() - entry.observedAt >= this.softTtlMs
+      this.scheduler.now() - entry.observedAt >= softTtlMs
     ) {
       this.markStatus(entry, 'stale', 'soft-ttl-expired');
     }
@@ -362,7 +375,7 @@ export class WorkspaceBillingRuntimeCoordinator {
       requireFresh ||
       entry.status !== 'fresh' ||
       entry.observedAt == null ||
-      this.scheduler.now() - entry.observedAt >= this.softTtlMs ||
+      this.scheduler.now() - entry.observedAt >= softTtlMs ||
       forceForInterest
     ) {
       this.requestRefresh(
@@ -448,12 +461,34 @@ export class WorkspaceBillingRuntimeCoordinator {
     }
   }
 
+  setRealtimeHealthy(workspaceId: string, healthy: boolean): void {
+    if (this.disposed) return;
+    const requested = workspaceId.trim();
+    if (!requested) return;
+    if (healthy) {
+      this.realtimeHealthyWorkspaces.add(requested);
+      return;
+    }
+    if (!this.realtimeHealthyWorkspaces.delete(requested)) return;
+    // A disconnect or source-health downgrade immediately restores the
+    // authoritative fallback and refreshes the last-good projection.
+    this.reconnect(requested);
+  }
+
   refreshAll(reason = 'catch-up'): void {
     if (this.disposed) return;
     for (const entry of this.entries.values()) {
       if (!this.hasActiveInterest(entry)) continue;
       if (entry.status === 'access-revoked') continue;
       if (reason === 'poll-floor' && entry.retryTimer) continue;
+      if (
+        reason === 'poll-floor' &&
+        this.realtimeHealthyWorkspaces.has(entry.key.workspaceId) &&
+        entry.observedAt != null &&
+        this.scheduler.now() - entry.observedAt < this.realtimePollFloorMs
+      ) {
+        continue;
+      }
       this.markStatus(entry, hasProjection(entry) ? 'stale' : 'loading', reason);
       this.requestRefresh(entry, reason, true);
     }
@@ -486,6 +521,7 @@ export class WorkspaceBillingRuntimeCoordinator {
   revokeWorkspace(workspaceId: string, reason = 'workspace-not-authorized'): void {
     const requested = workspaceId.trim();
     if (!requested) return;
+    this.realtimeHealthyWorkspaces.delete(requested);
     for (const entry of this.entries.values()) {
       if (entry.key.workspaceId !== requested) continue;
       this.revokeEntry(entry, reason);
@@ -555,6 +591,7 @@ export class WorkspaceBillingRuntimeCoordinator {
     }
     this.entries.clear();
     this.clients.clear();
+    this.realtimeHealthyWorkspaces.clear();
   }
 
   private acceptClientInterest(
@@ -883,6 +920,11 @@ export class WorkspaceBillingRuntimeCoordinator {
         const code = errorCode(error);
         if (isAccessRevokedError(error)) {
           this.revokeEntry(entry, code);
+          try {
+            this.options.onAccessRevoked?.({ ...entry.key }, error);
+          } catch {
+            // Revocation is already committed locally; observers are best-effort.
+          }
           return;
         }
         entry.status = 'error';
@@ -1006,6 +1048,8 @@ export class WorkspaceBillingRuntimeCoordinator {
   }
 
   private state(entry: RuntimeEntry): WorkspaceBillingRuntimeState {
+    const softTtlMs = this.effectiveSoftTtlMs(entry);
+    const hardTtlMs = this.effectiveHardTtlMs(entry);
     return {
       workspaceId: entry.key.workspaceId,
       workspaceMemberId: entry.key.workspaceMemberId,
@@ -1013,10 +1057,10 @@ export class WorkspaceBillingRuntimeCoordinator {
       revision: entry.revision.toString(),
       observedAt: timestamp(entry.observedAt),
       softExpiresAt: timestamp(
-        entry.observedAt == null ? null : entry.observedAt + this.softTtlMs,
+        entry.observedAt == null ? null : entry.observedAt + softTtlMs,
       ),
       hardExpiresAt: timestamp(
-        entry.observedAt == null ? null : entry.observedAt + this.hardTtlMs,
+        entry.observedAt == null ? null : entry.observedAt + hardTtlMs,
       ),
       retryAt: timestamp(entry.retryAt),
       errorCode: entry.errorCode,
@@ -1032,8 +1076,20 @@ export class WorkspaceBillingRuntimeCoordinator {
   private isHardExpired(entry: RuntimeEntry): boolean {
     return (
       entry.observedAt != null &&
-      this.scheduler.now() - entry.observedAt >= this.hardTtlMs
+      this.scheduler.now() - entry.observedAt >= this.effectiveHardTtlMs(entry)
     );
+  }
+
+  private effectiveSoftTtlMs(entry: RuntimeEntry): number {
+    return this.realtimeHealthyWorkspaces.has(entry.key.workspaceId)
+      ? this.realtimePollFloorMs
+      : this.softTtlMs;
+  }
+
+  private effectiveHardTtlMs(entry: RuntimeEntry): number {
+    return this.realtimeHealthyWorkspaces.has(entry.key.workspaceId)
+      ? Math.max(this.hardTtlMs, this.realtimePollFloorMs * 2)
+      : this.hardTtlMs;
   }
 
   private assertUsable(): void {
@@ -1118,7 +1174,9 @@ function validateProjectionScope(
       snapshot.workspaceMemberId !== key.workspaceMemberId
     )
   ) {
-    throw new Error('workspace_billing_scope_mismatch');
+    throw Object.assign(new Error('workspace billing scope mismatch'), {
+      code: 'workspace_billing_scope_mismatch',
+    });
   }
   if (
     balance &&
@@ -1128,7 +1186,9 @@ function validateProjectionScope(
       balance.workspaceMemberId !== key.workspaceMemberId
     )
   ) {
-    throw new Error('workspace_billing_scope_mismatch');
+    throw Object.assign(new Error('workspace billing scope mismatch'), {
+      code: 'workspace_billing_scope_mismatch',
+    });
   }
 }
 
@@ -1358,6 +1418,7 @@ function isAccessRevokedError(error: unknown): boolean {
     error instanceof WorkspaceBillingAccessRevokedError ||
     code === 'workspace_not_authorized' ||
     code === 'workspace_access_revoked' ||
+    code === 'workspace_billing_scope_mismatch' ||
     code === 'forbidden'
   );
 }

--- a/apps/daemon/src/collab/workspace-billing-runtime.ts
+++ b/apps/daemon/src/collab/workspace-billing-runtime.ts
@@ -96,6 +96,9 @@ export interface WorkspaceBillingRuntimeCoordinatorOptions {
   maxRefreshStartsPerWindow?: number;
   refreshStartWindowMs?: number;
   onInterestSetChange?: (interests: WorkspaceBillingRuntimeKey[]) => void;
+  /** Bounded observability hook; one callback equals one billing projection
+   * refresh avoided by the strict realtime safety floor. */
+  onPollSuppressed?: () => void;
 }
 
 interface ClientInterest {
@@ -487,6 +490,7 @@ export class WorkspaceBillingRuntimeCoordinator {
         entry.observedAt != null &&
         this.scheduler.now() - entry.observedAt < this.realtimePollFloorMs
       ) {
+        this.options.onPollSuppressed?.();
         continue;
       }
       this.markStatus(entry, hasProjection(entry) ? 'stale' : 'loading', reason);

--- a/apps/daemon/src/collab/workspace-exact-context-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-context-cache.ts
@@ -1,0 +1,131 @@
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import type {
+  WorkspaceContextProvider,
+  WorkspaceContextRequest,
+} from './workspace-context.js';
+
+export interface WorkspaceExactContextCacheOptions {
+  provider: WorkspaceContextProvider;
+  identity(): string;
+  realtimeTtlMs?: number;
+  now?: () => number;
+}
+
+export interface WorkspaceExactContextCache {
+  provider: WorkspaceContextProvider;
+  refresh(
+    request: WorkspaceContextRequest & { workspaceId: string },
+  ): Promise<WorkspaceCollabContext | null>;
+  cached(workspaceId: string): WorkspaceCollabContext | null;
+  setRealtimeHealthy(workspaceId: string, healthy: boolean): void;
+  invalidate(workspaceId?: string): void;
+}
+
+interface Entry {
+  context: WorkspaceCollabContext;
+  observedAt: number;
+}
+
+const DEFAULT_REALTIME_TTL_MS = 5 * 60_000;
+
+/** Exact-workspace cache for Vela's authenticated `/workspaces/current` read. */
+export function createWorkspaceExactContextCache(
+  options: WorkspaceExactContextCacheOptions,
+): WorkspaceExactContextCache {
+  const now = options.now ?? Date.now;
+  const realtimeTtlMs = Math.max(1, options.realtimeTtlMs ?? DEFAULT_REALTIME_TTL_MS);
+  const entries = new Map<string, Entry>();
+  const generations = new Map<string, number>();
+  const healthyIdentities = new Map<string, string>();
+
+  const cacheKey = (identity: string, workspaceId: string) =>
+    `${identity}\0${workspaceId}`;
+  const currentKey = (workspaceId: string) =>
+    cacheKey(options.identity(), workspaceId);
+  const advanceGeneration = (key: string): number => {
+    const generation = (generations.get(key) ?? 0) + 1;
+    generations.set(key, generation);
+    return generation;
+  };
+
+  const refresh = async (
+    request: WorkspaceContextRequest & { workspaceId: string },
+  ): Promise<WorkspaceCollabContext | null> => {
+    const workspaceId = request.workspaceId.trim();
+    if (!workspaceId || !options.provider.resolveExact) return null;
+    const key = currentKey(workspaceId);
+    if (!generations.has(key)) generations.set(key, 0);
+    const generation = generations.get(key) ?? 0;
+    const context = await options.provider.resolveExact({
+      ...request,
+      workspaceId,
+    });
+    if (
+      context &&
+      context.workspaceId === workspaceId &&
+      (generations.get(key) ?? 0) === generation
+    ) {
+      entries.set(key, { context, observedAt: now() });
+    }
+    return context;
+  };
+
+  const cached = (workspaceIdInput: string): WorkspaceCollabContext | null => {
+    const workspaceId = workspaceIdInput.trim();
+    const identity = options.identity();
+    if (!workspaceId || healthyIdentities.get(workspaceId) !== identity) return null;
+    const key = cacheKey(identity, workspaceId);
+    const entry = entries.get(key);
+    if (!entry || now() - entry.observedAt >= realtimeTtlMs) return null;
+    return entry.context;
+  };
+
+  const provider: WorkspaceContextProvider = {
+    ...options.provider,
+    ...(options.provider.resolveExact
+      ? {
+          resolveExact: async (
+            request: WorkspaceContextRequest & { workspaceId: string },
+          ): Promise<WorkspaceCollabContext | null> =>
+            cached(request.workspaceId) ?? refresh(request),
+        }
+      : {}),
+  };
+
+  return {
+    provider,
+    refresh,
+    cached,
+    setRealtimeHealthy(workspaceIdInput, healthy): void {
+      const workspaceId = workspaceIdInput.trim();
+      if (!workspaceId) return;
+      if (healthy) {
+        healthyIdentities.set(workspaceId, options.identity());
+        return;
+      }
+      healthyIdentities.delete(workspaceId);
+      const suffix = `\0${workspaceId}`;
+      for (const key of generations.keys()) {
+        if (!key.endsWith(suffix)) continue;
+        advanceGeneration(key);
+        entries.delete(key);
+      }
+    },
+    invalidate(workspaceIdInput): void {
+      const workspaceId = workspaceIdInput?.trim() ?? '';
+      if (workspaceId) {
+        healthyIdentities.delete(workspaceId);
+        const suffix = `\0${workspaceId}`;
+        for (const key of generations.keys()) {
+          if (!key.endsWith(suffix)) continue;
+          advanceGeneration(key);
+          entries.delete(key);
+        }
+        return;
+      }
+      healthyIdentities.clear();
+      for (const key of generations.keys()) advanceGeneration(key);
+      entries.clear();
+    },
+  };
+}

--- a/apps/daemon/src/collab/workspace-exact-context-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-context-cache.ts
@@ -176,7 +176,11 @@ export function createWorkspaceExactContextCache(
       const workspaceId = workspaceIdInput?.trim() ?? '';
       options.onInvalidation?.({ source: 'current', reason });
       if (workspaceId) {
-        healthyIdentities.delete(workspaceId);
+        // A thin event dirties the exact snapshot, not the proven health of
+        // the still-open realtime channel. Keep that health grant so a fresh
+        // post-event read can reseat the lease without waiting for a transport
+        // flap. Terminal backend rejection remains a hard health revocation.
+        if (reason === 'auth_reject') healthyIdentities.delete(workspaceId);
         const suffix = `\0${workspaceId}`;
         for (const key of generations.keys()) {
           if (!key.endsWith(suffix)) continue;
@@ -185,7 +189,7 @@ export function createWorkspaceExactContextCache(
         }
         return;
       }
-      healthyIdentities.clear();
+      if (reason === 'auth_reject') healthyIdentities.clear();
       for (const key of generations.keys()) advanceGeneration(key);
       entries.clear();
     },

--- a/apps/daemon/src/collab/workspace-exact-context-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-context-cache.ts
@@ -9,16 +9,34 @@ export interface WorkspaceExactContextCacheOptions {
   identity(): string;
   realtimeTtlMs?: number;
   now?: () => number;
+  onDecision?: (input: {
+    source: 'cache' | 'current';
+    reason: 'cold' | 'lease_hit' | 'lease_expired' | 'catch_up';
+    outcome: 'allow' | 'deny' | 'unavailable' | 'fallback';
+    ageMs?: number;
+  }) => void;
+  onSuppressedRequest?: (input: {
+    source: 'current';
+    reason: 'lease_hit';
+  }) => void;
+  onInvalidation?: (input: {
+    source: 'current';
+    reason: 'event_dirty' | 'auth_reject' | 'catch_up' | 'unhealthy';
+  }) => void;
 }
 
 export interface WorkspaceExactContextCache {
   provider: WorkspaceContextProvider;
   refresh(
     request: WorkspaceContextRequest & { workspaceId: string },
+    reason?: 'cold' | 'lease_expired' | 'catch_up',
   ): Promise<WorkspaceCollabContext | null>;
   cached(workspaceId: string): WorkspaceCollabContext | null;
   setRealtimeHealthy(workspaceId: string, healthy: boolean): void;
-  invalidate(workspaceId?: string): void;
+  invalidate(
+    workspaceId?: string,
+    reason?: 'event_dirty' | 'auth_reject' | 'catch_up',
+  ): void;
 }
 
 interface Entry {
@@ -50,16 +68,27 @@ export function createWorkspaceExactContextCache(
 
   const refresh = async (
     request: WorkspaceContextRequest & { workspaceId: string },
+    reason: 'cold' | 'lease_expired' | 'catch_up' = 'cold',
   ): Promise<WorkspaceCollabContext | null> => {
     const workspaceId = request.workspaceId.trim();
     if (!workspaceId || !options.provider.resolveExact) return null;
     const key = currentKey(workspaceId);
     if (!generations.has(key)) generations.set(key, 0);
     const generation = generations.get(key) ?? 0;
-    const context = await options.provider.resolveExact({
-      ...request,
-      workspaceId,
-    });
+    let context: WorkspaceCollabContext | null;
+    try {
+      context = await options.provider.resolveExact({
+        ...request,
+        workspaceId,
+      });
+    } catch (error) {
+      options.onDecision?.({
+        source: 'current',
+        reason,
+        outcome: 'unavailable',
+      });
+      throw error;
+    }
     if (
       context &&
       context.workspaceId === workspaceId &&
@@ -67,6 +96,13 @@ export function createWorkspaceExactContextCache(
     ) {
       entries.set(key, { context, observedAt: now() });
     }
+    options.onDecision?.({
+      source: 'current',
+      reason,
+      // The provider intentionally collapses signed-out, denied, and transport
+      // failures to null. Do not manufacture a deny label without evidence.
+      outcome: context ? 'allow' : 'unavailable',
+    });
     return context;
   };
 
@@ -76,7 +112,31 @@ export function createWorkspaceExactContextCache(
     if (!workspaceId || healthyIdentities.get(workspaceId) !== identity) return null;
     const key = cacheKey(identity, workspaceId);
     const entry = entries.get(key);
-    if (!entry || now() - entry.observedAt >= realtimeTtlMs) return null;
+    if (!entry) {
+      options.onDecision?.({
+        source: 'cache',
+        reason: 'cold',
+        outcome: 'fallback',
+      });
+      return null;
+    }
+    const ageMs = Math.max(0, now() - entry.observedAt);
+    if (ageMs >= realtimeTtlMs) {
+      options.onDecision?.({
+        source: 'cache',
+        reason: 'lease_expired',
+        outcome: 'fallback',
+        ageMs,
+      });
+      return null;
+    }
+    options.onDecision?.({
+      source: 'cache',
+      reason: 'lease_hit',
+      outcome: 'allow',
+      ageMs,
+    });
+    options.onSuppressedRequest?.({ source: 'current', reason: 'lease_hit' });
     return entry.context;
   };
 
@@ -87,7 +147,7 @@ export function createWorkspaceExactContextCache(
           resolveExact: async (
             request: WorkspaceContextRequest & { workspaceId: string },
           ): Promise<WorkspaceCollabContext | null> =>
-            cached(request.workspaceId) ?? refresh(request),
+            cached(request.workspaceId) ?? refresh(request, 'cold'),
         }
       : {}),
   };
@@ -103,6 +163,7 @@ export function createWorkspaceExactContextCache(
         healthyIdentities.set(workspaceId, options.identity());
         return;
       }
+      options.onInvalidation?.({ source: 'current', reason: 'unhealthy' });
       healthyIdentities.delete(workspaceId);
       const suffix = `\0${workspaceId}`;
       for (const key of generations.keys()) {
@@ -111,8 +172,9 @@ export function createWorkspaceExactContextCache(
         entries.delete(key);
       }
     },
-    invalidate(workspaceIdInput): void {
+    invalidate(workspaceIdInput, reason = 'event_dirty'): void {
       const workspaceId = workspaceIdInput?.trim() ?? '';
+      options.onInvalidation?.({ source: 'current', reason });
       if (workspaceId) {
         healthyIdentities.delete(workspaceId);
         const suffix = `\0${workspaceId}`;

--- a/apps/daemon/src/collab/workspace-invalidation-poller.ts
+++ b/apps/daemon/src/collab/workspace-invalidation-poller.ts
@@ -42,6 +42,9 @@ export interface WorkspaceInvalidationPollerDeps {
   ) => void;
   /** Poll cadence; defaults to 15s (matches the web team-projects/members poll). */
   pollIntervalMs?: number;
+  /** While the exact-workspace realtime stream is proven healthy, keep a
+   *  bounded authoritative poll floor instead of running every base tick. */
+  realtimePollFloorMs?: number;
   /** Ask the daemon recovery coordinator to inspect locally missing team
    * projects. This is a fire-and-forget request: a slow recovery must never
    * block workspace context, catalog, or member polling. `projects` is the
@@ -123,6 +126,8 @@ function membersSignature(members: CollabCloudMemberDirectoryEntry[]): string {
 export interface WorkspaceInvalidationPoller {
   /** Run one diff cycle (context → team reads → emit on change). */
   pollOnce(): Promise<void>;
+  /** Enable the slower poll floor only after strict realtime health is proven. */
+  setRealtimeHealthy(healthy: boolean): void;
   start(): void;
   stop(): void;
 }
@@ -131,11 +136,17 @@ export function createWorkspaceInvalidationPoller(
   deps: WorkspaceInvalidationPollerDeps,
 ): WorkspaceInvalidationPoller {
   const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const realtimePollFloorMs = Math.max(
+    pollIntervalMs,
+    deps.realtimePollFloorMs ?? 60_000,
+  );
   const recoveryFloorIntervalMs =
     deps.recoveryFloorIntervalMs ?? DEFAULT_RECOVERY_FLOOR_INTERVAL_MS;
   const now = deps.now ?? Date.now;
   let timer: NodeJS.Timeout | null = null;
   let running = false;
+  let realtimeHealthy = false;
+  let lastPollStartedAt: number | null = null;
   let recoveryWorkspaceId: string | null = null;
   let recoveryRequestedAt: number | null = null;
 
@@ -183,6 +194,7 @@ export function createWorkspaceInvalidationPoller(
 
   async function pollOnce(): Promise<void> {
     const observedAt = now();
+    lastPollStartedAt = observedAt;
     const context = await deps.getWorkspaceContext().catch((error) => {
       deps.onError?.(error);
       return null;
@@ -237,6 +249,13 @@ export function createWorkspaceInvalidationPoller(
 
   function tick(): void {
     if (running) return;
+    if (
+      realtimeHealthy &&
+      lastPollStartedAt != null &&
+      now() - lastPollStartedAt < realtimePollFloorMs
+    ) {
+      return;
+    }
     running = true;
     void pollOnce()
       .catch((error) => deps.onError?.(error))
@@ -247,6 +266,13 @@ export function createWorkspaceInvalidationPoller(
 
   return {
     pollOnce,
+    setRealtimeHealthy(healthy): void {
+      const wasHealthy = realtimeHealthy;
+      realtimeHealthy = healthy;
+      // Losing realtime authority is a fail-open-for-freshness transition:
+      // resume the 15s fallback immediately rather than waiting for its timer.
+      if (wasHealthy && !healthy) tick();
+    },
     start(): void {
       if (timer) return;
       timer = setInterval(tick, pollIntervalMs);

--- a/apps/daemon/src/collab/workspace-invalidation-poller.ts
+++ b/apps/daemon/src/collab/workspace-invalidation-poller.ts
@@ -58,6 +58,9 @@ export interface WorkspaceInvalidationPollerDeps {
   recoveryFloorIntervalMs?: number;
   /** Injectable wall clock for deterministic recovery-floor tests. */
   now?: () => number;
+  /** Bounded observability hook; one callback equals one upstream poll cycle
+   * avoided by the strict realtime safety floor. */
+  onPollSuppressed?: () => void;
   onError?: (error: unknown) => void;
 }
 
@@ -254,6 +257,7 @@ export function createWorkspaceInvalidationPoller(
       lastPollStartedAt != null &&
       now() - lastPollStartedAt < realtimePollFloorMs
     ) {
+      deps.onPollSuppressed?.();
       return;
     }
     running = true;

--- a/apps/daemon/src/integrations/vela-billing.ts
+++ b/apps/daemon/src/integrations/vela-billing.ts
@@ -41,6 +41,31 @@ export interface VelaWorkspaceBillingProjection {
   workspaceBalance: WorkspaceWalletBalance | null;
 }
 
+/** The Go CLI preserves the backend status/code in its wrapped stderr text,
+ * while injected/newer adapters may expose a string code directly. */
+export function isVelaWorkspaceAuthorizationError(error: unknown): boolean {
+  const code =
+    error && typeof error === 'object' && 'code' in error &&
+    typeof error.code === 'string'
+      ? error.code.trim().toLowerCase()
+      : '';
+  if (
+    code === 'workspace_not_authorized' ||
+    code === 'workspace_access_revoked' ||
+    code === 'auth_required' ||
+    code === 'forbidden'
+  ) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return (
+    /api request failed with status (?:401|403)(?::|\b)/i.test(message) ||
+    /\b(?:workspace_not_authorized|workspace_access_revoked|auth_required)\b/i.test(
+      message,
+    )
+  );
+}
+
 /** Fetch Vela's account-scoped billing summary through the CLI 收口. */
 export async function fetchVelaBillingSummary(
   options: FetchVelaBillingOptions = {},

--- a/apps/daemon/src/metrics/index.ts
+++ b/apps/daemon/src/metrics/index.ts
@@ -108,6 +108,7 @@ export async function getCritiqueMetrics(): Promise<string> {
 }
 
 export { register };
+export * from './workspace-authority.js';
 
 /**
  * Test-only: wipe the default registry so vitest cases can assert

--- a/apps/daemon/src/metrics/workspace-authority.ts
+++ b/apps/daemon/src/metrics/workspace-authority.ts
@@ -1,0 +1,167 @@
+import { Counter, Histogram, register } from 'prom-client';
+
+import type { WorkspaceAuthorityCacheMode } from '../collab/workspace-authority-health.js';
+
+export type WorkspaceAuthorityMetricSource =
+  | 'cache'
+  | 'directory'
+  | 'current'
+  | 'billing'
+  | 'sse';
+
+export type WorkspaceAuthorityMetricReason =
+  | 'cold'
+  | 'lease_hit'
+  | 'lease_expired'
+  | 'in_flight'
+  | 'fresh'
+  | 'mutation'
+  | 'event_dirty'
+  | 'auth_reject'
+  | 'catch_up'
+  | 'safety_floor'
+  | 'mode_disabled'
+  | 'capability_missing'
+  | 'source_gap'
+  | 'unhealthy'
+  | 'healthy';
+
+export type WorkspaceAuthorityMetricOutcome =
+  | 'allow'
+  | 'deny'
+  | 'unavailable'
+  | 'fallback';
+
+export const workspaceAuthorityDecisionsTotal = new Counter({
+  name: 'open_design_workspace_authority_decisions_total',
+  help: 'Workspace authority decisions by bounded mode, source, reason, and outcome.',
+  labelNames: ['mode', 'source', 'reason', 'outcome'] as const,
+  registers: [register],
+});
+
+export const workspaceAuthoritySuppressedRequestsTotal = new Counter({
+  name: 'open_design_workspace_authority_suppressed_requests_total',
+  help: 'Upstream Workspace authority requests avoided by a valid lease or realtime safety floor.',
+  labelNames: ['mode', 'source', 'reason'] as const,
+  registers: [register],
+});
+
+export const workspaceAuthorityInvalidationsTotal = new Counter({
+  name: 'open_design_workspace_authority_invalidations_total',
+  help: 'Workspace authority cache invalidations by bounded reason.',
+  labelNames: ['mode', 'source', 'reason'] as const,
+  registers: [register],
+});
+
+export const workspaceAuthorityRealtimeTransitionsTotal = new Counter({
+  name: 'open_design_workspace_authority_realtime_transitions_total',
+  help: 'Strict Workspace authority realtime health observations.',
+  labelNames: ['mode', 'health', 'member_events', 'listener_status', 'source_gap'] as const,
+  registers: [register],
+});
+
+export const workspaceAuthorityAgeMs = new Histogram({
+  name: 'open_design_workspace_authority_age_ms',
+  help: 'Age of cached Workspace authority when it is used for a local response.',
+  labelNames: ['mode', 'source'] as const,
+  buckets: [10, 100, 500, 1_000, 5_000, 10_000, 15_000, 30_000, 60_000, 300_000],
+  registers: [register],
+});
+
+export const workspaceAuthorityRevocationClearMs = new Histogram({
+  name: 'open_design_workspace_authority_revocation_clear_ms',
+  help: 'Time from receiving an access-revoked frame to clearing local authority state.',
+  labelNames: ['mode'] as const,
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000],
+  registers: [register],
+});
+
+export function recordWorkspaceAuthorityDecision(input: {
+  mode: WorkspaceAuthorityCacheMode;
+  source: WorkspaceAuthorityMetricSource;
+  reason: WorkspaceAuthorityMetricReason;
+  outcome: WorkspaceAuthorityMetricOutcome;
+  ageMs?: number;
+}): void {
+  try {
+    workspaceAuthorityDecisionsTotal.inc({
+      mode: input.mode,
+      source: input.source,
+      reason: input.reason,
+      outcome: input.outcome,
+    });
+    if (input.ageMs != null && Number.isFinite(input.ageMs) && input.ageMs >= 0) {
+      workspaceAuthorityAgeMs.observe(
+        { mode: input.mode, source: input.source },
+        input.ageMs,
+      );
+    }
+  } catch {
+    // Metrics are diagnostic only and must never change an authority result.
+  }
+}
+
+export function recordWorkspaceAuthoritySuppressedRequest(input: {
+  mode: WorkspaceAuthorityCacheMode;
+  source: WorkspaceAuthorityMetricSource;
+  reason: 'lease_hit' | 'in_flight' | 'safety_floor';
+}): void {
+  try {
+    workspaceAuthoritySuppressedRequestsTotal.inc(input);
+  } catch {
+    // Metrics are diagnostic only and must never change an authority result.
+  }
+}
+
+export function recordWorkspaceAuthorityInvalidation(input: {
+  mode: WorkspaceAuthorityCacheMode;
+  source: 'cache' | 'current';
+  reason: 'mutation' | 'event_dirty' | 'auth_reject' | 'catch_up' | 'unhealthy';
+}): void {
+  try {
+    workspaceAuthorityInvalidationsTotal.inc(input);
+  } catch {
+    // Metrics are diagnostic only and must never change an authority result.
+  }
+}
+
+export function recordWorkspaceAuthorityRealtimeTransition(input: {
+  mode: WorkspaceAuthorityCacheMode;
+  healthy: boolean;
+  memberEvents: boolean;
+  listenerStatus: boolean;
+  sourceGap: boolean;
+}): void {
+  try {
+    workspaceAuthorityRealtimeTransitionsTotal.inc({
+      mode: input.mode,
+      health: input.healthy ? 'healthy' : 'unhealthy',
+      member_events: input.memberEvents ? 'present' : 'missing',
+      listener_status: input.listenerStatus ? 'present' : 'missing',
+      source_gap: input.sourceGap ? 'yes' : 'no',
+    });
+  } catch {
+    // Metrics are diagnostic only and must never change an authority result.
+  }
+}
+
+export function recordWorkspaceAuthorityRevocationClear(
+  mode: WorkspaceAuthorityCacheMode,
+  durationMs: number,
+): void {
+  if (!Number.isFinite(durationMs) || durationMs < 0) return;
+  try {
+    workspaceAuthorityRevocationClearMs.observe({ mode }, durationMs);
+  } catch {
+    // Metrics are diagnostic only and must never change an authority result.
+  }
+}
+
+export function __resetWorkspaceAuthorityMetricsForTests(): void {
+  workspaceAuthorityDecisionsTotal.reset();
+  workspaceAuthoritySuppressedRequestsTotal.reset();
+  workspaceAuthorityInvalidationsTotal.reset();
+  workspaceAuthorityRealtimeTransitionsTotal.reset();
+  workspaceAuthorityAgeMs.reset();
+  workspaceAuthorityRevocationClearMs.reset();
+}

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -96,6 +96,17 @@ export function emitWorkspaceEventToScope(
 
 export interface RegisterCollabContextRoutesDeps {
   workspaceContext: WorkspaceContextProvider;
+  /** Optional settled verifier for the pure context GET. Mutations and SSE
+   * subscriptions retain their fresh directory verification below. */
+  verifyWorkspaceReadAuthority?: (
+    req: Request,
+  ) => Promise<VerifiedWorkspaceRequestContextResult>;
+  /** Returns an exact, strict-SSE-backed membership only in adaptive mode.
+   * Null preserves the legacy directory preflight byte-for-byte. */
+  readCachedWorkspaceAuthority?: (
+    req: Request,
+    workspaceId: string,
+  ) => WorkspaceCollabContext | null;
   /** Injectable for tests; defaults to consuming against B with the vela session. */
   consumeInvite?: (nonce: string) => Promise<InviteContinueOutcome>;
   /** Injectable for tests; defaults to creating invites on B with the vela session. */
@@ -360,10 +371,12 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
 
   app.get('/api/workspace/context', async (req, res) => {
     const authorization = req.header('authorization') ?? undefined;
-    const verified = await verifyWorkspaceRequestContext({
-      req,
-      fetchWorkspaceDirectory,
-    });
+    const verified = deps.verifyWorkspaceReadAuthority
+      ? await deps.verifyWorkspaceReadAuthority(req)
+      : await verifyWorkspaceRequestContext({
+          req,
+          fetchWorkspaceDirectory,
+        });
     if (!verified.ok) return sendWorkspaceVerificationFailure(res, verified);
     const enriched = await workspaceContext.resolveExact?.({
       authorization,
@@ -718,23 +731,33 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
     const clientId = req.header('x-od-workspace-runtime-client-id') ?? undefined;
     const clientGeneration =
       req.header('x-od-workspace-runtime-generation') ?? undefined;
-    const directoryResult = await fetchWorkspaceDirectory().catch(
-      (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
-    );
-    if (!directoryResult.ok) {
-      billingRuntime.markWorkspaceUnavailable(
-        requestedWorkspaceId,
-        'workspace_directory_unavailable',
+    const cachedAuthority = deps.readCachedWorkspaceAuthority?.(
+      req,
+      requestedWorkspaceId,
+    ) ?? null;
+    let membership: WorkspaceDirectoryItem | WorkspaceCollabContext | undefined =
+      cachedAuthority?.memberStatus === 'active' &&
+      cachedAuthority.lifecycleState === 'active'
+        ? cachedAuthority
+        : undefined;
+    if (!membership) {
+      const directoryResult = await fetchWorkspaceDirectory().catch(
+        (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
       );
-      return res.status(503).json({ error: 'workspace_directory_unavailable' });
+      if (!directoryResult.ok) {
+        billingRuntime.markWorkspaceUnavailable(
+          requestedWorkspaceId,
+          'workspace_directory_unavailable',
+        );
+        return res.status(503).json({ error: 'workspace_directory_unavailable' });
+      }
+      membership = directoryResult.items.find(
+        (item) =>
+          item.workspaceId === requestedWorkspaceId &&
+          item.memberStatus === 'active' &&
+          item.lifecycleState === 'active',
+      );
     }
-    const directory = directoryResult.items;
-    const membership = directory.find(
-      (item) =>
-        item.workspaceId === requestedWorkspaceId &&
-        item.memberStatus === 'active' &&
-        item.lifecycleState === 'active',
-    );
     if (!membership) {
       billingRuntime.revokeWorkspace(requestedWorkspaceId);
       return res.status(403).json({ error: 'workspace_not_authorized' });

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -204,6 +204,9 @@ export interface RegisterPluginRoutesDeps {
     removeProjectDir(projectsRoot: string, projectId: string): Promise<unknown>;
   };
   fetchProjectCreationWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
+  /** Settled, TTL-bounded authority for the pure Plugin catalog read. */
+  verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
+  /** Fresh authority for mutations and non-catalog reads. */
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
   conversations: {
     insertConversation(db: SqliteDbLike, conversation: unknown): unknown;
@@ -374,10 +377,12 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
   const resolveWorkspaceAuthority = async (
     req: Request,
     res: Response,
+    verifyAuthority: VerifyWorkspaceRequestAuthority | undefined =
+      deps.verifyWorkspaceRequestAuthority,
   ): Promise<WorkspaceCollabContext | null | undefined> => {
     const authority = await resolveOptionalWorkspaceRequestAuthority(
       req,
-      deps.verifyWorkspaceRequestAuthority,
+      verifyAuthority,
     );
     if (!authority.ok) {
       helpers.sendApiError(
@@ -447,7 +452,7 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     return binding.visibility === 'team'
       || binding.createdByWorkspaceMemberId === authority.workspaceMemberId;
   };
-  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
+  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res, deps.verifyWorkspaceReadAuthority ?? deps.verifyWorkspaceRequestAuthority); if (authority === undefined) return; const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
   // Keep this static route before /api/plugins/:id; Express matches in
   // registration order and would otherwise interpret "stats" as a plugin id.
   app.get('/api/plugins/stats', async (req, res) => {

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -72,6 +72,9 @@ export interface RegisterAtomRoutesDeps {
 }
 
 export interface RegisterStaticResourceRoutesDeps extends RouteDeps<'db' | 'http' | 'paths' | 'resources'> {
+  /** Settled, TTL-bounded authority for pure local catalog reads. */
+  verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
+  /** Fresh authority for mutations, materialization, and detail reads. */
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
   tokenContractRebuild?: {
     maybeStartForImportedDesignSystem?: (
@@ -263,7 +266,10 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
   const resolveWorkspaceAuthority = async (
     req: any,
     res: Response,
-    options: { allowNavigationQuery?: boolean } = {},
+    options: {
+      allowNavigationQuery?: boolean;
+      verifyAuthority?: VerifyWorkspaceRequestAuthority | undefined;
+    } = {},
   ): Promise<WorkspaceCollabContext | null | undefined> => {
     const scopedRequest = options.allowNavigationQuery
       ? requestWithNavigationScope(req)
@@ -279,7 +285,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
     }
     const authority = await resolveOptionalWorkspaceRequestAuthority(
       scopedRequest,
-      ctx.verifyWorkspaceRequestAuthority,
+      options.verifyAuthority ?? ctx.verifyWorkspaceRequestAuthority,
     );
     if (!authority.ok) {
       sendApiError(res, authority.status, authority.code, authority.message, {
@@ -483,7 +489,11 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       // Workspace-scoped (see `skillVisibleFromWorkspace` in skills.ts): a
       // skill imported into a different workspace than the caller's is
       // hidden, same one-way rule `GET /api/plugins` already applies.
-      const authority = await resolveWorkspaceAuthority(req, res);
+      const authority = await resolveWorkspaceAuthority(req, res, {
+        verifyAuthority:
+          ctx.verifyWorkspaceReadAuthority
+          ?? ctx.verifyWorkspaceRequestAuthority,
+      });
       if (authority === undefined) return;
       const workspaceId = authority?.workspaceId ?? null;
       const skills = await listAllSkills({
@@ -778,12 +788,17 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       // share one directory on disk, so without this the systems authored in
       // one workspace also filled a brand-new one. Every other caller of
       // `listAllDesignSystems` resolves a system by id and stays unscoped.
-      const workspaceContext = ctx.verifyWorkspaceRequestAuthority
-        ? await resolveWorkspaceAuthority(req, res)
+      const catalogAuthority =
+        ctx.verifyWorkspaceReadAuthority
+        ?? ctx.verifyWorkspaceRequestAuthority;
+      const workspaceContext = catalogAuthority
+        ? await resolveWorkspaceAuthority(req, res, {
+            verifyAuthority: catalogAuthority,
+          })
         : null;
       if (workspaceContext === undefined) return;
       const workspaceId = workspaceContext?.workspaceId
-        ?? (ctx.verifyWorkspaceRequestAuthority ? null : (await resolveWorkspaceScope?.(req)) ?? null);
+        ?? (catalogAuthority ? null : (await resolveWorkspaceScope?.(req)) ?? null);
       const workspaceMemberId = workspaceContext?.workspaceMemberId ?? null;
       const catalog = await listAllDesignSystems({
         workspaceId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -766,6 +766,7 @@ import {
   createWorkspaceDirectoryAuthorityBroker,
   createWorkspaceContextProviderFromEnv,
   fetchVelaWorkspaceDirectory,
+  velaWorkspaceDirectoryIdentity,
   workspaceContextFromDirectoryItem,
 } from './collab/vela-workspace-context.js';
 import { verifyWorkspaceRequestContext } from './collab/request-workspace-context.js';
@@ -778,6 +779,10 @@ import {
   AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY,
   startHubEventsSubscriber,
 } from './collab/hub-events-subscriber.js';
+import {
+  createWorkspaceAuthorityHealthCoordinator,
+  resolveWorkspaceAuthorityCacheMode,
+} from './collab/workspace-authority-health.js';
 import {
   createWorkspaceHubSubscriptionManager,
   type WorkspaceHubSubscriptionManager,
@@ -820,7 +825,10 @@ import {
   type RememberedTeamResourceScopeLease,
 } from './collab/remembered-team-resource-scopes.js';
 import { readVelaControlApiContext } from './integrations/vela.js';
-import { fetchVelaWorkspaceBillingProjection } from './integrations/vela-billing.js';
+import {
+  fetchVelaWorkspaceBillingProjection,
+  isVelaWorkspaceAuthorizationError,
+} from './integrations/vela-billing.js';
 import { createCollabPublishWatcher } from './collab/collab-publish-watcher.js';
 import {
   isUnmaterializedSharedPlaceholder,
@@ -858,6 +866,7 @@ import {
   createCommentRelayOutboxStore,
 } from './collab/comment-relay-outbox.js';
 import { createWorkspaceInvalidationPoller } from './collab/workspace-invalidation-poller.js';
+import { createWorkspaceExactContextCache } from './collab/workspace-exact-context-cache.js';
 import {
   handleHubProjectMetadataChanged,
   handleHubTeamProjectsChanged,
@@ -1388,7 +1397,32 @@ function emitWorkspaceEvent(
 export function handleHubWorkspaceContextChanged(
   workspaceId: string,
   pollWorkspaceInvalidation: () => Promise<void>,
+  invalidateWorkspaceDirectory: () => void = () => undefined,
 ): void {
+  // Retire the settled authority generation before either the web or the
+  // daemon can start a refresh. A directory request that began before this
+  // event is allowed to finish for its original caller, but the broker will
+  // not let it repopulate the post-event generation.
+  invalidateWorkspaceDirectory();
+  emitWorkspaceEvent(
+    workspaceId,
+    { type: 'workspace-context-changed', at: Date.now() },
+  );
+  void pollWorkspaceInvalidation().catch(() => undefined);
+}
+
+/** Terminal counterpart to workspace-context-changed. Vela has already
+ * re-derived the stream principal and is closing the connection, so local
+ * directory and billing projections must be retired synchronously before any
+ * reconciliation I/O starts. */
+export function handleHubWorkspaceAccessRevoked(
+  workspaceId: string,
+  pollWorkspaceInvalidation: () => Promise<void>,
+  invalidateWorkspaceDirectory: () => void,
+  revokeWorkspaceBilling: (workspaceId: string) => void,
+): void {
+  invalidateWorkspaceDirectory();
+  revokeWorkspaceBilling(workspaceId);
   emitWorkspaceEvent(
     workspaceId,
     { type: 'workspace-context-changed', at: Date.now() },
@@ -2412,6 +2446,9 @@ export async function startServer({
   let resolvedPort = port;
   let daemonShuttingDown = false;
   const extraAllowedOrigins = configuredAllowedOrigins();
+  const workspaceAuthorityCacheMode = resolveWorkspaceAuthorityCacheMode(
+    process.env.OD_WORKSPACE_AUTHORITY_CACHE_MODE,
+  );
 
   // Plan §3.K1 / spec §15.7 — bound-API-token guard.
   //
@@ -3223,6 +3260,36 @@ export async function startServer({
       clearLocalSelection: () => activeWorkspace.clear(),
     }),
   );
+  const workspaceExactContextCache = createWorkspaceExactContextCache({
+    provider: workspaceContext,
+    identity: () => velaWorkspaceDirectoryIdentity(),
+  });
+  const workspaceContextProvider = workspaceExactContextCache.provider;
+  const cachedWorkspaceContextForRequest = (
+    req: unknown,
+    requestedWorkspaceId?: string,
+  ): WorkspaceCollabContext | null => {
+    const claimed = workspaceResourceContextFromRequest(req);
+    if (!claimed || claimed === 'missing') return null;
+    if (
+      requestedWorkspaceId &&
+      claimed.workspaceId !== requestedWorkspaceId.trim()
+    ) {
+      return null;
+    }
+    const cached = workspaceExactContextCache.cached(claimed.workspaceId);
+    return cached &&
+      cached.workspaceMemberId === claimed.workspaceMemberId &&
+      cached.memberStatus === 'active' &&
+      cached.lifecycleState !== 'deleted'
+      ? cached
+      : null;
+  };
+  const verifyWorkspaceContextReadAuthority = async (req: unknown) => {
+    const cached = cachedWorkspaceContextForRequest(req);
+    if (cached) return { ok: true as const, context: cached };
+    return verifyWorkspaceReadAuthority(req);
+  };
   /**
    * Where a created project belongs for the surfaces with no authorization gate
    * of their own. An explicit pair is verified through the same fresh directory
@@ -3325,7 +3392,7 @@ export async function startServer({
     _workspaceId?: string,
   ): void => {};
   const collab = createCollabRuntime({
-    workspaceContext,
+    workspaceContext: workspaceContextProvider,
     canPublishProjectContent: (projectId) =>
       !projectIsUnmaterializedSharedPlaceholder(projectId),
     resolveProjectDir: async (projectId) => {
@@ -4668,22 +4735,22 @@ export async function startServer({
   };
   let workspaceHubSubscriptions: WorkspaceHubSubscriptionManager | null = null;
   const workspaceBillingRuntime = createWorkspaceBillingRuntimeCoordinator({
-    fetchProjection: async ({ workspaceId, workspaceMemberId }) => {
-      const directory = await fetchWorkspaceDirectory();
-      if (!directory.ok) {
-        throw Object.assign(new Error('workspace directory unavailable'), {
-          code: 'workspace_directory_unavailable',
-        });
+    fetchProjection: async ({ workspaceId }) => {
+      try {
+        // The Vela CLI sends only the Bearer credential plus workspace-id
+        // candidate. Vela re-derives the member principal server-side, and
+        // the runtime validates the returned member id before accepting it.
+        return await fetchVelaWorkspaceBillingProjection(workspaceId);
+      } catch (error) {
+        if (isVelaWorkspaceAuthorizationError(error)) {
+          throw new WorkspaceBillingAccessRevokedError();
+        }
+        throw error;
       }
-      const membership = directory.items.find(
-        (item) =>
-          item.workspaceId === workspaceId &&
-          item.workspaceMemberId === workspaceMemberId &&
-          item.memberStatus === 'active' &&
-          item.lifecycleState === 'active',
-      );
-      if (!membership) throw new WorkspaceBillingAccessRevokedError();
-      return fetchVelaWorkspaceBillingProjection(workspaceId);
+    },
+    onAccessRevoked: ({ workspaceId }) => {
+      workspaceDirectoryAuthority.invalidate();
+      workspaceExactContextCache.invalidate(workspaceId);
     },
     onStateChange: (state) => {
       // The request that created a runtime already receives this state in its
@@ -4737,6 +4804,8 @@ export async function startServer({
   let workspaceAnalyticsService: AnalyticsService | null = null;
   registerCollabContextRoutes(app, {
     workspaceContext: collab.workspaceContext,
+    verifyWorkspaceReadAuthority: verifyWorkspaceContextReadAuthority,
+    readCachedWorkspaceAuthority: cachedWorkspaceContextForRequest,
     activeWorkspace,
     // A tab-local selection leaves this exact Workspace's scoped caches cold.
     // Warm only the directory-verified id announced by that request; the
@@ -4824,6 +4893,36 @@ export async function startServer({
     if (!workspaceId) return Promise.resolve();
     return workspaceInvalidationPollerFor(workspaceId).pollOnce();
   };
+  const workspaceAuthorityHealth = createWorkspaceAuthorityHealthCoordinator({
+    mode: workspaceAuthorityCacheMode,
+    catchUp: async (workspaceId) => {
+      // A healthy transport is not enough to suppress legacy polling. First
+      // cross a fresh directory boundary and close the exact Workspace gap.
+      workspaceDirectoryAuthority.invalidate();
+      const exactContext = await workspaceExactContextCache.refresh({ workspaceId });
+      if (!exactContext || exactContext.workspaceId !== workspaceId) {
+        throw new Error('exact workspace catch-up was unavailable');
+      }
+      await refreshWorkspaceDigestFaces(workspaceId, {
+        revalidate: true,
+        freshAuthority: true,
+      });
+      await pollWorkspaceInvalidationForWorkspace(workspaceId);
+      workspaceBillingRuntime.reconnect(workspaceId);
+    },
+    setDirectoryPollingHealthy: (workspaceId, healthy) =>
+      workspaceInvalidationPollerFor(workspaceId).setRealtimeHealthy(healthy),
+    setBillingPollingHealthy: (workspaceId, healthy) =>
+      workspaceBillingRuntime.setRealtimeHealthy(workspaceId, healthy),
+    setContextCachingHealthy: (workspaceId, healthy) =>
+      workspaceExactContextCache.setRealtimeHealthy(workspaceId, healthy),
+    onError: (error) => {
+      console.warn(
+        '[od] workspace authority catch-up failed; retaining legacy polling:',
+        String(error),
+      );
+    },
+  });
   // Collab realtime hop-1: cloud hub → daemon push channel. The hub emits the
   // same thin invalidation signals the web would otherwise discover by
   // polling. Every upstream stream comes from an explicit leased Workspace
@@ -4881,6 +4980,12 @@ export async function startServer({
       }
       console.info(`[od] hub events channel ${state}`);
     },
+    onAuthorityHealthChange: ({ workspaceId, healthy }) => {
+      void workspaceAuthorityHealth.update({
+        workspaceId: workspaceId ?? subscribedWorkspaceId,
+        healthy,
+      });
+    },
     onConnect: ({ reconnect, workspaceId, capabilities }) => {
       const verifiedWorkspaceId = workspaceId ?? subscribedWorkspaceId;
       if (capabilities.includes(AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY)) {
@@ -4907,6 +5012,25 @@ export async function startServer({
         `[od] hub event dropped reason=${reason} event=${eventName} ` +
           `expectedWorkspaceId=${expectedWorkspaceId ?? 'unknown'} ` +
           `actualWorkspaceId=${actualWorkspaceId ?? 'unknown'}`,
+      );
+    },
+    onAccessRevoked: ({ workspaceId, reason }) => {
+      const exactWorkspaceId = workspaceId ?? subscribedWorkspaceId;
+      console.info(
+        `[od] hub workspace access revoked workspaceId=${exactWorkspaceId} reason=${reason ?? 'unknown'}`,
+      );
+      handleHubWorkspaceAccessRevoked(
+        exactWorkspaceId,
+        () => pollWorkspaceInvalidationForWorkspace(exactWorkspaceId),
+        () => {
+          workspaceDirectoryAuthority.invalidate();
+          workspaceExactContextCache.invalidate(exactWorkspaceId);
+        },
+        (revokedWorkspaceId) =>
+          workspaceBillingRuntime.revokeWorkspace(
+            revokedWorkspaceId,
+            'vela-access-revoked',
+          ),
       );
     },
     onEvent: (event) => {
@@ -5064,10 +5188,28 @@ export async function startServer({
           handleHubWorkspaceContextChanged(
             eventWorkspaceId,
             () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
+            () => {
+              workspaceDirectoryAuthority.invalidate();
+              workspaceExactContextCache.invalidate(eventWorkspaceId);
+            },
           );
           // Revalidate exact membership before the next billing projection.
           // A removed/rebound member must clear money and entitlement state,
           // even when no billing-specific event accompanies the roster change.
+          workspaceBillingRuntime.reconnect(subscribedWorkspaceId);
+          break;
+        case 'workspace-members-changed':
+          handleHubWorkspaceContextChanged(
+            eventWorkspaceId,
+            () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
+            () => {
+              workspaceDirectoryAuthority.invalidate();
+              workspaceExactContextCache.invalidate(eventWorkspaceId);
+            },
+          );
+          // A role update or removal changes both authorization and the
+          // billing member projection even when no billing event accompanies
+          // the roster mutation.
           workspaceBillingRuntime.reconnect(subscribedWorkspaceId);
           break;
         case 'billing-changed':
@@ -7298,6 +7440,7 @@ export async function startServer({
     db,
     http: httpDeps,
     paths: pathDeps,
+    verifyWorkspaceReadAuthority,
     verifyWorkspaceRequestAuthority,
     teamResources: collab.teamResources,
     resources: {
@@ -7972,6 +8115,7 @@ export async function startServer({
     projectStore: projectStoreDeps,
     conversations: conversationDeps,
     fetchProjectCreationWorkspaceDirectory,
+    verifyWorkspaceReadAuthority,
     verifyWorkspaceRequestAuthority,
     workspaceResources: {
       getWorkspaceResource,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -784,6 +784,13 @@ import {
   resolveWorkspaceAuthorityCacheMode,
 } from './collab/workspace-authority-health.js';
 import {
+  recordWorkspaceAuthorityDecision,
+  recordWorkspaceAuthorityInvalidation,
+  recordWorkspaceAuthorityRealtimeTransition,
+  recordWorkspaceAuthorityRevocationClear,
+  recordWorkspaceAuthoritySuppressedRequest,
+} from './metrics/workspace-authority.js';
+import {
   createWorkspaceHubSubscriptionManager,
   type WorkspaceHubSubscriptionManager,
 } from './collab/workspace-hub-subscriptions.js';
@@ -3015,6 +3022,18 @@ export async function startServer({
       if (result.ok) workspaceTypes.learn(result.items);
       return result;
     },
+    onDecision: (input) => recordWorkspaceAuthorityDecision({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
+    onSuppressedRequest: (input) => recordWorkspaceAuthoritySuppressedRequest({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
+    onInvalidation: (input) => recordWorkspaceAuthorityInvalidation({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
   });
   const fetchWorkspaceDirectory = workspaceDirectoryAuthority.read;
   const fetchFreshMutationWorkspaceDirectory =
@@ -3263,6 +3282,18 @@ export async function startServer({
   const workspaceExactContextCache = createWorkspaceExactContextCache({
     provider: workspaceContext,
     identity: () => velaWorkspaceDirectoryIdentity(),
+    onDecision: (input) => recordWorkspaceAuthorityDecision({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
+    onSuppressedRequest: (input) => recordWorkspaceAuthoritySuppressedRequest({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
+    onInvalidation: (input) => recordWorkspaceAuthorityInvalidation({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
   });
   const workspaceContextProvider = workspaceExactContextCache.provider;
   const cachedWorkspaceContextForRequest = (
@@ -4749,8 +4780,8 @@ export async function startServer({
       }
     },
     onAccessRevoked: ({ workspaceId }) => {
-      workspaceDirectoryAuthority.invalidate();
-      workspaceExactContextCache.invalidate(workspaceId);
+      workspaceDirectoryAuthority.invalidate('auth_reject');
+      workspaceExactContextCache.invalidate(workspaceId, 'auth_reject');
     },
     onStateChange: (state) => {
       // The request that created a runtime already receives this state in its
@@ -4769,6 +4800,11 @@ export async function startServer({
         interests.map((interest) => interest.workspaceId),
       );
     },
+    onPollSuppressed: () => recordWorkspaceAuthoritySuppressedRequest({
+      mode: workspaceAuthorityCacheMode,
+      source: 'billing',
+      reason: 'safety_floor',
+    }),
   });
   /**
    * Warm or revalidate both digest faces for one exact directory-verified
@@ -4876,6 +4912,11 @@ export async function startServer({
         },
         onTeamProjectsObserved: ({ workspaceId: observedWorkspaceId }) =>
           proactiveContentPull.advanceRecoveryFloor(observedWorkspaceId),
+        onPollSuppressed: () => recordWorkspaceAuthoritySuppressedRequest({
+          mode: workspaceAuthorityCacheMode,
+          source: 'directory',
+          reason: 'safety_floor',
+        }),
         onError: (error) =>
           console.warn(
             `[od] workspace ${workspaceId} invalidation recovery error:`,
@@ -4898,8 +4939,12 @@ export async function startServer({
     catchUp: async (workspaceId) => {
       // A healthy transport is not enough to suppress legacy polling. First
       // cross a fresh directory boundary and close the exact Workspace gap.
-      workspaceDirectoryAuthority.invalidate();
-      const exactContext = await workspaceExactContextCache.refresh({ workspaceId });
+      workspaceDirectoryAuthority.invalidate('catch_up');
+      workspaceExactContextCache.invalidate(workspaceId, 'catch_up');
+      const exactContext = await workspaceExactContextCache.refresh(
+        { workspaceId },
+        'catch_up',
+      );
       if (!exactContext || exactContext.workspaceId !== workspaceId) {
         throw new Error('exact workspace catch-up was unavailable');
       }
@@ -4916,6 +4961,10 @@ export async function startServer({
       workspaceBillingRuntime.setRealtimeHealthy(workspaceId, healthy),
     setContextCachingHealthy: (workspaceId, healthy) =>
       workspaceExactContextCache.setRealtimeHealthy(workspaceId, healthy),
+    onDecision: (input) => recordWorkspaceAuthorityDecision({
+      mode: workspaceAuthorityCacheMode,
+      ...input,
+    }),
     onError: (error) => {
       console.warn(
         '[od] workspace authority catch-up failed; retaining legacy polling:',
@@ -4980,7 +5029,21 @@ export async function startServer({
       }
       console.info(`[od] hub events channel ${state}`);
     },
-    onAuthorityHealthChange: ({ workspaceId, healthy }) => {
+    onAuthorityHealthChange: ({
+      workspaceId,
+      healthy,
+      capabilities,
+      listenerStatus,
+    }) => {
+      recordWorkspaceAuthorityRealtimeTransition({
+        mode: workspaceAuthorityCacheMode,
+        healthy,
+        memberEvents: capabilities.includes('workspace-member-events-v1'),
+        listenerStatus: capabilities.includes(
+          'workspace-event-listener-status-v1',
+        ),
+        sourceGap: listenerStatus?.sourceGap === true,
+      });
       void workspaceAuthorityHealth.update({
         workspaceId: workspaceId ?? subscribedWorkspaceId,
         healthy,
@@ -5015,6 +5078,7 @@ export async function startServer({
       );
     },
     onAccessRevoked: ({ workspaceId, reason }) => {
+      const revocationReceivedAt = performance.now();
       const exactWorkspaceId = workspaceId ?? subscribedWorkspaceId;
       console.info(
         `[od] hub workspace access revoked workspaceId=${exactWorkspaceId} reason=${reason ?? 'unknown'}`,
@@ -5023,14 +5087,21 @@ export async function startServer({
         exactWorkspaceId,
         () => pollWorkspaceInvalidationForWorkspace(exactWorkspaceId),
         () => {
-          workspaceDirectoryAuthority.invalidate();
-          workspaceExactContextCache.invalidate(exactWorkspaceId);
+          workspaceDirectoryAuthority.invalidate('auth_reject');
+          workspaceExactContextCache.invalidate(
+            exactWorkspaceId,
+            'auth_reject',
+          );
         },
         (revokedWorkspaceId) =>
           workspaceBillingRuntime.revokeWorkspace(
             revokedWorkspaceId,
             'vela-access-revoked',
           ),
+      );
+      recordWorkspaceAuthorityRevocationClear(
+        workspaceAuthorityCacheMode,
+        performance.now() - revocationReceivedAt,
       );
     },
     onEvent: (event) => {
@@ -5189,8 +5260,11 @@ export async function startServer({
             eventWorkspaceId,
             () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
             () => {
-              workspaceDirectoryAuthority.invalidate();
-              workspaceExactContextCache.invalidate(eventWorkspaceId);
+              workspaceDirectoryAuthority.invalidate('event_dirty');
+              workspaceExactContextCache.invalidate(
+                eventWorkspaceId,
+                'event_dirty',
+              );
             },
           );
           // Revalidate exact membership before the next billing projection.
@@ -5203,8 +5277,11 @@ export async function startServer({
             eventWorkspaceId,
             () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
             () => {
-              workspaceDirectoryAuthority.invalidate();
-              workspaceExactContextCache.invalidate(eventWorkspaceId);
+              workspaceDirectoryAuthority.invalidate('event_dirty');
+              workspaceExactContextCache.invalidate(
+                eventWorkspaceId,
+                'event_dirty',
+              );
             },
           );
           // A role update or removal changes both authorization and the

--- a/apps/daemon/tests/collab-context-routes.test.ts
+++ b/apps/daemon/tests/collab-context-routes.test.ts
@@ -143,6 +143,32 @@ describe('collab context routes', () => {
     })).body).toEqual({ context: TEAM_CONTEXT_PARSED });
   });
 
+  it('uses the settled read verifier for the pure context GET without changing its body', async () => {
+    const fetchWorkspaceDirectory = vi.fn(async () => {
+      throw new Error('fresh directory should not run');
+    });
+    const verifyWorkspaceReadAuthority = vi.fn(async () => ({
+      ok: true as const,
+      context: TEAM_CONTEXT_PARSED,
+    }));
+    const api = await startContextServer({
+      fetchWorkspaceDirectory,
+      verifyWorkspaceReadAuthority,
+    });
+    await api.req('/api/workspace/context', {
+      method: 'PUT',
+      body: TEAM_CONTEXT,
+    });
+
+    const response = await api.req('/api/workspace/context', {
+      headers: TEAM_HEADERS,
+    });
+
+    expect(response).toEqual({ status: 200, body: { context: TEAM_CONTEXT_PARSED } });
+    expect(verifyWorkspaceReadAuthority).toHaveBeenCalledTimes(1);
+    expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
+  });
+
   it('observes authoritative workspace size without sending names or member identity', async () => {
     const observeWorkspace = vi.fn();
     const api = await startContextServer({
@@ -501,6 +527,64 @@ describe('workspace billing routes', () => {
       balanceUsd: '7.89',
       billingScopeVersion: 2,
     });
+  });
+
+  it('uses strict cached authority for billing without a redundant directory preflight', async () => {
+    const fetchWorkspaceDirectory = vi.fn(async () => {
+      throw new Error('directory should remain cold');
+    });
+    const readCachedWorkspaceAuthority = vi.fn(() => ({
+      ...TEAM_CONTEXT_PARSED,
+      workspaceMemberId: 'member-1',
+    }));
+    const api = await startContextServer({
+      fetchWorkspaceDirectory,
+      readCachedWorkspaceAuthority,
+      fetchBilling: async () => null,
+      fetchWorkspaceBalance: async () => ({
+        workspaceId: 'wm-1',
+        workspaceMemberId: 'member-1',
+        balanceUsd: '7.89',
+        billingScopeVersion: 2,
+        expiresAt: null,
+        updatedAt: '2026-07-27T00:00:00Z',
+      }),
+    });
+
+    const response = await api.req(
+      '/api/workspace/billing?scope=workspace&workspaceId=wm-1',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.workspaceBalance).toMatchObject({
+      workspaceId: 'wm-1',
+      workspaceMemberId: 'member-1',
+      balanceUsd: '7.89',
+    });
+    expect(readCachedWorkspaceAuthority).toHaveBeenCalledTimes(1);
+    expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
+  });
+
+  it('does not let a cached non-active workspace bypass the legacy billing gate', async () => {
+    const fetchWorkspaceDirectory = vi.fn(async () => ({
+      ok: true as const,
+      items: [{ ...TEAM_DIRECTORY_ITEM, lifecycleState: 'locked' as const }],
+    }));
+    const api = await startContextServer({
+      fetchWorkspaceDirectory,
+      readCachedWorkspaceAuthority: () => ({
+        ...TEAM_CONTEXT_PARSED,
+        lifecycleState: 'locked',
+      }),
+    });
+
+    const response = await api.req(
+      '/api/workspace/billing?scope=workspace&workspaceId=wm-1',
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'workspace_not_authorized' });
+    expect(fetchWorkspaceDirectory).toHaveBeenCalledTimes(1);
   });
 
   it('returns a Personal Workspace balance only after exact directory authorization', async () => {
@@ -940,8 +1024,8 @@ describe('workspace billing routes', () => {
       workspaceRuntime: {
         workspaceId: 'wm-1',
         workspaceMemberId: 'member-1',
-        status: 'error',
-        errorCode: 'workspace_billing_scope_mismatch',
+        status: 'access-revoked',
+        errorCode: 'workspace_not_authorized',
       },
     });
   });

--- a/apps/daemon/tests/collab-workspace-invalidation-poller.test.ts
+++ b/apps/daemon/tests/collab-workspace-invalidation-poller.test.ts
@@ -57,6 +57,7 @@ function harness(initial: {
   projects?: TeamProject[] | null;
   members?: CollabCloudMemberDirectoryEntry[] | null;
   pollIntervalMs?: number;
+  realtimePollFloorMs?: number;
   recoveryFloorIntervalMs?: number;
   now?: () => number;
   onTeamProjectsObserved?: (input: {
@@ -102,6 +103,9 @@ function harness(initial: {
     onError: (error) => h.errors.push(error),
     ...(initial.pollIntervalMs != null
       ? { pollIntervalMs: initial.pollIntervalMs }
+      : {}),
+    ...(initial.realtimePollFloorMs != null
+      ? { realtimePollFloorMs: initial.realtimePollFloorMs }
       : {}),
     ...(initial.recoveryFloorIntervalMs != null
       ? { recoveryFloorIntervalMs: initial.recoveryFloorIntervalMs }
@@ -454,6 +458,34 @@ describe('workspace invalidation poller', () => {
     } finally {
       h.poller.stop();
       releaseObservation();
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the realtime poll floor only while healthy and resumes immediately on disconnect', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const h = harness({
+      pollIntervalMs: 10,
+      realtimePollFloorMs: 100,
+    });
+
+    try {
+      h.poller.start();
+      await vi.advanceTimersByTimeAsync(10);
+      expect(h.contextCalls).toBe(1);
+
+      h.poller.setRealtimeHealthy(true);
+      await vi.advanceTimersByTimeAsync(99);
+      expect(h.contextCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(h.contextCalls).toBe(2);
+
+      h.poller.setRealtimeHealthy(false);
+      await vi.runAllTicks();
+      expect(h.contextCalls).toBe(3);
+    } finally {
+      h.poller.stop();
       vi.useRealTimers();
     }
   });

--- a/apps/daemon/tests/collab-workspace-invalidation-poller.test.ts
+++ b/apps/daemon/tests/collab-workspace-invalidation-poller.test.ts
@@ -64,6 +64,7 @@ function harness(initial: {
     workspaceId: string;
     projects: readonly TeamProject[];
   }) => void | Promise<void>;
+  onPollSuppressed?: () => void;
 }): Harness {
   const h: Harness = {
     emitted: [],
@@ -101,6 +102,9 @@ function harness(initial: {
       h.emittedWorkspaceIds.push(context?.workspaceId ?? null);
     },
     onError: (error) => h.errors.push(error),
+    ...(initial.onPollSuppressed
+      ? { onPollSuppressed: initial.onPollSuppressed }
+      : {}),
     ...(initial.pollIntervalMs != null
       ? { pollIntervalMs: initial.pollIntervalMs }
       : {}),
@@ -465,9 +469,11 @@ describe('workspace invalidation poller', () => {
   it('uses the realtime poll floor only while healthy and resumes immediately on disconnect', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
+    const onPollSuppressed = vi.fn();
     const h = harness({
       pollIntervalMs: 10,
       realtimePollFloorMs: 100,
+      onPollSuppressed,
     });
 
     try {
@@ -478,6 +484,7 @@ describe('workspace invalidation poller', () => {
       h.poller.setRealtimeHealthy(true);
       await vi.advanceTimersByTimeAsync(99);
       expect(h.contextCalls).toBe(1);
+      expect(onPollSuppressed).toHaveBeenCalledTimes(9);
       await vi.advanceTimersByTimeAsync(1);
       expect(h.contextCalls).toBe(2);
 

--- a/apps/daemon/tests/collab/hub-events-subscriber.test.ts
+++ b/apps/daemon/tests/collab/hub-events-subscriber.test.ts
@@ -180,6 +180,19 @@ describe('parseHubWorkspaceEvent', () => {
     });
     expect(event).not.toHaveProperty('resourceStatus');
   });
+
+  it('parses additive workspace member changes without confusing the subject with the caller', () => {
+    expect(
+      parseHubWorkspaceEvent(
+        '{"type":"workspace-members-changed","workspaceId":"w1","memberId":"m1","memberChange":"removed"}',
+      ),
+    ).toEqual({
+      type: 'workspace-members-changed',
+      workspaceId: 'w1',
+      memberId: 'm1',
+      memberChange: 'removed',
+    });
+  });
 });
 
 describe('startHubEventsSubscriber', () => {
@@ -258,6 +271,62 @@ describe('startHubEventsSubscriber', () => {
     ]);
   });
 
+  it('reports strict authority health only with roster capability and a gap-free listener', async () => {
+    const health: boolean[] = [];
+    let resolveUnhealthy!: () => void;
+    const unhealthy = new Promise<void>((resolve) => {
+      resolveUnhealthy = resolve;
+    });
+
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onAuthorityHealthChange: (state) => {
+        health.push(state.healthy);
+        if (health.length === 3) resolveUnhealthy();
+      },
+      fetchImpl: async () => sseResponse([
+        'event: ready\ndata: {"workspaceId":"w1","capabilities":["workspace-member-events-v1","workspace-event-listener-status-v1"],"listenerEpoch":"listener-a","listenerHealth":"healthy","sourceGap":false}\n\n',
+        'event: heartbeat\ndata: {"listenerEpoch":"listener-a","listenerHealth":"healthy","sourceGap":false}\n\n',
+        'event: source-status\ndata: {"listenerEpoch":"listener-a","listenerHealth":"healthy","sourceGap":true}\n\n',
+      ], { holdOpen: true }),
+    });
+
+    await unhealthy;
+    expect(health).toEqual([false, true, false]);
+  });
+
+  it('keeps adaptive authority unhealthy when an old server omits roster capability', async () => {
+    let resolveHealth!: () => void;
+    const observed = new Promise<boolean>((resolve) => {
+      resolveHealth = () => resolve(false);
+    });
+    let actual = true;
+
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onAuthorityHealthChange: ({ healthy }) => {
+        actual = healthy;
+        resolveHealth();
+      },
+      fetchImpl: async () => sseResponse([
+        'event: ready\ndata: {"workspaceId":"w1","capabilities":["workspace-event-listener-status-v1"],"listenerEpoch":"listener-a","listenerHealth":"healthy","sourceGap":false}\n\n',
+      ], { holdOpen: true }),
+    });
+
+    await observed;
+    expect(actual).toBe(false);
+  });
+
   it('delivers workspace-events and reports connected state', async () => {
     const events: unknown[] = [];
     const states: string[] = [];
@@ -282,6 +351,69 @@ describe('startHubEventsSubscriber', () => {
     ]);
     expect(states).toEqual(['connected']);
     expect(subscriber.connected()).toBe(true);
+  });
+
+  it('reports terminal access revocation only after exact-scope ready verification', async () => {
+    const revocations: unknown[] = [];
+    let resolveRevoked!: () => void;
+    const revoked = new Promise<void>((resolve) => {
+      resolveRevoked = resolve;
+    });
+
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onAccessRevoked: (revocation) => {
+        revocations.push(revocation);
+        resolveRevoked();
+      },
+      backoffMinMs: 1_000_000,
+      fetchImpl: async () => sseResponse([
+        'event: ready\ndata: {"workspaceId":"w1","capabilities":["workspace-member-events-v1"]}\n\n',
+        'event: access-revoked\ndata: {"reason":"member-removed"}\n\n',
+      ], { holdOpen: true }),
+    });
+
+    await revoked;
+    expect(revocations).toEqual([
+      { workspaceId: 'w1', reason: 'member-removed' },
+    ]);
+    await vi.waitFor(() => expect(subscriber?.connected()).toBe(false));
+  });
+
+  it('backs terminal revocation reconnects off to the maximum interval', async () => {
+    let fetches = 0;
+    let resolveRevoked!: () => void;
+    const revoked = new Promise<void>((resolve) => {
+      resolveRevoked = resolve;
+    });
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onAccessRevoked: () => resolveRevoked(),
+      backoffMinMs: 1,
+      backoffMaxMs: 50,
+      fetchImpl: async () => {
+        fetches += 1;
+        return sseResponse([
+          'event: ready\ndata: {"workspaceId":"w1","capabilities":["workspace-member-events-v1"]}\n\n',
+          'event: access-revoked\ndata: {"reason":"member-removed"}\n\n',
+        ], { holdOpen: true });
+      },
+    });
+
+    await revoked;
+    expect(fetches).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(fetches).toBe(1);
   });
 
   it('fires onReconnect only from the second successful connect on', async () => {
@@ -547,6 +679,7 @@ describe('startHubEventsSubscriber', () => {
   it('reports a ready workspace mismatch and never runs connection catch-up', async () => {
     const onConnect = vi.fn();
     const onDrop = vi.fn();
+    const states: string[] = [];
     subscriber = startHubEventsSubscriber({
       resolveEndpoint: async () => ({
         url: 'https://hub/events',
@@ -556,6 +689,7 @@ describe('startHubEventsSubscriber', () => {
       onEvent: () => undefined,
       onConnect,
       onDrop,
+      onStateChange: (state) => states.push(state),
       backoffMinMs: 1_000_000,
       fetchImpl: async () =>
         sseResponse(['event: ready\ndata: {"workspaceId":"w2"}\n\n'], { holdOpen: true }),
@@ -570,6 +704,7 @@ describe('startHubEventsSubscriber', () => {
       });
     });
     expect(onConnect).not.toHaveBeenCalled();
+    expect(states).toEqual([]);
   });
 
 

--- a/apps/daemon/tests/collab/hub-workspace-context-changed-poll.test.ts
+++ b/apps/daemon/tests/collab/hub-workspace-context-changed-poll.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   handleHubVerifiedConnection,
+  handleHubWorkspaceAccessRevoked,
   handleHubWorkspaceContextChanged,
 } from '../../src/server.js';
 
@@ -36,10 +37,19 @@ describe('handleHubVerifiedConnection', () => {
 describe('handleHubWorkspaceContextChanged', () => {
   it('triggers an immediate workspace-invalidation poll cycle', async () => {
     const pollWorkspaceInvalidation = vi.fn(async () => undefined);
+    const invalidateWorkspaceDirectory = vi.fn();
 
-    handleHubWorkspaceContextChanged('workspace-1', pollWorkspaceInvalidation);
+    handleHubWorkspaceContextChanged(
+      'workspace-1',
+      pollWorkspaceInvalidation,
+      invalidateWorkspaceDirectory,
+    );
 
+    expect(invalidateWorkspaceDirectory).toHaveBeenCalledTimes(1);
     expect(pollWorkspaceInvalidation).toHaveBeenCalledTimes(1);
+    expect(invalidateWorkspaceDirectory.mock.invocationCallOrder[0]).toBeLessThan(
+      pollWorkspaceInvalidation.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('never lets a poll failure throw or reject out of the hub event handler', async () => {
@@ -56,6 +66,31 @@ describe('handleHubWorkspaceContextChanged', () => {
     expect(pollWorkspaceInvalidation).toHaveBeenCalledTimes(1);
     expect(unhandled).not.toHaveBeenCalled();
     process.removeListener('unhandledRejection', unhandled);
+  });
+});
+
+describe('handleHubWorkspaceAccessRevoked', () => {
+  it('invalidates directory and billing state before starting reconciliation', () => {
+    const pollWorkspaceInvalidation = vi.fn(async () => undefined);
+    const invalidateWorkspaceDirectory = vi.fn();
+    const revokeWorkspaceBilling = vi.fn();
+
+    handleHubWorkspaceAccessRevoked(
+      'workspace-1',
+      pollWorkspaceInvalidation,
+      invalidateWorkspaceDirectory,
+      revokeWorkspaceBilling,
+    );
+
+    expect(invalidateWorkspaceDirectory).toHaveBeenCalledTimes(1);
+    expect(revokeWorkspaceBilling).toHaveBeenCalledWith('workspace-1');
+    expect(pollWorkspaceInvalidation).toHaveBeenCalledTimes(1);
+    expect(invalidateWorkspaceDirectory.mock.invocationCallOrder[0]).toBeLessThan(
+      pollWorkspaceInvalidation.mock.invocationCallOrder[0]!,
+    );
+    expect(revokeWorkspaceBilling.mock.invocationCallOrder[0]).toBeLessThan(
+      pollWorkspaceInvalidation.mock.invocationCallOrder[0]!,
+    );
   });
 });
 
@@ -93,7 +128,7 @@ describe('hub events onEvent switch (source boundary)', () => {
     return source.slice(switchStart, i + 1);
   }
 
-  it('calls the immediate poll trigger from exactly one case: workspace-context-changed', () => {
+  it('calls the immediate poll trigger only for context and roster authority changes', () => {
     const switchBody = extractOnEventSwitchBody();
     const cases = switchBody.split(/(?=case '[a-z-]+':)/g).filter((chunk) => chunk.startsWith("case '"));
     expect(cases.length).toBeGreaterThanOrEqual(7);
@@ -101,7 +136,10 @@ describe('hub events onEvent switch (source boundary)', () => {
     const casesCallingPoll = cases.filter((chunk) => /handleHubWorkspaceContextChanged|workspaceInvalidationPoller\.pollOnce\(/.test(chunk));
     const caseNames = casesCallingPoll.map((chunk) => chunk.match(/^case '([a-z-]+)':/)?.[1]);
 
-    expect(caseNames).toEqual(['workspace-context-changed']);
+    expect(caseNames).toEqual([
+      'workspace-context-changed',
+      'workspace-members-changed',
+    ]);
   });
 
   it('preserves the renamed project id and metadata kind on the workspace invalidation', () => {

--- a/apps/daemon/tests/collab/workspace-authority-health.test.ts
+++ b/apps/daemon/tests/collab/workspace-authority-health.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createWorkspaceAuthorityHealthCoordinator,
@@ -12,6 +12,10 @@ function deferred() {
   });
   return { promise, resolve };
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('workspace authority health coordinator', () => {
   it('defaults absent modes to adaptive while unknown values use the legacy kill switch', () => {
@@ -83,5 +87,50 @@ describe('workspace authority health coordinator', () => {
 
     expect(directoryStates).toEqual([false, false]);
     expect(billingStates).toEqual([false, false]);
+  });
+
+  it('recovers adaptive polling after a transient catch-up failure', async () => {
+    vi.useFakeTimers();
+    const catchUp = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary directory outage'))
+      .mockResolvedValueOnce(undefined);
+    const states: boolean[] = [];
+    const coordinator = createWorkspaceAuthorityHealthCoordinator({
+      mode: 'adaptive',
+      catchUp,
+      catchUpRetryMs: 10,
+      setDirectoryPollingHealthy: (_workspaceId, healthy) => states.push(healthy),
+      setBillingPollingHealthy: () => undefined,
+    });
+
+    await coordinator.update({ workspaceId: 'w1', healthy: true });
+    expect(states).toEqual([false]);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(catchUp).toHaveBeenCalledTimes(2);
+    expect(states).toEqual([false, false, true]);
+  });
+
+  it('cancels a scheduled catch-up retry when realtime becomes unhealthy', async () => {
+    vi.useFakeTimers();
+    const catchUp = vi.fn().mockRejectedValue(
+      new Error('temporary directory outage'),
+    );
+    const states: boolean[] = [];
+    const coordinator = createWorkspaceAuthorityHealthCoordinator({
+      mode: 'adaptive',
+      catchUp,
+      catchUpRetryMs: 10,
+      setDirectoryPollingHealthy: (_workspaceId, healthy) => states.push(healthy),
+      setBillingPollingHealthy: () => undefined,
+    });
+
+    await coordinator.update({ workspaceId: 'w1', healthy: true });
+    await coordinator.update({ workspaceId: 'w1', healthy: false });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(catchUp).toHaveBeenCalledOnce();
+    expect(states).toEqual([false, false]);
   });
 });

--- a/apps/daemon/tests/collab/workspace-authority-health.test.ts
+++ b/apps/daemon/tests/collab/workspace-authority-health.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createWorkspaceAuthorityHealthCoordinator,
+  resolveWorkspaceAuthorityCacheMode,
+} from '../../src/collab/workspace-authority-health.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('workspace authority health coordinator', () => {
+  it('defaults unknown and absent modes to the legacy kill switch', () => {
+    expect(resolveWorkspaceAuthorityCacheMode(undefined)).toBe('legacy');
+    expect(resolveWorkspaceAuthorityCacheMode('unexpected')).toBe('legacy');
+    expect(resolveWorkspaceAuthorityCacheMode(' OBSERVE ')).toBe('observe');
+    expect(resolveWorkspaceAuthorityCacheMode('adaptive')).toBe('adaptive');
+  });
+
+  it('does not suppress a poll in legacy or observe mode', async () => {
+    for (const mode of ['legacy', 'observe'] as const) {
+      const catchUp = vi.fn(async () => undefined);
+      const states: boolean[] = [];
+      const coordinator = createWorkspaceAuthorityHealthCoordinator({
+        mode,
+        catchUp,
+        setDirectoryPollingHealthy: (_workspaceId, healthy) => states.push(healthy),
+        setBillingPollingHealthy: () => undefined,
+      });
+
+      await coordinator.update({ workspaceId: 'w1', healthy: true });
+      expect(catchUp).not.toHaveBeenCalled();
+      expect(states).toEqual([false]);
+    }
+  });
+
+  it('enables adaptive polling only after catch-up completes', async () => {
+    const gate = deferred();
+    const states: boolean[] = [];
+    const coordinator = createWorkspaceAuthorityHealthCoordinator({
+      mode: 'adaptive',
+      catchUp: () => gate.promise,
+      setDirectoryPollingHealthy: (_workspaceId, healthy) => states.push(healthy),
+      setBillingPollingHealthy: () => undefined,
+    });
+
+    const update = coordinator.update({ workspaceId: 'w1', healthy: true });
+    expect(states).toEqual([false]);
+    gate.resolve();
+    await update;
+    expect(states).toEqual([false, true]);
+  });
+
+  it('cannot re-enable adaptive polling from a catch-up that lost its health generation', async () => {
+    const gate = deferred();
+    const directoryStates: boolean[] = [];
+    const billingStates: boolean[] = [];
+    const coordinator = createWorkspaceAuthorityHealthCoordinator({
+      mode: 'adaptive',
+      catchUp: () => gate.promise,
+      setDirectoryPollingHealthy: (_workspaceId, healthy) =>
+        directoryStates.push(healthy),
+      setBillingPollingHealthy: (_workspaceId, healthy) =>
+        billingStates.push(healthy),
+    });
+
+    const connecting = coordinator.update({ workspaceId: 'w1', healthy: true });
+    await coordinator.update({ workspaceId: 'w1', healthy: false });
+    gate.resolve();
+    await connecting;
+
+    expect(directoryStates).toEqual([false, false]);
+    expect(billingStates).toEqual([false, false]);
+  });
+});

--- a/apps/daemon/tests/collab/workspace-authority-health.test.ts
+++ b/apps/daemon/tests/collab/workspace-authority-health.test.ts
@@ -14,8 +14,9 @@ function deferred() {
 }
 
 describe('workspace authority health coordinator', () => {
-  it('defaults unknown and absent modes to the legacy kill switch', () => {
-    expect(resolveWorkspaceAuthorityCacheMode(undefined)).toBe('legacy');
+  it('defaults absent modes to adaptive while unknown values use the legacy kill switch', () => {
+    expect(resolveWorkspaceAuthorityCacheMode(undefined)).toBe('adaptive');
+    expect(resolveWorkspaceAuthorityCacheMode('  ')).toBe('adaptive');
     expect(resolveWorkspaceAuthorityCacheMode('unexpected')).toBe('legacy');
     expect(resolveWorkspaceAuthorityCacheMode(' OBSERVE ')).toBe('observe');
     expect(resolveWorkspaceAuthorityCacheMode('adaptive')).toBe('adaptive');

--- a/apps/daemon/tests/collab/workspace-authority-health.test.ts
+++ b/apps/daemon/tests/collab/workspace-authority-health.test.ts
@@ -41,11 +41,13 @@ describe('workspace authority health coordinator', () => {
   it('enables adaptive polling only after catch-up completes', async () => {
     const gate = deferred();
     const states: boolean[] = [];
+    const onDecision = vi.fn();
     const coordinator = createWorkspaceAuthorityHealthCoordinator({
       mode: 'adaptive',
       catchUp: () => gate.promise,
       setDirectoryPollingHealthy: (_workspaceId, healthy) => states.push(healthy),
       setBillingPollingHealthy: () => undefined,
+      onDecision,
     });
 
     const update = coordinator.update({ workspaceId: 'w1', healthy: true });
@@ -53,6 +55,11 @@ describe('workspace authority health coordinator', () => {
     gate.resolve();
     await update;
     expect(states).toEqual([false, true]);
+    expect(onDecision).toHaveBeenCalledWith({
+      source: 'sse',
+      reason: 'healthy',
+      outcome: 'allow',
+    });
   });
 
   it('cannot re-enable adaptive polling from a catch-up that lost its health generation', async () => {

--- a/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
+++ b/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
@@ -736,11 +736,13 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     let calls = 0;
+    const onPollSuppressed = vi.fn();
     const runtime = createWorkspaceBillingRuntimeCoordinator({
       pollIntervalMs: 10,
       softTtlMs: 10,
       hardTtlMs: 40,
       realtimePollFloorMs: 100,
+      onPollSuppressed,
       fetchProjection: async () => {
         calls += 1;
         return projection('workspace-a', 'member-a', String(calls));
@@ -752,6 +754,7 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
     await vi.advanceTimersByTimeAsync(99);
     await runtime.read(KEY_A);
     expect(calls).toBe(1);
+    expect(onPollSuppressed).toHaveBeenCalledTimes(9);
 
     await vi.advanceTimersByTimeAsync(1);
     await vi.waitFor(() => expect(calls).toBe(2));

--- a/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
+++ b/apps/daemon/tests/collab/workspace-billing-runtime.test.ts
@@ -732,6 +732,37 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
     runtime.dispose();
   });
 
+  it('uses realtime events as the fast path but immediately restores polling after disconnect', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let calls = 0;
+    const runtime = createWorkspaceBillingRuntimeCoordinator({
+      pollIntervalMs: 10,
+      softTtlMs: 10,
+      hardTtlMs: 40,
+      realtimePollFloorMs: 100,
+      fetchProjection: async () => {
+        calls += 1;
+        return projection('workspace-a', 'member-a', String(calls));
+      },
+    });
+
+    await runtime.read(KEY_A);
+    runtime.setRealtimeHealthy('workspace-a', true);
+    await vi.advanceTimersByTimeAsync(99);
+    await runtime.read(KEY_A);
+    expect(calls).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(calls).toBe(2));
+
+    runtime.setRealtimeHealthy('workspace-a', false);
+    await Promise.resolve();
+    expect(calls).toBe(3);
+    expect(runtime.peek(KEY_A)?.state.reason).toBe('reconnect');
+    runtime.dispose();
+  });
+
   it('forces an authoritative catch-up after reconnect', async () => {
     let balance = '1.00';
     let calls = 0;
@@ -931,6 +962,34 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
       projection: { snapshot: null, workspaceBalance: null },
       state: { status: 'access-revoked' },
     });
+    runtime.dispose();
+  });
+
+  it('clears a projection and reports backend scope rejection to the authority cache', async () => {
+    const revoked: Array<{ workspaceId: string; workspaceMemberId: string }> = [];
+    let calls = 0;
+    const runtime = createWorkspaceBillingRuntimeCoordinator({
+      fetchProjection: async () => {
+        calls += 1;
+        return calls === 1
+          ? projection('workspace-a', 'member-a', '1.00')
+          : projection('workspace-a', 'member-replaced', '2.00');
+      },
+      onAccessRevoked: (key) => revoked.push(key),
+    });
+    await runtime.read(KEY_A);
+
+    runtime.reconnect('workspace-a');
+    const result = await runtime.read(KEY_A);
+
+    expect(result).toMatchObject({
+      projection: { snapshot: null, workspaceBalance: null },
+      state: {
+        status: 'access-revoked',
+        errorCode: 'workspace_not_authorized',
+      },
+    });
+    expect(revoked).toEqual([KEY_A]);
     runtime.dispose();
   });
 
@@ -1185,8 +1244,8 @@ describe('WorkspaceBillingRuntimeCoordinator', () => {
     expect(result).toMatchObject({
       projection: { snapshot: null, workspaceBalance: null },
       state: {
-        status: 'error',
-        errorCode: 'workspace_billing_scope_mismatch',
+        status: 'access-revoked',
+        errorCode: 'workspace_not_authorized',
       },
     });
     runtime.dispose();

--- a/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+import { createWorkspaceExactContextCache } from '../../src/collab/workspace-exact-context-cache.js';
+
+const context = (workspaceId: string): WorkspaceCollabContext =>
+  ({ workspaceId, workspaceMemberId: `member-${workspaceId}` }) as WorkspaceCollabContext;
+
+describe('workspace exact context cache', () => {
+  it('never caches in legacy health and reuses only a healthy exact scope', async () => {
+    let calls = 0;
+    const cache = createWorkspaceExactContextCache({
+      identity: () => 'account-a',
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => {
+          calls += 1;
+          return context(workspaceId);
+        },
+      },
+    });
+
+    await cache.provider.resolveExact?.({ workspaceId: 'w1' });
+    await cache.provider.resolveExact?.({ workspaceId: 'w1' });
+    expect(calls).toBe(2);
+
+    cache.setRealtimeHealthy('w1', true);
+    await cache.provider.resolveExact?.({ workspaceId: 'w1' });
+    expect(calls).toBe(2);
+    await cache.provider.resolveExact?.({ workspaceId: 'w2' });
+    expect(calls).toBe(3);
+  });
+
+  it('invalidates on health loss and cannot cross a credential identity', async () => {
+    let identity = 'account-a';
+    let calls = 0;
+    const cache = createWorkspaceExactContextCache({
+      identity: () => identity,
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => {
+          calls += 1;
+          return context(workspaceId);
+        },
+      },
+    });
+
+    await cache.refresh({ workspaceId: 'w1' });
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1')).toMatchObject({ workspaceId: 'w1' });
+
+    identity = 'account-b';
+    expect(cache.cached('w1')).toBeNull();
+    await cache.provider.resolveExact?.({ workspaceId: 'w1' });
+    expect(calls).toBe(2);
+
+    cache.setRealtimeHealthy('w1', false);
+    expect(cache.cached('w1')).toBeNull();
+  });
+
+  it('does not let a pre-invalidation response seed the next generation', async () => {
+    let resolve!: (value: WorkspaceCollabContext) => void;
+    const held = new Promise<WorkspaceCollabContext>((done) => {
+      resolve = done;
+    });
+    const cache = createWorkspaceExactContextCache({
+      identity: () => 'account-a',
+      provider: {
+        current: async () => null,
+        resolveExact: async () => held,
+      },
+    });
+
+    const old = cache.refresh({ workspaceId: 'w1' });
+    cache.invalidate('w1');
+    resolve(context('w1'));
+    await old;
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
@@ -106,4 +106,34 @@ describe('workspace exact context cache', () => {
     });
     expect(onSuppressedRequest).toHaveBeenCalledOnce();
   });
+
+  it('reseats a healthy lease after a routine event invalidation', async () => {
+    let calls = 0;
+    const cache = createWorkspaceExactContextCache({
+      identity: () => 'account-a',
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => {
+          calls += 1;
+          return context(workspaceId);
+        },
+      },
+    });
+
+    cache.setRealtimeHealthy('w1', true);
+    await cache.refresh({ workspaceId: 'w1' });
+    expect(cache.cached('w1')).toMatchObject({ workspaceId: 'w1' });
+
+    cache.invalidate('w1', 'event_dirty');
+    expect(cache.cached('w1')).toBeNull();
+    await cache.refresh({ workspaceId: 'w1' });
+
+    expect(calls).toBe(2);
+    expect(cache.cached('w1')).toMatchObject({ workspaceId: 'w1' });
+
+    cache.invalidate('w1', 'auth_reject');
+    await cache.refresh({ workspaceId: 'w1' });
+    expect(calls).toBe(3);
+    expect(cache.cached('w1')).toBeNull();
+  });
 });

--- a/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import { createWorkspaceExactContextCache } from '../../src/collab/workspace-exact-context-cache.js';
@@ -77,5 +77,33 @@ describe('workspace exact context cache', () => {
     await old;
     cache.setRealtimeHealthy('w1', true);
     expect(cache.cached('w1')).toBeNull();
+  });
+
+  it('reports a healthy lease hit as one suppressed current request', async () => {
+    let now = 1_000;
+    const onDecision = vi.fn();
+    const onSuppressedRequest = vi.fn();
+    const cache = createWorkspaceExactContextCache({
+      identity: () => 'account-a',
+      now: () => now,
+      onDecision,
+      onSuppressedRequest,
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => context(workspaceId),
+      },
+    });
+
+    await cache.refresh({ workspaceId: 'w1' });
+    cache.setRealtimeHealthy('w1', true);
+    now += 250;
+    expect(cache.cached('w1')).toMatchObject({ workspaceId: 'w1' });
+    expect(onDecision).toHaveBeenLastCalledWith({
+      source: 'cache',
+      reason: 'lease_hit',
+      outcome: 'allow',
+      ageMs: 250,
+    });
+    expect(onSuppressedRequest).toHaveBeenCalledOnce();
   });
 });

--- a/apps/daemon/tests/metrics/workspace-authority.test.ts
+++ b/apps/daemon/tests/metrics/workspace-authority.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetWorkspaceAuthorityMetricsForTests,
+  recordWorkspaceAuthorityDecision,
+  recordWorkspaceAuthorityInvalidation,
+  recordWorkspaceAuthorityRealtimeTransition,
+  recordWorkspaceAuthorityRevocationClear,
+  recordWorkspaceAuthoritySuppressedRequest,
+} from '../../src/metrics/workspace-authority.js';
+import { register } from '../../src/metrics/index.js';
+
+afterEach(() => __resetWorkspaceAuthorityMetricsForTests());
+
+describe('workspace authority metrics', () => {
+  it('exports bounded decision, suppression, invalidation, health, age, and revocation series', async () => {
+    recordWorkspaceAuthorityDecision({
+      mode: 'legacy',
+      source: 'cache',
+      reason: 'lease_hit',
+      outcome: 'allow',
+      ageMs: 1_250,
+    });
+    recordWorkspaceAuthoritySuppressedRequest({
+      mode: 'legacy',
+      source: 'directory',
+      reason: 'lease_hit',
+    });
+    recordWorkspaceAuthorityInvalidation({
+      mode: 'adaptive',
+      source: 'current',
+      reason: 'auth_reject',
+    });
+    recordWorkspaceAuthorityRealtimeTransition({
+      mode: 'adaptive',
+      healthy: false,
+      memberEvents: true,
+      listenerStatus: true,
+      sourceGap: true,
+    });
+    recordWorkspaceAuthorityRevocationClear('adaptive', 2.5);
+
+    const text = await register.metrics();
+    expect(text).toContain(
+      'open_design_workspace_authority_decisions_total{mode="legacy",source="cache",reason="lease_hit",outcome="allow"} 1',
+    );
+    expect(text).toContain(
+      'open_design_workspace_authority_suppressed_requests_total{mode="legacy",source="directory",reason="lease_hit"} 1',
+    );
+    expect(text).toContain(
+      'open_design_workspace_authority_invalidations_total{mode="adaptive",source="current",reason="auth_reject"} 1',
+    );
+    expect(text).toContain(
+      'open_design_workspace_authority_realtime_transitions_total{mode="adaptive",health="unhealthy",member_events="present",listener_status="present",source_gap="yes"} 1',
+    );
+    expect(text).toContain('open_design_workspace_authority_age_ms_bucket{');
+    expect(text).toContain('open_design_workspace_authority_revocation_clear_ms_bucket{');
+  });
+});

--- a/apps/daemon/tests/vela-billing.test.ts
+++ b/apps/daemon/tests/vela-billing.test.ts
@@ -6,6 +6,7 @@ import {
   fetchVelaBillingSummary,
   fetchVelaWorkspaceBillingProjection,
   fetchVelaWorkspaceBalance,
+  isVelaWorkspaceAuthorizationError,
   parseBillingCatalog,
   parseBillingSummary,
   parseWorkspaceBillingSnapshot,
@@ -275,6 +276,22 @@ describe('vela billing 收口', () => {
         },
       }),
     ).rejects.toThrow('control key expired');
+  });
+
+  it('recognizes old and new CLI authorization envelopes without classifying timeouts', () => {
+    expect(
+      isVelaWorkspaceAuthorizationError(
+        new Error(
+          'fetch workspace billing snapshot: API request failed with status 403: workspace_not_authorized',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isVelaWorkspaceAuthorizationError(
+        Object.assign(new Error('denied'), { code: 'auth_required' }),
+      ),
+    ).toBe(true);
+    expect(isVelaWorkspaceAuthorizationError(new Error('request timed out'))).toBe(false);
   });
 
   it('maps the vela team billing catalog JSON into client catalog data', () => {

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -234,6 +234,38 @@ describe('createCachedWorkspaceDirectoryFetcher', () => {
     reads[1]!.resolve({ ok: true, items: [] });
     await expect(accountB).resolves.toEqual({ ok: true, items: [] });
   });
+
+  it('reports directory lease hits and mutation invalidation without identity labels', async () => {
+    let now = 1_000;
+    const onDecision = vi.fn();
+    const onSuppressedRequest = vi.fn();
+    const onInvalidation = vi.fn();
+    const broker = createWorkspaceDirectoryAuthorityBroker({
+      now: () => now,
+      ttlMs: 5_000,
+      fetchDirectory: async () => ({ ok: true, items: [] }),
+      onDecision,
+      onSuppressedRequest,
+      onInvalidation,
+    });
+
+    await broker.read();
+    now += 250;
+    await broker.read();
+    expect(onDecision).toHaveBeenLastCalledWith({
+      source: 'cache',
+      reason: 'lease_hit',
+      outcome: 'allow',
+      ageMs: 250,
+    });
+    expect(onSuppressedRequest).toHaveBeenCalledOnce();
+
+    await broker.refreshAfterMutation();
+    expect(onInvalidation).toHaveBeenCalledWith({
+      source: 'cache',
+      reason: 'mutation',
+    });
+  });
 });
 
 describe('createFreshWorkspaceDirectoryFetcher', () => {

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDirectoryItem } from '@open-design/contracts';
 import {
   createCachedWorkspaceDirectoryFetcher,
   createFreshWorkspaceDirectoryFetcher,
@@ -35,6 +36,16 @@ const B_TEAM_CONTEXT = {
     canManageSharedResources: false,
   },
   lastActiveWorkspaceId: 'ws-team-1',
+};
+
+const B_DIRECTORY_ITEM: WorkspaceDirectoryItem = {
+  workspaceId: 'ws-team-1',
+  workspaceName: 'Team 1',
+  workspaceType: 'team',
+  workspaceMemberId: 'wm-1',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
 };
 
 const SESSION = { profile: 'prod', apiUrl: 'https://vela.example', controlKey: 'ck-1', user: null, configMtimeMs: null };
@@ -275,6 +286,69 @@ describe('createFreshWorkspaceDirectoryFetcher', () => {
 });
 
 describe('createWorkspaceDirectoryAuthorityBroker', () => {
+  it('invalidates the current account lease and forces the next read to refresh', async () => {
+    const first = {
+      ok: true as const,
+      items: [{ ...B_DIRECTORY_ITEM }],
+    };
+    const second = { ok: true as const, items: [] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+    });
+
+    await expect(authority.read()).resolves.toEqual(first);
+    await expect(authority.read()).resolves.toEqual(first);
+    authority.invalidate();
+    await expect(authority.read()).resolves.toEqual(second);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let an invalidated in-flight result seed or satisfy the new generation', async () => {
+    const pending: Array<
+      (result: { ok: true; items: WorkspaceDirectoryItem[] }) => void
+    > = [];
+    const fetchDirectory = vi.fn(
+      () =>
+        new Promise<{ ok: true; items: WorkspaceDirectoryItem[] }>(
+          (resolve) => pending.push(resolve),
+        ),
+    );
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+    });
+
+    const staleRead = authority.read();
+    authority.invalidate();
+    const currentRead = authority.read();
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+
+    const stale = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
+    pending[0]!(stale);
+    await expect(staleRead).resolves.toEqual(stale);
+
+    let currentSettled = false;
+    void currentRead.then(() => {
+      currentSettled = true;
+    });
+    await Promise.resolve();
+    expect(currentSettled).toBe(false);
+
+    const current = {
+      ok: true as const,
+      items: [{ ...B_DIRECTORY_ITEM, workspaceId: 'ws-team-2' }],
+    };
+    pending[1]!(current);
+    await expect(currentRead).resolves.toEqual(current);
+    await expect(authority.read()).resolves.toEqual(current);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
   it('exposes a cached-only lease that never starts I/O and is partitioned by account identity and expiry', async () => {
     let identity = 'account-a:config-a';
     let now = 0;

--- a/apps/daemon/tests/workspace-resource-read-authority.test.ts
+++ b/apps/daemon/tests/workspace-resource-read-authority.test.ts
@@ -1,0 +1,202 @@
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+import { registerPluginRoutes } from '../src/routes/plugins/index.js';
+import { registerStaticResourceRoutes } from '../src/routes/static-resource.js';
+
+const servers: Array<ReturnType<express.Express['listen']>> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+const AUTHORITY: WorkspaceCollabContext = {
+  workspaceId: 'workspace-team',
+  workspaceName: 'Team',
+  workspaceType: 'team',
+  workspaceMemberId: 'member-1',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: null,
+  providerMode: 'platform_credits',
+  seatSummary: {
+    seatLimit: 1,
+    usedSeats: 1,
+    availableSeats: 0,
+    isSeatFull: true,
+  },
+  permissions: {
+    canManageMembers: true,
+    canManageBilling: true,
+    canInviteMembers: true,
+    canManageAutoRecharge: true,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: true,
+  },
+};
+
+function verifier() {
+  return vi.fn(async () => ({ ok: true as const, context: AUTHORITY }));
+}
+
+async function listen(app: express.Express): Promise<string> {
+  const server = app.listen(0, '127.0.0.1');
+  servers.push(server);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}
+
+function localHeaders(): Record<string, string> {
+  return {
+    'x-od-workspace-id': AUTHORITY.workspaceId,
+    'x-od-workspace-member-id': AUTHORITY.workspaceMemberId,
+    'x-od-workspace-type': AUTHORITY.workspaceType,
+    'x-od-workspace-role': AUTHORITY.role,
+    'x-od-workspace-member-status': AUTHORITY.memberStatus,
+    'x-od-workspace-lifecycle-state': AUTHORITY.lifecycleState,
+  };
+}
+
+describe('Workspace resource read authority wiring', () => {
+  it('uses the settled verifier only for Skill and Design System catalog GETs', async () => {
+    const app = express();
+    const verifyWorkspaceReadAuthority = verifier();
+    const verifyWorkspaceRequestAuthority = verifier();
+
+    registerStaticResourceRoutes(app, {
+      db: {} as never,
+      http: {
+        isLocalSameOrigin: () => true,
+        resolvedPortRef: { current: 0 },
+        sendApiError: (
+          res: express.Response,
+          status: number,
+          code: string,
+          message: string,
+        ) => res.status(status).json({ error: code, message }),
+      },
+      paths: {
+        PROJECT_ROOT: '',
+        RUNTIME_DATA_DIR: '',
+        RUNTIME_DATA_DIR_CANONICAL: '',
+        DESIGN_SYSTEMS_DIR: '',
+        USER_DESIGN_SYSTEMS_DIR: '',
+        DESIGN_TEMPLATES_DIR: '',
+        USER_DESIGN_TEMPLATES_DIR: '',
+        SKILLS_DIR: '',
+        USER_SKILLS_DIR: '',
+        PROMPT_TEMPLATES_DIR: '',
+        BUNDLED_PETS_DIR: '',
+      },
+      verifyWorkspaceReadAuthority,
+      verifyWorkspaceRequestAuthority,
+      resources: {
+        listAllSkills: async () => [
+          { id: 'skill-1', body: '# Skill', dir: '/unused' },
+        ],
+        listAllDesignTemplates: async () => [],
+        listAllSkillLikeEntries: async () => [],
+        listAllDesignSystems: async () => [],
+        mimeFor: () => 'application/octet-stream',
+      },
+    } as unknown as Parameters<typeof registerStaticResourceRoutes>[1]);
+
+    const baseUrl = await listen(app);
+    const headers = localHeaders();
+    const [skills, designSystems] = await Promise.all([
+      fetch(`${baseUrl}/api/skills`, { headers }),
+      fetch(`${baseUrl}/api/design-systems`, { headers }),
+    ]);
+
+    expect(skills.status).toBe(200);
+    expect(designSystems.status).toBe(200);
+    await expect(skills.json()).resolves.toEqual({
+      skills: [{ id: 'skill-1', hasBody: true }],
+    });
+    await expect(designSystems.json()).resolves.toEqual({ designSystems: [] });
+    expect(verifyWorkspaceReadAuthority).toHaveBeenCalledTimes(2);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
+
+    const detail = await fetch(`${baseUrl}/api/skills/skill-1`, { headers });
+    expect(detail.status).toBe(200);
+    await expect(detail.json()).resolves.toMatchObject({
+      id: 'skill-1',
+      body: '# Skill',
+    });
+    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the settled verifier only for the Plugin catalog GET', async () => {
+    const app = express();
+    const verifyWorkspaceReadAuthority = verifier();
+    const verifyWorkspaceRequestAuthority = verifier();
+    const plugin = { id: 'plugin-1', source: '/unused/plugin-1' };
+
+    registerPluginRoutes(app, {
+      db: {
+        prepare: () => ({ all: () => [], get: () => null, run: () => undefined }),
+        transaction: (run: () => unknown) => () => run(),
+      },
+      authorizeProjectRequest: async () => ({ ok: true }),
+      paths: {
+        PROJECTS_DIR: '',
+        PLUGIN_REGISTRY_ROOTS: [],
+        PLUGIN_LOCKFILE_PATH: '',
+      },
+      ids: { randomId: () => 'unused' },
+      projectStore: {},
+      conversations: {},
+      verifyWorkspaceReadAuthority,
+      verifyWorkspaceRequestAuthority,
+      plugins: {
+        listInstalledPlugins: async () => [plugin],
+        getInstalledPlugin: () => plugin,
+        getWorkspacePlugin: async () => plugin,
+      },
+      helpers: {
+        applyBakedPreviews: (plugins: unknown) => plugins,
+        PLUGIN_PREVIEWS_DIR: '',
+        requireLocalDaemonRequest: (
+          _req: express.Request,
+          _res: express.Response,
+          next: express.NextFunction,
+        ) => next(),
+        sendApiError: (
+          res: express.Response,
+          status: number,
+          code: string,
+          message: string,
+        ) => res.status(status).json({ error: code, message }),
+      },
+    } as unknown as Parameters<typeof registerPluginRoutes>[1]);
+
+    const baseUrl = await listen(app);
+    const headers = localHeaders();
+    const listing = await fetch(`${baseUrl}/api/plugins`, { headers });
+
+    expect(listing.status).toBe(200);
+    await expect(listing.json()).resolves.toEqual({ plugins: [plugin] });
+    expect(verifyWorkspaceReadAuthority).toHaveBeenCalledTimes(1);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
+
+    const detail = await fetch(`${baseUrl}/api/plugins/plugin-1`, { headers });
+    expect(detail.status).toBe(200);
+    await expect(detail.json()).resolves.toEqual(plugin);
+    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -772,7 +772,12 @@ export function useWorkspaceContext(): WorkspaceContextState {
     { 'workspace-context-changed': () => void loadContext({ fresh: true }) },
     {
       workspaceContext: state.context,
-      onActive: () => void loadContext(),
+      // Reconnect is the gap-closing snapshot in the thin-event model. It must
+      // bypass settled one-second directory/context answers: a membership
+      // change may have landed while this browser had no sink, and accepting
+      // that stale snapshot would immediately slow the fallback poll to the
+      // healthy-SSE floor.
+      onActive: () => void loadContext({ fresh: true }),
     },
   );
 

--- a/apps/web/tests/useWorkspaceContext.invalidation.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.invalidation.test.tsx
@@ -15,6 +15,7 @@ import {
 
 class OpeningEventSource {
   static instances: OpeningEventSource[] = [];
+  static autoOpen = true;
 
   readonly url: string;
   readonly withCredentials = false;
@@ -30,10 +31,7 @@ class OpeningEventSource {
   constructor(url: string | URL) {
     this.url = String(url);
     OpeningEventSource.instances.push(this);
-    queueMicrotask(() => {
-      this.readyState = this.OPEN;
-      this.onopen?.(new Event('open'));
-    });
+    if (OpeningEventSource.autoOpen) queueMicrotask(() => this.open());
   }
 
   addEventListener(
@@ -66,6 +64,11 @@ class OpeningEventSource {
     this.readyState = this.CLOSED;
   }
 
+  open(): void {
+    this.readyState = this.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
   emit(type: string, data: unknown = {}): void {
     this.dispatchEvent(new MessageEvent(type, { data: JSON.stringify(data) }));
   }
@@ -96,6 +99,7 @@ describe('useWorkspaceContext invalidation freshness', () => {
     resetCoalescedGet();
     resetWorkspaceContextCache();
     OpeningEventSource.instances = [];
+    OpeningEventSource.autoOpen = true;
     vi.stubGlobal('EventSource', OpeningEventSource as unknown as typeof EventSource);
   });
 
@@ -105,9 +109,11 @@ describe('useWorkspaceContext invalidation freshness', () => {
     resetCoalescedGet();
     resetWorkspaceContextCache();
     OpeningEventSource.instances = [];
+    OpeningEventSource.autoOpen = true;
   });
 
   it('revalidates the directory after a pushed membership revocation', async () => {
+    OpeningEventSource.autoOpen = false;
     let membershipActive = true;
     let directoryReads = 0;
     let contextReads = 0;
@@ -147,6 +153,58 @@ describe('useWorkspaceContext invalidation freshness', () => {
       expect(directoryReads).toBe(2);
       expect(contextReads).toBe(2);
       expect(hook.result.current.context?.workspaceId).toBe(PERSONAL_CONTEXT.workspaceId);
+    });
+  });
+
+  it('uses a fresh snapshot when the workspace stream first connects', async () => {
+    OpeningEventSource.autoOpen = false;
+    let role: 'member' | 'admin' = 'member';
+    let directoryReads = 0;
+    let contextReads = 0;
+    const context = () => workspaceContextFixture({
+      ...TEAM_CONTEXT,
+      role,
+      permissions: {
+        ...TEAM_CONTEXT.permissions,
+        canInviteMembers: role === 'admin',
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/workspace/directory') {
+        directoryReads += 1;
+        return jsonResponse(workspaceDirectoryFixture([context()]));
+      }
+      if (url === '/api/workspace/context') {
+        contextReads += 1;
+        return jsonResponse({ context: context() });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const hook = renderHook(() => useWorkspaceContext());
+    await waitFor(() => {
+      expect(hook.result.current.context?.role).toBe('member');
+      expect(OpeningEventSource.instances).toHaveLength(1);
+    });
+    expect(directoryReads).toBe(1);
+    expect(contextReads).toBe(1);
+
+    // The role changed while the browser had no workspace-event sink. Opening
+    // the stream is the only catch-up signal; settled client caches still hold
+    // the old member snapshot at this point.
+    role = 'admin';
+    await act(async () => {
+      OpeningEventSource.instances[0]?.open();
+    });
+
+    await waitFor(() => {
+      expect(directoryReads).toBe(2);
+      expect(contextReads).toBe(2);
+      expect(hook.result.current.context).toMatchObject({
+        role: 'admin',
+        permissions: { canInviteMembers: true },
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #6751

## Why

Production traffic showed Vela `GET /api/v1/workspaces` at about 137 req/s, roughly four times `/api/v1/workspaces/current`. Read-only daemon routes were independently re-fetching the same workspace directory to verify identical authority, making the directory endpoint the hottest Vela route.

This PR reduces that fan-out without treating client-provided workspace headers as authority. Bearer authentication remains authoritative, write and materialization paths remain freshly verified, and the only relaxed boundary is an explicit, bounded read-revocation delay of at most 15 seconds for local catalog reads.

## What users will see

There is no new UI. Existing users should see the same Workspace, project, Design System, Plugin, and Skill behavior with fewer daemon-to-Vela requests. The packaged/default mode is `adaptive`: it starts at legacy cadence and reduces polling only after strict Vela capabilities, healthy SSE, no source gap, and an exact catch-up are all proven. Old/no-capability Vela servers therefore retain legacy behavior automatically. Operators may still explicitly select `legacy`, `observe`, or `adaptive` with `OD_WORKSPACE_AUTHORITY_CACHE_MODE`; unknown values use the legacy kill switch.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes daemon authority caching and polling behavior, not UI.

## Bug fix verification

- Test paths: `apps/daemon/tests/workspace-resource-read-authority.test.ts`, `apps/daemon/tests/collab/workspace-exact-context-cache.test.ts`, `apps/daemon/tests/metrics/workspace-authority.test.ts`, and the related workspace/SSE/billing suites changed in this PR.
- Did the test go red on `main` and green on this branch? **No.** The production regression is repeated upstream fan-out rather than a wrong response from one request, and the new cache seams do not exist on `main`. A local runtime characterization measured the pre-change and post-change request counts; that measurement harness and its production screenshots remain local and are intentionally not part of this PR.
- The committed tests cover failure non-caching, generation-fenced invalidation, in-flight invalidation, exact-scope separation, terminal revocation, strict SSE health/catch-up, backend rejection, locked/deleting lifecycle fallback, mid-transfer removal without persisting data, and bounded Prometheus labels.

## Observability

`/api/metrics` now exposes bounded counters/histograms for authority decisions, avoided upstream reads, invalidation reasons, realtime health transitions, cache age, and access-revocation clear latency. Labels contain only finite enums (`mode`, `source`, `reason`, `outcome`, capability/health state); no workspace, member, user, resource, or credential IDs are emitted. Metric failures are isolated from authorization behavior.

These series make the production claim falsifiable: compare avoided directory/current reads against fallback/unavailable decisions, verify cache age remains within the lease, and verify revocation state is cleared synchronously after the frame is received.

## Compatibility matrix

| Consumer / backend | Real artifact exercised | Result |
| --- | --- | --- |
| Open Design 0.18.0 | pinned `@powerformer/vela-cli@0.0.28` binary | Passed seven `team-projects list` success/error/timeout contract scenarios |
| Open Design 0.18.1 | pinned `@powerformer/vela-cli@0.0.28` binary | Passed the same seven scenarios |
| Open Design 0.19.0 release branch | pinned `@powerformer/vela-cli@0.0.32` binary | Passed the same seven scenarios |
| Latest Vela `origin/main` | detached clean worktree at `a68d64806`; API auth/current/directory/team-project suites | 69 tests passed |
| Older/no-capability Vela | daemon strict capability and source-gap suites | Falls back to legacy polling; no cached exact-context authorization |

The exercised CLI scenarios cover success, 401, structured and unstructured 403, 404, unknown command/flag behavior, and the real ~15-second transport timeout. Vela Bearer auth continues to ignore client `x-workspace-*` principal fields; a workspace ID only selects candidate scope and never grants membership.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- 200 tests across the eleven directly affected daemon test files after enabling the adaptive default
- Latest Vela `origin/main`: 69 API tests covering Bearer principal isolation, current/directory, personal workspace, and team-project contracts
- Real published Vela CLI 0.0.28 and 0.0.32 binaries: 14 compatibility scenarios passed
- Local HTTP/body characterization: 10 Design System reads → 1 directory fetch; five subsequent 10-request route probes → 0 additional directory fetches
- Real Chrome via Open Browser Use: Home, personal/team projects, Design Systems/Team, Plugins/Team, Skills, and Workspace switcher in explicit `legacy` and `adaptive` modes with unhealthy/no-capability SSE; zero new browser warnings/errors, and adaptive mode retained legacy polling
- Repository-wide daemon suite: 647 files passed (2 skipped), 8,226 tests passed (5 skipped)
