### PR TITLE
fix(daemon): keep a re-finalized personal design system bound and reachable

### DIFF
--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -76,6 +76,71 @@ export type DesignSystemAssetSyncOutcome =
   | { ok: true; synced: string[] }
   | { ok: false; reason: 'not-found' | 'no-workspace-project' };
 
+/**
+ * A design system's persisted `workspace_resources` binding is the visibility
+ * authority for a verified Workspace+member scope. The on-disk `metadata.json`
+ * claim is deliberately NOT consulted here: a brand re-finalize can drop the
+ * `workspaceId` claim while the envelope keeps the binding correct (issue
+ * #6763), so the envelope alone must decide for `visibility: 'personal'`
+ * systems. Mirrors `skillVisibleFromBinding` in `skills.ts`.
+ */
+function designSystemBindingAllowsRead(
+  binding: ReturnType<typeof getWorkspaceResourceByResourceId>,
+  workspaceId: string,
+  workspaceMemberId: string,
+): boolean {
+  return Boolean(
+    binding
+    && binding.workspaceId === workspaceId
+    && binding.visibility === 'personal'
+    && binding.resourceState !== 'deleted'
+    && binding.createdByWorkspaceMemberId === workspaceMemberId,
+  );
+}
+
+type DesignSystemUserReadScope = {
+  workspaceId?: string | null;
+  workspaceMemberId?: string | null;
+};
+
+/**
+ * Read options for a `user:` design-system directory read. `null` means the
+ * caller must NOT read the system at all (fail-closed). When the request
+ * carries a verified Workspace+member scope whose binding matches exactly,
+ * read the FS copy UNSCOPED (issue #6763) so an ownerless-but-bound system
+ * stays readable after a re-finalize dropped its metadata claim; otherwise
+ * keep the current metadata-gated read so claimed/hidden states behave as
+ * before. An explicit signed-out/incomplete scope hides envelope-bound
+ * systems, mirroring the catalog lane (spec 04 §10).
+ */
+function designSystemUserReadOptions(
+  db: Database.Database | undefined,
+  id: string,
+  scope: DesignSystemUserReadScope,
+): Pick<DesignSystemListOptions, 'idPrefix' | 'workspaceId'> | null {
+  const workspaceId = scope.workspaceId?.trim();
+  const workspaceMemberId = scope.workspaceMemberId?.trim();
+  const metadataGated: Pick<DesignSystemListOptions, 'idPrefix' | 'workspaceId'> = {
+    idPrefix: 'user:',
+    ...(scope.workspaceId !== undefined ? { workspaceId: scope.workspaceId } : {}),
+  };
+  if (scope.workspaceId !== undefined && (!workspaceId || !workspaceMemberId)) {
+    // Explicit signed-out/incomplete scope (`null`, `''`, or a memberless
+    // positive workspace): a persisted envelope is positive evidence the
+    // resource is not local-public and must stay hidden.
+    if (db && getWorkspaceResourceByResourceId(db, 'design_system', id)) return null;
+    return metadataGated;
+  }
+  if (!db || !workspaceId || !workspaceMemberId) return metadataGated;
+  const binding = getWorkspaceResourceByResourceId(db, 'design_system', id);
+  if (designSystemBindingAllowsRead(binding, workspaceId, workspaceMemberId)) {
+    // Issue #6763: the binding is authoritative even when a re-finalize
+    // dropped `workspaceId` from metadata.json — read the FS copy unscoped.
+    return { idPrefix: 'user:' };
+  }
+  return metadataGated;
+}
+
 export function createDesignSystemServerServices({
   getDb,
   roots,
@@ -282,13 +347,14 @@ export function createDesignSystemServerServices({
    * validation and request-bound lookups pass the project's exact persisted
    * Workspace, so shell navigation cannot retarget same-id resolution.
    *
-   * Forwarding the key whenever it is DEFINED (not just truthy) matters:
-   * `GET /api/design-systems` always passes `workspaceId`, with `null`
-   * whenever there is no verified vela session — that request DID ask to be
-   * scoped, just with no identity, and must still reach
-   * `designSystemVisibleFromWorkspace`'s filter so a claimed system is hidden
-   * from it (spec 04 §10) instead of silently landing in the unscoped branch a
-   * plain `options.workspaceId ? … : …` truthiness check would take.
+   * The USER directory is listed UNSCOPED and the `workspace_resources`
+   * envelope below is the sole visibility authority for any request that
+   * carries a scope key (issue #6763): a brand re-finalize can drop the
+   * `workspaceId` claim from `metadata.json` while the persisted binding keeps
+   * the system correctly bound, so the metadata alone must never decide. The
+   * signed-out lane hides BOTH envelope-bound systems and metadata-claimed
+   * systems (spec 04 §10) — only genuinely unclaimed resources stay visible
+   * to a headerless caller.
    */
   async function listAllDesignSystems(options: {
     workspaceId?: string | null;
@@ -308,7 +374,6 @@ export function createDesignSystemServerServices({
         source: 'user',
         isEditable: true,
         defaultStatus: 'draft',
-        ...(options.workspaceId !== undefined ? { workspaceId: options.workspaceId } : {}),
       });
     } catch {
       // User directory may not exist yet or be unreadable.
@@ -354,36 +419,35 @@ export function createDesignSystemServerServices({
       if (system.source !== 'user') return true;
       // A fully headerless request is the signed-out/local compatibility
       // lane. It may see resources that have never been claimed by any
-      // Workspace, but a persisted binding is positive evidence that the
-      // resource is not local-public and must stay hidden without authority.
+      // Workspace, but both a persisted binding and a metadata claim are
+      // positive evidence that the resource is not local-public and must stay
+      // hidden without authority (spec 04 §10, issue #6763).
       if (!exactWorkspaceId && !exactMemberId) {
         if (!db) return false;
-        return !getWorkspaceResourceByResourceId(
-          db,
-          'design_system',
-          system.id,
-        );
+        return !system.workspaceId?.trim()
+          && !getWorkspaceResourceByResourceId(
+            db,
+            'design_system',
+            system.id,
+          );
       }
       if (system.teamSynced === true) {
         return Boolean(exactWorkspaceId) && system.workspaceId === exactWorkspaceId;
       }
       if (!db || !exactWorkspaceId || !exactMemberId) return false;
-      const binding = getWorkspaceResourceByResourceId(
-        db,
-        'design_system',
-        system.id,
+      return designSystemBindingAllowsRead(
+        getWorkspaceResourceByResourceId(db, 'design_system', system.id),
+        exactWorkspaceId,
+        exactMemberId,
       );
-      return binding?.workspaceId === exactWorkspaceId
-        && binding.visibility === 'personal'
-        && binding.resourceState !== 'deleted'
-        && binding.createdByWorkspaceMemberId === exactMemberId;
     });
   }
 
   async function readAvailableDesignSystem(
     id: string,
-    options: { workspaceId?: string | null; exactTeam?: boolean } = {},
+    options: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean } = {},
   ) {
+    const db = getDb?.();
     const workspaceId = options.workspaceId?.trim();
     if (workspaceId && typeof id === 'string' && id.startsWith('user:')) {
       const scoped = await designSystems.readDesignSystem(
@@ -395,10 +459,9 @@ export function createDesignSystemServerServices({
       if (options.exactTeam) return null;
     }
     if (typeof id === 'string' && id.startsWith('user:')) {
-      return designSystems.readDesignSystem(paths.USER_DESIGN_SYSTEMS_DIR, id, {
-        idPrefix: 'user:',
-        ...(options.workspaceId !== undefined ? { workspaceId: options.workspaceId } : {}),
-      });
+      const readOptions = designSystemUserReadOptions(db, id, options);
+      if (readOptions === null) return null;
+      return designSystems.readDesignSystem(paths.USER_DESIGN_SYSTEMS_DIR, id, readOptions);
     }
     return (
       (await designSystems.readDesignSystem(paths.DESIGN_SYSTEMS_DIR, id))
@@ -408,8 +471,9 @@ export function createDesignSystemServerServices({
 
   async function readAvailableDesignSystemPackageInfo(
     id: string,
-    options: { workspaceId?: string | null; exactTeam?: boolean } = {},
+    options: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean } = {},
   ) {
+    const db = getDb?.();
     const workspaceId = options.workspaceId?.trim();
     if (workspaceId && typeof id === 'string' && id.startsWith('user:')) {
       const scoped = await designSystems.readDesignSystemPackageInfo(
@@ -421,10 +485,9 @@ export function createDesignSystemServerServices({
       if (options.exactTeam) return null;
     }
     if (typeof id === 'string' && id.startsWith('user:')) {
-      return designSystems.readDesignSystemPackageInfo(paths.USER_DESIGN_SYSTEMS_DIR, id, {
-        idPrefix: 'user:',
-        ...(options.workspaceId !== undefined ? { workspaceId: options.workspaceId } : {}),
-      });
+      const readOptions = designSystemUserReadOptions(db, id, options);
+      if (readOptions === null) return null;
+      return designSystems.readDesignSystemPackageInfo(paths.USER_DESIGN_SYSTEMS_DIR, id, readOptions);
     }
     return (
       (await designSystems.readDesignSystemPackageInfo(paths.DESIGN_SYSTEMS_DIR, id))
@@ -435,8 +498,9 @@ export function createDesignSystemServerServices({
   async function readAvailableDesignSystemStaticFile(
     id: string,
     filePath: string,
-    options: { workspaceId?: string | null; exactTeam?: boolean } = {},
+    options: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean } = {},
   ) {
+    const db = getDb?.();
     const workspaceId = options.workspaceId?.trim();
     if (workspaceId && typeof id === 'string' && id.startsWith('user:')) {
       const scoped = await designSystems.readDesignSystemStaticFile(
@@ -449,10 +513,14 @@ export function createDesignSystemServerServices({
       if (options.exactTeam) return null;
     }
     if (typeof id === 'string' && id.startsWith('user:')) {
-      return designSystems.readDesignSystemStaticFile(paths.USER_DESIGN_SYSTEMS_DIR, id, filePath, {
-        idPrefix: 'user:',
-        ...(options.workspaceId !== undefined ? { workspaceId: options.workspaceId } : {}),
-      });
+      const readOptions = designSystemUserReadOptions(db, id, options);
+      if (readOptions === null) return null;
+      return designSystems.readDesignSystemStaticFile(
+        paths.USER_DESIGN_SYSTEMS_DIR,
+        id,
+        filePath,
+        readOptions,
+      );
     }
     return (
       (await designSystems.readDesignSystemStaticFile(paths.DESIGN_SYSTEMS_DIR, id, filePath))

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -107,16 +107,16 @@ export interface RegisterDesignSystemRoutesDeps extends RouteDeps<'db' | 'paths'
     prepareDesignTokenContractRebuild: (root: string, id: string, options?: { force?: boolean }) => Promise<DesignTokenContractRebuildPreparation>;
     readAvailableDesignSystem: (
       id: string,
-      options?: { workspaceId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
     ) => Promise<string | null>;
     readAvailableDesignSystemPackageInfo: (
       id: string,
-      options?: { workspaceId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
     ) => Promise<DesignSystemPackageInfo | null>;
     readAvailableDesignSystemStaticFile: (
       id: string,
       filePath: string,
-      options?: { workspaceId?: string | null; exactTeam?: boolean },
+      options?: { workspaceId?: string | null; workspaceMemberId?: string | null; exactTeam?: boolean },
     ) => Promise<{
       bytes: Buffer;
       contentType: string;
@@ -702,6 +702,7 @@ export function registerDesignSystemRoutes(
       const projectBody = await readDesignSystemWorkspaceTextFile(db, summary, 'DESIGN.md');
       const body = projectBody ?? await readAvailableDesignSystem(req.params.id, {
         workspaceId,
+        workspaceMemberId,
         exactTeam: storage.exactTeam,
       });
       if (body === null || !summary) {
@@ -709,6 +710,7 @@ export function registerDesignSystemRoutes(
       }
       const packageInfo = await readAvailableDesignSystemPackageInfo(req.params.id, {
         workspaceId,
+        workspaceMemberId,
         exactTeam: storage.exactTeam,
       });
       // recvqb6mfyqXLD: mirror the exact PATCH/DELETE verdict onto the read
@@ -739,9 +741,14 @@ export function registerDesignSystemRoutes(
         headerValue(req, 'x-od-workspace-id')
         ?? designSystemNavigationWorkspaceQuery(req)?.workspaceId
         ?? null;
+      const workspaceMemberId =
+        headerValue(req, 'x-od-workspace-member-id')
+        ?? designSystemNavigationWorkspaceQuery(req)?.workspaceMemberId
+        ?? null;
       const storage = resolveDesignSystemStorage(req, req.params.id, true);
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
+        workspaceMemberId,
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -759,11 +766,15 @@ export function registerDesignSystemRoutes(
         headerValue(req, 'x-od-workspace-id')
         ?? designSystemNavigationWorkspaceQuery(req)?.workspaceId
         ?? null;
+      const workspaceMemberId =
+        headerValue(req, 'x-od-workspace-member-id')
+        ?? designSystemNavigationWorkspaceQuery(req)?.workspaceMemberId
+        ?? null;
       const storage = resolveDesignSystemStorage(req, req.params.id, true);
       const packaged = await readAvailableDesignSystemStaticFile(
         req.params.id,
         PACKAGED_SHOWCASE_PATH,
-        { workspaceId, exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam },
       );
       if (packaged?.contentType.startsWith('text/html')) {
         const workspaceQuery = designSystemNavigationWorkspaceQuery(req);
@@ -780,6 +791,7 @@ export function registerDesignSystemRoutes(
       }
       const body = await readAvailableDesignSystem(req.params.id, {
         workspaceId,
+        workspaceMemberId,
         exactTeam: storage.exactTeam,
       });
       if (body === null) return res.status(404).type('text/plain').send('not found');
@@ -797,12 +809,16 @@ export function registerDesignSystemRoutes(
         headerValue(req, 'x-od-workspace-id')
         ?? designSystemNavigationWorkspaceQuery(req)?.workspaceId
         ?? null;
+      const workspaceMemberId =
+        headerValue(req, 'x-od-workspace-member-id')
+        ?? designSystemNavigationWorkspaceQuery(req)?.workspaceMemberId
+        ?? null;
       const storage = resolveDesignSystemStorage(req, req.params.id, true);
       const requestedPath = typeof req.query.path === 'string' ? req.query.path : '';
       const file = await readAvailableDesignSystemStaticFile(
         req.params.id,
         requestedPath,
-        { workspaceId, exactTeam: storage.exactTeam },
+        { workspaceId, workspaceMemberId, exactTeam: storage.exactTeam },
       );
       if (!file) return res.status(404).type('text/plain').send('not found');
       res.setHeader('Cache-Control', 'no-store');

--- a/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
+++ b/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
@@ -375,12 +375,12 @@ describe('Design System route family exact Workspace authority', () => {
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'system/kit.html',
-      { workspaceId: WORKSPACE_ID, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, exactTeam: false },
     );
     expect(calls.static).toHaveBeenCalledWith(
       DESIGN_SYSTEM_ID,
       'tokens.css',
-      { workspaceId: WORKSPACE_ID, exactTeam: false },
+      { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, exactTeam: false },
     );
     expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(2);
   });

--- a/apps/daemon/tests/design-systems/re-finalize-workspace-claim.test.ts
+++ b/apps/daemon/tests/design-systems/re-finalize-workspace-claim.test.ts
@@ -1,0 +1,411 @@
+// Re-finalization drops the design-system workspaceId claim (issue #6763).
+//
+// A brand re-finalize drives `registerBrandDesignSystem`'s write path, which
+// ends at `updateUserDesignSystem` with an input that carries NO `workspaceId`
+// field. That write spreads the existing metadata and, because the metadata
+// already lost its claim, REWRITES `metadata.json` WITHOUT the `workspaceId` —
+// the "split-brain" state: the `workspace_resources` envelope still binds
+// `user:<id>` to a workspace + exact member, but the on-disk metadata no
+// longer says so.
+//
+// Before the fix the READ side trusted the metadata claim alone. `listAll
+// DesignSystems` forwarded `workspaceId` into the FS listing, every by-id read
+// gated on `metadata.workspaceId`, and the by-id HTTP routes never forwarded
+// `workspaceMemberId` to the wrappers at all — so a correctly-bound system
+// vanished from the workspace catalog AND from catalog/detail/preview/
+// showcase/static reads the moment its metadata lost the claim.
+//
+// This spec pins the read-side rescue (#6763): when the persisted
+// `workspace_resources` binding matches the exact verified scope (workspaceId,
+// visibility='personal', resourceState!='deleted',
+// createdByWorkspaceMemberId), the ENVELOPE — not the metadata claim — is the
+// visibility authority. The write side is intentionally NOT changed:
+// `metadata.json` must stay claim-less after re-finalization (asserted below)
+// and the catalog/by-id reads must keep serving the bound system anyway.
+//
+// The by-id negative rows pin the fail-closed contract on the wrappers AND on
+// the real HTTP detail route (which now forwards the verified
+// `workspaceMemberId` it already resolves for the catalog, so the envelope
+// rescue can fire end-to-end): the rescue must never leak the system to
+// another workspace, to a memberless scope, or to a signed-out/headerless
+// caller, and an ownerless system with no binding stays hidden from every
+// positive scope. A metadata-only claim (workspaceId in metadata, no envelope)
+// stays hidden from signed-out readers (spec 04 §10).
+
+import type http from 'node:http';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { workspaceContextFromDirectoryItem } from '../../src/collab/vela-workspace-context.js';
+import {
+  closeDatabase,
+  ensureWorkspaceResource,
+  getWorkspaceResource,
+  getWorkspaceResourceByResourceId,
+  openDatabase,
+} from '../../src/db.js';
+import * as designSystems from '../../src/design-systems/index.js';
+import { createDesignSystemServerServices } from '../../src/design-systems/server-services.js';
+import { registerDesignSystemRoutes } from '../../src/routes/design-systems.js';
+import * as skills from '../../src/skills.js';
+
+const WORKSPACE_A = 'vp44mftzknedrrqgy05oqpv9';
+const WORKSPACE_B = 'jg63to8cbic0kzbczbu95a4g';
+const MEMBER_A = 'member-a';
+const MEMBER_B = 'member-b';
+
+const SEEDED_BODY = 'A seeded system.';
+
+const roots: string[] = [];
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  closeDatabase();
+  await Promise.all(servers.splice(0).map((server) =>
+    new Promise<void>((resolve) => server.close(() => resolve())),
+  ));
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true }),
+  ));
+});
+
+async function createFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'od-ds-refinalize-'));
+  roots.push(root);
+  const userSkills = path.join(root, 'skills');
+  const userDesignSystems = path.join(root, 'design-systems');
+  const builtInSkills = path.join(root, 'built-in-skills');
+  const builtInDesignSystems = path.join(root, 'built-in-design-systems');
+  await Promise.all([
+    mkdir(userSkills, { recursive: true }),
+    mkdir(userDesignSystems, { recursive: true }),
+    mkdir(builtInSkills, { recursive: true }),
+    mkdir(builtInDesignSystems, { recursive: true }),
+  ]);
+  const db = openDatabase(root, { dataDir: root });
+  const services = createDesignSystemServerServices({
+    getDb: () => db,
+    roots: {
+      SKILL_ROOTS: [userSkills, builtInSkills],
+      DESIGN_TEMPLATE_ROOTS: [],
+      ALL_SKILL_LIKE_ROOTS: [],
+    },
+    paths: {
+      PROJECTS_DIR: path.join(root, 'projects'),
+      DESIGN_SYSTEMS_DIR: builtInDesignSystems,
+      USER_DESIGN_SYSTEMS_DIR: userDesignSystems,
+    },
+    skills: {
+      listSkills: skills.listSkills as never,
+      findSkillById: skills.findSkillById as never,
+    },
+    designSystems: designSystems as never,
+    projects: {} as never,
+  });
+  return { root, userDesignSystems, db, services };
+}
+
+/** Write a design system directly on disk with the given metadata. */
+async function seedSystem(
+  userDesignSystems: string,
+  dirId: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  const dir = path.join(userDesignSystems, dirId);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, 'DESIGN.md'), `# ${dirId}\n\n${SEEDED_BODY}\n`, 'utf8');
+  await writeFile(path.join(dir, 'metadata.json'), `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+}
+
+function bindOwnerlessPersonalSystem(
+  db: ReturnType<typeof openDatabase>,
+  id: string,
+  workspaceId: string,
+  memberId: string,
+): void {
+  ensureWorkspaceResource(db, 'design_system', workspaceId, id, {
+    visibility: 'personal',
+    resourceState: 'active',
+    createdByWorkspaceMemberId: memberId,
+    updatedByWorkspaceMemberId: memberId,
+  });
+}
+
+/** The exact by-id read options the HTTP routes hand to the wrappers. */
+function byIdReadOptions(scope: Record<string, string | null>) {
+  return {
+    workspaceId: scope.workspaceId ?? null,
+    workspaceMemberId: scope.workspaceMemberId ?? null,
+  };
+}
+
+function workspaceHeaders(
+  workspaceId: string | null,
+  workspaceMemberId: string | null,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (workspaceId) headers['x-od-workspace-id'] = workspaceId;
+  if (workspaceMemberId) headers['x-od-workspace-member-id'] = workspaceMemberId;
+  return headers;
+}
+
+async function listen(app: express.Express): Promise<string> {
+  const server = await new Promise<http.Server>((resolve) => {
+    const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+  });
+  servers.push(server);
+  const address = server.address() as { port: number };
+  return `http://127.0.0.1:${address.port}`;
+}
+
+/**
+ * The real HTTP detail route (`GET /api/design-systems/:id`) wired to the real
+ * server-services catalog/read implementations, so the route-level
+ * `workspaceMemberId` forwarding (part of this PR) is proven end-to-end — the
+ * service-only tests above cannot see whether the route ever forwards it.
+ */
+async function createRouteFixture() {
+  const fixture = await createFixture();
+  const craftDir = path.join(fixture.root, 'craft');
+  await mkdir(craftDir, { recursive: true });
+  const app = express();
+  app.use(express.json());
+  registerDesignSystemRoutes(app, {
+    db: fixture.db,
+    paths: { CRAFT_DIR: craftDir, USER_DESIGN_SYSTEMS_DIR: fixture.userDesignSystems } as never,
+    projectFiles: {} as never,
+    projectStore: {} as never,
+    verifyWorkspaceRequestAuthority: async (req: any) => ({
+      ok: true as const,
+      context: workspaceContextFromDirectoryItem({
+        workspaceId: req.get('x-od-workspace-id'),
+        workspaceName: 'Workspace fixture',
+        workspaceType: 'team',
+        workspaceMemberId: req.get('x-od-workspace-member-id'),
+        role: 'owner',
+        memberStatus: 'active',
+        lifecycleState: 'active',
+      }),
+    }),
+    workspaceResources: {
+      getWorkspaceResource: (handle, resourceType, workspaceId, resourceId) =>
+        getWorkspaceResource(handle, resourceType, workspaceId, resourceId),
+      getWorkspaceResourceByResourceId: (handle, resourceType, resourceId) =>
+        getWorkspaceResourceByResourceId(handle, resourceType, resourceId),
+    },
+    designSystems: {
+      buildUserDesignSystemArchive: async () => null,
+      canMutateUserDesignSystem: async () => true,
+      createUserDesignSystem: async () => {
+        throw new Error('unused createUserDesignSystem in route fixture');
+      },
+      deleteUserDesignSystem: async () => false,
+      ensureUserDesignSystemWorkspaceProject: async () => null,
+      // The factory's inferred signatures are looser than the strict route-deps
+      // types; the runtime behavior is exactly what this test exercises.
+      listAllDesignSystems: fixture.services.listAllDesignSystems as never,
+      listUserDesignSystemFiles: async () => null,
+      listUserDesignSystemRevisions: async () => null,
+      prepareDesignTokenContractRebuild: async () => ({ decision: { available: false } }) as never,
+      readAvailableDesignSystem: fixture.services.readAvailableDesignSystem as never,
+      readAvailableDesignSystemPackageInfo: fixture.services.readAvailableDesignSystemPackageInfo as never,
+      readAvailableDesignSystemStaticFile: fixture.services.readAvailableDesignSystemStaticFile as never,
+      readDesignSystemWorkspaceTextFile: fixture.services.readDesignSystemWorkspaceTextFile as never,
+      readUserDesignSystemFile: async () => null,
+      renderDesignSystemPreview: () => '',
+      renderDesignSystemShowcase: () => '',
+      syncUserDesignSystemAssetsFromWorkspace: async () => ({ ok: false, reason: 'not-found' }),
+      unshareTeamDesignSystemIfShared: async () => false,
+      updateUserDesignSystem: async () => null,
+      updateUserDesignSystemRevisionStatus: async () => null,
+    },
+    generationJobs: {
+      get: () => null,
+      rebuildTokenContract: () => ({}) as never,
+      revise: () => ({}) as never,
+      start: () => ({}) as never,
+    },
+  });
+  const baseUrl = await listen(app);
+  return { ...fixture, baseUrl };
+}
+
+describe('re-finalize workspaceId-drop: read-side rescue (issue #6763)', () => {
+  it('lists an ownerless-but-envelope-bound system only for its exact workspace member', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'x', { title: 'Bound but ownerless' });
+    bindOwnerlessPersonalSystem(fixture.db, 'user:x', WORKSPACE_A, MEMBER_A);
+
+    const scoped = await fixture.services.listAllDesignSystems({
+      workspaceId: WORKSPACE_A,
+      workspaceMemberId: MEMBER_A,
+    });
+    expect(scoped.some((system) => system.id === 'user:x')).toBe(true);
+
+    const otherWorkspace = await fixture.services.listAllDesignSystems({
+      workspaceId: WORKSPACE_B,
+      workspaceMemberId: MEMBER_B,
+    });
+    expect(otherWorkspace.some((system) => system.id === 'user:x')).toBe(false);
+
+    const memberless = await fixture.services.listAllDesignSystems({
+      workspaceId: WORKSPACE_A,
+    });
+    expect(memberless.some((system) => system.id === 'user:x')).toBe(false);
+
+    const signedOut = await fixture.services.listAllDesignSystems({
+      workspaceId: null,
+      workspaceMemberId: null,
+    });
+    expect(signedOut.some((system) => system.id === 'user:x')).toBe(false);
+  });
+
+  it('serves an ownerless-but-envelope-bound system by id for its exact workspace member', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'x', { title: 'Bound but ownerless' });
+    bindOwnerlessPersonalSystem(fixture.db, 'user:x', WORKSPACE_A, MEMBER_A);
+
+    // No project is seeded, so the by-id rescue must come from the FS copy,
+    // not from a `ds-*` workspace project serving DESIGN.md.
+    await expect(
+      fixture.services.readAvailableDesignSystem(
+        'user:x',
+        byIdReadOptions({ workspaceId: WORKSPACE_A, workspaceMemberId: MEMBER_A }),
+      ),
+    ).resolves.toContain(SEEDED_BODY);
+  });
+
+  it('keeps the bound system hidden from other-workspace, memberless, and signed-out by-id reads', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'x', { title: 'Bound but ownerless' });
+    bindOwnerlessPersonalSystem(fixture.db, 'user:x', WORKSPACE_A, MEMBER_A);
+
+    await expect(
+      fixture.services.readAvailableDesignSystem(
+        'user:x',
+        byIdReadOptions({ workspaceId: WORKSPACE_B, workspaceMemberId: MEMBER_B }),
+      ),
+    ).resolves.toBeNull();
+
+    await expect(
+      fixture.services.readAvailableDesignSystem(
+        'user:x',
+        byIdReadOptions({ workspaceId: WORKSPACE_A, workspaceMemberId: null }),
+      ),
+    ).resolves.toBeNull();
+
+    await expect(
+      fixture.services.readAvailableDesignSystem(
+        'user:x',
+        byIdReadOptions({ workspaceId: null, workspaceMemberId: null }),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('keeps an ownerless system with NO binding hidden from the scoped catalog and by-id', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'unbound', { title: 'Unbound ownerless' });
+
+    const scoped = await fixture.services.listAllDesignSystems({
+      workspaceId: WORKSPACE_A,
+      workspaceMemberId: MEMBER_A,
+    });
+    expect(scoped.some((system) => system.id === 'user:unbound')).toBe(false);
+
+    await expect(
+      fixture.services.readAvailableDesignSystem(
+        'user:unbound',
+        byIdReadOptions({ workspaceId: WORKSPACE_A, workspaceMemberId: MEMBER_A }),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('keeps a metadata-only claim (no envelope) out of the signed-out catalog (spec 04 §10)', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'metadata-only', {
+      title: 'Claim only',
+      workspaceId: WORKSPACE_A,
+    });
+
+    const signedOut = await fixture.services.listAllDesignSystems({
+      workspaceId: null,
+      workspaceMemberId: null,
+    });
+    expect(signedOut.some((system) => system.id === 'user:metadata-only')).toBe(false);
+  });
+
+  it('models re-finalize: metadata stays claim-less but the bound system stays reachable (idempotent)', async () => {
+    const fixture = await createFixture();
+    await seedSystem(fixture.userDesignSystems, 'x', { title: 'Bound but ownerless' });
+    bindOwnerlessPersonalSystem(fixture.db, 'user:x', WORKSPACE_A, MEMBER_A);
+
+    const assertPostUpdate = async () => {
+      const metadata = JSON.parse(
+        await readFile(path.join(fixture.userDesignSystems, 'x', 'metadata.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(metadata.workspaceId).toBeUndefined();
+
+      const scoped = await fixture.services.listAllDesignSystems({
+        workspaceId: WORKSPACE_A,
+        workspaceMemberId: MEMBER_A,
+      });
+      expect(scoped.some((system) => system.id === 'user:x')).toBe(true);
+
+      await expect(
+        fixture.services.readAvailableDesignSystem(
+          'user:x',
+          byIdReadOptions({ workspaceId: WORKSPACE_A, workspaceMemberId: MEMBER_A }),
+        ),
+      ).resolves.toContain('ClawdIA');
+    };
+
+    const updated = await designSystems.updateUserDesignSystem(
+      fixture.userDesignSystems,
+      'user:x',
+      { title: 'ClawdIA' },
+    );
+    expect(updated?.title).toBe('ClawdIA');
+    await assertPostUpdate();
+
+    await designSystems.updateUserDesignSystem(
+      fixture.userDesignSystems,
+      'user:x',
+      { title: 'ClawdIA' },
+    );
+    await assertPostUpdate();
+  });
+
+  it('serves the bound system over the real HTTP detail route only to its exact member (member forwarding)', async () => {
+    const fixture = await createRouteFixture();
+    await seedSystem(fixture.userDesignSystems, 'x', { title: 'Bound but ownerless' });
+    bindOwnerlessPersonalSystem(fixture.db, 'user:x', WORKSPACE_A, MEMBER_A);
+
+    const exactMember = await fetch(
+      `${fixture.baseUrl}/api/design-systems/${encodeURIComponent('user:x')}`,
+      { headers: workspaceHeaders(WORKSPACE_A, MEMBER_A) },
+    );
+    expect(exactMember.status).toBe(200);
+    const detail = await exactMember.json() as { designSystem?: { body?: string } };
+    expect(detail.designSystem?.body).toContain(SEEDED_BODY);
+
+    const otherWorkspace = await fetch(
+      `${fixture.baseUrl}/api/design-systems/${encodeURIComponent('user:x')}`,
+      { headers: workspaceHeaders(WORKSPACE_B, MEMBER_B) },
+    );
+    expect(otherWorkspace.status).toBe(403);
+
+    const memberless = await fetch(
+      `${fixture.baseUrl}/api/design-systems/${encodeURIComponent('user:x')}`,
+      { headers: workspaceHeaders(WORKSPACE_A, null) },
+    );
+    expect(memberless.status).toBe(400);
+
+    const headerless = await fetch(
+      `${fixture.baseUrl}/api/design-systems/${encodeURIComponent('user:x')}`,
+    );
+    expect(headerless.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Fixes #6763

## Why

A completed brand run re-finalizes the backing brand project, which
re-registers the derived design system. That write path rewrites the
system's metadata.json without re-asserting the workspace claim, so a
personal design system whose metadata claim was ever lost (for example
one created through the headerless extract-from-html path) stays
ownerless while its workspace_resources binding remains correct.

The scoped catalog applied the metadata filter before the database
binding check, so a correctly bound Personal system silently vanished
from the workspace that owns it — even though the binding itself was
valid and active.

## What users will see

A personal design system bound to the current workspace no longer
disappears from "Design systems → Your systems" after the backing brand
is refined and finalized again. Its detail, preview, showcase and static
views are reachable again for the owning member, and the system stays
hidden everywhere it should be: from other workspaces, from requests
without a verified member, and from signed-out catalog reads.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point  (skills/, design-systems/, design-templates/, craft/)
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None   (internal refactor, docs, tests, translation only)

## Screenshots

Not applicable — no UI change.

## Bug fix verification

Regression test: apps/daemon/tests/design-systems/re-finalize-workspace-claim.test.ts

- Went red on main (5 failures): the scoped catalog hid the bound system
  from its owning member, by-id reads returned null, a signed-out by-id
  read leaked the bound system's body, the re-finalize idempotence check
  failed, and the HTTP detail route returned 404.
- Green on this branch: 7/7 pass.

## Validation

- pnpm guard
- pnpm typecheck
- pnpm --filter @open-design/daemon typecheck
- pnpm exec vitest run -c vitest.config.ts tests/design-systems/re-finalize-workspace-claim.test.ts (7 passed)
- Related daemon design-system suites: 9 files / 95 tests passed
- Broader daemon suites touching the changed surface: 10 files / 54 tests passed