### PR TITLE
fix(collab): bound workspace refresh storms

### DIFF
--- a/apps/daemon/src/collab/account-billing-summary-cache.ts
+++ b/apps/daemon/src/collab/account-billing-summary-cache.ts
@@ -1,0 +1,57 @@
+import type { WorkspaceBillingSummary } from '@open-design/contracts';
+import { createPartitionedRefreshCache } from '../services/partitioned-refresh-cache.js';
+
+export interface AccountBillingSummaryCacheOptions {
+  identity(): string;
+  fetch(): Promise<WorkspaceBillingSummary | null>;
+  ttlMs?: number;
+  negativeTtlMs?: number;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+export interface AccountBillingSummaryCache {
+  read(): Promise<WorkspaceBillingSummary | null>;
+  invalidate(token?: string): void;
+  clear(): void;
+}
+
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_NEGATIVE_TTL_MS = 15_000;
+const DEFAULT_MAX_ENTRIES = 8;
+
+/**
+ * Process-local account billing cache, partitioned by the current credential
+ * revision. Concurrent readers share one command. If an SSE invalidation lands
+ * during that command, readers wait for at most one sequential trailing fetch
+ * instead of starting another process in parallel.
+ */
+export function createAccountBillingSummaryCache(
+  options: AccountBillingSummaryCacheOptions,
+): AccountBillingSummaryCache {
+  const now = options.now ?? Date.now;
+  const ttlMs = Math.max(0, options.ttlMs ?? DEFAULT_TTL_MS);
+  const negativeTtlMs = Math.max(
+    0,
+    options.negativeTtlMs ?? DEFAULT_NEGATIVE_TTL_MS,
+  );
+  const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const cache = createPartitionedRefreshCache<WorkspaceBillingSummary | null>({
+    fetch: () => options.fetch(),
+    ttlMs: (value) => value ? ttlMs : negativeTtlMs,
+    maxEntries,
+    now,
+  });
+
+  return {
+    read: () => cache.read(options.identity(), {
+      revalidateOnInvalidation: true,
+    }),
+    invalidate(tokenInput): void {
+      cache.invalidate(options.identity(), tokenInput);
+    },
+    clear(): void {
+      cache.clear();
+    },
+  };
+}

--- a/apps/daemon/src/collab/event-refresh-coordinator.ts
+++ b/apps/daemon/src/collab/event-refresh-coordinator.ts
@@ -1,0 +1,193 @@
+export interface EventRefreshScheduler {
+  now(): number;
+  setTimeout(
+    callback: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+}
+
+export interface EventRefreshCoordinatorOptions {
+  /**
+   * Leading refreshes still start immediately. A later refresh for the same
+   * resource starts no sooner than this floor, and only the latest queued task
+   * survives. This bounds an event storm without delaying the first signal or
+   * losing the final authoritative re-read.
+   */
+  minIntervalMs?: number;
+  maxKeys?: number;
+  scheduler?: EventRefreshScheduler;
+  onError?: (error: unknown, key: string) => void;
+}
+
+export interface EventRefreshCoordinator {
+  request(key: string, task: () => void | Promise<void>, token?: string): void;
+  dispose(): void;
+}
+
+interface RefreshLane {
+  activeToken: string | null;
+  lastCompletedToken: string | null;
+  pendingToken: string | null;
+  pendingTask: (() => void | Promise<void>) | null;
+  running: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+  lastStartedAt: number;
+  touchedAt: number;
+}
+
+const DEFAULT_MIN_INTERVAL_MS = 250;
+const DEFAULT_MAX_KEYS = 256;
+
+/**
+ * Bound background work caused by thin invalidation events.
+ *
+ * The first event for a resource runs immediately. While that work is running
+ * (or inside the short start-rate floor), newer events replace one pending
+ * trailing task. Duplicate revision/sequence tokens are ignored. This is safe
+ * for snapshot refreshes: intermediate transitions need not each trigger a GET,
+ * but the final state must always be observed.
+ */
+export function createEventRefreshCoordinator(
+  options: EventRefreshCoordinatorOptions = {},
+): EventRefreshCoordinator {
+  const scheduler = options.scheduler ?? defaultScheduler();
+  const minIntervalMs = Math.max(
+    0,
+    options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS,
+  );
+  const maxKeys = Math.max(1, options.maxKeys ?? DEFAULT_MAX_KEYS);
+  const lanes = new Map<string, RefreshLane>();
+  let disposed = false;
+
+  const touch = (key: string, lane: RefreshLane): void => {
+    lane.touchedAt = scheduler.now();
+    lanes.delete(key);
+    lanes.set(key, lane);
+  };
+
+  const trim = (targetSize: number): void => {
+    if (lanes.size <= targetSize) return;
+    for (const [key, lane] of lanes) {
+      if (lane.running || lane.timer || lane.pendingTask) continue;
+      lanes.delete(key);
+      if (lanes.size <= targetSize) return;
+    }
+  };
+
+  const laneFor = (key: string): RefreshLane => {
+    const existing = lanes.get(key);
+    if (existing) {
+      touch(key, existing);
+      return existing;
+    }
+    trim(maxKeys - 1);
+    const lane: RefreshLane = {
+      activeToken: null,
+      lastCompletedToken: null,
+      pendingToken: null,
+      pendingTask: null,
+      running: false,
+      timer: null,
+      lastStartedAt: Number.NEGATIVE_INFINITY,
+      touchedAt: scheduler.now(),
+    };
+    lanes.set(key, lane);
+    return lane;
+  };
+
+  const pump = (key: string, lane: RefreshLane): void => {
+    if (disposed || lane.running || lane.timer || !lane.pendingTask) return;
+    const elapsed = scheduler.now() - lane.lastStartedAt;
+    const delay = Math.max(0, minIntervalMs - elapsed);
+    if (delay > 0) {
+      lane.timer = scheduler.setTimeout(() => {
+        lane.timer = null;
+        pump(key, lane);
+      }, delay);
+      lane.timer.unref?.();
+      return;
+    }
+
+    const task = lane.pendingTask;
+    const token = lane.pendingToken;
+    lane.pendingTask = null;
+    lane.pendingToken = null;
+    lane.activeToken = token;
+    lane.running = true;
+    lane.lastStartedAt = scheduler.now();
+    touch(key, lane);
+
+    let result: void | Promise<void>;
+    try {
+      // Start the leading task in the caller's turn. Several invalidation
+      // handlers deliberately clear an authority lease before any sibling
+      // reconnect/read may run; deferring through Promise.resolve().then(...)
+      // would briefly expose the pre-event lease.
+      result = task();
+    } catch (error) {
+      result = Promise.reject(error);
+    }
+    let succeeded = false;
+    void Promise.resolve(result)
+      .then(() => {
+        succeeded = true;
+      })
+      .catch((error: unknown) => options.onError?.(error, key))
+      .finally(() => {
+        lane.running = false;
+        lane.activeToken = null;
+        if (disposed) return;
+        if (succeeded && token) lane.lastCompletedToken = token;
+        touch(key, lane);
+        pump(key, lane);
+        trim(maxKeys);
+      });
+  };
+
+  return {
+    request(keyInput, task, tokenInput): void {
+      if (disposed) return;
+      const key = keyInput.trim();
+      if (!key) return;
+      const token = tokenInput?.trim() || null;
+      const lane = laneFor(key);
+      if (
+        token &&
+        (
+          token === lane.activeToken ||
+          token === lane.lastCompletedToken ||
+          token === lane.pendingToken
+        )
+      ) {
+        return;
+      }
+      // Refreshes are latest-state reads. Replacing the queued task preserves
+      // the final snapshot while bounding intermediate work to one trailing run.
+      lane.pendingTask = task;
+      lane.pendingToken = token;
+      touch(key, lane);
+      pump(key, lane);
+    },
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      for (const lane of lanes.values()) {
+        if (lane.timer) scheduler.clearTimeout(lane.timer);
+        lane.timer = null;
+        lane.pendingTask = null;
+        lane.pendingToken = null;
+        lane.lastCompletedToken = null;
+      }
+      lanes.clear();
+    },
+  };
+}
+
+function defaultScheduler(): EventRefreshScheduler {
+  return {
+    now: () => Date.now(),
+    setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+    clearTimeout: (timer) => clearTimeout(timer),
+  };
+}

--- a/apps/daemon/src/collab/hub-events-subscriber.ts
+++ b/apps/daemon/src/collab/hub-events-subscriber.ts
@@ -276,6 +276,8 @@ export interface HubEventsSubscriberOptions {
   heartbeatTimeoutMs?: number;
   backoffMinMs?: number;
   backoffMaxMs?: number;
+  /** Injectable jitter source for deterministic reconnect tests. */
+  random?: () => number;
 }
 
 export interface HubEventsSubscriber {
@@ -290,6 +292,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
   const heartbeatTimeoutMs = options.heartbeatTimeoutMs ?? 45_000;
   const backoffMinMs = options.backoffMinMs ?? 1_000;
   const backoffMaxMs = options.backoffMaxMs ?? 30_000;
+  const random = options.random ?? Math.random;
 
   let stopped = false;
   let isConnected = false;
@@ -319,6 +322,13 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
         resolve();
       };
     });
+  const jitteredBackoff = (ms: number): number =>
+    Math.max(
+      1,
+      Math.floor(
+        ms * (1 + Math.min(0.999_999, Math.max(0, random())) * 0.5),
+      ),
+    );
 
   async function consumeStream(
     endpoint: HubEventsEndpoint,
@@ -592,7 +602,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
         if (generation !== endpointGeneration) continue;
         if (!endpoint) {
           // Signed out / no team workspace — idle at max backoff, keep probing.
-          await sleep(backoffMaxMs);
+          await sleep(jitteredBackoff(backoffMaxMs));
           continue;
         }
         const outcome = await consumeStream(endpoint);
@@ -615,7 +625,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
         backoffMs = backoffMinMs;
         continue;
       }
-      await sleep(backoffMs);
+      await sleep(jitteredBackoff(backoffMs));
       backoffMs = Math.min(backoffMs * 2, backoffMaxMs);
     }
   })();

--- a/apps/daemon/src/collab/hub-events-subscriber.ts
+++ b/apps/daemon/src/collab/hub-events-subscriber.ts
@@ -22,6 +22,13 @@ import type { WorkspaceBillingRevisionClock } from '@open-design/contracts';
 
 export type HubResourceStatus = 'shared' | 'retracted';
 export type HubWorkspaceMemberChange = 'added' | 'removed' | 'updated';
+export type HubWorkspaceDirectoryChange =
+  | 'created'
+  | 'updated'
+  | 'deleted'
+  | 'membership-added'
+  | 'membership-updated'
+  | 'membership-removed';
 export type HubListenerHealth = 'starting' | 'healthy' | 'reconnecting' | 'stopped';
 
 export interface HubListenerStatus {
@@ -43,6 +50,8 @@ const WORKSPACE_EVENT_LISTENER_STATUS_CAPABILITY =
   'workspace-event-listener-status-v1';
 export const AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY =
   'authoritative-project-presence-v1';
+export const WORKSPACE_DIRECTORY_EVENTS_CAPABILITY =
+  'workspace-directory-events-v1';
 const MAX_HANDLED_SOURCE_GAP_EPOCHS = 64;
 
 export interface HubWorkspaceEvent {
@@ -83,6 +92,14 @@ export interface HubWorkspaceEvent {
   at?: string;
 }
 
+/** Account-scoped dirty signal multiplexed onto any verified Workspace SSE. */
+export interface HubWorkspaceDirectoryEvent {
+  type: 'workspace-directory-changed';
+  workspaceId: string;
+  change: HubWorkspaceDirectoryChange;
+  at?: string;
+}
+
 const HUB_EVENT_TYPES = new Set<HubWorkspaceEvent['type']>([
   'team-projects-changed',
   'comment-changed',
@@ -102,6 +119,14 @@ const HUB_WORKSPACE_MEMBER_CHANGES = new Set<HubWorkspaceMemberChange>([
   'added',
   'removed',
   'updated',
+]);
+const HUB_WORKSPACE_DIRECTORY_CHANGES = new Set<HubWorkspaceDirectoryChange>([
+  'created',
+  'updated',
+  'deleted',
+  'membership-added',
+  'membership-updated',
+  'membership-removed',
 ]);
 
 export function parseHubWorkspaceEvent(data: string): HubWorkspaceEvent | null {
@@ -143,6 +168,31 @@ export function parseHubWorkspaceEvent(data: string): HubWorkspaceEvent | null {
   } catch {
     return null;
   }
+}
+
+export function parseHubWorkspaceDirectoryEvent(
+  data: string,
+): HubWorkspaceDirectoryEvent | null {
+  const parsed = parseJsonRecord(data);
+  const workspaceId =
+    typeof parsed?.workspaceId === 'string' ? parsed.workspaceId.trim() : '';
+  const change = parsed?.change;
+  if (
+    parsed?.type !== 'workspace-directory-changed'
+    || !workspaceId
+    || typeof change !== 'string'
+    || !HUB_WORKSPACE_DIRECTORY_CHANGES.has(
+      change as HubWorkspaceDirectoryChange,
+    )
+  ) {
+    return null;
+  }
+  return {
+    type: 'workspace-directory-changed',
+    workspaceId,
+    change: change as HubWorkspaceDirectoryChange,
+    ...(typeof parsed.at === 'string' ? { at: parsed.at } : {}),
+  };
 }
 
 export function parseHubReadyFrame(data: string): HubReadyFrame | null {
@@ -221,6 +271,8 @@ export interface HubEventsEndpoint {
   /** Expected workspace carried by the server's `ready` frame. Catch-up and
    *  events stay gated until the stream proves this exact scope. */
   workspaceId?: string;
+  /** Opaque local credential identity; never sent to or read from Vela. */
+  identityKey?: string;
 }
 
 export interface HubEventsSubscriberOptions {
@@ -230,20 +282,33 @@ export interface HubEventsSubscriberOptions {
    * max backoff; it keeps re-resolving so a later sign-in picks up.
    */
   resolveEndpoint: () => Promise<HubEventsEndpoint | null>;
-  onEvent: (event: HubWorkspaceEvent) => void;
+  onEvent: (
+    event: HubWorkspaceEvent,
+    connection: { identityKey?: string },
+  ) => void;
+  /** Account-directory dirty signal carried by any verified Workspace stream. */
+  onDirectoryEvent?: (
+    event: HubWorkspaceDirectoryEvent,
+    connection: { identityKey?: string },
+  ) => void;
   /** Terminal authorization signal emitted immediately before Vela closes a
    * revoked member's verified stream. */
   onAccessRevoked?: (revocation: {
     workspaceId?: string;
+    identityKey?: string;
     reason?: string;
   }) => void;
   /** Channel health transitions — drives poll-cadence switching. */
-  onStateChange?: (state: 'connected' | 'disconnected') => void;
+  onStateChange?: (
+    state: 'connected' | 'disconnected',
+    connection: { identityKey?: string },
+  ) => void;
   /** Strict authority health for adaptive polling. `healthy` is true only
    * after exact-scope verification, required roster/listener capabilities,
    * and a healthy gap-free producer status are all present. */
   onAuthorityHealthChange?: (health: {
     workspaceId?: string;
+    identityKey?: string;
     healthy: boolean;
     capabilities: readonly string[];
     listenerStatus: HubListenerStatus | null;
@@ -253,10 +318,15 @@ export interface HubEventsSubscriberOptions {
   onConnect?: (connection: {
     reconnect: boolean;
     workspaceId?: string;
+    identityKey?: string;
     capabilities: readonly string[];
   }) => void;
   /** One catch-up nudge per healthy producer-listener epoch that reports a gap. */
-  onSourceGap?: (gap: { workspaceId?: string; listenerEpoch: string }) => void;
+  onSourceGap?: (gap: {
+    workspaceId?: string;
+    identityKey?: string;
+    listenerEpoch: string;
+  }) => void;
   /** Secret-free parser/scope diagnostics. Raw payloads are never exposed. */
   onDrop?: (drop: {
     reason: 'invalid-ready' | 'workspace-mismatch' | 'unverified-scope' | 'invalid-payload';
@@ -269,7 +339,7 @@ export interface HubEventsSubscriberOptions {
    * events may have been missed. The caller should run one catch-up cycle
    * (its pollers' `pollOnce`).
    */
-  onReconnect?: () => void;
+  onReconnect?: (connection: { identityKey?: string }) => void;
   onError?: (error: unknown) => void;
   fetchImpl?: typeof fetch;
   /** Abort the stream when no frame (event OR heartbeat) arrives for this long. */
@@ -303,10 +373,12 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
   let endpointGeneration = 0;
   const handledSourceGapEpochs = new Set<string>();
 
-  const setConnected = (next: boolean) => {
+  const setConnected = (next: boolean, identityKey?: string) => {
     if (isConnected === next) return;
     isConnected = next;
-    options.onStateChange?.(next ? 'connected' : 'disconnected');
+    options.onStateChange?.(next ? 'connected' : 'disconnected', {
+      ...(identityKey ? { identityKey } : {}),
+    });
   };
 
   const sleep = (ms: number) =>
@@ -359,6 +431,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
       try {
         options.onAuthorityHealthChange?.({
           ...(verifiedWorkspaceId ? { workspaceId: verifiedWorkspaceId } : {}),
+          ...(endpoint.identityKey ? { identityKey: endpoint.identityKey } : {}),
           healthy,
           capabilities: [...verifiedCapabilities],
           listenerStatus: status,
@@ -415,6 +488,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
         if (!suppressCallback) {
           options.onSourceGap?.({
             ...(verifiedWorkspaceId ? { workspaceId: verifiedWorkspaceId } : {}),
+            ...(endpoint.identityKey ? { identityKey: endpoint.identityKey } : {}),
             listenerEpoch: status.listenerEpoch,
           });
         }
@@ -431,9 +505,16 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
           options.onConnect?.({
             reconnect,
             ...(workspaceId ? { workspaceId } : {}),
+            ...(endpoint.identityKey ? { identityKey: endpoint.identityKey } : {}),
             capabilities: [...capabilities],
           });
-          if (reconnect) options.onReconnect?.();
+          if (reconnect) {
+            options.onReconnect?.({
+              ...(endpoint.identityKey
+                ? { identityKey: endpoint.identityKey }
+                : {}),
+            });
+          }
         } catch (error) {
           options.onError?.(error);
         }
@@ -488,7 +569,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
             // failures. Terminal revocation below deliberately overrides this
             // with the maximum retry delay.
             backoffMs = backoffMinMs;
-            setConnected(true);
+            setConnected(true, endpoint.identityKey);
             revisionClocksEnabled = ready.capabilities.includes(
               BILLING_REVISION_CLOCKS_CAPABILITY,
             );
@@ -535,15 +616,49 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
                 ...(verifiedWorkspaceId
                   ? { workspaceId: verifiedWorkspaceId }
                   : {}),
+                ...(endpoint.identityKey
+                  ? { identityKey: endpoint.identityKey }
+                  : {}),
                 ...(reason ? { reason } : {}),
               });
             } catch (error) {
               options.onError?.(error);
             }
             publishAuthorityHealth(lastListenerStatus, true);
-            setConnected(false);
+            setConnected(false, endpoint.identityKey);
             abortController?.abort();
             return 'revoked';
+          }
+          if (eventName === 'workspace-directory-changed') {
+            if (!scopeVerified) {
+              options.onDrop?.({
+                reason: 'unverified-scope',
+                eventName,
+                ...(endpoint.workspaceId
+                  ? { expectedWorkspaceId: endpoint.workspaceId }
+                  : {}),
+              });
+              continue;
+            }
+            if (
+              !verifiedCapabilities.includes(
+                WORKSPACE_DIRECTORY_EVENTS_CAPABILITY,
+              )
+            ) {
+              options.onDrop?.({ reason: 'invalid-payload', eventName });
+              continue;
+            }
+            const directoryEvent = parseHubWorkspaceDirectoryEvent(data);
+            if (!directoryEvent) {
+              options.onDrop?.({ reason: 'invalid-payload', eventName });
+              continue;
+            }
+            // Its workspace may be brand new and therefore intentionally does
+            // NOT have to match the stream that carried the account signal.
+            options.onDirectoryEvent?.(directoryEvent, {
+              ...(endpoint.identityKey ? { identityKey: endpoint.identityKey } : {}),
+            });
+            continue;
           }
           if (eventName !== 'workspace-event') continue;
           if (!scopeVerified) {
@@ -576,9 +691,17 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
           }
           if (!revisionClocksEnabled && event.revisionClock) {
             const { revisionClock: _, ...legacyEvent } = event;
-            options.onEvent(legacyEvent);
+            options.onEvent(legacyEvent, {
+              ...(endpoint.identityKey
+                ? { identityKey: endpoint.identityKey }
+                : {}),
+            });
           } else {
-            options.onEvent(event);
+            options.onEvent(event, {
+              ...(endpoint.identityKey
+                ? { identityKey: endpoint.identityKey }
+                : {}),
+            });
           }
         }
       }
@@ -587,7 +710,7 @@ export function startHubEventsSubscriber(options: HubEventsSubscriberOptions): H
       if (watchdog) clearTimeout(watchdog);
       abortController = null;
       if (scopeVerified) publishAuthorityHealth(lastListenerStatus, true);
-      setConnected(false);
+      setConnected(false, endpoint.identityKey);
     }
   }
 

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -43,6 +43,13 @@ const DEFAULT_TIMEOUT_MS = 8_000;
 // Mutations never consume this lease: `fresh()` below always performs (or joins)
 // an unsettled authoritative read.
 const DEFAULT_DIRECTORY_CACHE_TTL_MS = 15_000;
+// A failed authority read must not turn every visible fallback surface into a
+// fresh upstream attempt. The first failure opens a short, jittered process-
+// local circuit; repeated failed probes grow to a two-minute base plus bounded
+// positive jitter. Successful reads and authoritative invalidations reset the
+// circuit immediately.
+const DEFAULT_DIRECTORY_FAILURE_BACKOFF_MIN_MS = 15_000;
+const DEFAULT_DIRECTORY_FAILURE_BACKOFF_MAX_MS = 120_000;
 // After a failed legacy default-workspace bootstrap, avoid repeating the
 // directory read on every compatibility request.
 const BOOTSTRAP_FAILURE_COOLDOWN_MS = 60_000;
@@ -557,38 +564,55 @@ export function velaWorkspaceDirectoryIdentity(
  * One daemon-owned authority broker shared by idempotent reads and mutations.
  *
  * Successful authority reads seed a bounded display-read lease. General
- * mutations ignore that settled lease and always perform a fresh directory
- * read, while still sharing an already-unsettled request from the same Vela
- * session. The cached-only accessor never starts I/O; its one production
- * consumer may use a valid same-session lease for personal local-only project
- * cleanup, then falls back to fresh authority on every miss. This keeps the 5s
- * status poll off the control plane without weakening Team/hub mutation
- * freshness, and prevents a status/heartbeat boundary from launching duplicate
- * directory requests.
+ * mutations ignore that settled success lease and perform a fresh directory
+ * read, while still sharing an already-unsettled request and a short outage
+ * circuit from the same Vela session. The cached-only accessor never starts
+ * I/O; its one production consumer may use a valid same-session lease for
+ * personal local-only project cleanup, then falls back to fresh authority on
+ * every miss. This keeps the 5s status poll off the control plane without
+ * weakening Team/hub mutation freshness, and prevents a status/heartbeat
+ * boundary from launching duplicate directory requests.
  */
 export function createWorkspaceDirectoryAuthorityBroker(options: {
   fetchDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   identityKey?: () => string;
   ttlMs?: number;
+  failureBackoffMinMs?: number;
+  failureBackoffMaxMs?: number;
   now?: () => number;
+  random?: () => number;
   onDecision?: (input: {
     source: 'cache' | 'directory';
-    reason: 'cold' | 'lease_hit' | 'lease_expired' | 'in_flight' | 'fresh';
+    reason:
+      | 'cold'
+      | 'lease_hit'
+      | 'lease_expired'
+      | 'in_flight'
+      | 'failure_backoff'
+      | 'fresh';
     outcome: 'allow' | 'deny' | 'unavailable' | 'fallback';
     ageMs?: number;
   }) => void;
   onSuppressedRequest?: (input: {
     source: 'directory';
-    reason: 'lease_hit' | 'in_flight';
+    reason: 'lease_hit' | 'in_flight' | 'failure_backoff';
   }) => void;
   onInvalidation?: (input: {
     source: 'cache';
     reason: 'mutation' | 'event_dirty' | 'auth_reject' | 'catch_up';
   }) => void;
+  /** Called only when a successful result belongs to the current generation. */
+  onAcceptedResult?: (
+    result: WorkspaceDirectoryFetchResult,
+    identity: string,
+  ) => void;
 } = {}): {
   cached: () => Promise<WorkspaceDirectoryFetchResult>;
   read: () => Promise<WorkspaceDirectoryFetchResult>;
+  /** User-initiated authority probe: ignores a settled outage circuit. */
   fresh: () => Promise<WorkspaceDirectoryFetchResult>;
+  /** Background fresh read: shares the account-wide outage circuit. */
+  backgroundFresh: () => Promise<WorkspaceDirectoryFetchResult>;
   invalidate: (reason?: 'event_dirty' | 'auth_reject' | 'catch_up') => void;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
 } {
@@ -596,7 +620,16 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     options.fetchDirectory ?? (() => fetchVelaWorkspaceDirectory());
   const identityKey = options.identityKey ?? velaWorkspaceDirectoryIdentity;
   const ttlMs = Math.max(0, options.ttlMs ?? DEFAULT_DIRECTORY_CACHE_TTL_MS);
+  const failureBackoffMinMs = Math.max(
+    1,
+    options.failureBackoffMinMs ?? DEFAULT_DIRECTORY_FAILURE_BACKOFF_MIN_MS,
+  );
+  const failureBackoffMaxMs = Math.max(
+    failureBackoffMinMs,
+    options.failureBackoffMaxMs ?? DEFAULT_DIRECTORY_FAILURE_BACKOFF_MAX_MS,
+  );
   const now = options.now ?? Date.now;
+  const random = options.random ?? Math.random;
   const cached = new Map<
     string,
     {
@@ -613,6 +646,14 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     }
   >();
   const generations = new Map<string, number>();
+  const failures = new Map<
+    string,
+    {
+      result: WorkspaceDirectoryFetchResult;
+      retryAt: number;
+      nextDelayMs: number;
+    }
+  >();
 
   const generationFor = (identity: string): number =>
     generations.get(identity) ?? 0;
@@ -620,6 +661,56 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   const invalidateIdentity = (identity: string): void => {
     generations.set(identity, generationFor(identity) + 1);
     cached.delete(identity);
+    failures.delete(identity);
+  };
+
+  const failureBackoffHit = (
+    identity: string,
+  ): WorkspaceDirectoryFetchResult | null => {
+    const failure = failures.get(identity);
+    if (!failure) return null;
+    if (now() >= failure.retryAt) return null;
+    recordDecision({
+      source: 'cache',
+      reason: 'failure_backoff',
+      outcome: 'unavailable',
+    });
+    options.onSuppressedRequest?.({
+      source: 'directory',
+      reason: 'failure_backoff',
+    });
+    return failure.result;
+  };
+
+  const rememberFailure = (
+    identity: string,
+    result: WorkspaceDirectoryFetchResult,
+  ): void => {
+    // Authentication rejection has its own credential-revision state machine.
+    // Do not hide a newly refreshed credential behind the old identity's
+    // transport circuit if an integration returns the same fingerprint.
+    if (result.reason === 'unauthorized') {
+      failures.delete(identity);
+      return;
+    }
+    const prior = failures.get(identity);
+    const delayMs = prior?.nextDelayMs ?? failureBackoffMinMs;
+    // Positive jitter in [100%, 150%) spreads a fleet-wide outage without ever
+    // retrying faster than the configured base floor. `failureBackoffMaxMs`
+    // caps the exponential base; keeping jitter above that base is what avoids
+    // every daemon re-synchronizing once the streak reaches its ceiling.
+    const jitteredDelayMs = Math.max(
+      1,
+      Math.floor(
+        delayMs
+        * (1 + Math.min(0.999_999, Math.max(0, random())) * 0.5),
+      ),
+    );
+    failures.set(identity, {
+      result,
+      retryAt: now() + jitteredDelayMs,
+      nextDelayMs: Math.min(delayMs * 2, failureBackoffMaxMs),
+    });
   };
 
   const recordDecision = (
@@ -641,11 +732,15 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     const request = fetchDirectory()
       .then((result) => {
         if (result.ok && generationFor(identity) === generation) {
+          failures.delete(identity);
           cached.set(identity, {
             generation,
             expiresAt: now() + ttlMs,
             result,
           });
+          options.onAcceptedResult?.(result, identity);
+        } else if (!result.ok && generationFor(identity) === generation) {
+          rememberFailure(identity, result);
         }
         recordDecision({
           source: 'directory',
@@ -691,7 +786,6 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
         return Promise.resolve(cachedEntry.result);
       }
       const reason = cachedEntry ? 'lease_expired' : 'cold';
-      cached.delete(identity);
       recordDecision({ source: 'cache', reason, outcome: 'fallback' });
       return Promise.resolve({ ok: false, items: [] });
     },
@@ -713,11 +807,20 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
         options.onSuppressedRequest?.({ source: 'directory', reason: 'lease_hit' });
         return Promise.resolve(cachedEntry.result);
       }
+      const backoffResult = failureBackoffHit(identity);
+      if (backoffResult) return Promise.resolve(backoffResult);
       const reason = cachedEntry ? 'lease_expired' : 'cold';
       cached.delete(identity);
       return start(identity, reason);
     },
     fresh: () => start(identityKey(), 'fresh'),
+    backgroundFresh: () => {
+      const identity = identityKey();
+      const backoffResult = failureBackoffHit(identity);
+      return backoffResult
+        ? Promise.resolve(backoffResult)
+        : start(identity, 'fresh');
+    },
     invalidate: (reason = 'event_dirty') => {
       invalidateIdentity(identityKey());
       options.onInvalidation?.({ source: 'cache', reason });
@@ -727,6 +830,10 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
       // after the mutation commits. Drain it, then deliberately start another
       // fetch so the settled lease is based on post-mutation authority.
       const identity = identityKey();
+      // The mutation has already succeeded upstream, which is a stronger
+      // recovery signal than the old failed directory probe. Refresh its
+      // authority immediately instead of waiting behind the read circuit.
+      failures.delete(identity);
       const pending = inFlight.get(identity)?.request;
       if (pending) await pending.catch(() => undefined);
       invalidateIdentity(identity);
@@ -744,7 +851,10 @@ export function createCachedWorkspaceDirectoryFetcher(options: {
   fetchDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   identityKey?: () => string;
   ttlMs?: number;
+  failureBackoffMinMs?: number;
+  failureBackoffMaxMs?: number;
   now?: () => number;
+  random?: () => number;
 } = {}): () => Promise<WorkspaceDirectoryFetchResult> {
   return createWorkspaceDirectoryAuthorityBroker(options).read;
 }

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -18,8 +18,10 @@ import type {
 import {
   markVelaAuthorizationExpired,
   readVelaControlApiContext,
+  type VelaControlApiContext,
   type VelaUser,
 } from '../integrations/vela.js';
+import type { HubEventsEndpoint } from './hub-events-subscriber.js';
 import {
   createDevWorkspaceContextProvider,
   resolveWorkspaceSettingsUrl,
@@ -546,6 +548,18 @@ export function velaWorkspaceDirectoryIdentity(
   configuredEnv: Record<string, string> = {},
 ): string {
   const session = readSession(process.env, configuredEnv);
+  return velaWorkspaceDirectoryIdentityForSession(session);
+}
+
+/**
+ * Derive the cache/stream identity from an already captured control session.
+ * Callers that also build an authenticated request should use this form so the
+ * URL, credential, and identity can never be assembled from different env
+ * snapshots.
+ */
+export function velaWorkspaceDirectoryIdentityForSession(
+  session: VelaControlApiContext | null,
+): string {
   if (!session?.controlKey || !session.apiUrl) return 'signed-out';
   const credentialFingerprint = createHash('sha256')
     .update(session.controlKey)
@@ -558,6 +572,39 @@ export function velaWorkspaceDirectoryIdentity(
     session.configMtimeMs ?? '',
     credentialFingerprint,
   ].join(':');
+}
+
+/** Build one Vela hub endpoint from one captured control session. */
+function createVelaWorkspaceHubEventsEndpoint(
+  session: VelaControlApiContext | null,
+  workspaceIdInput: string,
+): HubEventsEndpoint | null {
+  const workspaceId = workspaceIdInput.trim();
+  if (!workspaceId || !session?.controlKey || !session.apiUrl) return null;
+  return {
+    url: new URL('/api/v1/collab/events', session.apiUrl).toString(),
+    workspaceId,
+    identityKey: velaWorkspaceDirectoryIdentityForSession(session),
+    headers: {
+      authorization: `Bearer ${session.controlKey}`,
+      'x-vela-workspace-id': workspaceId,
+    },
+  };
+}
+
+/**
+ * Resolve a single merged session, then derive every authenticated hub field
+ * from that immutable snapshot.
+ */
+export function resolveVelaWorkspaceHubEventsEndpoint(
+  workspaceId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): HubEventsEndpoint | null {
+  return createVelaWorkspaceHubEventsEndpoint(
+    readVelaControlApiContext(env, configuredEnv),
+    workspaceId,
+  );
 }
 
 /**
@@ -615,6 +662,8 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   backgroundFresh: () => Promise<WorkspaceDirectoryFetchResult>;
   /** Keep successful display reads alive while account-directory SSE is strict. */
   setRealtimeHealthy: (healthy: boolean) => void;
+  /** Retire every identity partition and fence all unsettled directory reads. */
+  resetIdentity: () => void;
   invalidate: (reason?: 'event_dirty' | 'auth_reject' | 'catch_up') => void;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
 } {
@@ -668,6 +717,17 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
     generations.set(identity, generationFor(identity) + 1);
     cached.delete(identity);
     if (!preserveFailure) failures.delete(identity);
+  };
+
+  const resetIdentity = (): void => {
+    const identities = new Set([
+      ...generations.keys(),
+      ...cached.keys(),
+      ...inFlight.keys(),
+      ...failures.keys(),
+    ]);
+    for (const identity of identities) invalidateIdentity(identity);
+    realtimeHealthyIdentity = null;
   };
 
   const failureBackoffHit = (
@@ -834,6 +894,7 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
       const identity = identityKey();
       realtimeHealthyIdentity = healthy ? identity : null;
     },
+    resetIdentity,
     invalidate: (reason = 'event_dirty') => {
       // A dirty event voids successful state, but a sustained event storm must
       // not punch through the account-wide outage circuit on every frame.

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -613,6 +613,8 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
   fresh: () => Promise<WorkspaceDirectoryFetchResult>;
   /** Background fresh read: shares the account-wide outage circuit. */
   backgroundFresh: () => Promise<WorkspaceDirectoryFetchResult>;
+  /** Keep successful display reads alive while account-directory SSE is strict. */
+  setRealtimeHealthy: (healthy: boolean) => void;
   invalidate: (reason?: 'event_dirty' | 'auth_reject' | 'catch_up') => void;
   refreshAfterMutation: () => Promise<WorkspaceDirectoryFetchResult>;
 } {
@@ -654,14 +656,18 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
       nextDelayMs: number;
     }
   >();
+  let realtimeHealthyIdentity: string | null = null;
 
   const generationFor = (identity: string): number =>
     generations.get(identity) ?? 0;
 
-  const invalidateIdentity = (identity: string): void => {
+  const invalidateIdentity = (
+    identity: string,
+    preserveFailure = false,
+  ): void => {
     generations.set(identity, generationFor(identity) + 1);
     cached.delete(identity);
-    failures.delete(identity);
+    if (!preserveFailure) failures.delete(identity);
   };
 
   const failureBackoffHit = (
@@ -795,7 +801,10 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
       if (
         cachedEntry
         && cachedEntry.generation === generationFor(identity)
-        && now() < cachedEntry.expiresAt
+        && (
+          now() < cachedEntry.expiresAt
+          || realtimeHealthyIdentity === identity
+        )
       ) {
         const ageMs = Math.max(0, ttlMs - (cachedEntry.expiresAt - now()));
         recordDecision({
@@ -821,8 +830,16 @@ export function createWorkspaceDirectoryAuthorityBroker(options: {
         ? Promise.resolve(backoffResult)
         : start(identity, 'fresh');
     },
+    setRealtimeHealthy: (healthy) => {
+      const identity = identityKey();
+      realtimeHealthyIdentity = healthy ? identity : null;
+    },
     invalidate: (reason = 'event_dirty') => {
-      invalidateIdentity(identityKey());
+      // A dirty event voids successful state, but a sustained event storm must
+      // not punch through the account-wide outage circuit on every frame.
+      // Explicit catch-up/auth boundaries and successful mutations remain
+      // stronger signals and still clear the circuit immediately.
+      invalidateIdentity(identityKey(), reason === 'event_dirty');
       options.onInvalidation?.({ source: 'cache', reason });
     },
     refreshAfterMutation: async () => {

--- a/apps/daemon/src/collab/workspace-exact-authority-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-authority-cache.ts
@@ -1,0 +1,125 @@
+import type { WorkspaceDirectoryItem } from '@open-design/contracts';
+
+export interface WorkspaceExactAuthorityCacheOptions {
+  identity(): string;
+  ttlMs?: number;
+  now?: () => number;
+}
+
+export interface WorkspaceExactAuthorityCache {
+  /** Observe one successful, complete account-directory snapshot. */
+  observe(
+    identity: string,
+    items: readonly WorkspaceDirectoryItem[],
+  ): void;
+  /** Read only while this exact workspace's strict realtime grant is healthy. */
+  cached(
+    workspaceId: string,
+    workspaceMemberId: string,
+  ): WorkspaceDirectoryItem | null;
+  setRealtimeHealthy(workspaceId: string, healthy: boolean): void;
+  invalidate(workspaceId?: string): void;
+}
+
+interface Entry {
+  item: WorkspaceDirectoryItem;
+  observedAt: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60_000;
+
+/**
+ * Directory-sourced authority for one exact Workspace/member pair.
+ *
+ * An upstream Workspace SSE stream is scoped, while `/api/v1/workspaces` is an
+ * account-wide directory. A healthy stream therefore grants reuse only for its
+ * own membership row; it can never make the entire directory immortal or hide
+ * a newly-added workspace. A successful full directory read seeds rows, and a
+ * separate strict-health grant decides which row may suppress another read.
+ */
+export function createWorkspaceExactAuthorityCache(
+  options: WorkspaceExactAuthorityCacheOptions,
+): WorkspaceExactAuthorityCache {
+  const now = options.now ?? Date.now;
+  const ttlMs = Math.max(1, options.ttlMs ?? DEFAULT_TTL_MS);
+  const entries = new Map<string, Entry>();
+  const healthyIdentities = new Map<string, string>();
+
+  const key = (identity: string, workspaceId: string) =>
+    `${identity}\0${workspaceId}`;
+
+  return {
+    observe(identity, items): void {
+      const seen = new Set<string>();
+      const observedAt = now();
+      for (const item of items) {
+        const workspaceId = item.workspaceId.trim();
+        if (!workspaceId) continue;
+        const entryKey = key(identity, workspaceId);
+        seen.add(entryKey);
+        entries.set(entryKey, { item: { ...item }, observedAt });
+      }
+      // The source was a complete successful directory snapshot. Absence is
+      // authoritative for this identity, so retire rows it no longer lists.
+      const prefix = `${identity}\0`;
+      for (const entryKey of entries.keys()) {
+        if (entryKey.startsWith(prefix) && !seen.has(entryKey)) {
+          entries.delete(entryKey);
+        }
+      }
+    },
+
+    cached(workspaceIdInput, workspaceMemberIdInput) {
+      const workspaceId = workspaceIdInput.trim();
+      const workspaceMemberId = workspaceMemberIdInput.trim();
+      const identity = options.identity();
+      if (
+        !workspaceId
+        || !workspaceMemberId
+      ) {
+        return null;
+      }
+      if (healthyIdentities.get(workspaceId) !== identity) {
+        // Credential identity changed underneath the health grant. Retire it
+        // so switching back cannot revive a snapshot without a new catch-up.
+        healthyIdentities.delete(workspaceId);
+        return null;
+      }
+      const entry = entries.get(key(identity, workspaceId));
+      if (!entry || now() - entry.observedAt >= ttlMs) return null;
+      const item = entry.item;
+      return item.workspaceMemberId === workspaceMemberId
+        && item.memberStatus === 'active'
+        && item.lifecycleState !== 'deleted'
+        ? { ...item }
+        : null;
+    },
+
+    setRealtimeHealthy(workspaceIdInput, healthy): void {
+      const workspaceId = workspaceIdInput.trim();
+      if (!workspaceId) return;
+      if (healthy) {
+        healthyIdentities.set(workspaceId, options.identity());
+        return;
+      }
+      healthyIdentities.delete(workspaceId);
+      const suffix = `\0${workspaceId}`;
+      for (const entryKey of entries.keys()) {
+        if (entryKey.endsWith(suffix)) entries.delete(entryKey);
+      }
+    },
+
+    invalidate(workspaceIdInput): void {
+      const workspaceId = workspaceIdInput?.trim() ?? '';
+      if (!workspaceId) {
+        entries.clear();
+        healthyIdentities.clear();
+        return;
+      }
+      const suffix = `\0${workspaceId}`;
+      for (const entryKey of entries.keys()) {
+        if (entryKey.endsWith(suffix)) entries.delete(entryKey);
+      }
+    },
+  };
+}

--- a/apps/daemon/src/collab/workspace-exact-authority-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-authority-cache.ts
@@ -18,6 +18,8 @@ export interface WorkspaceExactAuthorityCache {
     workspaceMemberId: string,
   ): WorkspaceDirectoryItem | null;
   setRealtimeHealthy(workspaceId: string, healthy: boolean): void;
+  /** Retire every row and health grant across a credential transition. */
+  resetIdentity(): void;
   invalidate(workspaceId?: string): void;
 }
 
@@ -47,6 +49,10 @@ export function createWorkspaceExactAuthorityCache(
 
   const key = (identity: string, workspaceId: string) =>
     `${identity}\0${workspaceId}`;
+  const resetIdentity = (): void => {
+    entries.clear();
+    healthyIdentities.clear();
+  };
 
   return {
     observe(identity, items): void {
@@ -109,11 +115,12 @@ export function createWorkspaceExactAuthorityCache(
       }
     },
 
+    resetIdentity,
+
     invalidate(workspaceIdInput): void {
       const workspaceId = workspaceIdInput?.trim() ?? '';
       if (!workspaceId) {
-        entries.clear();
-        healthyIdentities.clear();
+        resetIdentity();
         return;
       }
       const suffix = `\0${workspaceId}`;

--- a/apps/daemon/src/collab/workspace-exact-context-cache.ts
+++ b/apps/daemon/src/collab/workspace-exact-context-cache.ts
@@ -33,6 +33,8 @@ export interface WorkspaceExactContextCache {
   ): Promise<WorkspaceCollabContext | null>;
   cached(workspaceId: string): WorkspaceCollabContext | null;
   setRealtimeHealthy(workspaceId: string, healthy: boolean): void;
+  /** Retire every snapshot and health grant across a credential transition. */
+  resetIdentity(): void;
   invalidate(
     workspaceId?: string,
     reason?: 'event_dirty' | 'auth_reject' | 'catch_up',
@@ -64,6 +66,13 @@ export function createWorkspaceExactContextCache(
     const generation = (generations.get(key) ?? 0) + 1;
     generations.set(key, generation);
     return generation;
+  };
+  const resetIdentity = (): void => {
+    // Keep generation tombstones so an old identity's in-flight response can
+    // never reseed its partition after A -> B -> A returns to the same key.
+    for (const key of generations.keys()) advanceGeneration(key);
+    entries.clear();
+    healthyIdentities.clear();
   };
 
   const refresh = async (
@@ -172,6 +181,7 @@ export function createWorkspaceExactContextCache(
         entries.delete(key);
       }
     },
+    resetIdentity,
     invalidate(workspaceIdInput, reason = 'event_dirty'): void {
       const workspaceId = workspaceIdInput?.trim() ?? '';
       options.onInvalidation?.({ source: 'current', reason });

--- a/apps/daemon/src/collab/workspace-hub-subscriptions.ts
+++ b/apps/daemon/src/collab/workspace-hub-subscriptions.ts
@@ -15,6 +15,7 @@ export interface WorkspaceHubSubscriptionManagerOptions {
  */
 export class WorkspaceHubSubscriptionManager {
   private billingWorkspaceIds = new Set<string>();
+  private readonly eventWorkspaceReferences = new Map<string, number>();
   private readonly subscribers = new Map<string, HubEventsSubscriber>();
   private disposed = false;
   private readonly maxSubscribers: number;
@@ -39,16 +40,58 @@ export class WorkspaceHubSubscriptionManager {
     return [...this.subscribers.keys()].sort();
   }
 
+  /**
+   * Keep an upstream carrier for a locally connected Workspace EventSource.
+   * The returned release is idempotent because Express may emit both `finish`
+   * and `close` for one response.
+   */
+  retainEventInterest(workspaceIdInput: string): () => void {
+    this.assertUsable();
+    const workspaceId = workspaceIdInput.trim();
+    if (!workspaceId) return () => undefined;
+    this.eventWorkspaceReferences.set(
+      workspaceId,
+      (this.eventWorkspaceReferences.get(workspaceId) ?? 0) + 1,
+    );
+    this.reconcile();
+    let released = false;
+    return () => {
+      if (released || this.disposed) return;
+      released = true;
+      const remaining = (this.eventWorkspaceReferences.get(workspaceId) ?? 1) - 1;
+      if (remaining > 0) {
+        this.eventWorkspaceReferences.set(workspaceId, remaining);
+      } else {
+        this.eventWorkspaceReferences.delete(workspaceId);
+      }
+      this.reconcile();
+    };
+  }
+
+  /** Re-resolve every live stream after the signed-in credential changes. */
+  refreshEndpoints(): void {
+    this.assertUsable();
+    for (const subscriber of this.subscribers.values()) {
+      subscriber.refreshEndpoint();
+    }
+  }
+
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
     for (const subscriber of this.subscribers.values()) subscriber.stop();
     this.subscribers.clear();
     this.billingWorkspaceIds.clear();
+    this.eventWorkspaceReferences.clear();
   }
 
   private reconcile(): void {
-    const ordered = [...this.billingWorkspaceIds];
+    // A visible browser stream gets first claim on the bounded upstream pool;
+    // billing-only interests then fill the remaining capacity.
+    const ordered = [
+      ...this.eventWorkspaceReferences.keys(),
+      ...this.billingWorkspaceIds,
+    ];
     const desired = new Set<string>();
     for (const workspaceId of ordered) {
       if (desired.size >= this.maxSubscribers) break;

--- a/apps/daemon/src/collab/workspace-projects-reconciler.ts
+++ b/apps/daemon/src/collab/workspace-projects-reconciler.ts
@@ -539,12 +539,12 @@ export async function reconcileWorkspaceProjectMetadataWithRemote(
 export function handleHubTeamProjectsChanged(
   emitTeamProjectsChangedDeduped: () => void,
   reconcileWorkspaceProjects: () => Promise<unknown>,
-): void {
+): Promise<void> {
   // The web treats this signal as permission to re-read the currently open
   // project's scope. Emit only after the authoritative catalog diff has been
   // persisted; an eager signal can race the revoke write, re-confirm the stale
   // Team binding, and then leave the open page with no durable follow-up.
-  void reconcileWorkspaceProjects()
+  return reconcileWorkspaceProjects()
     .then(() => emitTeamProjectsChangedDeduped())
     .catch(() => undefined);
 }
@@ -555,9 +555,9 @@ export function handleHubTeamProjectsChanged(
 export function handleHubProjectMetadataChanged(
   emitProjectMetadataChanged: () => void,
   reconcileProjectMetadata: () => Promise<boolean>,
-): void {
+): Promise<void> {
   emitProjectMetadataChanged();
-  void reconcileProjectMetadata()
+  return reconcileProjectMetadata()
     .then((changed) => {
       if (changed) emitProjectMetadataChanged();
     })

--- a/apps/daemon/src/metrics/workspace-authority.ts
+++ b/apps/daemon/src/metrics/workspace-authority.ts
@@ -14,6 +14,7 @@ export type WorkspaceAuthorityMetricReason =
   | 'lease_hit'
   | 'lease_expired'
   | 'in_flight'
+  | 'failure_backoff'
   | 'fresh'
   | 'mutation'
   | 'event_dirty'
@@ -104,7 +105,7 @@ export function recordWorkspaceAuthorityDecision(input: {
 export function recordWorkspaceAuthoritySuppressedRequest(input: {
   mode: WorkspaceAuthorityCacheMode;
   source: WorkspaceAuthorityMetricSource;
-  reason: 'lease_hit' | 'in_flight' | 'safety_floor';
+  reason: 'lease_hit' | 'in_flight' | 'failure_backoff' | 'safety_floor';
 }): void {
   try {
     workspaceAuthoritySuppressedRequestsTotal.inc(input);

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -96,8 +96,8 @@ export function emitWorkspaceEventToScope(
 
 export interface RegisterCollabContextRoutesDeps {
   workspaceContext: WorkspaceContextProvider;
-  /** Optional settled verifier for the pure context GET. Mutations and SSE
-   * subscriptions retain their fresh directory verification below. */
+  /** Optional settled verifier for exact-scoped display GETs. Mutations and
+   * SSE subscriptions retain their fresh directory verification below. */
   verifyWorkspaceReadAuthority?: (
     req: Request,
   ) => Promise<VerifiedWorkspaceRequestContextResult>;
@@ -602,16 +602,24 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
   // their exact-scope last-good catalog instead of treating the outage as an
   // authoritative removal of every project.
   app.get('/api/workspace/projects/team', async (req, res) => {
-    const verified = await verifyWorkspaceRequestContext({
-      req,
-      fetchWorkspaceDirectory,
-      requireTeam: true,
-    });
+    const verified = deps.verifyWorkspaceReadAuthority
+      ? await deps.verifyWorkspaceReadAuthority(req)
+      : await verifyWorkspaceRequestContext({
+          req,
+          fetchWorkspaceDirectory,
+          requireTeam: true,
+        });
     if (!verified.ok) {
       return res.status(verified.status).json({
         error: verified.code,
         message: verified.message,
         ...(verified.retryable ? { retryable: true } : {}),
+      });
+    }
+    if (verified.context.workspaceType !== 'team') {
+      return res.status(403).json({
+        error: 'WORKSPACE_ACCESS_DENIED',
+        message: 'the requested workspace is not available to this member',
       });
     }
     let projects: TeamProject[];
@@ -636,12 +644,22 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
   // represented as an authoritative empty roster: clients retain last-good
   // display metadata until a successful response says members really left.
   app.get('/api/workspace/members', async (req, res) => {
-    const verified = await verifyWorkspaceRequestContext({
-      req,
-      fetchWorkspaceDirectory,
-      requireTeam: true,
-    });
+    const verified = deps.verifyWorkspaceReadAuthority
+      ? await deps.verifyWorkspaceReadAuthority(req)
+      : await verifyWorkspaceRequestContext({
+          req,
+          fetchWorkspaceDirectory,
+          requireTeam: true,
+        });
     if (!verified.ok) return sendWorkspaceVerificationFailure(res, verified);
+    if (verified.context.workspaceType !== 'team') {
+      return sendWorkspaceVerificationFailure(res, {
+        ok: false,
+        status: 403,
+        code: 'WORKSPACE_ACCESS_DENIED',
+        message: 'the requested workspace is not available to this member',
+      });
+    }
     try {
       const members = await listMembers(verified.context);
       const body: CollabCloudMembersResponse = { members };

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -94,6 +94,34 @@ export function emitWorkspaceEventToScope(
   return true;
 }
 
+/**
+ * Deliver an account-level dirty signal through every already-authorized local
+ * Workspace stream. The payload deliberately contains no Workspace id/content,
+ * so this broad local nudge reveals no cross-workspace data; each browser then
+ * re-reads the account directory through the daemon's current credential.
+ */
+export function emitWorkspaceEventToAllScopes(
+  sinksByWorkspace: WorkspaceEventSinksByWorkspace,
+  payload: Extract<
+    WorkspaceInvalidationSsePayload,
+    { type: 'workspace-directory-changed' }
+  >,
+): boolean {
+  let emitted = false;
+  for (const [workspaceId, sinks] of Array.from(sinksByWorkspace)) {
+    for (const sink of Array.from(sinks)) {
+      try {
+        sink(payload);
+        emitted = true;
+      } catch {
+        sinks.delete(sink);
+      }
+    }
+    if (sinks.size === 0) sinksByWorkspace.delete(workspaceId);
+  }
+  return emitted;
+}
+
 export interface RegisterCollabContextRoutesDeps {
   workspaceContext: WorkspaceContextProvider;
   /** Optional settled verifier for exact-scoped display GETs. Mutations and
@@ -186,6 +214,8 @@ export interface RegisterCollabContextRoutesDeps {
     send: (event: string, data: unknown, id?: string | number | null) => boolean;
   };
   workspaceEventSinks?: WorkspaceEventSinksByWorkspace;
+  /** Keep one upstream Vela carrier while this local Workspace SSE is open. */
+  retainWorkspaceEventInterest?: (workspaceId: string) => () => void;
   /** Best-effort PostHog group update; never affects the route response. */
   observeWorkspace?: (
     req: Request,
@@ -468,6 +498,8 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
         workspaceEventSinks.set(workspaceId, workspaceSinks);
       }
       workspaceSinks.add(sink);
+      const releaseWorkspaceEventInterest =
+        deps.retainWorkspaceEventInterest?.(workspaceId) ?? (() => undefined);
       // Handshake so the client treats the stream as live and resets its
       // reconnect backoff immediately (mirrors the project stream's `ready`).
       sse.send('ready', { at: Date.now() });
@@ -476,6 +508,7 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
         if (workspaceSinks?.size === 0) {
           workspaceEventSinks.delete(workspaceId);
         }
+        releaseWorkspaceEventInterest();
       };
       res.on('close', cleanup);
       res.on('finish', cleanup);

--- a/apps/daemon/src/routes/collab-presence.ts
+++ b/apps/daemon/src/routes/collab-presence.ts
@@ -53,8 +53,14 @@ export interface RegisterCollabPresenceRoutesDeps {
     | null
   >;
   /**
+   * Leave must bypass any background authority outage lease so closing a tab
+   * still gets one chance to release its remote presence lease. Heartbeats use
+   * `verifyWorkspaceRequest`; leave falls back to it when this seam is absent.
+   */
+  verifyWorkspaceLeaveRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceRequest'];
+  /**
    * Bounded successful authority lease for the idempotent GET surface.
-   * Heartbeat and leave deliberately keep using `verifyWorkspaceRequest`.
+   * Heartbeat deliberately keeps using `verifyWorkspaceRequest`.
    */
   verifyWorkspaceReadRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceRequest'];
   /** Test/operations seam for the short-lived cloud list cache. */
@@ -737,12 +743,14 @@ export function registerCollabPresenceRoutes(
   async function verifiedContext(
     req: Request,
     projectId: string,
-    mode: 'read' | 'write',
+    mode: 'read' | 'heartbeat' | 'leave',
   ): Promise<PresenceWorkspaceVerification> {
-    const verify =
-      mode === 'read'
-        ? deps.verifyWorkspaceReadRequest ?? deps.verifyWorkspaceRequest
-        : deps.verifyWorkspaceRequest;
+    let verify = deps.verifyWorkspaceRequest;
+    if (mode === 'read') {
+      verify = deps.verifyWorkspaceReadRequest ?? verify;
+    } else if (mode === 'leave') {
+      verify = deps.verifyWorkspaceLeaveRequest ?? verify;
+    }
     if (!verify) {
       return { ok: true, context: null };
     }
@@ -819,7 +827,7 @@ export function registerCollabPresenceRoutes(
   app.post('/api/projects/:id/presence/heartbeat', async (req, res) => {
     const heartbeat = readHeartbeat(req.body);
     if (!heartbeat) return res.status(400).json({ error: 'memberId required' });
-    const verification = await verifiedContext(req, req.params.id, 'write');
+    const verification = await verifiedContext(req, req.params.id, 'heartbeat');
     if (cloud && !verification.ok) {
       return sendWorkspaceVerificationFailure(res, verification);
     }
@@ -920,14 +928,14 @@ export function registerCollabPresenceRoutes(
   app.post('/api/projects/:id/presence/leave', async (req, res) => {
     const leave = readLeave(req.body);
     if (!leave) return res.status(400).json({ error: 'memberId required' });
-    const verification = await verifiedContext(req, req.params.id, 'write');
+    const verification = await verifiedContext(req, req.params.id, 'leave');
     if (cloud && !verification.ok) {
       return sendWorkspaceVerificationFailure(res, verification);
     }
     const context = verification.ok ? verification.context : null;
     if (
       cloud
-      && deps.verifyWorkspaceRequest
+      && (deps.verifyWorkspaceLeaveRequest ?? deps.verifyWorkspaceRequest)
       && (!verification.ok || !context || leave.memberId !== context.workspaceMemberId)
     ) {
       return res.status(403).json({ error: 'WORKSPACE_PROJECT_PRESENCE_DENIED' });

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -146,6 +146,8 @@ export interface RegisterVelaRoutesDeps {
     getPublicBaseUrl?: PublicBaseUrlResolver;
   };
   env?: NodeJS.ProcessEnv;
+  /** Reconcile account-scoped caches/streams after credential observation. */
+  onCredentialStateObserved?: () => void;
 }
 
 interface AmrModelProbe {
@@ -403,6 +405,8 @@ function proxyVelaMessageCenterRequest(
 
 export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): void {
   const env = deps.env ?? process.env;
+  const onCredentialStateObserved =
+    deps.onCredentialStateObserved ?? (() => undefined);
   const { RUNTIME_DATA_DIR } = deps.paths;
   const { readAppConfig } = deps.appConfig;
   const getPublicBaseUrl = deps.http.getPublicBaseUrl ?? ((req: Request) => {
@@ -514,6 +518,7 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
     try {
       const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
       const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      onCredentialStateObserved();
       const amrDef = getAgentDef('amr');
       const amrLaunch = amrDef ? resolveAgentLaunch(amrDef, configuredEnv) : null;
       if (!(amrLaunch?.launchPath ?? amrLaunch?.selectedPath)) {
@@ -833,6 +838,7 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
         delete agentCliEnv.amr;
       }
       await writeAppConfig(RUNTIME_DATA_DIR, { agentCliEnv });
+      onCredentialStateObserved();
       res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ error: String(err) });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -749,6 +749,7 @@ import {
   type TeamMirrorPullScope,
 } from './routes/collab-sync.js';
 import {
+  emitWorkspaceEventToAllScopes,
   emitWorkspaceEventToScope,
   registerCollabContextRoutes,
 } from './routes/collab-context.js';
@@ -794,6 +795,7 @@ import {
 import {
   AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY,
   startHubEventsSubscriber,
+  WORKSPACE_DIRECTORY_EVENTS_CAPABILITY,
 } from './collab/hub-events-subscriber.js';
 import {
   createWorkspaceAuthorityHealthCoordinator,
@@ -1415,6 +1417,13 @@ function emitWorkspaceEvent(
     workspaceId,
     payload,
   );
+}
+
+function emitWorkspaceDirectoryChanged(): boolean {
+  return emitWorkspaceEventToAllScopes(workspaceEventSinks, {
+    type: 'workspace-directory-changed',
+    at: Date.now(),
+  });
 }
 
 function hubEventRefreshToken(event: {
@@ -3156,6 +3165,25 @@ export async function startServer({
     workspaceDirectoryAuthority.fresh;
   const fetchFreshBackgroundWorkspaceDirectory =
     workspaceDirectoryAuthority.backgroundFresh;
+  let workspaceHubSubscriptions: WorkspaceHubSubscriptionManager | null = null;
+  let workspaceHubAccountIdentity = velaWorkspaceDirectoryIdentity(
+    readVelaControlApiContext,
+    configuredAmrEnv(),
+  );
+  const refreshWorkspaceHubAccountIdentity = (): void => {
+    const currentIdentity = velaWorkspaceDirectoryIdentity(
+      readVelaControlApiContext,
+      configuredAmrEnv(),
+    );
+    if (currentIdentity === workspaceHubAccountIdentity) return;
+    workspaceHubAccountIdentity = currentIdentity;
+    workspaceDirectoryAuthority.setRealtimeHealthy(false);
+    workspaceHubSubscriptions?.refreshEndpoints();
+  };
+  const fetchWorkspaceDirectoryForAccountSurface = () => {
+    refreshWorkspaceHubAccountIdentity();
+    return fetchWorkspaceDirectory();
+  };
   const verifyExplicitWorkspaceRequestContext = async (input: {
     req: any;
     requireTeam?: boolean;
@@ -4246,7 +4274,9 @@ export async function startServer({
     // `createCollabPresenceCloudClient` for the invariant.
     cloud: createCollabPresenceCloudClient(velaCliCollabClient, presenceScopeFor),
     verifyWorkspaceRequest: (req, projectId) =>
-      verifyPresenceWorkspaceRequest(req, projectId, { backgroundFresh: true }),
+      verifyPresenceWorkspaceRequest(req, projectId, { fresh: false }),
+    verifyWorkspaceLeaveRequest: (req, projectId) =>
+      verifyPresenceWorkspaceRequest(req, projectId, { fresh: true }),
     verifyWorkspaceReadRequest: (req, projectId) =>
       verifyPresenceWorkspaceRequest(req, projectId, { fresh: false }),
     isProjectShared: async (projectId, context) => {
@@ -4906,7 +4936,6 @@ export async function startServer({
     if (!teamMembersCache) return [];
     return context ? teamMembersCache(context) : [];
   };
-  let workspaceHubSubscriptions: WorkspaceHubSubscriptionManager | null = null;
   const accountBillingSummary = createAccountBillingSummaryCache({
     identity: () => velaWorkspaceDirectoryIdentity(
       readVelaControlApiContext,
@@ -5002,7 +5031,7 @@ export async function startServer({
     // Same directory read the route would have made on its own, wrapped so every
     // workspace type it carries is memoized for the team-share invariant.
     listWorkspaceDirectory,
-    fetchWorkspaceDirectory,
+    fetchWorkspaceDirectory: fetchWorkspaceDirectoryForAccountSurface,
     refreshWorkspaceDirectoryAfterMutation:
       workspaceDirectoryAuthority.refreshAfterMutation,
     // Reuse the shared team-projects lister (which holds the shared vela-cli
@@ -5018,6 +5047,9 @@ export async function startServer({
     // registers/deregisters its sink here; the poller below feeds them.
     createSseResponse,
     workspaceEventSinks,
+    retainWorkspaceEventInterest: (workspaceId) =>
+      workspaceHubSubscriptions?.retainEventInterest(workspaceId)
+      ?? (() => undefined),
     observeWorkspace: async (req, context, properties) => {
       const service = workspaceAnalyticsService;
       const analyticsContext = readAnalyticsContext(req);
@@ -5149,6 +5181,51 @@ export async function startServer({
       console.warn(`[od] hub event refresh failed key=${key}:`, String(error));
     },
   });
+  const workspaceDirectoryRefreshes = createEventRefreshCoordinator({
+    // Directory events are account-wide and can be duplicated over several
+    // Workspace streams. Preserve an immediate leading refresh plus the final
+    // state while bounding a sustained storm to one upstream read per second.
+    minIntervalMs: 1_000,
+    onError: (error) => {
+      console.warn('[od] workspace directory event refresh failed:', String(error));
+    },
+  });
+  const directoryConnectionIdentities = new Map<string, string>();
+  const directoryHealthyConnections = new Set<string>();
+  const directoryConnectionKey = (
+    workspaceId: string,
+    identityKey: string,
+  ) => `${identityKey}\0${workspaceId}`;
+  const currentWorkspaceDirectoryIdentity = () =>
+    velaWorkspaceDirectoryIdentity(
+      readVelaControlApiContext,
+      configuredAmrEnv(),
+    );
+  const syncWorkspaceDirectoryRealtimeHealth = (): void => {
+    const currentIdentity = currentWorkspaceDirectoryIdentity();
+    workspaceDirectoryAuthority.setRealtimeHealthy(
+      [...directoryHealthyConnections].some((key) =>
+        key.startsWith(`${currentIdentity}\0`)),
+    );
+  };
+  const requestWorkspaceDirectoryRefresh = (
+    reason: 'event_dirty' | 'auth_reject' | 'catch_up',
+    token?: string,
+    expectedIdentity = currentWorkspaceDirectoryIdentity(),
+  ): void => {
+    workspaceDirectoryRefreshes.request(
+      'workspace-directory',
+      async () => {
+        if (currentWorkspaceDirectoryIdentity() !== expectedIdentity) return;
+        workspaceDirectoryAuthority.invalidate(reason);
+        const directory = await fetchFreshBackgroundWorkspaceDirectory();
+        if (currentWorkspaceDirectoryIdentity() !== expectedIdentity) return;
+        if (!directory.ok) return;
+        emitWorkspaceDirectoryChanged();
+      },
+      token,
+    );
+  };
   const restoreDirtyCommentProject = (projectId: string) => {
     dirtyCommentProjects.add(projectId);
     // The upstream hub event has already proved that this project changed.
@@ -5188,24 +5265,71 @@ export async function startServer({
       return {
         url: new URL('/api/v1/collab/events', session.apiUrl).toString(),
         workspaceId: subscribedWorkspaceId,
+        identityKey: currentWorkspaceDirectoryIdentity(),
         headers: {
           authorization: `Bearer ${session.controlKey}`,
           'x-vela-workspace-id': subscribedWorkspaceId,
         },
       };
     },
-    onStateChange: (state) => {
+    onStateChange: (state, connection) => {
       if (state === 'disconnected') {
         authoritativePresenceWorkspaces.delete(subscribedWorkspaceId);
+        const identityKey =
+          connection.identityKey
+          ?? directoryConnectionIdentities.get(subscribedWorkspaceId);
+        if (
+          !identityKey
+          || directoryConnectionIdentities.get(subscribedWorkspaceId)
+            === identityKey
+        ) {
+          directoryConnectionIdentities.delete(subscribedWorkspaceId);
+        }
+        if (identityKey) {
+          directoryHealthyConnections.delete(
+            directoryConnectionKey(subscribedWorkspaceId, identityKey),
+          );
+        }
+        syncWorkspaceDirectoryRealtimeHealth();
       }
       console.info(`[od] hub events channel ${state}`);
     },
     onAuthorityHealthChange: ({
       workspaceId,
+      identityKey,
       healthy,
       capabilities,
       listenerStatus,
     }) => {
+      if (
+        identityKey
+        && identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
+      const exactWorkspaceId = workspaceId ?? subscribedWorkspaceId;
+      const exactIdentityKey =
+        identityKey
+        ?? directoryConnectionIdentities.get(exactWorkspaceId)
+        ?? currentWorkspaceDirectoryIdentity();
+      if (capabilities.includes(WORKSPACE_DIRECTORY_EVENTS_CAPABILITY)) {
+        directoryConnectionIdentities.set(exactWorkspaceId, exactIdentityKey);
+      } else {
+        directoryConnectionIdentities.delete(exactWorkspaceId);
+      }
+      const connectionKey = directoryConnectionKey(
+        exactWorkspaceId,
+        exactIdentityKey,
+      );
+      if (
+        healthy
+        && capabilities.includes(WORKSPACE_DIRECTORY_EVENTS_CAPABILITY)
+      ) {
+        directoryHealthyConnections.add(connectionKey);
+      } else {
+        directoryHealthyConnections.delete(connectionKey);
+      }
+      syncWorkspaceDirectoryRealtimeHealth();
       recordWorkspaceAuthorityRealtimeTransition({
         mode: workspaceAuthorityCacheMode,
         healthy,
@@ -5216,16 +5340,43 @@ export async function startServer({
         sourceGap: listenerStatus?.sourceGap === true,
       });
       void workspaceAuthorityHealth.update({
-        workspaceId: workspaceId ?? subscribedWorkspaceId,
+        workspaceId: exactWorkspaceId,
         healthy,
       });
     },
-    onConnect: ({ reconnect, workspaceId, capabilities }) => {
+    onConnect: ({ reconnect, workspaceId, identityKey, capabilities }) => {
+      if (
+        identityKey
+        && identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
       const verifiedWorkspaceId = workspaceId ?? subscribedWorkspaceId;
+      const verifiedIdentityKey =
+        identityKey ?? currentWorkspaceDirectoryIdentity();
       if (capabilities.includes(AUTHORITATIVE_PROJECT_PRESENCE_CAPABILITY)) {
         authoritativePresenceWorkspaces.add(verifiedWorkspaceId);
       } else {
         authoritativePresenceWorkspaces.delete(verifiedWorkspaceId);
+      }
+      if (capabilities.includes(WORKSPACE_DIRECTORY_EVENTS_CAPABILITY)) {
+        const hadDirectoryCarrier = [
+          ...directoryConnectionIdentities.values(),
+        ].includes(verifiedIdentityKey);
+        directoryConnectionIdentities.set(
+          verifiedWorkspaceId,
+          verifiedIdentityKey,
+        );
+        // One account signal is fanned to every capable stream. Only the first
+        // live carrier needs a snapshot boundary; additional Workspace streams
+        // would produce the same GET and are intentionally free.
+        if (!hadDirectoryCarrier) {
+          requestWorkspaceDirectoryRefresh(
+            'catch_up',
+            undefined,
+            verifiedIdentityKey,
+          );
+        }
       }
       console.info(
         `[od] hub events workspace verified workspaceId=${workspaceId ?? 'unknown'} reconnect=${reconnect}`,
@@ -5248,7 +5399,13 @@ export async function startServer({
           `actualWorkspaceId=${actualWorkspaceId ?? 'unknown'}`,
       );
     },
-    onAccessRevoked: ({ workspaceId, reason }) => {
+    onAccessRevoked: ({ workspaceId, identityKey, reason }) => {
+      if (
+        identityKey
+        && identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
       const revocationReceivedAt = performance.now();
       const exactWorkspaceId = workspaceId ?? subscribedWorkspaceId;
       console.info(
@@ -5275,8 +5432,33 @@ export async function startServer({
         workspaceAuthorityCacheMode,
         performance.now() - revocationReceivedAt,
       );
+      requestWorkspaceDirectoryRefresh(
+        'auth_reject',
+        `revoked:${exactWorkspaceId}`,
+      );
     },
-    onEvent: (event) => {
+    onDirectoryEvent: (event, connection) => {
+      if (
+        connection.identityKey
+        && connection.identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
+      requestWorkspaceDirectoryRefresh(
+        'event_dirty',
+        event.at
+          ? [event.type, event.workspaceId, event.change, event.at].join(':')
+          : undefined,
+        connection.identityKey ?? currentWorkspaceDirectoryIdentity(),
+      );
+    },
+    onEvent: (event, connection) => {
+      if (
+        connection.identityKey
+        && connection.identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
       const eventWorkspaceId =
         event.workspaceId ?? subscribedWorkspaceId;
       console.info(
@@ -5594,7 +5776,13 @@ export async function startServer({
         }
       }
     },
-    onReconnect: () => {
+    onReconnect: (connection) => {
+      if (
+        connection.identityKey
+        && connection.identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
       // Close the disconnect gap: one catch-up cycle over the same reads the
       // pollers watch, plus a comment pull for open projects.
       void refreshWorkspaceDigestFaces(
@@ -5618,12 +5806,23 @@ export async function startServer({
       void reconcileTeamResourcesFromRemote(undefined, subscribedWorkspaceId, 'catch-up')
         .catch(() => undefined);
     },
-    onSourceGap: ({ workspaceId, listenerEpoch }) => {
+    onSourceGap: ({ workspaceId, identityKey, listenerEpoch }) => {
+      if (
+        identityKey
+        && identityKey !== currentWorkspaceDirectoryIdentity()
+      ) {
+        return;
+      }
       console.warn(
         `[od] hub source gap detected listenerEpoch=${listenerEpoch} ` +
           `workspaceId=${workspaceId ?? 'unknown'}`,
       );
       const exactWorkspaceId = workspaceId ?? subscribedWorkspaceId;
+      requestWorkspaceDirectoryRefresh(
+        'catch_up',
+        `source-gap:${listenerEpoch}`,
+        identityKey ?? currentWorkspaceDirectoryIdentity(),
+      );
       void refreshWorkspaceDigestFaces(exactWorkspaceId, { revalidate: true })
         .then(() => pollWorkspaceInvalidationForWorkspace(exactWorkspaceId))
         .catch(() => undefined);
@@ -8034,6 +8233,7 @@ export async function startServer({
     appConfig: { readAppConfig },
     http: { getPublicBaseUrl },
     env: process.env,
+    onCredentialStateObserved: refreshWorkspaceHubAccountIdentity,
   });
 
   const allowScopedPluginReplace = (
@@ -14620,6 +14820,7 @@ export async function startServer({
       clearInterval(teamResourcesPollTimer);
       workspaceHubSubscriptions?.dispose();
       hubEventRefreshes.dispose();
+      workspaceDirectoryRefreshes.dispose();
       workspaceBillingRuntime.dispose();
       proactiveContentPull.dispose();
       collabCloud?.dispose();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -783,6 +783,7 @@ import {
   createWorkspaceDirectoryAuthorityBroker,
   createWorkspaceContextProviderFromEnv,
   fetchVelaWorkspaceDirectory,
+  resolveVelaWorkspaceHubEventsEndpoint,
   velaWorkspaceDirectoryIdentity,
   workspaceContextFromDirectoryItem,
 } from './collab/vela-workspace-context.js';
@@ -3435,7 +3436,8 @@ export async function startServer({
     readVelaControlApiContext,
     configuredAmrEnv(),
   );
-  const resetWorkspaceExactIdentityCaches = (): void => {
+  const resetWorkspaceIdentityCaches = (): void => {
+    workspaceDirectoryAuthority.resetIdentity();
     workspaceExactAuthorityCache.resetIdentity();
     workspaceExactContextCache.resetIdentity();
   };
@@ -3446,8 +3448,7 @@ export async function startServer({
     );
     if (currentIdentity === workspaceHubAccountIdentity) return;
     workspaceHubAccountIdentity = currentIdentity;
-    resetWorkspaceExactIdentityCaches();
-    workspaceDirectoryAuthority.setRealtimeHealthy(false);
+    resetWorkspaceIdentityCaches();
     workspaceHubSubscriptions?.refreshEndpoints();
   };
   const fetchWorkspaceDirectoryForAccountSurface = () => {
@@ -3459,6 +3460,7 @@ export async function startServer({
     req: unknown,
     requestedWorkspaceId?: string,
   ): WorkspaceCollabContext | null => {
+    refreshWorkspaceHubAccountIdentity();
     const claimed = workspaceResourceContextFromRequest(req);
     if (!claimed || claimed === 'missing') return null;
     if (
@@ -3476,6 +3478,7 @@ export async function startServer({
       : null;
   };
   const verifyWorkspaceContextReadAuthority = async (req: unknown) => {
+    refreshWorkspaceHubAccountIdentity();
     const claimed = workspaceResourceContextFromRequest(req);
     if (claimed && claimed !== 'missing') {
       const cached = workspaceExactAuthorityCache.cached(
@@ -5265,17 +5268,11 @@ export async function startServer({
       // Same gating as the workspace-context provider: only the vela source
       // has a hub to subscribe to (dev daemons must not dial production).
       if (process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() !== 'vela') return null;
-      const session = readVelaControlApiContext(process.env);
-      if (!session?.controlKey || !session.apiUrl) return null;
-      return {
-        url: new URL('/api/v1/collab/events', session.apiUrl).toString(),
-        workspaceId: subscribedWorkspaceId,
-        identityKey: currentWorkspaceDirectoryIdentity(),
-        headers: {
-          authorization: `Bearer ${session.controlKey}`,
-          'x-vela-workspace-id': subscribedWorkspaceId,
-        },
-      };
+      return resolveVelaWorkspaceHubEventsEndpoint(
+        subscribedWorkspaceId,
+        process.env,
+        configuredAmrEnv(),
+      );
     },
     onStateChange: (state, connection) => {
       if (state === 'disconnected') {
@@ -7506,6 +7503,10 @@ export async function startServer({
     readAppConfig,
     writeAppConfig,
     onAppConfigWritten: () => {
+      // AMR credentials may be overridden through Settings. Observe every
+      // completed write so even an A -> B -> A transition with no intervening
+      // directory/status read fences exact authority from the old A session.
+      refreshWorkspaceHubAccountIdentity();
       void attributionService.processPending().catch((err: unknown) => {
         console.warn('[attribution] pending claim failed', err);
       });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3166,24 +3166,6 @@ export async function startServer({
   const fetchFreshBackgroundWorkspaceDirectory =
     workspaceDirectoryAuthority.backgroundFresh;
   let workspaceHubSubscriptions: WorkspaceHubSubscriptionManager | null = null;
-  let workspaceHubAccountIdentity = velaWorkspaceDirectoryIdentity(
-    readVelaControlApiContext,
-    configuredAmrEnv(),
-  );
-  const refreshWorkspaceHubAccountIdentity = (): void => {
-    const currentIdentity = velaWorkspaceDirectoryIdentity(
-      readVelaControlApiContext,
-      configuredAmrEnv(),
-    );
-    if (currentIdentity === workspaceHubAccountIdentity) return;
-    workspaceHubAccountIdentity = currentIdentity;
-    workspaceDirectoryAuthority.setRealtimeHealthy(false);
-    workspaceHubSubscriptions?.refreshEndpoints();
-  };
-  const fetchWorkspaceDirectoryForAccountSurface = () => {
-    refreshWorkspaceHubAccountIdentity();
-    return fetchWorkspaceDirectory();
-  };
   const verifyExplicitWorkspaceRequestContext = async (input: {
     req: any;
     requireTeam?: boolean;
@@ -3449,6 +3431,29 @@ export async function startServer({
       ...input,
     }),
   });
+  let workspaceHubAccountIdentity = velaWorkspaceDirectoryIdentity(
+    readVelaControlApiContext,
+    configuredAmrEnv(),
+  );
+  const resetWorkspaceExactIdentityCaches = (): void => {
+    workspaceExactAuthorityCache.resetIdentity();
+    workspaceExactContextCache.resetIdentity();
+  };
+  const refreshWorkspaceHubAccountIdentity = (): void => {
+    const currentIdentity = velaWorkspaceDirectoryIdentity(
+      readVelaControlApiContext,
+      configuredAmrEnv(),
+    );
+    if (currentIdentity === workspaceHubAccountIdentity) return;
+    workspaceHubAccountIdentity = currentIdentity;
+    resetWorkspaceExactIdentityCaches();
+    workspaceDirectoryAuthority.setRealtimeHealthy(false);
+    workspaceHubSubscriptions?.refreshEndpoints();
+  };
+  const fetchWorkspaceDirectoryForAccountSurface = () => {
+    refreshWorkspaceHubAccountIdentity();
+    return fetchWorkspaceDirectory();
+  };
   const workspaceContextProvider = workspaceExactContextCache.provider;
   const cachedWorkspaceContextForRequest = (
     req: unknown,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -850,9 +850,13 @@ import {
 } from './collab/remembered-team-resource-scopes.js';
 import { readVelaControlApiContext } from './integrations/vela.js';
 import {
+  fetchVelaBillingSummary,
   fetchVelaWorkspaceBillingProjection,
   isVelaWorkspaceAuthorizationError,
 } from './integrations/vela-billing.js';
+import { createAccountBillingSummaryCache } from './collab/account-billing-summary-cache.js';
+import { createEventRefreshCoordinator } from './collab/event-refresh-coordinator.js';
+import { createWorkspaceExactAuthorityCache } from './collab/workspace-exact-authority-cache.js';
 import { createCollabPublishWatcher } from './collab/collab-publish-watcher.js';
 import {
   isUnmaterializedSharedPlaceholder,
@@ -1413,6 +1417,56 @@ function emitWorkspaceEvent(
   );
 }
 
+function hubEventRefreshToken(event: {
+  type?: string;
+  revision?: string;
+  revisionClock?: { epoch: string; counter: string };
+  workspaceMemberId?: string;
+  memberId?: string;
+  projectId?: string;
+  resourceId?: string;
+  seq?: number;
+  version?: number;
+  at?: string;
+}): string | undefined {
+  const scope = [
+    event.type ?? '',
+    event.workspaceMemberId ?? '',
+    event.memberId ?? '',
+    event.projectId ?? '',
+    event.resourceId ?? '',
+  ].join(':');
+  if (event.revisionClock) {
+    return `${scope}:clock:${event.revisionClock.epoch}:${event.revisionClock.counter}`;
+  }
+  if (event.revision) return `${scope}:revision:${event.revision}`;
+  if (event.seq != null) return `${scope}:seq:${event.seq}`;
+  if (event.version != null) return `${scope}:version:${event.version}`;
+  if (event.at) return `${scope}:at:${event.at}`;
+  return undefined;
+}
+
+function accountBillingInvalidationToken(event: {
+  type: 'billing-changed' | 'billing-subscription-changed' | 'wallet-balance-changed';
+  revision?: string;
+  revisionClock?: { epoch: string; counter: string };
+  at?: string;
+}): string | undefined {
+  let revision: string | undefined;
+  if (event.revisionClock) {
+    revision = `clock:${event.revisionClock.epoch}:${event.revisionClock.counter}`;
+  } else if (event.revision) {
+    revision = `revision:${event.revision}`;
+  } else if (event.at) {
+    revision = `at:${event.at}`;
+  }
+  if (!revision) return undefined;
+  // Current Vela producers emit a subscription mutation under both names.
+  // Wallet clocks are independent and therefore need a separate domain.
+  const domain = event.type === 'wallet-balance-changed' ? 'wallet' : 'billing';
+  return `${domain}:${revision}`;
+}
+
 /**
  * Hub → daemon handling for the `workspace-context-changed` event (see
  * `startHubEventsSubscriber`'s `onEvent` below). Vela sends this same event
@@ -1429,7 +1483,7 @@ export function handleHubWorkspaceContextChanged(
   workspaceId: string,
   pollWorkspaceInvalidation: () => Promise<void>,
   invalidateWorkspaceDirectory: () => void = () => undefined,
-): void {
+): Promise<void> {
   // Retire the settled authority generation before either the web or the
   // daemon can start a refresh. A directory request that began before this
   // event is allowed to finish for its original caller, but the broker will
@@ -1439,7 +1493,7 @@ export function handleHubWorkspaceContextChanged(
     workspaceId,
     { type: 'workspace-context-changed', at: Date.now() },
   );
-  void pollWorkspaceInvalidation().catch(() => undefined);
+  return pollWorkspaceInvalidation().catch(() => undefined);
 }
 
 /** Terminal counterpart to workspace-context-changed. Vela has already
@@ -3064,6 +3118,12 @@ export async function startServer({
   const workspaceTypes = createWorkspaceTypeRegistry();
   const configuredAmrEnv = () =>
     agentCliEnvForAgent(readAppConfigSync(RUNTIME_DATA_DIR).agentCliEnv, 'amr');
+  const workspaceExactAuthorityCache = createWorkspaceExactAuthorityCache({
+    identity: () => velaWorkspaceDirectoryIdentity(
+      readVelaControlApiContext,
+      configuredAmrEnv(),
+    ),
+  });
   const workspaceDirectoryAuthority = createWorkspaceDirectoryAuthorityBroker({
     fetchDirectory: async () => {
       const result = await fetchVelaWorkspaceDirectory({
@@ -3088,21 +3148,28 @@ export async function startServer({
       mode: workspaceAuthorityCacheMode,
       ...input,
     }),
+    onAcceptedResult: (result, identity) =>
+      workspaceExactAuthorityCache.observe(identity, result.items),
   });
   const fetchWorkspaceDirectory = workspaceDirectoryAuthority.read;
   const fetchFreshMutationWorkspaceDirectory =
     workspaceDirectoryAuthority.fresh;
+  const fetchFreshBackgroundWorkspaceDirectory =
+    workspaceDirectoryAuthority.backgroundFresh;
   const verifyExplicitWorkspaceRequestContext = async (input: {
     req: any;
     requireTeam?: boolean;
-  }, options: { fresh?: boolean } = {}) => {
+  }, options: { fresh?: boolean; backgroundFresh?: boolean } = {}) => {
     if (process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela') {
+      let fetchDirectory = fetchFreshMutationWorkspaceDirectory;
+      if (options.fresh === false) {
+        fetchDirectory = fetchWorkspaceDirectory;
+      } else if (options.backgroundFresh) {
+        fetchDirectory = fetchFreshBackgroundWorkspaceDirectory;
+      }
       return verifyWorkspaceRequestContext({
         ...input,
-        fetchWorkspaceDirectory:
-          options.fresh === false
-            ? fetchWorkspaceDirectory
-            : fetchFreshMutationWorkspaceDirectory,
+        fetchWorkspaceDirectory: fetchDirectory,
       });
     }
     // Local/dev has no signed membership directory. Its explicit request
@@ -3180,15 +3247,17 @@ export async function startServer({
   };
   const resolveAuthoritativeTeamWorkspaceContext = async (
     workspaceId: string | null | undefined,
-    options: { fresh?: boolean } = {},
+    options: { fresh?: boolean; backgroundFresh?: boolean } = {},
   ): Promise<WorkspaceCollabContext | null> => {
     const requestedWorkspaceId = workspaceId?.trim() ?? '';
     if (!requestedWorkspaceId) return null;
-    const directory = await (
-      options.fresh
-        ? fetchFreshMutationWorkspaceDirectory()
-        : fetchWorkspaceDirectory()
-    ).catch(() => ({
+    let fetchDirectory = fetchWorkspaceDirectory;
+    if (options.fresh) {
+      fetchDirectory = options.backgroundFresh
+        ? fetchFreshBackgroundWorkspaceDirectory
+        : fetchFreshMutationWorkspaceDirectory;
+    }
+    const directory = await fetchDirectory().catch(() => ({
       ok: false as const,
       items: [],
     }));
@@ -3374,9 +3443,21 @@ export async function startServer({
       : null;
   };
   const verifyWorkspaceContextReadAuthority = async (req: unknown) => {
-    // `resolveExact` is enrichment, including when its strict-SSE lease is
-    // healthy. Only the membership directory can supply authority-bearing
-    // type, role, lifecycle, and permissions for the context response.
+    const claimed = workspaceResourceContextFromRequest(req);
+    if (claimed && claimed !== 'missing') {
+      const cached = workspaceExactAuthorityCache.cached(
+        claimed.workspaceId,
+        claimed.workspaceMemberId,
+      );
+      if (cached) {
+        return {
+          ok: true as const,
+          context: workspaceContextFromDirectoryItem(cached),
+        };
+      }
+    }
+    // The exact cache is directory-sourced and usable only under strict SSE
+    // health. Every miss preserves the legacy directory verification.
     return verifyWorkspaceReadAuthority(req);
   };
   /**
@@ -3594,7 +3675,10 @@ export async function startServer({
     if (!workspaceId) return null;
     const directory = await (
       options.fresh
-        ? fetchFreshMutationWorkspaceDirectory()
+        // `fresh` is requested only by the durable comment-outbox recovery
+        // service. It must bypass a settled success lease but share the daemon's
+        // account-wide outage circuit with other background recovery work.
+        ? fetchFreshBackgroundWorkspaceDirectory()
         : fetchWorkspaceDirectory()
     ).catch(() => ({
       ok: false as const,
@@ -3647,7 +3731,7 @@ export async function startServer({
         resolveCommentRelayWorkspaceContext: async (queuedIdentity) => {
           const context = await resolveAuthoritativeTeamWorkspaceContext(
             queuedIdentity.workspaceId,
-            { fresh: true },
+            { fresh: true, backgroundFresh: true },
           );
           const principal = contextToResourceHubPrincipal(context);
           if (
@@ -4134,7 +4218,7 @@ export async function startServer({
   const verifyPresenceWorkspaceRequest = async (
     req: any,
     projectId: string,
-    options: { fresh?: boolean } = {},
+    options: { fresh?: boolean; backgroundFresh?: boolean } = {},
   ) => {
     const verified = await verifyExplicitWorkspaceRequestContext(
       { req },
@@ -4162,7 +4246,7 @@ export async function startServer({
     // `createCollabPresenceCloudClient` for the invariant.
     cloud: createCollabPresenceCloudClient(velaCliCollabClient, presenceScopeFor),
     verifyWorkspaceRequest: (req, projectId) =>
-      verifyPresenceWorkspaceRequest(req, projectId),
+      verifyPresenceWorkspaceRequest(req, projectId, { backgroundFresh: true }),
     verifyWorkspaceReadRequest: (req, projectId) =>
       verifyPresenceWorkspaceRequest(req, projectId, { fresh: false }),
     isProjectShared: async (projectId, context) => {
@@ -4823,6 +4907,13 @@ export async function startServer({
     return context ? teamMembersCache(context) : [];
   };
   let workspaceHubSubscriptions: WorkspaceHubSubscriptionManager | null = null;
+  const accountBillingSummary = createAccountBillingSummaryCache({
+    identity: () => velaWorkspaceDirectoryIdentity(
+      readVelaControlApiContext,
+      configuredAmrEnv(),
+    ),
+    fetch: () => fetchVelaBillingSummary(),
+  });
   const workspaceBillingRuntime = createWorkspaceBillingRuntimeCoordinator({
     fetchProjection: async ({ workspaceId }) => {
       try {
@@ -4839,6 +4930,7 @@ export async function startServer({
     },
     onAccessRevoked: ({ workspaceId }) => {
       workspaceDirectoryAuthority.invalidate('auth_reject');
+      workspaceExactAuthorityCache.invalidate(workspaceId);
       workspaceExactContextCache.invalidate(workspaceId, 'auth_reject');
     },
     onStateChange: (state) => {
@@ -4905,6 +4997,7 @@ export async function startServer({
     // Warm only the directory-verified id announced by that request; the
     // daemon-global legacy pin is neither read nor updated.
     onWorkspaceSwitched: (workspaceId) => warmWorkspaceDigestFaces(workspaceId),
+    fetchBilling: accountBillingSummary.read,
     billingRuntime: workspaceBillingRuntime,
     // Same directory read the route would have made on its own, wrapped so every
     // workspace type it carries is memoized for the team-share invariant.
@@ -4998,7 +5091,18 @@ export async function startServer({
       // A healthy transport is not enough to suppress legacy polling. First
       // cross a fresh directory boundary and close the exact Workspace gap.
       workspaceDirectoryAuthority.invalidate('catch_up');
+      workspaceExactAuthorityCache.invalidate(workspaceId);
       workspaceExactContextCache.invalidate(workspaceId, 'catch_up');
+      const directory = await fetchFreshBackgroundWorkspaceDirectory();
+      const membership = directory.ok
+        ? directory.items.find((item) =>
+            item.workspaceId === workspaceId
+            && item.memberStatus === 'active'
+            && item.lifecycleState !== 'deleted')
+        : undefined;
+      if (!membership) {
+        throw new Error('exact workspace directory catch-up was unavailable');
+      }
       const exactContext = await workspaceExactContextCache.refresh(
         { workspaceId },
         'catch_up',
@@ -5008,7 +5112,6 @@ export async function startServer({
       }
       await refreshWorkspaceDigestFaces(workspaceId, {
         revalidate: true,
-        freshAuthority: true,
       });
       await pollWorkspaceInvalidationForWorkspace(workspaceId);
       workspaceBillingRuntime.reconnect(workspaceId);
@@ -5017,8 +5120,10 @@ export async function startServer({
       workspaceInvalidationPollerFor(workspaceId).setRealtimeHealthy(healthy),
     setBillingPollingHealthy: (workspaceId, healthy) =>
       workspaceBillingRuntime.setRealtimeHealthy(workspaceId, healthy),
-    setContextCachingHealthy: (workspaceId, healthy) =>
-      workspaceExactContextCache.setRealtimeHealthy(workspaceId, healthy),
+    setContextCachingHealthy: (workspaceId, healthy) => {
+      workspaceExactAuthorityCache.setRealtimeHealthy(workspaceId, healthy);
+      workspaceExactContextCache.setRealtimeHealthy(workspaceId, healthy);
+    },
     onDecision: (input) => recordWorkspaceAuthorityDecision({
       mode: workspaceAuthorityCacheMode,
       ...input,
@@ -5036,6 +5141,14 @@ export async function startServer({
   // interest; reconnect/source-gap handlers run one exact-scope poller cycle
   // to close the disconnect gap.
   const dirtyCommentProjects = new Set<string>();
+  // Thin events are invalidation hints, so repeated events for one resource
+  // may share refresh work. Authorization revocation and project content stay
+  // outside this coordinator: both have immediate, domain-specific handling.
+  const hubEventRefreshes = createEventRefreshCoordinator({
+    onError: (error, key) => {
+      console.warn(`[od] hub event refresh failed key=${key}:`, String(error));
+    },
+  });
   const restoreDirtyCommentProject = (projectId: string) => {
     dirtyCommentProjects.add(projectId);
     // The upstream hub event has already proved that this project changed.
@@ -5146,6 +5259,7 @@ export async function startServer({
         () => pollWorkspaceInvalidationForWorkspace(exactWorkspaceId),
         () => {
           workspaceDirectoryAuthority.invalidate('auth_reject');
+          workspaceExactAuthorityCache.invalidate(exactWorkspaceId);
           workspaceExactContextCache.invalidate(
             exactWorkspaceId,
             'auth_reject',
@@ -5175,17 +5289,21 @@ export async function startServer({
           // Catalog changed (share/unshare). Refresh the display cache and
           // signal the web, AND run a real `workspace_projects`
           // reconciliation pass — see `collab/workspace-projects-reconciler.ts`.
-          handleHubTeamProjectsChanged(
-            () => emitTeamProjectsChanged(
-              eventWorkspaceId,
-              {
-                ...(event.projectId ? { projectId: event.projectId } : {}),
-                kind: 'catalog',
-              },
+          hubEventRefreshes.request(
+            `team-projects:${eventWorkspaceId}`,
+            () => handleHubTeamProjectsChanged(
+              () => emitTeamProjectsChanged(
+                eventWorkspaceId,
+                {
+                  ...(event.projectId ? { projectId: event.projectId } : {}),
+                  kind: 'catalog',
+                },
+              ),
+              () => reconcileWorkspaceProjectsFromRemote(
+                eventWorkspaceId,
+              ),
             ),
-            () => reconcileWorkspaceProjectsFromRemote(
-              eventWorkspaceId,
-            ),
+            hubEventRefreshToken(event),
           );
           // Hub catalog writes carry the affected project id on current Vela
           // deployments, so keep the latency-sensitive recovery targeted. An
@@ -5218,14 +5336,18 @@ export async function startServer({
               });
             }
           };
-          handleHubProjectMetadataChanged(
-            emitMetadataChanged,
-            targetProjectId
-              ? () => reconcileWorkspaceProjectMetadataFromRemote(
-                  eventWorkspaceId,
-                  targetProjectId,
-                )
-              : async () => false,
+          hubEventRefreshes.request(
+            `project-metadata:${eventWorkspaceId}:${targetProjectId || '*'}`,
+            () => handleHubProjectMetadataChanged(
+              emitMetadataChanged,
+              targetProjectId
+                ? () => reconcileWorkspaceProjectMetadataFromRemote(
+                    eventWorkspaceId,
+                    targetProjectId,
+                  )
+                : async () => false,
+            ),
+            hubEventRefreshToken(event),
           );
           break;
         }
@@ -5314,16 +5436,22 @@ export async function startServer({
           break;
         }
         case 'workspace-context-changed':
-          handleHubWorkspaceContextChanged(
+          // Cache invalidation is an authorization boundary and must happen for
+          // every event in the caller's turn. Only the downstream snapshot work
+          // is coalesced below.
+          workspaceDirectoryAuthority.invalidate('event_dirty');
+          workspaceExactAuthorityCache.invalidate(eventWorkspaceId);
+          workspaceExactContextCache.invalidate(
             eventWorkspaceId,
-            () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
-            () => {
-              workspaceDirectoryAuthority.invalidate('event_dirty');
-              workspaceExactContextCache.invalidate(
-                eventWorkspaceId,
-                'event_dirty',
-              );
-            },
+            'event_dirty',
+          );
+          hubEventRefreshes.request(
+            `workspace-context:${eventWorkspaceId}`,
+            () => handleHubWorkspaceContextChanged(
+              eventWorkspaceId,
+              () => pollWorkspaceInvalidationForWorkspace(eventWorkspaceId),
+            ),
+            hubEventRefreshToken(event),
           );
           // Revalidate exact membership before the next billing projection.
           // A removed/rebound member must clear money and entitlement state,
@@ -5331,16 +5459,19 @@ export async function startServer({
           workspaceBillingRuntime.reconnect(subscribedWorkspaceId);
           break;
         case 'workspace-members-changed':
-          handleHubWorkspaceContextChanged(
+          workspaceDirectoryAuthority.invalidate('event_dirty');
+          workspaceExactAuthorityCache.invalidate(eventWorkspaceId);
+          workspaceExactContextCache.invalidate(
             eventWorkspaceId,
-            () => pollWorkspaceInvalidationForWorkspace(subscribedWorkspaceId),
-            () => {
-              workspaceDirectoryAuthority.invalidate('event_dirty');
-              workspaceExactContextCache.invalidate(
-                eventWorkspaceId,
-                'event_dirty',
-              );
-            },
+            'event_dirty',
+          );
+          hubEventRefreshes.request(
+            `workspace-context:${eventWorkspaceId}`,
+            () => handleHubWorkspaceContextChanged(
+              eventWorkspaceId,
+              () => pollWorkspaceInvalidationForWorkspace(eventWorkspaceId),
+            ),
+            hubEventRefreshToken(event),
           );
           // A role update or removal changes both authorization and the
           // billing member projection even when no billing event accompanies
@@ -5348,6 +5479,7 @@ export async function startServer({
           workspaceBillingRuntime.reconnect(subscribedWorkspaceId);
           break;
         case 'billing-changed':
+          accountBillingSummary.invalidate(accountBillingInvalidationToken(event));
           workspaceBillingRuntime.invalidate({
             domain: 'legacy',
             ...(event.workspaceId ? { workspaceId: event.workspaceId } : {}),
@@ -5355,15 +5487,22 @@ export async function startServer({
             ...(event.revisionClock ? { revisionClock: event.revisionClock } : {}),
             reason: 'vela-billing-changed',
           });
-          emitWorkspaceEvent(eventWorkspaceId, {
-            type: 'billing-changed',
-            workspaceId: eventWorkspaceId,
-            ...(event.revision ? { revision: event.revision } : {}),
-            at: Date.now(),
-          });
+          hubEventRefreshes.request(
+            `billing-signal:${eventWorkspaceId}`,
+            () => {
+              emitWorkspaceEvent(eventWorkspaceId, {
+                type: 'billing-changed',
+                workspaceId: eventWorkspaceId,
+                ...(event.revision ? { revision: event.revision } : {}),
+                at: Date.now(),
+              });
+            },
+            hubEventRefreshToken(event),
+          );
           break;
         case 'billing-subscription-changed':
           if (!event.workspaceId) break;
+          accountBillingSummary.invalidate(accountBillingInvalidationToken(event));
           workspaceBillingRuntime.invalidate({
             domain: 'subscription',
             workspaceId: event.workspaceId,
@@ -5371,15 +5510,22 @@ export async function startServer({
             ...(event.revisionClock ? { revisionClock: event.revisionClock } : {}),
             reason: 'vela-billing-subscription-changed',
           });
-          emitWorkspaceEvent(event.workspaceId, {
-            type: 'billing-subscription-changed',
-            workspaceId: event.workspaceId,
-            ...(event.revision ? { revision: event.revision } : {}),
-            at: Date.now(),
-          });
+          hubEventRefreshes.request(
+            `billing-signal:${event.workspaceId}`,
+            () => {
+              emitWorkspaceEvent(event.workspaceId!, {
+                type: 'billing-subscription-changed',
+                workspaceId: event.workspaceId!,
+                ...(event.revision ? { revision: event.revision } : {}),
+                at: Date.now(),
+              });
+            },
+            hubEventRefreshToken(event),
+          );
           break;
         case 'wallet-balance-changed':
           if (!event.workspaceId || !event.workspaceMemberId) break;
+          accountBillingSummary.invalidate(accountBillingInvalidationToken(event));
           workspaceBillingRuntime.invalidate({
             domain: 'wallet',
             workspaceId: event.workspaceId,
@@ -5388,13 +5534,19 @@ export async function startServer({
             ...(event.revisionClock ? { revisionClock: event.revisionClock } : {}),
             reason: 'vela-wallet-balance-changed',
           });
-          emitWorkspaceEvent(event.workspaceId, {
-            type: 'wallet-balance-changed',
-            workspaceId: event.workspaceId,
-            workspaceMemberId: event.workspaceMemberId,
-            ...(event.revision ? { revision: event.revision } : {}),
-            at: Date.now(),
-          });
+          hubEventRefreshes.request(
+            `billing-signal:${event.workspaceId}:${event.workspaceMemberId}`,
+            () => {
+              emitWorkspaceEvent(event.workspaceId!, {
+                type: 'wallet-balance-changed',
+                workspaceId: event.workspaceId!,
+                workspaceMemberId: event.workspaceMemberId!,
+                ...(event.revision ? { revision: event.revision } : {}),
+                at: Date.now(),
+              });
+            },
+            hubEventRefreshToken(event),
+          );
           break;
         case 'team-resources-changed': {
           // Project publish/retract operations are Resource Hub mutations and
@@ -5403,15 +5555,19 @@ export async function startServer({
           // generic resource coordinator intentionally handles only design
           // systems, plugins, and skills.
           if (event.resourceKind === 'project') {
-            handleHubTeamProjectsChanged(
-              () => emitTeamProjectsChanged(
-                eventWorkspaceId,
-                {
-                  ...(event.projectId ? { projectId: event.projectId } : {}),
-                  kind: 'catalog',
-                },
+            hubEventRefreshes.request(
+              `team-projects:${eventWorkspaceId}`,
+              () => handleHubTeamProjectsChanged(
+                () => emitTeamProjectsChanged(
+                  eventWorkspaceId,
+                  {
+                    ...(event.projectId ? { projectId: event.projectId } : {}),
+                    kind: 'catalog',
+                  },
+                ),
+                () => reconcileWorkspaceProjectsFromRemote(eventWorkspaceId),
               ),
-              () => reconcileWorkspaceProjectsFromRemote(eventWorkspaceId),
+              hubEventRefreshToken(event),
             );
             break;
           }
@@ -5424,12 +5580,16 @@ export async function startServer({
           // callback only ever RUNS once an actual SSE event arrives, well
           // after the rest of `startServer`'s synchronous setup — including
           // that declaration — has completed).
-          void reconcileTeamResourcesFromRemote(
-            event.resourceKind,
-            eventWorkspaceId,
-            'push',
-            event.resourceId,
-          ).catch(() => undefined);
+          hubEventRefreshes.request(
+            `team-resources:${eventWorkspaceId}:${event.resourceKind ?? '*'}`,
+            () => reconcileTeamResourcesFromRemote(
+              event.resourceKind,
+              eventWorkspaceId,
+              'push',
+              event.resourceId,
+            ),
+            hubEventRefreshToken(event),
+          );
           break;
         }
       }
@@ -14459,6 +14619,7 @@ export async function startServer({
       routineService?.stop();
       clearInterval(teamResourcesPollTimer);
       workspaceHubSubscriptions?.dispose();
+      hubEventRefreshes.dispose();
       workspaceBillingRuntime.dispose();
       proactiveContentPull.dispose();
       collabCloud?.dispose();

--- a/apps/daemon/src/services/partitioned-refresh-cache.ts
+++ b/apps/daemon/src/services/partitioned-refresh-cache.ts
@@ -1,0 +1,172 @@
+export interface PartitionedRefreshCacheOptions<T> {
+  fetch(key: string): Promise<T>;
+  /** Return null when this result must not be cached. */
+  ttlMs(value: T): number | null;
+  maxEntries?: number;
+  now?: () => number;
+}
+
+export interface PartitionedRefreshReadOptions {
+  /** Ignore a settled value, while still joining current-generation work. */
+  force?: boolean;
+  /**
+   * If invalidated while a read is in flight, join that read and perform at
+   * most one current-generation trailing refresh before answering.
+   */
+  revalidateOnInvalidation?: boolean;
+}
+
+export interface PartitionedRefreshCache<T> {
+  read(key: string, options?: PartitionedRefreshReadOptions): Promise<T>;
+  invalidate(key: string, token?: string): void;
+  clear(): void;
+}
+
+interface CacheEntry<T> {
+  generation: number;
+  hasValue: boolean;
+  value: T | undefined;
+  expiresAt: number;
+  inFlightByGeneration: Map<number, Promise<T>>;
+  lastInvalidationToken: string | null;
+  touchedAt: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 32;
+
+/**
+ * Small process-local primitive for event-invalidated upstream snapshots.
+ *
+ * Keys normally represent credential identity plus resource scope. Settled
+ * values and in-flight reads never cross keys. Invalidation advances an opaque
+ * generation, so work started before an event may finish for its original
+ * caller but cannot seed the post-event cache.
+ */
+export function createPartitionedRefreshCache<T>(
+  options: PartitionedRefreshCacheOptions<T>,
+): PartitionedRefreshCache<T> {
+  const now = options.now ?? Date.now;
+  const maxEntries = Math.max(1, options.maxEntries ?? DEFAULT_MAX_ENTRIES);
+  const entries = new Map<string, CacheEntry<T>>();
+
+  const touch = (key: string, entry: CacheEntry<T>): void => {
+    entry.touchedAt = now();
+    entries.delete(key);
+    entries.set(key, entry);
+  };
+
+  const trim = (targetSize: number): void => {
+    if (entries.size <= targetSize) return;
+    for (const [key, entry] of entries) {
+      if (entry.inFlightByGeneration.size > 0) continue;
+      entries.delete(key);
+      if (entries.size <= targetSize) return;
+    }
+  };
+
+  const entryFor = (key: string): CacheEntry<T> => {
+    const existing = entries.get(key);
+    if (existing) {
+      touch(key, existing);
+      return existing;
+    }
+    trim(maxEntries - 1);
+    const entry: CacheEntry<T> = {
+      generation: 0,
+      hasValue: false,
+      value: undefined,
+      expiresAt: 0,
+      inFlightByGeneration: new Map(),
+      lastInvalidationToken: null,
+      touchedAt: now(),
+    };
+    entries.set(key, entry);
+    return entry;
+  };
+
+  const hasFreshValue = (entry: CacheEntry<T>): boolean =>
+    entry.hasValue && now() < entry.expiresAt;
+
+  const latestInFlight = (entry: CacheEntry<T>): Promise<T> | undefined => {
+    let latest: Promise<T> | undefined;
+    for (const request of entry.inFlightByGeneration.values()) latest = request;
+    return latest;
+  };
+
+  const start = (
+    key: string,
+    entry: CacheEntry<T>,
+    generation: number,
+  ): Promise<T> => {
+    const existing = entry.inFlightByGeneration.get(generation);
+    if (existing) return existing;
+    const request = options.fetch(key)
+      .then((value) => {
+        if (entry.generation === generation) {
+          const ttlMs = options.ttlMs(value);
+          if (ttlMs != null) {
+            entry.hasValue = true;
+            entry.value = value;
+            entry.expiresAt = now() + Math.max(0, ttlMs);
+            touch(key, entry);
+          }
+        }
+        return value;
+      })
+      .finally(() => {
+        if (entry.inFlightByGeneration.get(generation) === request) {
+          entry.inFlightByGeneration.delete(generation);
+        }
+        trim(maxEntries);
+      });
+    entry.inFlightByGeneration.set(generation, request);
+    return request;
+  };
+
+  return {
+    async read(keyInput, readOptions = {}): Promise<T> {
+      const key = keyInput.trim();
+      if (!key) throw new Error('partitioned refresh cache key is required');
+      const entry = entryFor(key);
+      if (!readOptions.force && hasFreshValue(entry)) return entry.value as T;
+
+      const attempts = readOptions.revalidateOnInvalidation ? 2 : 1;
+      let latest: T | undefined;
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        const generation = entry.generation;
+        const request = readOptions.revalidateOnInvalidation
+          ? latestInFlight(entry) ?? start(key, entry, generation)
+          : start(key, entry, generation);
+        latest = await request;
+        if (
+          entry.generation === generation
+          && hasFreshValue(entry)
+        ) {
+          return entry.value as T;
+        }
+      }
+      return entry.hasValue ? entry.value as T : latest as T;
+    },
+
+    invalidate(keyInput, tokenInput): void {
+      const key = keyInput.trim();
+      if (!key) return;
+      const entry = entryFor(key);
+      const token = tokenInput?.trim() || null;
+      if (token && entry.lastInvalidationToken === token) return;
+      entry.lastInvalidationToken = token;
+      entry.generation += 1;
+      entry.hasValue = false;
+      entry.value = undefined;
+      entry.expiresAt = 0;
+      touch(key, entry);
+    },
+
+    clear(): void {
+      // Fence in-flight completions before dropping the entries. Otherwise a
+      // request that settles after clear() could touch itself back into the map.
+      for (const entry of entries.values()) entry.generation += 1;
+      entries.clear();
+    },
+  };
+}

--- a/apps/daemon/tests/collab-presence-routes.test.ts
+++ b/apps/daemon/tests/collab-presence-routes.test.ts
@@ -16,7 +16,10 @@ import {
   registerCollabPresenceRoutes,
 } from '../src/routes/collab-presence.js';
 import { verifyWorkspaceRequestContext } from '../src/collab/request-workspace-context.js';
-import { createCachedWorkspaceDirectoryFetcher } from '../src/collab/vela-workspace-context.js';
+import {
+  createCachedWorkspaceDirectoryFetcher,
+  createWorkspaceDirectoryAuthorityBroker,
+} from '../src/collab/vela-workspace-context.js';
 
 let server: http.Server | null = null;
 
@@ -34,6 +37,7 @@ async function startPresenceServer(
     isProjectShared?: (projectId: string) => Promise<boolean>;
     cloudAuthorizesProjectPresence?: (projectId: string) => boolean;
     verifyWorkspaceRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceRequest'];
+    verifyWorkspaceLeaveRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceLeaveRequest'];
     verifyWorkspaceReadRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceReadRequest'];
     presenceListCacheFreshMs?: number;
     presenceListCacheNow?: () => number;
@@ -50,6 +54,9 @@ async function startPresenceServer(
       : {}),
     ...(options.verifyWorkspaceRequest
       ? { verifyWorkspaceRequest: options.verifyWorkspaceRequest }
+      : {}),
+    ...(options.verifyWorkspaceLeaveRequest
+      ? { verifyWorkspaceLeaveRequest: options.verifyWorkspaceLeaveRequest }
       : {}),
     ...(options.verifyWorkspaceReadRequest
       ? { verifyWorkspaceReadRequest: options.verifyWorkspaceReadRequest }
@@ -1025,13 +1032,17 @@ describe('collab presence routes', () => {
     expect(listPresence).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps heartbeat and leave on fresh authority and publishes their latest result', async () => {
+  it('uses independent heartbeat and leave authority gates and publishes their latest result', async () => {
     const context = teamContext();
     const verifyWorkspaceRequest = vi.fn(async () => ({
       ok: true as const,
       context,
     }));
     const verifyWorkspaceReadRequest = vi.fn(async () => ({
+      ok: true as const,
+      context,
+    }));
+    const verifyWorkspaceLeaveRequest = vi.fn(async () => ({
       ok: true as const,
       context,
     }));
@@ -1044,6 +1055,7 @@ describe('collab presence routes', () => {
       { heartbeatPresence, listPresence, leavePresence },
       {
         verifyWorkspaceRequest,
+        verifyWorkspaceLeaveRequest,
         verifyWorkspaceReadRequest,
         cloudAuthorizesProjectPresence: () => true,
       },
@@ -1062,9 +1074,69 @@ describe('collab presence routes', () => {
     })).status).toBe(200);
     expect((await api.json('/api/projects/p1/presence')).body.present).toEqual([]);
 
-    expect(verifyWorkspaceRequest).toHaveBeenCalledTimes(2);
+    expect(verifyWorkspaceRequest).toHaveBeenCalledOnce();
+    expect(verifyWorkspaceLeaveRequest).toHaveBeenCalledOnce();
     expect(verifyWorkspaceReadRequest).toHaveBeenCalledTimes(2);
     expect(listPresence).not.toHaveBeenCalled();
+  });
+
+  it('lets leave bypass the outage lease opened by a failed heartbeat authority probe', async () => {
+    const context = teamContext();
+    const directoryItem = {
+      workspaceId: context.workspaceId,
+      workspaceName: context.workspaceName ?? context.workspaceId,
+      workspaceType: context.workspaceType,
+      workspaceMemberId: context.workspaceMemberId,
+      role: context.role,
+      memberStatus: context.memberStatus,
+      lifecycleState: context.lifecycleState,
+    };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false as const, items: [] })
+      .mockResolvedValueOnce({ ok: true as const, items: [directoryItem] });
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'presence-leave-account',
+      failureBackoffMinMs: 60_000,
+      failureBackoffMaxMs: 60_000,
+      random: () => 0,
+    });
+    const verify = (
+      req: unknown,
+      fetchWorkspaceDirectory: typeof authority.fresh,
+    ) => verifyWorkspaceRequestContext({ req, fetchWorkspaceDirectory });
+    const leavePresence = vi.fn(async () => []);
+    const api = await startPresenceServer(
+      {
+        heartbeatPresence: vi.fn(async () => []),
+        listPresence: vi.fn(async () => []),
+        leavePresence,
+      },
+      {
+        verifyWorkspaceRequest: (req) => verify(req, authority.backgroundFresh),
+        verifyWorkspaceLeaveRequest: (req) => verify(req, authority.fresh),
+        cloudAuthorizesProjectPresence: () => true,
+      },
+    );
+    const headers = {
+      'x-od-workspace-id': context.workspaceId,
+      'x-od-workspace-member-id': context.workspaceMemberId,
+    };
+
+    expect((await api.json('/api/projects/p1/presence/heartbeat', {
+      method: 'POST',
+      headers,
+      body: { memberId: context.workspaceMemberId },
+    })).status).toBe(503);
+    expect((await api.json('/api/projects/p1/presence/leave', {
+      method: 'POST',
+      headers,
+      body: { memberId: context.workspaceMemberId },
+    })).status).toBe(200);
+
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+    expect(leavePresence).toHaveBeenCalledTimes(1);
   });
 
   it('returns a retryable 503 without relay side effects when Workspace authority is unavailable', async () => {

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -1202,7 +1202,8 @@ describe('collab sync routes', () => {
     expect(resolveSharedProjectOwnerForStatus).toHaveBeenCalledTimes(1);
   });
 
-  it('does not cache a failed status authority read', async () => {
+  it('circuits failed status authority reads and retries after the outage lease', async () => {
+    let now = 0;
     const context = teamContext('ws-1', 'wm-1');
     const fetchReadDirectory = vi
       .fn()
@@ -1223,6 +1224,10 @@ describe('collab sync routes', () => {
       fetchDirectory: fetchReadDirectory,
       identityKey: () => 'account-a:config-a',
       ttlMs: 5_000,
+      failureBackoffMinMs: 100,
+      failureBackoffMaxMs: 100,
+      now: () => now,
+      random: () => 0,
     });
     const api = await startSyncServer(
       { current: async () => context },
@@ -1241,6 +1246,10 @@ describe('collab sync routes', () => {
     );
 
     expect((await api.json('/api/projects/p1/collab/status')).status).toBe(503);
+    expect((await api.json('/api/projects/p1/collab/status')).status).toBe(503);
+    expect(fetchReadDirectory).toHaveBeenCalledOnce();
+
+    now = 100;
     expect((await api.json('/api/projects/p1/collab/status')).status).toBe(200);
     expect(fetchReadDirectory).toHaveBeenCalledTimes(2);
   });

--- a/apps/daemon/tests/collab-team-projects-routes.test.ts
+++ b/apps/daemon/tests/collab-team-projects-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import http from 'node:http';
 import {
@@ -9,7 +9,10 @@ import {
 } from '@open-design/contracts';
 import { createTeamProjectsLister } from '../src/collab/team-projects.js';
 import type { WorkspaceContextProvider } from '../src/collab/workspace-context.js';
-import { registerCollabContextRoutes } from '../src/routes/collab-context.js';
+import {
+  registerCollabContextRoutes,
+  type RegisterCollabContextRoutesDeps,
+} from '../src/routes/collab-context.js';
 
 const PROJECTS: TeamProject[] = [
   {
@@ -69,10 +72,20 @@ async function startServer(deps: {
       lifecycleState: 'active' | 'billing_past_due' | 'locked' | 'deleting' | 'deleted';
     }>;
   }>;
+  verifyWorkspaceReadAuthority?: RegisterCollabContextRoutesDeps['verifyWorkspaceReadAuthority'];
 }) {
   const app = express();
   app.use(express.json());
-  registerCollabContextRoutes(app, deps);
+  registerCollabContextRoutes(app, {
+    workspaceContext: deps.workspaceContext,
+    listTeamProjects: deps.listTeamProjects,
+    ...(deps.fetchWorkspaceDirectory
+      ? { fetchWorkspaceDirectory: deps.fetchWorkspaceDirectory }
+      : {}),
+    ...(deps.verifyWorkspaceReadAuthority
+      ? { verifyWorkspaceReadAuthority: deps.verifyWorkspaceReadAuthority }
+      : {}),
+  });
   server = http.createServer(app);
   await new Promise<void>((resolve) => server!.listen(0, resolve));
   const address = server.address();
@@ -92,6 +105,31 @@ async function startServer(deps: {
 }
 
 describe('GET /api/workspace/projects/team', () => {
+  it('uses the settled exact-scope verifier without listing the account directory', async () => {
+    const verified = teamContextProvider().current({});
+    const fetchWorkspaceDirectory = vi.fn(async () => {
+      throw new Error('directory should not run');
+    });
+    const get = await startServer({
+      workspaceContext: teamContextProvider(),
+      listTeamProjects: async () => PROJECTS,
+      fetchWorkspaceDirectory,
+      verifyWorkspaceReadAuthority: async () => ({
+        ok: true,
+        context: (await verified)!,
+      }),
+    });
+
+    const response = await get({
+      'x-od-workspace-id': 'ws-1',
+      'x-od-workspace-member-id': 'wm-1',
+      'x-od-workspace-type': 'team',
+    });
+
+    expect(response).toEqual({ status: 200, body: { projects: PROJECTS } });
+    expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
+  });
+
   it('uses the request workspace rather than the daemon ambient workspace', async () => {
     const seen: unknown[] = [];
     const listTeamProjects = async (scope: WorkspaceCollabContext) => {

--- a/apps/daemon/tests/collab-workspace-events-route.test.ts
+++ b/apps/daemon/tests/collab-workspace-events-route.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import http from 'node:http';
 import type { Response } from 'express';
 import {
+  emitWorkspaceEventToAllScopes,
   emitWorkspaceEventToScope,
   registerCollabContextRoutes,
   type WorkspaceEventSinksByWorkspace,
@@ -34,7 +35,10 @@ afterEach(async () => {
   }
 });
 
-async function startServer(workspaceEventSinks: WorkspaceEventSinksByWorkspace) {
+async function startServer(
+  workspaceEventSinks: WorkspaceEventSinksByWorkspace,
+  retainWorkspaceEventInterest?: (workspaceId: string) => () => void,
+) {
   const app = express();
   app.use(express.json());
   registerCollabContextRoutes(app, {
@@ -53,6 +57,7 @@ async function startServer(workspaceEventSinks: WorkspaceEventSinksByWorkspace) 
     }),
     createSseResponse: (res) => makeSseResponse(res as Response),
     workspaceEventSinks,
+    ...(retainWorkspaceEventInterest ? { retainWorkspaceEventInterest } : {}),
   });
   server = http.createServer(app);
   await new Promise<void>((resolve) => server!.listen(0, resolve));
@@ -83,7 +88,9 @@ async function readUntil(
 describe('GET /api/workspace/events', () => {
   it('registers a sink, streams a pushed thin event, and drops the sink on disconnect', async () => {
     const sinks: WorkspaceEventSinksByWorkspace = new Map();
-    const base = await startServer(sinks);
+    const releaseInterest = vi.fn();
+    const retainInterest = vi.fn(() => releaseInterest);
+    const base = await startServer(sinks, retainInterest);
     const controller = new AbortController();
 
     const resp = await fetch(
@@ -98,6 +105,7 @@ describe('GET /api/workspace/events', () => {
     // The route sends a `ready` handshake and registers exactly one sink.
     await readUntil(reader, (text) => text.includes('event: ready'));
     expect(sinks.size).toBe(1);
+    expect(retainInterest).toHaveBeenCalledWith('workspace-a');
 
     // Emitting into the sinks streams the thin event with its `type` as the SSE
     // event name (the client re-fetches on receipt; no body is required).
@@ -126,6 +134,16 @@ describe('GET /api/workspace/events', () => {
     expect(resourceFrame).toContain('"resourceKind":"skill"');
     expect(resourceFrame).not.toContain('resourceStatus');
 
+    emitWorkspaceEventToAllScopes(sinks, {
+      type: 'workspace-directory-changed',
+      at: 125,
+    });
+    const directoryFrame = await readUntil(
+      reader,
+      (text) => text.includes('event: workspace-directory-changed'),
+    );
+    expect(directoryFrame).toContain('"type":"workspace-directory-changed"');
+
     // Disconnect → the route's res.on('close') cleanup drops the sink.
     controller.abort();
     await reader.cancel().catch(() => {});
@@ -134,6 +152,7 @@ describe('GET /api/workspace/events', () => {
       await new Promise((r) => setTimeout(r, 25));
     }
     expect(sinks.size).toBe(0);
+    expect(releaseInterest).toHaveBeenCalled();
   });
 
   it('404-free no-op: the route is simply absent when the SSE seams are omitted', async () => {

--- a/apps/daemon/tests/collab/account-billing-summary-cache.test.ts
+++ b/apps/daemon/tests/collab/account-billing-summary-cache.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceBillingSummary } from '@open-design/contracts';
+
+import { createAccountBillingSummaryCache } from '../../src/collab/account-billing-summary-cache.js';
+
+function summary(balanceUsd: string): WorkspaceBillingSummary {
+  return {
+    workspaceId: null,
+    membershipTier: 'free',
+    totalAvailableCredits: Number(balanceUsd),
+    subscriptionCredits: 0,
+    rechargeCredits: Number(balanceUsd),
+    balanceUsd,
+    subscriptionStatus: 'inactive',
+    availableActions: [],
+    workspaceBalance: null,
+  };
+}
+
+describe('account billing summary cache', () => {
+  it('single-flights concurrent reads and reuses the settled value within the ttl', async () => {
+    let now = 0;
+    let release!: (value: WorkspaceBillingSummary | null) => void;
+    const blocked = new Promise<WorkspaceBillingSummary | null>((resolve) => {
+      release = resolve;
+    });
+    const fetchSummary = vi.fn(() => blocked);
+    const cache = createAccountBillingSummaryCache({
+      identity: () => 'account-a',
+      fetch: fetchSummary,
+      ttlMs: 60_000,
+      now: () => now,
+    });
+
+    const first = cache.read();
+    const second = cache.read();
+    expect(fetchSummary).toHaveBeenCalledTimes(1);
+    release(summary('1.25'));
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      summary('1.25'),
+      summary('1.25'),
+    ]);
+
+    now = 59_999;
+    await expect(cache.read()).resolves.toEqual(summary('1.25'));
+    expect(fetchSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('partitions values by credential identity', async () => {
+    let identity = 'account-a';
+    const fetchSummary = vi
+      .fn<() => Promise<WorkspaceBillingSummary | null>>()
+      .mockResolvedValueOnce(summary('1.25'))
+      .mockResolvedValueOnce(summary('9.50'));
+    const cache = createAccountBillingSummaryCache({
+      identity: () => identity,
+      fetch: fetchSummary,
+    });
+
+    await expect(cache.read()).resolves.toEqual(summary('1.25'));
+    identity = 'account-b';
+    await expect(cache.read()).resolves.toEqual(summary('9.50'));
+    identity = 'account-a';
+    await expect(cache.read()).resolves.toEqual(summary('1.25'));
+    expect(fetchSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('joins an invalidated in-flight fetch and performs one trailing refresh', async () => {
+    let releaseFirst!: (value: WorkspaceBillingSummary | null) => void;
+    const firstBlocked = new Promise<WorkspaceBillingSummary | null>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const fetchSummary = vi
+      .fn<() => Promise<WorkspaceBillingSummary | null>>()
+      .mockReturnValueOnce(firstBlocked)
+      .mockResolvedValueOnce(summary('2.50'));
+    const cache = createAccountBillingSummaryCache({
+      identity: () => 'account-a',
+      fetch: fetchSummary,
+    });
+
+    const beforeEvent = cache.read();
+    cache.invalidate('revision:2');
+    cache.invalidate('revision:2');
+    const afterEvent = cache.read();
+    expect(fetchSummary).toHaveBeenCalledTimes(1);
+
+    releaseFirst(summary('1.25'));
+    await expect(Promise.all([beforeEvent, afterEvent])).resolves.toEqual([
+      summary('2.50'),
+      summary('2.50'),
+    ]);
+    expect(fetchSummary).toHaveBeenCalledTimes(2);
+    await expect(cache.read()).resolves.toEqual(summary('2.50'));
+  });
+});

--- a/apps/daemon/tests/collab/event-refresh-coordinator.test.ts
+++ b/apps/daemon/tests/collab/event-refresh-coordinator.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createEventRefreshCoordinator } from '../../src/collab/event-refresh-coordinator.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('event refresh coordinator', () => {
+  it('runs the leading refresh immediately and collapses a storm to the latest trailing refresh', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let releaseLeading!: () => void;
+    const leadingBlocked = new Promise<void>((resolve) => {
+      releaseLeading = resolve;
+    });
+    const calls: string[] = [];
+    const coordinator = createEventRefreshCoordinator({ minIntervalMs: 250 });
+
+    coordinator.request('workspace-a', async () => {
+      calls.push('leading');
+      await leadingBlocked;
+    }, 'revision:1');
+    // The first refresh starts in the event handler's turn. Authority
+    // invalidation must not trail sibling reconnect/read work by a microtask.
+    expect(calls).toEqual(['leading']);
+
+    for (let revision = 2; revision <= 100; revision += 1) {
+      coordinator.request('workspace-a', () => {
+        calls.push(`revision:${revision}`);
+      }, `revision:${revision}`);
+    }
+    releaseLeading();
+    await vi.advanceTimersByTimeAsync(249);
+    expect(calls).toEqual(['leading']);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls).toEqual(['leading', 'revision:100']);
+    coordinator.dispose();
+  });
+
+  it('deduplicates repeated revision tokens but keeps independent resources concurrent', async () => {
+    const calls: string[] = [];
+    const coordinator = createEventRefreshCoordinator({ minIntervalMs: 0 });
+
+    coordinator.request('workspace-a', () => {
+      calls.push('a');
+    }, 'revision:1');
+    coordinator.request('workspace-a', () => {
+      calls.push('duplicate');
+    }, 'revision:1');
+    coordinator.request('workspace-b', () => {
+      calls.push('b');
+    }, 'revision:1');
+    await vi.waitFor(() => expect(calls).toHaveLength(2));
+
+    expect(calls.sort()).toEqual(['a', 'b']);
+    coordinator.request('workspace-a', () => {
+      calls.push('duplicate-after-settle');
+    }, 'revision:1');
+    await Promise.resolve();
+    expect(calls.sort()).toEqual(['a', 'b']);
+    coordinator.dispose();
+  });
+
+  it('continues with one trailing refresh after the leading refresh fails', async () => {
+    const errors: string[] = [];
+    const calls: string[] = [];
+    let releaseLeading!: () => void;
+    const leadingBlocked = new Promise<void>((resolve) => {
+      releaseLeading = resolve;
+    });
+    const coordinator = createEventRefreshCoordinator({
+      minIntervalMs: 0,
+      onError: (error) => errors.push(String(error)),
+    });
+
+    coordinator.request('workspace-a', async () => {
+      calls.push('leading');
+      await leadingBlocked;
+      throw new Error('offline');
+    });
+    await vi.waitFor(() => expect(calls).toEqual(['leading']));
+    coordinator.request('workspace-a', () => {
+      calls.push('trailing');
+    });
+    releaseLeading();
+
+    await vi.waitFor(() => expect(calls).toEqual(['leading', 'trailing']));
+    expect(errors).toEqual(['Error: offline']);
+    coordinator.dispose();
+  });
+
+  it('does not revive a lane when an active refresh settles after dispose', async () => {
+    let release!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const calls: string[] = [];
+    const coordinator = createEventRefreshCoordinator({ minIntervalMs: 0 });
+
+    coordinator.request('workspace-a', async () => {
+      calls.push('leading');
+      await blocked;
+    });
+    coordinator.request('workspace-a', () => {
+      calls.push('trailing');
+    });
+    coordinator.dispose();
+    release();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['leading']);
+  });
+});

--- a/apps/daemon/tests/collab/hub-events-subscriber.test.ts
+++ b/apps/daemon/tests/collab/hub-events-subscriber.test.ts
@@ -196,6 +196,35 @@ describe('parseHubWorkspaceEvent', () => {
 });
 
 describe('startHubEventsSubscriber', () => {
+  it('jitters transport reconnects so simultaneous daemons do not retry in lockstep', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError('fetch failed'));
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({ url: 'https://hub/events', headers: {} }),
+      onEvent: () => undefined,
+      fetchImpl,
+      backoffMinMs: 1_000,
+      backoffMaxMs: 8_000,
+      random: () => 0.5,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1_249);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    // The un-jittered cursor still doubles to 2s; the deterministic draw turns
+    // the next retry into 2.5s and proves the fleet phase is randomized.
+    await vi.advanceTimersByTimeAsync(2_499);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   it('uses revision clocks only when the ready frame advertises the capability', async () => {
     const clockEvent =
       'event: workspace-event\ndata: {"type":"billing-subscription-changed","workspaceId":"w1","revision":"billing:v1:2","revisionClock":{"epoch":"billing-epoch-a","counter":"2"}}\n\n';

--- a/apps/daemon/tests/collab/hub-events-subscriber.test.ts
+++ b/apps/daemon/tests/collab/hub-events-subscriber.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  parseHubWorkspaceDirectoryEvent,
   parseHubWorkspaceEvent,
   startHubEventsSubscriber,
   type HubEventsSubscriber,
@@ -193,6 +194,24 @@ describe('parseHubWorkspaceEvent', () => {
       memberChange: 'removed',
     });
   });
+
+  it('parses account directory invalidations without requiring the carrier workspace', () => {
+    expect(
+      parseHubWorkspaceDirectoryEvent(
+        '{"type":"workspace-directory-changed","workspaceId":"workspace-new","change":"created","at":"2026-08-14T00:00:00.000Z"}',
+      ),
+    ).toEqual({
+      type: 'workspace-directory-changed',
+      workspaceId: 'workspace-new',
+      change: 'created',
+      at: '2026-08-14T00:00:00.000Z',
+    });
+    expect(
+      parseHubWorkspaceDirectoryEvent(
+        '{"type":"workspace-directory-changed","workspaceId":"workspace-new","change":"mystery"}',
+      ),
+    ).toBeNull();
+  });
 });
 
 describe('startHubEventsSubscriber', () => {
@@ -380,6 +399,63 @@ describe('startHubEventsSubscriber', () => {
     ]);
     expect(states).toEqual(['connected']);
     expect(subscriber.connected()).toBe(true);
+  });
+
+  it('delivers a capable account-directory event even when its new workspace differs from the carrier', async () => {
+    const directoryEvents: unknown[] = [];
+    let resolveDone!: () => void;
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve;
+    });
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onDirectoryEvent: (event) => {
+        directoryEvents.push(event);
+        resolveDone();
+      },
+      fetchImpl: async () => sseResponse([
+        'event: ready\ndata: {"workspaceId":"w1","capabilities":["workspace-directory-events-v1"]}\n\n',
+        'event: workspace-directory-changed\ndata: {"type":"workspace-directory-changed","workspaceId":"workspace-new","change":"created","at":"2026-08-14T00:00:00.000Z"}\n\n',
+      ], { holdOpen: true }),
+    });
+
+    await done;
+    expect(directoryEvents).toEqual([{
+      type: 'workspace-directory-changed',
+      workspaceId: 'workspace-new',
+      change: 'created',
+      at: '2026-08-14T00:00:00.000Z',
+    }]);
+  });
+
+  it('drops account-directory frames from an old server that did not advertise the capability', async () => {
+    const onDirectoryEvent = vi.fn();
+    const onDrop = vi.fn();
+    subscriber = startHubEventsSubscriber({
+      resolveEndpoint: async () => ({
+        url: 'https://hub/events',
+        headers: {},
+        workspaceId: 'w1',
+      }),
+      onEvent: () => undefined,
+      onDirectoryEvent,
+      onDrop,
+      fetchImpl: async () => sseResponse([
+        'event: ready\ndata: {"workspaceId":"w1","capabilities":[]}\n\n',
+        'event: workspace-directory-changed\ndata: {"type":"workspace-directory-changed","workspaceId":"workspace-new","change":"created"}\n\n',
+      ], { holdOpen: true }),
+    });
+
+    await vi.waitFor(() => expect(onDrop).toHaveBeenCalledWith({
+      reason: 'invalid-payload',
+      eventName: 'workspace-directory-changed',
+    }));
+    expect(onDirectoryEvent).not.toHaveBeenCalled();
   });
 
   it('reports terminal access revocation only after exact-scope ready verification', async () => {

--- a/apps/daemon/tests/collab/hub-workspace-context-changed-poll.test.ts
+++ b/apps/daemon/tests/collab/hub-workspace-context-changed-poll.test.ts
@@ -109,7 +109,7 @@ describe('hub events onEvent switch (source boundary)', () => {
   const source = fs.readFileSync(serverSourcePath, 'utf8');
 
   function extractOnEventSwitchBody(): string {
-    const anchor = 'onEvent: (event) => {';
+    const anchor = 'onEvent: (event, connection) => {';
     const start = source.indexOf(anchor);
     expect(start, 'expected to find the hub events onEvent handler in server.ts').toBeGreaterThan(-1);
     const switchStart = source.indexOf('switch (event.type) {', start);

--- a/apps/daemon/tests/collab/workspace-events-authority.test.ts
+++ b/apps/daemon/tests/collab/workspace-events-authority.test.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  emitWorkspaceEventToAllScopes,
   emitWorkspaceEventToScope,
   registerCollabContextRoutes,
   type WorkspaceEventSinksByWorkspace,
@@ -130,5 +131,16 @@ describe('GET /api/workspace/events exact authority', () => {
       'members-changed',
       { type: 'members-changed', at: 1 },
     );
+
+    expect(emitWorkspaceEventToAllScopes(sinks, {
+      type: 'workspace-directory-changed',
+      at: 2,
+    })).toBe(true);
+    for (const send of sends) {
+      expect(send).toHaveBeenCalledWith(
+        'workspace-directory-changed',
+        { type: 'workspace-directory-changed', at: 2 },
+      );
+    }
   });
 });

--- a/apps/daemon/tests/collab/workspace-exact-authority-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-authority-cache.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceDirectoryItem } from '@open-design/contracts';
+
+import { createWorkspaceExactAuthorityCache } from '../../src/collab/workspace-exact-authority-cache.js';
+
+const item = (
+  workspaceId: string,
+  workspaceMemberId = `member-${workspaceId}`,
+): WorkspaceDirectoryItem => ({
+  workspaceId,
+  workspaceName: workspaceId,
+  workspaceType: 'team',
+  workspaceMemberId,
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+});
+
+describe('workspace exact authority cache', () => {
+  it('reuses only a directory-observed row with a healthy exact-scope grant', () => {
+    const cache = createWorkspaceExactAuthorityCache({
+      identity: () => 'account-a',
+    });
+    cache.observe('account-a', [item('w1'), item('w2')]);
+
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1', 'member-w1')).toMatchObject({ workspaceId: 'w1' });
+    expect(cache.cached('w2', 'member-w2')).toBeNull();
+  });
+
+  it('expires, invalidates, and never crosses credential identity', () => {
+    let identity = 'account-a';
+    let now = 0;
+    const cache = createWorkspaceExactAuthorityCache({
+      identity: () => identity,
+      ttlMs: 100,
+      now: () => now,
+    });
+    cache.observe('account-a', [item('w1')]);
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1', 'member-w1')).not.toBeNull();
+
+    identity = 'account-b';
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+    cache.observe('account-a', [item('w1')]);
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+    identity = 'account-a';
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+    cache.setRealtimeHealthy('w1', true);
+    now = 100;
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+
+    now = 0;
+    cache.observe('account-a', [item('w1')]);
+    expect(cache.cached('w1', 'member-w1')).not.toBeNull();
+    cache.invalidate('w1');
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+  });
+
+  it('retires rows omitted by a later complete directory snapshot', () => {
+    const cache = createWorkspaceExactAuthorityCache({
+      identity: () => 'account-a',
+    });
+    cache.observe('account-a', [item('w1'), item('w2')]);
+    cache.setRealtimeHealthy('w1', true);
+    cache.observe('account-a', [item('w2')]);
+
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/collab/workspace-exact-authority-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-authority-cache.test.ts
@@ -69,4 +69,22 @@ describe('workspace exact authority cache', () => {
 
     expect(cache.cached('w1', 'member-w1')).toBeNull();
   });
+
+  it('does not revive account A after an A to B to A identity reset with no intervening read', () => {
+    let identity = 'account-a';
+    const cache = createWorkspaceExactAuthorityCache({
+      identity: () => identity,
+    });
+    cache.observe(identity, [item('w1')]);
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1', 'member-w1')).not.toBeNull();
+
+    identity = 'account-b';
+    cache.resetIdentity();
+    identity = 'account-a';
+    cache.resetIdentity();
+
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1', 'member-w1')).toBeNull();
+  });
 });

--- a/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
+++ b/apps/daemon/tests/collab/workspace-exact-context-cache.test.ts
@@ -136,4 +136,67 @@ describe('workspace exact context cache', () => {
     expect(calls).toBe(3);
     expect(cache.cached('w1')).toBeNull();
   });
+
+  it('refetches account A after an A to B to A identity reset with no intervening read', async () => {
+    let identity = 'account-a';
+    let calls = 0;
+    const cache = createWorkspaceExactContextCache({
+      identity: () => identity,
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => {
+          calls += 1;
+          return context(workspaceId);
+        },
+      },
+    });
+    await cache.refresh({ workspaceId: 'w1' });
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1')).not.toBeNull();
+
+    identity = 'account-b';
+    cache.resetIdentity();
+    identity = 'account-a';
+    cache.resetIdentity();
+
+    cache.setRealtimeHealthy('w1', true);
+    await expect(cache.provider.resolveExact?.({ workspaceId: 'w1' }))
+      .resolves.toMatchObject({ workspaceId: 'w1' });
+    expect(calls).toBe(2);
+  });
+
+  it('fences an account A response that settles after an A to B to A identity reset', async () => {
+    let identity = 'account-a';
+    let release!: (value: WorkspaceCollabContext) => void;
+    const blocked = new Promise<WorkspaceCollabContext>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    const cache = createWorkspaceExactContextCache({
+      identity: () => identity,
+      provider: {
+        current: async () => null,
+        resolveExact: async ({ workspaceId }) => {
+          calls += 1;
+          return calls === 1 ? blocked : context(workspaceId);
+        },
+      },
+    });
+
+    const staleAccountARead = cache.refresh({ workspaceId: 'w1' });
+    cache.setRealtimeHealthy('w1', true);
+    identity = 'account-b';
+    cache.resetIdentity();
+    identity = 'account-a';
+    cache.resetIdentity();
+
+    release(context('w1'));
+    await staleAccountARead;
+    cache.setRealtimeHealthy('w1', true);
+    expect(cache.cached('w1')).toBeNull();
+
+    await cache.provider.resolveExact?.({ workspaceId: 'w1' });
+    expect(calls).toBe(2);
+    expect(cache.cached('w1')).not.toBeNull();
+  });
 });

--- a/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
+++ b/apps/daemon/tests/collab/workspace-hub-subscriptions.test.ts
@@ -3,6 +3,44 @@ import type { HubEventsSubscriber } from '../../src/collab/hub-events-subscriber
 import { createWorkspaceHubSubscriptionManager } from '../../src/collab/workspace-hub-subscriptions.js';
 
 describe('WorkspaceHubSubscriptionManager', () => {
+  it('keeps one upstream carrier for local event streams without billing interest', () => {
+    const stop = vi.fn();
+    const manager = createWorkspaceHubSubscriptionManager({
+      start: (): HubEventsSubscriber => ({
+        connected: () => true,
+        refreshEndpoint: vi.fn(),
+        stop,
+      }),
+    });
+
+    const releaseFirst = manager.retainEventInterest('workspace-a');
+    const releaseSecond = manager.retainEventInterest('workspace-a');
+    expect(manager.activeWorkspaceIds()).toEqual(['workspace-a']);
+
+    releaseFirst();
+    releaseFirst();
+    expect(stop).not.toHaveBeenCalled();
+    releaseSecond();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(manager.activeWorkspaceIds()).toEqual([]);
+  });
+
+  it('re-resolves every active stream when the account credential changes', () => {
+    const refreshEndpoint = vi.fn();
+    const manager = createWorkspaceHubSubscriptionManager({
+      start: () => ({
+        stop: vi.fn(),
+        connected: () => true,
+        refreshEndpoint,
+      }),
+    });
+    manager.setBillingInterests(['workspace-a', 'workspace-b']);
+
+    manager.refreshEndpoints();
+
+    expect(refreshEndpoint).toHaveBeenCalledTimes(2);
+  });
+
   it('dedupes explicit billing interests into one upstream per workspace', () => {
     const started: string[] = [];
     const stopped: string[] = [];

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -180,7 +180,7 @@ describe('server.ts wiring (source boundary)', () => {
   const source = fs.readFileSync(serverSourcePath, 'utf8');
 
   function extractOnEventSwitchBody(): string {
-    const anchor = 'onEvent: (event) => {';
+    const anchor = 'onEvent: (event, connection) => {';
     const start = source.indexOf(anchor);
     expect(start, 'expected to find the hub events onEvent handler in server.ts').toBeGreaterThan(-1);
     const switchStart = source.indexOf('switch (event.type) {', start);
@@ -394,7 +394,7 @@ describe('server.ts wiring (source boundary)', () => {
       start,
     );
     const body = source.slice(start, end);
-    const reconnectStart = body.indexOf('onReconnect: () => {');
+    const reconnectStart = body.indexOf('onReconnect: (connection) => {');
     const sourceGapStart = body.indexOf('onSourceGap:', reconnectStart);
     const errorStart = body.indexOf('onError:', sourceGapStart);
     expect(reconnectStart).toBeGreaterThan(-1);

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -198,6 +198,25 @@ describe('server.ts wiring (source boundary)', () => {
     return source.slice(switchStart, i + 1);
   }
 
+  it('resets exact authority across credential changes before refreshing hub endpoints', () => {
+    const start = source.indexOf(
+      'const refreshWorkspaceHubAccountIdentity = (): void => {',
+    );
+    const end = source.indexOf(
+      'const fetchWorkspaceDirectoryForAccountSurface = () => {',
+      start,
+    );
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+    const resetStart = body.indexOf('resetWorkspaceExactIdentityCaches();');
+    const endpointRefreshStart = body.indexOf(
+      'workspaceHubSubscriptions?.refreshEndpoints();',
+    );
+    expect(resetStart).toBeGreaterThan(-1);
+    expect(endpointRefreshStart).toBeGreaterThan(resetStart);
+  });
+
   it('routes both project catalog event families through project reconciliation', () => {
     const switchBody = extractOnEventSwitchBody();
     const cases = switchBody.split(/(?=case '[a-z-]+':)/g).filter((chunk) => chunk.startsWith("case '"));

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -198,7 +198,10 @@ describe('server.ts wiring (source boundary)', () => {
     return source.slice(switchStart, i + 1);
   }
 
-  it('resets exact authority across credential changes before refreshing hub endpoints', () => {
+  it('resets directory and exact authority across credential changes before refreshing hub endpoints', () => {
+    const resetHelperStart = source.indexOf(
+      'const resetWorkspaceIdentityCaches = (): void => {',
+    );
     const start = source.indexOf(
       'const refreshWorkspaceHubAccountIdentity = (): void => {',
     );
@@ -206,10 +209,21 @@ describe('server.ts wiring (source boundary)', () => {
       'const fetchWorkspaceDirectoryForAccountSurface = () => {',
       start,
     );
-    expect(start).toBeGreaterThan(-1);
+    expect(resetHelperStart).toBeGreaterThan(-1);
+    expect(start).toBeGreaterThan(resetHelperStart);
     expect(end).toBeGreaterThan(start);
+    const resetHelperBody = source.slice(resetHelperStart, start);
+    expect(resetHelperBody).toContain(
+      'workspaceDirectoryAuthority.resetIdentity();',
+    );
+    expect(resetHelperBody).toContain(
+      'workspaceExactAuthorityCache.resetIdentity();',
+    );
+    expect(resetHelperBody).toContain(
+      'workspaceExactContextCache.resetIdentity();',
+    );
     const body = source.slice(start, end);
-    const resetStart = body.indexOf('resetWorkspaceExactIdentityCaches();');
+    const resetStart = body.indexOf('resetWorkspaceIdentityCaches();');
     const endpointRefreshStart = body.indexOf(
       'workspaceHubSubscriptions?.refreshEndpoints();',
     );

--- a/apps/daemon/tests/services/partitioned-refresh-cache.test.ts
+++ b/apps/daemon/tests/services/partitioned-refresh-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPartitionedRefreshCache } from '../../src/services/partitioned-refresh-cache.js';
+
+describe('partitioned refresh cache', () => {
+  it('partitions values and in-flight reads by key', async () => {
+    const fetchValue = vi.fn(async (key: string) => `${key}-value`);
+    const cache = createPartitionedRefreshCache({
+      fetch: fetchValue,
+      ttlMs: () => 1_000,
+    });
+
+    await expect(Promise.all([
+      cache.read('account-a'),
+      cache.read('account-a'),
+      cache.read('account-b'),
+    ])).resolves.toEqual(['account-a-value', 'account-a-value', 'account-b-value']);
+    expect(fetchValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let pre-invalidation work seed the next generation', async () => {
+    let release!: (value: string) => void;
+    const held = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+    const fetchValue = vi
+      .fn<(key: string) => Promise<string>>()
+      .mockReturnValueOnce(held)
+      .mockResolvedValueOnce('current');
+    const cache = createPartitionedRefreshCache({
+      fetch: fetchValue,
+      ttlMs: () => 1_000,
+    });
+
+    const beforeEvent = cache.read('account-a', {
+      revalidateOnInvalidation: true,
+    });
+    cache.invalidate('account-a', 'revision:2');
+    cache.invalidate('account-a', 'revision:2');
+    const afterEvent = cache.read('account-a', {
+      revalidateOnInvalidation: true,
+    });
+    release('stale');
+
+    await expect(Promise.all([beforeEvent, afterEvent])).resolves.toEqual([
+      'current',
+      'current',
+    ]);
+    expect(fetchValue).toHaveBeenCalledTimes(2);
+    await expect(cache.read('account-a')).resolves.toBe('current');
+  });
+
+  it('does not let an in-flight completion repopulate a cleared cache', async () => {
+    let release!: (value: string) => void;
+    const held = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+    const fetchValue = vi
+      .fn<(key: string) => Promise<string>>()
+      .mockReturnValueOnce(held)
+      .mockResolvedValueOnce('after-clear');
+    const cache = createPartitionedRefreshCache({
+      fetch: fetchValue,
+      ttlMs: () => 1_000,
+    });
+
+    const beforeClear = cache.read('account-a');
+    cache.clear();
+    release('before-clear');
+    await expect(beforeClear).resolves.toBe('before-clear');
+    await expect(cache.read('account-a')).resolves.toBe('after-clear');
+    expect(fetchValue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -405,6 +405,60 @@ describe('createFreshWorkspaceDirectoryFetcher', () => {
 });
 
 describe('createWorkspaceDirectoryAuthorityBroker', () => {
+  it('keeps a successful lease past 15s while realtime is healthy, then expires it after disconnect', async () => {
+    let now = 0;
+    const first = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
+    const second = { ok: true as const, items: [] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+      ttlMs: 15_000,
+      now: () => now,
+    });
+
+    await expect(authority.read()).resolves.toEqual(first);
+    authority.setRealtimeHealthy(true);
+    now = 120_000;
+    await expect(authority.read()).resolves.toEqual(first);
+    expect(fetchDirectory).toHaveBeenCalledOnce();
+
+    authority.setRealtimeHealthy(false);
+    await expect(authority.read()).resolves.toEqual(second);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the outage circuit when event storms invalidate successful state', async () => {
+    let now = 0;
+    const unavailable = {
+      ok: false as const,
+      items: [],
+      reason: 'network' as const,
+    };
+    const fetchDirectory = vi.fn(async () => unavailable);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+      failureBackoffMinMs: 15_000,
+      now: () => now,
+      random: () => 0,
+    });
+
+    await authority.backgroundFresh();
+    for (let index = 0; index < 100; index += 1) {
+      authority.invalidate('event_dirty');
+      await authority.backgroundFresh();
+    }
+    expect(fetchDirectory).toHaveBeenCalledOnce();
+
+    now = 15_000;
+    await authority.backgroundFresh();
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
   it('invalidates the current account lease and forces the next read to refresh', async () => {
     const first = {
       ok: true as const,
@@ -676,7 +730,7 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     expect(fetchDirectory).toHaveBeenCalledTimes(3);
   });
 
-  it('bounds 30s of status polls while every heartbeat mutation stays fresh', async () => {
+  it('avoids directory reads for status and heartbeat while realtime stays healthy', async () => {
     let now = 0;
     let activeReads = 0;
     let maxActiveReads = 0;
@@ -693,15 +747,18 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
       now: () => now,
     });
 
+    await authority.read();
+    authority.setRealtimeHealthy(true);
     // Model the production order pessimistically: status first every 5s, then
-    // heartbeat at each 10s boundary. A fresh heartbeat seeds the next read
-    // lease, but never consumes a settled lease itself.
+    // heartbeat at each 10s boundary. Both are idempotent display/presence
+    // reads of the same directory authority while the strict account event
+    // stream remains healthy.
     for (now = 0; now <= 30_000; now += 5_000) {
       await authority.read();
-      if (now % 10_000 === 0) await authority.fresh();
+      if (now % 10_000 === 0) await authority.read();
     }
 
-    expect(fetchDirectory).toHaveBeenCalledTimes(5);
+    expect(fetchDirectory).toHaveBeenCalledOnce();
     expect(maxActiveReads).toBe(1);
   });
 

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -263,14 +263,25 @@ describe('createCachedWorkspaceDirectoryFetcher', () => {
     await expect(refreshed).resolves.toEqual({ ok: true, items: [] });
   });
 
-  it('does not cache a failed directory read', async () => {
+  it('backs off a failed directory read and probes again after the outage lease', async () => {
+    let now = 0;
     const fetchDirectory = vi
       .fn()
       .mockResolvedValueOnce({ ok: false, items: [] })
       .mockResolvedValueOnce({ ok: true, items: [] });
-    const read = createCachedWorkspaceDirectoryFetcher({ fetchDirectory });
+    const read = createCachedWorkspaceDirectoryFetcher({
+      fetchDirectory,
+      failureBackoffMinMs: 100,
+      failureBackoffMaxMs: 100,
+      now: () => now,
+      random: () => 0,
+    });
 
     await expect(read()).resolves.toEqual({ ok: false, items: [] });
+    await expect(read()).resolves.toEqual({ ok: false, items: [] });
+    expect(fetchDirectory).toHaveBeenCalledOnce();
+
+    now = 100;
     await expect(read()).resolves.toEqual({ ok: true, items: [] });
     expect(fetchDirectory).toHaveBeenCalledTimes(2);
   });
@@ -426,9 +437,11 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
           (resolve) => pending.push(resolve),
         ),
     );
+    const onAcceptedResult = vi.fn();
     const authority = createWorkspaceDirectoryAuthorityBroker({
       fetchDirectory,
       identityKey: () => 'account-a:config-a',
+      onAcceptedResult,
     });
 
     const staleRead = authority.read();
@@ -439,6 +452,7 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     const stale = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
     pending[0]!(stale);
     await expect(staleRead).resolves.toEqual(stale);
+    expect(onAcceptedResult).not.toHaveBeenCalled();
 
     let currentSettled = false;
     void currentRead.then(() => {
@@ -453,6 +467,11 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     };
     pending[1]!(current);
     await expect(currentRead).resolves.toEqual(current);
+    expect(onAcceptedResult).toHaveBeenCalledOnce();
+    expect(onAcceptedResult).toHaveBeenCalledWith(
+      current,
+      'account-a:config-a',
+    );
     await expect(authority.read()).resolves.toEqual(current);
     expect(fetchDirectory).toHaveBeenCalledTimes(2);
   });
@@ -497,7 +516,7 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     expect(fetchDirectory).toHaveBeenCalledTimes(1);
   });
 
-  it('single-flights shell and project bootstrap reads per account generation without caching failures', async () => {
+  it('single-flights shell and project bootstrap reads per account generation and shares outage backoff', async () => {
     let identity = 'account-a:config-a';
     const fetchDirectory = vi.fn(async () => ({
       ok: true as const,
@@ -528,7 +547,133 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     });
     await failedAuthority.read();
     await failedAuthority.read();
-    expect(failedFetch).toHaveBeenCalledTimes(2);
+    expect(failedFetch).toHaveBeenCalledOnce();
+  });
+
+  it('uses one account-wide exponential outage circuit across read and fresh callers', async () => {
+    let now = 0;
+    const onDecision = vi.fn();
+    const onSuppressedRequest = vi.fn();
+    const networkFailure = {
+      ok: false as const,
+      items: [],
+      reason: 'network' as const,
+    };
+    const recovered = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(networkFailure)
+      .mockResolvedValueOnce(networkFailure)
+      .mockResolvedValueOnce(recovered);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+      failureBackoffMinMs: 100,
+      failureBackoffMaxMs: 400,
+      now: () => now,
+      random: () => 0,
+      onDecision,
+      onSuppressedRequest,
+    });
+
+    await expect(authority.read()).resolves.toEqual(networkFailure);
+    await expect(Promise.all([
+      authority.read(),
+      authority.backgroundFresh(),
+      authority.read(),
+    ])).resolves.toEqual([networkFailure, networkFailure, networkFailure]);
+    expect(fetchDirectory).toHaveBeenCalledOnce();
+    expect(onDecision).toHaveBeenCalledWith({
+      source: 'cache',
+      reason: 'failure_backoff',
+      outcome: 'unavailable',
+    });
+    expect(onSuppressedRequest).toHaveBeenCalledWith({
+      source: 'directory',
+      reason: 'failure_backoff',
+    });
+
+    now = 99;
+    await authority.read();
+    expect(fetchDirectory).toHaveBeenCalledOnce();
+    now = 100;
+    await authority.backgroundFresh();
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+
+    // The second failed probe doubles the floor to 200ms. Positive jitter never
+    // probes faster than that floor.
+    now = 299;
+    await authority.read();
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+    now = 300;
+    await expect(authority.read()).resolves.toEqual(recovered);
+    expect(fetchDirectory).toHaveBeenCalledTimes(3);
+
+    // A genuine recovery rewinds both the failure depth and the normal success
+    // lease, so later reads return immediately without another upstream call.
+    await expect(authority.read()).resolves.toEqual(recovered);
+    expect(fetchDirectory).toHaveBeenCalledTimes(3);
+  });
+
+  it('lets a user-initiated fresh authority read recover immediately through an open read circuit', async () => {
+    const networkFailure = {
+      ok: false as const,
+      items: [],
+      reason: 'network' as const,
+    };
+    const recovered = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(networkFailure)
+      .mockResolvedValueOnce(recovered);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+      failureBackoffMinMs: 120_000,
+      random: () => 0,
+    });
+
+    await expect(authority.read()).resolves.toEqual(networkFailure);
+    await expect(authority.fresh()).resolves.toEqual(recovered);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+    await expect(authority.read()).resolves.toEqual(recovered);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not outage-cache authorization rejection and lets authoritative invalidation probe immediately', async () => {
+    let now = 0;
+    const unauthorized = {
+      ok: false as const,
+      items: [],
+      reason: 'unauthorized' as const,
+      status: 401,
+    };
+    const networkFailure = {
+      ok: false as const,
+      items: [],
+      reason: 'network' as const,
+    };
+    const recovered = { ok: true as const, items: [{ ...B_DIRECTORY_ITEM }] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorized)
+      .mockResolvedValueOnce(networkFailure)
+      .mockResolvedValueOnce(recovered);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => 'account-a:config-a',
+      failureBackoffMinMs: 100,
+      now: () => now,
+      random: () => 0,
+    });
+
+    await expect(authority.read()).resolves.toEqual(unauthorized);
+    await expect(authority.read()).resolves.toEqual(networkFailure);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+
+    authority.invalidate('catch_up');
+    await expect(authority.fresh()).resolves.toEqual(recovered);
+    expect(fetchDirectory).toHaveBeenCalledTimes(3);
   });
 
   it('bounds 30s of status polls while every heartbeat mutation stays fresh', async () => {

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -10,10 +10,13 @@ import {
   createVelaWorkspaceContextProvider,
   fetchVelaWorkspaceDirectory,
   mapVelaWorkspaceContext,
+  resolveVelaWorkspaceHubEventsEndpoint,
+  velaWorkspaceDirectoryIdentityForSession,
   workspaceContextFromDirectoryItem,
 } from '../src/collab/vela-workspace-context.js';
 import {
   clearVelaAuthorizationState,
+  readVelaControlApiContext,
   readVelaLoginStatus,
 } from '../src/integrations/vela.js';
 
@@ -159,6 +162,35 @@ describe('mapVelaWorkspaceContext', () => {
 });
 
 describe('createCachedWorkspaceDirectoryFetcher', () => {
+  it('builds hub URL, authorization, and identity from the same merged session', () => {
+    const inherited = {
+      VELA_API_URL: 'https://account-a.example',
+      VELA_CONTROL_KEY: 'account-a-control-key',
+    } as NodeJS.ProcessEnv;
+    const configured = { VELA_API_URL: 'https://account-b.example' };
+    const accountA = readVelaControlApiContext(inherited);
+    const accountB = readVelaControlApiContext(inherited, configured);
+
+    const endpoint = resolveVelaWorkspaceHubEventsEndpoint(
+      ' workspace-b ',
+      inherited,
+      configured,
+    );
+
+    expect(endpoint).toEqual({
+      url: 'https://account-b.example/api/v1/collab/events',
+      workspaceId: 'workspace-b',
+      identityKey: velaWorkspaceDirectoryIdentityForSession(accountB),
+      headers: {
+        authorization: 'Bearer account-a-control-key',
+        'x-vela-workspace-id': 'workspace-b',
+      },
+    });
+    expect(endpoint?.identityKey).not.toBe(
+      velaWorkspaceDirectoryIdentityForSession(accountA),
+    );
+  });
+
   it('treats a missing local session as authoritative signed-out, not an outage', async () => {
     await expect(
       fetchVelaWorkspaceDirectory({ readSession: () => null }),
@@ -478,6 +510,32 @@ describe('createWorkspaceDirectoryAuthorityBroker', () => {
     await expect(authority.read()).resolves.toEqual(first);
     authority.invalidate();
     await expect(authority.read()).resolves.toEqual(second);
+    expect(fetchDirectory).toHaveBeenCalledTimes(2);
+  });
+
+  it('retires every settled lease across an observed A -> B -> A identity round trip', async () => {
+    let identity = 'account-a:config-a';
+    const accountA = {
+      ok: true as const,
+      items: [{ ...B_DIRECTORY_ITEM }],
+    };
+    const refreshedAccountA = { ok: true as const, items: [] };
+    const fetchDirectory = vi
+      .fn()
+      .mockResolvedValueOnce(accountA)
+      .mockResolvedValueOnce(refreshedAccountA);
+    const authority = createWorkspaceDirectoryAuthorityBroker({
+      fetchDirectory,
+      identityKey: () => identity,
+    });
+
+    await expect(authority.read()).resolves.toEqual(accountA);
+    authority.setRealtimeHealthy(true);
+    identity = 'account-b:config-b';
+    authority.resetIdentity();
+    identity = 'account-a:config-a';
+
+    await expect(authority.read()).resolves.toEqual(refreshedAccountA);
     expect(fetchDirectory).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/daemon/tests/workspace-billing-server-wiring.test.ts
+++ b/apps/daemon/tests/workspace-billing-server-wiring.test.ts
@@ -94,11 +94,14 @@ describe('server workspace billing runtime wiring', () => {
     };
     daemon = await serverModule.startServer({ port: 0, returnServer: true });
 
-    const response = await fetch(
-      `${daemon.url}/api/workspace/billing?scope=workspace&workspaceId=${PERSONAL.workspaceId}`,
-      { headers: workspaceHeaders() },
-    );
+    const billingUrl =
+      `${daemon.url}/api/workspace/billing?scope=workspace&workspaceId=${PERSONAL.workspaceId}`;
+    const [response, concurrentResponse] = await Promise.all([
+      fetch(billingUrl, { headers: workspaceHeaders() }),
+      fetch(billingUrl, { headers: workspaceHeaders() }),
+    ]);
     expect(response.status).toBe(200);
+    expect(concurrentResponse.status).toBe(200);
     const body = await response.json() as {
       workspaceBalance: {
         workspaceId: string;
@@ -116,9 +119,15 @@ describe('server workspace billing runtime wiring', () => {
       status: 'fresh',
       errorCode: null,
     });
-    expect(await readFile(process.env.OD_TEST_VELA_LOG!, 'utf8')).toContain(
+    expect((await concurrentResponse.json() as typeof body).workspaceBalance)
+      .toEqual(body.workspaceBalance);
+    const warmResponse = await fetch(billingUrl, { headers: workspaceHeaders() });
+    expect(warmResponse.status).toBe(200);
+    const commandLog = await readFile(process.env.OD_TEST_VELA_LOG!, 'utf8');
+    expect(commandLog).toContain(
       `billing workspace-snapshot --workspace-id ${PERSONAL.workspaceId}`,
     );
+    expect(commandLog.match(/billing summary --format json/g)).toHaveLength(1);
   }, 60_000);
 });
 

--- a/apps/daemon/tests/workspace-context-authority-server-wiring.test.ts
+++ b/apps/daemon/tests/workspace-context-authority-server-wiring.test.ts
@@ -63,10 +63,11 @@ afterEach(async () => {
 }, 30_000);
 
 describe('server workspace context authority wiring', () => {
-  it('keeps directory Team authority after a conflicting exact context cache becomes healthy', async () => {
+  it('keeps directory Team authority and fences an unread A -> B -> A Settings transition', async () => {
     scratch = await mkdtemp(join(tmpdir(), 'od-context-authority-wiring-'));
     let directoryReads = 0;
     let currentReads = 0;
+    let allowHubReady = true;
     let observeCatchUpCurrent!: () => void;
     const catchUpCurrentObserved = new Promise<void>((resolve) => {
       observeCatchUpCurrent = resolve;
@@ -79,6 +80,7 @@ describe('server workspace context authority wiring', () => {
         currentReads += 1;
         if (currentReads >= 2) observeCatchUpCurrent();
       },
+      isHubReady: () => allowHubReady,
     });
     const velaBin = await writeVelaStub(scratch);
     setEnv({
@@ -116,15 +118,12 @@ describe('server workspace context authority wiring', () => {
     await catchUpCurrentObserved;
 
     let warmContext: Record<string, unknown> | null = null;
-    for (let attempt = 0; attempt < 100; attempt += 1) {
+    await vi.waitFor(async () => {
       const readsBefore = currentReads;
       const context = await getWorkspaceContext();
-      if (currentReads === readsBefore) {
-        warmContext = context;
-        break;
-      }
-      await new Promise<void>((resolve) => setImmediate(resolve));
-    }
+      expect(currentReads).toBe(readsBefore);
+      warmContext = context;
+    }, { timeout: 10_000, interval: 50 });
 
     expect(warmContext).not.toBeNull();
     expect(warmContext).toMatchObject({
@@ -141,6 +140,26 @@ describe('server workspace context authority wiring', () => {
     await getWorkspaceContext();
     expect(directoryReads).toBe(directoryReadsAfterCatchUp);
     expect(currentReads).toBe(currentReadsAfterCatchUp);
+
+    // Red spec for the account-identity fence: both Settings writes complete
+    // without any directory/status read. The final credential identity is
+    // byte-for-byte A again, so a cache keyed only by the current identity
+    // would otherwise revive the old five-minute authority lease.
+    allowHubReady = false;
+    const directoryReadsBeforeCredentialRoundTrip = directoryReads;
+    const currentReadsBeforeCredentialRoundTrip = currentReads;
+    await putAmrApiUrl('https://account-b.example');
+    await putAmrApiUrl(authorityUrl);
+    expect(directoryReads).toBe(directoryReadsBeforeCredentialRoundTrip);
+
+    const afterCredentialRoundTrip = await getWorkspaceContext();
+    expect(afterCredentialRoundTrip).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      workspaceMemberId: MEMBER_ID,
+      role: 'admin',
+    });
+    expect(directoryReads).toBe(directoryReadsBeforeCredentialRoundTrip + 1);
+    expect(currentReads).toBe(currentReadsBeforeCredentialRoundTrip + 1);
   }, 60_000);
 });
 
@@ -174,9 +193,23 @@ async function getWorkspaceContext(): Promise<Record<string, unknown>> {
   return body.context;
 }
 
+async function putAmrApiUrl(apiUrl: string): Promise<void> {
+  const response = await fetch(`${daemon!.url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      agentCliEnv: {
+        amr: { VELA_API_URL: apiUrl },
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+}
+
 async function startAuthority(callbacks: {
   onDirectory: () => void;
   onCurrent: () => void;
+  isHubReady?: () => boolean;
 }): Promise<string> {
   authority = createServer((req, res) => {
     if (req.url === '/api/v1/workspaces' && req.method === 'GET') {
@@ -218,6 +251,7 @@ async function startAuthority(callbacks: {
         connection: 'keep-alive',
         'content-type': 'text/event-stream',
       });
+      if (callbacks.isHubReady?.() === false) return;
       res.write(
         `event: ready\ndata: ${JSON.stringify({
           workspaceId: WORKSPACE_ID,

--- a/apps/daemon/tests/workspace-context-authority-server-wiring.test.ts
+++ b/apps/daemon/tests/workspace-context-authority-server-wiring.test.ts
@@ -65,14 +65,20 @@ afterEach(async () => {
 describe('server workspace context authority wiring', () => {
   it('keeps directory Team authority after a conflicting exact context cache becomes healthy', async () => {
     scratch = await mkdtemp(join(tmpdir(), 'od-context-authority-wiring-'));
+    let directoryReads = 0;
     let currentReads = 0;
     let observeCatchUpCurrent!: () => void;
     const catchUpCurrentObserved = new Promise<void>((resolve) => {
       observeCatchUpCurrent = resolve;
     });
-    const authorityUrl = await startAuthority(() => {
-      currentReads += 1;
-      if (currentReads >= 2) observeCatchUpCurrent();
+    const authorityUrl = await startAuthority({
+      onDirectory: () => {
+        directoryReads += 1;
+      },
+      onCurrent: () => {
+        currentReads += 1;
+        if (currentReads >= 2) observeCatchUpCurrent();
+      },
     });
     const velaBin = await writeVelaStub(scratch);
     setEnv({
@@ -129,6 +135,12 @@ describe('server workspace context authority wiring', () => {
       teamId: WORKSPACE_ID,
       planId: 'team_pro',
     });
+    const directoryReadsAfterCatchUp = directoryReads;
+    const currentReadsAfterCatchUp = currentReads;
+    await getWorkspaceContext();
+    await getWorkspaceContext();
+    expect(directoryReads).toBe(directoryReadsAfterCatchUp);
+    expect(currentReads).toBe(currentReadsAfterCatchUp);
   }, 60_000);
 });
 
@@ -162,9 +174,13 @@ async function getWorkspaceContext(): Promise<Record<string, unknown>> {
   return body.context;
 }
 
-async function startAuthority(onCurrent: () => void): Promise<string> {
+async function startAuthority(callbacks: {
+  onDirectory: () => void;
+  onCurrent: () => void;
+}): Promise<string> {
   authority = createServer((req, res) => {
     if (req.url === '/api/v1/workspaces' && req.method === 'GET') {
+      callbacks.onDirectory();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({
         items: [{
@@ -180,7 +196,7 @@ async function startAuthority(onCurrent: () => void): Promise<string> {
       return;
     }
     if (req.url?.startsWith('/api/v1/workspaces/current') && req.method === 'GET') {
-      onCurrent();
+      callbacks.onCurrent();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({
         workspaceId: WORKSPACE_ID,

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -540,6 +540,23 @@ function explicitWorkspaceHeaders(selection: WorkspaceSelection): Record<string,
   };
 }
 
+function workspaceDirectoryItemFromContext(
+  context: WorkspaceCollabContext,
+): WorkspaceDirectoryItem {
+  return {
+    workspaceId: context.workspaceId,
+    workspaceName:
+      context.workspaceName?.trim()
+      || context.teamName?.trim()
+      || context.workspaceId,
+    workspaceType: context.workspaceType,
+    workspaceMemberId: context.workspaceMemberId,
+    role: context.role,
+    memberStatus: context.memberStatus,
+    lifecycleState: context.lifecycleState,
+  };
+}
+
 /** Test seam: clear the module-level context cache between tests. */
 export function resetWorkspaceContextCache(): void {
   cachedWorkspaceContext = null;
@@ -668,7 +685,12 @@ export function useWorkspaceContext(): WorkspaceContextState {
    * declaring a new local identity generation.
    */
   const loadContext = useCallback(async (
-    options: { markLoading?: boolean; fresh?: boolean } = {},
+    options: {
+      markLoading?: boolean;
+      fresh?: boolean;
+      /** Revalidate the already-selected scope without listing the account. */
+      exactScopeOnly?: boolean;
+    } = {},
   ) => {
     const requestEpoch = ++requestEpochRef.current;
     const requestGeneration = workspaceContextRequestToken;
@@ -684,16 +706,31 @@ export function useWorkspaceContext(): WorkspaceContextState {
     }
     try {
       const requestedSelection = readWorkspaceSelection();
+      const exactScopeContext =
+        options.exactScopeOnly
+        && requestedSelection
+        && cachedWorkspaceContext
+        && cachedWorkspaceContextGeneration === requestGeneration
+        && cachedWorkspaceContext.workspaceId === requestedSelection.workspaceId
+        && cachedWorkspaceContext.workspaceMemberId
+          === requestedSelection.workspaceMemberId
+          ? cachedWorkspaceContext
+          : null;
       const forceFresh = options.markLoading || options.fresh;
-      const directory = forceFresh
-        ? await readWorkspaceDirectoryForCurrentGeneration({ fresh: true })
-        : await readWorkspaceDirectoryForCurrentGeneration();
+      let directory: WorkspaceDirectoryResponse | null = null;
+      if (!exactScopeContext) {
+        directory = forceFresh
+          ? await readWorkspaceDirectoryForCurrentGeneration({ fresh: true })
+          : await readWorkspaceDirectoryForCurrentGeneration();
+      }
       if (
         !mountedRef.current
         || requestEpochRef.current !== requestEpoch
         || workspaceContextRequestToken !== requestGeneration
       ) return;
-      const selected = chooseWorkspaceForTab(directory.items ?? []);
+      const selected = exactScopeContext
+        ? workspaceDirectoryItemFromContext(exactScopeContext)
+        : chooseWorkspaceForTab(directory?.items ?? []);
       const exactSessionSelection = requestedSelection && selected
         && selected.workspaceId === requestedSelection.workspaceId
         && selected.workspaceMemberId === requestedSelection.workspaceMemberId
@@ -757,10 +794,11 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // Coalesced: every mounted consumer of this hook (and every focus/pageshow
       // refresh across them) fires the same read on a home-view burst — collapse
       // them to one request. The nav shell tolerates sub-second staleness.
-      // An explicit identity-change refresh forces a fresh read instead of
-      // sharing a settled answer that predates the change.
+      // Identity changes and exact-scope safety checks force a new generation
+      // read instead of sharing a settled answer that predates their trigger.
+      // `forceCoalescedGet` still single-flights the burst across consumers.
       const coalesceKey = workspaceContextCoalesceKey();
-      const body = forceFresh
+      const body = forceFresh || options.exactScopeOnly
         ? await forceCoalescedGet(coalesceKey, fetchContext)
         : await coalescedGet(coalesceKey, fetchContext);
       if (
@@ -846,7 +884,11 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // change may have landed while this browser had no sink, and accepting
       // that stale snapshot would immediately slow the fallback poll to the
       // healthy-SSE floor.
-      onActive: () => void loadContext({ fresh: true }),
+      onActive: (reason) => void loadContext(
+        reason === 'ambient'
+          ? { exactScopeOnly: true }
+          : { fresh: true },
+      ),
     },
   );
 
@@ -855,14 +897,20 @@ export function useWorkspaceContext(): WorkspaceContextState {
     // cadence when the stream is unavailable so there is no regression.
     const intervalMs = sseConnected ? WORKSPACE_CONTEXT_SSE_FLOOR_MS : WORKSPACE_CONTEXT_POLL_MS;
     const interval = setInterval(() => {
-      if (document.visibilityState === 'visible') void loadContext();
+      if (document.visibilityState !== 'visible') return;
+      // A healthy browser→daemon stream still gets a periodic safety read, but
+      // the scope is already known. Avoid listing the whole account merely to
+      // re-verify the current Workspace; the daemon decides whether its stricter
+      // upstream SSE authority is healthy enough to serve a bounded scoped
+      // cache or whether this request must fall back to `/api/v1/workspaces`.
+      void loadContext(sseConnected ? { exactScopeOnly: true } : undefined);
     }, intervalMs);
     return () => clearInterval(interval);
   }, [loadContext, sseConnected]);
 
   useEffect(() => {
     const refresh = () => {
-      void loadContext();
+      void loadContext(sseConnected ? { exactScopeOnly: true } : undefined);
     };
     // An EXPLICIT refresh means a caller just changed the identity (signed in
     // through onboarding or the rail callout) and is telling us so. Focus and
@@ -918,21 +966,28 @@ export function useWorkspaceContext(): WorkspaceContextState {
       if (detail?.requestKey !== workspaceContextRequestToken) return;
       void loadContext();
     };
-    window.addEventListener('focus', refresh);
+    // While the workspace EventSource is connected, its shared manager owns
+    // focus/visibility and labels those reads as ambient exact-scope checks.
+    // Keep these listeners only for the poll-only/disconnected fallback.
+    if (!sseConnected) window.addEventListener('focus', refresh);
     window.addEventListener('pageshow', refresh);
     window.addEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refreshAfterIdentityChange);
     window.addEventListener(WORKSPACE_CONTEXT_RETRY_EVENT, onContextRetry);
     window.addEventListener('storage', onStorage);
-    document.addEventListener('visibilitychange', onVisibilityChange);
+    if (!sseConnected) {
+      document.addEventListener('visibilitychange', onVisibilityChange);
+    }
     return () => {
-      window.removeEventListener('focus', refresh);
+      if (!sseConnected) window.removeEventListener('focus', refresh);
       window.removeEventListener('pageshow', refresh);
       window.removeEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refreshAfterIdentityChange);
       window.removeEventListener(WORKSPACE_CONTEXT_RETRY_EVENT, onContextRetry);
       window.removeEventListener('storage', onStorage);
-      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if (!sseConnected) {
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      }
     };
-  }, [loadContext]);
+  }, [loadContext, sseConnected]);
 
   const accountGeneration = currentWorkspaceAccountGeneration();
   return useMemo(

--- a/apps/web/src/collab/workspace-events.ts
+++ b/apps/web/src/collab/workspace-events.ts
@@ -3,7 +3,11 @@ import type {
   WorkspaceInvalidationEventName,
   WorkspaceInvalidationSsePayload,
 } from '@open-design/contracts';
-import { useEventStream, type UseEventStreamResult } from '../hooks/useEventStream';
+import {
+  useEventStream,
+  type EventStreamActiveReason,
+  type UseEventStreamResult,
+} from '../hooks/useEventStream';
 import { workspaceResourceUrl } from './workspace-identity';
 
 // Collab realtime hop-2 — the workspace-scoped invalidation SSE
@@ -34,7 +38,7 @@ export interface UseWorkspaceInvalidationOptions {
   /** Exact selected/project-persisted identity encoded into EventSource URL. */
   workspaceContext: WorkspaceCollabContext | null;
   /** Re-fetch the subscribed resource's snapshot on (re)connect + tab-visible. */
-  onActive?: () => void;
+  onActive?: (reason: EventStreamActiveReason) => void;
   /** When false the hook stays poll-only. Defaults to true. */
   enabled?: boolean;
 }

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -33,7 +33,7 @@ import {
   type Ref,
 } from 'react';
 import { createPortal } from 'react-dom';
-import { coalescedGet } from '../lib/coalesced-get';
+import { coalescedGet, evictCoalescedGet } from '../lib/coalesced-get';
 import type {
   WorkspaceActiveResponse,
   WorkspaceBillingSummary,
@@ -72,6 +72,7 @@ import {
 } from '../collab/useWorkspaceContext';
 import { canUpgradeFromPlanTier, hasTeamPlan, resolvePlanLabelTier } from '../collab/team-plan';
 import { AMR_CONSOLE_UPGRADE_INTENT, amrPlansUrlForProfile } from '../runtime/amr-guidance';
+import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import type { EntryHomeView } from '../router';
 import type {
   AccountMenuClickProps,
@@ -1273,7 +1274,7 @@ export function EntryNavRail({
           } satisfies WorkspaceDirectoryItem]
         : [];
 
-  async function loadWorkspaceDirectory() {
+  async function loadWorkspaceDirectory(options: { force?: boolean } = {}) {
     // Capture the identity this read is FOR, and compare against `contextRef`
     // (not the closed-over `context`, which is by definition the identity we are
     // reading for) before committing anything — see `beginWorkspaceScopedRead`.
@@ -1289,12 +1290,14 @@ export function EntryNavRail({
       // module cache does: `coalescedGet` shares a settled result for a second,
       // and this read's answer depends on WHO asked.
       const cacheKey = `workspace-directory:${workspaceIdentityCacheKey(read.context)}`;
-      const items = await coalescedGet(cacheKey, async () => {
+      if (options.force) evictCoalescedGet(cacheKey);
+      const readDirectory = async () => {
         const response = await fetch('/api/workspace/directory', { cache: 'no-store' });
         if (!response.ok) throw new Error(`directory ${response.status}`);
         const body = (await response.json()) as WorkspaceDirectoryResponse;
         return body.items ?? [];
-      });
+      };
+      const items = await coalescedGet(cacheKey, readDirectory);
       // The account may have changed while this was in flight. Writing here
       // would repopulate BOTH the module cache and the visible list with the
       // previous account's names, after the identity-change effect below had
@@ -1417,6 +1420,25 @@ export function EntryNavRail({
     if (!teamOpen) return;
     void loadWorkspaceDirectory();
   }, [teamOpen, railIdentity]);
+
+  // The account-directory event is delivered through the already-shared local
+  // Workspace EventSource. It stays mounted while the switcher is closed, so a
+  // remote create/join/rename/removal updates the cached list immediately. A
+  // reconnect/foreground edge also re-reads once to close a missed-event gap;
+  // this is event-driven catch-up, not a timer.
+  useWorkspaceInvalidation(
+    {
+      'workspace-directory-changed': () => {
+        void loadWorkspaceDirectory({ force: true });
+      },
+    },
+    {
+      workspaceContext: context,
+      onActive: () => {
+        void loadWorkspaceDirectory({ force: true });
+      },
+    },
+  );
 
   // This rail can outlive the identity that filled its list: an account swap
   // (sign out, sign in as someone else) does not necessarily unmount it, and

--- a/apps/web/src/hooks/useEventStream.ts
+++ b/apps/web/src/hooks/useEventStream.ts
@@ -29,6 +29,7 @@ import { BackoffController } from '../lib/backoff';
 // browser's ~6-per-host budget.
 
 export type EventStreamHandler = (data: unknown) => void;
+export type EventStreamActiveReason = 'connected' | 'ambient';
 
 export interface UseEventStreamOptions {
   /** Named-event handlers, keyed by SSE `event:` name. */
@@ -38,7 +39,7 @@ export interface UseEventStreamOptions {
    * visible/focus. Re-fetch the current snapshot of the subscribed resources
    * here to close any gap opened during a disconnect.
    */
-  onActive?: () => void;
+  onActive?: (reason: EventStreamActiveReason) => void;
   /** When false the hook never subscribes (stays poll-only). Defaults to true. */
   enabled?: boolean;
   /** Test seam: substitute a mock EventSource constructor. */
@@ -48,7 +49,7 @@ export interface UseEventStreamOptions {
 interface InternalSubscriber {
   eventNames: string[];
   getHandler: (name: string) => EventStreamHandler | undefined;
-  onActive: (() => void) | undefined;
+  onActive: ((reason: EventStreamActiveReason) => void) | undefined;
   onConnectedChange: (connected: boolean) => void;
 }
 
@@ -105,7 +106,7 @@ class EventStreamManager {
     sub.onConnectedChange(this.connected);
     this.ensureOpen();
     if (this.source) this.attachNames();
-    if (this.connected) sub.onActive?.();
+    if (this.connected) sub.onActive?.('connected');
     return () => this.unsubscribe(sub);
   }
 
@@ -149,7 +150,9 @@ class EventStreamManager {
       this.setConnected(true);
       // Snapshot catch-up on (re)connect — the thin-event model relies on this
       // instead of replaying buffered events.
-      for (const sub of Array.from(this.subscribers)) sub.onActive?.();
+      for (const sub of Array.from(this.subscribers)) {
+        sub.onActive?.('connected');
+      }
     };
     es.onerror = () => {
       // EventSource would auto-reconnect, but we drive our own jittered backoff
@@ -164,7 +167,9 @@ class EventStreamManager {
       if (!this.connected) {
         this.backoff.reset();
         this.setConnected(true);
-        for (const sub of Array.from(this.subscribers)) sub.onActive?.();
+        for (const sub of Array.from(this.subscribers)) {
+          sub.onActive?.('connected');
+        }
       }
     });
     this.attachNames();
@@ -254,7 +259,7 @@ class EventStreamManager {
       const now = Date.now();
       if (now - this.lastAmbientActiveAt < AMBIENT_ACTIVE_DEDUPE_MS) return;
       this.lastAmbientActiveAt = now;
-      for (const sub of Array.from(this.subscribers)) sub.onActive?.();
+      for (const sub of Array.from(this.subscribers)) sub.onActive?.('ambient');
     }
   };
 
@@ -335,7 +340,7 @@ export function useEventStream(
     const sub: InternalSubscriber = {
       eventNames: eventNamesRef.current,
       getHandler: (name) => eventsRef.current[name],
-      onActive: () => onActiveRef.current?.(),
+      onActive: (reason) => onActiveRef.current?.(reason),
       onConnectedChange: setConnected,
     };
     const unsubscribe = manager.subscribe(sub);

--- a/apps/web/tests/components/EntryNavRail.workspace-directory.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.workspace-directory.test.tsx
@@ -56,6 +56,33 @@ function teamContext(): WorkspaceCollabContext {
 
 const originalFetch = globalThis.fetch;
 
+class OpeningEventSource {
+  static instances: OpeningEventSource[] = [];
+  readonly listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(readonly url: string) {
+    OpeningEventSource.instances.push(this);
+    queueMicrotask(() => this.onopen?.());
+  }
+
+  addEventListener(name: string, listener: EventListenerOrEventListenerObject) {
+    const callback = listener as (event: MessageEvent) => void;
+    const current = this.listeners.get(name) ?? new Set();
+    current.add(callback);
+    this.listeners.set(name, current);
+  }
+
+  emit(name: string, data: unknown) {
+    for (const listener of this.listeners.get(name) ?? []) {
+      listener({ data: JSON.stringify(data) } as MessageEvent);
+    }
+  }
+
+  close() {}
+}
+
 /** Directory reads resolve only when released, so "before the network answers" is observable. */
 function installGatedFetch() {
   const releases: Array<() => void> = [];
@@ -99,16 +126,58 @@ function renderRail() {
 
 beforeEach(() => {
   resetWorkspaceDirectoryCache();
+  OpeningEventSource.instances = [];
+  vi.stubGlobal('EventSource', OpeningEventSource as unknown as typeof EventSource);
 });
 
 afterEach(() => {
   cleanup();
   globalThis.fetch = originalFetch;
   resetWorkspaceDirectoryCache();
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
 describe('workspace switcher directory', () => {
+  it('refreshes a remotely-created workspace while the switcher stays closed', async () => {
+    let items = DIRECTORY;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/workspace/directory')) {
+        return new Response(JSON.stringify({ items }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch;
+
+    renderRail();
+    await waitFor(() => expect(OpeningEventSource.instances).toHaveLength(1));
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/workspace/directory',
+      { cache: 'no-store' },
+    ));
+    expect(document.querySelector('.entry-nav-rail__team-menu')).toBeNull();
+
+    items = [
+      ...DIRECTORY,
+      {
+        workspaceId: 'ws-remote',
+        workspaceName: 'Remote-created team',
+        workspaceType: 'team',
+        workspaceMemberId: 'wm-remote',
+        role: 'owner',
+      },
+    ];
+    OpeningEventSource.instances[0]?.emit('workspace-directory-changed', {
+      type: 'workspace-directory-changed',
+      at: Date.now(),
+    });
+    await waitFor(() => expect(vi.mocked(globalThis.fetch).mock.calls.filter(
+      ([input]) => String(input).includes('/api/workspace/directory'),
+    )).toHaveLength(2));
+
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+    await waitFor(() => expect(menu().getByText('Remote-created team')).toBeTruthy());
+  });
+
   it('keeps actions outside the scrollable workspace list when the directory exceeds five items', async () => {
     const manyWorkspaces = Array.from({ length: 7 }, (_, index) => ({
       workspaceId: index === 0 ? 'ws-team' : `ws-${index + 1}`,

--- a/apps/web/tests/hooks/useEventStream.test.tsx
+++ b/apps/web/tests/hooks/useEventStream.test.tsx
@@ -166,6 +166,22 @@ describe('useEventStream', () => {
     expect(activeCount).toBe(3);
   });
 
+  it('distinguishes connection catch-up from ambient focus revalidation', () => {
+    const reasons: string[] = [];
+    renderHook(() =>
+      useEventStream('/api/workspace/events', {
+        events: {},
+        onActive: (reason) => reasons.push(reason),
+        EventSourceCtor: Ctor,
+      }),
+    );
+
+    act(() => MockEventSource.instances[0]!.open());
+    act(() => window.dispatchEvent(new Event('focus')));
+
+    expect(reasons).toEqual(['connected', 'ambient']);
+  });
+
   it('stays poll-only (never connects) when disabled', () => {
     const { result } = renderHook(() =>
       useEventStream('/api/workspace/events', {

--- a/apps/web/tests/useWorkspaceContext.invalidation.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.invalidation.test.tsx
@@ -105,6 +105,7 @@ describe('useWorkspaceContext invalidation freshness', () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     resetCoalescedGet();
     resetWorkspaceContextCache();
@@ -206,5 +207,80 @@ describe('useWorkspaceContext invalidation freshness', () => {
         permissions: { canInviteMembers: true },
       });
     });
+  });
+
+  it('uses an exact-scope safety read without relisting the account while SSE is connected', async () => {
+    vi.useFakeTimers();
+    OpeningEventSource.autoOpen = false;
+    let directoryReads = 0;
+    let contextReads = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/workspace/directory') {
+        directoryReads += 1;
+        return jsonResponse(workspaceDirectoryFixture([TEAM_CONTEXT]));
+      }
+      if (url === '/api/workspace/context') {
+        contextReads += 1;
+        return jsonResponse({ context: TEAM_CONTEXT });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const hook = renderHook(() => useWorkspaceContext());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(hook.result.current.context?.workspaceId).toBe(TEAM_CONTEXT.workspaceId);
+    expect(directoryReads).toBe(1);
+    expect(contextReads).toBe(1);
+
+    await act(async () => {
+      OpeningEventSource.instances[0]?.open();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(directoryReads).toBe(2);
+    expect(contextReads).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+    expect(directoryReads).toBe(2);
+    expect(contextReads).toBe(3);
+  });
+
+  it('uses an exact-scope read on focus while the stream remains connected', async () => {
+    OpeningEventSource.autoOpen = false;
+    let clock = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => clock);
+    let directoryReads = 0;
+    let contextReads = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/workspace/directory') {
+        directoryReads += 1;
+        return jsonResponse(workspaceDirectoryFixture([TEAM_CONTEXT]));
+      }
+      if (url === '/api/workspace/context') {
+        contextReads += 1;
+        return jsonResponse({ context: TEAM_CONTEXT });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const hook = renderHook(() => useWorkspaceContext());
+    await waitFor(() => {
+      expect(hook.result.current.context?.workspaceId).toBe(TEAM_CONTEXT.workspaceId);
+    });
+    act(() => OpeningEventSource.instances[0]?.open());
+    await waitFor(() => expect(directoryReads).toBe(2));
+    expect(contextReads).toBe(2);
+
+    // Outside forceCoalescedGet's same-transition burst window, this is a
+    // genuinely separate ambient safety check.
+    clock = 251;
+    act(() => window.dispatchEvent(new Event('focus')));
+    await waitFor(() => expect(contextReads).toBe(3));
+    expect(directoryReads).toBe(2);
   });
 });

--- a/e2e/lib/playwright/fake-collab-hub.ts
+++ b/e2e/lib/playwright/fake-collab-hub.ts
@@ -1,4 +1,4 @@
-import { chmod, cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { createServer, type Server, type ServerResponse } from 'node:http';
 import { join } from 'node:path';
 
@@ -30,6 +30,7 @@ type TeamProjectRecord = {
 };
 
 type ResourceRecord = {
+  workspaceId: string;
   projectId: string | null;
   resourceId: string;
   kind: string;
@@ -50,6 +51,19 @@ type HubEvent = {
   resourceStatus?: 'shared' | 'retracted';
   revision?: string;
   version?: number;
+};
+
+type WorkspaceDirectoryEvent = {
+  type: 'workspace-directory-changed';
+  workspaceId: string;
+  change:
+    | 'created'
+    | 'updated'
+    | 'deleted'
+    | 'membership-added'
+    | 'membership-updated'
+    | 'membership-removed';
+  at: string;
 };
 
 type CommandLog = {
@@ -92,6 +106,9 @@ export type FakeCollabHub = {
   emitEvent: (event: HubEvent) => void;
   removeMember: (memberId: string) => void;
   setMemberRole: (memberId: string, role: ClientIdentity['role']) => void;
+  addWorkspace: (memberId: string, workspaceId: string, workspaceName: string) => void;
+  setAccountMembershipTier: (memberId: string, membershipTier: string) => void;
+  setWorkspacePlan: (planId: string, billingState?: string) => void;
   setWorkspaceBalance: (memberId: string, balanceUsd: string) => void;
   close: () => Promise<void>;
 };
@@ -119,9 +136,28 @@ export async function startFakeCollabHub(options: {
   const memberRoles = new Map(
     options.clients.map((client) => [client.memberId, client.role]),
   );
+  const addedWorkspaces = new Map<
+    string,
+    Map<string, { workspaceId: string; workspaceName: string; workspaceMemberId: string }>
+  >();
   const workspaceBalances = new Map(
-    options.clients.map((client) => [client.memberId, { balanceUsd: '0.00', revision: 1 }]),
+    options.clients.map((client) => [
+      workspaceMemberKey(options.workspaceId, client.memberId),
+      { balanceUsd: '0.00', revision: 1 },
+    ]),
   );
+  const accountBilling = new Map(
+    options.clients.map((client) => [client.memberId, {
+      membershipTier: 'team_plus',
+      balanceUsd: '0.00',
+      revision: 1,
+    }]),
+  );
+  const workspaceBilling = new Map([[options.workspaceId, {
+    billingState: 'active',
+    planId: 'team_plus' as string | null,
+    revision: 1,
+  }]]);
   const commandLog: CommandLog[] = [];
   const eventLog: HubEvent[] = [];
   const requestLog: RequestLog[] = [];
@@ -190,6 +226,10 @@ export async function startFakeCollabHub(options: {
 
       if (url.pathname === '/api/v1/workspaces/current' && request.method === 'GET') {
         if (!identity) return json(response, 401, { error: 'unauthorized' });
+        const addedWorkspace = addedWorkspaces.get(identity.memberId)?.get(workspaceId);
+        if (addedWorkspace) {
+          return json(response, 200, addedWorkspaceContext(addedWorkspace));
+        }
         if (
           options.includePersonalWorkspace
           && workspaceId === personalWorkspaceId(identity.memberId)
@@ -210,14 +250,18 @@ export async function startFakeCollabHub(options: {
           // This is a membership directory for the authenticated app user,
           // not a workspace roster. Two clients in the same workspace each
           // receive their own one membership row.
-          items: removedMembers.has(identity.memberId)
-            ? [personalWorkspaceDirectoryItem(identity)]
-            : options.includePersonalWorkspace
-              ? [
-                  personalWorkspaceDirectoryItem(identity),
-                  workspaceDirectoryItem(options, identity),
-                ]
-              : [workspaceDirectoryItem(options, identity)],
+          items: [
+            ...(removedMembers.has(identity.memberId)
+              ? [personalWorkspaceDirectoryItem(identity)]
+              : options.includePersonalWorkspace
+                ? [
+                    personalWorkspaceDirectoryItem(identity),
+                    workspaceDirectoryItem(options, identity),
+                  ]
+                : [workspaceDirectoryItem(options, identity)]),
+            ...[...(addedWorkspaces.get(identity.memberId)?.values() ?? [])]
+              .map(addedWorkspaceDirectoryItem),
+          ],
         });
       }
       if (url.pathname === '/api/v1/collab/events' && request.method === 'GET') {
@@ -251,8 +295,12 @@ export async function startFakeCollabHub(options: {
                   'workspace-member-events-v1',
                   'workspace-event-listener-status-v1',
                   'billing-revision-clocks-v1',
+                  'workspace-directory-events-v1',
                 ]
-              : ['authoritative-project-presence-v1'],
+              : [
+                  'authoritative-project-presence-v1',
+                  'workspace-directory-events-v1',
+                ],
             ...(options.strictAuthorityEvents ? listenerStatus : {}),
           })}\n\n`,
         );
@@ -297,6 +345,8 @@ export async function startFakeCollabHub(options: {
           resourcesRoot,
           comments,
           presence,
+          accountBilling,
+          workspaceBilling,
           workspaceBalances,
           memberRoles,
           removedMembers,
@@ -320,6 +370,14 @@ export async function startFakeCollabHub(options: {
       if (subscriber.workspaceId === event.workspaceId) {
         subscriber.response.write(frame);
       }
+    }
+  }
+
+  function emitDirectory(memberId: string, event: WorkspaceDirectoryEvent): void {
+    const frame =
+      `event: workspace-directory-changed\ndata: ${JSON.stringify(event)}\n\n`;
+    for (const subscriber of subscribers) {
+      if (subscriber.memberId === memberId) subscriber.response.write(frame);
     }
   }
 
@@ -375,10 +433,59 @@ export async function startFakeCollabHub(options: {
       memberRoles.set(memberId, role);
       emit({ type: 'workspace-context-changed', workspaceId: options.workspaceId });
     },
-    setWorkspaceBalance: (memberId, balanceUsd) => {
-      const previous = workspaceBalances.get(memberId) ?? { balanceUsd: '0.00', revision: 0 };
+    addWorkspace: (memberId, workspaceId, workspaceName) => {
+      if (!identitiesByMemberId(options.clients).has(memberId)) {
+        throw new Error(`unknown fake collaboration member: ${memberId}`);
+      }
+      const memberships = addedWorkspaces.get(memberId) ?? new Map();
+      memberships.set(workspaceId, {
+        workspaceId,
+        workspaceName,
+        workspaceMemberId: `member-${memberId}-${workspaceId}`,
+      });
+      addedWorkspaces.set(memberId, memberships);
+      // Account-directory invalidation rides any existing Workspace stream for
+      // this account; the new Workspace itself need not be subscribed yet.
+      emitDirectory(memberId, {
+        type: 'workspace-directory-changed',
+        workspaceId,
+        change: 'created',
+        at: new Date().toISOString(),
+      });
+    },
+    setAccountMembershipTier: (memberId, membershipTier) => {
+      const previous = accountBilling.get(memberId) ?? {
+        membershipTier: 'team_plus',
+        balanceUsd: '0.00',
+        revision: 0,
+      };
       const revision = previous.revision + 1;
-      workspaceBalances.set(memberId, { balanceUsd, revision });
+      accountBilling.set(memberId, { ...previous, membershipTier, revision });
+      emit({
+        type: 'billing-changed',
+        workspaceId: options.workspaceId,
+        revision: `account-${memberId}-${revision}`,
+      });
+    },
+    setWorkspacePlan: (planId, billingState = 'active') => {
+      const previous = workspaceBilling.get(options.workspaceId) ?? {
+        billingState: 'free',
+        planId: null,
+        revision: 0,
+      };
+      const revision = previous.revision + 1;
+      workspaceBilling.set(options.workspaceId, { billingState, planId, revision });
+      emit({
+        type: 'billing-subscription-changed',
+        workspaceId: options.workspaceId,
+        revision: `billing-${revision}`,
+      });
+    },
+    setWorkspaceBalance: (memberId, balanceUsd) => {
+      const key = workspaceMemberKey(options.workspaceId, memberId);
+      const previous = workspaceBalances.get(key) ?? { balanceUsd: '0.00', revision: 0 };
+      const revision = previous.revision + 1;
+      workspaceBalances.set(key, { balanceUsd, revision });
       emit({
         type: 'wallet-balance-changed',
         workspaceId: options.workspaceId,
@@ -405,6 +512,14 @@ async function handleCommand(input: {
   resourcesRoot: string;
   comments: Map<string, Array<Record<string, unknown>>>;
   presence: Map<string, Map<string, Record<string, unknown>>>;
+  accountBilling: Map<
+    string,
+    { membershipTier: string; balanceUsd: string; revision: number }
+  >;
+  workspaceBilling: Map<
+    string,
+    { billingState: string; planId: string | null; revision: number }
+  >;
   workspaceBalances: Map<string, { balanceUsd: string; revision: number }>;
   memberRoles: Map<string, ClientIdentity['role']>;
   removedMembers: Set<string>;
@@ -419,12 +534,26 @@ async function handleCommand(input: {
     return jsonLine({ models: [] });
   }
   if (args[0] === 'billing' && args[1] === 'summary') {
-    return jsonLine({ membershipTier: 'team_plus', balanceUsd: '0.00' });
+    const billing = input.accountBilling.get(input.identity.memberId) ?? {
+      membershipTier: 'team_plus',
+      balanceUsd: '0.00',
+    };
+    return jsonLine({
+      membershipTier: billing.membershipTier,
+      balanceUsd: billing.balanceUsd,
+    });
   }
   if (args[0] === 'billing' && args[1] === 'workspace-snapshot') {
-    const balance = input.workspaceBalances.get(input.identity.memberId) ?? {
+    const billing = input.workspaceBilling.get(input.workspaceId) ?? {
+      billingState: 'free',
+      planId: null,
+      revision: 0,
+    };
+    const balance = input.workspaceBalances.get(
+      workspaceMemberKey(input.workspaceId, input.identity.memberId),
+    ) ?? {
       balanceUsd: '0.00',
-      revision: 1,
+      revision: 0,
     };
     const updatedAt = new Date().toISOString();
     return jsonLine({
@@ -432,10 +561,13 @@ async function handleCommand(input: {
       workspaceId: input.workspaceId,
       workspaceMemberId: input.identity.memberId,
       billingScopeVersion: 2,
-      billing: { billingState: 'active', planId: 'team_plus' },
+      billing: {
+        billingState: billing.billingState,
+        planId: billing.planId,
+      },
       wallet: { balanceUsd: balance.balanceUsd, expiresAt: null, updatedAt },
       revisions: {
-        billing: 'billing-1',
+        billing: `billing-${billing.revision}`,
         wallet: `wallet-${balance.revision}`,
       },
     });
@@ -476,25 +608,34 @@ async function handleTeamProjectsCommand(input: {
     return jsonLine(recordForIdentity(project, input.identity));
   }
   if (command === 'pull' && projectId) {
-    const targetDir = input.args[3];
+    const authorizeOnly = input.args.includes('--authorize-only');
+    const targetDir = authorizeOnly ? null : input.args[3];
     const expectedVersion = Number(flag(input.args, '--expected-version'));
     const project = input.projects.get(projectId);
-    const resource = project ? input.resources.get(project.resourceId) : null;
+    const resource = project
+      ? input.resources.get(workspaceResourceKey(input.workspaceId, project.resourceId))
+      : null;
     const requestedSnapshot = resource?.versions.get(expectedVersion);
     if (
       !project ||
       !resource ||
       !requestedSnapshot ||
-      !targetDir ||
+      (!authorizeOnly && !targetDir) ||
       !Number.isSafeInteger(expectedVersion)
     ) {
       throw new Error('authorized_team_project_pull_rejected');
     }
-    // Vela replaces the caller-created empty stage inode before returning its
-    // short-lived authorization receipt.
-    await rm(targetDir, { force: true, recursive: true });
-    await cp(requestedSnapshot, targetDir, { recursive: true });
+    if (targetDir) {
+      // Vela replaces the caller-created empty stage inode before returning its
+      // short-lived authorization receipt.
+      await rm(targetDir, { force: true, recursive: true });
+      await cp(requestedSnapshot, targetDir, { recursive: true });
+    }
     const authorizedAt = Date.now();
+    const manifestEntryCount = authorizeOnly
+      ? (await readdir(requestedSnapshot, { recursive: true, withFileTypes: true }))
+          .filter((entry) => entry.isFile()).length
+      : undefined;
     return jsonLine({
       schemaVersion: 1,
       workspaceId: input.workspaceId,
@@ -510,6 +651,7 @@ async function handleTeamProjectsCommand(input: {
       lifecycleState: 'active',
       authorizedAt: new Date(authorizedAt).toISOString(),
       expiresAt: new Date(authorizedAt + 2_000).toISOString(),
+      ...(manifestEntryCount === undefined ? {} : { manifestEntryCount }),
     });
   }
   if (command === 'upsert' && projectId) {
@@ -574,17 +716,23 @@ async function handleResourceCommand(input: {
       typeof metadata?.projectId === 'string'
         ? metadata.projectId
         : [...input.projects.values()]
-            .find((project) => project.resourceId === resourceId)?.projectId ?? null;
+            .find(
+              (project) =>
+                project.workspaceId === input.workspaceId
+                && project.resourceId === resourceId,
+            )?.projectId ?? null;
     if (kind === 'project' && !projectId) throw new Error('resource push missing project id');
-    const previous = input.resources.get(resourceId);
+    const resourceKey = workspaceResourceKey(input.workspaceId, resourceId);
+    const previous = input.resources.get(resourceKey);
     const version = (previous?.version ?? 0) + 1;
-    const resourceRoot = join(input.resourcesRoot, encodeURIComponent(resourceId));
+    const resourceRoot = join(input.resourcesRoot, encodeURIComponent(resourceKey));
     const snapshotDir = join(resourceRoot, `v${version}`);
     await rm(snapshotDir, { force: true, recursive: true });
     await cp(sourceDir, snapshotDir, { recursive: true });
     const versions = previous?.versions ?? new Map<number, string>();
     versions.set(version, snapshotDir);
-    input.resources.set(resourceId, {
+    input.resources.set(resourceKey, {
+      workspaceId: input.workspaceId,
       projectId,
       resourceId,
       kind,
@@ -614,7 +762,9 @@ async function handleResourceCommand(input: {
   }
   if (command === 'head') {
     const resourceId = input.args[2];
-    const resource = resourceId ? input.resources.get(resourceId) : null;
+    const resource = resourceId
+      ? input.resources.get(workspaceResourceKey(input.workspaceId, resourceId))
+      : null;
     return jsonLine(
       resource
         ? { version: resource.version, versionId: `v${resource.version}` }
@@ -624,7 +774,9 @@ async function handleResourceCommand(input: {
   if (command === 'pull') {
     const resourceId = input.args[3];
     const targetDir = input.args[4];
-    const resource = resourceId ? input.resources.get(resourceId) : null;
+    const resource = resourceId
+      ? input.resources.get(workspaceResourceKey(input.workspaceId, resourceId))
+      : null;
     if (!resource || !targetDir) throw new Error('resource_not_found');
     // Deliberately replace the directory inode. This is the production pull
     // shape that used to orphan the already-open member daemon's watcher.
@@ -667,7 +819,9 @@ async function handleResourceCommand(input: {
     const results = [];
     let succeeded = 0;
     for (const request of requests) {
-      const resource = input.resources.get(request.resourceId);
+      const resource = input.resources.get(
+        workspaceResourceKey(input.workspaceId, request.resourceId),
+      );
       if (!resource) {
         results.push({
           ...request,
@@ -691,8 +845,11 @@ async function handleResourceCommand(input: {
   }
   if (command === 'remove') {
     const resourceId = input.args[2];
-    const resource = resourceId ? input.resources.get(resourceId) : null;
-    if (resourceId) input.resources.delete(resourceId);
+    const resourceKey = resourceId
+      ? workspaceResourceKey(input.workspaceId, resourceId)
+      : null;
+    const resource = resourceKey ? input.resources.get(resourceKey) : null;
+    if (resourceKey) input.resources.delete(resourceKey);
     if (resource && resource.kind !== 'project') {
       input.emit({
         type: 'team-resources-changed',
@@ -710,7 +867,11 @@ async function handleResourceCommand(input: {
   if (command === 'shared') {
     return jsonLine({
       resources: [...input.resources.values()]
-        .filter((resource) => resource.kind !== 'project')
+        .filter(
+          (resource) =>
+            resource.workspaceId === input.workspaceId
+            && resource.kind !== 'project',
+        )
         .map((resource) => ({
           id: resource.resourceId,
           kind: resource.kind,
@@ -888,8 +1049,44 @@ function workspaceDirectoryItem(
   };
 }
 
+function addedWorkspaceDirectoryItem(workspace: {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceMemberId: string;
+}) {
+  return {
+    ...workspace,
+    workspaceType: 'team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  };
+}
+
+function addedWorkspaceContext(workspace: {
+  workspaceId: string;
+  workspaceName: string;
+  workspaceMemberId: string;
+}) {
+  return {
+    ...addedWorkspaceDirectoryItem(workspace),
+    billingState: 'free',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 1, usedSeats: 1, availableSeats: 0, isSeatFull: true },
+  };
+}
+
 function personalWorkspaceId(memberId: string): string {
   return `personal-${memberId}`;
+}
+
+function workspaceMemberKey(workspaceId: string, memberId: string): string {
+  return `${workspaceId}\0${memberId}`;
+}
+
+function workspaceResourceKey(workspaceId: string, resourceId: string): string {
+  return `${workspaceId}\0${resourceId}`;
 }
 
 function personalWorkspaceDirectoryItem(identity: ClientIdentity) {
@@ -927,7 +1124,7 @@ const response = await fetch(new URL('/__e2e/command', process.env.VELA_API_URL)
   headers: {
     authorization: 'Bearer ' + process.env.VELA_CONTROL_KEY,
     'content-type': 'application/json',
-    'x-vela-workspace-id': process.env.OPEN_DESIGN_WORKSPACE_ID || '',
+    'x-vela-workspace-id': process.env.VELA_WORKSPACE_ID || process.env.OPEN_DESIGN_WORKSPACE_ID || '',
   },
   body: JSON.stringify({ args, stdin }),
 });

--- a/e2e/lib/playwright/fake-collab-hub.ts
+++ b/e2e/lib/playwright/fake-collab-hub.ts
@@ -58,10 +58,18 @@ type CommandLog = {
   workspaceId: string;
 };
 
+type RequestLog = {
+  method: string;
+  path: string;
+  memberId: string | null;
+  workspaceId: string;
+};
+
 type Subscriber = {
   response: ServerResponse;
   workspaceId: string;
   memberId: string;
+  heartbeat: ReturnType<typeof setInterval> | null;
 };
 
 export type FakeCollabHub = {
@@ -69,6 +77,7 @@ export type FakeCollabHub = {
   workspaceId: string;
   commandLog: CommandLog[];
   eventLog: HubEvent[];
+  requestLog: RequestLog[];
   writeVelaBin: (path: string) => Promise<string>;
   waitForCommand: (
     predicate: (entry: CommandLog) => boolean,
@@ -80,6 +89,7 @@ export type FakeCollabHub = {
   ) => Promise<HubEvent>;
   setEventsAvailable: (memberId: string, available: boolean) => void;
   eventSubscriberCount: (memberId: string) => number;
+  emitEvent: (event: HubEvent) => void;
   removeMember: (memberId: string) => void;
   setMemberRole: (memberId: string, role: ClientIdentity['role']) => void;
   setWorkspaceBalance: (memberId: string, balanceUsd: string) => void;
@@ -92,6 +102,8 @@ export async function startFakeCollabHub(options: {
   workspaceName: string;
   clients: readonly ClientIdentity[];
   includePersonalWorkspace?: boolean;
+  /** Opt into the producer-health contract used by authority-cache E2E. */
+  strictAuthorityEvents?: boolean;
 }): Promise<FakeCollabHub> {
   const resourcesRoot = join(options.root, 'resources');
   await mkdir(resourcesRoot, { recursive: true });
@@ -112,6 +124,14 @@ export async function startFakeCollabHub(options: {
   );
   const commandLog: CommandLog[] = [];
   const eventLog: HubEvent[] = [];
+  const requestLog: RequestLog[] = [];
+
+  const closeSubscriber = (subscriber: Subscriber): void => {
+    if (subscriber.heartbeat) clearInterval(subscriber.heartbeat);
+    subscriber.heartbeat = null;
+    subscribers.delete(subscriber);
+    subscriber.response.end();
+  };
 
   const server: Server = createServer(async (request, response) => {
     try {
@@ -125,6 +145,48 @@ export async function startFakeCollabHub(options: {
         : null;
       const workspaceId =
         headerValue(request.headers['x-vela-workspace-id']) || options.workspaceId;
+      requestLog.push({
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        memberId: identity?.memberId ?? null,
+        workspaceId,
+      });
+
+      if (url.pathname === '/__e2e/stats' && request.method === 'GET') {
+        return json(response, 200, {
+          commands: commandLog,
+          events: eventLog,
+          requests: requestLog,
+          subscribers: [...subscribers].map((subscriber) => ({
+            memberId: subscriber.memberId,
+            workspaceId: subscriber.workspaceId,
+          })),
+        });
+      }
+      if (url.pathname === '/__e2e/event' && request.method === 'POST') {
+        const body = await readJsonBody(request) as HubEvent;
+        emit(body);
+        return json(response, 200, { ok: true });
+      }
+      if (url.pathname === '/__e2e/events-available' && request.method === 'POST') {
+        const body = await readJsonBody(request) as {
+          available?: unknown;
+          memberId?: unknown;
+        };
+        const memberId = typeof body.memberId === 'string' ? body.memberId.trim() : '';
+        if (!memberId || typeof body.available !== 'boolean') {
+          return json(response, 400, { error: 'invalid_events_available_input' });
+        }
+        if (body.available) {
+          blockedEventMembers.delete(memberId);
+        } else {
+          blockedEventMembers.add(memberId);
+          for (const subscriber of [...subscribers]) {
+            if (subscriber.memberId === memberId) closeSubscriber(subscriber);
+          }
+        }
+        return json(response, 200, { ok: true });
+      }
 
       if (url.pathname === '/api/v1/workspaces/current' && request.method === 'GET') {
         if (!identity) return json(response, 401, { error: 'unauthorized' });
@@ -168,15 +230,49 @@ export async function startFakeCollabHub(options: {
           connection: 'keep-alive',
           'content-type': 'text/event-stream; charset=utf-8',
         });
-        const subscriber = { response, workspaceId, memberId: identity.memberId };
+        const subscriber: Subscriber = {
+          response,
+          workspaceId,
+          memberId: identity.memberId,
+          heartbeat: null,
+        };
         subscribers.add(subscriber);
+        const listenerStatus = {
+          listenerEpoch: `fake-hub-${identity.memberId}`,
+          listenerHealth: 'healthy',
+          sourceGap: false,
+        } as const;
         response.write(
           `event: ready\ndata: ${JSON.stringify({
             workspaceId,
-            capabilities: ['authoritative-project-presence-v1'],
+            capabilities: options.strictAuthorityEvents
+              ? [
+                  'authoritative-project-presence-v1',
+                  'workspace-member-events-v1',
+                  'workspace-event-listener-status-v1',
+                  'billing-revision-clocks-v1',
+                ]
+              : ['authoritative-project-presence-v1'],
+            ...(options.strictAuthorityEvents ? listenerStatus : {}),
           })}\n\n`,
         );
-        request.on('close', () => subscribers.delete(subscriber));
+        if (options.strictAuthorityEvents) {
+          const writeHeartbeat = () => {
+            if (!subscribers.has(subscriber)) return;
+            response.write(
+              `event: heartbeat\ndata: ${JSON.stringify(listenerStatus)}\n\n`,
+            );
+          };
+          // `ready` is deliberately not sufficient for authority health. The
+          // immediate post-ready heartbeat proves the producer listener has
+          // crossed its membership revalidation boundary.
+          writeHeartbeat();
+          subscriber.heartbeat = setInterval(writeHeartbeat, 5_000);
+          subscriber.heartbeat.unref?.();
+        }
+        request.on('close', () => {
+          if (subscribers.has(subscriber)) closeSubscriber(subscriber);
+        });
         return;
       }
       if (url.pathname === '/__e2e/command' && request.method === 'POST') {
@@ -239,6 +335,7 @@ export async function startFakeCollabHub(options: {
     workspaceId: options.workspaceId,
     commandLog,
     eventLog,
+    requestLog,
     writeVelaBin: async (path) => {
       await writeFile(path, fakeVelaScript(), 'utf8');
       await chmod(path, 0o755);
@@ -256,12 +353,12 @@ export async function startFakeCollabHub(options: {
       blockedEventMembers.add(memberId);
       for (const subscriber of [...subscribers]) {
         if (subscriber.memberId !== memberId) continue;
-        subscribers.delete(subscriber);
-        subscriber.response.end();
+        closeSubscriber(subscriber);
       }
     },
     eventSubscriberCount: (memberId) =>
       [...subscribers].filter((subscriber) => subscriber.memberId === memberId).length,
+    emitEvent: emit,
     removeMember: (memberId) => {
       removedMembers.add(memberId);
       for (const roster of presence.values()) {
@@ -290,7 +387,7 @@ export async function startFakeCollabHub(options: {
       });
     },
     close: async () => {
-      for (const subscriber of subscribers) subscriber.response.end();
+      for (const subscriber of [...subscribers]) closeSubscriber(subscriber);
       await new Promise<void>((resolve) => server.close(() => resolve()));
       await rm(resourcesRoot, { force: true, recursive: true });
     },

--- a/e2e/tests/fake-collab-hub.test.ts
+++ b/e2e/tests/fake-collab-hub.test.ts
@@ -80,6 +80,38 @@ describe('fake collaboration hub authorization receipts', () => {
 
     const authorizedAt = Date.parse(receipt.authorizedAt);
     expect(Date.parse(receipt.expiresAt) - authorizedAt).toBe(2_000);
+
+    const inspection = JSON.parse(await command([
+      'team-projects',
+      'pull',
+      projectId,
+      '--authorize-only',
+      '--expected-version',
+      '1',
+      '--json',
+    ], MEMBER.controlKey)) as { manifestEntryCount: number };
+    expect(inspection.manifestEntryCount).toBe(1);
+  });
+
+  it('forwards the resource command workspace instead of the agent trace workspace', async () => {
+    fixtureRoot = await mkdtemp(join(tmpdir(), 'open-design-fake-collab-hub-'));
+    const velaBin = join(fixtureRoot, 'vela');
+    hub = await startFakeCollabHub({
+      root: fixtureRoot,
+      workspaceId: WORKSPACE_ID,
+      workspaceName: 'Workspace header contract',
+      clients: [OWNER],
+    });
+    await hub.writeVelaBin(velaBin);
+
+    const snapshot = JSON.parse(await velaCommand(
+      velaBin,
+      ['billing', 'workspace-snapshot', '--json'],
+      undefined,
+      'ws-selected-by-resource-command',
+    )) as { workspaceId: string };
+
+    expect(snapshot.workspaceId).toBe('ws-selected-by-resource-command');
   });
 });
 
@@ -87,11 +119,15 @@ describe('fake collaboration hub Vela resource pulls', () => {
   it('keeps single pull compatibility and isolates batch item failures', async () => {
     fixtureRoot = await mkdtemp(join(tmpdir(), 'open-design-fake-collab-hub-'));
     const sourceDir = join(fixtureRoot, 'source');
+    const otherSourceDir = join(fixtureRoot, 'other-source');
     const singleTarget = join(fixtureRoot, 'single-target');
+    const otherTarget = join(fixtureRoot, 'other-target');
     const batchTarget = join(fixtureRoot, 'batch-target');
     const velaBin = join(fixtureRoot, 'vela');
     await mkdir(sourceDir, { recursive: true });
+    await mkdir(otherSourceDir, { recursive: true });
     await writeFile(join(sourceDir, 'index.html'), '<h1>resource fixture</h1>', 'utf8');
+    await writeFile(join(otherSourceDir, 'index.html'), '<h1>other workspace</h1>', 'utf8');
     hub = await startFakeCollabHub({
       root: fixtureRoot,
       workspaceId: WORKSPACE_ID,
@@ -103,6 +139,12 @@ describe('fake collaboration hub Vela resource pulls', () => {
     await velaCommand(velaBin, [
       'resource', 'push', 'plugin', 'plugin-present', sourceDir, '--json',
     ]);
+    await velaCommand(
+      velaBin,
+      ['resource', 'push', 'plugin', 'plugin-present', otherSourceDir, '--json'],
+      undefined,
+      'ws-other',
+    );
 
     const single = JSON.parse(await velaCommand(velaBin, [
       'resource', 'pull', 'plugin', 'plugin-present', singleTarget, '--json',
@@ -110,6 +152,14 @@ describe('fake collaboration hub Vela resource pulls', () => {
     expect(single.version).toBe(1);
     await expect(readFile(join(singleTarget, 'index.html'), 'utf8'))
       .resolves.toContain('resource fixture');
+    await velaCommand(
+      velaBin,
+      ['resource', 'pull', 'plugin', 'plugin-present', otherTarget, '--json'],
+      undefined,
+      'ws-other',
+    );
+    await expect(readFile(join(otherTarget, 'index.html'), 'utf8'))
+      .resolves.toContain('other workspace');
 
     const batch = JSON.parse(await velaCommand(
       velaBin,
@@ -174,6 +224,7 @@ async function velaCommand(
   bin: string,
   args: string[],
   input?: string,
+  workspaceId = WORKSPACE_ID,
 ): Promise<string> {
   if (!hub) throw new Error('fake collaboration hub is not running');
   return await new Promise<string>((resolve, reject) => {
@@ -181,6 +232,7 @@ async function velaCommand(
       env: {
         ...process.env,
         OPEN_DESIGN_WORKSPACE_ID: WORKSPACE_ID,
+        VELA_WORKSPACE_ID: workspaceId,
         VELA_API_URL: hub!.url,
         VELA_CONTROL_KEY: OWNER.controlKey,
       },

--- a/e2e/ui/workspace-multi-client-collab.test.ts
+++ b/e2e/ui/workspace-multi-client-collab.test.ts
@@ -32,7 +32,229 @@ const MEMBER = {
   role: 'member' as const,
 };
 
+const ADAPTIVE_AUTHORITY_HEALTHY_SERIES =
+  'open_design_workspace_authority_decisions_total' +
+  '{mode="adaptive",source="sse",reason="healthy",outcome="allow"}';
+const ADAPTIVE_AUTHORITY_UNHEALTHY_SERIES =
+  'open_design_workspace_authority_decisions_total' +
+  '{mode="adaptive",source="sse",reason="unhealthy",outcome="fallback"}';
+
 test.describe.configure({ timeout: T.xlong * 5 });
+
+test('[P0] strict SSE health suppresses authority reads and bounds event storms per account', async ({
+  browser,
+}, testInfo) => {
+  const hubRoot = testInfo.outputPath('fake-authority-cache-hub');
+  await mkdir(hubRoot, { recursive: true });
+  const hub = await startFakeCollabHub({
+    root: hubRoot,
+    workspaceId: WORKSPACE_ID,
+    workspaceName: 'Multi-client team',
+    clients: [OWNER, MEMBER],
+    strictAuthorityEvents: true,
+  });
+  const velaBin = await hub.writeVelaBin(testInfo.outputPath('fake-vela-authority-cache'));
+  const commonEnv = {
+    OD_COLLAB_TRANSPORT: 'vela-cli',
+    OD_RESOURCE_TRANSPORT: 'vela-cli',
+    OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+    OD_WORKSPACE_AUTHORITY_CACHE_MODE: 'adaptive',
+    OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+    VELA_API_URL: hub.url,
+    VELA_BIN: velaBin,
+  };
+  let cluster: CollabCluster | undefined;
+  let failed = false;
+  try {
+    cluster = await test.step('start isolated owner and member clients', async () =>
+      await createCollabCluster(browser, testInfo, [
+        {
+          id: 'authority-owner',
+          env: { ...commonEnv, VELA_CONTROL_KEY: OWNER.controlKey },
+        },
+        {
+          id: 'authority-member',
+          env: { ...commonEnv, VELA_CONTROL_KEY: MEMBER.controlKey },
+        },
+      ]));
+    const owner = cluster.clients['authority-owner']!;
+    const member = cluster.clients['authority-member']!;
+
+    await test.step('establish exact team interests and strict producer health', async () => {
+      await Promise.all([
+        pinWorkspace(owner.page, OWNER.memberId),
+        pinWorkspace(member.page, MEMBER.memberId),
+      ]);
+      await Promise.all([
+        registerWorkspaceEventInterest(owner.page, 'authority-owner', OWNER.memberId),
+        registerWorkspaceEventInterest(member.page, 'authority-member', MEMBER.memberId),
+      ]);
+      await expect.poll(
+        () => [
+          hub.eventSubscriberCount(OWNER.memberId),
+          hub.eventSubscriberCount(MEMBER.memberId),
+        ],
+        { timeout: T.long },
+      ).toEqual([1, 1]);
+      await Promise.all([
+        expectMetricGreaterThan(
+          owner.runtime.url.daemon(),
+          ADAPTIVE_AUTHORITY_HEALTHY_SERIES,
+          0,
+        ),
+        expectMetricGreaterThan(
+          member.runtime.url.daemon(),
+          ADAPTIVE_AUTHORITY_HEALTHY_SERIES,
+          0,
+        ),
+      ]);
+      await Promise.all([
+        waitForHubRequestCountToSettle(hub, OWNER.memberId, '/api/v1/workspaces'),
+        waitForHubRequestCountToSettle(hub, MEMBER.memberId, '/api/v1/workspaces'),
+      ]);
+    });
+
+    await test.step('serve concurrent exact-scoped display reads without touching AMR', async () => {
+      const before = workspaceDirectoryCounts(hub);
+      await Promise.all([
+        readWorkspaceContextBurst(owner.page, OWNER, 50),
+        readWorkspaceContextBurst(member.page, MEMBER, 50),
+        readWorkspaceTeamDataBurst(owner.page, OWNER, 25),
+        readWorkspaceTeamDataBurst(member.page, MEMBER, 25),
+      ]);
+      expect(workspaceDirectoryCounts(hub)).toEqual(before);
+    });
+
+    await test.step('collapse duplicate billing invalidations into one fetch per account', async () => {
+      const before = billingCommandCounts(hub, 'summary');
+      for (let index = 0; index < 100; index += 1) {
+        hub.emitEvent({
+          type: 'billing-changed',
+          workspaceId: WORKSPACE_ID,
+          revision: 'billing-storm-1',
+        });
+      }
+      await Promise.all([
+        readAccountBillingBurst(owner.page, 50),
+        readAccountBillingBurst(member.page, 50),
+      ]);
+      expect(billingCommandCounts(hub, 'summary')).toEqual({
+        [OWNER.memberId]: (before[OWNER.memberId] ?? 0) + 1,
+        [MEMBER.memberId]: (before[MEMBER.memberId] ?? 0) + 1,
+      });
+    });
+
+    await test.step('bound duplicate workspace invalidations and return to zero-read steady state', async () => {
+      const beforeStorm = workspaceDirectoryCounts(hub);
+      for (let index = 0; index < 100; index += 1) {
+        hub.emitEvent({
+          type: 'workspace-context-changed',
+          workspaceId: WORKSPACE_ID,
+          revision: 'workspace-storm-1',
+        });
+      }
+      await Promise.all([
+        waitForHubRequestCountToSettle(hub, OWNER.memberId, '/api/v1/workspaces'),
+        waitForHubRequestCountToSettle(hub, MEMBER.memberId, '/api/v1/workspaces'),
+      ]);
+      // An event can invalidate the exact cache after its leading refresh has
+      // already started. The first post-storm read is then the one bounded
+      // trailing revalidation; include it in the storm budget.
+      await Promise.all([
+        readWorkspaceContextBurst(owner.page, OWNER, 50),
+        readWorkspaceContextBurst(member.page, MEMBER, 50),
+      ]);
+      await Promise.all([
+        waitForHubRequestCountToSettle(hub, OWNER.memberId, '/api/v1/workspaces'),
+        waitForHubRequestCountToSettle(hub, MEMBER.memberId, '/api/v1/workspaces'),
+      ]);
+      const afterRecovery = workspaceDirectoryCounts(hub);
+      expect((afterRecovery[OWNER.memberId] ?? 0) - (beforeStorm[OWNER.memberId] ?? 0))
+        .toBeLessThanOrEqual(3);
+      expect((afterRecovery[MEMBER.memberId] ?? 0) - (beforeStorm[MEMBER.memberId] ?? 0))
+        .toBeLessThanOrEqual(3);
+
+      await Promise.all([
+        readWorkspaceContextBurst(owner.page, OWNER, 50),
+        readWorkspaceContextBurst(member.page, MEMBER, 50),
+      ]);
+      expect(workspaceDirectoryCounts(hub)).toEqual(afterRecovery);
+    });
+
+    await test.step('degrade only the disconnected account to the legacy authority floor', async () => {
+      const ownerUnhealthyBefore = await readMetricCounter(
+        owner.runtime.url.daemon(),
+        ADAPTIVE_AUTHORITY_UNHEALTHY_SERIES,
+      );
+      hub.setEventsAvailable(OWNER.memberId, false);
+      await expect.poll(
+        () => hub.eventSubscriberCount(OWNER.memberId),
+        { timeout: T.long },
+      ).toBe(0);
+      await expectMetricGreaterThan(
+        owner.runtime.url.daemon(),
+        ADAPTIVE_AUTHORITY_UNHEALTHY_SERIES,
+        ownerUnhealthyBefore,
+      );
+
+      const before = workspaceDirectoryCounts(hub);
+      // Keep asking the exact same read. The first requests may still use the
+      // valid 15s lease; once it expires, the disconnected account must resume
+      // a real directory verification instead of trusting stale SSE state.
+      await expect.poll(
+        async () => {
+          await readWorkspaceContextBurst(owner.page, OWNER, 1);
+          return workspaceDirectoryCounts(hub)[OWNER.memberId] ?? 0;
+        },
+        { timeout: T.long },
+      ).toBeGreaterThan(before[OWNER.memberId] ?? 0);
+
+      const memberBefore = workspaceDirectoryCounts(hub)[MEMBER.memberId] ?? 0;
+      await readWorkspaceContextBurst(member.page, MEMBER, 50);
+      expect(workspaceDirectoryCounts(hub)[MEMBER.memberId] ?? 0).toBe(memberBefore);
+    });
+
+    await test.step('reconnect, catch up, and restore the zero-read steady state', async () => {
+      const ownerHealthyBefore = await readMetricCounter(
+        owner.runtime.url.daemon(),
+        ADAPTIVE_AUTHORITY_HEALTHY_SERIES,
+      );
+      hub.setEventsAvailable(OWNER.memberId, true);
+      await expect.poll(
+        () => hub.eventSubscriberCount(OWNER.memberId),
+        { timeout: T.long },
+      ).toBe(1);
+      await expectMetricGreaterThan(
+        owner.runtime.url.daemon(),
+        ADAPTIVE_AUTHORITY_HEALTHY_SERIES,
+        ownerHealthyBefore,
+      );
+      await waitForHubRequestCountToSettle(
+        hub,
+        OWNER.memberId,
+        '/api/v1/workspaces',
+      );
+
+      const before = workspaceDirectoryCounts(hub)[OWNER.memberId] ?? 0;
+      await readWorkspaceContextBurst(owner.page, OWNER, 50);
+      expect(workspaceDirectoryCounts(hub)[OWNER.memberId] ?? 0).toBe(before);
+    });
+  } catch (error) {
+    failed = true;
+    await testInfo.attach('fake-authority-cache-hub-log', {
+      body: JSON.stringify({
+        commands: hub.commandLog,
+        events: hub.eventLog,
+        requests: hub.requestLog,
+      }, null, 2),
+      contentType: 'application/json',
+    });
+    throw error;
+  } finally {
+    await cluster?.close({ preserve: failed });
+    await hub.close();
+  }
+});
 
 test('[P0] two isolated clients converge live content, presence, and owner unshare', async ({
   browser,
@@ -519,6 +741,139 @@ async function expectRosterRole(page: Page, role: 'admin' | 'member'): Promise<v
     },
     { timeout: T.long },
   ).toMatchObject({ memberId: MEMBER.memberId, role });
+}
+
+async function readWorkspaceContextBurst(
+  page: Page,
+  identity: typeof OWNER | typeof MEMBER,
+  count: number,
+): Promise<void> {
+  const responses = await Promise.all(
+    Array.from({ length: count }, () => page.request.get('/api/workspace/context', {
+      headers: workspaceHeaders(identity),
+      timeout: T.long,
+    })),
+  );
+  for (const response of responses) {
+    const raw = await response.text();
+    expect(response.ok(), raw).toBeTruthy();
+    const body = JSON.parse(raw) as {
+      context?: { workspaceId?: string; workspaceMemberId?: string } | null;
+    };
+    expect(body.context).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      workspaceMemberId: identity.memberId,
+    });
+  }
+}
+
+async function readWorkspaceTeamDataBurst(
+  page: Page,
+  client: typeof OWNER | typeof MEMBER,
+  count: number,
+): Promise<void> {
+  const responses = await Promise.all(
+    Array.from({ length: count }, (_, index) => page.request.get(
+      index % 2 === 0
+        ? '/api/workspace/projects/team'
+        : '/api/workspace/members',
+      {
+        headers: workspaceHeaders(client),
+        timeout: T.long,
+      },
+    )),
+  );
+  for (const response of responses) {
+    const raw = await response.text();
+    expect(response.ok(), raw).toBeTruthy();
+  }
+}
+
+async function readAccountBillingBurst(page: Page, count: number): Promise<void> {
+  const responses = await Promise.all(
+    Array.from({ length: count }, () => page.request.get(
+      '/api/workspace/billing?scope=account',
+      { timeout: T.long },
+    )),
+  );
+  for (const response of responses) {
+    const raw = await response.text();
+    expect(response.ok(), raw).toBeTruthy();
+    const body = JSON.parse(raw) as {
+      summary?: { membershipTier?: string } | null;
+    };
+    expect(body.summary?.membershipTier).toBe('team_plus');
+  }
+}
+
+function workspaceDirectoryCounts(hub: Awaited<ReturnType<typeof startFakeCollabHub>>):
+  Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const request of hub.requestLog) {
+    if (request.path !== '/api/v1/workspaces' || !request.memberId) continue;
+    counts[request.memberId] = (counts[request.memberId] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function billingCommandCounts(
+  hub: Awaited<ReturnType<typeof startFakeCollabHub>>,
+  command: string,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const entry of hub.commandLog) {
+    if (entry.args[0] !== 'billing' || entry.args[1] !== command) continue;
+    counts[entry.memberId] = (counts[entry.memberId] ?? 0) + 1;
+  }
+  return counts;
+}
+
+async function waitForHubRequestCountToSettle(
+  hub: Awaited<ReturnType<typeof startFakeCollabHub>>,
+  memberId: string,
+  path: string,
+): Promise<void> {
+  let previous = -1;
+  let stableSamples = 0;
+  await expect.poll(
+    () => {
+      const current = hub.requestLog.filter(
+        (request) => request.memberId === memberId && request.path === path,
+      ).length;
+      stableSamples = current === previous ? stableSamples + 1 : 0;
+      previous = current;
+      return stableSamples;
+    },
+    // One event lane may legally run a leading refresh, one trailing refresh,
+    // and a billing-member reconnect. Require a real quiescence window after
+    // all three, rather than sampling only the first short gap between them.
+    { intervals: [100], timeout: T.medium },
+  ).toBeGreaterThanOrEqual(20);
+}
+
+async function readMetricCounter(
+  daemonUrl: string,
+  series: string,
+): Promise<number> {
+  const response = await fetch(new URL('/api/metrics', daemonUrl));
+  if (!response.ok) {
+    throw new Error(`metrics ${response.status}: ${await response.text()}`);
+  }
+  const line = (await response.text())
+    .split('\n')
+    .find((entry) => entry.startsWith(`${series} `));
+  return Number(line?.slice(series.length + 1).trim() ?? 0);
+}
+
+async function expectMetricGreaterThan(
+  daemonUrl: string,
+  series: string,
+  floor: number,
+): Promise<void> {
+  await expect.poll(
+    () => readMetricCounter(daemonUrl, series),
+    { timeout: T.long },
+  ).toBeGreaterThan(floor);
 }
 
 async function createProject(page: Page): Promise<string> {

--- a/e2e/ui/workspace-multi-client-collab.test.ts
+++ b/e2e/ui/workspace-multi-client-collab.test.ts
@@ -18,6 +18,16 @@ const PROJECT_NAME = 'Realtime shared workspace';
 // the richer FileViewer test-id variants mount. There is exactly one visible
 // artifact iframe in this flow.
 const PREVIEW_SELECTOR = 'iframe:visible';
+const COLLAB_COMMENT_NOTE = 'Member asks for a clearer shared headline.';
+const COLLAB_COMMENT_TARGET = {
+  filePath: 'index.html',
+  elementId: 'shared-heading',
+  selector: '[data-od-id="shared-heading"]',
+  label: 'h1',
+  text: 'Owner version 1',
+  htmlHint: '<h1>',
+  position: { x: 0, y: 0, width: 0, height: 0 },
+};
 
 const OWNER = {
   controlKey: 'multi-client-owner-key',
@@ -142,6 +152,67 @@ test('[P0] strict SSE health suppresses authority reads and bounds event storms 
         [OWNER.memberId]: (before[OWNER.memberId] ?? 0) + 1,
         [MEMBER.memberId]: (before[MEMBER.memberId] ?? 0) + 1,
       });
+    });
+
+    await test.step('converge account plan changes independently per account', async () => {
+      const before = billingCommandCounts(hub, 'summary');
+      const startedAt = Date.now();
+      hub.setAccountMembershipTier(OWNER.memberId, 'max');
+      await expect.poll(
+        () => readAccountMembershipTier(owner.page),
+        { timeout: T.medium },
+      ).toBe('max');
+      expect(Date.now() - startedAt).toBeLessThan(T.medium);
+      await expect(readAccountMembershipTier(member.page)).resolves.toBe('team_plus');
+      const after = billingCommandCounts(hub, 'summary');
+      expect((after[OWNER.memberId] ?? 0) - (before[OWNER.memberId] ?? 0))
+        .toBeLessThanOrEqual(2);
+      // The legacy account event is workspace-wide and therefore dirties the
+      // member's account cache too, but its independent summary must remain
+      // unchanged and may cost at most one lazy verification when read.
+      expect((after[MEMBER.memberId] ?? 0) - (before[MEMBER.memberId] ?? 0))
+        .toBeLessThanOrEqual(1);
+    });
+
+    await test.step('converge plan upgrades and bound high-frequency wallet refreshes', async () => {
+      const planBefore = billingCommandCounts(hub, 'workspace-snapshot');
+      const planStartedAt = Date.now();
+      hub.setWorkspacePlan('team_max');
+      await Promise.all([
+        expect.poll(
+          () => readWorkspaceBilling(owner.page, OWNER),
+          { timeout: T.medium },
+        ).toMatchObject({ planId: 'team_max', balanceUsd: '0.00' }),
+        expect.poll(
+          () => readWorkspaceBilling(member.page, MEMBER),
+          { timeout: T.medium },
+        ).toMatchObject({ planId: 'team_max', balanceUsd: '0.00' }),
+      ]);
+      expect(Date.now() - planStartedAt).toBeLessThan(T.medium);
+      const planAfter = billingCommandCounts(hub, 'workspace-snapshot');
+      expect((planAfter[OWNER.memberId] ?? 0) - (planBefore[OWNER.memberId] ?? 0))
+        .toBeLessThanOrEqual(2);
+      expect((planAfter[MEMBER.memberId] ?? 0) - (planBefore[MEMBER.memberId] ?? 0))
+        .toBeLessThanOrEqual(2);
+
+      const walletBefore = billingCommandCounts(hub, 'workspace-snapshot');
+      const walletStartedAt = Date.now();
+      for (let index = 1; index <= 100; index += 1) {
+        hub.setWorkspaceBalance(OWNER.memberId, (100 - index).toFixed(2));
+      }
+      await expect.poll(
+        () => readWorkspaceBilling(owner.page, OWNER),
+        { timeout: T.medium },
+      ).toMatchObject({ planId: 'team_max', balanceUsd: '0.00' });
+      expect(Date.now() - walletStartedAt).toBeLessThan(T.medium);
+      await expect(readWorkspaceBilling(member.page, MEMBER)).resolves.toMatchObject({
+        planId: 'team_max',
+        balanceUsd: '0.00',
+      });
+      const walletAfter = billingCommandCounts(hub, 'workspace-snapshot');
+      expect((walletAfter[OWNER.memberId] ?? 0) - (walletBefore[OWNER.memberId] ?? 0))
+        .toBeLessThanOrEqual(2);
+      expect(walletAfter[MEMBER.memberId] ?? 0).toBe(walletBefore[MEMBER.memberId] ?? 0);
     });
 
     await test.step('bound duplicate workspace invalidations and return to zero-read steady state', async () => {
@@ -392,6 +463,62 @@ test('[P0] two isolated clients converge live content, presence, and owner unsha
     });
     await expect(twoPersonPresence.locator('[data-self="true"]')).toHaveCount(1);
     await expect(twoPersonPresence.locator('[title]')).toHaveCount(2);
+
+    await test.step('relay a member comment into the owner UI', async () => {
+      const [ownerConversationId, memberConversationId] = await Promise.all([
+        firstConversationId(ownerPage, projectId, OWNER),
+        firstConversationId(memberPage, projectId, MEMBER),
+      ]);
+      const commentStartedAt = Date.now();
+      const response = await memberPage.request.post(
+        `/api/projects/${projectId}/conversations/${memberConversationId}/comments`,
+        {
+          data: { target: COLLAB_COMMENT_TARGET, note: COLLAB_COMMENT_NOTE },
+          headers: workspaceHeaders(MEMBER),
+          timeout: T.long,
+        },
+      );
+      expect(response.ok(), await response.text()).toBeTruthy();
+      await hub.waitForCommand(
+        (entry) =>
+          entry.memberId === MEMBER.memberId
+          && entry.args[0] === 'collab'
+          && entry.args[1] === 'comment'
+          && entry.args[2] === 'push'
+          && entry.args[3] === projectId,
+        T.medium,
+      );
+      await expect.poll(
+        async () => {
+          const ownerComments = await ownerPage.request.get(
+            `/api/projects/${projectId}/conversations/${ownerConversationId}/comments`,
+            { headers: workspaceHeaders(OWNER), timeout: T.long },
+          );
+          if (!ownerComments.ok()) return [];
+          const body = await ownerComments.json() as {
+            comments?: Array<{ note?: string }>;
+          };
+          return body.comments?.map((comment) => comment.note) ?? [];
+        },
+        { timeout: T.medium },
+      ).toContain(COLLAB_COMMENT_NOTE);
+      expect(Date.now() - commentStartedAt).toBeLessThan(T.medium);
+
+      await ownerPage.goto(`/projects/${projectId}/files/index.html`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expect(ownerPage.getByTestId('file-workspace')).toBeVisible({
+        timeout: T.long,
+      });
+      await ownerPage.getByTestId('board-mode-toggle').click();
+      await ownerPage.getByTestId('comment-panel-toggle').click();
+      await expect(
+        ownerPage
+          .getByTestId('comment-side-panel')
+          .getByTestId('comment-side-item')
+          .filter({ hasText: COLLAB_COMMENT_NOTE }),
+      ).toBeVisible({ timeout: T.medium });
+    });
 
     const memberDocumentMarker = await memberPage.evaluate(() => {
       const target = window as Window & typeof globalThis & {
@@ -657,6 +784,272 @@ test('[P0] two active clients converge when a member gains then loses admin acce
   }
 });
 
+test('[P0] two isolated clients converge shared plugins and skills without scope leaks', async ({
+  browser,
+}, testInfo) => {
+  const hubRoot = testInfo.outputPath('fake-team-extension-hub');
+  await mkdir(hubRoot, { recursive: true });
+  const hub = await startFakeCollabHub({
+    root: hubRoot,
+    workspaceId: WORKSPACE_ID,
+    workspaceName: 'Multi-client team',
+    clients: [OWNER, MEMBER],
+    includePersonalWorkspace: true,
+  });
+  const velaBin = await hub.writeVelaBin(testInfo.outputPath('fake-vela-team-extensions'));
+  const commonEnv = {
+    OD_COLLAB_TRANSPORT: 'vela-cli',
+    OD_RESOURCE_TRANSPORT: 'vela-cli',
+    OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+    OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+    VELA_API_URL: hub.url,
+    VELA_BIN: velaBin,
+  };
+  let cluster: CollabCluster | undefined;
+  let failed = false;
+  const pluginId = `shared-plugin-${testInfo.workerIndex}-${Date.now()}`;
+  const skillId = `shared-skill-${testInfo.workerIndex}-${Date.now()}`;
+  try {
+    cluster = await createCollabCluster(browser, testInfo, [
+      {
+        id: 'extension-owner',
+        env: { ...commonEnv, VELA_CONTROL_KEY: OWNER.controlKey },
+      },
+      {
+        id: 'extension-member',
+        env: { ...commonEnv, VELA_CONTROL_KEY: MEMBER.controlKey },
+      },
+    ]);
+    const ownerPage = cluster.clients['extension-owner']!.page;
+    const memberPage = cluster.clients['extension-member']!.page;
+    await Promise.all([
+      applyStandardMocks(ownerPage),
+      applyStandardMocks(memberPage),
+      pinWorkspace(ownerPage, OWNER.memberId),
+      pinWorkspace(memberPage, MEMBER.memberId),
+      registerWorkspaceEventInterest(ownerPage, 'extension-owner', OWNER.memberId),
+      registerWorkspaceEventInterest(memberPage, 'extension-member', MEMBER.memberId),
+    ]);
+    await expect.poll(
+      () => [
+        hub.eventSubscriberCount(OWNER.memberId),
+        hub.eventSubscriberCount(MEMBER.memberId),
+      ],
+      { timeout: T.long },
+    ).toEqual([1, 1]);
+
+    const projectId = await createProject(ownerPage);
+    await writeProjectTextFile(
+      ownerPage,
+      projectId,
+      'plugin-source/open-design.json',
+      JSON.stringify({
+        $schema: 'https://open-design.ai/schemas/plugin.v1.json',
+        name: pluginId,
+        title: 'Realtime Shared Plugin',
+        version: '0.1.0',
+        description: 'A real two-daemon extension fixture.',
+        license: 'MIT',
+        od: { kind: 'atom', capabilities: ['prompt:inject'] },
+      }),
+    );
+    await writeProjectTextFile(
+      ownerPage,
+      projectId,
+      'plugin-source/SKILL.md',
+      `---\nname: ${pluginId}\ndescription: E2E shared plugin fixture.\n---\n# Fixture\n`,
+    );
+    const installPlugin = await ownerPage.request.post(
+      `/api/projects/${projectId}/plugins/install-folder`,
+      {
+        data: { path: 'plugin-source' },
+        headers: workspaceHeaders(OWNER),
+        timeout: T.long,
+      },
+    );
+    expect(installPlugin.ok(), await installPlugin.text()).toBeTruthy();
+    const importSkill = await ownerPage.request.post('/api/skills/import', {
+      data: {
+        name: skillId,
+        description: 'A real two-daemon Skill fixture.',
+        body: '# Shared Skill\n\nReturn the shared skill fixture.',
+      },
+      headers: workspaceHeaders(OWNER),
+      timeout: T.long,
+    });
+    expect(importSkill.ok(), await importSkill.text()).toBeTruthy();
+
+    for (const [kind, resourceId] of [
+      ['plugins', pluginId],
+      ['skills', skillId],
+    ] as const) {
+      const shareStartedAt = Date.now();
+      const share = await ownerPage.request.post(
+        `/api/workspace/${kind}/${encodeURIComponent(resourceId)}/share`,
+        { headers: workspaceHeaders(OWNER), timeout: T.long },
+      );
+      expect(share.ok(), await share.text()).toBeTruthy();
+      await expect.poll(
+        () => readTeamResourceIds(memberPage, MEMBER, kind),
+        { timeout: T.medium },
+      ).toContain(resourceId);
+      expect(Date.now() - shareStartedAt).toBeLessThan(T.medium);
+      await expect.poll(
+        () => readLocalResourceIds(memberPage, MEMBER, kind),
+        { timeout: T.medium },
+      ).toContain(resourceId);
+
+      if (kind === 'plugins') {
+        const unshareStartedAt = Date.now();
+        const unshare = await ownerPage.request.delete(
+          `/api/workspace/${kind}/${encodeURIComponent(resourceId)}/share`,
+          { headers: workspaceHeaders(OWNER), timeout: T.long },
+        );
+        expect(unshare.ok(), await unshare.text()).toBeTruthy();
+        await expect.poll(
+          () => readTeamResourceIds(memberPage, MEMBER, kind),
+          { timeout: T.medium },
+        ).not.toContain(resourceId);
+        expect(Date.now() - unshareStartedAt).toBeLessThan(T.medium);
+      }
+    }
+
+    await openHome(memberPage);
+    await ensureRailOpen(memberPage);
+    const remoteWorkspaceId = 'ws-created-remotely';
+    const remoteWorkspaceName = 'Remote-created team';
+    await expect(memberPage.getByRole('menu')).toHaveCount(0);
+    const workspaceCreatedAt = Date.now();
+    hub.addWorkspace(MEMBER.memberId, remoteWorkspaceId, remoteWorkspaceName);
+
+    // The account event refreshes the rail cache even while the switcher is
+    // closed. Opening it is only how this test observes the already-updated
+    // state; it is not what triggers discovery.
+    await expect.poll(
+      async () => {
+        const directory = await memberPage.request.get(
+          '/api/workspace/directory',
+          { timeout: T.long },
+        );
+        if (!directory.ok()) return [];
+        const body = await directory.json() as {
+          items?: Array<{ workspaceId?: string }>;
+        };
+        return body.items?.map((item) => item.workspaceId) ?? [];
+      },
+      { timeout: T.short },
+    ).toContain(remoteWorkspaceId);
+    const workspaceDirectoryLatencyMs = Date.now() - workspaceCreatedAt;
+    expect(workspaceDirectoryLatencyMs).toBeLessThan(T.short);
+    await testInfo.attach('remote-workspace-directory-latency', {
+      body: JSON.stringify({ workspaceDirectoryLatencyMs }),
+      contentType: 'application/json',
+    });
+    await memberPage.getByTestId('workspace-switcher').click();
+    await expect(
+      memberPage.getByRole('menu').getByRole('menuitem', { name: remoteWorkspaceName }),
+    ).toBeVisible({ timeout: T.medium });
+    expect(Date.now() - workspaceCreatedAt).toBeLessThan(T.medium);
+
+    const ownerDirectory = await ownerPage.request.get('/api/workspace/directory', {
+      timeout: T.long,
+    });
+    expect(ownerDirectory.ok(), await ownerDirectory.text()).toBeTruthy();
+    const ownerDirectoryBody = await ownerDirectory.json() as {
+      items?: Array<{ workspaceId?: string }>;
+    };
+    expect(ownerDirectoryBody.items?.map((item) => item.workspaceId) ?? [])
+      .not.toContain(remoteWorkspaceId);
+
+    await memberPage
+      .getByRole('menu')
+      .getByRole('menuitem', { name: remoteWorkspaceName })
+      .click();
+    await expect(memberPage.getByTestId('workspace-switcher')).toContainText(
+      remoteWorkspaceName,
+      { timeout: T.medium },
+    );
+    const remoteHeaders = addedWorkspaceHeaders(
+      MEMBER,
+      remoteWorkspaceId,
+    );
+    await expect(
+      readTeamResourceIds(memberPage, MEMBER, 'skills', remoteHeaders),
+    ).resolves.not.toContain(skillId);
+    await expect(
+      readLocalResourceIds(
+        memberPage,
+        MEMBER,
+        'plugins',
+        remoteHeaders,
+      ),
+    ).resolves.not.toContain(pluginId);
+    await expect(
+      readLocalResourceIds(
+        memberPage,
+        MEMBER,
+        'skills',
+        remoteHeaders,
+      ),
+    ).resolves.not.toContain(skillId);
+    await expect.poll(
+      () => readWorkspaceBilling(
+        memberPage,
+        MEMBER,
+        remoteWorkspaceId,
+        remoteHeaders,
+      ),
+      { timeout: T.medium },
+    ).toMatchObject({ planId: null, balanceUsd: null });
+
+    const unshareSkill = await ownerPage.request.delete(
+      `/api/workspace/skills/${encodeURIComponent(skillId)}/share`,
+      { headers: workspaceHeaders(OWNER), timeout: T.long },
+    );
+    expect(unshareSkill.ok(), await unshareSkill.text()).toBeTruthy();
+
+    // The member was subscribed to the remote workspace while the original
+    // team's retraction event fired. Switching back must catch up the missed
+    // removal without reviving either resource from a different scope.
+    await ensureRailOpen(memberPage);
+    await memberPage.getByTestId('workspace-switcher').click();
+    await memberPage
+      .getByRole('menu')
+      .getByRole('menuitem', { name: 'Multi-client team' })
+      .click();
+    await expect(memberPage.getByTestId('workspace-switcher')).toContainText(
+      'Multi-client team',
+      { timeout: T.medium },
+    );
+    await expect.poll(
+      () => readWorkspaceBilling(memberPage, MEMBER),
+      { timeout: T.medium },
+    ).toMatchObject({ planId: 'team_plus', balanceUsd: '0.00' });
+    await expect.poll(
+      () => readTeamResourceIds(memberPage, MEMBER, 'skills'),
+      { timeout: T.medium },
+    ).not.toContain(skillId);
+    await expect.poll(
+      () => readLocalResourceIds(memberPage, MEMBER, 'skills'),
+      { timeout: T.medium },
+    ).not.toContain(skillId);
+  } catch (error) {
+    failed = true;
+    await testInfo.attach('fake-team-extension-hub-log', {
+      body: JSON.stringify({
+        commands: hub.commandLog,
+        events: hub.eventLog,
+        requests: hub.requestLog,
+      }, null, 2),
+      contentType: 'application/json',
+    });
+    throw error;
+  } finally {
+    await cluster?.close({ preserve: failed });
+    await hub.close();
+  }
+});
+
 async function pinWorkspace(page: Page, workspaceMemberId: string): Promise<void> {
   const response = await page.request.put('/api/workspace/active', {
     data: { workspaceId: WORKSPACE_ID, workspaceMemberId },
@@ -806,6 +1199,40 @@ async function readAccountBillingBurst(page: Page, count: number): Promise<void>
   }
 }
 
+async function readAccountMembershipTier(page: Page): Promise<string | null> {
+  const response = await page.request.get('/api/workspace/billing?scope=account', {
+    timeout: T.long,
+  });
+  if (!response.ok()) return null;
+  const body = await response.json() as {
+    summary?: { membershipTier?: string } | null;
+  };
+  return body.summary?.membershipTier ?? null;
+}
+
+async function readWorkspaceBilling(
+  page: Page,
+  identity: typeof OWNER | typeof MEMBER,
+  workspaceId = WORKSPACE_ID,
+  headers = workspaceHeaders(identity),
+): Promise<{ planId: string | null; balanceUsd: string | null } | null> {
+  const response = await page.request.get(
+    `/api/workspace/billing?scope=workspace&workspaceId=${encodeURIComponent(workspaceId)}`,
+    { headers, timeout: T.long },
+  );
+  if (!response.ok()) return null;
+  const body = await response.json() as {
+    workspaceSnapshot?: {
+      billing?: { planId?: string | null };
+      wallet?: { balanceUsd?: string | null };
+    } | null;
+  };
+  return {
+    planId: body.workspaceSnapshot?.billing?.planId ?? null,
+    balanceUsd: body.workspaceSnapshot?.wallet?.balanceUsd ?? null,
+  };
+}
+
 function workspaceDirectoryCounts(hub: Awaited<ReturnType<typeof startFakeCollabHub>>):
   Record<string, number> {
   const counts: Record<string, number> = {};
@@ -897,6 +1324,27 @@ async function createProject(page: Page): Promise<string> {
   return body.project.id;
 }
 
+async function firstConversationId(
+  page: Page,
+  projectId: string,
+  identity: typeof OWNER | typeof MEMBER,
+): Promise<string> {
+  const response = await page.request.get(`/api/projects/${projectId}/conversations`, {
+    headers: workspaceHeaders(identity),
+    timeout: T.long,
+  });
+  expect(response.ok(), await response.text()).toBeTruthy();
+  const body = await response.json() as {
+    conversations?: Array<{ id?: string; updatedAt?: number }>;
+  };
+  const conversation = [...(body.conversations ?? [])]
+    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0))[0];
+  if (!conversation?.id) {
+    throw new Error(`project ${projectId} has no routable conversation`);
+  }
+  return conversation.id;
+}
+
 async function writeHtml(page: Page, projectId: string, content: string): Promise<void> {
   const response = await page.request.post(`/api/projects/${projectId}/files`, {
     data: {
@@ -917,6 +1365,54 @@ async function writeHtml(page: Page, projectId: string, content: string): Promis
   expect(response.ok(), await response.text()).toBeTruthy();
 }
 
+async function writeProjectTextFile(
+  page: Page,
+  projectId: string,
+  name: string,
+  content: string,
+): Promise<void> {
+  const response = await page.request.post(`/api/projects/${projectId}/files`, {
+    data: { name, content },
+    headers: workspaceHeaders(OWNER),
+    timeout: T.long,
+  });
+  expect(response.ok(), await response.text()).toBeTruthy();
+}
+
+async function readTeamResourceIds(
+  page: Page,
+  identity: typeof OWNER | typeof MEMBER,
+  kind: 'plugins' | 'skills',
+  headers = workspaceHeaders(identity),
+): Promise<string[]> {
+  const response = await page.request.get(`/api/workspace/${kind}/team`, {
+    headers,
+    timeout: T.long,
+  });
+  if (!response.ok()) return [];
+  const body = await response.json() as { ids?: string[] };
+  return body.ids ?? [];
+}
+
+async function readLocalResourceIds(
+  page: Page,
+  identity: typeof OWNER | typeof MEMBER,
+  kind: 'plugins' | 'skills',
+  headers = workspaceHeaders(identity),
+): Promise<string[]> {
+  const response = await page.request.get(`/api/${kind}`, {
+    headers,
+    timeout: T.long,
+  });
+  if (!response.ok()) return [];
+  const body = await response.json() as {
+    plugins?: Array<{ id?: string }>;
+    skills?: Array<{ id?: string }>;
+  };
+  return (kind === 'plugins' ? body.plugins : body.skills)
+    ?.flatMap((resource) => resource.id ? [resource.id] : []) ?? [];
+}
+
 function workspaceHeaders(identity: typeof OWNER | typeof MEMBER): Record<string, string> {
   return {
     'x-od-workspace-id': WORKSPACE_ID,
@@ -927,6 +1423,20 @@ function workspaceHeaders(identity: typeof OWNER | typeof MEMBER): Record<string
     'x-od-workspace-lifecycle-state': 'active',
     'x-od-workspace-can-share-projects': 'true',
     'x-od-workspace-can-write-synced-files': 'true',
+  };
+}
+
+function addedWorkspaceHeaders(
+  identity: typeof OWNER | typeof MEMBER,
+  workspaceId: string,
+): Record<string, string> {
+  return {
+    'x-od-workspace-id': workspaceId,
+    'x-od-workspace-type': 'team',
+    'x-od-workspace-member-id': `member-${identity.memberId}-${workspaceId}`,
+    'x-od-workspace-role': 'owner',
+    'x-od-workspace-member-status': 'active',
+    'x-od-workspace-lifecycle-state': 'active',
   };
 }
 

--- a/packages/contracts/src/sse/collab.ts
+++ b/packages/contracts/src/sse/collab.ts
@@ -122,6 +122,18 @@ export interface WorkspaceContextChangedSsePayload {
   at?: number;
 }
 
+/**
+ * The signed-in account's workspace membership directory changed.
+ *
+ * This is intentionally account-wide and carries no Workspace id or content:
+ * a newly-created/joined Workspace cannot yet have a local Workspace-scoped
+ * stream, and consumers only need a signal to re-read the authoritative list.
+ */
+export interface WorkspaceDirectoryChangedSsePayload {
+  type: 'workspace-directory-changed';
+  at?: number;
+}
+
 /** Subscription / seat billing changed. */
 export interface WorkspaceBillingChangedSsePayload {
   type: 'billing-changed';
@@ -168,6 +180,7 @@ export type WorkspaceInvalidationSsePayload =
   | TeamResourcesChangedSsePayload
   | WorkspaceMembersChangedSsePayload
   | WorkspaceContextChangedSsePayload
+  | WorkspaceDirectoryChangedSsePayload
   | WorkspaceBillingChangedSsePayload
   | WorkspaceBillingSubscriptionChangedSsePayload
   | WorkspaceWalletBalanceChangedSsePayload;
@@ -179,6 +192,7 @@ export const WORKSPACE_INVALIDATION_EVENTS = [
   'team-resources-changed',
   'members-changed',
   'workspace-context-changed',
+  'workspace-directory-changed',
   'billing-changed',
   'billing-subscription-changed',
   'wallet-balance-changed',


### PR DESCRIPTION
## Why

While investigating an AMR infrastructure incident, we found local clients repeatedly refreshing /api/v1/workspaces and /api/v1/account/billing/summary. Event bursts and unhealthy upstream SSE connections could multiply those reads across browser hooks and daemon routes, increasing socket pressure exactly when the cloud service was degraded.

This change keeps SSE-driven freshness as the normal path while adding account/workspace isolation, single-flight refreshes, bounded event coalescing, and outage backoff. The companion Vela producer is powerformer/vela#1586.

## What users will see

There is no new visual UI. With a healthy verified SSE stream and unchanged cloud data, workspace directory reads and presence heartbeats no longer cause periodic real /api/v1/workspaces calls. A remote workspace create/join/rename/removal/delete invalidates the closed switcher immediately; reconnect and source-gap boundaries perform one catch-up snapshot. Billing, comments, files, presence, shared projects, plugins, design systems, and skills retain their existing freshness paths with event-storm protection.

If SSE becomes unhealthy, the client falls back to the 15-second directory lease and account-wide jittered outage circuit (15s growing to a 120s base) instead of multiplying requests. Presence leave deliberately bypasses that circuit so remote leases still get a cleanup attempt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [x] **API / contract** — adds the local workspace-directory-changed SSE invalidation contract
- [ ] **Extension point** — skills, design systems, templates, or craft
- [ ] **i18n keys** — added translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — healthy steady-state refreshes are event-driven instead of TTL-driven
- [ ] **None**

## Screenshots

Not applicable: this changes background freshness and has no visual UI delta.

## Bug fix verification

- Red-spec surfaces: e2e/ui/workspace-multi-client-collab.test.ts, apps/daemon/tests/collab-presence-routes.test.ts, apps/daemon/tests/vela-workspace-context.test.ts, and apps/web/tests/components/EntryNavRail.workspace-directory.test.tsx.
- Main did not have the Vela account-directory event producer or the fake-hub instrumentation required to encode the full cross-runtime failure. The new P0 starts two isolated web + daemon + data-root clients under two accounts and asserts upstream request counts directly.
- The blocking review regression is covered explicitly: one failed heartbeat directory read opens the outage lease, then an immediate leave uses fresh authority and reaches cloud cleanup.

## Validation

- pnpm guard — passed
- pnpm typecheck — passed
- Focused daemon suites — 220 tests passed; final presence/directory set — 73 tests passed
- Focused web workspace-directory suite — 4 tests passed
- E2E Vitest fake hub — passed
- e2e package typecheck — passed
- Dual-account strict-SSE P0 — passed in 54.6s: healthy zero-read steady state, 100-event storm bound, one-account disconnect fallback, independent peer, reconnect back to zero reads
- Dual-account extensions/workspace P0 — passed in 36.7s; remote workspace became visible in the member daemon directory in 10ms and is hard-gated under 3s locally while the switcher remained closed
- git diff --check — passed

## Dependencies

- Vela producer PR: powerformer/vela#1586
- Backward compatible: without workspace-directory-events-v1, the daemon keeps the bounded legacy fallback.