### PR TITLE
fix(daemon): let MCP clients pin a workspace via OD_MCP_WORKSPACE_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [Fixed] Long speaker notes are now scrollable inside the presenter view instead of being clipped when notes push the layout past the viewport. (#6271)
+- [Fixed] The MCP bridge now honors an `OD_MCP_WORKSPACE_ID` env var so accounts with both a personal and a team workspace can point MCP project/run tools at the team workspace instead of always defaulting to the personal one.
 
 ## [0.9.0] - 2026-05-29
 

--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -16,7 +16,14 @@ import type {
  *
  * Selection mirrors the daemon's own `selectDefaultCandidate`
  * (collab/vela-workspace-context.ts): active memberships only, then the
- * personal workspace, then the first remaining candidate.
+ * personal workspace, then the first remaining candidate. The daemon-side
+ * caller feeds its locally pinned workspace in as the preferred id, but the
+ * bridge is a separate stdio process with no view of the UI's per-request
+ * workspace headers — so for a multi-workspace account (personal + team) the
+ * default pick is always the personal workspace and a UI switch changes
+ * nothing. `OD_MCP_WORKSPACE_ID` lets an MCP client pin the bridge to another
+ * workspace (e.g. the team one); an id that is not an active membership falls
+ * back to the default pick.
  */
 
 export interface McpWorkspaceContext {
@@ -30,6 +37,13 @@ export interface McpWorkspaceContext {
 export const MCP_WORKSPACE_CONTEXT_TTL_MS = 15_000;
 /** Back off after a directory outage instead of hammering the daemon. */
 export const MCP_WORKSPACE_FAILURE_COOLDOWN_MS = 60_000;
+
+/**
+ * Env var pinning the bridge to one workspace. The default pick is
+ * personal-first, so a multi-workspace account needs this to reach its team
+ * workspace from MCP at all.
+ */
+export const MCP_WORKSPACE_OVERRIDE_ENV = 'OD_MCP_WORKSPACE_ID';
 
 const DIRECTORY_TIMEOUT_MS = 8_000;
 
@@ -63,9 +77,11 @@ const lastFailureAt = new Map<string, number>();
 
 /**
  * Resolve the signed-in workspace to scope MCP project/run calls, or null for a
- * headerless fallback (non-vela, signed-out, or a directory outage). Results are
- * cached per base URL for MCP_WORKSPACE_CONTEXT_TTL_MS; failures suppress
- * re-fetch for MCP_WORKSPACE_FAILURE_COOLDOWN_MS. `force` bypasses both.
+ * headerless fallback (non-vela, signed-out, or a directory outage). Honors
+ * `OD_MCP_WORKSPACE_ID` as the preferred workspace before the personal-first
+ * default. Results are cached per base URL for MCP_WORKSPACE_CONTEXT_TTL_MS;
+ * failures suppress re-fetch for MCP_WORKSPACE_FAILURE_COOLDOWN_MS. `force`
+ * bypasses both.
  */
 export async function resolveMcpWorkspaceContext(
   baseUrl: string,
@@ -94,7 +110,8 @@ export async function resolveMcpWorkspaceContext(
       return null;
     }
     const data = (await resp.json()) as WorkspaceDirectoryResponse;
-    const selected = selectDefaultMcpCandidate(data.items);
+    const preferredId = process.env[MCP_WORKSPACE_OVERRIDE_ENV]?.trim() || undefined;
+    const selected = selectDefaultMcpCandidate(data.items, preferredId);
     if (!selected) {
       // 200 with empty items — non-vela (dev provider) or no live membership.
       recordFailure(baseUrl);

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -427,7 +427,8 @@ export const TOOL_DEFS = [
   },
   {
     name: 'list_projects',
-    description: 'List every Open Design project on this daemon.',
+    description:
+      'List every Open Design project on this daemon. For accounts with several workspaces this lists the one the bridge selected (personal workspace first); pin a specific workspace by setting OD_MCP_WORKSPACE_ID in the MCP server environment.',
     inputSchema: {
       type: 'object',
       properties: { pluginWorkflowId: PLUGIN_WORKFLOW_ID_ARG },

--- a/apps/daemon/tests/mcp-workspace-projects.test.ts
+++ b/apps/daemon/tests/mcp-workspace-projects.test.ts
@@ -218,3 +218,104 @@ describe('MCP headerless fallback (#6569)', () => {
     expect(body.projects[0]?.name).toBe('Unbound');
   });
 });
+
+describe('MCP workspace selection for multi-workspace accounts', () => {
+  const MULTI_DIRECTORY = {
+    items: [
+      {
+        workspaceId: 'ws-team',
+        workspaceName: 'Team',
+        workspaceType: 'team',
+        workspaceMemberId: 'mem-team',
+        role: 'owner',
+        memberStatus: 'active',
+        lifecycleState: 'active',
+      },
+      {
+        workspaceId: 'ws-personal',
+        workspaceName: 'Personal',
+        workspaceType: 'personal',
+        workspaceMemberId: 'mem-personal',
+        role: 'owner',
+        memberStatus: 'active',
+        lifecycleState: 'active',
+      },
+    ],
+    activeWorkspaceId: null,
+  };
+
+  function multiDirectoryResponse(): Response {
+    return new Response(JSON.stringify(MULTI_DIRECTORY), { status: 200 });
+  }
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function listProjectsFetchMock(seen: Array<{ url: string; init?: RequestInit | undefined }>) {
+    return vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return multiDirectoryResponse();
+      if (url.includes('/api/workspaces/ws-team/projects')) {
+        return new Response(
+          JSON.stringify({
+            projects: [{ id: 't1', name: 'Team Demo', workspaceId: 'ws-team' }],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes('/api/workspaces/ws-personal/projects')) {
+        return new Response(
+          JSON.stringify({
+            projects: [{ id: 'p1', name: 'Personal Demo', workspaceId: 'ws-personal' }],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ projects: [] }), { status: 200 });
+    });
+  }
+
+  it('defaults to the personal workspace when no override is set', async () => {
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    vi.stubGlobal('fetch', listProjectsFetchMock(seen));
+
+    const result = await handleMcpToolCall(BASE, 'list_projects', {});
+
+    const scoped = seen.find((c) => c.url.includes('/api/workspaces/ws-personal/projects'));
+    expect(scoped).toBeTruthy();
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-personal');
+    const body = firstJson<{ projects: Array<{ name: string }> }>(result);
+    expect(body.projects[0]?.name).toBe('Personal Demo');
+  });
+
+  it('OD_MCP_WORKSPACE_ID pins the bridge to the team workspace', async () => {
+    vi.stubEnv('OD_MCP_WORKSPACE_ID', 'ws-team');
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    vi.stubGlobal('fetch', listProjectsFetchMock(seen));
+
+    const result = await handleMcpToolCall(BASE, 'list_projects', {});
+
+    const scoped = seen.find((c) => c.url.includes('/api/workspaces/ws-team/projects'));
+    expect(scoped).toBeTruthy();
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-team');
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-team');
+    const body = firstJson<{ projects: Array<{ name: string }> }>(result);
+    expect(body.projects[0]?.name).toBe('Team Demo');
+  });
+
+  it('falls back to the default pick when the override is not an active membership', async () => {
+    vi.stubEnv('OD_MCP_WORKSPACE_ID', 'ws-gone');
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
+    vi.stubGlobal('fetch', listProjectsFetchMock(seen));
+
+    const result = await handleMcpToolCall(BASE, 'list_projects', {});
+
+    const scoped = seen.find((c) => c.url.includes('/api/workspaces/ws-personal/projects'));
+    expect(scoped).toBeTruthy();
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    const body = firstJson<{ projects: Array<{ name: string }> }>(result);
+    expect(body.projects[0]?.name).toBe('Personal Demo');
+  });
+});


### PR DESCRIPTION
## Problem

For an account holding both a personal and a team workspace, the MCP stdio bridge can only ever see the personal workspace:

- `list_projects` never lists team-workspace projects
- reads of a team-workspace project fail with `403 WORKSPACE_PROJECT_PERMISSION_DENIED`
- switching the active workspace in the app changes nothing: the UI selection travels per request (`x-od-workspace-*` headers, #6569) and the bridge is a separate stdio process with no view of it

## Root cause

`resolveMcpWorkspaceContext` (`apps/daemon/src/mcp-workspace-context.ts`) picks the workspace with `selectDefaultMcpCandidate`, a port of the daemon's own `selectDefaultCandidate` (`collab/vela-workspace-context.ts`). The daemon-side caller feeds its locally pinned workspace in as the preferred id; the bridge port dropped that input, so the bridge's `preferredId` parameter was dead code and the pick is always personal-first.

## Fix

Wire the dead `preferredId` input to an `OD_MCP_WORKSPACE_ID` env var that MCP clients can set in their server configuration:

```json
{ "mcpServers": { "open-design": { "env": { "OD_MCP_WORKSPACE_ID": "<workspace-id>" } } } }
```

An id that is not an active membership falls back to the default personal-first pick, matching daemon-side `selectDefaultCandidate` semantics. All 15 project/run tools pick up the override because they share `resolveMcpWorkspaceContext`.

Also documents the override in the `list_projects` tool description so agents can discover it, plus a CHANGELOG entry.

## Testing

- 3 new cases in `apps/daemon/tests/mcp-workspace-projects.test.ts`: default pick is the personal workspace for a multi-workspace account; `OD_MCP_WORKSPACE_ID` pins the bridge to the team workspace; an unknown id falls back to the default pick.
- `pnpm vitest run tests/mcp` in `apps/daemon`: 26 files / 344 tests pass.
- `pnpm run typecheck` in `apps/daemon` passes.