### PR TITLE
test(e2e): make beta recovery fixture version-independent

### DIFF
--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -102,6 +102,8 @@ describe('CLI startup boundaries', () => {
       ...process.env,
       OD_BIND_HOST: '127.0.0.1',
       OD_DATA_DIR: dataDir,
+      POSTHOG_KEY: '',
+      POSTHOG_HOST: '',
       OPEN_DESIGN_VELA_TELEMETRY: 'off',
       OPEN_DESIGN_TELEMETRY_RELAY_URL: '',
       LANGFUSE_PUBLIC_KEY: '',
@@ -169,11 +171,16 @@ describe('CLI startup boundaries', () => {
         const line = await waitForStdoutLine(second, /\[od\] listening on (http:\/\/[^\s]+)/u);
         expect(line).toContain(`127.0.0.1:${port}`);
         await waitFor(() => {
-          const state = JSON.parse(readFileSync(statePath, 'utf8')) as { status?: string };
+          const state = JSON.parse(readFileSync(statePath, 'utf8')) as {
+            status?: string;
+            analyticsRecovery?: { completedAt?: number };
+          };
           const checkDb = new Database(join(dataDir, 'app.sqlite'), { readonly: true });
           try {
             const row = checkDb.prepare(`SELECT run_status AS status FROM messages WHERE id = ?`).get(messageId) as { status?: string } | undefined;
-            return state.status === 'failed' && row?.status === 'failed';
+            return state.status === 'failed'
+              && row?.status === 'failed'
+              && typeof state.analyticsRecovery?.completedAt === 'number';
           } finally {
             checkDb.close();
           }

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -2079,14 +2079,15 @@ process.stdin.on("end", () => {
   });
 
   it.skip("[P1] lets the daily main build recover a shared beta advanced by a feature branch", async () => {
-    const packagedVersion = await readPackagedVersion();
+    const packagedVersion = "1.2.3";
+    const foreignAheadBaseVersion = "1.3.0";
     const objects: Record<string, unknown> = {
       "beta/latest/metadata.json": {
-        baseVersion: "0.19.0",
+        baseVersion: foreignAheadBaseVersion,
         channel: "beta",
         github: { branch: "feat/standalone-closure" },
         releaseNumber: 9,
-        releaseVersion: "0.19.0-beta.9",
+        releaseVersion: `${foreignAheadBaseVersion}-beta.9`,
       },
     };
     const fixture = await startStablePrereleaseMetadataServer(objects);


### PR DESCRIPTION
## Why

While diagnosing the packaged E2E failure on backport PR #6809, the daily-beta recovery fixture compared the repository package version (`0.19.1`) with a hard-coded foreign beta (`0.19.0-beta.9`). That beta was no longer ahead, so the script correctly returned `beta-not-ahead` while the test expected recovery.

This made release/backport CI depend on the repository's current version and allowed an unrelated version bump to break the fixture again.

## What users will see

No product UI change. Release maintainers get a version-independent beta-recovery fixture whose semantic relationship remains stable across package version bumps.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [ ] **API / contract** — new endpoint, event, or contract shape
- [ ] **Extension point** — skills, design systems, templates, craft, or protocol change
- [ ] **i18n keys** — added translation keys
- [ ] **New top-level dependency** — root dependency change
- [ ] **Default behavior change** — changes existing user behavior
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; test-only change.

## Bug fix verification

- Test path: `e2e/tests/packaged-smoke-workflow.test.ts`
- Red: on PR #6809's head, the focused test returned `force:false; promote:true (beta-not-ahead)` instead of the expected recovery decision.
- Green: after replacing the repository-version snapshot with explicit semantic fixtures (`1.2.3` vs `1.3.0-beta.9`), the focused test passed before restoring parity with the skip introduced by #6808.
- The final diff preserves the existing `it.skip` from `main`, avoiding overlap with #6808 and its release backport.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts` — 71 passed, 1 skipped
- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/contracts build`
- `corepack pnpm typecheck`
