### PR TITLE
fix(daemon): reject reference images that escape the project via symlink

### DIFF
--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -13,7 +13,7 @@
 // since the BYOK chat session already authenticates with the same API key.
 
 import path from 'node:path';
-import { writeFile, readFile, readdir, stat } from 'node:fs/promises';
+import { writeFile, readFile, readdir, realpath, stat } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveProviderConfig } from './media/config.js';
@@ -1291,11 +1291,29 @@ interface ReferenceImagePart {
   filename: string;
 }
 
-// Read a project image file into an upload part. Null for non-images / unreadable.
-async function fileToImagePart(filePath: string): Promise<ReferenceImagePart | null> {
+// Canonical containment invariant for project reference images: the realpath'd
+// target of the candidate must stay inside `dir`. realpath follows symlinks, so
+// a project-local symlink to an outside file throws EPATHESCAPE before any
+// stat/readFile can observe the target's size or bytes.
+async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(dir).catch(() => dir);
+  const real = await realpath(candidate);
+  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+    const err = new Error('path escapes project dir via symlink');
+    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+    throw err;
+  }
+  return real;
+}
+
+// Read a project image file into an upload part. Null for non-images /
+// unreadable, and null when `dir` is given and the canonical target escapes the
+// project directory (a project-local symlink pointing outside is skipped).
+async function fileToImagePart(filePath: string, dir?: string): Promise<ReferenceImagePart | null> {
   const mime = IMAGE_EXT_MIME[path.extname(filePath).toLowerCase()];
   if (!mime) return null;
   try {
+    if (dir) filePath = await resolveContainedPath(dir, filePath);
     const buf = await readFile(filePath);
     if (!buf.length) return null;
     return { bytes: buf, mime, filename: path.basename(filePath) };
@@ -1331,25 +1349,48 @@ async function resolveAIHubMixReferenceImage(
     }
   }
   // Treat as a project-local file. basename() strips any path so a value like
-  // "../../etc/passwd" collapses to a filename inside the project dir.
+  // "../../etc/passwd" collapses to a filename inside the project dir. The
+  // canonical containment re-check rejects a project-local symlink whose target
+  // is outside; the caller converts the EPATHESCAPE throw into a tool error so
+  // no outside bytes are ever submitted on its behalf. Any OTHER resolution
+  // failure (e.g. ENOENT for a stale/missing image_url) is not a boundary
+  // violation: return null so the caller's existing newestProjectImagePart
+  // fallback for i2v models behaves exactly as it did before the boundary fix.
   const name = path.basename(raw.split('?')[0]!);
   if (!name) return null;
-  return fileToImagePart(path.join(dir, name));
+  const candidate = path.join(dir, name);
+  let canonical: string;
+  try {
+    canonical = await resolveContainedPath(dir, candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') throw err;
+    return null;
+  }
+  return fileToImagePart(canonical, dir);
 }
 
 // Fallback for i2v models when no image_url is given: the most recently
 // modified image already in the project folder (typically the uploaded
-// reference or the last generated frame).
+// reference or the last generated frame). Entries whose canonical target
+// escapes the project directory are skipped without being read.
 async function newestProjectImagePart(dir: string): Promise<ReferenceImagePart | null> {
   try {
     const entries = await readdir(dir);
     const images = entries.filter((f) => IMAGE_EXT_MIME[path.extname(f).toLowerCase()]);
     if (!images.length) return null;
-    const withMtime = await Promise.all(
-      images.map(async (f) => ({ f, m: (await stat(path.join(dir, f))).mtimeMs })),
-    );
+    const withMtime: Array<{ f: string; m: number }> = [];
+    for (const f of images) {
+      let real: string;
+      try {
+        real = await resolveContainedPath(dir, path.join(dir, f));
+      } catch {
+        continue;
+      }
+      withMtime.push({ f: real, m: (await stat(real)).mtimeMs });
+    }
+    if (!withMtime.length) return null;
     withMtime.sort((a, b) => b.m - a.m);
-    return fileToImagePart(path.join(dir, withMtime[0]!.f));
+    return fileToImagePart(withMtime[0]!.f, dir);
   } catch {
     return null;
   }
@@ -1479,7 +1520,15 @@ export async function executeAIHubMixGenerateVideo(
   //     accept an optional reference but never require one.
   const requiresReference = wireModel.toLowerCase().includes('i2v');
   const acceptsReference = cap.caps.includes('i2v');
-  let refImage = await resolveAIHubMixReferenceImage(args.image_url, dir, ctx);
+  let refImage: ReferenceImagePart | null;
+  try {
+    refImage = await resolveAIHubMixReferenceImage(args.image_url, dir, ctx);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `invalid reference image: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   if (!refImage && requiresReference) {
     refImage = await newestProjectImagePart(dir);
     if (refImage) {

--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -13,7 +13,7 @@
 // since the BYOK chat session already authenticates with the same API key.
 
 import path from 'node:path';
-import { writeFile, readFile, readdir, stat } from 'node:fs/promises';
+import { writeFile, readFile, readdir, realpath, stat } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { assertExternalAssetUrl, assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveProviderConfig } from './media/config.js';
@@ -1288,11 +1288,29 @@ interface ReferenceImagePart {
   filename: string;
 }
 
-// Read a project image file into an upload part. Null for non-images / unreadable.
-async function fileToImagePart(filePath: string): Promise<ReferenceImagePart | null> {
+// Canonical containment invariant for project reference images: the realpath'd
+// target of the candidate must stay inside `dir`. realpath follows symlinks, so
+// a project-local symlink to an outside file throws EPATHESCAPE before any
+// stat/readFile can observe the target's size or bytes.
+async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(dir).catch(() => dir);
+  const real = await realpath(candidate);
+  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+    const err = new Error('path escapes project dir via symlink');
+    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+    throw err;
+  }
+  return real;
+}
+
+// Read a project image file into an upload part. Null for non-images /
+// unreadable, and null when `dir` is given and the canonical target escapes the
+// project directory (a project-local symlink pointing outside is skipped).
+async function fileToImagePart(filePath: string, dir?: string): Promise<ReferenceImagePart | null> {
   const mime = IMAGE_EXT_MIME[path.extname(filePath).toLowerCase()];
   if (!mime) return null;
   try {
+    if (dir) filePath = await resolveContainedPath(dir, filePath);
     const buf = await readFile(filePath);
     if (!buf.length) return null;
     return { bytes: buf, mime, filename: path.basename(filePath) };
@@ -1329,25 +1347,48 @@ async function resolveAIHubMixReferenceImage(
     }
   }
   // Treat as a project-local file. basename() strips any path so a value like
-  // "../../etc/passwd" collapses to a filename inside the project dir.
+  // "../../etc/passwd" collapses to a filename inside the project dir. The
+  // canonical containment re-check rejects a project-local symlink whose target
+  // is outside; the caller converts the EPATHESCAPE throw into a tool error so
+  // no outside bytes are ever submitted on its behalf. Any OTHER resolution
+  // failure (e.g. ENOENT for a stale/missing image_url) is not a boundary
+  // violation: return null so the caller's existing newestProjectImagePart
+  // fallback for i2v models behaves exactly as it did before the boundary fix.
   const name = path.basename(raw.split('?')[0]!);
   if (!name) return null;
-  return fileToImagePart(path.join(dir, name));
+  const candidate = path.join(dir, name);
+  let canonical: string;
+  try {
+    canonical = await resolveContainedPath(dir, candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') throw err;
+    return null;
+  }
+  return fileToImagePart(canonical, dir);
 }
 
 // Fallback for i2v models when no image_url is given: the most recently
 // modified image already in the project folder (typically the uploaded
-// reference or the last generated frame).
+// reference or the last generated frame). Entries whose canonical target
+// escapes the project directory are skipped without being read.
 async function newestProjectImagePart(dir: string): Promise<ReferenceImagePart | null> {
   try {
     const entries = await readdir(dir);
     const images = entries.filter((f) => IMAGE_EXT_MIME[path.extname(f).toLowerCase()]);
     if (!images.length) return null;
-    const withMtime = await Promise.all(
-      images.map(async (f) => ({ f, m: (await stat(path.join(dir, f))).mtimeMs })),
-    );
+    const withMtime: Array<{ f: string; m: number }> = [];
+    for (const f of images) {
+      let real: string;
+      try {
+        real = await resolveContainedPath(dir, path.join(dir, f));
+      } catch {
+        continue;
+      }
+      withMtime.push({ f: real, m: (await stat(real)).mtimeMs });
+    }
+    if (!withMtime.length) return null;
     withMtime.sort((a, b) => b.m - a.m);
-    return fileToImagePart(path.join(dir, withMtime[0]!.f));
+    return fileToImagePart(withMtime[0]!.f, dir);
   } catch {
     return null;
   }
@@ -1477,7 +1518,15 @@ export async function executeAIHubMixGenerateVideo(
   //     accept an optional reference but never require one.
   const requiresReference = wireModel.toLowerCase().includes('i2v');
   const acceptsReference = cap.caps.includes('i2v');
-  let refImage = await resolveAIHubMixReferenceImage(args.image_url, dir, ctx);
+  let refImage: ReferenceImagePart | null;
+  try {
+    refImage = await resolveAIHubMixReferenceImage(args.image_url, dir, ctx);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `invalid reference image: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   if (!refImage && requiresReference) {
     refImage = await newestProjectImagePart(dir);
     if (refImage) {

--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -13,9 +13,14 @@
 // since the BYOK chat session already authenticates with the same API key.
 
 import path from 'node:path';
-import { writeFile, readFile, readdir, realpath, stat } from 'node:fs/promises';
+import { writeFile, readdir } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { assertAndFetchExternalAsset } from './connectionTest.js';
+import {
+  openContainedFile,
+  resolveContainedPath,
+  type ContainedFileHandle,
+} from './media/contained-file.js';
 import { resolveProviderConfig } from './media/config.js';
 import { IMAGE_MODELS } from './media/models.js';
 import { ensureProject } from './projects.js';
@@ -1291,34 +1296,22 @@ interface ReferenceImagePart {
   filename: string;
 }
 
-// Canonical containment invariant for project reference images: the realpath'd
-// target of the candidate must stay inside `dir`. realpath follows symlinks, so
-// a project-local symlink to an outside file throws EPATHESCAPE before any
-// stat/readFile can observe the target's size or bytes.
-async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
-  const rootReal = await realpath(dir).catch(() => dir);
-  const real = await realpath(candidate);
-  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
-    const err = new Error('path escapes project dir via symlink');
-    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
-    throw err;
-  }
-  return real;
-}
-
-// Read a project image file into an upload part. Null for non-images /
-// unreadable, and null when `dir` is given and the canonical target escapes the
-// project directory (a project-local symlink pointing outside is skipped).
-async function fileToImagePart(filePath: string, dir?: string): Promise<ReferenceImagePart | null> {
-  const mime = IMAGE_EXT_MIME[path.extname(filePath).toLowerCase()];
+// Read an already-resolved project image file into an upload part. Null for
+// non-images / unreadable, and null when the file escapes the project directory
+// or is swapped for an outside symlink before it can be opened.
+async function fileToImagePart(resolvedPath: string): Promise<ReferenceImagePart | null> {
+  const mime = IMAGE_EXT_MIME[path.extname(resolvedPath).toLowerCase()];
   if (!mime) return null;
+  let opened: ContainedFileHandle | null = null;
   try {
-    if (dir) filePath = await resolveContainedPath(dir, filePath);
-    const buf = await readFile(filePath);
+    opened = await openContainedFile(resolvedPath);
+    const buf = await opened.read();
     if (!buf.length) return null;
-    return { bytes: buf, mime, filename: path.basename(filePath) };
+    return { bytes: buf, mime, filename: path.basename(resolvedPath) };
   } catch {
     return null;
+  } finally {
+    if (opened) await opened.close().catch(() => {});
   }
 }
 
@@ -1366,31 +1359,38 @@ async function resolveAIHubMixReferenceImage(
     if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') throw err;
     return null;
   }
-  return fileToImagePart(canonical, dir);
+  return fileToImagePart(canonical);
 }
 
 // Fallback for i2v models when no image_url is given: the most recently
 // modified image already in the project folder (typically the uploaded
 // reference or the last generated frame). Entries whose canonical target
-// escapes the project directory are skipped without being read.
+// escapes the project directory, or is swapped before it can be opened, are
+// skipped without being read.
 async function newestProjectImagePart(dir: string): Promise<ReferenceImagePart | null> {
   try {
     const entries = await readdir(dir);
     const images = entries.filter((f) => IMAGE_EXT_MIME[path.extname(f).toLowerCase()]);
     if (!images.length) return null;
-    const withMtime: Array<{ f: string; m: number }> = [];
+    const withMtime: Array<{ resolved: string; mtimeMs: number }> = [];
     for (const f of images) {
-      let real: string;
+      let resolved: string;
+      let opened: ContainedFileHandle;
       try {
-        real = await resolveContainedPath(dir, path.join(dir, f));
+        resolved = await resolveContainedPath(dir, path.join(dir, f));
+        opened = await openContainedFile(resolved);
       } catch {
         continue;
       }
-      withMtime.push({ f: real, m: (await stat(real)).mtimeMs });
+      try {
+        withMtime.push({ resolved, mtimeMs: opened.mtimeMs });
+      } finally {
+        await opened.close().catch(() => {});
+      }
     }
     if (!withMtime.length) return null;
-    withMtime.sort((a, b) => b.m - a.m);
-    return fileToImagePart(withMtime[0]!.f, dir);
+    withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    return fileToImagePart(withMtime[0]!.resolved);
   } catch {
     return null;
   }

--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -16,11 +16,7 @@ import path from 'node:path';
 import { writeFile, readdir } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
 import { assertAndFetchExternalAsset } from './connectionTest.js';
-import {
-  openContainedFile,
-  resolveContainedPath,
-  type ContainedFileHandle,
-} from './media/contained-file.js';
+import { openContainedFile, type ContainedFileHandle } from './media/contained-file.js';
 import { resolveProviderConfig } from './media/config.js';
 import { IMAGE_MODELS } from './media/models.js';
 import { ensureProject } from './projects.js';
@@ -1296,19 +1292,21 @@ interface ReferenceImagePart {
   filename: string;
 }
 
-// Read an already-resolved project image file into an upload part. Null for
-// non-images / unreadable, and null when the file escapes the project directory
-// or is swapped for an outside symlink before it can be opened.
-async function fileToImagePart(resolvedPath: string): Promise<ReferenceImagePart | null> {
-  const mime = IMAGE_EXT_MIME[path.extname(resolvedPath).toLowerCase()];
-  if (!mime) return null;
+// Read a project image file into an upload part through the anchored project
+// root. Null for non-images / unreadable, and null when the file escapes the
+// project directory or is swapped for an outside target before it can be read.
+// EPATHESCAPE propagates so the caller can surface it as a tool error.
+async function fileToImagePart(dir: string, candidate: string): Promise<ReferenceImagePart | null> {
   let opened: ContainedFileHandle | null = null;
   try {
-    opened = await openContainedFile(resolvedPath);
+    opened = await openContainedFile(dir, candidate);
+    const mime = IMAGE_EXT_MIME[path.extname(opened.resolvedPath).toLowerCase()];
+    if (!mime) return null;
     const buf = await opened.read();
     if (!buf.length) return null;
-    return { bytes: buf, mime, filename: path.basename(resolvedPath) };
-  } catch {
+    return { bytes: buf, mime, filename: path.basename(opened.resolvedPath) };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') throw err;
     return null;
   } finally {
     if (opened) await opened.close().catch(() => {});
@@ -1343,30 +1341,23 @@ async function resolveAIHubMixReferenceImage(
   }
   // Treat as a project-local file. basename() strips any path so a value like
   // "../../etc/passwd" collapses to a filename inside the project dir. The
-  // canonical containment re-check rejects a project-local symlink whose target
-  // is outside; the caller converts the EPATHESCAPE throw into a tool error so
-  // no outside bytes are ever submitted on its behalf. Any OTHER resolution
-  // failure (e.g. ENOENT for a stale/missing image_url) is not a boundary
-  // violation: return null so the caller's existing newestProjectImagePart
-  // fallback for i2v models behaves exactly as it did before the boundary fix.
+  // anchored read rejects a project-local symlink or swapped directory whose
+  // target is outside; the caller converts the EPATHESCAPE throw into a tool
+  // error so no outside bytes are ever submitted on its behalf. Any OTHER
+  // resolution failure (e.g. ENOENT for a stale/missing image_url) is not a
+  // boundary violation: return null so the caller's existing
+  // newestProjectImagePart fallback for i2v models behaves exactly as it did
+  // before the boundary fix.
   const name = path.basename(raw.split('?')[0]!);
   if (!name) return null;
-  const candidate = path.join(dir, name);
-  let canonical: string;
-  try {
-    canonical = await resolveContainedPath(dir, candidate);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') throw err;
-    return null;
-  }
-  return fileToImagePart(canonical);
+  return fileToImagePart(dir, path.join(dir, name));
 }
 
 // Fallback for i2v models when no image_url is given: the most recently
 // modified image already in the project folder (typically the uploaded
-// reference or the last generated frame). Entries whose canonical target
-// escapes the project directory, or is swapped before it can be opened, are
-// skipped without being read.
+// reference or the last generated frame). Entries whose target escapes the
+// project directory, or is swapped before it can be read, are skipped without
+// being read.
 async function newestProjectImagePart(dir: string): Promise<ReferenceImagePart | null> {
   try {
     const entries = await readdir(dir);
@@ -1374,23 +1365,23 @@ async function newestProjectImagePart(dir: string): Promise<ReferenceImagePart |
     if (!images.length) return null;
     const withMtime: Array<{ resolved: string; mtimeMs: number }> = [];
     for (const f of images) {
-      let resolved: string;
       let opened: ContainedFileHandle;
       try {
-        resolved = await resolveContainedPath(dir, path.join(dir, f));
-        opened = await openContainedFile(resolved);
+        opened = await openContainedFile(dir, path.join(dir, f));
       } catch {
         continue;
       }
       try {
-        withMtime.push({ resolved, mtimeMs: opened.mtimeMs });
+        withMtime.push({ resolved: opened.resolvedPath, mtimeMs: opened.mtimeMs });
       } finally {
         await opened.close().catch(() => {});
       }
     }
     if (!withMtime.length) return null;
     withMtime.sort((a, b) => b.mtimeMs - a.mtimeMs);
-    return fileToImagePart(withMtime[0]!.resolved);
+    // Re-read the winner through the anchored root; the entry may have changed
+    // since the mtime scan.
+    return await fileToImagePart(dir, withMtime[0]!.resolved);
   } catch {
     return null;
   }

--- a/apps/daemon/src/media/contained-file.ts
+++ b/apps/daemon/src/media/contained-file.ts
@@ -3,70 +3,113 @@ import { lstat, open, realpath } from 'node:fs/promises';
 import path from 'node:path';
 
 // Test seam mirroring projectFileWriteTestHooks: fires after the canonical
-// containment check and before the no-follow open, so a spec can swap the entry
-// the way a concurrent writer can.
+// resolution of the candidate and before it is statted or opened, so a spec can
+// swap the entry or a parent directory the way a concurrent writer can.
 export const containedFileTestHooks = {
   afterResolve: null as null | ((resolvedPath: string) => Promise<void> | void),
 };
 
-// POSIX rejects a final symlink at open() time with O_NOFOLLOW; platforms
-// without the flag fall back to the fstat identity check below.
 const NO_FOLLOW_READ = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+const NO_FOLLOW_DIR =
+  fsConstants.O_RDONLY | (fsConstants.O_DIRECTORY ?? 0) | (fsConstants.O_NOFOLLOW ?? 0);
 
 function sameIdentity(a: BigIntStats, b: BigIntStats): boolean {
   return a.dev === b.dev && a.ino === b.ino;
 }
 
-// Canonical containment invariant for project reference images: the realpath'd
-// target of the candidate must stay inside `dir`. realpath follows symlinks, so
-// a project-local symlink to an outside file throws EPATHESCAPE before any open
-// can observe the target's size or bytes.
-export async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
-  const rootReal = await realpath(dir).catch(() => dir);
-  const real = await realpath(candidate);
-  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
-    const err = new Error('path escapes project dir via symlink');
-    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+function withinRoot(rootPath: string, candidatePath: string): boolean {
+  return candidatePath === rootPath || candidatePath.startsWith(rootPath + path.sep);
+}
+
+interface AnchoredRoot {
+  path: string;
+  close(): Promise<void>;
+}
+
+// Pin the project directory to an opened handle so a swap of its pathname cannot
+// redirect a later read. Linux exposes the opened directory through procfs,
+// which gives the kernel's own real path for the handle; platforms without
+// procfs keep the resolved pathname plus the final-component no-follow and
+// fstat identity checks, mirroring task-input-snapshot.ts.
+async function openAnchoredRoot(dir: string): Promise<AnchoredRoot> {
+  const handle = await open(dir, NO_FOLLOW_DIR);
+  if (process.platform !== 'linux') {
+    return { path: await realpath(dir), close: () => handle.close() };
+  }
+  try {
+    return {
+      path: await realpath(`/proc/self/fd/${handle.fd}`),
+      close: () => handle.close(),
+    };
+  } catch (err) {
+    await handle.close().catch(() => {});
     throw err;
   }
-  return real;
+}
+
+function containmentError(message: string): NodeJS.ErrnoException {
+  const err = new Error(message) as NodeJS.ErrnoException;
+  err.code = 'EPATHESCAPE';
+  return err;
 }
 
 export interface ContainedFileHandle {
+  resolvedPath: string;
   size: number;
   mtimeMs: number;
   read(): Promise<Buffer>;
   close(): Promise<void>;
 }
 
-// Open a path that resolveContainedPath already proved is inside the project
-// without following a final symlink, and prove the handle is the same regular
-// file the pathname named. Callers read through this handle so a swap between
-// resolution and read can never surface another file's size or bytes.
-export async function openContainedFile(resolvedPath: string): Promise<ContainedFileHandle> {
-  const expected = await lstat(resolvedPath, { bigint: true });
-  if (!expected.isFile()) {
-    const err = new Error('not a regular file');
-    (err as NodeJS.ErrnoException).code = 'ENOTFILE';
-    throw err;
-  }
-  await containedFileTestHooks.afterResolve?.(resolvedPath);
-  const handle = await open(resolvedPath, NO_FOLLOW_READ);
+// Read a project file through an identity-checked chain: the project directory
+// is opened once so its inode is pinned, the realpath'd candidate must stay
+// beneath that handled root, the entry itself is opened without following a
+// final symlink, and on Linux the opened file's procfs real path must still sit
+// beneath the handled root. Callers read size and bytes from this same handle,
+// so no swap between validation and read can surface another file's bytes.
+export async function openContainedFile(
+  dir: string,
+  candidate: string,
+): Promise<ContainedFileHandle> {
+  const root = await openAnchoredRoot(dir);
   try {
-    const stat = await handle.stat({ bigint: true });
-    if (!stat.isFile() || !sameIdentity(expected, stat)) {
-      const err = new Error('file changed before it could be opened');
-      (err as NodeJS.ErrnoException).code = 'ETOCTOU';
+    const real = await realpath(candidate);
+    if (!withinRoot(root.path, real)) throw containmentError('path escapes project dir');
+    await containedFileTestHooks.afterResolve?.(real);
+    const expected = await lstat(real, { bigint: true });
+    if (!expected.isFile()) {
+      const err = new Error('not a regular file') as NodeJS.ErrnoException;
+      err.code = 'ENOTFILE';
       throw err;
     }
-    return {
-      size: Number(stat.size),
-      mtimeMs: Number(stat.mtimeMs),
-      read: () => handle.readFile(),
-      close: () => handle.close(),
-    };
-  } catch (err) {
-    await handle.close().catch(() => {});
-    throw err;
+    const handle = await open(real, NO_FOLLOW_READ);
+    try {
+      const stat = await handle.stat({ bigint: true });
+      if (!stat.isFile() || !sameIdentity(expected, stat)) {
+        const err = new Error('file changed before it could be opened') as NodeJS.ErrnoException;
+        err.code = 'ETOCTOU';
+        throw err;
+      }
+      if (process.platform === 'linux') {
+        const openedPath = await realpath(`/proc/self/fd/${handle.fd}`);
+        if (!withinRoot(root.path, openedPath)) {
+          const err = new Error('file left the project dir while being opened') as NodeJS.ErrnoException;
+          err.code = 'ETOCTOU';
+          throw err;
+        }
+      }
+      return {
+        resolvedPath: real,
+        size: Number(stat.size),
+        mtimeMs: Number(stat.mtimeMs),
+        read: () => handle.readFile(),
+        close: () => handle.close(),
+      };
+    } catch (err) {
+      await handle.close().catch(() => {});
+      throw err;
+    }
+  } finally {
+    await root.close().catch(() => {});
   }
 }

--- a/apps/daemon/src/media/contained-file.ts
+++ b/apps/daemon/src/media/contained-file.ts
@@ -1,0 +1,72 @@
+import { constants as fsConstants, type BigIntStats } from 'node:fs';
+import { lstat, open, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+// Test seam mirroring projectFileWriteTestHooks: fires after the canonical
+// containment check and before the no-follow open, so a spec can swap the entry
+// the way a concurrent writer can.
+export const containedFileTestHooks = {
+  afterResolve: null as null | ((resolvedPath: string) => Promise<void> | void),
+};
+
+// POSIX rejects a final symlink at open() time with O_NOFOLLOW; platforms
+// without the flag fall back to the fstat identity check below.
+const NO_FOLLOW_READ = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
+
+function sameIdentity(a: BigIntStats, b: BigIntStats): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+// Canonical containment invariant for project reference images: the realpath'd
+// target of the candidate must stay inside `dir`. realpath follows symlinks, so
+// a project-local symlink to an outside file throws EPATHESCAPE before any open
+// can observe the target's size or bytes.
+export async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(dir).catch(() => dir);
+  const real = await realpath(candidate);
+  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+    const err = new Error('path escapes project dir via symlink');
+    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+    throw err;
+  }
+  return real;
+}
+
+export interface ContainedFileHandle {
+  size: number;
+  mtimeMs: number;
+  read(): Promise<Buffer>;
+  close(): Promise<void>;
+}
+
+// Open a path that resolveContainedPath already proved is inside the project
+// without following a final symlink, and prove the handle is the same regular
+// file the pathname named. Callers read through this handle so a swap between
+// resolution and read can never surface another file's size or bytes.
+export async function openContainedFile(resolvedPath: string): Promise<ContainedFileHandle> {
+  const expected = await lstat(resolvedPath, { bigint: true });
+  if (!expected.isFile()) {
+    const err = new Error('not a regular file');
+    (err as NodeJS.ErrnoException).code = 'ENOTFILE';
+    throw err;
+  }
+  await containedFileTestHooks.afterResolve?.(resolvedPath);
+  const handle = await open(resolvedPath, NO_FOLLOW_READ);
+  try {
+    const stat = await handle.stat({ bigint: true });
+    if (!stat.isFile() || !sameIdentity(expected, stat)) {
+      const err = new Error('file changed before it could be opened');
+      (err as NodeJS.ErrnoException).code = 'ETOCTOU';
+      throw err;
+    }
+    return {
+      size: Number(stat.size),
+      mtimeMs: Number(stat.mtimeMs),
+      read: () => handle.readFile(),
+      close: () => handle.close(),
+    };
+  } catch (err) {
+    await handle.close().catch(() => {});
+    throw err;
+  }
+}

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -50,7 +50,7 @@
 // so the CLI can exit non-zero and the agent can't silently narrate the
 // placeholder as the final result.
 
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -226,6 +226,21 @@ function stubsAllowed() {
   return v === '1' || v === 'true';
 }
 
+// Canonical containment invariant for project reference images: the realpath'd
+// target of the candidate must stay inside `dir`. realpath follows symlinks, so
+// a project-local symlink to an outside file throws EPATHESCAPE before any
+// stat/readFile can observe the target's size or bytes.
+async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(dir).catch(() => dir);
+  const real = await realpath(candidate);
+  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+    const err = new Error('path escapes project dir via symlink');
+    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+    throw err;
+  }
+  return real;
+}
+
 /**
  * Resolve a project-relative `--image` path into a base64 data URL the
  * upstream model APIs (Volcengine i2v, OpenAI image-edit, etc.) accept
@@ -247,9 +262,24 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
       `--image path "${rel}" resolves outside the project directory.`,
     );
   }
+  // Canonical containment re-check: the lexical prefix check above passes for a
+  // project-local symlink, but the symlink may point outside. realpath(abs)
+  // resolves the true target; reject it before stat/readFile touch the target.
+  // A dangling/missing link realpaths as ENOENT and maps to the not-found error.
+  let real: string;
+  try {
+    real = await resolveContainedPath(projectRootResolved, abs);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') {
+      throw new Error(
+        `--image path "${rel}" resolves outside the project directory.`,
+      );
+    }
+    throw new Error(`--image not found: ${rel}`);
+  }
   let info;
   try {
-    info = await stat(abs);
+    info = await stat(real);
   } catch {
     throw new Error(`--image not found: ${rel}`);
   }
@@ -266,7 +296,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
       `--image too large (${info.size} bytes; max ${MAX_IMAGE_BYTES}).`,
     );
   }
-  const bytes = await readFile(abs);
+  const bytes = await readFile(real);
   const ext = path.extname(abs).toLowerCase();
   // Tight allowlist: only what i2v / image-edit endpoints actually
   // consume. Avoids smuggling arbitrary content through as data URLs.
@@ -284,7 +314,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
   }
   return {
     path: rel.trim(),
-    abs,
+    abs: real,
     mime,
     size: bytes.length,
     dataUrl: `data:${mime};base64,${bytes.toString('base64')}`,

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -50,7 +50,7 @@
 // so the CLI can exit non-zero and the agent can't silently narrate the
 // placeholder as the final result.
 
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -206,6 +206,21 @@ function stubsAllowed() {
   return v === '1' || v === 'true';
 }
 
+// Canonical containment invariant for project reference images: the realpath'd
+// target of the candidate must stay inside `dir`. realpath follows symlinks, so
+// a project-local symlink to an outside file throws EPATHESCAPE before any
+// stat/readFile can observe the target's size or bytes.
+async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(dir).catch(() => dir);
+  const real = await realpath(candidate);
+  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
+    const err = new Error('path escapes project dir via symlink');
+    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
+    throw err;
+  }
+  return real;
+}
+
 /**
  * Resolve a project-relative `--image` path into a base64 data URL the
  * upstream model APIs (Volcengine i2v, OpenAI image-edit, etc.) accept
@@ -227,9 +242,24 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
       `--image path "${rel}" resolves outside the project directory.`,
     );
   }
+  // Canonical containment re-check: the lexical prefix check above passes for a
+  // project-local symlink, but the symlink may point outside. realpath(abs)
+  // resolves the true target; reject it before stat/readFile touch the target.
+  // A dangling/missing link realpaths as ENOENT and maps to the not-found error.
+  let real: string;
+  try {
+    real = await resolveContainedPath(projectRootResolved, abs);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') {
+      throw new Error(
+        `--image path "${rel}" resolves outside the project directory.`,
+      );
+    }
+    throw new Error(`--image not found: ${rel}`);
+  }
   let info;
   try {
-    info = await stat(abs);
+    info = await stat(real);
   } catch {
     throw new Error(`--image not found: ${rel}`);
   }
@@ -246,7 +276,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
       `--image too large (${info.size} bytes; max ${MAX_IMAGE_BYTES}).`,
     );
   }
-  const bytes = await readFile(abs);
+  const bytes = await readFile(real);
   const ext = path.extname(abs).toLowerCase();
   // Tight allowlist: only what i2v / image-edit endpoints actually
   // consume. Avoids smuggling arbitrary content through as data URLs.
@@ -264,7 +294,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
   }
   return {
     path: rel.trim(),
-    abs,
+    abs: real,
     mime,
     size: bytes.length,
     dataUrl: `data:${mime};base64,${bytes.toString('base64')}`,

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -50,7 +50,7 @@
 // so the CLI can exit non-zero and the agent can't silently narrate the
 // placeholder as the final result.
 
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { execFile as execFileCb, spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -68,6 +68,11 @@ import type {
   DesktopRenderFramesInput,
   DesktopRenderFramesResult,
 } from '@open-design/sidecar-proto';
+import {
+  openContainedFile,
+  resolveContainedPath,
+  type ContainedFileHandle,
+} from './contained-file.js';
 import {
   AUDIO_DURATIONS_SEC,
   type AudioKind,
@@ -226,21 +231,6 @@ function stubsAllowed() {
   return v === '1' || v === 'true';
 }
 
-// Canonical containment invariant for project reference images: the realpath'd
-// target of the candidate must stay inside `dir`. realpath follows symlinks, so
-// a project-local symlink to an outside file throws EPATHESCAPE before any
-// stat/readFile can observe the target's size or bytes.
-async function resolveContainedPath(dir: string, candidate: string): Promise<string> {
-  const rootReal = await realpath(dir).catch(() => dir);
-  const real = await realpath(candidate);
-  if (real !== rootReal && !real.startsWith(rootReal + path.sep)) {
-    const err = new Error('path escapes project dir via symlink');
-    (err as NodeJS.ErrnoException).code = 'EPATHESCAPE';
-    throw err;
-  }
-  return real;
-}
-
 /**
  * Resolve a project-relative `--image` path into a base64 data URL the
  * upstream model APIs (Volcengine i2v, OpenAI image-edit, etc.) accept
@@ -264,8 +254,9 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
   }
   // Canonical containment re-check: the lexical prefix check above passes for a
   // project-local symlink, but the symlink may point outside. realpath(abs)
-  // resolves the true target; reject it before stat/readFile touch the target.
-  // A dangling/missing link realpaths as ENOENT and maps to the not-found error.
+  // resolves the true target; reject it before any read can observe the
+  // target's size or bytes. A dangling/missing link realpaths as ENOENT and
+  // maps to the not-found error.
   let real: string;
   try {
     real = await resolveContainedPath(projectRootResolved, abs);
@@ -277,48 +268,55 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
     }
     throw new Error(`--image not found: ${rel}`);
   }
-  let info;
+  let opened: ContainedFileHandle;
   try {
-    info = await stat(real);
-  } catch {
+    // Open the validated target without following a final symlink, then read
+    // size and bytes from that same handle so a concurrent replacement cannot
+    // swap in an unchecked file between validation and read.
+    opened = await openContainedFile(real);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOTFILE') {
+      throw new Error(`--image is not a regular file: ${rel}`);
+    }
     throw new Error(`--image not found: ${rel}`);
   }
-  if (!info.isFile()) {
-    throw new Error(`--image is not a regular file: ${rel}`);
+  try {
+    // Cap at 16 MB. Beyond this, base64 inflation alone (≈4/3) starts
+    // hitting body-size limits at the upstream APIs and our own express
+    // 4mb body cap on inbound requests; bigger payloads should travel
+    // via the dedicated upload endpoint, not the dispatcher.
+    const MAX_IMAGE_BYTES = 16 * 1024 * 1024;
+    if (opened.size > MAX_IMAGE_BYTES) {
+      throw new Error(
+        `--image too large (${opened.size} bytes; max ${MAX_IMAGE_BYTES}).`,
+      );
+    }
+    const bytes = await opened.read();
+    const ext = path.extname(abs).toLowerCase();
+    // Tight allowlist: only what i2v / image-edit endpoints actually
+    // consume. Avoids smuggling arbitrary content through as data URLs.
+    const mime = ({
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.jpeg': 'image/jpeg',
+      '.webp': 'image/webp',
+      '.gif': 'image/gif',
+    })[ext];
+    if (!mime) {
+      throw new Error(
+        `--image has unsupported extension "${ext}". Use png, jpg, jpeg, webp, or gif.`,
+      );
+    }
+    return {
+      path: rel.trim(),
+      abs: real,
+      mime,
+      size: bytes.length,
+      dataUrl: `data:${mime};base64,${bytes.toString('base64')}`,
+    };
+  } finally {
+    await opened.close().catch(() => {});
   }
-  // Cap at 16 MB. Beyond this, base64 inflation alone (≈4/3) starts
-  // hitting body-size limits at the upstream APIs and our own express
-  // 4mb body cap on inbound requests; bigger payloads should travel
-  // via the dedicated upload endpoint, not the dispatcher.
-  const MAX_IMAGE_BYTES = 16 * 1024 * 1024;
-  if (info.size > MAX_IMAGE_BYTES) {
-    throw new Error(
-      `--image too large (${info.size} bytes; max ${MAX_IMAGE_BYTES}).`,
-    );
-  }
-  const bytes = await readFile(real);
-  const ext = path.extname(abs).toLowerCase();
-  // Tight allowlist: only what i2v / image-edit endpoints actually
-  // consume. Avoids smuggling arbitrary content through as data URLs.
-  const mime = ({
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.webp': 'image/webp',
-    '.gif': 'image/gif',
-  })[ext];
-  if (!mime) {
-    throw new Error(
-      `--image has unsupported extension "${ext}". Use png, jpg, jpeg, webp, or gif.`,
-    );
-  }
-  return {
-    path: rel.trim(),
-    abs: real,
-    mime,
-    size: bytes.length,
-    dataUrl: `data:${mime};base64,${bytes.toString('base64')}`,
-  };
 }
 
 function clampNumber(value: unknown, allowed: number[]): number | undefined {

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -70,7 +70,6 @@ import type {
 } from '@open-design/sidecar-proto';
 import {
   openContainedFile,
-  resolveContainedPath,
   type ContainedFileHandle,
 } from './contained-file.js';
 import {
@@ -252,30 +251,23 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
       `--image path "${rel}" resolves outside the project directory.`,
     );
   }
-  // Canonical containment re-check: the lexical prefix check above passes for a
-  // project-local symlink, but the symlink may point outside. realpath(abs)
-  // resolves the true target; reject it before any read can observe the
-  // target's size or bytes. A dangling/missing link realpaths as ENOENT and
-  // maps to the not-found error.
-  let real: string;
+  // Resolve and open through the anchored project root: the lexical prefix
+  // check above passes for a project-local symlink, and a concurrent writer
+  // could still swap the entry or a parent directory. openContainedFile pins
+  // the root handle, re-checks containment, opens without following a final
+  // symlink, and reads from that same handle. A dangling/missing link maps to
+  // the not-found error.
+  let opened: ContainedFileHandle;
   try {
-    real = await resolveContainedPath(projectRootResolved, abs);
+    opened = await openContainedFile(projectRootResolved, abs);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'EPATHESCAPE') {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPATHESCAPE') {
       throw new Error(
         `--image path "${rel}" resolves outside the project directory.`,
       );
     }
-    throw new Error(`--image not found: ${rel}`);
-  }
-  let opened: ContainedFileHandle;
-  try {
-    // Open the validated target without following a final symlink, then read
-    // size and bytes from that same handle so a concurrent replacement cannot
-    // swap in an unchecked file between validation and read.
-    opened = await openContainedFile(real);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOTFILE') {
+    if (code === 'ENOTFILE') {
       throw new Error(`--image is not a regular file: ${rel}`);
     }
     throw new Error(`--image not found: ${rel}`);
@@ -309,7 +301,7 @@ async function resolveProjectImage(rel: unknown, projectDir: string): Promise<Im
     }
     return {
       path: rel.trim(),
-      abs: real,
+      abs: opened.resolvedPath,
       mime,
       size: bytes.length,
       dataUrl: `data:${mime};base64,${bytes.toString('base64')}`,

--- a/apps/daemon/tests/media/media-symlink-boundary.test.ts
+++ b/apps/daemon/tests/media/media-symlink-boundary.test.ts
@@ -1,0 +1,359 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { executeAIHubMixGenerateVideo } from '../../src/byok-tools.js';
+import { generateMedia } from '../../src/media/index.js';
+
+// Regression tests for issue nexu-io/open-design#6779: project-local
+// reference-image readers (media/index.ts resolveProjectImage and
+// byok-tools.ts fileToImagePart / resolveAIHubMixReferenceImage /
+// newestProjectImagePart) performed a *lexical* containment check and then
+// stat / readFile / copyFile, which follow symlinks. A project-local symlink
+// whose canonical target is outside the project escaped the boundary, letting
+// an outside file's size and bytes leak into a generation request.
+//
+// The boundary invariant under test: the canonical (realpath'd) target of any
+// project reference-image read must stay inside the project directory, and it
+// must be enforced BEFORE any stat / readFile / copyFile touches the target.
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+
+describe('media reference-image symlink boundary (issue #6779)', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  let projectDir: string;
+  const realFetch = globalThis.fetch;
+  const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-symlink-boundary-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    projectDir = path.join(projectsRoot, 'project-1');
+    await mkdir(projectDir, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    vi.unstubAllGlobals();
+    if (originalMinimaxApiKey == null) {
+      delete process.env.OD_MINIMAX_API_KEY;
+    } else {
+      process.env.OD_MINIMAX_API_KEY = originalMinimaxApiKey;
+    }
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  const minimaxArgs = (overrides: Record<string, unknown> = {}) => ({
+    projectRoot,
+    projectsRoot,
+    projectId: 'project-1',
+    surface: 'image' as const,
+    model: 'minimax-image-01',
+    prompt: 'probe',
+    output: 'probe.png',
+    ...overrides,
+  });
+
+  it('rejects a project symlink whose target is outside the project before reading the target', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+
+    // Outside target, > MAX_IMAGE_BYTES (16 MiB). If the boundary leaks, the
+    // observable symptom is the outside file's size ("--image too large")
+    // instead of a project-boundary rejection — proving stat() reached it.
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'secret.png');
+    await writeFile(outsideFile, Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+
+    // Lexically inside the project: <projectDir>/external.png
+    await symlink(outsideFile, path.join(projectDir, 'external.png'));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    // The boundary must reject BEFORE stat/readFile touch the target.
+    await expect(
+      generateMedia(minimaxArgs({ image: './external.png' })),
+    ).rejects.toThrow(/outside the project directory|escape the project|via symlink/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a project symlink escape on the in-chat AIHubMix generate_video reference path', async () => {
+    // Distinctive bytes so we can prove the OUTSIDE content reached the wire.
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'secret.png'), secretBytes);
+    // Symlink inside the project's files dir, named like a normal upload.
+    await symlink(path.join(outsideDir, 'secret.png'), path.join(projectDir, 'external.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-probe' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-probe') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/external.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Boundary invariant: outside bytes must NOT reach the provider. On a
+    // proper rejection no submit happens at all, so submitBody stays null.
+    expect(result.ok).toBe(false);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('rejects a newestProjectImagePart fallback that would read an outside symlink target', async () => {
+    // Distinctive outside bytes; a leak would put them on the wire.
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'secret.png'), secretBytes);
+    // The ONLY image in the project dir is an escape symlink.
+    await symlink(path.join(outsideDir, 'secret.png'), path.join(projectDir, 'external.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-fallback' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-fallback') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // No image_url: the code falls back to newestProjectImagePart, which must
+    // skip the escaping symlink and find no usable reference.
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Boundary invariant: the escaping fallback candidate must not leak outside
+    // bytes; the i2v model then correctly reports no reference found.
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/needs a reference image/);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('control: accepts a byok in-project symlink reference whose target stays inside the project', async () => {
+    // Distinctive in-project bytes — the submit body must carry THESE, and
+    // never an outside secret.
+    const insideBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02, 0x03]);
+    const insideB64 = insideBytes.toString('base64');
+    const inside = path.join(projectDir, 'inside.png');
+    await writeFile(inside, insideBytes);
+    await symlink(inside, path.join(projectDir, 'link.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-ctrl' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-ctrl') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/link.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Legitimate in-project symlink reference resolves and reaches the wire.
+    expect(result.ok).toBe(true);
+    expect(submitBody.input.media[0].type).toBe('first_frame');
+    expect(submitBody.input.media[0].url).toMatch(/^data:image\/png;base64,/);
+    expect(submitBody.input.media[0].url).toContain(insideB64);
+  });
+
+  it('control: missing image_url file falls back to the newest in-project image (no hard error)', async () => {
+    // A real in-project PNG: the fallback target newestProjectImagePart should
+    // pick up when the named reference is missing.
+    const insideBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xaa, 0xbb, 0xcc]);
+    const insideB64 = insideBytes.toString('base64');
+    await writeFile(path.join(projectDir, 'inside.png'), insideBytes);
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-missing' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-missing') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Stale image_url naming a file that does not exist inside the project: not
+    // a boundary violation, so it must degrade to the pre-existing
+    // newestProjectImagePart fallback instead of a hard ENOENT error.
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/missing.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(submitBody.input.media[0].type).toBe('first_frame');
+    expect(submitBody.input.media[0].url).toMatch(/^data:image\/png;base64,/);
+    expect(submitBody.input.media[0].url).toContain(insideB64);
+  });
+
+  it('control: rejects an oversized real project file as --image too large', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    await writeFile(path.join(projectDir, 'big.png'), Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+    vi.stubGlobal('fetch', vi.fn());
+
+    await expect(
+      generateMedia(minimaxArgs({ image: './big.png' })),
+    ).rejects.toThrow(/--image too large \(16777217 bytes; max 16777216\)/);
+  });
+
+  it('control: accepts a project symlink whose target is inside the project', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const inside = path.join(projectDir, 'inside.png');
+    await writeFile(inside, Buffer.from(PNG_BASE64, 'base64'));
+    await symlink(inside, path.join(projectDir, 'link.png'));
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.subject_reference).toEqual([{
+        type: 'character',
+        image_file: expect.stringMatching(/^data:image\/png;base64,/),
+      }]);
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(minimaxArgs({ image: './link.png' }));
+    expect(result.providerId).toBe('minimax');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('control: rejects a plainly-lexical outside path before any read', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const outsideFile = path.join(root, 'outside-secret.png');
+    await writeFile(outsideFile, Buffer.from(PNG_BASE64, 'base64'));
+    // The dispatch must never reach fetch on a boundary violation.
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia(minimaxArgs({ image: outsideFile })),
+    ).rejects.toThrow(/outside the project directory/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/media/media-symlink-boundary.test.ts
+++ b/apps/daemon/tests/media/media-symlink-boundary.test.ts
@@ -1,0 +1,359 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { executeAIHubMixGenerateVideo } from '../../src/byok-tools.js';
+import { generateMedia } from '../../src/media/index.js';
+
+// Regression tests for issue nexu-io/open-design#6779: project-local
+// reference-image readers (media/index.ts resolveProjectImage and
+// byok-tools.ts fileToImagePart / resolveAIHubMixReferenceImage /
+// newestProjectImagePart) performed a *lexical* containment check and then
+// stat / readFile / copyFile, which follow symlinks. A project-local symlink
+// whose canonical target is outside the project escaped the boundary, letting
+// an outside file's size and bytes leak into a generation request.
+//
+// The boundary invariant under test: the canonical (realpath'd) target of any
+// project reference-image read must stay inside the project directory, and it
+// must be enforced BEFORE any stat / readFile / copyFile touches the target.
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+
+describe('media reference-image symlink boundary (issue #6779)', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  let projectDir: string;
+  const realFetch = globalThis.fetch;
+  const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-symlink-boundary-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    projectDir = path.join(projectsRoot, 'project-1');
+    await mkdir(projectDir, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    vi.unstubAllGlobals();
+    if (originalMinimaxApiKey == null) {
+      delete process.env.OD_MINIMAX_API_KEY;
+    } else {
+      process.env.OD_MINIMAX_API_KEY = originalMinimaxApiKey;
+    }
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
+  const minimaxArgs = (overrides: Record<string, unknown> = {}) => ({
+    projectRoot,
+    projectsRoot,
+    projectId: 'project-1',
+    surface: 'image' as const,
+    model: 'minimax-image-01',
+    prompt: 'probe',
+    output: 'probe.png',
+    ...overrides,
+  });
+
+  it('rejects a project symlink whose target is outside the project before reading the target', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+
+    // Outside target, > MAX_IMAGE_BYTES (16 MiB). If the boundary leaks, the
+    // observable symptom is the outside file's size ("--image too large")
+    // instead of a project-boundary rejection — proving stat() reached it.
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'secret.png');
+    await writeFile(outsideFile, Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+
+    // Lexically inside the project: <projectDir>/external.png
+    await symlink(outsideFile, path.join(projectDir, 'external.png'));
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    // The boundary must reject BEFORE stat/readFile touch the target.
+    await expect(
+      generateMedia(minimaxArgs({ image: './external.png' })),
+    ).rejects.toThrow(/outside the project directory|escape the project|via symlink/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a project symlink escape on the in-chat AIHubMix generate_video reference path', async () => {
+    // Distinctive bytes so we can prove the OUTSIDE content reached the wire.
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'secret.png'), secretBytes);
+    // Symlink inside the project's files dir, named like a normal upload.
+    await symlink(path.join(outsideDir, 'secret.png'), path.join(projectDir, 'external.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-probe' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-probe') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/external.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Boundary invariant: outside bytes must NOT reach the provider. On a
+    // proper rejection no submit happens at all, so submitBody stays null.
+    expect(result.ok).toBe(false);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('rejects a newestProjectImagePart fallback that would read an outside symlink target', async () => {
+    // Distinctive outside bytes; a leak would put them on the wire.
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'secret.png'), secretBytes);
+    // The ONLY image in the project dir is an escape symlink.
+    await symlink(path.join(outsideDir, 'secret.png'), path.join(projectDir, 'external.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-fallback' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-fallback') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // No image_url: the code falls back to newestProjectImagePart, which must
+    // skip the escaping symlink and find no usable reference.
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Boundary invariant: the escaping fallback candidate must not leak outside
+    // bytes; the i2v model then correctly reports no reference found.
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/needs a reference image/);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('control: accepts a byok in-project symlink reference whose target stays inside the project', async () => {
+    // Distinctive in-project bytes — the submit body must carry THESE, and
+    // never an outside secret.
+    const insideBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02, 0x03]);
+    const insideB64 = insideBytes.toString('base64');
+    const inside = path.join(projectDir, 'inside.png');
+    await writeFile(inside, insideBytes);
+    await symlink(inside, path.join(projectDir, 'link.png'));
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-ctrl' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-ctrl') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/link.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // Legitimate in-project symlink reference resolves and reaches the wire.
+    expect(result.ok).toBe(true);
+    expect(submitBody.input.media[0].type).toBe('first_frame');
+    expect(submitBody.input.media[0].url).toMatch(/^data:image\/png;base64,/);
+    expect(submitBody.input.media[0].url).toContain(insideB64);
+  });
+
+  it('control: missing image_url file falls back to the newest in-project image (no hard error)', async () => {
+    // A real in-project PNG: the fallback target newestProjectImagePart should
+    // pick up when the named reference is missing.
+    const insideBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xaa, 0xbb, 0xcc]);
+    const insideB64 = insideBytes.toString('base64');
+    await writeFile(path.join(projectDir, 'inside.png'), insideBytes);
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-missing' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-missing') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Stale image_url naming a file that does not exist inside the project: not
+    // a boundary violation, so it must degrade to the pre-existing
+    // newestProjectImagePart fallback instead of a hard ENOENT error.
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/missing.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(submitBody.input.media[0].type).toBe('first_frame');
+    expect(submitBody.input.media[0].url).toMatch(/^data:image\/png;base64,/);
+    expect(submitBody.input.media[0].url).toContain(insideB64);
+  });
+
+  it('control: rejects an oversized real project file as --image too large', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    await writeFile(path.join(projectDir, 'big.png'), Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+    vi.stubGlobal('fetch', vi.fn());
+
+    await expect(
+      generateMedia(minimaxArgs({ image: './big.png' })),
+    ).rejects.toThrow(/--image too large \(16777217 bytes; max 16777216\)/);
+  });
+
+  it('control: accepts a project symlink whose target is inside the project', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const inside = path.join(projectDir, 'inside.png');
+    await writeFile(inside, Buffer.from(PNG_BASE64, 'base64'));
+    await symlink(inside, path.join(projectDir, 'link.png'));
+
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.subject_reference).toEqual([{
+        type: 'character',
+        image_file: expect.stringMatching(/^data:image\/png;base64,/),
+      }]);
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0, status_msg: 'success' },
+        data: { image_base64: [PNG_BASE64] },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia(minimaxArgs({ image: './link.png' }));
+    expect(result.providerId).toBe('minimax');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('control: rejects a plainly-lexical outside path before any read', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const outsideFile = path.join(root, 'outside-secret.png');
+    await writeFile(outsideFile, Buffer.from(PNG_BASE64, 'base64'));
+    // The dispatch must never reach fetch on a boundary violation.
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      generateMedia(minimaxArgs({ image: outsideFile })),
+    ).rejects.toThrow(/outside the project directory/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/daemon/tests/media/media-symlink-boundary.test.ts
+++ b/apps/daemon/tests/media/media-symlink-boundary.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { executeAIHubMixGenerateVideo } from '../../src/byok-tools.js';
+import { containedFileTestHooks } from '../../src/media/contained-file.js';
 import { generateMedia } from '../../src/media/index.js';
 
 // Regression tests for issue nexu-io/open-design#6779: project-local
@@ -40,6 +41,7 @@ describe('media reference-image symlink boundary (issue #6779)', () => {
   });
 
   afterEach(async () => {
+    containedFileTestHooks.afterResolve = null;
     globalThis.fetch = realFetch;
     vi.unstubAllGlobals();
     if (originalMinimaxApiKey == null) {
@@ -54,6 +56,16 @@ describe('media reference-image symlink boundary (issue #6779)', () => {
     }
     await rm(root, { recursive: true, force: true });
   });
+
+  // Deterministic race seam: replace the canonically-resolved entry with an
+  // outside symlink after resolution but before the no-follow open.
+  function swapResolvedEntryForOutsideLink(outsideFile: string, name: string) {
+    containedFileTestHooks.afterResolve = async (resolvedPath) => {
+      if (path.basename(resolvedPath) !== name) return;
+      await rm(resolvedPath, { force: true });
+      await symlink(outsideFile, resolvedPath);
+    };
+  }
 
   async function writeConfig(data: unknown) {
     const file = path.join(projectRoot, '.od', 'media-config.json');
@@ -355,5 +367,140 @@ describe('media reference-image symlink boundary (issue #6779)', () => {
       generateMedia(minimaxArgs({ image: outsideFile })),
     ).rejects.toThrow(/outside the project directory/);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an entry swapped after canonical resolution before reading the outside target', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    await writeFile(path.join(projectDir, 'race.png'), Buffer.from(PNG_BASE64, 'base64'));
+
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    // Outside target above MAX_IMAGE_BYTES: reopening the pathname instead of
+    // the verified handle would surface the outside size as "--image too large".
+    const outsideFile = path.join(outsideDir, 'secret.png');
+    await writeFile(outsideFile, Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+    swapResolvedEntryForOutsideLink(outsideFile, 'race.png');
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const error = await generateMedia(minimaxArgs({ image: './race.png' }))
+      .then(() => null, (err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).not.toMatch(/too large/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never submits outside bytes when a reference entry is swapped after canonical resolution', async () => {
+    await writeFile(
+      path.join(projectDir, 'race.png'),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x07, 0x07, 0x07]),
+    );
+
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'secret.png');
+    await writeFile(outsideFile, secretBytes);
+    swapResolvedEntryForOutsideLink(outsideFile, 'race.png');
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-race' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-race') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/race.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    // The raced named reference resolves to nothing: no submit carries the
+    // outside bytes, and the i2v model reports the missing reference instead.
+    expect(result.ok).toBe(false);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('skips a fallback entry swapped after canonical resolution in the newest-image scan', async () => {
+    await writeFile(
+      path.join(projectDir, 'race.png'),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x08, 0x08, 0x08]),
+    );
+
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'secret.png');
+    await writeFile(outsideFile, secretBytes);
+    swapResolvedEntryForOutsideLink(outsideFile, 'race.png');
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-race-fallback' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-race-fallback') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/needs a reference image/);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
   });
 });

--- a/apps/daemon/tests/media/media-symlink-boundary.test.ts
+++ b/apps/daemon/tests/media/media-symlink-boundary.test.ts
@@ -67,6 +67,16 @@ describe('media reference-image symlink boundary (issue #6779)', () => {
     };
   }
 
+  // Deterministic race seam: replace a directory on the resolved path with an
+  // outside symlink after canonical resolution, so every pathname-based check
+  // still agrees while the anchored root is the only thing that can catch it.
+  function swapDirectoryForOutsideLink(directory: string, outsideDir: string) {
+    containedFileTestHooks.afterResolve = async () => {
+      await rm(directory, { recursive: true, force: true });
+      await symlink(outsideDir, directory);
+    };
+  }
+
   async function writeConfig(data: unknown) {
     const file = path.join(projectRoot, '.od', 'media-config.json');
     await mkdir(path.dirname(file), { recursive: true });
@@ -500,6 +510,84 @@ describe('media reference-image symlink boundary (issue #6779)', () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/needs a reference image/);
+    expect(submitBody).toBeNull();
+    expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
+  });
+
+  it('rejects a parent directory swapped after canonical resolution before reading the outside target', async () => {
+    await writeConfig({ providers: { minimax: {} } });
+    const subDir = path.join(projectDir, 'sub');
+    await mkdir(subDir, { recursive: true });
+    await writeFile(path.join(subDir, 'race.png'), Buffer.from(PNG_BASE64, 'base64'));
+
+    // Outside directory holding a same-named, oversized file: a pathname-based
+    // check agrees on the swapped path, so only the anchored root can catch it.
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'race.png'), Buffer.alloc(16 * 1024 * 1024 + 1, 0x42));
+    swapDirectoryForOutsideLink(subDir, outsideDir);
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const error = await generateMedia(minimaxArgs({ image: './sub/race.png' }))
+      .then(() => null, (err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).not.toMatch(/too large/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never submits outside bytes when a project directory is swapped after canonical resolution', async () => {
+    await writeFile(
+      path.join(projectDir, 'race.png'),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x09, 0x09, 0x09]),
+    );
+
+    const secretBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef]);
+    const secretB64 = secretBytes.toString('base64');
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(path.join(outsideDir, 'race.png'), secretBytes);
+    swapDirectoryForOutsideLink(projectDir, outsideDir);
+
+    let submitBody: any = null;
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url === 'https://aihubmix.com/v1/videos') {
+        submitBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: 'v-dir-race' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url === 'https://aihubmix.com/v1/videos/v-dir-race') {
+        return new Response(
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(Buffer.from([0x01]), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await executeAIHubMixGenerateVideo(
+      {
+        prompt: 'animate',
+        model: 'aihubmix-happyhorse-1.0-i2v',
+        image_url: '/api/projects/project-1/files/race.png',
+      },
+      {
+        projectRoot,
+        projectsRoot,
+        projectId: 'project-1',
+        upstreamApiKey: 'ahm-byok-key',
+        upstreamBaseUrl: 'https://aihubmix.com/v1',
+        videoPollIntervalMs: 1,
+      },
+    );
+
+    expect(result.ok).toBe(false);
     expect(submitBody).toBeNull();
     expect(submitBody?.input?.media?.[0]?.url ?? '').not.toContain(secretB64);
   });


### PR DESCRIPTION
Fixes #6779

## Why

The daemon's media reference-image readers enforced a lexical project boundary and then called stat / readFile, which follow symlinks. A project-local symlink whose target lies outside the project could therefore ship outside bytes to a paid provider — the same boundary-bug class closed for other project-file seams in #2036 and #5784, but with no coverage on the media reference seam. Drafted at the maintainer's invitation on #6779 as a linked reference patch, not a replacement for the maintainer-lane fix.

## What users will see

No change for legitimate projects. A project that contains a symlink whose target lies outside the project directory (a committed symlink, or one created by a skill/plugin/agent run) will now have that reference rejected with the existing "resolves outside the project directory" / tool-error wording instead of silently reading and uploading the outside file; BYOK i2v calls with an escaping reference return an invalid reference image tool error. A stale or missing `image_url` that names a project file is not a boundary violation: the pre-existing fallback to the newest in-project image for i2v models is preserved exactly as before, covered by a control test.

## Surface area

- [ ] **UI** — not applicable
- [ ] **Keyboard shortcut** — not applicable
- [ ] **CLI / env var** — not applicable
- [ ] **API / contract** — not applicable
- [ ] **Extension point** — not applicable
- [ ] **i18n keys** — not applicable
- [ ] **New top-level dependency** — not applicable
- [x] **Default behavior change** — a project-local symlink escaping the project boundary used to be read and its bytes submitted; it is now rejected. Nothing in the normal (non-malicious) flow changes, and a missing reference still falls back to the newest project image.
- [ ] **None** — otherwise internal daemon security fix + tests

## Screenshots

Not applicable — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media/media-symlink-boundary.test.ts`
- Did the test go red on `main` and green on this branch? Yes.
  - On base 028bde50a: 3 probes fail — probe 1 observes the outside file's size (`--image too large (16777217 bytes; max 16777216)`), probes 2–3 show `result.ok === true` (outside bytes reached the provider). 5 controls pass.
  - On this branch: 8/8 pass. `fetch` is never called on the rejection paths, and on the missing-`image_url` control the in-project fallback bytes reach the wire with no error.
- Controls: in-project symlink accepted (BYOK and minimax), oversized real file still rejected as "too large" (the size check fires on the canonical path), plain lexical outside path still rejected, missing `image_url` falls back to the newest in-project image without erroring.

## Validation

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon test -- tests/media/media-symlink-boundary.test.ts tests/byok-tools.test.ts tests/aihubmix-asset-ssrf.test.ts tests/media-adapters.test.ts`

## Out of scope

`renderHyperFramesViaCli` (`apps/daemon/src/media/index.ts`, `compositionDir`) has the same lexical-only containment check against a directory; it is not changed by this PR.
