### PR TITLE
fix(web): make deck thumbnails drive deck-stage previews

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -154,6 +154,7 @@ import {
   planDeckImageCapture,
   requestPreviewSnapshot,
   sourceLooksLikeExportableDeck,
+  sourceLooksLikeNavigableDeck,
   type ExportProgress,
   type ImageExportFormat,
 } from '../runtime/exports';
@@ -3242,7 +3243,7 @@ function sourceLooksLikeDeckPreview(source: string | null | undefined): boolean 
   if (!source) return false;
   return (
     /class\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(source) ||
-    sourceLooksLikeExportableDeck(source)
+    sourceLooksLikeNavigableDeck(source)
   );
 }
 

--- a/apps/web/src/runtime/deck-slide-structure.ts
+++ b/apps/web/src/runtime/deck-slide-structure.ts
@@ -1,0 +1,107 @@
+import {
+  DECK_LEGACY_SCREEN_SLIDE_SELECTOR,
+  legacyDeckScreenNumber,
+} from '@open-design/contracts/runtime/deck-stage-fallback';
+
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+function hasDistinctScreenNumbers(elements: Element[]): boolean {
+  const numbers = new Set<number>();
+  for (const element of elements) {
+    const number = legacyDeckScreenNumber(element.getAttribute('data-screen-label'));
+    if (number !== null) numbers.add(number);
+  }
+  return numbers.size > 1;
+}
+
+/**
+ * Find the compatibility-only shape used by older containerless decks. A
+ * collection is valid only when numbered, page-like sections are direct
+ * siblings; arbitrary annotation nodes elsewhere in a prototype never join it.
+ */
+export function collectLegacyDeckScreenSlides(root: ParentNode): Element[] {
+  const groups = new Map<ParentNode, Element[]>();
+  for (const element of root.querySelectorAll(DECK_LEGACY_SCREEN_SLIDE_SELECTOR)) {
+    if (legacyDeckScreenNumber(element.getAttribute('data-screen-label')) === null) continue;
+    const parent = element.parentNode;
+    if (!parent) continue;
+    const group = groups.get(parent);
+    if (group) group.push(element);
+    else groups.set(parent, [element]);
+  }
+
+  let best: Element[] = [];
+  for (const group of groups.values()) {
+    if (group.length > best.length && hasDistinctScreenNumbers(group)) best = group;
+  }
+  return best;
+}
+
+function screenLabelFromTag(tag: string): string | null {
+  const match = /\bdata-screen-label\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i.exec(tag);
+  return match?.[1] ?? match?.[2] ?? match?.[3] ?? null;
+}
+
+/**
+ * SSR-safe source equivalent of collectLegacyDeckScreenSlides. This deliberately
+ * tokenizes only enough HTML to preserve direct-parent identity; scripts,
+ * styles, and comments are removed first so markup-looking strings cannot
+ * manufacture slides.
+ */
+export function sourceHasLegacyDeckScreenSlides(source: string): boolean {
+  const sanitized = source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  const tagPattern = /<\s*(\/?)\s*([a-z][\w:-]*)\b[^>]*>/gi;
+  const stack: Array<{ id: number; tag: string }> = [];
+  const groups = new Map<number, Set<number>>();
+  let nextId = 1;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagPattern.exec(sanitized))) {
+    const closing = match[1] === '/';
+    const tagName = match[2]!.toLowerCase();
+    const tag = match[0];
+    if (closing) {
+      for (let index = stack.length - 1; index >= 0; index -= 1) {
+        if (stack[index]!.tag !== tagName) continue;
+        stack.length = index;
+        break;
+      }
+      continue;
+    }
+
+    const parentId = stack.at(-1)?.id ?? 0;
+    if (tagName === 'section') {
+      const number = legacyDeckScreenNumber(screenLabelFromTag(tag));
+      if (number !== null) {
+        const numbers = groups.get(parentId) ?? new Set<number>();
+        numbers.add(number);
+        groups.set(parentId, numbers);
+        if (numbers.size > 1) return true;
+      }
+    }
+
+    if (!VOID_ELEMENTS.has(tagName) && !/\/\s*>$/.test(tag)) {
+      stack.push({ id: nextId, tag: tagName });
+      nextId += 1;
+    }
+  }
+
+  return false;
+}

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -19,7 +19,10 @@
 
 import DOMPurify from 'dompurify';
 
-import { DECK_SLIDE_SELECTOR } from '@open-design/contracts/runtime/deck-stage-fallback';
+import {
+  DECK_SLIDE_SELECTOR,
+  DECK_STRUCTURED_SLIDE_SELECTOR,
+} from '@open-design/contracts/runtime/deck-stage-fallback';
 
 export type DeckThumbnailFallbackReason =
   | 'no-dom-parser'
@@ -58,16 +61,6 @@ export interface ParsedDeckThumbnails {
 const DEFAULT_DESIGN_WIDTH = 1920;
 const DEFAULT_DESIGN_HEIGHT = 1080;
 const MAX_SLIDES = 200;
-
-// Structured-first slide detection, mirroring the deck bridge's `slides()` in
-// srcdoc.ts: prefer slides that are direct children of a recognized stage so
-// decorative `.slide` markup elsewhere isn't miscounted, then fall back to the
-// shared selector.
-const STRUCTURED_SLIDE_SELECTOR =
-  'deck-stage > .slide, .deck > .slide, .deck-stage > .slide, .deck-shell > .slide, ' +
-  '#deck > .slide, body > .slide, ' +
-  'deck-stage > [data-screen-label], .deck-stage > [data-screen-label], ' +
-  '#deck > [data-screen-label], body > [data-screen-label]';
 
 const FONT_HOSTS = new Set([
   'fonts.googleapis.com',
@@ -205,7 +198,14 @@ function rewriteViewportUnits(css: string, width: number, height: number): strin
 }
 
 function collectSlideElements(doc: Document): Element[] {
-  const structured = Array.from(doc.querySelectorAll(STRUCTURED_SLIDE_SELECTOR));
+  const deckStage = doc.querySelector('deck-stage');
+  if (deckStage) {
+    const nested = Array.from(deckStage.querySelectorAll(DECK_SLIDE_SELECTOR));
+    const direct = nested.filter((slide) => slide.parentElement === deckStage);
+    if (direct.length > 0) return direct;
+    if (nested.length > 0) return nested;
+  }
+  const structured = Array.from(doc.querySelectorAll(DECK_STRUCTURED_SLIDE_SELECTOR));
   if (structured.length > 0) return structured;
   return Array.from(doc.querySelectorAll(DECK_SLIDE_SELECTOR));
 }

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -20,6 +20,8 @@
 import DOMPurify from 'dompurify';
 
 import {
+  DECK_EXPLICIT_SLIDE_SELECTOR,
+  DECK_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
 } from '@open-design/contracts/runtime/deck-stage-fallback';
@@ -207,7 +209,10 @@ function collectSlideElements(doc: Document): Element[] {
   }
   const structured = Array.from(doc.querySelectorAll(DECK_STRUCTURED_SLIDE_SELECTOR));
   if (structured.length > 0) return structured;
-  return Array.from(doc.querySelectorAll(DECK_SLIDE_SELECTOR));
+  const explicit = Array.from(doc.querySelectorAll(DECK_EXPLICIT_SLIDE_SELECTOR));
+  if (explicit.length > 0) return explicit;
+  const screenLabeled = Array.from(doc.querySelectorAll(DECK_SCREEN_SLIDE_SELECTOR));
+  return screenLabeled.length > 1 ? screenLabeled : [];
 }
 
 // Walk from the slide's parent up to (but excluding) <body>/<html>, so

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -21,10 +21,10 @@ import DOMPurify from 'dompurify';
 
 import {
   DECK_EXPLICIT_SLIDE_SELECTOR,
-  DECK_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
 } from '@open-design/contracts/runtime/deck-stage-fallback';
+import { collectLegacyDeckScreenSlides } from './deck-slide-structure';
 
 export type DeckThumbnailFallbackReason =
   | 'no-dom-parser'
@@ -211,8 +211,7 @@ function collectSlideElements(doc: Document): Element[] {
   if (structured.length > 0) return structured;
   const explicit = Array.from(doc.querySelectorAll(DECK_EXPLICIT_SLIDE_SELECTOR));
   if (explicit.length > 0) return explicit;
-  const screenLabeled = Array.from(doc.querySelectorAll(DECK_SCREEN_SLIDE_SELECTOR));
-  return screenLabeled.length > 1 ? screenLabeled : [];
+  return collectLegacyDeckScreenSlides(doc);
 }
 
 // Walk from the slide's parent up to (but excluding) <body>/<html>, so

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1010,10 +1010,9 @@ export async function exportProjectAsPptx(opts: {
 // structure such as `data-title` or a `.deck` wrapper. Deliberately DO NOT treat
 // a plain `.slide` class as proof of a deck: ordinary pages often use that token
 // for carousels/testimonials and still need full-page/scroll-stitch capture.
-export function sourceLooksLikeExportableDeck(source: string | null | undefined): boolean {
-  if (!source) return false;
+function sourceLooksLikeStructuredDeck(source: string): boolean {
   return (
-    /<deck-stage[\s/>]|\bdata-screen-label\s*=|class\s*=\s*['"](?:[^'"]*\s)?(?:deck-slide|ppt-slide)(?:\s|['"])/i.test(
+    /<deck-stage[\s/>]|class\s*=\s*['"](?:[^'"]*\s)?(?:deck-slide|ppt-slide)(?:\s|['"])/i.test(
       source,
     ) ||
     /<[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])[^>]*\bdata-title\s*=|<[^>]*\bdata-title\s*=[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(
@@ -1023,6 +1022,22 @@ export function sourceLooksLikeExportableDeck(source: string | null | undefined)
       source,
     )
   );
+}
+
+export function sourceLooksLikeExportableDeck(source: string | null | undefined): boolean {
+  if (!source) return false;
+  return sourceLooksLikeStructuredDeck(source) || /\bdata-screen-label\s*=/i.test(source);
+}
+
+/**
+ * Viewer navigation needs stronger evidence than export. `data-screen-label`
+ * is shared with ordinary prototype annotations, so a lone occurrence may be
+ * exportable as a slide but must not turn the live preview into deck mode.
+ */
+export function sourceLooksLikeNavigableDeck(source: string | null | undefined): boolean {
+  if (!source) return false;
+  if (sourceLooksLikeStructuredDeck(source)) return true;
+  return (source.match(/\bdata-screen-label\s*=/gi)?.length ?? 0) > 1;
 }
 
 // Decides how a current-slide / whole-deck / page image capture should run.

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -24,6 +24,7 @@ import {
   workspaceProjectHeaders,
   workspaceResourceUrl,
 } from '../collab/workspace-identity';
+import { sourceHasLegacyDeckScreenSlides } from './deck-slide-structure';
 
 // Re-exported so app components can gate desktop-only export paths without
 // importing the host package directly.
@@ -1031,13 +1032,14 @@ export function sourceLooksLikeExportableDeck(source: string | null | undefined)
 
 /**
  * Viewer navigation needs stronger evidence than export. `data-screen-label`
- * is shared with ordinary prototype annotations, so a lone occurrence may be
- * exportable as a slide but must not turn the live preview into deck mode.
+ * is shared with ordinary prototype annotations, so only explicit deck
+ * structure or a numbered sibling collection of legacy slide sections may
+ * turn the live preview into deck mode.
  */
 export function sourceLooksLikeNavigableDeck(source: string | null | undefined): boolean {
   if (!source) return false;
   if (sourceLooksLikeStructuredDeck(source)) return true;
-  return (source.match(/\bdata-screen-label\s*=/gi)?.length ?? 0) > 1;
+  return sourceHasLegacyDeckScreenSlides(source);
 }
 
 // Decides how a current-slide / whole-deck / page image capture should run.

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -14,7 +14,11 @@
  *   { type: 'od:slide-state', active: number, count: number }
  * after every navigation so the host can render its own counter / dots.
  */
-import { injectDeckStageFallback } from '@open-design/contracts/runtime/deck-stage-fallback';
+import {
+  DECK_SLIDE_SELECTOR,
+  DECK_STRUCTURED_SLIDE_SELECTOR,
+  injectDeckStageFallback,
+} from '@open-design/contracts/runtime/deck-stage-fallback';
 import { buildPreviewObservabilityBridge } from '@open-design/contracts/runtime/preview-observability';
 
 import {
@@ -2882,15 +2886,69 @@ function injectDeckBridge(
     }, true);
   }
   window.__odDeckBridgeOwnListenerInstall = false;
+  function deckStageSlides(stage){
+    if (!stage) return [];
+    var nested = stage.querySelectorAll(${JSON.stringify(DECK_SLIDE_SELECTOR)});
+    var direct = [];
+    for (var i = 0; i < nested.length; i++) {
+      if (nested[i].parentElement === stage) direct.push(nested[i]);
+    }
+    return direct.length ? direct : nested;
+  }
   function slides(){
-    // Structured selectors first so decorative .slide markup in non-deck
-    // pages (icons, badges, code samples) is not counted as deck slides;
-    // fall back to all .slide only when nothing structured matched, so
-    // freeform decks that nest slides under an extra wrapper still report
-    // the real count instead of leaving the host counter at 1 / 0.
-    var structured = document.querySelectorAll('deck-stage > .slide, .deck > .slide, .deck-stage > .slide, .deck-shell > .slide, body > .slide');
+    // An explicit deck-stage owns its descendants, so unrelated annotated
+    // screens elsewhere in the document cannot leak into its count. Otherwise
+    // prefer direct children of recognized legacy containers before falling
+    // back to every supported persisted slide marker.
+    var stageSlides = deckStageSlides(document.querySelector('deck-stage'));
+    if (stageSlides.length) return stageSlides;
+    var structured = document.querySelectorAll(${JSON.stringify(DECK_STRUCTURED_SLIDE_SELECTOR)});
     if (structured.length) return structured;
-    return document.querySelectorAll('.slide');
+    return document.querySelectorAll(${JSON.stringify(DECK_SLIDE_SELECTOR)});
+  }
+  function deckStageForSlides(list){
+    var stage = document.querySelector('deck-stage');
+    if (!stage) return null;
+    if (list && list.length && !stage.contains(list[0])) return null;
+    return stage;
+  }
+  function activeIndexFromDeckStage(list){
+    var stage = deckStageForSlides(list);
+    if (!stage) return -1;
+    var index = Number(stage.index);
+    if (!Number.isFinite(index)) return -1;
+    index = Math.floor(index);
+    return index >= 0 && index < list.length ? index : -1;
+  }
+  function navigateViaDeckStage(list, action, index){
+    if (!list.length) return false;
+    var stage = deckStageForSlides(list);
+    if (!stage) return false;
+    try {
+      if (action === 'go' && typeof index === 'number' && typeof stage.goTo === 'function') {
+        stage.goTo(index);
+      } else if (action === 'next' && typeof stage.next === 'function') {
+        stage.next();
+      } else if (action === 'prev' && typeof stage.prev === 'function') {
+        stage.prev();
+      } else if (action === 'first' && typeof stage.reset === 'function') {
+        stage.reset();
+      } else if (action === 'first' && typeof stage.goTo === 'function') {
+        stage.goTo(0);
+      } else if (action === 'last' && typeof stage.goTo === 'function') {
+        stage.goTo(list.length - 1);
+      } else {
+        return false;
+      }
+      // Public deck-stage methods are synchronous in the authored runtime.
+      // Report here for older implementations that do not emit slidechange;
+      // modern implementations also emit the event and are harmlessly
+      // coalesced by React state equality in the host.
+      report();
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
   function scrollOverflow(el){
     if (!el) return 0;
@@ -2989,6 +3047,8 @@ function injectDeckBridge(
       var w = Math.max(1, window.innerWidth);
       return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollLeft() / w)));
     }
+    var byDeckStage = activeIndexFromDeckStage(list);
+    if (byDeckStage >= 0) return byDeckStage;
     var byTransform = activeIndexFromTransform(list);
     if (byTransform >= 0) return byTransform;
     var byClass = findActiveByClass(list);
@@ -3287,6 +3347,7 @@ function injectDeckBridge(
   function go(action){
     var list = slides();
     if (!list.length) return;
+    if (navigateViaDeckStage(list, action)) return;
     if (isScrollDeck()) {
       scrollGo(Math.max(0, Math.min(list.length - 1, targetFor(action, list))));
       return;
@@ -3307,6 +3368,7 @@ function injectDeckBridge(
     var list = slides();
     if (!list.length) return;
     var target = Math.max(0, Math.min(list.length - 1, i));
+    if (navigateViaDeckStage(list, 'go', target)) return;
     if (isScrollDeck()) { scrollGo(target); return; }
     if (activeIndex(list) === target) { report(); return; }
     stepToIndexViaKeys(target, function(stepped){
@@ -3390,6 +3452,17 @@ function injectDeckBridge(
       }
     } catch (e) {}
   }
+  // Runtime-managed decks can also move themselves through their own tap
+  // zones, keyboard handler, or public API. Normalize both generations of
+  // deck-stage state notification back into the host-owned slide protocol.
+  document.addEventListener('slidechange', function(ev){
+    var stage = document.querySelector('deck-stage');
+    if (stage && ev.target === stage) report();
+  });
+  window.addEventListener('message', function(ev){
+    var data = ev && ev.data;
+    if (data && typeof data.slideIndexChanged === 'number') report();
+  });
   window.__odDeckSlideState = function(){
     var list = slides();
     return { active: activeIndex(list), count: list.length };

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -16,7 +16,8 @@
  */
 import {
   DECK_EXPLICIT_SLIDE_SELECTOR,
-  DECK_SCREEN_SLIDE_SELECTOR,
+  DECK_LEGACY_SCREEN_LABEL_RE_SOURCE,
+  DECK_LEGACY_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
   injectDeckStageFallback,
@@ -2897,6 +2898,32 @@ function injectDeckBridge(
     }
     return direct.length ? direct : nested;
   }
+  function legacyScreenSlides(){
+    var candidates = document.querySelectorAll(${JSON.stringify(DECK_LEGACY_SCREEN_SLIDE_SELECTOR)});
+    var labelRe = new RegExp(${JSON.stringify(DECK_LEGACY_SCREEN_LABEL_RE_SOURCE)}, 'i');
+    var groups = [];
+    for (var i = 0; i < candidates.length; i++) {
+      var match = labelRe.exec(candidates[i].getAttribute('data-screen-label') || '');
+      if (!match || !candidates[i].parentNode) continue;
+      var group = null;
+      for (var j = 0; j < groups.length; j++) {
+        if (groups[j].parent === candidates[i].parentNode) { group = groups[j]; break; }
+      }
+      if (!group) {
+        group = { parent: candidates[i].parentNode, slides: [], numbers: {} };
+        groups.push(group);
+      }
+      group.slides.push(candidates[i]);
+      group.numbers[String(Number(match[1]))] = true;
+    }
+    var best = [];
+    for (var k = 0; k < groups.length; k++) {
+      if (Object.keys(groups[k].numbers).length > 1 && groups[k].slides.length > best.length) {
+        best = groups[k].slides;
+      }
+    }
+    return best;
+  }
   function slides(){
     // An explicit deck-stage owns its descendants, so unrelated annotated
     // screens elsewhere in the document cannot leak into its count. Otherwise
@@ -2908,8 +2935,7 @@ function injectDeckBridge(
     if (structured.length) return structured;
     var explicit = document.querySelectorAll(${JSON.stringify(DECK_EXPLICIT_SLIDE_SELECTOR)});
     if (explicit.length) return explicit;
-    var screenLabeled = document.querySelectorAll(${JSON.stringify(DECK_SCREEN_SLIDE_SELECTOR)});
-    return screenLabeled.length > 1 ? screenLabeled : [];
+    return legacyScreenSlides();
   }
   function deckStageForSlides(list){
     var stage = document.querySelector('deck-stage');

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -15,6 +15,8 @@
  * after every navigation so the host can render its own counter / dots.
  */
 import {
+  DECK_EXPLICIT_SLIDE_SELECTOR,
+  DECK_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
   injectDeckStageFallback,
@@ -2904,7 +2906,10 @@ function injectDeckBridge(
     if (stageSlides.length) return stageSlides;
     var structured = document.querySelectorAll(${JSON.stringify(DECK_STRUCTURED_SLIDE_SELECTOR)});
     if (structured.length) return structured;
-    return document.querySelectorAll(${JSON.stringify(DECK_SLIDE_SELECTOR)});
+    var explicit = document.querySelectorAll(${JSON.stringify(DECK_EXPLICIT_SLIDE_SELECTOR)});
+    if (explicit.length) return explicit;
+    var screenLabeled = document.querySelectorAll(${JSON.stringify(DECK_SCREEN_SLIDE_SELECTOR)});
+    return screenLabeled.length > 1 ? screenLabeled : [];
   }
   function deckStageForSlides(list){
     var stage = document.querySelector('deck-stage');

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -6003,6 +6003,12 @@ describe('FileViewer SVG artifacts', () => {
       'slides.html',
       '<section class="slide">A</section><section class="slide">B</section>',
     ).deck).toBe(true);
+
+    expect(fileVersionPreviewOptions(
+      'project-1',
+      'prototype.html',
+      '<main><h1 data-screen-label="Hero title">Prototype</h1></main>',
+    ).deck).toBe(false);
   });
 
   it('routes history deck arrow keys to the preview unless a text input is focused', async () => {

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -139,6 +139,19 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.slides[1]).toContain('02 Agenda');
   });
 
+  it('does not treat a lone prototype annotation as a deck slide', () => {
+    const html = `<!doctype html><html><head><style>
+      h1 { color: tomato; }
+    </style></head><body><main>
+      <h1 data-screen-label="Hero title">Prototype headline</h1>
+    </main></body></html>`;
+
+    const parsed = parseDeckThumbnails(html);
+
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('no-slides');
+  });
+
   it('rewrites viewport units in CSS to canvas px (renderable, faithful)', () => {
     // No explicit px canvas → defaults to 1920×1080; 100vw→1920px, 100vh→1080px.
     const html = `<!doctype html><html><head><style>

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -120,6 +120,25 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.ancestors.map((a) => a.tag)).toEqual(['deck-stage']);
   });
 
+  it('prefers deck-stage children over unrelated screen labels elsewhere in the document', () => {
+    const html = `<!doctype html><html><head><style>
+      deck-stage > section { width: 1280px; height: 720px; }
+    </style></head><body>
+      <aside data-screen-label="Prototype navigation">Not a slide</aside>
+      <deck-stage width="1280" height="720">
+        <section data-screen-label="01 Cover">A</section>
+        <section data-screen-label="02 Agenda">B</section>
+      </deck-stage>
+    </body></html>`;
+
+    const parsed = parseDeckThumbnails(html);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.slides).toHaveLength(2);
+    expect(parsed.slides[0]).toContain('01 Cover');
+    expect(parsed.slides[1]).toContain('02 Agenda');
+  });
+
   it('rewrites viewport units in CSS to canvas px (renderable, faithful)', () => {
     // No explicit px canvas → defaults to 1920×1080; 100vw→1920px, 100vh→1080px.
     const html = `<!doctype html><html><head><style>

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -139,17 +139,34 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.slides[1]).toContain('02 Agenda');
   });
 
-  it('does not treat a lone prototype annotation as a deck slide', () => {
+  it('does not treat ordinary prototype annotations as deck slides', () => {
     const html = `<!doctype html><html><head><style>
       h1 { color: tomato; }
     </style></head><body><main>
       <h1 data-screen-label="Hero title">Prototype headline</h1>
+      <button data-screen-label="CTA">Buy now</button>
     </main></body></html>`;
 
     const parsed = parseDeckThumbnails(html);
 
     expect(parsed.renderable).toBe(false);
     expect(parsed.reason).toBe('no-slides');
+  });
+
+  it('requires containerless legacy slides to be numbered direct siblings', () => {
+    const separated = `<!doctype html><html><head><style>
+      section { width: 1920px; height: 1080px; }
+    </style></head><body><main>
+      <section data-screen-label="01 Cover">A</section>
+      <div><section data-screen-label="02 Agenda">B</section></div>
+    </main></body></html>`;
+    expect(parseDeckThumbnails(separated).reason).toBe('no-slides');
+
+    const siblings = separated.replace(
+      '<div><section data-screen-label="02 Agenda">B</section></div>',
+      '<section data-screen-label="02 Agenda">B</section>',
+    );
+    expect(parseDeckThumbnails(siblings).slides).toHaveLength(2);
   });
 
   it('rewrites viewport units in CSS to canvas px (renderable, faithful)', () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -24,6 +24,7 @@ import {
   planDeckImageCapture,
   requestPreviewSnapshot,
   sourceLooksLikeExportableDeck,
+  sourceLooksLikeNavigableDeck,
 } from '../../src/runtime/exports';
 import { workspaceContextFixture } from '../helpers/workspace-context';
 
@@ -125,6 +126,24 @@ describe('sourceLooksLikeExportableDeck (#4604 horizontal deck export)', () => {
     expect(sourceLooksLikeExportableDeck('')).toBe(false);
     expect(sourceLooksLikeExportableDeck(null)).toBe(false);
     expect(sourceLooksLikeExportableDeck(undefined)).toBe(false);
+  });
+});
+
+describe('sourceLooksLikeNavigableDeck', () => {
+  it('does not turn a lone prototype annotation into deck chrome', () => {
+    expect(
+      sourceLooksLikeNavigableDeck('<h1 data-screen-label="Hero title">Prototype</h1>'),
+    ).toBe(false);
+  });
+
+  it('keeps explicit and multi-screen persisted decks navigable', () => {
+    expect(sourceLooksLikeNavigableDeck(
+      '<deck-stage><section data-screen-label="Cover">A</section></deck-stage>',
+    )).toBe(true);
+    expect(sourceLooksLikeNavigableDeck(
+      '<main><section data-screen-label="Cover">A</section>' +
+      '<section data-screen-label="Agenda">B</section></main>',
+    )).toBe(true);
   });
 });
 

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -130,10 +130,18 @@ describe('sourceLooksLikeExportableDeck (#4604 horizontal deck export)', () => {
 });
 
 describe('sourceLooksLikeNavigableDeck', () => {
-  it('does not turn a lone prototype annotation into deck chrome', () => {
+  it('does not turn ordinary prototype annotations into deck chrome', () => {
     expect(
       sourceLooksLikeNavigableDeck('<h1 data-screen-label="Hero title">Prototype</h1>'),
     ).toBe(false);
+    expect(sourceLooksLikeNavigableDeck(
+      '<main><h1 data-screen-label="Hero">Prototype</h1>' +
+      '<button data-screen-label="CTA">Buy</button></main>',
+    )).toBe(false);
+    expect(sourceLooksLikeNavigableDeck(
+      '<main><section data-screen-label="01 Hero">One</section>' +
+      '<div><section data-screen-label="02 CTA">Two</section></div></main>',
+    )).toBe(false);
   });
 
   it('keeps explicit and multi-screen persisted decks navigable', () => {
@@ -141,8 +149,8 @@ describe('sourceLooksLikeNavigableDeck', () => {
       '<deck-stage><section data-screen-label="Cover">A</section></deck-stage>',
     )).toBe(true);
     expect(sourceLooksLikeNavigableDeck(
-      '<main><section data-screen-label="Cover">A</section>' +
-      '<section data-screen-label="Agenda">B</section></main>',
+      '<main><section data-screen-label="01 Cover">A</section>' +
+      '<section data-screen-label="02 Agenda">B</section></main>',
     )).toBe(true);
   });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-deck-stage-api.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-deck-stage-api.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+import { buildSrcdoc } from '../../src/runtime/srcdoc';
+
+function extractDeckBridgeScript(srcdoc: string): string {
+  const match = srcdoc.match(/<script data-od-deck-bridge>([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error('deck bridge script not found in srcdoc');
+  return match[1];
+}
+
+function setupDeckStage(markup: string) {
+  const source = `<!doctype html><html><body>
+    ${markup}
+    <script>document.addEventListener('keydown', function deckKeyboardNavigation() {});</script>
+  </body></html>`;
+  const script = extractDeckBridgeScript(buildSrcdoc(source, { deck: true }));
+  const dom = new JSDOM(`<!doctype html><html><body>${markup}</body></html>`, {
+    pretendToBeVisual: true,
+    runScripts: 'outside-only',
+    url: 'https://example.test/deck.html',
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  const timerCallbacks: Array<() => void> = [];
+  Object.defineProperty(win, 'setTimeout', {
+    configurable: true,
+    value: vi.fn((callback: () => void) => {
+      if (typeof callback === 'function') timerCallbacks.push(callback);
+      return timerCallbacks.length;
+    }),
+  });
+  Object.defineProperty(win, 'clearTimeout', {
+    configurable: true,
+    value: vi.fn(),
+  });
+
+  let syntheticKeyEvents = 0;
+  win.document.addEventListener('keydown', () => {
+    syntheticKeyEvents += 1;
+  });
+
+  win.eval(`
+    customElements.define('deck-stage', class extends HTMLElement {
+      connectedCallback() {
+        this._slides = Array.from(this.children);
+        this._index = 0;
+        this.calls = [];
+        this._apply('init');
+      }
+      get index() { return this._index; }
+      get length() { return this._slides.length; }
+      _apply(reason) {
+        this._slides.forEach((slide, index) => {
+          slide.toggleAttribute('data-deck-active', index === this._index);
+        });
+        this.dispatchEvent(new CustomEvent('slidechange', {
+          detail: { index: this._index, total: this._slides.length, reason },
+          bubbles: true,
+          composed: true,
+        }));
+      }
+      goTo(index) {
+        this.calls.push(['goTo', index]);
+        this._index = Math.max(0, Math.min(this._slides.length - 1, index));
+        this._apply('api');
+      }
+      next() {
+        this.calls.push(['next']);
+        this.goTo(this._index + 1);
+      }
+      prev() {
+        this.calls.push(['prev']);
+        this.goTo(this._index - 1);
+      }
+      reset() {
+        this.calls.push(['reset']);
+        this.goTo(0);
+      }
+    });
+  `);
+
+  const evaluate = new win.Function(script);
+  evaluate.call(win);
+
+  const stage = win.document.querySelector('deck-stage') as HTMLElement & {
+    calls: unknown[][];
+    index: number;
+    goTo(index: number): void;
+  };
+  return {
+    dom,
+    flushTimers() {
+      for (let i = 0; i < 100 && timerCallbacks.length; i += 1) {
+        timerCallbacks.shift()?.();
+      }
+    },
+    parentPostMessage,
+    stage,
+    syntheticKeyEvents: () => syntheticKeyEvents,
+    win,
+  };
+}
+
+function lastSlideState(postMessage: ReturnType<typeof vi.fn>) {
+  return postMessage.mock.calls
+    .map(([message]) => message)
+    .filter((message) => message?.type === 'od:slide-state')
+    .at(-1);
+}
+
+describe('deck bridge - deck-stage public API compatibility', () => {
+  it('navigates data-screen-label-only decks through the stage API', () => {
+    const { dom, flushTimers, parentPostMessage, stage, syntheticKeyEvents, win } = setupDeckStage(`
+      <deck-stage>
+        <section class="cover" data-screen-label="01 Cover">One</section>
+        <section class="agenda" data-screen-label="02 Agenda">Two</section>
+        <section class="statement" data-screen-label="03 Statement">Three</section>
+      </deck-stage>
+    `);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    flushTimers();
+
+    expect(stage.index).toBe(2);
+    expect(stage.calls).toContainEqual(['goTo', 2]);
+    expect(syntheticKeyEvents()).toBe(0);
+    expect(stage.children[2]?.hasAttribute('data-deck-active')).toBe(true);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
+
+    dom.window.close();
+  });
+
+  it('routes sequential and boundary navigation through the stage API', () => {
+    const { dom, flushTimers, stage, syntheticKeyEvents, win } = setupDeckStage(`
+      <deck-stage>
+        <section data-screen-label="01 Cover">One</section>
+        <section data-screen-label="02 Agenda">Two</section>
+        <section data-screen-label="03 Close">Three</section>
+      </deck-stage>
+    `);
+    const send = (action: 'next' | 'prev' | 'first' | 'last') => {
+      win.dispatchEvent(new win.MessageEvent('message', {
+        data: { type: 'od:slide', action },
+      }));
+      flushTimers();
+    };
+
+    send('next');
+    expect(stage.index).toBe(1);
+    send('last');
+    expect(stage.index).toBe(2);
+    send('prev');
+    expect(stage.index).toBe(1);
+    send('first');
+    expect(stage.index).toBe(0);
+
+    expect(stage.calls).toContainEqual(['next']);
+    expect(stage.calls).toContainEqual(['goTo', 2]);
+    expect(stage.calls).toContainEqual(['prev']);
+    expect(stage.calls).toContainEqual(['reset']);
+    expect(syntheticKeyEvents()).toBe(0);
+
+    dom.window.close();
+  });
+
+  it('counts mixed legacy and modern slide markers once and in document order', () => {
+    const { dom, flushTimers, parentPostMessage, stage, win } = setupDeckStage(`
+      <deck-stage>
+        <section class="slide" data-screen-label="01 Both">One</section>
+        <section class="agenda" data-screen-label="02 Modern">Two</section>
+        <section class="deck-slide">Three</section>
+        <section class="ppt-slide">Four</section>
+      </deck-stage>
+    `);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 3 },
+    }));
+    flushTimers();
+
+    expect(stage.index).toBe(3);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 3, count: 4 });
+
+    dom.window.close();
+  });
+
+  it('prefers an explicit deck-stage over unrelated screen labels elsewhere in the document', () => {
+    const { dom, flushTimers, parentPostMessage, stage, win } = setupDeckStage(`
+      <aside data-screen-label="Prototype navigation">Not a slide</aside>
+      <deck-stage>
+        <section data-screen-label="01 Cover">One</section>
+        <section data-screen-label="02 Agenda">Two</section>
+      </deck-stage>
+    `);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 1 },
+    }));
+    flushTimers();
+
+    expect(stage.index).toBe(1);
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 2 });
+
+    dom.window.close();
+  });
+
+  it('reports direct deck-stage navigation back to host-owned chrome', () => {
+    const { dom, parentPostMessage, stage } = setupDeckStage(`
+      <deck-stage>
+        <section data-screen-label="01 Cover">One</section>
+        <section data-screen-label="02 Agenda">Two</section>
+      </deck-stage>
+    `);
+    parentPostMessage.mockClear();
+
+    stage.goTo(1);
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 2 });
+
+    dom.window.close();
+  });
+});

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -69,9 +69,21 @@ function postSlide(win: ReturnType<typeof setupDeckBridge>['win'], action: 'next
 }
 
 describe('deck bridge — nested slide markup (#1530)', () => {
-  it('does not claim a lone prototype annotation as deck navigation state', async () => {
+  it('does not claim ordinary prototype annotations as deck navigation state', async () => {
     const { win, parentPostMessage } = setupDeckBridge(
-      '<main><h1 data-screen-label="Hero title">Prototype headline</h1></main>',
+      '<main><h1 data-screen-label="Hero title">Prototype headline</h1>' +
+      '<button data-screen-label="CTA">Buy now</button></main>',
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 0 });
+  });
+
+  it('does not combine numbered screen sections from different parents', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(
+      '<main><section data-screen-label="01 Cover">One</section>' +
+      '<div><section data-screen-label="02 Agenda">Two</section></div></main>',
     );
 
     await new Promise<void>((resolve) => win.setTimeout(resolve, 350));

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -69,6 +69,27 @@ function postSlide(win: ReturnType<typeof setupDeckBridge>['win'], action: 'next
 }
 
 describe('deck bridge — nested slide markup (#1530)', () => {
+  it('does not claim a lone prototype annotation as deck navigation state', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(
+      '<main><h1 data-screen-label="Hero title">Prototype headline</h1></main>',
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 0 });
+  });
+
+  it('keeps containerless multi-screen legacy decks navigable', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(
+      '<main><section data-screen-label="01 Cover">One</section>' +
+      '<section data-screen-label="02 Agenda">Two</section></main>',
+    );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 2 });
+  });
+
   it('counts nested .slide elements through a fallback when no structured container matches', async () => {
     // 8 slides nested two levels deep — none of `.deck > .slide`,
     // `.deck-stage > .slide`, `.deck-shell > .slide`, or `body > .slide`

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { JSDOM } from 'jsdom';
+import { DECK_STRUCTURED_SLIDE_SELECTOR } from '@open-design/contracts/runtime/deck-stage-fallback';
 import { buildSrcdoc } from '../../src/runtime/srcdoc';
 
 const deckHtml = `<!doctype html>
@@ -184,7 +185,7 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain('data-od-deck-stage-fallback');
     expect(srcdoc).toContain("window.customElements.define('deck-stage'");
     expect(srcdoc).toContain(
-      "document.querySelectorAll('deck-stage > .slide, .deck > .slide, .deck-stage > .slide, .deck-shell > .slide, body > .slide')",
+      `document.querySelectorAll(${JSON.stringify(DECK_STRUCTURED_SLIDE_SELECTOR)})`,
     );
     expect(srcdoc.indexOf('data-od-deck-stage-fallback')).toBeLessThan(
       srcdoc.indexOf('data-od-deck-bridge'),

--- a/e2e/resources/playwright.ts
+++ b/e2e/resources/playwright.ts
@@ -512,14 +512,15 @@ export const playwrightUiScenarios: UiScenario[] = [
     flow: 'deck-pagination-next-prev-correctness',
     automated: true,
     description:
-      'Should verify that deck preview pagination moves to the actual previous and next slide instead of routing both actions to the same page.',
+      'Should verify that persisted deck-stage thumbnails and pagination move the real preview while host chrome and speaker notes stay synchronized.',
     create: {
       projectName: 'Deck pagination controls',
       tab: 'deck',
     },
     prompt: 'Review pagination behavior in a multi-slide deck preview',
     notes: [
-      'Seeds deterministic deck HTML through the project files API and verifies previous/next controls in Playwright.',
+      'Seeds mixed legacy and modern slide markers through the project files API, including a decoy screen label outside the explicit deck-stage.',
+      'Verifies thumbnail selection, previous/next controls, and deck-originated navigation in Playwright.',
     ],
   },
   {

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1009,17 +1009,45 @@ async function runCommentAttachmentFlow(
 
 async function runDeckPaginationNextPrevCorrectnessFlow(page: Page) {
   const { projectId } = await getCurrentProjectContext(page);
-  await seedDeckArtifact(page, projectId, 'pagination.html', 'Pagination Deck', ['Slide One', 'Slide Two', 'Slide Three']);
+  await seedDeckStageArtifact(page, projectId, 'pagination.html', 'Pagination Deck', [
+    'Slide One',
+    'Slide Two',
+    'Slide Three',
+  ]);
   await gotoDesignFile(page, projectId, 'pagination.html');
 
   const frame = artifactPreviewFrame(page);
+  const thumbnails = page.locator('.deck-thumbnail-button');
+  const stage = frame.locator('deck-stage');
+  const speakerNotes = page.getByTestId('speaker-notes-panel');
+  await expect(thumbnails).toHaveCount(3);
   await expect(frame.getByText('Slide One')).toBeVisible();
-  await clickDeckNextSlide(page);
-  await expect(frame.getByText('Slide Two')).toBeVisible();
-  await clickDeckNextSlide(page);
+  await expect(speakerNotes).toContainText('Speaker note for Slide One');
+
+  await thumbnails.nth(2).click();
+  await expect(thumbnails.nth(2)).toHaveAttribute('aria-current', 'true');
+  await expect(stage).toHaveJSProperty('index', 2);
   await expect(frame.getByText('Slide Three')).toBeVisible();
+  await expect(frame.getByText('Slide One')).toBeHidden();
+  await expect(page.locator('.deck-floating-count')).toContainText('3/3');
+  await expect(speakerNotes).toContainText('Speaker note for Slide Three');
+
   await clickDeckPreviousSlide(page);
+  await expect(stage).toHaveJSProperty('index', 1);
   await expect(frame.getByText('Slide Two')).toBeVisible();
+  await expect(page.locator('.deck-floating-count')).toContainText('2/3');
+  await expect(speakerNotes).toContainText('Speaker note for Slide Two');
+
+  await clickDeckNextSlide(page);
+  await expect(stage).toHaveJSProperty('index', 2);
+  await expect(frame.getByText('Slide Three')).toBeVisible();
+
+  await stage.evaluate((element) => {
+    (element as HTMLElement & { goTo(index: number): void }).goTo(0);
+  });
+  await expect(thumbnails.nth(0)).toHaveAttribute('aria-current', 'true');
+  await expect(page.locator('.deck-floating-count')).toContainText('1/3');
+  await expect(speakerNotes).toContainText('Speaker note for Slide One');
 }
 
 async function runDeckPaginationPerFileIsolatedFlow(page: Page) {
@@ -1076,6 +1104,88 @@ async function seedDeckArtifact(
     projectId,
     fileName,
     `<!doctype html><html><body>${slideHtml}</body></html>`,
+    undefined,
+    {
+      version: 1,
+      kind: 'deck',
+      title,
+      entry: fileName,
+      renderer: 'deck-html',
+      exports: ['html', 'pdf'],
+    },
+  );
+}
+
+async function seedDeckStageArtifact(
+  page: Page,
+  projectId: string,
+  fileName: string,
+  title: string,
+  slides: string[],
+) {
+  const slideHtml = slides
+    .map((slide, index) => {
+      let marker = 'class="ppt-slide"';
+      if (index === 0) {
+        marker = `class="slide" data-screen-label="01 ${slide}"`;
+      } else if (index === 1) {
+        marker = `class="agenda" data-screen-label="02 ${slide}"`;
+      }
+      return `<section ${marker}><h1>${slide}</h1></section>`;
+    })
+    .join('\n');
+  const notes = JSON.stringify(slides.map((slide) => `Speaker note for ${slide}`));
+  await seedProjectFile(
+    page,
+    projectId,
+    fileName,
+    `<!doctype html>
+<html>
+<head>
+  <style>
+    body { margin: 0; background: #111827; color: white; font-family: sans-serif; }
+    aside { display: none; }
+    deck-stage { display: block; width: 100vw; height: 100vh; }
+    deck-stage > section { display: none; width: 100%; height: 100%; place-items: center; }
+    deck-stage > section[data-deck-active] { display: grid; }
+  </style>
+</head>
+<body>
+  <aside data-screen-label="Prototype navigation">Not a slide</aside>
+  <deck-stage width="1280" height="720">${slideHtml}</deck-stage>
+  <script>
+    customElements.define('deck-stage', class extends HTMLElement {
+      connectedCallback() {
+        this._slides = Array.from(this.children);
+        this._index = 0;
+        this._apply('init');
+      }
+      get index() { return this._index; }
+      get length() { return this._slides.length; }
+      _apply(reason) {
+        this._slides.forEach((slide, index) => {
+          slide.toggleAttribute('data-deck-active', index === this._index);
+          slide.setAttribute('aria-hidden', index === this._index ? 'false' : 'true');
+        });
+        window.postMessage({ slideIndexChanged: this._index }, '*');
+        this.dispatchEvent(new CustomEvent('slidechange', {
+          detail: { index: this._index, total: this._slides.length, reason },
+          bubbles: true,
+          composed: true,
+        }));
+      }
+      goTo(index) {
+        this._index = Math.max(0, Math.min(this._slides.length - 1, index));
+        this._apply('api');
+      }
+      next() { this.goTo(this._index + 1); }
+      prev() { this.goTo(this._index - 1); }
+      reset() { this.goTo(0); }
+    });
+  </script>
+  <script type="application/json" id="speaker-notes">${notes}</script>
+</body>
+</html>`,
     undefined,
     {
       version: 1,

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -13,21 +13,28 @@ const DECK_SLIDE_MARKERS = [
   '.deck-slide',
   '.ppt-slide',
 ] as const;
+const DECK_EXPLICIT_SLIDE_MARKERS = [
+  '.slide',
+  '.deck-slide',
+  '.ppt-slide',
+] as const;
 const DECK_SLIDE_CONTAINERS = [
   'deck-stage',
   '.deck',
   '.deck-stage',
   '.deck-shell',
   '#deck',
-  'body',
 ] as const;
 
 export const DECK_SLIDE_SELECTOR = DECK_SLIDE_MARKERS.join(', ');
+export const DECK_EXPLICIT_SLIDE_SELECTOR = DECK_EXPLICIT_SLIDE_MARKERS.join(', ');
+export const DECK_SCREEN_SLIDE_SELECTOR = '[data-screen-label]';
 
 /**
- * Prefer direct children of known deck containers before using the generic
- * marker selector. This keeps decorative `.slide` nodes elsewhere in an
- * artifact out of the deck while accepting every persisted slide convention.
+ * Prefer direct children of known deck containers before using generic marker
+ * fallbacks. `body` is deliberately not a container: `data-screen-label` is
+ * also the annotation identity used by ordinary prototypes, so one annotated
+ * body descendant is not sufficient evidence of a deck.
  */
 export const DECK_STRUCTURED_SLIDE_SELECTOR = DECK_SLIDE_CONTAINERS
   .flatMap((container) => DECK_SLIDE_MARKERS.map((marker) => `${container} > ${marker}`))

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -29,6 +29,22 @@ const DECK_SLIDE_CONTAINERS = [
 export const DECK_SLIDE_SELECTOR = DECK_SLIDE_MARKERS.join(', ');
 export const DECK_EXPLICIT_SLIDE_SELECTOR = DECK_EXPLICIT_SLIDE_MARKERS.join(', ');
 export const DECK_SCREEN_SLIDE_SELECTOR = '[data-screen-label]';
+export const DECK_LEGACY_SCREEN_SLIDE_SELECTOR = 'section[data-screen-label]';
+export const DECK_LEGACY_SCREEN_LABEL_RE_SOURCE = '^\\s*(\\d{1,3})(?:\\s|[.)\\u00b7:_-]|$)';
+
+/**
+ * Bare `data-screen-label` is also used by prototype annotations. Legacy decks
+ * without an explicit stage are distinguishable because each page is a
+ * numbered section (`01 Cover`, `02 Agenda`, ...). Callers must additionally
+ * require at least two of these sections to share one direct parent.
+ */
+export function legacyDeckScreenNumber(label: string | null | undefined): number | null {
+  if (!label) return null;
+  const match = new RegExp(DECK_LEGACY_SCREEN_LABEL_RE_SOURCE, 'i').exec(label);
+  if (!match) return null;
+  const number = Number(match[1]);
+  return Number.isFinite(number) && number > 0 ? number : null;
+}
 
 /**
  * Prefer direct children of known deck containers before using generic marker

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -5,9 +5,33 @@ const DECK_STAGE_FALLBACK_MARKER = 'data-od-deck-stage-fallback';
  * The selector family that identifies a deck's slide elements. Single source of
  * truth shared by the runtime `<deck-stage>` fallback (below) and any host-side
  * static slide extraction (e.g. the web app's shadow-root thumbnail parser), so
- * both agree on what counts as a slide. Ordered structured→generic.
+ * both agree on what counts as a slide.
  */
-export const DECK_SLIDE_SELECTOR = '.slide, [data-screen-label], .deck-slide, .ppt-slide';
+const DECK_SLIDE_MARKERS = [
+  '.slide',
+  '[data-screen-label]',
+  '.deck-slide',
+  '.ppt-slide',
+] as const;
+const DECK_SLIDE_CONTAINERS = [
+  'deck-stage',
+  '.deck',
+  '.deck-stage',
+  '.deck-shell',
+  '#deck',
+  'body',
+] as const;
+
+export const DECK_SLIDE_SELECTOR = DECK_SLIDE_MARKERS.join(', ');
+
+/**
+ * Prefer direct children of known deck containers before using the generic
+ * marker selector. This keeps decorative `.slide` nodes elsewhere in an
+ * artifact out of the deck while accepting every persisted slide convention.
+ */
+export const DECK_STRUCTURED_SLIDE_SELECTOR = DECK_SLIDE_CONTAINERS
+  .flatMap((container) => DECK_SLIDE_MARKERS.map((marker) => `${container} > ${marker}`))
+  .join(', ');
 
 const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(function(){
   if (window.__odDeckStageFallbackInstalled) return;
@@ -105,6 +129,14 @@ const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(functio
       return numeric(this.getAttribute('height'), 1080);
     }
 
+    get index() {
+      return this._index;
+    }
+
+    get length() {
+      return this._slides.length;
+    }
+
     _syncSize() {
       this.style.setProperty('--od-deck-stage-width', this.designWidth + 'px');
       this.style.setProperty('--od-deck-stage-height', this.designHeight + 'px');
@@ -195,6 +227,22 @@ const DECK_STAGE_FALLBACK_SCRIPT = `<script data-od-deck-stage-fallback>(functio
         this._index = slides.length - 1;
       }
       this._apply();
+    }
+
+    goTo(index) {
+      this.go('go', index);
+    }
+
+    next() {
+      this.go('next');
+    }
+
+    prev() {
+      this.go('prev');
+    }
+
+    reset() {
+      this.go('first');
     }
 
     _onMessage(ev) {

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DECK_SLIDE_SELECTOR,
+  DECK_STRUCTURED_SLIDE_SELECTOR,
   htmlUsesDeckStageElement,
   injectDeckStageFallback,
 } from '../src/runtime/deck-stage-fallback.js';
 
 describe('deck-stage fallback runtime injection', () => {
+  it('publishes one selector contract for legacy, modern, and imported slide markers', () => {
+    expect(DECK_SLIDE_SELECTOR).toBe('.slide, [data-screen-label], .deck-slide, .ppt-slide');
+    for (const container of ['deck-stage', '.deck', '.deck-stage', '.deck-shell', '#deck', 'body']) {
+      for (const marker of ['.slide', '[data-screen-label]', '.deck-slide', '.ppt-slide']) {
+        expect(DECK_STRUCTURED_SLIDE_SELECTOR).toContain(`${container} > ${marker}`);
+      }
+    }
+  });
+
   it('does nothing for ordinary HTML without a deck-stage element', () => {
     const html = '<!doctype html><html><body><main>Hero</main></body></html>';
 
@@ -22,6 +33,9 @@ describe('deck-stage fallback runtime injection', () => {
     expect(out).toContain('data-od-deck-stage-fallback');
     expect(out).toContain("window.customElements.define('deck-stage'");
     expect(out).toContain("type: 'od:slide-state'");
+    expect(out).toContain('get index()');
+    expect(out).toContain('goTo(index)');
+    expect(out).toContain("this.go('next')");
     expect(out.indexOf('data-od-deck-stage-fallback')).toBeLessThan(out.indexOf('</body>'));
   });
 

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DECK_EXPLICIT_SLIDE_SELECTOR,
+  DECK_LEGACY_SCREEN_LABEL_RE_SOURCE,
+  DECK_LEGACY_SCREEN_SLIDE_SELECTOR,
   DECK_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
   htmlUsesDeckStageElement,
   injectDeckStageFallback,
+  legacyDeckScreenNumber,
 } from '../src/runtime/deck-stage-fallback.js';
 
 describe('deck-stage fallback runtime injection', () => {
@@ -14,12 +17,22 @@ describe('deck-stage fallback runtime injection', () => {
     expect(DECK_SLIDE_SELECTOR).toBe('.slide, [data-screen-label], .deck-slide, .ppt-slide');
     expect(DECK_EXPLICIT_SLIDE_SELECTOR).toBe('.slide, .deck-slide, .ppt-slide');
     expect(DECK_SCREEN_SLIDE_SELECTOR).toBe('[data-screen-label]');
+    expect(DECK_LEGACY_SCREEN_SLIDE_SELECTOR).toBe('section[data-screen-label]');
+    expect(new RegExp(DECK_LEGACY_SCREEN_LABEL_RE_SOURCE).test('01 Cover')).toBe(true);
     for (const container of ['deck-stage', '.deck', '.deck-stage', '.deck-shell', '#deck']) {
       for (const marker of ['.slide', '[data-screen-label]', '.deck-slide', '.ppt-slide']) {
         expect(DECK_STRUCTURED_SLIDE_SELECTOR).toContain(`${container} > ${marker}`);
       }
     }
     expect(DECK_STRUCTURED_SLIDE_SELECTOR).not.toContain('body >');
+  });
+
+  it('recognizes numbered legacy slide labels without accepting prototype labels', () => {
+    expect(legacyDeckScreenNumber('01 Cover')).toBe(1);
+    expect(legacyDeckScreenNumber('2. Agenda')).toBe(2);
+    expect(legacyDeckScreenNumber('00 Draft')).toBeNull();
+    expect(legacyDeckScreenNumber('Hero title')).toBeNull();
+    expect(legacyDeckScreenNumber('CTA')).toBeNull();
   });
 
   it('does nothing for ordinary HTML without a deck-stage element', () => {

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  DECK_EXPLICIT_SLIDE_SELECTOR,
+  DECK_SCREEN_SLIDE_SELECTOR,
   DECK_SLIDE_SELECTOR,
   DECK_STRUCTURED_SLIDE_SELECTOR,
   htmlUsesDeckStageElement,
@@ -10,11 +12,14 @@ import {
 describe('deck-stage fallback runtime injection', () => {
   it('publishes one selector contract for legacy, modern, and imported slide markers', () => {
     expect(DECK_SLIDE_SELECTOR).toBe('.slide, [data-screen-label], .deck-slide, .ppt-slide');
-    for (const container of ['deck-stage', '.deck', '.deck-stage', '.deck-shell', '#deck', 'body']) {
+    expect(DECK_EXPLICIT_SLIDE_SELECTOR).toBe('.slide, .deck-slide, .ppt-slide');
+    expect(DECK_SCREEN_SLIDE_SELECTOR).toBe('[data-screen-label]');
+    for (const container of ['deck-stage', '.deck', '.deck-stage', '.deck-shell', '#deck']) {
       for (const marker of ['.slide', '[data-screen-label]', '.deck-slide', '.ppt-slide']) {
         expect(DECK_STRUCTURED_SLIDE_SELECTOR).toContain(`${container} > ${marker}`);
       }
     }
+    expect(DECK_STRUCTURED_SLIDE_SELECTOR).not.toContain('body >');
   });
 
   it('does nothing for ordinary HTML without a deck-stage element', () => {


### PR DESCRIPTION
## Why

A generated HTML slide deck reproduced a production-facing failure where selecting a thumbnail updated the host-owned selection, counter, and speaker notes, but the main preview stayed on slide 1. The persisted deck used `<deck-stage>` children identified by `data-screen-label`, while the injected navigation bridge only treated `.slide` elements as pages.

This fixes the underlying contract drift between static thumbnail extraction, the injected preview bridge, and the deck-stage runtime so existing saved decks do not need to be regenerated or migrated.

## What users will see

Clicking a thumbnail in an existing HTML/PPT deck now moves the main preview to that slide. Thumbnail selection, the page counter, speaker notes, previous/next controls, and navigation initiated inside the deck remain synchronized across legacy and current slide markers.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout is added or changed. This is an interaction-only fix; the browser regression below exercises the existing thumbnail rail and asserts the visible preview, counter, and speaker-notes transitions.

## Bug fix verification

- Reproduction: `e2e/ui/app.test.ts`, scenario `deck-pagination-next-prev-correctness`.
- Red on `main`: after selecting thumbnail 3, the host thumbnail became active while Playwright observed `<deck-stage>.index === 0` instead of `2`.
- Green on this branch: the same scenario passes and additionally covers previous/next controls plus deck-originated reverse synchronization.
- Focused runtime coverage: `apps/web/tests/runtime/srcdoc-deck-bridge-deck-stage-api.test.ts` verifies data-screen-label-only decks, mixed marker deduplication, explicit-stage ownership, public API routing, and reverse state reporting.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/contracts test` — 290 passed
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/runtime/srcdoc.test.ts tests/runtime/srcdoc-deck-bridge-*.test.ts tests/runtime/deck-thumbnail-parser.test.ts --reporter=dot` — 90 passed
- `pnpm typecheck` in `e2e`
- `pnpm exec playwright test -c playwright.config.ts ui/app.test.ts --grep deck-pagination-next-prev-correctness --workers=1` — 1 passed in an isolated daemon/web/data-root runtime
