### PR TITLE
stop the Launch Week hero sliding under the header

### DIFF
--- a/apps/landing-page/app/_partials/launch-week.css
+++ b/apps/landing-page/app/_partials/launch-week.css
@@ -1118,6 +1118,10 @@ html:has(main.lw) {
 
 /* ---------- narrow screens ---------- */
 @media (max-width: 900px) {
+  /* A fixed-height hero clips whatever doesn't fit. On a phone the content is
+     the thing that must win, so let the section grow past one screen instead. */
+  .lw .hero { height: auto; min-height: calc(100svh - var(--lw-header, 85px)); }
+
   /* Five day-labels cannot share one row on a phone; they stack and the tape
      marks today the same way it does on desktop. */
   .lw .killticker {


### PR DESCRIPTION
## Why

Reported in the release channel with a screenshot: on a phone the Launch Week
wordmark is cut in half by the fixed site header.

It reproduces on short viewports only — 360x640 and 375x667 fail, 390x844 is
fine. That is exactly why my earlier mobile sweep missed it: it ran at 390 and
checked for horizontal overflow and missing elements, neither of which this is.

`.hero-main` centres its column, and a centred flex container overflows in
**both** directions. Once the hero content is taller than its box, half the
excess goes upward — and upward is where the header sits.

## What users will see

The wordmark, slogan and question are fully visible on small phones instead of
starting underneath the header. No change at 390px and above.

## Surface area

- [x] **UI** — Launch Week hero on small viewports
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

### The fix

`justify-content: safe center` keeps the centring while there is room and falls
back to start-alignment the moment there isn't. A plain `center` sits above it
for engines that don't parse the keyword, so they keep today's behaviour rather
than losing the declaration entirely.

On phones the hero's fixed `height` also becomes `min-height`: content that
doesn't fit should grow the section, not be clipped by it. A one-screen rhythm
is worth having until it costs you the headline.

## Screenshots

360x640, Chinese page — before: "LAUNCH WEEK" sheared through the middle by the
header, with only the lower half of the letterforms visible. After: the eyebrow,
wordmark, Vol.01 lockup, slogan, kill question and CTA all render in full.

## Bug fix verification

No red spec — this is a layout regression visible only in a rendered browser at
specific viewport sizes, and asserting it in the test suite would mean running a
browser there, which this package's tests don't do. Verified in the browser
instead, with the check the earlier sweep was missing:

```
assert h1.getBoundingClientRect().top >= header.getBoundingClientRect().bottom
```

Confirmed failing on `main` at 360x640 and 375x667 before the change.

## Validation

- `pnpm --filter @open-design/landing-page test` — 134/134 pass.
- Browser, 11 locales x 320x568 / 360x640 / 375x667 / 390x844 / 768x1024 /
  1440x900 = 66 cases: wordmark clears the header in every one, no horizontal
  overflow, no page errors.
