### PR TITLE
Add Trust Agent — design system plugin

### DIFF
--- a/plugins/community/trust-agent-design-system-msq3q020/SKILL.md
+++ b/plugins/community/trust-agent-design-system-msq3q020/SKILL.md
@@ -1,0 +1,41 @@
+# Trust Agent — design system
+
+Registered system: `user:app-agenttrusthq-com`  
+Source: https://app.agenttrusthq.com/  
+Default theme: dark terminal (2026-08 UX redesign)
+
+This package was AI-optimized in place. The first programmatic pass produced a usable but thin 7-color spec and a **light Ant Design** kit that does not match the product. This revision re-measures production CSS and the live marketing HTML.
+
+## Start here
+
+| File | What it is |
+| --- | --- |
+| `DESIGN.md` | Tokens, type, motion, components, posture |
+| `BRAND.md` | Logo, voice, do/don’t |
+| `SKILL.md` | How to apply the system in a new HTML artifact |
+| `brand.json` | Machine-readable brand record |
+| `system/variables.css` | `:root` dark + `[data-theme=light]` |
+| `system/kit.html` | Dark component kit (default) |
+| `system/kit.dark.html` | Same kit locked to dark (gallery slot) |
+| `system/index.html` | Package gallery |
+| `system/COMPONENTS.md` | Primitive contract (Button, Chip, Panel, …) |
+| `fonts/` | IBM Plex Sans / Mono / Condensed (latin) |
+| `logos/wordmark.svg` | `trust_agent` |
+| `logos/mark.svg` | Concentric-circle mark |
+| `context/provenance.md` | What was measured vs inferred |
+
+## Product prototypes (this project)
+
+Not the kit: logged-in and marketing HTML already in the project root (`app-shell.html`, `marketplace-landing.html`, `about.html`, `trust-scores.html`, `developers.html`). They should follow this system; the kit is the reusable reference.
+
+## Caveats
+
+- First-pass `logos/header-inline.svg` was a hamburger icon; archived as `logos/menu-icon.svg`.
+- First-pass webfonts were Vietnamese subsets; replaced with latin fontsource files. Live next/font latin preloads are in `fonts/source-next/`.
+- IBM Plex Sans Condensed is used by the app (`next/font/google`) but was missing from the first extraction.
+- Ant Design 218-token ramps in the old `variables.css` are retired. Do not regenerate from `colorPrimary: #0c7a4d` on white.
+- Light theme exists and must be checked, but dark is the brand face.
+
+## Provenance
+
+Formalized by Open Design from candidate 295aedfd-12cd-43ec-8d94-60891f317c3f.

--- a/plugins/community/trust-agent-design-system-msq3q020/open-design.json
+++ b/plugins/community/trust-agent-design-system-msq3q020/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "trust-agent-design-system-msq3q020",
+  "title": "Trust Agent — design system",
+  "version": "0.1.0",
+  "description": "Registered system: `user:app-agenttrusthq-com` Source: https://app.agenttrusthq.com/ Default theme: dark terminal (2026-08 UX redesign)",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/trust-agent-design-system-msq3q020/references/provenance.json
+++ b/plugins/community/trust-agent-design-system-msq3q020/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "295aedfd-12cd-43ec-8d94-60891f317c3f",
+  "projectId": "brand-app-31b2af",
+  "runId": "d230657f-0eca-4c19-9509-5ba8f9457d97",
+  "conversationId": "8e65c5e9-1d73-4c63-a973-7d157bbdf981",
+  "provenance": {
+    "summary": "Detected from README.md, SKILL.md after a successful run.",
+    "detectedAt": 1786536713411
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 2024,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 1841,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/trust-agent-design-system-msq3q020/references/source-1-README.md
+++ b/plugins/community/trust-agent-design-system-msq3q020/references/source-1-README.md
@@ -1,0 +1,37 @@
+# Trust Agent — design system
+
+Registered system: `user:app-agenttrusthq-com`  
+Source: https://app.agenttrusthq.com/  
+Default theme: dark terminal (2026-08 UX redesign)
+
+This package was AI-optimized in place. The first programmatic pass produced a usable but thin 7-color spec and a **light Ant Design** kit that does not match the product. This revision re-measures production CSS and the live marketing HTML.
+
+## Start here
+
+| File | What it is |
+| --- | --- |
+| `DESIGN.md` | Tokens, type, motion, components, posture |
+| `BRAND.md` | Logo, voice, do/don’t |
+| `SKILL.md` | How to apply the system in a new HTML artifact |
+| `brand.json` | Machine-readable brand record |
+| `system/variables.css` | `:root` dark + `[data-theme=light]` |
+| `system/kit.html` | Dark component kit (default) |
+| `system/kit.dark.html` | Same kit locked to dark (gallery slot) |
+| `system/index.html` | Package gallery |
+| `system/COMPONENTS.md` | Primitive contract (Button, Chip, Panel, …) |
+| `fonts/` | IBM Plex Sans / Mono / Condensed (latin) |
+| `logos/wordmark.svg` | `trust_agent` |
+| `logos/mark.svg` | Concentric-circle mark |
+| `context/provenance.md` | What was measured vs inferred |
+
+## Product prototypes (this project)
+
+Not the kit: logged-in and marketing HTML already in the project root (`app-shell.html`, `marketplace-landing.html`, `about.html`, `trust-scores.html`, `developers.html`). They should follow this system; the kit is the reusable reference.
+
+## Caveats
+
+- First-pass `logos/header-inline.svg` was a hamburger icon; archived as `logos/menu-icon.svg`.
+- First-pass webfonts were Vietnamese subsets; replaced with latin fontsource files. Live next/font latin preloads are in `fonts/source-next/`.
+- IBM Plex Sans Condensed is used by the app (`next/font/google`) but was missing from the first extraction.
+- Ant Design 218-token ramps in the old `variables.css` are retired. Do not regenerate from `colorPrimary: #0c7a4d` on white.
+- Light theme exists and must be checked, but dark is the brand face.

--- a/plugins/community/trust-agent-design-system-msq3q020/references/source-2-SKILL.md
+++ b/plugins/community/trust-agent-design-system-msq3q020/references/source-2-SKILL.md
@@ -1,0 +1,37 @@
+---
+name: trust-agent-design-system
+description: Apply the Trust Agent terminal design system to any HTML artifact. Dark phosphor default, IBM Plex, pill buttons, 8px cards, evidence-first copy.
+---
+
+# Trust Agent — apply this system
+
+You are implementing Trust Agent, not a generic dark dashboard.
+
+## Bind first
+
+1. Paste `fonts/fonts.css` (or the `@font-face` block) and `system/variables.css` into the first `<style>`.
+2. Set `<html data-theme="dark">` unless the brief is explicitly the paper theme.
+3. Use token names (`var(--tt-accent)`), never a new hex.
+4. Read `DESIGN.md` posture rules before inventing a component.
+
+## Hard rules
+
+- Buttons: `border-radius: 999px`, IBM Plex Mono, uppercase, `letter-spacing: 0.08em`, `transition` via `--ease-spring`, `:active { transform: scale(0.98) }`.
+- Cards / panels: `8px`. Inputs: `6px`. Chips: `4px`. Landing preview cards: `10px`.
+- One accent. Outline controls use `--tt-border-accent`, not `--tt-accent`, as the border.
+- IBM Plex Sans for titles/body. Mono for chrome, scores, buttons, kickers. Condensed only for display numerals and the landing H1.
+- Copy: no em-dashes, no star ratings, no invented metrics. If a number is unknown, label a placeholder.
+- Motion behind `prefers-reduced-motion`. Feed lines must fall back to `opacity: 1`.
+- Focus: do not add `outline: none` without restoring the global 2px accent outline.
+
+## Screen jobs (logged-in)
+
+Home = what needs you. Marketplace = hire. Tasks = every agreement. Sell = agents / listings / earnings. Settings = account + money. Empty states continue the path.
+
+## Do not
+
+- Recreate the first-pass light Ant Design kit.
+- Use Inter, Roboto, Fraunces, or a serif.
+- Put a color bar on the left edge of a card as decoration.
+- Wash the page in `#7ee2a8`.
+- Ship 8px rectangle primary buttons (that was the prototype lag).


### PR DESCRIPTION
Add Trust Agent — design system (trust-agent-design-system-msq3q020) plugin.
Version: 0.1.0
Description: Registered system: `user:app-agenttrusthq-com` Source: https://app.agenttrusthq.com/ Default theme: dark terminal (2026-08 UX redesign)