### PR TITLE
fix(web): layer plugin modal above account chrome

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -9,6 +9,7 @@ import {
   type KeyboardEvent,
   type SetStateAction,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { Dialog } from '@open-design/components';
 import {
   PLUGIN_SHARE_ACTION_PLUGIN_IDS,
@@ -3215,7 +3216,7 @@ function AvailablePluginDetailsModal({
     });
   }
 
-  return (
+  const modal = (
     <div
       className="plugin-details-modal-backdrop"
       role="dialog"
@@ -3519,6 +3520,9 @@ function AvailablePluginDetailsModal({
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined') return modal;
+  return createPortal(modal, document.body);
 }
 
 function SourcesPanel({

--- a/apps/web/tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx
@@ -171,8 +171,8 @@ describe('ExtensionsMarketplace installed plugin detail entry', () => {
     expect(screen.queryByTestId('plugin-detail')).toBeNull();
   });
 
-  it('keeps an uninstalled Community card in the existing install modal', async () => {
-    renderHarness();
+  it('keeps an uninstalled Community card in a root-level install modal', async () => {
+    const { container } = renderHarness();
 
     fireEvent.click(
       await screen.findByTestId(
@@ -183,6 +183,13 @@ describe('ExtensionsMarketplace installed plugin detail entry', () => {
     const modal = await screen.findByTestId('plugins-available-details-modal');
     expect(window.location.pathname).toBe('/plugins');
     expect(screen.queryByTestId('plugin-detail')).toBeNull();
+    // The top-right account cluster is also portalled to <body>. Keeping the
+    // scrim inside the marketplace stacking context lets that cluster paint
+    // above the backdrop and escape its blur.
+    expect(modal.parentElement).toBe(document.body);
+    expect(
+      container.querySelector('[data-testid="plugins-available-details-modal"]'),
+    ).toBeNull();
     expect(within(modal).getByText('Community Plugin Kit')).toBeTruthy();
     expect(
       within(modal).getByTestId(


### PR DESCRIPTION
## Why

Opening an uninstalled Community plugin's install details left the top-right GitHub and account controls visually above the modal scrim instead of blurring them with the rest of the background.

The install-details backdrop was still rendered inside the Marketplace stacking context, while the top-right account cluster is portalled to `document.body`. That let the account chrome escape the backdrop even though the scrim's local z-index was higher.

## What users will see

When an uninstalled Community plugin details modal is open, the GitHub badge and account/credits controls in the top-right now dim and blur together with the rest of the background. Installed-plugin details and the install workflow are otherwise unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not included per requester instruction. The regression is covered by a root-layer DOM contract test.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, the modal's direct parent was `.plugin-marketplace`; on this branch it is `document.body`.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/ExtensionsMarketplace.sync-to-team.test.tsx tests/components/ExtensionsMarketplace.create-dialog-layout.test.tsx tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx tests/components/ExtensionsMarketplace.team-scope.test.tsx tests/components/ExtensionsMarketplace.workspace-mutation-scope.test.tsx tests/components/ExtensionsMarketplace.card-actions.test.tsx tests/components/PluginDetailsModal.dispatch.test.tsx tests/components/PluginDetailsModal.layering.test.tsx --maxWorkers=2` (8 files, 62 tests)