### PR TITLE
fix(daemon): preserve scripts during preview URL rewriting

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -122,35 +122,29 @@ import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 
-export function rewriteCssUrlsOutsideScripts(
+export function rewriteOutsideScriptContents(
   html: string,
-  rewriteReference: (reference: string) => string,
+  rewriteChunk: (chunk: string) => string,
 ): string {
-  const cssUrl = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
-  const rewriteCssUrls = (value: string): string =>
-    value.replace(cssUrl, (match, quote: string, reference: string) => {
-      const rewritten = rewriteReference(reference);
-      return rewritten === reference ? match : `url(${quote}${rewritten}${quote})`;
-    });
   const scriptRanges = load(html, { sourceCodeLocationInfo: true }, false)('script')
     .toArray()
     .flatMap((node) => {
       const location = node.sourceCodeLocation;
       if (!location?.startTag) return [];
       return [{
-        start: location.startTag.startOffset,
-        end: location.endTag?.endOffset ?? html.length,
+        start: location.startTag.endOffset,
+        end: location.endTag?.startOffset ?? html.length,
       }];
     });
 
   let rewrittenHtml = '';
   let cursor = 0;
   for (const range of scriptRanges) {
-    rewrittenHtml += rewriteCssUrls(html.slice(cursor, range.start));
+    rewrittenHtml += rewriteChunk(html.slice(cursor, range.start));
     rewrittenHtml += html.slice(range.start, range.end);
     cursor = range.end;
   }
-  return rewrittenHtml + rewriteCssUrls(html.slice(cursor));
+  return rewrittenHtml + rewriteChunk(html.slice(cursor));
 }
 
 function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScope | null {
@@ -5466,6 +5460,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     const linkTag = /<link\b[^>]*>/gi;
     const linkHref = /(\shref\s*=\s*)(["'])([^"']*)\2/i;
     const srcsetAttr = /(\ssrcset\s*=\s*)(["'])([^"']*)\2/gi;
+    const cssUrl = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
     const ownerDir = path.posix.dirname(ownerFilePath);
     const scopeQuery = `workspaceId=${encodeURIComponent(workspaceId)}`
       + `&workspaceMemberId=${encodeURIComponent(workspaceMemberId)}`;
@@ -5493,39 +5488,46 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       return `${scoped}&${suffix.slice(1)}`;
     };
 
-    let next = html.replace(
-      assetAttr,
-      (match, space: string, name: string, eq: string, quote: string, value: string) => {
-        const rewritten = rewrite(value);
-        return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
-      },
-    );
-    next = next.replace(linkTag, (tag) =>
-      tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
-        const rewritten = rewrite(value);
+    const rewriteChunk = (chunk: string): string => {
+      let next = chunk.replace(
+        assetAttr,
+        (match, space: string, name: string, eq: string, quote: string, value: string) => {
+          const rewritten = rewrite(value);
+          return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
+        },
+      );
+      next = next.replace(linkTag, (tag) =>
+        tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
+          const rewritten = rewrite(value);
+          return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
+        }),
+      );
+      next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
+        // A data URL contains an unescaped comma, so the lightweight candidate
+        // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
+        // whole attribute untouched rather than corrupting embedded bytes.
+        if (/(?:^|,\s*)data:/i.test(value)) return match;
+        const rewritten = value
+          .split(',')
+          .map((candidate) => {
+            const body = candidate.trim();
+            if (!body) return candidate;
+            const [url = '', ...descriptors] = body.split(/\s+/);
+            const rewrittenUrl = rewrite(url);
+            if (rewrittenUrl === url) return candidate;
+            const leading = candidate.match(/^\s*/)?.[0] ?? '';
+            return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
+          })
+          .join(',');
         return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-      }),
-    );
-    next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
-      // A data URL contains an unescaped comma, so the lightweight candidate
-      // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
-      // whole attribute untouched rather than corrupting embedded bytes.
-      if (/(?:^|,\s*)data:/i.test(value)) return match;
-      const rewritten = value
-        .split(',')
-        .map((candidate) => {
-          const body = candidate.trim();
-          if (!body) return candidate;
-          const [url = '', ...descriptors] = body.split(/\s+/);
-          const rewrittenUrl = rewrite(url);
-          if (rewrittenUrl === url) return candidate;
-          const leading = candidate.match(/^\s*/)?.[0] ?? '';
-          return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
-        })
-        .join(',');
-      return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-    });
-    return rewriteCssUrlsOutsideScripts(next, rewrite);
+      });
+      return next.replace(cssUrl, (match, quote: string, value: string) => {
+        const rewritten = rewrite(value);
+        return rewritten === value ? match : `url(${quote}${rewritten}${quote})`;
+      });
+    };
+
+    return rewriteOutsideScriptContents(html, rewriteChunk);
   }
 
   async function maybeResolveVitePreviewHtml({

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -150,9 +150,15 @@ export function rewriteOutsideExecutableHtmlRanges(
         startOffset: number;
         endOffset: number;
       }> | undefined;
+      const element = node as Extract<typeof node, { attribs: Record<string, string> }>;
+      // parse5 stores namespaced values by local name and keeps their source prefix separately.
+      const valuesBySourceName = new Map(Object.entries(element.attribs).map(([localName, value]) => {
+        const prefix = element['x-attribsPrefix']?.[localName];
+        return [(prefix ? `${prefix}:${localName}` : localName).toLowerCase(), value] as const;
+      }));
       return Object.entries(attributes ?? {}).flatMap(([name, location]) => {
-        const value = $(node).attr(name) ?? '';
         const normalizedName = name.toLowerCase();
+        const value = valuesBySourceName.get(normalizedName) ?? '';
         const normalizedSchemeValue = value.replace(/[\t\n\r]/g, '');
         if (
           normalizedName.startsWith('on')

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -132,9 +132,13 @@ export function rewriteOutsideExecutableHtmlRanges(
     .flatMap((node) => {
       const location = node.sourceCodeLocation;
       if (!location?.startTag) return [];
+      const startTag = html.slice(location.startTag.startOffset, location.startTag.endOffset);
+      const isSelfClosingForeignScript = node.namespace !== 'http://www.w3.org/1999/xhtml'
+        && startTag.endsWith('/>');
       return [{
         start: location.startTag.endOffset,
-        end: location.endTag?.startOffset ?? html.length,
+        end: location.endTag?.startOffset
+          ?? (isSelfClosingForeignScript ? location.startTag.endOffset : html.length),
       }];
     });
   const executableAttributeRanges = $('*')
@@ -149,11 +153,11 @@ export function rewriteOutsideExecutableHtmlRanges(
       return Object.entries(attributes ?? {}).flatMap(([name, location]) => {
         const value = $(node).attr(name) ?? '';
         const normalizedName = name.toLowerCase();
+        const normalizedSchemeValue = value.replace(/[\t\n\r]/g, '');
         if (
           normalizedName.startsWith('on')
           || normalizedName === 'srcdoc'
-          || /^\s*javascript:/i.test(value)
-          || /^\s*data:/i.test(value)
+          || /^\s*(?:javascript|vbscript|data):/i.test(normalizedSchemeValue)
         ) {
           return [{ start: location.startOffset, end: location.endOffset }];
         }

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import { load } from 'cheerio';
@@ -153,6 +153,7 @@ export function rewriteOutsideExecutableHtmlRanges(
           normalizedName.startsWith('on')
           || normalizedName === 'srcdoc'
           || /^\s*javascript:/i.test(value)
+          || /^\s*data:/i.test(value)
         ) {
           return [{ start: location.startOffset, end: location.endOffset }];
         }
@@ -171,8 +172,15 @@ export function rewriteOutsideExecutableHtmlRanges(
       return ranges;
     }, []);
 
-  let markerPrefix = '__OD_PROTECTED_HTML_RANGE_';
-  while (html.includes(markerPrefix)) markerPrefix = `_${markerPrefix}`;
+  let markerPrefix: string | null = null;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const candidate = `__OD_PROTECTED_HTML_RANGE_${randomUUID()}_`;
+    if (!html.includes(candidate)) {
+      markerPrefix = candidate;
+      break;
+    }
+  }
+  if (!markerPrefix) throw new Error('Unable to allocate protected HTML marker');
 
   const protectedValues: Array<{ marker: string; value: string }> = [];
   let maskedHtml = '';

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -171,14 +171,26 @@ export function rewriteOutsideExecutableHtmlRanges(
       return ranges;
     }, []);
 
-  let rewrittenHtml = '';
+  let markerPrefix = '__OD_PROTECTED_HTML_RANGE_';
+  while (html.includes(markerPrefix)) markerPrefix = `_${markerPrefix}`;
+
+  const protectedValues: Array<{ marker: string; value: string }> = [];
+  let maskedHtml = '';
   let cursor = 0;
-  for (const range of protectedRanges) {
-    rewrittenHtml += rewriteChunk(html.slice(cursor, range.start));
-    rewrittenHtml += html.slice(range.start, range.end);
+  for (const [index, range] of protectedRanges.entries()) {
+    const marker = `${markerPrefix}${index}__`;
+    maskedHtml += html.slice(cursor, range.start);
+    maskedHtml += marker;
+    protectedValues.push({ marker, value: html.slice(range.start, range.end) });
     cursor = range.end;
   }
-  return rewrittenHtml + rewriteChunk(html.slice(cursor));
+  maskedHtml += html.slice(cursor);
+
+  let rewrittenHtml = rewriteChunk(maskedHtml);
+  for (const { marker, value } of protectedValues) {
+    rewrittenHtml = rewrittenHtml.split(marker).join(value);
+  }
+  return rewrittenHtml;
 }
 
 function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScope | null {

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -122,11 +122,12 @@ import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 
-export function rewriteOutsideScriptContents(
+export function rewriteOutsideExecutableHtmlRanges(
   html: string,
   rewriteChunk: (chunk: string) => string,
 ): string {
-  const scriptRanges = load(html, { sourceCodeLocationInfo: true }, false)('script')
+  const $ = load(html, { sourceCodeLocationInfo: true }, false);
+  const scriptRanges = $('script')
     .toArray()
     .flatMap((node) => {
       const location = node.sourceCodeLocation;
@@ -136,10 +137,43 @@ export function rewriteOutsideScriptContents(
         end: location.endTag?.startOffset ?? html.length,
       }];
     });
+  const executableAttributeRanges = $('*')
+    .toArray()
+    .flatMap((node) => {
+      const sourceLocation = node.sourceCodeLocation;
+      if (!sourceLocation || !('attrs' in sourceLocation)) return [];
+      const attributes = sourceLocation.attrs as Record<string, {
+        startOffset: number;
+        endOffset: number;
+      }> | undefined;
+      return Object.entries(attributes ?? {}).flatMap(([name, location]) => {
+        const value = $(node).attr(name) ?? '';
+        const normalizedName = name.toLowerCase();
+        if (
+          normalizedName.startsWith('on')
+          || normalizedName === 'srcdoc'
+          || /^\s*javascript:/i.test(value)
+        ) {
+          return [{ start: location.startOffset, end: location.endOffset }];
+        }
+        return [];
+      });
+    });
+  const protectedRanges = [...scriptRanges, ...executableAttributeRanges]
+    .sort((left, right) => left.start - right.start)
+    .reduce<Array<{ start: number; end: number }>>((ranges, range) => {
+      const previous = ranges.at(-1);
+      if (!previous || range.start > previous.end) {
+        ranges.push({ ...range });
+      } else {
+        previous.end = Math.max(previous.end, range.end);
+      }
+      return ranges;
+    }, []);
 
   let rewrittenHtml = '';
   let cursor = 0;
-  for (const range of scriptRanges) {
+  for (const range of protectedRanges) {
     rewrittenHtml += rewriteChunk(html.slice(cursor, range.start));
     rewrittenHtml += html.slice(range.start, range.end);
     cursor = range.end;
@@ -5527,7 +5561,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       });
     };
 
-    return rewriteOutsideScriptContents(html, rewriteChunk);
+    return rewriteOutsideExecutableHtmlRanges(html, rewriteChunk);
   }
 
   async function maybeResolveVitePreviewHtml({

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
+import { load } from 'cheerio';
 import type { Express, Request, Response } from 'express';
 import {
   PREVIEW_OBSERVABILITY_BRIDGE_MARKER,
@@ -120,6 +121,37 @@ import {
 import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
+
+export function rewriteCssUrlsOutsideScripts(
+  html: string,
+  rewriteReference: (reference: string) => string,
+): string {
+  const cssUrl = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
+  const rewriteCssUrls = (value: string): string =>
+    value.replace(cssUrl, (match, quote: string, reference: string) => {
+      const rewritten = rewriteReference(reference);
+      return rewritten === reference ? match : `url(${quote}${rewritten}${quote})`;
+    });
+  const scriptRanges = load(html, { sourceCodeLocationInfo: true }, false)('script')
+    .toArray()
+    .flatMap((node) => {
+      const location = node.sourceCodeLocation;
+      if (!location?.startTag) return [];
+      return [{
+        start: location.startTag.startOffset,
+        end: location.endTag?.endOffset ?? html.length,
+      }];
+    });
+
+  let rewrittenHtml = '';
+  let cursor = 0;
+  for (const range of scriptRanges) {
+    rewrittenHtml += rewriteCssUrls(html.slice(cursor, range.start));
+    rewrittenHtml += html.slice(range.start, range.end);
+    cursor = range.end;
+  }
+  return rewrittenHtml + rewriteCssUrls(html.slice(cursor));
+}
 
 function parseLocalCatalogScope(value: unknown, field: string): LocalCatalogScope | null {
   if (value === undefined || value === null) return null;
@@ -5434,7 +5466,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     const linkTag = /<link\b[^>]*>/gi;
     const linkHref = /(\shref\s*=\s*)(["'])([^"']*)\2/i;
     const srcsetAttr = /(\ssrcset\s*=\s*)(["'])([^"']*)\2/gi;
-    const cssUrl = /url\(\s*(['"]?)([^'")]+)\1\s*\)/gi;
     const ownerDir = path.posix.dirname(ownerFilePath);
     const scopeQuery = `workspaceId=${encodeURIComponent(workspaceId)}`
       + `&workspaceMemberId=${encodeURIComponent(workspaceMemberId)}`;
@@ -5494,10 +5525,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         .join(',');
       return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
     });
-    return next.replace(cssUrl, (match, quote: string, value: string) => {
-      const rewritten = rewrite(value);
-      return rewritten === value ? match : `url(${quote}${rewritten}${quote})`;
-    });
+    return rewriteCssUrlsOutsideScripts(next, rewrite);
   }
 
   async function maybeResolveVitePreviewHtml({

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -162,6 +162,9 @@ describe('project preview containment routes', () => {
     ].join(' ');
     const inlineHandler = 'URL.revokeObjectURL(url)';
     const dataUrl = 'data:text/html,<script>URL.revokeObjectURL(url)</script>';
+    const newlineJavascriptUrl = 'java\nscript:URL.revokeObjectURL(url)';
+    const tabJavascriptUrl = 'java\tscript:URL.revokeObjectURL(url)';
+    const vbscriptUrl = 'vbscript:URL.revokeObjectURL(url)';
     await writeProjectFile(
       projectId,
       'index.html',
@@ -178,6 +181,9 @@ describe('project preview containment routes', () => {
         `<link onload="${inlineHandler}" href="assets/theme-before.css" rel="stylesheet">`,
         `<link href="assets/theme-after.css" onload="${inlineHandler}" rel="stylesheet">`,
         `<iframe src="${dataUrl}"></iframe>`,
+        `<a href="${newlineJavascriptUrl}">Newline executable URL</a>`,
+        `<a href="${tabJavascriptUrl}">Tab executable URL</a>`,
+        `<a href="${vbscriptUrl}">Legacy executable URL</a>`,
         '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
       ].join(''),
@@ -211,6 +217,9 @@ describe('project preview containment routes', () => {
       `<link href="${scopedAssetUrl('assets/theme-after.css')}" onload="${inlineHandler}"`,
     );
     expect(html).toContain(`<iframe src="${dataUrl}"></iframe>`);
+    expect(html).toContain(`<a href="${newlineJavascriptUrl}">Newline executable URL</a>`);
+    expect(html).toContain(`<a href="${tabJavascriptUrl}">Tab executable URL</a>`);
+    expect(html).toContain(`<a href="${vbscriptUrl}">Legacy executable URL</a>`);
     expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
   });
 
@@ -490,6 +499,22 @@ describe('project preview HTML rewriting', () => {
 
     expect(rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
       chunk.replace('blob:preview', rewriteReference('blob:preview')))).toBe(html);
+  });
+
+  it('treats a self-closing slash on an HTML script as unclosed', () => {
+    const html = '<script/>const url = "blob:preview"; URL.revokeObjectURL(url)';
+
+    expect(rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
+      chunk.replace('blob:preview', rewriteReference('blob:preview')))).toBe(html);
+  });
+
+  it('continues rewriting after a self-closing SVG script', () => {
+    const html = '<svg><script src="runtime.js" /></svg>'
+      + '<style>body { background: url(assets/hero.png); }</style>';
+
+    expect(rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
+      chunk.replace('assets/hero.png', rewriteReference('assets/hero.png'))))
+      .toContain('url(/preview/assets/hero.png)');
   });
 
   it('avoids collisions with protected range markers already in the document', () => {

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { ensureWorkspaceProject, openDatabase } from '../src/db.js';
 import { startServer } from '../src/server.js';
-import { rewriteCssUrlsOutsideScripts } from '../src/routes/project/index.js';
+import { rewriteOutsideScriptContents } from '../src/routes/project/index.js';
 
 describe('project preview containment routes', () => {
   let server: http.Server;
@@ -149,12 +149,17 @@ describe('project preview containment routes', () => {
     expect(await assetResponse.text()).toContain('color: black');
   });
 
-  it('preserves script contents while rewriting workspace-scoped CSS asset URLs', async () => {
+  it('preserves script contents while rewriting workspace-scoped asset URLs', async () => {
     const workspaceId = `workspace-${randomUUID()}`;
     const workspaceMemberId = `member-${randomUUID()}`;
     const projectId = await createProject({ entryFile: 'index.html' });
-    const script = "const cssText = 'background: url(\"assets/runtime.png\")'; "
-      + "const url = 'blob:preview'; URL.revokeObjectURL(url);";
+    const script = [
+      'const src = "assets/runtime.png";',
+      'const markup = \'<link href="styles/runtime.css">'
+        + '<img src="assets/runtime.png" srcset="assets/runtime.png 1x">\';',
+      "const cssText = 'background: url(\"assets/runtime.png\")';",
+      "const url = 'blob:preview'; URL.revokeObjectURL(url);",
+    ].join(' ');
     await writeProjectFile(
       projectId,
       'index.html',
@@ -163,13 +168,15 @@ describe('project preview containment routes', () => {
         '<html><head>',
         '<!-- code sample: <script> -->',
         '<textarea><script></textarea>',
+        '<script src="assets/external.js"></script>',
         `<script>${script}</script>`,
         '</head><body>',
-        '<style>.hero { background: url("assets/hero.png"); }</style>',
+        '<img src="assets/image.png" srcset="assets/image-1x.png 1x">',
+        '<link href="assets/theme.css" rel="stylesheet">',
+        '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
       ].join(''),
     );
-    await writeProjectFile(projectId, 'assets/hero.png', 'hero-bytes');
     bindPersonalProject(projectId, workspaceId, workspaceMemberId);
 
     const scopeQuery = new URLSearchParams({ workspaceId, workspaceMemberId });
@@ -178,12 +185,16 @@ describe('project preview containment routes', () => {
     );
     expect(response.status).toBe(200);
     const html = await response.text();
+    const scopedAssetUrl = (assetPath: string) =>
+      `/api/projects/${projectId}/raw/${assetPath}?workspaceId=${workspaceId}`
+      + `&workspaceMemberId=${workspaceMemberId}`;
 
     expect(html).toContain(`<script>${script}</script>`);
-    expect(html).toContain(
-      `/api/projects/${projectId}/raw/assets/hero.png?workspaceId=${workspaceId}`
-      + `&workspaceMemberId=${workspaceMemberId}`,
-    );
+    expect(html).toContain(`<script src="${scopedAssetUrl('assets/external.js')}">`);
+    expect(html).toContain(`<img src="${scopedAssetUrl('assets/image.png')}"`);
+    expect(html).toContain(`srcset="${scopedAssetUrl('assets/image-1x.png')} 1x"`);
+    expect(html).toContain(`<link href="${scopedAssetUrl('assets/theme.css')}"`);
+    expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
   });
 
   it('serves generated PNG assets through preview scopes and clearly 404s missing image references', async () => {
@@ -427,7 +438,13 @@ describe('project preview HTML rewriting', () => {
       '</body></html>',
     ].join('');
 
-    const rewritten = rewriteCssUrlsOutsideScripts(html, rewriteReference);
+    const rewritten = rewriteOutsideScriptContents(html, (chunk) =>
+      chunk.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (match, quote: string, reference: string) => {
+        const rewrittenReference = rewriteReference(reference);
+        return rewrittenReference === reference
+          ? match
+          : `url(${quote}${rewrittenReference}${quote})`;
+      }));
 
     expect(rewritten).toContain(`<script>${script}</script>`);
     expect(rewritten).toContain('url("/preview/assets/hero.png")');
@@ -436,6 +453,7 @@ describe('project preview HTML rewriting', () => {
   it('preserves an unclosed script through the end of the document', () => {
     const html = '<script>const url = "blob:preview"; URL.revokeObjectURL(url)';
 
-    expect(rewriteCssUrlsOutsideScripts(html, rewriteReference)).toBe(html);
+    expect(rewriteOutsideScriptContents(html, (chunk) =>
+      chunk.replace('blob:preview', rewriteReference('blob:preview')))).toBe(html);
   });
 });

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -165,6 +165,8 @@ describe('project preview containment routes', () => {
     const newlineJavascriptUrl = 'java\nscript:URL.revokeObjectURL(url)';
     const tabJavascriptUrl = 'java\tscript:URL.revokeObjectURL(url)';
     const vbscriptUrl = 'vbscript:URL.revokeObjectURL(url)';
+    const xlinkJavascriptUrl = "javascript:url('assets/executable.svg')";
+    const xlinkDataUrl = "data:image/svg+xml,<svg onload=url('assets/data.svg')></svg>";
     await writeProjectFile(
       projectId,
       'index.html',
@@ -184,6 +186,8 @@ describe('project preview containment routes', () => {
         `<a href="${newlineJavascriptUrl}">Newline executable URL</a>`,
         `<a href="${tabJavascriptUrl}">Tab executable URL</a>`,
         `<a href="${vbscriptUrl}">Legacy executable URL</a>`,
+        `<svg><a xlink:href="${xlinkJavascriptUrl}">Namespaced executable URL</a></svg>`,
+        `<svg><a xlink:href="${xlinkDataUrl}">Namespaced data URL</a></svg>`,
         '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
       ].join(''),
@@ -220,6 +224,8 @@ describe('project preview containment routes', () => {
     expect(html).toContain(`<a href="${newlineJavascriptUrl}">Newline executable URL</a>`);
     expect(html).toContain(`<a href="${tabJavascriptUrl}">Tab executable URL</a>`);
     expect(html).toContain(`<a href="${vbscriptUrl}">Legacy executable URL</a>`);
+    expect(html).toContain(`xlink:href="${xlinkJavascriptUrl}"`);
+    expect(html).toContain(`xlink:href="${xlinkDataUrl}"`);
     expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
   });
 

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { ensureWorkspaceProject, openDatabase } from '../src/db.js';
 import { startServer } from '../src/server.js';
-import { rewriteOutsideScriptContents } from '../src/routes/project/index.js';
+import { rewriteOutsideExecutableHtmlRanges } from '../src/routes/project/index.js';
 
 describe('project preview containment routes', () => {
   let server: http.Server;
@@ -160,6 +160,7 @@ describe('project preview containment routes', () => {
       "const cssText = 'background: url(\"assets/runtime.png\")';",
       "const url = 'blob:preview'; URL.revokeObjectURL(url);",
     ].join(' ');
+    const inlineHandler = 'URL.revokeObjectURL(url)';
     await writeProjectFile(
       projectId,
       'index.html',
@@ -171,7 +172,8 @@ describe('project preview containment routes', () => {
         '<script src="assets/external.js"></script>',
         `<script>${script}</script>`,
         '</head><body>',
-        '<img src="assets/image.png" srcset="assets/image-1x.png 1x">',
+        `<button onclick="${inlineHandler}" style="background: url(assets/button.png)">Revoke</button>`,
+        `<img src="assets/image.png" srcset="assets/image-1x.png 1x" onerror="${inlineHandler}">`,
         '<link href="assets/theme.css" rel="stylesheet">',
         '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
@@ -190,8 +192,14 @@ describe('project preview containment routes', () => {
       + `&workspaceMemberId=${workspaceMemberId}`;
 
     expect(html).toContain(`<script>${script}</script>`);
+    expect(html).toContain(
+      `onclick="${inlineHandler}" style="background: url(${scopedAssetUrl('assets/button.png')})"`,
+    );
     expect(html).toContain(`<script src="${scopedAssetUrl('assets/external.js')}">`);
-    expect(html).toContain(`<img src="${scopedAssetUrl('assets/image.png')}"`);
+    expect(html).toContain(
+      `<img src="${scopedAssetUrl('assets/image.png')}"`
+      + ` srcset="${scopedAssetUrl('assets/image-1x.png')} 1x" onerror="${inlineHandler}">`,
+    );
     expect(html).toContain(`srcset="${scopedAssetUrl('assets/image-1x.png')} 1x"`);
     expect(html).toContain(`<link href="${scopedAssetUrl('assets/theme.css')}"`);
     expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
@@ -438,7 +446,7 @@ describe('project preview HTML rewriting', () => {
       '</body></html>',
     ].join('');
 
-    const rewritten = rewriteOutsideScriptContents(html, (chunk) =>
+    const rewritten = rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
       chunk.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (match, quote: string, reference: string) => {
         const rewrittenReference = rewriteReference(reference);
         return rewrittenReference === reference
@@ -450,10 +458,28 @@ describe('project preview HTML rewriting', () => {
     expect(rewritten).toContain('url("/preview/assets/hero.png")');
   });
 
+  it('preserves executable HTML attributes while rewriting CSS URLs', () => {
+    const html = [
+      '<button onclick="URL.revokeObjectURL(url)" style="background: url(assets/hero.png)">Revoke</button>',
+      '<a href="javascript:URL.revokeObjectURL(url)">Revoke</a>',
+      '<iframe srcdoc="<script>URL.revokeObjectURL(url)</script>"></iframe>',
+    ].join('');
+
+    const rewritten = rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
+      chunk.replace(/url\(\s*(['"]?)([^'")]+)\1\s*\)/gi, (_match, quote: string, reference: string) =>
+        `url(${quote}${rewriteReference(reference)}${quote})`));
+
+    expect(rewritten).toContain(
+      'onclick="URL.revokeObjectURL(url)" style="background: url(/preview/assets/hero.png)"',
+    );
+    expect(rewritten).toContain('href="javascript:URL.revokeObjectURL(url)"');
+    expect(rewritten).toContain('srcdoc="<script>URL.revokeObjectURL(url)</script>"');
+  });
+
   it('preserves an unclosed script through the end of the document', () => {
     const html = '<script>const url = "blob:preview"; URL.revokeObjectURL(url)';
 
-    expect(rewriteOutsideScriptContents(html, (chunk) =>
+    expect(rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
       chunk.replace('blob:preview', rewriteReference('blob:preview')))).toBe(html);
   });
 });

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { ensureWorkspaceProject, openDatabase } from '../src/db.js';
 import { startServer } from '../src/server.js';
+import { rewriteCssUrlsOutsideScripts } from '../src/routes/project/index.js';
 
 describe('project preview containment routes', () => {
   let server: http.Server;
@@ -146,6 +147,43 @@ describe('project preview containment routes', () => {
     expect(assetResponse.headers.get('access-control-allow-origin')).toBe('*');
     expect(assetResponse.headers.get('content-type')).toContain('text/css');
     expect(await assetResponse.text()).toContain('color: black');
+  });
+
+  it('preserves script contents while rewriting workspace-scoped CSS asset URLs', async () => {
+    const workspaceId = `workspace-${randomUUID()}`;
+    const workspaceMemberId = `member-${randomUUID()}`;
+    const projectId = await createProject({ entryFile: 'index.html' });
+    const script = "const cssText = 'background: url(\"assets/runtime.png\")'; "
+      + "const url = 'blob:preview'; URL.revokeObjectURL(url);";
+    await writeProjectFile(
+      projectId,
+      'index.html',
+      [
+        '<!doctype html>',
+        '<html><head>',
+        '<!-- code sample: <script> -->',
+        '<textarea><script></textarea>',
+        `<script>${script}</script>`,
+        '</head><body>',
+        '<style>.hero { background: url("assets/hero.png"); }</style>',
+        '</body></html>',
+      ].join(''),
+    );
+    await writeProjectFile(projectId, 'assets/hero.png', 'hero-bytes');
+    bindPersonalProject(projectId, workspaceId, workspaceMemberId);
+
+    const scopeQuery = new URLSearchParams({ workspaceId, workspaceMemberId });
+    const response = await fetch(
+      `${baseUrl}/api/projects/${projectId}/raw/index.html?${scopeQuery}`,
+    );
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).toContain(`<script>${script}</script>`);
+    expect(html).toContain(
+      `/api/projects/${projectId}/raw/assets/hero.png?workspaceId=${workspaceId}`
+      + `&workspaceMemberId=${workspaceMemberId}`,
+    );
   });
 
   it('serves generated PNG assets through preview scopes and clearly 404s missing image references', async () => {
@@ -370,5 +408,34 @@ describe('project preview containment routes', () => {
       `${baseUrl}/api/projects/${projectId}/preview-url?file=${encodeURIComponent('../index.html')}`,
     );
     expect(escapingPath.status).toBe(400);
+  });
+});
+
+describe('project preview HTML rewriting', () => {
+  const rewriteReference = (reference: string): string => `/preview/${reference}`;
+
+  it('preserves scripts while rewriting CSS URLs elsewhere in the document', () => {
+    const script = "const css = 'url(\"assets/runtime.png\")'; "
+      + "const url = 'blob:preview'; URL.revokeObjectURL(url);";
+    const html = [
+      '<!doctype html><html><head>',
+      '<!-- code sample: <script> -->',
+      '<textarea><script></textarea>',
+      `<script>${script}</script>`,
+      '</head><body>',
+      '<style>.hero { background: url("assets/hero.png"); }</style>',
+      '</body></html>',
+    ].join('');
+
+    const rewritten = rewriteCssUrlsOutsideScripts(html, rewriteReference);
+
+    expect(rewritten).toContain(`<script>${script}</script>`);
+    expect(rewritten).toContain('url("/preview/assets/hero.png")');
+  });
+
+  it('preserves an unclosed script through the end of the document', () => {
+    const html = '<script>const url = "blob:preview"; URL.revokeObjectURL(url)';
+
+    expect(rewriteCssUrlsOutsideScripts(html, rewriteReference)).toBe(html);
   });
 });

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -174,7 +174,8 @@ describe('project preview containment routes', () => {
         '</head><body>',
         `<button onclick="${inlineHandler}" style="background: url(assets/button.png)">Revoke</button>`,
         `<img src="assets/image.png" srcset="assets/image-1x.png 1x" onerror="${inlineHandler}">`,
-        '<link href="assets/theme.css" rel="stylesheet">',
+        `<link onload="${inlineHandler}" href="assets/theme-before.css" rel="stylesheet">`,
+        `<link href="assets/theme-after.css" onload="${inlineHandler}" rel="stylesheet">`,
         '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
       ].join(''),
@@ -201,7 +202,12 @@ describe('project preview containment routes', () => {
       + ` srcset="${scopedAssetUrl('assets/image-1x.png')} 1x" onerror="${inlineHandler}">`,
     );
     expect(html).toContain(`srcset="${scopedAssetUrl('assets/image-1x.png')} 1x"`);
-    expect(html).toContain(`<link href="${scopedAssetUrl('assets/theme.css')}"`);
+    expect(html).toContain(
+      `<link onload="${inlineHandler}" href="${scopedAssetUrl('assets/theme-before.css')}"`,
+    );
+    expect(html).toContain(
+      `<link href="${scopedAssetUrl('assets/theme-after.css')}" onload="${inlineHandler}"`,
+    );
     expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
   });
 
@@ -481,5 +487,18 @@ describe('project preview HTML rewriting', () => {
 
     expect(rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
       chunk.replace('blob:preview', rewriteReference('blob:preview')))).toBe(html);
+  });
+
+  it('avoids collisions with protected range markers already in the document', () => {
+    const script = 'const marker = "__OD_PROTECTED_HTML_RANGE_";';
+    const html = `<style>.__OD_PROTECTED_HTML_RANGE_ { background: url(assets/hero.png); }</style>`
+      + `<script>${script}</script>`;
+
+    const rewritten = rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
+      chunk.replace('assets/hero.png', rewriteReference('assets/hero.png')));
+
+    expect(rewritten).toContain('.__OD_PROTECTED_HTML_RANGE_');
+    expect(rewritten).toContain('url(/preview/assets/hero.png)');
+    expect(rewritten).toContain(`<script>${script}</script>`);
   });
 });

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -161,6 +161,7 @@ describe('project preview containment routes', () => {
       "const url = 'blob:preview'; URL.revokeObjectURL(url);",
     ].join(' ');
     const inlineHandler = 'URL.revokeObjectURL(url)';
+    const dataUrl = 'data:text/html,<script>URL.revokeObjectURL(url)</script>';
     await writeProjectFile(
       projectId,
       'index.html',
@@ -176,6 +177,7 @@ describe('project preview containment routes', () => {
         `<img src="assets/image.png" srcset="assets/image-1x.png 1x" onerror="${inlineHandler}">`,
         `<link onload="${inlineHandler}" href="assets/theme-before.css" rel="stylesheet">`,
         `<link href="assets/theme-after.css" onload="${inlineHandler}" rel="stylesheet">`,
+        `<iframe src="${dataUrl}"></iframe>`,
         '<style>.hero { background: url("assets/background.png"); }</style>',
         '</body></html>',
       ].join(''),
@@ -208,6 +210,7 @@ describe('project preview containment routes', () => {
     expect(html).toContain(
       `<link href="${scopedAssetUrl('assets/theme-after.css')}" onload="${inlineHandler}"`,
     );
+    expect(html).toContain(`<iframe src="${dataUrl}"></iframe>`);
     expect(html).toContain(`url("${scopedAssetUrl('assets/background.png')}")`);
   });
 
@@ -501,4 +504,19 @@ describe('project preview HTML rewriting', () => {
     expect(rewritten).toContain('url(/preview/assets/hero.png)');
     expect(rewritten).toContain(`<script>${script}</script>`);
   });
+
+  it('bounds marker allocation for long prefix-like input', () => {
+    const script = 'const url = "blob:preview"; URL.revokeObjectURL(url);';
+    const html = `${'_'.repeat(100_000)}__OD_PROTECTED_HTML_RANGE_`
+      + `<style>body { background: url(assets/hero.png); }</style>`
+      + `<script>${script}</script>`;
+    const startedAt = performance.now();
+
+    const rewritten = rewriteOutsideExecutableHtmlRanges(html, (chunk) =>
+      chunk.replace('assets/hero.png', rewriteReference('assets/hero.png')));
+
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+    expect(rewritten).toContain('url(/preview/assets/hero.png)');
+    expect(rewritten).toContain(`<script>${script}</script>`);
+  }, 15_000);
 });


### PR DESCRIPTION
Fixes #6932

## Why

Workspace-scoped preview rewriting treated every `url(...)` substring in an HTML response as a CSS asset reference. That also matched JavaScript inside `<script>` elements, so calls such as `URL.revokeObjectURL(url)` were rewritten into invalid JavaScript and could make the whole preview non-interactive.

## What users will see

Inline scripts are now delivered unchanged in project previews, while CSS asset references outside scripts remain workspace-scoped as before.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This fixes preview response rewriting without changing the UI.

## Bug fix verification

- Test path: `apps/daemon/tests/project-preview-containment.test.ts`
- The route-level regression test failed on `main` because the delivered script was corrupted, then passed with this change.
- The tests also cover script-like text in comments and textareas, a complete HTML document, CSS asset references after scripts, and an unclosed script that must remain unchanged through end-of-file.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/project-preview-containment.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard`
