### PR TITLE
fix(web): route Cloud sign-out to login

### DIFF
--- a/apps/daemon/src/collab/created-project-workspace.ts
+++ b/apps/daemon/src/collab/created-project-workspace.ts
@@ -80,6 +80,24 @@ export function resolveCreatedProjectWorkspace(
 }
 
 /**
+ * Capture optional local attribution for an ordinary local project create.
+ *
+ * PRODUCT INVARIANT: `POST /api/projects` creates local data first. Workspace
+ * identity on that request is metadata for `personal` + `local_only` routing;
+ * it is not permission to publish and must not trigger a directory/network
+ * lookup or block creation. A complete request snapshot is retained as local
+ * attribution even if its remote state may have changed; missing or partial
+ * identity produces an unbound local project. Later share/sync/move-to-Team
+ * operations perform fresh authority checks at their actual remote boundary.
+ */
+export function localProjectWorkspaceAttribution(
+  req: unknown,
+): WorkspaceResourceContext | null {
+  const context = workspaceResourceContextFromRequest(req);
+  return context === null || context === 'missing' ? null : context;
+}
+
+/**
  * Authorize an explicitly-scoped project create against the signed-in
  * membership directory. The caller-selected workspace/member pair is the
  * lookup key; the daemon's ambient active workspace is deliberately absent
@@ -216,9 +234,9 @@ export function createCreatedProjectWorkspaceResolver(deps: {
  * `GET /api/projects/:id/workspace-scope` answers `unbound` for it, which strips
  * the workspace off the run request (`ProjectView`'s `projectRunWorkspaceContext`
  * → an Open Design Cloud run nothing can bill) and blanks the balance/plan area
- * while that project is open (`AvatarMenu`). It is also denied a run outright by
- * `enforceWorkspaceResourceMutation` the moment the caller carries any workspace
- * header, because the two-key lookup comes back empty.
+ * while that project is open (`AvatarMenu`). Headerless local AMR runs may use
+ * the signed-in account wallet, but any later request that asserts a Workspace
+ * still needs an exact persisted binding before workspace mutation gates allow it.
  *
  * `context` is the caller's exact verified Workspace when the request named
  * one. A headerless legacy request supplies null and remains unbound.
@@ -242,6 +260,12 @@ export function bindCreatedProjectToWorkspace(
   now: number,
 ): void {
   if (!context) return;
+  // This row is local attribution, not publication. It keeps billing and later
+  // run routing associated with the browser's captured Workspace/member while
+  // the project remains `personal` + `local_only`. Creating it must never be
+  // interpreted as sharing the project or as authorization to use any local
+  // plugin/Skill/Design System. The move/share/sync routes own those remote
+  // authorization boundaries.
   ensureWorkspaceProject({
     projectId,
     workspaceId: context.workspaceId,

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -11,6 +11,7 @@ import {
   getWorkspaceResourceByResourceId,
 } from '../db.js';
 import { workspaceTeamSkillBindingAllowsRead } from '../skills/workspace-team-binding.js';
+import { workspaceTeamDesignSystemBindingAllowsRead } from './workspace-team-binding.js';
 
 type JsonRecord = Record<string, unknown>;
 type SkillEntry = { id: string; dir?: string } & JsonRecord;
@@ -391,8 +392,21 @@ export function createDesignSystemServerServices({
             workspaceId,
           },
         );
-        const teamIds = new Set(team.map((system) => system.id));
-        const teamSystems = team.map((system) => ({ ...system, teamSynced: true }));
+        // Team directories are intentionally retained after reconciliation so
+        // offline/local data is recoverable. Availability comes from the local
+        // binding row: filter both after async filesystem parsing and before
+        // exposing the catalogue, matching the Skill catalogue's boundary.
+        // This is local SSE/poll state, not a network membership check.
+        const teamDb = getDb?.();
+        const reconciledTeam = teamDb
+          ? team.filter((system) => workspaceTeamDesignSystemBindingAllowsRead(
+              teamDb,
+              workspaceId,
+              system.id,
+            ))
+          : team;
+        const teamIds = new Set(reconciledTeam.map((system) => system.id));
+        const teamSystems = reconciledTeam.map((system) => ({ ...system, teamSynced: true }));
         installed = options.exactTeam
           ? teamSystems
           : [
@@ -539,6 +553,11 @@ export function createDesignSystemServerServices({
       workspaceMemberId?: string | null;
     } = {},
   ) {
+    // Product boundary: this validator identifies the item in the daemon's
+    // locally reconciled catalog; it is not a fresh Team-authorization gate.
+    // A not-yet-reconciled local copy remains usable, while a locally recorded
+    // tombstone removes it from future selection. Never add a network
+    // membership check to this project-create path.
     if (id === undefined || id === null || id === '') return { ok: true, id: null };
     if (typeof id !== 'string') {
       return {
@@ -570,6 +589,11 @@ export function createDesignSystemServerServices({
     id: unknown,
     options: { workspaceId?: string | null } = {},
   ) {
+    // Same invariant as Design Systems and exact-source plugins: project
+    // creation follows locally reconciled content. Team membership is checked
+    // by remote install/pull/sync/share operations, not by Send. Eventual
+    // consistency is intentional: a stale local copy remains usable until
+    // reconciliation records the retraction in the local catalog.
     if (id === undefined || id === null || id === '') {
       return { ok: true, id: null };
     }

--- a/apps/daemon/src/design-systems/workspace-team-binding.ts
+++ b/apps/daemon/src/design-systems/workspace-team-binding.ts
@@ -1,3 +1,9 @@
+import type Database from 'better-sqlite3';
+
+import { getWorkspaceResourceByResourceId } from '../db.js';
+
+type SqliteDb = Database.Database;
+
 const WORKSPACE_TEAM_DESIGN_SYSTEM_BINDING_PREFIX = 'team-mirror:';
 
 /**
@@ -40,4 +46,19 @@ export function designSystemLogicalResourceId(bindingResourceId: string): string
   } catch {
     return bindingResourceId;
   }
+}
+
+export function workspaceTeamDesignSystemBindingAllowsRead(
+  db: SqliteDb,
+  workspaceId: string,
+  designSystemId: string,
+): boolean {
+  const binding = getWorkspaceResourceByResourceId(
+    db,
+    'design_system',
+    workspaceTeamDesignSystemBindingResourceId(workspaceId, designSystemId),
+  );
+  return binding?.workspaceId === workspaceId
+    && binding.visibility === 'team'
+    && binding.resourceState !== 'deleted';
 }

--- a/apps/daemon/src/plugins/index.ts
+++ b/apps/daemon/src/plugins/index.ts
@@ -3,6 +3,7 @@
 // and accidentally bypasses the snapshot writer (spec §8.2.1).
 export * from './atoms.js';
 export * from './apply.js';
+export * from './local-source.js';
 export {
   validatePluginFolder,
   flattenValidationDiagnostics,

--- a/apps/daemon/src/plugins/local-source.ts
+++ b/apps/daemon/src/plugins/local-source.ts
@@ -1,0 +1,106 @@
+import type Database from 'better-sqlite3';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+import {
+  readTeamResourceMaterialization,
+  teamResourceMaterializationDir,
+} from '../collab/team-resource-materialization.js';
+import { isSafePluginId } from './installer.js';
+import {
+  getInstalledPlugin,
+  resolvePluginFolder,
+  resolveWorkspaceTeamPluginWithBindingGate,
+  workspaceTeamPluginBindingAllowsRead,
+} from './registry.js';
+
+const TEAM_PLUGIN_SOURCE_PREFIX = 'team:plugin:';
+
+function workspaceIdFromTeamPluginSource(
+  source: string,
+  pluginId: string,
+): string | null {
+  const suffix = `:${pluginId}`;
+  if (!source.startsWith(TEAM_PLUGIN_SOURCE_PREFIX) || !source.endsWith(suffix)) {
+    return null;
+  }
+  const workspaceId = source.slice(
+    TEAM_PLUGIN_SOURCE_PREFIX.length,
+    -suffix.length,
+  ).trim();
+  return workspaceId || null;
+}
+
+/**
+ * Select the local registry partition that belongs to an exact plugin source.
+ *
+ * PRODUCT INVARIANT: this is filesystem provenance, not membership authority.
+ * It lets a locally materialized Team plugin resolve the locally materialized
+ * Skill and Design System records stored in the same catalogue partition. Do
+ * not compare this Workspace with a project, fetch identity, or block Send.
+ */
+export function localPluginRegistryScope(
+  plugin: { id?: unknown; source?: unknown },
+): { workspaceId: string; workspaceMemberId: null } | undefined {
+  if (typeof plugin.id !== 'string' || typeof plugin.source !== 'string') {
+    return undefined;
+  }
+  const workspaceId = workspaceIdFromTeamPluginSource(plugin.source, plugin.id);
+  return workspaceId ? { workspaceId, workspaceMemberId: null } : undefined;
+}
+
+/**
+ * Resolve the exact record already selected from a local catalogue.
+ *
+ * PRODUCT INVARIANT: this is local identity resolution, not authorization.
+ * The catalogue's Workspace partition and its SSE/poll reconciliation own
+ * availability. Do not add a network membership check, compare against a new
+ * project's Workspace, or turn this helper into a Send preflight. Remote
+ * install/share/sync/move operations enforce their own current authority.
+ */
+export async function resolveLocalPluginBySource(input: {
+  db: Database.Database;
+  id: string;
+  source: string;
+  userPluginsRoot: string;
+}): Promise<InstalledPluginRecord | null> {
+  const { db, id, source, userPluginsRoot } = input;
+  const installed = getInstalledPlugin(db, id);
+  const workspaceId = workspaceIdFromTeamPluginSource(source, id);
+  if (installed?.source === source) {
+    return workspaceId && !workspaceTeamPluginBindingAllowsRead(db, workspaceId, id)
+      ? null
+      : installed;
+  }
+
+  if (!isSafePluginId(id)) return null;
+  if (!workspaceId) return null;
+  // A tombstone is a local catalogue fact, not a remote authorization check.
+  // Reconciliation intentionally keeps the materialized directory recoverable,
+  // so fence both sides of async filesystem parsing to prevent stale bytes from
+  // becoming a new apply/project after the local binding has retired.
+  return resolveWorkspaceTeamPluginWithBindingGate({
+    bindingAllowsRead: () => workspaceTeamPluginBindingAllowsRead(db, workspaceId, id),
+    resolve: async () => {
+      const marker = await readTeamResourceMaterialization(
+        userPluginsRoot,
+        workspaceId,
+        id,
+        id,
+      );
+      if (
+        !marker
+        || marker.kind !== 'plugin'
+        || marker.resourceId !== id
+        || marker.workspaceId !== workspaceId
+        || marker.sourceKey !== source
+      ) return null;
+
+      const resolved = await resolvePluginFolder({
+        folder: teamResourceMaterializationDir(userPluginsRoot, workspaceId, id, id),
+        folderId: id,
+        sourceKind: 'user',
+        source,
+      });
+      return resolved.ok ? resolved.record : null;
+    },
+  });
+}

--- a/apps/daemon/src/plugins/resolve-snapshot.ts
+++ b/apps/daemon/src/plugins/resolve-snapshot.ts
@@ -62,6 +62,8 @@ export interface ResolveSnapshotInput {
   // Pluggable for tests; in production these are the daemon's live
   // skill / design-system catalogs (server.ts wires them).
   registry: RegistryView;
+  /** Exact already-local record selected by a record-aware caller. */
+  plugin?: InstalledPluginRecord | undefined;
   connectorProbe?: ConnectorProbe | undefined;
   // Optional active-project DS binding. Forwarded to `applyPlugin` so
   // plugins that declared `od.context.designSystem.primary: true` get
@@ -220,7 +222,9 @@ export function resolvePluginSnapshot(input: ResolveSnapshotInput): ResolveSnaps
   }
 
   // Path 2: pluginId — run apply, persist a new snapshot.
-  const plugin = getInstalledPlugin(input.db, fields.pluginId!);
+  const plugin = input.plugin?.id === fields.pluginId
+    ? input.plugin
+    : getInstalledPlugin(input.db, fields.pluginId!);
   if (!plugin) {
     return {
       ok: false,

--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -673,7 +673,8 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
       });
       // A capture opened as an editable page is a project the user will
       // immediately chat into, so it needs the same home workspace every other
-      // created project gets — an unbound one is denied its first run outright.
+      // created project gets; otherwise it can only use the account-scoped
+      // local run lane and has no durable Workspace for later mutations.
       bindCreatedProjectToWorkspace(
         (input) => ensureWorkspaceProject(db, input),
         createWorkspace.context,

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -30,6 +30,7 @@ import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-
 import type { PluginShareAction } from '../../services/plugin-share-tasks.js';
 import type { AuthorizeProjectRequest } from '../../collab/project-request-authority.js';
 import { workspaceTeamPluginBindingResourceId } from '../../plugins/registry.js';
+import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import {
   classifyPluginInstallError,
   type PluginInstallErrorCode,
@@ -255,6 +256,11 @@ export interface RegisterPluginRoutesDeps {
       workspaceId: string | null,
       workspaceMemberId?: string | null,
     ) => InstalledPluginLike | null | Promise<InstalledPluginLike | null>;
+    getLocalPluginBySource?: (
+      db: SqliteDbLike,
+      id: string,
+      source: string,
+    ) => InstalledPluginLike | null | Promise<InstalledPluginLike | null>;
     installPlugin: (db: SqliteDbLike, args: unknown) => AsyncIterable<unknown>;
     isSafePluginId: (id: string) => boolean;
     uninstallPlugin: (db: SqliteDbLike, id: string, roots: string[]) => Promise<{ ok: boolean; removedFolder?: boolean; warning?: string }>;
@@ -403,6 +409,34 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     return plugins.getWorkspacePlugin
       ? plugins.getWorkspacePlugin(db, id, workspaceId, authority?.workspaceMemberId ?? null)
       : plugins.getInstalledPlugin(db, id);
+  };
+  const applyResolvedPlugin = async (
+    req: Request,
+    res: Response,
+    plugin: InstalledPluginLike,
+    registry: unknown,
+  ) => {
+    const body = req.body && typeof req.body === 'object'
+      ? req.body as Record<string, unknown>
+      : {};
+    const inputs = body.inputs && typeof body.inputs === 'object' ? body.inputs : {};
+    const grantCaps = Array.isArray(body.grantCaps)
+      ? body.grantCaps.filter((capability: unknown): capability is string => typeof capability === 'string')
+      : [];
+    const locale = typeof body.locale === 'string' ? body.locale : undefined;
+    const connectorProbe = helpers.buildConnectorProbe(helpers.connectorService);
+    const computed = plugins.applyPlugin({ plugin, inputs, registry, locale, connectorProbe });
+    if (grantCaps.length > 0) {
+      const merged = new Set([...computed.result.capabilitiesGranted, ...grantCaps]);
+      computed.result.capabilitiesGranted = Array.from(merged);
+      computed.result.appliedPlugin.capabilitiesGranted = Array.from(merged);
+    }
+    return res.json({
+      ok: true,
+      ...computed.result,
+      warnings: computed.warnings,
+      manifestSourceDigest: computed.manifestSourceDigest,
+    });
   };
   const isTeamPlugin = (plugin: InstalledPluginLike | null | undefined): boolean =>
     typeof plugin?.source === 'string' && plugin.source.startsWith('team:plugin:');
@@ -579,20 +613,47 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     )) return;
     return helpers.installOrUpgradePlugin(req, res, 'upgrade', authority);
   });
+  app.post('/api/plugins/:id/apply-local', async (req, res) => {
+    // This endpoint identifies bytes the local catalogue already returned. It
+    // deliberately performs no Workspace authority read; catalogue sync owns
+    // local availability and remote mutations retain their own fresh gates.
+    res.setHeader('x-od-plugin-apply-local', '1');
+    try {
+      const body = req.body && typeof req.body === 'object'
+        ? req.body as Record<string, unknown>
+        : {};
+      const source = typeof body.source === 'string' ? body.source.trim() : '';
+      if (!source || !plugins.getLocalPluginBySource) {
+        return res.status(404).json({ error: 'plugin not found' });
+      }
+      const plugin = await plugins.getLocalPluginBySource(db, req.params.id, source);
+      if (!plugin) return res.status(404).json({ error: 'plugin not found' });
+      const registry = await helpers.loadPluginRegistryView(
+        localPluginRegistryScope(plugin),
+      );
+      // Registry loading walks local Skill/Design System files asynchronously.
+      // Re-resolve immediately before apply so a local reconciliation tombstone
+      // that landed during that walk cannot activate stale plugin bytes.
+      const currentPlugin = await plugins.getLocalPluginBySource(
+        db,
+        req.params.id,
+        source,
+      );
+      if (!currentPlugin) return res.status(404).json({ error: 'plugin not found' });
+      return applyResolvedPlugin(req, res, currentPlugin, registry);
+    } catch (err: unknown) {
+      if (err instanceof plugins.MissingInputError) {
+        return res.status(422).json({ error: 'missing_inputs', fields: err.fields });
+      }
+      return res.status(500).json({ error: String(err) });
+    }
+  });
   app.post('/api/plugins/:id/apply', async (req, res) => {
     try {
       const authority = await resolveWorkspaceAuthority(req, res);
       if (authority === undefined) return;
       const plugin = await resolveRequestPlugin(req.params.id, authority);
       if (!plugin) return res.status(404).json({ error: 'plugin not found' });
-      const body = req.body && typeof req.body === 'object'
-        ? req.body as Record<string, unknown>
-        : {};
-      const inputs = body.inputs && typeof body.inputs === 'object' ? body.inputs : {};
-      const grantCaps = Array.isArray(body.grantCaps)
-        ? body.grantCaps.filter((c: unknown): c is string => typeof c === 'string')
-        : [];
-      const locale = typeof body.locale === 'string' ? body.locale : undefined;
       const registry = await helpers.loadPluginRegistryView({
         workspaceId: authority?.workspaceId ?? null,
         workspaceMemberId: authority?.workspaceMemberId ?? null,
@@ -613,19 +674,7 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
       ) {
         return res.status(404).json({ error: 'plugin not found' });
       }
-      const connectorProbe = helpers.buildConnectorProbe(helpers.connectorService);
-      const computed = plugins.applyPlugin({ plugin, inputs, registry, locale, connectorProbe });
-      if (grantCaps.length > 0) {
-        const merged = new Set([...computed.result.capabilitiesGranted, ...grantCaps]);
-        computed.result.capabilitiesGranted = Array.from(merged);
-        computed.result.appliedPlugin.capabilitiesGranted = Array.from(merged);
-      }
-      res.json({
-        ok: true,
-        ...computed.result,
-        warnings: computed.warnings,
-        manifestSourceDigest: computed.manifestSourceDigest,
-      });
+      return applyResolvedPlugin(req, res, plugin, registry);
     } catch (err: unknown) {
       if (err instanceof plugins.MissingInputError) {
         return res.status(422).json({ error: 'missing_inputs', fields: err.fields });

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -9,6 +9,7 @@ import {
 import {
   defaultScenarioPluginIdForProjectMetadata,
   type ChatSessionMode,
+  type LocalCatalogScope,
   type PluginManifest,
   type PreviewComment,
   type ProjectDesignTokenSuggestionProp,
@@ -52,6 +53,8 @@ import {
   getInstalledPlugin,
   listInstalledPlugins,
   resolvePluginSnapshot,
+  type ResolveSnapshotError,
+  type ResolveSnapshotOk,
 } from '../../plugins/index.js';
 import { connectorService } from '../../connectors/service.js';
 import type { RouteDeps } from '../../server-context.js';
@@ -109,14 +112,36 @@ import {
   type AuthorizeProjectRequest,
 } from '../../collab/project-request-authority.js';
 import {
-  authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
   createCreatedProjectWorkspaceResolver,
   CreatedProjectWorkspaceResolutionError,
-  sendCreatedProjectWorkspaceError,
+  localProjectWorkspaceAttribution,
 } from '../../collab/created-project-workspace.js';
+import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
+
+function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScope | null {
+  if (value === undefined || value === null) return null;
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${field} must contain workspaceId and workspaceMemberId`);
+  }
+  const record = value as Record<string, unknown>;
+  const workspaceId = typeof record.workspaceId === 'string'
+    ? record.workspaceId.trim()
+    : '';
+  const workspaceMemberId = typeof record.workspaceMemberId === 'string'
+    ? record.workspaceMemberId.trim()
+    : '';
+  if (!workspaceId || !workspaceMemberId) {
+    throw new Error(`${field} must contain workspaceId and workspaceMemberId`);
+  }
+  return { workspaceId, workspaceMemberId };
+}
+
+function sameLocalCatalogScopes(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
 
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation' | 'collabSync'> {
   pluginScope?: {
@@ -128,6 +153,10 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
       id: string,
       options: { workspaceId: string | null; workspaceMemberId: string | null },
     ) => Promise<unknown | null>;
+    getLocalPluginBySource?: (
+      id: string,
+      source: string,
+    ) => Promise<Parameters<typeof resolvePluginSnapshot>[0]['plugin'] | null>;
   };
   teamProjectCatalog?: VelaTeamProjectCatalogClient;
   /** Bounded authoritative verifier for idempotent Workspace project reads. */
@@ -2842,9 +2871,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             // A project this scan adopts off disk is as much a created project
             // as one typed into the composer, and needs the same home
             // workspace. Without this the imported project is an orphan the
-            // moment it appears: denied its first run by
-            // the verified Workspace mutation gate, and billing-less on any run
-            // that does get through.
+            // moment it appears: account-scoped local runs remain possible,
+            // but Workspace mutations and Workspace-pinned billing would have
+            // no durable home.
             bindCreatedProjectToWorkspace(
               (input) => ensureWorkspaceProject(db, input),
               createHome,
@@ -3395,13 +3424,13 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.post('/api/projects', async (req, res) => {
     try {
-      const createWorkspace = await authorizeCreatedProjectWorkspace(
-        req,
-        ctx.fetchProjectCreationWorkspaceDirectory,
-      );
-      if (!createWorkspace.ok) {
-        return sendCreatedProjectWorkspaceError(res, createWorkspace);
-      }
+      // Ordinary project creation is local. Capture any complete identity that
+      // the Web already has for local attribution, but do not turn Workspace
+      // directory availability into a Send dependency. Remote share/sync/move
+      // routes retain their authoritative checks.
+      const createWorkspace = {
+        context: localProjectWorkspaceAttribution(req),
+      };
       const { id, name, projectLocationId, skillId, designSystemId, pendingPrompt, metadata, customInstructions, skipDiscoveryBrief } =
         req.body || {};
       if (typeof id !== 'string' || !isSafeId(id)) {
@@ -3465,9 +3494,27 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         workspaceId: createWorkspace.context?.workspaceId ?? null,
         workspaceMemberId: createWorkspace.context?.workspaceMemberId ?? null,
       };
+      let skillCatalogScope: LocalCatalogScope | null;
+      let designSystemCatalogScope: LocalCatalogScope | null;
+      try {
+        skillCatalogScope = parseLocalCatalogScope(
+          req.body?.skillCatalogScope,
+          'skillCatalogScope',
+        );
+        designSystemCatalogScope = parseLocalCatalogScope(
+          req.body?.designSystemCatalogScope,
+          'designSystemCatalogScope',
+        );
+      } catch (error) {
+        return sendApiError(res, 400, 'BAD_REQUEST', String(error));
+      }
+      // A staged local resource can outlive the shell's current identity
+      // snapshot while a Workspace switch is loading. Use the partition that
+      // produced that exact selection for local lookup only. It does not bind
+      // this local project to that Workspace or prove current membership.
       const designSystemValidation = await validateProjectDesignSystemId(
         designSystemId,
-        creationWorkspaceScope,
+        designSystemCatalogScope ?? creationWorkspaceScope,
       );
       if (!designSystemValidation.ok) {
         return sendApiError(
@@ -3480,7 +3527,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       const normalizedDesignSystemId = designSystemValidation.id;
       const skillValidation = await validateProjectSkillId(
         skillId,
-        creationWorkspaceScope,
+        skillCatalogScope ?? creationWorkspaceScope,
       );
       if (!skillValidation.ok) {
         return sendApiError(res, 400, skillValidation.code, skillValidation.message);
@@ -3490,10 +3537,29 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         typeof req.body?.pluginId === 'string' && req.body.pluginId.trim().length > 0
           ? req.body.pluginId.trim()
           : null;
+      const requestedPluginSource =
+        typeof req.body?.pluginSource === 'string' && req.body.pluginSource.trim().length > 0
+          ? req.body.pluginSource.trim()
+          : null;
+      // Local identity resolution only. Do not compare this historical source
+      // with the project's current Workspace or perform a membership request:
+      // Home already reconciles staged selections against its current local
+      // catalogue, and this project is local until a later share/sync/move.
+      const selectedLocalPlugin = requestedPluginId && requestedPluginSource
+        ? await ctx.pluginScope?.getLocalPluginBySource?.(
+            requestedPluginId,
+            requestedPluginSource,
+          ) ?? null
+        : null;
       if (requestedPluginId) {
-        const visiblePlugin = ctx.pluginScope
-          ? await ctx.pluginScope.getPlugin(requestedPluginId, creationWorkspaceScope)
-          : getInstalledPlugin(db, requestedPluginId);
+        // Once a source is supplied, never substitute a same-id Personal or
+        // other catalogue record. A missing local source is a missing plugin,
+        // not a Workspace authorization verdict.
+        const visiblePlugin = requestedPluginSource
+          ? selectedLocalPlugin
+          : ctx.pluginScope
+            ? await ctx.pluginScope.getPlugin(requestedPluginId, creationWorkspaceScope)
+            : getInstalledPlugin(db, requestedPluginId);
         if (!visiblePlugin) {
           return sendApiError(res, 404, 'PLUGIN_NOT_FOUND', 'plugin not found');
         }
@@ -3522,10 +3588,26 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         && (metadata as { intent?: unknown }).intent === 'web-clone'
         && typeof pendingPrompt === 'string'
         && /https?:\/\/\S+/i.test(pendingPrompt);
+      const localCatalogScopes = {
+        ...(normalizedSkillId && skillCatalogScope ? { skill: skillCatalogScope } : {}),
+        ...(normalizedDesignSystemId && designSystemCatalogScope
+          ? { designSystem: designSystemCatalogScope }
+          : {}),
+      };
+      const hasLocalCatalogScopes = Object.keys(localCatalogScopes).length > 0;
+      // This metadata is daemon-owned. A caller may supply provenance through
+      // the typed top-level fields, but cannot smuggle a different partition
+      // inside the otherwise extensible project metadata object.
+      const clientMetadata = metadata && typeof metadata === 'object'
+        ? Object.fromEntries(
+            Object.entries(metadata).filter(([key]) => key !== 'localCatalogScopes'),
+          )
+        : null;
       const projectMetadata =
-        metadata && typeof metadata === 'object'
+        clientMetadata
           ? {
-              ...metadata,
+              ...clientMetadata,
+              ...(hasLocalCatalogScopes ? { localCatalogScopes } : {}),
               ...(skipDiscoveryBrief === true || webCloneUrlSkipsDiscovery
                 ? { skipDiscoveryBrief: true }
                 : {}),
@@ -3536,9 +3618,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
                     projectLocationId: selectedLocationId,
                   }
                 : {}),
-              ...(Array.isArray(metadata.linkedDirs)
+              ...(Array.isArray(clientMetadata.linkedDirs)
                 ? (() => {
-                    const v = validateLinkedDirs(metadata.linkedDirs);
+                    const v = validateLinkedDirs(clientMetadata.linkedDirs);
                     return v.error ? {} : { linkedDirs: v.dirs };
                   })()
                 : {}),
@@ -3546,6 +3628,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           : skipDiscoveryBrief === true
             ? {
                 skipDiscoveryBrief: true,
+                ...(hasLocalCatalogScopes ? { localCatalogScopes } : {}),
                 ...(externalProjectDir
                   ? {
                       baseDir: externalProjectDir,
@@ -3561,13 +3644,40 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
                   importedFrom: 'project-location',
                   projectLocationId: selectedLocationId,
                 }
-              : null;
+              : hasLocalCatalogScopes
+                ? {
+                    localCatalogScopes,
+                  }
+                : null;
       const now = Date.now();
       const cid = randomId();
       const initialSessionMode = normalizeChatSessionMode(
         req.body?.conversationMode ?? req.body?.sessionMode,
       );
+      const explicitPlugin =
+        typeof req.body?.pluginId === 'string' && req.body.pluginId.trim().length > 0
+          ? true
+          : typeof req.body?.appliedPluginSnapshotId === 'string'
+            && req.body.appliedPluginSnapshotId.trim().length > 0;
+      let resolveBody =
+        explicitPlugin ? (req.body as Record<string, unknown>) : null;
+      if (!resolveBody && initialSessionMode === 'design') {
+        const fallbackPluginId = defaultScenarioPluginIdForProjectMetadata(
+          projectMetadata && typeof projectMetadata.kind === 'string'
+            ? projectMetadata as Parameters<
+                typeof defaultScenarioPluginIdForProjectMetadata
+              >[0]
+            : null,
+        );
+        if (fallbackPluginId && getInstalledPlugin(db, fallbackPluginId)) {
+          resolveBody = { ...(req.body || {}), pluginId: fallbackPluginId };
+        }
+      }
       let project;
+      const pluginResolutionState: {
+        snapshot: ResolveSnapshotOk | null;
+        failure: ResolveSnapshotError | null;
+      } = { snapshot: null, failure: null };
       try {
         if (externalProjectDir) {
           await writeProjectManifest(externalProjectDir, {
@@ -3579,6 +3689,31 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             skillId: normalizedSkillId,
             designSystemId: normalizedDesignSystemId,
           });
+        }
+        const registry = resolveBody
+          ? await loadPluginRegistryView(
+              selectedLocalPlugin
+                ? localPluginRegistryScope(selectedLocalPlugin)
+                : creationWorkspaceScope,
+            )
+          : null;
+        let pluginForSnapshot = selectedLocalPlugin;
+        if (requestedPluginId && requestedPluginSource) {
+          // All preparation above is asynchronous. Re-resolve the exact local
+          // source immediately before the synchronous SQLite transaction so a
+          // reconciliation tombstone cannot leave a project/conversation or
+          // snapshot behind. This is local catalogue freshness only: do not
+          // turn it into a remote membership or current-Workspace gate.
+          pluginForSnapshot = await ctx.pluginScope?.getLocalPluginBySource?.(
+            requestedPluginId,
+            requestedPluginSource,
+          ) ?? null;
+          if (!pluginForSnapshot) {
+            if (externalProjectDir) {
+              await rm(externalProjectDir, { recursive: true, force: true }).catch(() => {});
+            }
+            return sendApiError(res, 404, 'PLUGIN_NOT_FOUND', 'plugin not found');
+          }
         }
         project = db.transaction(() => {
           const createdProject = insertProject(db, {
@@ -3611,6 +3746,33 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             id,
             now,
           );
+          if (resolveBody && registry) {
+            const resolved = resolvePluginSnapshot({
+              db,
+              body: resolveBody,
+              projectId: id,
+              conversationId: cid,
+              registry,
+              activeProjectDesignSystem:
+                typeof normalizedDesignSystemId === 'string' && normalizedDesignSystemId.length > 0
+                  ? { id: normalizedDesignSystemId }
+                  : undefined,
+              connectorProbe: buildConnectorProbe(connectorService),
+              ...(pluginForSnapshot ? { plugin: pluginForSnapshot } : {}),
+            });
+            if (resolved && !resolved.ok) {
+              if (!explicitPlugin) {
+                console.warn(
+                  `[plugins] default-scenario fallback skipped for project ${id}: ${resolved.body?.error?.code ?? 'unknown'}`,
+                );
+              } else {
+                pluginResolutionState.failure = resolved;
+                throw new Error('explicit plugin resolution failed');
+              }
+            } else {
+              pluginResolutionState.snapshot = resolved;
+            }
+          }
           return createdProject;
         })();
       } catch (err) {
@@ -3620,47 +3782,12 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         if (externalProjectDir) {
           await rm(externalProjectDir, { recursive: true, force: true }).catch(() => {});
         }
+        if (pluginResolutionState.failure) {
+          return res
+            .status(pluginResolutionState.failure.status)
+            .json(pluginResolutionState.failure.body);
+        }
         throw err;
-      }
-      const explicitPlugin =
-        typeof req.body?.pluginId === 'string' && req.body.pluginId.trim().length > 0
-          ? true
-          : typeof req.body?.appliedPluginSnapshotId === 'string'
-            && req.body.appliedPluginSnapshotId.trim().length > 0;
-      let resolveBody =
-        explicitPlugin ? (req.body as Record<string, unknown>) : null;
-      if (!resolveBody && initialSessionMode === 'design') {
-        const fallbackPluginId = defaultScenarioPluginIdForProjectMetadata(projectMetadata);
-        if (fallbackPluginId && getInstalledPlugin(db, fallbackPluginId)) {
-          resolveBody = { ...(req.body || {}), pluginId: fallbackPluginId };
-        }
-      }
-      let resolvedSnapshot = null;
-      if (resolveBody) {
-        const registry = await loadPluginRegistryView(creationWorkspaceScope);
-        const resolved = resolvePluginSnapshot({
-          db,
-          body: resolveBody,
-          projectId: id,
-          conversationId: cid,
-          registry,
-          activeProjectDesignSystem:
-            typeof normalizedDesignSystemId === 'string' && normalizedDesignSystemId.length > 0
-              ? { id: normalizedDesignSystemId }
-              : undefined,
-          connectorProbe: buildConnectorProbe(connectorService),
-        });
-        if (resolved && !resolved.ok) {
-          if (!explicitPlugin) {
-            console.warn(
-              `[plugins] default-scenario fallback skipped for project ${id}: ${resolved.body?.error?.code ?? 'unknown'}`,
-            );
-          } else {
-            return res.status(resolved.status).json(resolved.body);
-          }
-        } else {
-          resolvedSnapshot = resolved;
-        }
       }
       // For "from template" projects, seed the chosen template's snapshot
       // HTML into the new project folder so the agent can Read/edit files
@@ -3700,7 +3827,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         }
       }
       /** @type {import('@open-design/contracts').CreateProjectResponse} */
-      const createdProject = resolvedSnapshot?.ok ? getProject(db, id) ?? project : project;
+      const createdProject = pluginResolutionState.snapshot
+        ? getProject(db, id) ?? project
+        : project;
       const body = {
         // The binding above is part of the same transaction as the project and
         // seed conversation. Return that authority immediately so the Web can
@@ -3711,8 +3840,8 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           ? { ...createdProject, workspaceId: createWorkspace.context.workspaceId }
           : createdProject,
         conversationId: cid,
-        ...(resolvedSnapshot?.ok
-          ? { appliedPluginSnapshotId: resolvedSnapshot.snapshotId }
+        ...(pluginResolutionState.snapshot
+          ? { appliedPluginSnapshotId: pluginResolutionState.snapshot.snapshotId }
           : {}),
       };
       res.json(body);
@@ -4209,6 +4338,20 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       if (patch.metadata && typeof patch.metadata === 'object') {
         const existing = getProject(db, req.params.id);
         const existingMeta = existing?.metadata;
+        if (
+          'localCatalogScopes' in patch.metadata
+          && !sameLocalCatalogScopes(
+            patch.metadata.localCatalogScopes,
+            existingMeta?.localCatalogScopes,
+          )
+        ) {
+          return sendApiError(
+            res,
+            400,
+            'BAD_REQUEST',
+            'localCatalogScopes can only be set during project creation',
+          );
+        }
         if ('fromTrustedPicker' in patch.metadata
             && patch.metadata.fromTrustedPicker !== existingMeta?.fromTrustedPicker) {
           return sendApiError(
@@ -4252,6 +4395,9 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           }
           patch.metadata = {
             ...patch.metadata,
+            ...(existingMeta?.localCatalogScopes
+              ? { localCatalogScopes: existingMeta.localCatalogScopes }
+              : {}),
             baseDir: existingMeta.baseDir,
             ...(existingMeta.importedFrom === 'folder'
               ? { importedFrom: 'folder' }
@@ -4281,6 +4427,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             res, 400, 'BAD_REQUEST',
             'orchestratorWorkspace can only be set via POST /api/import/folder or POST /api/projects/:id/working-dir',
           );
+        } else if (existingMeta?.localCatalogScopes) {
+          patch.metadata = {
+            ...patch.metadata,
+            localCatalogScopes: existingMeta.localCatalogScopes,
+          };
         }
       }
       if (patch.metadata?.linkedDirs) {
@@ -4334,6 +4485,33 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           return sendApiError(res, 400, skillValidation.code, skillValidation.message);
         }
         patch.skillId = skillValidation.id;
+      }
+      if (
+        (Object.prototype.hasOwnProperty.call(patch, 'skillId')
+          && patch.skillId !== patchProject.skillId)
+        || (Object.prototype.hasOwnProperty.call(patch, 'designSystemId')
+          && patch.designSystemId !== patchProject.designSystemId)
+      ) {
+        const currentMetadata = patch.metadata && typeof patch.metadata === 'object'
+          ? patch.metadata
+          : patchProject.metadata;
+        const currentScopes = currentMetadata?.localCatalogScopes;
+        if (currentScopes) {
+          const nextScopes = { ...currentScopes };
+          if (
+            Object.prototype.hasOwnProperty.call(patch, 'skillId')
+            && patch.skillId !== patchProject.skillId
+          ) delete nextScopes.skill;
+          if (
+            Object.prototype.hasOwnProperty.call(patch, 'designSystemId')
+            && patch.designSystemId !== patchProject.designSystemId
+          ) delete nextScopes.designSystem;
+          const { localCatalogScopes: _localCatalogScopes, ...metadataWithoutScopes } =
+            currentMetadata;
+          patch.metadata = Object.keys(nextScopes).length > 0
+            ? { ...metadataWithoutScopes, localCatalogScopes: nextScopes }
+            : metadataWithoutScopes;
+        }
       }
       if (typeof patch.name === 'string' && patch.name.trim().length > 0) {
         // Design-system workspace projects mirror their design system's

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -124,8 +124,9 @@ import {
   runAskedUserQuestion,
 } from '../runtimes/run-artifacts.js';
 import {
+  accountScopedRunWorkspaceScopeForProject,
   pinRunWorkspaceScopeForProject,
-  type PinnedRunWorkspaceScope,
+  type RunWorkspaceScope,
 } from '../runtimes/project-amr-trace-env.js';
 import {
   runArtifactCountForRun,
@@ -291,7 +292,7 @@ interface ChatRun {
   clientRequestId?: string | null;
   requestFingerprint?: string | null;
   agentId: string | null;
-  workspaceScope?: PinnedRunWorkspaceScope | null;
+  workspaceScope?: RunWorkspaceScope | null;
   model?: string | null;
   status: ChatRunStatus;
   createdAt: number;
@@ -380,7 +381,7 @@ interface RunCreateMeta extends JsonRecord {
   message?: string;
   currentPrompt?: string;
   projectMetadata?: ProjectMetadata;
-  workspaceScope?: PinnedRunWorkspaceScope | null;
+  workspaceScope?: RunWorkspaceScope | null;
 }
 
 interface RunListFilters {
@@ -979,7 +980,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     agentId: unknown,
     authorizedBoundMutation = false,
   ): Promise<
-    | { ok: true; workspaceScope: PinnedRunWorkspaceScope | null }
+    | { ok: true; workspaceScope: RunWorkspaceScope | null }
     | { ok: false }
   > {
     if (!ctx.projectStore) return { ok: true, workspaceScope: null };
@@ -1052,13 +1053,16 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     }
 
     if (requestContext === null) {
-      sendApiError(
-        res,
-        409,
-        'AMR_WORKSPACE_SCOPE_REQUIRED',
-        'open the project from your Personal Workspace before running AMR Cloud',
-      );
-      return { ok: false };
+      // A headerless, genuinely unbound project is the local/account-scoped
+      // compatibility lane. Home may create it before Workspace discovery
+      // settles, after already running the account balance gate; requiring a
+      // later identity here would turn that accepted first prompt into a 409.
+      // Explicitly bound projects still pin their persisted Workspace above,
+      // and any asserted identity below is freshly verified before adoption.
+      return {
+        ok: true,
+        workspaceScope: accountScopedRunWorkspaceScopeForProject(projectId),
+      };
     }
     if (requestContext === 'missing') {
       sendApiError(
@@ -1284,7 +1288,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         console.warn('[runs] agent id fallback failed', err);
       }
     }
-    let preparedWorkspaceScope: PinnedRunWorkspaceScope | null = null;
+    let preparedWorkspaceScope: RunWorkspaceScope | null = null;
     if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
       const prepared = await prepareRunWorkspaceScope(
         req,

--- a/apps/daemon/src/runtimes/project-amr-trace-env.ts
+++ b/apps/daemon/src/runtimes/project-amr-trace-env.ts
@@ -10,6 +10,28 @@ export type PinnedRunWorkspaceScope = Readonly<{
   source: 'persisted_project_binding';
 }>;
 
+export type AccountScopedRunWorkspaceScope = Readonly<{
+  schemaVersion: 1;
+  projectId: string;
+  workspaceId: null;
+  source: 'unbound_account';
+}>;
+
+export type RunWorkspaceScope =
+  | PinnedRunWorkspaceScope
+  | AccountScopedRunWorkspaceScope;
+
+export function accountScopedRunWorkspaceScopeForProject(
+  projectId: string,
+): AccountScopedRunWorkspaceScope {
+  return Object.freeze({
+    schemaVersion: 1,
+    projectId,
+    workspaceId: null,
+    source: 'unbound_account',
+  });
+}
+
 /**
  * The spawn wallet is an address, not a local authorization decision.
  *
@@ -20,6 +42,7 @@ export type PinnedRunWorkspaceScope = Readonly<{
  */
 export type ProjectWorkspaceScopeOutcomeKind =
   | 'resolved_persisted_binding'
+  | 'account_scoped_unbound'
   | 'refused_unbound';
 
 export interface ProjectWorkspaceScopeOutcome {
@@ -47,7 +70,9 @@ export class AmrWorkspaceScopeRequiredError extends Error {
  * Freeze the billing address before a run is created.
  *
  * This is the only function in the run path that reads the mutable project
- * binding. Its result is stored on the run and reused for every attempt.
+ * binding. Its result is stored on the run and reused for every attempt. The
+ * separate account-scoped proof records a genuinely unbound local project;
+ * null remains "no proof" and may not silently select a wallet.
  */
 export function pinRunWorkspaceScopeForProject(
   db: SqliteDb,
@@ -78,7 +103,8 @@ export function pinRunWorkspaceScopeForProject(
  * switches to B, authority lookup is unavailable, or the project is later
  * rebound. Vela/AMR receives the signed-in account credentials plus
  * `OPEN_DESIGN_WORKSPACE_ID=A` and remains the final authorization/billing
- * authority. Missing proof is refused instead of falling through to Personal.
+ * authority. A genuinely unbound local project stays account-scoped and omits
+ * the Workspace env var on every attempt.
  */
 export async function openDesignAmrTraceEnvForRun(
   input: {
@@ -87,7 +113,7 @@ export async function openDesignAmrTraceEnvForRun(
     conversationId?: string | null;
     runAttempt: number;
     projectId?: string | null;
-    workspaceScope?: PinnedRunWorkspaceScope | null;
+    workspaceScope?: RunWorkspaceScope | null;
     externalPluginAnalytics?: Record<string, unknown> | null;
   },
   deps: {
@@ -109,6 +135,11 @@ export async function openDesignAmrTraceEnvForRun(
 
   const projectId = input.projectId?.trim();
   if (!projectId) throw new AmrWorkspaceScopeRequiredError(null);
+  const accountScoped =
+    input.workspaceScope?.projectId === projectId
+    && input.workspaceScope.source === 'unbound_account'
+    && input.workspaceScope.schemaVersion === 1
+    && input.workspaceScope.workspaceId === null;
   const workspaceId =
     input.workspaceScope?.projectId === projectId
     && input.workspaceScope.source === 'persisted_project_binding'
@@ -117,11 +148,18 @@ export async function openDesignAmrTraceEnvForRun(
       ? input.workspaceScope.workspaceId.trim()
       : null;
   deps.onWorkspaceScopeOutcome?.({
-    kind: workspaceId ? 'resolved_persisted_binding' : 'refused_unbound',
+    kind: workspaceId
+      ? 'resolved_persisted_binding'
+      : accountScoped
+        ? 'account_scoped_unbound'
+        : 'refused_unbound',
     projectId,
     workspaceId,
   });
-  if (!workspaceId) throw new AmrWorkspaceScopeRequiredError(projectId);
+  if (!workspaceId) {
+    if (accountScoped) return openDesignAmrTraceEnv(traceInput);
+    throw new AmrWorkspaceScopeRequiredError(projectId);
+  }
 
   return openDesignAmrTraceEnv({
     ...traceInput,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -372,6 +372,7 @@ import {
   registerBuiltInAtomWorkers,
   registerBundledPlugins,
   registryRootsForDataDir,
+  resolveLocalPluginBySource,
   restoreProjectSnapshotLink,
   resolvePluginSnapshot,
   runPipelineForRun,
@@ -7299,6 +7300,11 @@ export async function startServer({
         options.workspaceId,
         options.workspaceMemberId,
       ),
+      getLocalPluginBySource: (id, source) => getLocalPluginBySource(
+        db,
+        id,
+        source,
+      ),
     },
     events: projectEventDeps,
     ids: idDeps,
@@ -8207,6 +8213,16 @@ export async function startServer({
       (plugin) => plugin.id === id,
     ) ?? null;
   };
+  const getLocalPluginBySource = async (
+    dbHandle,
+    id: string,
+    source: string,
+  ) => resolveLocalPluginBySource({
+    db: dbHandle,
+    id,
+    source,
+    userPluginsRoot: PLUGIN_REGISTRY_ROOTS.userPluginsRoot,
+  });
 
   registerPluginRoutes(app, {
     db,
@@ -8229,6 +8245,7 @@ export async function startServer({
       listInstalledPlugins: listWorkspacePlugins,
       getInstalledPlugin,
       getWorkspacePlugin: getWorkspacePluginForRequest,
+      getLocalPluginBySource,
       installPlugin,
       isSafePluginId,
       uninstallPlugin,
@@ -8350,8 +8367,33 @@ export async function startServer({
       typeof projectWorkspaceBinding?.createdByWorkspaceMemberId === 'string'
         ? projectWorkspaceBinding.createdByWorkspaceMemberId.trim()
         : '';
+    const metadata = project?.metadata;
+    const localCatalogScope = (value) => {
+      const workspaceId = typeof value?.workspaceId === 'string'
+        ? value.workspaceId.trim()
+        : '';
+      const workspaceMemberId = typeof value?.workspaceMemberId === 'string'
+        ? value.workspaceMemberId.trim()
+        : '';
+      return workspaceId && workspaceMemberId
+        ? { workspaceId, workspaceMemberId }
+        : null;
+    };
+    // Resource provenance is intentionally independent from project
+    // attribution. A Home selection can be staged while Workspace identity is
+    // transitioning; the daemon persists the local catalogue partition so
+    // the first run reads the same local record without waiting for identity
+    // discovery or treating this as remote membership authority.
+    const skillCatalogScope = localCatalogScope(metadata?.localCatalogScopes?.skill);
+    const designSystemCatalogScope = localCatalogScope(
+      metadata?.localCatalogScopes?.designSystem,
+    );
+    const designSystemWorkspaceId =
+      designSystemCatalogScope?.workspaceId ?? projectWorkspaceId;
+    const designSystemMemberId =
+      designSystemCatalogScope?.workspaceMemberId ?? projectCreatorMemberId;
     const projectDesignSystemBinding = (summary) => {
-      if (!projectWorkspaceId || summary?.source === 'built-in') return null;
+      if (!designSystemWorkspaceId || summary?.source === 'built-in') return null;
       const logicalResourceId =
         typeof summary?.id === 'string' ? summary.id.trim() : '';
       if (!logicalResourceId) return null;
@@ -8359,9 +8401,9 @@ export async function startServer({
         const canonicalTeamBinding = getWorkspaceResource(
           db,
           'design_system',
-          projectWorkspaceId,
+          designSystemWorkspaceId,
           workspaceTeamDesignSystemBindingResourceId(
-            projectWorkspaceId,
+            designSystemWorkspaceId,
             logicalResourceId,
           ),
         );
@@ -8372,7 +8414,7 @@ export async function startServer({
       return getWorkspaceResource(
         db,
         'design_system',
-        projectWorkspaceId,
+        designSystemWorkspaceId,
         logicalResourceId,
       ) ?? null;
     };
@@ -8381,7 +8423,7 @@ export async function startServer({
       // A truly unbound local project is the legacy CLI/BYOK lane. Bound
       // projects must resolve resources from their persisted project scope;
       // shell/current Workspace state never participates.
-      if (!projectWorkspaceId) return true;
+      if (!designSystemWorkspaceId) return true;
       const binding = projectDesignSystemBinding(summary);
       if (
         !binding
@@ -8391,8 +8433,8 @@ export async function startServer({
       }
       if (binding.visibility === 'team') return true;
       return binding.visibility === 'personal'
-        && Boolean(projectCreatorMemberId)
-        && binding.createdByWorkspaceMemberId?.trim() === projectCreatorMemberId;
+        && Boolean(designSystemMemberId)
+        && binding.createdByWorkspaceMemberId?.trim() === designSystemMemberId;
     };
     let appConfigForPrompt = null;
     try {
@@ -8417,7 +8459,6 @@ export async function startServer({
     }
     const effectiveSkillId =
       typeof skillId === 'string' && skillId ? skillId : project?.skillId;
-    const metadata = project?.metadata;
     // Website Clone runs reproduce someone else's site: the fidelity target
     // is the original page. Treating a project/app design system as
     // authoritative would overwrite the cloned site's palette/typography
@@ -8443,16 +8484,21 @@ export async function startServer({
       typeof projectId === 'string' && projectId
         ? getWorkspaceProjectByProjectId(db, projectId)
         : null;
-    let allSkillsPromise: ReturnType<typeof listAllSkillLikeEntries> | null = null;
-    const loadAllSkills = async () => {
-      allSkillsPromise ??= projectResourceScope?.workspaceId
-        ? listAllSkillLikeEntries({
+    const skillResourceScope = skillCatalogScope ?? (
+      projectResourceScope?.workspaceId
+        ? {
             workspaceId: String(projectResourceScope.workspaceId),
             workspaceMemberId:
               typeof projectResourceScope.createdByWorkspaceMemberId === 'string'
                 ? projectResourceScope.createdByWorkspaceMemberId
                 : null,
-          })
+          }
+        : null
+    );
+    let allSkillsPromise: ReturnType<typeof listAllSkillLikeEntries> | null = null;
+    const loadAllSkills = async () => {
+      allSkillsPromise ??= skillResourceScope
+        ? listAllSkillLikeEntries(skillResourceScope)
         : listAllSkillLikeEntries();
       return await allSkillsPromise;
     };
@@ -8710,10 +8756,10 @@ export async function startServer({
     let activeDesignSystemId = null;
     let designSystemDigest = null;
     if (effectiveDesignSystemId) {
-      const designSystemListOptions = projectWorkspaceId
+      const designSystemListOptions = designSystemWorkspaceId
         ? {
-            workspaceId: projectWorkspaceId,
-            workspaceMemberId: projectCreatorMemberId || null,
+            workspaceId: designSystemWorkspaceId,
+            workspaceMemberId: designSystemMemberId || null,
           }
         : {};
       let systems = await listAllDesignSystems(designSystemListOptions);
@@ -8754,8 +8800,8 @@ export async function startServer({
         // from real disk fixtures (see `tests/design-system-assets.test.ts`).
         const resourceBinding = projectDesignSystemBinding(summary);
         const scopedUserDesignSystemsRoot =
-          projectWorkspaceId && resourceBinding?.visibility === 'team'
-            ? teamResourceWorkspaceRoot(USER_DESIGN_SYSTEMS_DIR, projectWorkspaceId)
+          designSystemWorkspaceId && resourceBinding?.visibility === 'team'
+            ? teamResourceWorkspaceRoot(USER_DESIGN_SYSTEMS_DIR, designSystemWorkspaceId)
             : USER_DESIGN_SYSTEMS_DIR;
         const assets = await resolveDesignSystemAssets(
           effectiveDesignSystemId,

--- a/apps/daemon/tests/collab/created-project-workspace.test.ts
+++ b/apps/daemon/tests/collab/created-project-workspace.test.ts
@@ -3,6 +3,7 @@ import {
   authorizeCreatedProjectWorkspace,
   createdProjectWorkspaceHome,
   CreatedProjectWorkspaceResolutionError,
+  localProjectWorkspaceAttribution,
   type CreatedProjectWorkspaceResolution,
 } from '../../src/collab/created-project-workspace.js';
 
@@ -146,6 +147,23 @@ describe('authorizeCreatedProjectWorkspace', () => {
 
     expectDenied(result, 400, 'WORKSPACE_CONTEXT_INCOMPLETE');
     expect(fetchDirectory).not.toHaveBeenCalled();
+  });
+});
+
+describe('localProjectWorkspaceAttribution', () => {
+  it('keeps a complete local attribution without consulting remote authority', () => {
+    expect(localProjectWorkspaceAttribution(request())).toMatchObject({
+      workspaceId: 'workspace-a',
+      workspaceMemberId: 'member-a',
+      workspaceType: 'team',
+    });
+  });
+
+  it('leaves missing or partial identity unbound instead of blocking local creation', () => {
+    expect(localProjectWorkspaceAttribution(request({}))).toBeNull();
+    expect(localProjectWorkspaceAttribution(request({
+      'x-od-workspace-id': 'workspace-a',
+    }))).toBeNull();
   });
 });
 

--- a/apps/daemon/tests/design-systems/team-resource-consumer-scope.test.ts
+++ b/apps/daemon/tests/design-systems/team-resource-consumer-scope.test.ts
@@ -2,12 +2,18 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { closeDatabase, ensureWorkspaceResource, openDatabase } from '../../src/db.js';
+import {
+  closeDatabase,
+  ensureWorkspaceResource,
+  openDatabase,
+  updateWorkspaceResource,
+} from '../../src/db.js';
 import * as designSystems from '../../src/design-systems/index.js';
 import { createDesignSystemServerServices } from '../../src/design-systems/server-services.js';
 import * as skills from '../../src/skills.js';
 import { materializeWorkspaceScopedTeamResource } from '../../src/collab/team-resource-materialization.js';
 import { workspaceTeamSkillBindingResourceId } from '../../src/skills/workspace-team-binding.js';
+import { workspaceTeamDesignSystemBindingResourceId } from '../../src/design-systems/workspace-team-binding.js';
 
 const roots: string[] = [];
 
@@ -100,6 +106,16 @@ describe('Team resource consumers use explicit Workspace scope', () => {
       });
       ensureWorkspaceResource(
         fixture.db,
+        'design_system',
+        workspaceId,
+        workspaceTeamDesignSystemBindingResourceId(
+          workspaceId,
+          'user:same-design-system',
+        ),
+        { visibility: 'team', resourceState: 'active' },
+      );
+      ensureWorkspaceResource(
+        fixture.db,
         'skill',
         workspaceId,
         workspaceTeamSkillBindingResourceId(workspaceId, 'same-skill'),
@@ -165,6 +181,49 @@ describe('Team resource consumers use explicit Workspace scope', () => {
         { workspaceId: 'workspace-b' },
       ),
     ).resolves.toEqual({ ok: true, id: 'user:same-design-system' });
+  });
+
+  it('drops a Team design system after local reconciliation tombstones its binding', async () => {
+    const fixture = await createFixture();
+    const workspaceId = 'workspace-a';
+    const designSystemId = 'user:reconciled-away';
+    const bindingId = workspaceTeamDesignSystemBindingResourceId(
+      workspaceId,
+      designSystemId,
+    );
+    await materializeWorkspaceScopedTeamResource({
+      kindRoot: fixture.userDesignSystems,
+      storageName: 'reconciled-away',
+      identity: {
+        kind: 'design_system',
+        workspaceId,
+        resourceId: designSystemId,
+        hubResourceId: 'ds-reconciled-away',
+      },
+      pullInto: (dir) => writeDesignSystem(dir, workspaceId, 'still on disk'),
+      verifyWorkspaceScope: async () => true,
+      verifyStillShared: async () => true,
+    });
+    ensureWorkspaceResource(fixture.db, 'design_system', workspaceId, bindingId, {
+      visibility: 'team',
+      resourceState: 'active',
+    });
+
+    await expect(fixture.services.listAllDesignSystems({
+      workspaceId,
+      exactTeam: true,
+    })).resolves.toEqual([
+      expect.objectContaining({ id: designSystemId, teamSynced: true }),
+    ]);
+
+    updateWorkspaceResource(fixture.db, 'design_system', workspaceId, bindingId, {
+      resourceState: 'deleted',
+    });
+
+    await expect(fixture.services.listAllDesignSystems({
+      workspaceId,
+      exactTeam: true,
+    })).resolves.toEqual([]);
   });
 
   it('lets only the exact Personal creator validate a same-Workspace design system', async () => {

--- a/apps/daemon/tests/design-systems/workspace-project-scope.test.ts
+++ b/apps/daemon/tests/design-systems/workspace-project-scope.test.ts
@@ -8,6 +8,7 @@ import { materializeWorkspaceScopedTeamResource } from '../../src/collab/team-re
 import {
   closeDatabase,
   ensureWorkspaceProject,
+  ensureWorkspaceResource,
   getProject,
   insertProject,
   openDatabase,
@@ -15,6 +16,7 @@ import {
 } from '../../src/db.js';
 import * as designSystems from '../../src/design-systems/index.js';
 import { createDesignSystemServerServices } from '../../src/design-systems/server-services.js';
+import { workspaceTeamDesignSystemBindingResourceId } from '../../src/design-systems/workspace-team-binding.js';
 import {
   isSafeId,
   listFiles,
@@ -171,6 +173,22 @@ describe('design-system workspace projects preserve exact Workspace scope', () =
       verifyWorkspaceScope: async () => true,
       verifyStillShared: async () => true,
     });
+    // Team-resource sync writes the local materialization and its binding
+    // together. Keep this fixture faithful so read-time tombstone filtering
+    // can distinguish an active mirror from a stale directory left on disk.
+    ensureWorkspaceResource(
+      db,
+      'design_system',
+      'team-workspace',
+      workspaceTeamDesignSystemBindingResourceId('team-workspace', personal.id),
+      {
+        visibility: 'team',
+        resourceState: 'active',
+        createdByWorkspaceMemberId: 'team-member',
+        updatedByWorkspaceMemberId: 'team-member',
+        resourceHubResourceId: 'team-shopify-resource',
+      },
+    );
     return { designSystemId: personal.id, logoBytes, personalProjectId };
   }
 

--- a/apps/daemon/tests/plugins-apply-workspace-retraction.test.ts
+++ b/apps/daemon/tests/plugins-apply-workspace-retraction.test.ts
@@ -1,8 +1,10 @@
 import express from 'express';
+import type { InstalledPluginRecord } from '@open-design/contracts';
 import type { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { registerPluginRoutes } from '../src/routes/plugins/index.js';
+import { applyPlugin as applyPluginCore } from '../src/plugins/apply.js';
 
 const servers: Array<ReturnType<express.Express['listen']>> = [];
 
@@ -104,5 +106,216 @@ describe('Team plugin apply retraction gate', () => {
     const response = await responsePromise;
     expect(response.status).toBe(404);
     expect(applyPlugin).not.toHaveBeenCalled();
+  });
+
+  it('applies a selected local record without Workspace authority headers', async () => {
+    const app = express();
+    app.use(express.json());
+    const loadPluginRegistryView = vi.fn(async () => ({}));
+    const applyPlugin = vi.fn((input: { plugin: { source?: string } }) => ({
+      result: {
+        query: input.plugin.source,
+        capabilitiesGranted: [],
+        appliedPlugin: { capabilitiesGranted: [] },
+      },
+      warnings: [],
+      manifestSourceDigest: 'team-digest',
+    }));
+    const middleware: express.RequestHandler = (_req, _res, next) => next();
+
+    registerPluginRoutes(app, {
+      db: {
+        prepare: () => ({ all: () => [], get: () => null, run: () => undefined }),
+        transaction: (run: () => unknown) => () => run(),
+      },
+      paths: { PROJECTS_DIR: '', PLUGIN_REGISTRY_ROOTS: [], PLUGIN_LOCKFILE_PATH: '' },
+      ids: { randomId: () => 'unused' },
+      projectStore: {},
+      conversations: {},
+      plugins: {
+        getInstalledPlugin: () => null,
+        getWorkspacePlugin: async () => null,
+        getLocalPluginBySource: async (_db: unknown, id: string, source: string) => ({ id, source }),
+        listInstalledPlugins: () => [],
+        applyPlugin,
+        MissingInputError: class MissingInputError extends Error { fields: string[] = []; },
+      },
+      helpers: {
+        requireLocalDaemonRequest: middleware,
+        pluginUpload: { single: () => middleware, array: () => middleware },
+        loadPluginRegistryView,
+        buildConnectorProbe: () => ({}),
+        connectorService: {},
+        sendApiError: (res: express.Response, status: number, code: string, message: string) =>
+          res.status(status).json({ error: { code, message } }),
+      },
+    } as unknown as Parameters<typeof registerPluginRoutes>[1]);
+
+    const server = app.listen(0, '127.0.0.1');
+    servers.push(server);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/api/plugins/shared-id/apply-local`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'team:plugin:workspace-a:shared-id' }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ query: 'team:plugin:workspace-a:shared-id' });
+    expect(loadPluginRegistryView).toHaveBeenCalledWith({
+      workspaceId: 'workspace-a',
+      workspaceMemberId: null,
+    });
+    expect(applyPlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not apply an exact local source retired while registry loading is pending', async () => {
+    const app = express();
+    app.use(express.json());
+    let bindingLive = true;
+    let finishRegistryLoad!: (value: Record<string, never>) => void;
+    const registryGate = new Promise<Record<string, never>>((resolve) => {
+      finishRegistryLoad = resolve;
+    });
+    let registryLoadStarted!: () => void;
+    const registryStarted = new Promise<void>((resolve) => {
+      registryLoadStarted = resolve;
+    });
+    const applyPlugin = vi.fn(() => ({
+      result: { capabilitiesGranted: [], appliedPlugin: { capabilitiesGranted: [] } },
+      warnings: [],
+    }));
+    const getLocalPluginBySource = vi.fn(async (_db: unknown, id: string, source: string) =>
+      bindingLive ? { id, source } : null,
+    );
+    const middleware: express.RequestHandler = (_req, _res, next) => next();
+
+    registerPluginRoutes(app, {
+      db: {
+        prepare: () => ({ all: () => [], get: () => null, run: () => undefined }),
+        transaction: (run: () => unknown) => () => run(),
+      },
+      paths: { PROJECTS_DIR: '', PLUGIN_REGISTRY_ROOTS: [], PLUGIN_LOCKFILE_PATH: '' },
+      ids: { randomId: () => 'unused' },
+      projectStore: {},
+      conversations: {},
+      plugins: {
+        getInstalledPlugin: () => null,
+        getWorkspacePlugin: async () => null,
+        getLocalPluginBySource,
+        listInstalledPlugins: () => [],
+        applyPlugin,
+        MissingInputError: class MissingInputError extends Error { fields: string[] = []; },
+      },
+      helpers: {
+        requireLocalDaemonRequest: middleware,
+        pluginUpload: { single: () => middleware, array: () => middleware },
+        loadPluginRegistryView: async () => {
+          registryLoadStarted();
+          return registryGate;
+        },
+        buildConnectorProbe: () => ({}),
+        connectorService: {},
+        sendApiError: (res: express.Response, status: number, code: string, message: string) =>
+          res.status(status).json({ error: { code, message } }),
+      },
+    } as unknown as Parameters<typeof registerPluginRoutes>[1]);
+
+    const server = app.listen(0, '127.0.0.1');
+    servers.push(server);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const { port } = server.address() as AddressInfo;
+    const responsePromise = fetch(`http://127.0.0.1:${port}/api/plugins/shared-id/apply-local`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'team:plugin:workspace-a:shared-id' }),
+    });
+    await registryStarted;
+    bindingLive = false;
+    finishRegistryLoad({});
+
+    const response = await responsePromise;
+    expect(response.status).toBe(404);
+    expect(getLocalPluginBySource).toHaveBeenCalledTimes(2);
+    expect(applyPlugin).not.toHaveBeenCalled();
+  });
+
+  it('omits a locally tombstoned Team Design System from exact local apply context', async () => {
+    const app = express();
+    app.use(express.json());
+    const teamPlugin: InstalledPluginRecord = {
+      id: 'team-plugin',
+      title: 'Team plugin',
+      version: '1.0.0',
+      sourceKind: 'user',
+      source: 'team:plugin:workspace-a:team-plugin',
+      trust: 'trusted',
+      capabilitiesGranted: [],
+      fsPath: '/tmp/team-plugin',
+      installedAt: 1,
+      updatedAt: 1,
+      manifest: {
+        name: 'team-plugin',
+        title: 'Team plugin',
+        version: '1.0.0',
+        od: {
+          kind: 'skill',
+          context: { designSystem: { ref: 'user:removed-system' } },
+        },
+      },
+    };
+    const middleware: express.RequestHandler = (_req, _res, next) => next();
+
+    registerPluginRoutes(app, {
+      db: {
+        prepare: () => ({ all: () => [], get: () => null, run: () => undefined }),
+        transaction: (run: () => unknown) => () => run(),
+      },
+      paths: { PROJECTS_DIR: '', PLUGIN_REGISTRY_ROOTS: [], PLUGIN_LOCKFILE_PATH: '' },
+      ids: { randomId: () => 'unused' },
+      projectStore: {},
+      conversations: {},
+      plugins: {
+        getInstalledPlugin: () => null,
+        getWorkspacePlugin: async () => null,
+        getLocalPluginBySource: async () => teamPlugin,
+        listInstalledPlugins: () => [],
+        applyPlugin: applyPluginCore,
+        MissingInputError: class MissingInputError extends Error { fields: string[] = []; },
+      },
+      helpers: {
+        requireLocalDaemonRequest: middleware,
+        pluginUpload: { single: () => middleware, array: () => middleware },
+        // The local catalogue filter has already removed the tombstoned DS even
+        // though its materialized directory remains recoverable on disk.
+        loadPluginRegistryView: async () => ({
+          skills: [], designSystems: [], craft: [], atoms: [], scenarios: [],
+        }),
+        buildConnectorProbe: () => ({}),
+        connectorService: {},
+        sendApiError: (res: express.Response, status: number, code: string, message: string) =>
+          res.status(status).json({ error: { code, message } }),
+      },
+    } as unknown as Parameters<typeof registerPluginRoutes>[1]);
+
+    const server = app.listen(0, '127.0.0.1');
+    servers.push(server);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(
+      `http://127.0.0.1:${port}/api/plugins/team-plugin/apply-local`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ source: teamPlugin.source }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { contextItems?: Array<{ id: string }> };
+    expect(body.contextItems ?? []).not.toContainEqual(
+      expect.objectContaining({ id: 'user:removed-system' }),
+    );
   });
 });

--- a/apps/daemon/tests/plugins-local-source.test.ts
+++ b/apps/daemon/tests/plugins-local-source.test.ts
@@ -1,0 +1,174 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ensureWorkspaceResource,
+  openDatabase,
+  updateWorkspaceResource,
+} from '../src/db.js';
+import {
+  materializeWorkspaceScopedTeamResource,
+  teamResourceMaterializationDir,
+} from '../src/collab/team-resource-materialization.js';
+import {
+  localPluginRegistryScope,
+  resolveLocalPluginBySource,
+  resolvePluginFolder,
+  resolvePluginSnapshot,
+  upsertInstalledPlugin,
+  workspaceTeamPluginBindingResourceId,
+} from '../src/plugins/index.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) =>
+    rm(root, { recursive: true, force: true }),
+  ));
+});
+
+async function pluginManifest(folder: string, title: string): Promise<void> {
+  await mkdir(folder, { recursive: true });
+  await writeFile(
+    path.join(folder, 'open-design.json'),
+    JSON.stringify({ name: 'shared-id', title, version: '1.0.0' }),
+  );
+}
+
+describe('resolveLocalPluginBySource', () => {
+  it('derives local registry provenance only for an exact Team source', () => {
+    expect(localPluginRegistryScope({
+      id: 'shared-id',
+      source: 'team:plugin:workspace-a:shared-id',
+    })).toEqual({ workspaceId: 'workspace-a', workspaceMemberId: null });
+    expect(localPluginRegistryScope({
+      id: 'shared-id',
+      source: 'local:personal:shared-id',
+    })).toBeUndefined();
+  });
+
+  it('selects the exact local record when Personal and Team share an id', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'od-local-plugin-source-'));
+    roots.push(root);
+    const dataDir = path.join(root, 'data');
+    const pluginsRoot = path.join(dataDir, 'plugins');
+    const db = openDatabase(root, { dataDir });
+
+    const personalFolder = path.join(root, 'personal-plugin');
+    await pluginManifest(personalFolder, 'Personal copy');
+    const personal = await resolvePluginFolder({
+      folder: personalFolder,
+      folderId: 'shared-id',
+      sourceKind: 'local',
+      source: 'local:personal:shared-id',
+    });
+    if (!personal.ok) throw new Error(personal.errors.join('; '));
+    upsertInstalledPlugin(db, personal.record);
+
+    const team = await materializeWorkspaceScopedTeamResource({
+      kindRoot: pluginsRoot,
+      identity: {
+        kind: 'plugin',
+        workspaceId: 'workspace-a',
+        resourceId: 'shared-id',
+        hubResourceId: 'hub-team-shared-id',
+      },
+      storageName: 'shared-id',
+      pullInto: (dir) => pluginManifest(dir, 'Team copy'),
+      verifyWorkspaceScope: async () => true,
+      verifyStillShared: async () => true,
+    });
+    if (team.status !== 'committed') throw new Error('fixture did not materialize');
+
+    const exactTeamPlugin = await resolveLocalPluginBySource({
+      db,
+      id: 'shared-id',
+      source: team.sourceKey,
+      userPluginsRoot: pluginsRoot,
+    });
+    expect(exactTeamPlugin).toMatchObject({
+      id: 'shared-id',
+      title: 'Team copy',
+      source: 'team:plugin:workspace-a:shared-id',
+      fsPath: teamResourceMaterializationDir(
+        pluginsRoot,
+        'workspace-a',
+        'shared-id',
+        'shared-id',
+      ),
+    });
+    await expect(resolveLocalPluginBySource({
+      db,
+      id: 'shared-id',
+      source: 'local:personal:shared-id',
+      userPluginsRoot: pluginsRoot,
+    })).resolves.toMatchObject({ title: 'Personal copy' });
+
+    db.prepare(`
+      INSERT INTO projects (id, name, created_at, updated_at)
+      VALUES (?, ?, ?, ?)
+    `).run('team-project', 'Team project', 1, 1);
+    const snapshot = resolvePluginSnapshot({
+      db,
+      body: { pluginId: 'shared-id' },
+      projectId: 'team-project',
+      registry: { skills: [], designSystems: [], craft: [], atoms: [] },
+      plugin: exactTeamPlugin ?? undefined,
+    });
+    expect(snapshot?.ok).toBe(true);
+    if (snapshot?.ok) expect(snapshot.snapshot.pluginTitle).toBe('Team copy');
+  });
+
+  it('rejects a forged Team source without a local materialization marker', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'od-local-plugin-source-'));
+    roots.push(root);
+    const dataDir = path.join(root, 'data');
+    const db = openDatabase(root, { dataDir });
+
+    await expect(resolveLocalPluginBySource({
+      db,
+      id: 'shared-id',
+      source: 'team:plugin:workspace-forged:shared-id',
+      userPluginsRoot: path.join(dataDir, 'plugins'),
+    })).resolves.toBeNull();
+  });
+
+  it('rejects a Team source after its local binding is tombstoned', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'od-local-plugin-source-'));
+    roots.push(root);
+    const dataDir = path.join(root, 'data');
+    const pluginsRoot = path.join(dataDir, 'plugins');
+    const db = openDatabase(root, { dataDir });
+    const source = 'team:plugin:workspace-a:shared-id';
+
+    await materializeWorkspaceScopedTeamResource({
+      kindRoot: pluginsRoot,
+      identity: {
+        kind: 'plugin',
+        workspaceId: 'workspace-a',
+        resourceId: 'shared-id',
+        hubResourceId: 'hub-team-shared-id',
+      },
+      storageName: 'shared-id',
+      pullInto: (dir) => pluginManifest(dir, 'Retired Team copy'),
+      verifyWorkspaceScope: async () => true,
+      verifyStillShared: async () => true,
+    });
+    const bindingId = workspaceTeamPluginBindingResourceId('workspace-a', 'shared-id');
+    ensureWorkspaceResource(db, 'plugin', 'workspace-a', bindingId, {
+      visibility: 'team',
+      resourceState: 'active',
+    });
+    updateWorkspaceResource(db, 'plugin', 'workspace-a', bindingId, {
+      resourceState: 'deleted',
+    });
+
+    await expect(resolveLocalPluginBySource({
+      db,
+      id: 'shared-id',
+      source,
+      userPluginsRoot: pluginsRoot,
+    })).resolves.toBeNull();
+  });
+});

--- a/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
+++ b/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
@@ -30,9 +30,11 @@ function buildDeps(input: {
   validateDesignSystem?: ReturnType<typeof vi.fn>;
   validateSkill?: ReturnType<typeof vi.fn>;
   getPlugin?: ReturnType<typeof vi.fn>;
+  getLocalPluginBySource?: ReturnType<typeof vi.fn>;
   loadRegistry?: ReturnType<typeof vi.fn>;
   insertProject?: ReturnType<typeof vi.fn>;
   insertConversation?: ReturnType<typeof vi.fn>;
+  fetchProjectCreationWorkspaceDirectory?: ReturnType<typeof vi.fn>;
 } = {}) {
   const binding = {
     projectId: PROJECT_ID,
@@ -121,18 +123,19 @@ function buildDeps(input: {
         lifecycleState: 'active',
       }),
     }),
-    fetchProjectCreationWorkspaceDirectory: async () => ({
-      ok: true,
-      items: [{
-        workspaceId: WORKSPACE_ID,
-        workspaceName: 'Project scope workspace',
-        workspaceType: 'personal',
-        workspaceMemberId: MEMBER_ID,
-        role: 'owner',
-        memberStatus: 'active',
-        lifecycleState: 'active',
-      }],
-    }),
+    fetchProjectCreationWorkspaceDirectory:
+      input.fetchProjectCreationWorkspaceDirectory ?? vi.fn(async () => ({
+        ok: true,
+        items: [{
+          workspaceId: WORKSPACE_ID,
+          workspaceName: 'Project scope workspace',
+          workspaceType: 'personal',
+          workspaceMemberId: MEMBER_ID,
+          role: 'owner',
+          memberStatus: 'active',
+          lifecycleState: 'active',
+        }],
+      })),
     pluginScope: {
       loadRegistry: input.loadRegistry ?? vi.fn(async () => ({
         skills: [],
@@ -142,6 +145,9 @@ function buildDeps(input: {
         scenarios: [],
       })),
       getPlugin: input.getPlugin ?? vi.fn(async () => ({})),
+      ...(input.getLocalPluginBySource
+        ? { getLocalPluginBySource: input.getLocalPluginBySource }
+        : {}),
     },
   } as unknown as Parameters<typeof registerProjectRoutes>[1];
 }
@@ -167,6 +173,86 @@ function headers() {
 }
 
 describe('project resource selection uses the persisted exact member', () => {
+  it('creates a local-only project without fetching Workspace authority', async () => {
+    const fetchProjectCreationWorkspaceDirectory = vi.fn(async () => ({
+      ok: false,
+      items: [],
+    }));
+    const insertProject = vi.fn((_: unknown, input: Record<string, unknown>) => input);
+    const baseUrl = await start(buildDeps({
+      fetchProjectCreationWorkspaceDirectory,
+      insertProject,
+    }));
+
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: headers(),
+      body: JSON.stringify({
+        id: 'local-only-create',
+        name: 'Local-only create',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchProjectCreationWorkspaceDirectory).not.toHaveBeenCalled();
+    expect(insertProject).toHaveBeenCalledOnce();
+  });
+
+  it('uses selected local catalog provenance while project attribution is unavailable', async () => {
+    const validateDesignSystem = vi.fn(async (id) => ({ ok: true, id }));
+    const validateSkill = vi.fn(async (id) => ({ ok: true, id }));
+    const insertProject = vi.fn((_: unknown, input: Record<string, unknown>) => input);
+    const baseUrl = await start(buildDeps({
+      validateDesignSystem,
+      validateSkill,
+      insertProject,
+    }));
+
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: 'cold-local-catalog-create',
+        name: 'Cold local catalog create',
+        designSystemId: 'user:workspace-brand',
+        designSystemCatalogScope: {
+          workspaceId: WORKSPACE_ID,
+          workspaceMemberId: MEMBER_ID,
+        },
+        skillId: 'workspace-skill',
+        skillCatalogScope: {
+          workspaceId: WORKSPACE_ID,
+          workspaceMemberId: MEMBER_ID,
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(validateDesignSystem).toHaveBeenCalledWith('user:workspace-brand', {
+      workspaceId: WORKSPACE_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+    expect(validateSkill).toHaveBeenCalledWith('workspace-skill', {
+      workspaceId: WORKSPACE_ID,
+      workspaceMemberId: MEMBER_ID,
+    });
+    expect(insertProject).toHaveBeenCalledOnce();
+    expect(insertProject).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      metadata: {
+        localCatalogScopes: {
+          skill: {
+            workspaceId: WORKSPACE_ID,
+            workspaceMemberId: MEMBER_ID,
+          },
+          designSystem: {
+            workspaceId: WORKSPACE_ID,
+            workspaceMemberId: MEMBER_ID,
+          },
+        },
+      },
+    }));
+  });
+
   it('passes exact member scope to both create validators', async () => {
     const validateDesignSystem = vi.fn(async (id) => ({ ok: true, id }));
     const validateSkill = vi.fn(async () => ({
@@ -260,5 +346,113 @@ describe('project resource selection uses the persisted exact member', () => {
     expect(insertProject).not.toHaveBeenCalled();
     expect(insertConversation).not.toHaveBeenCalled();
     expect(loadRegistry).not.toHaveBeenCalled();
+  });
+
+  it('does not reject an exact local Team plugin from a different historical Workspace', async () => {
+    const insertProject = vi.fn((_: unknown, input: Record<string, unknown>) => input);
+    const source = 'team:plugin:historical-workspace:shared-id';
+    const loadRegistry = vi.fn(async () => ({
+      skills: [],
+      designSystems: [],
+      craft: [],
+      atoms: [],
+      scenarios: [],
+    }));
+    const getLocalPluginBySource = vi.fn(async () => ({
+      id: 'shared-id',
+      source,
+    }));
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      getLocalPluginBySource,
+      loadRegistry,
+    }));
+
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: headers(),
+      body: JSON.stringify({
+        id: 'cross-workspace-local-plugin',
+        name: 'Cross-Workspace local plugin',
+        pluginId: 'shared-id',
+        pluginSource: source,
+      }),
+    });
+
+    // This narrow route fixture does not implement snapshot persistence, so the
+    // handler later returns BAD_REQUEST. The boundary under test is that exact
+    // source resolution and the local project write both occur instead of an
+    // early Workspace-mismatch 404.
+    expect(response.status).toBe(400);
+    expect(getLocalPluginBySource).toHaveBeenCalledWith('shared-id', source);
+    expect(loadRegistry).toHaveBeenCalledWith({
+      workspaceId: 'historical-workspace',
+      workspaceMemberId: null,
+    });
+    expect(insertProject).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a plugin source missing from the reconciled local catalog', async () => {
+    const insertProject = vi.fn();
+    const source = `team:plugin:${WORKSPACE_ID}:shared-id`;
+    const getLocalPluginBySource = vi.fn(async () => null);
+    const baseUrl = await start(buildDeps({ insertProject, getLocalPluginBySource }));
+
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: headers(),
+      body: JSON.stringify({
+        id: 'locally-retired-plugin',
+        name: 'Locally retired plugin',
+        pluginId: 'shared-id',
+        pluginSource: source,
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'PLUGIN_NOT_FOUND' },
+    });
+    expect(getLocalPluginBySource).toHaveBeenCalledWith('shared-id', source);
+    expect(insertProject).not.toHaveBeenCalled();
+  });
+
+  it('does not create a project when an exact source retires during registry loading', async () => {
+    const insertProject = vi.fn();
+    const insertConversation = vi.fn();
+    const source = `team:plugin:${WORKSPACE_ID}:shared-id`;
+    let bindingLive = true;
+    const getLocalPluginBySource = vi.fn(async () =>
+      bindingLive ? { id: 'shared-id', source } : null,
+    );
+    const loadRegistry = vi.fn(async () => {
+      bindingLive = false;
+      return { skills: [], designSystems: [], craft: [], atoms: [], scenarios: [] };
+    });
+    const baseUrl = await start(buildDeps({
+      insertProject,
+      insertConversation,
+      getLocalPluginBySource,
+      loadRegistry,
+    }));
+
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: headers(),
+      body: JSON.stringify({
+        id: 'retired-during-registry-load',
+        name: 'Retired during registry load',
+        pluginId: 'shared-id',
+        pluginSource: source,
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'PLUGIN_NOT_FOUND' },
+    });
+    expect(getLocalPluginBySource).toHaveBeenCalledTimes(2);
+    expect(insertProject).not.toHaveBeenCalled();
+    expect(insertConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/daemon/tests/routes/workspace-projects.test.ts
+++ b/apps/daemon/tests/routes/workspace-projects.test.ts
@@ -264,7 +264,7 @@ describe('workspace project routes', () => {
     expect(allB.projects.map((item) => item.id)).not.toContain(projectId);
   });
 
-  it('rejects partial or revoked workspace-aware creates without leaving an unbound project', async () => {
+  it('keeps ordinary local creates independent from partial or stale Workspace identity', async () => {
     const suffix = Date.now();
     const partialId = `workspace-create-partial-${suffix}`;
     const partial = await fetch(`${baseUrl}/api/projects`, {
@@ -280,9 +280,15 @@ describe('workspace project routes', () => {
         designSystemId: null,
       }),
     });
-    expect(partial.status).toBe(400);
-    expect(await fetch(`${baseUrl}/api/projects/${partialId}`).then((response) => response.status))
-      .toBe(404);
+    expect(partial.status).toBe(200);
+    await expect(partial.json()).resolves.toMatchObject({
+      project: { id: partialId },
+    });
+    const partialDetail = await fetch(`${baseUrl}/api/projects/${partialId}`);
+    expect(partialDetail.status).toBe(200);
+    await expect(partialDetail.json()).resolves.toMatchObject({
+      project: { id: partialId, workspaceId: null },
+    });
 
     const revokedId = `workspace-create-revoked-${suffix}`;
     const revoked = await fetch(`${baseUrl}/api/projects`, {
@@ -297,9 +303,28 @@ describe('workspace project routes', () => {
         designSystemId: null,
       }),
     });
-    expect(revoked.status).toBe(403);
-    expect(await fetch(`${baseUrl}/api/projects/${revokedId}`).then((response) => response.status))
-      .toBe(404);
+    expect(revoked.status).toBe(200);
+    await expect(revoked.json()).resolves.toMatchObject({
+      project: {
+        id: revokedId,
+        workspaceId: `${workspaceId}-revoked`,
+      },
+    });
+
+    // PRODUCT INVARIANT: identity headers are optional local attribution on
+    // ordinary creates, never a live Team authorization check. A complete but
+    // stale snapshot remains attributable locally; fresh authority belongs to
+    // the later share/sync/move-to-Team boundary.
+    const revokedDetail = await fetch(`${baseUrl}/api/projects/${revokedId}`, {
+      headers: workspaceHeaders(`${workspaceId}-revoked`, 'member-revoked'),
+    });
+    expect(revokedDetail.status).toBe(200);
+    await expect(revokedDetail.json()).resolves.toMatchObject({
+      project: {
+        id: revokedId,
+        workspaceId: `${workspaceId}-revoked`,
+      },
+    });
   });
 
   it('keeps the persisted workspace binding on the project detail read model', async () => {

--- a/apps/daemon/tests/run-create-workspace-gate.test.ts
+++ b/apps/daemon/tests/run-create-workspace-gate.test.ts
@@ -1437,7 +1437,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
   });
 
   it.each(['/api/runs', '/api/chat'])(
-    'refuses a signed-in AMR run through %s when an unbound project has no explicit Personal identity',
+    'keeps a signed-in AMR run through %s account-scoped when its local project is unbound',
     async (route) => {
     const verifyWorkspaceRequestAuthority = vi.fn();
     const baseUrl = await startServer({
@@ -1455,10 +1455,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
       }),
     });
 
-      expect(response.status).toBe(409);
-      await expect(response.json()).resolves.toMatchObject({
-        error: { code: 'AMR_WORKSPACE_SCOPE_REQUIRED' },
-      });
+      expect(response.status).toBe(202);
       expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
       expect(
         getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT),

--- a/apps/daemon/tests/runtimes/project-amr-trace-env.test.ts
+++ b/apps/daemon/tests/runtimes/project-amr-trace-env.test.ts
@@ -10,6 +10,7 @@ import {
   openDatabase,
 } from '../../src/db.js';
 import {
+  accountScopedRunWorkspaceScopeForProject,
   openDesignAmrTraceEnvForRun,
   pinRunWorkspaceScopeForProject,
 } from '../../src/runtimes/project-amr-trace-env.js';
@@ -118,17 +119,30 @@ describe('openDesignAmrTraceEnvForRun', () => {
     expect(env.OPEN_DESIGN_WORKSPACE_ID).toBe('workspace-personal');
   });
 
-  it('refuses a truly unbound project instead of spawning AMR on the account wallet', async () => {
+  it('spawns a truly unbound local project on the signed-in account wallet', async () => {
     const db = projectDb({ projectId: 'project-legacy' });
-    await expect(openDesignAmrTraceEnvForRun({
+    const env = await openDesignAmrTraceEnvForRun({
       agentId: 'amr',
       runId: 'run-legacy',
       runAttempt: 0,
       projectId: 'project-legacy',
-      workspaceScope: pinRunWorkspaceScopeForProject(db, 'project-legacy'),
+      workspaceScope: accountScopedRunWorkspaceScopeForProject('project-legacy'),
+    });
+    expect(env.OPEN_DESIGN_RUN_ID).toBe('run-legacy');
+    expect(env).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
+  });
+
+  it('does not infer account scope from a missing run proof', async () => {
+    projectDb({ projectId: 'project-proof-missing' });
+    await expect(openDesignAmrTraceEnvForRun({
+      agentId: 'amr',
+      runId: 'run-proof-missing',
+      runAttempt: 0,
+      projectId: 'project-proof-missing',
+      workspaceScope: null,
     })).rejects.toMatchObject({
       code: 'AMR_WORKSPACE_SCOPE_REQUIRED',
-      projectId: 'project-legacy',
+      projectId: 'project-proof-missing',
     });
   });
 

--- a/apps/daemon/tests/runtimes/project-amr-workspace-proof.test.ts
+++ b/apps/daemon/tests/runtimes/project-amr-workspace-proof.test.ts
@@ -11,6 +11,7 @@ import {
   rebindWorkspaceProject,
 } from '../../src/db.js';
 import {
+  accountScopedRunWorkspaceScopeForProject,
   openDesignAmrTraceEnvForRun,
   pinRunWorkspaceScopeForProject,
   type ProjectWorkspaceScopeOutcome,
@@ -228,36 +229,32 @@ describe('AMR persisted project Workspace scope', () => {
     expect(retry.OPEN_DESIGN_WORKSPACE_ID).toBe('workspace-personal');
   });
 
-  it('refuses an unbound AMR project on both initial spawn and retry', async () => {
+  it('keeps an unbound local AMR project account-scoped on initial spawn and retry', async () => {
     const db = seedProject({ projectId: 'project-legacy' });
     const outcomes: ProjectWorkspaceScopeOutcome[] = [];
-    await expect(openDesignAmrTraceEnvForRun({
+    const initial = await openDesignAmrTraceEnvForRun({
       agentId: 'amr',
       runId: 'run-legacy',
       runAttempt: 0,
       projectId: 'project-legacy',
-      workspaceScope: pinRunWorkspaceScopeForProject(db, 'project-legacy'),
+      workspaceScope: accountScopedRunWorkspaceScopeForProject('project-legacy'),
     }, {
       onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
-    })).rejects.toMatchObject({
-      code: 'AMR_WORKSPACE_SCOPE_REQUIRED',
-      projectId: 'project-legacy',
     });
-    await expect(openDesignAmrTraceEnvForRun({
+    const retry = await openDesignAmrTraceEnvForRun({
       agentId: 'amr',
       runId: 'run-legacy',
       runAttempt: 1,
       projectId: 'project-legacy',
-      workspaceScope: pinRunWorkspaceScopeForProject(db, 'project-legacy'),
+      workspaceScope: accountScopedRunWorkspaceScopeForProject('project-legacy'),
     }, {
       onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
-    })).rejects.toMatchObject({
-      code: 'AMR_WORKSPACE_SCOPE_REQUIRED',
-      projectId: 'project-legacy',
     });
+    expect(initial).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
+    expect(retry).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
     expect(outcomes).toHaveLength(2);
     expect(outcomes).toEqual([0, 1].map(() => ({
-      kind: 'refused_unbound',
+      kind: 'account_scoped_unbound',
       projectId: 'project-legacy',
       workspaceId: null,
     })));

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
 import type {
   AmrModelsResponse,
   ChatSessionMode,
+  LocalCatalogScope,
   RunContextSelection,
   TeamProject,
   WorkspaceCollabContext,
@@ -121,6 +122,7 @@ import {
   useWorkspaceBilling,
   useWorkspaceContext,
   workspaceIdentityCacheKey,
+  workspaceResourceReadContext,
 } from './collab/useWorkspaceContext';
 import {
   projectResourceReadsCanStart,
@@ -226,6 +228,9 @@ type AppCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   metadata?: CreateInput['metadata'];
   pendingPrompt?: string;
   pluginId?: string;
+  pluginSource?: string;
+  skillCatalogScope?: LocalCatalogScope | null;
+  designSystemCatalogScope?: LocalCatalogScope | null;
   pluginType?: string;
   appliedPluginSnapshotId?: string;
   pluginInputs?: Record<string, unknown>;
@@ -2860,26 +2865,15 @@ function AppInner() {
       let optimisticProjectId: string | null = null;
       let result;
       try {
-        const executionConfig = configRef.current;
-        const usesAmrCloud =
-          executionConfig.mode === 'daemon'
-          && executionConfig.agentId === AMR_AGENT_ID;
-        const isExplicitlySignedOut =
-          amrLoginStatusRef.current?.loggedIn === false;
-        createWorkspaceContext = resolvedWorkspaceContextForWrite(
-          workspaceContextStateRef.current,
-          {
-            // Local/BYOK may create without AMR Workspace authority only after
-            // the independent login read explicitly proves there is no AMR
-            // identity. An unknown or signed-in identity can still own a Team
-            // Workspace whose directory read is merely slow/unavailable, so
-            // executor selection must not silently turn that Team project into
-            // an unscoped Personal one. Unsupported/settled no-workspace states
-            // already retain their explicit compatibility behavior below.
-            unavailablePolicy:
-              !usesAmrCloud && isExplicitlySignedOut ? 'unscoped' : 'reject',
-          },
-        );
+        // PRODUCT INVARIANT: ordinary project creation is local. Reuse a
+        // current in-memory Workspace snapshot for `personal` + `local_only`
+        // attribution when available, but never start identity discovery or
+        // block creation on Workspace availability. Remote share/sync/move
+        // operations retain their authoritative gates.
+        const createWorkspaceState = workspaceContextStateRef.current;
+        createWorkspaceContext = createWorkspaceState.failure === 'unsupported'
+          ? null
+          : workspaceResourceReadContext(createWorkspaceState);
         if (
           input.amrGatePrecheckWitness &&
           !amrBalanceGateScopesMatch(
@@ -2937,11 +2931,18 @@ function AppInner() {
           ...(optimisticProjectId ? { id: optimisticProjectId } : {}),
           name: input.name,
           skillId: input.skillId,
+          ...(input.skillCatalogScope
+            ? { skillCatalogScope: input.skillCatalogScope }
+            : {}),
           designSystemId: input.designSystemId,
+          ...(input.designSystemCatalogScope
+            ? { designSystemCatalogScope: input.designSystemCatalogScope }
+            : {}),
           pendingPrompt: derivedPendingPrompt,
           metadata,
           ...(input.conversationMode ? { conversationMode: input.conversationMode } : {}),
           ...(input.pluginId ? { pluginId: input.pluginId } : {}),
+          ...(input.pluginSource ? { pluginSource: input.pluginSource } : {}),
           ...(input.appliedPluginSnapshotId
             ? { appliedPluginSnapshotId: input.appliedPluginSnapshotId }
             : {}),

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -353,25 +353,11 @@ export interface CurrentWorkspaceContextReadWitness {
   isStillCurrent: () => boolean;
 }
 
-/**
- * Resolve the Workspace selected by this browser tab from the account
- * directory, without waiting for the shell's richer `/workspace/context`
- * projection to commit to React state.
- *
- * This is an authorization witness, not a display cache: the directory read
- * verifies the exact Workspace/member pair and the returned lifetime closes
- * over both the account/context generation and the tab-local selection. A
- * concurrent sign-in or Workspace switch therefore invalidates an in-flight
- * project action before it may commit.
- */
-export async function resolveCurrentWorkspaceContextReadWitness(
-  options: { fresh?: boolean } = {},
-): Promise<CurrentWorkspaceContextReadWitness> {
-  const requestToken = workspaceContextRequestToken;
-  const accountGeneration = currentWorkspaceAccountGeneration();
-  const directory = await readWorkspaceDirectoryForCurrentGeneration(options);
-  const selected = chooseWorkspaceForTab(directory.items ?? []);
-  const context = selected ? workspaceContextFromDirectoryItem(selected) : null;
+function createCurrentWorkspaceContextReadWitness(
+  context: WorkspaceCollabContext | null,
+  requestToken: string,
+  accountGeneration: number,
+): CurrentWorkspaceContextReadWitness {
   const selectedWorkspaceId = context?.workspaceId ?? null;
   const selectedWorkspaceMemberId = context?.workspaceMemberId ?? null;
   return {
@@ -381,13 +367,63 @@ export async function resolveCurrentWorkspaceContextReadWitness(
         workspaceContextRequestToken !== requestToken
         || currentWorkspaceAccountGeneration() !== accountGeneration
       ) return false;
-      const currentSelection = readWorkspaceSelection();
+      const currentSelection = readWorkspaceSelectionResult();
+      // The directory-backed identity remains authoritative in memory when a
+      // privacy-restricted browser disables sessionStorage. An available
+      // store still guards explicit tab selection changes below.
+      if (!currentSelection.available) return true;
       return context
-        ? currentSelection?.workspaceId === selectedWorkspaceId
-          && currentSelection.workspaceMemberId === selectedWorkspaceMemberId
-        : currentSelection === null;
+        ? currentSelection.selection?.workspaceId === selectedWorkspaceId
+          && currentSelection.selection.workspaceMemberId === selectedWorkspaceMemberId
+        : currentSelection.selection === null;
     },
   };
+}
+
+/**
+ * Reuse the identity last established by the directory-backed shell state.
+ * This is the steady-state submit path: no new directory request is needed.
+ * The witness protects the client from local account/selection races; mutation
+ * routes still perform the final authorization check in the daemon.
+ */
+export function workspaceContextReadWitnessFromState(
+  state: Pick<WorkspaceContextState, 'resourceReadIdentity'>,
+): CurrentWorkspaceContextReadWitness | null {
+  const identity = state.resourceReadIdentity;
+  if (!identity || identity.generation !== workspaceContextRequestToken) return null;
+  const witness = createCurrentWorkspaceContextReadWitness(
+    identity.context,
+    identity.generation,
+    currentWorkspaceAccountGeneration(),
+  );
+  return witness.isStillCurrent() ? witness : null;
+}
+
+/**
+ * Resolve the Workspace selected by this browser tab from the account
+ * directory, without waiting for the shell's richer `/workspace/context`
+ * projection to commit to React state.
+ *
+ * This is a client-side selection witness, not the final authorization check:
+ * the directory read identifies the exact Workspace/member pair and the
+ * returned lifetime closes over both the account/context generation and the
+ * tab-local selection. A concurrent sign-in or Workspace switch therefore
+ * invalidates an in-flight project action before it may commit; mutation
+ * routes independently re-authorize the claimed pair in the daemon.
+ */
+export async function resolveCurrentWorkspaceContextReadWitness(
+  options: { fresh?: boolean } = {},
+): Promise<CurrentWorkspaceContextReadWitness> {
+  const requestToken = workspaceContextRequestToken;
+  const accountGeneration = currentWorkspaceAccountGeneration();
+  const directory = await readWorkspaceDirectoryForCurrentGeneration(options);
+  const selected = chooseWorkspaceForTab(directory.items ?? []);
+  const context = selected ? workspaceContextFromDirectoryItem(selected) : null;
+  return createCurrentWorkspaceContextReadWitness(
+    context,
+    requestToken,
+    accountGeneration,
+  );
 }
 
 // Last successfully-resolved workspace context, kept at module scope so it
@@ -407,10 +443,27 @@ interface WorkspaceSelection {
   workspaceMemberId: string;
 }
 
-function readWorkspaceSelection(): WorkspaceSelection | null {
-  if (typeof window === 'undefined') return null;
+// `undefined` means storage is authoritative. A value (including null) means
+// the latest write failed and this tab's in-memory choice is authoritative.
+let inMemoryWorkspaceSelection: WorkspaceSelection | null | undefined;
+
+type WorkspaceSelectionRead =
+  | { available: true; selection: WorkspaceSelection | null }
+  | { available: false; selection: null };
+
+function readWorkspaceSelectionResult(): WorkspaceSelectionRead {
+  if (typeof window === 'undefined') return { available: true, selection: null };
+  if (inMemoryWorkspaceSelection !== undefined) {
+    return { available: true, selection: inMemoryWorkspaceSelection };
+  }
+  let storedSelection: string | null;
   try {
-    const raw = JSON.parse(window.sessionStorage.getItem(WORKSPACE_SELECTION_SESSION_KEY) ?? 'null') as {
+    storedSelection = window.sessionStorage.getItem(WORKSPACE_SELECTION_SESSION_KEY);
+  } catch {
+    return { available: false, selection: null };
+  }
+  try {
+    const raw = JSON.parse(storedSelection ?? 'null') as {
       workspaceId?: unknown;
       workspaceMemberId?: unknown;
     } | null;
@@ -418,22 +471,31 @@ function readWorkspaceSelection(): WorkspaceSelection | null {
       typeof raw?.workspaceId === 'string' ? raw.workspaceId.trim() : '';
     const workspaceMemberId =
       typeof raw?.workspaceMemberId === 'string' ? raw.workspaceMemberId.trim() : '';
-    return workspaceId && workspaceMemberId
-      ? { workspaceId, workspaceMemberId }
-      : null;
+    return {
+      available: true,
+      selection: workspaceId && workspaceMemberId
+        ? { workspaceId, workspaceMemberId }
+        : null,
+    };
   } catch {
-    return null;
+    return { available: true, selection: null };
   }
+}
+
+function readWorkspaceSelection(): WorkspaceSelection | null {
+  return readWorkspaceSelectionResult().selection;
 }
 
 function writeWorkspaceSelection(selection: WorkspaceSelection | null): void {
   if (typeof window === 'undefined') return;
+  inMemoryWorkspaceSelection = selection ? { ...selection } : null;
   try {
     if (selection) {
       window.sessionStorage.setItem(WORKSPACE_SELECTION_SESSION_KEY, JSON.stringify(selection));
     } else {
       window.sessionStorage.removeItem(WORKSPACE_SELECTION_SESSION_KEY);
     }
+    inMemoryWorkspaceSelection = undefined;
   } catch {
     // A tab with unavailable sessionStorage still remains isolated in memory.
   }
@@ -490,6 +552,7 @@ export function resetWorkspaceContextCache(): void {
   workspaceAccountGeneration = 0;
   workspaceAccountGenerationStamp = 'initial';
   resetWorkspaceContextRetrySchedules();
+  inMemoryWorkspaceSelection = undefined;
   writeWorkspaceSelection(null);
 }
 

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -597,13 +597,14 @@ export function EntryShell({
   // view from the route rather than keeping it in component state.
   const route = useRoute();
   const view: EntryViewKind = route.kind === 'home' ? route.view : 'home';
+  const usesOpenDesignCloud = config.mode === 'daemon' && config.agentId === 'amr';
   useEffect(() => {
-    // The entry shell is the authenticated Home surface. A definitive
-    // signed-out result returns it to the Cloud identity gate while leaving
-    // the saved model source untouched for passive reauthentication.
-    if (amrLoggedIn !== false || view === 'onboarding') return;
+    // Only Hosted execution requires a Cloud session. Local CLI and BYOK stay
+    // usable while signed out; an explicit Cloud sign-out is routed to the
+    // login surface by App.handleActiveCloudSignOut.
+    if (!usesOpenDesignCloud || amrLoggedIn !== false || view === 'onboarding') return;
     navigate({ kind: 'home', view: 'onboarding' }, { replace: true });
-  }, [amrLoggedIn, view]);
+  }, [amrLoggedIn, usesOpenDesignCloud, view]);
   // The one shared workspace context. Any non-null context is a real workspace
   // (personal or team); workspace surfaces gate on B's permission bits, not on
   // workspaceType.

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -106,8 +106,8 @@ import { AmrBalanceDialog } from './AmrBalanceDialog';
 import { AmrLowBalanceDialog, type AmrLowBalanceDecision } from './AmrLowBalanceDialog';
 import {
   amrBalanceGateScopeForWorkspaceContext,
-  amrBalanceGateScopesMatch,
   checkAmrBalanceGate,
+  retryUnavailableAmrBalanceGate,
   type AmrBalanceGateScope,
 } from '../runtime/amr-balance-gate';
 import { isPaidAmrPlan, resolveAmrPlan } from '../runtime/amr-low-balance-plan';
@@ -137,6 +137,7 @@ import {
   useTeamProjects,
   useWorkspaceBillingResponse,
   useWorkspaceContext,
+  workspaceResourceReadContext,
   workspaceBillingBalanceUsd,
   workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
@@ -280,6 +281,9 @@ type EntryCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   metadata?: CreateInput['metadata'];
   pendingPrompt?: string;
   pluginId?: string;
+  pluginSource?: string;
+  skillCatalogScope?: PluginLoopSubmit['skillCatalogScope'];
+  designSystemCatalogScope?: PluginLoopSubmit['designSystemCatalogScope'];
   pluginType?: string;
   appliedPluginSnapshotId?: string;
   pluginInputs?: Record<string, unknown>;
@@ -614,6 +618,8 @@ export function EntryShell({
   );
   const workspaceContextRef = useRef(workspaceContext);
   workspaceContextRef.current = workspaceContext;
+  const workspaceContextStateRef = useRef(workspaceContextState);
+  workspaceContextStateRef.current = workspaceContextState;
   const workspaceBillingResponse = useWorkspaceBillingResponse();
   // Plan and money are both workspace-scoped questions, so both go through a
   // context-partitioned projection. `response.summary` on its own is an ACCOUNT
@@ -1285,15 +1291,26 @@ export function EntryShell({
     // and the composer keeps its draft. In-project sends are gated separately
     // in ProjectView.handleSend.
     let amrGatePrecheckWitness: AmrBalanceGateScope | undefined;
+    let amrGatePrecheckPassed = false;
     if (config.mode === 'daemon' && config.agentId === 'amr') {
-      // Awaiting the wallet or either dialog can outlive a workspace switch.
-      // Re-run once against the latest exact workspace/member authority; if it
-      // changes again, fail closed instead of reusing a stale decision.
-      for (let workspaceAttempt = 0; workspaceAttempt < 2; workspaceAttempt += 1) {
-        const gateScope = amrBalanceGateScopeForWorkspaceContext(
-          workspaceContextRef.current,
+      // PRODUCT INVARIANT: Send never starts Workspace identity discovery.
+      // Billing consumes the shell's current in-memory snapshot; if it has not
+      // arrived yet, the existing account-scoped gate is used. The daemon's
+      // ordinary project-create route is local and does not need live Workspace
+      // authority. Account/scope generation checks below only prevent a result
+      // from being reused after the user switches identity while the balance
+      // request or dialog is in flight.
+      for (let scopeAttempt = 0; scopeAttempt < 2; scopeAttempt += 1) {
+        const gateAccountGeneration = currentWorkspaceAccountGeneration();
+        const gateWorkspaceState = workspaceContextStateRef.current;
+        const gateWorkspaceContext = gateWorkspaceState.failure === 'unsupported'
+          ? null
+          : workspaceResourceReadContext(gateWorkspaceState);
+        const gateWorkspaceIdentity = workspaceIdentityCacheKey(gateWorkspaceContext);
+        const gateScope = amrBalanceGateScopeForWorkspaceContext(gateWorkspaceContext);
+        let gate = await retryUnavailableAmrBalanceGate(
+          () => checkAmrBalanceGate(gateScope),
         );
-        let gate = await checkAmrBalanceGate(gateScope);
         // Hard blocks hold THIS submit open: the dialog resolves 'retry' when
         // its blocking condition clears (sign-in completed, recharge landed)
         // and the gate re-runs, so the task auto-continues through the normal
@@ -1310,9 +1327,11 @@ export function EntryShell({
           });
           setAmrBalanceGateBlock(null);
           if (decision === 'dismiss') return 'blocked' as const;
-          gate = await checkAmrBalanceGate(gateScope);
+          gate = await retryUnavailableAmrBalanceGate(
+            () => checkAmrBalanceGate(gateScope),
+          );
         }
-        if (gate.kind === 'unavailable') return 'blocked' as const;
+        if (gate.kind === 'unavailable') return false;
         if (gate.kind === 'soft') {
           // Hold THIS submit while the reminder waits for a decision; 'proceed'
           // resumes the same create-and-run below, so HomeView's normal accept
@@ -1326,16 +1345,21 @@ export function EntryShell({
             if (decision !== 'proceed') return 'blocked' as const;
           }
         }
-        const currentScope = amrBalanceGateScopeForWorkspaceContext(
-          workspaceContextRef.current,
-        );
-        if (!amrBalanceGateScopesMatch(gateScope, currentScope)) continue;
+        if (
+          currentWorkspaceAccountGeneration() !== gateAccountGeneration
+          || workspaceIdentityCacheKey(
+            workspaceContextStateRef.current.failure === 'unsupported'
+              ? null
+              : workspaceResourceReadContext(workspaceContextStateRef.current),
+          ) !== gateWorkspaceIdentity
+        ) {
+          continue;
+        }
         amrGatePrecheckWitness = gateScope;
+        amrGatePrecheckPassed = true;
         break;
       }
-      if (!amrGatePrecheckWitness) {
-        return 'blocked' as const;
-      }
+      if (!amrGatePrecheckPassed) return false;
     }
     const summarizedName = summarizeProjectNameFromPrompt(payload.prompt);
     const head = payload.prompt.trim().split(/\s+/).slice(0, 8).join(' ');
@@ -1383,10 +1407,17 @@ export function EntryShell({
     return onCreateProject({
       name,
       skillId: payload.skillId ?? null,
+      ...(payload.skillCatalogScope
+        ? { skillCatalogScope: payload.skillCatalogScope }
+        : {}),
       designSystemId: payload.designSystemId ?? null,
+      ...(payload.designSystemCatalogScope
+        ? { designSystemCatalogScope: payload.designSystemCatalogScope }
+        : {}),
       metadata,
       pendingPrompt: payload.prompt,
       ...(payload.pluginId ? { pluginId: payload.pluginId } : {}),
+      ...(payload.pluginSource ? { pluginSource: payload.pluginSource } : {}),
       ...(payload.pluginType ? { pluginType: payload.pluginType } : {}),
       ...(payload.appliedPluginSnapshotId
         ? { appliedPluginSnapshotId: payload.appliedPluginSnapshotId }
@@ -1610,6 +1641,7 @@ export function EntryShell({
                 projects={homeProjectsList}
                 projectsLoading={projectsLoading}
                 designSystems={designSystems}
+                designSystemsLoading={designSystemsLoading}
                 defaultDesignSystemId={defaultDesignSystemId}
                 onSubmit={handlePluginLoopSubmit}
                 onOpenProject={onOpenProject}

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -16,7 +16,9 @@ import type {
   InputFieldSpec,
   McpServerConfig,
   InstalledPluginRecord,
+  LocalCatalogScope,
   ProjectKind,
+  WorkspaceCollabContext,
   WorkspaceProjectSummary,
   AudioVoiceOption,
   WorkspaceContextItem,
@@ -239,6 +241,7 @@ interface Props {
   projects: Project[];
   projectsLoading?: boolean;
   designSystems?: DesignSystemSummary[];
+  designSystemsLoading?: boolean;
   defaultDesignSystemId?: string | null;
   // `'blocked'` means the shell refused the submit but already surfaced its
   // own UI (e.g. the AMR balance gate dialog): keep the draft, show no error.
@@ -316,6 +319,7 @@ const EMPTY_PROMPT_TEMPLATES: PromptTemplateSummary[] = [];
 // safely.
 const HOME_COMPOSER_PROMPT_KEY = 'open-design:home-composer:prompt';
 const HOME_COMPOSER_DESIGN_SYSTEM_KEY = 'open-design:home-composer:design-system';
+const HOME_COMPOSER_DESIGN_SYSTEM_SCOPE_KEY = 'open-design:home-composer:design-system-scope';
 // The active type-chip + bound plugin (the "创作类型" + "示例提示词" pick) is a
 // third piece of composer state that used to fall through this same crack:
 // `active` (below) held only a live `InstalledPluginRecord` + resolved apply
@@ -364,6 +368,31 @@ function writeHomeComposerDraft(key: string, value: string | null): void {
   }
 }
 
+function localCatalogScopeFromWorkspaceContext(
+  context: WorkspaceCollabContext | null,
+): LocalCatalogScope | null {
+  if (!context?.workspaceId?.trim() || !context.workspaceMemberId?.trim()) return null;
+  return {
+    workspaceId: context.workspaceId.trim(),
+    workspaceMemberId: context.workspaceMemberId.trim(),
+  };
+}
+
+function readLocalCatalogScopeDraft(key: string): LocalCatalogScope | null {
+  const raw = readHomeComposerDraft(key);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<LocalCatalogScope> | null;
+    if (!parsed?.workspaceId?.trim() || !parsed.workspaceMemberId?.trim()) return null;
+    return {
+      workspaceId: parsed.workspaceId.trim(),
+      workspaceMemberId: parsed.workspaceMemberId.trim(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 function readHomeComposerChipDraft(): HomeComposerChipDraft | null {
   const raw = readHomeComposerDraft(HOME_COMPOSER_CHIP_KEY);
   if (!raw) return null;
@@ -389,6 +418,7 @@ function writeHomeComposerChipDraft(draft: HomeComposerChipDraft | null): void {
 function clearHomeComposerDraft(): void {
   writeHomeComposerDraft(HOME_COMPOSER_PROMPT_KEY, null);
   writeHomeComposerDraft(HOME_COMPOSER_DESIGN_SYSTEM_KEY, null);
+  writeHomeComposerDraft(HOME_COMPOSER_DESIGN_SYSTEM_SCOPE_KEY, null);
   writeHomeComposerChipDraft(null);
 }
 
@@ -411,6 +441,7 @@ export function HomeView({
   projects,
   projectsLoading,
   designSystems = EMPTY_DESIGN_SYSTEMS,
+  designSystemsLoading = false,
   defaultDesignSystemId = null,
   onSubmit,
   onOpenProject,
@@ -447,6 +478,13 @@ export function HomeView({
   const analytics = useAnalytics();
   const workspaceContextState = useWorkspaceContext();
   const { context: workspaceContext } = workspaceContextState;
+  const lastSettledLocalCatalogScopeRef = useRef<LocalCatalogScope | null>(
+    localCatalogScopeFromWorkspaceContext(workspaceContext),
+  );
+  if (!workspaceContextState.identityChangePending) {
+    lastSettledLocalCatalogScopeRef.current =
+      localCatalogScopeFromWorkspaceContext(workspaceContext);
+  }
   const pluginAccountGeneration = currentWorkspaceAccountGeneration();
   const pluginCatalogOptions = {
     workspaceContext,
@@ -529,6 +567,7 @@ export function HomeView({
   const [fallbackProjectMetadata, setFallbackProjectMetadata] =
     useState<ProjectMetadata | null>(null);
   const [active, setActive] = useState<ActivePlugin | null>(null);
+  const reconciledPluginCatalogKeyRef = useRef<string | null>(null);
   const previousWorkspaceNameRef = useRef<string | null>(null);
   // A placeholder-carousel scenario the user submitted on an empty composer.
   // We seed the prompt + bind the template synchronously, then let an effect
@@ -539,6 +578,8 @@ export function HomeView({
   } | null>(null);
   const [sessionMode, setSessionMode] = useState<ChatSessionMode>('design');
   const [activeSkill, setActiveSkill] = useState<SkillSummary | null>(null);
+  const [activeSkillCatalogScope, setActiveSkillCatalogScope] =
+    useState<LocalCatalogScope | null>(null);
   const [selectedPluginContexts, setSelectedPluginContexts] = useState<SelectedPluginContext[]>([]);
   const [selectedMcpContexts, setSelectedMcpContexts] = useState<SelectedMcpContext[]>([]);
   const [selectedConnectorContexts, setSelectedConnectorContexts] = useState<SelectedConnectorContext[]>([]);
@@ -562,11 +603,15 @@ export function HomeView({
   const restoredDraftRef = useRef<{
     prompt: string;
     designSystemId: string | null;
+    designSystemCatalogScope: LocalCatalogScope | null;
   } | null>(null);
   if (restoredDraftRef.current === null) {
     restoredDraftRef.current = {
       prompt: readHomeComposerDraft(HOME_COMPOSER_PROMPT_KEY) ?? '',
       designSystemId: readHomeComposerDraft(HOME_COMPOSER_DESIGN_SYSTEM_KEY),
+      designSystemCatalogScope: readLocalCatalogScopeDraft(
+        HOME_COMPOSER_DESIGN_SYSTEM_SCOPE_KEY,
+      ),
     };
   }
   const restoredDraft = restoredDraftRef.current;
@@ -574,6 +619,12 @@ export function HomeView({
     restoredDraft.designSystemId ??
     homeDefaultDesignSystemId(designSystems, defaultDesignSystemId),
   );
+  const [designSystemCatalogScope, setDesignSystemCatalogScope] =
+    useState<LocalCatalogScope | null>(() =>
+      restoredDraft.designSystemId
+        ? restoredDraft.designSystemCatalogScope
+        : localCatalogScopeFromWorkspaceContext(workspaceContext),
+    );
   // A restored pick counts as user-touched so the async default re-seed effect
   // below does not overwrite it once the catalogue resolves.
   const designSystemTouchedRef = useRef(restoredDraft.designSystemId != null);
@@ -614,6 +665,14 @@ export function HomeView({
   useEffect(() => {
     writeHomeComposerDraft(HOME_COMPOSER_DESIGN_SYSTEM_KEY, designSystemId);
   }, [designSystemId]);
+  useEffect(() => {
+    writeHomeComposerDraft(
+      HOME_COMPOSER_DESIGN_SYSTEM_SCOPE_KEY,
+      designSystemId && designSystemCatalogScope
+        ? JSON.stringify(designSystemCatalogScope)
+        : null,
+    );
+  }, [designSystemCatalogScope, designSystemId]);
   // Persist the active chip/plugin identity the same way — only the three
   // serializable fields, not `active` itself (see the module note above).
   // Clearing on `active === null` covers the explicit-clear (×) and the
@@ -971,6 +1030,7 @@ export function HomeView({
 
     setActive(null);
     setActiveSkill(null);
+    setActiveSkillCatalogScope(null);
     setSelectedPluginContexts([]);
     setSelectedMcpContexts([]);
     setSelectedConnectorContexts([]);
@@ -1085,12 +1145,92 @@ export function HomeView({
     () => selectableHomeDesignSystems(designSystems, defaultDesignSystemId),
     [defaultDesignSystemId, designSystems],
   );
+  useEffect(() => {
+    if (pluginsLoading) return;
+    const pluginById = new Map(plugins.map((record) => [record.id, record]));
+
+    // Catalogue reads are already partitioned by Workspace. Reconcile staged
+    // choices here when that partition settles: same ids bind to the CURRENT
+    // catalogue record; missing ids lose only their selection. Keep the prompt,
+    // attachments and the rest of the draft intact. Do not move this policy to
+    // project creation or turn it into remote authorization — local catalogue
+    // refresh/SSE is the product boundary for plugin availability.
+    if (reconciledPluginCatalogKeyRef.current !== pluginCatalogKey) {
+      // An apply started against the prior Workspace must not commit after the
+      // catalogue partition changes. Ordinary same-Workspace SSE refreshes do
+      // not cancel an in-flight local apply.
+      activePluginApplyRequestRef.current += 1;
+      reconciledPluginCatalogKeyRef.current = pluginCatalogKey;
+    }
+    setActive((current) => {
+      if (!current) return current;
+      const nextRecord = pluginById.get(current.record.id);
+      if (!nextRecord) return null;
+      if (nextRecord === current.record) return current;
+      return {
+        ...current,
+        record: nextRecord,
+        // An apply snapshot belongs to the old catalogue record. Preserve the
+        // user's inputs, but force submit to resolve against the rebound record.
+        result: null,
+      };
+    });
+    setSelectedPluginContexts((current) => {
+      let changed = false;
+      const next = current.flatMap((selection) => {
+        const nextRecord = pluginById.get(selection.record.id);
+        if (!nextRecord) {
+          changed = true;
+          return [];
+        }
+        if (nextRecord === selection.record) return [selection];
+        changed = true;
+        return [{ ...selection, record: nextRecord }];
+      });
+      return changed ? next : current;
+    });
+    setDetailsRecord((current) => {
+      if (!current) return current;
+      return pluginById.get(current.id) ?? null;
+    });
+  }, [pluginCatalogKey, plugins, pluginsLoading]);
+
+  useEffect(() => {
+    if (skillsLoading) return;
+    setActiveSkill((current) => {
+      if (!current) return current;
+      const rebound = selectableSkills.find((skill) => skill.id === current.id) ?? null;
+      setActiveSkillCatalogScope(
+        rebound ? localCatalogScopeFromWorkspaceContext(workspaceContext) : null,
+      );
+      return rebound;
+    });
+    setDetailsSkill((current) => {
+      if (!current) return current;
+      return selectableSkills.find((skill) => skill.id === current.id) ?? null;
+    });
+  }, [selectableSkills, skillsLoading, workspaceContext]);
+
+  useEffect(() => {
+    if (designSystemsLoading || !designSystemId) return;
+    if (designSystemPickerSystems.some((system) => system.id === designSystemId)) {
+      setDesignSystemCatalogScope(localCatalogScopeFromWorkspaceContext(workspaceContext));
+      return;
+    }
+    setDesignSystemId(null);
+    setDesignSystemCatalogScope(null);
+  }, [designSystemId, designSystemPickerSystems, designSystemsLoading, workspaceContext]);
+
   // Re-seed the default selection when the catalogue or the user's default
   // resolves after mount (async load), unless the user already picked one.
   useEffect(() => {
     if (designSystemTouchedRef.current) return;
-    setDesignSystemId(homeDefaultDesignSystemId(designSystems, defaultDesignSystemId));
-  }, [designSystems, defaultDesignSystemId]);
+    const nextId = homeDefaultDesignSystemId(designSystems, defaultDesignSystemId);
+    setDesignSystemId(nextId);
+    setDesignSystemCatalogScope(
+      nextId ? localCatalogScopeFromWorkspaceContext(workspaceContext) : null,
+    );
+  }, [designSystems, defaultDesignSystemId, workspaceContext]);
   // Title of the globally-selected design system (or the "No design system"
   // label). Seeds the active plugin's `designSystem` input — the apply-template
   // hint the rendered brief references — so it mirrors the persistent picker.
@@ -1199,6 +1339,7 @@ export function HomeView({
     const applyRequestId = activePluginApplyRequestRef.current + 1;
     activePluginApplyRequestRef.current = applyRequestId;
     setActiveSkill(null);
+    setActiveSkillCatalogScope(null);
     const shouldResolveImmediately = options?.deferApply !== true;
     const inputFields = options?.inputFields ?? record.manifest?.od?.inputs ?? [];
     const optimisticInputs = hydratePluginInputs(
@@ -1362,13 +1503,7 @@ export function HomeView({
     applyRequestId?: number,
   ): Promise<ApplyResult | null> {
     setPendingApplyId(record.id);
-    let writeWorkspaceContext;
-    try {
-      if (workspaceContextState.identityChangePending) {
-        throw new Error('workspace identity change pending');
-      }
-      writeWorkspaceContext = resolvedWorkspaceContextForWrite(workspaceContextState);
-    } catch {
+    function clearPendingApply() {
       if (
         applyRequestId === undefined
         || activePluginApplyRequestRef.current === applyRequestId
@@ -1376,20 +1511,25 @@ export function HomeView({
         setPendingApplyId(null);
         setPendingChipId(null);
       }
-      setError(
-        'Workspace context is unavailable. Try again when workspace sync finishes.',
-      );
-      return null;
     }
+    // Applying a record that the local, Workspace-scoped catalogue already
+    // returned is local composition work. Do not add a second identity wait or
+    // membership probe here: directory refresh/SSE owns catalogue freshness,
+    // while remote install/share/sync mutations enforce current authority.
+    // During an identity transition, omit attribution instead of blocking Send.
+    const writeWorkspaceContext = workspaceContextState.identityChangePending
+      ? null
+      : resolvedWorkspaceContextForWrite(
+          workspaceContextState,
+          { unavailablePolicy: 'unscoped' },
+        );
     const result = await applyPlugin(record.id, {
       locale,
       inputs,
+      pluginSource: record.source,
       workspaceContext: writeWorkspaceContext,
     });
-    if (applyRequestId === undefined || activePluginApplyRequestRef.current === applyRequestId) {
-      setPendingApplyId(null);
-      setPendingChipId(null);
-    }
+    clearPendingApply();
     return result;
   }
 
@@ -1720,7 +1860,14 @@ export function HomeView({
         // agent title arrives — see the matching note in
         // EntryShell.startBlankProjectFromRail.
         metadata: { kind: 'other', nameSource: 'generated' },
-        workspaceContext: resolvedWorkspaceContextForWrite(workspaceContextState),
+        // Blank project creation is local too. During an identity transition,
+        // omit stale attribution instead of blocking on Workspace discovery.
+        workspaceContext: workspaceContextState.identityChangePending
+          ? null
+          : resolvedWorkspaceContextForWrite(
+              workspaceContextState,
+              { unavailablePolicy: 'unscoped' },
+            ),
       });
       onOpenProject(project.id);
     } catch {
@@ -1903,6 +2050,9 @@ export function HomeView({
   function handleDesignSystemChange(id: string | null) {
     designSystemTouchedRef.current = true;
     setDesignSystemId(id);
+    setDesignSystemCatalogScope(
+      id ? localCatalogScopeFromWorkspaceContext(workspaceContext) : null,
+    );
     if (active && active.inputFields.some((field) => field.name === 'designSystem')) {
       const title = id
         ? designSystemPickerSystems.find((system) => system.id === id)?.title
@@ -1996,6 +2146,7 @@ export function HomeView({
     setFallbackProjectKind(null);
     setFallbackProjectMetadata(null);
     setActiveSkill(skill);
+    setActiveSkillCatalogScope(localCatalogScopeFromWorkspaceContext(workspaceContext));
     setError(null);
     const replacement = nextPrompt ?? localizeSkillPrompt(locale, skill) ?? '';
     if (replacement.trim().length > 0) {
@@ -2058,6 +2209,7 @@ export function HomeView({
     runWithReplacementConfirmation('Plugin authoring', nextPrompt, async () => {
       setActive(null);
       setActiveSkill(null);
+      setActiveSkillCatalogScope(null);
       setFallbackProjectKind('other');
       setFallbackProjectMetadata(null);
       setError(null);
@@ -2464,8 +2616,16 @@ export function HomeView({
       const accepted = await onSubmit({
         prompt: trimmed,
         pluginId: routedPluginId,
+        ...(submittedActive?.record.source
+          ? { pluginSource: submittedActive.record.source }
+          : {}),
         pluginType: submittedActive?.record.marketplaceTrust ?? (routedPluginId ? 'official' : null),
         skillId: resolvedSkillId,
+        ...(resolvedSkillId && activeSkillCatalogScope
+          ? { skillCatalogScope: activeSkillCatalogScope }
+          : resolvedSkillId && lastSettledLocalCatalogScopeRef.current
+            ? { skillCatalogScope: lastSettledLocalCatalogScopeRef.current }
+          : {}),
         appliedPluginSnapshotId: submittedActive?.result?.appliedPlugin?.snapshotId ?? null,
         pluginTitle: submittedActive?.record.title ?? null,
         taskKind: submittedActive?.result?.appliedPlugin?.taskKind ?? null,
@@ -2473,6 +2633,11 @@ export function HomeView({
         projectKind: submittedProjectKind,
         projectMetadata: submittedProjectMetadata,
         designSystemId: submittedDesignSystemId,
+        ...(submittedDesignSystemId && designSystemCatalogScope
+          ? { designSystemCatalogScope }
+          : submittedDesignSystemId && lastSettledLocalCatalogScopeRef.current
+            ? { designSystemCatalogScope: lastSettledLocalCatalogScopeRef.current }
+          : {}),
         contextPlugins,
         contextMcpServers,
         contextConnectors,
@@ -2558,7 +2723,10 @@ export function HomeView({
         showActivePluginChip={showActivePluginChip}
         onClearActivePlugin={clearActivePlugin}
         onClearActiveChip={clearActiveChipSelection}
-        onClearActiveSkill={() => setActiveSkill(null)}
+        onClearActiveSkill={() => {
+          setActiveSkill(null);
+          setActiveSkillCatalogScope(null);
+        }}
         selectedPluginContexts={selectedPluginContexts.map((item) => item.record)}
         selectedMcpContexts={selectedMcpContexts.map((item) => item.server)}
         selectedConnectorContexts={selectedConnectorContexts.map((item) => item.connector)}

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -2652,7 +2652,7 @@ export function HomeView({
         ...(examplePromptToSend ? { examplePromptContext: examplePromptToSend } : {}),
       });
       if (accepted === false) {
-        setError('Failed to start the run. Make sure the daemon is reachable, then try again.');
+        setError('Failed to start the run. Try again.');
         return;
       }
       // Blocked-and-handled (AMR balance gate): the shell already shows its
@@ -2674,7 +2674,7 @@ export function HomeView({
       // A submit handler that throws (instead of resolving false) lands on
       // the same recovery path as a rejected creation.
       console.warn('Home composer submit failed', err);
-      setError('Failed to start the run. Make sure the daemon is reachable, then try again.');
+      setError('Failed to start the run. Try again.');
     } finally {
       setSending(false);
     }

--- a/apps/web/src/components/PluginLoopHome.tsx
+++ b/apps/web/src/components/PluginLoopHome.tsx
@@ -5,6 +5,7 @@ import type {
   InstalledPluginRecord,
   ProjectKind,
   ProjectMetadata,
+  LocalCatalogScope,
   RunContextSelection,
 } from '@open-design/contracts';
 import {
@@ -30,10 +31,13 @@ import { useWorkspaceContext } from '../collab/useWorkspaceContext';
 export interface PluginLoopSubmit {
   prompt: string;
   pluginId: string | null;
+  /** Exact identity of the local catalogue record selected by the user. */
+  pluginSource?: string | null;
   // Marketplace trust of the routed plugin (official / community / …), used
   // to attribute project_create_result to a plugin type. Null when no plugin.
   pluginType?: string | null;
   skillId?: string | null;
+  skillCatalogScope?: LocalCatalogScope | null;
   appliedPluginSnapshotId: string | null;
   pluginTitle: string | null;
   taskKind: string | null;
@@ -43,6 +47,7 @@ export interface PluginLoopSubmit {
   contextConnectors?: Array<{ id: string; name: string; provider?: string; category?: string; status?: string; accountLabel?: string }> | null;
   initialRunContext?: RunContextSelection | null;
   designSystemId?: string | null;
+  designSystemCatalogScope?: LocalCatalogScope | null;
   // Stage B of plugin-driven-flow-plan: when the user picked a Home
   // chip the rail tells the submit handler which `ProjectKind` to
   // stamp on the new project's metadata. The daemon-side default

--- a/apps/web/src/runtime/amr-balance-gate.ts
+++ b/apps/web/src/runtime/amr-balance-gate.ts
@@ -43,6 +43,28 @@ export type AmrBalanceGateResult =
   | { kind: 'hard'; reason: 'signed_out'; snapshot: AmrWalletSnapshot }
   | { kind: 'soft'; snapshot: AmrWalletSnapshot };
 
+export const HOME_AMR_BALANCE_RETRY_DELAYS_MS = [400, 1_200] as const;
+
+/**
+ * Home has no project queue to hold a send while a cold Workspace billing
+ * projection catches up. Give that transient state a small, bounded recovery
+ * window before returning control to the composer. Only `unavailable` is
+ * retried; definitive allow/soft/hard decisions are never delayed.
+ */
+export async function retryUnavailableAmrBalanceGate(
+  check: () => Promise<AmrBalanceGateResult>,
+): Promise<AmrBalanceGateResult> {
+  let result = await check();
+  for (const delayMs of HOME_AMR_BALANCE_RETRY_DELAYS_MS) {
+    if (result.kind !== 'unavailable') return result;
+    await new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, delayMs);
+    });
+    result = await check();
+  }
+  return result;
+}
+
 export interface AmrBalanceGateScope {
   workspaceType: 'personal' | 'team';
   workspaceId: string;
@@ -208,7 +230,15 @@ async function fetchTeamWorkspaceWalletSnapshot(
 async function checkTeamWorkspaceBalanceGate(
   scope: AmrBalanceGateScope,
 ): Promise<AmrBalanceGateResult> {
-  let accountSnapshot = await fetchAmrWalletSnapshot().catch(() => null);
+  // The URL carries the selected workspace identity. The daemon authorizes
+  // that exact directory membership and returns a v2 identity-stamped wallet.
+  // Start it alongside the cached account snapshot: the latter preserves the
+  // existing signed-out confirmation and profile-aware recovery links, but no
+  // longer sits in front of the authoritative Workspace read.
+  let [accountSnapshot, workspaceSnapshot] = await Promise.all([
+    fetchAmrWalletSnapshot().catch(() => null),
+    fetchTeamWorkspaceWalletSnapshot(scope, null).catch(() => null),
+  ]);
   if (accountSnapshot?.status === 'signed_out') {
     const freshAccount = await fetchAmrWalletSnapshot({ refresh: true }).catch(() => null);
     if (freshAccount?.status === 'signed_out') {
@@ -220,14 +250,13 @@ async function checkTeamWorkspaceBalanceGate(
     }
     accountSnapshot = freshAccount;
   }
-
-  // The URL carries the selected workspace identity. The daemon authorizes
-  // that exact directory membership and returns a v2 identity-stamped wallet.
-  // No account number participates in this decision.
-  const workspaceSnapshot = await fetchTeamWorkspaceWalletSnapshot(
-    scope,
-    accountSnapshot,
-  ).catch(() => null);
+  if (workspaceSnapshot && accountSnapshot) {
+    workspaceSnapshot = {
+      ...workspaceSnapshot,
+      profile: accountSnapshot.profile,
+      user: accountSnapshot.user,
+    };
+  }
   const balance = amrWalletBalanceUsd(workspaceSnapshot);
   if (balance == null) return { kind: 'unavailable' };
   if (balance <= AMR_HARD_BLOCK_BALANCE_USD) {

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -21,6 +21,7 @@ import type {
   ImportFolderRequest,
   ImportFolderResponse,
   InstalledPluginRecord,
+  LocalCatalogScope,
   PluginDuplicateProjectResponse,
   PluginInstallOutcome,
   PluginShareAction,
@@ -139,13 +140,11 @@ export type WorkspaceContextWriteResolutionOptions = {
  * When the read is momentarily blocked (loading, a pending identity change, or
  * a transient `unavailable` outage) but the shell still holds a directory-
  * verified last-good context that belongs to the CURRENT identity generation,
- * that context is honored instead of throwing. The daemon re-verifies the
- * claimed identity on the write (`authorizeCreatedProjectWorkspace`: valid →
- * allow, cross-workspace → 403, authority down → 503 retryable), so a
- * client-side fail-closed here is a redundant second lock that, under a flaky
- * network, only turns a create the server would have honored into a dead
- * button + retry storm. A context from a RETIRED generation (an account switch
- * bumped the token) still fails closed — that is the cross-account guard.
+ * that context is honored instead of throwing. Remote mutation routes still
+ * re-verify authority at their network boundary; ordinary `POST /api/projects`
+ * is deliberately local-first and no longer uses this helper or performs that
+ * verification. A context from a RETIRED generation (an account switch bumped
+ * the token) still fails closed — that is the cross-account guard.
  */
 export function resolvedWorkspaceContextForWrite(
   state: WorkspaceContextForWrite,
@@ -596,7 +595,9 @@ export async function createProject(
     name: string;
     projectLocationId?: string;
     skillId: string | null;
+    skillCatalogScope?: LocalCatalogScope | null;
     designSystemId: string | null;
+    designSystemCatalogScope?: LocalCatalogScope | null;
     pendingPrompt?: string;
     metadata?: ProjectMetadata;
     conversationMode?: ChatSessionMode;
@@ -604,6 +605,7 @@ export async function createProject(
     // (or pre-applied snapshot id) to resolve and pin a plugin to the new
     // project. Used by the PluginLoopHome flow on Home.
     pluginId?: string;
+    pluginSource?: string;
     appliedPluginSnapshotId?: string;
     pluginInputs?: Record<string, unknown>;
     workspaceContext?: WorkspaceCollabContext | null;
@@ -1573,9 +1575,10 @@ export async function persistTabsToDaemonNow(
 // Plan §3.C1 — plugin discovery + apply.
 //
 // applyPlugin() is the canonical entry point for both the inline rail
-// (NewProjectPanel + ChatComposer) and the marketplace detail page. It
-// hits POST /api/plugins/:id/apply, which is the same pure resolver
-// the daemon uses; the response carries everything the composer needs:
+// (NewProjectPanel + ChatComposer) and the marketplace detail page. A caller
+// with a catalogue record supplies its exact local source; id-only callers
+// retain the Workspace-scoped compatibility route. Both return everything the
+// composer needs:
 //   - query (pre-filled brief)
 //   - contextItems (chip strip)
 //   - inputs (form fields)
@@ -2036,8 +2039,8 @@ export type PluginShareProjectOutcome =
  * `workspaceContext` MUST be attached, for the same reason every sibling create
  * in this file attaches it: the project this endpoint creates gets a
  * `workspace_projects` binding from the request's own identity, and a headerless
- * create leaves it unbound — denied its first run by the daemon's workspace gate
- * and carrying no workspace to bill on any run that does get through. This call
+ * create leaves it unbound — its first run can use the signed-in account wallet,
+ * but it has no pinned Workspace for later Team billing or mutations. This call
  * was the one create in this file with no `workspaceContext` parameter at all,
  * so it was permanently unbound rather than merely racy.
  */
@@ -2430,28 +2433,37 @@ export async function applyPlugin(
     projectId?: string;
     grantCaps?: string[];
     locale?: string;
+    pluginSource?: string;
     workspaceContext?: WorkspaceCollabContext | null;
   } = {},
 ): Promise<ApplyResult | null> {
   try {
-    const resp = await fetch(
-      `/api/plugins/${encodeURIComponent(pluginId)}/apply`,
+    const requestBody = JSON.stringify({
+      ...(options.pluginSource ? { source: options.pluginSource } : {}),
+      inputs: options.inputs ?? {},
+      projectId: options.projectId,
+      grantCaps: options.grantCaps ?? [],
+      locale: options.locale,
+    });
+    const pluginUrl = `/api/plugins/${encodeURIComponent(pluginId)}`;
+    let resp = await fetch(
+      `${pluginUrl}/${options.pluginSource ? 'apply-local' : 'apply'}`,
       {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(options.workspaceContext
+          ...(!options.pluginSource && options.workspaceContext
             ? workspaceProjectHeaders(options.workspaceContext)
             : {}),
         },
-        body: JSON.stringify({
-          inputs: options.inputs ?? {},
-          projectId: options.projectId,
-          grantCaps: options.grantCaps ?? [],
-          locale: options.locale,
-        }),
+        body: requestBody,
       },
     );
+    // Exact-source requests must never degrade to the legacy ID-only route:
+    // its response cannot prove which same-ID local record it applied. New
+    // daemons still accept old ID-only clients through /apply; during the brief
+    // new-Web/old-daemon upgrade window, omitting the plugin is safer than
+    // silently substituting different local bytes.
     if (!resp.ok) return null;
     const json = (await resp.json()) as ApplyResult & { ok?: boolean };
     return json;

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -1340,7 +1340,7 @@ describe('App project creation routing', () => {
     ['Local CLI', { ...baseConfig, mode: 'daemon' as const, agentId: 'codex' }],
     ['BYOK', { ...baseConfig, mode: 'api' as const, agentId: 'amr' }],
   ])(
-    'lets %s create an unscoped project while AMR workspace discovery is unavailable',
+    'lets %s create an unscoped project without waiting for AMR identity discovery',
     async (_label, executionConfig) => {
       mockedLoadConfig.mockReturnValue(executionConfig);
       mockedListProjects.mockResolvedValue([]);
@@ -1349,15 +1349,7 @@ describe('App project creation routing', () => {
         vi.fn(async (input: RequestInfo | URL) => {
           const pathname = new URL(String(input), 'http://d.local').pathname;
           if (pathname.endsWith('/integrations/vela/status')) {
-            return new Response(JSON.stringify({
-              loggedIn: false,
-              profile: 'default',
-              user: null,
-              configPath: '/test/vela.json',
-            }), {
-              status: 200,
-              headers: { 'content-type': 'application/json' },
-            });
+            return new Promise<Response>(() => {});
           }
           if (pathname.endsWith('/workspace/directory')) {
             return new Promise<Response>(() => {});
@@ -1370,7 +1362,7 @@ describe('App project creation routing', () => {
       );
 
       render(<App />);
-      await screen.findByText('false', { selector: '[data-testid="amr-login-status"]' });
+      await screen.findByText('null', { selector: '[data-testid="amr-login-status"]' });
       fireEvent.click(await screen.findByRole('button', { name: 'Create project' }));
 
       await waitFor(() => {
@@ -1382,11 +1374,62 @@ describe('App project creation routing', () => {
     },
   );
 
+  it('does not wait for directory identity while the richer Workspace context is still loading', async () => {
+    const context = workspaceContext('ws-cold-create', 'wm-cold-create');
+    const richContextRead = deferred<Response>();
+    mockedLoadConfig.mockReturnValue({
+      ...baseConfig,
+      mode: 'daemon',
+      agentId: 'amr',
+    });
+    mockedListProjects.mockResolvedValue([]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        if (pathname.endsWith('/integrations/vela/status')) {
+          return new Response(JSON.stringify({
+            loggedIn: true,
+            profile: 'default',
+            user: { id: 'account-team-member' },
+            configPath: '/test/vela.json',
+          }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (pathname.endsWith('/workspace/directory')) {
+          return new Response(
+            JSON.stringify(workspaceDirectoryFixture([context])),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        if (pathname.endsWith('/workspace/context')) return richContextRead.promise;
+        return new Response('{}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }),
+    );
+
+    render(<App />);
+    await screen.findByText('true', { selector: '[data-testid="amr-login-status"]' });
+    fireEvent.click(await screen.findByRole('button', { name: 'Create project' }));
+
+    await waitFor(() => {
+      expect(mockedCreateProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspaceContext: null,
+        }),
+      );
+    });
+  });
+
   it.each([
     ['Local CLI', 'loading', { ...baseConfig, mode: 'daemon' as const, agentId: 'codex' }],
     ['BYOK', 'unavailable', { ...baseConfig, mode: 'api' as const, agentId: 'amr' }],
   ])(
-    'keeps %s project creation fail-closed for a signed-in account while Team workspace discovery is %s',
+    'lets %s create locally for a signed-in account while Team workspace discovery is %s',
     async (_label, discoveryState, executionConfig) => {
       mockedLoadConfig.mockReturnValue(executionConfig);
       mockedListProjects.mockResolvedValue([]);
@@ -1421,12 +1464,15 @@ describe('App project creation routing', () => {
       fireEvent.click(await screen.findByRole('button', { name: 'Create project' }));
 
       await waitFor(() => {
-        expect(mockedCreateProject).not.toHaveBeenCalled();
+        expect(mockedCreateProject).toHaveBeenCalledWith(
+          expect.objectContaining({ workspaceContext: null }),
+        );
       });
+      expect(screen.getByTestId('project-title').textContent).toBe('Fresh project');
     },
   );
 
-  it('keeps AMR Cloud project creation fail-closed while workspace discovery is loading even when signed out', async () => {
+  it('allows an unbound local AMR project while workspace discovery is loading', async () => {
     mockedLoadConfig.mockReturnValue({
       ...baseConfig,
       mode: 'daemon',
@@ -1463,7 +1509,9 @@ describe('App project creation routing', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Create project' }));
 
     await waitFor(() => {
-      expect(mockedCreateProject).not.toHaveBeenCalled();
+      expect(mockedCreateProject).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceContext: null }),
+      );
     });
   });
 

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -220,7 +220,10 @@ beforeEach(() => {
         headers: { 'content-type': 'application/json' },
       });
     }
-    if (url.includes('/api/plugins/') && url.endsWith('/apply')) {
+    if (
+      url.includes('/api/plugins/')
+      && (url.endsWith('/apply') || url.endsWith('/apply-local'))
+    ) {
       return new Response(JSON.stringify(APPLY_RESULT), {
         status: 200,
         headers: { 'content-type': 'application/json' },

--- a/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
+++ b/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import {
   buildWorkspacePermissions,
   buildWorkspaceSeatSummary,
@@ -28,6 +28,20 @@ vi.mock('../../src/runtime/amr-balance-gate', async (importOriginal) => {
     checkAmrBalanceGate: vi.fn(),
   };
 });
+
+vi.mock('../../src/components/AmrBalanceDialog', () => ({
+  AmrBalanceDialog: ({
+    reason,
+    onClose,
+  }: {
+    reason: 'insufficient' | 'signed_out';
+    onClose: () => void;
+  }) => (
+    <div data-testid="amr-balance-dialog" data-reason={reason}>
+      <button type="button" onClick={onClose}>Close gate</button>
+    </div>
+  ),
+}));
 
 const mockedCheckAmrBalanceGate = vi.mocked(checkAmrBalanceGate);
 const originalFetch = globalThis.fetch;
@@ -107,6 +121,8 @@ describe('EntryShell AMR workspace precheck race', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     cleanup();
     globalThis.fetch = originalFetch;
     globalThis.ResizeObserver = originalResizeObserver;
@@ -116,7 +132,447 @@ describe('EntryShell AMR workspace precheck race', () => {
     resetTeamProjectsCache();
   });
 
+<<<<<<< HEAD
   it('keeps a locally signed-in account in syncing state while Cloud is unavailable', async () => {
+=======
+  it.each(['get', 'set'] as const)(
+    'starts the team gate from in-memory directory identity when sessionStorage %sItem fails',
+    async (blockedOperation) => {
+      window.history.replaceState(null, '', '/');
+      if (blockedOperation === 'get') {
+        const originalStorageGetItem = Storage.prototype.getItem;
+        vi.spyOn(Storage.prototype, 'getItem').mockImplementation(function getItem(
+          this: Storage,
+          key,
+        ) {
+          if (key === 'od.workspaceSelection.v1') {
+            throw new DOMException('Storage is unavailable', 'SecurityError');
+          }
+          return originalStorageGetItem.call(this, key);
+        });
+      } else {
+        const originalStorageSetItem = Storage.prototype.setItem;
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function setItem(
+          this: Storage,
+          key,
+          value,
+        ) {
+          if (key === 'od.workspaceSelection.v1') {
+            throw new DOMException('Storage is read-only', 'QuotaExceededError');
+          }
+          return originalStorageSetItem.call(this, key, value);
+        });
+      }
+      const workspace = teamContext('workspace-cold', 'member-cold');
+      const contextRead = deferred<Response>();
+      let directoryReads = 0;
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/api/workspace/directory')) {
+          directoryReads += 1;
+          return jsonResponse(workspaceDirectoryFixture([workspace]));
+        }
+        if (url.endsWith('/api/workspace/context')) return contextRead.promise;
+        if (url.includes('/api/workspace/billing?')) {
+          return jsonResponse({ summary: null, workspaceBalance: null });
+        }
+        if (url.endsWith('/api/workspace/projects/team')) {
+          return jsonResponse({ projects: [] });
+        }
+        if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+        if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+        if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+        if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+        return jsonResponse({});
+      }) as typeof fetch;
+      mockedCheckAmrBalanceGate.mockResolvedValue({ kind: 'allow' });
+      const onCreateProject = vi.fn(async () => true);
+
+      render(
+        <I18nProvider initial="en">
+          <EntryShell
+            skills={[]}
+            designTemplates={[]}
+            designSystems={[]}
+            projects={[]}
+            templates={[]}
+            promptTemplates={[]}
+            defaultDesignSystemId={null}
+            connectors={[]}
+            connectorsLoading={false}
+            config={amrConfig()}
+            agents={[amrAgent()]}
+            daemonLive
+            onModeChange={vi.fn()}
+            onAgentChange={vi.fn()}
+            onAgentModelChange={vi.fn()}
+            onApiProtocolChange={vi.fn()}
+            onApiModelChange={vi.fn()}
+            onConfigPersist={vi.fn()}
+            onRefreshAgents={vi.fn(() => [amrAgent()])}
+            onCreateProject={onCreateProject}
+            onCreatePluginShareProject={vi.fn()}
+            onImportClaudeDesign={vi.fn()}
+            onOpenProject={vi.fn()}
+            onOpenLiveArtifact={vi.fn()}
+            onDeleteProject={vi.fn()}
+            onRenameProject={vi.fn()}
+            onChangeDefaultDesignSystem={vi.fn()}
+            onPersistComposioKey={vi.fn()}
+            onOpenSettings={vi.fn()}
+            onCompleteOnboarding={vi.fn()}
+          />
+        </I18nProvider>,
+      );
+
+      await waitFor(() => expect(directoryReads).toBe(1));
+      setHomeHeroPrompt('Create a launch poster without waiting for account chrome.');
+      fireEvent.click(await screen.findByTestId('home-hero-submit'));
+
+      await waitFor(() => expect(mockedCheckAmrBalanceGate).toHaveBeenCalled());
+      await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
+      expect(directoryReads).toBe(1);
+    },
+  );
+
+  it('opens the existing sign-in gate when the confirmed directory is empty', async () => {
+    window.history.replaceState(null, '', '/');
+    let directoryReads = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/workspace/directory')) {
+        directoryReads += 1;
+        return jsonResponse(workspaceDirectoryFixture([]));
+      }
+      if (url.endsWith('/api/workspace/projects/team')) {
+        return jsonResponse({ projects: [] });
+      }
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+    mockedCheckAmrBalanceGate.mockResolvedValue({
+      kind: 'hard',
+      reason: 'signed_out',
+      snapshot: {
+        status: 'signed_out',
+        profile: 'default',
+        user: null,
+        balanceUsd: null,
+        updatedAt: null,
+        fetchedAt: new Date(0).toISOString(),
+        stale: false,
+        source: 'unavailable',
+        error: { code: 'signed_out', message: 'Sign in to view wallet balance.' },
+      },
+    });
+    const onCreateProject = vi.fn(async () => true);
+
+    render(
+      <I18nProvider initial="en">
+        <EntryShell
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          projects={[]}
+          templates={[]}
+          promptTemplates={[]}
+          defaultDesignSystemId={null}
+          connectors={[]}
+          connectorsLoading={false}
+          config={amrConfig()}
+          agents={[amrAgent()]}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiProtocolChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onConfigPersist={vi.fn()}
+          onRefreshAgents={vi.fn(() => [amrAgent()])}
+          onCreateProject={onCreateProject}
+          onCreatePluginShareProject={vi.fn()}
+          onImportClaudeDesign={vi.fn()}
+          onOpenProject={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDeleteProject={vi.fn()}
+          onRenameProject={vi.fn()}
+          onChangeDefaultDesignSystem={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onCompleteOnboarding={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(directoryReads).toBeGreaterThan(0));
+    setHomeHeroPrompt('Create a poster after I sign in.');
+    fireEvent.click(await screen.findByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined));
+    const dialog = await screen.findByTestId('amr-balance-dialog');
+    expect(dialog.getAttribute('data-reason')).toBe('signed_out');
+    expect(onCreateProject).not.toHaveBeenCalled();
+    fireEvent.click(within(dialog).getByText('Close gate'));
+    await waitFor(() => expect(screen.queryByTestId('amr-balance-dialog')).toBeNull());
+  });
+
+  it('keeps the account-scoped gate when an unsupported daemon retains a team context', async () => {
+    window.history.replaceState(null, '', '/');
+    const workspace = teamContext('workspace-retained', 'member-retained');
+    let directoryReads = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/workspace/directory')) {
+        directoryReads += 1;
+        if (directoryReads === 1) {
+          return jsonResponse(workspaceDirectoryFixture([workspace]));
+        }
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/workspace/context')) {
+        return jsonResponse({ context: workspace });
+      }
+      if (url.endsWith('/api/workspace/projects/team')) {
+        return jsonResponse({ projects: [] });
+      }
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+    mockedCheckAmrBalanceGate.mockResolvedValue({ kind: 'allow' });
+    const onCreateProject = vi.fn(async () => true);
+
+    render(
+      <I18nProvider initial="en">
+        <EntryShell
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          projects={[]}
+          templates={[]}
+          promptTemplates={[]}
+          defaultDesignSystemId={null}
+          connectors={[]}
+          connectorsLoading={false}
+          config={amrConfig()}
+          agents={[amrAgent()]}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiProtocolChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onConfigPersist={vi.fn()}
+          onRefreshAgents={vi.fn(() => [amrAgent()])}
+          onCreateProject={onCreateProject}
+          onCreatePluginShareProject={vi.fn()}
+          onImportClaudeDesign={vi.fn()}
+          onOpenProject={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDeleteProject={vi.fn()}
+          onRenameProject={vi.fn()}
+          onChangeDefaultDesignSystem={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onCompleteOnboarding={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(directoryReads).toBe(1));
+    await new Promise((resolve) => setTimeout(resolve, 1_050));
+    act(() => window.dispatchEvent(new Event('focus')));
+    await waitFor(() => expect(directoryReads).toBeGreaterThan(1));
+    setHomeHeroPrompt('Create through the old daemon compatibility lane.');
+    fireEvent.click(await screen.findByTestId('home-hero-submit'));
+
+    await waitFor(() => expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined));
+    await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects an unsupported-daemon submit when identity refreshes during balance retry', async () => {
+    window.history.replaceState(null, '', '/');
+    let directoryReads = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/workspace/directory')) {
+        directoryReads += 1;
+        return new Response(JSON.stringify({ error: 'not_found' }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+    mockedCheckAmrBalanceGate
+      .mockResolvedValueOnce({ kind: 'unavailable' })
+      .mockResolvedValueOnce({ kind: 'allow' });
+    const onCreateProject = vi.fn(async () => true);
+
+    render(
+      <I18nProvider initial="en">
+        <EntryShell
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          projects={[]}
+          templates={[]}
+          promptTemplates={[]}
+          defaultDesignSystemId={null}
+          connectors={[]}
+          connectorsLoading={false}
+          config={amrConfig()}
+          agents={[amrAgent()]}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiProtocolChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onConfigPersist={vi.fn()}
+          onRefreshAgents={vi.fn(() => [amrAgent()])}
+          onCreateProject={onCreateProject}
+          onCreatePluginShareProject={vi.fn()}
+          onImportClaudeDesign={vi.fn()}
+          onOpenProject={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDeleteProject={vi.fn()}
+          onRenameProject={vi.fn()}
+          onChangeDefaultDesignSystem={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onCompleteOnboarding={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(directoryReads).toBeGreaterThan(0));
+    setHomeHeroPrompt('Do not cross an identity refresh.');
+    const submitButton = await screen.findByTestId('home-hero-submit');
+    vi.useFakeTimers();
+    fireEvent.click(submitButton);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(mockedCheckAmrBalanceGate).toHaveBeenCalledTimes(1);
+
+    act(() => notifyWorkspaceContextRefresh());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+      await Promise.resolve();
+    });
+
+    expect(onCreateProject).not.toHaveBeenCalled();
+  });
+
+  it('keeps one Home submit loading until a transient team billing read recovers', async () => {
+    window.history.replaceState(null, '', '/');
+    const workspace = teamContext('workspace-a', 'member-a');
+    let contextReads = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/workspace/directory')) {
+        return jsonResponse(workspaceDirectoryFixture([workspace]));
+      }
+      if (url.endsWith('/api/workspace/context')) {
+        contextReads += 1;
+        return jsonResponse({ context: workspace });
+      }
+      if (url.includes('/api/workspace/billing?')) {
+        return jsonResponse({ summary: null, workspaceBalance: null });
+      }
+      if (url.endsWith('/api/workspace/projects/team')) {
+        return jsonResponse({ projects: [] });
+      }
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    mockedCheckAmrBalanceGate
+      .mockResolvedValueOnce({ kind: 'unavailable' })
+      .mockResolvedValueOnce({ kind: 'unavailable' })
+      .mockResolvedValueOnce({ kind: 'allow' });
+    const onCreateProject = vi.fn(async () => true);
+
+    render(
+      <I18nProvider initial="en">
+        <EntryShell
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          projects={[]}
+          templates={[]}
+          promptTemplates={[]}
+          defaultDesignSystemId={null}
+          connectors={[]}
+          connectorsLoading={false}
+          config={amrConfig()}
+          agents={[amrAgent()]}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiProtocolChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onConfigPersist={vi.fn()}
+          onRefreshAgents={vi.fn(() => [amrAgent()])}
+          onCreateProject={onCreateProject}
+          onCreatePluginShareProject={vi.fn()}
+          onImportClaudeDesign={vi.fn()}
+          onOpenProject={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDeleteProject={vi.fn()}
+          onRenameProject={vi.fn()}
+          onChangeDefaultDesignSystem={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onCompleteOnboarding={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(contextReads).toBeGreaterThan(0));
+    const submitButton = await screen.findByTestId('home-hero-submit');
+    setHomeHeroPrompt('Create an image of a quiet reading room.');
+    vi.useFakeTimers();
+    fireEvent.click(submitButton);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockedCheckAmrBalanceGate).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('true');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    expect(mockedCheckAmrBalanceGate).toHaveBeenCalledTimes(2);
+    expect(onCreateProject).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_200);
+    });
+    expect(mockedCheckAmrBalanceGate).toHaveBeenCalledTimes(3);
+    expect(onCreateProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves a locally signed-in account from initial syncing to compact auto recovery', async () => {
+>>>>>>> b55d443b4 (fix(web): streamline Home submit preflight (#6756))
     window.history.replaceState(null, '', '/');
     const workspace = teamContext('workspace-a', 'member-a');
     const contextFailure = deferred<Response>();

--- a/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
+++ b/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
@@ -132,9 +132,6 @@ describe('EntryShell AMR workspace precheck race', () => {
     resetTeamProjectsCache();
   });
 
-<<<<<<< HEAD
-  it('keeps a locally signed-in account in syncing state while Cloud is unavailable', async () => {
-=======
   it.each(['get', 'set'] as const)(
     'starts the team gate from in-memory directory identity when sessionStorage %sItem fails',
     async (blockedOperation) => {
@@ -572,7 +569,6 @@ describe('EntryShell AMR workspace precheck race', () => {
   });
 
   it('moves a locally signed-in account from initial syncing to compact auto recovery', async () => {
->>>>>>> b55d443b4 (fix(web): streamline Home submit preflight (#6756))
     window.history.replaceState(null, '', '/');
     const workspace = teamContext('workspace-a', 'member-a');
     const contextFailure = deferred<Response>();

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -659,6 +659,27 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(props.onAgentChange).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['Local CLI', baseConfig({ mode: 'daemon', agentId: 'claude-code' })],
+    ['BYOK', baseConfig({
+      mode: 'api',
+      agentId: 'amr',
+      apiKey: 'persisted-key',
+      baseUrl: 'https://api.anthropic.com',
+      model: 'claude-sonnet-4-5',
+    })],
+  ])('keeps Home available for signed-out %s execution', async (_label, config) => {
+    globalThis.fetch = vi.fn(async () => jsonResponse({})) as typeof fetch;
+
+    renderHome({ config, amrLoggedIn: false });
+
+    expect(await screen.findByTestId('home-hero-input')).toBeTruthy();
+    expect(window.location.pathname).toBe('/');
+    expect(
+      screen.queryByRole('heading', { name: 'Sign in to Open Design' }),
+    ).toBeNull();
+  });
+
   it('shows the model-source chooser after Cloud sign-in without exposing legacy onboarding steps', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -643,10 +643,8 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     ) as typeof fetch;
     const config = baseConfig({
       onboardingCompleted: true,
-      mode: 'api',
-      apiKey: 'persisted-key',
-      baseUrl: 'https://api.anthropic.com',
-      model: 'claude-sonnet-4-5',
+      mode: 'daemon',
+      agentId: 'amr',
     });
     const props = renderHome({ config, amrLoggedIn: false });
 

--- a/apps/web/tests/components/HomeView.context-picker.test.tsx
+++ b/apps/web/tests/components/HomeView.context-picker.test.tsx
@@ -3,12 +3,36 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildWorkspacePermissions,
+  buildWorkspaceSeatSummary,
   DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID,
+  type DesignSystemSummary,
   type InstalledPluginRecord,
   type ConnectorDetail,
   type McpServerConfig,
   type SkillSummary,
+  type WorkspaceCollabContext,
 } from '@open-design/contracts';
+
+const workspaceA: WorkspaceCollabContext = {
+  workspaceId: 'workspace-a',
+  workspaceType: 'team',
+  workspaceMemberId: 'member-a',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: 'team_plus',
+  providerMode: 'platform_credits',
+  seatSummary: buildWorkspaceSeatSummary({ seatLimit: 5, usedSeats: 1 }),
+  permissions: buildWorkspacePermissions({ role: 'member', lifecycleState: 'active' }),
+};
+let workspaceContextState: {
+  context: WorkspaceCollabContext | null;
+  loading: boolean;
+  failure?: 'unsupported';
+  identityChangePending?: boolean;
+} = { context: workspaceA, loading: false };
 
 vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
   PlaceholderCarousel: () => null,
@@ -18,11 +42,7 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>();
   return {
     ...actual,
-    useWorkspaceContext: () => ({
-      context: null,
-      loading: false,
-      failure: 'unsupported' as const,
-    }),
+    useWorkspaceContext: () => workspaceContextState,
   };
 });
 
@@ -72,6 +92,14 @@ const DECK_SKILL: SkillSummary = {
   mode: 'deck',
   examplePrompt: 'Design a focused investor deck.',
 };
+const WORKSPACE_DESIGN_SYSTEM: DesignSystemSummary = {
+  id: 'user:workspace-brand',
+  title: 'Workspace Brand',
+  category: 'brand',
+  summary: 'Workspace-scoped brand system.',
+  source: 'user',
+  status: 'published',
+};
 
 const WEB_PROTOTYPE_PLUGIN = makePlugin('example-web-prototype', 'Web Prototype');
 const MCP_SERVER: McpServerConfig = {
@@ -120,6 +148,7 @@ function makePlugin(id: string, title: string): InstalledPluginRecord {
 }
 
 afterEach(() => {
+  workspaceContextState = { context: workspaceA, loading: false };
   cleanup();
   vi.unstubAllGlobals();
 });
@@ -134,6 +163,80 @@ async function pickHomeTemplate(id: string) {
 }
 
 describe('HomeView context picker', () => {
+  it('preserves selected local catalog provenance while Workspace identity transitions', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      if (typeof url === 'string' && url === '/api/mcp/servers') {
+        return new Response(JSON.stringify({ servers: [], templates: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    const onSubmit = vi.fn();
+    const view = render(
+      <HomeView
+        projects={[]}
+        skills={[SKILL]}
+        designSystems={[WORKSPACE_DESIGN_SYSTEM]}
+        defaultDesignSystemId={WORKSPACE_DESIGN_SYSTEM.id}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    await screen.findByTestId('home-hero-input');
+    setHomeHeroPrompt('@proto');
+    await settle();
+    fireEvent.mouseDown(await screen.findByRole('option', { name: /prototype lab/i }));
+    await waitFor(() => expect(screen.getByTestId('home-hero-active-skill')).toBeTruthy());
+
+    workspaceContextState = {
+      context: null,
+      loading: true,
+      identityChangePending: true,
+    };
+    view.rerender(
+      <HomeView
+        projects={[]}
+        skills={[SKILL]}
+        skillsLoading
+        designSystems={[WORKSPACE_DESIGN_SYSTEM]}
+        designSystemsLoading
+        defaultDesignSystemId={WORKSPACE_DESIGN_SYSTEM.id}
+        onSubmit={onSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      skillId: SKILL.id,
+      skillCatalogScope: {
+        workspaceId: workspaceA.workspaceId,
+        workspaceMemberId: workspaceA.workspaceMemberId,
+      },
+      designSystemId: WORKSPACE_DESIGN_SYSTEM.id,
+      designSystemCatalogScope: {
+        workspaceId: workspaceA.workspaceId,
+        workspaceMemberId: workspaceA.workspaceMemberId,
+      },
+    }));
+  });
+
   it('stages pasted files on Home and submits them as first-turn context', async () => {
     const fetchMock = vi.fn<typeof fetch>(async (url) => {
       if (typeof url === 'string' && url === '/api/plugins') {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -3,6 +3,16 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const workspaceContextMock = vi.hoisted(() => ({
+  state: {
+    context: null,
+    resourceReadIdentity: null,
+    loading: false,
+    identityChangePending: false,
+    failure: 'unsupported' as 'unsupported' | 'unavailable' | undefined,
+  },
+}));
+
 vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
   PlaceholderCarousel: () => null,
 }));
@@ -11,11 +21,7 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>();
   return {
     ...actual,
-    useWorkspaceContext: () => ({
-      context: null,
-      loading: false,
-      failure: 'unsupported' as const,
-    }),
+    useWorkspaceContext: () => workspaceContextMock.state,
   };
 });
 
@@ -69,6 +75,13 @@ afterEach(() => {
   cleanup();
   window.localStorage.clear();
   window.sessionStorage.clear();
+  workspaceContextMock.state = {
+    context: null,
+    resourceReadIdentity: null,
+    loading: false,
+    identityChangePending: false,
+    failure: 'unsupported',
+  };
 });
 
 describe('HomeView media composer options', () => {
@@ -433,6 +446,144 @@ describe('HomeView media composer options', () => {
     })));
   });
 
+  it('does not wait for rich Workspace context after a directory-scoped plugin was selected', async () => {
+    const fetchMock = stubFetch({ teamMediaPlugin: true });
+    const onSubmit = vi.fn();
+    const props = homeProps({ onSubmit });
+    const view = render(<HomeView {...props} />);
+
+    await clickHomeRailChip('video');
+    await setHomePrompt('Create a directory-scoped launch teaser.');
+    workspaceContextMock.state = {
+      context: null,
+      resourceReadIdentity: null,
+      loading: true,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    view.rerender(<HomeView {...props} />);
+    await submitHome();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const localApply = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string'
+      && url.includes('/api/plugins/od-media-generation/apply')
+    )).at(-1);
+    expect(localApply).toBeTruthy();
+    expect(new Headers(localApply?.[1]?.headers).has('x-od-workspace-id')).toBe(false);
+  });
+
+  it('keeps bundled plugins usable when identity is pending and the directory is empty', async () => {
+    const fetchMock = stubFetch({ emptyWorkspaceDirectory: true });
+    const onSubmit = vi.fn();
+    const props = homeProps({ onSubmit });
+    const view = render(<HomeView {...props} />);
+
+    await clickHomeRailChip('video');
+    await setHomePrompt('Create a launch teaser after signing out.');
+    const applyCountBeforeSubmit = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    )).length;
+    workspaceContextMock.state = {
+      context: null,
+      resourceReadIdentity: null,
+      loading: false,
+      identityChangePending: true,
+      failure: undefined,
+    };
+    view.rerender(<HomeView {...props} />);
+    await submitHome();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const applyCountAfterSubmit = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    )).length;
+    expect(applyCountAfterSubmit).toBe(applyCountBeforeSubmit + 1);
+    const submittedApply = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    )).at(-1);
+    expect(new Headers(submittedApply?.[1]?.headers).has('x-od-workspace-id')).toBe(false);
+  });
+
+  it('does not wait for directory discovery when applying a bundled plugin', async () => {
+    const fetchMock = stubFetch({ workspaceDirectoryStatus: 503 });
+    const onSubmit = vi.fn();
+    const props = homeProps({ onSubmit });
+    const view = render(<HomeView {...props} />);
+
+    await clickHomeRailChip('video');
+    await setHomePrompt('Create a local launch teaser while identity is unavailable.');
+    workspaceContextMock.state = {
+      context: null,
+      resourceReadIdentity: null,
+      loading: true,
+      identityChangePending: true,
+      failure: 'unavailable',
+    };
+    view.rerender(<HomeView {...props} />);
+    const directoryReadsBeforeSubmit = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url === '/api/workspace/directory'
+    )).length;
+    await submitHome();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const directoryReadsAfterSubmit = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url === '/api/workspace/directory'
+    )).length;
+    expect(directoryReadsAfterSubmit).toBe(directoryReadsBeforeSubmit);
+    const submittedApply = fetchMock.mock.calls.filter(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    )).at(-1);
+    expect(new Headers(submittedApply?.[1]?.headers).has('x-od-workspace-id')).toBe(false);
+  });
+
+  it('does not expose a team plugin for unscoped apply while workspace identity is pending', async () => {
+    const fetchMock = stubFetch({
+      emptyWorkspaceDirectory: true,
+      teamMediaPlugin: true,
+    });
+    workspaceContextMock.state = {
+      context: null,
+      resourceReadIdentity: null,
+      loading: false,
+      identityChangePending: true,
+      failure: undefined,
+    };
+    renderHome();
+
+    await screen.findByTestId('home-hero-input');
+    expect((screen.getByTestId('home-hero-template-trigger') as HTMLButtonElement).disabled).toBe(true);
+    expect(fetchMock.mock.calls.some(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    ))).toBe(false);
+  });
+
+  it('keeps a locally catalogued plugin usable until local reconciliation removes it', async () => {
+    const fetchMock = stubFetch({
+      emptyWorkspaceDirectory: true,
+      teamMediaPlugin: true,
+    });
+    workspaceContextMock.state = {
+      context: null,
+      resourceReadIdentity: null,
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    renderHome();
+
+    await clickHomeRailChip('video');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('false');
+    });
+    const apply = fetchMock.mock.calls.find(([url]) => (
+      typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
+    ));
+    expect(apply).toBeTruthy();
+    expect(new Headers(apply?.[1]?.headers).has('x-od-workspace-id')).toBe(false);
+  });
+
   it('preserves od-media-generation required inputs when applying media chips', async () => {
     const fetchMock = stubFetch();
     renderHome();
@@ -474,17 +625,45 @@ function homeProps(overrides: Partial<React.ComponentProps<typeof HomeView>> = {
   };
 }
 
-function stubFetch(options: { elevenLabsVoices?: Array<{ voiceId: string; name: string; category?: string }>; elevenLabsVoiceError?: string } = {}) {
+function stubFetch(options: {
+  elevenLabsVoices?: Array<{ voiceId: string; name: string; category?: string }>;
+  elevenLabsVoiceError?: string;
+  emptyWorkspaceDirectory?: boolean;
+  teamMediaPlugin?: boolean;
+  workspaceDirectoryStatus?: number;
+} = {}) {
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     cb(0);
     return 0;
   });
+  const mediaPlugin = options.teamMediaPlugin
+    ? { ...MEDIA_PLUGIN, source: 'team:plugin:workspace-a:od-media-generation' }
+    : MEDIA_PLUGIN;
   const fetchMock = vi.fn<typeof fetch>(async (url, init) => {
     if (typeof url === 'string' && url === '/api/plugins') {
-      return json({ plugins: [MEDIA_PLUGIN, PROTOTYPE_PLUGIN, HYPERFRAMES_PLUGIN] });
+      return json({ plugins: [mediaPlugin, PROTOTYPE_PLUGIN, HYPERFRAMES_PLUGIN] });
     }
     if (typeof url === 'string' && url === '/api/mcp/servers') {
       return json({ servers: [], templates: [] });
+    }
+    if (typeof url === 'string' && url === '/api/workspace/directory') {
+      if (options.workspaceDirectoryStatus) {
+        return json({ error: 'workspace_unavailable' }, options.workspaceDirectoryStatus);
+      }
+      return json({
+        items: options.emptyWorkspaceDirectory
+          ? []
+          : [{
+              workspaceId: 'workspace-cold',
+              workspaceName: 'Cold workspace',
+              workspaceType: 'team',
+              workspaceMemberId: 'member-cold',
+              role: 'member',
+              memberStatus: 'active',
+              lifecycleState: 'active',
+            }],
+        activeWorkspaceId: null,
+      });
     }
     if (typeof url === 'string' && url.includes('/apply')) {
       const pluginId = url.split('/api/plugins/')[1]?.split('/apply')[0] ?? 'od-media-generation';

--- a/apps/web/tests/components/HomeView.plugin-workspace-scope.test.tsx
+++ b/apps/web/tests/components/HomeView.plugin-workspace-scope.test.tsx
@@ -50,15 +50,47 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
 
 vi.mock('../../src/components/HomeHero', () => ({
   HomeHero: React.forwardRef(function HomeHeroMock(props: {
-    pluginOptions: Array<{ id: string }>;
+    pluginOptions: Array<{ id: string; title: string }>;
     pluginsLoading: boolean;
+    prompt: string;
     onStartBlankProject: () => void;
-  }) {
+    activePluginTitle: string | null;
+    activePluginRecord: { id: string; title: string } | null;
+    activeSkillRecord: { id: string; name: string } | null;
+    selectedPluginContexts: Array<{ id: string; title: string }>;
+    selectedDesignSystemId: string | null;
+    onPickExamplePlugin: (record: any, chipId: string, promptText: string) => void;
+    onPickPlugin: (record: any, nextPrompt: string | null) => void;
+    onPickSkill: (skill: any, nextPrompt: string | null) => void;
+    onDesignSystemChange: (id: string | null) => void;
+  }, _ref) {
     return (
       <div>
         <output data-testid="plugin-catalog">
           {props.pluginsLoading ? 'loading' : props.pluginOptions.map((plugin) => plugin.id).join(',')}
         </output>
+        <output data-testid="prompt">{props.prompt}</output>
+        <output data-testid="active-plugin">
+          {props.activePluginRecord ? `${props.activePluginRecord.id}:${props.activePluginRecord.title}` : 'none'}
+        </output>
+        <output data-testid="plugin-contexts">
+          {props.selectedPluginContexts.map((record) => `${record.id}:${record.title}`).join(',') || 'none'}
+        </output>
+        <output data-testid="active-skill">
+          {props.activeSkillRecord ? `${props.activeSkillRecord.id}:${props.activeSkillRecord.name}` : 'none'}
+        </output>
+        <output data-testid="active-design-system">{props.selectedDesignSystemId ?? 'none'}</output>
+        {props.pluginOptions.map((record) => (
+          <span key={record.id}>
+            <button type="button" onClick={() => props.onPickExamplePlugin(record, 'prototype', 'draft')}>active-{record.id}</button>
+            <button type="button" onClick={() => props.onPickPlugin(record, null)}>context-{record.id}</button>
+          </span>
+        ))}
+        <button
+          type="button"
+          onClick={() => props.onPickSkill({ id: 'shared-skill', name: 'Skill A', description: '', triggers: [], mode: 'prototype', previewType: 'none', designSystemRequired: false, defaultFor: [], upstream: null, hasBody: true, examplePrompt: '' }, null)}
+        >skill</button>
+        <button type="button" onClick={() => props.onDesignSystemChange('shared-ds')}>design-system</button>
         <button type="button" onClick={props.onStartBlankProject}>blank</button>
       </div>
     );
@@ -92,10 +124,10 @@ function teamContext(workspaceId: string, workspaceMemberId: string): WorkspaceC
   };
 }
 
-function plugin(id: string) {
+function plugin(id: string, title = id) {
   return {
     id,
-    title: id,
+    title,
     version: '1.0.0',
     trust: 'bundled',
     sourceKind: 'bundled',
@@ -104,7 +136,38 @@ function plugin(id: string) {
     fsPath: `/tmp/${id}`,
     installedAt: 0,
     updatedAt: 0,
-    manifest: { name: id, title: id, version: '1.0.0', od: { kind: 'scenario' } },
+    manifest: { name: id, title, version: '1.0.0', od: { kind: 'scenario' } },
+  };
+}
+
+function designSystem(id: string, title: string) {
+  return {
+    id,
+    title,
+    source: 'user' as const,
+    status: 'published' as const,
+    category: 'Brand',
+    summary: `${title} summary`,
+    swatches: ['#111111'],
+    surface: 'web' as const,
+    isEditable: true,
+  };
+}
+
+function skill(name: string) {
+  return {
+    id: 'shared-skill',
+    name,
+    description: '',
+    triggers: [],
+    mode: 'prototype' as const,
+    previewType: 'none',
+    designSystemRequired: false,
+    defaultFor: [],
+    upstream: null,
+    hasBody: true,
+    examplePrompt: '',
+    aggregatesExamples: false,
   };
 }
 
@@ -254,7 +317,180 @@ describe('HomeView workspace-scoped plugin catalog', () => {
     expect(screen.getByTestId('plugin-catalog').textContent).toBe('plugin-b');
   });
 
-  it('does not create through the previous workspace while an identity change is pending', async () => {
+  it('rebinds same-id staged resources to B without clearing the draft', async () => {
+    let workspaceB = false;
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input) => {
+      if (String(input) === '/api/plugins') {
+        return new Response(JSON.stringify({
+          plugins: [plugin('shared-plugin', workspaceB ? 'Plugin B' : 'Plugin A')],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    workspaceMock.state = {
+      context: teamContext('workspace-a', 'member-a'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    const view = render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[skill('Skill A')]}
+        designSystems={[designSystem('shared-ds', 'DS A')]}
+      />,
+    );
+    await screen.findByRole('button', { name: 'active-shared-plugin' });
+    fireEvent.click(screen.getByRole('button', { name: 'active-shared-plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'context-shared-plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'design-system' }));
+
+    workspaceB = true;
+    workspaceMock.state = {
+      context: teamContext('workspace-b', 'member-b'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    view.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[skill('Skill B')]}
+        designSystems={[designSystem('shared-ds', 'DS B')]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-plugin').textContent).toBe('shared-plugin:Plugin B'));
+    expect(screen.getByTestId('plugin-contexts').textContent).toBe('shared-plugin:Plugin B');
+    expect(screen.getByTestId('prompt').textContent).toBe('draft');
+    expect(screen.getByTestId('active-design-system').textContent).toBe('shared-ds');
+  });
+
+  it('invalidates only staged resources missing from B', async () => {
+    let workspaceB = false;
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input) => {
+      if (String(input) === '/api/plugins') {
+        return new Response(JSON.stringify({
+          plugins: workspaceB ? [] : [plugin('workspace-a-plugin', 'Plugin A')],
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    workspaceMock.state = {
+      context: teamContext('workspace-a', 'member-a'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    const view = render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[skill('Skill A')]}
+        designSystems={[designSystem('shared-ds', 'DS A')]}
+      />,
+    );
+    await screen.findByRole('button', { name: 'active-workspace-a-plugin' });
+    fireEvent.click(screen.getByRole('button', { name: 'active-workspace-a-plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'context-workspace-a-plugin' }));
+    fireEvent.click(screen.getByRole('button', { name: 'design-system' }));
+
+    workspaceB = true;
+    workspaceMock.state = {
+      context: teamContext('workspace-b', 'member-b'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    view.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[]}
+        designSystems={[]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('active-plugin').textContent).toBe('none'));
+    expect(screen.getByTestId('plugin-contexts').textContent).toBe('none');
+    expect(screen.getByTestId('prompt').textContent).toBe('draft');
+    expect(screen.getByTestId('active-design-system').textContent).toBe('none');
+  });
+
+  it('rebinds a same-id active skill and invalidates it when the next catalog omits it', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input) => {
+      if (String(input) === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    workspaceMock.state = {
+      context: teamContext('workspace-a', 'member-a'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    const view = render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[skill('Skill A')]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'skill' }));
+    expect(screen.getByTestId('active-skill').textContent).toBe('shared-skill:Skill A');
+
+    workspaceMock.state = {
+      context: teamContext('workspace-b', 'member-b'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    view.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[skill('Skill B')]}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('active-skill').textContent).toBe('shared-skill:Skill B'));
+
+    workspaceMock.state = {
+      context: teamContext('workspace-c', 'member-c'),
+      loading: false,
+      identityChangePending: false,
+      failure: undefined,
+    };
+    view.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        skills={[]}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('active-skill').textContent).toBe('none'));
+  });
+
+  it('creates locally without stale Workspace attribution while identity changes', async () => {
     const projectCreates: RequestInit[] = [];
     vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input);
@@ -277,8 +513,10 @@ describe('HomeView workspace-scoped plugin catalog', () => {
     renderHome();
     fireEvent.click(screen.getByRole('button', { name: 'blank' }));
 
-    await Promise.resolve();
-    expect(projectCreates).toHaveLength(0);
+    await waitFor(() => expect(projectCreates).toHaveLength(1));
+    const requestHeaders = new Headers(projectCreates[0]?.headers);
+    expect(requestHeaders.has('x-od-workspace-id')).toBe(false);
+    expect(requestHeaders.has('x-od-workspace-member-id')).toBe(false);
   });
 
   it('restarts a cold plugin read after a transient identity mask instead of joining the cancelled request', async () => {

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -496,6 +496,51 @@ describe('HomeView prompt handoff', () => {
     window.sessionStorage.clear();
   });
 
+  it('keeps the existing sending state visible and preserves the draft when submit fails', async () => {
+    let resolveSubmit: (accepted: boolean) => void = () => undefined;
+    const submitResult = new Promise<boolean>((resolve) => {
+      resolveSubmit = resolve;
+    });
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        return new Response(JSON.stringify({ plugins: [] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    stubAnimationFrame();
+
+    render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => submitResult}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+
+    await setPromptAndSettle('Create an image of a quiet reading room.');
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('true');
+    });
+    expect(homeHeroPromptValue()).toBe('Create an image of a quiet reading room.');
+
+    await act(async () => {
+      resolveSubmit(false);
+      await submitResult;
+    });
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to start the run. Try again.',
+    );
+    expect(homeHeroPromptValue()).toBe('Create an image of a quiet reading room.');
+    expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('false');
+  });
+
   it('keeps creation types actionable while an expired plugin cache refreshes after a project round trip', async () => {
     let resolveRefresh: (response: Response) => void = () => undefined;
     const refreshResponse = new Promise<Response>((resolve) => {
@@ -573,7 +618,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply-local')) {
         return applyResponse;
       }
       throw new Error(`unexpected fetch ${url}`);
@@ -601,7 +646,7 @@ describe('HomeView prompt handoff', () => {
     expect(inputCard?.style.getPropertyValue('--home-hero-prompt-max-height')).toBe('132px');
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-plugin-authoring/apply',
+      '/api/plugins/od-plugin-authoring/apply-local',
       expect.anything(),
     ));
     resolveApply(new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
@@ -635,7 +680,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply-local')) {
         return new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -673,7 +718,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply-local')) {
         return new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -700,12 +745,12 @@ describe('HomeView prompt handoff', () => {
     const dialog = await screen.findByRole('dialog', { name: /replace current prompt/i });
     expect(homeHeroPromptText()).toBe('Keep my custom plugin brief');
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply')
+      typeof url === 'string' && url.includes('/api/plugins/od-plugin-authoring/apply-local')
     ))).toBe(false);
 
     fireEvent.click(within(dialog).getByRole('button', { name: 'Replace' }));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-plugin-authoring/apply',
+      '/api/plugins/od-plugin-authoring/apply-local',
       expect.anything(),
     ));
     await waitFor(() => expect(homeHeroPromptText()).toBe(PLUGIN_AUTHORING_PROMPT));
@@ -720,7 +765,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -750,7 +795,7 @@ describe('HomeView prompt handoff', () => {
       expect(screen.getByTestId('home-hero-active-plugin')).toBeTruthy();
     });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
     await screen.findByTestId('home-hero-input');
@@ -816,7 +861,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(DEFAULT_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -839,11 +884,11 @@ describe('HomeView prompt handoff', () => {
 
     await clickHomeShortcut('create-plugin');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-new-generation/apply',
+      '/api/plugins/od-new-generation/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply')
+      typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply-local')
     ));
     expect(JSON.parse(String((applyCall?.[1] as RequestInit).body))).toMatchObject({
       inputs: {
@@ -880,7 +925,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -910,7 +955,7 @@ describe('HomeView prompt handoff', () => {
       expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('UI Mockup');
     });
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ))).toBe(false);
     // The design-system picker is now a persistent control in the row below the
     // composer (next to the working-directory picker), available for every
@@ -940,11 +985,11 @@ describe('HomeView prompt handoff', () => {
     fireEvent.click(screen.getByTestId('home-hero-submit'));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ));
     const protoApplyInputs = JSON.parse(String((applyCall?.[1] as RequestInit).body)).inputs;
     expect(protoApplyInputs).toMatchObject({
@@ -980,7 +1025,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply-local')) {
         return new Response(JSON.stringify(DOCUMENT_NEW_GENERATION_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1014,11 +1059,11 @@ describe('HomeView prompt handoff', () => {
     fireEvent.click(submit);
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-new-generation/apply',
+      '/api/plugins/od-new-generation/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply')
+      typeof url === 'string' && url.includes('/api/plugins/od-new-generation/apply-local')
     ));
     expect(JSON.parse(String((applyCall?.[1] as RequestInit).body))).toMatchObject({
       inputs: {
@@ -1044,7 +1089,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1085,11 +1130,11 @@ describe('HomeView prompt handoff', () => {
     fireEvent.click(screen.getByTestId('home-hero-submit'));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ));
     const protoApplyInputs = JSON.parse(String((applyCall?.[1] as RequestInit).body)).inputs;
     expect(protoApplyInputs).toMatchObject({ designSystem: 'No design system' });
@@ -1109,7 +1154,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1173,7 +1218,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1213,7 +1258,7 @@ describe('HomeView prompt handoff', () => {
       );
     });
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ))).toBe(false);
     expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('UI Mockup');
     // The design-system picker is now the persistent control below the composer.
@@ -1236,11 +1281,11 @@ describe('HomeView prompt handoff', () => {
     fireEvent.click(screen.getByTestId('home-hero-submit'));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ));
     // The preset card seeds the prompt as plain text while preserving the
     // chip's structured inputs (artifactKind / fidelity / audience /
@@ -1277,7 +1322,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(LIVE_ARTIFACT_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1321,7 +1366,7 @@ describe('HomeView prompt handoff', () => {
       expect(homeHeroPromptText()).toBe('Create a live Notion dashboard artifact.');
     });
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/apply')
+      typeof url === 'string' && url.includes('/apply-local')
     ))).toBe(false);
     expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Live artifact');
     expect(screen.queryByTestId('plugin-inputs-form')).toBeNull();
@@ -1333,7 +1378,7 @@ describe('HomeView prompt handoff', () => {
     // reference), while the live-artifact chip's project kind + metadata are
     // carried forward. Submit resolves the snapshot for the preset plugin.
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/image-template-notion-team-dashboard-live-artifact/apply',
+      '/api/plugins/image-template-notion-team-dashboard-live-artifact/apply-local',
       expect.anything(),
     ));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
@@ -1357,7 +1402,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply-local')) {
         return new Response(JSON.stringify(LIVE_ARTIFACT_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1385,17 +1430,17 @@ describe('HomeView prompt handoff', () => {
       expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Live artifact');
     });
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply-local')
     ))).toBe(false);
     await setPromptAndSettle('Build a refreshable Stripe revenue dashboard.');
     fireEvent.click(screen.getByTestId('home-hero-submit'));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-live-artifact/apply',
+      '/api/plugins/example-live-artifact/apply-local',
       expect.anything(),
     ));
     const applyCall = fetchMock.mock.calls.find(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-live-artifact/apply-local')
     ));
     expect(JSON.parse(String((applyCall?.[1] as RequestInit).body))).toMatchObject({
       inputs: {},
@@ -1425,7 +1470,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply-local')) {
         return new Response(JSON.stringify(SIMPLE_DECK_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1480,7 +1525,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(DEFAULT_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1509,7 +1554,7 @@ describe('HomeView prompt handoff', () => {
       expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('UI Mockup');
     });
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ))).toBe(false);
     expect(homeHeroPromptText()).toBe('Keep my current brief');
     expect(screen.queryByRole('dialog', { name: /replace current prompt/i })).toBeNull();
@@ -1523,13 +1568,13 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply-local')) {
         return new Response(JSON.stringify(SIMPLE_DECK_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1560,7 +1605,7 @@ describe('HomeView prompt handoff', () => {
     expect(screen.getByTestId('home-hero-plugin-presets').textContent).toContain('Simple Deck');
     fireEvent.click(screen.getAllByTestId('home-hero-plugin-preset')[0]!);
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-simple-deck/apply-local')
     ))).toBe(false);
     await waitFor(() => {
       expect(homeHeroPromptText()).toBe(
@@ -1575,7 +1620,7 @@ describe('HomeView prompt handoff', () => {
     });
     fireEvent.click(screen.getAllByTestId('home-hero-plugin-preset')[0]!);
     expect(fetchMock.mock.calls.some(([url]) => (
-      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')
+      typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')
     ))).toBe(false);
     await waitFor(() => {
       expect(homeHeroPromptText()).toBe(
@@ -1592,7 +1637,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1644,7 +1689,7 @@ describe('HomeView prompt handoff', () => {
       expect(screen.getByTestId('home-hero-active-plugin')).toBeTruthy();
     });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
   });
@@ -1662,7 +1707,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1701,7 +1746,7 @@ describe('HomeView prompt handoff', () => {
       'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.';
     await waitFor(() => expect(homeHeroPromptText()).toBe(seed));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
 
@@ -1733,7 +1778,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1774,7 +1819,7 @@ describe('HomeView prompt handoff', () => {
     const appended = `Keep my current brief\n\n${query}`;
     await waitFor(() => expect(homeHeroPromptText()).toBe(appended));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
 
@@ -1806,7 +1851,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply-local')) {
         return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1845,7 +1890,7 @@ describe('HomeView prompt handoff', () => {
       'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.';
     await waitFor(() => expect(homeHeroPromptText()).toBe(seed));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-web-prototype/apply',
+      '/api/plugins/example-web-prototype/apply-local',
       expect.anything(),
     ));
 
@@ -1876,7 +1921,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/api/plugins/example-meta-landing/apply')) {
+      if (typeof url === 'string' && url.includes('/api/plugins/example-meta-landing/apply-local')) {
         return new Response(JSON.stringify(META_INSTRUCTION_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1914,7 +1959,7 @@ describe('HomeView prompt handoff', () => {
     expect(homeHeroPromptText()).not.toContain('verbatim');
     expect(homeHeroPromptText()).not.toContain('example.html');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/example-meta-landing/apply',
+      '/api/plugins/example-meta-landing/apply-local',
       expect.anything(),
     ));
   });
@@ -1927,7 +1972,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -1951,7 +1996,7 @@ describe('HomeView prompt handoff', () => {
     await clearActiveTypeChip();
     await clickHomeShortcut('create-plugin');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-plugin-authoring/apply',
+      '/api/plugins/od-plugin-authoring/apply-local',
       expect.anything(),
     ));
     await waitFor(() => {
@@ -1983,7 +2028,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return new Response(JSON.stringify(AUTHORING_APPLY_RESULT), {
           status: 200,
           headers: { 'content-type': 'application/json' },
@@ -2007,7 +2052,7 @@ describe('HomeView prompt handoff', () => {
     await clearActiveTypeChip();
     await clickHomeShortcut('create-plugin');
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
-      '/api/plugins/od-plugin-authoring/apply',
+      '/api/plugins/od-plugin-authoring/apply-local',
       expect.anything(),
     ));
 
@@ -2042,7 +2087,7 @@ describe('HomeView prompt handoff', () => {
           headers: { 'content-type': 'application/json' },
         });
       }
-      if (typeof url === 'string' && url.includes('/apply')) {
+      if (typeof url === 'string' && url.includes('/apply-local')) {
         return applyResponse;
       }
       throw new Error(`unexpected fetch ${url}`);

--- a/apps/web/tests/components/HomeView.template-use-send-enabled.test.tsx
+++ b/apps/web/tests/components/HomeView.template-use-send-enabled.test.tsx
@@ -268,7 +268,7 @@ function stubFetch() {
           headers: { 'content-type': 'application/json' },
         });
       if (href === '/api/plugins') return json({ plugins: ALL });
-      const applyMatch = /^\/api\/plugins\/([^/]+)\/apply$/.exec(href);
+      const applyMatch = /^\/api\/plugins\/([^/]+)\/(?:apply|apply-local)$/.exec(href);
       if (applyMatch) {
         const record = ALL.find((entry) => entry.id === decodeURIComponent(applyMatch[1]!));
         const posted = (JSON.parse(String(init?.body ?? '{}')) as { inputs?: Record<string, unknown> })

--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -952,6 +952,31 @@ describe('a Home auto-send observes a project billing scope that settles after m
     await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalled());
   });
 
+  it('auto-sends a cold unbound local project through the account-scoped Cloud lane', async () => {
+    window.sessionStorage.setItem(`od:auto-send-first:${PROJECT_ID}`, '1');
+    workspaceScopeMocks.ambientContext = null;
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    };
+    const stableOverrides: Partial<ComponentProps<typeof ProjectView>> = {
+      project: { ...project(), workspaceId: undefined },
+    };
+    renderProjectView(stableOverrides);
+
+    await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalledTimes(1));
+    // Home already performed the account-scoped balance gate. ProjectView
+    // must not duplicate it while handing off the accepted first prompt.
+    expect(mockedCheckAmrBalanceGate).not.toHaveBeenCalled();
+    expect(mockedStreamViaDaemon.mock.calls[0]?.[0].workspaceContext).toBeNull();
+    expect(window.sessionStorage.getItem(`od:auto-send-first:${PROJECT_ID}`)).toBeNull();
+  });
+
   it('reconciles files and comments with the exact Team scope when the project event stream becomes ready', async () => {
     window.sessionStorage.removeItem(`od:auto-send-first:${PROJECT_ID}`);
     workspaceScopeMocks.projectScope = {

--- a/apps/web/tests/runtime/amr-balance-gate.test.ts
+++ b/apps/web/tests/runtime/amr-balance-gate.test.ts
@@ -4,12 +4,14 @@ import type { AmrWalletSnapshot } from '@open-design/contracts';
 import {
   AMR_HARD_BLOCK_BALANCE_USD,
   AMR_LOW_BALANCE_WARN_USD,
+  HOME_AMR_BALANCE_RETRY_DELAYS_MS,
   amrBalanceGateScopeForWorkspaceContext,
   amrBalanceGateScopesMatch,
   amrWalletBalanceInsufficient,
   amrWalletBalanceUsd,
   checkAmrBalanceGate,
   isAmrLowBalanceWarnOptedOut,
+  retryUnavailableAmrBalanceGate,
   setAmrLowBalanceWarnOptedOut,
 } from '../../src/runtime/amr-balance-gate';
 import { fetchAmrWalletSnapshot } from '../../src/providers/daemon';
@@ -19,6 +21,14 @@ vi.mock('../../src/providers/daemon', () => ({
 }));
 
 const mockedFetch = vi.mocked(fetchAmrWalletSnapshot);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
 
 function snapshot(overrides: Partial<AmrWalletSnapshot> = {}): AmrWalletSnapshot {
   return {
@@ -268,11 +278,14 @@ describe('checkAmrBalanceGate', () => {
     });
   });
 
-  it('gates a team run from its explicit workspace balance, not the healthy account balance', async () => {
-    mockedFetch.mockResolvedValue(snapshot({ balanceUsd: '247.50' }));
+  it('starts the authoritative workspace request in parallel with the account snapshot', async () => {
+    const accountRead = deferred<AmrWalletSnapshot>();
+    mockedFetch.mockReturnValue(accountRead.promise);
+    let workspaceReadStarted = false;
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
+        workspaceReadStarted = true;
         expect(input.toString()).toBe(
           '/api/workspace/billing?scope=workspace&workspaceId=ws-team-a&freshness=authoritative',
         );
@@ -311,15 +324,20 @@ describe('checkAmrBalanceGate', () => {
       }),
     );
 
-    const result = await checkAmrBalanceGate({
+    const pendingResult = checkAmrBalanceGate({
       workspaceType: 'team',
       workspaceId: 'ws-team-a',
       workspaceMemberId: 'wm-a',
     });
+    await Promise.resolve();
+    expect(workspaceReadStarted).toBe(true);
+    accountRead.resolve(snapshot({ balanceUsd: '247.50' }));
+    const result = await pendingResult;
     expect(result.kind).toBe('soft');
     if (result.kind === 'soft') {
       expect(result.snapshot.balanceUsd).toBe('1.25');
     }
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
   });
 
   it('does not authorize a positive balance from a daemon that cannot prove an authoritative read', async () => {
@@ -498,5 +516,57 @@ describe('checkAmrBalanceGate', () => {
     const resultA = await teamA;
     expect(resultA.kind).toBe('soft');
     if (resultA.kind === 'soft') expect(resultA.snapshot.balanceUsd).toBe('1.50');
+  });
+});
+
+describe('retryUnavailableAmrBalanceGate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps one Home submit pending across the bounded cold-start retries', async () => {
+    const check = vi.fn()
+      .mockResolvedValueOnce({ kind: 'unavailable' } as const)
+      .mockResolvedValueOnce({ kind: 'unavailable' } as const)
+      .mockResolvedValueOnce({ kind: 'allow' } as const);
+
+    const result = retryUnavailableAmrBalanceGate(check);
+    await Promise.resolve();
+    expect(check).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(HOME_AMR_BALANCE_RETRY_DELAYS_MS[0] - 1);
+    expect(check).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(check).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(HOME_AMR_BALANCE_RETRY_DELAYS_MS[1] - 1);
+    expect(check).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toEqual({ kind: 'allow' });
+    expect(check).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns a definitive decision immediately without scheduling a retry', async () => {
+    const check = vi.fn().mockResolvedValue({ kind: 'allow' } as const);
+
+    await expect(retryUnavailableAmrBalanceGate(check)).resolves.toEqual({ kind: 'allow' });
+
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('returns unavailable after exhausting the bounded retry budget', async () => {
+    const check = vi.fn().mockResolvedValue({ kind: 'unavailable' } as const);
+
+    const result = retryUnavailableAmrBalanceGate(check);
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({ kind: 'unavailable' });
+    expect(check).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -82,6 +82,82 @@ function teamWorkspaceContext(
   };
 }
 
+describe('createProject local plugin identity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves the selected local plugin source in the create payload', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({
+      project: {
+        id: 'project-local-plugin',
+        name: 'Local plugin project',
+        skillId: null,
+        designSystemId: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      conversationId: 'conversation-1',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createProject({
+      name: 'Local plugin project',
+      skillId: null,
+      designSystemId: null,
+      pluginId: 'shared-plugin-id',
+      pluginSource: 'team:plugin:workspace-a:shared-plugin-id',
+    });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toMatchObject({
+      pluginId: 'shared-plugin-id',
+      pluginSource: 'team:plugin:workspace-a:shared-plugin-id',
+    });
+  });
+
+  it('preserves selected local resource catalogue scopes without adding Workspace headers', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({
+      project: {
+        id: 'project-local-resources',
+        name: 'Local resource project',
+        skillId: 'workspace-skill',
+        designSystemId: 'user:workspace-brand',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      conversationId: 'conversation-1',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createProject({
+      name: 'Local resource project',
+      skillId: 'workspace-skill',
+      skillCatalogScope: {
+        workspaceId: 'workspace-a',
+        workspaceMemberId: 'member-a',
+      },
+      designSystemId: 'user:workspace-brand',
+      designSystemCatalogScope: {
+        workspaceId: 'workspace-a',
+        workspaceMemberId: 'member-a',
+      },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(new Headers(init?.headers).has('x-od-workspace-id')).toBe(false);
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      skillCatalogScope: {
+        workspaceId: 'workspace-a',
+        workspaceMemberId: 'member-a',
+      },
+      designSystemCatalogScope: {
+        workspaceId: 'workspace-a',
+        workspaceMemberId: 'member-a',
+      },
+    });
+  });
+});
+
 describe('createConversation', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -292,6 +368,59 @@ describe('applyPlugin', () => {
       grantCaps: [],
       locale: 'zh-CN',
     });
+  });
+
+  it('uses the selected local source without Workspace headers', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ ok: true }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await applyPlugin('shared-plugin-id', {
+      pluginSource: 'team:plugin:workspace-a:shared-plugin-id',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('/api/plugins/shared-plugin-id/apply-local');
+    expect(new Headers(init?.headers).has('x-od-workspace-id')).toBe(false);
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      source: 'team:plugin:workspace-a:shared-plugin-id',
+      inputs: {},
+      grantCaps: [],
+    });
+  });
+
+  it('does not let an old daemon substitute an exact selected source', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (String(url).endsWith('/apply-local')) return new Response('not found', { status: 404 });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(applyPlugin('bundled-plugin', {
+      pluginSource: 'bundled:bundled-plugin',
+    })).resolves.toBeNull();
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/plugins/bundled-plugin/apply-local',
+    ]);
+  });
+
+  it('does not fall back when the new local resolver rejects a source', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: 'plugin not found' }),
+      { status: 404, headers: { 'x-od-plugin-apply-local': '1' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(applyPlugin('shared-plugin-id', {
+      pluginSource: 'team:plugin:workspace-a:shared-plugin-id',
+    })).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('scopes same-id plugin apply requests to the exact A/B workspace', async () => {

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -407,14 +407,10 @@ test('[P0] completed BYOK setup resumes after passive Cloud reauthentication wit
   await clickCloudPrimary(page);
   await expectOnboardingFinished(page);
   await expect(page.getByRole('heading', { name: /Choose your model source|选择模型来源/i })).toHaveCount(0);
-<<<<<<< HEAD
-  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(1);
-=======
   // PRODUCT INVARIANT: Cloud identity gates Open Design Cloud execution only.
   // A configured BYOK runtime neither redirects to onboarding nor starts a
   // passive Cloud login merely because the independent AMR status is signed out.
   await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(0);
->>>>>>> b55d443b4 (fix(web): streamline Home submit preflight (#6756))
   await pollStoredConfig(page).toMatchObject({
     mode: 'api',
     apiKey: 'persisted-byok-key',

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -407,7 +407,14 @@ test('[P0] completed BYOK setup resumes after passive Cloud reauthentication wit
   await clickCloudPrimary(page);
   await expectOnboardingFinished(page);
   await expect(page.getByRole('heading', { name: /Choose your model source|选择模型来源/i })).toHaveCount(0);
+<<<<<<< HEAD
   await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(1);
+=======
+  // PRODUCT INVARIANT: Cloud identity gates Open Design Cloud execution only.
+  // A configured BYOK runtime neither redirects to onboarding nor starts a
+  // passive Cloud login merely because the independent AMR status is signed out.
+  await expect.poll(() => page.evaluate(() => window.__amrOnboardingLoginCalls ?? 0)).toBe(0);
+>>>>>>> b55d443b4 (fix(web): streamline Home submit preflight (#6756))
   await pollStoredConfig(page).toMatchObject({
     mode: 'api',
     apiKey: 'persisted-byok-key',

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -538,7 +538,11 @@ test.beforeEach(async ({ page }) => {
     });
   });
 
-  await page.route('**/api/plugins/*/apply', async (route) => {
+  // Exact local-source selection uses /apply-local; keep /apply covered for
+  // old-daemon compatibility. Both paths must stay hermetic instead of
+  // falling through to whichever plugins happen to exist in the worker's
+  // daemon data root.
+  await page.route('**/api/plugins/*/apply*', async (route) => {
     const pluginId = route.request().url().split('/api/plugins/')[1]?.split('/apply')[0];
     const body = pluginId ? APPLY_RESPONSES[pluginId] : null;
     await route.fulfill({

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -78,6 +78,22 @@ export interface PromptTemplateMetadata {
   source?: PromptTemplateMetadataSource;
 }
 
+/**
+ * The local Workspace/member partition from which a catalogue item was picked.
+ *
+ * This is lookup provenance only. It does not bind the project to a Workspace,
+ * prove current membership, or authorize a remote operation.
+ */
+export interface LocalCatalogScope {
+  workspaceId: string;
+  workspaceMemberId: string;
+}
+
+export interface ProjectResourceCatalogScopes {
+  skill?: LocalCatalogScope;
+  designSystem?: LocalCatalogScope;
+}
+
 export type DesignSystemReviewDecision = 'looks-good' | 'needs-work';
 
 export type DesignSystemReviewTaskStatus = 'queued' | 'sent' | 'failed';
@@ -196,6 +212,12 @@ export interface ProjectMetadata {
   contextPlugins?: ProjectContextPluginRef[];
   contextMcpServers?: ProjectContextMcpServerRef[];
   contextConnectors?: ProjectContextConnectorRef[];
+  /**
+   * Daemon-stamped provenance for locally selected project resources. This
+   * keeps the first run on the same local catalogue partition when Workspace
+   * identity is still loading; it is never Workspace ownership or authority.
+   */
+  localCatalogScopes?: ProjectResourceCatalogScopes;
   // Stored on design-system projects so the review overview can remember
   // which generated sections were accepted or sent back for another pass.
   designSystemReview?: Record<string, DesignSystemReviewEntry>;
@@ -313,10 +335,16 @@ export interface CreateProjectRequest {
   /** Optional project library location id. Omit or use `default` for .od/projects. */
   projectLocationId?: string;
   skillId?: string | null;
+  /** Local lookup provenance captured when the Skill was selected. */
+  skillCatalogScope?: LocalCatalogScope;
   designSystemId?: string | null;
+  /** Local lookup provenance captured when the Design System was selected. */
+  designSystemCatalogScope?: LocalCatalogScope;
   pendingPrompt?: string;
   metadata?: ProjectMetadata;
   pluginId?: string;
+  /** Exact identity of the local catalogue record selected by the caller. */
+  pluginSource?: string;
   appliedPluginSnapshotId?: string;
   pluginInputs?: Record<string, unknown>;
   /** Session mode for the default conversation seeded with the project. */


### PR DESCRIPTION
## Summary

- route signed-out users to the Cloud login surface only when Open Design Cloud is the active execution source
- keep Local CLI and BYOK Home execution available when the independent Cloud session is signed out
- restore the expected Home submit failure copy
- resolve conflict markers left by the backport in Web and E2E tests

## Root cause

The backport conflict simplified the authentication guard to redirect every signed-out state to `/onboarding`. That incorrectly gated Local CLI and BYOK execution, and left unresolved conflict markers in two test files.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 --shard=2/2 --reporter=dot`
  - 307 test files passed
  - 3125 tests passed, 1 expected failure, 7 skipped
- `git diff --check`