### PR TITLE
fix(web): scope artifact upgrade gate to AMR

### DIFF
--- a/apps/web/src/components/AmrArtifactUpgradeGate.tsx
+++ b/apps/web/src/components/AmrArtifactUpgradeGate.tsx
@@ -110,6 +110,7 @@ export function AmrArtifactUpgradeGate({
         !detail
         || typeof detail.runId !== 'string'
         || !detail.runId.trim()
+        || detail.agentId !== 'amr'
         || !sessionKey
         || detail.result !== 'success'
         || !Number.isFinite(detail.artifactCount)

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5462,6 +5462,7 @@ export function ProjectView({
           || spuriouslyFailedPending
           || recoverableGenericDisconnectFailed;
         void reattachDaemonRun({
+          agentId: message.agentId,
           runId,
           projectId: project.id,
           conversationId: reattachConversationId,
@@ -5769,9 +5770,11 @@ export function ProjectView({
                     if (
                       shouldPublishRunFinishedEvent
                       && latestRunStatus?.status === 'succeeded'
+                      && latestRunStatus.agentId === 'amr'
                       && typeof latestRunStatus.artifactCount === 'number'
                     ) {
                       publishDaemonRunFinishedEvent({
+                        agentId: latestRunStatus.agentId,
                         runId,
                         projectId: project.id,
                         conversationId: reattachConversationId,
@@ -5862,9 +5865,11 @@ export function ProjectView({
                   } else if (latestRunStatus.status === 'succeeded') {
                     if (
                       shouldPublishRunFinishedEvent
+                      && latestRunStatus.agentId === 'amr'
                       && typeof latestRunStatus.artifactCount === 'number'
                     ) {
                       publishDaemonRunFinishedEvent({
+                        agentId: latestRunStatus.agentId,
                         runId,
                         projectId: project.id,
                         conversationId: reattachConversationId,
@@ -7416,8 +7421,12 @@ export function ProjectView({
                 }
                 if (!latestRunStatus || isActiveRunStatus(latestRunStatus.status)) {
                 } else if (latestRunStatus.status === 'succeeded') {
-                  if (typeof latestRunStatus.artifactCount === 'number') {
+                  if (
+                    latestRunStatus.agentId === 'amr'
+                    && typeof latestRunStatus.artifactCount === 'number'
+                  ) {
                     publishDaemonRunFinishedEvent({
+                      agentId: latestRunStatus.agentId,
                       runId: runIdForGenericDisconnect,
                       projectId: project.id,
                       conversationId: runConversationId,
@@ -7969,7 +7978,11 @@ export function ProjectView({
       commentAttachments: ChatCommentAttachment[],
       meta?: ChatSendMeta,
     ): Promise<ChatSendOutcome> => {
-      if (activeConversationId) {
+      if (
+        activeConversationId
+        && config.mode === 'daemon'
+        && config.agentId === 'amr'
+      ) {
         const decision = await requestAmrArtifactUpgrade({
           projectId: project.id,
           conversationId: activeConversationId,
@@ -7979,7 +7992,7 @@ export function ProjectView({
       }
       void handleSend(prompt, attachments, commentAttachments, meta);
     },
-    [activeConversationId, handleSend, project.id],
+    [activeConversationId, config.agentId, config.mode, handleSend, project.id],
   );
 
   // Cancel every in-flight run for the current conversation (the user's own

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -348,6 +348,8 @@ export interface DaemonStreamOptions {
 }
 
 export interface DaemonReattachOptions {
+  /** Runtime that owns the reattached run, when persisted with its message. */
+  agentId?: string;
   runId: string;
   projectId?: string | null;
   conversationId?: string | null;
@@ -367,6 +369,7 @@ export const RUNS_CHANGED_EVENT = 'open-design:runs-changed';
 export const DAEMON_RUN_FINISHED_EVENT = 'open-design:daemon-run-finished';
 
 export interface DaemonRunFinishedEventDetail {
+  agentId: string;
   runId: string;
   projectId: string;
   conversationId: string;
@@ -379,6 +382,7 @@ export function publishDaemonRunFinishedEvent(
 ): void {
   if (
     typeof window === 'undefined'
+    || detail.agentId !== 'amr'
     || !detail.runId.trim()
     || !detail.projectId.trim()
     || !detail.conversationId.trim()
@@ -1171,7 +1175,7 @@ async function consumeDaemonRun({
   conversationId,
   workspaceContext,
   publishRunFinishedEvent,
-}: DaemonReattachOptions & { agentId?: string }): Promise<void> {
+}: DaemonReattachOptions): Promise<void> {
   let acc = '';
   let stderrBuf = '';
   let exitCode: number | null = null;
@@ -1485,6 +1489,7 @@ async function consumeDaemonRun({
     }
     if (
       publishRunFinishedEvent
+      && agentId === 'amr'
       && Boolean(projectId?.trim())
       && Boolean(conversationId?.trim())
       && serverDeclaredSuccess
@@ -1493,6 +1498,7 @@ async function consumeDaemonRun({
       && resolvedArtifactCount > 0
     ) {
       publishDaemonRunFinishedEvent({
+        agentId,
         runId,
         projectId: projectId!,
         conversationId: conversationId!,

--- a/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
+++ b/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
@@ -9,18 +9,22 @@ import {
 } from '../../src/providers/daemon';
 import { requestAmrArtifactUpgrade } from '../../src/runtime/amr-artifact-upgrade';
 
-function publishFinishedRun(detail: Partial<DaemonRunFinishedEventDetail> = {}) {
+type RuntimeAwareFinishedRunDetail = DaemonRunFinishedEventDetail & {
+  agentId?: string;
+};
+
+function publishFinishedRun(detail: Partial<RuntimeAwareFinishedRunDetail> = {}): void {
+  const payload: RuntimeAwareFinishedRunDetail = {
+    runId: detail.runId ?? 'run-1',
+    projectId: detail.projectId ?? 'project-1',
+    conversationId: detail.conversationId ?? 'conversation-1',
+    result: detail.result ?? 'success',
+    artifactCount: detail.artifactCount ?? 1,
+    agentId: detail.agentId ?? 'amr',
+  };
   window.dispatchEvent(new CustomEvent<DaemonRunFinishedEventDetail>(
     DAEMON_RUN_FINISHED_EVENT,
-    {
-      detail: {
-        runId: detail.runId ?? 'run-1',
-        projectId: detail.projectId ?? 'project-1',
-        conversationId: detail.conversationId ?? 'conversation-1',
-        result: detail.result ?? 'success',
-        artifactCount: detail.artifactCount ?? 1,
-      },
-    },
+    { detail: payload },
   ));
 }
 
@@ -71,6 +75,15 @@ describe('AmrArtifactUpgradeGate', () => {
     act(() => publishFinishedRun());
 
     await expect(requestSend('project-1', 'conversation-2')).resolves.toBe('proceed');
+    expect(screen.queryByTestId('amr-artifact-upgrade-dialog')).toBeNull();
+  });
+
+  it('does not prompt a Free-plan user after Kimi creates an artifact', async () => {
+    render(<AmrArtifactUpgradeGate {...BASE_PROPS} plan="free" planResolved />);
+
+    act(() => publishFinishedRun({ agentId: 'kimi' }));
+
+    await expect(requestSend()).resolves.toBe('proceed');
     expect(screen.queryByTestId('amr-artifact-upgrade-dialog')).toBeNull();
   });
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -515,6 +515,7 @@ describe('ProjectView daemon reattach restore', () => {
       {
         id: 'msg-reattach',
         role: 'assistant',
+        agentId: 'kimi',
         content: '',
         createdAt: startedAt,
         startedAt,
@@ -561,6 +562,7 @@ describe('ProjectView daemon reattach restore', () => {
 
     await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
     expect(reattachDaemonRun).toHaveBeenCalledWith(expect.objectContaining({
+      agentId: 'kimi',
       publishRunFinishedEvent: true,
     }));
     expect(capturedHandlers).not.toBeNull();

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -132,7 +132,7 @@ describe('streamViaDaemon', () => {
     }));
 
     await streamViaDaemon({
-      agentId: 'mock',
+      agentId: 'amr',
       history: [{ id: '1', role: 'user', content: 'make a design' }],
       systemPrompt: '',
       signal: new AbortController().signal,
@@ -143,6 +143,7 @@ describe('streamViaDaemon', () => {
     });
 
     expect(published).toEqual([{
+      agentId: 'amr',
       runId: 'run-artifact-success',
       projectId: 'project-1',
       conversationId: 'conversation-1',
@@ -151,6 +152,41 @@ describe('streamViaDaemon', () => {
     }]);
     expect(artifactPaths).toEqual([['existing.png', 'renders/new.png']]);
   });
+
+  it.each(['kimi', 'codex'])(
+    'does not publish a local %s artifact run to the AMR upgrade gate',
+    async (agentId) => {
+      const handlers = createDaemonHandlers();
+      const eventTarget = new EventTarget();
+      const published: DaemonRunFinishedEventDetail[] = [];
+      eventTarget.addEventListener(DAEMON_RUN_FINISHED_EVENT, (event) => {
+        published.push((event as CustomEvent<DaemonRunFinishedEventDetail>).detail);
+      });
+      vi.stubGlobal('window', eventTarget);
+      vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === '/api/runs') return jsonResponse({ runId: `run-${agentId}` });
+        if (url === `/api/runs/run-${agentId}/events`) {
+          return sseResponse(
+            'event: end\ndata: {"code":0,"status":"succeeded","artifactCount":1}\n\n',
+          );
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }));
+
+      await streamViaDaemon({
+        agentId,
+        history: [{ id: '1', role: 'user', content: 'make a design' }],
+        systemPrompt: '',
+        signal: new AbortController().signal,
+        handlers,
+        projectId: 'project-1',
+        conversationId: 'conversation-1',
+      });
+
+      expect(published).toEqual([]);
+    },
+  );
 
   it.each([
     ['no artifact', '{"code":0,"status":"succeeded","artifactCount":0}'],

--- a/e2e/ui/amr-artifact-upgrade-gate.test.ts
+++ b/e2e/ui/amr-artifact-upgrade-gate.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from '@/playwright/suite';
+import {
+  AMR_PERSONAL_WORKSPACE_HEADERS,
+  createProjectViaApi,
+  gotoProject,
+  putAppConfig,
+  seedBrowserConfig,
+} from '@/playwright/amr';
+import {
+  routeAgents,
+  routeSuccessfulRuns,
+  suppressWhatsNew,
+} from '@/playwright/mock-factory';
+import { T } from '@/timeouts';
+import type { Page } from '@playwright/test';
+
+const KIMI_AGENT = {
+  id: 'kimi',
+  name: 'Kimi CLI',
+  bin: 'kimi',
+  available: true,
+  version: 'test',
+  models: [{ id: 'default', label: 'Default' }],
+};
+
+const KIMI_CONFIG = {
+  mode: 'daemon',
+  apiKey: '',
+  baseUrl: '',
+  model: '',
+  agentId: 'kimi',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  privacyDecisionAt: 1,
+  telemetry: { metrics: false, content: false, artifactManifest: false },
+  agentModels: { kimi: { model: 'default', reasoning: 'default' } },
+};
+
+const KIMI_ARTIFACT_RUN = [
+  'event: stdout',
+  `data: ${JSON.stringify({
+    chunk: '<artifact identifier="kimi-upgrade-gate" type="text/html" title="Kimi artifact"><!doctype html><html><body><h1>Kimi artifact</h1></body></html></artifact>',
+  })}`,
+  '',
+  'event: end',
+  'data: {"code":0,"status":"succeeded","artifactCount":1}',
+  '',
+  '',
+].join('\n');
+
+test('[P1] Kimi artifact follow-ups bypass the AMR Free upgrade dialog', async ({ page }) => {
+  test.setTimeout(T.xlong);
+
+  await suppressWhatsNew(page);
+  await routeAgents(page, [KIMI_AGENT]);
+  await page.route('**/api/integrations/vela/status*', async (route) => {
+    await route.fulfill({
+      json: {
+        loggedIn: true,
+        profile: 'local',
+        configPath: '/tmp/.amr/config.json',
+        user: {
+          id: 'kimi-upgrade-gate-user',
+          email: 'kimi-upgrade-gate@example.com',
+          plan: 'free',
+        },
+        account: { plan: 'free', balanceUsd: '0.00' },
+      },
+    });
+  });
+  await seedBrowserConfig(page, KIMI_CONFIG);
+  await putAppConfig(page, KIMI_CONFIG);
+  const projectId = `kimi-upgrade-gate-${Date.now()}`;
+  const runs = await routeSuccessfulRuns(page, {
+    runIdPrefix: 'kimi-upgrade-gate',
+    eventBody: async (requestIndex) => {
+      if (requestIndex === 1) {
+        const response = await page.request.post(`/api/projects/${projectId}/files`, {
+          headers: { ...AMR_PERSONAL_WORKSPACE_HEADERS },
+          data: {
+            name: 'kimi-upgrade-gate.html',
+            content: '<!doctype html><html><body><h1>Kimi artifact</h1></body></html>',
+            artifactManifest: {
+              version: 1,
+              kind: 'html',
+              title: 'Kimi artifact',
+              entry: 'kimi-upgrade-gate.html',
+              renderer: 'html',
+              status: 'complete',
+              exports: ['html'],
+              primary: true,
+              metadata: { identifier: 'kimi-upgrade-gate' },
+            },
+          },
+        });
+        expect(response.ok(), await response.text()).toBeTruthy();
+      }
+      return KIMI_ARTIFACT_RUN;
+    },
+  });
+
+  await createProjectViaApi(page, projectId, 'Kimi upgrade gate');
+  await gotoProject(page, projectId);
+
+  await sendPrompt(page, 'Create a Kimi artifact');
+  await runs.expectCount(1);
+  await expect(page.frameLocator(
+    '[data-testid="artifact-preview-frame"]:visible, '
+    + '[data-testid="artifact-preview-frame-url-load"]:visible, '
+    + '[data-testid="artifact-preview-frame-srcdoc"]:visible, '
+    + '[data-testid="live-artifact-preview-frame"]:visible',
+  ).getByRole('heading', { name: 'Kimi artifact' })).toBeVisible({ timeout: T.long });
+  await expect(page.getByTestId('amr-artifact-upgrade-dialog')).toHaveCount(0);
+
+  await sendPrompt(page, 'Refine the Kimi artifact');
+  await runs.expectCount(2, {
+    timeout: T.long,
+    message: 'the Kimi follow-up should reach POST /api/runs without an AMR upsell gate',
+  });
+  await expect(page.getByTestId('amr-artifact-upgrade-dialog')).toHaveCount(0);
+});
+
+async function sendPrompt(page: Page, prompt: string): Promise<void> {
+  const input = page.getByTestId('chat-composer-input');
+  await expect(input).toBeVisible({ timeout: T.medium });
+  await input.fill(prompt);
+  await expect(page.getByTestId('chat-send')).toBeEnabled();
+  await input.press('Enter');
+}


### PR DESCRIPTION
## Why

A Kimi Code user was blocked by the AMR Free-plan upgrade dialog after successfully creating an artifact. The completed-run browser event did not carry the runtime identity, so the AMR-specific artifact gate treated successful artifact runs from every daemon agent as AMR usage.

This scopes the upgrade decision to the AMR runtime while keeping the existing AMR Free-plan behavior intact.

## What users will see

Kimi Code, Codex, and other local agent users can continue refining an artifact without seeing the AMR membership upgrade dialog. AMR Free-plan users still receive the existing upgrade prompt after an AMR artifact run.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this adds no UI surface. The user-visible result is the absence of an incorrect dialog, covered by the Kimi Playwright regression.

## Bug fix verification

- Red specs: `apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx` and `apps/web/tests/providers/sse.test.ts`
- The tests went red against the old source: 3 failed, 90 passed.
- The same tests went green after the fix: 93 passed.
- End-to-end regression: `e2e/ui/amr-artifact-upgrade-gate.test.ts` creates a real HTML artifact, sends a Kimi follow-up, and verifies the follow-up reaches `POST /api/runs` without the upgrade dialog.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 613 files, 6366 passed, 1 expected failure, 11 skipped
- focused Vitest regression suite — 3 files, 127 passed
- `pnpm --filter @open-design/web build`
- `pnpm --filter @open-design/e2e typecheck`
- focused Playwright regression — 1 passed
