### PR TITLE
fix(web): restore PreviewModal fullscreen and sidebar controls

### DIFF
--- a/apps/web/src/components/PreviewModal.tsx
+++ b/apps/web/src/components/PreviewModal.tsx
@@ -948,23 +948,7 @@ export function PreviewModal({
                 title={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
                 aria-label={fullscreen ? t('common.exitFullscreen') : t('common.fullscreen')}
               >
-                <svg
-                  width="15"
-                  height="15"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  {fullscreen ? (
-                    <path d="M9 3v6H3M3 9l6-6M15 21v-6h6M21 15l-6 6" />
-                  ) : (
-                    <path d="M3 9V3h6M3 3l6 6M21 15v6h-6M21 21l-6-6" />
-                  )}
-                </svg>
+                <Icon name={fullscreen ? 'minimize' : 'maximize'} size={15} />
               </button>
             ) : null}
             {isCustomView ? (

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -2306,6 +2306,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   z-index: 4;
   width: 32px;
   height: 32px;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2320,12 +2321,9 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
     background 140ms ease;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.16);
 }
-/* Force the stroke-based icon to paint with the button's color — guards against
-   any stray global svg reset that would otherwise leave the button blank. */
-.ds-modal-stage-fullscreen svg {
+/* Keep the shared icon aligned without overriding its fill-based glyph. */
+.ds-modal-stage-fullscreen .od-icon {
   display: block;
-  stroke: currentColor;
-  fill: none;
 }
 .ds-modal-stage-iframe:hover .ds-modal-stage-fullscreen,
 .ds-modal-stage-fullscreen:focus-visible {
@@ -2396,7 +2394,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
   top: 50%;
   width: 18px;
   height: 56px;
-  transform: translateY(-50%);
+  translate: 0 -50%;
   background: var(--bg-panel);
   border: 1px solid var(--border);
   color: var(--text-muted);
@@ -2836,7 +2834,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
     bottom: 0;
     width: 56px;
     height: 18px;
-    transform: translateX(50%);
+    translate: 50% 0;
     border-right: 1px solid var(--border);
     border-bottom: none;
     border-radius: 8px 8px 0 0;
@@ -2848,7 +2846,7 @@ button.qf-chip-other:disabled { cursor: default; opacity: 0.6; }
     left: 50%;
     width: 56px;
     height: 18px;
-    transform: translateX(-50%);
+    translate: -50% 0;
     border-top: none;
     border-left: 1px solid var(--border);
     border-radius: 0 0 8px 8px;

--- a/apps/web/tests/components/preview-modal-fullscreen.test.tsx
+++ b/apps/web/tests/components/preview-modal-fullscreen.test.tsx
@@ -35,6 +35,28 @@ describe('PreviewModal fullscreen exit', () => {
     setNativeFullscreenElement(null);
   });
 
+  it('uses the shared fill-based icon for both fullscreen states', () => {
+    const { container } = render(
+      <PreviewModal {...baseProps} onClose={() => {}} />,
+    );
+    const fsButton = container.querySelector(
+      'button[title="Fullscreen"]',
+    ) as HTMLButtonElement;
+    const enterIcon = fsButton.querySelector('svg.od-icon');
+    const enterPath = enterIcon?.querySelector('path')?.getAttribute('d');
+
+    expect(enterIcon?.getAttribute('fill')).toBe('currentColor');
+    expect(enterPath).toBeTruthy();
+
+    fireEvent.click(fsButton);
+
+    const exitIcon = fsButton.querySelector('svg.od-icon');
+    const exitPath = exitIcon?.querySelector('path')?.getAttribute('d');
+    expect(exitIcon?.getAttribute('fill')).toBe('currentColor');
+    expect(exitPath).toBeTruthy();
+    expect(exitPath).not.toBe(enterPath);
+  });
+
   it('drops the fullscreen overlay when the browser exits native fullscreen', () => {
     const onClose = vi.fn();
     const { container } = render(

--- a/apps/web/tests/styles/design-system-modal-layer.test.ts
+++ b/apps/web/tests/styles/design-system-modal-layer.test.ts
@@ -4,17 +4,29 @@ import { readExpandedIndexCss } from '../helpers/read-expanded-css';
 
 const expandedIndexCss = readExpandedIndexCss();
 
-function cssBlock(css: string, selector: string): string {
+function cssBlocks(css: string, selector: string): string[] {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
-  if (!match) throw new Error(`Missing CSS block for ${selector}`);
-  return match[1] ?? '';
+  return Array.from(
+    css.matchAll(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, 'g')),
+    (match) => match[1] ?? '',
+  );
+}
+
+function cssBlock(css: string, selector: string): string {
+  const [block] = cssBlocks(css, selector);
+  if (block === undefined) throw new Error(`Missing CSS block for ${selector}`);
+  return block;
+}
+
+function optionalRuleValue(block: string, property: string): string | undefined {
+  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
+  return match?.[1]?.trim();
 }
 
 function ruleValue(block: string, property: string): string {
-  const match = new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+);`).exec(block);
-  if (!match) throw new Error(`Missing CSS property ${property}`);
-  return match[1]!.trim();
+  const value = optionalRuleValue(block, property);
+  if (value === undefined) throw new Error(`Missing CSS property ${property}`);
+  return value;
 }
 
 describe('design system modal layering', () => {
@@ -41,5 +53,41 @@ describe('design system modal layering', () => {
     expect(ruleValue(stageHandle, 'position')).toBe('absolute');
     expect(ruleValue(collapseHandle, 'left')).toBe('0');
     expect(Number(ruleValue(collapseHandle, 'z-index'))).toBeGreaterThanOrEqual(5);
+  });
+
+  it('keeps stage handle positioning independent from button press feedback', () => {
+    const stageHandle = cssBlock(expandedIndexCss, '.ds-modal-stage-handle');
+    const expandHandles = cssBlocks(
+      expandedIndexCss,
+      '.ds-modal-stage-handle.is-expand',
+    );
+    const collapseHandles = cssBlocks(
+      expandedIndexCss,
+      '.ds-modal-stage-handle.is-collapse',
+    );
+
+    expect(ruleValue(stageHandle, 'translate')).toBe('0 -50%');
+    expect(optionalRuleValue(stageHandle, 'transform')).toBeUndefined();
+    expect(
+      expandHandles.map((block) => optionalRuleValue(block, 'translate')),
+    ).toContain('50% 0');
+    expect(
+      collapseHandles.map((block) => optionalRuleValue(block, 'translate')),
+    ).toContain('-50% 0');
+  });
+
+  it('keeps the fullscreen icon visible inside its fixed-size button', () => {
+    const fullscreenButton = cssBlock(
+      expandedIndexCss,
+      '.ds-modal-stage-fullscreen',
+    );
+    const fullscreenIcon = cssBlock(
+      expandedIndexCss,
+      '.ds-modal-stage-fullscreen .od-icon',
+    );
+
+    expect(ruleValue(fullscreenButton, 'padding')).toBe('0');
+    expect(ruleValue(fullscreenIcon, 'display')).toBe('block');
+    expect(optionalRuleValue(fullscreenIcon, 'fill')).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #6791

## Why

I hit two broken controls while inspecting a real Community preview modal: the fullscreen button appeared as a blank square, and the sidebar seam handle moved away from the pointer during press so the panel could not be collapsed reliably.

The fullscreen control is fixed at 32px but inherited 16px horizontal padding from the global button primitive, collapsing its SVG content width to zero. The sidebar handle used `transform` for centering, while the global active-button rule also writes `transform`; during pointer press, that active rule replaced the positioning transform.

## What users will see

- The preview fullscreen button now shows the shared enter/exit fullscreen glyphs.
- Clicking the preview/sidebar seam handle reliably collapses and reopens the sidebar.
- Sidebar handles keep the same positioning in desktop and stacked mobile layouts.

## Surface area

- [x] **UI** — fixes existing PreviewModal controls in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

### Before

![Blank fullscreen icon and sidebar seam handle](https://raw.githubusercontent.com/kuigoo/open-design/5addad814dff9fbf89a28b4fb21256bd380949cf/.github/screenshots/pr-6792-before.png)

### After

![Visible fullscreen icon and working sidebar controls](https://raw.githubusercontent.com/kuigoo/open-design/5addad814dff9fbf89a28b4fb21256bd380949cf/.github/screenshots/pr-6792-after.jpg)

## Bug fix verification

- Test paths that reproduce the bugs:
  - `apps/web/tests/components/preview-modal-fullscreen.test.tsx`
  - `apps/web/tests/styles/design-system-modal-layer.test.ts`
- Did the tests go red on `main` and green on this branch? **Yes.** The new icon and CSS-invariant assertions failed before the source changes and pass with this fix.
- Manual verification: opened a Community preview modal in the web app, confirmed a rendered 15x15 fullscreen icon, toggled enter/exit fullscreen, and collapsed/reopened the sidebar with pointer clicks.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 614 files passed; 6397 passed, 1 expected fail, 11 skipped
- `pnpm --filter @open-design/web build`
- `git diff --check`
