### PR TITLE
fix(web): remove stale Gemini CLI guidance

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -211,6 +211,7 @@ import {
 import { closeAmrActivationWindowBestEffort } from './AmrLoginPill';
 import { smoothScrollToTop } from '../utils/smoothScrollToTop';
 import { summarizeProjectNameFromPrompt } from '../utils/projectName';
+import { isVisibleLocalCliAgent } from '../utils/visibleAgents';
 import { LIBRARY_UI_VISIBLE } from '../features/libraryUi';
 import {
   providerModelsCacheKey,
@@ -2085,7 +2086,12 @@ function OnboardingView({
         (apiProtocol === 'azure' && provider.baseUrl === '' && Boolean(config.baseUrl?.trim()))
       ),
   ) ?? null;
-  const availableCliAgents = agents.filter((agent) => agent.available && agent.id !== 'amr');
+  const availableCliAgents = agents.filter(
+    (agent) =>
+      agent.available &&
+      agent.id !== 'amr' &&
+      isVisibleLocalCliAgent(agent),
+  );
   const visibleAgents = availableCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
   const amrSignedIn = amrStatus?.loggedIn === true;
   const selectedAgent = visibleAgents.find((agent) => agent.id === config.agentId) ?? null;
@@ -2139,7 +2145,12 @@ function OnboardingView({
       : config.agentId === 'amr'
         || Boolean(
           config.agentId
-          && agents.some((agent) => agent.id === config.agentId && agent.available),
+          && agents.some(
+            (agent) =>
+              agent.id === config.agentId &&
+              agent.available &&
+              isVisibleLocalCliAgent(agent),
+          ),
         );
 
   useEffect(() => {
@@ -2155,7 +2166,10 @@ function OnboardingView({
     const scanToken = cliScanTokenRef.current;
     if (cliRefreshPendingTokenRef.current === scanToken) return;
     const currentAvailableAgents = agents.filter(
-      (agent) => agent.available && agent.id !== 'amr',
+      (agent) =>
+        agent.available &&
+        agent.id !== 'amr' &&
+        isVisibleLocalCliAgent(agent),
     );
     if (currentAvailableAgents.length > 0) {
       const selectedCliAgent = selectDefaultCliAgent(currentAvailableAgents);
@@ -2865,7 +2879,10 @@ function OnboardingView({
   async function scanCliAgents(options: { preferExisting?: boolean } = {}) {
     const scanToken = beginCliScan({ clearVisible: !options.preferExisting });
     const currentAvailableAgents = agents.filter(
-      (agent) => agent.available && agent.id !== 'amr',
+      (agent) =>
+        agent.available &&
+        agent.id !== 'amr' &&
+        isVisibleLocalCliAgent(agent),
     );
     if (options.preferExisting && currentAvailableAgents.length > 0) {
       const selectedCliAgent = selectDefaultCliAgent(currentAvailableAgents);
@@ -2888,7 +2905,12 @@ function OnboardingView({
       const nextAgents = await onRefreshAgents();
       if (cliScanTokenRef.current !== scanToken) return;
       cliRefreshPendingTokenRef.current = null;
-      const availableAgents = nextAgents.filter((agent) => agent.available && agent.id !== 'amr');
+      const availableAgents = nextAgents.filter(
+        (agent) =>
+          agent.available &&
+          agent.id !== 'amr' &&
+          isVisibleLocalCliAgent(agent),
+      );
       const selectedCliAgent = selectDefaultCliAgent(availableAgents);
       // Scan-result semantics: zero available CLIs is a `failed` outcome
       // because the user's runtime path is blocked, even though the

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -57,7 +57,10 @@ import {
   type VelaLoginStatus,
 } from '../providers/daemon';
 import { amrProfileBadgeLabel } from '../runtime/amr-guidance';
-import { isVisibleLocalCliAgent } from '../utils/visibleAgents';
+import {
+  isRetiredLocalCliAgentId,
+  isVisibleLocalCliAgent,
+} from '../utils/visibleAgents';
 import { ExportDiagnosticsRow } from './ExportDiagnosticsButton';
 import { Icon } from './Icon';
 import { defaultAgentModelId, effectiveAgentModelChoice } from './agentModelSelection';
@@ -1408,7 +1411,10 @@ export function shouldEnableSettingsSave(
   if (activeSection !== 'execution') return true;
   if (cfg.mode === 'daemon') {
     return Boolean(
-      cfg.agentId && agents.find((a) => a.id === cfg.agentId)?.available,
+      cfg.agentId &&
+      agents.find(
+        (a) => a.id === cfg.agentId && isVisibleLocalCliAgent(a),
+      )?.available,
     );
   }
   return Boolean(cfg.apiKey.trim() && cfg.model.trim() && isBaseUrlValid);
@@ -2083,7 +2089,10 @@ export function SettingsDialog({
 
   const selectedMemoryChatAgent =
     cfg.mode === 'daemon' && cfg.agentId
-      ? agents.find((agent) => agent.id === cfg.agentId) ?? null
+      ? agents.find(
+          (agent) =>
+            agent.id === cfg.agentId && isVisibleLocalCliAgent(agent),
+        ) ?? null
       : null;
   const selectedMemoryChatModel =
     cfg.mode === 'daemon' && cfg.agentId
@@ -2333,7 +2342,9 @@ export function SettingsDialog({
       const nextAgents = Array.isArray(refreshed) ? refreshed : agents;
       setAgentRescanNotice({
         kind: 'success',
-        count: nextAgents.filter((a) => a.available).length,
+        count: nextAgents.filter(
+          (a) => a.available && isVisibleLocalCliAgent(a),
+        ).length,
       });
     } catch {
       setAgentRescanNotice({ kind: 'error' });
@@ -2470,7 +2481,12 @@ export function SettingsDialog({
     if (agentTestState.status === 'running') {
       return;
     }
-    const selected = agents.find((a) => a.id === cfg.agentId && a.available);
+    const selected = agents.find(
+      (a) =>
+        a.id === cfg.agentId &&
+        a.available &&
+        isVisibleLocalCliAgent(a),
+    );
     if (!selected) return;
     const choice = cfg.agentModels?.[selected.id] ?? {};
     const controller = new AbortController();
@@ -3848,6 +3864,10 @@ export function SettingsDialog({
   };
   const activeHeader = sectionHeader[activeSection];
   const visibleAgents = agents.filter(isVisibleLocalCliAgent);
+  const retiredGeminiCliSelected = isRetiredLocalCliAgentId(cfg.agentId);
+  const googleGeminiByokProvider = BYOK_PROVIDER_PRESETS.find(
+    (provider) => provider.id === 'google-ai-studio',
+  );
   const installedAgents = orderAgentsWithOpenDesignFirst(
     visibleAgents.filter((a) => a.available),
   );
@@ -4525,6 +4545,24 @@ export function SettingsDialog({
                 </div>
               ) : (
                 <>
+                  {retiredGeminiCliSelected ? (
+                    <div
+                      className="agent-install-guide"
+                      data-testid="settings-retired-gemini-cli-guidance"
+                    >
+                      <p className="hint">
+                        {t('settings.retiredGeminiCliGuidance')}
+                      </p>
+                      {googleGeminiByokProvider ? (
+                        <Button
+                          variant="ghost"
+                          onClick={() => setByokProvider(googleGeminiByokProvider)}
+                        >
+                          {`${googleGeminiByokProvider.title} · ${t('settings.onboardingByokTitle')}`}
+                        </Button>
+                      ) : null}
+                    </div>
+                  ) : null}
                   <div className="agent-group">
                     <div className="agent-group-head">
                       <h4>
@@ -5208,7 +5246,8 @@ export function SettingsDialog({
                     selected, the guide has done its job and only adds
                     noise.
                   */}
-                  {!agents.find(
+                  {!retiredGeminiCliSelected &&
+                  !visibleAgents.find(
                     (a) => a.id === cfg.agentId && a.available,
                   ) ? (
                     <div className="agent-install-guide">
@@ -5227,7 +5266,10 @@ export function SettingsDialog({
               )}
               {(() => {
                 const selected = agents.find(
-                  (a) => a.id === cfg.agentId && a.available,
+                  (a) =>
+                    a.id === cfg.agentId &&
+                    a.available &&
+                    isVisibleLocalCliAgent(a),
                 );
                 if (!selected) return null;
                 const hasModels =

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -433,6 +433,7 @@ export const ar: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'موفرو API',
+  'settings.retiredGeminiCliGuidance': 'لم يعد Gemini CLI وقت تشغيل Local CLI مدعومًا. استخدم Google Gemini ضمن موفري API باستخدام مفتاح API الخاص بك بدلًا من ذلك.',
   'settings.byokNoFileToolsNotice': 'لا يمكن لـ BYOK قراءة ملفات المشروع أو الكتابة فيها أو تعديلها. استخدم Local CLI عندما تحتاج إلى تغييرات في الكود.',
   'settings.byokDraftNotice': 'أكمل الحقول المطلوبة لحفظ هذا الموفر. سيظل إعدادك الحالي نشطًا.',
   'settings.codeAgent': 'وكيل الكود',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -433,6 +433,7 @@ export const de: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'API-Anbieter',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI wird nicht mehr als lokale CLI-Laufzeit unterstützt. Verwenden Sie stattdessen Google Gemini unter den API-Anbietern mit Ihrem eigenen API-Schlüssel.',
   'settings.byokNoFileToolsNotice': 'BYOK kann Projektdateien nicht lesen, schreiben oder bearbeiten. Verwenden Sie die Local CLI, wenn Sie Codeänderungen benötigen.',
   'settings.byokDraftNotice': 'Füllen Sie die Pflichtfelder aus, um diesen Anbieter zu speichern. Ihre aktuelle Konfiguration bleibt aktiv.',
   'settings.codeAgent': 'Code-Agent',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -433,6 +433,7 @@ export const en: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'API providers',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI is no longer a supported Local CLI runtime. Use Google Gemini under API providers with your own API key instead.',
   'settings.byokNoFileToolsNotice': 'BYOK can\'t read, write, or edit project files. Use Local CLI when you need code changes.',
   'settings.byokDraftNotice': 'Complete the required fields to save this provider. Your current setup will remain active.',
   'settings.codeAgent': 'Code agent',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -433,6 +433,7 @@ export const esES: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Proveedores de API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI ya no es un entorno de ejecución Local CLI compatible. Usa Google Gemini en Proveedores de API con tu propia clave de API.',
   'settings.byokNoFileToolsNotice': 'BYOK no puede leer, escribir ni editar archivos del proyecto. Usa la CLI local cuando necesites cambios en el código.',
   'settings.byokDraftNotice': 'Completa los campos obligatorios para guardar este proveedor. Tu configuración actual seguirá activa.',
   'settings.codeAgent': 'Agente de código',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -433,6 +433,7 @@ export const fa: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'ارائه‌دهندگان API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI دیگر یک زمان‌اجرای Local CLI پشتیبانی‌شده نیست. به‌جای آن از Google Gemini در ارائه‌دهندگان API با کلید API خود استفاده کنید.',
   'settings.byokNoFileToolsNotice': 'BYOK نمی‌تواند فایل‌های پروژه را بخواند، بنویسد یا ویرایش کند. وقتی به تغییرات کد نیاز دارید از Local CLI استفاده کنید.',
   'settings.byokDraftNotice': 'برای ذخیره این ارائه‌دهنده، فیلدهای الزامی را تکمیل کنید. پیکربندی فعلی فعال می‌ماند.',
   'settings.codeAgent': 'عامل کد',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -433,6 +433,7 @@ export const fr: Dict = {
   'settings.cloudCalloutBody': "Connectez-vous à la version cloud pour activer les espaces d'équipe, les projets partagés, les permissions des membres et le tableau de bord d'audit.",
   'settings.cloudCalloutButton': "Se connecter / S'inscrire",
   'settings.modeApiMeta': 'Fournisseurs d’API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI n’est plus un runtime Local CLI pris en charge. Utilisez plutôt Google Gemini dans les fournisseurs d’API avec votre propre clé API.',
   'settings.byokNoFileToolsNotice': 'BYOK ne peut pas lire, écrire ni modifier les fichiers du projet. Utilisez la CLI locale quand vous avez besoin de changements de code.',
   'settings.byokDraftNotice': 'Remplissez les champs obligatoires pour enregistrer ce fournisseur. Votre configuration actuelle restera active.',
   'settings.codeAgent': 'Agent de code',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -433,6 +433,7 @@ export const hu: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'API-szolgáltatók',
+  'settings.retiredGeminiCliGuidance': 'A Gemini CLI már nem támogatott Local CLI-futtatókörnyezet. Helyette használd a Google Gemini szolgáltatást az API-szolgáltatók között, saját API-kulccsal.',
   'settings.byokNoFileToolsNotice': 'A BYOK nem tud projektfájlokat olvasni, írni vagy szerkeszteni. Ha kódmódosításra van szüksége, használja a Local CLI-t.',
   'settings.byokDraftNotice': 'Töltsd ki a kötelező mezőket a szolgáltató mentéséhez. A jelenlegi beállítás aktív marad.',
   'settings.codeAgent': 'Kód Agent',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -433,6 +433,7 @@ export const id: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Penyedia API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI tidak lagi didukung sebagai runtime Local CLI. Gunakan Google Gemini di penyedia API dengan kunci API Anda sendiri.',
   'settings.byokNoFileToolsNotice': 'BYOK tidak dapat membaca, menulis, atau mengedit file proyek. Gunakan Local CLI saat Anda perlu mengubah kode.',
   'settings.byokDraftNotice': 'Lengkapi bidang wajib untuk menyimpan penyedia ini. Konfigurasi saat ini akan tetap aktif.',
   'settings.codeAgent': 'Agent kode',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -433,6 +433,7 @@ export const it: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Provider API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI non è più un runtime Local CLI supportato. Usa invece Google Gemini tra i provider API con la tua chiave API.',
   'settings.byokNoFileToolsNotice': 'BYOK non può leggere, scrivere o modificare i file del progetto. Usa la Local CLI quando hai bisogno di modifiche al codice.',
   'settings.byokDraftNotice': 'Completa i campi obbligatori per salvare questo provider. La configurazione attuale rimarrà attiva.',
   'settings.codeAgent': 'Agente di codice',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -433,6 +433,7 @@ export const ja: Dict = {
   'settings.cloudCalloutBody': 'クラウド版にサインインすると、チームスペース、共有プロジェクト、メンバー権限、監査ダッシュボードが利用できます。',
   'settings.cloudCalloutButton': 'ログイン / 登録',
   'settings.modeApiMeta': 'API プロバイダー',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI は Local CLI ランタイムとしてサポートされなくなりました。代わりに API プロバイダーの Google Gemini を独自の API キーで使用してください。',
   'settings.byokNoFileToolsNotice': 'BYOK ではプロジェクトファイルの読み取り、書き込み、編集はできません。コードを変更する場合は Local CLI を使用してください。',
   'settings.byokDraftNotice': '必須項目を入力すると、このプロバイダーを保存できます。現在の設定は引き続き有効です。',
   'settings.codeAgent': 'コードエージェント',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -433,6 +433,7 @@ export const ko: Dict = {
   'settings.cloudCalloutBody': '클라우드 버전에 로그인하면 팀 스페이스, 공유 프로젝트, 멤버 권한, 감사 대시보드를 사용할 수 있습니다.',
   'settings.cloudCalloutButton': '로그인 / 가입',
   'settings.modeApiMeta': 'API 제공업체',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI는 더 이상 지원되는 Local CLI 런타임이 아닙니다. 대신 API 제공업체의 Google Gemini를 개인 API 키로 사용하세요.',
   'settings.byokNoFileToolsNotice': 'BYOK는 프로젝트 파일을 읽거나 쓰거나 편집할 수 없습니다. 코드 변경이 필요한 경우 Local CLI를 사용하세요.',
   'settings.byokDraftNotice': '필수 항목을 입력하면 이 제공업체를 저장할 수 있습니다. 현재 설정은 계속 활성 상태로 유지됩니다.',
   'settings.codeAgent': '코드 에이전트',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -433,6 +433,7 @@ export const pl: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Dostawcy API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI nie jest już obsługiwanym środowiskiem Local CLI. Zamiast tego użyj Google Gemini wśród dostawców API z własnym kluczem API.',
   'settings.byokNoFileToolsNotice': 'BYOK nie może odczytywać, zapisywać ani edytować plików projektu. Użyj Local CLI, gdy potrzebujesz zmian w kodzie.',
   'settings.byokDraftNotice': 'Uzupełnij wymagane pola, aby zapisać tego dostawcę. Bieżąca konfiguracja pozostanie aktywna.',
   'settings.codeAgent': 'Agent kodu',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -433,6 +433,7 @@ export const ptBR: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Provedores de API',
+  'settings.retiredGeminiCliGuidance': 'O Gemini CLI não é mais compatível como runtime Local CLI. Em vez disso, use o Google Gemini nos provedores de API com sua própria chave de API.',
   'settings.byokNoFileToolsNotice': 'O BYOK não consegue ler, gravar ou editar arquivos do projeto. Use o Local CLI quando precisar fazer alterações no código.',
   'settings.byokDraftNotice': 'Preencha os campos obrigatórios para salvar este provedor. Sua configuração atual continuará ativa.',
   'settings.codeAgent': 'Agente de código',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -433,6 +433,7 @@ export const ru: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'API-провайдеры',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI больше не поддерживается как среда Local CLI. Вместо него используйте Google Gemini в разделе поставщиков API со своим ключом API.',
   'settings.byokNoFileToolsNotice': 'BYOK не может читать, записывать или редактировать файлы проекта. Используйте Local CLI, когда нужны изменения в коде.',
   'settings.byokDraftNotice': 'Заполните обязательные поля, чтобы сохранить этого провайдера. Текущая конфигурация останется активной.',
   'settings.codeAgent': 'Код-агент',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -433,6 +433,7 @@ export const th: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'ผู้ให้บริการ API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI ไม่ได้รับการรองรับเป็นรันไทม์ Local CLI อีกต่อไป โปรดใช้ Google Gemini ในผู้ให้บริการ API ด้วยคีย์ API ของคุณแทน',
   'settings.byokNoFileToolsNotice': 'BYOK ไม่สามารถอ่าน เขียน หรือแก้ไขไฟล์โปรเจกต์ได้ ใช้ Local CLI เมื่อคุณต้องการเปลี่ยนแปลงโค้ด',
   'settings.byokDraftNotice': 'กรอกช่องที่จำเป็นเพื่อบันทึกผู้ให้บริการนี้ การตั้งค่าปัจจุบันจะยังคงใช้งานอยู่',
   'settings.codeAgent': 'เอเจนต์โค้ด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -433,6 +433,7 @@ export const tr: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'API sağlayıcıları',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI artık desteklenen bir Local CLI çalışma zamanı değildir. Bunun yerine API sağlayıcıları altındaki Google Gemini’ı kendi API anahtarınızla kullanın.',
   'settings.byokNoFileToolsNotice': 'BYOK proje dosyalarını okuyamaz, yazamaz veya düzenleyemez. Kod değişiklikleri gerektiğinde Local CLI kullanın.',
   'settings.byokDraftNotice': 'Bu sağlayıcıyı kaydetmek için gerekli alanları doldurun. Mevcut yapılandırmanız etkin kalır.',
   'settings.codeAgent': 'Kod ajanı',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -433,6 +433,7 @@ export const uk: Dict = {
   'settings.cloudCalloutBody': 'Sign in to the cloud version to enable team spaces, shared projects, member permissions, and the audit dashboard.',
   'settings.cloudCalloutButton': 'Sign in / Register',
   'settings.modeApiMeta': 'Постачальники API',
+  'settings.retiredGeminiCliGuidance': 'Gemini CLI більше не підтримується як середовище Local CLI. Натомість використовуйте Google Gemini у розділі постачальників API зі своїм ключем API.',
   'settings.byokNoFileToolsNotice': 'BYOK не може читати, записувати чи редагувати файли проєкту. Використовуйте Local CLI, коли потрібні зміни в коді.',
   'settings.byokDraftNotice': 'Заповніть обов’язкові поля, щоб зберегти цього постачальника. Поточна конфігурація залишатиметься активною.',
   'settings.codeAgent': 'Кодовий агент',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -423,6 +423,7 @@ export const zhCN: Dict = {
   "settings.cloudCalloutBody": "登录云端版本后可启用团队空间、共享项目、成员权限和审计大盘。",
   "settings.cloudCalloutButton": "登录 / 注册",
   "settings.modeApiMeta": "API 提供商",
+  "settings.retiredGeminiCliGuidance": "Gemini CLI 已不再是受支持的 Local CLI 运行时。请改用 API 提供商中的 Google Gemini，并使用你自己的 API 密钥。",
   "settings.byokNoFileToolsNotice":
     "BYOK 无法读写或修改项目文件；需要改代码时请使用本机 CLI。",
   "settings.byokDraftNotice":

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -423,6 +423,7 @@ export const zhTW: Dict = {
   "settings.cloudCalloutBody": "登入雲端版本後可啟用團隊空間、共享專案、成員權限和稽核儀表板。",
   "settings.cloudCalloutButton": "登入 / 註冊",
   "settings.modeApiMeta": "API 供應商",
+  "settings.retiredGeminiCliGuidance": "Gemini CLI 已不再是受支援的 Local CLI 執行階段。請改用 API 提供商中的 Google Gemini，並使用你自己的 API 金鑰。",
   "settings.byokNoFileToolsNotice":
     "BYOK 無法讀取、寫入或編輯專案檔案。需要變更程式碼時，請使用 Local CLI。",
   "settings.byokDraftNotice":

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -384,6 +384,7 @@ export interface Dict {
   'settings.cloudCalloutBody': string;
   'settings.cloudCalloutButton': string;
   'settings.modeApiMeta': string;
+  'settings.retiredGeminiCliGuidance': string;
   'settings.byokNoFileToolsNotice': string;
   'settings.byokDraftNotice': string;
   'settings.codeAgent': string;

--- a/apps/web/src/utils/visibleAgents.ts
+++ b/apps/web/src/utils/visibleAgents.ts
@@ -1,6 +1,16 @@
 import type { AgentInfo } from '../types';
 
-const HIDDEN_LOCAL_CLI_AGENT_IDS = new Set(['byok-opencode']);
+const RETIRED_LOCAL_CLI_AGENT_IDS = new Set(['gemini']);
+const HIDDEN_LOCAL_CLI_AGENT_IDS = new Set([
+  'byok-opencode',
+  ...RETIRED_LOCAL_CLI_AGENT_IDS,
+]);
+
+export function isRetiredLocalCliAgentId(
+  agentId: string | null | undefined,
+): boolean {
+  return typeof agentId === 'string' && RETIRED_LOCAL_CLI_AGENT_IDS.has(agentId);
+}
 
 export function isVisibleLocalCliAgent(agent: Pick<AgentInfo, 'id'>): boolean {
   return !HIDDEN_LOCAL_CLI_AGENT_IDS.has(agent.id);

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -961,6 +961,36 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(localPanel?.textContent).not.toContain('AMR');
   });
 
+  it('excludes retired Gemini CLI payloads from the Local CLI agent list', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        loggedIn: true,
+        profile: 'prod',
+        user: { id: 'u', email: 'user@example.com' },
+        configPath: '/x',
+      }),
+    ) as typeof fetch;
+    const claude = cliAgent();
+    const retiredGemini = cliAgent({
+      id: 'gemini',
+      name: 'Gemini CLI',
+      bin: 'gemini',
+      models: [{ id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }],
+    });
+    const props = renderOnboarding({
+      config: baseConfig({ agentId: 'gemini' }),
+      agents: [amrAgent(), retiredGemini, claude],
+      onRefreshAgents: vi.fn(() => [amrAgent(), retiredGemini, claude]),
+    });
+
+    await openLocalRuntimeSetup();
+
+    const localPanel = screen.getByText('Local CLI').closest('.onboarding-view__setup-panel');
+    expect(localPanel?.textContent).toContain('Claude Code');
+    expect(localPanel?.textContent).not.toContain('Gemini CLI');
+    expect(props.onAgentChange).not.toHaveBeenCalledWith('gemini');
+  });
+
   it('tests the selected Local CLI agent from onboarding', async () => {
     const fetchMock = vi.fn(async (input, init) => {
       const url = String(input);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2792,6 +2792,69 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     );
   });
 
+  it('redirects legacy Gemini CLI settings to Google Gemini BYOK without install guidance', () => {
+    const retiredGemini: AgentInfo = {
+      id: 'gemini',
+      name: 'Gemini CLI',
+      bin: 'gemini',
+      available: false,
+      version: null,
+      models: [],
+      installUrl: 'https://github.com/google-gemini/gemini-cli',
+      docsUrl: 'https://github.com/google-gemini/gemini-cli/blob/main/README.md',
+      diagnostics: [
+        {
+          reason: 'not-on-path',
+          severity: 'error',
+          message: 'Gemini (`gemini`) was not found on your PATH.',
+          fixActions: [{ kind: 'openInstall' }, { kind: 'rescan' }],
+        },
+      ],
+    };
+    const unavailableKimi: AgentInfo = {
+      id: 'kimi',
+      name: 'Kimi CLI',
+      bin: 'kimi',
+      available: false,
+      version: null,
+      models: [],
+      installUrl: 'https://github.com/MoonshotAI/kimi-cli',
+    };
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'gemini' },
+      { agents: [retiredGemini, unavailableKimi] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI/i }));
+
+    expect(screen.queryByRole('group', { name: /Gemini CLI/i })).toBeNull();
+    expect(
+      screen.queryByText('Gemini (`gemini`) was not found on your PATH.'),
+    ).toBeNull();
+    expect(screen.getByText('Available CLIs (1)')).toBeTruthy();
+    const kimiGroup = screen.getByRole('group', { name: /Kimi CLI/i });
+    expect(
+      within(kimiGroup).getByRole('link', {
+        name: en['settings.agentInstall.install'],
+      }),
+    ).toBeTruthy();
+
+    expect(
+      screen.getByText(/Gemini CLI is no longer a supported Local CLI runtime/i),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole('button', { name: /Google Gemini.*Bring Your Own Key/i }),
+    );
+
+    expect(
+      screen.getByRole('tab', { name: /API providers/i }).getAttribute('aria-selected'),
+    ).toBe('true');
+    expect(
+      screen.getByRole('tab', { name: 'Google Gemini' }).getAttribute('aria-selected'),
+    ).toBe('true');
+  });
+
   it('filters long Local CLI model lists in Settings without hiding the current selection', () => {
     renderSettingsDialog(
       { mode: 'daemon', agentId: 'codex', agentModels: { codex: { model: 'gpt-4.1-mini' } } },


### PR DESCRIPTION
Fixes #6681

## Why

I picked this up after the Windows report exposed a mismatch between the current runtime registry and the desktop guidance. The standalone Gemini CLI runtime was intentionally retired in #5023, but stale/cached agent payloads and a persisted legacy `agentId: "gemini"` could still flow through the web Settings and onboarding UI. That made Open Design tell users to install Gemini CLI or fix their PATH even though current versions cannot register that runtime.

This patch corrects the misleading product messaging. It does **not** restore the retired Gemini CLI runtime, add Gemini executable detection, or change Windows PATH handling. It also leaves Antigravity and Gemini-shaped compatibility parsing untouched. I reviewed the unavailable-agent UI work in draft PR #4733 and kept this change independent of its broader component extraction.

## What users will see

- Gemini CLI is no longer shown or selected as an available Local CLI, even if a stale agent payload still contains the retired `gemini` ID.
- A legacy Settings configuration that still selects `gemini` no longer shows Gemini install links, diagnostics, or generic PATH-repair steps.
- Instead, Settings explains that Gemini CLI is no longer a supported Local CLI runtime and offers a direct action to the supported **Google Gemini** provider under **API providers / Bring Your Own Key**.
- Other unavailable Local CLI agents continue to show their normal documentation and installation actions.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before — the reporter's Settings → Local CLI entry point:

![Settings showing the Local CLI detection area before the fix](https://github.com/user-attachments/assets/8d5c6237-96b7-4ddb-b6df-5d9c1d1d15b2)

An after screenshot was not captured because the current daemon already removes the retired `gemini` ID, so the legacy state cannot be reproduced reliably through a normal local runtime. The focused component regression test injects the stale payload/configuration directly and verifies both the removed guidance and the Google Gemini BYOK action.

## Bug fix verification

- Regression tests: `apps/web/tests/components/SettingsDialog.execution.test.tsx` and `apps/web/tests/components/EntryShell.onboarding.test.tsx`.
- Red on unmodified `main`: **yes**. The focused run failed both new tests: Settings rendered the stale Gemini install/diagnostic card, and onboarding rendered/selectable-labelled Gemini CLI (`2 failed, 180 passed`).
- Green on this branch: **yes**. The final focused run, including locale parity, passed all `199` tests across `3` files.
- Coverage verifies that a legacy `gemini` configuration does not emit install/PATH guidance, Google Gemini BYOK is selected by the replacement action, stale Gemini payloads are excluded from onboarding, and another unavailable Local CLI (Kimi) retains its installation link.

## Validation

- ✅ `pnpm --filter @open-design/web test tests/components/SettingsDialog.execution.test.tsx tests/components/EntryShell.onboarding.test.tsx tests/i18n/locales.test.ts` — 3 files passed, 199 tests passed.
- ✅ `pnpm --filter @open-design/web typecheck` — passed.
- ✅ `pnpm i18n:check` — passed.
- ✅ `pnpm typecheck` — passed across the workspace.
- ✅ `git diff --check` — passed.
- ⚠️ `pnpm guard` — exited 1 on current `main` checkout because the guard expects missing `apps/telemetry-worker/package.json` and reports an already-mismatched guarded command block in `ci.yml`; web import, style policy, test layout, i18n, and other relevant checks passed. No guard-owned files are changed here.
- ⚠️ `pnpm --filter @open-design/web test` — 607 files / 6,359 tests passed; 7 unrelated tests failed. One failure is a Windows-native sidecar socket `EACCES`; the remaining failures are existing CSS source-string checks affected by CRLF line endings (`ComposerPlusMenu` and five style tests). The two affected component suites and locale suite pass in isolation as recorded above.

