### PR TITLE
fix(web): show creator identity on recent projects

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -374,12 +374,12 @@ export function createVelaWorkspaceContextProvider(
           const body: unknown = await response.json();
           const mapped = mapVelaWorkspaceContext(body);
           if (mapped && (!localSelection || mapped.workspaceId === localSelection)) {
-            return withDisplayName(mapped, session);
+            return withUserIdentity(mapped, session);
           }
           if (localSelection) {
             // Server disagrees with the pinned scope → synthesize from the
             // membership directory instead of silently following the server.
-            return withDisplayName(await resolvePinnedWorkspace(session, localSelection), session);
+            return withUserIdentity(await resolvePinnedWorkspace(session, localSelection), session);
           }
           return null;
         }
@@ -390,7 +390,7 @@ export function createVelaWorkspaceContextProvider(
         if (localSelection) {
           // The pinned workspace could not be read from current — resolve it
           // from the directory (clears the pin only on a CONFIRMED removal).
-          return withDisplayName(await resolvePinnedWorkspace(session, localSelection), session);
+          return withUserIdentity(await resolvePinnedWorkspace(session, localSelection), session);
         }
         if (missingPrincipal) {
           // Fresh account: B has no current workspace and the client has no
@@ -398,7 +398,7 @@ export function createVelaWorkspaceContextProvider(
           const picked = await pickDefaultWorkspace(session);
           if (!picked) return null;
           await options.setLocalSelection?.(picked.workspaceId);
-          return withDisplayName(workspaceContextFromDirectoryItem(picked), session);
+          return withUserIdentity(workspaceContextFromDirectoryItem(picked), session);
         }
         return null;
       } catch {
@@ -419,7 +419,7 @@ export function createVelaWorkspaceContextProvider(
       if (response.ok) {
         const mapped = mapVelaWorkspaceContext(await response.json());
         if (mapped?.workspaceId === workspaceId) {
-          return withDisplayName(mapped, session);
+          return withUserIdentity(mapped, session);
         }
       } else if (response.status === 401) {
         return null;
@@ -437,7 +437,7 @@ export function createVelaWorkspaceContextProvider(
           && entry.lifecycleState !== 'deleted',
       );
       return item
-        ? withDisplayName(workspaceContextFromDirectoryItem(item), session)
+        ? withUserIdentity(workspaceContextFromDirectoryItem(item), session)
         : null;
     } catch {
       return null;
@@ -496,13 +496,17 @@ export function workspaceContextFromDirectoryItem(
   return context;
 }
 
-function withDisplayName(
+function withUserIdentity(
   context: WorkspaceCollabContext | null,
   session: { user: VelaUser | null },
 ): WorkspaceCollabContext | null {
   if (context && !context.displayName) {
     const displayName = velaUserDisplayName(session.user);
     if (displayName) context.displayName = displayName;
+  }
+  if (context && context.avatarUrl === undefined) {
+    const avatarUrl = str(session.user?.image);
+    if (avatarUrl) context.avatarUrl = avatarUrl;
   }
   return context;
 }

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -643,6 +643,27 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
 });
 
 describe('createVelaWorkspaceContextProvider', () => {
+  it('adds the signed-in user name and profile image to the workspace identity', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, B_TEAM_CONTEXT)) as unknown as typeof fetch;
+    const provider = createVelaWorkspaceContextProvider({
+      fetch: fetchImpl,
+      readSession: () => ({
+        ...SESSION,
+        user: {
+          id: 'auth-user-1',
+          email: 'elian@example.com',
+          name: 'Elian Zhang',
+          image: 'https://example.com/elian.png',
+        },
+      }),
+    });
+
+    await expect(provider.current({})).resolves.toMatchObject({
+      displayName: 'Elian Zhang',
+      avatarUrl: 'https://example.com/elian.png',
+    });
+  });
+
   it('fetches B with the vela session bearer token and maps the result', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(200, B_TEAM_CONTEXT)) as unknown as typeof fetch;
     const provider = createVelaWorkspaceContextProvider({

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -348,10 +348,8 @@ export function RecentProjectsStrip({
   const analyticsPage = space === 'drafts' ? 'drafts' : space === 'team' ? 'all_projects' : 'home';
   const rowRef = useRef<HTMLDivElement | null>(null);
   // Real creator resolution (replaces the demo's mock 李娜/张伟 roster): the
-  // member directory turns an ownerMemberId into a display name, and the
-  // workspace context tells us which member is "me" so the owner's own cards
-  // read "我创建" instead of their display name. Both hooks degrade to
-  // empty/null off-team, so every card safely falls back to "我创建".
+  // member directory turns an ownerMemberId into a display name, while the
+  // workspace context supplies the signed-in user's own name and profile image.
   const { resolve: resolveMember } = useTeamMembers();
   const {
     context: workspaceContext,
@@ -499,21 +497,29 @@ export function RecentProjectsStrip({
   // 全部项目 / 草稿 partition reads the very same predicate, so the badge and the
   // card's grid can no longer disagree.
   const isShared = isSharedProject ?? NOTHING_SHARED;
-  // The card's "{creator}创建" line. A project the team hub attributes to another
-  // member resolves through the directory to that member's display name; my own
-  // shares and every local (non-shared) project read "我创建". Falls back to a
-  // generic "团队成员" when a shared project's owner is not yet in the directory
-  // (off-team, or a member the daemon has not seen register), never an opaque id.
-  const resolveCreator = (projectId: string): { name: string; initial: string; ownedBySelf: boolean } => {
+  // The card's "{creator}创建" line. Self-owned projects use the account identity
+  // instead of the literal "我 / Me" (whose first letter previously produced the
+  // misleading M avatar). Other owners still resolve through the team directory.
+  const resolveCreator = (projectId: string): {
+    name: string;
+    initial: string;
+    avatarUrl: string | null;
+    ownedBySelf: boolean;
+  } => {
     const ownerMemberId = projectOwnerMemberIds?.get(projectId) ?? null;
     if (ownerMemberId === selfMemberId || (!ownerMemberId && !isShared(projectId))) {
-      const name = t('recentProjects.selfCreator');
+      const name = workspaceContext?.displayName?.trim() || t('recentProjects.selfCreator');
       const initial = Array.from(name.trim())[0]?.toUpperCase() ?? 'M';
-      return { name, initial, ownedBySelf: true };
+      return {
+        name,
+        initial,
+        avatarUrl: workspaceContext?.avatarUrl?.trim() || null,
+        ownedBySelf: true,
+      };
     }
     const name = resolveMember(ownerMemberId)?.displayName ?? t('recentProjects.teamMemberCreator');
     const initial = (Array.from(name.trim())[0] ?? 'T').toUpperCase();
-    return { name, initial, ownedBySelf: false };
+    return { name, initial, avatarUrl: null, ownedBySelf: false };
   };
   const visibleProjects = useMemo(
     () => sortedProjects
@@ -532,10 +538,14 @@ export function RecentProjectsStrip({
       kindFilter,
       ownerFilter,
       projectOwnerMemberIds,
+      resolveMember,
       resolvedLimit,
       selfMemberId,
       showOwnerFilter,
       sortedProjects,
+      t,
+      workspaceContext?.avatarUrl,
+      workspaceContext?.displayName,
     ],
   );
   const menuContainerRef = useRef<HTMLDivElement | null>(null);
@@ -1812,6 +1822,16 @@ export function RecentProjectsStrip({
                     <div className="recent-projects__card-time">
                       <span className="recent-projects__card-owner" aria-hidden>
                         {creator.initial}
+                        {creator.avatarUrl ? (
+                          <img
+                            key={creator.avatarUrl}
+                            src={creator.avatarUrl}
+                            alt=""
+                            onError={(event) => {
+                              event.currentTarget.style.display = 'none';
+                            }}
+                          />
+                        ) : null}
                       </span>
                       <span>{t('recentProjects.creatorLine', { name: creator.name })}</span>
                       <span className="recent-projects__card-sep" aria-hidden>·</span>

--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -1131,6 +1131,8 @@
   opacity: 1;
 }
 .recent-projects__card-owner {
+  position: relative;
+  overflow: hidden;
   width: 16px;
   height: 16px;
   border-radius: var(--radius-pill);
@@ -1144,7 +1146,15 @@
   flex: 0 0 16px;
 }
 
-.recent-projects__card-owner img { width: 100%; height: 100%; border-radius: 50%; object-fit: cover; display: block; }
+.recent-projects__card-owner img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
 
 /* First open of a team-shared card runs a full content pull before the
    project can open; the overlay makes that wait visible (previously the

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -94,6 +94,10 @@ vi.mock('../../src/providers/registry', () => ({
 
 afterEach(() => {
   cleanup();
+  Object.assign(recentWorkspaceState.context, {
+    displayName: undefined,
+    avatarUrl: undefined,
+  });
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.mocked(invalidateProjectFilesCache).mockClear();
@@ -268,6 +272,25 @@ describe('RecentProjectsStrip', () => {
         }),
       }),
     );
+  });
+
+  it('renders the signed-in creator name and profile image for a self-owned project', async () => {
+    Object.assign(recentWorkspaceState.context, {
+      displayName: 'Elian Zhang',
+      avatarUrl: 'https://example.com/elian.png',
+    });
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={[project({ id: 'project-owned', name: 'Owned project' })]}
+        onOpen={() => {}}
+      />,
+    );
+
+    await screen.findByText('Created by Elian Zhang');
+    expect(screen.queryByText('Created by Me')).toBeNull();
+    const avatar = container.querySelector<HTMLImageElement>('.recent-projects__card-owner img');
+    expect(avatar?.src).toBe('https://example.com/elian.png');
   });
 
   it('refreshes only the card named by team-project-content-ready', async () => {

--- a/packages/contracts/src/api/collab.ts
+++ b/packages/contracts/src/api/collab.ts
@@ -300,6 +300,8 @@ export interface WorkspaceCollabContext {
   workspaceName?: string;
   /** Display name for the presence overlay (optional; falls back to the id). */
   displayName?: string;
+  /** Signed-in user's profile image for identity surfaces such as project bylines. */
+  avatarUrl?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Why

While reviewing a team-shared project in Recent projects, the signed-in creator was rendered as the generic localized label “Me”. That label also generated a misleading “M” avatar instead of showing the account identity already stored by the local Vela session.

This fixes the user-facing attribution without adding a user-profile request: the daemon reuses the locally persisted Vela login name and avatar URL and includes them in the existing workspace-context projection.

## What users will see

Self-owned projects in Recent projects show the signed-in account name and profile image. If either value is unavailable, the existing localized “Me” label and initial fallback remain in place. The avatar image uses normal browser HTTP caching and a failed image load falls back to the initial.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The reported entry point is the creator byline directly below each Recent projects card. No new UI is introduced; this PR replaces the generic “Me”/“M” values there with the existing account identity.

## Bug fix verification

- Test paths: `apps/web/tests/components/RecentProjectsStrip.test.tsx` and `apps/daemon/tests/vela-workspace-context.test.ts`
- The web regression assertion fails against the old behavior (`Created by Me`) and passes with this branch (`Created by Elian Zhang` plus the profile image).
- The daemon test verifies that the existing workspace-context response is enriched from the local signed-in session rather than a new profile request.

## Validation

- `pnpm install --frozen-lockfile` (including workspace postinstall builds)
- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx --maxWorkers=2` (33 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/vela-workspace-context.test.ts` (40 passed)

Note: an accidental full-web invocation surfaced one unrelated existing `FileViewer` test failure before it was interrupted; the correctly filtered RecentProjectsStrip suite is green.
