### PR TITLE
fix: make DeepSeek Harness cancellation authoritative

### DIFF
--- a/apps/daemon/src/agent-protocol/dsh-profile/session.ts
+++ b/apps/daemon/src/agent-protocol/dsh-profile/session.ts
@@ -185,6 +185,8 @@ export function attachDshProfileSession({
         if (!requireSession()) return;
         send('agent', {
           type: 'usage',
+          provider: frame.provider,
+          model: frame.model,
           usage: {
             input_tokens: frame.input_tokens,
             output_tokens: frame.output_tokens,

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -504,6 +504,7 @@ export function scanRunEventsForUsageAnalytics(
           usage?: Record<string, unknown> | null;
           modelUsage?: Record<string, unknown> | null;
           label?: string;
+          provider?: unknown;
           model?: unknown;
           detail?: unknown;
         }
@@ -576,6 +577,20 @@ export function scanRunEventsForUsageAnalytics(
           cacheReadInputTokens !== undefined &&
           cacheCreationInputTokens !== undefined;
       }
+    }
+
+    if (
+      !agentReportedModel &&
+      ev?.event === 'agent' &&
+      data?.type === 'usage' &&
+      typeof data.model === 'string' &&
+      data.model.trim()
+    ) {
+      const model = data.model.trim();
+      const provider = typeof data.provider === 'string' ? data.provider.trim() : '';
+      agentReportedModel = provider && !model.includes('/')
+        ? `${provider}/${model}`
+        : model;
     }
 
     if (

--- a/apps/daemon/tests/agent-protocol/dsh-profile.test.ts
+++ b/apps/daemon/tests/agent-protocol/dsh-profile.test.ts
@@ -389,6 +389,18 @@ describe('DeepSeek Harness profile session controller', () => {
       'usage',
       'thinking_end',
     ]);
+    assert.deepEqual(events.find(({ payload }) => payload.type === 'usage')?.payload, {
+      type: 'usage',
+      provider: 'deepseek-official',
+      model: 'model-1',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+        cached_read_tokens: 0,
+        cached_write_tokens: 0,
+        total_tokens: 12,
+      },
+    });
   });
 
   test('ignores other requests and rejects a changed resumed session id', () => {

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -105,6 +105,32 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.cache_hit_ratio).toBeUndefined();
   });
 
+  it('uses provider-qualified model attribution from DeepSeek Harness usage', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            provider: 'deepseek-official',
+            model: 'deepseek-v4-flash',
+            usage: {
+              input_tokens: 300,
+              output_tokens: 30,
+            },
+          },
+        },
+      ],
+      'default',
+      10,
+    );
+
+    expect(result.agent_reported_model).toBe(
+      'deepseek-official/deepseek-v4-flash',
+    );
+    expect(result.token_count_source).toBe('provider_usage');
+  });
+
   it('treats normalized cached_read_tokens / cached_write_tokens aliases as input subsets', () => {
     const result = scanRunEventsForUsageAnalytics(
       [

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -4087,13 +4087,13 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "streaming" ||
         ev.label === "starting" ||
         ev.label === "running" ||
-        // Runtime lifecycle markers are transport telemetry, not assistant
-        // content. The footer and terminal run badge already own this state;
-        // keeping a persisted `working` / `completed` pill after cancellation
-        // makes a correctly canceled turn look contradictory on reload.
-        ev.label === "working" ||
-        ev.label === "done" ||
-        ev.label === "completed" ||
+        // Bare runtime lifecycle markers are transport telemetry, not
+        // assistant content. Detail-bearing rows are product workflow badges
+        // and must remain visible (for example plugin share/contribute).
+        ((ev.label === "working" ||
+          ev.label === "done" ||
+          ev.label === "completed") &&
+          !ev.detail?.trim()) ||
         ev.label === "requesting" ||
         ev.label === "thinking" ||
         ev.label === "empty_response" ||

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -892,6 +892,7 @@ function AssistantMessageImpl({
             runStreaming={streaming}
             runSucceeded={runSucceeded}
             terminalRunSucceeded={message.runStatus === "succeeded"}
+            runCanceled={message.runStatus === "canceled"}
             runFailed={
               !streaming &&
               (message.runStatus === "failed" ||
@@ -1081,6 +1082,7 @@ function AssistantMessageImpl({
                   streaming,
                   hasUnfinishedTodos: unfinishedTodos.length > 0,
                   hasEmptyResponse,
+                  canceled: message.runStatus === "canceled",
                   preparing,
                   preparingStatus,
                   copyMarkdown,
@@ -1099,6 +1101,7 @@ function AssistantMessageImpl({
                 streaming={streaming}
                 hasUnfinishedTodos={unfinishedTodos.length > 0}
                 hasEmptyResponse={hasEmptyResponse}
+                canceled={message.runStatus === "canceled"}
                 preparing={preparing}
                 preparingStatus={preparingStatus}
                 copyMarkdown={copyMarkdown}
@@ -1539,6 +1542,7 @@ interface AssistantFooterProps {
   streaming: boolean;
   hasUnfinishedTodos: boolean;
   hasEmptyResponse: boolean;
+  canceled?: boolean;
   // Pre-output phase: streaming but nothing rendered yet. The label shimmers
   // "Preparing…"; once content lands it flips to "Working".
   preparing?: boolean;
@@ -1560,6 +1564,7 @@ function AssistantFooter({
   streaming,
   hasUnfinishedTodos,
   hasEmptyResponse,
+  canceled = false,
   preparing = false,
   preparingStatus = "preparing",
   copyMarkdown,
@@ -1576,6 +1581,7 @@ function AssistantFooter({
     !streaming &&
     !hasUnfinishedTodos &&
     !hasEmptyResponse &&
+    !canceled &&
     !copyMarkdown &&
     !onFork
   )
@@ -1599,6 +1605,8 @@ function AssistantFooter({
                 : t("assistant.workingLabel")
               : hasEmptyResponse
               ? t("assistant.emptyResponseLabel")
+              : canceled
+              ? t("assistant.canceledLabel")
               : hasUnfinishedTodos
               ? t("assistant.unfinishedLabel")
               : t("assistant.doneLabel")}
@@ -3635,6 +3643,7 @@ function TaskActivityCard({
   runStreaming,
   runSucceeded,
   terminalRunSucceeded,
+  runCanceled,
   runFailed,
   startedAt,
   endedAt,
@@ -3649,6 +3658,7 @@ function TaskActivityCard({
   runStreaming: boolean;
   runSucceeded: boolean;
   terminalRunSucceeded: boolean;
+  runCanceled: boolean;
   runFailed: boolean;
   startedAt: number | undefined;
   endedAt: number | undefined;
@@ -3683,10 +3693,18 @@ function TaskActivityCard({
         )));
   const stateLabel = running
     ? t("assistant.workingLabel")
-    : hasError
-      ? t("critiqueTheater.failedHeading")
-      : t("assistant.doneLabel");
-  const runState = running ? "running" : hasError ? "error" : "completed";
+    : runCanceled
+      ? t("assistant.canceledLabel")
+      : hasError
+        ? t("critiqueTheater.failedHeading")
+        : t("assistant.doneLabel");
+  const runState = running
+    ? "running"
+    : runCanceled
+      ? "canceled"
+      : hasError
+        ? "error"
+        : "completed";
   const elapsed = useLiveElapsed(runStreaming, startedAt, endedAt, durationMs);
 
   if (running && !hasConclusion && currentEntry) {

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -4087,6 +4087,13 @@ function buildBlocks(events: AgentEvent[]): Block[] {
         ev.label === "streaming" ||
         ev.label === "starting" ||
         ev.label === "running" ||
+        // Runtime lifecycle markers are transport telemetry, not assistant
+        // content. The footer and terminal run badge already own this state;
+        // keeping a persisted `working` / `completed` pill after cancellation
+        // makes a correctly canceled turn look contradictory on reload.
+        ev.label === "working" ||
+        ev.label === "done" ||
+        ev.label === "completed" ||
         ev.label === "requesting" ||
         ev.label === "thinking" ||
         ev.label === "empty_response" ||

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -69,9 +69,9 @@ interface Props {
 /**
  * Compact runtime control. Click opens a dropdown with the Open Design account
  * and the model picker for the active agent. Execution wiring that is not a
- * per-message choice (execution mode, which CLI agent, PATH rescan, reasoning
- * effort, BYOK model) lives in Settings → Execution; this popover stays a
- * one-decision surface.
+ * per-message choice (execution mode, which CLI agent, PATH rescan, BYOK
+ * provider setup) lives in Settings → Execution; this popover keeps the
+ * active agent's model and reasoning choices close to the composer.
  */
 export function AvatarMenu({
   config,
@@ -303,8 +303,8 @@ export function AvatarMenu({
   };
 
   // Resolve the user's model + reasoning pick for the active agent. Falls
-  // back to the agent's first declared option (`'default'`) when the user
-  // hasn't touched the picker yet so the labels don't read as empty.
+  // back to the agent's declared default when the saved effort is absent or
+  // belongs to a different model route.
   const currentChoice =
     (config.agentId && config.agentModels?.[config.agentId]) || {};
   const normalizedCurrentChoice = effectiveAgentModelChoice(currentAgent, currentChoice) ?? currentChoice;
@@ -314,8 +314,10 @@ export function AvatarMenu({
     currentAgent?.models?.find((model) => model.id === currentModelId)?.reasoningOptions ??
     currentAgent?.reasoningOptions;
   const currentReasoningId =
-    activeReasoningOptions?.some((option) => option.id === currentChoice.reasoning)
-      ? currentChoice.reasoning!
+    activeReasoningOptions?.some(
+      (option) => option.id === normalizedCurrentChoice.reasoning,
+    )
+      ? normalizedCurrentChoice.reasoning!
       : activeReasoningOptions?.find((option) => option.default)?.id ??
         activeReasoningOptions?.[0]?.id ?? null;
   const currentModelOption = currentAgent?.models?.find(
@@ -328,9 +330,6 @@ export function AvatarMenu({
   )
     ? currentChoice.serviceTier!
     : 'default';
-  const currentReasoningLabel =
-    activeReasoningOptions?.find((option) => option.id === currentReasoningId)?.label ??
-    currentReasoningId;
   const apiModelLabel = config.model?.trim() || null;
 
   // BYOK catalogue for the composer popover. The popover is the model picker
@@ -589,13 +588,27 @@ export function AvatarMenu({
                   ) : null}
                   {activeReasoningOptions &&
                   activeReasoningOptions.length > 0 &&
-                  currentReasoningLabel ? (
-                    <div className="avatar-select-row">
+                  currentReasoningId ? (
+                    <label className="avatar-select-row">
                       <span className="avatar-select-label">
                         {t('avatar.reasoningLabel')}
                       </span>
-                      <div className="avatar-static-value">{currentReasoningLabel}</div>
-                    </div>
+                      <select
+                        className="avatar-select"
+                        value={currentReasoningId}
+                        onChange={(event) =>
+                          onAgentModelChange(currentAgent.id, {
+                            reasoning: event.target.value,
+                          })
+                        }
+                      >
+                        {activeReasoningOptions.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
                   ) : null}
                   {currentServiceTierOptions.length > 0 ? (
                     <label className="avatar-select-row">

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -4521,12 +4521,12 @@ export function isAssistantMessageStreaming(
   forceStreamingMessageIds?: Set<string>,
 ): boolean {
   if (message.role !== 'assistant') return false;
+  if (isTerminalRunStatus(message.runStatus)) return false;
   if (forceStreamingMessageIds?.has(message.id)) return true;
   if (isActiveRunStatus(message.runStatus)) return true;
   if (message.id !== lastAssistantId) return false;
   if (!paneStreaming) return false;
   if (message.endedAt !== undefined) return false;
-  if (isTerminalRunStatus(message.runStatus)) return false;
   return true;
 }
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -845,6 +845,7 @@ const HIDDEN_BRAND_ASSISTANT_STATUS_LABELS = new Set([
   'streaming',
   'starting',
   'running',
+  'working',
   'requesting',
   'thinking',
   'empty_response',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3468,6 +3468,7 @@ export const ar: Dict = {
   'assistant.role': 'المساعد',
   'assistant.workingLabel': 'جاري العمل',
   'assistant.doneLabel': 'تم',
+  'assistant.canceledLabel': 'ملغى',
   'assistant.copyMarkdown': 'نسخ Markdown الرد',
   'assistant.forkConversation': 'تفرع من هنا',
   'assistant.forkingConversation': 'جارٍ التفرع…',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3468,6 +3468,7 @@ export const de: Dict = {
   'assistant.role': 'Assistent',
   'assistant.workingLabel': 'Arbeitet',
   'assistant.doneLabel': 'Fertig',
+  'assistant.canceledLabel': 'Abgebrochen',
   'assistant.copyMarkdown': 'Antwort-Markdown kopieren',
   'assistant.forkConversation': 'Ab hier forken',
   'assistant.forkingConversation': 'Fork wird erstellt…',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3482,6 +3482,7 @@ export const en: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'Working',
   'assistant.doneLabel': 'Done',
+  'assistant.canceledLabel': 'Canceled',
   'assistant.copyMarkdown': 'Copy response markdown',
   'assistant.forkConversation': 'Fork from here',
   'assistant.forkingConversation': 'Forking…',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3468,6 +3468,7 @@ export const esES: Dict = {
   'assistant.role': 'Asistente',
   'assistant.workingLabel': 'Trabajando',
   'assistant.doneLabel': 'Listo',
+  'assistant.canceledLabel': 'Cancelado',
   'assistant.copyMarkdown': 'Copiar Markdown de la respuesta',
   'assistant.forkConversation': 'Bifurcar desde aquí',
   'assistant.forkingConversation': 'Bifurcando…',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3468,6 +3468,7 @@ export const fa: Dict = {
   'assistant.role': 'دستیار',
   'assistant.workingLabel': 'در حال کار',
   'assistant.doneLabel': 'انجام شد',
+  'assistant.canceledLabel': 'لغو شد',
   'assistant.copyMarkdown': 'کپی Markdown پاسخ',
   'assistant.forkConversation': 'فورک از اینجا',
   'assistant.forkingConversation': 'در حال فورک…',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3468,6 +3468,7 @@ export const fr: Dict = {
   'assistant.role': 'Assistant',
   'assistant.workingLabel': 'En cours',
   'assistant.doneLabel': 'Terminé',
+  'assistant.canceledLabel': 'Annulé',
   'assistant.copyMarkdown': 'Copier le Markdown de la réponse',
   'assistant.forkConversation': 'Créer un fork à partir d’ici',
   'assistant.forkingConversation': 'Création du fork…',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3468,6 +3468,7 @@ export const hu: Dict = {
   'assistant.role': 'Asszisztens',
   'assistant.workingLabel': 'Dolgozik',
   'assistant.doneLabel': 'Kész',
+  'assistant.canceledLabel': 'Megszakítva',
   'assistant.copyMarkdown': 'Válasz Markdown másolása',
   'assistant.forkConversation': 'Fork innen',
   'assistant.forkingConversation': 'Fork létrehozása…',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3468,6 +3468,7 @@ export const id: Dict = {
   'assistant.role': 'Asisten',
   'assistant.workingLabel': 'Sedang bekerja',
   'assistant.doneLabel': 'Selesai',
+  'assistant.canceledLabel': 'Dibatalkan',
   'assistant.copyMarkdown': 'Salin Markdown respons',
   'assistant.forkConversation': 'Fork dari sini',
   'assistant.forkingConversation': 'Membuat fork…',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3468,6 +3468,7 @@ export const it: Dict = {
   'assistant.role': 'Assistente',
   'assistant.workingLabel': 'In corso',
   'assistant.doneLabel': 'Completato',
+  'assistant.canceledLabel': 'Annullato',
   'assistant.copyMarkdown': 'Copia il Markdown della risposta',
   'assistant.forkConversation': 'Fork da qui',
   'assistant.forkingConversation': 'Creazione fork…',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3468,6 +3468,7 @@ export const ja: Dict = {
   'assistant.role': 'アシスタント',
   'assistant.workingLabel': '作業中',
   'assistant.doneLabel': '完了',
+  'assistant.canceledLabel': 'キャンセル済み',
   'assistant.copyMarkdown': '応答のMarkdownをコピー',
   'assistant.forkConversation': 'ここからフォーク',
   'assistant.forkingConversation': 'フォーク中…',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3468,6 +3468,7 @@ export const ko: Dict = {
   'assistant.role': '어시스턴트 (Assistant)',
   'assistant.workingLabel': '작업 중',
   'assistant.doneLabel': '완료됨',
+  'assistant.canceledLabel': '취소됨',
   'assistant.copyMarkdown': '응답 Markdown 복사',
   'assistant.forkConversation': '여기서 포크',
   'assistant.forkingConversation': '포크 중…',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3468,6 +3468,7 @@ export const pl: Dict = {
   'assistant.role': 'Asystent',
   'assistant.workingLabel': 'Pracuję',
   'assistant.doneLabel': 'Gotowe',
+  'assistant.canceledLabel': 'Anulowano',
   'assistant.copyMarkdown': 'Kopiuj Markdown odpowiedzi',
   'assistant.forkConversation': 'Fork od tego miejsca',
   'assistant.forkingConversation': 'Tworzenie forka…',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3468,6 +3468,7 @@ export const ptBR: Dict = {
   'assistant.role': 'Assistente',
   'assistant.workingLabel': 'Trabalhando',
   'assistant.doneLabel': 'Concluído',
+  'assistant.canceledLabel': 'Cancelado',
   'assistant.copyMarkdown': 'Copiar Markdown da resposta',
   'assistant.forkConversation': 'Bifurcar daqui',
   'assistant.forkingConversation': 'Bifurcando…',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3468,6 +3468,7 @@ export const ru: Dict = {
   'assistant.role': 'Ассистент',
   'assistant.workingLabel': 'Работает',
   'assistant.doneLabel': 'Готово',
+  'assistant.canceledLabel': 'Отменено',
   'assistant.copyMarkdown': 'Скопировать Markdown ответа',
   'assistant.forkConversation': 'Создать форк отсюда',
   'assistant.forkingConversation': 'Создание форка…',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3468,6 +3468,7 @@ export const th: Dict = {
   'assistant.role': 'หน่วยผู้ช่วยเหลือส่วนตัว',
   'assistant.workingLabel': 'ดำเนินระบบรับทำงานอยู่',
   'assistant.doneLabel': 'บรรลุสู่ระดับพร้อมแล้ว',
+  'assistant.canceledLabel': 'ยกเลิกแล้ว',
   'assistant.copyMarkdown': 'คัดลอก Markdown ของคำตอบ',
   'assistant.forkConversation': 'Fork จากตรงนี้',
   'assistant.forkingConversation': 'กำลัง fork…',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3468,6 +3468,7 @@ export const tr: Dict = {
   'assistant.role': 'Asistan',
   'assistant.workingLabel': 'Çalışıyor',
   'assistant.doneLabel': 'Bitti',
+  'assistant.canceledLabel': 'İptal edildi',
   'assistant.copyMarkdown': 'Yanıt Markdown\'unu kopyala',
   'assistant.forkConversation': 'Buradan fork et',
   'assistant.forkingConversation': 'Fork ediliyor…',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3468,6 +3468,7 @@ export const uk: Dict = {
   'assistant.role': 'Асистент',
   'assistant.workingLabel': 'Роботи',
   'assistant.doneLabel': 'Готово',
+  'assistant.canceledLabel': 'Скасовано',
   'assistant.copyMarkdown': 'Скопіювати Markdown відповіді',
   'assistant.forkConversation': 'Створити форк звідси',
   'assistant.forkingConversation': 'Створення форка…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3663,6 +3663,7 @@ export const zhCN: Dict = {
   "assistant.role": "助手",
   "assistant.workingLabel": "执行中",
   "assistant.doneLabel": "已完成",
+  "assistant.canceledLabel": "已取消",
   "assistant.copyMarkdown": "复制回复 Markdown",
   "assistant.forkConversation": "从这里分叉",
   "assistant.forkingConversation": "正在分叉…",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3673,6 +3673,7 @@ export const zhTW: Dict = {
   "assistant.role": "助手",
   "assistant.workingLabel": "執行中",
   "assistant.doneLabel": "已完成",
+  "assistant.canceledLabel": "已取消",
   "assistant.copyMarkdown": "複製回覆 Markdown",
   "assistant.forkConversation": "從這裡分叉",
   "assistant.forkingConversation": "正在分叉…",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -4339,6 +4339,7 @@ export interface Dict {
   'assistant.role': string;
   'assistant.workingLabel': string;
   'assistant.doneLabel': string;
+  'assistant.canceledLabel': string;
   'assistant.copyMarkdown': string;
   'assistant.forkConversation': string;
   'assistant.forkingConversation': string;

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -136,6 +136,25 @@ const claudeAgent: AgentInfo = {
   ],
 };
 
+const deepSeekHarnessAgent: AgentInfo = {
+  id: 'deepseek-harness',
+  name: 'DeepSeek Harness',
+  bin: 'dsh',
+  available: true,
+  version: '0.1.0-rc.6',
+  models: [
+    {
+      id: 'deepseek/deepseek-v4-flash',
+      label: 'DeepSeek-V4-Flash · DeepSeek',
+      reasoningOptions: [
+        { id: 'off', label: 'Off' },
+        { id: 'high', label: 'High', default: true },
+        { id: 'max', label: 'Max' },
+      ],
+    },
+  ],
+};
+
 const baseConfig: AppConfig = {
   mode: 'daemon',
   apiKey: '',
@@ -326,21 +345,35 @@ describe('AvatarMenu', () => {
     expect(screen.queryByRole('link', { name: 'settings.amrUpgrade' })).toBeNull();
   });
 
-  it('renders the active reasoning effort as a read-only readout', () => {
-    renderMenu();
+  it('changes reasoning effort from the composer popover', () => {
+    const { onAgentModelChange } = renderMenu({
+      config: {
+        ...baseConfig,
+        agentId: 'deepseek-harness',
+        agentModels: {
+          'deepseek-harness': {
+            model: 'deepseek/deepseek-v4-flash',
+            reasoning: 'high',
+          },
+        },
+      },
+      agents: [deepSeekHarnessAgent],
+    });
 
     const menu = openMenu();
-    const rows = Array.from(menu.querySelectorAll('.avatar-select-row'));
-    const reasoningRow = rows.find((row) =>
-      row.querySelector('.avatar-select-label')?.textContent ===
+    const reasoningSelect = within(menu).getByLabelText(
       'avatar.reasoningLabel',
     );
-    expect(reasoningRow).toBeTruthy();
+    expect(reasoningSelect).toHaveValue('high');
     expect(
-      reasoningRow!.querySelector('.avatar-static-value')?.textContent,
-    ).toBe('Default');
-    // Read-only: no control to change it from the composer.
-    expect(reasoningRow!.querySelector('select')).toBeNull();
+      within(reasoningSelect).getAllByRole('option').map((option) => option.textContent),
+    ).toEqual(['Off', 'High', 'Max']);
+
+    fireEvent.change(reasoningSelect, { target: { value: 'max' } });
+
+    expect(onAgentModelChange).toHaveBeenCalledWith('deepseek-harness', {
+      reasoning: 'max',
+    });
   });
 
   it('selects a model from the inline list and dismisses the popover', () => {

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -663,12 +663,14 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.status-pill')).toBeNull();
   });
 
-  it('still renders status rows that carry a displayable detail', () => {
+  it('still renders lifecycle and model status rows that carry a displayable detail', () => {
     const { container } = render(
       <AssistantMessage
         projectKind="prototype"
         conversationId="conv-1"
         message={messageWithEvents([
+          { kind: 'status', label: 'working', detail: 'Publishing plugin' },
+          { kind: 'status', label: 'done', detail: 'CLI command finished' },
           { kind: 'status', label: 'model', detail: 'claude-opus-4-7-high' },
         ])}
         streaming={false}
@@ -676,8 +678,13 @@ describe('AssistantMessage tool status', () => {
       />,
     );
 
-    expect(container.querySelector('[data-status="model"]')).not.toBeNull();
-    expect(container.querySelector('.status-detail')?.textContent).toContain('claude-opus-4-7-high');
+    expect(container.querySelector('[data-status="working"]')).not.toBeNull();
+    expect(container.querySelector('[data-status="done"]')).not.toBeNull();
+    expect(container.textContent).toContain('Publishing plugin');
+    expect(container.textContent).toContain('CLI command finished');
+    const modelStatus = container.querySelector('[data-status="model"]');
+    expect(modelStatus).not.toBeNull();
+    expect(modelStatus?.querySelector('.status-detail')?.textContent).toContain('claude-opus-4-7-high');
   });
 
   it('renders URLs in JSON-like status details without trailing structural characters', () => {

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -301,7 +301,7 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.op-status-done')).toBeNull();
   });
 
-  it('does not show Done when a canceled run is missing a tool result', () => {
+  it('shows Canceled when a canceled run is missing a tool result', () => {
     const { container } = render(
       <AssistantMessage
         projectKind="prototype"
@@ -322,9 +322,29 @@ describe('AssistantMessage tool status', () => {
       />,
     );
 
-    expect(screen.getByTestId('task-activity-toggle').textContent).toContain('Run failed');
+    const activity = screen.getByTestId('task-activity-toggle');
+    expect(activity.textContent).toContain('Canceled');
+    expect(activity.getAttribute('data-run-state')).toBe('canceled');
     expect(container.querySelector('[data-tool-category="run"][data-tool-state="error"]')).not.toBeNull();
     expect(container.querySelector('.op-status-done')).toBeNull();
+  });
+
+  it('shows Canceled instead of Done when a canceled run has no activity card', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={{
+          ...messageWithEvents([{ kind: 'text', text: 'Partial response.' }]),
+          content: 'Partial response.',
+          runStatus: 'canceled',
+        }}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    expect(container.querySelector('.assistant-label')?.textContent).toBe('Canceled');
   });
 
   it.each(['no_result', 'delivery_failed'] as const)(

--- a/apps/web/tests/components/assistant-message-tool-status.test.tsx
+++ b/apps/web/tests/components/assistant-message-tool-status.test.tsx
@@ -640,6 +640,29 @@ describe('AssistantMessage tool status', () => {
     expect(container.querySelector('.status-pill')).toBeNull();
   });
 
+  it('hides persisted lifecycle status rows after a run reaches a terminal state', () => {
+    const { container } = render(
+      <AssistantMessage
+        projectKind="prototype"
+        conversationId="conv-1"
+        message={{
+          ...messageWithEvents([
+            { kind: 'status', label: 'working' },
+            { kind: 'status', label: 'completed' },
+          ]),
+          runStatus: 'canceled',
+          endedAt: 2,
+        }}
+        streaming={false}
+        projectId="project-1"
+      />,
+    );
+
+    expect(container.querySelector('[data-status="working"]')).toBeNull();
+    expect(container.querySelector('[data-status="completed"]')).toBeNull();
+    expect(container.querySelector('.status-pill')).toBeNull();
+  });
+
   it('still renders status rows that carry a displayable detail', () => {
     const { container } = render(
       <AssistantMessage

--- a/apps/web/tests/components/conversation-timestamps.test.tsx
+++ b/apps/web/tests/components/conversation-timestamps.test.tsx
@@ -146,6 +146,14 @@ describe('conversation timestamps', () => {
     expect(isAssistantMessageStreaming(message, true, 'assistant-1')).toBe(false);
     expect(
       isAssistantMessageStreaming(
+        { ...message, runStatus: 'canceled' },
+        true,
+        'assistant-1',
+        new Set(['assistant-1']),
+      ),
+    ).toBe(false);
+    expect(
+      isAssistantMessageStreaming(
         { ...message, id: 'assistant-2', runStatus: 'running' },
         false,
         'assistant-1',

--- a/e2e/ui/visual-workspace.test.ts
+++ b/e2e/ui/visual-workspace.test.ts
@@ -342,15 +342,13 @@ test('[P1] Avatar menu stays a model picker for a signed-in Open Design account'
   await captureVisual(page, 'visual-avatar-open-design-model-picker');
 });
 
-test('[P2] captures the avatar reasoning readout surface', async ({ page }) => {
+test('[P2] captures the avatar reasoning selector surface', async ({ page }) => {
   await configureVisualPage(page, {
     // AvatarMenu only draws the reasoning row for an agent that reports
     // `reasoningOptions`, and the shared `VISUAL_CLI_AGENTS` codex entry
-    // declares models only — so the readout this capture is named for never
-    // rendered, and the assertion has been failing since 68cecac1c introduced
-    // it. The real daemon does report them (apps/daemon/src/runtimes/defs/
-    // codex.ts), so declare them here rather than widening the shared fixture
-    // that the other captures in this file share.
+    // declares models only. The real daemon does report them (apps/daemon/src/
+    // runtimes/defs/codex.ts), so declare them here rather than widening the
+    // shared fixture that the other captures in this file share.
     agents: [
       { ...VISUAL_CODEX_AGENT, reasoningOptions: VISUAL_CODEX_REASONING_OPTIONS },
       ...VISUAL_CLI_AGENTS.filter((agent) => agent.id !== 'codex'),
@@ -364,12 +362,10 @@ test('[P2] captures the avatar reasoning readout surface', async ({ page }) => {
   await gotoVisualWorkspace(page);
 
   const menu = await prepareVisualAvatarMenu(page);
-  // Reasoning effort is shown as a read-only readout; it is changed in
-  // Settings → Execution, not from the composer.
-  const reasoningReadout = menu.locator('.avatar-static-value');
-  await expect(reasoningReadout).toHaveCount(1);
-  await expect(reasoningReadout).toHaveText('Default');
-  await expect(menu.locator('.avatar-model-section select')).toHaveCount(0);
+  const reasoningSelect = menu.getByRole('combobox', { name: 'Reasoning' });
+  await expect(reasoningSelect).toHaveCount(1);
+  await expect(reasoningSelect).toHaveValue('default');
+  await expect(reasoningSelect.locator('option')).toHaveText(['Default', 'Medium', 'High']);
 
   await captureVisual(page, 'visual-avatar-local-agent-list');
   await captureVisualTarget(page, 'visual-avatar-local-agent-list-panel', menu);

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
 import type { Context } from '@deepseek-ai/cordis';
 import type {} from '@deepseek-ai/cordis-plugin-loader';
 import {
@@ -375,9 +376,15 @@ async function execute(
   }
 }
 
-async function serve(ctx: Context, output: Output, exit: (code: number) => void): Promise<void> {
+async function serve(
+  ctx: Context,
+  output: Output,
+  exit: (code: number) => void,
+  input: Readable = process.stdin,
+  finishProfile: (exitCallback: (code: number) => void) => void = requestProfileExit,
+): Promise<void> {
   writeFrame(output, identityFrame('ready', PLUGIN_VERSION));
-  const lines = createInterface({ input: process.stdin, crlfDelay: Infinity });
+  const lines = createInterface({ input, crlfDelay: Infinity });
   let requestId: string | null = null;
   let handle: AgentHandle | undefined;
   let task: Promise<void> | undefined;
@@ -390,7 +397,7 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
       if (settled) return;
       settled = true;
       lines.close();
-      process.stdin.destroy();
+      input.destroy();
       resolve();
     };
     lines.on('line', (line) => {
@@ -438,7 +445,7 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
       if (!task) settle();
     });
   });
-  requestProfileExit(exit);
+  finishProfile(exit);
 }
 
 export function apply(ctx: Context): void {
@@ -473,5 +480,6 @@ export const internals = {
   requestProfileExit,
   resultStatus,
   resultError,
+  serve,
   terminalOutput,
 };

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -40,6 +40,10 @@ const PLUGIN_VERSION = '0.1.0';
 type Output = { write(chunk: string): unknown };
 type ExitFallbackTimer = { unref(): unknown };
 type ExitFallbackScheduler = (callback: () => void, delayMs: number) => ExitFallbackTimer;
+type CancellationLatch = {
+  activate(requestId: string, controller: AbortController): void;
+  cancel(requestId: string): void;
+};
 
 const PROCESS_EXIT_FALLBACK_MS = 1_000;
 
@@ -127,6 +131,34 @@ function requestProfileExit(
   // The agent handle and session flush have already settled here, so retain a
   // bounded process fallback below OD's three-second cancellation grace.
   schedule(forceExit, PROCESS_EXIT_FALLBACK_MS).unref();
+}
+
+function createCancellationLatch(cancelActiveAgent: () => void): CancellationLatch {
+  const pendingRequestIds = new Set<string>();
+  let activeRequest: { requestId: string; controller: AbortController } | undefined;
+
+  const cancelActive = () => {
+    if (!activeRequest || activeRequest.controller.signal.aborted) return;
+    activeRequest.controller.abort();
+    cancelActiveAgent();
+  };
+
+  return {
+    activate(requestId, controller) {
+      activeRequest = { requestId, controller };
+      if (pendingRequestIds.delete(requestId)) cancelActive();
+    },
+    cancel(requestId) {
+      if (activeRequest?.requestId === requestId) {
+        cancelActive();
+        return;
+      }
+      // The host can cancel during the child-spawn/profile-handshake window,
+      // before the execute line has created its AbortController. Retain that
+      // request-scoped intent and replay it as soon as execute becomes active.
+      pendingRequestIds.add(requestId);
+    },
+  };
 }
 
 function usageFrame(requestId: string, provider: string, model: string, usage: TokenUsage) {
@@ -349,7 +381,9 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
   let requestId: string | null = null;
   let handle: AgentHandle | undefined;
   let task: Promise<void> | undefined;
-  let taskAbort: AbortController | undefined;
+  const cancellation = createCancellationLatch(() => {
+    handle?.agent.cancel({ kind: 'user' });
+  });
   await new Promise<void>((resolve) => {
     let settled = false;
     const settle = () => {
@@ -375,10 +409,7 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
         return;
       }
       if (command.type === 'cancel') {
-        if (command.request_id === requestId && taskAbort && !taskAbort.signal.aborted) {
-          taskAbort.abort();
-          handle?.agent.cancel({ kind: 'user' });
-        }
+        cancellation.cancel(command.request_id);
         return;
       }
       if (task) {
@@ -392,7 +423,8 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
         return;
       }
       requestId = command.request_id;
-      taskAbort = new AbortController();
+      const taskAbort = new AbortController();
+      cancellation.activate(requestId, taskAbort);
       task = execute(
         ctx,
         command,
@@ -433,6 +465,7 @@ export function apply(ctx: Context): void {
 
 export const internals = {
   contentText,
+  createCancellationLatch,
   errorFacts,
   emitSessionEvent,
   execute,

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -38,18 +38,28 @@ export const inject = [
 const PLUGIN_VERSION = '0.1.0';
 
 type Output = { write(chunk: string): unknown };
+type ExitFallbackTimer = { unref(): unknown };
+type ExitFallbackScheduler = (callback: () => void, delayMs: number) => ExitFallbackTimer;
+
+const PROCESS_EXIT_FALLBACK_MS = 1_000;
 
 function writeFrame(output: Output, frame: unknown): void {
   output.write(`${JSON.stringify(frame)}\n`);
 }
 
-function errorFacts(error: unknown, fallbackCode: string) {
-  return {
-    code: typeof (error as { code?: unknown } | null)?.code === 'string'
-      ? (error as { code: string }).code
-      : fallbackCode,
-    message: error instanceof Error ? error.message : String(error),
-  };
+function errorFacts(error: unknown, fallbackCode: string): { code: string; message: string } {
+  const candidate = typeof error === 'object' && error !== null
+    ? error as { code?: unknown; message?: unknown }
+    : undefined;
+  const code = typeof candidate?.code === 'string' && candidate.code !== ''
+    ? candidate.code
+    : fallbackCode;
+  if (error instanceof Error && error.message !== '') return { code, message: error.message };
+  if (typeof candidate?.message === 'string' && candidate.message !== '') {
+    return { code, message: candidate.message };
+  }
+  if (typeof error === 'string' && error !== '') return { code, message: error };
+  return { code, message: 'DeepSeek Harness reported an execution error.' };
 }
 
 function contentText(content: readonly ContentBlock[]): string {
@@ -104,6 +114,19 @@ function writeCancelledResult(output: Output, requestId: string, sessionId: stri
     session_id: sessionId,
     resume_rejected: false,
   });
+}
+
+function requestProfileExit(
+  exit: (code: number) => void,
+  forceExit: () => void = () => process.exit(0),
+  schedule: ExitFallbackScheduler = (callback, delayMs) => setTimeout(callback, delayMs),
+): void {
+  exit(0);
+  // rc.6 can finish root disposal before its launcher-owned file watchers are
+  // attached, leaving a one-shot profile alive when the host keeps stdin open.
+  // The agent handle and session flush have already settled here, so retain a
+  // bounded process fallback below OD's three-second cancellation grace.
+  schedule(forceExit, PROCESS_EXIT_FALLBACK_MS).unref();
 }
 
 function usageFrame(requestId: string, provider: string, model: string, usage: TokenUsage) {
@@ -280,6 +303,10 @@ async function execute(
     }));
     await handle.agent.whenIdle();
     await ctx.sessions.flush(handle.agent.session);
+    if (signal.aborted) {
+      writeCancelledResult(output, request.request_id, String(sessionId));
+      return;
+    }
 
     const reason = turnEnd?.data.reason;
     const status = resultStatus(reason);
@@ -329,6 +356,7 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
       if (settled) return;
       settled = true;
       lines.close();
+      process.stdin.destroy();
       resolve();
     };
     lines.on('line', (line) => {
@@ -347,8 +375,8 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
         return;
       }
       if (command.type === 'cancel') {
-        if (command.request_id === requestId) {
-          taskAbort?.abort();
+        if (command.request_id === requestId && taskAbort && !taskAbort.signal.aborted) {
+          taskAbort.abort();
           handle?.agent.cancel({ kind: 'user' });
         }
         return;
@@ -378,7 +406,7 @@ async function serve(ctx: Context, output: Output, exit: (code: number) => void)
       if (!task) settle();
     });
   });
-  exit(0);
+  requestProfileExit(exit);
 }
 
 export function apply(ctx: Context): void {
@@ -405,9 +433,11 @@ export function apply(ctx: Context): void {
 
 export const internals = {
   contentText,
+  errorFacts,
   emitSessionEvent,
   execute,
   listModelCatalog,
+  requestProfileExit,
   resultStatus,
   resultError,
   terminalOutput,

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { describe, test } from 'vitest';
 import { identityFrame, modelsFrame, parseHostCommand } from '../src/protocol.js';
 import { internals } from '../src/index.js';
@@ -160,20 +161,63 @@ describe('@open-design/dsh-runtime protocol', () => {
     assert.deepEqual(calls, ['managed:0', 'scheduled:1000', 'unref', 'forced']);
   });
 
-  test('replays cancellation that arrives before the request AbortController exists', () => {
-    let activeAgentCancelCalls = 0;
-    const cancellation = internals.createCancellationLatch(() => {
-      activeAgentCancelCalls += 1;
-    });
-    const abort = new AbortController();
+  test('replays cancellation received before execute initializes its AbortController', async () => {
+    let createSignal: AbortSignal | undefined;
+    let disposeCalls = 0;
+    const handle = {
+      agent: {
+        session: { seq: 0 },
+        whenIdle: async () => {},
+        followup: async () => {},
+        cancel: () => {},
+      },
+      dispose: async () => { disposeCalls += 1; },
+    };
+    const ctx = {
+      agentDefaultModel: {
+        currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-chat' }),
+      },
+      agents: {
+        create: async ({ signal }: { signal: AbortSignal }) => {
+          createSignal = signal;
+          return handle;
+        },
+      },
+      on: () => () => {},
+      sessions: { flush: async () => {} },
+    };
+    const input = new PassThrough();
+    const chunks: string[] = [];
+    const exitCodes: number[] = [];
+    const serving = internals.serve(
+      ctx as never,
+      { write: (chunk: string) => chunks.push(chunk) },
+      (code) => exitCodes.push(code),
+      input,
+      (exit) => exit(0),
+    );
 
-    cancellation.cancel('run-handshake-cancel');
-    assert.equal(abort.signal.aborted, false);
+    input.write(`${JSON.stringify({
+      v: 1,
+      type: 'cancel',
+      request_id: 'run-handshake-cancel',
+    })}\n`);
+    input.write(`${JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'run-handshake-cancel',
+      cwd: '/project',
+      prompt: 'do not start',
+      mcp_servers: [],
+    })}\n`);
+    await serving;
 
-    cancellation.activate('run-handshake-cancel', abort);
-
-    assert.equal(abort.signal.aborted, true);
-    assert.equal(activeAgentCancelCalls, 1);
+    assert.equal(createSignal?.aborted, true);
+    assert.equal(disposeCalls, 1);
+    assert.deepEqual(exitCodes, [0]);
+    const frames = chunks.map((chunk) => JSON.parse(chunk) as { type: string; status?: string });
+    assert.equal(frames.at(-1)?.type, 'result');
+    assert.equal(frames.at(-1)?.status, 'cancelled');
   });
 
   test('cancels a resumed request during restore without starting its follow-up turn', async () => {

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -160,6 +160,22 @@ describe('@open-design/dsh-runtime protocol', () => {
     assert.deepEqual(calls, ['managed:0', 'scheduled:1000', 'unref', 'forced']);
   });
 
+  test('replays cancellation that arrives before the request AbortController exists', () => {
+    let activeAgentCancelCalls = 0;
+    const cancellation = internals.createCancellationLatch(() => {
+      activeAgentCancelCalls += 1;
+    });
+    const abort = new AbortController();
+
+    cancellation.cancel('run-handshake-cancel');
+    assert.equal(abort.signal.aborted, false);
+
+    cancellation.activate('run-handshake-cancel', abort);
+
+    assert.equal(abort.signal.aborted, true);
+    assert.equal(activeAgentCancelCalls, 1);
+  });
+
   test('cancels a resumed request during restore without starting its follow-up turn', async () => {
     let finishRestore!: () => void;
     const restoring = new Promise<void>((resolveRestore) => { finishRestore = resolveRestore; });

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -124,6 +124,42 @@ describe('@open-design/dsh-runtime protocol', () => {
     assert.equal(internals.resultError({ kind: 'aborted', reason: { kind: 'user' } }), undefined);
   });
 
+  test('preserves structured Harness error facts without object coercion', () => {
+    assert.deepEqual(internals.errorFacts({
+      code: 'MISSING_CREDENTIAL',
+      message: 'Configure a DeepSeek API key in Harness.',
+    }, 'DSH_PROFILE_TURN_FAILED'), {
+      code: 'MISSING_CREDENTIAL',
+      message: 'Configure a DeepSeek API key in Harness.',
+    });
+    assert.deepEqual(internals.errorFacts({ code: 'UNKNOWN', detail: 'private provider data' }, 'fallback'), {
+      code: 'UNKNOWN',
+      message: 'DeepSeek Harness reported an execution error.',
+    });
+    assert.doesNotMatch(
+      internals.errorFacts({ code: 'UNKNOWN' }, 'fallback').message,
+      /\[object Object\]/,
+    );
+  });
+
+  test('keeps a bounded process-exit fallback after managed profile shutdown', () => {
+    const calls: string[] = [];
+    let scheduled: (() => void) | undefined;
+    internals.requestProfileExit(
+      (code) => calls.push(`managed:${code}`),
+      () => calls.push('forced'),
+      (callback, delayMs) => {
+        calls.push(`scheduled:${delayMs}`);
+        scheduled = callback;
+        return { unref: () => calls.push('unref') };
+      },
+    );
+
+    assert.deepEqual(calls, ['managed:0', 'scheduled:1000', 'unref']);
+    scheduled?.();
+    assert.deepEqual(calls, ['managed:0', 'scheduled:1000', 'unref', 'forced']);
+  });
+
   test('cancels a resumed request during restore without starting its follow-up turn', async () => {
     let finishRestore!: () => void;
     const restoring = new Promise<void>((resolveRestore) => { finishRestore = resolveRestore; });
@@ -183,5 +219,59 @@ describe('@open-design/dsh-runtime protocol', () => {
         resume_rejected: false,
       },
     ]);
+  });
+
+  test('cancellation remains authoritative while the active turn is being flushed', async () => {
+    let idleCalls = 0;
+    let notifyFlushStarted!: () => void;
+    const flushStarted = new Promise<void>((resolveFlush) => { notifyFlushStarted = resolveFlush; });
+    let finishFlush!: () => void;
+    const flushFinished = new Promise<void>((resolveFlush) => { finishFlush = resolveFlush; });
+    let disposeCalls = 0;
+    const handle = {
+      agent: {
+        session: { seq: 0 },
+        whenIdle: async () => { idleCalls += 1; },
+        followup: async () => {},
+      },
+      dispose: async () => { disposeCalls += 1; },
+    };
+    const ctx = {
+      agentDefaultModel: {
+        currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-chat' }),
+      },
+      agents: {
+        create: async () => handle,
+      },
+      on: () => () => {},
+      sessions: {
+        flush: async () => {
+          notifyFlushStarted();
+          await flushFinished;
+        },
+      },
+    };
+    const chunks: string[] = [];
+    const abort = new AbortController();
+    const execution = internals.execute(ctx as never, {
+      v: 1,
+      type: 'execute',
+      request_id: 'run-active-cancel',
+      cwd: '/project',
+      prompt: 'keep working',
+      mcp_servers: [],
+    }, { write: (chunk: string) => chunks.push(chunk) }, () => {}, abort.signal);
+
+    await flushStarted;
+    abort.abort();
+    finishFlush();
+    await execution;
+
+    assert.equal(idleCalls, 2);
+    assert.equal(disposeCalls, 1);
+    const frames = chunks.map((chunk) => JSON.parse(chunk) as { type: string; status?: string; error?: unknown });
+    assert.equal(frames.filter((frame) => frame.type === 'result').length, 1);
+    assert.equal(frames.at(-1)?.status, 'cancelled');
+    assert.equal(frames.at(-1)?.error, undefined);
   });
 });


### PR DESCRIPTION
## Why

QA acceptance of the DeepSeek Harness integration found five linked lifecycle defects: provider-time cancellation could be reported as a missing-turn failure, quick cancellation could leave the stdio profile alive, structured upstream errors degraded to `[object Object]`, canceled runs rendered as Working/Done, and Harness usage lost provider/model attribution.

These defects made cancellation unsafe and diagnostics misleading for anyone using the newly landed DSH profile integration.

## What users will see

- Canceling a DeepSeek Harness run now settles once as canceled and the profile process exits within the daemon grace period.
- Canceled assistant turns display Canceled instead of Working, Done, or Run failed.
- DeepSeek provider errors retain their useful code and message.
- Run diagnostics attribute default-model executions to the provider-qualified Harness model.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Pending a local desktop capture of the canceled terminal label before this draft is marked ready.

## Bug fix verification

- Regression tests:
  - `packages/dsh-runtime/tests/protocol.test.ts`
  - `apps/daemon/tests/agent-protocol/dsh-profile.test.ts`
  - `apps/daemon/tests/run-analytics-observability.test.ts`
  - `apps/web/tests/components/assistant-message-tool-status.test.tsx`
  - `apps/web/tests/components/conversation-timestamps.test.tsx`
- Red on `main`, green on branch: no. The failures were reproduced against the merged implementation and official `dsh 0.1.0-rc.6`; the new source-level tests encode those reproduced boundaries and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/dsh-runtime test`
- `pnpm --filter @open-design/dsh-runtime typecheck`
- `pnpm --filter @open-design/dsh-runtime build`
- Focused daemon tests: 70 passed
- Focused web tests: 29 passed
- Fresh isolated `DSH_HOME`: local profile install, `--probe`, and `--models`
- Official `dsh 0.1.0-rc.6`: no-credential execution preserved `MISSING_CREDENTIAL` and exited in about 1.0s with stdin held open
- Official `dsh 0.1.0-rc.6`: immediate execute/cancel emitted exactly one canceled result and exited in about 1.8s with stdin held open
