### PR TITLE
fix(web): scope DeepSeek campaign badge to AMR

### DIFF
--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -729,6 +729,14 @@ export function InlineModelSwitcher({
       : configuredModelId ?? defaultAgentModelId(currentAgent);
   const currentModelOption =
     currentAgentModels.find((m) => m.id === currentModelId) ?? null;
+  // `agentId` and `agentModels` intentionally retain the last local-agent
+  // choice while BYOK is active so switching back restores that choice. Do
+  // not let campaign UI read that dormant AMR state: in BYOK mode the visible
+  // model comes from `config.model` and usage is billed by the user's provider.
+  const deepSeekCampaignVisibleForCurrentExecution =
+    campaignVisibility.visible
+    && config.mode === 'daemon'
+    && currentAgent?.id === 'amr';
 
   useEffect(() => {
     if (!currentAgentId || !normalizedCurrentModelId) return;
@@ -802,7 +810,7 @@ export function InlineModelSwitcher({
     }
     if (
       !compact
-      || !campaignVisibility.visible
+      || !deepSeekCampaignVisibleForCurrentExecution
       || campaignBenefitTrackedForOpenRef.current
       || !compactModelRows.some(({ model }) => isDeepSeekV4FlashCampaignModel(model.id))
     ) {
@@ -820,9 +828,9 @@ export function InlineModelSwitcher({
   }, [
     analytics.track,
     campaignNeedsUpgrade,
-    campaignVisibility.visible,
     compact,
     compactModelRows,
+    deepSeekCampaignVisibleForCurrentExecution,
     open,
   ]);
 
@@ -1163,7 +1171,8 @@ export function InlineModelSwitcher({
               aria-hidden="true"
             />
             <span className="inline-switcher__chip-model-name">{chipModel}</span>
-            {campaignVisibility.visible && isDeepSeekV4FlashCampaignModel(currentModelId) ? (
+            {deepSeekCampaignVisibleForCurrentExecution
+              && isDeepSeekV4FlashCampaignModel(currentModelId) ? (
               <span
                 className={`inline-switcher__campaign-badge od-tooltip${campaignBadgeStateClass}`}
                 data-tooltip={campaignModelTooltip}
@@ -1391,7 +1400,7 @@ export function InlineModelSwitcher({
                     // A model above the caller's plan is shown, but honestly:
                     // disabled with the reason the settings picker already uses,
                     // never as a normal row whose click gets reverted.
-                    const campaignModel = campaignVisibility.visible
+                    const campaignModel = deepSeekCampaignVisibleForCurrentExecution
                       && isDeepSeekV4FlashCampaignModel(m.id);
                     const lockedHint = selectable
                       ? null

--- a/apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx
@@ -280,6 +280,31 @@ describe('compact home model list — a clicked model reaches the chip', () => {
     expect(within(popover).queryByText('Unlimited')).toBeNull();
   });
 
+  it('never applies the AMR campaign badge to a BYOK model', () => {
+    // BYOK deliberately retains the last local-agent model in `agentModels` so
+    // switching back to local execution restores it. That dormant AMR choice
+    // must not decorate the visible BYOK model: BYOK usage is charged by the
+    // user's own provider and is outside this hosted-model campaign.
+    mockNow(DEEPSEEK_V4_FLASH_CAMPAIGN.window.startAt);
+    render(
+      <StatefulSwitcher
+        agents={[amrAgentAllEnabled]}
+        initialConfig={{
+          mode: 'api',
+          model: 'grok-4.5',
+          agentId: 'amr',
+          agentModels: {
+            amr: { model: DEEPSEEK_V4_FLASH_CAMPAIGN.modelId },
+          },
+        }}
+      />,
+    );
+
+    const chip = screen.getByTestId('inline-model-switcher-chip');
+    expect(chip).toHaveTextContent('grok-4.5');
+    expect(within(chip).queryByText('Unlimited')).toBeNull();
+  });
+
   it('still closes on a click genuinely outside the switcher', () => {
     render(
       <div>


### PR DESCRIPTION
## Why

While using the Home composer with a BYOK model, the model chip could show the DeepSeek V4 Flash "Unlimited" campaign badge next to an unrelated provider model such as `grok-4.5`. This happened because Open Design deliberately retains the last local-agent selection while BYOK is active, and the badge read that dormant AMR model state without first checking the active execution path.

The misleading badge suggests that a user-funded BYOK request is covered by the hosted AMR campaign. The campaign benefit must only be advertised when the current execution actually goes through AMR/vela with DeepSeek V4 Flash during the campaign window.

## What users will see

BYOK models no longer show the DeepSeek V4 Flash "Unlimited" badge. The badge remains visible only when the active execution uses AMR/vela, selects `deepseek-v4-flash`, and the campaign window is open. Claude Code, Codex, other local CLI agents, and all BYOK providers remain unbadged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the reported Home composer showed `grok-4.5` with the green `Unlimited` campaign badge (see the issue report screenshot/context).

After: the same BYOK state shows `grok-4.5` without the campaign badge. There is no layout or style change; the incorrect conditional badge is removed. The AMR/vela + DeepSeek V4 Flash campaign state is unchanged.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** On unmodified `main`, the new regression test received an `Unlimited` badge next to `grok-4.5`; on this branch the full focused file passes 10/10.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/InlineModelSwitcher.compact-model-click.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Local runtime smoke test with `pnpm tools-dev run web` and an isolated daemon data root:
  - AMR/vela + `deepseek-v4-flash`: the Home model chip showed one `Unlimited` campaign badge.
  - BYOK + a local OpenAI-compatible test provider + `grok-4.5`: the same chip showed zero campaign badges.
  - The global DeepSeek campaign entry remained visible, confirming the change is scoped to execution-model badges.
