### PR TITLE
todos: accept a TodoWrite task list encoded as a JSON string

### DIFF
--- a/apps/web/src/runtime/todos.ts
+++ b/apps/web/src/runtime/todos.ts
@@ -9,6 +9,18 @@ export interface TodoItem {
   activeForm?: string;
 }
 
+function jsonArrayFromString(value: unknown): unknown[] | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[')) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function parseTodoWriteInput(input: unknown): TodoItem[] {
   if (!input || typeof input !== 'object') return [];
   const obj = input as { plan?: unknown; todos?: unknown };
@@ -16,7 +28,9 @@ export function parseTodoWriteInput(input: unknown): TodoItem[] {
     ? obj.todos
     : Array.isArray(obj.plan)
       ? obj.plan
-      : [];
+      // Mirrors todoItemsFromToolInput in packages/contracts: some runs encode
+      // the list as a JSON string, which would otherwise render an empty card.
+      : (jsonArrayFromString(obj.todos) ?? jsonArrayFromString(obj.plan) ?? []);
   return rawItems
     .map((todo): TodoItem | null => {
       if (!todo || typeof todo !== 'object') return null;

--- a/apps/web/tests/runtime/todos.test.ts
+++ b/apps/web/tests/runtime/todos.test.ts
@@ -121,6 +121,31 @@ describe('todo event helpers', () => {
     ]);
   });
 
+  it('accepts a JSON-encoded task list', () => {
+    // Observed with the claude runtime: `todos` arrives as a JSON string rather
+    // than an array, which an Array.isArray-only read renders as an empty card.
+    expect(parseTodoWriteInput({
+      todos: JSON.stringify([
+        { content: 'Lay the tokens', status: 'completed' },
+        { content: 'Build the hero', status: 'in_progress' },
+      ]),
+    })).toEqual([
+      { content: 'Lay the tokens', status: 'completed', activeForm: undefined },
+      { content: 'Build the hero', status: 'in_progress', activeForm: undefined },
+    ]);
+    expect(parseTodoWriteInput({
+      plan: JSON.stringify([{ step: 'Ship it', status: 'pending' }]),
+    })).toEqual([
+      { content: 'Ship it', status: 'pending', activeForm: undefined },
+    ]);
+  });
+
+  it('returns no items for an encoded payload that is not a task list', () => {
+    for (const todos of ['[{"content"', 'not json at all', '{"content":"a"}', '']) {
+      expect(parseTodoWriteInput({ todos })).toEqual([]);
+    }
+  });
+
   it('accepts native task item text aliases used by different agents', () => {
     expect(parseTodoWriteInput({
       todos: [

--- a/packages/contracts/src/api/run-completeness.ts
+++ b/packages/contracts/src/api/run-completeness.ts
@@ -61,7 +61,23 @@ function todoItemsFromToolInput(input: unknown): unknown {
   const record = input as { todos?: unknown; plan?: unknown };
   if (Array.isArray(record.todos)) return record.todos;
   if (Array.isArray(record.plan)) return record.plan;
-  return undefined;
+  // Some runs emit the list as a JSON *string* rather than an array
+  // (`{"todos":"[{\"content\":…}]"}`). Dropping those silently costs the Todos
+  // card AND makes eventsEndedWithUnfinishedWork() read a run with open work as
+  // Completed, so accept the encoded form too.
+  return jsonArrayFromString(record.todos) ?? jsonArrayFromString(record.plan);
+}
+
+function jsonArrayFromString(value: unknown): unknown[] | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[')) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined; // a partial or malformed payload stays dropped, as before
+  }
 }
 
 /** TodoWrite surfaces under several tool aliases across runtimes. Mirrors

--- a/packages/contracts/tests/run-completeness.test.ts
+++ b/packages/contracts/tests/run-completeness.test.ts
@@ -92,4 +92,43 @@ describe('eventsEndedWithUnfinishedWork', () => {
     expect(eventsEndedWithUnfinishedWork([{ kind: 'text', text: 'done' }])).toBe(false);
     expect(eventsEndedWithUnfinishedWork(undefined)).toBe(false);
   });
+
+  // Observed with the claude runtime: the task list arrives JSON-ENCODED rather
+  // than as an array. An Array.isArray-only read drops the snapshot, and a
+  // dropped snapshot reports a run with open work as Completed — the exact
+  // divergence this predicate exists to prevent.
+  it('reads a JSON-encoded task list', () => {
+    expect(
+      eventsEndedWithUnfinishedWork([
+        {
+          kind: 'tool_use',
+          id: '1',
+          name: 'TodoWrite',
+          input: { todos: JSON.stringify([{ content: 'a', status: 'pending' }]) },
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      eventsEndedWithUnfinishedWork([
+        {
+          kind: 'tool_use',
+          id: '1',
+          name: 'update_plan',
+          input: { plan: JSON.stringify([{ step: 'a', status: 'completed' }]) },
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  it('still drops an encoded payload that is not a task list', () => {
+    // Malformed or non-array strings behave exactly as before the encoded form
+    // was accepted: no snapshot, so the run stays Completed.
+    for (const todos of ['[{"content"', 'not json at all', '{"content":"a"}', '']) {
+      expect(
+        eventsEndedWithUnfinishedWork([
+          { kind: 'tool_use', id: '1', name: 'TodoWrite', input: { todos } },
+        ]),
+      ).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## What

`todoItemsFromToolInput` (packages/contracts) and `parseTodoWriteInput` (apps/web) both read the task list with `Array.isArray` only. When a runtime emits the list JSON-**encoded** — `{"todos":"[{\"content\":…}]"}` — the snapshot is dropped.

Both now decode a string that unambiguously contains a JSON array. Anything malformed, non-array, or empty is dropped exactly as before.

## Why it matters

Two things break, and only one of them is visible:

- The live Todos card renders empty, so the user loses the plan the discovery prompt calls *"the user's primary way to see your plan and redirect cheaply"* (`prompts/discovery.ts:135`).
- `eventsEndedWithUnfinishedWork()` reads the same dropped snapshot and returns `false`, so **a run that stopped with open tasks is recorded as Completed** — the divergence #1247 / #1060 exists to prevent.

## How it was found

Local install, `claude` runtime, Claude Code CLI, Open Design 0.18.2. Querying `app.sqlite` after a session: **2 of 2** TodoWrite tool_use events carried `todos` as a string, 0 as an array. Small sample, but not intermittent on this runtime — the Todos card never populated once.

The streaming path is not the cause: `claude-stream.ts` `JSON.parse`s accumulated `input_json_delta` correctly at `content_block_stop`. The encoded form arrives from the model itself, so tolerating it at the parser seemed truer to the comments already describing these two functions as mirrors that "accept both" shapes.

## Tests

Added to the existing suites — each new case fails against the parsers before this change and passes after:

- `packages/contracts/tests/run-completeness.test.ts` — encoded list, `update_plan`-style encoded `plan`, plus a case pinning that malformed/non-array strings still drop
- `apps/web/tests/runtime/todos.test.ts` — same two shapes through the card parser

Verified: `pnpm --filter @open-design/contracts test` → 282 passed · web todos suite → 16 passed · `pnpm typecheck` → clean across the workspace.