### PR TITLE
fix: guide DeepSeek Harness API key setup

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -48,6 +48,7 @@ import {
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
   cursorAuthGuidance,
+  normalizeDeepSeekHarnessFailure,
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
@@ -2042,7 +2043,21 @@ function attachAgentStreamHandlers(
       prompt,
       cwd,
       model: model ?? null,
-      send,
+      send: (event, payload) => {
+        if (event !== 'error') {
+          send(event, payload);
+          return;
+        }
+        const failure = normalizeDeepSeekHarnessFailure(payload);
+        send('error', {
+          message: failure.message,
+          error: {
+            code: failure.code,
+            message: failure.message,
+            retryable: failure.authRequired,
+          },
+        });
+      },
     });
   } else if (def.streamFormat === 'json-event-stream') {
     const handler = createJsonEventStreamHandler(

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -24,7 +24,7 @@ const DEEPSEEK_AUTH_GUIDANCE =
   'DeepSeek TUI is installed but is not authenticated. Add or verify your API key in `~/.deepseek/config.toml` as `api_key = "..."`, or expose DEEPSEEK_API_KEY to the Open Design daemon process, then retry. If Open Design is launched outside an interactive shell, shell rc files such as ~/.zshrc may not be loaded.';
 
 const DEEPSEEK_HARNESS_AUTH_GUIDANCE =
-  'DeepSeek Harness is installed and compatible, but its provider credential is missing. Add your DeepSeek API key on the Models page, or expose DEEPSEEK_API_KEY to the Open Design daemon process, then retry.';
+  'DeepSeek Harness has no model API key configured. Open a terminal and run `dsh web`, then open Settings → Models and add your DeepSeek API key. Return to Open Design and retry. For automation, expose DEEPSEEK_API_KEY to the Open Design process.';
 
 // agy's print mode (`-p`) detects a missing OAuth token, prints the
 // Google sign-in URL to stdout, waits 30s for completion, then exits
@@ -125,12 +125,63 @@ export function isDeepSeekAuthFailureText(text: string): boolean {
   const value = String(text || '');
   if (!value.trim()) return false;
   return (
+    /\b(?:MISSING_CREDENTIAL|DSH_PROVIDER_AUTH_FAILED)\b/i.test(value) ||
     /KEY=<your-key>/i.test(value) ||
     /api_key\s*=\s*["']<your-key>["']/i.test(value) ||
     (/~\/\.deepseek\/config\.toml/i.test(value) && /api[_ -]?key|KEY=/i.test(value)) ||
     (/DEEPSEEK_API_KEY/i.test(value) &&
       /auth|api[_ -]?key|missing|not set|required|unauthorized/i.test(value))
   );
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function unknownRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  return value as UnknownRecord;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export type DeepSeekHarnessFailure = {
+  code: string;
+  message: string;
+  authRequired: boolean;
+};
+
+/**
+ * Turns the profile's structured error payload into a safe user-facing error.
+ * Harness SDK errors can place an object in `message`; never coerce that object
+ * to text because it produces `[object Object]` and can expose provider data.
+ */
+export function normalizeDeepSeekHarnessFailure(payload: unknown): DeepSeekHarnessFailure {
+  const root = unknownRecord(payload);
+  const nestedError = unknownRecord(root?.error);
+  const embeddedMessage = unknownRecord(root?.message);
+  const code = firstNonEmptyString(
+    nestedError?.code,
+    root?.code,
+    embeddedMessage?.code,
+  ) ?? 'AGENT_EXECUTION_FAILED';
+  const rawMessage = firstNonEmptyString(
+    typeof payload === 'string' ? payload : undefined,
+    root?.message,
+    nestedError?.message,
+    embeddedMessage?.message,
+  );
+  const authRequired = isDeepSeekAuthFailureText(`${code}\n${rawMessage ?? ''}`);
+  return {
+    code,
+    message: authRequired
+      ? deepseekHarnessAuthGuidance()
+      : rawMessage ?? 'DeepSeek Harness profile error.',
+    authRequired,
+  };
 }
 
 export function isReasonixAuthFailureText(text: string): boolean {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -441,6 +441,7 @@ import {
   classifyAgentAuthFailure,
   classifyAgentServiceFailure,
   cursorAuthGuidance,
+  normalizeDeepSeekHarnessFailure,
 } from './runtimes/auth.js';
 import { readOpenCodeServiceFailure } from './runtimes/opencode-log.js';
 import { createAgentStderrVisibilityFilter } from './amr-stderr-filter.js';
@@ -13385,16 +13386,8 @@ export async function startServer({
             return;
           }
           if (event === 'error') {
-            const payload = data as {
-              message?: unknown;
-              error?: { code?: unknown };
-            } | null;
-            const message = String(
-              payload?.message ?? 'DeepSeek Harness profile error',
-            );
-            const code = String(
-              payload?.error?.code ?? 'AGENT_EXECUTION_FAILED',
-            );
+            const failure = normalizeDeepSeekHarnessFailure(data);
+            const { code, message } = failure;
             agentStreamError = message;
             agentStreamErrorObservedBeforeCancellation = !run.cancelRequested;
             acpFatalErrorObservedBeforeCancellation = !run.cancelRequested;
@@ -13415,7 +13408,8 @@ export async function startServer({
             }
             if (!run.cancelRequested) {
               send('error', createSseErrorPayload(code, message, {
-                retryable: code === 'DSH_PROFILE_RESUME_REJECTED',
+                retryable:
+                  failure.authRequired || code === 'DSH_PROFILE_RESUME_REJECTED',
               }));
             }
             return;

--- a/apps/daemon/tests/fixtures/dsh-profile/fake-dsh.ts
+++ b/apps/daemon/tests/fixtures/dsh-profile/fake-dsh.ts
@@ -84,6 +84,21 @@ function sessionState(): { sessionId: string; firstPrompt: string } | null {
 }
 
 function handleExecute(command: Extract<DshProfileHostCommand, { type: 'execute' }>): void {
+  if (mode === 'missing-credential') {
+    emit({
+      type: 'result',
+      request_id: command.request_id,
+      status: 'failed',
+      session_id: 'fixture-missing-credential',
+      resume_rejected: false,
+      error: {
+        code: 'MISSING_CREDENTIAL',
+        message: 'No API key for provider route "deepseek-official".',
+      },
+    });
+    finish();
+    return;
+  }
   const stored = sessionState();
   const requested = command.resume_session_id;
   if (requested) {

--- a/apps/daemon/tests/runtimes/deepseek-harness-windows.test.ts
+++ b/apps/daemon/tests/runtimes/deepseek-harness-windows.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:f
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
-import path from 'node:path';
+import path, { delimiter } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
@@ -11,9 +11,11 @@ import {
 } from '../../src/runtimes/defs/deepseek-harness.js';
 import { detectAgent, getDetectedRuntimeVersions } from '../../src/runtimes/detection.js';
 import { resolveAgentExecutable } from '../../src/runtimes/executables.js';
+import { testAgentConnection } from '../../src/connectionTest.js';
 import {
   classifyAgentAuthFailure,
   deepseekHarnessAuthGuidance,
+  normalizeDeepSeekHarnessFailure,
 } from '../../src/runtimes/auth.js';
 import { minimalAgentDef } from './helpers/test-helpers.js';
 import {
@@ -114,8 +116,73 @@ describe('DeepSeek Harness Windows carrier', () => {
       status: 'missing',
       message: deepseekHarnessAuthGuidance(),
     });
-    expect(deepseekHarnessAuthGuidance()).toMatch(/Models page/);
+    expect(deepseekHarnessAuthGuidance()).toMatch(/dsh web/);
+    expect(deepseekHarnessAuthGuidance()).toMatch(/Settings.*Models/);
     expect(deepseekHarnessAuthGuidance()).toMatch(/DEEPSEEK_API_KEY/);
+  });
+
+  it('turns structured missing-credential payloads into safe configuration guidance', () => {
+    const failure = normalizeDeepSeekHarnessFailure({
+      message: {
+        code: 'MISSING_CREDENTIAL',
+        message: 'No API key for the selected provider.',
+      },
+    });
+
+    expect(failure).toEqual({
+      code: 'MISSING_CREDENTIAL',
+      message: deepseekHarnessAuthGuidance(),
+      authRequired: true,
+    });
+    expect(failure.message).not.toContain('[object Object]');
+  });
+
+  it('preserves plain provider failures and never stringifies unknown objects', () => {
+    expect(normalizeDeepSeekHarnessFailure({
+      error: { code: 'UPSTREAM_UNAVAILABLE', message: 'Provider unavailable.' },
+    })).toEqual({
+      code: 'UPSTREAM_UNAVAILABLE',
+      message: 'Provider unavailable.',
+      authRequired: false,
+    });
+    expect(normalizeDeepSeekHarnessFailure({ message: { private: true } })).toEqual({
+      code: 'AGENT_EXECUTION_FAILED',
+      message: 'DeepSeek Harness profile error.',
+      authRequired: false,
+    });
+  });
+
+  it('returns configuration guidance from the full connection-test path', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'od-dsh-auth-'));
+    const previous = {
+      PATH: process.env.PATH,
+      DSH_HOME: process.env.DSH_HOME,
+      OD_DSH_FAKE_MODE: process.env.OD_DSH_FAKE_MODE,
+      OD_DSH_FAKE_SESSION_ROOT: process.env.OD_DSH_FAKE_SESSION_ROOT,
+    };
+    try {
+      writeFakeDshCarrier(dir);
+      process.env.PATH = `${dir}${delimiter}${previous.PATH ?? ''}`;
+      process.env.DSH_HOME = createProfileHome(dir);
+      process.env.OD_DSH_FAKE_MODE = 'missing-credential';
+      process.env.OD_DSH_FAKE_SESSION_ROOT = dir;
+
+      const result = await testAgentConnection({ agentId: 'deepseek-harness' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        kind: 'agent_auth_required',
+        agentName: 'DeepSeek Harness',
+        detail: deepseekHarnessAuthGuidance(),
+      });
+      expect(result.detail).not.toContain('[object Object]');
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it.runIf(process.platform === 'win32')(


### PR DESCRIPTION
## Why

QA reproduced the missing-credential path for DeepSeek Harness in both Settings connection testing and a real chat run. Harness returned a structured `MISSING_CREDENTIAL` error, but Open Design could coerce its object-valued message into `[object Object]`, leaving users without any way to recover.

This bug fix keeps the structured diagnostic code while turning the failure into actionable setup guidance. It does not add credential storage to Open Design.

## What users will see

When DeepSeek Harness has no model API key configured, Settings and chat now tell users to run `dsh web`, open Settings → Models, add their DeepSeek API key, return to Open Design, and retry. Automation users are also told they can expose `DEEPSEEK_API_KEY` to the Open Design process.

Structured or object-valued Harness errors no longer render as `[object Object]`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. The existing Settings result and chat failure card now render the actionable daemon-provided message.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/deepseek-harness-windows.test.ts`
- The guidance assertion went red before the source change and green on this branch: yes.
- The fake DSH fixture now reproduces `MISSING_CREDENTIAL` through the full connection-test process, including the object-valued message shape that previously rendered as `[object Object]`.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/runtimes/deepseek-harness-windows.test.ts tests/agent-protocol/dsh-profile.test.ts` — 33 passed, 1 Windows-only skipped on macOS
- `pnpm --filter @open-design/dsh-runtime test` — 12 passed
- `pnpm guard`
- `pnpm typecheck`
- Isolated local `tools-dev` web + daemon run with a deterministic missing-credential DSH profile
- Chrome/Open Browser Use: Settings connection test showed the `dsh web` setup guidance
- Chrome/Open Browser Use: real chat failure card and diagnostics showed the same guidance with `error_code: MISSING_CREDENTIAL`
- Browser assertion: `hasGuidance: true`, `hasObjectObject: false`
