### PR TITLE
fix(web): remove deleted projects from workspace tabs

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3854,6 +3854,7 @@ function AppInner() {
       });
     }
     clearLocalProject(id, { deleted: true });
+    removeWorkspaceProjectTabs(id);
     iframeKeepAlivePool.evictProject(id, { includeActive: true });
     setProjects((curr) => curr.filter((p) => p.id !== id));
     if (route.kind === 'project' && route.projectId === id) {

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -1778,7 +1778,7 @@ describe('App project creation routing', () => {
     expect(screen.queryByTestId('entry-project-project-existing')).toBeNull();
   });
 
-  it('does not re-add a locally deleted project when an older project list resolves stale', async () => {
+  it('removes a locally deleted project from workspace tabs and ignores a stale list', async () => {
     const initialProjects = deferred<Project[]>();
     const staleRefreshProjects = deferred<Project[]>();
     mockedListProjects
@@ -1802,6 +1802,8 @@ describe('App project creation routing', () => {
     await waitFor(() => {
       expect(screen.getByTestId('project-title').textContent).toBe('Fresh project');
     });
+    workspaceTabsHarness.projectIds.add('project-new');
+    expect(workspaceTabsHarness.projectIds.has('project-new')).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh projects' }));
     expect(mockedListProjects).toHaveBeenCalledTimes(2);
@@ -1812,6 +1814,7 @@ describe('App project creation routing', () => {
     await waitFor(() => {
       expect(mockedDeleteProject).toHaveBeenCalledWith('project-new', null);
       expect(screen.queryByTestId('entry-project-project-new')).toBeNull();
+      expect(workspaceTabsHarness.projectIds.has('project-new')).toBe(false);
     });
 
     await act(async () => {


### PR DESCRIPTION
## Summary

- remove a project's persisted workspace tab after the project is deleted successfully
- extend the existing deletion regression test to cover workspace-tab cleanup

## Root cause

Project deletion removed the project from the catalog and local caches, but did not notify `WorkspaceTabsBar`. The tab state is persisted separately, so deleted projects could remain visible in the project dropdown.

## User impact

Deleted projects now disappear from the workspace project dropdown immediately and stay removed after reload.

## Validation

- `App.project-create-race.test.tsx`: 70 passed
- `WorkspaceTabsBar.test.tsx`: 41 passed, 1 skipped
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
