### PR TITLE
fix(web): coalesce full replay events during reattach

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5531,7 +5531,7 @@ export function ProjectView({
                 genericDisconnectRetriesRef.current.delete(runId);
               }
               genericDisconnectBackoffUntilRef.current.delete(runId);
-              replayedEvents = [...replayedEvents, ev];
+              replayedEvents = appendCoalescedAgentEvent(replayedEvents, ev);
               textBuffer.appendEvent(ev);
             },
             onDone: async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -940,6 +940,76 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('coalesces adjacent thinking events while saving a full reattach replay', async () => {
+    const startedAt = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-reattach-full-replay-thinking',
+        role: 'assistant',
+        content: '',
+        createdAt: startedAt,
+        startedAt,
+        runId: 'run-full-replay-thinking',
+        runStatus: 'running',
+        preTurnFileNames: [],
+        events: [],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-full-replay-thinking',
+      status: 'running',
+      createdAt: startedAt,
+      updatedAt: startedAt,
+      exitCode: null,
+      signal: null,
+    });
+    listActiveChatRuns.mockResolvedValue([]);
+
+    let captured: {
+      onAgentEvent: (ev: unknown) => void;
+      onDone: () => void;
+    } | null = null;
+    reattachDaemonRun.mockImplementation(async (options: any) => {
+      captured = {
+        onAgentEvent: options.handlers.onAgentEvent,
+        onDone: options.handlers.onDone,
+      };
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+
+    await waitFor(() => expect(reattachDaemonRun).toHaveBeenCalledTimes(1));
+    expect(captured).not.toBeNull();
+    for (let index = 0; index < 1_500; index += 1) {
+      captured!.onAgentEvent({ kind: 'thinking', text: 'thought ' });
+    }
+    captured!.onDone();
+
+    await waitFor(() => {
+      const finalMessage = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .filter(
+          (message) =>
+            message?.id === 'msg-reattach-full-replay-thinking' &&
+            message.runStatus === 'succeeded',
+        )
+        .at(-1);
+      expect(finalMessage?.events).toHaveLength(1);
+      expect(finalMessage?.events).toEqual([
+        { kind: 'thinking', text: 'thought '.repeat(1_500) },
+      ]);
+    });
+  });
+
   it('clears touched-file paths after a failed run before the next successful run finalizes', async () => {
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([]);


### PR DESCRIPTION
Fixes #6924

## Why

During a full daemon reattach replay, `ProjectView` feeds each event through the buffered UI path but also accumulates a separate raw `replayedEvents` array. On completion, that raw array replaces the already-coalesced message events. Long adjacent text or thinking streams therefore regain transport-level fragmentation and the accumulator repeatedly copies an ever-growing array.

The existing `appendCoalescedAgentEvent` helper already defines the intended event semantics, so the full-replay accumulator should reuse it while events arrive rather than introduce another compaction rule or defer work until `onDone`.

## What users will see

- Long full-replay reattach streams keep adjacent text and thinking deltas compact through completion instead of expanding back into raw transport events.
- Text/thinking transitions and tool use/result, status, and error event boundaries remain unchanged.
- Partial replay behavior remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this changes replay event accumulation without adding or changing a visual surface.

## Bug fix verification

- Red spec: `apps/web/tests/components/ProjectView.reattach-restore.test.tsx`
- Red on the pre-fix callsite: the real `onAgentEvent → onDone → saveMessage` path persisted 1,500 adjacent thinking events when the assertion expected 1.
- Green on this branch: the same path persists one thinking event containing the combined text.

## Validation

- Focused full-replay regression: 1 passed, 36 skipped
- `ProjectView.reattach-restore.test.tsx` + `buffered-text-pending.test.tsx`: 39 passed
- Daemon message-event persistence regressions: 8 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

## Overlap with draft PR #6508

Draft PR #6508 touches the same broad `ProjectView` reattach region for bounded terminal Design delivery replay. It does not address this raw full-replay accumulator. This PR is intentionally limited to the accumulator callsite and its integration regression; if #6508 lands first, the overlap should require only a mechanical rebase while preserving this coalescing behavior.
