### PR TITLE
fix(daemon): point users at the Settings section that actually exists

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -56,6 +56,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { Agent as UndiciAgent } from 'undici';
+import { SETTINGS_MEDIA_PROVIDERS_PATH } from '@open-design/contracts';
 import {
   AUDIO_DURATIONS_SEC,
   type AudioKind,
@@ -195,7 +196,7 @@ class StubProviderDisabledError extends Error {
   status = 503;
   constructor(model: string) {
     super(
-      `provider not configured: ${model}. Add your API key in Settings -> Media Providers to enable real generation.`,
+      `provider not configured: ${model}. Add your API key in ${SETTINGS_MEDIA_PROVIDERS_PATH} to enable real generation.`,
     );
     this.name = 'StubProviderDisabledError';
   }
@@ -893,7 +894,7 @@ function withMediaRequestInit(
 }
 
 const OPENAI_IMAGE_NO_CREDENTIAL_MESSAGE =
-  'no OpenAI credential - configure an API key in Settings or set OPENAI_API_KEY.';
+  `no OpenAI credential — configure an API key in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OPENAI_API_KEY.`;
 
 async function renderOpenAIImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
@@ -983,7 +984,7 @@ async function renderOpenAIImage(ctx: MediaContext, credentials: ProviderConfig)
 async function renderImageRouterImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no ImageRouter API key — configure it in Settings or set OD_IMAGEROUTER_API_KEY',
+      `no ImageRouter API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_IMAGEROUTER_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || IMAGEROUTER_DEFAULT_BASE_URL).trim();
@@ -1018,7 +1019,7 @@ async function renderImageRouterImage(ctx: MediaContext, credentials: ProviderCo
 async function renderImageRouterVideo(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no ImageRouter API key — configure it in Settings or set OD_IMAGEROUTER_API_KEY',
+      `no ImageRouter API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_IMAGEROUTER_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || IMAGEROUTER_DEFAULT_BASE_URL).trim();
@@ -1054,7 +1055,7 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
   const baseUrl = (credentials.baseUrl || '').trim();
   if (!baseUrl) {
     throw new Error(
-      'Custom Image API base URL required — configure an OpenAI-compatible /v1/images/generations or /v1/images/edits endpoint in Settings',
+      `Custom Image API base URL required — configure an OpenAI-compatible /v1/images/generations or /v1/images/edits endpoint in ${SETTINGS_MEDIA_PROVIDERS_PATH}`,
     );
   }
   const wireModel = (
@@ -1063,7 +1064,7 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
   ).trim();
   if (!wireModel) {
     throw new Error(
-      'Custom Image API model required — configure the provider model in Settings',
+      `Custom Image API model required — configure the provider model in ${SETTINGS_MEDIA_PROVIDERS_PATH}`,
     );
   }
 
@@ -1316,7 +1317,7 @@ function openaiSpeechFormatFor(fileName: string): string {
 
 async function renderOpenAISpeech(ctx: MediaContext, credentials: ProviderConfig, fileName: string): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no OpenAI credential — configure an API key in Settings or set OPENAI_API_KEY');
+    throw new Error(`no OpenAI credential — configure an API key in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OPENAI_API_KEY`);
   }
   const rawBase = credentials.baseUrl || 'https://api.openai.com/v1';
   const azure = detectAzureEndpoint(rawBase);
@@ -1398,7 +1399,7 @@ async function renderOpenAISpeech(ctx: MediaContext, credentials: ProviderConfig
 async function renderVolcengineVideo(ctx: MediaContext, credentials: ProviderConfig, onProgress?: ProgressFn): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no Volcengine Ark API key — configure it in Settings or set ARK_API_KEY',
+      `no Volcengine Ark API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set ARK_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://ark.cn-beijing.volces.com/api/v3').replace(/\/$/, '');
@@ -1541,7 +1542,7 @@ function volcengineRatioFor(aspect?: string): string {
 // POST /api/v3/images/generations (OpenAI-compatible payload).
 async function renderVolcengineImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no Volcengine Ark API key — configure it in Settings or set ARK_API_KEY');
+    throw new Error(`no Volcengine Ark API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set ARK_API_KEY`);
   }
   const baseUrl = (credentials.baseUrl || 'https://ark.cn-beijing.volces.com/api/v3').replace(/\/$/, '');
 
@@ -1612,7 +1613,7 @@ async function renderVolcengineImage(ctx: MediaContext, credentials: ProviderCon
 async function renderGrokImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no xAI credentials — sign in with your SuperGrok subscription (in OD or via `hermes auth add xai-oauth`), set XAI_API_KEY, or configure a key in Settings',
+      `no xAI credentials — sign in with your SuperGrok subscription (in OD or via \`hermes auth add xai-oauth\`), set XAI_API_KEY, or configure a key in ${SETTINGS_MEDIA_PROVIDERS_PATH}`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://api.x.ai/v1').replace(/\/$/, '');
@@ -1671,7 +1672,7 @@ async function renderNanoBananaImage(ctx: MediaContext, credentials: ProviderCon
   const apiKey = credentials.apiKey;
   if (!apiKey) {
     throw new Error(
-      'no Nano Banana API key — configure it in Settings or set OD_NANOBANANA_API_KEY',
+      `no Nano Banana API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_NANOBANANA_API_KEY`,
     );
   }
 
@@ -1813,7 +1814,7 @@ async function renderOpenRouterImage(
 ): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no OpenRouter API key — configure it in Settings or set OPENROUTER_API_KEY',
+      `no OpenRouter API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OPENROUTER_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
@@ -1944,7 +1945,7 @@ async function renderOpenRouterVideo(
 ): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no OpenRouter API key — configure it in Settings or set OPENROUTER_API_KEY',
+      `no OpenRouter API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OPENROUTER_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://openrouter.ai/api/v1').replace(/\/$/, '');
@@ -2173,7 +2174,7 @@ function openRouterAspectFor(aspect?: string): string {
 async function renderLeonardoImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no Leonardo.ai API key — configure it in Settings or set LEONARDO_API_KEY',
+      `no Leonardo.ai API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set LEONARDO_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://cloud.leonardo.ai/api/rest/v1').replace(/\/$/, '');
@@ -2302,7 +2303,7 @@ async function renderLeonardoImage(ctx: MediaContext, credentials: ProviderConfi
 async function renderGrokVideo(ctx: MediaContext, credentials: ProviderConfig, onProgress?: ProgressFn): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no xAI credentials — sign in with your SuperGrok subscription (in OD or via `hermes auth add xai-oauth`), set XAI_API_KEY, or configure a key in Settings',
+      `no xAI credentials — sign in with your SuperGrok subscription (in OD or via \`hermes auth add xai-oauth\`), set XAI_API_KEY, or configure a key in ${SETTINGS_MEDIA_PROVIDERS_PATH}`,
     );
   }
   const baseUrl = (credentials.baseUrl || 'https://api.x.ai/v1').replace(/\/$/, '');
@@ -2467,7 +2468,7 @@ const XAI_TTS_DEFAULT_LANGUAGE = 'en';
 async function renderXAITTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no xAI credentials — sign in with your SuperGrok subscription (in OD or via `hermes auth add xai-oauth`), set XAI_API_KEY, or configure a key in Settings',
+      `no xAI credentials — sign in with your SuperGrok subscription (in OD or via \`hermes auth add xai-oauth\`), set XAI_API_KEY, or configure a key in ${SETTINGS_MEDIA_PROVIDERS_PATH}`,
     );
   }
   const baseUrl = (credentials.baseUrl || XAI_TTS_DEFAULT_BASE_URL).replace(
@@ -2569,7 +2570,7 @@ function assertElevenLabsSfxPromptLength(text: string) {
 async function renderElevenLabsTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no ElevenLabs API key - configure it in Settings or set OD_ELEVENLABS_API_KEY',
+      `no ElevenLabs API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_ELEVENLABS_API_KEY`,
     );
   }
 
@@ -2622,7 +2623,7 @@ async function renderElevenLabsTTS(ctx: MediaContext, credentials: ProviderConfi
 async function renderElevenLabsSfx(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no ElevenLabs API key - configure it in Settings or set OD_ELEVENLABS_API_KEY',
+      `no ElevenLabs API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_ELEVENLABS_API_KEY`,
     );
   }
 
@@ -2712,7 +2713,7 @@ const MINIMAX_IMAGE_MODEL_MAP = {
 async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
+      `no MiniMax API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_MINIMAX_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || MINIMAX_DEFAULT_BASE_URL).replace(
@@ -2820,7 +2821,7 @@ async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig):
 async function renderMinimaxImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no MiniMax API key — configure it in Settings or set OD_MINIMAX_API_KEY',
+      `no MiniMax API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_MINIMAX_API_KEY`,
     );
   }
   // Base URL precedence:
@@ -2958,7 +2959,7 @@ const SENSEAUDIO_TTS_MODEL_MAP = {
 async function renderSenseAudioTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no SenseAudio API key — configure it in Settings or set OD_SENSEAUDIO_API_KEY',
+      `no SenseAudio API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_SENSEAUDIO_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || SENSEAUDIO_DEFAULT_BASE_URL).replace(
@@ -3068,7 +3069,7 @@ function senseAudioImageSize(aspect?: string): string {
 async function renderSenseAudioImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no SenseAudio API key — configure it in Settings or set OD_SENSEAUDIO_API_KEY',
+      `no SenseAudio API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_SENSEAUDIO_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || SENSEAUDIO_DEFAULT_BASE_URL).replace(
@@ -3164,7 +3165,7 @@ async function renderSenseAudioImage(ctx: MediaContext, credentials: ProviderCon
 
 async function renderAIHubMixImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no AIHubMix API key — configure it in Settings or set OD_AIHUBMIX_API_KEY');
+    throw new Error(`no AIHubMix API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_AIHUBMIX_API_KEY`);
   }
   const baseUrl = credentials.baseUrl || AIHUBMIX_DEFAULT_BASE_URL;
   const wireModel = aihubmixWireModel(credentials.model || ctx.wireModel);
@@ -3238,7 +3239,7 @@ async function renderAIHubMixGeminiImage(
   wireModel: string,
 ): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no AIHubMix API key — configure it in Settings or set OD_AIHUBMIX_API_KEY');
+    throw new Error(`no AIHubMix API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_AIHUBMIX_API_KEY`);
   }
   const aspect = ctx.aspect || '1:1';
   const bytes = await aihubmixGeminiImageBytes(
@@ -3260,7 +3261,7 @@ async function renderAIHubMixGeminiImage(
 
 async function renderAIHubMixTTS(ctx: MediaContext, credentials: ProviderConfig, fileName: string): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no AIHubMix API key — configure it in Settings or set OD_AIHUBMIX_API_KEY');
+    throw new Error(`no AIHubMix API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_AIHUBMIX_API_KEY`);
   }
   const baseUrl = credentials.baseUrl || AIHUBMIX_DEFAULT_BASE_URL;
   const wireModel = aihubmixWireModel(credentials.model || ctx.wireModel);
@@ -3316,7 +3317,7 @@ async function renderAIHubMixVideo(
   onProgress?: ProgressFn,
 ): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no AIHubMix API key — configure it in Settings or set OD_AIHUBMIX_API_KEY');
+    throw new Error(`no AIHubMix API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_AIHUBMIX_API_KEY`);
   }
   const baseUrl = (credentials.baseUrl || AIHUBMIX_DEFAULT_BASE_URL).replace(/\/$/, '');
   const wireModel = aihubmixWireModel(credentials.model || ctx.wireModel);
@@ -3477,7 +3478,7 @@ const FISHAUDIO_TTS_MODEL_MAP = {
 async function renderFishAudioTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
     throw new Error(
-      'no FishAudio API key — configure it in Settings or set OD_FISHAUDIO_API_KEY',
+      `no FishAudio API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_FISHAUDIO_API_KEY`,
     );
   }
   const baseUrl = (credentials.baseUrl || FISHAUDIO_DEFAULT_BASE_URL).replace(
@@ -3694,7 +3695,7 @@ function falQueueBase(baseUrl: string): string {
 
 async function renderFalImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no Fal API key — configure it in Settings or set FAL_KEY');
+    throw new Error(`no Fal API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set FAL_KEY`);
   }
   const queueBase = falQueueBase((credentials.baseUrl || 'https://fal.run').replace(/\/$/, ''));
   const endpoint = FAL_ENDPOINTS[ctx.model] ?? ctx.model;
@@ -3735,7 +3736,7 @@ async function renderFalImage(ctx: MediaContext, credentials: ProviderConfig): P
 
 async function renderFalVideo(ctx: MediaContext, credentials: ProviderConfig, onProgress?: ProgressFn): Promise<RenderResult> {
   if (!credentials.apiKey) {
-    throw new Error('no Fal API key — configure it in Settings or set FAL_KEY');
+    throw new Error(`no Fal API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set FAL_KEY`);
   }
   const queueBase = falQueueBase((credentials.baseUrl || 'https://fal.run').replace(/\/$/, ''));
   const endpoint = FAL_ENDPOINTS[ctx.model] ?? ctx.model;

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -47,7 +47,7 @@ import { renderPanelPrompt } from './panel.js';
 import { defaultCritiqueConfig, type CritiqueConfig } from '@open-design/contracts/critique';
 import {
   executionProfileFromStreamFormat,
-  SETTINGS_EXTERNAL_MCP_PATH,
+  INTEGRATIONS_MCP_PATH,
   SETTINGS_MEDIA_PROVIDERS_PATH,
   type ByokMediaDefaults,
   type ChatSessionMode,
@@ -1528,7 +1528,7 @@ export function renderConnectedExternalMcpDirective(
     lines.join('\n'),
     '\n\n',
     '**Do NOT call any tool whose name matches `mcp__<server>__authenticate` or `mcp__<server>__complete_authentication` for the servers above.** Those are synthetic fallback tools Claude Code exposes when its first HTTP connect briefly flipped the server into a needs-auth state. The flow they drive (a `localhost:<random>/callback` redirect) cannot complete in this environment, and the real tools (e.g. `generate_image`, `models_explore`, `balance`, …) are already reachable.\n\n',
-    `If a real tool actually fails with an auth-related error, report the exact tool name and error text and stop — the user will reconnect the server in ${SETTINGS_EXTERNAL_MCP_PATH}. Do not retry by invoking any \`*_authenticate\` tool.\n`,
+    `If a real tool actually fails with an auth-related error, report the exact tool name and error text and stop — the user will reconnect the server in ${INTEGRATIONS_MCP_PATH}. Do not retry by invoking any \`*_authenticate\` tool.\n`,
   ].join('');
 }
 

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -47,6 +47,8 @@ import { renderPanelPrompt } from './panel.js';
 import { defaultCritiqueConfig, type CritiqueConfig } from '@open-design/contracts/critique';
 import {
   executionProfileFromStreamFormat,
+  SETTINGS_EXTERNAL_MCP_PATH,
+  SETTINGS_MEDIA_PROVIDERS_PATH,
   type ByokMediaDefaults,
   type ChatSessionMode,
   type ExecutionProfile,
@@ -132,7 +134,7 @@ function formatElevenLabsVoiceOptionsErrorForPrompt(
   if (!trimmed) return undefined;
 
   if (/no ElevenLabs API key/i.test(trimmed)) {
-    return `${ELEVENLABS_VOICE_OPTIONS_PROMPT_PREFIX} because the ElevenLabs API key is missing. Tell the user to configure it in Settings or paste a voice id manually.`;
+    return `${ELEVENLABS_VOICE_OPTIONS_PROMPT_PREFIX} because the ElevenLabs API key is missing. Tell the user to configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or paste a voice id manually.`;
   }
 
   const statusMatch = trimmed.match(
@@ -1526,7 +1528,7 @@ export function renderConnectedExternalMcpDirective(
     lines.join('\n'),
     '\n\n',
     '**Do NOT call any tool whose name matches `mcp__<server>__authenticate` or `mcp__<server>__complete_authentication` for the servers above.** Those are synthetic fallback tools Claude Code exposes when its first HTTP connect briefly flipped the server into a needs-auth state. The flow they drive (a `localhost:<random>/callback` redirect) cannot complete in this environment, and the real tools (e.g. `generate_image`, `models_explore`, `balance`, …) are already reachable.\n\n',
-    'If a real tool actually fails with an auth-related error, report the exact tool name and error text and stop — the user will reconnect the server in Settings → External MCP. Do not retry by invoking any `*_authenticate` tool.\n',
+    `If a real tool actually fails with an auth-related error, report the exact tool name and error text and stop — the user will reconnect the server in ${SETTINGS_EXTERNAL_MCP_PATH}. Do not retry by invoking any \`*_authenticate\` tool.\n`,
   ].join('');
 }
 

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
+import { INTEGRATIONS_MCP_PATH } from '@open-design/contracts';
 
 import {
   composeSystemPrompt,
@@ -554,7 +555,12 @@ describe('composeSystemPrompt', () => {
         '**Do NOT call any tool whose name matches `mcp__<server>__authenticate` or `mcp__<server>__complete_authentication`',
       );
       expect(directive).toContain('localhost:<random>/callback');
-      expect(directive).toContain('Settings → External MCP');
+      // Reconnect lives in the top-level Integrations view, NOT in Settings:
+      // `mcpClient` kept its Settings render block but lost its sidebar nav
+      // item, so "Settings → External MCP" named a place users cannot navigate
+      // to. Asserted through the contract so this cannot drift again.
+      expect(directive).toContain(INTEGRATIONS_MCP_PATH);
+      expect(directive).not.toContain('Settings → External MCP');
     });
 
     it('skips entries with blank ids and emits nothing when none remain', () => {

--- a/e2e/tests/settings-nav-copy.test.ts
+++ b/e2e/tests/settings-nav-copy.test.ts
@@ -1,31 +1,40 @@
 /**
- * Settings-destination drift gate.
+ * In-app destination drift gate.
  *
  * When the daemon or the agent tells a user to go fix something —
- * "no Fal API key — configure it in Settings → …" — it names a
- * Settings section. Nothing tied that name to the Settings dialog, so
- * it drifted: media errors and the od-media-generation skill kept
- * pointing at a section called "Media" after the nav item had been
- * renamed to "Media providers" (`媒体生成提供商` in zh-CN), and users
- * following the instruction found no such entry. That was V0.19.1
- * acceptance bug recvre8FrTE2Oa.
+ * "no Fal API key — configure it in Settings → …" — it names a place in the
+ * app. Nothing tied that name to the screen it points at, so it drifted: media
+ * errors and the od-media-generation skill kept pointing at a section called
+ * "Media" after the nav item had been renamed to "Media providers"
+ * (`媒体生成提供商` in zh-CN), and users following the instruction found no such
+ * entry. That was V0.19.1 acceptance bug recvre8FrTE2Oa.
  *
  * `packages/contracts/src/settings-nav.ts` is now the single place a
- * Settings destination is spelled. This gate holds the two ends
- * together:
+ * destination is spelled. This gate holds the two ends together:
  *
- *   1. Each constant still equals the English label the Settings nav
- *      actually renders (`apps/web/src/i18n/locales/en.ts`), so
- *      renaming the nav item without updating the constant fails here
- *      rather than in front of a user.
- *   2. No producer re-inlines its own guess: the daemon's media
- *      provider errors and the prompt/skill guidance must route
- *      through the constants, and must not name a Settings section
- *      that the nav does not have.
+ *   1. Each constant names something the UI ACTUALLY RENDERS as navigation.
+ *   2. No producer re-inlines its own guess.
+ *   3. No referenced prompt or skill names a destination that does not exist.
  *
- * Lives in `e2e/tests/` per the root `AGENTS.md` boundary rule — it
- * reads `apps/web`, `apps/daemon`, `packages/contracts`, and
- * `plugins/` together, which no single app package is allowed to do.
+ * ## Why this reads the rendered navigation, not the i18n dictionary
+ *
+ * The first version of this gate compared each constant to its i18n key's
+ * value. That is too weak, and PR review caught it: `settings.externalMcpTitle`
+ * ("External MCP") is still in the dictionary, but `mcpClient` lost its Settings
+ * sidebar nav item and external MCP moved to the top-level Integrations view.
+ * So a dictionary-based check happily green-lit "Settings → External MCP" — a
+ * destination no user can navigate to — and the gate meant to catch dead paths
+ * would have spent the rest of its life defending one.
+ *
+ * A key surviving in the dictionary proves nothing about reachability. This
+ * version therefore parses the actual rendered nav (`settings-nav-item` buttons
+ * in `SettingsDialog.tsx`, `INTEGRATION_TABS` in `IntegrationsView.tsx`) and
+ * resolves those keys through the dictionary — dictionary as a lookup, rendered
+ * markup as the source of truth.
+ *
+ * Lives in `e2e/tests/` per the root `AGENTS.md` boundary rule — it reads
+ * `apps/web`, `apps/daemon`, `packages/contracts`, and `plugins/` together,
+ * which no single app package is allowed to do.
  */
 
 import { readFileSync } from 'node:fs';
@@ -34,21 +43,22 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-type SettingsNavContracts = {
+type DestinationContracts = {
   SETTINGS_MEDIA_PROVIDERS: string;
-  SETTINGS_EXTERNAL_MCP: string;
   SETTINGS_MEDIA_PROVIDERS_PATH: string;
-  SETTINGS_EXTERNAL_MCP_PATH: string;
+  INTEGRATIONS: string;
+  INTEGRATIONS_MCP: string;
+  INTEGRATIONS_MCP_PATH: string;
 };
 
-const navModules = import.meta.glob<SettingsNavContracts>(
+const navModules = import.meta.glob<DestinationContracts>(
   '../../packages/contracts/src/settings-nav.ts',
   { eager: true },
 );
 const nav = Object.values(navModules)[0];
 if (!nav) {
   throw new Error(
-    'settings-nav gate could not load packages/contracts/src/settings-nav.ts via import.meta.glob; '
+    'destination gate could not load packages/contracts/src/settings-nav.ts via import.meta.glob; '
       + 'this almost always means the file was renamed or moved.',
   );
 }
@@ -59,7 +69,7 @@ function read(relative: string): string {
   return readFileSync(path.join(REPO_ROOT, relative), 'utf8');
 }
 
-/** The value of one `'key': 'value'` entry in the English locale dictionary. */
+/** Resolve one `'key': 'value'` entry from the English locale dictionary. */
 function englishLabel(key: string): string {
   const en = read('apps/web/src/i18n/locales/en.ts');
   const match = en.match(
@@ -69,17 +79,80 @@ function englishLabel(key: string): string {
   return match[2]!.replace(/\\(['"\\])/g, '$1');
 }
 
-describe('Settings destinations quoted to users', () => {
-  it.each([
-    ['SETTINGS_MEDIA_PROVIDERS', 'settings.mediaProviders'],
-    ['SETTINGS_EXTERNAL_MCP', 'settings.externalMcpTitle'],
-  ])('%s matches the label the Settings nav renders (%s)', (constant, key) => {
-    expect(nav[constant as keyof SettingsNavContracts]).toBe(englishLabel(key));
+/**
+ * The labels the Settings sidebar actually renders as nav items.
+ *
+ * Sections can keep a render block after losing their nav entry (the file's own
+ * comment lists workspace / mcpClient / composio / designSystems as exactly
+ * that), so presence of a section constant — or of its i18n key — is not
+ * evidence a user can reach it. Only a `settings-nav-item` button is.
+ */
+function renderedSettingsNavLabels(): readonly string[] {
+  const source = read('apps/web/src/components/SettingsDialog.tsx');
+  const labels = [...source.matchAll(
+    /settings-nav-item[\s\S]{0,400}?<strong>\{t\(\s*'([^']+)'\s*\)\}<\/strong>/g,
+  )].map((m) => englishLabel(m[1]!));
+  if (labels.length === 0) {
+    throw new Error(
+      'could not parse any settings-nav-item labels from SettingsDialog.tsx — '
+        + 'the nav markup changed shape and this gate needs updating, not deleting.',
+    );
+  }
+  return labels;
+}
+
+/**
+ * The tab labels the top-level Integrations view actually renders.
+ *
+ * The id → i18n key mapping is irregular (`connectors` resolves to
+ * `entry.tabConnectors`, not `integrations.tabLabel.connectors`), so this reads
+ * the `integrationTabLabel` switch instead of assuming a key convention, and
+ * keeps only ids that `INTEGRATION_TABS` actually lists.
+ */
+function renderedIntegrationsTabLabels(): readonly string[] {
+  const source = read('apps/web/src/components/IntegrationsView.tsx');
+  const tabsBlock = source.match(/const INTEGRATION_TABS[\s\S]*?\n\];/)?.[0];
+  if (!tabsBlock) throw new Error('could not locate INTEGRATION_TABS in IntegrationsView.tsx');
+  const listed = new Set([...tabsBlock.matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1]!));
+
+  const labelBlock = source.match(/function integrationTabLabel[\s\S]*?\n\}/)?.[0];
+  if (!labelBlock) throw new Error('could not locate integrationTabLabel in IntegrationsView.tsx');
+  const labels = [...labelBlock.matchAll(/case\s*'([^']+)':\s*return\s*t\(\s*'([^']+)'\s*\)/g)]
+    .filter((m) => listed.has(m[1]!))
+    .map((m) => englishLabel(m[2]!));
+  if (labels.length === 0) {
+    throw new Error(
+      'could not parse any Integrations tab labels — the view changed shape and '
+        + 'this gate needs updating, not deleting.',
+    );
+  }
+  return labels;
+}
+
+describe('destinations quoted to users', () => {
+  it('names a Settings section the sidebar actually renders', () => {
+    expect(renderedSettingsNavLabels()).toContain(nav.SETTINGS_MEDIA_PROVIDERS);
   });
 
-  it('writes a destination as "Settings → <section>"', () => {
+  it('names an Integrations tab the view actually renders', () => {
+    expect(renderedIntegrationsTabLabels()).toContain(nav.INTEGRATIONS_MCP);
+    expect(englishLabel('entry.navIntegrations')).toBe(nav.INTEGRATIONS);
+  });
+
+  // Regression guard for the review finding on PR #6831. The first version of
+  // this gate would have passed with "External MCP" as a Settings destination,
+  // because `settings.externalMcpTitle` is still in the dictionary. If this
+  // assertion ever fails it means either the label came back to the sidebar (fine
+  // — delete this test) or the gate stopped reading rendered markup (not fine).
+  it('rejects a label that survives in the dictionary but renders nowhere', () => {
+    const stale = englishLabel('settings.externalMcpTitle');
+    expect(stale).toBe('External MCP');
+    expect(renderedSettingsNavLabels()).not.toContain(stale);
+  });
+
+  it('writes a destination as "<Area> → <Section>"', () => {
     expect(nav.SETTINGS_MEDIA_PROVIDERS_PATH).toBe(`Settings → ${nav.SETTINGS_MEDIA_PROVIDERS}`);
-    expect(nav.SETTINGS_EXTERNAL_MCP_PATH).toBe(`Settings → ${nav.SETTINGS_EXTERNAL_MCP}`);
+    expect(nav.INTEGRATIONS_MCP_PATH).toBe(`${nav.INTEGRATIONS} → ${nav.INTEGRATIONS_MCP}`);
   });
 
   it('never sends a media-credential error to a bare, unnamed "Settings"', () => {
@@ -95,8 +168,8 @@ describe('Settings destinations quoted to users', () => {
 
   it('routes every media-credential error through the shared destination', () => {
     const source = read('apps/daemon/src/media/index.ts');
-    // Sanity: the file really does still carry these errors, so an
-    // accidental deletion cannot make the gate above vacuously pass.
+    // Sanity: the file really does still carry these errors, so an accidental
+    // deletion cannot make the gate above vacuously pass.
     const routed = source.match(/\$\{SETTINGS_MEDIA_PROVIDERS_PATH\}/g) ?? [];
     expect(routed.length).toBeGreaterThanOrEqual(25);
   });
@@ -107,20 +180,25 @@ describe('Settings destinations quoted to users', () => {
     'packages/contracts/src/prompts/system.ts',
     'skills/hatch-pet/SKILL.md',
     'plugins/_official/examples/hatch-pet/SKILL.md',
-  ])('does not name a Settings section that the nav does not have: %s', (relative) => {
+  ])('does not name a destination that does not exist: %s', (relative) => {
     // Markdown wraps mid-phrase, so compare against whitespace-normalized text
     // — otherwise "Settings → Media\n  providers" reads as a section named
     // "Media" and the gate reports a violation that isn't one.
     const text = read(relative).replace(/\s+/g, ' ');
-    const known = [nav.SETTINGS_MEDIA_PROVIDERS, nav.SETTINGS_EXTERNAL_MCP, 'General'];
-    for (const match of text.matchAll(/Settings\s*(?:→|->)\s*/g)) {
+    const known = [
+      ...renderedSettingsNavLabels(),
+      ...renderedIntegrationsTabLabels(),
+      // Sub-sections folded into General keep their own heading inside it.
+      'Pets',
+    ];
+    for (const match of text.matchAll(/(?:Settings|Integrations)\s*(?:→|->)\s*/g)) {
       const rest = text.slice(match.index! + match[0].length);
       // A template expression is the constant itself, already verified above.
       if (rest.startsWith('${')) continue;
       expect(
         known.some((section) => rest.startsWith(section)),
-        `${relative} points at "Settings → ${rest.slice(0, 40)}…", which is not a Settings nav item. `
-          + `Known sections: ${known.join(', ')}.`,
+        `${relative} points at "…→ ${rest.slice(0, 40)}…", which the UI does not render. `
+          + `Rendered destinations: ${known.join(', ')}.`,
       ).toBe(true);
     }
   });

--- a/e2e/tests/settings-nav-copy.test.ts
+++ b/e2e/tests/settings-nav-copy.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Settings-destination drift gate.
+ *
+ * When the daemon or the agent tells a user to go fix something —
+ * "no Fal API key — configure it in Settings → …" — it names a
+ * Settings section. Nothing tied that name to the Settings dialog, so
+ * it drifted: media errors and the od-media-generation skill kept
+ * pointing at a section called "Media" after the nav item had been
+ * renamed to "Media providers" (`媒体生成提供商` in zh-CN), and users
+ * following the instruction found no such entry. That was V0.19.1
+ * acceptance bug recvre8FrTE2Oa.
+ *
+ * `packages/contracts/src/settings-nav.ts` is now the single place a
+ * Settings destination is spelled. This gate holds the two ends
+ * together:
+ *
+ *   1. Each constant still equals the English label the Settings nav
+ *      actually renders (`apps/web/src/i18n/locales/en.ts`), so
+ *      renaming the nav item without updating the constant fails here
+ *      rather than in front of a user.
+ *   2. No producer re-inlines its own guess: the daemon's media
+ *      provider errors and the prompt/skill guidance must route
+ *      through the constants, and must not name a Settings section
+ *      that the nav does not have.
+ *
+ * Lives in `e2e/tests/` per the root `AGENTS.md` boundary rule — it
+ * reads `apps/web`, `apps/daemon`, `packages/contracts`, and
+ * `plugins/` together, which no single app package is allowed to do.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+type SettingsNavContracts = {
+  SETTINGS_MEDIA_PROVIDERS: string;
+  SETTINGS_EXTERNAL_MCP: string;
+  SETTINGS_MEDIA_PROVIDERS_PATH: string;
+  SETTINGS_EXTERNAL_MCP_PATH: string;
+};
+
+const navModules = import.meta.glob<SettingsNavContracts>(
+  '../../packages/contracts/src/settings-nav.ts',
+  { eager: true },
+);
+const nav = Object.values(navModules)[0];
+if (!nav) {
+  throw new Error(
+    'settings-nav gate could not load packages/contracts/src/settings-nav.ts via import.meta.glob; '
+      + 'this almost always means the file was renamed or moved.',
+  );
+}
+
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
+function read(relative: string): string {
+  return readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+}
+
+/** The value of one `'key': 'value'` entry in the English locale dictionary. */
+function englishLabel(key: string): string {
+  const en = read('apps/web/src/i18n/locales/en.ts');
+  const match = en.match(
+    new RegExp(`^\\s*['"]${key.replace(/\./g, '\\.')}['"]\\s*:\\s*(['"])((?:\\\\.|(?!\\1).)*)\\1`, 'm'),
+  );
+  if (!match) throw new Error(`i18n key ${key} is missing from apps/web/src/i18n/locales/en.ts`);
+  return match[2]!.replace(/\\(['"\\])/g, '$1');
+}
+
+describe('Settings destinations quoted to users', () => {
+  it.each([
+    ['SETTINGS_MEDIA_PROVIDERS', 'settings.mediaProviders'],
+    ['SETTINGS_EXTERNAL_MCP', 'settings.externalMcpTitle'],
+  ])('%s matches the label the Settings nav renders (%s)', (constant, key) => {
+    expect(nav[constant as keyof SettingsNavContracts]).toBe(englishLabel(key));
+  });
+
+  it('writes a destination as "Settings → <section>"', () => {
+    expect(nav.SETTINGS_MEDIA_PROVIDERS_PATH).toBe(`Settings → ${nav.SETTINGS_MEDIA_PROVIDERS}`);
+    expect(nav.SETTINGS_EXTERNAL_MCP_PATH).toBe(`Settings → ${nav.SETTINGS_EXTERNAL_MCP}`);
+  });
+
+  it('never sends a media-credential error to a bare, unnamed "Settings"', () => {
+    const source = read('apps/daemon/src/media/index.ts');
+    const offenders = source
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      // Only lines that actually instruct the user, not prose comments.
+      .filter(([, line]) => /configure[^\n]*\bin Settings\b|key in Settings\b/.test(line))
+      .filter(([, line]) => !line.trimStart().startsWith('//'));
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes every media-credential error through the shared destination', () => {
+    const source = read('apps/daemon/src/media/index.ts');
+    // Sanity: the file really does still carry these errors, so an
+    // accidental deletion cannot make the gate above vacuously pass.
+    const routed = source.match(/\$\{SETTINGS_MEDIA_PROVIDERS_PATH\}/g) ?? [];
+    expect(routed.length).toBeGreaterThanOrEqual(25);
+  });
+
+  it.each([
+    'plugins/_official/scenarios/od-media-generation/SKILL.md',
+    'apps/daemon/src/prompts/system.ts',
+    'packages/contracts/src/prompts/system.ts',
+    'skills/hatch-pet/SKILL.md',
+    'plugins/_official/examples/hatch-pet/SKILL.md',
+  ])('does not name a Settings section that the nav does not have: %s', (relative) => {
+    // Markdown wraps mid-phrase, so compare against whitespace-normalized text
+    // — otherwise "Settings → Media\n  providers" reads as a section named
+    // "Media" and the gate reports a violation that isn't one.
+    const text = read(relative).replace(/\s+/g, ' ');
+    const known = [nav.SETTINGS_MEDIA_PROVIDERS, nav.SETTINGS_EXTERNAL_MCP, 'General'];
+    for (const match of text.matchAll(/Settings\s*(?:→|->)\s*/g)) {
+      const rest = text.slice(match.index! + match[0].length);
+      // A template expression is the constant itself, already verified above.
+      if (rest.startsWith('${')) continue;
+      expect(
+        known.some((section) => rest.startsWith(section)),
+        `${relative} points at "Settings → ${rest.slice(0, 40)}…", which is not a Settings nav item. `
+          + `Known sections: ${known.join(', ')}.`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export * from './common.js';
 export * from './errors.js';
+export * from './settings-nav.js';
 export * from './tasks.js';
 export * from './api/app-config.js';
 export * from './api/agent-sessions.js';

--- a/packages/contracts/src/prompts/system.ts
+++ b/packages/contracts/src/prompts/system.ts
@@ -35,6 +35,7 @@ import { OFFICIAL_DESIGNER_PROMPT, renderOfficialDesignerPrompt } from './offici
 import { DISCOVERY_AND_PHILOSOPHY } from './discovery.js';
 import { DECK_FRAMEWORK_DIRECTIVE } from './deck-framework.js';
 import { MEDIA_GENERATION_CONTRACT } from './media-contract.js';
+import { SETTINGS_MEDIA_PROVIDERS_PATH } from '../settings-nav.js';
 
 export const BASE_SYSTEM_PROMPT = OFFICIAL_DESIGNER_PROMPT;
 const ELEVENLABS_VOICE_PROMPT_OPTION_LIMIT = 100;
@@ -111,7 +112,7 @@ export function formatElevenLabsVoiceOptionsErrorForPrompt(
   if (!trimmed) return undefined;
 
   if (/no ElevenLabs API key/i.test(trimmed)) {
-    return `${ELEVENLABS_VOICE_OPTIONS_PROMPT_PREFIX} because the ElevenLabs API key is missing. Tell the user to configure it in Settings or paste a voice id manually.`;
+    return `${ELEVENLABS_VOICE_OPTIONS_PROMPT_PREFIX} because the ElevenLabs API key is missing. Tell the user to configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or paste a voice id manually.`;
   }
 
   const statusMatch = trimmed.match(

--- a/packages/contracts/src/settings-nav.ts
+++ b/packages/contracts/src/settings-nav.ts
@@ -1,0 +1,35 @@
+// Names of the Settings destinations that non-UI surfaces send users to.
+//
+// The daemon's provider errors and the agent's system prompt both tell users
+// where to go and fix something ("configure it in Settings"). Those strings are
+// written far away from the Settings dialog, so they drift: an error kept
+// pointing at a section called "Media" long after the nav item was renamed, and
+// users hunting for it found nothing (V0.19.1 acceptance bug recvre8FrTE2Oa).
+//
+// Every such destination must be spelled here, once, and every producer must
+// read it from here rather than inlining its own guess. Each constant's value
+// is the ENGLISH label rendered by the Settings nav, so it stays verifiable:
+// `e2e/tests/settings/settings-nav-copy.test.ts` asserts each one still equals
+// the `apps/web/src/i18n/locales/en.ts` key named in its docblock, and fails
+// the build when the UI is renamed without updating this file.
+//
+// These are English labels. A localized client renders the same section under
+// its own translation, so a destination quoted to the user in another language
+// should be the translation of this label, not this literal.
+
+/** The Settings nav item where media/API-generation credentials are entered — `settings.mediaProviders`. */
+export const SETTINGS_MEDIA_PROVIDERS = 'Media providers';
+
+/** The Settings nav item where external MCP servers are added/reconnected — `settings.externalMcpTitle`. */
+export const SETTINGS_EXTERNAL_MCP = 'External MCP';
+
+/** How a Settings destination is written when pointing a user at it: `Settings → Media providers`. */
+export function settingsPath(section: string): string {
+  return `Settings → ${section}`;
+}
+
+/** `Settings → Media providers` — the destination for every missing-credential error. */
+export const SETTINGS_MEDIA_PROVIDERS_PATH = settingsPath(SETTINGS_MEDIA_PROVIDERS);
+
+/** `Settings → External MCP` — the destination for MCP auth failures. */
+export const SETTINGS_EXTERNAL_MCP_PATH = settingsPath(SETTINGS_EXTERNAL_MCP);

--- a/packages/contracts/src/settings-nav.ts
+++ b/packages/contracts/src/settings-nav.ts
@@ -1,35 +1,53 @@
-// Names of the Settings destinations that non-UI surfaces send users to.
+// Names of the in-app destinations that non-UI surfaces send users to.
 //
 // The daemon's provider errors and the agent's system prompt both tell users
-// where to go and fix something ("configure it in Settings"). Those strings are
-// written far away from the Settings dialog, so they drift: an error kept
+// where to go and fix something ("configure it in Settings → …"). Those strings
+// are written far away from the screens they name, so they drift: an error kept
 // pointing at a section called "Media" long after the nav item was renamed, and
 // users hunting for it found nothing (V0.19.1 acceptance bug recvre8FrTE2Oa).
 //
 // Every such destination must be spelled here, once, and every producer must
 // read it from here rather than inlining its own guess. Each constant's value
-// is the ENGLISH label rendered by the Settings nav, so it stays verifiable:
-// `e2e/tests/settings/settings-nav-copy.test.ts` asserts each one still equals
-// the `apps/web/src/i18n/locales/en.ts` key named in its docblock, and fails
-// the build when the UI is renamed without updating this file.
+// is the ENGLISH label the app renders, so it stays verifiable:
+// `e2e/tests/settings-nav-copy.test.ts` resolves the labels the UI ACTUALLY
+// RENDERS as navigation and fails the build when a constant names something
+// unreachable.
 //
-// These are English labels. A localized client renders the same section under
-// its own translation, so a destination quoted to the user in another language
-// should be the translation of this label, not this literal.
+// That gate deliberately checks the rendered navigation rather than the i18n
+// dictionary. A key can survive in the dictionary long after nothing renders
+// it — which is exactly how `Settings → External MCP` stayed in the prompt
+// after external MCP moved out of Settings entirely.
+//
+// These are English labels. A localized client renders the same destination
+// under its own translation, so a destination quoted to the user in another
+// language should be the translation of this label, not this literal.
+
+/** How a destination is written when pointing a user at it: `Settings → Media providers`. */
+export function destinationPath(...segments: readonly string[]): string {
+  return segments.join(' → ');
+}
 
 /** The Settings nav item where media/API-generation credentials are entered — `settings.mediaProviders`. */
 export const SETTINGS_MEDIA_PROVIDERS = 'Media providers';
 
-/** The Settings nav item where external MCP servers are added/reconnected — `settings.externalMcpTitle`. */
-export const SETTINGS_EXTERNAL_MCP = 'External MCP';
-
-/** How a Settings destination is written when pointing a user at it: `Settings → Media providers`. */
-export function settingsPath(section: string): string {
-  return `Settings → ${section}`;
-}
-
 /** `Settings → Media providers` — the destination for every missing-credential error. */
-export const SETTINGS_MEDIA_PROVIDERS_PATH = settingsPath(SETTINGS_MEDIA_PROVIDERS);
+export const SETTINGS_MEDIA_PROVIDERS_PATH = destinationPath(
+  'Settings',
+  SETTINGS_MEDIA_PROVIDERS,
+);
 
-/** `Settings → External MCP` — the destination for MCP auth failures. */
-export const SETTINGS_EXTERNAL_MCP_PATH = settingsPath(SETTINGS_EXTERNAL_MCP);
+/** The top-level Integrations view — `entry.navIntegrations`. NOT a Settings section. */
+export const INTEGRATIONS = 'Integrations';
+
+/** The Integrations tab that adds/reconnects external MCP servers — `integrations.tabLabel.mcp`. */
+export const INTEGRATIONS_MCP = 'MCP';
+
+/**
+ * `Integrations → MCP` — where a user reconnects an external MCP server.
+ *
+ * NOT under Settings. `McpClientSection` still has a Settings render block, but
+ * it lost its sidebar nav item and is now reachable there only through an
+ * `initialSection` deep link, so telling a user to open "Settings → External
+ * MCP" sends them somewhere they cannot navigate to.
+ */
+export const INTEGRATIONS_MCP_PATH = destinationPath(INTEGRATIONS, INTEGRATIONS_MCP);

--- a/plugins/_official/examples/hatch-pet/SKILL.md
+++ b/plugins/_official/examples/hatch-pet/SKILL.md
@@ -35,7 +35,7 @@ od:
 > vendored under `skills/hatch-pet/` so any Open Design agent can run it. After
 > the skill finishes packaging, the resulting `spritesheet.webp` (under
 > `${CODEX_HOME:-$HOME/.codex}/pets/<pet-name>/`) can be imported into the
-> floating pet companion via **Settings → Pets → Import Codex sprite**. The
+> floating pet companion via **Settings → General → Pets → Import Codex sprite**. The
 > import flow auto-detects the 8×9 / `192×208` atlas and lets the user pick
 > which animation row to play (idle, running-right, waving, …).
 

--- a/plugins/_official/scenarios/od-media-generation/SKILL.md
+++ b/plugins/_official/scenarios/od-media-generation/SKILL.md
@@ -51,8 +51,9 @@ artifact reference that `live-artifact` can wrap:
   `16:9`. The contracts `MediaAspect` union enumerates the legal
   values.
 - `provider` — left blank by default so the daemon picks the user's
-  configured provider for this media kind (see Settings → Media). Only
-  set this when the user names a provider explicitly.
+  configured provider for this media kind
+  (see Settings → Media providers).
+  Only set this when the user names a provider explicitly.
 
 After the media atom returns:
 

--- a/skills/hatch-pet/SKILL.md
+++ b/skills/hatch-pet/SKILL.md
@@ -34,7 +34,7 @@ od:
 > vendored under `skills/hatch-pet/` so any Open Design agent can run it. After
 > the skill finishes packaging, the resulting `spritesheet.webp` (under
 > `${CODEX_HOME:-$HOME/.codex}/pets/<pet-name>/`) can be imported into the
-> floating pet companion via **Settings → Pets → Import Codex sprite**. The
+> floating pet companion via **Settings → General → Pets → Import Codex sprite**. The
 > import flow auto-detects the 8×9 / `192×208` atlas and lets the user pick
 > which animation row to play (idle, running-right, waving, …).
 


### PR DESCRIPTION
## Why

Found during V0.19.1 acceptance (Feishu record `recvre8FrTE2Oa`): when image
generation failed for a missing credential, the reply told the user

> 请在「设置 → Media」配置 Fal 凭证

There is no Settings section called "Media". The nav item is **Media providers**
(`媒体生成提供商`), sitting between Memory and External MCP. A user following the
instruction finds nothing and has no way to complete the recovery the message is
telling them to perform.

Chasing it down, the specific string was the visible tip. Settings destinations
were being spelled independently wherever a producer happened to need one, with
nothing tying any of them to the Settings dialog — so a rename could not reach
them:

- `apps/daemon/src/media/index.ts` — **29** missing-credential errors, each
  hardcoding its own path. 28 named a bare unnamed `Settings`; one said
  `Settings -> Media Providers` (wrong casing, wrong arrow).
- `plugins/_official/scenarios/od-media-generation/SKILL.md` — `see Settings → Media`.
  This is the one the agent paraphrased into 「设置 → Media」.

Fixing only the reported sentence would leave 29 other strings free to drift the
same way on the next rename.

## What users will see

A failed generation now points at the section that exists:

> **Before:** `no Fal API key — configure it in Settings or set FAL_KEY`
> **After:** `no Fal API key — configure it in Settings → Media providers or set FAL_KEY`

Same for every other provider (OpenAI, ImageRouter, Volcengine Ark, Nano Banana,
OpenRouter, Leonardo.ai, xAI, ElevenLabs, MiniMax, SenseAudio, AIHubMix,
FishAudio, Fal, Custom Image API) and for the "provider not configured" stub
message — all of which previously said only "Settings" without naming where.

Also swept in the same drift class: both `hatch-pet` SKILL.md copies pointed at
`Settings → Pets`, but #5517 folded the pet picker into General and there is no
Pets nav item. Now `Settings → General → Pets`.

`Settings → External MCP` and the `memory.ts` comment were already correct and
were only rerouted through the shared constant, not reworded.

## Surface area

- [ ] **UI** — no `apps/web` / `apps/desktop` change; this corrects text *about* the UI
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — new `packages/contracts/src/settings-nav.ts`, exported from the package index. No endpoint or wire-shape change
- [x] **Extension point** — copy fix in `plugins/_official/scenarios/od-media-generation/SKILL.md`, `plugins/_official/examples/hatch-pet/SKILL.md`, `skills/hatch-pet/SKILL.md`
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A — no UI surface changed. The strings are daemon error text and agent prompt
guidance.

## Bug fix verification

- Test path: `e2e/tests/settings-nav-copy.test.ts` (new)
- Red on the pre-fix tree, green on this branch: **yes** — 3 failing assertions
  before the fix:
  1. 29 media errors named a bare unnamed "Settings"
  2. zero errors routed through the shared destination
  3. the skill pointed at `Settings → Media`, which is not a nav item

The gate lives in `e2e/tests/` per the root `AGENTS.md` boundary rule — it reads
`apps/web`, `apps/daemon`, `packages/contracts`, and `plugins/` together, which
no single app package is permitted to do.

It holds three invariants, the third being the one that actually prevents
recurrence:

1. Each constant equals the English label `apps/web` renders, so renaming a nav
   item fails CI instead of a user.
2. No producer re-inlines its own guess.
3. No referenced prompt or skill names a section the nav does not have.

Worth noting the gate earned its keep immediately: it caught a defect in my own
first fix, where a markdown reflow split `Settings → Media providers` mid-phrase
so it still read as a section named "Media".

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/contracts test` — 39 files / 280 passed
- `pnpm --filter @open-design/web test` — 616 files / 6429 passed
- `e2e` — new gate green (10 assertions). Full e2e suite **not** run.
- `pnpm --filter @open-design/daemon test` — 8306 passed, **4 pre-existing
  failures** in `codex-model-capability-preflight` and
  `runtimes/codex-model-preflight`. Verified identical on the baseline with this
  branch stashed; unrelated to media/prompts.

## Adjacent issues (not fixed here)

**The constants are English, and the agent translates them ad hoc.** The daemon
cannot import `apps/web`'s i18n dictionary — that would be a cross-app import of
another app's private `src/`, which the root `AGENTS.md` forbids. So a zh-CN
client can still be told 「设置 → 媒体提供商」 when the UI actually reads
「媒体生成提供商」.

This PR closes the reported defect (the English side is aligned, and the gate
prevents silent renames) but does not root-cause that half. Doing so means
moving the section-name translations into `packages/contracts` and feeding the
right one to the agent through the locale injection that
`renderUiLocalePrompt` already performs — a design change, filed separately
rather than smuggled in here.
