### PR TITLE
feat: add one-click DeepSeek Harness bootstrap installers

### DIFF
--- a/.github/workflows/landing-page-production.yml
+++ b/.github/workflows/landing-page-production.yml
@@ -183,6 +183,41 @@ jobs:
             exit 1
           fi
 
+      # The short open-design.ai/install-dsh.* entry points ship with the
+      # landing page. Preserve the exact production bytes separately under an
+      # immutable R2 version before allowing Pages to deploy them. Re-running a
+      # production promotion is idempotent; changing an already-published v1
+      # fails closed and requires an explicit v2 instead.
+      - name: Publish immutable DeepSeek Harness bootstrap installers to R2
+        env:
+          DSH_BOOTSTRAP_SOURCE_DIR: apps/landing-page/public
+          DSH_BOOTSTRAP_VERSION: v1
+          RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
+          RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
+          RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
+          RELEASE_STORAGE_REGION: auto
+          RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+        run: pnpm exec tools-release publish-dsh-bootstrap
+
+      - name: Verify public DeepSeek Harness bootstrap downloads
+        env:
+          RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+        run: |
+          set -euo pipefail
+          download_dir="$(mktemp -d)"
+          trap 'rm -rf "$download_dir"' EXIT
+          for name in install-dsh.sh install-dsh.ps1 install-dsh.cmd SHA256SUMS; do
+            curl --fail --silent --show-error --location \
+              --retry 5 --retry-delay 1 --retry-all-errors \
+              "$RELEASE_PUBLIC_ORIGIN/bootstrap/dsh/v1/$name" \
+              --output "$download_dir/$name"
+          done
+          (
+            cd "$download_dir"
+            sha256sum --check SHA256SUMS
+          )
+
       # `--branch=main` IS the Cloudflare Pages production branch, so this
       # publishes to the production domain (open-design.ai).
       - name: Apply attribution ledger migrations (production)

--- a/apps/landing-page/public/install-dsh.cmd
+++ b/apps/landing-page/public/install-dsh.cmd
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+where powershell.exe >nul 2>nul
+if errorlevel 1 (
+  echo DeepSeek Harness installer: Windows PowerShell is required. 1>&2
+  exit /b 1
+)
+
+set "OD_DSH_PS1=%TEMP%\open-design-install-dsh-%RANDOM%-%RANDOM%.ps1"
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing 'https://open-design.ai/install-dsh.ps1?version=1' -OutFile $env:OD_DSH_PS1"
+if errorlevel 1 (
+  echo DeepSeek Harness installer: could not download install-dsh.ps1. 1>&2
+  exit /b 1
+)
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%OD_DSH_PS1%" %*
+set "OD_DSH_EXIT=%ERRORLEVEL%"
+del /q "%OD_DSH_PS1%" >nul 2>nul
+exit /b %OD_DSH_EXIT%

--- a/apps/landing-page/public/install-dsh.cmd
+++ b/apps/landing-page/public/install-dsh.cmd
@@ -8,7 +8,7 @@ if errorlevel 1 (
 )
 
 set "OD_DSH_PS1=%TEMP%\open-design-install-dsh-%RANDOM%-%RANDOM%.ps1"
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing 'https://releases.open-design.ai/bootstrap/dsh/v1/install-dsh.ps1' -OutFile $env:OD_DSH_PS1"
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing 'https://open-design.ai/install-dsh.ps1?version=1' -OutFile $env:OD_DSH_PS1"
 if errorlevel 1 (
   echo DeepSeek Harness installer: could not download install-dsh.ps1. 1>&2
   exit /b 1

--- a/apps/landing-page/public/install-dsh.cmd
+++ b/apps/landing-page/public/install-dsh.cmd
@@ -8,7 +8,7 @@ if errorlevel 1 (
 )
 
 set "OD_DSH_PS1=%TEMP%\open-design-install-dsh-%RANDOM%-%RANDOM%.ps1"
-powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing 'https://open-design.ai/install-dsh.ps1?version=1' -OutFile $env:OD_DSH_PS1"
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -UseBasicParsing 'https://releases.open-design.ai/bootstrap/dsh/v1/install-dsh.ps1' -OutFile $env:OD_DSH_PS1"
 if errorlevel 1 (
   echo DeepSeek Harness installer: could not download install-dsh.ps1. 1>&2
   exit /b 1

--- a/apps/landing-page/public/install-dsh.ps1
+++ b/apps/landing-page/public/install-dsh.ps1
@@ -1,0 +1,175 @@
+param(
+  [switch]$NoLaunch
+)
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$NodeVersion = '24.19.0'
+$DshVersion = '0.1.0-rc.6'
+$PnpmVersion = '11.7.0'
+
+function Fail([string]$Message) {
+  throw "DeepSeek Harness installer: $Message"
+}
+
+function First-Line([string]$Command, [string[]]$Arguments) {
+  try {
+    return ((& $Command @Arguments 2>$null | Select-Object -First 1) -as [string]).Trim()
+  } catch {
+    return ''
+  }
+}
+
+function Test-NodeVersion([string]$Version) {
+  $clean = $Version.TrimStart('v')
+  $parsed = $null
+  if (-not [version]::TryParse($clean, [ref]$parsed)) { return $false }
+  return (($parsed.Major -eq 22 -and $parsed.Minor -ge 19) -or $parsed.Major -ge 24)
+}
+
+if (-not $HOME) { Fail 'HOME is not set.' }
+
+$LocalData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME 'AppData\Local' }
+$InstallRoot = if ($env:OD_DSH_INSTALL_ROOT) { $env:OD_DSH_INSTALL_ROOT } else { Join-Path $LocalData 'OpenDesign\toolchains\dsh' }
+$BinDir = if ($env:OD_DSH_INSTALL_BIN_DIR) { $env:OD_DSH_INSTALL_BIN_DIR } else { Join-Path $HOME '.local\bin' }
+$Launcher = Join-Path $BinDir 'dsh.cmd'
+$DistBase = if ($env:OD_DSH_INSTALL_DIST_BASE) { $env:OD_DSH_INSTALL_DIST_BASE.TrimEnd('/') } else { "https://nodejs.org/dist/v$NodeVersion" }
+$RuntimeTarget = Join-Path $InstallRoot "runtime-dsh-$DshVersion"
+
+$Architecture = if ($env:OD_DSH_INSTALL_PLATFORM) {
+  $env:OD_DSH_INSTALL_PLATFORM
+} elseif ($env:PROCESSOR_ARCHITECTURE -match 'ARM64') {
+  'win-arm64'
+} elseif ($env:PROCESSOR_ARCHITECTURE -match 'AMD64|x86_64') {
+  'win-x64'
+} else {
+  Fail "unsupported CPU architecture: $env:PROCESSOR_ARCHITECTURE"
+}
+if ($Architecture -notin @('win-x64', 'win-arm64')) { Fail "unsupported platform: $Architecture" }
+
+$NodeTarget = Join-Path $InstallRoot "node-v$NodeVersion-$Architecture"
+$ManagedBin = Join-Path $RuntimeTarget 'node_modules\.bin'
+
+function Write-ManagedLauncher([string]$NodeDir, [string]$RuntimeBin) {
+  New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+  $body = @"
+@echo off
+set "PATH=$RuntimeBin;$NodeDir;%PATH%"
+call "$RuntimeBin\dsh.cmd" %*
+exit /b %ERRORLEVEL%
+"@
+  Set-Content -LiteralPath $Launcher -Value $body -Encoding ascii
+}
+
+function Write-ExistingLauncher([string]$NodePath, [string]$DshPath, [string]$PnpmPath) {
+  $nodeDir = Split-Path -Parent $NodePath
+  $dshDir = Split-Path -Parent $DshPath
+  $pnpmDir = Split-Path -Parent $PnpmPath
+  New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+  $body = @"
+@echo off
+set "PATH=$pnpmDir;$nodeDir;$dshDir;%PATH%"
+call "$DshPath" %*
+exit /b %ERRORLEVEL%
+"@
+  Set-Content -LiteralPath $Launcher -Value $body -Encoding ascii
+}
+
+function Finish([string]$Label) {
+  Write-Host "DeepSeek Harness $DshVersion is ready ($Label)."
+  Write-Host "Command: $Launcher"
+  Write-Host 'Open Design can discover this command without editing your PATH.'
+  if (-not $NoLaunch) {
+    Write-Host 'Starting dsh web. Configure your API key in Settings -> Models; press Ctrl+C to stop.'
+    & $Launcher web
+    exit $LASTEXITCODE
+  }
+}
+
+$ManagedNode = Join-Path $NodeTarget 'node.exe'
+$ManagedDsh = Join-Path $ManagedBin 'dsh.cmd'
+$ManagedPnpm = Join-Path $ManagedBin 'pnpm.cmd'
+if ((Test-Path -LiteralPath $Launcher) -and (Test-Path -LiteralPath $ManagedNode) -and (Test-Path -LiteralPath $ManagedDsh) -and (Test-Path -LiteralPath $ManagedPnpm)) {
+  $previousPath = $env:PATH
+  $env:PATH = "$ManagedBin;$NodeTarget;$env:PATH"
+  $installedDsh = First-Line $Launcher @('--version')
+  $installedNode = First-Line $ManagedNode @('--version')
+  $installedPnpm = First-Line $ManagedNode @('-e', 'console.log(require(process.argv[1]).version)', (Join-Path $RuntimeTarget 'node_modules\pnpm\package.json'))
+  $env:PATH = $previousPath
+  if ($installedDsh -eq $DshVersion -and (Test-NodeVersion $installedNode) -and $installedPnpm -eq $PnpmVersion) {
+    Write-Host "DeepSeek Harness $DshVersion is already installed."
+    Finish 'managed toolchain'
+    exit 0
+  }
+}
+
+$nodeCommand = Get-Command node.exe -ErrorAction SilentlyContinue
+$dshCommand = Get-Command dsh.cmd,dsh.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+$pnpmCommand = Get-Command pnpm.cmd,pnpm.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($nodeCommand -and $dshCommand -and $pnpmCommand -and $dshCommand.Source -ne $Launcher) {
+  $existingNode = First-Line $nodeCommand.Source @('--version')
+  $existingDsh = First-Line $dshCommand.Source @('--version')
+  $existingPnpm = First-Line $pnpmCommand.Source @('--version')
+  if ((Test-NodeVersion $existingNode) -and $existingDsh -eq $DshVersion -and $existingPnpm -eq $PnpmVersion) {
+    Write-ExistingLauncher $nodeCommand.Source $dshCommand.Source $pnpmCommand.Source
+    Finish 'existing Node, dsh, and pnpm'
+    exit 0
+  }
+}
+
+New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("od-dsh-install-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $TempRoot | Out-Null
+try {
+  $archiveName = "node-v$NodeVersion-$Architecture.zip"
+  $archive = Join-Path $TempRoot $archiveName
+  $checksums = Join-Path $TempRoot 'SHASUMS256.txt'
+  $managedNodeVersion = if (Test-Path -LiteralPath $ManagedNode) { First-Line $ManagedNode @('--version') } else { '' }
+  if ((Test-Path -LiteralPath (Join-Path $NodeTarget 'npm.cmd')) -and (Test-NodeVersion $managedNodeVersion)) {
+    Write-Host "Using the verified managed Node.js $managedNodeVersion already on this machine."
+  } else {
+    Write-Host "Downloading official Node.js v$NodeVersion for $Architecture..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$DistBase/SHASUMS256.txt" -OutFile $checksums
+    Invoke-WebRequest -UseBasicParsing -Uri "$DistBase/$archiveName" -OutFile $archive
+
+    $checksumLine = Get-Content -LiteralPath $checksums | Where-Object { $_ -match "^[0-9a-fA-F]{64}\s+$([regex]::Escape($archiveName))$" } | Select-Object -First 1
+    if (-not $checksumLine) { Fail "checksum entry missing for $archiveName." }
+    $expected = ($checksumLine -split '\s+')[0].ToLowerInvariant()
+    $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) { Fail "checksum verification failed for $archiveName." }
+    Write-Host 'Node.js checksum verified.'
+
+    Expand-Archive -LiteralPath $archive -DestinationPath $TempRoot
+    $extracted = Join-Path $TempRoot "node-v$NodeVersion-$Architecture"
+    if (-not (Test-Path -LiteralPath (Join-Path $extracted 'node.exe'))) { Fail 'the Node.js archive did not contain node.exe.' }
+    if (-not (Test-Path -LiteralPath (Join-Path $extracted 'npm.cmd'))) { Fail 'the Node.js archive did not contain npm.cmd.' }
+    if (Test-Path -LiteralPath $NodeTarget) { Move-Item -LiteralPath $NodeTarget -Destination "$NodeTarget.incomplete.$PID" }
+    Move-Item -LiteralPath $extracted -Destination $NodeTarget
+  }
+
+  $runtimeStaging = Join-Path $InstallRoot ".runtime-dsh-$DshVersion.$PID"
+  New-Item -ItemType Directory -Force -Path $runtimeStaging | Out-Null
+  Write-Host "Installing dsh $DshVersion and pnpm $PnpmVersion in Open Design's user toolchain..."
+  & (Join-Path $NodeTarget 'npm.cmd') install --prefix $runtimeStaging --no-save --no-package-lock --omit=dev "@deepseek-ai/dsh@$DshVersion" "pnpm@$PnpmVersion"
+  if ($LASTEXITCODE -ne 0) { Fail "npm install exited with code $LASTEXITCODE." }
+
+  $stagingBin = Join-Path $runtimeStaging 'node_modules\.bin'
+  $stagingDsh = Join-Path $stagingBin 'dsh.cmd'
+  $stagingPnpm = Join-Path $stagingBin 'pnpm.cmd'
+  if (-not (Test-Path -LiteralPath $stagingDsh)) { Fail 'npm completed without creating dsh.cmd.' }
+  if (-not (Test-Path -LiteralPath $stagingPnpm)) { Fail 'npm completed without creating pnpm.cmd.' }
+  $env:PATH = "$stagingBin;$NodeTarget;$env:PATH"
+  $verifiedDsh = First-Line $stagingDsh @('--version')
+  $verifiedPnpm = First-Line $ManagedNode @('-e', 'console.log(require(process.argv[1]).version)', (Join-Path $runtimeStaging 'node_modules\pnpm\package.json'))
+  if ($verifiedDsh -ne $DshVersion) { Fail "installed dsh reported '$verifiedDsh', expected '$DshVersion'." }
+  if ($verifiedPnpm -ne $PnpmVersion) { Fail "installed pnpm reported '$verifiedPnpm', expected '$PnpmVersion'." }
+
+  if (Test-Path -LiteralPath $RuntimeTarget) { Move-Item -LiteralPath $RuntimeTarget -Destination "$RuntimeTarget.previous.$PID" }
+  Move-Item -LiteralPath $runtimeStaging -Destination $RuntimeTarget
+  Write-ManagedLauncher $NodeTarget $ManagedBin
+} finally {
+  if (Test-Path -LiteralPath $TempRoot) { Remove-Item -LiteralPath $TempRoot -Recurse -Force }
+}
+
+Finish 'managed Node.js toolchain'

--- a/apps/landing-page/public/install-dsh.sh
+++ b/apps/landing-page/public/install-dsh.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env sh
+set -eu
+
+NODE_VERSION='24.19.0'
+DSH_VERSION='0.1.0-rc.6'
+PNPM_VERSION='11.7.0'
+
+NO_LAUNCH=0
+
+usage() {
+  cat <<'EOF'
+Install the DeepSeek Harness toolchain supported by Open Design.
+
+Usage:
+  install-dsh.sh [--no-launch]
+
+Options:
+  --no-launch  Install and verify dsh without starting its Web UI.
+  -h, --help   Show this help.
+EOF
+}
+
+fail() {
+  printf 'DeepSeek Harness installer: %s\n' "$*" >&2
+  exit 1
+}
+
+info() {
+  printf '%s\n' "$*"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-launch) NO_LAUNCH=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -n "${HOME:-}" ] || fail 'HOME is not set.'
+
+INSTALL_ROOT=${OD_DSH_INSTALL_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/open-design/toolchains/dsh}
+BIN_DIR=${OD_DSH_INSTALL_BIN_DIR:-$HOME/.local/bin}
+LAUNCHER=$BIN_DIR/dsh
+DIST_BASE=${OD_DSH_INSTALL_DIST_BASE:-https://nodejs.org/dist/v$NODE_VERSION}
+NODE_TARGET_BASE=$INSTALL_ROOT/node-v$NODE_VERSION
+RUNTIME_TARGET=$INSTALL_ROOT/runtime-dsh-$DSH_VERSION
+
+command_output() {
+  "$@" 2>/dev/null | head -n 1 | tr -d '\r'
+}
+
+node_is_supported() {
+  version=${1#v}
+  major=${version%%.*}
+  remainder=${version#*.}
+  minor=${remainder%%.*}
+  case "$major:$minor" in
+    22:*) [ "$minor" -ge 19 ] 2>/dev/null ;;
+    2[4-9]:*|[3-9][0-9]:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+same_command() {
+  [ "${1:-}" = "${2:-}" ]
+}
+
+write_managed_launcher() {
+  node_bin_dir=$1
+  runtime_bin_dir=$2
+  mkdir -p "$BIN_DIR"
+  launcher_tmp=$BIN_DIR/.dsh.tmp.$$
+  {
+    printf '%s\n' '#!/usr/bin/env sh' 'set -eu'
+    printf "NODE_BIN_DIR='%s'\n" "$(printf '%s' "$node_bin_dir" | sed "s/'/'\\\\''/g")"
+    printf "RUNTIME_BIN_DIR='%s'\n" "$(printf '%s' "$runtime_bin_dir" | sed "s/'/'\\\\''/g")"
+    printf '%s\n' 'PATH="$RUNTIME_BIN_DIR:$NODE_BIN_DIR:${PATH:-}"' 'export PATH' 'exec "$RUNTIME_BIN_DIR/dsh" "$@"'
+  } > "$launcher_tmp"
+  chmod 755 "$launcher_tmp"
+  mv "$launcher_tmp" "$LAUNCHER"
+}
+
+write_existing_launcher() {
+  node_path=$1
+  dsh_path=$2
+  pnpm_path=$3
+  node_bin_dir=$(dirname "$node_path")
+  dsh_bin_dir=$(dirname "$dsh_path")
+  pnpm_bin_dir=$(dirname "$pnpm_path")
+  mkdir -p "$BIN_DIR"
+  launcher_tmp=$BIN_DIR/.dsh.tmp.$$
+  {
+    printf '%s\n' '#!/usr/bin/env sh' 'set -eu'
+    printf "NODE_BIN_DIR='%s'\n" "$(printf '%s' "$node_bin_dir" | sed "s/'/'\\\\''/g")"
+    printf "DSH_BIN_DIR='%s'\n" "$(printf '%s' "$dsh_bin_dir" | sed "s/'/'\\\\''/g")"
+    printf "PNPM_BIN_DIR='%s'\n" "$(printf '%s' "$pnpm_bin_dir" | sed "s/'/'\\\\''/g")"
+    printf "DSH_BIN='%s'\n" "$(printf '%s' "$dsh_path" | sed "s/'/'\\\\''/g")"
+    printf '%s\n' 'PATH="$PNPM_BIN_DIR:$NODE_BIN_DIR:$DSH_BIN_DIR:${PATH:-}"' 'export PATH' 'exec "$DSH_BIN" "$@"'
+  } > "$launcher_tmp"
+  chmod 755 "$launcher_tmp"
+  mv "$launcher_tmp" "$LAUNCHER"
+}
+
+finish() {
+  label=$1
+  info "DeepSeek Harness $DSH_VERSION is ready ($label)."
+  info "Command: $LAUNCHER"
+  info 'Open Design can discover this command without editing your shell profile.'
+  if [ "$NO_LAUNCH" -eq 1 ]; then
+    return 0
+  fi
+  info 'Starting dsh web. Configure your API key in Settings → Models; press Ctrl+C to stop.'
+  exec "$LAUNCHER" web
+}
+
+managed_node_dir=''
+if [ -n "${OD_DSH_INSTALL_PLATFORM:-}" ]; then
+  platform=$OD_DSH_INSTALL_PLATFORM
+else
+  os=$(uname -s 2>/dev/null || true)
+  arch=$(uname -m 2>/dev/null || true)
+  case "$os" in
+    Darwin) os=darwin ;;
+    Linux)
+      os=linux
+      [ ! -f /etc/alpine-release ] || fail 'Alpine Linux is not supported by the official Node.js archive. Install Node.js 24 and run npx @deepseek-ai/dsh@0.1.0-rc.6 web.'
+      ;;
+    *) fail "unsupported operating system: $os" ;;
+  esac
+  case "$arch" in
+    x86_64|amd64) arch=x64 ;;
+    arm64|aarch64) arch=arm64 ;;
+    *) fail "unsupported CPU architecture: $arch" ;;
+  esac
+  platform=$os-$arch
+fi
+
+case "$platform" in
+  darwin-x64|darwin-arm64|linux-x64|linux-arm64) ;;
+  *) fail "unsupported platform: $platform" ;;
+esac
+
+managed_node_dir=$NODE_TARGET_BASE-$platform
+managed_runtime_bin=$RUNTIME_TARGET/node_modules/.bin
+
+if [ -x "$LAUNCHER" ] && [ -x "$managed_node_dir/bin/node" ] && [ -x "$managed_runtime_bin/dsh" ] && [ -x "$managed_runtime_bin/pnpm" ]; then
+  installed_dsh=$(command_output "$LAUNCHER" --version || true)
+  installed_node=$(command_output "$managed_node_dir/bin/node" --version || true)
+  installed_pnpm=$(command_output "$managed_node_dir/bin/node" -e 'console.log(require(process.argv[1]).version)' "$RUNTIME_TARGET/node_modules/pnpm/package.json" || true)
+  if [ "$installed_dsh" = "$DSH_VERSION" ] && node_is_supported "$installed_node" && [ "$installed_pnpm" = "$PNPM_VERSION" ]; then
+    info "DeepSeek Harness $DSH_VERSION is already installed."
+    finish 'managed toolchain'
+    exit 0
+  fi
+fi
+
+existing_node=$(command -v node 2>/dev/null || true)
+existing_dsh=$(command -v dsh 2>/dev/null || true)
+existing_pnpm=$(command -v pnpm 2>/dev/null || true)
+if [ -n "$existing_node" ] && [ -n "$existing_dsh" ] && [ -n "$existing_pnpm" ] && ! same_command "$existing_dsh" "$LAUNCHER"; then
+  existing_node_version=$(command_output "$existing_node" --version || true)
+  existing_dsh_version=$(command_output "$existing_dsh" --version || true)
+  existing_pnpm_version=$(command_output "$existing_pnpm" --version || true)
+  if node_is_supported "$existing_node_version" && [ "$existing_dsh_version" = "$DSH_VERSION" ] && [ "$existing_pnpm_version" = "$PNPM_VERSION" ]; then
+    write_existing_launcher "$existing_node" "$existing_dsh" "$existing_pnpm"
+    finish 'existing Node, dsh, and pnpm'
+    exit 0
+  fi
+fi
+
+for required in tar awk mktemp; do
+  command -v "$required" >/dev/null 2>&1 || fail "$required is required but was not found."
+done
+if command -v curl >/dev/null 2>&1; then
+  download() { curl -fL --retry 3 --connect-timeout 20 --output "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  download() { wget -O "$2" "$1"; }
+else
+  fail 'curl or wget is required to download Node.js.'
+fi
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/od-dsh-install.XXXXXX")
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT HUP INT TERM
+
+archive_name=node-v$NODE_VERSION-$platform.tar.gz
+archive=$tmp_dir/$archive_name
+checksums=$tmp_dir/SHASUMS256.txt
+managed_node_version=$(command_output "$managed_node_dir/bin/node" --version || true)
+if [ -x "$managed_node_dir/bin/npm" ] && node_is_supported "$managed_node_version"; then
+  info "Using the verified managed Node.js $managed_node_version already on this machine."
+else
+  info "Downloading official Node.js v$NODE_VERSION for $platform..."
+  download "$DIST_BASE/SHASUMS256.txt" "$checksums"
+  download "$DIST_BASE/$archive_name" "$archive"
+
+  expected=$(awk -v name="$archive_name" '$2 == name { print $1; exit }' "$checksums")
+  [ -n "$expected" ] || fail "checksum entry missing for $archive_name."
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$archive" | awk '{ print $1 }')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+  else
+    fail 'sha256sum or shasum is required to verify the Node.js download.'
+  fi
+  [ "$actual" = "$expected" ] || fail "checksum verification failed for $archive_name."
+  info 'Node.js checksum verified.'
+
+  tar -xzf "$archive" -C "$tmp_dir"
+  extracted=$tmp_dir/node-v$NODE_VERSION-$platform
+  [ -x "$extracted/bin/node" ] || fail 'the Node.js archive did not contain the expected executable.'
+  [ -x "$extracted/bin/npm" ] || fail 'the Node.js archive did not contain npm.'
+
+  mkdir -p "$INSTALL_ROOT"
+  if [ -e "$managed_node_dir" ]; then
+    mv "$managed_node_dir" "$managed_node_dir.incomplete.$$"
+  fi
+  mv "$extracted" "$managed_node_dir"
+fi
+
+runtime_staging=$INSTALL_ROOT/.runtime-dsh-$DSH_VERSION.$$
+mkdir -p "$runtime_staging"
+info "Installing dsh $DSH_VERSION and pnpm $PNPM_VERSION in Open Design's user toolchain..."
+PATH="$managed_node_dir/bin:${PATH:-}" "$managed_node_dir/bin/npm" install \
+  --prefix "$runtime_staging" \
+  --no-save \
+  --no-package-lock \
+  --omit=dev \
+  "@deepseek-ai/dsh@$DSH_VERSION" \
+  "pnpm@$PNPM_VERSION"
+
+staging_bin=$runtime_staging/node_modules/.bin
+[ -x "$staging_bin/dsh" ] || fail 'npm completed without creating the dsh executable.'
+[ -x "$staging_bin/pnpm" ] || fail 'npm completed without creating the pnpm executable.'
+verified_dsh=$(PATH="$managed_node_dir/bin:$staging_bin:${PATH:-}" command_output "$staging_bin/dsh" --version || true)
+verified_pnpm=$(command_output "$managed_node_dir/bin/node" -e 'console.log(require(process.argv[1]).version)' "$runtime_staging/node_modules/pnpm/package.json" || true)
+[ "$verified_dsh" = "$DSH_VERSION" ] || fail "installed dsh reported '$verified_dsh', expected '$DSH_VERSION'."
+[ "$verified_pnpm" = "$PNPM_VERSION" ] || fail "installed pnpm reported '$verified_pnpm', expected '$PNPM_VERSION'."
+
+if [ -e "$RUNTIME_TARGET" ]; then
+  mv "$RUNTIME_TARGET" "$RUNTIME_TARGET.previous.$$"
+fi
+mv "$runtime_staging" "$RUNTIME_TARGET"
+write_managed_launcher "$managed_node_dir/bin" "$managed_runtime_bin"
+
+finish 'managed Node.js toolchain'

--- a/apps/landing-page/tests/install-dsh-static.test.ts
+++ b/apps/landing-page/tests/install-dsh-static.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { test } from 'node:test';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const posixInstaller = join(repoRoot, 'apps/landing-page/public/install-dsh.sh');
+const powershellInstaller = join(repoRoot, 'apps/landing-page/public/install-dsh.ps1');
+const cmdInstaller = join(repoRoot, 'apps/landing-page/public/install-dsh.cmd');
+
+test('publishes pinned cross-platform DeepSeek Harness installers', () => {
+  const shell = readFileSync(posixInstaller, 'utf8');
+  const powershell = readFileSync(powershellInstaller, 'utf8');
+  const cmd = readFileSync(cmdInstaller, 'utf8');
+
+  assert.match(shell, /^#!\/usr\/bin\/env sh\n/);
+  assert.match(shell, /NODE_VERSION=['"]?24\.19\.0/);
+  assert.match(shell, /DSH_VERSION=['"]?0\.1\.0-rc\.6/);
+  assert.match(shell, /PNPM_VERSION=['"]?11\.7\.0/);
+  assert.match(shell, /SHASUMS256\.txt/);
+  assert.match(shell, /--no-launch/);
+  assert.doesNotMatch(shell, /npm\s+(?:install|i)\s+-g/);
+
+  assert.match(powershell, /NodeVersion\s*=\s*'24\.19\.0'/);
+  assert.match(powershell, /DshVersion\s*=\s*'0\.1\.0-rc\.6'/);
+  assert.match(powershell, /PnpmVersion\s*=\s*'11\.7\.0'/);
+  assert.match(powershell, /Get-FileHash/);
+  assert.match(powershell, /NoLaunch/);
+  assert.doesNotMatch(powershell, /npm(?:\.cmd)?\s+(?:install|i)\s+-g/);
+
+  assert.match(cmd, /^@echo off\r?\n/);
+  assert.match(cmd, /powershell\.exe/);
+  assert.match(cmd, /https:\/\/open-design\.ai\/install-dsh\.ps1/);
+  assert.doesNotMatch(cmd, /DEEPSEEK_API_KEY/);
+});
+
+test('POSIX installer performs a checksum-verified isolated install and is idempotent', () => {
+  if (process.platform === 'win32') return;
+
+  const tmp = mkdtempSync(join(tmpdir(), 'od-dsh-installer-'));
+  const dist = join(tmp, 'dist');
+  const fixtureRoot = join(tmp, 'node-v24.19.0-linux-x64');
+  const fixtureBin = join(fixtureRoot, 'bin');
+  const installRoot = join(tmp, 'managed');
+  const binDir = join(tmp, 'bin');
+  const archiveName = 'node-v24.19.0-linux-x64.tar.gz';
+  const archive = join(dist, archiveName);
+  mkdirSync(fixtureBin, { recursive: true });
+  mkdirSync(dist, { recursive: true });
+
+  writeFileSync(
+    join(fixtureBin, 'node'),
+    `#!/bin/sh
+if [ "$1" = "-e" ]; then printf '%s\\n' '11.7.0'; exit 0; fi
+printf '%s\\n' 'v24.19.0'
+`,
+  );
+  writeFileSync(
+    join(fixtureBin, 'npm'),
+    `#!/bin/sh
+prefix=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then prefix="$2"; shift 2; continue; fi
+  shift
+done
+mkdir -p "$prefix/node_modules/@deepseek-ai/dsh/lib" "$prefix/node_modules/.bin"
+: > "$prefix/node_modules/@deepseek-ai/dsh/lib/bin.js"
+cat > "$prefix/node_modules/.bin/dsh" <<'EOF'
+#!/bin/sh
+if [ "$1" = "--version" ]; then printf '%s\\n' '0.1.0-rc.6'; exit 0; fi
+if [ "$1" = "plugin" ]; then pnpm --version; exit $?; fi
+printf '%s\\n' "dsh:$*"
+EOF
+cat > "$prefix/node_modules/.bin/pnpm" <<'EOF'
+#!/bin/sh
+if [ "$1" = "--version" ]; then printf '%s\\n' '11.7.0'; exit 0; fi
+printf '%s\\n' "pnpm:$*"
+EOF
+chmod +x "$prefix/node_modules/.bin/dsh" "$prefix/node_modules/.bin/pnpm"
+`,
+  );
+  writeFileSync(
+    join(fixtureBin, 'pnpm'),
+    `#!/bin/sh
+printf '%s\\n' '10.33.2'
+`,
+  );
+  chmodSync(join(fixtureBin, 'node'), 0o755);
+  chmodSync(join(fixtureBin, 'npm'), 0o755);
+  chmodSync(join(fixtureBin, 'pnpm'), 0o755);
+
+  const tar = spawnSync('tar', ['-czf', archive, '-C', tmp, 'node-v24.19.0-linux-x64'], {
+    encoding: 'utf8',
+  });
+  assert.equal(tar.status, 0, tar.stderr);
+  const hash = createHash('sha256').update(readFileSync(archive)).digest('hex');
+  writeFileSync(join(dist, 'SHASUMS256.txt'), `${hash}  ${archiveName}\n`);
+
+  const env = {
+    ...process.env,
+    OD_DSH_INSTALL_PLATFORM: 'linux-x64',
+    OD_DSH_INSTALL_DIST_BASE: `file://${dist}`,
+    OD_DSH_INSTALL_ROOT: installRoot,
+    OD_DSH_INSTALL_BIN_DIR: binDir,
+    PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
+  };
+
+  try {
+    const first = spawnSync('sh', [posixInstaller, '--no-launch'], { encoding: 'utf8', env });
+    assert.equal(first.status, 0, first.stderr);
+    assert.match(first.stdout, /DeepSeek Harness 0\.1\.0-rc\.6 is ready/);
+
+    const version = spawnSync(join(binDir, 'dsh'), ['--version'], { encoding: 'utf8', env });
+    assert.equal(version.status, 0, version.stderr);
+    assert.equal(version.stdout.trim(), '0.1.0-rc.6');
+
+    const pluginPnpm = spawnSync(join(binDir, 'dsh'), ['plugin'], { encoding: 'utf8', env });
+    assert.equal(pluginPnpm.status, 0, pluginPnpm.stderr);
+    assert.equal(pluginPnpm.stdout.trim(), '11.7.0');
+
+    const second = spawnSync('sh', [posixInstaller, '--no-launch'], { encoding: 'utf8', env });
+    assert.equal(second.status, 0, second.stderr);
+    assert.match(second.stdout, /already installed/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('POSIX installer reuses a complete compatible toolchain without downloading Node', () => {
+  if (process.platform === 'win32') return;
+
+  const tmp = mkdtempSync(join(tmpdir(), 'od-dsh-existing-'));
+  const pathDir = join(tmp, 'path');
+  const binDir = join(tmp, 'bin');
+  mkdirSync(pathDir, { recursive: true });
+  for (const [name, version] of [
+    ['node', 'v24.19.0'],
+    ['dsh', '0.1.0-rc.6'],
+    ['pnpm', '11.7.0'],
+  ] as const) {
+    const executable = join(pathDir, name);
+    writeFileSync(executable, `#!/bin/sh\nprintf '%s\\n' '${version}'\n`);
+    chmodSync(executable, 0o755);
+  }
+
+  const env = {
+    ...process.env,
+    OD_DSH_INSTALL_DIST_BASE: 'https://invalid.example.test/should-not-download',
+    OD_DSH_INSTALL_ROOT: join(tmp, 'managed'),
+    OD_DSH_INSTALL_BIN_DIR: binDir,
+    PATH: `${pathDir}:/usr/bin:/bin:/usr/sbin:/sbin`,
+  };
+
+  try {
+    const result = spawnSync('sh', [posixInstaller, '--no-launch'], { encoding: 'utf8', env });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /existing Node, dsh, and pnpm/);
+    assert.doesNotMatch(result.stdout + result.stderr, /Downloading/);
+    const version = spawnSync(join(binDir, 'dsh'), ['--version'], { encoding: 'utf8', env });
+    assert.equal(version.status, 0, version.stderr);
+    assert.equal(version.stdout.trim(), '0.1.0-rc.6');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/apps/landing-page/tests/install-dsh-static.test.ts
+++ b/apps/landing-page/tests/install-dsh-static.test.ts
@@ -40,7 +40,7 @@ test('publishes pinned cross-platform DeepSeek Harness installers', () => {
 
   assert.match(cmd, /^@echo off\r?\n/);
   assert.match(cmd, /powershell\.exe/);
-  assert.match(cmd, /https:\/\/open-design\.ai\/install-dsh\.ps1/);
+  assert.match(cmd, /https:\/\/releases\.open-design\.ai\/bootstrap\/dsh\/v1\/install-dsh\.ps1/);
   assert.doesNotMatch(cmd, /DEEPSEEK_API_KEY/);
 });
 

--- a/apps/landing-page/tests/install-dsh-static.test.ts
+++ b/apps/landing-page/tests/install-dsh-static.test.ts
@@ -40,7 +40,7 @@ test('publishes pinned cross-platform DeepSeek Harness installers', () => {
 
   assert.match(cmd, /^@echo off\r?\n/);
   assert.match(cmd, /powershell\.exe/);
-  assert.match(cmd, /https:\/\/releases\.open-design\.ai\/bootstrap\/dsh\/v1\/install-dsh\.ps1/);
+  assert.match(cmd, /https:\/\/open-design\.ai\/install-dsh\.ps1/);
   assert.doesNotMatch(cmd, /DEEPSEEK_API_KEY/);
 });
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -356,6 +356,29 @@ the active-run staging implementation is in
 - Open Design launches the user's official `dsh` installation; it does not
   bundle Harness or Node. Install the tested DSH release first and use
   `DSH_BIN` only when its executable is outside the daemon's PATH.
+  Open Design publishes checksum-verifying bootstrap installers for users who
+  do not already have the compatible Node, DSH, and pnpm toolchain. They place
+  an OD-discoverable launcher in the user's local bin directory and open the
+  Harness Web UI for provider setup after installation:
+
+  ```sh
+  curl -fsSL 'https://open-design.ai/install-dsh.sh?version=1' | sh
+  ```
+
+  ```powershell
+  & ([scriptblock]::Create((irm 'https://open-design.ai/install-dsh.ps1?version=1')))
+  ```
+
+  From Windows Command Prompt, the equivalent bootstrap is:
+
+  ```bat
+  curl -fsSL "https://open-design.ai/install-dsh.cmd?version=1" -o "%TEMP%\install-dsh.cmd" && call "%TEMP%\install-dsh.cmd"
+  ```
+
+  Pass `--no-launch` to the downloaded POSIX script or `-NoLaunch` to the
+  downloaded PowerShell script for unattended installation. The installers
+  pin the exact versions in the adapter's compatibility policy and do not use
+  a global npm install.
 - The adapter also requires an Open Design-owned Harness profile named
   `open-design`. The package source lives at
   [`packages/dsh-runtime`](../packages/dsh-runtime). Packaged OD builds embed

--- a/docs/deepseek-harness-one-click-install.zh-CN.md
+++ b/docs/deepseek-harness-one-click-install.zh-CN.md
@@ -40,14 +40,57 @@ curl -fsSL 'https://open-design.ai/install-dsh.sh?version=1' | sh
 curl -fsSL "https://open-design.ai/install-dsh.cmd?version=1" -o "%TEMP%\install-dsh.cmd" && call "%TEMP%\install-dsh.cmd"
 ```
 
-## 安装完成后
+## 配置 DeepSeek API Key
 
-1. 安装器会自动启动 `dsh web`。
-2. 在 DeepSeek Harness 的 Models 页面根据引导配置 DeepSeek API Key。
-3. 配置完成后，可以按 `Ctrl+C` 关闭 `dsh web`；日常使用 Open Design 时不需要让该页面常驻。
-4. 回到 Open Design 的“本地 Agent”页面，点击“重新扫描”。
-5. 选择“DeepSeek Harness”。如果出现“安装 Open Design 连接组件”的确认提示，确认安装即可。
-6. 点击“测试”；测试通过后即可选择模型并开始生成。
+是的，API Key 在 DeepSeek Harness 自己的 Web UI 中配置，不需要粘贴到 Open Design。
+
+### 1. 打开 DeepSeek Harness Web UI
+
+安装完成后，安装器会直接运行：
+
+```sh
+dsh web
+```
+
+终端会显示 Web UI 的访问地址，默认是：
+
+```text
+http://127.0.0.1:3080
+```
+
+如果浏览器没有自动打开，请复制终端显示的地址，在浏览器中手动访问；始终以终端实际打印的地址为准。
+
+以后需要重新配置时，也可以在终端再次运行 `dsh web`。
+
+### 2. 填写 API Key
+
+首次打开 DeepSeek Harness 时，可能会依次看到：
+
+1. “内测声明”：点击“继续”。
+2. DeepSeek API Key 配置：将 Key 粘贴到输入框，点击“保存”或“应用”。
+
+如果没有出现 API Key 弹窗，或者之前选择了稍后配置，请打开：
+
+**设置 → 模型 → DeepSeek → API 密钥**
+
+输入 API Key 后点击“保存”或“应用”。配置会立即生效，不需要重启 `dsh web`。
+
+> 只粘贴 API Key 本身。不要粘贴 `DEEPSEEK_API_KEY=...`，也不要在 Key 外面添加引号。
+
+如果还没有 API Key，请先前往 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 创建。
+
+### 3. 确认配置成功
+
+保存后，DeepSeek 提供方会显示为已配置，对应模型会出现在模型选择器中。如果页面提示 `MISSING_CREDENTIAL`，请回到 DeepSeek 卡片重新保存 API Key。
+
+DeepSeek Harness 会以只写方式保存凭据：页面只能知道 Key 是否已经配置，无法重新读取或显示 Key 明文。官方说明见 [DeepSeek Harness 模型配置指南](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/providers.zh.md)。
+
+### 4. 回到 Open Design
+
+1. API Key 配置完成后，可以在运行 `dsh web` 的终端按 `Ctrl+C`；日常使用 Open Design 时不需要让该页面常驻。
+2. 回到 Open Design 的“本地 Agent”页面，点击“重新扫描”。
+3. 选择“DeepSeek Harness”。如果出现“安装 Open Design 连接组件”的确认提示，确认安装即可。
+4. 点击“测试”；测试通过后即可选择模型并开始生成。
 
 ## 安装器会做什么
 
@@ -93,7 +136,7 @@ DeepSeek API Key 在 DeepSeek Harness 自己的页面中配置和保存。Open D
 
 ## 适合社群直接转发的短版
 
-DeepSeek Harness 已接入 Open Design。没有 Node.js、pnpm 或 dsh 也没关系：复制一行命令即可自动补齐兼容环境，安装完成后会打开 Harness 的 API Key 配置页面。配置完成，回到 Open Design 重新扫描并选择 DeepSeek Harness，就可以开始生成设计。
+DeepSeek Harness 已接入 Open Design。没有 Node.js、pnpm 或 dsh 也没关系：复制一行命令即可自动补齐兼容环境。安装完成后，在 Harness Web UI 的“设置 → 模型 → DeepSeek”中保存 API Key，再回到 Open Design 重新扫描并选择 DeepSeek Harness，就可以开始生成设计。
 
 - macOS / Linux：`curl -fsSL 'https://open-design.ai/install-dsh.sh?version=1' | sh`
 - Windows PowerShell：`& ([scriptblock]::Create((irm 'https://open-design.ai/install-dsh.ps1?version=1')))`

--- a/docs/deepseek-harness-one-click-install.zh-CN.md
+++ b/docs/deepseek-harness-one-click-install.zh-CN.md
@@ -2,6 +2,13 @@
 
 > 运营发布状态：文案已可评审，安装脚本尚未发布到正式下载地址。正式对外发送前，请确认下方三个 `open-design.ai/install-dsh.*` 地址均可访问，并分别完成一次 macOS、Windows PowerShell 和 Windows CMD 验证。
 
+正式发布不采用开发机手动上传。脚本合并到 `main` 后，由 `landing-page-production` 生产发布 workflow 自动完成两件事：
+
+1. 将脚本和 `SHA256SUMS` 以不可覆盖的 `v1` 版本保存到 `https://releases.open-design.ai/bootstrap/dsh/v1/`。
+2. 将相同脚本发布为下方 `open-design.ai/install-dsh.*` 用户短链接。
+
+如果 R2 中已有同名 `v1` 但内容不同，workflow 会停止，必须提升为 `v2`，不能静默覆盖已经对外分发的安装器。
+
 ## 对外宣发文案
 
 ### DeepSeek Harness 已接入 Open Design

--- a/docs/deepseek-harness-one-click-install.zh-CN.md
+++ b/docs/deepseek-harness-one-click-install.zh-CN.md
@@ -1,0 +1,112 @@
+# DeepSeek Harness × Open Design 一键安装指引
+
+> 运营发布状态：文案已可评审，安装脚本尚未发布到正式下载地址。正式对外发送前，请确认下方三个 `open-design.ai/install-dsh.*` 地址均可访问，并分别完成一次 macOS、Windows PowerShell 和 Windows CMD 验证。
+
+## 对外宣发文案
+
+### DeepSeek Harness 已接入 Open Design
+
+现在，你可以在 Open Design 中使用 DeepSeek Harness 完成设计生成任务。
+
+如果电脑上还没有 Node.js、pnpm 或 `dsh`，无需逐项配置环境：运行对应系统的一行安装命令，即可安装 Open Design 当前兼容的 DeepSeek Harness 工具链，并进入 API Key 配置页面。
+
+安装过程不会修改系统级 Node.js，也不需要 `sudo` 或管理员权限；已有的兼容环境会被自动复用。
+
+## 一键安装
+
+### macOS / Linux
+
+打开“终端”，粘贴下面一行并按回车：
+
+```sh
+curl -fsSL 'https://open-design.ai/install-dsh.sh?version=1' | sh
+```
+
+支持 Apple Silicon、Intel Mac，以及主流 x64/arm64 Linux 发行版。Alpine Linux 暂不支持自动安装。
+
+### Windows PowerShell
+
+打开 PowerShell，粘贴下面一行并按回车：
+
+```powershell
+& ([scriptblock]::Create((irm 'https://open-design.ai/install-dsh.ps1?version=1')))
+```
+
+### Windows CMD
+
+打开“命令提示符”，粘贴下面一行并按回车：
+
+```bat
+curl -fsSL "https://open-design.ai/install-dsh.cmd?version=1" -o "%TEMP%\install-dsh.cmd" && call "%TEMP%\install-dsh.cmd"
+```
+
+## 安装完成后
+
+1. 安装器会自动启动 `dsh web`。
+2. 在 DeepSeek Harness 的 Models 页面根据引导配置 DeepSeek API Key。
+3. 配置完成后，可以按 `Ctrl+C` 关闭 `dsh web`；日常使用 Open Design 时不需要让该页面常驻。
+4. 回到 Open Design 的“本地 Agent”页面，点击“重新扫描”。
+5. 选择“DeepSeek Harness”。如果出现“安装 Open Design 连接组件”的确认提示，确认安装即可。
+6. 点击“测试”；测试通过后即可选择模型并开始生成。
+
+## 安装器会做什么
+
+- 检查电脑上是否已有兼容版本的 Node.js、pnpm 和 DeepSeek Harness。
+- 已有环境满足要求时直接复用，不重复下载。
+- 缺少环境时，在当前用户目录中安装隔离的 Node.js 和 DeepSeek Harness 工具链。
+- 固定安装 Open Design 已验证的版本，避免自动升级造成兼容问题。
+- 校验从 Node.js 官网下载的安装包 SHA-256，校验失败会停止安装。
+- 为 Open Design 创建可发现的 `dsh` 启动入口，但不会覆盖用户已有的全局 Node.js。
+
+## API Key 与隐私
+
+DeepSeek API Key 在 DeepSeek Harness 自己的页面中配置和保存。Open Design 不要求用户把 Key 粘贴到应用内，也不会将 Key 写入 Open Design 的应用配置。
+
+安装器需要联网访问 Open Design 下载地址、Node.js 官网和 npm registry。它不会上传项目文件或 API Key。
+
+## 常见问题
+
+### 已经安装过 dsh，还需要运行吗？
+
+可以运行。安装器会先检测现有版本；Node.js、pnpm 和 dsh 都满足兼容要求时会直接复用，不会重复安装。
+
+### 安装器会覆盖我电脑上的 Node.js 吗？
+
+不会。自动补齐的运行环境安装在当前用户的独立工具链目录，不修改系统 Node.js，也不替换其他项目使用的版本。
+
+### 为什么安装后终端里仍然找不到 dsh？
+
+先重新打开一个终端窗口。Open Design 会扫描常见的用户级工具目录，通常不需要手动修改 PATH；如果 Open Design 已经打开，请回到“本地 Agent”页面点击“重新扫描”。
+
+### dsh web 必须一直开着吗？
+
+不需要。它主要用于首次配置模型和 API Key。配置完成后可以关闭，Open Design 在运行任务时会自行调用本机的 dsh。
+
+### Open Design 仍然没有检测到 DeepSeek Harness 怎么办？
+
+请依次确认：
+
+1. 安装命令最后显示 DeepSeek Harness 已就绪。
+2. 已重新启动 Open Design，或在“本地 Agent”页面点击“重新扫描”。
+3. DeepSeek Harness 版本与 Open Design 当前支持版本一致。
+4. 如仍无法识别，将安装器最后一屏输出和 Open Design 的测试提示一并反馈给支持人员。
+
+## 适合社群直接转发的短版
+
+DeepSeek Harness 已接入 Open Design。没有 Node.js、pnpm 或 dsh 也没关系：复制一行命令即可自动补齐兼容环境，安装完成后会打开 Harness 的 API Key 配置页面。配置完成，回到 Open Design 重新扫描并选择 DeepSeek Harness，就可以开始生成设计。
+
+- macOS / Linux：`curl -fsSL 'https://open-design.ai/install-dsh.sh?version=1' | sh`
+- Windows PowerShell：`& ([scriptblock]::Create((irm 'https://open-design.ai/install-dsh.ps1?version=1')))`
+- Windows CMD：`curl -fsSL "https://open-design.ai/install-dsh.cmd?version=1" -o "%TEMP%\install-dsh.cmd" && call "%TEMP%\install-dsh.cmd"`
+
+API Key 由 DeepSeek Harness 自己保存，Open Design 不保存你的 Key。
+
+## 运营发布前检查
+
+- 三个下载地址均返回对应脚本，而不是 HTML 页面或 404。
+- R2 上的版本化对象、SHA-256 清单和 `open-design.ai` 稳定入口已经发布。
+- 用全新 macOS 用户环境完成安装、配置、Open Design 重新扫描和一次真实生成。
+- 用 Windows PowerShell 完成同样的全链路验证。
+- 用 Windows CMD 至少验证下载、PowerShell 转发和安装完成。
+- 确认宣发文案中的兼容 dsh 版本与 Open Design 当前 release 一致。
+- 删除本文顶部“运营发布状态”提示后再面向用户发布。

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -2587,6 +2587,17 @@ process.stdin.on("end", () => {
     }
     expect(productionWorkflow).toContain('wranglerVersion: "4.110.0"');
     expect(productionWorkflow).toContain("d1 migrations apply open-design-landing-attribution --remote");
+    expect(productionWorkflow).toContain("Publish immutable DeepSeek Harness bootstrap installers to R2");
+    expect(productionWorkflow).toContain("DSH_BOOTSTRAP_VERSION: v1");
+    expect(productionWorkflow).toContain("DSH_BOOTSTRAP_SOURCE_DIR: apps/landing-page/public");
+    expect(productionWorkflow).toContain("RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}");
+    expect(productionWorkflow).toContain("RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}");
+    expect(productionWorkflow).toContain("RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}");
+    expect(productionWorkflow).toContain("RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}");
+    expect(productionWorkflow).toContain("pnpm exec tools-release publish-dsh-bootstrap");
+    expect(productionWorkflow.indexOf("pnpm exec tools-release publish-dsh-bootstrap")).toBeLessThan(
+      productionWorkflow.indexOf("pages deploy out"),
+    );
 
     expect(script).toContain('const STAGING_URL = "https://staging.open-design.ai"');
     expect(script).toContain('const STAGING_WORKFLOW = "landing-page-staging.yml"');

--- a/tools/release/src/index.ts
+++ b/tools/release/src/index.ts
@@ -51,6 +51,12 @@ cli
   });
 
 cli
+  .command("publish-dsh-bootstrap", "Publish immutable DeepSeek Harness bootstrap installers")
+  .action(async () => {
+    await import("./storage/publish-dsh-bootstrap.ts");
+  });
+
+cli
   .command("prepare-release-note", "Discover and validate release note sources")
   .action(async () => {
     await import("./release-note/prepare.ts");

--- a/tools/release/src/storage/common.ts
+++ b/tools/release/src/storage/common.ts
@@ -51,6 +51,10 @@ export function writeText(path: string, value: string): void {
 }
 
 export function contentType(name: string): string {
+  if (name.endsWith(".sh")) return "text/x-shellscript; charset=utf-8";
+  if (name.endsWith(".ps1") || name.endsWith(".cmd") || name.endsWith("SHA256SUMS")) {
+    return "text/plain; charset=utf-8";
+  }
   if (name.endsWith(".dmg")) return "application/x-apple-diskimage";
   if (name.endsWith(".zip")) return "application/zip";
   if (name.endsWith(".exe")) return "application/vnd.microsoft.portable-executable";

--- a/tools/release/src/storage/publish-dsh-bootstrap.ts
+++ b/tools/release/src/storage/publish-dsh-bootstrap.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { contentType, publicUrl, required, storageConfigFromEnv } from "./common.ts";
+import { getStorageObject, putStorageObjectWithStatus, type StorageConfig } from "./s3-upload.ts";
+
+const BOOTSTRAP_FILES = ["install-dsh.cmd", "install-dsh.ps1", "install-dsh.sh"] as const;
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+type BootstrapObject = {
+  body: Buffer;
+  name: string;
+};
+
+function sha256(body: Buffer): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+async function publishImmutableBootstrapObject(
+  storage: StorageConfig,
+  prefix: string,
+  object: BootstrapObject,
+): Promise<void> {
+  const objectKey = `${prefix}/${object.name}`;
+  const result = await putStorageObjectWithStatus({
+    ...storage,
+    body: object.body,
+    cacheControl: IMMUTABLE_CACHE_CONTROL,
+    contentType: contentType(object.name),
+    headers: { "if-none-match": "*" },
+    objectKey,
+  });
+  if (result.ok) return;
+  if (result.status !== 412) {
+    throw new Error(`PUT ${result.url} failed with HTTP ${result.status}${result.body.length > 0 ? `: ${result.body}` : ""}`);
+  }
+
+  const existing = await getStorageObject({ ...storage, objectKey });
+  if (existing == null) {
+    throw new Error(`bootstrap object disappeared after immutable PUT conflict: ${objectKey}`);
+  }
+  if (!existing.bytes.equals(object.body)) {
+    throw new Error(`immutable bootstrap object already exists with different content: ${objectKey}`);
+  }
+  console.log(`reused identical immutable bootstrap object ${objectKey}`);
+}
+
+const version = required("DSH_BOOTSTRAP_VERSION");
+if (!/^v[1-9]\d*$/.test(version)) {
+  throw new Error(`DSH_BOOTSTRAP_VERSION must look like v1 or v2; got ${version}`);
+}
+
+const sourceDir = required("DSH_BOOTSTRAP_SOURCE_DIR");
+const publicOrigin = required("RELEASE_PUBLIC_ORIGIN");
+const storage = storageConfigFromEnv();
+const prefix = `bootstrap/dsh/${version}`;
+const installers = BOOTSTRAP_FILES.map((name) => ({
+  body: readFileSync(join(sourceDir, name)),
+  name,
+}));
+const checksums = Buffer.from(
+  installers.map(({ body, name }) => `${sha256(body)}  ${name}`).join("\n") + "\n",
+  "utf8",
+);
+const objects: BootstrapObject[] = [...installers, { body: checksums, name: "SHA256SUMS" }];
+
+for (const object of objects) {
+  await publishImmutableBootstrapObject(storage, prefix, object);
+}
+
+for (const object of objects) {
+  const objectKey = `${prefix}/${object.name}`;
+  const published = await getStorageObject({ ...storage, objectKey });
+  if (published == null || !published.bytes.equals(object.body)) {
+    throw new Error(`published bootstrap object failed byte-for-byte verification: ${objectKey}`);
+  }
+  console.log(publicUrl(publicOrigin, prefix, object.name));
+}

--- a/tools/serve/tests/dsh-bootstrap-publish.test.ts
+++ b/tools/serve/tests/dsh-bootstrap-publish.test.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { startReleaseStorageFixtureServer } from "../src/release-storage-fixture.js";
+
+function runPublisher(repoRoot: string, env: NodeJS.ProcessEnv): Promise<string> {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(
+      process.execPath,
+      ["--experimental-strip-types", "tools/release/src/storage/publish-dsh-bootstrap.ts"],
+      { cwd: repoRoot, env },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", rejectRun);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolveRun(stdout);
+      } else {
+        rejectRun(new Error(`publisher exited ${String(code)}\n${stdout}\n${stderr}`));
+      }
+    });
+  });
+}
+
+describe("DeepSeek Harness bootstrap publisher", () => {
+  it("publishes immutable cross-platform installers and their checksum manifest", async () => {
+    const repoRoot = resolve(import.meta.dirname, "../../..");
+    const sourceDir = await mkdtemp(join(tmpdir(), "od-dsh-bootstrap-publish-"));
+    const server = await startReleaseStorageFixtureServer();
+    const files = {
+      "install-dsh.cmd": "@echo off\r\necho cmd\r\n",
+      "install-dsh.ps1": "Write-Host 'powershell'\n",
+      "install-dsh.sh": "#!/usr/bin/env sh\necho posix\n",
+    };
+    await Promise.all(Object.entries(files).map(([name, body]) => writeFile(join(sourceDir, name), body, "utf8")));
+
+    const env = {
+      ...process.env,
+      DSH_BOOTSTRAP_SOURCE_DIR: sourceDir,
+      DSH_BOOTSTRAP_VERSION: "v1",
+      RELEASE_PUBLIC_ORIGIN: "https://releases.example.test",
+      RELEASE_STORAGE_ACCESS_KEY_ID: "ak",
+      RELEASE_STORAGE_BUCKET: server.info.bucket,
+      RELEASE_STORAGE_ENDPOINT: server.info.endpointUrl,
+      RELEASE_STORAGE_REGION: "auto",
+      RELEASE_STORAGE_SECRET_ACCESS_KEY: "sk",
+    };
+
+    try {
+      const output = await runPublisher(repoRoot, env);
+      expect(output).toContain("https://releases.example.test/bootstrap/dsh/v1/install-dsh.sh");
+      expect(server.listObjectKeys()).toEqual([
+        "bootstrap/dsh/v1/SHA256SUMS",
+        "bootstrap/dsh/v1/install-dsh.cmd",
+        "bootstrap/dsh/v1/install-dsh.ps1",
+        "bootstrap/dsh/v1/install-dsh.sh",
+      ]);
+      for (const [name, body] of Object.entries(files)) {
+        expect(server.getObject(`bootstrap/dsh/v1/${name}`)?.toString("utf8")).toBe(body);
+      }
+      expect(server.getObject("bootstrap/dsh/v1/SHA256SUMS")?.toString("utf8")).toMatch(
+        /^[a-f0-9]{64}  install-dsh\.cmd\n[a-f0-9]{64}  install-dsh\.ps1\n[a-f0-9]{64}  install-dsh\.sh\n$/,
+      );
+
+      await expect(runPublisher(repoRoot, env)).resolves.toContain("reused identical immutable bootstrap object");
+
+      await writeFile(join(sourceDir, "install-dsh.sh"), "#!/usr/bin/env sh\necho changed\n", "utf8");
+      await expect(runPublisher(repoRoot, env)).rejects.toThrow(
+        /immutable bootstrap object already exists with different content/,
+      );
+    } finally {
+      await server.close();
+      await rm(sourceDir, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

While validating the DeepSeek Harness integration in Open Design, we found that a detected-but-not-installed `dsh` still leaves desktop users with a multi-step Node.js, pnpm, CLI, and credential setup. This PR turns that onboarding gap into a one-line, cross-platform bootstrap path for the current OD-compatible Harness version.

It also removes manual distribution as an operational dependency. The production landing-page promotion now archives the exact installer bytes and checksum manifest under an immutable R2 version before publishing the short `open-design.ai` entry points.

## What users will see

After the next production landing-page promotion, users can copy one command for macOS/Linux, Windows PowerShell, or Windows CMD. The installer reuses compatible local tools when possible; otherwise it installs an isolated user-scoped Node.js 24 toolchain, the pinned DeepSeek Harness release, and pnpm without requiring `sudo` or replacing the system Node.js.

The installer launches `dsh web` so users can save their DeepSeek API key in Harness, then return to Open Design and rescan local agents. The accompanying Chinese operations guide documents installation, credential setup, troubleshooting, and the publication checklist.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — adds the internal `tools-release publish-dsh-bootstrap` production command and its explicit publication inputs
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this PR adds downloadable scripts, documentation, and trusted production publication automation; it does not change an application UI surface.

## Bug fix verification

- Not applicable; this is a feature and distribution workflow. The new R2 publisher test was nevertheless introduced first and failed against the old code because the publisher did not exist, then passed after implementation.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color .github/workflows/landing-page-production.yml`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/tools-release test` — 41 passed
- `pnpm --filter @open-design/tools-serve test` — 29 passed
- `pnpm --filter @open-design/landing-page test` — 140 passed, including checksum-verified POSIX bootstrap and idempotent reuse
- `pnpm --dir e2e test tests/packaged-smoke-workflow.test.ts` — 71 passed, 1 skipped
- Red/green evidence: `tools/serve/tests/dsh-bootstrap-publish.test.ts` failed before implementation with `MODULE_NOT_FOUND`, then passed with first publish, identical replay, checksum manifest, and immutable-content-conflict coverage
- Windows scripts are covered by static contract assertions in `apps/landing-page/tests/install-dsh-static.test.ts`; real Windows end-to-end validation remains an explicit production-release checklist item
