### PR TITLE
fix(web): remove deck preview letterboxing

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2726,6 +2726,7 @@
    height + title-row height to prototype/HyperFrames/image tiles. */
 .home-hero__plugin-preset[data-od-mode="deck"] .home-hero__plugin-preset-preview {
   aspect-ratio: auto;
+  background: var(--bg-panel);
   --deck-preview-scale: 0.166;
 }
 .home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__html-frame {
@@ -2748,6 +2749,31 @@
   width: 1280px;
   height: 720px;
   transform: translate(-50%, -50%) scale(var(--deck-preview-scale));
+}
+
+/* Baked deck posters/clips use the gallery's 1.31:1 capture frame, with the
+   actual 16:9 slide centered inside it. Put that media in its native 16:9 box
+   before object-fit crops it, otherwise the capture's dark stage background
+   survives as a black strip above the slide. Keep the deck out of the generic
+   poster zoom below as well: once the 16:9 crop removes the baked letterbox,
+   another scale would cut real slide content off all four edges. */
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__preview--media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-panel);
+}
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media {
+  position: relative;
+  inset: auto;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+}
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-img,
+.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-video {
+  object-position: center;
+  transform: none;
 }
 
 /* Baseline zoom — a FRAMING transform, not a hover effect (the hover cover

--- a/apps/web/tests/styles/home-hero-deck-preview.test.ts
+++ b/apps/web/tests/styles/home-hero-deck-preview.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroCss = readFileSync(
+  new URL('../../src/styles/home/home-hero.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = homeHeroCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [
+    ...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g')),
+  ];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('HomeHero deck preset previews', () => {
+  it('center-crops baked 1.31 posters through a 16:9 media frame', () => {
+    const frame = cssDeclarations(
+      '.home-hero__plugin-preset[data-od-mode="deck"] .home-hero__plugin-preset-preview',
+    );
+    const preview = cssDeclarations(
+      '.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__preview--media',
+    );
+    const media = cssDeclarations(
+      '.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media',
+    );
+    const image = cssDeclarations(
+      '.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-img',
+    );
+    const video = cssDeclarations(
+      '.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__media-video',
+    );
+
+    expect(ruleValue(frame, 'background')).toBe('var(--bg-panel)');
+    expect(ruleValue(preview, 'background')).toBe('var(--bg-panel)');
+    expect(ruleValue(preview, 'display')).toBe('flex');
+    expect(ruleValue(preview, 'align-items')).toBe('center');
+    expect(ruleValue(preview, 'justify-content')).toBe('center');
+
+    expect(ruleValue(media, 'position')).toBe('relative');
+    expect(ruleValue(media, 'width')).toBe('100%');
+    expect(ruleValue(media, 'height')).toBe('auto');
+    expect(ruleValue(media, 'aspect-ratio')).toBe('16 / 9');
+
+    expect(ruleValue(image, 'object-position')).toBe('center');
+    expect(ruleValue(video, 'object-position')).toBe('center');
+    expect(ruleValue(image, 'transform')).toBe('none');
+    expect(ruleValue(video, 'transform')).toBe('none');
+  });
+});


### PR DESCRIPTION
## Why

A user reported that slide-deck example cards on Home showed a black empty strip above the slide. The baked preview is captured in a 1.31:1 frame while the slide itself is 16:9, so the capture's stage background remained visible around the centered slide. After removing the dark strip, the remaining `bg-subtle` fill still looked gray against the card.

This fixes that user-facing framing regression without changing the deck content or the treatment of non-deck template previews.

## What users will see

Slide-deck example thumbnails on Home are center-cropped through a native 16:9 media frame. The surrounding top/bottom fill now matches the card background, so there is no black or gray letterbox strip. Other template preview types keep their existing framing.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — existing Home deck preview cards use the corrected framing by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before/after were captured against the local `tools-dev` desktop runtime. The final capture confirms the card, deck preview frame, and media surface all resolve to `rgb(250, 250, 250)`. Image attachments still need to be added before marking the Draft ready.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/home-hero-deck-preview.test.ts`
- The test went red before the source change because the deck-specific 16:9 baked-media frame and background overrides were absent.
- The same test is green on this branch and locks the 16:9 crop, centered media, no generic poster zoom, and card-matching background.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/home-hero-deck-preview.test.ts tests/styles/acceptance-visual-fixes.test.ts --maxWorkers=2` — 2 files, 8 tests passed
- Local desktop runtime visual verification through `pnpm tools-dev inspect desktop screenshot`
- Runtime style verification: card, preview frame, and media surface all resolve to `rgb(250, 250, 250)`
- Root `pnpm typecheck` was attempted but remains blocked by an unrelated existing error in `apps/daemon/src/diagnostics-export.ts:286`: `summaries` is not a property of `DiagnosticsExportInput`
