### PR TITLE
Let a headless AMR caller reach its own Workspace

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -26,6 +26,7 @@ import {
   type WorkspaceContextProvider,
   type WorkspaceContextRequest,
 } from './workspace-context.js';
+import { selectDefaultWorkspaceCandidate } from './workspace-directory-selection.js';
 
 // Real B-integration provider (T2). The daemon reuses the SAME vela login session
 // that AMR / the vela CLI use — `readVelaControlApiContext` reads the control key
@@ -256,21 +257,6 @@ export function createVelaWorkspaceContextProvider(
     }
   }
 
-  /** Pick the best default membership out of an already-fetched directory list. */
-  function selectDefaultCandidate(
-    items: WorkspaceDirectoryItem[],
-    preferredId: string | undefined,
-  ): WorkspaceDirectoryItem | undefined {
-    const candidates = items.filter(
-      (item) => item.memberStatus === 'active' && item.lifecycleState === 'active',
-    );
-    return (
-      (preferredId ? candidates.find((item) => item.workspaceId === preferredId) : undefined) ??
-      candidates.find((item) => item.workspaceType === 'personal') ??
-      candidates[0]
-    );
-  }
-
   /**
    * Fresh-account default pick. B's workspace selection is server-side state
    * and a new account has NO current workspace, so every workspace-scoped
@@ -294,7 +280,7 @@ export function createVelaWorkspaceContextProvider(
       prefetched ??
       (await fetchVelaWorkspaceDirectory({ fetch: fetchImpl, readSession: () => session, timeoutMs }));
     const preferredId = options.getActiveWorkspaceId?.()?.trim();
-    const pick = selectDefaultCandidate(result.items, preferredId);
+    const pick = selectDefaultWorkspaceCandidate(result.items, preferredId);
     if (!pick) {
       lastBootstrapFailureAt = Date.now();
       return null;

--- a/apps/daemon/src/collab/workspace-directory-selection.ts
+++ b/apps/daemon/src/collab/workspace-directory-selection.ts
@@ -1,0 +1,65 @@
+import type { WorkspaceDirectoryItem } from '@open-design/contracts';
+
+/**
+ * Choosing a membership out of an already-fetched Workspace directory.
+ *
+ * Every caller that has an account but no explicit `x-od-workspace-*` header
+ * has to answer the same question — which membership am I acting as? — and the
+ * answer has to be identical everywhere, or the MCP bridge, the UI and the run
+ * gate disagree about which Workspace a project belongs to.
+ *
+ * This lived as a closure-local `selectDefaultCandidate` in
+ * vela-workspace-context.ts, so the MCP bridge could not reach it and shipped a
+ * commented "verbatim port" instead. Two copies kept in sync by hand is one
+ * edit away from divergence; the rule lives here now and both call it.
+ */
+
+/** Memberships that are usable at all — the precondition for every rule below. */
+export function activeWorkspaceCandidates(
+  items: WorkspaceDirectoryItem[],
+): WorkspaceDirectoryItem[] {
+  return items.filter(
+    (item) => item.memberStatus === 'active' && item.lifecycleState === 'active',
+  );
+}
+
+/**
+ * The default membership to act as: the preferred one when it is still active,
+ * else the personal Workspace, else any active membership.
+ *
+ * The trailing "any" is what makes this a *default* rather than a decision. It
+ * is right for presenting a starting point the user can change, and wrong for
+ * anything that silently writes a durable binding — see `selectPersonalWorkspace`.
+ */
+export function selectDefaultWorkspaceCandidate(
+  items: WorkspaceDirectoryItem[],
+  preferredId?: string,
+): WorkspaceDirectoryItem | undefined {
+  const candidates = activeWorkspaceCandidates(items);
+  return (
+    (preferredId
+      ? candidates.find((item) => item.workspaceId === preferredId)
+      : undefined) ??
+    candidates.find((item) => item.workspaceType === 'personal') ??
+    candidates[0]
+  );
+}
+
+/**
+ * The account's personal Workspace, or nothing.
+ *
+ * Deliberately not a "default": a caller adopting an unbound project needs the
+ * one Workspace that is unambiguously the account's own. Falling back to an
+ * arbitrary active membership would silently bind someone's project into a
+ * team. No personal membership means the caller must be told, not guessed for.
+ */
+export function selectPersonalWorkspace(
+  items: WorkspaceDirectoryItem[],
+): WorkspaceDirectoryItem | undefined {
+  const personal = activeWorkspaceCandidates(items).filter(
+    (item) => item.workspaceType === 'personal',
+  );
+  // More than one personal Workspace is not a shape the account model produces.
+  // If it ever appears, it is ambiguity, and guessing would bind the wrong one.
+  return personal.length === 1 ? personal[0] : undefined;
+}

--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -1,7 +1,6 @@
-import type {
-  WorkspaceDirectoryItem,
-  WorkspaceDirectoryResponse,
-} from '@open-design/contracts';
+import type { WorkspaceDirectoryResponse } from '@open-design/contracts';
+
+import { selectDefaultWorkspaceCandidate } from './collab/workspace-directory-selection.js';
 
 /**
  * Workspace-aware request context for the MCP stdio bridge (#6569).
@@ -34,23 +33,11 @@ export const MCP_WORKSPACE_FAILURE_COOLDOWN_MS = 60_000;
 const DIRECTORY_TIMEOUT_MS = 8_000;
 
 /**
- * Pick the best default membership out of an already-fetched directory list.
- * Verbatim port of `selectDefaultCandidate` in vela-workspace-context.ts so the
- * bridge and the UI pick the same workspace for a multi-workspace user.
+ * The bridge's default membership. Kept as a named export because it is this
+ * module's published surface; the rule itself is shared, so the bridge and the
+ * UI can no longer drift apart.
  */
-export function selectDefaultMcpCandidate(
-  items: WorkspaceDirectoryItem[],
-  preferredId?: string,
-): WorkspaceDirectoryItem | undefined {
-  const candidates = items.filter(
-    (item) => item.memberStatus === 'active' && item.lifecycleState === 'active',
-  );
-  return (
-    (preferredId ? candidates.find((item) => item.workspaceId === preferredId) : undefined) ??
-    candidates.find((item) => item.workspaceType === 'personal') ??
-    candidates[0]
-  );
-}
+export const selectDefaultMcpCandidate = selectDefaultWorkspaceCandidate;
 
 interface CacheEntry {
   context: McpWorkspaceContext;

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1281,6 +1281,35 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return true;
     }
 
+    // Same reason creation resolves rather than refuses: a headless AMR caller
+    // has no headers to assert with, so exact-authority-only locks it out of
+    // the lifecycle of the very run it just created. Authorize it against the
+    // Workspace the daemon resolves, and only for a project actually bound
+    // there. A team project stays exact-authority-only — it is a single-writer
+    // resource and a resolved Personal identity is not a claim on it.
+    if (
+      run.agentId === 'amr'
+      && requestContext === null
+      && !carriesNavigationScope
+      && ctx.projectStore
+      && ctx.amrWorkspaceScope?.resolvePersonalWorkspace
+    ) {
+      const resolved = await ctx.amrWorkspaceScope.resolvePersonalWorkspace();
+      if (resolved.ok) {
+        const binding = ctx.projectStore.getWorkspaceProjectByProjectId(
+          db,
+          run.projectId,
+        );
+        if (
+          binding
+          && binding.visibility !== 'team'
+          && binding.workspaceId === resolved.context.workspaceId
+        ) {
+          return true;
+        }
+      }
+    }
+
     return ctx.authorizeProjectRequest(req, res, run.projectId, options);
   }
 

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -31,12 +31,15 @@ import { newInsertId, readAnalyticsContext } from '../analytics.js';
 import type { AnalyticsContext } from '../analytics.js';
 import { spawnEnvForAgent } from '../agents.js';
 import { agentCliEnvForAgent, readAppConfig } from '../app-config.js';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
 import type { AuthorizeProjectRequest } from '../collab/project-request-authority.js';
 import {
   workspaceResourceContextFromRequest,
+  workspaceResourceContextFromVerified,
   type BoundWorkspaceResourceMutationGate,
   type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
+  type WorkspaceResourceContext,
 } from '../collab/workspace-resource-mutation.js';
 import {
   codexSessionIdFromRunEvents,
@@ -607,6 +610,16 @@ export interface RegisterRunRoutesDeps {
   amrWorkspaceScope?: {
     isSignedIn: () => boolean | Promise<boolean>;
     verifyWorkspaceRequestAuthority: VerifyWorkspaceRequestAuthority;
+    /**
+     * The account's own Workspace, for a caller that holds credentials but has
+     * no UI to have chosen one in — the MCP bridge, an eval runner, any
+     * headless automation. Absent means the daemon cannot resolve one and the
+     * caller must be told rather than guessed for.
+     */
+    resolvePersonalWorkspace?: () => Promise<
+      | { ok: true; context: WorkspaceCollabContext }
+      | { ok: false; reason?: string }
+    >;
   };
 }
 
@@ -1052,14 +1065,56 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return { ok: true, workspaceScope: null };
     }
 
+    // A headerless caller is not necessarily a browser that forgot to send its
+    // context. It may be automation that holds credentials and has no UI in
+    // which a Workspace could ever have been chosen — the MCP bridge, an eval
+    // runner. For those, "signed in but no Workspace named" is not a fixable
+    // state, it is the only state they can be in, so refusing them here made
+    // AMR unreachable to every headless caller. Resolve the account's own
+    // Workspace instead, and refuse only when there genuinely is not one.
     if (requestContext === null) {
-      sendApiError(
+      const resolver = ctx.amrWorkspaceScope.resolvePersonalWorkspace;
+      const resolved = resolver ? await resolver() : { ok: false as const };
+      if (!resolved.ok) {
+        if (resolved.reason === 'unauthorized') {
+          sendApiError(
+            res,
+            401,
+            'AMR_AUTH_REQUIRED',
+            'AMR authorization expired. Sign in again to continue.',
+          );
+          return { ok: false };
+        }
+        // An outage is not the same answer as "you have no Personal
+        // Workspace"; the caller can retry the first and cannot fix it by
+        // opening a project.
+        if (resolved.reason && resolved.reason !== 'no_personal_workspace') {
+          sendApiError(
+            res,
+            503,
+            'WORKSPACE_AUTHORITY_UNAVAILABLE',
+            'workspace membership authority is temporarily unavailable',
+            { retryable: true },
+          );
+          return { ok: false };
+        }
+        sendApiError(
+          res,
+          409,
+          'AMR_WORKSPACE_SCOPE_REQUIRED',
+          'open the project from your Personal Workspace before running AMR Cloud',
+        );
+        return { ok: false };
+      }
+      // Authority came from the directory itself, not from a caller claim, so
+      // it is already verified — re-running the header verifier below would
+      // only re-check headers that do not exist.
+      return await adoptIntoPersonalWorkspace(
         res,
-        409,
-        'AMR_WORKSPACE_SCOPE_REQUIRED',
-        'open the project from your Personal Workspace before running AMR Cloud',
+        projectId,
+        ctx.projectStore,
+        workspaceResourceContextFromVerified(resolved.context),
       );
-      return { ok: false };
     }
     if (requestContext === 'missing') {
       sendApiError(
@@ -1095,7 +1150,33 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       );
       return { ok: false };
     }
-    if (verified.context.workspaceType !== 'personal') {
+    return await adoptIntoPersonalWorkspace(
+      res,
+      projectId,
+      ctx.projectStore,
+      workspaceResourceContextFromVerified(verified.context),
+    );
+  }
+
+  /**
+   * Bind a truly unbound historical project to the caller's Personal Workspace
+   * and pin the run to it. Shared by the two ways a caller can arrive with a
+   * verified Personal identity: explicit `x-od-workspace-*` headers, or a
+   * headless caller whose Workspace the daemon resolved from the account
+   * directory. The identity is already authoritative either way — this only
+   * writes the binding.
+   */
+  async function adoptIntoPersonalWorkspace(
+    res: ApiResponse,
+    projectId: string,
+    // Passed in rather than read off ctx: the caller has already established
+    // it exists, and threading it keeps that fact visible here.
+    projectStore: NonNullable<RegisterRunRoutesDeps['projectStore']>,
+    context: WorkspaceResourceContext,
+  ): Promise<
+    { ok: true; workspaceScope: PinnedRunWorkspaceScope | null } | { ok: false }
+  > {
+    if (context.workspaceType !== 'personal') {
       sendApiError(
         res,
         409,
@@ -1104,7 +1185,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       );
       return { ok: false };
     }
-    const ensureWorkspaceProject = ctx.projectStore.ensureWorkspaceProject;
+    const ensureWorkspaceProject = projectStore.ensureWorkspaceProject;
     if (!ensureWorkspaceProject) {
       sendApiError(
         res,
@@ -1120,17 +1201,17 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
       return { ok: false };
     }
-    const { getWorkspaceProjectByProjectId } = ctx.projectStore;
+    const { getWorkspaceProjectByProjectId } = projectStore;
     const bindPersonal = db.transaction(() => {
       const existing = getWorkspaceProjectByProjectId(db, projectId);
       if (existing) return existing;
       ensureWorkspaceProject(db, {
         projectId,
-        workspaceId: verified.context.workspaceId,
+        workspaceId: context.workspaceId,
         visibility: 'personal',
         resourceState: 'active',
-        createdByWorkspaceMemberId: verified.context.workspaceMemberId,
-        updatedByWorkspaceMemberId: verified.context.workspaceMemberId,
+        createdByWorkspaceMemberId: context.workspaceMemberId,
+        updatedByWorkspaceMemberId: context.workspaceMemberId,
         syncState: 'local_only',
         resourceHubResourceId: null,
         cloudTombstonedAt: null,
@@ -1140,7 +1221,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return getWorkspaceProjectByProjectId(db, projectId);
     });
     const adopted = bindPersonal();
-    if (adopted?.workspaceId !== verified.context.workspaceId) {
+    if (adopted?.workspaceId !== context.workspaceId) {
       sendApiError(
         res,
         409,
@@ -1150,7 +1231,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return { ok: false };
     }
     const workspaceScope = pinRunWorkspaceScopeForProject(db, projectId);
-    if (!workspaceScope || workspaceScope.workspaceId !== verified.context.workspaceId) {
+    if (!workspaceScope || workspaceScope.workspaceId !== context.workspaceId) {
       sendApiError(
         res,
         409,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -777,6 +777,7 @@ import {
   velaWorkspaceDirectoryIdentity,
   workspaceContextFromDirectoryItem,
 } from './collab/vela-workspace-context.js';
+import { selectPersonalWorkspace } from './collab/workspace-directory-selection.js';
 import { verifyWorkspaceRequestContext } from './collab/request-workspace-context.js';
 import {
   createWorkspaceBillingRuntimeCoordinator,
@@ -13727,6 +13728,17 @@ export async function startServer({
         ).loggedIn;
       },
       verifyWorkspaceRequestAuthority,
+      // Adoption is a durable write, so this reads the directory fresh rather
+      // than through the request cache, matching every other mutation path.
+      resolvePersonalWorkspace: async () => {
+        const directory = await fetchFreshMutationWorkspaceDirectory().catch(
+          () => ({ ok: false as const, items: [] }),
+        );
+        if (!directory.ok) return { ok: false, reason: directory.reason };
+        const membership = selectPersonalWorkspace(directory.items);
+        if (!membership) return { ok: false, reason: 'no_personal_workspace' };
+        return { ok: true, context: workspaceContextFromDirectoryItem(membership) };
+      },
     },
     authorizeProjectRequest,
   });

--- a/apps/daemon/tests/run-create-workspace-gate.test.ts
+++ b/apps/daemon/tests/run-create-workspace-gate.test.ts
@@ -1524,6 +1524,46 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
     },
   );
 
+  it('lets a headless caller read back the lifecycle of the AMR run it created', async () => {
+    // Creating the run and then being locked out of its event stream is not a
+    // usable outcome: the acceptance run got 400 on GET /api/runs/:id/events
+    // seconds after adoption had succeeded.
+    const baseUrl = await startServer({
+      isAmrSignedIn: () => true,
+      resolvePersonalWorkspace: async () => ({
+        ok: true,
+        context: workspaceContextFromDirectoryItem({
+          workspaceId: 'ws-personal-resolved',
+          workspaceName: 'ws-personal-resolved',
+          workspaceType: 'personal',
+          workspaceMemberId: OWNER_MEMBER_ID,
+          role: 'owner',
+          memberStatus: 'active',
+          lifecycleState: 'active',
+        }),
+      }),
+    });
+
+    const created = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: UNBOUND_PROJECT,
+        agentId: 'amr',
+        message: 'headless lifecycle',
+      }),
+    });
+    expect(created.status).toBeLessThan(400);
+    const body = await created.json() as Record<string, any>;
+    const runId = body.id ?? body.run?.id ?? body.runId;
+    expect(typeof runId).toBe('string');
+
+    const events = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+      headers: { accept: 'text/event-stream' },
+    });
+    expect(events.status).toBeLessThan(400);
+  });
+
   it('still refuses when the account genuinely has no Personal Workspace', async () => {
     const baseUrl = await startServer({
       isAmrSignedIn: () => true,

--- a/apps/daemon/tests/run-create-workspace-gate.test.ts
+++ b/apps/daemon/tests/run-create-workspace-gate.test.ts
@@ -175,6 +175,7 @@ async function startServer(opts?: {
     capability: any,
   ) => Promise<boolean>;
   isAmrSignedIn?: () => boolean | Promise<boolean>;
+  resolvePersonalWorkspace?: () => Promise<any>;
   verifyWorkspaceRequestAuthority?: (req: any) => Promise<any>;
   authorizePluginRequest?: (req: any, res: any, pluginId: string) => Promise<boolean>;
   authorizePluginWithWorkspaceAuthority?: boolean;
@@ -347,6 +348,9 @@ async function startServer(opts?: {
     amrWorkspaceScope: {
       isSignedIn: opts?.isAmrSignedIn ?? (() => false),
       verifyWorkspaceRequestAuthority,
+      ...(opts?.resolvePersonalWorkspace
+        ? { resolvePersonalWorkspace: opts.resolvePersonalWorkspace }
+        : {}),
     },
     authorizeProjectRequest: createAuthorizeProjectRequest({
       db,
@@ -1446,7 +1450,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
   });
 
   it.each(['/api/runs', '/api/chat'])(
-    'refuses a signed-in AMR run through %s when an unbound project has no explicit Personal identity',
+    'refuses a signed-in AMR run through %s when there is no identity and no resolver',
     async (route) => {
     const verifyWorkspaceRequestAuthority = vi.fn();
     const baseUrl = await startServer({
@@ -1474,6 +1478,125 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
       ).toBeUndefined();
     },
   );
+
+  it.each(['/api/runs', '/api/chat'])(
+    'adopts an unbound project through %s for a headless caller the daemon can resolve',
+    async (route) => {
+      // The eval runner and the MCP bridge hold credentials but have no UI in
+      // which a Workspace could ever have been chosen. Before this, they were
+      // refused unconditionally, which made AMR unreachable to every headless
+      // caller rather than prompting anyone to fix anything.
+      const verifyWorkspaceRequestAuthority = vi.fn();
+      const baseUrl = await startServer({
+        isAmrSignedIn: () => true,
+        verifyWorkspaceRequestAuthority,
+        resolvePersonalWorkspace: async () => ({
+          ok: true,
+          context: workspaceContextFromDirectoryItem({
+            workspaceId: 'ws-personal-resolved',
+            workspaceName: 'ws-personal-resolved',
+            workspaceType: 'personal',
+            workspaceMemberId: OWNER_MEMBER_ID,
+            role: 'owner',
+            memberStatus: 'active',
+            lifecycleState: 'active',
+          }),
+        }),
+      });
+
+      const response = await fetch(`${baseUrl}${route}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          projectId: UNBOUND_PROJECT,
+          agentId: 'amr',
+          message: 'headless caller',
+        }),
+      });
+
+      expect(response.status).toBeLessThan(400);
+      // Authority came from the directory, so the header verifier has nothing
+      // to check and must not be consulted.
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
+      expect(
+        getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT),
+      ).toMatchObject({ workspaceId: 'ws-personal-resolved' });
+    },
+  );
+
+  it('still refuses when the account genuinely has no Personal Workspace', async () => {
+    const baseUrl = await startServer({
+      isAmrSignedIn: () => true,
+      resolvePersonalWorkspace: async () => ({
+        ok: false,
+        reason: 'no_personal_workspace',
+      }),
+    });
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: UNBOUND_PROJECT,
+        agentId: 'amr',
+        message: 'nothing to adopt into',
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'AMR_WORKSPACE_SCOPE_REQUIRED' },
+    });
+    expect(
+      getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT),
+    ).toBeUndefined();
+  });
+
+  it('reports a directory outage as retryable rather than as a missing Workspace', async () => {
+    // A caller can retry an outage. It cannot fix one by opening a project, so
+    // answering 409 would send it to do something that changes nothing.
+    const baseUrl = await startServer({
+      isAmrSignedIn: () => true,
+      resolvePersonalWorkspace: async () => ({ ok: false, reason: 'timeout' }),
+    });
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: UNBOUND_PROJECT,
+        agentId: 'amr',
+        message: 'authority down',
+      }),
+    });
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'WORKSPACE_AUTHORITY_UNAVAILABLE', retryable: true },
+    });
+  });
+
+  it('asks a caller with expired AMR authorization to sign in again', async () => {
+    const baseUrl = await startServer({
+      isAmrSignedIn: () => true,
+      resolvePersonalWorkspace: async () => ({ ok: false, reason: 'unauthorized' }),
+    });
+
+    const response = await fetch(`${baseUrl}/api/runs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId: UNBOUND_PROJECT,
+        agentId: 'amr',
+        message: 'expired',
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'AMR_AUTH_REQUIRED' },
+    });
+  });
 
   it('never adopts an unbound historical project into a Team Workspace', async () => {
     const verifyWorkspaceRequestAuthority = vi.fn(async () => ({


### PR DESCRIPTION
## What breaks

Every AMR run through `open-design-branch` has failed since 08-05 with:

```
POST /api/runs → 409
{"error":{"code":"AMR_WORKSPACE_SCOPE_REQUIRED",
 "message":"open the project from your Personal Workspace before running AMR Cloud"}}
```

Not model-specific: `seedream-5.0` (08-11, 27/27) and `grok-4.6` (08-13, 21/21) both fail identically, while `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash` and `qwen3.8-max` all succeeded before the line. Last clean success 2026-08-04T08:57Z; the guard landed 2026-08-05T00:31Z in #6142.

## Why

Workspace-scoped billing made every AMR run need a Workspace to belong to, and the gate in `routes/runs.ts` was written from the UI's point of view: the app always knows which Workspace you are in, so it sends `x-od-workspace-*`, and a request without those headers means you have not opened the project from a Workspace yet.

That reading does not hold for a caller with credentials and no UI. The MCP bridge and the eval runner are signed in — the eval platform injects Vela credentials per lease, so `isSignedIn()` is true — but no human ever chose a Workspace for them. "Signed in and no Workspace named" is not a state they can leave, so the gate took AMR away from every headless caller rather than prompting anyone to fix anything.

`amrWorkspaceScope` could not self-heal either: it exposed only `isSignedIn` and `verifyWorkspaceRequestAuthority`, no way to resolve the account's own Workspace.

## Change

Resolve instead of refusing, and refuse only when there genuinely is no Personal Workspace. Identity then comes from the directory rather than from a caller claim, so it needs no header verification — there are no headers to verify.

Three answers kept distinct, because they ask the caller for different things:

| condition | before | after |
|---|---|---|
| no personal Workspace | 409 | 409 (unchanged) |
| authority outage | 409 | 503 retryable |
| expired authorization | 409 | 401 |

`0938e69ee` extends the same reasoning to `authorizeRunProject`. Without it the caller creates a run and is then locked out of its own event stream — which is what the first acceptance run hit: adoption succeeded, then `GET /api/runs/:id/events` returned 400 six seconds later.

## Shared selection rule

The rule this needs already existed twice: a closure-local `selectDefaultCandidate` in `vela-workspace-context.ts` that the MCP bridge could not reach, and the bridge's commented *"Verbatim port … so the bridge and the UI pick the same workspace"*. Both now call one shared `collab/workspace-directory-selection.ts`, so they can no longer drift.

Adoption uses a stricter rule than the default pick: exactly one active personal membership, never the "any active membership" fallback, which would silently bind someone's project into a team. Reads the directory fresh rather than through the request cache, like every other mutation path.

## Verification

- `run-create-workspace-gate` 57/57, collab surface 62 files 1005 passed / 4 skipped, both tsconfigs clean.
- With no resolver wired the gate behaves exactly as before — pinned by the 52 pre-existing cases, unmodified.
- End to end on a real headless node (Windows, eval runner, lease-injected credentials): run `succeeded`, `agent=open-design:amr`, `model=gpt-5.6-sol`, ttft 14.9s, 204k input tokens. Same shape that was 21/21 failing on four other nodes the same morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)