### PR TITLE
fix(daemon): normalize invalid Windows PATHEXT for agent runtimes

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1601,6 +1601,18 @@ export function createAgentRuntimeEnv(
   for (const key of Object.keys(env)) {
     if (key.toUpperCase() === 'OD_API_TOKEN') delete env[key];
   }
+  // A GUI-launched daemon can inherit a broken PATHEXT such as `.CPL` (issue
+  // #6934). Nested native commands then lose stdout/stderr or fail with
+  // ERROR_NO_DATA. On Windows, recover a usable executable-extension list while
+  // preserving an already-valid value and the inherited key casing.
+  if (process.platform === 'win32') {
+    const pathextKey =
+      Object.keys(env).find((key) => key.toLowerCase() === 'pathext') ?? 'PATHEXT';
+    const pathextValue = typeof env[pathextKey] === 'string' ? (env[pathextKey] as string) : '';
+    if (!/\.exe/i.test(pathextValue)) {
+      env[pathextKey] = '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC';
+    }
+  }
   const sidecarIpcPath = baseEnv[SIDECAR_ENV.IPC_PATH];
   if (typeof sidecarIpcPath === 'string' && sidecarIpcPath.length > 0) {
     env[SIDECAR_ENV.IPC_PATH] = sidecarIpcPath;

--- a/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../src/server.js';
 import { applyAgentLaunchEnv } from '../../src/runtimes/launch.js';
 import { spawnEnvForAgent } from '../../src/runtimes/env.js';
+import { withPlatform } from './helpers/test-helpers.js';
 
 describe('agent runtime tool environment', () => {
   it('prefers explicit OD_NODE_BIN over the process executable', () => {
@@ -116,6 +117,66 @@ describe('agent runtime tool environment', () => {
 
     expect(env.OD_TOOL_TOKEN).toBe('run-scoped-token');
     expect(Object.keys(env).some((key) => key.toUpperCase() === 'OD_API_TOKEN')).toBe(false);
+  });
+
+  it('normalizes a narrowed Windows PATHEXT so executable lookup still finds .EXE entries', () => {
+    // A GUI-launched daemon can inherit a broken PATHEXT such as `.CPL` (issue
+    // #6934). Without normalization, nested native commands lose stdout/stderr
+    // or fail with ERROR_NO_DATA. The runtime must recover a usable extension
+    // list so `.EXE` entries resolve again.
+    const env = withPlatform('win32', () =>
+      createAgentRuntimeEnv(
+        { PATH: '/bin', PATHEXT: '.CPL' },
+        'http://127.0.0.1:7456',
+        null,
+        '/opt/open-design/bin/node',
+      ),
+    );
+
+    expect(env.PATHEXT).toMatch(/\.exe/i);
+  });
+
+  it('preserves a valid Windows PATHEXT that already contains .EXE', () => {
+    const env = withPlatform('win32', () =>
+      createAgentRuntimeEnv(
+        { PATH: '/bin', PATHEXT: '.CUSTOM;.EXE;.CMD' },
+        'http://127.0.0.1:7456',
+        null,
+        '/opt/open-design/bin/node',
+      ),
+    );
+
+    expect(env.PATHEXT).toBe('.CUSTOM;.EXE;.CMD');
+  });
+
+  it('normalizes PATHEXT in place when the inherited env uses Windows-style lowercase casing', () => {
+    // Node de-duplicates env keys case-insensitively on Windows, so writing a
+    // fresh 'PATHEXT' alongside an existing 'pathext' would be ignored. The
+    // existing differently-cased key must be updated instead.
+    const env = withPlatform('win32', () =>
+      createAgentRuntimeEnv(
+        { PATH: '/bin', pathext: '.CPL' },
+        'http://127.0.0.1:7456',
+        null,
+        '/opt/open-design/bin/node',
+      ),
+    );
+
+    expect(env.pathext).toMatch(/\.exe/i);
+    expect(env.PATHEXT).toBeUndefined();
+  });
+
+  it('leaves PATHEXT untouched on non-Windows platforms', () => {
+    const env = withPlatform('linux', () =>
+      createAgentRuntimeEnv(
+        { PATH: '/bin', PATHEXT: '.CPL' },
+        'http://127.0.0.1:7456',
+        null,
+        '/opt/open-design/bin/node',
+      ),
+    );
+
+    expect(env.PATHEXT).toBe('.CPL');
   });
 
   it('pins the daemon runtime data dir into agent sessions', () => {


### PR DESCRIPTION
Fixes #6934

## Why

I hit a packaged Windows failure where nested native commands launched by an agent lost output or failed with `2147942632` / `0x800700e8` / `ERROR_NO_DATA`.

The daemon can inherit a narrowed `PATHEXT`, such as `.CPL`, and pass it unchanged into spawned agent runtimes. `createAgentRuntimeEnv()` already handles Windows `Path` casing, while inherited `PATHEXT` is passed through unmodified.

## What users will see

Agent sessions on Windows retain working native child-command execution when the daemon inherits a missing, empty, or narrowed `PATHEXT`. Existing values containing `.EXE` remain unchanged, and non-Windows behavior is untouched.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-runtime-env.test.ts`
- Red on `main`: 2 failed and 21 passed because narrowed `.CPL` values were not normalized.
- Green with the fix: 23 passed.
- Pass/fail/pass proof: 23 passed with the fix, the two focused cases failed after temporarily removing only the production block, then 23 passed after restoring it.

The regression cases cover a narrowed `PATHEXT`, exact preservation of a valid custom value, case-insensitive key handling without a duplicate key, and unchanged non-Windows behavior.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — passed.
- `vitest run -c vitest.config.ts tests/runtimes/agent-runtime-env.test.ts` — 23 passed.
- `git diff --check` — passed.
- `pnpm guard` — one pre-existing unrelated failure: `ci.yml` no longer contains the guarded tools-dev, packaged unit, and focused E2E command block. This change does not touch `ci.yml`.

## Adjacent issues

#6049 hardens host-side Windows executable resolution. It is complementary and untouched by this change, which repairs the environment passed into spawned agent runtimes.

