### PR TITLE
fix(daemon): install DSH companion from a shell-safe profile path

### DIFF
--- a/apps/daemon/src/agent-companion-setup.ts
+++ b/apps/daemon/src/agent-companion-setup.ts
@@ -16,7 +16,10 @@ import { spawnEnvForAgent } from './runtimes/env.js';
 import { execAgentFile } from './runtimes/invocation.js';
 import { applyAgentLaunchEnv, resolveAgentLaunch } from './runtimes/launch.js';
 import { getAgentDef } from './runtimes/registry.js';
-import { hasOpenDesignProfile } from './runtimes/defs/deepseek-harness.js';
+import {
+  hasOpenDesignProfile,
+  resolveOpenDesignProfileDir,
+} from './runtimes/defs/deepseek-harness.js';
 
 const execFileAsync = promisify(execFile);
 const DSH_AGENT_ID = 'deepseek-harness';
@@ -111,7 +114,7 @@ async function resolveVerifiedBundle(options: {
   projectRoot: string;
   resourceRoot: string;
   runtimeDataDir: string;
-}): Promise<{ manifest: RuntimeManifest; tarballPath: string }> {
+}): Promise<{ bytes: Buffer; manifest: RuntimeManifest }> {
   let directory = path.join(options.resourceRoot, DSH_RUNTIME_RESOURCE_DIRECTORY);
   if (!(await fileExists(path.join(directory, 'manifest.json')))) {
     directory = await materializeDevelopmentBundle(options.projectRoot, options.runtimeDataDir);
@@ -135,11 +138,48 @@ async function resolveVerifiedBundle(options: {
     throw new AgentCompanionSetupError('BUNDLED_COMPANION_INVALID', 'Invalid connection package manifest.');
   }
   const tarballPath = path.join(directory, manifest.file);
-  const actualHash = createHash('sha256').update(await readFile(tarballPath)).digest('hex');
+  const bytes = await readFile(tarballPath);
+  const actualHash = createHash('sha256').update(bytes).digest('hex');
   if (actualHash !== manifest.sha256) {
     throw new AgentCompanionSetupError('BUNDLED_COMPANION_INVALID', 'Connection package integrity check failed.');
   }
-  return { manifest, tarballPath };
+  return { bytes, manifest };
+}
+
+async function stageVerifiedBundleInProfile(
+  env: NodeJS.ProcessEnv,
+  manifest: RuntimeManifest,
+  bytes: Buffer,
+): Promise<string> {
+  const relativeDirectory = '.open-design';
+  const file = `${manifest.sha256}.tgz`;
+  const profileDirectory = resolveOpenDesignProfileDir(env);
+  const bundleDirectory = path.join(profileDirectory, relativeDirectory);
+  await mkdir(bundleDirectory, { recursive: true });
+  await writeFile(path.join(bundleDirectory, file), bytes);
+  // dsh runs pnpm with the profile directory as cwd. Keeping this spec
+  // relative avoids rc.6's Windows shell forwarder splitting an absolute
+  // packaged-app path such as "Open Design" at its spaces.
+  return `${relativeDirectory}/${file}`;
+}
+
+function commandFailureDetail(error: unknown): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const candidate = error as { code?: unknown; signal?: unknown; stderr?: unknown };
+  let stderr = '';
+  if (typeof candidate.stderr === 'string') {
+    stderr = candidate.stderr.trim();
+  } else if (Buffer.isBuffer(candidate.stderr)) {
+    stderr = candidate.stderr.toString('utf8').trim();
+  }
+  const parts = [
+    typeof candidate.code === 'string' || typeof candidate.code === 'number'
+      ? `code=${candidate.code}`
+      : null,
+    typeof candidate.signal === 'string' ? `signal=${candidate.signal}` : null,
+    stderr ? `stderr=${stderr.slice(-4_000)}` : null,
+  ].filter((part): part is string => part !== null);
+  return parts.length > 0 ? parts.join(' ') : null;
 }
 
 let activeSetup: Promise<AgentCompanionSetupResponse> | null = null;
@@ -168,7 +208,7 @@ async function installDeepSeekHarnessCompanionOnce(options: {
   const appConfig = await readAppConfig(options.runtimeDataDir);
   const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, DSH_AGENT_ID);
   const before = await detectAgent(def, configuredEnv);
-  const { manifest, tarballPath } = await resolveVerifiedBundle(options);
+  const { bytes, manifest } = await resolveVerifiedBundle(options);
   if (before.available) {
     return { action: 'already-compatible', agent: before, ok: true, packageVersion: manifest.version };
   }
@@ -185,13 +225,18 @@ async function installDeepSeekHarnessCompanionOnce(options: {
     launch,
   );
   const profileWasPresent = hasOpenDesignProfile(childEnv);
+  const packageSpec = await stageVerifiedBundleInProfile(childEnv, manifest, bytes);
   try {
     await execAgentFile(
       launch.launchPath,
-      ['plugin', '--profile', 'open-design', 'add', tarballPath],
+      ['plugin', '--profile', 'open-design', 'add', packageSpec],
       { env: childEnv, timeout: 120_000, maxBuffer: 2 * 1024 * 1024 },
     );
-  } catch {
+  } catch (error) {
+    console.error(
+      '[od] DeepSeek Harness connection component install failed',
+      commandFailureDetail(error) ?? 'no command diagnostics were available',
+    );
     throw new AgentCompanionSetupError(
       'COMPANION_INSTALL_FAILED',
       'DeepSeek Harness could not install the Open Design connection component. No agent selection was changed.',

--- a/apps/daemon/src/runtimes/defs/deepseek-harness.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek-harness.ts
@@ -30,11 +30,15 @@ function parseModels(stdout: string) {
 }
 
 export function hasOpenDesignProfile(env: NodeJS.ProcessEnv): boolean {
+  return existsSync(path.join(resolveOpenDesignProfileDir(env), 'package.json'));
+}
+
+export function resolveOpenDesignProfileDir(env: NodeJS.ProcessEnv): string {
   const configuredHome = env.DSH_HOME?.trim();
   const dshHome = configuredHome
     ? path.resolve(configuredHome)
     : path.join(homedir(), '.dsh');
-  return existsSync(path.join(dshHome, 'profiles', 'open-design', 'package.json'));
+  return path.join(dshHome, 'profiles', 'open-design');
 }
 
 const DSH_VERSION_RE = /^v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/u;

--- a/apps/daemon/tests/agent-companion-setup.test.ts
+++ b/apps/daemon/tests/agent-companion-setup.test.ts
@@ -76,6 +76,14 @@ if (args[0] === '--version') {
   }
 } else if (args[0] === 'plugin' && args[1] === '--profile' && args[2] === 'open-design' && args[3] === 'add') {
   if (process.env.OD_DSH_SETUP_FAKE_MODE === 'install-fail') process.exit(7);
+  if (process.env.OD_DSH_SETUP_FAKE_MODE === 'require-profile-bundle') {
+    const [directory, filename, extra] = args[4].split('/');
+    const digest = filename?.endsWith('.tgz') ? filename.slice(0, -4) : '';
+    const digestIsHex = digest.length === 64 && digest.replace(/[a-f0-9]/g, '') === '';
+    if (directory !== '.open-design' || extra !== undefined || !digestIsHex) process.exit(8);
+    const bundle = await readFile(path.join(profileRoot, args[4]), 'utf8');
+    if (bundle !== 'fixture runtime package') process.exit(9);
+  }
   await mkdir(profileRoot, { recursive: true });
   let count = 0;
   try { count = Number(await readFile(${JSON.stringify(stateFile)}, 'utf8')); } catch {}
@@ -164,6 +172,16 @@ describe('DeepSeek Harness companion setup', () => {
       installDeepSeekHarnessCompanion(probeFailure.options),
       'COMPANION_STILL_INCOMPATIBLE',
     );
+  });
+
+  it('keeps the bundled package path out of the dsh Windows shell boundary', async () => {
+    const test = await fixture();
+    process.env.OD_DSH_SETUP_FAKE_MODE = 'require-profile-bundle';
+
+    await expect(installDeepSeekHarnessCompanion(test.options)).resolves.toMatchObject({
+      action: 'installed',
+      ok: true,
+    });
   });
 
   it('deduplicates concurrent setup requests', async () => {


### PR DESCRIPTION
## Why

QA installed DeepSeek Harness on Windows, started its web setup, and configured the API key, but Open Design still failed while installing its connection component. The packaged application path contains `Open Design`, and DSH `0.1.0-rc.6` invokes its plugin package manager through a Windows shell. Passing the packaged runtime tarball's absolute path therefore allowed the shell to split the package spec at the space.

This prevented an otherwise valid DSH installation from being selected in Open Design. The fix keeps DSH and its credentials user-managed and removes the unsafe absolute path from the shell boundary, without requiring an upstream Harness change.

## What users will see

On Windows, selecting DeepSeek Harness and confirming **Install and select** now installs the Open Design connection component even when the Open Design application path or DSH home contains spaces. Existing UI and credential behavior are unchanged.

If DSH or its package manager still fails, daemon diagnostics now include the command exit code, signal, and bounded stderr output so the failure can be diagnosed from the support bundle.

## Surface area

- [ ] Web UI
- [ ] Desktop shell
- [x] Daemon / agent runtime
- [ ] `od` CLI
- [ ] HTTP API or shared contract
- [ ] Environment variable
- [ ] i18n
- [ ] Extension point (`skills/`, `design-systems/`, `design-templates/`, or `craft/`)
- [x] Default behavior change
- [ ] Top-level dependency
- [ ] None of the above

## Screenshots

Not applicable. This changes the existing DeepSeek Harness setup implementation; the setup dialog and all other UI remain unchanged.

## Bug fix verification

- Regression test: `apps/daemon/tests/agent-companion-setup.test.ts`
- Red on the previous implementation: the focused test failed with `COMPANION_INSTALL_FAILED` because the fake Windows-shell boundary rejected the absolute tarball path.
- Green on this branch: the focused file passes 7/7 and verifies that DSH receives a safe profile-relative package spec while installing the exact verified bundle bytes.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon test` — 668 files passed, 2 skipped; 8,514 tests passed, 6 skipped
- `git diff --check`
- Real DSH `0.1.0-rc.6` end-to-end install from a `DSH_HOME` path containing spaces, followed by `dsh --profile open-design --probe`; protocol v1, session resume/cancel, and structured-event capabilities were reported successfully

