### PR TITLE
fix(desktop): stop expanding $ replacement patterns in export titles

### DIFF
--- a/apps/desktop/src/main/artifact-export.ts
+++ b/apps/desktop/src/main/artifact-export.ts
@@ -114,7 +114,9 @@ function injectBaseHref(doc: string, baseHref: string | undefined): string {
 
 function injectTitle(doc: string, title: string): string {
   const tag = `<title>${escapeText(title)}</title>`;
-  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, tag);
+  // Function replacement: a string replacement would expand the title's
+  // $$, $&, $`, $' substitution patterns, corrupting it (issue #6795).
+  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, () => tag);
   if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${tag}`);
   return doc;
 }

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -266,7 +266,9 @@ function injectBaseHref(doc: string, baseHref: string | undefined): string {
 
 function injectTitle(doc: string, title: string): string {
   const tag = `<title>${escapeHtmlText(title)}</title>`;
-  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, tag);
+  // Function replacement: a string replacement would expand the title's
+  // $$, $&, $`, $' substitution patterns, corrupting it (issue #6795).
+  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, () => tag);
   if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (match) => `${match}${tag}`);
   if (/<html[^>]*>/i.test(doc)) return doc.replace(/<html[^>]*>/i, (match) => `${match}<head>${tag}</head>`);
   return `<!doctype html><html><head>${tag}</head><body>${doc}</body></html>`;

--- a/apps/desktop/tests/main/export-title-replacement-patterns.test.ts
+++ b/apps/desktop/tests/main/export-title-replacement-patterns.test.ts
@@ -1,0 +1,142 @@
+// Issue #6795 — injectTitle() in both export paths passed the user-derived
+// `<title>` tag as the *string* replacement argument of String.replace(), so
+// ECMA-262 GetSubstitution expanded `$$`, `$&`, `` $` ``, `$'` sequences from
+// the artifact title: `Save $$$ This Quarter` lost a `$`, `$&`/`$'` spliced
+// the matched tag or the whole document tail into the title (leaking visible
+// text into the exported PDF/image). The sibling injectBaseHref/injectStyle
+// helpers already used function replacements and were unaffected.
+//
+// These tests pin the "replace an existing <title>" branch — the branch that
+// runs for virtually every generated artifact — by capturing the document each
+// exporter loads into its hidden render window and asserting the title landed
+// verbatim (HTML-escaped only) with no duplicated document content.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const rendererState = vi.hoisted(() => ({
+  loadedUrls: [] as string[],
+  savePath: '' as string,
+}));
+
+vi.mock('electron', () => {
+  const image = {
+    getSize: () => ({ height: 1, width: 1 }),
+    toBitmap: () => Buffer.alloc(4),
+    toJPEG: () => Buffer.from('jpeg'),
+    toPNG: () => Buffer.from('png'),
+  };
+
+  class BrowserWindow {
+    readonly webContents = {
+      capturePage: async () => image,
+      executeJavaScript: async (source: string): Promise<unknown> => {
+        if (source.includes('document.documentElement.scrollHeight')) return 1;
+        return true;
+      },
+      on: () => undefined,
+      printToPDF: async () => Buffer.from('pdf'),
+      setWindowOpenHandler: () => undefined,
+    };
+
+    async loadURL(url: string): Promise<void> {
+      rendererState.loadedUrls.push(url);
+    }
+
+    destroy(): void {}
+    getContentSize(): [number, number] { return [1440, 900]; }
+    isDestroyed(): boolean { return false; }
+    setContentSize(): void {}
+  }
+
+  return {
+    BrowserWindow,
+    dialog: {
+      showSaveDialog: async () => ({ canceled: false, filePath: rendererState.savePath }),
+    },
+  };
+});
+
+import { exportArtifact } from '../../src/main/artifact-export.js';
+import { exportPdfFromHtml } from '../../src/main/pdf-export.js';
+
+const sourceHtml =
+  '<!doctype html><html><head><title>Old</title></head><body><p>BODY MARKER</p></body></html>';
+
+// One title per GetSubstitution pattern a string replacement would expand.
+// `expectedTitleTag` is the verbatim, HTML-escaped-only insertion the escape
+// helpers around injectTitle clearly intend.
+const titles = [
+  { expectedTitleTag: '<title>Save $$$ This Quarter</title>', title: 'Save $$$ This Quarter' },
+  { expectedTitleTag: '<title>Before $&amp; After</title>', title: 'Before $& After' },
+  { expectedTitleTag: "<title>Rock $'n Roll Tour</title>", title: "Rock $'n Roll Tour" },
+];
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'od-title-patterns-'));
+  rendererState.savePath = join(workDir, 'out.pdf');
+});
+
+afterEach(async () => {
+  rendererState.loadedUrls.length = 0;
+  await rm(workDir, { force: true, recursive: true });
+});
+
+describe('export titles containing replacement patterns', () => {
+  it.each(titles)(
+    'exportPdfFromHtml renders the title $title verbatim',
+    async ({ expectedTitleTag, title }) => {
+      const result = await exportPdfFromHtml({
+        deck: false,
+        defaultFilename: 'artifact.pdf',
+        html: sourceHtml,
+        title,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(loadedDocument()).toContain(expectedTitleTag);
+      expect(countBodyMarkers(loadedDocument())).toBe(1);
+    },
+  );
+
+  it.each(titles)(
+    'exportArtifact renders the title $title verbatim',
+    async ({ expectedTitleTag, title }) => {
+      const result = await exportArtifact({
+        deck: false,
+        format: 'image',
+        html: sourceHtml,
+        imageFormat: 'png',
+        title,
+      });
+
+      try {
+        expect(result.ok).toBe(true);
+        expect(loadedDocument()).toContain(expectedTitleTag);
+        expect(countBodyMarkers(loadedDocument())).toBe(1);
+      } finally {
+        if (result.path) await rm(dirname(result.path), { force: true, recursive: true });
+      }
+    },
+  );
+});
+
+function loadedDocument(): string {
+  expect(rendererState.loadedUrls).toHaveLength(1);
+  const url = rendererState.loadedUrls[0];
+  if (!url) throw new Error('renderer did not load a document');
+  const prefix = 'data:text/html;charset=utf-8,';
+  expect(url.startsWith(prefix)).toBe(true);
+  return decodeURIComponent(url.slice(prefix.length));
+}
+
+// A `$'`/`$&` expansion splices document content into the <title>, so the
+// corrupted output carries the body text more than once.
+function countBodyMarkers(doc: string): number {
+  return doc.split('BODY MARKER').length - 1;
+}


### PR DESCRIPTION
Fixes #6795

## Why

Exporting an artifact whose title contains JavaScript replacement-pattern sequences corrupts the rendered document. `injectTitle()` in both desktop export paths passes the user-derived `<title>` tag as the **string** replacement argument of `String.prototype.replace`, so ECMA-262 `GetSubstitution` expands `$$`, `$&`, `` $` ``, `$'` coming from the artifact title:

- `Save $$$ This Quarter` → `<title>Save $$ This Quarter</title>` (silently drops a `$`, wrong PDF Title metadata)
- `Before $& After` → the matched `<title>Old</title>` is spliced in and the tag closes early; the leftover `amp; After` lands outside `<head>` and renders as visible text in the exported PDF/image
- `Rock $'n Roll Tour` → the whole document tail is spliced into the title (content duplicated, title becomes HTML soup)

I hit this while exercising the export paths with `$`-bearing deck titles (pricing decks like "Save $$$ …" are a realistic shape). The escape helpers around the call (`escapeHtmlText` / `escapeText`) only cover `& < >`, so they clearly intend "insert the title verbatim" — the string-replacement expansion defeats that intent. The sibling helpers `injectBaseHref` / `injectStyle` already use function replacements and are unaffected; only the "document already has a `<title>`" branch of `injectTitle` used a string, and generated artifacts virtually always carry a `<title>`, so that is the branch that runs.

The fix mirrors `injectBaseHref`: use a function replacement (`() => tag`), whose return value is inserted literally. One line in each file:

- `apps/desktop/src/main/pdf-export.ts` (desktop "Export as PDF" path)
- `apps/desktop/src/main/artifact-export.ts` (`od export` pdf/image path)

## What users will see

Exported PDFs and images now render the artifact title exactly as typed. A deck named `Save $$$ This Quarter` exports with that title (previously `Save $$ This Quarter` in the PDF Title metadata), and titles containing `$&` / `` $` `` / `$'` no longer splice document HTML into the `<title>` or leak stray text into the visible exported page. No settings, UI, or defaults change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — bug fix in export rendering plus its regression test; no new surface

## Screenshots

Not a UI change (no new entry point); the observable change is the exported document's `<title>` content, covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/export-title-replacement-patterns.test.ts` — six cases (three `$`-pattern titles × both exporters), capturing the document each exporter loads into its hidden render window and asserting the title lands verbatim (HTML-escaped only) with no duplicated document content.
- Did the test go red on `main` and green on this branch? **Yes.** On `main` (028bde50) all six cases fail, e.g.:

  ```text
  FAIL  … > exportArtifact renders the title 'Before $& After' verbatim
  Expected: "<title>Before $&amp; After</title>"
  Received: "…<title>Before <title>Old</title>amp; After</title>…"

  FAIL  … > exportArtifact renders the title 'Rock $'n Roll Tour' verbatim
  Expected: "<title>Rock $'n Roll Tour</title>"
  Received: "…<title>Rock </head><body><p>BODY MARKER</p></body></html>n Roll Tour</title>…"

  Test Files  1 failed (1)   Tests  6 failed (6)
  ```

  With the fix, `Test Files 1 passed (1)  Tests 6 passed (6)`.

## Validation

- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/export-title-replacement-patterns.test.ts` — red on `main` (6 failed), green on this branch (6 passed).
- `pnpm --filter @open-design/desktop test` — **36 files passed, 332 tests passed | 1 skipped**. Baseline on `main` in the same tree before the change: 35 files, 326 passed | 1 skipped — the delta is exactly this PR's six new cases, no regressions.
- `pnpm guard` — all design-system guards pass.
- `pnpm typecheck` — whole-workspace typecheck completes cleanly (exit 0).

Environment note: run on Node v22 (engines want `~24`), which only produces pnpm engine warnings; the same suites pass identically before and after the change on this machine.

## Adjacent issues (not in this PR)

`assembleExample()` in `apps/daemon/src/routes/static-resource.ts` (L1488-L1492) interpolates a skill-derived title through the same string-replacement mechanism. Its trigger surface is much smaller (skill names), so per the bug follow-up workflow it belongs in its own follow-up rather than widening this diff.

---

_This PR was prepared with AI assistance; I reproduced the bug locally, wrote and ran the red/green regression test, and reviewed every line._
