### PR TITLE
fix(daemon): close undici dispatcher before exit in od media commands

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -625,7 +625,7 @@ if (first && SUBCOMMAND_MAP[first]) {
   await SUBCOMMAND_MAP[first](rest);
   // Respect a non-zero exit code a handler set via process.exitCode (e.g. a
   // failed `od resource get`); default to 0 when it left it unset.
-  process.exit(process.exitCode ?? 0);
+  await exitAfterClosingDispatcher(process.exitCode ?? 0);
 }
 
 if (argv[0] === 'tools' && argv[1] === 'live-artifacts') {
@@ -1599,18 +1599,18 @@ async function runMediaGenerate(rawArgs) {
     });
   } catch (err) {
     surfaceFetchError(err, daemonUrl);
-    process.exit(3);
+    await exitAfterClosingDispatcher(3);
   }
   if (!resp.ok) {
     const text = await resp.text();
     console.error(`daemon ${resp.status}: ${text}`);
-    process.exit(4);
+    await exitAfterClosingDispatcher(4);
   }
   const accepted = await resp.json();
   const { taskId } = accepted;
   if (!taskId) {
     console.error('daemon did not return a taskId');
-    process.exit(4);
+    await exitAfterClosingDispatcher(4);
   }
   console.error(`task ${taskId} queued (${accepted.status || 'queued'})`);
   await pollUntilDoneOrBudget(daemonUrl, taskId, 0, {
@@ -1659,6 +1659,26 @@ async function runMediaWait(rawArgs) {
   });
 }
 
+// Invariant: no undici keep-alive socket may still be live when the process
+// exits after an HTTP round-trip. The CLI uses Node's global fetch (global
+// undici dispatcher), whose pooled keep-alive sockets would otherwise still be
+// open while process.exit() tears the process down; on Windows/Node 24 that
+// aborts with libuv's UV_HANDLE_CLOSING assertion (src/win/async.c:94,
+// 0xC0000409). Upstream: nodejs/node#56645; fix #61999 is not in a released
+// Node. Removable once a fixed Node is the minimum runtime. destroy() (not
+// close()) is used so teardown can never wait on in-flight requests.
+async function exitAfterClosingDispatcher(code) {
+  const dispatcher = globalThis[Symbol.for('undici.globalDispatcher.1')];
+  if (dispatcher && typeof dispatcher.destroy === 'function') {
+    try {
+      await dispatcher.destroy();
+    } catch {
+      // Already closed.
+    }
+  }
+  process.exit(code);
+}
+
 async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}) {
   const totalBudgetMs = typeof options.totalBudgetMs === 'number' ? options.totalBudgetMs : 25_000;
   const perCallTimeoutMs = 4_000;
@@ -1688,23 +1708,23 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       });
     } catch (err) {
       surfaceFetchError(err, daemonUrl);
-      process.exit(3);
+      await exitAfterClosingDispatcher(3);
     }
     if (resp.status === 404) {
       console.error(`task ${taskId} not found (expired or never queued)`);
-      process.exit(4);
+      await exitAfterClosingDispatcher(4);
     }
     if (!resp.ok) {
       const text = await resp.text();
       console.error(`daemon ${resp.status}: ${text}`);
-      process.exit(4);
+      await exitAfterClosingDispatcher(4);
     }
     let snap;
     try {
       snap = await resp.json();
     } catch {
       console.error('daemon returned non-JSON for /wait');
-      process.exit(4);
+      await exitAfterClosingDispatcher(4);
     }
     lastSnapshot = snap;
     if (Array.isArray(snap.progress)) {
@@ -1732,7 +1752,7 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
         );
       }
       process.stdout.write(JSON.stringify({ file }) + '\n');
-      process.exit(file.providerError ? 5 : 0);
+      await exitAfterClosingDispatcher(file.providerError ? 5 : 0);
     }
     if (snap.status === 'failed') {
       const msg = snap.error?.message || 'task failed';
@@ -1740,7 +1760,7 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       process.stdout.write(
         JSON.stringify({ taskId, status: 'failed', error: snap.error || {} }) + '\n',
       );
-      process.exit(snap.error?.status || 5);
+      await exitAfterClosingDispatcher(snap.error?.status || 5);
     }
     if (snap.status === 'interrupted') {
       const msg = snap.error?.message || 'task interrupted';
@@ -1748,7 +1768,7 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       process.stdout.write(
         JSON.stringify({ taskId, status: 'interrupted', error: snap.error || {} }) + '\n',
       );
-      process.exit(snap.error?.status || 5);
+      await exitAfterClosingDispatcher(snap.error?.status || 5);
     }
   }
 
@@ -1768,7 +1788,7 @@ async function pollUntilDoneOrBudget(daemonUrl, taskId, sinceStart, options = {}
       `Run \`"$OD_NODE_BIN" "$OD_BIN" media wait ${taskId} --since ${since}\` to continue in an agent runtime ` +
       `(${stillRunningHint}).\n`,
   );
-  process.exit(stillRunningExitCode);
+  await exitAfterClosingDispatcher(stillRunningExitCode);
 }
 
 function surfaceFetchError(err, daemonUrl) {

--- a/apps/daemon/tests/media-generate-exit-teardown.test.ts
+++ b/apps/daemon/tests/media-generate-exit-teardown.test.ts
@@ -1,0 +1,163 @@
+// Regression spec — `od media generate` must close its undici keep-alive
+// connection to the daemon BEFORE the process exits.
+//
+// Background: on Node 24 + native Windows, a fetch-then-process.exit() on the
+// same tick aborts the process with the libuv UV_HANDLE_CLOSING assertion
+// (src/win/async.c:94, 0xC0000409; upstream nodejs/node#56645, fix #61999 not
+// in a released Node). The undici global dispatcher's keep-alive socket is
+// still live while the process tears down, so libuv hits a closed async handle.
+//
+// The abort itself is unobservable on Linux, so this spec proves the
+// Linux-provable proxy: the child must close its connection to the daemon at
+// least 1ms before the process exits. On base, process.exit() fires while the
+// keep-alive socket is still live, so the server observes the close ~0-1ms
+// before (or at) the child's exit. After the fix (global dispatcher destroyed
+// first) the close is observed 2-3ms before the child exits. Three iterations
+// are used because a single run can pass on base ~17% of the time; asserting on
+// the minimum margin across 3 runs keeps the regression red.
+
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const daemonRoot = fileURLToPath(new URL('..', import.meta.url));
+const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+
+const PROMPT = 'teardown-regression prompt for socket-close ordering';
+
+let server: http.Server | undefined;
+let baseUrl = '';
+let seenBodies: string[] = [];
+let socketCloseTimes: number[] = [];
+
+beforeEach(async () => {
+  seenBodies = [];
+  socketCloseTimes = [];
+  server = http.createServer((req, res) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      if (req.method === 'POST' && (req.url ?? '').includes('/media/generate')) {
+        seenBodies.push(body);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ taskId: 'task-x', status: 'queued' }));
+        return;
+      }
+      if ((req.url ?? '').includes('/media/tasks/')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'done', file: { name: 'out.png', size: 3 } }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+  server.on('connection', (sock) => {
+    sock.on('close', () => socketCloseTimes.push(Date.now()));
+  });
+  await new Promise<void>((resolve) => server!.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterEach(async () => {
+  if (server) await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+});
+
+interface Iteration {
+  marginMs: number;
+  totalMs: number;
+  code: number;
+  stderr: string;
+}
+
+async function runOnce(): Promise<Iteration> {
+  const args = [
+    '--import',
+    'tsx',
+    cliEntry,
+    'media',
+    'generate',
+    '--surface',
+    'image',
+    '--model',
+    'test-model',
+    '--prompt',
+    PROMPT,
+    '--daemon-url',
+    baseUrl,
+  ];
+  const closeBaseline = socketCloseTimes.length;
+  const spawnAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: daemonRoot,
+      env: { ...process.env, OD_PROJECT_ID: 'project-1' },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      const childExitAt = Date.now();
+      // Yield one macrotask so a socket-close event that was queued just before
+      // the child-exit event is not missed.
+      setImmediate(() => {
+        const newCloses = socketCloseTimes.slice(closeBaseline);
+        const lastSocketCloseAt =
+          newCloses.length > 0 ? newCloses[newCloses.length - 1]! : childExitAt;
+        resolve({
+          marginMs: childExitAt - lastSocketCloseAt,
+          totalMs: childExitAt - spawnAt,
+          code: code ?? -1,
+          stderr,
+        });
+      });
+    });
+  });
+}
+
+describe('od media generate exit teardown', () => {
+  it('closes its keep-alive connection to the daemon before exiting on every run', async () => {
+    const ITERATIONS = 3;
+    const runs: Iteration[] = [];
+    for (let i = 0; i < ITERATIONS; i++) {
+      runs.push(await runOnce());
+    }
+
+    // Contract before timing/exit assertions: one generate POST per spawn, and
+    // every one of them carried our prompt.
+    expect(seenBodies).toHaveLength(ITERATIONS);
+    for (const body of seenBodies) {
+      expect(JSON.parse(body).prompt).toBe(PROMPT);
+    }
+
+    // Ordering assertion (the Linux proxy for the Windows-only abort): the
+    // child must close its connection to the daemon at least 1ms before the
+    // process exits. Base measures 0-1ms (process.exit() short-circuits
+    // teardown while the pooled keep-alive socket is still live); the fixed
+    // version measures 2-3ms (dispatcher destroyed first). Use the minimum
+    // margin across all 3 runs so one lucky run cannot mask a regression.
+    const margins = runs.map((r) => r.marginMs);
+    const minMargin = Math.min(...margins);
+    expect(
+      minMargin,
+      `margins (ms): ${margins.join(', ')} (base ~0-1ms, fixed ~2-3ms)`,
+    ).toBeGreaterThanOrEqual(1);
+
+    // Pins against a natural-drain regression: the undici keep-alive pool holds
+    // the loop ~4s (keepAliveTimeout default), which would push every run past
+    // the 2s ceiling.
+    for (const run of runs) {
+      expect(run.totalMs, `total ms: ${run.totalMs}`).toBeLessThan(2000);
+    }
+
+    // Exit 0 — on native Windows the same code path aborts with 0xC0000409.
+    for (const run of runs) {
+      expect(run.code, `exit ${run.code}; stderr:\n${run.stderr}`).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6832

## Why

On native Windows with Node 24, `od media generate` and `od media wait` can abort during process teardown with libuv's `UV_HANDLE_CLOSING` assertion (`Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94`) and exit code `0xC0000409` instead of the documented exit code.

The terminal branches of the media poll loop write their final result and then call `process.exit()` on the same synchronous tick as the last completed `fetch()`. The global fetch dispatcher (undici) keeps the daemon connection in its keep-alive pool, so the socket is still live while the process tears down. On Windows/Node 24 that race trips libuv's teardown assertion and kills the process with a native abort. This is the same crash family as #5728 and matches the upstream Node issue nodejs/node#56645; the upstream fix (#61999) is not in any released Node, so CLI consumers close their own dispatcher before exiting (pnpm did the same in pnpm/pnpm#12121).

## What users will see

No change on Linux/macOS — output and exit codes are identical. On native Windows, `od media generate` / `od media wait` and subcommands that return through the top-level dispatch now close their keep-alive connection to the daemon before `process.exit()` (the media poll-loop branches), instead of leaving the socket live during teardown.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] CLI or env var — changes the `od` CLI exit sequence after HTTP round-trips; no new flag or env var is introduced
- [ ] API or contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

N/A — no UI surface.

## Bug fix verification

Test path that reproduces the bug: `apps/daemon/tests/media-generate-exit-teardown.test.ts` spawns the real CLI against a fake daemon and asserts the child closes its keep-alive connection to the daemon before the process exits.

Did the test go red on `main` and green on this branch? Yes, via the Linux-provable proxy: the Windows abort itself is not reproducible on Linux, so the spec asserts the ordering invariant that prevents it — the child must close its daemon connection at least 1ms before exit (3 iterations, minimum margin). On `main` the margin is ~0ms (the keep-alive socket is still live when `process.exit()` fires); on this branch it is several ms (dispatcher destroyed first). The same spec also asserts exit 0, which is the exact path that aborts with `0xC0000409` on native Windows (issue #6832's repro shape: stdout ignored, stderr piped).

## Validation

- `pnpm --filter @open-design/daemon typecheck` — pass
- Focused: `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media-generate-exit-teardown.test.ts` — pass (red on base, green on this branch)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media-generate-prompt-file.test.ts tests/media-generate-multi-image.test.ts` — pass 4/4 (including the six-image exit-2 validation path, unchanged)
- `pnpm guard`

## Adjacent issues

- #6800 (flush stdout/stderr before exit, #6540) rewrites the same poll-loop exit lines. Both changes touch identical lines; whichever merges first wins and the other rebases. Different bugs, no semantic overlap.
- #5728 (same assertion on failed media tasks): the poll-loop failed/interrupted/error exits now go through the same helper, so that variant is likely covered as well.
- The remaining `fetch -> process.exit()` handlers elsewhere in `cli.ts` still exit directly after network work and can hit the same Windows abort. The top-level SUBCOMMAND_MAP dispatch path is covered here; handlers that call `process.exit()` themselves are not. Follow-ups.


