### PR TITLE
test(e2e): make beta recovery fixture version-independent

### DIFF
--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -2079,14 +2079,15 @@ process.stdin.on("end", () => {
   });
 
   it.skip("[P1] lets the daily main build recover a shared beta advanced by a feature branch", async () => {
-    const packagedVersion = await readPackagedVersion();
+    const packagedVersion = "1.2.3";
+    const foreignAheadBaseVersion = "1.3.0";
     const objects: Record<string, unknown> = {
       "beta/latest/metadata.json": {
-        baseVersion: "0.19.0",
+        baseVersion: foreignAheadBaseVersion,
         channel: "beta",
         github: { branch: "feat/standalone-closure" },
         releaseNumber: 9,
-        releaseVersion: "0.19.0-beta.9",
+        releaseVersion: `${foreignAheadBaseVersion}-beta.9`,
       },
     };
     const fixture = await startStablePrereleaseMetadataServer(objects);


### PR DESCRIPTION
## Why

While diagnosing the packaged E2E failure on backport PR #6809, the daily-beta recovery fixture compared the repository package version (`0.19.1`) with a hard-coded foreign beta (`0.19.0-beta.9`). That beta was no longer ahead, so the script correctly returned `beta-not-ahead` while the test expected recovery.

This made release/backport CI depend on the repository's current version and allowed an unrelated version bump to break the fixture again.

## What users will see

No product UI change. Release maintainers get a version-independent beta-recovery fixture whose semantic relationship remains stable across package version bumps.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; test-only change.

## Bug fix verification

- Test path: `e2e/tests/packaged-smoke-workflow.test.ts`
- Red: on PR #6809's head, the focused test returned `force:false; promote:true (beta-not-ahead)` instead of the expected recovery decision.
- Green: after replacing the repository-version snapshot with explicit semantic fixtures (`1.2.3` vs `1.3.0-beta.9`), the focused test passed before restoring parity with the skip introduced by #6808 and backported in #6811.
- The final diff preserves the existing `it.skip` from the current `release/v0.19.1` base, avoiding overlap with #6808/#6811.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts` — 71 passed, 1 skipped
- `corepack pnpm guard`
- `corepack pnpm typecheck`
