### PR TITLE
fix(landing): prevent studio screenshot clipping on narrow phones (#6097)

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
## Summary

The **"A studio, not a script"** screenshot gallery on `/codex-slides/` uses a fixed 420 px minimum grid track:

```css
.ha-showcase-wide {
  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
}
```

On narrow phones (< 420 px gallery width), each studio screenshot card overflows its container and the right side is visibly clipped.

## Fix

Use `min(100%, 420px)` as the intrinsic-size floor so tracks shrink to the available container width on narrow screens:

```css
grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
```

This preserves the existing desktop behavior (two 420 px columns above 860 px) while preventing overflow on phones.

## Surface area

- [ ] **Daemon** — no daemon changes
- [x] **UI** — landing-page `/codex-slides/` gallery layout
- [ ] **CLI** — no CLI changes
- [ ] **Packaged** — no packaged changes
- [ ] **Docs** — no doc changes
- [ ] **Tests** — no test changes (static CSS)

## Bug fix verification

Reproduced the clip at narrow viewports and confirmed zero clipping after the fix:

| Viewport | Before | After |
|----------|--------|-------|
| 320 px | 114 px clipped past viewport | 0 px clipping |
| 375 px | 59 px clipped past viewport | 0 px clipping |
| 430 px | 6 px clipped past viewport | 0 px clipping |
| 768 px+ | no clipping (unchanged) | no clipping (unchanged) |

Desktop two-column behavior preserved: 860 px+ remains two 420 px columns.

## Validation

- Desktop layout preserved: 860 px+ remains two 420 px columns
- Narrow screens (320–430 px): zero viewport clipping and zero container overflow
- Existing `min(100%, ...)` pattern is already used elsewhere in the codebase

Closes #6097
