### PR TITLE
fix: batch streamed events and simplify project exports

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -469,6 +469,8 @@ async function runAgent(args) {
 
 const EXPORT_STRING_FLAGS = new Set([
   'daemon-url', 'project', 'format', 'out', 'output', 'image-format', 'title', 'file',
+  // Backwards-compatible no-ops. Older scripts may still pass these, but
+  // export authority is derived from the project id by the daemon.
   'workspace', 'workspace-member',
 ]);
 const EXPORT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'deck', 'page', 'no-deck']);
@@ -493,8 +495,6 @@ Options:
   --deck                   Treat the artifact as a multi-slide deck
   --page, --no-deck        Treat the artifact as a normal scrollable page
   --title <title>          Title used for metadata / default filename
-  --workspace <id>        Explicit Workspace id for a bound project
-  --workspace-member <id> Explicit Workspace member id for a bound project
   --json                   Print a machine-readable result envelope
   --daemon-url <url>       Override daemon URL
 
@@ -541,7 +541,7 @@ async function runExport(args) {
   const token = process.env.OD_TOOL_TOKEN;
   const requestHeaders = token
     ? { authorization: `Bearer ${token}` }
-    : workspaceHeadersFromExplicitFlags(flags) ?? {};
+    : {};
   // Visual formats rasterize through the desktop screenshot renderer so the
   // CLI matches the UI exactly. In particular `pdf` uses `/export/pdf-image`
   // (one raster page per deck slide / per viewport for a page) — NOT the generic

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -2584,6 +2584,9 @@ export function conversationTurnIndexForRun(
 }
 
 export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
+  const persistedEvents = Array.isArray(m.events)
+    ? compactAdjacentMessageAgentEvents(m.events)
+    : m.events;
   const existing = db
     .prepare(`SELECT position FROM messages WHERE id = ?`)
     .get(m.id) as DbRow | undefined;
@@ -2613,7 +2616,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.runStatus ?? null,
       normalizeResultDeliveryStateForStorage(m.resultDeliveryState),
       m.lastRunEventId ?? null,
-      m.events ? JSON.stringify(m.events) : null,
+      persistedEvents ? JSON.stringify(persistedEvents) : null,
       m.attachments ? JSON.stringify(m.attachments) : null,
       m.commentAttachments ? JSON.stringify(m.commentAttachments) : null,
       m.producedFiles ? JSON.stringify(m.producedFiles) : null,
@@ -2667,7 +2670,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.runStatus ?? null,
       normalizeResultDeliveryStateForStorage(m.resultDeliveryState),
       m.lastRunEventId ?? null,
-      m.events ? JSON.stringify(m.events) : null,
+      persistedEvents ? JSON.stringify(persistedEvents) : null,
       m.attachments ? JSON.stringify(m.attachments) : null,
       m.commentAttachments ? JSON.stringify(m.commentAttachments) : null,
       m.producedFiles ? JSON.stringify(m.producedFiles) : null,
@@ -2759,25 +2762,73 @@ export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event:
   return next;
 }
 
-export function appendMessageAgentEvent(db: SqliteDb, messageId: string, event: DbRow) {
-  if (!event || typeof event !== 'object') return null;
-  const kind = typeof event.kind === 'string' ? event.kind : '';
-  if (!kind) return null;
+export function compactAdjacentMessageAgentEvents(
+  incomingEvents: readonly DbRow[],
+): DbRow[] {
+  const events: DbRow[] = [];
+  for (const event of incomingEvents) {
+    const kind = typeof event?.kind === 'string' ? event.kind : '';
+    const last = events[events.length - 1];
+    const isMergeableDelta =
+      (kind === 'text' || kind === 'thinking') && typeof event?.text === 'string';
+    if (isMergeableDelta && last?.kind === kind && typeof last.text === 'string') {
+      events[events.length - 1] = { ...last, text: last.text + event.text };
+    } else {
+      events.push(event);
+    }
+  }
+  return events;
+}
+
+export function appendMessageAgentEvents(
+  db: SqliteDb,
+  messageId: string,
+  incomingEvents: readonly DbRow[],
+): DbRow[] | null {
+  if (incomingEvents.length === 0) return null;
   const row = db
     .prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
     .get(messageId) as DbRow | undefined;
   if (!row) return null;
   const parsed = parseJsonOrUndef(row.eventsJson);
-  const events = Array.isArray(parsed) ? parsed : [];
-  const last = events[events.length - 1];
-  if (last && JSON.stringify(last) === JSON.stringify(event)) {
-    return events;
+  const parsedEvents = Array.isArray(parsed) ? parsed : [];
+  const events = compactAdjacentMessageAgentEvents(parsedEvents);
+  let textDelta = '';
+  let changed = events.length !== parsedEvents.length;
+
+  for (const event of incomingEvents) {
+    if (!event || typeof event !== 'object') continue;
+    const kind = typeof event.kind === 'string' ? event.kind : '';
+    if (!kind) continue;
+    const last = events[events.length - 1];
+    const isMergeableDelta =
+      (kind === 'text' || kind === 'thinking') && typeof event.text === 'string';
+    if (isMergeableDelta && last?.kind === kind && typeof last.text === 'string') {
+      last.text += event.text;
+      if (kind === 'text') textDelta += event.text;
+      changed = changed || event.text.length > 0;
+      continue;
+    }
+    if (!isMergeableDelta && last && JSON.stringify(last) === JSON.stringify(event)) {
+      continue;
+    }
+    events.push(event);
+    if (kind === 'text' && typeof event.text === 'string') textDelta += event.text;
+    changed = true;
   }
-  const next = [...events, event];
-  const textDelta = kind === 'text' && typeof event.text === 'string' ? event.text : '';
+
+  if (!changed) return events;
   db.prepare(`UPDATE messages SET content = COALESCE(content, '') || ?, events_json = ? WHERE id = ?`)
-    .run(textDelta, JSON.stringify(next), messageId);
-  return next;
+    .run(textDelta, JSON.stringify(events), messageId);
+  return events;
+}
+
+export function appendMessageAgentEvent(
+  db: SqliteDb,
+  messageId: string,
+  event: DbRow,
+): DbRow[] | null {
+  return appendMessageAgentEvents(db, messageId, [event]);
 }
 
 export function deleteMessage(db: SqliteDb, id: string) {

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -602,7 +602,11 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   async function authorizeExportRead(
     req: any,
     res: any,
-    options: { allowNavigationQuery?: boolean; toolEndpoint?: string } = {},
+    options: {
+      allowNavigationQuery?: boolean;
+      deriveWorkspaceFromProject?: boolean;
+      toolEndpoint?: string;
+    } = {},
   ): Promise<AuthorizedExportRead | null> {
     const authorization = req.get('authorization');
     if (
@@ -623,6 +627,14 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       const authority = await ctx.authorizeProjectToolRequest(
         res,
         grant.projectId,
+        { mode: 'read' },
+      );
+      return authority ? { previewWorkspace: authority.workspace } : null;
+    }
+    if (options.deriveWorkspaceFromProject) {
+      const authority = await ctx.authorizeProjectToolRequest(
+        res,
+        req.params.id,
         { mode: 'read' },
       );
       return authority ? { previewWorkspace: authority.workspace } : null;
@@ -1392,7 +1404,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // PNG and assemble a one-image-per-slide .pptx. Replaces the old "send a prompt
   // to the agent and hope it runs python-pptx" path with a deterministic export.
   app.post('/api/projects/:id/export/pptx', async (req, res) => {
-    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    const authority = await authorizeExportRead(req, res, {
+      deriveWorkspaceFromProject: true,
+      toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+    });
     if (!authority) return;
     await handleScreenshotExport(res, 'pptx', req.params.id, { authority, body: req.body });
   });
@@ -1401,7 +1416,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // The print-ready vector PDF stays on POST /export/pdf; this is the "exactly
   // what you see" counterpart that shares the slide renderer with PPTX.
   app.post('/api/projects/:id/export/pdf-image', async (req, res) => {
-    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    const authority = await authorizeExportRead(req, res, {
+      deriveWorkspaceFromProject: true,
+      toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+    });
     if (!authority) return;
     await handleScreenshotExport(res, 'pdf', req.params.id, { authority, body: req.body });
   });
@@ -1411,7 +1429,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // the whole document at natural size. Viewport-independent — unlike the
   // host-compositor snapshot, the size never depends on the preview pane.
   app.post('/api/projects/:id/export/image', async (req, res) => {
-    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    const authority = await authorizeExportRead(req, res, {
+      deriveWorkspaceFromProject: true,
+      toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+    });
     if (!authority) return;
     await handleScreenshotExport(res, 'image', req.params.id, { authority, body: req.body });
   });
@@ -1420,7 +1441,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
   // embedded by the daemon. Remote HTTP(S) dependencies remain external and
   // are listed in a machine-readable manifest inside the output.
   app.post('/api/projects/:id/export/html', async (req, res) => {
-    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    const authority = await authorizeExportRead(req, res, {
+      deriveWorkspaceFromProject: true,
+      toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+    });
     if (!authority) return;
     await handleStandaloneHtmlExport(res, req.params.id, req.body);
   });
@@ -1438,7 +1462,10 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
     if (!isExportFormat(format)) {
       return sendApiError(res, 400, 'BAD_REQUEST', 'invalid export format');
     }
-    const authority = await authorizeExportRead(req, res, { toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT });
+    const authority = await authorizeExportRead(req, res, {
+      deriveWorkspaceFromProject: true,
+      toolEndpoint: PROJECT_EXPORT_TOOL_ENDPOINT,
+    });
     if (!authority) return;
     if (format === 'html') {
       return handleStandaloneHtmlExport(res, req.params.id, {

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -10,6 +10,7 @@ import { TERMINAL_RUN_STATUSES } from '../../runtimes/runs.js';
 import { registerProjectCommentRoutes } from './comments.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 import {
+  compactAdjacentMessageAgentEvents,
   deleteConversationAndRepairTeamCommentAnchor,
   isProjectCommentAnchorConversationId,
 } from '../../db.js';
@@ -548,8 +549,11 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
     if (existing === null && getMessage(db, req.params.mid) !== null) {
       return res.status(404).json({ error: 'message not found' });
     }
+    const normalizedMessage = Array.isArray(m.events)
+      ? { ...m, events: compactAdjacentMessageAgentEvents(m.events) }
+      : m;
     const saved = upsertMessage(db, req.params.cid, {
-      ...mergeMessageWriteForDaemonBacked(existing, m),
+      ...mergeMessageWriteForDaemonBacked(existing, normalizedMessage),
       id: req.params.mid,
     });
     // Bump the parent project's updatedAt so the project list re-orders.

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -1,7 +1,7 @@
 import type Database from 'better-sqlite3';
 import type { PersistedAgentEvent } from '@open-design/contracts';
 import {
-  appendMessageAgentEvent,
+  appendMessageAgentEvents,
   upsertMessage,
 } from '../db.js';
 
@@ -22,6 +22,18 @@ type ChatRunMessageState = {
   failureDetail?: string | null;
 };
 
+type PendingMessageEvents = {
+  db: SqliteDb;
+  messageId: string;
+  events: PersistedAgentEvent[];
+  bytes: number;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+export const RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS = 250;
+const RUN_MESSAGE_EVENT_FLUSH_BYTES = 64 * 1024;
+const pendingMessageEvents = new WeakMap<ChatRunMessageState, PendingMessageEvents>();
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
 }
@@ -34,9 +46,67 @@ export function persistRunEventToAssistantMessage(
 ): void {
   if (!run.assistantMessageId) return;
   const persisted = runSseEventToPersistedAgentEvent(event, data);
-  if (!persisted) return;
+  if (!persisted) {
+    if (event === 'end' || event === 'close') flushRunMessageEvents(run);
+    return;
+  }
+
+  let pending = pendingMessageEvents.get(run);
+  if (pending && (pending.db !== db || pending.messageId !== run.assistantMessageId)) {
+    flushRunMessageEvents(run);
+    pending = undefined;
+  }
+  if (!pending) {
+    pending = {
+      db,
+      messageId: run.assistantMessageId,
+      events: [],
+      bytes: 0,
+      timer: null,
+    };
+    pendingMessageEvents.set(run, pending);
+  }
+  appendPendingMessageEvent(pending, persisted);
+
+  const isDelta = persisted.kind === 'text' || persisted.kind === 'thinking';
+  if (!isDelta || pending.bytes >= RUN_MESSAGE_EVENT_FLUSH_BYTES) {
+    flushRunMessageEvents(run);
+    return;
+  }
+  if (!pending.timer) {
+    pending.timer = setTimeout(() => {
+      flushRunMessageEvents(run);
+    }, RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS);
+    pending.timer.unref?.();
+  }
+}
+
+function appendPendingMessageEvent(
+  pending: PendingMessageEvents,
+  event: PersistedAgentEvent,
+): void {
+  const last = pending.events[pending.events.length - 1];
+  if (
+    (event.kind === 'text' || event.kind === 'thinking') &&
+    last?.kind === event.kind
+  ) {
+    last.text += event.text;
+  } else {
+    pending.events.push(event);
+  }
+  pending.bytes += event.kind === 'text' || event.kind === 'thinking'
+    ? event.text.length
+    : JSON.stringify(event).length;
+}
+
+export function flushRunMessageEvents(run: ChatRunMessageState): void {
+  const pending = pendingMessageEvents.get(run);
+  if (!pending) return;
+  pendingMessageEvents.delete(run);
+  if (pending.timer) clearTimeout(pending.timer);
+  if (pending.events.length === 0) return;
   try {
-    appendMessageAgentEvent(db, run.assistantMessageId, persisted);
+    appendMessageAgentEvents(pending.db, pending.messageId, pending.events);
   } catch (err) {
     console.warn('[runs] message event persistence failed', err);
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -124,6 +124,7 @@ import {
 import {
   daemonAgentPayloadToPersistedAgentEvent,
   persistRunEventToAssistantMessage,
+  flushRunMessageEvents,
   persistRunFailureClassification,
   pinAssistantMessageOnRunCreate,
 } from './runtimes/chat-run-messages.js';
@@ -9717,6 +9718,10 @@ export async function startServer({
     if (typeof clientRequestId === 'string' && clientRequestId)
       run.clientRequestId = clientRequestId;
     if (typeof agentId === 'string' && agentId) run.agentId = agentId;
+    const finishRun = (status, code = null, signal = null) => {
+      flushRunMessageEvents(run);
+      return design.runs.finish(run, status, code, signal);
+    };
     // Freeze the billing address once, before the first asynchronous setup
     // step. HTTP-created runs already carry the scope captured by the request
     // authorization transaction. Internal runs pin here. Retries reuse the
@@ -11044,6 +11049,7 @@ export async function startServer({
     };
     const finishWithRetryDecision = (status, code = null, signal = null) => {
       lifecycle.mark('finalize_start');
+      flushRunMessageEvents(run);
       // Persist the transport-level close mechanism before classifying this
       // attempt. Runtime fatal/stream signals are only known in the close
       // handler, and the retry classifier reads this diagnostic to distinguish
@@ -11278,7 +11284,7 @@ export async function startServer({
           });
         }
       }
-      design.runs.finish(run, status, code, signal);
+      finishRun(status, code, signal);
       return false;
     };
     const mcpServers = buildLiveArtifactsMcpServersForAgent(def, {
@@ -11422,7 +11428,7 @@ export async function startServer({
           { retryable: false },
         ),
       );
-      return design.runs.finish(run, 'failed', 1, null);
+      return finishRun('failed', 1, null);
     }
 
     let mmdRouteLaunchEnv = null;
@@ -11550,7 +11556,7 @@ export async function startServer({
                 'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.',
               action: 'relogin',
             });
-            return design.runs.finish(run, 'failed', 1, null);
+            return finishRun('failed', 1, null);
           }
         }
         // Logged in but no catalog at all AND no resolvable model: only now is
@@ -11559,7 +11565,7 @@ export async function startServer({
           send('error', createAmrModelUnavailablePayload(safeModel, {
             reason: 'model_catalog_unavailable',
           }));
-          return design.runs.finish(run, 'failed', 1, null);
+          return finishRun('failed', 1, null);
         }
         // Otherwise fall through with the user's selected model and let vela's
         // `session/set_model` be the authoritative gate.
@@ -11569,7 +11575,7 @@ export async function startServer({
           typeof model === 'string' && model.trim() ? model : safeModel,
           { availableModels: [...liveModelIds] },
         ));
-        return design.runs.finish(run, 'failed', 1, null);
+        return finishRun('failed', 1, null);
       }
       // NOTE: when the selected model is absent from the (possibly preset-only
       // or stale) catalog we intentionally do NOT fail-close. The cached/preset
@@ -11781,7 +11787,7 @@ export async function startServer({
           { retryable: false },
         ),
       );
-      return design.runs.finish(run, 'failed', 1, null);
+      return finishRun('failed', 1, null);
     }
 
     // Companion guard for non-shim Windows installs (e.g. a cargo-built
@@ -11809,7 +11815,7 @@ export async function startServer({
           { retryable: false },
         ),
       );
-      return design.runs.finish(run, 'failed', 1, null);
+      return finishRun('failed', 1, null);
     }
 
     let persistDeliveredAgentSessionState = () => {};
@@ -12166,7 +12172,7 @@ export async function startServer({
           'Install it and refresh the agent list (GET /api/agents) before retrying.',
         { retryable: true },
       ));
-      return design.runs.finish(run, 'failed', 1, null);
+      return finishRun('failed', 1, null);
     }
     const browserUseRuntimeEnv = run.browserUse
       ? {
@@ -12199,7 +12205,7 @@ export async function startServer({
           message: 'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.',
           action: 'relogin',
         });
-        return design.runs.finish(run, 'failed', 1, null);
+        return finishRun('failed', 1, null);
       }
     }
     const odMediaEnv = createOpenDesignToolEnv({
@@ -12447,7 +12453,7 @@ export async function startServer({
           ? err.message
           : `spawn failed: ${err.message}`,
       ));
-      design.runs.finish(run, 'failed', 1, null);
+      finishRun('failed', 1, null);
       return;
     }
 
@@ -12695,16 +12701,16 @@ export async function startServer({
           const succeeded = orchestratorResult.status === 'shipped'
             || orchestratorResult.status === 'below_threshold';
           if (run.cancelRequested) {
-            design.runs.finish(run, 'canceled', 1, null);
+            finishRun('canceled', 1, null);
           } else if (succeeded) {
-            design.runs.finish(run, 'succeeded', 0, null);
+            finishRun('succeeded', 0, null);
           } else {
-            design.runs.finish(run, 'failed', 1, null);
+            finishRun('failed', 1, null);
           }
         } catch (err) {
           flushVisibleAgentStderr();
           send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err instanceof Error ? err.message : String(err)));
-          design.runs.finish(run, 'failed', 1, null);
+          finishRun('failed', 1, null);
         } finally {
           critiqueRunRegistry.unregister(critiqueProjectKey, critiqueRunId);
         }
@@ -13594,7 +13600,7 @@ export async function startServer({
           'The previous session could not be resumed (it may have expired). Resend your message to continue with a fresh session.',
           { retryable: true },
         ));
-        return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
+        return finishRun('failed', code ?? 1, signal ?? null);
       }
       if (acpFatalErrorObservedBeforeCancellation && acpSession?.hasFatalError()) {
         markRpcCloseReason('fatal_rpc_error');
@@ -14092,7 +14098,7 @@ export async function startServer({
               ...(details ? { details } : {}),
             },
           ));
-          design.runs.finish(run, 'failed', 1, signal);
+          finishRun('failed', 1, signal);
           return;
         }
         try {

--- a/apps/daemon/tests/db-message-events.test.ts
+++ b/apps/daemon/tests/db-message-events.test.ts
@@ -194,4 +194,42 @@ describe('message event persistence', () => {
       { kind: 'text', text: 'done.' },
     ]);
   });
+
+  it('compacts adjacent streamed deltas from whole-message client snapshots', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Streaming snapshot project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Streaming snapshot run',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-stream-1',
+      role: 'assistant',
+      content: '',
+      runId: 'agent-run-1',
+      runStatus: 'running',
+      events: [
+        { kind: 'status', label: 'thinking' },
+        ...Array.from({ length: 1_500 }, () => ({ kind: 'thinking', text: 'x' })),
+        ...Array.from({ length: 1_500 }, () => ({ kind: 'text', text: 'y' })),
+      ],
+      startedAt: now,
+    });
+
+    expect(listMessages(db, 'conv-1')[0]?.events).toEqual([
+      { kind: 'status', label: 'thinking' },
+      { kind: 'thinking', text: 'x'.repeat(1_500) },
+      { kind: 'text', text: 'y'.repeat(1_500) },
+    ]);
+  });
 });

--- a/apps/daemon/tests/export-tool-token-authority.test.ts
+++ b/apps/daemon/tests/export-tool-token-authority.test.ts
@@ -233,6 +233,37 @@ describe('od export run-scoped project authority', () => {
     expect(existsSync(outputPath)).toBe(true);
   });
 
+  it('derives a bound project workspace without a tool token or workspace flags', async () => {
+    // Given: Harness did not forward the short-lived bearer token into its nested shell tool.
+    const outputPath = path.join(outputDir, 'project-id-bound.png');
+
+    // When: the documented wrapper command identifies only the project and file.
+    const result = await runExportCli(projectId, outputPath);
+
+    // Then: the daemon derives the exact persisted project binding instead of
+    // requiring the caller to know an active/default Workspace.
+    expect(result.code, result.stderr).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
+  it('accepts legacy workspace flags as ignored compatibility inputs', async () => {
+    // Given: an older caller still supplies stale Workspace flags.
+    const outputPath = path.join(outputDir, 'legacy-workspace-flags.png');
+
+    // When: it exports after the CLI contract has moved to project-id-only addressing.
+    const result = await runExportCli(projectId, outputPath, undefined, [
+      '--workspace',
+      'stale-workspace',
+      '--workspace-member',
+      'stale-member',
+    ]);
+
+    // Then: parsing remains backwards compatible and the stale values do not
+    // override the project's persisted binding.
+    expect(result.code, result.stderr).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+  });
+
   it('loads relative renderer assets for a bound project whose HTML already declares a base', async () => {
     // Given: a valid run token bound to a Workspace project whose renderer needs relative assets
     // and whose source HTML already declares an unrelated external base.
@@ -463,6 +494,7 @@ describe('od export run-scoped project authority', () => {
     requestedProjectId: string,
     outputPath: string,
     token?: string,
+    extraArgs: string[] = [],
   ): Promise<{ code: number; stdout: string; stderr: string }> {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
@@ -486,6 +518,7 @@ describe('od export run-scoped project authority', () => {
           'image',
           '--out',
           outputPath,
+          ...extraArgs,
         ],
         {
           cwd: daemonRoot,

--- a/apps/daemon/tests/project-consumer-cli-workspace-scope.test.ts
+++ b/apps/daemon/tests/project-consumer-cli-workspace-scope.test.ts
@@ -53,6 +53,10 @@ function authorizeProjectRequest(request: RequestRecord): {
   code?: string;
 } {
   if (request.headers.authorization === 'Bearer tool-proof') return { status: 200 };
+  // `od export` is addressed by project id. The real daemon derives the
+  // persisted Workspace binding server-side, so this transport fixture must
+  // not require caller-supplied Workspace headers for export routes.
+  if (request.url.includes('/export/')) return { status: 200 };
   if (projectForRequest(request) === 'unbound') return { status: 200 };
   const workspaceId = request.headers['x-od-workspace-id'];
   const memberId = request.headers['x-od-workspace-member-id'];
@@ -199,19 +203,6 @@ type ConsumerFixture = {
 
 const consumers: ConsumerFixture[] = [
   {
-    label: 'export',
-    args: (projectId, outputPath) => [
-      'export',
-      'index.html',
-      '--project',
-      projectId,
-      '--format',
-      'image',
-      '--out',
-      outputPath,
-    ],
-  },
-  {
     label: 'media generate and wait',
     args: (projectId) => [
       'media',
@@ -291,6 +282,17 @@ const consumers: ConsumerFixture[] = [
   },
 ];
 
+const exportArgs = (projectId: string, outputPath: string): string[] => [
+  'export',
+  'index.html',
+  '--project',
+  projectId,
+  '--format',
+  'image',
+  '--out',
+  outputPath,
+];
+
 function workspaceFlags(memberId: string): string[] {
   return [
     '--workspace',
@@ -301,6 +303,35 @@ function workspaceFlags(memberId: string): string[] {
 }
 
 describe('project consumer CLI explicit Workspace fixture matrix', () => {
+  it('export addresses a bound project without Workspace flags', async () => {
+    requests = [];
+    const result = await runCli([
+      ...exportArgs('bound-project', path.join(outputDir, 'export-project-only.out')),
+      '--daemon-url',
+      baseUrl,
+    ]);
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.headers['x-od-workspace-id']).toBeUndefined();
+    expect(requests[0]?.headers['x-od-workspace-member-id']).toBeUndefined();
+  });
+
+  it('export accepts legacy Workspace flags without forwarding them', async () => {
+    requests = [];
+    const result = await runCli([
+      ...exportArgs('bound-project', path.join(outputDir, 'export-legacy-flags.out')),
+      ...workspaceFlags(OTHER_MEMBER_ID),
+      '--daemon-url',
+      baseUrl,
+    ]);
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.headers['x-od-workspace-id']).toBeUndefined();
+    expect(requests[0]?.headers['x-od-workspace-member-id']).toBeUndefined();
+  });
+
   for (const consumer of consumers) {
     it(`${consumer.label}: allows the bound project creator`, async () => {
       requests = [];

--- a/apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts
+++ b/apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts
@@ -1,0 +1,134 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  persistRunEventToAssistantMessage,
+  RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS,
+} from '../../src/runtimes/chat-run-messages.js';
+
+function createDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      content TEXT NOT NULL DEFAULT '',
+      events_json TEXT
+    );
+    CREATE TABLE message_event_updates (count INTEGER NOT NULL DEFAULT 0);
+    INSERT INTO message_event_updates (count) VALUES (0);
+    CREATE TRIGGER count_message_event_updates
+      AFTER UPDATE OF events_json ON messages
+      BEGIN
+        UPDATE message_event_updates SET count = count + 1;
+      END;
+  `);
+  return db;
+}
+
+describe('run message event persistence', () => {
+  let db: Database.Database | null = null;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    db?.close();
+    db = null;
+  });
+
+  it('coalesces a high-volume delta stream before synchronously rewriting the message', () => {
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+    const deltas = Array.from({ length: 1_500 }, (_, index) => `chunk-${index};`);
+
+    for (const delta of deltas) {
+      persistRunEventToAssistantMessage(db, run, 'agent', {
+        type: 'text_delta',
+        delta,
+      });
+    }
+    persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+
+    const message = db.prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-1') as { content: string; eventsJson: string };
+    const updates = db.prepare(`SELECT count FROM message_event_updates`).get() as { count: number };
+    const text = deltas.join('');
+
+    expect(message.content).toBe(text);
+    expect(JSON.parse(message.eventsJson)).toEqual([{ kind: 'text', text }]);
+    expect(updates.count).toBeLessThanOrEqual(2);
+  });
+
+  it('keeps 100,000 tiny deltas linear in persisted size and database writes', () => {
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+
+    for (let index = 0; index < 100_000; index += 1) {
+      persistRunEventToAssistantMessage(db, run, 'agent', {
+        type: index < 50_000 ? 'text_delta' : 'thinking_delta',
+        delta: 'x',
+      });
+    }
+    persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+
+    const message = db.prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-1') as { content: string; eventsJson: string };
+    const updates = db.prepare(`SELECT count FROM message_event_updates`).get() as { count: number };
+    const events = JSON.parse(message.eventsJson) as Array<{ kind: string; text: string }>;
+
+    expect(message.content).toHaveLength(50_000);
+    expect(events).toEqual([
+      { kind: 'text', text: 'x'.repeat(50_000) },
+      { kind: 'thinking', text: 'x'.repeat(50_000) },
+    ]);
+    expect(updates.count).toBeLessThanOrEqual(2);
+  });
+
+  it('flushes deltas on the interval boundary and semantic events immediately', async () => {
+    vi.useFakeTimers();
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+
+    persistRunEventToAssistantMessage(db, run, 'agent', {
+      type: 'text_delta',
+      delta: 'hello',
+    });
+    await vi.advanceTimersByTimeAsync(RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS - 1);
+    expect(db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-1')).toEqual({ eventsJson: '[]' });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-1')).toEqual({
+      eventsJson: JSON.stringify([{ kind: 'text', text: 'hello' }]),
+    });
+
+    persistRunEventToAssistantMessage(db, run, 'agent', {
+      type: 'thinking_delta',
+      delta: 'checking',
+    });
+    persistRunEventToAssistantMessage(db, run, 'agent', {
+      type: 'tool_use',
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'brief.md' },
+    });
+
+    const message = db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-1') as { eventsJson: string };
+    expect(JSON.parse(message.eventsJson)).toEqual([
+      { kind: 'text', text: 'hello' },
+      { kind: 'thinking', text: 'checking' },
+      {
+        kind: 'tool_use',
+        id: 'tool-1',
+        name: 'Read',
+        input: { file_path: 'brief.md' },
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6982,7 +6982,10 @@ export function ProjectView({
       };
       const pushEvent = (ev: AgentEvent) => {
         textBuffer.flush();
-        updateAssistant((prev) => ({ ...prev, events: [...(prev.events ?? []), ev] }));
+        updateAssistant((prev) => ({
+          ...prev,
+          events: appendCoalescedAgentEvent(prev.events ?? [], ev),
+        }));
         if (ev.kind === 'live_artifact') {
           setLiveArtifactEvents((prev) => appendLiveArtifactEventItem(prev, ev));
           void refreshLiveArtifacts().then(() => {
@@ -7179,6 +7182,7 @@ export function ProjectView({
             return;
           }
           if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
+          else if (ev.kind === 'thinking') textBuffer.appendEvent(ev);
           else pushEvent(ev);
         },
         onToolInputDelta: (id: string, name: string, delta: string) => {
@@ -12395,6 +12399,7 @@ export function createBufferedTextUpdates({
 }) {
   let pendingContentDelta = '';
   let pendingTextEventDelta = '';
+  let pendingThinkingEventDelta = '';
   let flushFrame: number | null = null;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   let disposed = false;
@@ -12421,27 +12426,36 @@ export function createBufferedTextUpdates({
       return;
     }
     cancelScheduledFlush();
-    if (!pendingContentDelta && !pendingTextEventDelta && !needsFlush) return;
+    if (
+      !pendingContentDelta
+      && !pendingTextEventDelta
+      && !pendingThinkingEventDelta
+      && !needsFlush
+    ) return;
     flushing = true;
     needsFlush = false;
     const contentDelta = pendingContentDelta;
     const textEventDelta = pendingTextEventDelta;
+    const thinkingEventDelta = pendingThinkingEventDelta;
     pendingContentDelta = '';
     pendingTextEventDelta = '';
+    pendingThinkingEventDelta = '';
     try {
       updateMessage((prev) => ({
         ...prev,
         content: prev.content + contentDelta,
-        events: textEventDelta
-          ? [...(prev.events ?? []), { kind: 'text', text: textEventDelta }]
-          : prev.events,
+        events: appendBufferedAgentDeltas(
+          prev.events ?? [],
+          textEventDelta,
+          thinkingEventDelta,
+        ),
       }));
       persistSoon();
       if (contentDelta) onContentDelta?.(contentDelta);
     } finally {
       flushing = false;
     }
-    if (pendingContentDelta || pendingTextEventDelta || needsFlush) {
+    if (pendingContentDelta || pendingTextEventDelta || pendingThinkingEventDelta || needsFlush) {
       needsFlush = false;
       scheduleFlush();
     }
@@ -12468,6 +12482,7 @@ export function createBufferedTextUpdates({
 
   const appendTextEvent = (delta: string) => {
     if (disposed) return;
+    if (pendingThinkingEventDelta) flush();
     pendingTextEventDelta += delta;
     needsFlush = true;
     scheduleFlush();
@@ -12479,8 +12494,18 @@ export function createBufferedTextUpdates({
       appendTextEvent(ev.text);
       return;
     }
+    if (ev.kind === 'thinking') {
+      if (pendingTextEventDelta) flush();
+      pendingThinkingEventDelta += ev.text;
+      needsFlush = true;
+      scheduleFlush();
+      return;
+    }
     flush();
-    updateMessage((prev) => ({ ...prev, events: [...(prev.events ?? []), ev] }));
+    updateMessage((prev) => ({
+      ...prev,
+      events: appendCoalescedAgentEvent(prev.events ?? [], ev),
+    }));
     persistSoon();
   };
 
@@ -12489,6 +12514,7 @@ export function createBufferedTextUpdates({
     cancelScheduledFlush();
     pendingContentDelta = '';
     pendingTextEventDelta = '';
+    pendingThinkingEventDelta = '';
     needsFlush = false;
     if (hasDocument) {
       document.removeEventListener('visibilitychange', onVisibilityChange);
@@ -12524,4 +12550,31 @@ export function createBufferedTextUpdates({
   const hasPendingText = () => pendingTextEventDelta.length > 0;
 
   return { appendContent, appendTextEvent, appendEvent, flush, cancel, hasPendingText };
+}
+
+function appendCoalescedAgentEvent(events: AgentEvent[], event: AgentEvent): AgentEvent[] {
+  const last = events[events.length - 1];
+  if (
+    (event.kind === 'text' || event.kind === 'thinking')
+    && last?.kind === event.kind
+  ) {
+    return [
+      ...events.slice(0, -1),
+      { ...last, text: last.text + event.text },
+    ];
+  }
+  return [...events, event];
+}
+
+function appendBufferedAgentDeltas(
+  events: AgentEvent[],
+  textDelta: string,
+  thinkingDelta: string,
+): AgentEvent[] {
+  let next = events;
+  if (textDelta) next = appendCoalescedAgentEvent(next, { kind: 'text', text: textDelta });
+  if (thinkingDelta) {
+    next = appendCoalescedAgentEvent(next, { kind: 'thinking', text: thinkingDelta });
+  }
+  return next;
 }

--- a/apps/web/tests/components/buffered-text-pending.test.tsx
+++ b/apps/web/tests/components/buffered-text-pending.test.tsx
@@ -40,4 +40,29 @@ describe('createBufferedTextUpdates pending text accounting', () => {
 
     buf.cancel();
   });
+
+  it('coalesces adjacent thinking deltas into one frame update', () => {
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+
+    let msg = { events: [] } as unknown as ChatMessage;
+    let updates = 0;
+    const buf = createBufferedTextUpdates({
+      updateMessage: (u) => {
+        msg = u(msg);
+        updates += 1;
+      },
+      persistSoon: () => {},
+    });
+
+    for (let index = 0; index < 1_500; index += 1) {
+      buf.appendEvent({ kind: 'thinking', text: 'x' });
+    }
+
+    expect(msg.events).toEqual([]);
+    buf.flush();
+    expect(msg.events).toEqual([{ kind: 'thinking', text: 'x'.repeat(1_500) }]);
+    expect(updates).toBe(1);
+    buf.cancel();
+  });
 });


### PR DESCRIPTION
## Why

While validating DeepSeek Harness end to end, long thinking/text streams caused the web client and daemon to repeatedly rewrite an ever-growing message event snapshot. The page could remain busy long after useful output appeared, and cancellation/terminal transitions risked leaving the last buffered deltas unpersisted.

The same validation exposed a second recurring failure: agents knew the project and artifact path but `od export` still required Workspace headers. Missing or stale Workspace context caused `WORKSPACE_CONTEXT_REQUIRED` / access failures, retries, and wasted tokens even though the project already has one persisted Workspace binding.

## What users will see

- Thinking and text continue to appear progressively in chat, while persistence and React updates are coalesced behind the scenes so long streams remain responsive.
- `od export <file> --project <id> ...` works without Workspace/member arguments. Existing scripts that still pass `--workspace` or `--workspace-member` keep working; those legacy values are accepted and ignored.
- Image/PDF/PPTX export still uses the desktop renderer. If the desktop renderer is unavailable, the existing renderer error remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface. The existing chat remains visually streaming; the change reduces update/persistence frequency without changing the rendered result.

## Bug fix verification

- Red specs:
  - `apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts`
  - `apps/daemon/tests/db-message-events.test.ts`
  - `apps/web/tests/components/buffered-text-pending.test.tsx`
  - `apps/daemon/tests/export-tool-token-authority.test.ts`
  - `apps/daemon/tests/project-consumer-cli-workspace-scope.test.ts`
- Red on the pre-fix source:
  - each stream delta produced an immediate message-table rewrite and adjacent text/thinking events remained fragmented;
  - project-only export returned `WORKSPACE_CONTEXT_REQUIRED`;
  - stale legacy Workspace flags returned `WORKSPACE_ACCESS_DENIED`.
- Green on this branch: yes.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 6,513 passed, 1 expected failure, 11 skipped
- `pnpm --filter @open-design/daemon test` — 8,518 passed, 6 skipped across 671 files
- Focused daemon/web regression tests for batching, terminal flush, event compaction, project-only export, and legacy flag compatibility
- DeepSeek Harness + local daemon/web/desktop + Chrome end-to-end:
  - project-only standalone HTML export: 40,378 bytes
  - project-only PNG export: valid RGB PNG, 2,880 × 2,000, 387,191 bytes
  - exactly one `od export` invocation, without Workspace/member flags, help lookup, or retry
- Open Browser Use independently verified the completed run and absence of `WORKSPACE_CONTEXT_REQUIRED`
- `od export --help` no longer exposes Workspace/member flags

