### PR TITLE
feat(landing): extend DeepSeek campaign banner through Aug 27

### DIFF
--- a/apps/landing-page/app/_lib/deepseek-v4-flash-campaign.ts
+++ b/apps/landing-page/app/_lib/deepseek-v4-flash-campaign.ts
@@ -1,4 +1,4 @@
 export const DEEPSEEK_V4_FLASH_CAMPAIGN = {
   startAt: '2026-08-06T00:00:00+08:00',
-  endAtExclusive: '2026-08-13T20:00:00+08:00',
+  endAtExclusive: '2026-08-27T20:00:00+08:00',
 } as const;

--- a/apps/landing-page/app/pages/index.astro
+++ b/apps/landing-page/app/pages/index.astro
@@ -123,15 +123,15 @@ const campaignPricingHref = localePath(locale, '/pricing/');
 const campaignCopy = locale.startsWith('zh')
   ? {
       badge: '活动倒计时',
-      title: '这次，别省着用。DeepSeek V4 Flash 无限用。',
-      detail: '8 月 6 日—8 月 13 日，一周免费用',
+      title: '这次，顶级智能放开用。',
+      detail: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用',
       linkLabel: '查看活动权益',
       closeLabel: '关闭活动横幅',
     }
   : {
       badge: 'Campaign countdown',
-      title: 'Stop rationing. Use DeepSeek V4 Flash without limits.',
-      detail: 'Aug 6—Aug 13 · FREE all week',
+      title: 'This time, top-tier intelligence is wide open.',
+      detail: 'DeepSeek V4 Pro and V4 Flash · two weeks free',
       linkLabel: 'View campaign benefits',
       closeLabel: 'Dismiss campaign banner',
     };

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -120,24 +120,24 @@ const renderCatalogLabel = (label: string) => fillTemplate(label, catalogLabelVa
 const deepSeekCampaign = locale.startsWith('zh')
   ? {
       badge: '无限使用',
-      headline: '这次，别省着用。DeepSeek V4 Flash 无限用。',
-      body: '8月6日—8月13日，一周免费用',
+      headline: '这次，顶级智能放开用。',
+      body: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用',
       windowLabel: '活动倒计时',
-      windowValue: '7天 00:00:00',
-      modelBenefit: 'DeepSeek V4 Flash 无限使用',
-      paidBenefitNote: '8月6日—8月13日 · 一周免费用',
-      teamBenefitNote: '8月6日—8月13日 · 一周免费用',
+      windowValue: '14天 00:00:00',
+      modelBenefit: 'DeepSeek V4 Pro 与 V4 Flash 两周免费',
+      paidBenefitNote: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用',
+      teamBenefitNote: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用',
       disclaimer: '套餐内的无限制模型额度与免费生成次数，仅可通过Open Design使用；无法在MCP/CLI/API及其他场景使用。解释权归官方所有。',
     }
   : {
       badge: 'Unlimited',
-      headline: 'Stop rationing. Use DeepSeek V4 Flash without limits.',
-      body: 'FREE all week, Aug 6—Aug 13',
+      headline: 'This time, top-tier intelligence is wide open.',
+      body: 'DeepSeek V4 Pro and V4 Flash · two weeks free',
       windowLabel: 'Campaign countdown',
-      windowValue: '7d 00:00:00',
-      modelBenefit: 'Unlimited DeepSeek V4 Flash',
-      paidBenefitNote: 'Aug 6—Aug 13 · FREE all week',
-      teamBenefitNote: 'Aug 6—Aug 13 · FREE all week',
+      windowValue: '14d 00:00:00',
+      modelBenefit: 'DeepSeek V4 Pro and V4 Flash free for two weeks',
+      paidBenefitNote: 'DeepSeek V4 Pro and V4 Flash · two weeks free',
+      teamBenefitNote: 'DeepSeek V4 Pro and V4 Flash · two weeks free',
       disclaimer: 'Unlimited model quota and free generations included in a plan are available only in open design, not through MCP, CLI, API, or other scenarios.',
     };
 

--- a/apps/landing-page/tests/home-campaign-banner.test.ts
+++ b/apps/landing-page/tests/home-campaign-banner.test.ts
@@ -6,6 +6,10 @@ const source = readFileSync(
   new URL('../app/pages/index.astro', import.meta.url),
   'utf8',
 );
+const campaign = readFileSync(
+  new URL('../app/_lib/deepseek-v4-flash-campaign.ts', import.meta.url),
+  'utf8',
+);
 
 test('home campaign banner keeps only the arrow visible while preserving an accessible link label', () => {
   assert.doesNotMatch(source, /限时抢购/);
@@ -44,14 +48,17 @@ test('home campaign banner has no URL preview backdoor left', () => {
   assert.doesNotMatch(source, /get\('campaign'\)/);
 });
 
-test('home campaign banner uses the fixed seven-day activity window', () => {
+test('home campaign banner uses the fixed two-week activity window', () => {
   assert.match(source, /DEEPSEEK_V4_FLASH_CAMPAIGN\.startAt/);
   assert.match(source, /DEEPSEEK_V4_FLASH_CAMPAIGN\.endAtExclusive/);
   assert.match(source, /now >= startAt && now < endAt/);
   assert.match(source, /data-home-campaign-banner[^>]*hidden/);
   assert.match(source, /home-campaign-banner-active/);
-  assert.match(source, /8 月 6 日—8 月 13 日，一周免费用/);
-  assert.match(source, /FREE all week/);
+  assert.match(source, /这次，顶级智能放开用。/);
+  assert.match(source, /DeepSeek V4 Pro 与 V4 Flash · 两周免费用/);
+  assert.match(source, /This time, top-tier intelligence is wide open\./);
+  assert.match(source, /DeepSeek V4 Pro and V4 Flash · two weeks free/);
+  assert.match(campaign, /endAtExclusive: '2026-08-27T20:00:00\+08:00'/);
   assert.doesNotMatch(source, /home-campaign-banner__disclaimer/);
   assert.doesNotMatch(source, /套餐内的<strong>无限制模型额度<\/strong>与<strong>免费生成次数<\/strong>/);
   assert.doesNotMatch(source, /2026-08-22T00:00:00\+08:00/);

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -87,18 +87,18 @@ describe("pricing contract", () => {
   it("renders the final DeepSeek campaign promise on personal and team pricing", async () => {
     const page = await readFile(PRICING_PAGE_PATH, "utf8");
 
-    assert.match(page, /DeepSeek V4 Flash 无限使用/);
+    assert.match(page, /DeepSeek V4 Pro 与 V4 Flash 两周免费/);
     assert.match(page, /badge: '无限使用'/);
     assert.match(page, /windowLabel: '活动倒计时'/);
-    assert.match(page, /windowValue: '7天 00:00:00'/);
+    assert.match(page, /windowValue: '14天 00:00:00'/);
     assert.match(page, /data-pricing-campaign-countdown/);
     assert.doesNotMatch(page, /距开始/);
-    assert.match(page, /FREE all week/);
-    assert.match(page, /body: '8月6日—8月13日，一周免费用'/);
-    assert.match(page, /body: 'FREE all week, Aug 6—Aug 13'/);
+    assert.match(page, /two weeks free/);
+    assert.match(page, /body: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用'/);
+    assert.match(page, /body: 'DeepSeek V4 Pro and V4 Flash · two weeks free'/);
     assert.doesNotMatch(page, /body: ['\"][^'\"]*20:00/);
-    assert.match(page, /paidBenefitNote: '8月6日—8月13日 · 一周免费用'/);
-    assert.match(page, /teamBenefitNote: '8月6日—8月13日 · 一周免费用'/);
+    assert.match(page, /paidBenefitNote: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用'/);
+    assert.match(page, /teamBenefitNote: 'DeepSeek V4 Pro 与 V4 Flash · 两周免费用'/);
     assert.match(page, /DEEPSEEK_V4_FLASH_CAMPAIGN\.startAt/);
     assert.match(page, /DEEPSEEK_V4_FLASH_CAMPAIGN\.endAtExclusive/);
     assert.match(page, /now >= campaignStartAt && now < campaignEndAt/);


### PR DESCRIPTION
## Why

Marketing asked to refresh the live DeepSeek campaign banner on the landing site: the current homepage/pricing strip still promises a one-week Flash-only window that ended 2026-08-13 20:00 Asia/Shanghai, so the banner would hide as soon as that exclusive end passed.

This PR updates the landing-page offer copy to the new two-week Pro + Flash message and extends the exclusive end to 2026-08-27 20:00 Asia/Shanghai so the banner stays visible through the new window.

Adjacent: #6849 is a broader in-product + landing campaign rewrite. This PR is the small landing-only copy/window change requested for the live banner.

## What users will see

- Homepage top banner: `这次，顶级智能放开用。` / `DeepSeek V4 Pro 与 V4 Flash · 两周免费用` (EN: `This time, top-tier intelligence is wide open.` / `DeepSeek V4 Pro and V4 Flash · two weeks free`)
- Countdown now runs until 2026-08-27 20:00 Asia/Shanghai
- Pricing page campaign strip uses the same headline, benefit line, and window

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Landing-page marketing banner and pricing campaign strip only. Product web campaign copy is unchanged.

## Screenshots

Copy/window-only change on the existing homepage banner and pricing campaign strip. No layout change.

## Bug fix verification

-

## Validation

- `node --import tsx --test tests/home-campaign-banner.test.ts tests/pricing-contract.test.ts` in `apps/landing-page` — 27 passed
