### PR TITLE
fix(web): keep succeeded runs done after recovered tool errors

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -891,6 +891,7 @@ function AssistantMessageImpl({
             hasConclusion={hasConclusion}
             runStreaming={streaming}
             runSucceeded={runSucceeded}
+            terminalRunSucceeded={message.runStatus === "succeeded"}
             runFailed={
               !streaming &&
               (message.runStatus === "failed" ||
@@ -3633,6 +3634,7 @@ function TaskActivityCard({
   hasConclusion,
   runStreaming,
   runSucceeded,
+  terminalRunSucceeded,
   runFailed,
   startedAt,
   endedAt,
@@ -3646,6 +3648,7 @@ function TaskActivityCard({
   hasConclusion: boolean;
   runStreaming: boolean;
   runSucceeded: boolean;
+  terminalRunSucceeded: boolean;
   runFailed: boolean;
   startedAt: number | undefined;
   endedAt: number | undefined;
@@ -3674,9 +3677,10 @@ function TaskActivityCard({
   const hasError =
     !runStreaming &&
     (runFailed ||
-      settledItems.some(
-        (item) => item.result?.isError || (!item.result && !runSucceeded),
-      ));
+      (!terminalRunSucceeded &&
+        settledItems.some(
+          (item) => item.result?.isError || (!item.result && !runSucceeded),
+        )));
   const stateLabel = running
     ? t("assistant.workingLabel")
     : hasError

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -73,6 +73,88 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.op-status-error')).toBeNull();
   });
 
+  it('keeps legacy messages with a failed tool result marked as Run failed', () => {
+    render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={{
+          ...messageWithEvents([
+            {
+              kind: 'tool_use',
+              id: 'tool-1',
+              name: 'Read',
+              input: { file_path: '/repo/missing.ts' },
+            },
+            {
+              kind: 'tool_result',
+              toolUseId: 'tool-1',
+              content: 'File not found',
+              isError: true,
+            },
+          ]),
+          runStatus: undefined,
+        }}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    const activity = screen.getByTestId('task-activity-toggle');
+    expect(activity.textContent).toContain('Run failed');
+    expect(activity.getAttribute('data-run-state')).toBe('error');
+  });
+
+  it('keeps a succeeded run Done after a tool error is recovered by a retry', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={messageWithEvents([
+          {
+            kind: 'tool_use',
+            id: 'failed-read',
+            name: 'Read',
+            input: { file_path: '/repo/missing.ts' },
+          },
+          {
+            kind: 'tool_result',
+            toolUseId: 'failed-read',
+            content: 'File not found',
+            isError: true,
+          },
+          {
+            kind: 'tool_use',
+            id: 'successful-read',
+            name: 'Read',
+            input: { file_path: '/repo/source.ts' },
+          },
+          {
+            kind: 'tool_result',
+            toolUseId: 'successful-read',
+            content: 'source',
+            isError: false,
+          },
+        ])}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    const activity = screen.getByTestId('task-activity-toggle');
+    expect(activity.textContent).toContain('Done');
+    expect(activity.getAttribute('data-run-state')).toBe('completed');
+
+    fireEvent.click(activity);
+    expect(activity.getAttribute('aria-expanded')).toBe('true');
+    const failedRead = container.querySelector(
+      '[data-tool-category="read"][data-tool-state="error"]',
+    );
+    expect(failedRead).not.toBeNull();
+    expect(failedRead?.getAttribute('title')).toBe('File not found');
+    expect(failedRead?.closest('.op-card')?.textContent).toContain('missing.ts');
+  });
+
   it('shows Done in a grouped completed run when tool results are missing', () => {
     const { container } = render(
       <AssistantMessage
@@ -244,6 +326,41 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('[data-tool-category="run"][data-tool-state="error"]')).not.toBeNull();
     expect(container.querySelector('.op-status-done')).toBeNull();
   });
+
+  it.each(['no_result', 'delivery_failed'] as const)(
+    'keeps a succeeded run with %s delivery failure marked as Run failed',
+    (resultDeliveryState) => {
+      render(
+        <AssistantMessage
+          projectKind="prototype"
+          conversationId="conv-1"
+          message={{
+            ...messageWithEvents([
+              {
+                kind: 'tool_use',
+                id: 'tool-1',
+                name: 'Write',
+                input: { file_path: '/repo/index.html', content: '<main />' },
+              },
+              {
+                kind: 'tool_result',
+                toolUseId: 'tool-1',
+                content: 'ok',
+                isError: false,
+              },
+            ]),
+            resultDeliveryState,
+          }}
+          streaming={false}
+          projectId="project-1"
+        />,
+      );
+
+      const activity = screen.getByTestId('task-activity-toggle');
+      expect(activity.textContent).toContain('Run failed');
+      expect(activity.getAttribute('data-run-state')).toBe('error');
+    },
+  );
 
   it('keeps Running for a streaming tool use that has no tool result', () => {
     const { container } = render(


### PR DESCRIPTION
Fixes #6757

## Why

A terminally successful run could still be summarized as **Run failed** whenever any earlier tool attempt returned `isError: true`. I claimed this issue because the incorrect aggregate status makes a recovered run look unsuccessful even though the retry completed and the run produced a valid result.

The pain is user trust and status accuracy: historical tool failures are useful diagnostic evidence, but they must not override an authoritative terminal `succeeded` status for the whole run.

## What users will see

Runs ending with `runStatus: 'succeeded'` now show **Done** in the collapsed activity disclosure, including when an earlier tool attempt failed and a retry succeeded. Expanding the history still shows the original failed tool call with its error state. Terminal failed/canceled runs, delivery failures, and legacy messages retain their previous behavior.

## Surface area

- [x] UI — collapsed assistant activity status
- [ ] Keyboard / accessibility
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point (`skills/`, `design-systems/`, `design-templates/`, `craft/`)
- [ ] i18n
- [ ] Dependency
- [ ] Default behavior / settings
- [ ] None of the above

## Screenshots

Before (from the issue reproduction):

![A terminally successful run incorrectly summarized as failed](https://odcrew-attachments.powerformer.com/media/attachments/ddf75e08-12f8-4afd-97cb-01bcbc5e038e/codex-clipboard-be47de23-fc60-461d-92d5-1444611f7183.png)

An after screenshot was not captured because reliably recreating that persisted prerelease run locally requires its runtime data. The focused component regression verifies the visible collapsed **Done** label, `data-run-state="completed"`, and the preserved expanded historical error.

## Bug fix verification

- Red spec: `apps/web/tests/components/assistant-message-tool-status.test.tsx`
- Red on unmodified `main`: the new recovered-retry case failed because it expected `Done` but received `Run failed2.0s`; the other 17 cases passed.
- Green after the fix: 21/21 focused cases pass.
- Added semantic guards confirm legacy messages with historical tool errors still fail in aggregate and `no_result` / `delivery_failed` still override terminal success.

## Validation

- `pnpm --filter @open-design/web test tests/components/assistant-message-tool-status.test.tsx` — PASS (21 tests)
- `pnpm --filter @open-design/web typecheck` — PASS
- `pnpm typecheck` — PASS across the workspace (landing-page check reported 0 errors, 0 warnings, 178 hints)
- `git diff --check upstream/main...HEAD` — PASS
- `pnpm guard` — FAILS on inherited `main` guard inputs unrelated to this two-file diff: the packaged-leaf check cannot find its expected CI command block, and the app registry expects the absent `apps/telemetry-worker/package.json`. The web test-layout, web import-isolation, style-policy, package-spec, CI-topology, and other relevant checks pass.
- `pnpm --filter @open-design/web test` — attempted but not completed within a practical local runtime. Before stopping, it exposed two unrelated existing failures in `ComposerPlusMenu.test.tsx` (stylesheet flyout-placement assertion) and `sidecar-proxy.test.ts` (standalone backend readiness); the focused suite remains fully green.

All commands used the repository-pinned `pnpm@10.33.2`. No dependencies, i18n keys, contracts, API shapes, or individual tool-card semantics changed.
