### PR TITLE
fix(packaged): widen macOS sidecar status timeout to 90s for 0.18.1 cold starts

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -248,6 +248,13 @@ const WIN32_STATUS_TIMEOUT_MS = 90_000;
 // widened budget is the safety net for slow devices, mirroring the win32
 // rationale above (same "slow, not dead" failure class as #5515).
 const LINUX_STATUS_TIMEOUT_MS = 90_000;
+// Packaged 0.18.1 macOS cold starts on Apple Silicon can exceed the 35s
+// baseline: the daemon sidecar needs extra time to finish initialization
+// before the desktop's status timeout fires. Widening the darwin budget
+// to 90s matches the win32/linux safety net for "slow, not dead" first
+// launches and prevents the timeout cascade that leaves the desktop on a
+// stale web URL (issue #6637).
+const DARWIN_STATUS_TIMEOUT_MS = 90_000;
 const DAEMON_MIGRATION_STATUS_TIMEOUT_MS = 30 * 60 * 1000;
 
 // Poll cadence for waitForStatus: start tight so a fast daemon is detected
@@ -259,18 +266,21 @@ const STATUS_POLL_MAX_MS = 1500;
 
 // Baseline status wait budget by platform, before the daemon-only legacy
 // migration override. win32 gets the wider AV-scan headroom, linux gets the
-// same headroom for AppImage FUSE cold starts; every other OS keeps the 35s
-// baseline.
+// same headroom for AppImage FUSE cold starts; darwin gets the same headroom
+// for packaged 0.18.1+ cold starts on Apple Silicon; every other OS keeps the
+// 35s baseline.
 function baseStatusTimeoutMs(platform: NodeJS.Platform = process.platform): number {
   if (platform === "win32") return WIN32_STATUS_TIMEOUT_MS;
   if (platform === "linux") return LINUX_STATUS_TIMEOUT_MS;
+  if (platform === "darwin") return DARWIN_STATUS_TIMEOUT_MS;
   return DAEMON_STATUS_TIMEOUT_MS;
 }
 
 /**
  * Daemon status wait budget. The platform baseline (35s, or 90s on win32 for
- * AV-scan headroom and on linux for AppImage FUSE cold starts) is fine for
- * normal cold boots, but the OD_LEGACY_DATA_DIR
+ * AV-scan headroom, on linux for AppImage FUSE cold starts, and on darwin for
+ * packaged 0.18.1+ Apple Silicon cold starts) is fine for normal cold boots,
+ * but the OD_LEGACY_DATA_DIR
  * one-shot recovery flow can synch-copy a multi-GB legacy `.od/` payload before
  * SQLite even opens, and killing the child mid-migration can leave dataDir
  * half-promoted. When the env var is set, use a 30-minute budget so the parent

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -45,7 +45,16 @@ function slashPath(value: string): string {
 
 describe('resolveDaemonStatusTimeoutMs', () => {
   it('uses the 35-second baseline budget on platforms without a known slow-cold-start class', () => {
-    expect(resolveDaemonStatusTimeoutMs({}, 'darwin')).toBe(35_000);
+    expect(resolveDaemonStatusTimeoutMs({}, 'freebsd')).toBe(35_000);
+  });
+
+  it('widens the baseline to 90 seconds on darwin for packaged 0.18.1+ Apple Silicon cold starts', () => {
+    // Packaged 0.18.1 macOS launches can exceed the 35s baseline on slower
+    // Apple Silicon cold boots, after which the parent tears the sidecars down
+    // and the desktop falls back to a stale web URL. The wider budget matches
+    // the win32/linux "slow, not dead" safety net.
+    // https://github.com/nexu-io/open-design/issues/6637
+    expect(resolveDaemonStatusTimeoutMs({}, 'darwin')).toBe(90_000);
   });
 
   it('widens the baseline to 90 seconds on linux for AppImage FUSE cold starts', () => {
@@ -67,7 +76,7 @@ describe('resolveDaemonStatusTimeoutMs', () => {
   });
 
   it('treats an empty OD_LEGACY_DATA_DIR as unset', () => {
-    expect(resolveDaemonStatusTimeoutMs({ OD_LEGACY_DATA_DIR: '' }, 'darwin')).toBe(35_000);
+    expect(resolveDaemonStatusTimeoutMs({ OD_LEGACY_DATA_DIR: '' }, 'freebsd')).toBe(35_000);
   });
 
   it('extends the budget to 30 minutes when OD_LEGACY_DATA_DIR is set', () => {
@@ -90,7 +99,7 @@ describe('resolveDaemonStatusTimeoutMs', () => {
     try {
       delete process.env.OD_LEGACY_DATA_DIR;
       expect(resolveDaemonStatusTimeoutMs(undefined, 'linux')).toBe(90_000);
-      expect(resolveDaemonStatusTimeoutMs(undefined, 'darwin')).toBe(35_000);
+      expect(resolveDaemonStatusTimeoutMs(undefined, 'darwin')).toBe(90_000);
       process.env.OD_LEGACY_DATA_DIR = '/some/legacy/path';
       expect(resolveDaemonStatusTimeoutMs(undefined, 'linux')).toBe(30 * 60 * 1000);
     } finally {


### PR DESCRIPTION
## Summary

Packaged 0.18.1 on Apple Silicon can exceed the 35s daemon/web status budget during a cold launch, causing `startPackagedSidecars()` to time out, tear the sidecars down, and leave the desktop looping on a stale `currentWebUrl` / `od://` 502.

This change gives `darwin` the same 90s "slow, not dead" safety net already used on `win32` and `linux` for similar cold-start failure classes, matching the behavior requested in #6637.

## Changes

- Added `DARWIN_STATUS_TIMEOUT_MS = 90_000` in `apps/packaged/src/sidecars.ts`.
- Updated `baseStatusTimeoutMs` to return the darwin budget for `darwin`.
- Updated the `resolveDaemonStatusTimeoutMs` test suite to assert the new darwin baseline and keep the generic fallback on an unknown platform.

## Test plan

- `apps/packaged/tests/sidecars.test.ts` updated to cover the new darwin behavior.
- Manual logic check passed for `resolveDaemonStatusTimeoutMs` across `darwin`, `linux`, `win32`, `freebsd`, and `OD_LEGACY_DATA_DIR`.
- Full `pnpm --filter @open-design/packaged test` was not run in this environment because the workspace is a sparse checkout without installed `node_modules`.

Fixes #6637.

Generated with [Devin](https://devin.ai)

Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>