### PR TITLE
fix(desktop): prevent injectTitle from expanding JS replacement patterns in titles

### DIFF
--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -1488,7 +1488,7 @@ function normalizeDesignSystemCraftApplies(value: unknown): string[] | undefined
 export function assembleExample(templateHtml: string, slidesHtml: string, title: string) {
   return templateHtml
     .replace('<!-- SLIDES_HERE -->', slidesHtml)
-    .replace(/<title>.*?<\/title>/, `<title>${title} | Open Design Example</title>`);
+    .replace(/<title>.*?<\/title>/, () => `<title>${title} | Open Design Example</title>`);
 }
 
 export function rewriteSkillAssetUrls(

--- a/apps/desktop/src/main/artifact-export.ts
+++ b/apps/desktop/src/main/artifact-export.ts
@@ -114,8 +114,10 @@ function injectBaseHref(doc: string, baseHref: string | undefined): string {
 
 function injectTitle(doc: string, title: string): string {
   const tag = `<title>${escapeText(title)}</title>`;
-  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, tag);
-  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${tag}`);
+  if (/<title[^>]*>.*?<\/title>/is.test(doc))
+    return doc.replace(/<title[^>]*>.*?<\/title>/is, () => tag);
+  if (/<head[^>]*>/i.test(doc))
+    return doc.replace(/<head[^>]*>/i, (m) => `${m}${tag}`);
   return doc;
 }
 

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -266,9 +266,12 @@ function injectBaseHref(doc: string, baseHref: string | undefined): string {
 
 function injectTitle(doc: string, title: string): string {
   const tag = `<title>${escapeHtmlText(title)}</title>`;
-  if (/<title[^>]*>.*?<\/title>/is.test(doc)) return doc.replace(/<title[^>]*>.*?<\/title>/is, tag);
-  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (match) => `${match}${tag}`);
-  if (/<html[^>]*>/i.test(doc)) return doc.replace(/<html[^>]*>/i, (match) => `${match}<head>${tag}</head>`);
+  if (/<title[^>]*>.*?<\/title>/is.test(doc))
+    return doc.replace(/<title[^>]*>.*?<\/title>/is, () => tag);
+  if (/<head[^>]*>/i.test(doc))
+    return doc.replace(/<head[^>]*>/i, (match) => `${match}${tag}`);
+  if (/<html[^>]*>/i.test(doc))
+    return doc.replace(/<html[^>]*>/i, (match) => `${match}<head>${tag}</head>`);
   return `<!doctype html><html><head>${tag}</head><body>${doc}</body></html>`;
 }
 


### PR DESCRIPTION
Closing as duplicate — the fix (using () => callback form in String.replace to prevent JS GetSubstitution expansion) has already been applied to main in the affected files (apps/daemon/src/routes/static-resource.ts, apps/desktop/src/main/artifact-export.ts, apps/desktop/src/main/pdf-export.ts). The maintainer team may have merged this directly.