### PR TITLE
fix(nix): replace deprecated stdenv.is* with stdenv.hostPlatform.is*

### DIFF
--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -102,7 +102,7 @@
   # the default Nix profile. Darwin gets the standard launchd PATH.
   daemonPathEntries =
     ["${config.home.profileDirectory}/bin"]
-    ++ lib.optionals pkgs.stdenv.isLinux [
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
       "/run/wrappers/bin"
       "/etc/profiles/per-user/${config.home.username}/bin"
       "/run/current-system/sw/bin"
@@ -111,7 +111,7 @@
       "/usr/bin"
       "/bin"
     ]
-    ++ lib.optionals pkgs.stdenv.isDarwin [
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
       "/usr/local/bin"
       "/usr/bin"
       "/bin"
@@ -200,7 +200,7 @@ in {
     }
 
     # ----- Linux: systemd --user units --------------------------------
-    (lib.mkIf (pkgs.stdenv.isLinux && cfg.autoStart) {
+    (lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && cfg.autoStart) {
       systemd.user.services.open-design = {
         Unit = {
           Description = "Open Design daemon (user service)";
@@ -222,7 +222,7 @@ in {
       };
     })
 
-    (lib.mkIf (pkgs.stdenv.isLinux && cfg.webFrontend.enable) {
+    (lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && cfg.webFrontend.enable) {
       systemd.user.services.open-design-web = {
         Unit = {
           Description = "Open Design web frontend (static file server)";
@@ -240,7 +240,7 @@ in {
     })
 
     # ----- macOS: launchd agents -------------------------------------
-    (lib.mkIf (pkgs.stdenv.isDarwin && cfg.autoStart) (let
+    (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && cfg.autoStart) (let
       # launchd has no EnvironmentFile equivalent. When the user supplies
       # one, wrap the daemon exec in a tiny shell that sources the file
       # at runtime — keeps secrets out of the world-readable Nix store
@@ -271,7 +271,7 @@ in {
       };
     }))
 
-    (lib.mkIf (pkgs.stdenv.isDarwin && cfg.webFrontend.enable) {
+    (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && cfg.webFrontend.enable) {
       launchd.agents.open-design-web = {
         enable = true;
         config = {


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->

## Why

nixpkgs deprecated the `stdenv.is<Platform>` aliases on 2026-05-09; every evaluation that loads the Home Manager module now prints two `evaluation warning` lines (verified still present on current `main` and v0.19.0). The aliases are identity passthroughs, and `nix/module-common.nix` already migrated the same class of deprecation (`pkgs.system` → `pkgs.stdenv.hostPlatform.system`). This PR brings the remaining 6 call sites in `nix/home-manager.nix` in line with that precedent.

## What users will see

Nothing functional; the two warning lines disappear.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A (no UI).

## Bug fix verification

Not a bug fix — mechanical rename of 6 call sites in `nix/home-manager.nix` (2 × `lib.optionals`, 4 × `lib.mkIf` conditions); no remaining `stdenv.is*` occurrences in `nix/` or `flake.nix`.

## Validation

Verified on my NixOS flake config consuming `homeManagerModules.default`: `nix eval` succeeds and the module's deprecation warnings are gone.
