### PR TITLE
Fix OpenCode tool error normalization

### DIFF
--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -7,6 +7,7 @@ type ParserState = {
   cursorTextSoFar: string;
   cursorTurnStart: number;
   openCodeToolUses: Set<string>;
+  openCodeToolResults: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
   codexPreviousEventWasAgentMessage: boolean;
@@ -153,6 +154,48 @@ function formatOpenCodeUsage(tokens: unknown): Usage | null {
   return Object.keys(usage).length > 0 ? usage : null;
 }
 
+function isPowerShellErrorRecord(toolName: string, output: unknown): boolean {
+  const normalizedTool = toolName.toLowerCase();
+  if (normalizedTool !== 'bash' && normalizedTool !== 'shell') return false;
+  if (typeof output !== 'string') return false;
+
+  // A PowerShell non-terminating error can leave the shell process at exit 0.
+  // Require both canonical ErrorRecord fields so ordinary output containing a
+  // word such as "failed" does not become an error result.
+  return (
+    /(?:^|\r?\n)\s*\+\s*CategoryInfo\s*:/u.test(output) &&
+    /(?:^|\r?\n)\s*\+\s*FullyQualifiedErrorId\s*:/u.test(output)
+  );
+}
+
+function openCodeToolResult(
+  toolName: string,
+  statePart: JsonObject,
+): { content: string; isError: boolean } | null {
+  const status = typeof statePart.status === 'string' ? statePart.status.toLowerCase() : '';
+  if (status !== 'completed' && status !== 'error' && status !== 'failed') return null;
+
+  const metadata = isRecord(statePart.metadata) ? statePart.metadata : {};
+  const exitCodes = [statePart.exit, statePart.exitCode, metadata.exit];
+  const hasNonZeroExit = exitCodes.some(
+    (exitCode) => typeof exitCode === 'number' && Number.isFinite(exitCode) && exitCode !== 0,
+  );
+  const explicitError =
+    (typeof statePart.error === 'string' && statePart.error.trim().length > 0) ||
+    (isRecord(statePart.error) && Object.keys(statePart.error).length > 0)
+      ? statePart.error
+      : null;
+  const isError =
+    status === 'error' ||
+    status === 'failed' ||
+    explicitError !== null ||
+    hasNonZeroExit ||
+    isPowerShellErrorRecord(toolName, statePart.output);
+  const contentSource = explicitError ?? statePart.output;
+
+  return { content: stringifyContent(contentSource), isError };
+}
+
 function handleOpenCodeEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
   const part = isRecord(obj.part) ? obj.part : {};
@@ -188,12 +231,14 @@ function handleOpenCodeEvent(obj: unknown, onEvent: StreamEventHandler, state: P
         input: safeParseJson(statePart?.input) ?? statePart?.input ?? null,
       });
     }
-    if (statePart?.status === 'completed') {
+    const result = statePart ? openCodeToolResult(part.tool, statePart) : null;
+    if (result && !state.openCodeToolResults.has(key)) {
+      state.openCodeToolResults.add(key);
       onEvent({
         type: 'tool_result',
         toolUseId: part.callID,
-        content: stringifyContent(statePart.output),
-        isError: false,
+        content: result.content,
+        isError: result.isError,
       });
     }
     return true;
@@ -876,6 +921,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
     cursorTextSoFar: '',
     cursorTurnStart: 0,
     openCodeToolUses: new Set<string>(),
+    openCodeToolResults: new Set<string>(),
     codexToolUses: new Set<string>(),
     codexErrorEmitted: false,
     codexPreviousEventWasAgentMessage: false,

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { createJsonEventStreamHandler } from '../../src/runtimes/json-event-stream.js';
+import { createToolLoopGuard, type ToolLoopVerdict } from '../../src/tool-loop-guard.js';
 
 type JsonStreamEvent = Record<string, unknown>;
 
@@ -74,6 +75,221 @@ test('opencode json stream emits tool events', () => {
     { type: 'tool_use', id: 'call-1', name: 'read', input: { file: 'foo.txt' } },
     { type: 'tool_result', toolUseId: 'call-1', content: 'done', isError: false },
   ]);
+});
+
+test('opencode json stream marks structured tool failures as errors', () => {
+  const cases = [
+    {
+      name: 'completed tool with a non-zero metadata exit',
+      state: { status: 'completed', output: 'command failed', metadata: { exit: 1 } },
+      content: 'command failed',
+    },
+    {
+      name: 'completed tool with a direct non-zero exitCode',
+      state: { status: 'completed', output: 'command failed', exitCode: 2 },
+      content: 'command failed',
+    },
+    {
+      name: 'completed tool with a direct non-zero exit',
+      state: { status: 'completed', output: 'command failed', exit: 3 },
+      content: 'command failed',
+    },
+    {
+      name: 'completed tool with an explicit error',
+      state: { status: 'completed', output: 'partial output', error: 'tool failed' },
+      content: 'tool failed',
+    },
+    {
+      name: 'official error state',
+      state: { status: 'error', output: 'partial output', error: 'permission denied' },
+      content: 'permission denied',
+    },
+    {
+      name: 'legacy failed state',
+      state: { status: 'failed', output: 'process failed' },
+      content: 'process failed',
+    },
+    {
+      name: 'PowerShell non-terminating ErrorRecord with exit zero',
+      state: {
+        status: 'completed',
+        output:
+          "Get-Content : Cannot find path 'missing.txt' because it does not exist.\r\n" +
+          '    + CategoryInfo          : ObjectNotFound: (missing.txt:String) [Get-Content], ItemNotFoundException\r\n' +
+          '    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand',
+        metadata: { exit: 0 },
+      },
+      content:
+        "Get-Content : Cannot find path 'missing.txt' because it does not exist.\r\n" +
+        '    + CategoryInfo          : ObjectNotFound: (missing.txt:String) [Get-Content], ItemNotFoundException\r\n' +
+        '    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand',
+    },
+  ];
+
+  for (const [index, testCase] of cases.entries()) {
+    const { events, handler } = collectEvents('opencode');
+    handler.feed(
+      JSON.stringify({
+        type: 'tool_use',
+        part: {
+          tool: 'bash',
+          callID: `call-${index}`,
+          state: {
+            input: { command: 'exit 1' },
+            ...testCase.state,
+          },
+        },
+      }) + '\n',
+    );
+
+    assert.deepEqual(
+      events.at(-1),
+      {
+        type: 'tool_result',
+        toolUseId: `call-${index}`,
+        content: testCase.content,
+        isError: true,
+      },
+      testCase.name,
+    );
+  }
+});
+
+test('opencode json stream preserves successful and non-terminal tool states', () => {
+  const { events, handler } = collectEvents('opencode');
+
+  for (const [callID, state] of [
+    ['success', { status: 'completed', output: 'done', metadata: { exit: 0 } }],
+    ['false-error', { status: 'completed', output: 'done', error: false }],
+    ['zero-error', { status: 'completed', output: 'done', error: 0 }],
+    ['pending', { status: 'pending', input: { command: 'pwd' } }],
+    ['running', { status: 'running', input: { command: 'pwd' } }],
+  ] as const) {
+    handler.feed(
+      JSON.stringify({ type: 'tool_use', part: { tool: 'bash', callID, state } }) + '\n',
+    );
+  }
+
+  assert.deepEqual(events, [
+    { type: 'tool_use', id: 'success', name: 'bash', input: null },
+    { type: 'tool_result', toolUseId: 'success', content: 'done', isError: false },
+    { type: 'tool_use', id: 'false-error', name: 'bash', input: null },
+    { type: 'tool_result', toolUseId: 'false-error', content: 'done', isError: false },
+    { type: 'tool_use', id: 'zero-error', name: 'bash', input: null },
+    { type: 'tool_result', toolUseId: 'zero-error', content: 'done', isError: false },
+    { type: 'tool_use', id: 'pending', name: 'bash', input: { command: 'pwd' } },
+    { type: 'tool_use', id: 'running', name: 'bash', input: { command: 'pwd' } },
+  ]);
+});
+
+test('opencode json stream emits a terminal tool result only once per call', () => {
+  const { events, handler } = collectEvents('opencode');
+  const terminal = JSON.stringify({
+    type: 'tool_use',
+    sessionID: 'session-1',
+    part: {
+      tool: 'bash',
+      callID: 'call-1',
+      state: { status: 'completed', output: 'failed', metadata: { exit: 1 } },
+    },
+  });
+
+  handler.feed(`${terminal}\n${terminal}\n`);
+
+  assert.deepEqual(events, [
+    { type: 'tool_use', id: 'call-1', name: 'bash', input: null },
+    { type: 'tool_result', toolUseId: 'call-1', content: 'failed', isError: true },
+  ]);
+});
+
+test('opencode PowerShell signatures stay narrow to canonical shell ErrorRecords', () => {
+  const { events, handler } = collectEvents('opencode');
+  const errorRecord =
+    '+ CategoryInfo : ObjectNotFound: (missing.txt:String) [Get-Content], ItemNotFoundException\n' +
+    '+ FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand';
+  const documentation =
+    'CategoryInfo : copied from a troubleshooting document\n' +
+    'FullyQualifiedErrorId : copied-example';
+
+  for (const [tool, callID, output] of [
+    ['read', 'read-error-record', errorRecord],
+    ['bash', 'bash-documentation', documentation],
+  ] as const) {
+    handler.feed(
+      JSON.stringify({
+        type: 'tool_use',
+        part: {
+          tool,
+          callID,
+          state: { status: 'completed', output, metadata: { exit: 0 } },
+        },
+      }) + '\n',
+    );
+  }
+
+  assert.deepEqual(events, [
+    { type: 'tool_use', id: 'read-error-record', name: 'read', input: null },
+    {
+      type: 'tool_result',
+      toolUseId: 'read-error-record',
+      content: errorRecord,
+      isError: false,
+    },
+    { type: 'tool_use', id: 'bash-documentation', name: 'bash', input: null },
+    {
+      type: 'tool_result',
+      toolUseId: 'bash-documentation',
+      content: documentation,
+      isError: false,
+    },
+  ]);
+});
+
+test('opencode structured failures reach the repeated-failure tool-loop halt', () => {
+  const guard = createToolLoopGuard({ mode: 'halt' });
+  const verdicts: ToolLoopVerdict[] = [];
+  const handler = createJsonEventStreamHandler('opencode', (event) => {
+    if (event.type === 'tool_use') {
+      guard.observeToolUse(String(event.id), String(event.name), event.input);
+    }
+    if (event.type === 'tool_result') {
+      const verdict = guard.observeToolResult(
+        String(event.toolUseId),
+        event.isError === true,
+        typeof event.content === 'string' ? event.content : undefined,
+      );
+      if (verdict) verdicts.push(verdict);
+    }
+  });
+
+  for (let index = 0; index < 8; index += 1) {
+    handler.feed(
+      JSON.stringify({
+        type: 'tool_use',
+        part: {
+          tool: 'bash',
+          callID: `call-${index}`,
+          state: {
+            status: 'completed',
+            input: { command: 'Get-Content -LiteralPath missing.txt' },
+            output:
+              "Get-Content : Cannot find path 'missing.txt' because it does not exist.\r\n" +
+              '    + CategoryInfo          : ObjectNotFound: (missing.txt:String) [Get-Content], ItemNotFoundException\r\n' +
+              '    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand',
+            metadata: { exit: 0 },
+          },
+        },
+      }) + '\n',
+    );
+  }
+
+  assert.deepEqual(
+    verdicts.map(({ reason, action, count }) => ({ reason, action, count })),
+    [
+      { reason: 'repeated-failure', action: 'warn', count: 4 },
+      { reason: 'repeated-failure', action: 'halt', count: 8 },
+    ],
+  );
 });
 
 test('opencode json stream emits structured errors as error events', () => {


### PR DESCRIPTION
Fixes #6927

## Why

OpenCode reports a shell tool as `completed` even when the command itself failed. Open Design then hardcoded the normalized `tool_result` to `isError: false`, so eight identical PowerShell failures looked like eight successes and the existing tool-loop guard never had a chance to intervene.

This fixes that normalization boundary. The parser now preserves structured OpenCode failures, including non-zero exit metadata and official error states. It also recognizes the narrow PowerShell ErrorRecord shape needed for non-terminating errors that still exit zero.

## What users will see

Repeated failing OpenCode shell commands can now trigger the existing tool-loop warning and halt behavior instead of allowing the run to finish as a clean success.

Successful commands and non-terminal pending/running states keep their existing behavior. No new UI or configuration is introduced.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — daemon parser behavior only.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/json-event-stream.test.ts`
- Red/green: yes. Before the source change, the new parser/guard regressions failed because `completed` tool results always emitted `isError: false`; they pass on this branch.
- Coverage includes official `error`, legacy `failed`, direct and metadata exit codes, a PowerShell non-terminating ErrorRecord with exit zero, successful/non-terminal states, terminal-frame deduplication, falsey error fields, and the real guard escalation at repeat counts 4 and 8.
- The PowerShell fallback is deliberately narrow: only `bash`/`shell`, with both canonical `+ CategoryInfo:` and `+ FullyQualifiedErrorId:` lines required. Tests cover non-shell and documentation-output false positives.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/json-event-stream.test.ts tests/tool-loop-guard.test.ts` — 90 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard`
- `pnpm --filter @open-design/daemon test mocks-golden` — 3 recorded-session goldens passed
- `git diff --check`
- Two independent code reviews completed; all findings resolved
