### PR TITLE
test(e2e): cover shared design system logo assets

### DIFF
--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -86,6 +86,14 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
       pinWorkspace(memberPage, MEMBER.memberId),
     ]);
 
+    await gotoHome(ownerPage);
+    await ensureRailOpen(ownerPage);
+    await ownerPage.getByTestId('workspace-switcher').click();
+    await ownerPage.getByRole('menuitem', { name: 'Design System Team' }).click();
+    await expect(ownerPage.getByTestId('workspace-switcher')).toContainText(
+      'Design System Team',
+    );
+
     const createResponse = await ownerPage.request.post('/api/design-systems', {
       data: {
         title: 'Shared Product Language',
@@ -138,12 +146,6 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
     );
 
     await gotoDesignSystems(ownerPage);
-    await ensureRailOpen(ownerPage);
-    await ownerPage.getByTestId('workspace-switcher').click();
-    await ownerPage.getByRole('menuitem', { name: 'Design System Team' }).click();
-    await expect(ownerPage.getByTestId('workspace-switcher')).toContainText(
-      'Design System Team',
-    );
     await ownerPage.getByRole('tab', { name: /Your systems/i }).click();
     const ownerCard = ownerPage.getByTestId(`design-system-card-${designSystemId}`);
     await expect(ownerCard).toBeVisible({ timeout: T.xlong });

--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -46,6 +46,7 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
   const commonEnv = {
     OD_COLLAB_TRANSPORT: 'vela-cli',
     OD_RESOURCE_TRANSPORT: 'vela-cli',
+    OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
     OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
     VELA_API_URL: hub.url,
     VELA_BIN: velaBin,
@@ -111,6 +112,39 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
       },
     );
     expect(workspaceResponse.ok(), await workspaceResponse.text()).toBeTruthy();
+    const workspace = await workspaceResponse.json() as { project?: { id?: string } };
+    const projectId = workspace.project?.id;
+    expect(projectId).toBeTruthy();
+
+    await writeLogoProjectFile(
+      ownerPage,
+      projectId!,
+      'brand.json',
+      JSON.stringify(sharedLogoBrand()),
+    );
+    await writeLogoProjectFile(ownerPage, projectId!, 'assets/logo.svg', sharedLogoSvg());
+    const syncResponse = await ownerPage.request.post(
+      `/api/design-systems/${encodeURIComponent(designSystemId!)}/sync-assets`,
+      { headers: workspaceHeaders(OWNER), timeout: T.long },
+    );
+    expect(syncResponse.ok(), await syncResponse.text()).toBeTruthy();
+
+    await ownerPage.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+    await ownerPage.getByTestId('design-system-project-tab').click();
+    await expectSharedLogo(
+      ownerPage.getByTestId('design-system-project-kit'),
+      'Shared Product Language',
+      OWNER.memberId,
+    );
+
+    await gotoDesignSystems(ownerPage);
+    await ownerPage.getByRole('tab', { name: /Your systems/i }).click();
+    await ownerPage.getByTestId(`design-system-card-${designSystemId}`).click();
+    await expectSharedLogo(
+      ownerPage.getByTestId(`design-system-detail-${designSystemId}`),
+      'Shared Product Language',
+      OWNER.memberId,
+    );
 
     const shareResponse = await ownerPage.request.post(
       `/api/workspace/design-systems/${encodeURIComponent(designSystemId!)}/share`,
@@ -153,6 +187,25 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
     const teamOption = picker.getByTestId(`project-ds-picker-option-${designSystemId}`);
     await expect(teamOption).toContainText('Shared Product Language');
     await teamOption.click();
+    await expect(memberPage.getByTestId('home-hero-design-system-trigger')).toContainText(
+      'Shared Product Language',
+    );
+
+    await gotoDesignSystems(memberPage);
+    await memberPage.getByRole('tab', { name: /^Team/ }).click();
+    const memberCard = memberPage.getByTestId(`design-system-card-${designSystemId}`);
+    await expect(memberCard).toBeVisible({ timeout: T.xlong });
+    await memberCard.click();
+    await expectSharedLogo(
+      memberPage.getByTestId(`design-system-detail-${designSystemId}`),
+      'Shared Product Language',
+      MEMBER.memberId,
+    );
+    await gotoHome(memberPage);
+    await ensureRailOpen(memberPage);
+    await expect(memberPage.getByTestId('workspace-switcher')).toContainText(
+      'Design System Team',
+    );
     await expect(memberPage.getByTestId('home-hero-design-system-trigger')).toContainText(
       'Shared Product Language',
     );
@@ -349,147 +402,6 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
   }
 });
 
-test('[P0] shared design-system logos render for an isolated team member', async ({
-  browser,
-}, testInfo) => {
-  const hubRoot = testInfo.outputPath('fake-team-design-system-logo-hub');
-  await mkdir(hubRoot, { recursive: true });
-  const hub = await startFakeCollabHub({
-    root: hubRoot,
-    workspaceId: WORKSPACE_ID,
-    workspaceName: 'Design System Team',
-    clients: [OWNER, MEMBER],
-    includePersonalWorkspace: true,
-  });
-  const velaBin = await hub.writeVelaBin(testInfo.outputPath('fake-vela-team-design-system-logo'));
-  const commonEnv = {
-    OD_COLLAB_TRANSPORT: 'vela-cli',
-    OD_RESOURCE_TRANSPORT: 'vela-cli',
-    OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
-    OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
-    VELA_API_URL: hub.url,
-    VELA_BIN: velaBin,
-  };
-  let cluster: CollabCluster | undefined;
-  let failed = false;
-
-  try {
-    cluster = await createCollabCluster(browser, testInfo, [
-      {
-        id: 'owner-design-system-logo',
-        env: { ...commonEnv, VELA_CONTROL_KEY: OWNER.controlKey },
-      },
-      {
-        id: 'member-design-system-logo',
-        env: { ...commonEnv, VELA_CONTROL_KEY: MEMBER.controlKey },
-      },
-    ]);
-    const ownerPage = cluster.clients['owner-design-system-logo']!.page;
-    const memberPage = cluster.clients['member-design-system-logo']!.page;
-    await Promise.all([applyStandardMocks(ownerPage), applyStandardMocks(memberPage)]);
-    await Promise.all([
-      pinWorkspace(ownerPage, OWNER.memberId),
-      pinWorkspace(memberPage, MEMBER.memberId),
-    ]);
-
-    const createResponse = await ownerPage.request.post('/api/design-systems', {
-      data: {
-        title: 'Shared Logo Language',
-        summary: 'A Team-owned design system with a real logo asset.',
-        category: 'Custom',
-        status: 'published',
-      },
-      headers: workspaceHeaders(OWNER),
-      timeout: T.long,
-    });
-    expect(createResponse.ok(), await createResponse.text()).toBeTruthy();
-    const created = await createResponse.json() as {
-      id?: string;
-      designSystem?: { id?: string };
-    };
-    const designSystemId = created.id ?? created.designSystem?.id;
-    expect(designSystemId).toBeTruthy();
-
-    const workspaceResponse = await ownerPage.request.post(
-      `/api/design-systems/${encodeURIComponent(designSystemId!)}/workspace`,
-      { headers: workspaceHeaders(OWNER), timeout: T.long },
-    );
-    expect(workspaceResponse.ok(), await workspaceResponse.text()).toBeTruthy();
-    const workspace = await workspaceResponse.json() as { project?: { id?: string } };
-    const projectId = workspace.project?.id;
-    expect(projectId).toBeTruthy();
-
-    await writeLogoProjectFile(
-      ownerPage,
-      projectId!,
-      'brand.json',
-      JSON.stringify(sharedLogoBrand()),
-    );
-    await writeLogoProjectFile(ownerPage, projectId!, 'assets/logo.svg', sharedLogoSvg());
-    const syncResponse = await ownerPage.request.post(
-      `/api/design-systems/${encodeURIComponent(designSystemId!)}/sync-assets`,
-      { headers: workspaceHeaders(OWNER), timeout: T.long },
-    );
-    expect(syncResponse.ok(), await syncResponse.text()).toBeTruthy();
-
-    await ownerPage.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
-    await ownerPage.getByTestId('design-system-project-tab').click();
-    await expectSharedLogo(
-      ownerPage.getByTestId('design-system-project-kit'),
-      'Shared Logo Language',
-      OWNER.memberId,
-    );
-
-    await gotoDesignSystems(ownerPage);
-    await ownerPage.getByRole('tab', { name: /Your systems/i }).click();
-    await ownerPage.getByTestId(`design-system-card-${designSystemId}`).click();
-    await expectSharedLogo(
-      ownerPage.getByTestId(`design-system-detail-${designSystemId}`),
-      'Shared Logo Language',
-      OWNER.memberId,
-    );
-
-    await ownerPage.getByTestId('design-kit-more-actions').click();
-    const shareResponse = ownerPage.waitForResponse((response) => {
-      const request = response.request();
-      const url = new URL(response.url());
-      return request.method() === 'POST'
-        && url.pathname === `/api/workspace/design-systems/${designSystemId}/share`;
-    });
-    await ownerPage.getByRole('menuitem', { name: /Share to team/i }).click();
-    expect((await shareResponse).ok()).toBeTruthy();
-    await expect(
-      ownerPage.getByRole('tab', { name: /^Team/ }),
-    ).toContainText('1', { timeout: T.long });
-
-    await gotoDesignSystems(memberPage);
-    await memberPage.getByTestId('workspace-switcher').click();
-    await memberPage.getByRole('menuitem', { name: 'Design System Team' }).click();
-    await expect(memberPage.getByTestId('workspace-switcher')).toContainText(
-      'Design System Team',
-    );
-    await memberPage.getByRole('tab', { name: /^Team/ }).click();
-    const memberCard = memberPage.getByTestId(`design-system-card-${designSystemId}`);
-    await expect(memberCard).toBeVisible({ timeout: T.xlong });
-    await memberCard.click();
-    await expectSharedLogo(
-      memberPage.getByTestId(`design-system-detail-${designSystemId}`),
-      'Shared Logo Language',
-      MEMBER.memberId,
-    );
-  } catch (error) {
-    failed = true;
-    await testInfo.attach('fake-team-design-system-logo-hub-log', {
-      body: JSON.stringify({ commands: hub.commandLog, events: hub.eventLog }, null, 2),
-      contentType: 'application/json',
-    });
-    throw error;
-  } finally {
-    await cluster?.close({ preserve: failed });
-    await hub.close();
-  }
-});
-
 async function pinWorkspace(page: Page, workspaceMemberId: string): Promise<void> {
   const response = await page.request.put('/api/workspace/active', {
     data: { workspaceId: WORKSPACE_ID, workspaceMemberId },
@@ -569,7 +481,7 @@ function sharedLogoSvg(): string {
 
 function sharedLogoBrand() {
   return {
-    name: 'Shared Logo Language',
+    name: 'Shared Product Language',
     tagline: 'One visual language for the Team.',
     description: 'A Team-owned design system with a real logo asset.',
     sourceUrl: '',

--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -349,6 +349,147 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
   }
 });
 
+test('[P0] shared design-system logos render for an isolated team member', async ({
+  browser,
+}, testInfo) => {
+  const hubRoot = testInfo.outputPath('fake-team-design-system-logo-hub');
+  await mkdir(hubRoot, { recursive: true });
+  const hub = await startFakeCollabHub({
+    root: hubRoot,
+    workspaceId: WORKSPACE_ID,
+    workspaceName: 'Design System Team',
+    clients: [OWNER, MEMBER],
+    includePersonalWorkspace: true,
+  });
+  const velaBin = await hub.writeVelaBin(testInfo.outputPath('fake-vela-team-design-system-logo'));
+  const commonEnv = {
+    OD_COLLAB_TRANSPORT: 'vela-cli',
+    OD_RESOURCE_TRANSPORT: 'vela-cli',
+    OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+    OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+    VELA_API_URL: hub.url,
+    VELA_BIN: velaBin,
+  };
+  let cluster: CollabCluster | undefined;
+  let failed = false;
+
+  try {
+    cluster = await createCollabCluster(browser, testInfo, [
+      {
+        id: 'owner-design-system-logo',
+        env: { ...commonEnv, VELA_CONTROL_KEY: OWNER.controlKey },
+      },
+      {
+        id: 'member-design-system-logo',
+        env: { ...commonEnv, VELA_CONTROL_KEY: MEMBER.controlKey },
+      },
+    ]);
+    const ownerPage = cluster.clients['owner-design-system-logo']!.page;
+    const memberPage = cluster.clients['member-design-system-logo']!.page;
+    await Promise.all([applyStandardMocks(ownerPage), applyStandardMocks(memberPage)]);
+    await Promise.all([
+      pinWorkspace(ownerPage, OWNER.memberId),
+      pinWorkspace(memberPage, MEMBER.memberId),
+    ]);
+
+    const createResponse = await ownerPage.request.post('/api/design-systems', {
+      data: {
+        title: 'Shared Logo Language',
+        summary: 'A Team-owned design system with a real logo asset.',
+        category: 'Custom',
+        status: 'published',
+      },
+      headers: workspaceHeaders(OWNER),
+      timeout: T.long,
+    });
+    expect(createResponse.ok(), await createResponse.text()).toBeTruthy();
+    const created = await createResponse.json() as {
+      id?: string;
+      designSystem?: { id?: string };
+    };
+    const designSystemId = created.id ?? created.designSystem?.id;
+    expect(designSystemId).toBeTruthy();
+
+    const workspaceResponse = await ownerPage.request.post(
+      `/api/design-systems/${encodeURIComponent(designSystemId!)}/workspace`,
+      { headers: workspaceHeaders(OWNER), timeout: T.long },
+    );
+    expect(workspaceResponse.ok(), await workspaceResponse.text()).toBeTruthy();
+    const workspace = await workspaceResponse.json() as { project?: { id?: string } };
+    const projectId = workspace.project?.id;
+    expect(projectId).toBeTruthy();
+
+    await writeLogoProjectFile(
+      ownerPage,
+      projectId!,
+      'brand.json',
+      JSON.stringify(sharedLogoBrand()),
+    );
+    await writeLogoProjectFile(ownerPage, projectId!, 'assets/logo.svg', sharedLogoSvg());
+    const syncResponse = await ownerPage.request.post(
+      `/api/design-systems/${encodeURIComponent(designSystemId!)}/sync-assets`,
+      { headers: workspaceHeaders(OWNER), timeout: T.long },
+    );
+    expect(syncResponse.ok(), await syncResponse.text()).toBeTruthy();
+
+    await ownerPage.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+    await ownerPage.getByTestId('design-system-project-tab').click();
+    await expectSharedLogo(
+      ownerPage.getByTestId('design-system-project-kit'),
+      'Shared Logo Language',
+      OWNER.memberId,
+    );
+
+    await gotoDesignSystems(ownerPage);
+    await ownerPage.getByRole('tab', { name: /Your systems/i }).click();
+    await ownerPage.getByTestId(`design-system-card-${designSystemId}`).click();
+    await expectSharedLogo(
+      ownerPage.getByTestId(`design-system-detail-${designSystemId}`),
+      'Shared Logo Language',
+      OWNER.memberId,
+    );
+
+    await ownerPage.getByTestId('design-kit-more-actions').click();
+    const shareResponse = ownerPage.waitForResponse((response) => {
+      const request = response.request();
+      const url = new URL(response.url());
+      return request.method() === 'POST'
+        && url.pathname === `/api/workspace/design-systems/${designSystemId}/share`;
+    });
+    await ownerPage.getByRole('menuitem', { name: /Share to team/i }).click();
+    expect((await shareResponse).ok()).toBeTruthy();
+    await expect(
+      ownerPage.getByRole('tab', { name: /^Team/ }),
+    ).toContainText('1', { timeout: T.long });
+
+    await gotoDesignSystems(memberPage);
+    await memberPage.getByTestId('workspace-switcher').click();
+    await memberPage.getByRole('menuitem', { name: 'Design System Team' }).click();
+    await expect(memberPage.getByTestId('workspace-switcher')).toContainText(
+      'Design System Team',
+    );
+    await memberPage.getByRole('tab', { name: /^Team/ }).click();
+    const memberCard = memberPage.getByTestId(`design-system-card-${designSystemId}`);
+    await expect(memberCard).toBeVisible({ timeout: T.xlong });
+    await memberCard.click();
+    await expectSharedLogo(
+      memberPage.getByTestId(`design-system-detail-${designSystemId}`),
+      'Shared Logo Language',
+      MEMBER.memberId,
+    );
+  } catch (error) {
+    failed = true;
+    await testInfo.attach('fake-team-design-system-logo-hub-log', {
+      body: JSON.stringify({ commands: hub.commandLog, events: hub.eventLog }, null, 2),
+      contentType: 'application/json',
+    });
+    throw error;
+  } finally {
+    await cluster?.close({ preserve: failed });
+    await hub.close();
+  }
+});
+
 async function pinWorkspace(page: Page, workspaceMemberId: string): Promise<void> {
   const response = await page.request.put('/api/workspace/active', {
     data: { workspaceId: WORKSPACE_ID, workspaceMemberId },
@@ -364,6 +505,45 @@ async function gotoHome(page: Page): Promise<void> {
   });
 }
 
+async function gotoDesignSystems(page: Page): Promise<void> {
+  await page.goto('/design-systems', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, {
+    timeout: T.xlong,
+  });
+}
+
+async function writeLogoProjectFile(
+  page: Page,
+  projectId: string,
+  name: string,
+  content: string,
+): Promise<void> {
+  const response = await page.request.post(`/api/projects/${projectId}/files`, {
+    data: { name, content },
+    headers: workspaceHeaders(OWNER),
+    timeout: T.long,
+  });
+  expect(response.ok(), await response.text()).toBeTruthy();
+}
+
+async function expectSharedLogo(
+  container: ReturnType<Page['getByTestId']>,
+  alt: string,
+  workspaceMemberId: string,
+): Promise<void> {
+  const logo = container.getByTestId('design-kit-logo-section').getByRole('img', { name: alt });
+  await expect(logo).toBeVisible({ timeout: T.xlong });
+  await expect.poll(
+    () => logo.evaluate((image: HTMLImageElement) => ({
+      complete: image.complete,
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+      workspaceMemberId: new URL(image.src).searchParams.get('workspaceMemberId'),
+    })),
+    { timeout: T.long },
+  ).toEqual({ complete: true, width: 320, height: 160, workspaceMemberId });
+}
+
 function workspaceHeaders(identity: typeof OWNER | typeof MEMBER): Record<string, string> {
   return {
     'x-od-workspace-id': WORKSPACE_ID,
@@ -375,5 +555,52 @@ function workspaceHeaders(identity: typeof OWNER | typeof MEMBER): Record<string
     'x-od-workspace-can-share-projects': identity.role === 'owner' ? 'true' : 'false',
     'x-od-workspace-can-write-synced-files': identity.role === 'owner' ? 'true' : 'false',
     'x-od-workspace-can-manage-shared-resources': identity.role === 'owner' ? 'true' : 'false',
+  };
+}
+
+function sharedLogoSvg(): string {
+  return [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="160" viewBox="0 0 320 160">',
+    '<rect width="320" height="160" rx="32" fill="#1867c0"/>',
+    '<text x="160" y="102" text-anchor="middle" font-family="sans-serif" font-size="72" fill="white">SL</text>',
+    '</svg>',
+  ].join('');
+}
+
+function sharedLogoBrand() {
+  return {
+    name: 'Shared Logo Language',
+    tagline: 'One visual language for the Team.',
+    description: 'A Team-owned design system with a real logo asset.',
+    sourceUrl: '',
+    logo: {
+      primary: 'assets/logo.svg',
+      alternates: [],
+      notes: 'Shared logo regression witness.',
+    },
+    colors: [{
+      role: 'accent',
+      hex: '#1867c0',
+      oklch: '',
+      name: 'Team blue',
+      usage: 'Primary actions',
+    }],
+    typography: {
+      display: { family: 'Inter', fallbacks: ['sans-serif'], weights: [700] },
+      body: { family: 'Inter', fallbacks: ['sans-serif'], weights: [400] },
+    },
+    voice: {
+      adjectives: ['clear'],
+      tone: 'direct',
+      messagingPillars: ['Build together'],
+      vocabulary: { use: ['team'], avoid: ['silo'] },
+    },
+    imagery: { style: 'graphic', subjects: [], treatment: 'flat', avoid: [] },
+    layout: {
+      radius: '12px',
+      borderWeight: '1px',
+      spacing: '8px grid',
+      postureRules: ['Keep layouts open'],
+    },
   };
 }

--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -138,8 +138,16 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
     );
 
     await gotoDesignSystems(ownerPage);
+    await ensureRailOpen(ownerPage);
+    await ownerPage.getByTestId('workspace-switcher').click();
+    await ownerPage.getByRole('menuitem', { name: 'Design System Team' }).click();
+    await expect(ownerPage.getByTestId('workspace-switcher')).toContainText(
+      'Design System Team',
+    );
     await ownerPage.getByRole('tab', { name: /Your systems/i }).click();
-    await ownerPage.getByTestId(`design-system-card-${designSystemId}`).click();
+    const ownerCard = ownerPage.getByTestId(`design-system-card-${designSystemId}`);
+    await expect(ownerCard).toBeVisible({ timeout: T.xlong });
+    await ownerCard.click();
     await expectSharedLogo(
       ownerPage.getByTestId(`design-system-detail-${designSystemId}`),
       'Shared Product Language',

--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -138,9 +138,8 @@ test('[P0] Team design systems catch up missed shares, updates, and retractions'
     expect(syncResponse.ok(), await syncResponse.text()).toBeTruthy();
 
     await ownerPage.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
-    await ownerPage.getByTestId('design-system-project-tab').click();
-    await expectSharedLogo(
-      ownerPage.getByTestId('design-system-project-kit'),
+    await expectProjectSharedLogo(
+      ownerPage,
       'Shared Product Language',
       OWNER.memberId,
     );
@@ -464,6 +463,50 @@ async function expectSharedLogo(
     })),
     { timeout: T.long },
   ).toEqual({ complete: true, width: 320, height: 160, workspaceMemberId });
+}
+
+async function expectProjectSharedLogo(
+  page: Page,
+  alt: string,
+  workspaceMemberId: string,
+): Promise<void> {
+  const tab = page.getByTestId('design-system-project-tab');
+  const panel = page.getByTestId('design-system-project-tab-panel');
+  const logo = page
+    .getByTestId('design-system-project-kit')
+    .getByTestId('design-kit-logo-section')
+    .getByRole('img', { name: alt });
+  let matchingSince = 0;
+
+  await expect.poll(async () => {
+    const tabReady = await tab.getAttribute('aria-selected') === 'true'
+      && await panel.isVisible();
+    if (!tabReady) {
+      matchingSince = 0;
+      await tab.click({ timeout: T.short });
+      return 0;
+    }
+
+    const image = await logo.evaluate((element: HTMLImageElement) => ({
+      complete: element.complete,
+      width: element.naturalWidth,
+      height: element.naturalHeight,
+      workspaceMemberId: new URL(element.src).searchParams.get('workspaceMemberId'),
+    })).catch(() => null);
+    const matches = image?.complete === true
+      && image.width === 320
+      && image.height === 160
+      && image.workspaceMemberId === workspaceMemberId;
+    if (!matches) {
+      matchingSince = 0;
+      return 0;
+    }
+    if (matchingSince === 0) matchingSince = Date.now();
+    return Date.now() - matchingSince;
+  }, {
+    message: 'project Design system tab and scoped logo should survive workspace restoration',
+    timeout: T.xlong,
+  }).toBeGreaterThanOrEqual(500);
 }
 
 function workspaceHeaders(identity: typeof OWNER | typeof MEMBER): Record<string, string> {


### PR DESCRIPTION
## Why

While validating a report that design-system logos disappeared after sharing to a team, I reproduced the full owner/member workflow with two isolated Open Design runtimes. The product behavior is already fixed on current `main`, but the existing P0 collaboration coverage did not assert that a project-backed logo remains readable under the receiving member's workspace identity.

This adds a regression boundary around the user-visible failure mode so future changes to project moves, resource transport, or workspace-scoped asset URLs cannot silently break shared design-system images.

## What users will see

No user-visible behavior changes. This PR adds automated regression coverage for the existing team-sharing behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: test-only change with no UI modification.

## Bug fix verification

- Test path: `e2e/ui/workspace-team-design-system-picker.test.ts`
- Red on `main`, green on this branch: no. The underlying product fixes are already present on current `main`; this PR records the previously untested asset-sharing regression as a P0 test.
- The test creates a design system backed by a real 320×160 SVG, verifies it in the owner's project and design-system details, shares it to the team, then verifies the receiving member loads the same intrinsic image dimensions through a URL scoped to that member.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm exec playwright test -c playwright.config.ts ui/workspace-team-design-system-picker.test.ts --list` (1 test registered)
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` (71 passed, 1 skipped)
- Manual E2E with the currently open Chrome via Open Browser Use: two isolated web/daemon runtimes and owner/member accounts; logo rendered at 320×160 in the owner project, owner design-system detail, and member team design-system detail after sharing.
