### PR TITLE
fix(web): expand message center rows inline

### DIFF
--- a/apps/web/src/components/MessageCenter.module.css
+++ b/apps/web/src/components/MessageCenter.module.css
@@ -227,6 +227,7 @@
 .item {
   flex: 0 0 auto;
   position: relative;
+  min-width: 0;
 }
 
 .item:not(:last-child)::after {
@@ -243,38 +244,18 @@
   box-shadow: inset 2px 0 0 var(--accent);
 }
 
-.itemViewHint {
-  position: absolute;
-  top: 10px;
-  right: 13px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 12px;
-  border-radius: var(--radius-pill, 999px);
-  background: var(--accent);
-  color: #00ff08;
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 1.3;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 120ms;
-}
-
-.item:hover .itemViewHint {
-  opacity: 1;
-}
-
 .itemSummary {
+  box-sizing: border-box;
   width: 100%;
+  height: auto;
+  min-width: 0;
   min-height: 84px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
   gap: 6px;
-  padding: 12px 13px 10px 3px;
+  padding: 12px 13px 10px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -287,6 +268,8 @@
 }
 
 .itemMeta {
+  min-width: 0;
+  max-width: 100%;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -297,12 +280,14 @@
 }
 
 .itemMeta span {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .itemSummary strong {
+  max-width: 100%;
   overflow: hidden;
   color: var(--text);
   font-size: 13.5px;
@@ -317,6 +302,7 @@
 }
 
 .bodyPreview {
+  max-width: 100%;
   overflow: hidden;
   color: var(--text-muted);
   font-size: 12.5px;
@@ -331,35 +317,16 @@
   color: var(--text);
   font-size: 13px;
   line-height: 1.58;
+  overflow-wrap: anywhere;
   text-overflow: clip;
   white-space: normal;
 }
 
-.itemActions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0 13px 12px 3px;
-}
-
-.itemActions .primaryAction {
-  min-height: 30px;
-  padding: 0 12px;
-  border: 1px solid color-mix(in srgb, var(--accent) 72%, var(--border));
-  border-radius: var(--radius-sm);
-  background: var(--accent);
-  color: var(--accent-contrast, #fff);
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.14);
-  white-space: nowrap;
-}
-
-.itemActions .primaryAction:hover {
-  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
-  background: color-mix(in srgb, var(--accent) 86%, var(--text-strong));
-  color: var(--accent-contrast, #fff);
+.itemExpanded .itemSummary strong {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .empty {

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -292,23 +292,9 @@ function MessageItem({
   onRead: (id: string) => Promise<void>;
   onError: () => void;
 }) {
-  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const formatted = formatPublishedDate(message.publishedAt, locale);
-  const ctaUrl = safeExternalUrl(message.ctaUrl);
-  return <article className={`${styles.item}${message.readAt ? '' : ` ${styles.itemUnread}`}`}>
-    <span className={styles.itemViewHint} aria-hidden>{t('settings.memoryToastClickHint')}<Icon name="arrow-right" size={14} /></span>
+  return <article className={`${styles.item}${message.readAt ? '' : ` ${styles.itemUnread}`}${expanded ? ` ${styles.itemExpanded}` : ''}`}>
     <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id).catch(onError); }}><span className={styles.itemMeta}><span>{message.typeName}</span>{formatted ? <time dateTime={message.publishedAt}>{formatted}</time> : null}</span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
-    {expanded && message.ctaLabel && ctaUrl ? <div className={styles.itemActions}><button type="button" className={styles.primaryAction} onClick={() => window.open(ctaUrl, '_blank', 'noopener,noreferrer')}>{message.ctaLabel}</button></div> : null}
   </article>;
-}
-
-function safeExternalUrl(value: string | null): string | null {
-  if (!value) return null;
-  try {
-    const parsed = new URL(value, window.location.href);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null;
-  } catch {
-    return null;
-  }
 }

--- a/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
+++ b/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
@@ -74,7 +74,7 @@ export function PlaceholderCarousel({ scenarios, active, paused = false, onScena
 
   // Report the active scenario up on every index change (incl. first show).
   useEffect(() => {
-    if (!active || paused || scenarios.length === 0) return;
+    if (!active || scenarios.length === 0) return;
     const scenario = scenarios[state.index % scenarios.length];
     if (scenario && reportedIndexRef.current !== state.index) {
       reportedIndexRef.current = state.index;

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -130,13 +130,21 @@ describe('MessageCenter', () => {
     await waitFor(() => expect(screen.getByText('All caught up')).toBeTruthy());
   });
 
-  it('opens CTA URLs with the existing external-link behavior', async () => {
-    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+  it('expands the whole message row without rendering view actions', async () => {
     renderMessageCenter();
     await openCenter();
-    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
-    fireEvent.click(screen.getByRole('button', { name: 'View update' }));
-    expect(open).toHaveBeenCalledWith('https://open-design.ai/update', '_blank', 'noopener,noreferrer');
+    const row = screen.getByRole('button', { name: /Open Design 0\.14 is available/ });
+
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('View')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'View update' })).toBeNull();
+
+    fireEvent.click(row);
+
+    expect(row).toHaveAttribute('aria-expanded', 'true');
+    expect(row.closest('article')?.className).toContain('itemExpanded');
+    expect(screen.getByText('The new release is ready.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'View update' })).toBeNull();
   });
 
   it('keeps both anonymous reads when two expands resolve out of order', async () => {
@@ -465,16 +473,6 @@ describe('MessageCenter', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
     expect(readAttempts).toBe(1);
-  });
-
-  it('hides CTA actions for non-http URLs', async () => {
-    mockFetch({
-      messages: [{ ...defaultMessages[0]!, ctaUrl: 'javascript:alert(1)' }],
-    });
-    renderMessageCenter();
-    await openCenter();
-    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
-    expect(screen.queryByRole('button', { name: 'View update' })).toBeNull();
   });
 
   it('closes with Escape and restores trigger focus', async () => {

--- a/apps/web/tests/components/home-hero/PlaceholderCarousel.paused.test.tsx
+++ b/apps/web/tests/components/home-hero/PlaceholderCarousel.paused.test.tsx
@@ -23,11 +23,12 @@ const SCENARIOS = [
 describe('PlaceholderCarousel — paused while the editor has focus (#118)', () => {
   it('renders nothing and schedules no timer once paused', () => {
     vi.useFakeTimers();
+    const onScenarioChange = vi.fn();
     const { container, rerender } = render(
       <PlaceholderCarousel
         scenarios={[...SCENARIOS]}
         active
-        onScenarioChange={() => {}}
+        onScenarioChange={onScenarioChange}
       />,
     );
     // The typewriter starts at zero characters; let it type a few first so the
@@ -52,6 +53,22 @@ describe('PlaceholderCarousel — paused while the editor has focus (#118)', () 
     // passing must not bring any text back under the caret.
     typeAFewCharacters();
     expect(container.textContent).toBe('');
+    expect(onScenarioChange).toHaveBeenCalledWith(SCENARIOS[0]);
+  });
+
+  it('reports the active scenario while initially paused so empty input stays submittable', () => {
+    const onScenarioChange = vi.fn();
+
+    render(
+      <PlaceholderCarousel
+        scenarios={[...SCENARIOS]}
+        active
+        paused
+        onScenarioChange={onScenarioChange}
+      />,
+    );
+
+    expect(onScenarioChange).toHaveBeenCalledWith(SCENARIOS[0]);
   });
 
   it('keeps animating while unpaused', () => {


### PR DESCRIPTION
## Why

While reviewing the message center UI, the row-level `View` hint and the additional CTA made a simple notification feel like a two-step navigation flow. Long message content also stayed visually constrained instead of expanding naturally, and the asymmetric horizontal padding made the right edge feel crowded.

This fixes the user-facing interaction so a message can be read in place with one click, while keeping long content inside the panel bounds. It also repairs a pre-existing Home placeholder-carousel focus race exposed by the PR CI: pausing the typing animation no longer prevents the active suggestion from becoming submittable.

## What users will see

Clicking anywhere on a message row now expands or collapses the full title and body inline. The hover `View` hint and expanded CTA are gone. Expanded long text wraps within the row, with balanced 13px horizontal spacing and no horizontal overflow. On Home, focusing an empty composer still hides the animated placeholder, while its active suggestion remains available to submit.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached per request. The post-change interaction and layout were verified in Chrome with the quantitative checks listed below.

## Bug fix verification

- Test paths: `apps/web/tests/components/MessageCenter.test.tsx`, `apps/web/tests/components/home-hero/PlaceholderCarousel.paused.test.tsx`
- Red on `main`: yes — the Message Center assertion failed because `main` rendered two `View` hints; the Home regression assertion failed because a focused/paused carousel reported no active scenario.
- Green on this branch: yes — all 19 focused MessageCenter tests pass; the paused-carousel regression test passes; and the four previously failing Home Playwright cases pass with two workers.

## Validation

- `pnpm install --offline --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/home-hero/PlaceholderCarousel.paused.test.tsx tests/components/MessageCenter.test.tsx --maxWorkers=2` — 23/23 passed
- Focused Playwright rerun of the four previously failing Home cases with two workers — 4/4 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Chrome + Open Browser Use against an isolated `tools-dev` runtime: collapsed row 84.14px → expanded row 168.39px; inner and outer right gaps 13px; row and item `scrollWidth === clientWidth`; no `View` text or action rendered.

