### PR TITLE
feat(analytics): attribute runs, projects and traces to their Workspace

### DIFF
--- a/apps/daemon/src/analytics.ts
+++ b/apps/daemon/src/analytics.ts
@@ -204,6 +204,13 @@ export interface AnalyticsService {
     appVersion: string;
     properties: Record<string, unknown>;
     insertId: string;
+    /**
+     * PostHog group association (currently only `workspace`). Passing it lets
+     * daemon-side events be aggregated per Workspace exactly like the web-side
+     * events that already ship `$groups` — without it, run/project volume
+     * cannot be attributed to a team workspace at all.
+     */
+    groups?: Record<string, string>;
   }): Promise<void>;
   /**
    * Safety / reliability events (renderer crashes, daemon uncaught errors,
@@ -295,7 +302,7 @@ export function createAnalyticsService(args: {
   client.on?.('error', () => undefined);
 
   return {
-    capture: async ({ eventName, context, appVersion, properties, insertId }) => {
+    capture: async ({ eventName, context, appVersion, properties, insertId, groups }) => {
       // Defense-in-depth consent re-check. The route handler already gates
       // on header presence, but a future header leak or a Settings toggle
       // mid-request would still let events through without this. Reading
@@ -353,6 +360,7 @@ export function createAnalyticsService(args: {
             // from being counted twice.
             $insert_id: insertId,
           },
+          ...(groups && Object.keys(groups).length ? { groups } : {}),
         });
       } catch {
         // Swallowed by design; capture failures must never propagate.

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -20,7 +20,7 @@ import {
 
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
-import { listMessages } from './db.js';
+import { getWorkspaceProjectByProjectId, listMessages } from './db.js';
 import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-relay.js';
 import {
   deriveLangfuseDeliveryState,
@@ -1120,6 +1120,20 @@ export async function reportRunCompletedFromDaemon(
       prefs,
       ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
     } satisfies Parameters<typeof buildTraceObjectManifests>[0];
+    // Resolve the project's Workspace binding once per report. A failure here
+    // must never block telemetry, so it degrades to "no workspace tag".
+    let workspaceIdForTrace: string | null = null;
+    if (run.projectId) {
+      try {
+        const bound = getWorkspaceProjectByProjectId(
+          db as Parameters<typeof getWorkspaceProjectByProjectId>[0],
+          run.projectId,
+        ) as { workspaceId?: string } | undefined;
+        workspaceIdForTrace = bound?.workspaceId ?? null;
+      } catch {
+        workspaceIdForTrace = null;
+      }
+    }
     const buildContext = (
       finalManifests: FinalTraceSafeManifests,
       traceObjectSummary = buildTraceObjectSummary({
@@ -1129,6 +1143,7 @@ export async function reportRunCompletedFromDaemon(
     ): ReportContext => ({
       installationId,
       projectId: run.projectId ?? '',
+      ...(workspaceIdForTrace ? { workspaceId: workspaceIdForTrace } : {}),
       conversationId: run.conversationId ?? '',
       ...(run.agentId ? { agentId: run.agentId } : {}),
       run: {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -318,6 +318,12 @@ export interface TurnInfo {
 export interface ReportContext {
   installationId: string | null;
   projectId: string;
+  /**
+   * Workspace the run's project is bound to, when any. Traces carried no
+   * workspace identity at all before this — only `userId = installationId`
+   * (device-level) — so per-team eval slicing was impossible.
+   */
+  workspaceId?: string | null;
   conversationId: string;
   agentId?: string;
   run: RunSummary;
@@ -544,6 +550,7 @@ function truncate(value: string | undefined, maxBytes: number): string | undefin
 
 function buildTagList(ctx: ReportContext): string[] {
   const tags = ['open-design', `project:${ctx.projectId}`];
+  if (ctx.workspaceId) tags.push(`workspace:${ctx.workspaceId}`);
   if (ctx.agentId) tags.push(`agent:${ctx.agentId}`);
   if (ctx.turn?.model) tags.push(`model:${ctx.turn.model}`);
   if (ctx.turn?.skillId) tags.push(`skill:${ctx.turn.skillId}`);
@@ -1606,6 +1613,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
       ? (ctx.manifestCompleteness ?? 'unavailable')
       : undefined,
     projectId: ctx.projectId || undefined,
+    workspaceId: ctx.workspaceId || undefined,
     agent: ctx.agentId,
     model: ctx.turn?.model,
     reasoning: ctx.turn?.reasoning,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -2032,7 +2032,20 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
               ? 'mark'
               : 'chat'
           : undefined;
+      // Workspace attribution: a run inherits the Workspace its project is
+      // bound to (persisted binding, resolved above). Without this the run
+      // volume of a team workspace cannot be separated from personal usage.
+      const runWorkspaceProps: Record<string, unknown> = preparedWorkspaceScope
+        ? {
+            workspace_key: preparedWorkspaceScope.workspaceId,
+            workspace_scope: preparedWorkspaceScope.source,
+          }
+        : { workspace_scope: 'unbound' };
+      const runWorkspaceGroups = preparedWorkspaceScope
+        ? { workspace: preparedWorkspaceScope.workspaceId }
+        : undefined;
       const baseProps: Record<string, unknown> = {
+        ...runWorkspaceProps,
         page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
         area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
         ...configureGlobals,
@@ -2154,6 +2167,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         appVersion: design.getAppVersion(),
         properties: baseProps,
         insertId: runInsertId,
+        ...(runWorkspaceGroups ? { groups: runWorkspaceGroups } : {}),
       });
       design.runs.wait(run).then(async (status: TerminalRunStatus) => {
         const appCfgAtFinish = await readAppConfig(RUNTIME_DATA_DIR).catch(
@@ -2606,6 +2620,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           appVersion: design.getAppVersion(),
           properties: finishedProperties,
           insertId: `${runInsertId}-finish`,
+          ...(runWorkspaceGroups ? { groups: runWorkspaceGroups } : {}),
         }));
         design.runs.markAnalyticsCompleted?.(run);
       }).catch(() => {});

--- a/apps/daemon/tests/analytics-env.test.ts
+++ b/apps/daemon/tests/analytics-env.test.ts
@@ -95,6 +95,58 @@ describe('analytics telemetry environment', () => {
     });
   });
 
+  it('forwards the workspace group so daemon events aggregate per Workspace', async () => {
+    posthogCapture.mockReset();
+    const dataDir = await mkdtemp(path.join(tmpdir(), 'od-analytics-groups-'));
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify({
+      installationId: 'install-1',
+      telemetry: { metrics: true },
+    }));
+    const { createAnalyticsService } = await import('../src/analytics.js');
+    const analytics = createAnalyticsService({
+      dataDir,
+      env: { POSTHOG_KEY: 'phc_test', OD_TELEMETRY_ENV: 'local_development' },
+    });
+
+    const context = {
+      deviceId: 'device-1',
+      sessionId: 'session-1',
+      clientType: 'web' as const,
+      locale: 'en',
+      requestId: null,
+    };
+    analytics.capture({
+      eventName: 'run_created',
+      appVersion: '1.2.3',
+      context,
+      insertId: 'insert-ws',
+      properties: { workspace_key: 'ws-team-1' },
+      groups: { workspace: 'ws-team-1' },
+    });
+    await vi.waitFor(() => {
+      expect(posthogCapture).toHaveBeenCalled();
+    });
+    expect(posthogCapture.mock.calls[0]?.[0]).toMatchObject({
+      event: 'run_created',
+      groups: { workspace: 'ws-team-1' },
+      properties: { workspace_key: 'ws-team-1' },
+    });
+
+    // Personal (unbound) runs must not carry an empty `groups` key.
+    posthogCapture.mockReset();
+    analytics.capture({
+      eventName: 'run_created',
+      appVersion: '1.2.3',
+      context,
+      insertId: 'insert-personal',
+      properties: { workspace_scope: 'unbound' },
+    });
+    await vi.waitFor(() => {
+      expect(posthogCapture).toHaveBeenCalled();
+    });
+    expect(posthogCapture.mock.calls[0]?.[0]).not.toHaveProperty('groups');
+  });
+
   it('updates a workspace group only when analytics consent is enabled', async () => {
     posthogGroupIdentify.mockReset();
     const dataDir = await mkdtemp(path.join(tmpdir(), 'od-analytics-group-'));

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1070,6 +1070,26 @@ describe('buildTracePayload', () => {
     ]);
   });
 
+  it('tags the trace with its Workspace when the project is workspace-bound', () => {
+    const batch = buildTracePayload(makeCtx({ workspaceId: 'ws-team-1' }));
+    expect((batch[0] as any).body.tags).toEqual([
+      'open-design',
+      'project:proj-1',
+      'workspace:ws-team-1',
+      'agent:claude',
+    ]);
+    expect((batch[0] as any).body.metadata.workspaceId).toBe('ws-team-1');
+  });
+
+  it('omits the workspace tag for unbound (personal) projects', () => {
+    const batch = buildTracePayload(makeCtx());
+    expect((batch[0] as any).body.tags).not.toContain('workspace:ws-team-1');
+    expect(
+      ((batch[0] as any).body.tags as string[]).some((t) => t.startsWith('workspace:')),
+    ).toBe(false);
+    expect((batch[0] as any).body.metadata.workspaceId).toBeUndefined();
+  });
+
   it('adds turn-level tags (model / skill / DS) and runtime tags (os / client)', () => {
     const batch = buildTracePayload(
       makeCtx({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   trackProjectCreateResult,
 } from './analytics/events';
 import { deriveUploadCohort } from './analytics/upload-tracking';
+import { workspaceAnalyticsDimensions } from './analytics/workspace';
 import { setPendingDesignSystemCreateEntry } from './analytics/ds-create-entry';
 import { detectClientType } from './analytics/identity';
 import {
@@ -2902,6 +2903,7 @@ function AppInner() {
             project_id: null,
             project_kind: projectKindFromMetadataToTracking(metadata),
             fidelity,
+            ...workspaceAnalyticsDimensions(createWorkspaceContext),
             result: 'failed',
             error_code: errorCode,
           },
@@ -2921,6 +2923,7 @@ function AppInner() {
             fidelity,
             ...(input.pluginId ? { plugin_id: input.pluginId } : {}),
             ...(input.pluginType ? { plugin_type: input.pluginType } : {}),
+            ...workspaceAnalyticsDimensions(createWorkspaceContext),
             result: 'failed',
             error_code: 'CREATE_REQUEST_FAILED',
           },
@@ -3007,6 +3010,7 @@ function AppInner() {
           fidelity,
           ...(input.pluginId ? { plugin_id: input.pluginId } : {}),
           ...(input.pluginType ? { plugin_type: input.pluginType } : {}),
+          ...workspaceAnalyticsDimensions(createWorkspaceContext),
           result: 'success',
         },
         { requestId: input.requestId },

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -10,6 +10,7 @@ import type {
   AnalyticsPublisherClass,
   TrackingRuntimeType,
 } from '../public-params.js';
+import type { TrackingWorkspaceDimensions } from './workspace.js';
 import type { ReleaseChannel } from '@open-design/release';
 import type { ArtifactOriginEntrySurface, ArtifactOriginStatus } from '../../api/files.js';
 import type { TrackingDesignSystemEditSurface, TrackingDesignSystemKind, TrackingDesignSystemLengthBucket, TrackingDesignSystemOrigin, TrackingDesignSystemRunEntryFrom } from './design-systems.js';
@@ -42,7 +43,10 @@ export interface MediaGenerationResultProps {
   used_stub_fallback: boolean;
 }
 
-export interface ProjectCreateResultProps {
+// Workspace dimensions ride along so a created project can be attributed to
+// the Workspace it landed in. Without them "how much gets produced inside a
+// team workspace" is unanswerable — the event carries no workspace identity.
+export interface ProjectCreateResultProps extends TrackingWorkspaceDimensions {
   page_name: 'home';
   area: 'new_project';
   project_source: TrackingProjectSource;


### PR DESCRIPTION
## Why

Team-plan analysis is currently impossible to do inside product analytics.

Measured on the live project (PostHog 420348, 30d):

- `run_created` / `run_finished` / `project_create_result` carry **no workspace identity at all** — `$group_0` coverage is **0%**.
- Langfuse traces only know `userId = installationId` (device-level), with no workspace tag.

So two questions cannot be answered today: *how much is actually produced inside a team workspace*, and *how do team-workspace turns differ in evals*. Both are needed to judge whether the Team plan is delivering value after purchase.

## What

Wires the **existing** workspace dimensions into those surfaces — no new field vocabulary is invented.

- **contracts** — `ProjectCreateResultProps` now extends the existing `TrackingWorkspaceDimensions` (`workspace_key` / `workspace_type` / `workspace_role` / `plan_bucket` / `seat_state` / `$groups`).
- **web** — the three `trackProjectCreateResult` call sites spread `workspaceAnalyticsDimensions(createWorkspaceContext)`, the same helper the `workspace_*` events already use.
- **daemon `analytics.ts`** — `capture()` accepts an optional `groups`, forwarded to posthog-node, so daemon-side events can join the PostHog `workspace` group exactly like web-side events already do.
- **daemon `runs.ts`** — `run_created` / `run_finished` carry `workspace_key` + `workspace_scope`, taken from the run's already-pinned project binding (`preparedWorkspaceScope`). Runs on unbound projects report `workspace_scope: 'unbound'` and deliberately send **no** `groups` key.
- **langfuse** — `ReportContext.workspaceId` adds a `workspace:<id>` tag and a `workspaceId` metadata field. The binding is resolved once per report via `getWorkspaceProjectByProjectId` and degrades to "no workspace tag" on any lookup failure, so telemetry is never blocked by it.

## Privacy

`workspace_key` is the same opaque workspace id the web-side `workspace_*` events already send — no display names, no PII. Unbound (personal) runs send no group association.

## Tests

New regression coverage:

- trace carries `workspace:<id>` tag + `workspaceId` metadata when the project is workspace-bound;
- trace carries **no** `workspace:` tag for unbound/personal projects;
- `groups` is forwarded to posthog-node only when the run is workspace-bound (and the key is absent otherwise).

Verified locally: `@open-design/contracts` build + test (280 passed), `@open-design/web` typecheck (0 errors), `@open-design/daemon` typecheck (0 errors), daemon suites `langfuse-trace` / `langfuse-bridge` / `analytics-env` / `workspace-project-analytics` / `run-analytics-observability` (178 passed), `pnpm guard`.

## Known gap (out of scope here)

Team-plan **subscription** events are emitted server-side by vela (`$lib: posthog-node`, `source: vela_team_subscription_mutation`) and their `plan_id` only has `plus / pro / max` — no team tier. That leaves the team funnel's middle section (price view → upgrade click → checkout → paid) invisible in PostHog and reconstructable only from Stripe. Fixing it needs a change in the vela service, not this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)