### PR TITLE
fix(desktop): preserve editable PPTX font fidelity

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -56,21 +56,41 @@ type FontStylesheetFetcher = (
   init?: RequestInit,
 ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
 
+const GOOGLE_FONT_STYLESHEET_TIMEOUT_MS = 10_000;
+
 export async function fetchGoogleFontStylesheets(
   urls: string[],
   fetcher: FontStylesheetFetcher = fetch,
 ): Promise<Array<{ cssText: string; url: string }>> {
   const stylesheets: Array<{ cssText: string; url: string }> = [];
   for (const url of urls) {
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
       if (new URL(url).hostname !== "fonts.googleapis.com") continue;
       // A generic UA makes Google Fonts return complete TTF faces. Chromium's
       // WOFF2 subsets are less reliable in the vendored PowerPoint converter.
-      const response = await fetcher(url, { headers: { "user-agent": "Mozilla/5.0" } });
-      if (!response.ok) continue;
-      stylesheets.push({ cssText: await response.text(), url });
+      const stylesheet = await Promise.race([
+        (async () => {
+          const response = await fetcher(url, {
+            headers: { "user-agent": "Mozilla/5.0" },
+            signal: controller.signal,
+          });
+          if (!response.ok) return null;
+          return { cssText: await response.text(), url };
+        })(),
+        new Promise<null>((resolve) => {
+          timeout = setTimeout(() => {
+            controller.abort();
+            resolve(null);
+          }, GOOGLE_FONT_STYLESHEET_TIMEOUT_MS);
+        }),
+      ]);
+      if (stylesheet) stylesheets.push(stylesheet);
     } catch {
       // The renderer-side fetch remains the fallback when prefetching fails.
+    } finally {
+      if (timeout !== undefined) clearTimeout(timeout);
     }
   }
   return stylesheets;

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -51,6 +51,31 @@ export async function readDomToPptxBundleFile(candidate: string): Promise<string
   return bytes.toString("utf8");
 }
 
+type FontStylesheetFetcher = (
+  url: string,
+  init?: RequestInit,
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+export async function fetchGoogleFontStylesheets(
+  urls: string[],
+  fetcher: FontStylesheetFetcher = fetch,
+): Promise<Array<{ cssText: string; url: string }>> {
+  const stylesheets: Array<{ cssText: string; url: string }> = [];
+  for (const url of urls) {
+    try {
+      if (new URL(url).hostname !== "fonts.googleapis.com") continue;
+      // A generic UA makes Google Fonts return complete TTF faces. Chromium's
+      // WOFF2 subsets are less reliable in the vendored PowerPoint converter.
+      const response = await fetcher(url, { headers: { "user-agent": "Mozilla/5.0" } });
+      if (!response.ok) continue;
+      stylesheets.push({ cssText: await response.text(), url });
+    } catch {
+      // The renderer-side fetch remains the fallback when prefetching fails.
+    }
+  }
+  return stylesheets;
+}
+
 // Returns the rendered images either as on-disk files (when the daemon provided
 // an `outputDir`) or as base64 data URLs (legacy/fallback). Writing files keeps
 // tens of MB of image bytes off the JSON IPC channel — the daemon, which owns
@@ -403,11 +428,16 @@ async function renderEditablePptx(
     true,
   );
   await nextFrames(window);
+  const importedStylesheetUrls = (await window.webContents.executeJavaScript(
+    `(${collectImportedStylesheetUrls.toString()})()`,
+    true,
+  )) as string[];
+  const importedStylesheetOverrides = await fetchGoogleFontStylesheets(importedStylesheetUrls);
   await window.webContents.executeJavaScript(await loadDomToPptxBundle(), true);
   // runDomToPptx calls cjkPromotedFontFamily by name; define it in the same scope
   // as the serialized body so the reference resolves inside the render window.
   const out = (await window.webContents.executeJavaScript(
-    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}); })()`,
+    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${JSON.stringify(importedStylesheetOverrides)}); })()`,
     true,
   )) as { b64?: string; error?: string };
   if (!out || out.error || !out.b64) {
@@ -962,6 +992,23 @@ function showAllSlides(slideSelector: string): number {
   return slides.length;
 }
 
+function collectImportedStylesheetUrls(): string[] {
+  const urls = new Set<string>();
+  const pattern = /@import\s+(?:url\(\s*)?(?:(["'])([\s\S]*?)\1|([^"')\s;]+))\s*\)?[^;]*;/giu;
+  document.querySelectorAll("style").forEach((style) => {
+    for (const match of (style.textContent || "").matchAll(pattern)) {
+      const raw = match[2] || match[3];
+      if (!raw) continue;
+      try {
+        urls.add(new URL(raw, document.baseURI).href);
+      } catch {
+        // Ignore malformed author CSS and let the normal browser fallback apply.
+      }
+    }
+  });
+  return Array.from(urls);
+}
+
 // Picks the typeface the exported PPTX should name for a run of `text`, given its
 // CSS `font-family` stack. dom-to-pptx names ONE typeface per run — the first
 // family in the stack — and writes it to the PowerPoint `<a:latin>`, `<a:ea>`
@@ -1005,7 +1052,130 @@ export function cjkPromotedFontFamily(fontFamily: string, text: string): string 
 // Serialized into the page: runs the injected dom-to-pptx engine over every real
 // slide and returns the .pptx bytes as base64 (or an error). Fonts are
 // auto-detected + embedded; SVGs stay vector (editable in PowerPoint).
-export async function runDomToPptx(slideSelector: string): Promise<{ b64?: string; error?: string }> {
+export async function runDomToPptx(
+  slideSelector: string,
+  importedStylesheetOverrides: Array<{ cssText: string; url: string }> = [],
+): Promise<{ b64?: string; error?: string }> {
+  function importedStylesheetUrls(cssText: string, baseHref: string): string[] {
+    const urls: string[] = [];
+    const importPattern =
+      /@import\s+(?:url\(\s*)?(?:(["'])([\s\S]*?)\1|([^"')\s;]+))\s*\)?[^;]*;/giu;
+    for (const match of cssText.matchAll(importPattern)) {
+      const raw = match[2] || match[3];
+      if (!raw) continue;
+      try {
+        urls.push(new URL(raw, baseHref).href);
+      } catch {
+        // Ignore malformed author CSS and let the existing font fallback apply.
+      }
+    }
+    return urls;
+  }
+
+  function importedFontFaceCss(cssText: string, baseHref: string): string {
+    const faces = (cssText.match(/@font-face\s*\{[\s\S]*?\}/giu) || []).map((rule) => {
+      const value = (property: string): string =>
+        rule.match(new RegExp(`${property}\\s*:\\s*([^;]+)`, "iu"))?.[1]?.trim() || "";
+      return {
+        family: value("font-family").replace(/^['"]|['"]$/g, ""),
+        rule,
+        style: value("font-style").toLowerCase() || "normal",
+        unicodeRange: value("unicode-range"),
+        weight: value("font-weight").toLowerCase() || "400",
+      };
+    });
+    const preferredFace = new Map<string, { rank: number; style: string; weight: string }>();
+    for (const face of faces) {
+      const rank = face.style === "normal" ? (face.weight === "400" || face.weight === "normal" ? 0 : 1) : 2;
+      const current = preferredFace.get(face.family);
+      if (!current || rank < current.rank) {
+        preferredFace.set(face.family, { rank, style: face.style, weight: face.weight });
+      }
+    }
+
+    const preferredRule = new Map<string, { rank: number; rule: string }>();
+    for (const face of faces) {
+      const preferred = preferredFace.get(face.family);
+      if (preferred?.style !== face.style || preferred.weight !== face.weight) continue;
+      // Google Fonts commonly returns one @font-face per unicode subset. The
+      // vendored converter can fail while merging some families' subsets, so
+      // prefer the complete face when present, then its Latin core subset.
+      const rank = face.unicodeRange === "" ? 0 : /U\+0000-00FF/iu.test(face.unicodeRange) ? 1 : 2;
+      const current = preferredRule.get(face.family);
+      if (!current || rank < current.rank) preferredRule.set(face.family, { rank, rule: face.rule });
+    }
+
+    return faces
+      .filter((face) => preferredRule.get(face.family)?.rule === face.rule)
+      .map((rule) =>
+        rule.rule.replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/giu, (_match, _quote, raw: string) => {
+          try {
+            return `url("${new URL(raw.trim(), baseHref).href}")`;
+          } catch {
+            return `url("${raw.trim()}")`;
+          }
+        }),
+      )
+      .join("\n");
+  }
+
+  // dom-to-pptx's autoEmbedFonts scanner sees top-level CSSFontFaceRule entries,
+  // but many Open Design decks load Google Fonts through an inline `@import`.
+  // Expand those imports into a throwaway top-level style so the vendored engine
+  // can discover and embed the actual font files instead of only writing their
+  // family names into the PPTX. The render window is destroyed after export, so
+  // this never mutates the authored HTML or the live preview.
+  async function exposeImportedFontFaces(): Promise<Array<{ name: string; urls: string[] }>> {
+    const importedUrls = new Set<string>();
+    document.querySelectorAll("style").forEach((style) => {
+      for (const url of importedStylesheetUrls(style.textContent || "", document.baseURI)) {
+        importedUrls.add(url);
+      }
+    });
+    if (importedUrls.size === 0) return [];
+
+    const visited = new Set<string>();
+    const fontFaceRules: string[] = [];
+    const collect = async (url: string): Promise<void> => {
+      if (visited.has(url)) return;
+      visited.add(url);
+      try {
+        const override = importedStylesheetOverrides.find((entry) => entry.url === url);
+        const response = override ? null : await fetch(url);
+        if (response && !response.ok) throw new Error(`HTTP ${response.status}`);
+        const cssText = override?.cssText ?? (await response!.text());
+        for (const nested of importedStylesheetUrls(cssText, url)) await collect(nested);
+        const fontCss = importedFontFaceCss(cssText, url);
+        if (fontCss) fontFaceRules.push(fontCss);
+      } catch (error) {
+        console.warn("Cannot expose imported fonts for editable PPTX:", url, error);
+      }
+    };
+    for (const url of importedUrls) await collect(url);
+    if (fontFaceRules.length === 0) return [];
+
+    const combinedCss = fontFaceRules.join("\n");
+    const style = document.createElement("style");
+    style.setAttribute("data-od-pptx-imported-font-faces", "true");
+    style.textContent = combinedCss;
+    document.head.appendChild(style);
+
+    const fontsByFamily = new Map<string, Set<string>>();
+    for (const rule of combinedCss.match(/@font-face\s*\{[\s\S]*?\}/giu) || []) {
+      const family = rule
+        .match(/font-family\s*:\s*([^;]+)/iu)?.[1]
+        ?.trim()
+        .replace(/^['"]|['"]$/g, "");
+      if (!family) continue;
+      const urls = fontsByFamily.get(family) || new Set<string>();
+      for (const match of rule.matchAll(/url\(\s*["']?([^"')]+)["']?\s*\)/giu)) {
+        if (match[1]) urls.add(match[1]);
+      }
+      if (urls.size > 0) fontsByFamily.set(family, urls);
+    }
+    return Array.from(fontsByFamily, ([name, urls]) => ({ name, urls: Array.from(urls) }));
+  }
+
   function isTransparentColor(input: string): boolean {
     const value = input.trim().toLowerCase();
     return value === "" || value === "transparent" || value === "rgba(0, 0, 0, 0)";
@@ -1132,6 +1302,20 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
     }
   }
 
+  // An authored `<br>` is a deliberate line boundary. Prevent PowerPoint/WPS
+  // from applying a second soft wrap inside either line when its font metrics
+  // differ slightly from Chromium's. dom-to-pptx maps `white-space: nowrap` to
+  // `wrap: false` while retaining explicit breakLine runs.
+  function stabilizeAuthoredHeadingLines(slides: HTMLElement[]): void {
+    for (const slide of slides) {
+      slide.querySelectorAll<HTMLElement>("h1, h2, h3").forEach((heading) => {
+        if (heading.querySelector("br")) {
+          heading.style.setProperty("white-space", "nowrap", "important");
+        }
+      });
+    }
+  }
+
   // Reorder each text run's font-family so CJK runs name their CJK typeface (not
   // the Latin webfont that leads our template stacks) before dom-to-pptx reads it,
   // so PowerPoint/WPS/Keynote all resolve the same real font. See
@@ -1170,8 +1354,11 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
       .call(document.querySelectorAll(slideSelector))
       .filter((el) => !(el as HTMLElement).closest(".mini-slide, .overview, .notes-overlay, .thumb"));
     if (slides.length === 0) return { error: "no slides to export" };
+    const importedFonts = await exposeImportedFontFaces();
+    await document.fonts?.ready;
     ensureExplicitSlideBackgrounds(slides as HTMLElement[]);
     stabilizeLargeSingleLineText(slides as HTMLElement[]);
+    stabilizeAuthoredHeadingLines(slides as HTMLElement[]);
     promoteCjkTypefaces(slides as HTMLElement[]);
     // dom-to-pptx assumes `node.className` is a string, but SVG elements expose
     // an SVGAnimatedString, so its DOM walk throws on decks containing inline SVG.
@@ -1194,6 +1381,7 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
       fileName: "deck.pptx",
       skipDownload: true,
       autoEmbedFonts: true,
+      ...(importedFonts.length > 0 ? { fonts: importedFonts } : {}),
       svgAsVector: true,
     });
     if (!blob || typeof (blob as Blob).arrayBuffer !== "function") {

--- a/apps/desktop/tests/main/pptx-editable-fidelity.test.ts
+++ b/apps/desktop/tests/main/pptx-editable-fidelity.test.ts
@@ -29,6 +29,7 @@ const previousGlobals = {
 
 afterEach(() => {
   Object.assign(globalThis, previousGlobals);
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -147,6 +148,7 @@ describe('editable PPTX font fidelity', () => {
     expect(fetcher).toHaveBeenCalledOnce();
     expect(fetcher).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Fraunces', {
       headers: { 'user-agent': 'Mozilla/5.0' },
+      signal: expect.any(AbortSignal),
     });
     expect(stylesheets).toEqual([
       {
@@ -154,6 +156,29 @@ describe('editable PPTX font fidelity', () => {
         url: 'https://fonts.googleapis.com/css2?family=Fraunces',
       },
     ]);
+  });
+
+  test('stops waiting when a Google Fonts stylesheet request never resolves', async () => {
+    vi.useFakeTimers();
+    let requestSignal: AbortSignal | undefined;
+    const fetcher = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>(() => {
+          requestSignal = init?.signal ?? undefined;
+        }),
+    );
+
+    const pending = fetchGoogleFontStylesheets(
+      ['https://fonts.googleapis.com/css2?family=Fraunces'],
+      fetcher,
+    );
+    const settled = vi.fn();
+    void pending.then(settled);
+
+    await vi.runAllTimersAsync();
+
+    expect(settled).toHaveBeenCalledWith([]);
+    expect(requestSignal?.aborted).toBe(true);
   });
 
   test('exposes @font-face rules from imported stylesheets before export', async () => {

--- a/apps/desktop/tests/main/pptx-editable-fidelity.test.ts
+++ b/apps/desktop/tests/main/pptx-editable-fidelity.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { fetchGoogleFontStylesheets, runDomToPptx } from '../../src/main/deck-capture.js';
+
+class FakeStyle {
+  private readonly values = new Map<string, { value: string; priority: string }>();
+
+  setProperty(name: string, value: string, priority = ''): void {
+    this.values.set(name, { value, priority });
+  }
+
+  getPropertyValue(name: string): string {
+    return this.values.get(name)?.value ?? '';
+  }
+
+  getPropertyPriority(name: string): string {
+    return this.values.get(name)?.priority ?? '';
+  }
+}
+
+const previousGlobals = {
+  document: globalThis.document,
+  fetch: globalThis.fetch,
+  getComputedStyle: globalThis.getComputedStyle,
+  Node: globalThis.Node,
+  NodeFilter: globalThis.NodeFilter,
+  window: globalThis.window,
+};
+
+afterEach(() => {
+  Object.assign(globalThis, previousGlobals);
+  vi.restoreAllMocks();
+});
+
+function fakeElement(): HTMLElement {
+  return {
+    childNodes: [],
+    children: [],
+    closest: () => null,
+    getAttribute: () => null,
+    prepend: () => undefined,
+    querySelectorAll: () => [],
+    style: new FakeStyle(),
+  } as unknown as HTMLElement;
+}
+
+function installEditablePptxDom(options: {
+  headingWithBreak?: boolean;
+  importedCss: string;
+  sourceCss: string;
+  onExport: (
+    injectedStyles: string[],
+    heading: HTMLElement | null,
+    exportOptions: Record<string, unknown>,
+  ) => void;
+}): void {
+  const slide = fakeElement();
+  const heading = options.headingWithBreak ? fakeElement() : null;
+  if (heading) heading.querySelector = ((selector: string) => (selector === 'br' ? fakeElement() : null)) as HTMLElement['querySelector'];
+  slide.querySelectorAll = ((selector: string) =>
+    selector === 'h1, h2, h3' && heading ? [heading] : []) as unknown as HTMLElement['querySelectorAll'];
+  const body = fakeElement();
+  const documentElement = fakeElement();
+  const injectedStyles: string[] = [];
+
+  const fakeDocument = {
+    baseURI: 'https://example.test/decks/course/index.html',
+    body,
+    createElement: (tagName: string) => {
+      if (tagName !== 'style') return fakeElement();
+      return {
+        setAttribute: () => undefined,
+        textContent: '',
+      };
+    },
+    createTreeWalker: () => ({ nextNode: () => null }),
+    documentElement,
+    head: {
+      appendChild: (node: { textContent?: string }) => {
+        injectedStyles.push(node.textContent ?? '');
+        return node;
+      },
+    },
+    querySelectorAll: (selector: string) => {
+      if (selector === '.slide') return [slide];
+      if (selector === 'style') return [{ textContent: options.sourceCss }];
+      return [];
+    },
+  };
+
+  Object.assign(globalThis, {
+    document: fakeDocument as unknown as Document,
+    fetch: vi.fn(async () => new Response(options.importedCss)),
+    getComputedStyle: () => ({
+      backgroundClip: 'border-box',
+      backgroundColor: 'transparent',
+      backgroundImage: 'none',
+      backgroundOrigin: 'padding-box',
+      backgroundPosition: '0% 0%',
+      backgroundRepeat: 'repeat',
+      backgroundSize: 'auto',
+      fontFamily: 'Fraunces, serif',
+      position: 'relative',
+      zIndex: 'auto',
+    }),
+    Node: class FakeNode {
+      static readonly TEXT_NODE = 3;
+    },
+    NodeFilter: class FakeNodeFilter {
+      static readonly SHOW_TEXT = 4;
+    },
+    window: {
+      domToPptx: {
+        exportToPptx: async (_target: unknown, exportOptions: Record<string, unknown>) => {
+          options.onExport(injectedStyles, heading, exportOptions);
+          return new Blob(['pptx']);
+        },
+      },
+    },
+  });
+}
+
+describe('editable PPTX font fidelity', () => {
+  test('keeps semicolons inside a quoted @import URL', async () => {
+    const importedUrl =
+      'https://fonts.googleapis.com/css2?family=Fraunces:ital,wght@0,400;1,400&family=Source+Sans+3:wght@400';
+    installEditablePptxDom({
+      sourceCss: `@import url('${importedUrl}');`,
+      importedCss: "@font-face { font-family: 'Fraunces'; src: url('./fraunces.woff2'); }",
+      onExport: () => undefined,
+    });
+
+    const result = await runDomToPptx('.slide');
+
+    expect(result.error).toBeUndefined();
+    expect(globalThis.fetch).toHaveBeenCalledWith(importedUrl);
+  });
+
+  test('asks Google Fonts for TTF-compatible CSS in the desktop process', async () => {
+    const fetcher = vi.fn(async () => new Response("@font-face { src: url('font.ttf'); }"));
+
+    const stylesheets = await fetchGoogleFontStylesheets(
+      ['https://fonts.googleapis.com/css2?family=Fraunces', 'https://example.test/fonts.css'],
+      fetcher,
+    );
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Fraunces', {
+      headers: { 'user-agent': 'Mozilla/5.0' },
+    });
+    expect(stylesheets).toEqual([
+      {
+        cssText: "@font-face { src: url('font.ttf'); }",
+        url: 'https://fonts.googleapis.com/css2?family=Fraunces',
+      },
+    ]);
+  });
+
+  test('exposes @font-face rules from imported stylesheets before export', async () => {
+    let exportedStyles: string[] = [];
+    installEditablePptxDom({
+      sourceCss: "@import url('https://fonts.example/fraunces.css');",
+      importedCss: `@font-face {
+        font-family: 'Fraunces';
+        src: url('./fraunces.woff2') format('woff2');
+      }`,
+      onExport: (injectedStyles) => {
+        exportedStyles = injectedStyles;
+      },
+    });
+
+    const result = await runDomToPptx('.slide');
+
+    expect(result.error).toBeUndefined();
+    expect(exportedStyles.join('\n')).toContain("font-family: 'Fraunces'");
+    expect(exportedStyles.join('\n')).toContain('https://fonts.example/fraunces.woff2');
+  });
+
+  test('embeds one regular Latin face per family instead of merging incompatible variants and subsets', async () => {
+    let exportedStyles: string[] = [];
+    let exportedOptions: Record<string, unknown> = {};
+    installEditablePptxDom({
+      sourceCss: "@import url('https://fonts.example/deck-fonts.css');",
+      importedCss: `
+        @font-face { font-family: 'Fraunces'; font-style: italic; font-weight: 400; src: url('./fraunces-italic.woff2'); }
+        @font-face { font-family: 'Fraunces'; font-style: normal; font-weight: 400; src: url('./fraunces-symbols.woff2'); unicode-range: U+2000-206F; }
+        @font-face { font-family: 'Fraunces'; font-style: normal; font-weight: 400; src: url('./fraunces-latin.woff2'); unicode-range: U+0000-00FF; }
+        @font-face { font-family: 'Source Sans 3'; font-style: normal; font-weight: 400; src: url('./source-sans-regular.woff2'); }
+        @font-face { font-family: 'Source Sans 3'; font-style: normal; font-weight: 700; src: url('./source-sans-bold.woff2'); }
+      `,
+      onExport: (injectedStyles, _heading, exportOptions) => {
+        exportedStyles = injectedStyles;
+        exportedOptions = exportOptions;
+      },
+    });
+
+    const result = await runDomToPptx('.slide');
+    const css = exportedStyles.join('\n');
+
+    expect(result.error).toBeUndefined();
+    expect(css).toContain('fraunces-latin.woff2');
+    expect(css).not.toContain('fraunces-symbols.woff2');
+    expect(css).toContain('source-sans-regular.woff2');
+    expect(css).not.toContain('fraunces-italic.woff2');
+    expect(css).not.toContain('source-sans-bold.woff2');
+    expect(exportedOptions.fonts).toEqual([
+      {
+        name: 'Fraunces',
+        urls: ['https://fonts.example/fraunces-latin.woff2'],
+      },
+      {
+        name: 'Source Sans 3',
+        urls: ['https://fonts.example/source-sans-regular.woff2'],
+      },
+    ]);
+  });
+
+  test('keeps authored heading lines from soft-wrapping again in PowerPoint', async () => {
+    let exportedHeading: HTMLElement | null = null;
+    installEditablePptxDom({
+      headingWithBreak: true,
+      sourceCss: '',
+      importedCss: '',
+      onExport: (_injectedStyles, heading) => {
+        exportedHeading = heading;
+      },
+    });
+
+    const result = await runDomToPptx('.slide');
+
+    expect(result.error).toBeUndefined();
+    expect(exportedHeading).not.toBeNull();
+    expect(exportedHeading!.style.getPropertyValue('white-space')).toBe('nowrap');
+    expect(exportedHeading!.style.getPropertyPriority('white-space')).toBe('important');
+  });
+});


### PR DESCRIPTION
Fixes #6839

## Why

While reproducing a real editable PPTX export in WPS, imported Google fonts were missing and a heading with an authored line break rewrapped into the body copy. The export looked correct in Open Design but changed substantially after opening the `.pptx`.

The editable export path parsed an `@import` URL as if the semicolon inside the quoted Google Fonts CSS2 query ended the declaration. That truncated the import, so the exporter never discovered most of the font faces. The generated PPTX therefore fell back to local Office fonts with different metrics. Headings containing `<br>` could also soft-wrap a second time after conversion, producing the overlap shown in the report.

## What users will see

Using **Export → Export as PPTX** now embeds compatible imported Google Fonts in editable decks and preserves authored heading line boundaries. The existing export entry point and file format are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI entry point changed. The real seven-slide deck from the report was exported through an isolated Open Design runtime and rendered for visual verification.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/pptx-editable-fidelity.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Coverage includes quoted import URLs containing semicolons, imported stylesheet collection, compatible regular/Latin font-face selection, and heading wrap preservation.

## Validation

- `pnpm --filter @open-design/desktop test` — 36 files passed; 331 tests passed, 1 skipped
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm typecheck`
- `pnpm guard`
- `git diff --check origin/main...HEAD`
- Real seven-slide export: embedded Fraunces, JetBrains Mono, and Source Sans 3; rendered slide scan reported no overflow
