### PR TITLE
fix(daemon): resolve PptxGenJS constructor across tsx CJS interop shapes

### DIFF
--- a/apps/daemon/src/deck-export.ts
+++ b/apps/daemon/src/deck-export.ts
@@ -8,9 +8,28 @@ import type { DesktopRenderSlidesInput } from '@open-design/sidecar-proto';
 
 // pptxgenjs ships a default-export class, but its NodeNext typings resolve the
 // default to the module namespace (no construct signature). At runtime the ESM
-// build's default IS the class, so reach it and re-type as a constructor.
+// build's default IS the class — except under tsx (the tools-dev daemon
+// runtime), which loads the CJS build and double-wraps it so `Module.default`
+// is `{ default: PptxGenJS }`, and `new PptxGenJSModule.default()` dies with
+// "PptxGenJS is not a constructor". Resolve every known shape once at module
+// load: bare CJS (the namespace itself is the class), pure ESM (default = the
+// class), and tsx CJS interop (default.default = the class).
 type PptxInstance = InstanceType<typeof import('pptxgenjs').default>;
-const PptxGenJS = PptxGenJSModule.default as unknown as { new (): PptxInstance };
+export type PptxConstructor = { new (): PptxInstance };
+
+export function resolvePptxConstructor(mod: unknown): PptxConstructor {
+  if (typeof mod === 'function') return mod as PptxConstructor;
+  const candidate = (mod as { default?: unknown } | null | undefined)?.default;
+  if (typeof candidate === 'function') return candidate as PptxConstructor;
+  const nested = (candidate as { default?: unknown } | null | undefined)?.default;
+  if (typeof nested === 'function') return nested as PptxConstructor;
+  throw new Error(
+    'unable to resolve the PptxGenJS constructor from the pptxgenjs module shape '
+      + `(typeof module: ${typeof mod}, typeof default: ${typeof candidate})`,
+  );
+}
+
+const PptxGenJS: PptxConstructor = resolvePptxConstructor(PptxGenJSModule);
 
 import { readProjectFile } from './projects.js';
 

--- a/apps/daemon/tests/deck-export.test.ts
+++ b/apps/daemon/tests/deck-export.test.ts
@@ -12,6 +12,7 @@ import {
   buildDeckRenderInput,
   decodeSlideDataUrls,
   readSlideFiles,
+  resolvePptxConstructor,
 } from '../src/deck-export.js';
 
 // 1x1 transparent PNG.
@@ -45,6 +46,34 @@ describe('decodeSlideDataUrls', () => {
 
   it('rejects a value that is not a data URL', () => {
     expect(() => decodeSlideDataUrls(['not-a-data-url'])).toThrow();
+  });
+});
+
+describe('resolvePptxConstructor', () => {
+  // Stands in for the real class; only the module shape matters here.
+  class FakePptxGenJS {}
+
+  it('resolves the bare CJS shape where the namespace itself is the constructor', () => {
+    expect(resolvePptxConstructor(FakePptxGenJS)).toBe(FakePptxGenJS);
+  });
+
+  it('resolves the pure ESM shape where default is the constructor', () => {
+    expect(resolvePptxConstructor({ default: FakePptxGenJS })).toBe(FakePptxGenJS);
+  });
+
+  it('resolves the tsx CJS-interop shape where default is double-wrapped', () => {
+    // tsx (the tools-dev daemon runtime) loads pptxgenjs's CJS build and wraps
+    // it so the namespace's `.default` is an object whose own `.default` is the
+    // class. Reaching only one level — as the old
+    // `PptxGenJSModule.default as ...` did — constructs a plain Object and
+    // fails with "PptxGenJS is not a constructor" on every PPTX export.
+    expect(resolvePptxConstructor({ default: { default: FakePptxGenJS } })).toBe(FakePptxGenJS);
+  });
+
+  it('throws on shapes with no reachable constructor', () => {
+    expect(() => resolvePptxConstructor({})).toThrow(/unable to resolve/);
+    expect(() => resolvePptxConstructor({ default: {} })).toThrow(/unable to resolve/);
+    expect(() => resolvePptxConstructor(null)).toThrow(/unable to resolve/);
   });
 });
 


### PR DESCRIPTION
## Why

Hit this myself while running OD from source on WSL2. After starting the full dev stack (`pnpm tools-dev start desktop`, so the desktop sidecar renderer is live), every PPTX export from the file viewer failed with:

```
{"error":{"code":"BAD_REQUEST","message":"PptxGenJS is not a constructor"}}
```

Root cause: `apps/daemon/src/deck-export.ts` reached the PptxGenJS class via `PptxGenJSModule.default`. In the packaged runtime (pure ESM) that is the class, so this worked. But the tools-dev daemon runs through **tsx**, which loads pptxgenjs's CommonJS build and double-wraps it — the namespace's `.default` is `{ default: PptxGenJS }`. Constructing that yields a plain `Object`, and `buildScreenshotPptx` dies at `new PptxGenJS()` before any slide is assembled. The vitest suite never caught it because vitest resolves the same import through Node's own CJS interop, where `.default` is the class.

## What users will see

Nothing new — a broken path works again. In dev-mode daemon runs (`tools-dev`), "Export as PPTX" (both screenshot and editable modes) returns a real `.pptx` instead of a 400 with "PptxGenJS is not a constructor". Packaged runtime behavior is unchanged.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal bug fix in `apps/daemon` plus regression tests; no new surface.

## Screenshots

N/A — no UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/deck-export.test.ts` → `describe('resolvePptxConstructor')` (4 new specs covering bare-CJS, pure-ESM, tsx double-wrapped, and unreachable-constructor shapes).
- Did the test go red on `main` and green on this branch? **Yes.** With the new tests applied on top of unmodified `main` source: `4 failed | 17 passed`. With this branch: `21 passed` (`pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/deck-export.test.ts`).

## Validation

- `pnpm guard` — pass.
- `pnpm typecheck` — pass.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/deck-export.test.ts` — 21/21 pass.
- End-to-end on the dev stack (WSL2, daemon via `tools-dev start desktop`): `POST /api/projects/:id/export/pptx` now returns HTTP 200 with a valid OOXML zip (screenshot mode, 261 KB; editable mode, 18 KB with native slide XML), where the same request returned HTTP 400 `PptxGenJS is not a constructor` before the fix.
