### PR TITLE
fix(web): cover composer with move dialog

### DIFF
--- a/apps/web/src/components/MoveToTeamConfirmDialog.tsx
+++ b/apps/web/src/components/MoveToTeamConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useId, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 import { useT } from '../i18n';
 
@@ -31,10 +32,9 @@ export function MoveToTeamConfirmDialog({
   const t = useT();
   const titleId = useId();
   const [dontRemind, setDontRemind] = useState(false);
-  return (
+  const dialog = (
     <Dialog
       className="modal-confirm"
-      backdropClassName="modal-backdrop--no-blur"
       role="alertdialog"
       onClose={onCancel}
       closeOnEscape
@@ -93,4 +93,6 @@ export function MoveToTeamConfirmDialog({
       </DialogFooter>
     </Dialog>
   );
+
+  return typeof document !== 'undefined' ? createPortal(dialog, document.body) : dialog;
 }

--- a/apps/web/tests/components/MoveToTeamConfirmDialog.test.tsx
+++ b/apps/web/tests/components/MoveToTeamConfirmDialog.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MoveToTeamConfirmDialog } from '../../src/components/MoveToTeamConfirmDialog';
+
+describe('MoveToTeamConfirmDialog', () => {
+  it('escapes the workspace stacking context so its backdrop also covers the global composer', () => {
+    render(
+      <div data-testid="workspace-stacking-context">
+        <MoveToTeamConfirmDialog
+          action="to-team"
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </div>,
+    );
+
+    const workspaceLayer = screen.getByTestId('workspace-stacking-context');
+    const dialog = screen.getByRole('alertdialog', { name: 'Move to team space' });
+    const backdrop = dialog.parentElement;
+
+    expect(workspaceLayer).not.toContainElement(dialog);
+    expect(backdrop?.parentElement).toBe(document.body);
+    expect(backdrop).not.toHaveClass('modal-backdrop--no-blur');
+  });
+});


### PR DESCRIPTION
## Why

The editor's “Move to team space” confirmation left the lower-left prompt composer bright and visually interactive while the rest of the editor was blurred. The composer is rendered in a body-level fixed portal, but the dialog was trapped inside the workspace stacking context and also opted out of the shared backdrop blur.

This fixes the editor modal hierarchy so the composer participates in the same background treatment as the canvas and surrounding chrome.

## What users will see

Opening the move-to-team confirmation from the editor now blurs and dims the entire editor, including the lower-left prompt composer. The confirmation dialog remains sharp and highlighted above the backdrop.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

After — the whole editor and composer share the blurred backdrop while the confirmation stays sharp:

<img width="1600" height="1000" alt="Editor move-to-team modal with the full editor and prompt composer blurred behind it" src="https://github.com/user-attachments/assets/9c2e3474-89c7-4ee7-9017-e950b060eb58" />

## Bug fix verification

- Test path: `apps/web/tests/components/MoveToTeamConfirmDialog.test.tsx`
- The regression spec went red on `main` (the dialog remained inside the workspace stacking context) and green on this branch.
- A focused Playwright visual check also verified that the dialog is body-level, its backdrop has blur, and hit-testing the composer center resolves to the modal backdrop.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/MoveToTeamConfirmDialog.test.tsx`
- Focused Playwright visual check: 1 passed
- Full `@open-design/web` suite: 6,476 passed; one unrelated concurrent `SettingsDialog.execution.test.tsx` retry-count assertion failed, then passed in an isolated rerun

No GitHub issue is linked; this was directly reported and reproduced in the editor.
