### PR TITLE
fix(web): recover aborted srcdoc preview navigation

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10135,6 +10135,8 @@ function HtmlViewer({
     workspaceContext,
   ]);
 
+  const srcDocBaseHref = effectiveScopedSrcDocPreviewBase
+    ?? projectRawUrl(projectId, baseDirFor(file.name), workspaceContext);
   const srcDocTransportGeneration = useMemo(
     () => nextPreviewTransportGeneration(),
     [
@@ -10145,10 +10147,9 @@ function HtmlViewer({
       reloadKey,
       transportPreviewMeasurementDocumentEpoch,
       workspaceContext,
+      srcDocBaseHref,
     ],
   );
-  const srcDocBaseHref = effectiveScopedSrcDocPreviewBase
-    ?? projectRawUrl(projectId, baseDirFor(file.name), workspaceContext);
   const srcDoc = useMemo(
     () => (previewSource ? buildSrcdoc(previewSource, {
       deck: effectiveDeck,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10205,16 +10205,17 @@ function HtmlViewer({
     frame: HTMLIFrameElement;
     generation: string;
     probeId: string;
+    recoverOnFailure: boolean;
   } | null>(null);
   const replayPreviewBridgeModes = useCallback((target: HTMLIFrameElement | null) => {
     if (!workspaceActive) return;
     const win = target?.contentWindow;
     if (!win) return;
-    const ready = readySrcDocTransportRef.current;
+    const verified = verifiedSrcDocTransportRef.current;
     if (
       target === srcDocPreviewIframeRef.current
-      && ready?.frame === target
-      && ready.generation === expectedSrcDocTransportGenerationRef.current
+      && verified?.frame === target
+      && verified.generation === expectedSrcDocTransportGenerationRef.current
     ) {
       postAndConsumePreviewRuntimeState(target);
     }
@@ -10338,9 +10339,23 @@ function HtmlViewer({
     }
     const frame = srcDocPreviewIframeRef.current;
     if (!frame) return;
+    const pending = pendingSrcDocTransportProbeRef.current;
+    const pendingRecoveryProbeMatches = (
+      pending?.frame === frame
+      && pending.generation === generation
+      && pending.recoverOnFailure
+    );
+    // Recovery probes can be shared by the timer and onLoad paths. A passive
+    // prewarm probe may target the lazy shell, so the real srcDoc must replace it.
+    if (pendingRecoveryProbeMatches) return;
     srcDocTransportProbeSequenceRef.current += 1;
     const probeId = `${generation}:probe-${srcDocTransportProbeSequenceRef.current}`;
-    pendingSrcDocTransportProbeRef.current = { frame, generation, probeId };
+    pendingSrcDocTransportProbeRef.current = {
+      frame,
+      generation,
+      probeId,
+      recoverOnFailure,
+    };
     // An eager acknowledgement from the injected head bridge is provisional:
     // Chromium can still abort the about:srcdoc navigation after it was sent.
     // Only this exact challenge response proves the current browsing context is
@@ -10362,7 +10377,7 @@ function HtmlViewer({
         return;
       }
       pendingSrcDocTransportProbeRef.current = null;
-      if (recoverOnFailure) recoverUnacknowledgedSrcDocTransport(generation);
+      if (pending.recoverOnFailure) recoverUnacknowledgedSrcDocTransport(generation);
     }, SRC_DOC_READY_PROBE_TIMEOUT_MS);
   }, [recoverUnacknowledgedSrcDocTransport]);
   // Sticky once the srcDoc iframe has materialized the real artifact for the
@@ -10936,11 +10951,11 @@ function HtmlViewer({
     const target = iframeRef.current;
     const win = target?.contentWindow;
     if (!win) return;
-    const ready = readySrcDocTransportRef.current;
+    const verified = verifiedSrcDocTransportRef.current;
     if (
       target === srcDocPreviewIframeRef.current
-      && ready?.frame === target
-      && ready.generation === expectedSrcDocTransportGenerationRef.current
+      && verified?.frame === target
+      && verified.generation === expectedSrcDocTransportGenerationRef.current
     ) {
       postAndConsumePreviewRuntimeState(target);
     }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -618,6 +618,7 @@ const htmlPreviewZoomState = new Map<string, { zoom: number; zoomMode: 'auto' | 
 const MAX_CACHED_PREVIEW_CONTENT_WIDTHS = 128;
 const PREVIEW_CONTENT_WIDTH_CACHE_VERSION = 2;
 const SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS = 1500;
+const SRC_DOC_READY_PROBE_TIMEOUT_MS = 1500;
 let previewContentMeasurementDocumentEpochSequence = 0;
 let previewContentMeasurementHostInstanceSequence = 0;
 let previewTransportGenerationSequence = 0;
@@ -10192,6 +10193,19 @@ function HtmlViewer({
     frame: HTMLIFrameElement;
     generation: string;
   } | null>(null);
+  // Eager readiness keeps the existing bridge features responsive. Navigation
+  // recovery uses the separately challenged witness below because Chromium can
+  // abort about:srcdoc after the head bridge has already announced itself.
+  const verifiedSrcDocTransportRef = useRef<{
+    frame: HTMLIFrameElement;
+    generation: string;
+  } | null>(null);
+  const srcDocTransportProbeSequenceRef = useRef(0);
+  const pendingSrcDocTransportProbeRef = useRef<{
+    frame: HTMLIFrameElement;
+    generation: string;
+    probeId: string;
+  } | null>(null);
   const replayPreviewBridgeModes = useCallback((target: HTMLIFrameElement | null) => {
     if (!workspaceActive) return;
     const win = target?.contentWindow;
@@ -10300,16 +10314,57 @@ function HtmlViewer({
       return;
     }
     const frame = srcDocPreviewIframeRef.current;
-    const ready = readySrcDocTransportRef.current;
-    if (frame && ready?.frame === frame && ready.generation === generation) return;
+    const verified = verifiedSrcDocTransportRef.current;
+    if (frame && verified?.frame === frame && verified.generation === generation) return;
     if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
     srcDocRecoveryAttemptedGenerationRef.current = generation;
+    pendingSrcDocTransportProbeRef.current = null;
+    verifiedSrcDocTransportRef.current = null;
     readySrcDocTransportRef.current = null;
     activatedSrcDocTransportHtmlRef.current = null;
     setSrcDocShellReady(false);
     setSrcDocRecoveryGeneration(generation);
     setSrcDocTransportResetKey((key) => key + 1);
   }, []);
+  const probeSrcDocTransport = useCallback((
+    generation: string,
+    recoverOnFailure: boolean,
+  ) => {
+    if (
+      !workspaceActiveRef.current
+      || expectedSrcDocTransportGenerationRef.current !== generation
+    ) {
+      return;
+    }
+    const frame = srcDocPreviewIframeRef.current;
+    if (!frame) return;
+    srcDocTransportProbeSequenceRef.current += 1;
+    const probeId = `${generation}:probe-${srcDocTransportProbeSequenceRef.current}`;
+    pendingSrcDocTransportProbeRef.current = { frame, generation, probeId };
+    // An eager acknowledgement from the injected head bridge is provisional:
+    // Chromium can still abort the about:srcdoc navigation after it was sent.
+    // Only this exact challenge response proves the current browsing context is
+    // alive after the navigation had a chance to commit.
+    verifiedSrcDocTransportRef.current = null;
+    frame.contentWindow?.postMessage({
+      type: 'od:srcdoc-transport-ready-probe',
+      generation,
+      probeId,
+    }, '*');
+    window.setTimeout(() => {
+      const pending = pendingSrcDocTransportProbeRef.current;
+      if (
+        !pending
+        || pending.frame !== frame
+        || pending.generation !== generation
+        || pending.probeId !== probeId
+      ) {
+        return;
+      }
+      pendingSrcDocTransportProbeRef.current = null;
+      if (recoverOnFailure) recoverUnacknowledgedSrcDocTransport(generation);
+    }, SRC_DOC_READY_PROBE_TIMEOUT_MS);
+  }, [recoverUnacknowledgedSrcDocTransport]);
   // Sticky once the srcDoc iframe has materialized the real artifact for the
   // first time (i.e. the first entry into Mark/Edit/Comment/Inspect). Until
   // then the srcDoc iframe stays on the lazy shell — so passive preview never
@@ -10364,7 +10419,12 @@ function HtmlViewer({
     function onMessage(ev: MessageEvent) {
       const frame = srcDocPreviewIframeRef.current;
       if (ev.source !== frame?.contentWindow) return;
-      const data = ev.data as { type?: unknown; generation?: unknown } | null;
+      const data = ev.data as {
+        type?: unknown;
+        generation?: unknown;
+        probeId?: unknown;
+      } | null;
+      const pending = pendingSrcDocTransportProbeRef.current;
       if (
         data?.type !== 'od:srcdoc-transport-activated'
         || typeof data.generation !== 'string'
@@ -10373,32 +10433,45 @@ function HtmlViewer({
         return;
       }
       readySrcDocTransportRef.current = { frame, generation: data.generation };
+      if (
+        typeof data.probeId === 'string'
+        && pending
+        && pending.frame === frame
+        && pending.generation === data.generation
+        && pending.probeId === data.probeId
+      ) {
+        pendingSrcDocTransportProbeRef.current = null;
+        verifiedSrcDocTransportRef.current = { frame, generation: data.generation };
+      }
       if (frame === iframeRef.current) replayPreviewBridgeModes(frame);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
   }, [replayPreviewBridgeModes, workspaceActive]);
   // React can commit a fresh `srcdoc` attribute while Chromium aborts the
-  // corresponding about:srcdoc navigation. The host then believes the latest
-  // revision is applied, but the iframe stays on its old/empty document until
-  // Code -> Preview happens to remount it. Every real srcDoc carries an exact
-  // generation ACK; if the active frame never acknowledges that generation,
-  // retry through the small lazy shell automatically; Chromium can commit that
-  // shell even when it aborts a large direct srcDoc navigation, after which the
-  // existing ready handshake safely document.write's the latest HTML. One
-  // fallback per generation avoids a loop when an authored document is
-  // fundamentally unable to execute scripts.
+  // corresponding about:srcdoc navigation. The injected head bridge may run
+  // and announce eagerly before that abort, so a plain generation ACK is not a
+  // committed-document witness. Challenge the current browsing context after
+  // the navigation had time to settle and require the exact probe token back;
+  // otherwise retry through the small lazy shell automatically. Chromium can
+  // commit that shell even when it aborts a large direct srcDoc navigation,
+  // after which the existing ready handshake safely document.write's the
+  // latest HTML. One fallback per generation avoids a loop when an authored
+  // document is fundamentally unable to execute scripts.
   useEffect(() => {
     if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
     const generation = srcDocTransportGeneration;
     if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
     const timeout = window.setTimeout(() => {
-      recoverUnacknowledgedSrcDocTransport(generation);
+      const frame = srcDocPreviewIframeRef.current;
+      const verified = verifiedSrcDocTransportRef.current;
+      if (frame && verified?.frame === frame && verified.generation === generation) return;
+      probeSrcDocTransport(generation, true);
     }, SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS);
     return () => window.clearTimeout(timeout);
   }, [
     mode,
-    recoverUnacknowledgedSrcDocTransport,
+    probeSrcDocTransport,
     srcDoc,
     srcDocTransportGeneration,
     useUrlLoadPreview,
@@ -10589,21 +10662,7 @@ function HtmlViewer({
   function verifyLoadedSrcDocTransport(target: HTMLIFrameElement | null) {
     if (!target || target !== srcDocPreviewIframeRef.current) return;
     const generation = srcDocTransportGeneration;
-    if (!useUrlLoadPreview && srcDoc) {
-      // `load` may belong to a provisional about:blank/about:srcdoc document.
-      // Drop any earlier ACK and require the document that actually completed
-      // this load to answer the generation probe. This closes the window where
-      // a provisional document announces from its head and is then aborted.
-      readySrcDocTransportRef.current = null;
-    }
-    target.contentWindow?.postMessage({
-      type: 'od:srcdoc-transport-ready-probe',
-      generation,
-    }, '*');
-    if (useUrlLoadPreview || !srcDoc) return;
-    window.setTimeout(() => {
-      recoverUnacknowledgedSrcDocTransport(generation);
-    }, SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS);
+    probeSrcDocTransport(generation, !useUrlLoadPreview && Boolean(srcDoc));
   }
   useEffect(() => {
     if (useUrlLoadPreview) {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -531,18 +531,20 @@ function injectSrcdocTransportActivationBridge(doc: string, generation: string):
   const encodedGeneration = JSON.stringify(generation);
   const script = `<script data-od-srcdoc-transport-activation>(function(){
   var generation = ${encodedGeneration};
-  function announceReady(){
+  function announceReady(probeId){
     if (!generation) return;
     try {
       if (window.parent && window.parent !== window) {
-        window.parent.postMessage({ type: 'od:srcdoc-transport-activated', generation: generation }, '*');
+        var message = { type: 'od:srcdoc-transport-activated', generation: generation };
+        if (typeof probeId === 'string' && probeId) message.probeId = probeId;
+        window.parent.postMessage(message, '*');
       }
     } catch (_) { /* sandboxed parent */ }
   }
   window.addEventListener('message', function(ev){
     var data = ev && ev.data;
     if (data && data.type === 'od:srcdoc-transport-ready-probe') {
-      if (data.generation === generation) announceReady();
+      if (data.generation === generation) announceReady(data.probeId);
       return;
     }
     if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string' || typeof data.generation !== 'string' || !data.generation) return;

--- a/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
@@ -124,19 +124,61 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
     );
 
     const refreshedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(refreshedFrame.contentWindow!, 'postMessage');
     act(() => {
+      // An eager head-script acknowledgement is provisional: Chromium can
+      // still abort the about:srcdoc navigation after this message.
       fireEvent.load(refreshedFrame);
+      const probe = postMessage.mock.calls.find(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )?.[0] as { generation?: string; probeId?: string } | undefined;
+      expect(probe?.probeId).toBeTruthy();
       window.dispatchEvent(new MessageEvent('message', {
         source: refreshedFrame.contentWindow,
         data: {
           type: 'od:srcdoc-transport-activated',
           generation: transportGeneration(refreshedFrame),
+          probeId: probe!.probeId,
         },
       }));
       vi.runAllTimers();
     });
 
     expect(screen.getByTestId('artifact-preview-frame')).toBe(refreshedFrame);
+  });
+
+  it('recovers when an eager activation acknowledgement is followed by an aborted navigation with no load', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('aborted-after-ack')}
+      />,
+    );
+
+    const abortedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    act(() => {
+      // This is the incident ordering: the injected head bridge runs, then
+      // Electron reports ERR_ABORTED for about:srcdoc and no iframe load event
+      // follows to invalidate the eager acknowledgement.
+      window.dispatchEvent(new MessageEvent('message', {
+        source: abortedFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: transportGeneration(abortedFrame),
+        },
+      }));
+      vi.runAllTimers();
+    });
+
+    const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(recoveredFrame).not.toBe(abortedFrame);
+    expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
   });
 
   it('revalidates an early activation acknowledgement after the frame load completes', () => {

--- a/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
@@ -147,6 +147,52 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
     expect(screen.getByTestId('artifact-preview-frame')).toBe(refreshedFrame);
   });
 
+  it('reuses an in-flight recovery probe when iframe load overlaps the recovery timer', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('overlapping-probes')}
+      />,
+    );
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    const firstProbe = postMessage.mock.calls.find(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    )?.[0] as { generation?: string; probeId?: string } | undefined;
+    expect(firstProbe?.probeId).toBeTruthy();
+
+    fireEvent.load(frame);
+    const probes = postMessage.mock.calls.filter(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    );
+    expect(probes).toHaveLength(1);
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: firstProbe!.generation,
+          probeId: firstProbe!.probeId,
+        },
+      }));
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+  });
+
   it('recovers when an eager activation acknowledgement is followed by an aborted navigation with no load', () => {
     vi.useFakeTimers();
     vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -2550,7 +2550,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByRole('menuitem', { name: /export as image/i })).toBeTruthy();
   });
 
-  it('restores captured URL preview state once after the matching prewarmed document is ready', async () => {
+  it('restores captured URL preview state once after the matching prewarmed document is verified', async () => {
     const file = baseFile({
       name: 'page.html',
       path: 'page.html',
@@ -2597,13 +2597,24 @@ describe('FileViewer SVG artifacts', () => {
     const srcDocFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement | null;
     expect(srcDocFrame?.getAttribute('data-od-active')).toBe('false');
     expect(srcDocFrame?.srcdoc).toContain('__odArtifactBootCount');
+    const srcDocPostSpy = vi.spyOn(srcDocFrame!.contentWindow!, 'postMessage');
     fireEvent.load(srcDocFrame!);
 
     const readyGeneration = srcDocFrame?.srcdoc.match(
       /data-od-srcdoc-transport-activation>[\s\S]*?var generation = "([^"]+)";/,
     )?.[1];
     expect(readyGeneration).toBeTruthy();
+    const readinessProbe = srcDocPostSpy.mock.calls.find(
+      ([message]) => (
+        (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe'
+        && (message as { generation?: unknown }).generation === readyGeneration
+      ),
+    )?.[0] as { generation?: string; probeId?: string } | undefined;
+    expect(readinessProbe?.generation).toBe(readyGeneration);
+    expect(readinessProbe?.probeId).toBeTruthy();
     act(() => {
+      // The eager head acknowledgement is provisional and must not consume
+      // URL runtime state before the challenged witness arrives.
       window.dispatchEvent(new MessageEvent('message', {
         source: srcDocFrame?.contentWindow,
         data: {
@@ -2623,7 +2634,6 @@ describe('FileViewer SVG artifacts', () => {
     });
 
     const urlPostSpy = vi.spyOn(urlFrame.contentWindow!, 'postMessage');
-    const srcDocPostSpy = vi.spyOn(srcDocFrame!.contentWindow!, 'postMessage');
     fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
 
     const captureRequest = await waitFor(() => {
@@ -2691,6 +2701,24 @@ describe('FileViewer SVG artifacts', () => {
     expect(srcDocFrameAfter).toBe(srcDocFrame);
     expect(srcDocFrameAfter?.srcdoc).toContain('__odArtifactBootCount');
     expect(srcDocFrameAfter?.srcdoc).toContain('data-od-edit-bridge');
+
+    const restoreCalls = () => srcDocPostSpy.mock.calls.filter(([message]) => (
+      typeof message === 'object'
+      && message !== null
+      && (message as { type?: unknown }).type === 'od:preview-runtime-state-restore'
+    ));
+    expect(restoreCalls()).toHaveLength(0);
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: srcDocFrameAfter?.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: readinessProbe!.generation,
+          probeId: readinessProbe!.probeId,
+        },
+      }));
+    });
     await waitFor(() => {
       expect(srcDocPostSpy).toHaveBeenCalledWith(
         { type: 'od:preview-runtime-state-restore', state: capturedState },
@@ -2698,11 +2726,6 @@ describe('FileViewer SVG artifacts', () => {
       );
     });
 
-    const restoreCalls = () => srcDocPostSpy.mock.calls.filter(([message]) => (
-      typeof message === 'object'
-      && message !== null
-      && (message as { type?: unknown }).type === 'od:preview-runtime-state-restore'
-    ));
     expect(restoreCalls()).toHaveLength(1);
 
     srcDocPostSpy.mockClear();
@@ -7648,6 +7671,7 @@ describe('FileViewer tweaks toolbar', () => {
     // happens only after the user enters an interactive mode.
     const initialSrcDocFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
     expect(initialSrcDocFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+    const postMessage = vi.spyOn(initialSrcDocFrame.contentWindow!, 'postMessage');
 
     // Materialize once via Draw. The manual-edit bridge must already be present
     // even though Edit is NOT active — it boots dormant and only acts on the
@@ -7661,11 +7685,17 @@ describe('FileViewer tweaks toolbar', () => {
       return f.srcdoc;
     });
     const materializedFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
-    const postMessage = vi.spyOn(materializedFrame.contentWindow!, 'postMessage');
+    const materializedGeneration = materializedFrame.srcdoc.match(
+      /data-od-srcdoc-transport-activation>[\s\S]*?var generation = "([^"]+)";/,
+    )?.[1];
+    expect(materializedGeneration).toBeTruthy();
     fireEvent.load(materializedFrame);
     const probe = await waitFor(() => {
       const value = postMessage.mock.calls.find(
-        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+        ([message]) => (
+          (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe'
+          && (message as { generation?: unknown }).generation === materializedGeneration
+        ),
       )?.[0] as { generation?: string; probeId?: string } | undefined;
       expect(value?.generation).toBeTruthy();
       expect(value?.probeId).toBeTruthy();

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7660,6 +7660,27 @@ describe('FileViewer tweaks toolbar', () => {
       expect(f.srcdoc).toContain('data-od-edit-bridge');
       return f.srcdoc;
     });
+    const materializedFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(materializedFrame.contentWindow!, 'postMessage');
+    fireEvent.load(materializedFrame);
+    const probe = await waitFor(() => {
+      const value = postMessage.mock.calls.find(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )?.[0] as { generation?: string; probeId?: string } | undefined;
+      expect(value?.generation).toBeTruthy();
+      expect(value?.probeId).toBeTruthy();
+      return value!;
+    });
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: materializedFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: probe.generation,
+          probeId: probe.probeId,
+        },
+      }));
+    });
 
     // Leave Draw and enter Edit. Because the edit bridge was already in the
     // materialized srcDoc, entering Edit must NOT change the document string —

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7314,6 +7314,91 @@ describe('FileViewer tweaks toolbar', () => {
     ))).toHaveLength(1);
   });
 
+  it('recovers when an asynchronously scoped base replaces an already verified srcDoc navigation', async () => {
+    vi.useFakeTimers();
+    const context = teamWorkspaceContext();
+    const previewBaseResponse = deferredResponse();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/projects/project-1/preview-url')) {
+        return previewBaseResponse.promise;
+      }
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      renderWithProjectWorkspace(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'brand.html', path: 'brand.html' })}
+          liveHtml={'<!doctype html><html><body><script>location.reload()</script></body></html>'}
+        />,
+        context,
+      );
+
+      const initialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const initialGeneration = initialFrame.srcdoc.match(
+        /data-od-srcdoc-transport-activation>[\s\S]*?var generation = "([^"]+)";/,
+      )?.[1];
+      expect(initialGeneration).toBeTruthy();
+
+      const postMessage = vi.spyOn(initialFrame.contentWindow!, 'postMessage');
+      fireEvent.load(initialFrame);
+      const initialProbe = postMessage.mock.calls.find(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )?.[0] as { probeId?: string } | undefined;
+      expect(initialProbe?.probeId).toBeTruthy();
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: initialFrame.contentWindow,
+          data: {
+            type: 'od:srcdoc-transport-activated',
+            generation: initialGeneration,
+            probeId: initialProbe!.probeId,
+          },
+        }));
+      });
+
+      await act(async () => {
+        previewBaseResponse.resolve(new Response(JSON.stringify({
+          url: '/api/projects/project-1/preview/scope-1/brand.html',
+          file: 'brand.html',
+          csp: "default-src 'none'",
+          iframeSandbox: 'allow-scripts allow-forms',
+          opaqueOrigin: true,
+        }), { status: 200 }));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const scopedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(scopedFrame).toBe(initialFrame);
+      expect(scopedFrame.srcdoc).toContain(
+        '<base href="/api/projects/project-1/preview/scope-1/">',
+      );
+      const scopedGeneration = scopedFrame.srcdoc.match(
+        /data-od-srcdoc-transport-activation>[\s\S]*?var generation = "([^"]+)";/,
+      )?.[1];
+      expect(scopedGeneration).toBeTruthy();
+      expect(scopedGeneration).not.toBe(initialGeneration);
+
+      act(() => {
+        // Model Electron's aborted second about:srcdoc navigation: the new
+        // document sends neither load nor activation, so recovery must not
+        // trust the verified witness from the pre-base document.
+        vi.runAllTimers();
+      });
+
+      const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(recoveredFrame).not.toBe(scopedFrame);
+      expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+    } finally {
+      previewBaseResponse.resolve(new Response('', { status: 404 }));
+      vi.useRealTimers();
+    }
+  });
+
   it('preserves an authored base without minting a project-scoped preview capability', async () => {
     const context = teamWorkspaceContext();
     const authoredBase = '<base href="https://cdn.example/assets/">';

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -107,6 +107,16 @@ describe('buildSrcdoc', () => {
     expect(buildSrcdoc(html)).not.toContain('data-od-preview-observability');
   });
 
+  it('echoes the host challenge token from the srcDoc transport readiness probe', () => {
+    const srcdoc = buildSrcdoc('<main>Preview</main>', {
+      transportActivationGeneration: 'generation-42',
+    });
+
+    expect(srcdoc).toContain("data.type === 'od:srcdoc-transport-ready-probe'");
+    expect(srcdoc).toContain('announceReady(data.probeId)');
+    expect(srcdoc).toContain('message.probeId = probeId');
+  });
+
   it('paints an opaque background before drawing so empty rasters never flatten to black', () => {
     const srcdoc = buildSrcdoc('<main style="color:red">Hero</main>');
 


### PR DESCRIPTION
## Why

A generated presentation intermittently rendered as a blank preview until the user switched to another project and back. The incident diagnostics showed the artifact had finished generating before Electron reported a subframe `did-fail-load` with `errorCode: -3` for `about:srcdoc`.

The injected head bridge could announce activation before Chromium committed the navigation. If Chromium aborted afterward and no iframe `load` event followed, the host retained that provisional acknowledgement and skipped the existing recovery remount indefinitely.

## What users will see

Generated HTML presentations recover automatically when Chromium aborts a `srcDoc` navigation. The preview no longer remains blank until the user switches projects; normal previews, workspace-tab switching, live file refreshes, and Edit mode retain their existing appearance and behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout or entry point changes. Runtime verification used two real repository HTML presentation templates; both rendered correctly before and after switching workspace tabs, and the active presentation remained visible after a live file refresh.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** The red test reproduces the incident ordering: an eager activation acknowledgement, followed by an aborted navigation with no iframe `load` event. On `main`, the same frame remains stranded; on this branch, the host revalidates the live browsing context and remounts through the lazy shell when the challenge is not answered.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx tests/runtime/srcdoc.test.ts` — 311 passed
- Six focused srcDoc/deck recovery files — 62 passed
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- Real Electron runtime via `tools-dev` with an isolated daemon data root: seeded two repository HTML PPT templates through the daemon API, opened both in workspace tabs, switched C → D → C, toggled Edit mode, and applied a live file refresh. Electron logged four matching `about:srcdoc` subframe failures with `errorCode: -3`; every preview remained visible and the refreshed content appeared without a project-switch workaround.
