### PR TITLE
docs(release): highlight DeepSeek Harness in 0.19.1 notes

### DIFF
--- a/docs/CHANGELOG/v0.19.1/en.md
+++ b/docs/CHANGELOG/v0.19.1/en.md
@@ -1,9 +1,9 @@
 ---
-title: Open Design 0.19.1 — DeepSeek Harness, Connected
+title: Open Design 0.19.1 — Design with DeepSeek Harness
 description: Connect your official DeepSeek Harness installation to Open Design for model discovery, structured runs, and session resume. Paid plans also get DeepSeek V4 Pro and Flash unlimited for two weeks.
 ---
 
-### 🌟 Codename: *DeepSeek Harness, Connected*
+### 🌟 Codename: *Design with DeepSeek Harness*
 
 🧰 **59 PRs · 24 contributors · 4 days** — **DeepSeek Harness now runs as an
 agent inside Open Design.** Open Design finds your official `dsh`, guides setup

--- a/docs/CHANGELOG/v0.19.1/en.md
+++ b/docs/CHANGELOG/v0.19.1/en.md
@@ -1,40 +1,55 @@
 ---
-title: Open Design 0.19.1 — Start Faster, Stay in Flow
-description: Move from Home into a project immediately, recover expired Open Design Cloud sessions cleanly, and keep large team workspaces responsive under load.
+title: Open Design 0.19.1 — DeepSeek Harness, Connected
+description: Connect your official DeepSeek Harness installation to Open Design for model discovery, structured runs, and session resume. Paid plans also get DeepSeek V4 Pro and Flash unlimited for two weeks.
 ---
 
-### 🌟 Codename: *Start Faster, Stay in Flow*
+### 🌟 Codename: *DeepSeek Harness, Connected*
 
-🚀 **54 PRs · 24 contributors · 3 days** — **Open Design 0.19.1 gets you
-from an idea on Home into a working project with less waiting.** It also turns
-expired Cloud sessions into a recoverable sign-in flow and keeps large team
-projects responsive by putting firm bounds around background work.
+🧰 **59 PRs · 24 contributors · 4 days** — **DeepSeek Harness now runs as an
+agent inside Open Design.** Open Design finds your official `dsh`, guides setup
+of the Open Design connection profile, lists Harness models and
+reasoning options, and resumes the same Harness session on later turns. 0.19.1
+also starts two weeks of unlimited DeepSeek V4 Pro and Flash for paid plans and
+keeps Home and team projects responsive under load.
 
 ## 🔥 Highlights
 
-- 🏠 **Home stops making you wait at the door.** The refreshed Home adds a
+- 🧰 **Bring your official DeepSeek Harness installation into Open Design.**
+  Open Design discovers `dsh`, reads its model and reasoning choices, and gives
+  specific guidance for missing credentials, profile setup, or an untested
+  Harness version. Settings and `od agent setup deepseek-harness` can install or
+  repair only the Open Design connection profile; Open Design does not replace
+  or upgrade Harness itself. Runs stream thinking, text, tool calls, results,
+  and usage as structured events, then resume the same Harness session on later
+  turns. Cancellation and process cleanup also cover Windows `.cmd` installs.
+  (#6874)
+
+- 🎁 **Paid plans get two weeks of unlimited DeepSeek V4 Pro and Flash.**
+  From August 13 at 20:00 to August 27 at 20:00 (Asia/Shanghai), both models
+  carry the Unlimited badge across the workbench, and the campaign action picks
+  V4 Pro. Users who dismissed the previous Flash campaign still see this one
+  once. When a rolling model window fills up, Open Design shows the retry time
+  and confirms that the request was not charged. (#6861)
+
+- 🏠 **Home gets you into a project sooner.** The refreshed Home adds a
   clearer creation-type row and more direct workspace controls. Local projects
   no longer wait for a Cloud workspace identity before they can start, while
   Cloud projects keep their balance checks. After you submit, Open Design moves
   straight into the new project's Preparing state and rolls back cleanly if
   creation fails. (#6692, #6741, #6756)
 
-- 🔐 **An expired Cloud session leads back to sign-in, not a dead end.** Invalid
+- 🔐 **An expired Cloud session returns you to sign-in.** Invalid
   credentials are cleared, the existing sign-in flow takes over, and transient
   workspace-authority failures retry without duplicating the request. Headless
   operators also gain `od amr status` and `od amr logout` for checking and
   resetting Cloud authentication from the CLI. (#6786)
 
-- ⚡ **Large team projects keep background work within bounds.** Shared-resource
+- ⚡ **Team workspaces keep background work within bounds.** Shared-resource
   pulls are batched, sync fan-out is capped, workspace-authority reads are
-  cached safely, and large project scans, archives, and push queues no longer
-  expand without limit. The result is steadier sync and lower memory pressure
-  as a workspace grows. (#6711, #6752, #6782, #6788)
-
-- 🖼️ **Generated work lands where you expect it.** New image and video outputs
-  open in the preview automatically. When an agent explicitly names an existing
-  artifact, the write now updates that file in place instead of quietly
-  creating a numbered duplicate. (#6688, #6719)
+  cached safely, and large project scans, archives, and push queues have firm
+  limits. Workspace and billing refreshes now coalesce under event bursts and
+  back off during an outage instead of multiplying upstream requests.
+  (#6711, #6752, #6782, #6788, #6871)
 
 ## ✨ Added
 
@@ -42,13 +57,19 @@ projects responsive by putting firm bounds around background work.
   as a visual foundation for generated interfaces. (#6769)
 - `od mcp install claude-desktop` can configure Open Design for Claude Desktop
   on macOS and Windows. (#6489)
+- The public Pricing page now describes hosted image generation alongside text
+  models. (#6395)
 - Launch Week is easier to discover from the landing page, and community links
-  are labeled before they take you away from Open Design. (#6395, #6680, #6684)
+  are labeled before they take you away from Open Design. (#6680, #6684)
 
 ## 🔁 Changed
 
-- Message Center rows expand and collapse in place, so details stay in context
-  instead of replacing the list. (#6851)
+- New image and video outputs open in the preview when generation finishes.
+  When an agent names an existing artifact, the write updates that file in
+  place instead of creating a numbered duplicate. (#6688, #6719)
+- Message Center rows expand and collapse in place. Saving an annotation also
+  leaves the comments panel in the state you chose instead of forcing it open.
+  (#6851, #6862)
 - Home search includes personal projects, and projects created from Community
   templates retain the template's original project type. (#6838, #6847)
 - MCP slash commands explain what they do, and newly created custom skills load
@@ -67,6 +88,8 @@ projects responsive by putting firm bounds around background work.
   of falling back to a personal or empty scope. (#6736, #6773)
 - Re-finalizing a personal design system keeps it bound to the project and
   reachable afterwards. (#6776)
+- Deleted projects leave the workspace project dropdown as soon as deletion
+  succeeds and stay gone after reload. (#6886)
 
 ### 🧠 Runs and agents
 
@@ -88,7 +111,7 @@ projects responsive by putting firm bounds around background work.
 - Social share icons render in the packaged app, portable Windows installs
   write NSIS logs to the runtime path, and slower macOS cold starts get enough
   time for the sidecar to report healthy. (#6559, #6750, #6762)
-- Docker browser peers authenticate correctly, and the packaged runtime picks up
+- Docker browser peers can authenticate, and the packaged runtime picks up
   patched dependency floors for known container vulnerabilities. (#6715, #6733)
 - Korean browser-assist UI and French fallback copy are complete again.
   (#6212, #6612)

--- a/docs/CHANGELOG/v0.19.1/zh-CN.md
+++ b/docs/CHANGELOG/v0.19.1/zh-CN.md
@@ -1,9 +1,9 @@
 ---
-title: Open Design 0.19.1 — DeepSeek Harness, Connected
+title: Open Design 0.19.1 — Design with DeepSeek Harness
 description: 把你安装的官方 DeepSeek Harness 接入 Open Design，使用模型发现、结构化运行与会话续接；付费套餐还可在两周内不限量使用 DeepSeek V4 Pro 和 Flash。
 ---
 
-### 🌟 Codename: *DeepSeek Harness, Connected*
+### 🌟 Codename: *Design with DeepSeek Harness*
 
 🧰 **59 个 PR · 24 位贡献者 · 4 天** — **DeepSeek Harness 现在可以作为 Agent
 直接在 Open Design 里运行。** Open Design 会找到你安装的官方 `dsh`，引导完成连接

--- a/docs/CHANGELOG/v0.19.1/zh-CN.md
+++ b/docs/CHANGELOG/v0.19.1/zh-CN.md
@@ -1,35 +1,46 @@
 ---
-title: Open Design 0.19.1 — Start Faster, Stay in Flow
-description: 从首页提交后立即进入项目，Open Design Cloud 会话过期时自然回到登录流程，大型团队工作区也能在高负载下保持响应。
+title: Open Design 0.19.1 — DeepSeek Harness, Connected
+description: 把你安装的官方 DeepSeek Harness 接入 Open Design，使用模型发现、结构化运行与会话续接；付费套餐还可在两周内不限量使用 DeepSeek V4 Pro 和 Flash。
 ---
 
-### 🌟 Codename: *Start Faster, Stay in Flow*
+### 🌟 Codename: *DeepSeek Harness, Connected*
 
-🚀 **54 个 PR · 24 位贡献者 · 3 天** — **Open Design 0.19.1 让你从首页的
-一个想法更快进入可以工作的项目。** Cloud 会话过期后会直接回到登录流程；大型
-团队项目的后台任务也有了明确上限，工作区变大后依然能保持响应。
+🧰 **59 个 PR · 24 位贡献者 · 4 天** — **DeepSeek Harness 现在可以作为 Agent
+直接在 Open Design 里运行。** Open Design 会找到你安装的官方 `dsh`，引导完成连接
+profile 设置，列出 Harness 提供的模型与 reasoning 选项，并在后续轮次续接同一个
+Harness session。0.19.1 还为付费套餐带来两周不限量的 DeepSeek V4 Pro 和 Flash，
+同时继续改善首页与团队项目在高负载下的响应速度。
 
 ## 🔥 亮点
 
-- 🏠 **首页不再让你等在门口。** 新版首页提供更清晰的创建类型入口和更直接的
+- 🧰 **把你安装的官方 DeepSeek Harness 接入 Open Design。** Open Design 会发现
+  `dsh`，读取它提供的模型与 reasoning 选项；缺少凭据、profile 未配置或 Harness
+  版本尚未验证时，界面会给出具体处理办法。Settings 与
+  `od agent setup deepseek-harness` 只安装或修复 Open Design 的连接 profile，
+  不会替换或升级 Harness。运行过程会以结构化事件传回 thinking、正文、工具调用、
+  结果与用量，并在下一轮续接同一个 Harness session。Windows `.cmd` 安装也有对应
+  的取消和进程清理处理。 (#6874)
+
+- 🎁 **付费套餐可在两周内不限量使用 DeepSeek V4 Pro 和 Flash。** 活动时间为
+  8 月 13 日 20:00 至 8 月 27 日 20:00（Asia/Shanghai）。工作台中的两款模型
+  都会显示 Unlimited 标记，活动按钮会直接选择 V4 Pro。即使用户已经关闭过上一轮
+  Flash 活动，这次仍会展示一次。碰到模型滚动用量窗口上限后，Open Design 会显示
+  可重试时间，并明确说明本次请求没有扣费。 (#6861)
+
+- 🏠 **从首页更快进入项目。** 新版首页提供更清晰的创建类型入口和更直接的
   workspace 控件。创建本地项目时，不再需要先等 Cloud workspace identity；Cloud
   项目仍会保留余额检查。提交后会立即进入新项目的 Preparing 状态；如果创建失败，
   页面会撤销这次跳转。 (#6692, #6741, #6756)
 
-- 🔐 **Cloud 会话过期后会回到登录流程，而不是卡在死路上。** 无效凭据会被清理，
+- 🔐 **Cloud 会话过期后会直接回到登录流程。** 无效凭据会被清理，
   页面会直接回到已有的登录流程；短暂的 workspace authority 故障可以重试，同时
-  不会重复提交请求。在无界面环境里，也可以通过 `od amr status` 和 `od amr logout`
-  从 CLI
-  检查或重置 Cloud 登录状态。 (#6786)
+  不会重复提交请求。在无界面环境里，也可以从 CLI 运行 `od amr status` 或
+  `od amr logout`，检查或重置 Cloud 登录状态。 (#6786)
 
-- ⚡ **大型团队项目的后台任务不再无限扩张。** 共享资源改为批量拉取，同步
+- ⚡ **团队 workspace 的后台任务有了明确上限。** 共享资源改为批量拉取，同步
   fan-out 有了上限，workspace authority 读取会安全缓存，大型项目的扫描、归档和
-  push queue 也不会无限扩张。随着 workspace 规模增长，同步会更稳定，内存压力也
-  更可控。 (#6711, #6752, #6782, #6788)
-
-- 🖼️ **生成结果会落在你预期的位置。** 新图片和视频生成完成后会自动打开预览。
-  当 Agent 明确指定一个已有 artifact 时，现在会原地更新这个文件，不再悄悄生成
-  带编号的副本。 (#6688, #6719)
+  push queue 也不会无限扩张。事件集中到达时，workspace 与 billing 刷新会合并处理；
+  上游故障时则会退避，不再放大请求量。 (#6711, #6752, #6782, #6788, #6871)
 
 ## ✨ 新增
 
@@ -37,13 +48,16 @@ description: 从首页提交后立即进入项目，Open Design Cloud 会话过�
   (#6769)
 - macOS 和 Windows 上可以通过 `od mcp install claude-desktop` 为 Claude Desktop
   配置 Open Design。 (#6489)
+- 公开 Pricing 页现在会写明托管图像生成，而不再只描述文本模型。 (#6395)
 - Launch Week 在落地页上更容易被发现；离开 Open Design 的社区链接也会提前标明
-  去向。 (#6395, #6680, #6684)
+  去向。 (#6680, #6684)
 
 ## 🔁 变更
 
-- Message Center 的消息行改为原地展开和收起，查看详情时不会再把列表整个替换掉。
-  (#6851)
+- 新图片和视频生成完成后会打开预览。Agent 指定已有 artifact 时，会原地更新这个
+  文件，不再生成带编号的副本。 (#6688, #6719)
+- Message Center 的消息行改为原地展开和收起。保存批注后，评论面板也会保持你选择
+  的开关状态，不会被强制打开。 (#6851, #6862)
 - 首页搜索会包含个人项目；从 Community template 创建项目时，也会保留模板原本的
   项目类型。 (#6838, #6847)
 - MCP slash command 会说明各自用途；新建 custom skill 后，它的文件也会立即加载，
@@ -60,6 +74,8 @@ description: 从首页提交后立即进入项目，Open Design Cloud 会话过�
 - `od project list` 与 MCP resource 读取会使用当前登录的 workspace，不再退回个人
   scope 或返回空列表。 (#6736, #6773)
 - Personal design system 重新 finalize 后仍会绑定到项目，并且可以继续访问。 (#6776)
+- 项目删除成功后会从 workspace 的项目下拉菜单中消失，刷新页面后也不会回来。
+  (#6886)
 
 ### 🧠 Run 与 Agent
 


### PR DESCRIPTION
## Why

Five product PRs landed on `release/v0.19.1` after the first release-note PR
merged and backported. The existing source notes and manual GitHub Release
Draft therefore omit DeepSeek Harness, the new DeepSeek V4 campaign, and three
follow-up reliability fixes.

This PR refreshes both Markdown locales from the current release branch. It
also preserves the unmerged pricing-copy split prepared on the previous release
note branch.

## What users will see

The release title changes to **Open Design 0.19.1 — Design with DeepSeek
Harness**. DeepSeek Harness becomes the lead highlight, covering discovery of
the user's official `dsh`, Open Design profile setup and repair, model and
reasoning-option discovery, structured runs, session resume, CLI setup, and
Windows process cleanup.

The second highlight covers the two-week unlimited DeepSeek V4 Pro and Flash
campaign for paid plans. The notes also add bounded workspace refreshes, comment
panel behavior after save, deleted-project tab cleanup, and updated release
statistics: 59 product PRs, 24 contributors, and 4 days.

There is no runtime behavior change in this documentation-only PR.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this PR updates Markdown release-note sources only.

## Bug fix verification

Not applicable; this is a documentation-only release preparation PR.

## Validation

- `RELEASE_NOTE_SOURCE_ROOT="$PWD/docs/CHANGELOG" RELEASE_CHANNEL=stable RELEASE_VERSION=0.19.1 RELEASE_NOTE_PLAN_PATH="$PWD/.tmp/release-note-v0191-refresh/plan.json" corepack pnpm --filter @open-design/tools-release dev prepare-release-note`
  - ready: `en`, `zh-CN`
- `corepack pnpm --filter @open-design/tools-release test` — 41 passed
- `corepack pnpm guard`
- `corepack pnpm typecheck` — 0 errors; existing Astro hints only
- Refreshed `origin/release/v0.19.1` and verified all five newly landed product PRs are cited; no cited PR falls outside the 59-PR release set
- Rechecked the contributor list against the new PR authors; the human contributor count remains 24
