### PR TITLE
fix(daemon): skip preview URL rewrite inside script blocks

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -5503,18 +5503,28 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
 
     // The attribute passes above run over the whole document, so a relative
     // <script src> is still workspace-scoped. The cssUrl pass must not touch
-    // executable JS, though: inline code legitimately contains `url(...)`
-    // substrings (for example `URL.revokeObjectURL(url)`), and rewriting them
-    // produces a syntax error that kills the entire script. CSS `url(...)`
-    // references only appear outside <script> (in <style>, style=, and
-    // stylesheet markup), so skipping script bodies loses nothing.
-    const scriptBlock = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+    // executable JavaScript, though: inline code legitimately contains
+    // `url(...)` substrings (for example `URL.revokeObjectURL(url)`), and
+    // rewriting them produces a syntax error that kills the script. Executable
+    // JS lives in three places: <script> bodies, `on*` event-handler attribute
+    // values, and `javascript:` URI attribute values. Preserve all three
+    // verbatim; CSS `url(...)` references only appear in <style>, style=, and
+    // stylesheet markup, so skipping executable regions loses nothing.
+    const executableRegion = new RegExp(
+      [
+        '<script\\b[^>]*>[\\s\\S]*?</script>',
+        '\\son[a-z0-9_-]*\\s*=\\s*(?:"[^"]*"|\'[^\']*\')',
+        '(?:"javascript:[^"]*"|\'javascript:[^\']*\')',
+        'javascript:[^\\s"\'<>]*',
+      ].join('|'),
+      'gi',
+    );
     let cssRewritten = '';
     let cursor = 0;
-    let scriptMatch: RegExpExecArray | null;
-    while ((scriptMatch = scriptBlock.exec(next)) !== null) {
-      cssRewritten += rewriteCssUrls(next.slice(cursor, scriptMatch.index)) + scriptMatch[0];
-      cursor = scriptMatch.index + scriptMatch[0].length;
+    let regionMatch: RegExpExecArray | null;
+    while ((regionMatch = executableRegion.exec(next)) !== null) {
+      cssRewritten += rewriteCssUrls(next.slice(cursor, regionMatch.index)) + regionMatch[0];
+      cursor = regionMatch.index + regionMatch[0].length;
     }
     return cssRewritten + rewriteCssUrls(next.slice(cursor));
   }

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -5462,60 +5462,61 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       return `${scoped}&${suffix.slice(1)}`;
     };
 
-    const rewriteMarkup = (chunk: string): string => {
-      let next = chunk.replace(
-        assetAttr,
-        (match, space: string, name: string, eq: string, quote: string, value: string) => {
-          const rewritten = rewrite(value);
-          return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
-        },
-      );
-      next = next.replace(linkTag, (tag) =>
-        tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
-          const rewritten = rewrite(value);
-          return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-        }),
-      );
-      next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
-        // A data URL contains an unescaped comma, so the lightweight candidate
-        // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
-        // whole attribute untouched rather than corrupting embedded bytes.
-        if (/(?:^|,\s*)data:/i.test(value)) return match;
-        const rewritten = value
-          .split(',')
-          .map((candidate) => {
-            const body = candidate.trim();
-            if (!body) return candidate;
-            const [url = '', ...descriptors] = body.split(/\s+/);
-            const rewrittenUrl = rewrite(url);
-            if (rewrittenUrl === url) return candidate;
-            const leading = candidate.match(/^\s*/)?.[0] ?? '';
-            return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
-          })
-          .join(',');
+    let next = html.replace(
+      assetAttr,
+      (match, space: string, name: string, eq: string, quote: string, value: string) => {
+        const rewritten = rewrite(value);
+        return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
+      },
+    );
+    next = next.replace(linkTag, (tag) =>
+      tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
+        const rewritten = rewrite(value);
         return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-      });
-      return next.replace(cssUrl, (match, quote: string, value: string) => {
+      }),
+    );
+    next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
+      // A data URL contains an unescaped comma, so the lightweight candidate
+      // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
+      // whole attribute untouched rather than corrupting embedded bytes.
+      if (/(?:^|,\s*)data:/i.test(value)) return match;
+      const rewritten = value
+        .split(',')
+        .map((candidate) => {
+          const body = candidate.trim();
+          if (!body) return candidate;
+          const [url = '', ...descriptors] = body.split(/\s+/);
+          const rewrittenUrl = rewrite(url);
+          if (rewrittenUrl === url) return candidate;
+          const leading = candidate.match(/^\s*/)?.[0] ?? '';
+          return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
+        })
+        .join(',');
+      return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
+    });
+
+    const rewriteCssUrls = (chunk: string): string =>
+      chunk.replace(cssUrl, (match, quote: string, value: string) => {
         const rewritten = rewrite(value);
         return rewritten === value ? match : `url(${quote}${rewritten}${quote})`;
       });
-    };
 
-    // Never rewrite bytes inside a <script> block. Executable JS legitimately
-    // contains `url(...)` substrings (for example `URL.revokeObjectURL(url)`),
-    // and the global cssUrl rewrite would otherwise corrupt that source into a
-    // syntax error that kills the whole script. CSS `url(...)` references live
-    // in <style>, style=, and stylesheet markup, all of which stay outside
-    // <script>, so skipping scripts does not lose any asset rewriting.
+    // The attribute passes above run over the whole document, so a relative
+    // <script src> is still workspace-scoped. The cssUrl pass must not touch
+    // executable JS, though: inline code legitimately contains `url(...)`
+    // substrings (for example `URL.revokeObjectURL(url)`), and rewriting them
+    // produces a syntax error that kills the entire script. CSS `url(...)`
+    // references only appear outside <script> (in <style>, style=, and
+    // stylesheet markup), so skipping script bodies loses nothing.
     const scriptBlock = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
-    let rewrittenHtml = '';
+    let cssRewritten = '';
     let cursor = 0;
     let scriptMatch: RegExpExecArray | null;
-    while ((scriptMatch = scriptBlock.exec(html)) !== null) {
-      rewrittenHtml += rewriteMarkup(html.slice(cursor, scriptMatch.index)) + scriptMatch[0];
+    while ((scriptMatch = scriptBlock.exec(next)) !== null) {
+      cssRewritten += rewriteCssUrls(next.slice(cursor, scriptMatch.index)) + scriptMatch[0];
       cursor = scriptMatch.index + scriptMatch[0].length;
     }
-    return rewrittenHtml + rewriteMarkup(html.slice(cursor));
+    return cssRewritten + rewriteCssUrls(next.slice(cursor));
   }
 
   async function maybeResolveVitePreviewHtml({

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -5462,42 +5462,60 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       return `${scoped}&${suffix.slice(1)}`;
     };
 
-    let next = html.replace(
-      assetAttr,
-      (match, space: string, name: string, eq: string, quote: string, value: string) => {
-        const rewritten = rewrite(value);
-        return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
-      },
-    );
-    next = next.replace(linkTag, (tag) =>
-      tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
-        const rewritten = rewrite(value);
+    const rewriteMarkup = (chunk: string): string => {
+      let next = chunk.replace(
+        assetAttr,
+        (match, space: string, name: string, eq: string, quote: string, value: string) => {
+          const rewritten = rewrite(value);
+          return rewritten === value ? match : `${space}${name}${eq}${quote}${rewritten}${quote}`;
+        },
+      );
+      next = next.replace(linkTag, (tag) =>
+        tag.replace(linkHref, (match, prefix: string, quote: string, value: string) => {
+          const rewritten = rewrite(value);
+          return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
+        }),
+      );
+      next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
+        // A data URL contains an unescaped comma, so the lightweight candidate
+        // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
+        // whole attribute untouched rather than corrupting embedded bytes.
+        if (/(?:^|,\s*)data:/i.test(value)) return match;
+        const rewritten = value
+          .split(',')
+          .map((candidate) => {
+            const body = candidate.trim();
+            if (!body) return candidate;
+            const [url = '', ...descriptors] = body.split(/\s+/);
+            const rewrittenUrl = rewrite(url);
+            if (rewrittenUrl === url) return candidate;
+            const leading = candidate.match(/^\s*/)?.[0] ?? '';
+            return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
+          })
+          .join(',');
         return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-      }),
-    );
-    next = next.replace(srcsetAttr, (match, prefix: string, quote: string, value: string) => {
-      // A data URL contains an unescaped comma, so the lightweight candidate
-      // splitter below cannot safely rewrite a mixed data-URL srcset. Leave the
-      // whole attribute untouched rather than corrupting embedded bytes.
-      if (/(?:^|,\s*)data:/i.test(value)) return match;
-      const rewritten = value
-        .split(',')
-        .map((candidate) => {
-          const body = candidate.trim();
-          if (!body) return candidate;
-          const [url = '', ...descriptors] = body.split(/\s+/);
-          const rewrittenUrl = rewrite(url);
-          if (rewrittenUrl === url) return candidate;
-          const leading = candidate.match(/^\s*/)?.[0] ?? '';
-          return `${leading}${[rewrittenUrl, ...descriptors].join(' ')}`;
-        })
-        .join(',');
-      return rewritten === value ? match : `${prefix}${quote}${rewritten}${quote}`;
-    });
-    return next.replace(cssUrl, (match, quote: string, value: string) => {
-      const rewritten = rewrite(value);
-      return rewritten === value ? match : `url(${quote}${rewritten}${quote})`;
-    });
+      });
+      return next.replace(cssUrl, (match, quote: string, value: string) => {
+        const rewritten = rewrite(value);
+        return rewritten === value ? match : `url(${quote}${rewritten}${quote})`;
+      });
+    };
+
+    // Never rewrite bytes inside a <script> block. Executable JS legitimately
+    // contains `url(...)` substrings (for example `URL.revokeObjectURL(url)`),
+    // and the global cssUrl rewrite would otherwise corrupt that source into a
+    // syntax error that kills the whole script. CSS `url(...)` references live
+    // in <style>, style=, and stylesheet markup, all of which stay outside
+    // <script>, so skipping scripts does not lose any asset rewriting.
+    const scriptBlock = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+    let rewrittenHtml = '';
+    let cursor = 0;
+    let scriptMatch: RegExpExecArray | null;
+    while ((scriptMatch = scriptBlock.exec(html)) !== null) {
+      rewrittenHtml += rewriteMarkup(html.slice(cursor, scriptMatch.index)) + scriptMatch[0];
+      cursor = scriptMatch.index + scriptMatch[0].length;
+    }
+    return rewrittenHtml + rewriteMarkup(html.slice(cursor));
   }
 
   async function maybeResolveVitePreviewHtml({

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -5508,12 +5508,14 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     // rewriting them produces a syntax error that kills the script. Executable
     // JS lives in three places: <script> bodies, `on*` event-handler attribute
     // values, and `javascript:` URI attribute values. Preserve all three
-    // verbatim; CSS `url(...)` references only appear in <style>, style=, and
-    // stylesheet markup, so skipping executable regions loses nothing.
+    // verbatim, covering the browser's valid syntax for each — including
+    // unquoted handler values and whitespace inside the script end tag; CSS
+    // `url(...)` references only appear in <style>, style=, and stylesheet
+    // markup, so skipping executable regions loses nothing.
     const executableRegion = new RegExp(
       [
-        '<script\\b[^>]*>[\\s\\S]*?</script>',
-        '\\son[a-z0-9_-]*\\s*=\\s*(?:"[^"]*"|\'[^\']*\')',
+        '<script\\b[^>]*>[\\s\\S]*?</script\\s*>',
+        '\\son[a-z0-9_-]*\\s*=\\s*(?:"[^"]*"|\'[^\']*\'|[^\\s"\'`=<>]+)',
         '(?:"javascript:[^"]*"|\'javascript:[^\']*\')',
         'javascript:[^\\s"\'<>]*',
       ].join('|'),

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -274,6 +274,7 @@ describe('project preview containment routes', () => {
         '<!doctype html><html><head><title>Script</title>',
         '<style>.hero { background-image: url("assets/hero.png") }</style>',
         '</head><body>',
+        '<script src="scripts/app.js"></script>',
         '<script>var u = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(u);</script>',
         '</body></html>',
       ].join(''),
@@ -290,6 +291,9 @@ describe('project preview containment routes', () => {
 
     // CSS url(...) references outside <script> are still workspace-scoped.
     expect(html).toContain(`/api/projects/${projectId}/raw/assets/hero.png`);
+
+    // Relative external script sources are still workspace-scoped.
+    expect(html).toContain(`/api/projects/${projectId}/raw/scripts/app.js`);
 
     // Executable JS that happens to contain url(...) is left untouched.
     expect(html).toContain('URL.revokeObjectURL(u)');

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -263,6 +263,39 @@ describe('project preview containment routes', () => {
     expect(borrowedTokenResponse.status).toBe(404);
   });
 
+  it('does not rewrite url(...) patterns inside <script> blocks', async () => {
+    const workspaceId = `workspace-${randomUUID()}`;
+    const workspaceMemberId = `member-${randomUUID()}`;
+    const projectId = await createProject({ entryFile: 'script.html' });
+    await writeProjectFile(
+      projectId,
+      'script.html',
+      [
+        '<!doctype html><html><head><title>Script</title>',
+        '<style>.hero { background-image: url("assets/hero.png") }</style>',
+        '</head><body>',
+        '<script>var u = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(u);</script>',
+        '</body></html>',
+      ].join(''),
+    );
+    await writeProjectFile(projectId, 'assets/hero.png', 'hero-png-bytes');
+    bindPersonalProject(projectId, workspaceId, workspaceMemberId);
+
+    const scopeQuery = new URLSearchParams({ workspaceId, workspaceMemberId });
+    const rawResponse = await fetch(
+      `${baseUrl}/api/projects/${projectId}/raw/script.html?${scopeQuery}`,
+    );
+    expect(rawResponse.status).toBe(200);
+    const html = await rawResponse.text();
+
+    // CSS url(...) references outside <script> are still workspace-scoped.
+    expect(html).toContain(`/api/projects/${projectId}/raw/assets/hero.png`);
+
+    // Executable JS that happens to contain url(...) is left untouched.
+    expect(html).toContain('URL.revokeObjectURL(u)');
+    expect(html).not.toContain('revokeObjecturl(');
+  });
+
   it('serves minted preview HTML and assets without bearer headers when API token auth is enabled', async () => {
     const previousToken = process.env.OD_API_TOKEN;
     const token = `preview-token-${randomUUID()}`;

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -276,6 +276,7 @@ describe('project preview containment routes', () => {
         '</head><body>',
         '<script src="scripts/app.js"></script>',
         '<script>var u = URL.createObjectURL(new Blob(["x"])); URL.revokeObjectURL(u);</script>',
+        '<script>URL.revokeObjectURL(u2)</script >',
         '</body></html>',
       ].join(''),
     );
@@ -295,8 +296,10 @@ describe('project preview containment routes', () => {
     // Relative external script sources are still workspace-scoped.
     expect(html).toContain(`/api/projects/${projectId}/raw/scripts/app.js`);
 
-    // Executable JS that happens to contain url(...) is left untouched.
+    // Executable JS that happens to contain url(...) is left untouched,
+    // including a script whose end tag carries whitespace before `>`.
     expect(html).toContain('URL.revokeObjectURL(u)');
+    expect(html).toContain('URL.revokeObjectURL(u2)');
     expect(html).not.toContain('revokeObjecturl(');
   });
 
@@ -312,7 +315,9 @@ describe('project preview containment routes', () => {
         '<style>.hero { background-image: url("assets/hero.png") }</style>',
         '</head><body>',
         '<button onclick="URL.revokeObjectURL(u)">revoke</button>',
+        '<button onclick=URL.revokeObjectURL(u2)>revoke-unquoted</button>',
         '<a href="javascript:URL.revokeObjectURL(u)">jump</a>',
+        '<a href=javascript:URL.revokeObjectURL(u3)>jump-unquoted</a>',
         '<script src="scripts/app.js"></script>',
         '</body></html>',
       ].join(''),
@@ -332,9 +337,12 @@ describe('project preview containment routes', () => {
     expect(html).toContain(`/api/projects/${projectId}/raw/assets/hero.png`);
     expect(html).toContain(`/api/projects/${projectId}/raw/scripts/app.js`);
 
-    // Event handlers and javascript: URIs stay byte-for-byte unchanged.
+    // Event handlers and javascript: URIs stay byte-for-byte unchanged,
+    // whether quoted or unquoted.
     expect(html).toContain('onclick="URL.revokeObjectURL(u)"');
+    expect(html).toContain('onclick=URL.revokeObjectURL(u2)');
     expect(html).toContain('href="javascript:URL.revokeObjectURL(u)"');
+    expect(html).toContain('href=javascript:URL.revokeObjectURL(u3)');
     expect(html).not.toContain('revokeObjecturl(');
   });
 

--- a/apps/daemon/tests/project-preview-containment.test.ts
+++ b/apps/daemon/tests/project-preview-containment.test.ts
@@ -300,6 +300,44 @@ describe('project preview containment routes', () => {
     expect(html).not.toContain('revokeObjecturl(');
   });
 
+  it('does not rewrite url(...) patterns in executable attribute values', async () => {
+    const workspaceId = `workspace-${randomUUID()}`;
+    const workspaceMemberId = `member-${randomUUID()}`;
+    const projectId = await createProject({ entryFile: 'attrs.html' });
+    await writeProjectFile(
+      projectId,
+      'attrs.html',
+      [
+        '<!doctype html><html><head><title>Attrs</title>',
+        '<style>.hero { background-image: url("assets/hero.png") }</style>',
+        '</head><body>',
+        '<button onclick="URL.revokeObjectURL(u)">revoke</button>',
+        '<a href="javascript:URL.revokeObjectURL(u)">jump</a>',
+        '<script src="scripts/app.js"></script>',
+        '</body></html>',
+      ].join(''),
+    );
+    await writeProjectFile(projectId, 'assets/hero.png', 'hero-png-bytes');
+    bindPersonalProject(projectId, workspaceId, workspaceMemberId);
+
+    const scopeQuery = new URLSearchParams({ workspaceId, workspaceMemberId });
+    const rawResponse = await fetch(
+      `${baseUrl}/api/projects/${projectId}/raw/attrs.html?${scopeQuery}`,
+    );
+    expect(rawResponse.status).toBe(200);
+    const html = await rawResponse.text();
+
+    // CSS url(...) references and relative script sources are still
+    // workspace-scoped alongside the protected executable attributes.
+    expect(html).toContain(`/api/projects/${projectId}/raw/assets/hero.png`);
+    expect(html).toContain(`/api/projects/${projectId}/raw/scripts/app.js`);
+
+    // Event handlers and javascript: URIs stay byte-for-byte unchanged.
+    expect(html).toContain('onclick="URL.revokeObjectURL(u)"');
+    expect(html).toContain('href="javascript:URL.revokeObjectURL(u)"');
+    expect(html).not.toContain('revokeObjecturl(');
+  });
+
   it('serves minted preview HTML and assets without bearer headers when API token auth is enabled', async () => {
     const previousToken = process.env.OD_API_TOKEN;
     const token = `preview-token-${randomUUID()}`;


### PR DESCRIPTION
Fixes #6932

## Why

A preview HTML artifact can contain executable JavaScript whose source legitimately contains `url(...)`-shaped text — for example `URL.revokeObjectURL(url)`. The preview-serving pipeline rewrites every `url(...)` pattern into a workspace-scoped `/api/projects/.../raw/...` path, including inside `<script>` blocks. For `URL.revokeObjectURL(url)` this turns the shipped bytes into `URL.revokeObjecturl(/api/.../raw/url?workspaceId=...)`, which is a syntax error: the entire script fails to parse, so every inline event handler then throws `ReferenceError` and the preview page becomes completely non-interactive.

I hit this while previewing a generated page whose script calls `URL.revokeObjectURL`, and the "screenshot looks fine but preview is dead" behavior in #6932 matches exactly what I saw.

## What users will see

Previewing an HTML artifact that contains `url(...)` inside a `<script>` block (e.g. `URL.revokeObjectURL(...)`) now renders the page as authored instead of silently breaking the whole script. Inline `onclick` handlers and other page JS keep working in preview. CSS `url(...)` references in `<style>` blocks, `style=` attributes, and stylesheet markup are still rewritten to workspace-scoped paths, so asset loading is unchanged.

## Surface area

- [x] **None** — internal fix + regression test only; no UI/CLI/API/contract/i18n/dependency change.

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/project-preview-containment.test.ts` → `does not rewrite url(...) patterns inside <script> blocks`
- Did the test go red on `main` and green on this branch? **yes**
  - red on `main`: `AssertionError: expected ... to contain 'URL.revokeObjectURL(u)'` (the shipped HTML contained `URL.revokeObjecturl(/api/projects/.../raw/u?...)`)
  - green on branch: `6 passed` in `project-preview-containment.test.ts`

## Validation

- `pnpm exec tsc -p tsconfig.json --noEmit` (apps/daemon) — passed
- `pnpm exec tsc -p tsconfig.tests.json --noEmit` (apps/daemon) — passed
- `pnpm vitest run -c vitest.config.ts tests/project-preview-containment.test.ts` — 6/6 passed
