### PR TITLE
docs(craft): note A11Y.md now covers native platforms and legal-floor versioning

### DIFF
--- a/craft/accessibility-baseline.md
+++ b/craft/accessibility-baseline.md
@@ -19,7 +19,10 @@ Existing OSS a11y guidance for AI agents (`fecarrico/A11Y.md`,
 WCAG SCs without versioning the legal floor or specifying which
 constraints survive on iOS / Android / Flutter. This file scopes
 narrower: the compliance floor an OD artifact must clear, with
-jurisdiction notes and native-mobile parity. Heuristic rules and
+jurisdiction notes and native-mobile parity. Since this file was
+written, `fecarrico/A11Y.md` has come to cover both points: a
+native-platform translation layer in v1.1.0 and versioned compliance
+guidance in v1.5.0. Heuristic rules and
 linter-checked items live in sibling craft files
 (`anti-ai-slop.md`, `state-coverage.md`); WCAG SC numbers map to
 specific rules below rather than being re-listed.


### PR DESCRIPTION
Follows up on #6875, where @lefarcen suggested a small docs PR — thanks for the quick and generous reply there.

One sentence added to the *Prior art and scope* paragraph in `craft/accessibility-baseline.md`. I deliberately left the existing sentence untouched:

- **It was accurate when written.** The file dates to 2026-05-06; the native-platform layer shipped in A11Y.md v1.1.0 on 2026-07-20 and versioned compliance guidance in v1.5.0. The critique wasn't wrong — it aged.
- **The scope claim is unaffected.** "This file scopes narrower" is still true and still a good reason for the file to exist. Rewriting the paragraph would mean rewriting your own rationale, which isn't mine to do.
- **I only speak for my own project.** I haven't audited `awesome-copilot` or `Community-Access/accessibility-agents`, so I've said nothing about them — going in to correct a claim about my project and generalising about two others would repeat the mistake.

The note is dated ("since this file was written") so the comparison stays honest as things keep moving on both sides.

Wrapping follows the file's existing manual ~70-column style. Happy to reword, shorten, or drop this entirely if you'd rather handle the paragraph your own way.

— Felipe Carriço