### PR TITLE
test(e2e): assert Cloud sign-in after logout

### DIFF
--- a/e2e/ui/amr-logout-requires-relogin.test.ts
+++ b/e2e/ui/amr-logout-requires-relogin.test.ts
@@ -50,7 +50,7 @@ function amrAgentToggle(settings: Locator): Locator {
   return settings.getByTestId('settings-agent-card-amr').getByRole('button').first();
 }
 
-test('[P0] after local Sign out, the app returns to onboarding without clearing setup', async ({ page }) => {
+test('[P0] after local Sign out, the app returns to Cloud sign-in without clearing setup', async ({ page }) => {
   await stubCatalogsEmpty(page);
   const root = join(tmpdir(), `open-design-amr-logout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const reloginVelaBin = await writeFakeVelaBin(join(root, 'bin-relogin'), {
@@ -129,14 +129,15 @@ test('[P0] after local Sign out, the app returns to onboarding without clearing 
     const response = await fetch('/api/integrations/vela/logout', { method: 'POST' });
     if (!response.ok) throw new Error(`logout failed: ${response.status}`);
   });
-  // A definitive signed-out Cloud status now gates the entry on onboarding.
+  // A definitive signed-out Cloud status now gates the entry on sign-in.
   // This is passive session loss (the logout endpoint was called directly),
   // so the saved AMR setup must survive for reauthentication.
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await expect(page).toHaveURL(/\/onboarding$/, { timeout: T.long });
   await expect(
     page.getByRole('heading', { name: /Sign in to Open Design|登录 Open Design/i }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: T.long });
+  await expect(page.getByRole('button', { name: /Sign in to Open Design|登录 Open Design/i })).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toHaveCount(0);
   await expect.poll(() => page.evaluate(() => {
     const raw = window.localStorage.getItem('open-design:config');
     return raw ? JSON.parse(raw) : null;

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -466,7 +466,7 @@ test('[P0] definitively expired Cloud auth also gates project deep links', async
   await expect(page.getByRole('alertdialog')).toHaveCount(0);
 });
 
-test('[P0] active Cloud sign-out clears execution setup, preserves unrelated preferences, and returns to onboarding', async ({ page }) => {
+test('[P0] active Cloud sign-out clears execution setup, preserves unrelated preferences, and returns to sign-in', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
     initialLoggedIn: true,
@@ -493,7 +493,9 @@ test('[P0] active Cloud sign-out clears execution setup, preserves unrelated pre
   await expect(page.getByTestId('sign-out-confirm-dialog')).toBeVisible();
   await page.getByTestId('sign-out-confirm-accept').click();
 
-  await expect(page).toHaveURL(/\/onboarding$/);
+  await expect(connectLandingHeading(page)).toBeVisible();
+  await expect(cloudPrimaryButton(page)).toHaveText(/Sign in to Open Design|登录 Open Design/i);
+  await expect(page.getByTestId('home-hero-input')).toHaveCount(0);
   await pollStoredConfig(page).toMatchObject({
     mode: 'daemon',
     apiKey: '',


### PR DESCRIPTION
## What changed

- Update the active Cloud sign-out E2E to assert the actual Open Design sign-in surface instead of coupling success to the internal `/onboarding` route.
- Update the passive session-loss E2E with the same user-visible sign-in assertions.
- Assert that the Home composer is unavailable after sign-out.

## Why

The failed CI run exposed unresolved conflict markers in the onboarding E2E, causing Playwright collection to fail before tests ran. On `main` those markers are already absent, but the logout coverage still asserted the implementation route rather than the requested login-page behavior.

## Validation

- `pnpm -C e2e exec playwright test -c playwright.config.ts ui/amr-logout-requires-relogin.test.ts --workers=1` (1 passed)
- `pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group entry-settings` (75 passed; 2 tests did not start because parallel local daemon builds conflicted, unrelated to this diff)
- `git diff --check`
- Verified no Git conflict markers remain under `e2e` or `apps/web/tests`.
