### PR TITLE
fix(web): gate comment bridge readiness on the committed preview URL

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -628,6 +628,9 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   var activeCommentElementId = null;
   var activeCommentSelector = null;
   var activeTargetPending = false;
+  function postReady(){
+    window.parent.postMessage({ type: 'od:url-selection-bridge-ready', href: window.location.href }, '*');
+  }
   function esc(value){
     try { return window.CSS && CSS.escape ? CSS.escape(value) : String(value).replace(/"/g, '\\\\"'); }
     catch (_) { return String(value); }
@@ -973,7 +976,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
     var data = ev && ev.data;
     if (!data || !data.type) return;
     if (data.type === 'od:url-selection-bridge-probe') {
-      window.parent.postMessage({ type: 'od:url-selection-bridge-ready' }, '*');
+      postReady();
       return;
     }
     if (data.type === 'od:preview-runtime-state-capture' && data.id) {
@@ -1107,7 +1110,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   var mo = new MutationObserver(schedulePostTargets);
   mo.observe(document.documentElement, { subtree: true, childList: true });
   ensureStyle();
-  window.parent.postMessage({ type: 'od:url-selection-bridge-ready' }, '*');
+  postReady();
 })();
 </script>`;
 

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -390,6 +390,8 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain("type: 'od:comment-target'");
     expect(html).toContain("type: 'od:preview-runtime-state-captured'");
     expect(html).toContain('roots: roots');
+    expect(html).toContain('function postReady(');
+    expect(html).toContain('href: window.location.href');
     expect(html).not.toContain('data-od-url-scroll-bridge');
   });
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10364,8 +10364,19 @@ function HtmlViewer({
       const frame = urlPreviewIframeRef.current;
       if (ev.source !== frame?.contentWindow) return;
       if (frame.getAttribute('src') === 'about:blank') return;
-      const data = ev.data as { type?: string } | null;
+      const data = ev.data as { type?: string; href?: string } | null;
       if (data?.type !== 'od:url-selection-bridge-ready') return;
+      // The latch must describe the currently committed document's bridge, so
+      // the ready must carry and match the document href.
+      if (typeof data.href !== 'string' || data.href.length === 0) return;
+      let matches: boolean;
+      try {
+        matches = new URL(data.href, window.location.href).href
+          === new URL(frame.getAttribute('src') ?? '', window.location.href).href;
+      } catch {
+        return;
+      }
+      if (!matches) return;
       setUrlSelectionBridgeReady(true);
     }
     window.addEventListener('message', onMessage);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7387,7 +7387,10 @@ describe('FileViewer tweaks toolbar', () => {
     act(() => {
       window.dispatchEvent(new MessageEvent('message', {
         source: urlFrame.contentWindow,
-        data: { type: 'od:url-selection-bridge-ready' },
+        data: {
+          type: 'od:url-selection-bridge-ready',
+          href: new URL(urlFrame.getAttribute('src') ?? '', window.location.href).href,
+        },
       }));
     });
 
@@ -7795,7 +7798,10 @@ describe('FileViewer tweaks toolbar', () => {
     act(() => {
       window.dispatchEvent(new MessageEvent('message', {
         source: urlFrame.contentWindow,
-        data: { type: 'od:url-selection-bridge-ready' },
+        data: {
+          type: 'od:url-selection-bridge-ready',
+          href: new URL(urlFrame.getAttribute('src') ?? '', window.location.href).href,
+        },
       }));
     });
 
@@ -7822,6 +7828,133 @@ describe('FileViewer tweaks toolbar', () => {
 
     const urlFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(urlFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    const srcDocFrame = await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      return frame;
+    });
+    expect(srcDocFrame.srcdoc).toContain('data-od-selection-bridge');
+  });
+
+  it('ignores stale URL selection bridge readiness after the preview URL changes and falls back to srcDoc comments', async () => {
+    const { rerender } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile({ mtime: 1710000001 })}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const urlFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(urlFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+    const srcA = urlFrame.getAttribute('src') ?? '';
+    expect(srcA).toContain('odPreviewBridge=selection');
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: urlFrame.contentWindow,
+        data: {
+          type: 'od:url-selection-bridge-ready',
+          href: new URL(srcA, window.location.href).href,
+        },
+      }));
+    });
+
+    // Same file with a new mtime keeps the pooled iframe element and its
+    // WindowProxy; only the src (v=/odPreviewEpoch cache bust) changes.
+    rerender(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile({ mtime: 1710000002 })}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    await waitFor(() => {
+      expect(urlFrame.getAttribute('src')).not.toBe(srcA);
+    });
+
+    // The real navigation onLoad clears the latch and re-probes.
+    fireEvent.load(urlFrame);
+
+    // A ready posted by the PREVIOUS document (href A) must not re-latch the
+    // bridge for the currently committed document.
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: urlFrame.contentWindow,
+        data: {
+          type: 'od:url-selection-bridge-ready',
+          href: new URL(srcA, window.location.href).href,
+        },
+      }));
+    });
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    const srcDocFrame = await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      return frame;
+    });
+    expect(srcDocFrame.srcdoc).toContain('data-od-selection-bridge');
+  });
+
+  it('accepts a URL selection bridge ready matching the current preview URL', async () => {
+    const { rerender } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile({ mtime: 1710000001 })}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const urlFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const srcA = urlFrame.getAttribute('src') ?? '';
+
+    rerender(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile({ mtime: 1710000002 })}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+    await waitFor(() => {
+      expect(urlFrame.getAttribute('src')).not.toBe(srcA);
+    });
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: urlFrame.contentWindow,
+        data: {
+          type: 'od:url-selection-bridge-ready',
+          href: new URL(urlFrame.getAttribute('src') ?? '', window.location.href).href,
+        },
+      }));
+    });
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    // A matching-href ready keeps Comment on the URL-load engine instead of
+    // falling back to srcdoc. od:comment-mode delivery to the URL frame is
+    // covered by the "keeps the URL-loaded preview mounted when opening
+    // comments" test.
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(urlFrame);
+      expect(urlFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+    });
+  });
+
+  it('rejects a URL selection bridge ready without href and falls back to srcDoc comments', async () => {
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main></body></html>'
+      />,
+    );
+
+    const urlFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(urlFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: urlFrame.contentWindow,
+        data: { type: 'od:url-selection-bridge-ready' },
+      }));
+    });
 
     fireEvent.click(screen.getByTestId('comment-panel-toggle'));
 


### PR DESCRIPTION
Fixes #6702

## Why

Comment mode on the site preview runs through an injected selection bridge. While the preview is URL-loaded, the host keeps Comment on that engine only while `urlSelectionBridgeReady` is set — a flag latched by the `od:url-selection-bridge-ready` post from the daemon-injected bridge.

That latch did not verify which document the ready described. The iframe's WindowProxy is reused across navigations, so a ready posted by a previously loaded document can arrive after the preview has moved on (live reload bumping the `odPreviewEpoch` cache-buster, an aborted navigation, or a bridge-less revision such as an HTML payload over 2MB where the daemon skips bridge injection) and latch the flag for a document that has no bridge. Result: Comment stays on the URL-load engine with no live picker — the "comment tool does nothing" symptom class from #6702.

The ready message now carries the document href, and the host only latches when that href matches the currently committed iframe src. If the bridge is not genuinely ready for the current document, the preview falls back to the srcDoc engine, where the selection bridge is always injected.

This is a scoped hardening of the remaining stale-latch window on current main. The primary 0.18.1 mechanism (srcDoc transport activation stall) was already addressed upstream by #6714; this PR does not claim to have diagnosed the reporter's exact 0.18.1 root cause.

## What users will see

Comment (and Draw, which shares the same readiness flag) now activates reliably on the HTML preview. When the URL-load bridge cannot prove it is ready for the current document, the preview falls back to the srcDoc engine and Comment still works there, instead of staying on a dead URL-load picker.

## Surface area

- [x] **UI** — Comment / Draw tools on the HTML preview in `apps/web`
- [ ] **Keyboard shortcut** — n/a
- [ ] **CLI / env var** — n/a
- [ ] **API / contract** — n/a (the `od:url-selection-bridge-ready` message is an injected-bridge postMessage, not an endpoint or `packages/contracts` shape)
- [ ] **Extension point** — n/a
- [ ] **i18n keys** — n/a
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — an artifact whose committed URL differs from the iframe src (server-side URL normalization, self-redirect, post-load hash mutation) now gets Comment via srcDoc instead of URL-load. Comment still works; only the transport degrades.

## Screenshots

No new UI surface is introduced by this change; it restores existing Comment/Draw behavior on the HTML preview. A before/after capture is not included because reproducing the failure requires a live desktop preview session; the red-spec tests in Bug fix verification cover the behavior.

## Bug fix verification

Red specs (red on unmodified `main`, green on this branch):
- `apps/web/tests/components/FileViewer.test.tsx` — "ignores stale URL selection bridge readiness after the preview URL changes and falls back to srcDoc comments" (main: expected 'srcdoc', got 'url-load')
- `apps/web/tests/components/FileViewer.test.tsx` — "rejects a URL selection bridge ready without href and falls back to srcDoc comments"
- `apps/daemon/tests/project-file-range.test.ts` — asserts the injected bridge posts the document href in both ready paths

Note: the RED web run also surfaced one pre-existing unrelated flaky test ("lets Draw direct send emit a queued annotation while a task is running"); it passes on the baseline and in all GREEN runs and is not touched by this change.

## Validation

- `pnpm --filter @open-design/web test` — 268/268 (three consecutive runs)
- Related srcdoc/transport/recovery suites — 71/71
- `pnpm --filter @open-design/daemon test` (project-file-range) — 49/49
- `pnpm --filter @open-design/web typecheck`, `pnpm --filter @open-design/daemon typecheck` — clean
- `git diff --check` — clean
- Full `pnpm guard` / CI web shards require upstream execution.

## Adjacent issues

- #6714 already fixed the srcDoc transport activation stall, the most likely trigger of the original 0.18.1 report; this change closes the remaining stale-readiness window on the URL-load engine.
- This re-implements, with a stricter host-side check (href required, no backward-compat guard), the previously reviewed-and-approved approach from #4511, which was closed only for author inactivity.
- Merge sequencing: FileViewer.tsx and `apps/daemon/tests/project-file-range.test.ts` are touched by several open PRs (#6785, #6768, #2344, #2325, #4892); the diff regions are disjoint, so conflicts, if any, are mechanical.