### PR TITLE
Fix workspace-scoped MCP resources/list and resources/read (#6770)

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -952,6 +952,138 @@ export function createLocalMcpBriefStore() {
   return createBriefStore();
 }
 
+/** Handler body for MCP `resources/list`. Exported so tests can call it
+ * directly without a real server. Mirrors the inline logic in
+ * `runMcpStdio` to keep the test harness cheap. */
+export async function _listMcpResources(
+  daemonTarget: ReturnType<typeof createMcpDaemonTarget>,
+): Promise<{ resources: Array<{ uri: string; name: string; description: string; mimeType: string }> }> {
+  const catalog = await daemonTarget.call(
+    'list_resources',
+    {},
+    async (baseUrl) => {
+      // Resource listings (`/api/skills`, `/api/design-systems`) are scoped
+      // the same way project/run tools are (#6569): a headerless caller reads
+      // the NO-SCOPE catalog, so claimed Personal design systems are filtered
+      // out. Resolve the signed-in workspace once and forward the headers on
+      // both listing calls so the MCP resource catalog matches what the user
+      // sees in the app. See #6770.
+      const workspaceContext = await resolveMcpWorkspaceContext(baseUrl);
+      const headers = workspaceContext?.headers;
+      const [skillsData, dsData] = await Promise.all([
+        getJson<SkillsPayload>(`${baseUrl}/api/skills`, headers).catch((): SkillsPayload => ({ skills: [] })),
+        getJson<DesignSystemsPayload>(`${baseUrl}/api/design-systems`, headers).catch((): DesignSystemsPayload => ({ designSystems: [] })),
+      ]);
+      return ok({ skillsData, dsData });
+    },
+  );
+  const catalogPayload = parseMcpResult(catalog);
+  const skillsData = (catalogPayload?.skillsData ?? {}) as SkillsPayload;
+  const dsData = (catalogPayload?.dsData ?? {}) as DesignSystemsPayload;
+  const resources = [
+    ...localMcpResourceDefinitions(),
+    {
+      uri: 'od://focus/active',
+      name: 'Active Open Design context',
+      description: 'The project/file the user has open in Open Design right now.',
+      mimeType: 'application/json',
+    },
+  ];
+  for (const s of skillsData?.skills || []) {
+    resources.push({
+      uri: `od://skills/${encodeURIComponent(s.id)}/SKILL.md`,
+      name: `Skill: ${s.name || s.id}`,
+      description: oneLine(s.description) ?? '',
+      mimeType: 'text/markdown',
+    });
+  }
+  for (const d of dsData?.designSystems || []) {
+    resources.push({
+      uri: `od://design-systems/${encodeURIComponent(d.id)}/DESIGN.md`,
+      name: `Design system: ${d.title || d.name || d.id}`,
+      description: oneLine(d.summary) ?? '',
+      mimeType: 'text/markdown',
+    });
+  }
+  return { resources };
+}
+
+/** Handler body for MCP `resources/read`. Exported so tests can call it
+ * directly without a real server. Mirrors the inline logic in
+ * `runMcpStdio` to keep the test harness cheap. */
+export async function _readMcpResource(
+  daemonTarget: ReturnType<typeof createMcpDaemonTarget>,
+  uri: string,
+): Promise<{ contents: Array<{ uri: string; mimeType: string; text: string; _meta?: Record<string, unknown> }> }> {
+  if (uri === OPEN_DESIGN_BRIEF_APP_RESOURCE) {
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'text/html;profile=mcp-app',
+          text: OPEN_DESIGN_BRIEF_APP_HTML,
+          _meta: { version: OPEN_DESIGN_BRIEF_APP_VERSION },
+        },
+      ],
+    };
+  }
+  if (uri === 'od://focus/active') {
+    const result = await daemonTarget.call('read_resource', {}, async (baseUrl) =>
+      ok(await getJson<ActiveContext>(`${baseUrl}/api/active`)),
+    );
+    if (result.isError === true) throw new Error(result.content[0]?.text);
+    const data = parseMcpResult(result);
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(data, null, 2),
+        },
+      ],
+    };
+  }
+  const m = String(uri || '').match(/^od:\/\/(skills|design-systems)\/([^/]+)\/(.+)$/);
+  if (!m) {
+    throw new Error(`unsupported resource URI: ${uri}`);
+  }
+  const [, kind, id] = m as [string, 'skills' | 'design-systems', string, string];
+  const route = kind === 'skills' ? 'skills' : 'design-systems';
+  // Reading a `od://design-systems/<id>/DESIGN.md` resource resolves the
+  // bound Personal design system. The daemon treats a headerless read as a
+  // NO-SCOPE caller, so the design-system route returns 404 for a Personal
+  // system that the workspace actually owns. Forward the same workspace
+  // headers as the project/run tools (#6569) so the resource read lands on
+  // the binding instead of returning `404 design system not found`. See #6770.
+  const result = await daemonTarget.call('read_resource', {}, async (baseUrl) => {
+    const workspaceContext = await resolveMcpWorkspaceContext(baseUrl);
+    const headers = workspaceContext?.headers;
+    return ok(await getJson<ResourcePayload>(
+      `${baseUrl}/api/${route}/${encodeURIComponent(decodeURIComponent(id))}`,
+      headers,
+    ));
+  });
+  if (result.isError === true) throw new Error(result.content[0]?.text);
+  const data = parseMcpResult(result) as ResourcePayload | null;
+  const text =
+    data?.skill?.body ??
+    data?.skill?.content ??
+    data?.designSystem?.body ??
+    data?.designSystem?.content ??
+    data?.body ??
+    data?.content ??
+    '';
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'text/markdown',
+        text,
+      },
+    ],
+  };
+}
+
 interface McpObservedCall {
   attribution: McpPluginAttribution | null;
   attemptNumber: number;
@@ -1778,110 +1910,12 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
   })));
 
   server.setRequestHandler(ListResourcesRequestSchema, withMcpActivity(async () => {
-    const catalog = await daemonTarget.call(
-      'list_resources',
-      {},
-      async (baseUrl) => {
-        const [skillsData, dsData] = await Promise.all([
-          getJson<SkillsPayload>(`${baseUrl}/api/skills`).catch((): SkillsPayload => ({ skills: [] })),
-          getJson<DesignSystemsPayload>(`${baseUrl}/api/design-systems`).catch((): DesignSystemsPayload => ({ designSystems: [] })),
-        ]);
-        return ok({ skillsData, dsData });
-      },
-    );
-    const catalogPayload = parseMcpResult(catalog);
-    const skillsData = (catalogPayload?.skillsData ?? {}) as SkillsPayload;
-    const dsData = (catalogPayload?.dsData ?? {}) as DesignSystemsPayload;
-    const resources = [
-      ...localMcpResourceDefinitions(),
-      {
-        uri: 'od://focus/active',
-        name: 'Active Open Design context',
-        description: 'The project/file the user has open in Open Design right now.',
-        mimeType: 'application/json',
-      },
-    ];
-    for (const s of skillsData?.skills || []) {
-      resources.push({
-        uri: `od://skills/${encodeURIComponent(s.id)}/SKILL.md`,
-        name: `Skill: ${s.name || s.id}`,
-        description: oneLine(s.description) ?? '',
-        mimeType: 'text/markdown',
-      });
-    }
-    for (const d of dsData?.designSystems || []) {
-      resources.push({
-        uri: `od://design-systems/${encodeURIComponent(d.id)}/DESIGN.md`,
-        name: `Design system: ${d.title || d.name || d.id}`,
-        description: oneLine(d.summary) ?? '',
-        mimeType: 'text/markdown',
-      });
-    }
-    return { resources };
+    return await _listMcpResources(daemonTarget);
   }));
 
   server.setRequestHandler(ReadResourceRequestSchema, withMcpActivity(async (req) => {
-    const uri = req.params?.uri;
-    if (uri === OPEN_DESIGN_BRIEF_APP_RESOURCE) {
-      return {
-        contents: [
-          {
-            uri,
-            mimeType: 'text/html;profile=mcp-app',
-            text: OPEN_DESIGN_BRIEF_APP_HTML,
-            _meta: {
-              version: OPEN_DESIGN_BRIEF_APP_VERSION,
-            },
-          },
-        ],
-      };
-    }
-    if (uri === 'od://focus/active') {
-      const result = await daemonTarget.call('read_resource', {}, async (baseUrl) =>
-        ok(await getJson<ActiveContext>(`${baseUrl}/api/active`)),
-      );
-      if (result.isError === true) throw new Error(result.content[0]?.text);
-      const data = parseMcpResult(result);
-      return {
-        contents: [
-          {
-            uri,
-            mimeType: 'application/json',
-            text: JSON.stringify(data, null, 2),
-          },
-        ],
-      };
-    }
-    const m = String(uri || '').match(/^od:\/\/(skills|design-systems)\/([^/]+)\/(.+)$/);
-    if (!m) {
-      throw new Error(`unsupported resource URI: ${uri}`);
-    }
-    const [, kind, id] = m as [string, 'skills' | 'design-systems', string, string];
-    const route = kind === 'skills' ? 'skills' : 'design-systems';
-    const result = await daemonTarget.call('read_resource', {}, async (baseUrl) =>
-      ok(await getJson<ResourcePayload>(
-        `${baseUrl}/api/${route}/${encodeURIComponent(decodeURIComponent(id))}`,
-      )),
-    );
-    if (result.isError === true) throw new Error(result.content[0]?.text);
-    const data = parseMcpResult(result) as ResourcePayload | null;
-    const text =
-      data?.skill?.body ??
-      data?.skill?.content ??
-      data?.designSystem?.body ??
-      data?.designSystem?.content ??
-      data?.body ??
-      data?.content ??
-      '';
-    return {
-      contents: [
-        {
-          uri,
-          mimeType: 'text/markdown',
-          text,
-        },
-      ],
-    };
+    const uri = String(req.params?.uri ?? '');
+    return await _readMcpResource(daemonTarget, uri);
   }));
 
   server.setRequestHandler(CallToolRequestSchema, withMcpActivity(async (req) => {

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -66,7 +66,7 @@ import {
 const SERVER_NAME = 'open-design';
 const SERVER_VERSION = '0.2.0';
 const MCP_STDIO_IDLE_EXIT_MS = 30 * 60 * 1000;
-const OPEN_DESIGN_BRIEF_APP_RESOURCE =
+export const OPEN_DESIGN_BRIEF_APP_RESOURCE =
   'ui://open-design/artifact-card-v8.html';
 
 export const MCP_SERVER_INSTRUCTIONS = [

--- a/apps/daemon/tests/mcp-resources-workspace-scope.test.ts
+++ b/apps/daemon/tests/mcp-resources-workspace-scope.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  _listMcpResources,
+  _readMcpResource,
+  createMcpDaemonTarget,
+  OPEN_DESIGN_BRIEF_APP_RESOURCE,
+} from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
+
+const originalFetch = globalThis.fetch;
+const BASE = 'http://127.0.0.1:19001';
+
+const DIRECTORY = {
+  items: [
+    {
+      workspaceId: 'ws-personal',
+      workspaceName: 'Personal',
+      workspaceType: 'personal',
+      workspaceMemberId: 'mem-1',
+      role: 'owner',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+    },
+  ],
+  activeWorkspaceId: null,
+};
+
+function directoryResponse(): Response {
+  return new Response(JSON.stringify(DIRECTORY), { status: 200 });
+}
+
+function target() {
+  return createMcpDaemonTarget({ daemonUrl: BASE });
+}
+
+afterEach(() => {
+  _resetMcpWorkspaceContextCacheForTests();
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+describe('MCP workspace-scoped resource handlers (#6770)', () => {
+  it('list_resources forwards workspace headers on /api/skills and /api/design-systems', async () => {
+    const calls: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.endsWith('/api/skills')) {
+        return new Response(
+          JSON.stringify({ skills: [{ id: 'deck', name: 'Deck', description: 'Build a deck.' }] }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith('/api/design-systems')) {
+        return new Response(
+          JSON.stringify({
+            designSystems: [
+              {
+                id: 'brand-1',
+                title: 'Personal Brand',
+                summary: 'Owned by the personal workspace.',
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _listMcpResources(target());
+
+    // directory bootstrap
+    expect(calls.some((c) => c.url.endsWith('/api/workspace/directory'))).toBe(true);
+    // both listing calls were made
+    const skillCall = calls.find((c) => c.url.endsWith('/api/skills'));
+    const dsCall = calls.find((c) => c.url.endsWith('/api/design-systems'));
+    expect(skillCall).toBeTruthy();
+    expect(dsCall).toBeTruthy();
+    // both carry the workspace headers — this is the regression from #6770:
+    // before the fix they were headerless and the daemon returned the NO-SCOPE
+    // catalog, hiding claimed Personal design systems from the MCP client.
+    expect((skillCall?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((skillCall?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-1');
+    expect((dsCall?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((dsCall?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-1');
+
+    // the personal design system actually shows up
+    const uris = result.resources.map((r) => r.uri);
+    expect(uris).toContain('od://skills/deck/SKILL.md');
+    expect(uris).toContain('od://design-systems/brand-1/DESIGN.md');
+  });
+
+  it('list_resources falls back to headerless behavior when no workspace context resolves', async () => {
+    const calls: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) {
+        // No active membership — non-vela fallback.
+        return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+      }
+      if (url.endsWith('/api/skills')) {
+        return new Response(JSON.stringify({ skills: [] }), { status: 200 });
+      }
+      if (url.endsWith('/api/design-systems')) {
+        return new Response(JSON.stringify({ designSystems: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _listMcpResources(target());
+
+    const skillCall = calls.find((c) => c.url.endsWith('/api/skills'));
+    const dsCall = calls.find((c) => c.url.endsWith('/api/design-systems'));
+    expect(skillCall?.init?.headers).toBeUndefined();
+    expect(dsCall?.init?.headers).toBeUndefined();
+    // Built-in resources still listed.
+    expect(result.resources.some((r) => r.uri === OPEN_DESIGN_BRIEF_APP_RESOURCE)).toBe(true);
+    expect(result.resources.some((r) => r.uri === 'od://focus/active')).toBe(true);
+  });
+
+  it('read_resource forwards workspace headers when reading a Personal design system', async () => {
+    const calls: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.match(/\/api\/design-systems\/[^/]+$/u)) {
+        return new Response(
+          JSON.stringify({
+            designSystem: {
+              id: 'brand-1',
+              body: 'palette: indigo/violet\nfonts: Inter\nvoice: crisp',
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _readMcpResource(target(), 'od://design-systems/brand-1/DESIGN.md');
+
+    const read = calls.find((c) => c.url.endsWith('/api/design-systems/brand-1'));
+    expect(read).toBeTruthy();
+    // Without this header, the daemon returns `404 design system not found`
+    // for a Personal design system the workspace actually owns (#6770).
+    expect((read?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((read?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-1');
+
+    expect(result.contents[0]?.mimeType).toBe('text/markdown');
+    expect(result.contents[0]?.text).toContain('palette: indigo/violet');
+  });
+
+  it('read_resource still serves the brief app resource without touching the daemon', async () => {
+    const fetchMock = vi.fn(async () => new Response('should-not-be-called', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _readMcpResource(target(), OPEN_DESIGN_BRIEF_APP_RESOURCE);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.contents[0]?.mimeType).toBe('text/html;profile=mcp-app');
+  });
+
+  it('read_resource rejects unsupported URIs', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 200 })));
+
+    await expect(
+      _readMcpResource(target(), 'od://unknown/foo/bar'),
+    ).rejects.toThrow(/unsupported resource URI/u);
+  });
+});


### PR DESCRIPTION
## Problem

MCP `resources/list` and `resources/read` call the daemon's `/api/skills` and `/api/design-systems` without forwarding the workspace headers (`x-od-workspace-id`, `x-od-workspace-member-id`). This means:

- An MCP client's resource catalog is filtered to the NO-SCOPE view — any Personal design system that the workspace actually owns is hidden.
- Reading `od://design-systems/<personal-id>/DESIGN.md` returns `404 design system not found`, even though the binding exists under the workspace.

This differs from the project/run tools (introduced in #6569) which already resolve the signed-in workspace and forward headers on every daemon call.

## Fix

1. **`_listMcpResources`** — extract the `ListResourcesRequestSchema` handler body into an exported helper. Inside the `daemonTarget.call` callback, resolve the workspace context once and pass the headers to both `getJson` calls for `/api/skills` and `/api/design-systems`.
2. **`_readMcpResource`** — same pattern for `ReadResourceRequestSchema`. The skill/design-systems branch now resolves the workspace and forwards headers so reads of Personal design systems land on the binding instead of returning 404.
3. The original stdio `server.setRequestHandler` bodies now delegate to the helpers (no behavioral change to the stdio path).

## Tests

Added `apps/daemon/tests/mcp-resources-workspace-scope.test.ts` covering:

- Header forwarding on `resources/list` calls
- Header forwarding on `resources/read` for design-system URIs
- NO-SCOPE fallback when no workspace context resolves
- Brief-app resource fast-path (bypasses daemon)
- Unsupported URI rejection

## Related

Closes #6770
