### PR TITLE
fix(ci): pin Blacksmith apt mirror before Playwright deps install

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -99,6 +99,28 @@ runs:
         package_dir="${PACKAGE_JSON_PATH%/*}"
         pnpm -C "$package_dir" exec playwright install chromium
 
+    - name: Pin Blacksmith apt mirror to the canonical archive
+      if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' }}
+      shell: bash
+      env:
+        RUNNER_LABELS_JSON: ${{ inputs.runner-labels }}
+      run: |
+        # Blacksmith VMs resolve apt through a mirrorlist of third-party
+        # university mirrors. When one goes down, apt retries it for every
+        # index file before falling back, so the `apt-get update` inside
+        # `playwright install --with-deps` hangs until the job timeout.
+        # Browser OS deps are NOT fully preinstalled on the Blacksmith image
+        # (xvfb, fonts, libasound are missing), so apt must stay in the path;
+        # pin the canonical archive so it stays deterministic instead.
+        case "$RUNNER_LABELS_JSON" in
+          *'"blacksmith-'*) ;;
+          *) exit 0 ;;
+        esac
+        mirrorlist=/etc/apt/blacksmith-ubuntu-mirrors.txt
+        if [ -f "$mirrorlist" ]; then
+          printf 'http://archive.ubuntu.com/ubuntu\tpriority:1\n' | sudo tee "$mirrorlist"
+        fi
+
     - name: Install Playwright browsers
       if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' }}
       shell: bash

--- a/.github/workflows/visual-baseline.yml
+++ b/.github/workflows/visual-baseline.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: '["blacksmith-8vcpu-ubuntu-2404"]'
 
       - name: Prebuild workspace type declarations
         run: |

--- a/e2e/tests/actions-cache-workflows.test.ts
+++ b/e2e/tests/actions-cache-workflows.test.ts
@@ -28,6 +28,24 @@ describe("GitHub Actions cache workflows", () => {
     expect(action).toContain("run: ${{ inputs.install-command }}");
   });
 
+  it("[P1] pins the Blacksmith apt mirrorlist before installing browser deps", async () => {
+    const action = await readFile(setupPlaywrightAction, "utf8");
+
+    // A dead third-party mirror in the Blacksmith mirrorlist makes the
+    // apt-get update inside `playwright install --with-deps` hang until the
+    // job timeout; the action must pin the canonical archive first.
+    const pinIndex = action.indexOf("Pin Blacksmith apt mirror");
+    expect(pinIndex).toBeGreaterThanOrEqual(0);
+    expect(pinIndex).toBeLessThan(action.indexOf("run: ${{ inputs.install-command }}"));
+    expect(action).toContain("*'\"blacksmith-'*");
+    expect(action).toContain("/etc/apt/blacksmith-ubuntu-mirrors.txt");
+    expect(action).toContain("http://archive.ubuntu.com/ubuntu");
+
+    const baseline = await readFile(visualBaselineWorkflow, "utf8");
+    const setupPlaywrightStep = sectionBetween(baseline, "- name: Setup Playwright", "- name: Prebuild");
+    expect(setupPlaywrightStep).toContain("runner-labels:");
+  });
+
   it("[P1] keeps pnpm cache writes on explicit trusted main seed jobs", async () => {
     const action = await readFile(setupWorkspaceAction, "utf8");
 


### PR DESCRIPTION
## Why

`OD_CI_RUNNER_MODE=blacksmith` became unusable this morning: every Playwright-bearing job (E2E Vitest, UI P0, Playwright visual) hung in the `Setup Playwright` step until the job timeout, killing five consecutive CI runs (e.g. run 31566411472, where the step ran 05:26 → 06:10 UTC before cancellation). We had to fall back to `OD_CI_RUNNER_MODE=economic` (GitHub-hosted), which is noticeably slower for the hot paths. This PR fixes the root cause so we can switch back to Blacksmith.

Root cause, from the job logs: Blacksmith VMs resolve apt through a mirrorlist (`/etc/apt/blacksmith-ubuntu-mirrors.txt`) of third-party mirrors. Today its entry `mirror.arizona.edu` went down, and apt retries the dead mirror for every index file before falling back, so the `apt-get update` inside `pnpm -C e2e exec playwright install --with-deps chromium` effectively never finishes.

Skipping `--with-deps` on Blacksmith (attempted in a since-reverted commit on another branch) is not safe: a healthy-mirror run from the same morning shows the deps pass actually installing packages on the Blacksmith image (`21 upgraded, 9 newly installed` — xvfb, CJK fonts, libasound, libnss3 among them), so the apt step must stay. The deterministic fix is to stop depending on volunteer mirror health: when the runner labels indicate a Blacksmith VM, overwrite the mirrorlist with the canonical `http://archive.ubuntu.com/ubuntu` before running the install command. On the healthy-mirror baseline the whole apt pass takes ~8s, and the canonical archive was reachable from the Blacksmith fleet throughout today's incident (its direct `security.ubuntu.com` fetches succeeded while the mirror was down).

`visual-baseline.yml` runs on a hardcoded Blacksmith runner but did not pass `runner-labels` to the action, so it would have missed the guard; this PR wires the label through.

## What users will see

No product-facing change. CI maintainers can set `OD_CI_RUNNER_MODE=blacksmith` without Playwright jobs hanging when a Blacksmith apt mirror goes down.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path: `e2e/tests/actions-cache-workflows.test.ts` — new spec "pins the Blacksmith apt mirrorlist before installing browser deps" asserts the pin step exists, runs before the install command, targets `/etc/apt/blacksmith-ubuntu-mirrors.txt`, and that `visual-baseline.yml` passes `runner-labels`.
- Red on `main`, green on this branch: yes — with `main`'s action/workflow files checked out, the new spec fails ("Pin Blacksmith apt mirror" step absent); with this branch's files it passes (6/6).
- The hang itself is an infra-availability condition (a dead upstream mirror) that a unit test cannot reproduce; the failing-run evidence is linked above (run 31566411472 step timings + step log showing the `Ign: http://mirror.arizona.edu/ubuntu` retry loop). Acceptance for the runtime behavior is switching `OD_CI_RUNNER_MODE` back to `blacksmith` after merge and watching the first Playwright-bearing runs.

## Validation

- `pnpm --filter @open-design/e2e test tests/actions-cache-workflows.test.ts` (6 tests passed; red-on-main verified for the new spec)
- `pnpm guard`
- YAML parse check on both edited files
- `git diff --check`
