### PR TITLE
fix stale P1 and P2 E2E coverage

### DIFF
--- a/apps/web/src/styles/viewer/theater.css
+++ b/apps/web/src/styles/viewer/theater.css
@@ -1039,14 +1039,16 @@
   -webkit-backdrop-filter: blur(16px);
   opacity: 0;
   transform: translate(-50%, 6px);
-  pointer-events: none;
+  /* Keep the pill's own hitbox active while visually hidden. An iframe does
+     not reliably propagate hover to its parent canvas, so disabling pointer
+     events here made the iframe permanently intercept the navigation. */
+  pointer-events: auto;
   transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1), transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .comment-preview-canvas:hover .deck-floating-nav,
 .deck-floating-nav:hover {
   opacity: 1;
   transform: translate(-50%, 0);
-  pointer-events: auto;
 }
 .deck-floating-button {
   width: 30px;

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@/playwright/suite';
 import { ensureRailOpen, openNewProjectModal } from '@/playwright/rail';
-import { settingsSurface } from '@/playwright/amr';
+import { openSettingsDialog, settingsSurface } from '@/playwright/amr';
 import { expectStableCount } from '@/playwright/assertions';
 import { openHomeTemplateMenu } from '@/playwright/home-hero';
 import type {
@@ -731,6 +731,7 @@ test('[P1] Settings About reads desktop updater status and runs a manual update 
           (window as unknown as { __odUpdaterCalls: string[] }).__odUpdaterCalls.push('check');
           return checkedStatus;
         },
+        'clear-cache': async () => idleStatus,
         download: async () => checkedStatus,
         install: async () => checkedStatus,
         quit: async () => ({ ok: true }),
@@ -755,10 +756,7 @@ test('[P1] Settings About reads desktop updater status and runs a manual update 
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('entry-settings-menu-trigger').click();
-  await page.getByTestId('entry-settings-open-details').click();
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
 
   await dialog.getByRole('button', { name: /^About\b/i }).click();
   await expect(dialog.locator('.settings-about-version-num')).toContainText('0.13.4');
@@ -825,6 +823,7 @@ test('[P1] Settings About surfaces prerelease updater check failures with retry 
           (window as unknown as { __odUpdaterCalls: string[] }).__odUpdaterCalls.push('check');
           return failedStatus;
         },
+        'clear-cache': async () => idleStatus,
         download: async () => failedStatus,
         install: async () => failedStatus,
         quit: async () => ({ ok: true }),
@@ -849,10 +848,7 @@ test('[P1] Settings About surfaces prerelease updater check failures with retry 
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('entry-settings-menu-trigger').click();
-  await page.getByTestId('entry-settings-open-details').click();
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
 
   await dialog.getByRole('button', { name: /^About\b/i }).click();
   await expect(dialog.locator('.settings-about-version-num')).toContainText('0.16.0-prerelease.1');
@@ -941,10 +937,7 @@ test('[P1] Settings BYOK connection failures emit a classified analytics error c
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('entry-settings-menu-trigger').click();
-  await page.getByTestId('entry-settings-open-details').click();
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const dialog = await openSettingsDialog(page);
 
   const connectionTest = dialog.locator('.settings-byok-connection-test');
   await expect(connectionTest).toBeVisible();

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@/playwright/suite';
 import { ensureRailOpen } from '@/playwright/rail';
 import { settingsSurface } from '@/playwright/amr';
-import { routeAgents } from '@/playwright/mock-factory';
+import { routeAgents, suppressWhatsNew } from '@/playwright/mock-factory';
 import { T } from '@/timeouts';
 import type { Page } from '@playwright/test';
 
@@ -27,6 +27,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await suppressWhatsNew(page);
   await page.addInitScript((key) => {
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -939,7 +939,7 @@ test('[P1] home composer sends referenced workspace context into project creatio
 
 test('[P1] home staged workspace context auto-sends into the first project run', async ({ page }) => {
   const prompt = 'Create a project and immediately use the Home-staged context.';
-  const projectId = 'home-autosend-context-project';
+  let projectId = '';
   const conversationId = 'conv-home-autosend-context';
   const runBodies: Array<Record<string, unknown>> = [];
   let createdProjectMetadata: Record<string, unknown> = {};
@@ -963,7 +963,13 @@ test('[P1] home staged workspace context auto-sends into the first project run',
       return;
     }
     if (request.method() === 'POST') {
-      const body = request.postDataJSON() as { metadata?: Record<string, unknown>; name?: string; pendingPrompt?: string };
+      const body = request.postDataJSON() as {
+        id?: string;
+        metadata?: Record<string, unknown>;
+        name?: string;
+        pendingPrompt?: string;
+      };
+      projectId = body.id ?? 'home-autosend-context-project';
       createdProjectMetadata = body.metadata ?? {};
       await route.fulfill({
         json: {
@@ -992,8 +998,12 @@ test('[P1] home staged workspace context auto-sends into the first project run',
       },
     });
   });
-  await page.route(`**/api/projects/${projectId}`, async (route) => {
+  await page.route('**/api/projects/*', async (route) => {
     const request = route.request();
+    if (!projectId || new URL(request.url()).pathname !== `/api/projects/${projectId}`) {
+      await route.fallback();
+      return;
+    }
     if (request.method() === 'GET') {
       await route.fulfill({
         json: {
@@ -1030,7 +1040,14 @@ test('[P1] home staged workspace context auto-sends into the first project run',
     }
     await route.fallback();
   });
-  await page.route(`**/api/projects/${projectId}/conversations`, async (route) => {
+  await page.route('**/api/projects/*/conversations', async (route) => {
+    if (
+      !projectId
+      || new URL(route.request().url()).pathname !== `/api/projects/${projectId}/conversations`
+    ) {
+      await route.fallback();
+      return;
+    }
     if (route.request().method() !== 'GET') {
       await route.fallback();
       return;
@@ -1051,24 +1068,53 @@ test('[P1] home staged workspace context auto-sends into the first project run',
       },
     });
   });
-  await page.route(`**/api/projects/${projectId}/conversations/${conversationId}/messages`, async (route) => {
+  await page.route('**/api/projects/*/conversations/*/messages', async (route) => {
+    if (
+      !projectId
+      || new URL(route.request().url()).pathname
+        !== `/api/projects/${projectId}/conversations/${conversationId}/messages`
+    ) {
+      await route.fallback();
+      return;
+    }
     if (route.request().method() !== 'GET') {
       await route.fallback();
       return;
     }
     await route.fulfill({ json: { messages: [] } });
   });
-  await page.route(`**/api/projects/${projectId}/conversations/${conversationId}/messages/*`, async (route) => {
+  await page.route('**/api/projects/*/conversations/*/messages/*', async (route) => {
+    if (
+      !projectId
+      || !new URL(route.request().url()).pathname.startsWith(
+        `/api/projects/${projectId}/conversations/${conversationId}/messages/`,
+      )
+    ) {
+      await route.fallback();
+      return;
+    }
     if (route.request().method() !== 'PUT') {
       await route.fallback();
       return;
     }
     await route.fulfill({ json: { ok: true } });
   });
-  await page.route(`**/api/projects/${projectId}/conversations/${conversationId}/comments`, async (route) => {
+  await page.route('**/api/projects/*/conversations/*/comments', async (route) => {
+    if (
+      !projectId
+      || new URL(route.request().url()).pathname
+        !== `/api/projects/${projectId}/conversations/${conversationId}/comments`
+    ) {
+      await route.fallback();
+      return;
+    }
     await route.fulfill({ json: { comments: [] } });
   });
-  await page.route(`**/api/projects/${projectId}/files`, async (route) => {
+  await page.route('**/api/projects/*/files', async (route) => {
+    if (!projectId || new URL(route.request().url()).pathname !== `/api/projects/${projectId}/files`) {
+      await route.fallback();
+      return;
+    }
     await route.fulfill({ json: { files: [] } });
   });
   await page.route('**/api/live-artifacts**', async (route) => {
@@ -1354,7 +1400,7 @@ test('[P1] home suggestion entry remains retryable after create failures', async
   await expect.poll(projectCreateCount).toBe(1);
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByTestId('home-hero-submit')).toBeEnabled();
-  await expect(page.getByRole('alert').filter({ hasText: /Failed to start the run/i })).toBeVisible();
+  await expect(page.getByRole('alert').filter({ hasText: /Could not create project/i })).toBeVisible();
   await runRequests.expectNone({ message: 'failed blank project create should not start a run' });
 
   await page.getByTestId('home-hero-submit').click();

--- a/e2e/ui/message-center.test.ts
+++ b/e2e/ui/message-center.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@/playwright/suite';
-import { routeAgents } from '@/playwright/mock-factory';
+import { routeAgents, suppressWhatsNew } from '@/playwright/mock-factory';
 import { ensureRailOpen } from '@/playwright/rail';
 import type { Page } from '@playwright/test';
 
@@ -9,6 +9,7 @@ const READ_KEY = 'open-design.message-center.anonymous-read-ids.v1';
 test.describe.configure({ timeout: 30_000 });
 
 async function seedEntryHome(page: Page, options?: { locale?: string }) {
+  await suppressWhatsNew(page);
   await page.addInitScript(({ key, locale }) => {
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -2302,7 +2302,6 @@ test('[P1] BYOK OpenCode project run sends provider config through the daemon co
       apiKey: 'sk-openai-e2e',
       baseUrl: 'https://api.openai.com/v1',
       model: 'gpt-4o-mini',
-      apiVersion: '',
     },
     analyticsHints: {
       runtimeType: 'byok',
@@ -4181,10 +4180,8 @@ async function routeHandoffEditors(page: Page): Promise<void> {
 }
 
 async function openHandoffCliTab(page: Page): Promise<Locator> {
-  await page.getByRole('button', { name: 'Share', exact: true }).click();
-  const unifiedPopover = page.locator('.chrome-unified-popover:visible');
-  await unifiedPopover.getByRole('tab', { name: 'Send to...' }).click();
-  const menu = unifiedPopover.getByTestId('handoff-menu');
+  await page.getByTestId('handoff-caret').click();
+  const menu = page.getByTestId('handoff-menu');
   await expect(menu).toBeVisible();
   await menu.getByRole('tab', { name: /^Copy for CLI$/ }).click();
   return menu;

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -7,7 +7,7 @@ import {
   createFakeAgentRuntimes,
   FAKE_AGENT_RUNTIME_IDS,
 } from '@/playwright/fake-agents';
-import { trackRunRequests } from '@/playwright/mock-factory';
+import { suppressWhatsNew, trackRunRequests } from '@/playwright/mock-factory';
 import type { FakeAgentId } from '@/playwright/fake-agents';
 import { T } from '@/timeouts';
 
@@ -48,6 +48,7 @@ test.beforeAll(async () => {
 
 test.beforeEach(async ({ page }) => {
   test.setTimeout(T.xlong);
+  await suppressWhatsNew(page);
 
   await resetDaemonAppConfig(page);
 
@@ -206,7 +207,7 @@ test('[P1] real daemon run treats an in-place artifact edit as produced work', a
     }, { timeout: 15_000 })
     .toContainEqual({
       runStatus: 'succeeded',
-      producedFiles: [],
+      producedFiles: [GENERATED_FILE],
       traceObjectFiles: [GENERATED_FILE],
       resultDeliveryState: 'delivered',
     });

--- a/e2e/ui/reload-spurious-failed-run.test.ts
+++ b/e2e/ui/reload-spurious-failed-run.test.ts
@@ -46,62 +46,18 @@ test.afterEach(async ({ page }) => {
   await resetDaemonAppConfig(page);
 });
 
-// Regression spec for the #4607 follow-up (spuriouslyFailedPending recovery):
-// the bug requires a genuine client/daemon MISMATCH at reload time, not
-// merely "reload while running" or "reload after already-succeeded" (both
-// already covered elsewhere, on a different timing). The mismatch this test
-// locks: the persisted assistant message shows runStatus:'failed' with no
-// producedFiles and a real runId (because the browser's live SSE connection
-// to the run was severed and the client's onError path gave up and persisted
-// a failed+empty-files row) while the daemon's authoritative
-// /api/runs/:runId record independently reached 'succeeded' -- the daemon
-// process behind the run is unaffected by the browser losing its stream,
-// exactly as it survives a page reload.
-//
-// We force this precondition through real client behavior only: we sever
-// the transport (abort every connection attempt the *page* makes to the
-// run's status/SSE endpoints) and let the actual client error-handling code
-// persist the failed row via its normal production HTTP call. Nothing here
-// hand-writes message state -- that would prove a fake flow instead of the
-// real one.
-//
-// `content` is captured and logged for visibility on every run, but is
-// deliberately NOT part of the gating precondition match. Empirically
-// (confirmed across repeated runs with both `/api/runs/:id` and
-// `/api/runs/:id/events` blocked from the page), `content` still resyncs to
-// the real generated text within the same window even though runStatus and
-// producedFiles stay pinned at their spurious values -- this looks like a
-// daemon-side write that never traverses the page's network stack, so
-// page.route() structurally cannot intercept or hold it back. Gating on
-// content staying empty made the precondition unreachable more often than
-// not; runStatus + producedFiles + runId + daemonStatus is the slice of the
-// mismatch this harness can force and hold reliably, and is what is locked
-// below. The post-reload assertions further down remain strict on content.
-test('[P1] reload recovers a spuriously-failed pending message once the daemon run actually succeeded', async ({ page }) => {
+// Regression coverage for #4607. The client now self-heals status and content
+// after the page transport drops, so the old failed-message precondition is no
+// longer reachable. The produced-file list still needs reload reconciliation;
+// lock that remaining mismatch and recovery without manufacturing persisted
+// message state in the test.
+test('[P1] reload restores produced files after dropped run transport', async ({ page }) => {
   await page.goto('/');
   await createProject(page, 'Spurious failed reload smoke');
   await expectWorkspaceReady(page);
 
-  // Sever the browser's live view of the run for the whole test: every
-  // attempt BY THE PAGE to open (or reopen) the event stream, or to poll the
-  // run's plain status endpoint, fails immediately -- simulating a dropped
-  // connection. This only interferes with the transport the *browser* uses;
-  // it does not touch the daemon process running the agent (which keeps
-  // going), and it does not affect this test's own out-of-band
-  // `page.request` polling below (Playwright's APIRequestContext bypasses
-  // page.route() entirely, so our assertions still see the daemon's real
-  // status throughout).
-  //
-  // Blocking only the SSE stream was not enough to hold runStatus at
-  // 'failed': the client apparently also reconciles runStatus via a plain
-  // status poll independent of the event stream, so a route that only
-  // aborted `/events` let runStatus quietly resync to 'succeeded' before
-  // this test could observe it. Blocking both endpoints keeps runStatus and
-  // producedFiles pinned at their spurious failed+empty values for the
-  // whole test, confirmed stable across repeated runs (see the precondition
-  // poll below). `content`, however, still resyncs to the real generated
-  // text within this same window even with both endpoints blocked -- see
-  // the note on the precondition poll for what that means for this test.
+  // Abort the page's status/SSE transport without affecting the daemon or
+  // Playwright's out-of-band APIRequestContext.
   await page.route('**/api/runs/**', async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -118,29 +74,9 @@ test('[P1] reload recovers a spuriously-failed pending message once the daemon r
 
   const { projectId, conversationId } = await currentProjectContext(page);
 
-  // Wait for the reproducible slice of the client/daemon mismatch this test
-  // locks, captured as ONE atomic snapshot per poll iteration (persisted
-  // message + daemon status fetched back to back, with no reload or other
-  // action in between). Polling each side separately would leave a window
-  // where a same-page self-heal (observed empirically: the client can, on
-  // its own, eventually reconcile parts of a severed-then-restored stream
-  // without a reload) could repair the row between "check A passed" and
-  // "check B passed", producing a false precondition read. Capturing both in
-  // the same iteration and gating on that exact captured object removes that
-  // gap. `content` rides along in the same snapshot for the informational
-  // assertion + log below, but is intentionally excluded from the gate
-  // itself -- see the file-level comment above for why.
-  type PreconditionSnapshot = {
-    runId: string | null;
-    runStatus: string | null;
-    content: string;
-    producedFiles: string[];
-    daemonStatus: string;
-  };
-  // A mutable ref object (rather than a plain `let`) sidesteps a TypeScript
-  // control-flow narrowing quirk where a `let` reassigned only inside a
-  // nested async closure gets narrowed to `never` at the point of use below.
-  const preconditionRef: { current: PreconditionSnapshot | null } = { current: null };
+  // Even while those page requests remain blocked, daemon-side result
+  // delivery reconciles status and content. The browser has not received the
+  // produced-file list yet, which is the real pre-reload condition here.
   await expect
     .poll(async () => {
       const assistant = await findAssistantMessage(page, projectId, conversationId);
@@ -148,65 +84,29 @@ test('[P1] reload recovers a spuriously-failed pending message once the daemon r
       const daemonStatus = daemonStatusResponse.ok()
         ? ((await daemonStatusResponse.json()) as { status: string }).status
         : `http-${daemonStatusResponse.status()}`;
-      const snapshot: PreconditionSnapshot = {
+      return {
         runId: assistant?.runId ?? null,
         runStatus: assistant?.runStatus ?? null,
-        content: assistant?.content ?? '',
+        hasContent: Boolean(assistant?.content?.trim()),
         producedFiles: assistant?.producedFiles?.map((file) => file.name) ?? [],
         daemonStatus,
-      };
-      preconditionRef.current = snapshot;
-      // Gate on the reliably-reproducible fields only (runId, runStatus,
-      // producedFiles, daemonStatus). `content` is omitted from the match on
-      // purpose so the gate does not depend on winning a race this harness
-      // cannot control -- see the file-level comment above.
-      return {
-        runId: snapshot.runId,
-        runStatus: snapshot.runStatus,
-        producedFiles: snapshot.producedFiles,
-        daemonStatus: snapshot.daemonStatus,
       };
     }, { timeout: 90_000, intervals: [200] })
     .toEqual({
       runId,
-      runStatus: 'failed',
+      runStatus: 'succeeded',
+      hasContent: true,
       producedFiles: [],
       daemonStatus: 'succeeded',
     });
 
-  // Precondition assertion + informational log: `precondition` holds the
-  // exact atomic snapshot that satisfied the gating poll above (message +
-  // daemon status fetched back to back, no reload or other action in
-  // between). The gating fields are re-asserted strictly here so the proof
-  // is tied to the snapshot that actually triggered the reload below, not a
-  // fresh read that could already have self-healed. `content` is logged for
-  // visibility but is informational only, per the harness limitation
-  // documented at the top of this test.
-  const precondition = preconditionRef.current;
-  console.log('[precondition] persisted message + daemon status:', JSON.stringify(precondition));
-  expect(precondition?.runId, 'precondition: persisted runId must match the real run').toBe(runId);
-  expect(precondition?.runStatus, 'precondition: persisted runStatus must be failed').toBe('failed');
-  expect(precondition?.producedFiles, 'precondition: persisted producedFiles must be empty').toEqual([]);
-  expect(
-    precondition?.daemonStatus,
-    'precondition: the daemon must independently report succeeded',
-  ).toBe('succeeded');
-
-  // Stop severing the stream so the reload/reattach recovery pass can behave
-  // normally -- the bug is about what recovery does with the already-
-  // mismatched persisted row, not about a stream that is still broken.
-  // unrouteAll (not a string-matched unroute) guarantees the handler
-  // registered above is actually removed before reload.
   await page.unrouteAll({ behavior: 'ignoreErrors' });
 
   await page.reload({ waitUntil: 'domcontentloaded' });
   await expectWorkspaceReady(page);
 
-  // Required post-reload behavior:
-  //   1. content recovers (no longer empty)
-  //   2 + 3. producedFiles is repopulated with the real artifact
-  //   4. the SAME runId + conversationId are reattached in place, not a
-  //      recreated run/conversation
+  // Reload must preserve the same successful message rather than duplicate
+  // the run or conversation.
   await expect
     .poll(async () => {
       const messages = await listConversationMessages(page, projectId, conversationId);

--- a/e2e/ui/settings-mcp-snippet-chip.test.ts
+++ b/e2e/ui/settings-mcp-snippet-chip.test.ts
@@ -31,7 +31,7 @@ test('[P1] MCP server snippet code stays transparent, not the inline-code chip (
   await page.goto('/', { waitUntil: 'domcontentloaded' });
 
   const settings = await openSettingsDialog(page);
-  await settings.getByRole('button', { name: /^MCP server\b/ }).click();
+  await settings.getByRole('button', { name: /^Open Design MCP\b/ }).click();
 
   const code = settings.locator('pre code').filter({ hasText: 'claude mcp add-json' });
   await expect(code).toBeVisible({ timeout: T.short });


### PR DESCRIPTION
## Why

The prerelease P1/P2 run exposed a group of failures caused by tests that still targeted retired entry points, outdated request contracts, and superseded state-reconciliation behavior. Keeping those assertions produced false regression signals. The same run also uncovered a real deck navigation bug: the controls were visible, but the preview iframe intercepted pointer events and prevented clicks.

## What users will see

- The previous/next controls at the bottom of a deck preview are clickable again instead of being intercepted by the preview iframe.
- All other changes only update E2E setup and expectations to match current product behavior.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual styling changes. This fixes pointer hit testing for the existing floating deck navigation.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/app.test.ts` (`deck-pagination-per-file-isolated`)
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, it consistently timed out with `iframe intercepts pointer events`; it passes on this branch.
- The PR also updates E2E contracts for the current Settings, MCP, handoff, Home optimistic project ID, BYOK payload, daemon-produced files, and reload reconciliation behavior. Unrelated entry-point tests now explicitly suppress the prerelease What's New popup.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/web typecheck`
- Deck regression: 1/1 passed
- Updated non-daemon P1 assertions: 8/8 passed
- Entry/message-center coverage with the release popup isolated: 7/7 passed
- Targeted real-daemon regressions (plugin authoring, in-place edit, and reload reconciliation): 3/3 passed
- `git diff --check`
