### PR TITLE
fix(daemon): make streamed message persistence append-only

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -229,6 +229,21 @@ function migrate(db: SqliteDb): void {
     CREATE INDEX IF NOT EXISTS idx_messages_conv
       ON messages(conversation_id, position);
 
+    -- Agent streams write small immutable batches while a run is active. The
+    -- batches are folded into messages.events_json once, at the terminal
+    -- boundary, so a long thinking stream never rewrites its full history on
+    -- every flush window.
+    CREATE TABLE IF NOT EXISTS message_event_batches (
+      id INTEGER PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      events_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY(message_id) REFERENCES messages(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_message_event_batches_message
+      ON message_event_batches(message_id, id);
+
     CREATE TABLE IF NOT EXISTS preview_comments (
       id TEXT PRIMARY KEY,
       project_id TEXT NOT NULL,
@@ -2501,7 +2516,7 @@ export function clearAgentSession(
 // ---------- messages ----------
 
 export function listMessages(db: SqliteDb, conversationId: string) {
-  return (db
+  const messages = db
     .prepare(
       `SELECT id, role, content, agent_id AS agentId, agent_name AS agentName,
               run_id AS runId, run_status AS runStatus,
@@ -2524,8 +2539,13 @@ export function listMessages(db: SqliteDb, conversationId: string) {
         WHERE conversation_id = ?
         ORDER BY position ASC`,
     )
-    .all(conversationId) as DbRow[])
-    .map(normalizeMessage);
+    .all(conversationId) as DbRow[];
+  const eventBatches = readConversationMessageEventBatches(db, conversationId);
+  return messages.map((message) => normalizeMessage(
+    db,
+    message,
+    eventBatches.get(String(message.id)) ?? [],
+  ));
 }
 
 export function getMessage(db: SqliteDb, id: string, conversationId?: string) {
@@ -2551,7 +2571,7 @@ export function getMessage(db: SqliteDb, id: string, conversationId?: string) {
         WHERE id = ?${conversationId ? ' AND conversation_id = ?' : ''}`,
     )
     .get(conversationId ? [id, conversationId] : id) as DbRow | undefined;
-  return row ? normalizeMessage(row) : null;
+  return row ? normalizeMessage(db, row) : null;
 }
 
 export function conversationTurnIndexForRun(
@@ -2587,11 +2607,40 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
   const persistedEvents = Array.isArray(m.events)
     ? compactAdjacentMessageAgentEvents(m.events)
     : m.events;
+  const eventBatchProjection = hasMessageEventBatchStorage(db)
+    ? `EXISTS(
+                SELECT 1 FROM message_event_batches AS batch
+                 WHERE batch.message_id = messages.id
+              )`
+    : '0';
   const existing = db
-    .prepare(`SELECT position FROM messages WHERE id = ?`)
+    .prepare(
+      `SELECT position, run_id AS runId, run_status AS runStatus,
+              content, events_json AS eventsJson,
+              ${eventBatchProjection} AS hasEventBatches
+         FROM messages WHERE id = ?`,
+    )
     .get(m.id) as DbRow | undefined;
   const now = Date.now();
   if (existing) {
+    // While the daemon owns an active run, its append-only batches are the
+    // event source of truth. Browser PUT snapshots can arrive between two
+    // daemon flushes; writing that whole snapshot here would duplicate the
+    // same events when the next batch is read or finalized.
+    const incomingRunIsTerminal = isTerminalMessageRunStatus(m.runStatus);
+    const preserveDaemonEventSnapshot =
+      existing.hasEventBatches === 1 ||
+      (typeof existing.runId === 'string' &&
+        (existing.runStatus === 'queued' || existing.runStatus === 'running') &&
+        !incomingRunIsTerminal);
+    const nextEventsJson = preserveDaemonEventSnapshot
+      ? existing.eventsJson ?? null
+      : persistedEvents
+        ? JSON.stringify(persistedEvents)
+        : null;
+    const nextContent = preserveDaemonEventSnapshot
+      ? existing.content ?? ''
+      : m.content;
     db.prepare(
       `UPDATE messages
           SET role = ?, content = ?, agent_id = ?, agent_name = ?,
@@ -2609,14 +2658,14 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
         WHERE id = ?`,
     ).run(
       m.role,
-      m.content,
+      nextContent,
       m.agentId ?? null,
       m.agentName ?? null,
       m.runId ?? null,
       m.runStatus ?? null,
       normalizeResultDeliveryStateForStorage(m.resultDeliveryState),
       m.lastRunEventId ?? null,
-      persistedEvents ? JSON.stringify(persistedEvents) : null,
+      nextEventsJson,
       m.attachments ? JSON.stringify(m.attachments) : null,
       m.commentAttachments ? JSON.stringify(m.commentAttachments) : null,
       m.producedFiles ? JSON.stringify(m.producedFiles) : null,
@@ -2715,7 +2764,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
          FROM messages WHERE id = ?`,
     )
     .get(m.id) as DbRow | undefined;
-  return row ? normalizeMessage(row) : null;
+  return row ? normalizeMessage(db, row) : null;
 }
 
 export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: string) {
@@ -2743,6 +2792,10 @@ export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event:
   const label = typeof event?.label === 'string' ? event.label.trim() : '';
   const detail = typeof event?.detail === 'string' ? event.detail.trim() : '';
   if (!label) return null;
+  // Status events are written outside the high-volume run stream (for
+  // example, routine completion). Fold any crash-left batches first so this
+  // update cannot strand or overwrite them.
+  finalizeMessageAgentEvents(db, messageId);
   const row = db
     .prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
     .get(messageId) as DbRow | undefined;
@@ -2780,22 +2833,11 @@ export function compactAdjacentMessageAgentEvents(
   return events;
 }
 
-export function appendMessageAgentEvents(
-  db: SqliteDb,
-  messageId: string,
+function mergeMessageAgentEvents(
+  existingEvents: readonly DbRow[],
   incomingEvents: readonly DbRow[],
-): DbRow[] | null {
-  if (incomingEvents.length === 0) return null;
-  const row = db
-    .prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
-    .get(messageId) as DbRow | undefined;
-  if (!row) return null;
-  const parsed = parseJsonOrUndef(row.eventsJson);
-  const parsedEvents = Array.isArray(parsed) ? parsed : [];
-  const events = compactAdjacentMessageAgentEvents(parsedEvents);
-  let textDelta = '';
-  let changed = events.length !== parsedEvents.length;
-
+): DbRow[] {
+  const events = compactAdjacentMessageAgentEvents(existingEvents);
   for (const event of incomingEvents) {
     if (!event || typeof event !== 'object') continue;
     const kind = typeof event.kind === 'string' ? event.kind : '';
@@ -2805,22 +2847,163 @@ export function appendMessageAgentEvents(
       (kind === 'text' || kind === 'thinking') && typeof event.text === 'string';
     if (isMergeableDelta && last?.kind === kind && typeof last.text === 'string') {
       last.text += event.text;
-      if (kind === 'text') textDelta += event.text;
-      changed = changed || event.text.length > 0;
       continue;
     }
     if (!isMergeableDelta && last && JSON.stringify(last) === JSON.stringify(event)) {
       continue;
     }
     events.push(event);
-    if (kind === 'text' && typeof event.text === 'string') textDelta += event.text;
-    changed = true;
   }
-
-  if (!changed) return events;
-  db.prepare(`UPDATE messages SET content = COALESCE(content, '') || ?, events_json = ? WHERE id = ?`)
-    .run(textDelta, JSON.stringify(events), messageId);
   return events;
+}
+
+const messageEventBatchStorageByDb = new WeakMap<SqliteDb, boolean>();
+
+function hasMessageEventBatchStorage(db: SqliteDb): boolean {
+  const cached = messageEventBatchStorageByDb.get(db);
+  if (cached !== undefined) return cached;
+  let exists = false;
+  try {
+    exists = Boolean(
+      db.prepare(
+        `SELECT 1
+           FROM sqlite_master
+          WHERE type = 'table' AND name = 'message_event_batches'`,
+      ).get(),
+    );
+  } catch {
+    // A few integration boundaries deliberately expose only the prepared
+    // statements they consume. Treat those lightweight DB adapters like a
+    // pre-batch schema and preserve the legacy snapshot behavior.
+  }
+  messageEventBatchStorageByDb.set(db, exists);
+  return exists;
+}
+
+export function clearMessageAgentEventBatches(db: SqliteDb, messageId: string): void {
+  if (!hasMessageEventBatchStorage(db)) return;
+  db.prepare(`DELETE FROM message_event_batches WHERE message_id = ?`).run(messageId);
+}
+
+function readMessageEventBatches(db: SqliteDb, messageId: string): DbRow[][] {
+  if (!hasMessageEventBatchStorage(db)) return [];
+  const rows = db.prepare(
+    `SELECT events_json AS eventsJson
+       FROM message_event_batches
+      WHERE message_id = ?
+      ORDER BY id ASC`,
+  ).all(messageId) as DbRow[];
+  return rows.flatMap((batch) => {
+    const parsed = parseJsonOrUndef(batch.eventsJson);
+    return Array.isArray(parsed) ? [parsed] : [];
+  });
+}
+
+function readConversationMessageEventBatches(
+  db: SqliteDb,
+  conversationId: string,
+): Map<string, DbRow[][]> {
+  if (!hasMessageEventBatchStorage(db)) return new Map();
+  const rows = db.prepare(
+    `SELECT batch.message_id AS messageId, batch.events_json AS eventsJson
+       FROM message_event_batches AS batch
+       JOIN messages AS message ON message.id = batch.message_id
+      WHERE message.conversation_id = ?
+      ORDER BY batch.id ASC`,
+  ).all(conversationId) as DbRow[];
+  const batches = new Map<string, DbRow[][]>();
+  for (const row of rows) {
+    const parsed = parseJsonOrUndef(row.eventsJson);
+    if (!Array.isArray(parsed)) continue;
+    const messageId = String(row.messageId);
+    const messageBatches = batches.get(messageId) ?? [];
+    messageBatches.push(parsed);
+    batches.set(messageId, messageBatches);
+  }
+  return batches;
+}
+
+function materializeMessageAgentEvents(
+  db: SqliteDb,
+  messageId: string,
+  eventsJson: unknown,
+  eventBatches?: DbRow[][],
+): { events: DbRow[]; batchCount: number; baseEventCount: number; textDelta: string } {
+  const parsed = parseJsonOrUndef(eventsJson);
+  const baseEvents = Array.isArray(parsed) ? parsed : [];
+  let events = compactAdjacentMessageAgentEvents(baseEvents);
+  const batches = eventBatches ?? readMessageEventBatches(db, messageId);
+  let textDelta = '';
+  for (const batch of batches) {
+    for (const event of batch) {
+      if (event?.kind === 'text' && typeof event.text === 'string') textDelta += event.text;
+    }
+    events = mergeMessageAgentEvents(events, batch);
+  }
+  return {
+    events,
+    batchCount: batches.length,
+    baseEventCount: baseEvents.length,
+    textDelta,
+  };
+}
+
+export function appendMessageAgentEvents(
+  db: SqliteDb,
+  messageId: string,
+  incomingEvents: readonly DbRow[],
+): DbRow[] | null {
+  if (incomingEvents.length === 0) return null;
+  const events = mergeMessageAgentEvents([], incomingEvents);
+  if (events.length === 0) return null;
+  if (!hasMessageEventBatchStorage(db)) {
+    const row = db
+      .prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get(messageId) as DbRow | undefined;
+    if (!row) return null;
+    const parsed = parseJsonOrUndef(row.eventsJson);
+    const existingEvents = Array.isArray(parsed) ? parsed : [];
+    const materializedEvents = mergeMessageAgentEvents(existingEvents, events);
+    const textDelta = events
+      .filter((event) => event?.kind === 'text' && typeof event.text === 'string')
+      .map((event) => event.text)
+      .join('');
+    db.prepare(
+      `UPDATE messages
+          SET content = COALESCE(content, '') || ?, events_json = ?
+        WHERE id = ?`,
+    ).run(textDelta, JSON.stringify(materializedEvents), messageId);
+    return materializedEvents;
+  }
+  const inserted = db.prepare(
+    `INSERT INTO message_event_batches (message_id, events_json, created_at)
+     SELECT ?, ?, ?
+      WHERE EXISTS (SELECT 1 FROM messages WHERE id = ?)`,
+  ).run(messageId, JSON.stringify(events), Date.now(), messageId);
+  return inserted.changes > 0 ? events : null;
+}
+
+export function finalizeMessageAgentEvents(
+  db: SqliteDb,
+  messageId: string,
+): DbRow[] | null {
+  return db.transaction(() => {
+    const row = db.prepare(
+      `SELECT events_json AS eventsJson FROM messages WHERE id = ?`,
+    ).get(messageId) as DbRow | undefined;
+    if (!row) return null;
+    const materialized = materializeMessageAgentEvents(db, messageId, row.eventsJson);
+    if (materialized.batchCount === 0 || !hasMessageEventBatchStorage(db)) {
+      return materialized.events;
+    }
+    db.prepare(
+      `UPDATE messages
+          SET content = COALESCE(content, '') || ?, events_json = ?
+        WHERE id = ?`,
+    ).run(materialized.textDelta, JSON.stringify(materialized.events), messageId);
+    clearMessageAgentEventBatches(db, messageId);
+    return materialized.events;
+  })();
 }
 
 export function appendMessageAgentEvent(
@@ -3742,18 +3925,146 @@ function randomCommentId(): string {
   return `cmt_${randomUUID().slice(0, 8)}`;
 }
 
-function normalizeMessage(row: DbRow) {
+const LEGACY_MESSAGE_EVENT_COMPACTION_MIN_CHARS = 256 * 1024;
+const MESSAGE_EVENT_MAINTENANCE_QUEUE_LIMIT = 1;
+
+type MessageEventMaintenanceJob =
+  | {
+      kind: 'compact_legacy';
+      messageId: string;
+      expectedEventsJson: string;
+      events: DbRow[];
+    }
+  | {
+      kind: 'finalize_batches';
+      messageId: string;
+    };
+
+type MessageEventMaintenanceState = {
+  queue: MessageEventMaintenanceJob[];
+  queuedMessageIds: Set<string>;
+  scheduled: boolean;
+  running: boolean;
+};
+
+const messageEventMaintenanceStates = new WeakMap<SqliteDb, MessageEventMaintenanceState>();
+
+function isTerminalMessageRunStatus(value: unknown): boolean {
+  return value === 'succeeded' || value === 'failed' || value === 'canceled';
+}
+
+function scheduleMessageEventMaintenance(
+  db: SqliteDb,
+  job: MessageEventMaintenanceJob,
+): void {
+  let state = messageEventMaintenanceStates.get(db);
+  if (!state) {
+    state = {
+      queue: [],
+      queuedMessageIds: new Set(),
+      scheduled: false,
+      running: false,
+    };
+    messageEventMaintenanceStates.set(db, state);
+  }
+  if (
+    state.queuedMessageIds.has(job.messageId) ||
+    state.queuedMessageIds.size >= MESSAGE_EVENT_MAINTENANCE_QUEUE_LIMIT
+  ) return;
+  state.queue.push(job);
+  state.queuedMessageIds.add(job.messageId);
+  scheduleNextMessageEventMaintenance(db, state);
+}
+
+function scheduleNextMessageEventMaintenance(
+  db: SqliteDb,
+  state: MessageEventMaintenanceState,
+): void {
+  if (state.scheduled || state.running || state.queue.length === 0) return;
+  state.scheduled = true;
+  const immediate = setImmediate(() => {
+    state.scheduled = false;
+    const job = state.queue.shift();
+    if (!job) return;
+    state.running = true;
+    try {
+      if (!db.open) return;
+      if (job.kind === 'finalize_batches') {
+        finalizeMessageAgentEvents(db, job.messageId);
+      } else {
+        const compactedJson = JSON.stringify(job.events);
+        if (compactedJson.length < job.expectedEventsJson.length) {
+          const noPendingBatches = hasMessageEventBatchStorage(db)
+            ? `AND NOT EXISTS (
+                  SELECT 1 FROM message_event_batches AS batch
+                   WHERE batch.message_id = messages.id
+                )`
+            : '';
+          db.prepare(
+            `UPDATE messages
+                SET events_json = ?
+              WHERE id = ?
+                AND events_json = ?
+                AND run_status IN ('succeeded', 'failed', 'canceled')
+                ${noPendingBatches}`,
+          ).run(compactedJson, job.messageId, job.expectedEventsJson);
+        }
+      }
+    } catch (error) {
+      console.warn('[db] message event maintenance failed', error);
+    } finally {
+      state.running = false;
+      state.queuedMessageIds.delete(job.messageId);
+      scheduleNextMessageEventMaintenance(db, state);
+    }
+  });
+  immediate.unref?.();
+}
+
+function normalizeMessage(db: SqliteDb, row: DbRow, eventBatches?: DbRow[][]) {
+  const eventsJson = typeof row.eventsJson === 'string' ? row.eventsJson : null;
+  const materializedEvents = materializeMessageAgentEvents(
+    db,
+    String(row.id),
+    eventsJson,
+    eventBatches,
+  );
+  if (isTerminalMessageRunStatus(row.runStatus)) {
+    if (materializedEvents.batchCount > 0) {
+      // A terminal row with batches means the daemon stopped between its last
+      // append and terminal folding. Recover only when that conversation is
+      // actually read; startup never scans or parses every historical row.
+      scheduleMessageEventMaintenance(db, {
+        kind: 'finalize_batches',
+        messageId: String(row.id),
+      });
+    } else if (
+      eventsJson &&
+      eventsJson.length >= LEGACY_MESSAGE_EVENT_COMPACTION_MIN_CHARS &&
+      materializedEvents.events.length < materializedEvents.baseEventCount
+    ) {
+      scheduleMessageEventMaintenance(db, {
+        kind: 'compact_legacy',
+        messageId: String(row.id),
+        expectedEventsJson: eventsJson,
+        events: materializedEvents.events,
+      });
+    }
+  }
   return {
     id: row.id,
     role: row.role,
-    content: row.content,
+    content: `${typeof row.content === 'string' ? row.content : ''}${materializedEvents.textDelta}`,
     agentId: row.agentId ?? undefined,
     agentName: row.agentName ?? undefined,
     runId: row.runId ?? undefined,
     runStatus: row.runStatus ?? undefined,
     resultDeliveryState: normalizeResultDeliveryState(row.resultDeliveryState),
     lastRunEventId: row.lastRunEventId ?? undefined,
-    events: parseJsonOrUndef(row.eventsJson),
+    events:
+      eventsJson !== null || materializedEvents.batchCount > 0
+        ? materializedEvents.events
+        : undefined,
     attachments: parseJsonOrUndef(row.attachmentsJson),
     commentAttachments: parseJsonOrUndef(row.commentAttachmentsJson),
     producedFiles: parseJsonOrUndef(row.producedFilesJson),

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -119,6 +119,7 @@ import {
   BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE,
 } from '../runtimes/byok-opencode.js';
 import { resolveChatRunInactivityTimeoutMs } from '../runtimes/chat-run-lifecycle.js';
+import { runMessageEventPersistenceAnalytics } from '../runtimes/chat-run-messages.js';
 import { TERMINAL_RUN_STATUSES } from '../runtimes/runs.js';
 import {
   deriveActivationMilestones,
@@ -2704,6 +2705,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             tool_error_count: toolAnalytics.tool_error_count,
             tool_name_count: toolAnalytics.tool_name_count,
             tool_names: toolAnalytics.tool_names_csv,
+            ...runMessageEventPersistenceAnalytics(run),
           };
         Object.assign(
           finishedProperties,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -1,7 +1,11 @@
+import { performance } from 'node:perf_hooks';
 import type Database from 'better-sqlite3';
 import type { PersistedAgentEvent } from '@open-design/contracts';
+import type { RunFinishedProps } from '@open-design/contracts/analytics';
 import {
   appendMessageAgentEvents,
+  clearMessageAgentEventBatches,
+  finalizeMessageAgentEvents,
   upsertMessage,
 } from '../db.js';
 
@@ -26,13 +30,113 @@ type PendingMessageEvents = {
   db: SqliteDb;
   messageId: string;
   events: PersistedAgentEvent[];
-  bytes: number;
+  chars: number;
   timer: ReturnType<typeof setTimeout> | null;
 };
 
+export type RunMessageEventPersistenceTelemetry = {
+  storageMode: 'append_only';
+  inputEventCount: number;
+  deltaEventCount: number;
+  inputCharCount: number;
+  flushCount: number;
+  batchEventCount: number;
+  persistedEventCount: number;
+  flushTotalMs: number;
+  flushMaxMs: number;
+  pendingCharPeak: number;
+  finalizeCount: number;
+  finalizeTotalMs: number;
+  finalizeMaxMs: number;
+  finalEventCount: number;
+  persistenceErrorCount: number;
+};
+
+type RunMessageEventPersistenceAnalytics = Pick<
+  RunFinishedProps,
+  | 'message_event_storage_mode'
+  | 'message_event_input_count'
+  | 'message_event_delta_count'
+  | 'message_event_input_char_count'
+  | 'message_event_flush_count'
+  | 'message_event_batch_event_count'
+  | 'message_event_persisted_count'
+  | 'message_event_flush_total_ms'
+  | 'message_event_flush_max_ms'
+  | 'message_event_pending_char_peak'
+  | 'message_event_finalize_count'
+  | 'message_event_finalize_total_ms'
+  | 'message_event_finalize_max_ms'
+  | 'message_event_final_event_count'
+  | 'message_event_persistence_error_count'
+>;
+
 export const RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS = 250;
-const RUN_MESSAGE_EVENT_FLUSH_BYTES = 64 * 1024;
+const RUN_MESSAGE_EVENT_FLUSH_CHARS = 64 * 1024;
 const pendingMessageEvents = new WeakMap<ChatRunMessageState, PendingMessageEvents>();
+const finalizedInputEventCounts = new WeakMap<ChatRunMessageState, number>();
+const messageEventPersistenceTelemetry = new WeakMap<
+  ChatRunMessageState,
+  RunMessageEventPersistenceTelemetry
+>();
+
+function ensureRunMessageEventPersistenceTelemetry(
+  run: ChatRunMessageState,
+): RunMessageEventPersistenceTelemetry {
+  let telemetry = messageEventPersistenceTelemetry.get(run);
+  if (!telemetry) {
+    telemetry = {
+      storageMode: 'append_only',
+      inputEventCount: 0,
+      deltaEventCount: 0,
+      inputCharCount: 0,
+      flushCount: 0,
+      batchEventCount: 0,
+      persistedEventCount: 0,
+      flushTotalMs: 0,
+      flushMaxMs: 0,
+      pendingCharPeak: 0,
+      finalizeCount: 0,
+      finalizeTotalMs: 0,
+      finalizeMaxMs: 0,
+      finalEventCount: 0,
+      persistenceErrorCount: 0,
+    };
+    messageEventPersistenceTelemetry.set(run, telemetry);
+  }
+  return telemetry;
+}
+
+export function readRunMessageEventPersistenceTelemetry(
+  run: ChatRunMessageState,
+): RunMessageEventPersistenceTelemetry | null {
+  const telemetry = messageEventPersistenceTelemetry.get(run);
+  return telemetry ? { ...telemetry } : null;
+}
+
+export function runMessageEventPersistenceAnalytics(
+  run: ChatRunMessageState,
+): RunMessageEventPersistenceAnalytics | Record<string, never> {
+  const telemetry = readRunMessageEventPersistenceTelemetry(run);
+  if (!telemetry) return {};
+  return {
+    message_event_storage_mode: telemetry.storageMode,
+    message_event_input_count: telemetry.inputEventCount,
+    message_event_delta_count: telemetry.deltaEventCount,
+    message_event_input_char_count: telemetry.inputCharCount,
+    message_event_flush_count: telemetry.flushCount,
+    message_event_batch_event_count: telemetry.batchEventCount,
+    message_event_persisted_count: telemetry.persistedEventCount,
+    message_event_flush_total_ms: Math.round(telemetry.flushTotalMs),
+    message_event_flush_max_ms: Math.round(telemetry.flushMaxMs),
+    message_event_pending_char_peak: telemetry.pendingCharPeak,
+    message_event_finalize_count: telemetry.finalizeCount,
+    message_event_finalize_total_ms: Math.round(telemetry.finalizeTotalMs),
+    message_event_finalize_max_ms: Math.round(telemetry.finalizeMaxMs),
+    message_event_final_event_count: telemetry.finalEventCount,
+    message_event_persistence_error_count: telemetry.persistenceErrorCount,
+  };
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -61,15 +165,21 @@ export function persistRunEventToAssistantMessage(
       db,
       messageId: run.assistantMessageId,
       events: [],
-      bytes: 0,
+      chars: 0,
       timer: null,
     };
     pendingMessageEvents.set(run, pending);
   }
-  appendPendingMessageEvent(pending, persisted);
-
+  const telemetry = ensureRunMessageEventPersistenceTelemetry(run);
   const isDelta = persisted.kind === 'text' || persisted.kind === 'thinking';
-  if (!isDelta || pending.bytes >= RUN_MESSAGE_EVENT_FLUSH_BYTES) {
+  const eventChars = isDelta ? persisted.text.length : JSON.stringify(persisted).length;
+  telemetry.inputEventCount += 1;
+  telemetry.inputCharCount += eventChars;
+  if (isDelta) telemetry.deltaEventCount += 1;
+  appendPendingMessageEvent(pending, persisted);
+  telemetry.pendingCharPeak = Math.max(telemetry.pendingCharPeak, pending.chars);
+
+  if (!isDelta || pending.chars >= RUN_MESSAGE_EVENT_FLUSH_CHARS) {
     flushRunMessageEvents(run);
     return;
   }
@@ -94,7 +204,7 @@ function appendPendingMessageEvent(
   } else {
     pending.events.push(event);
   }
-  pending.bytes += event.kind === 'text' || event.kind === 'thinking'
+  pending.chars += event.kind === 'text' || event.kind === 'thinking'
     ? event.text.length
     : JSON.stringify(event).length;
 }
@@ -105,10 +215,47 @@ export function flushRunMessageEvents(run: ChatRunMessageState): void {
   pendingMessageEvents.delete(run);
   if (pending.timer) clearTimeout(pending.timer);
   if (pending.events.length === 0) return;
+  const telemetry = ensureRunMessageEventPersistenceTelemetry(run);
+  telemetry.flushCount += 1;
+  telemetry.batchEventCount += pending.events.length;
+  const startedAt = performance.now();
   try {
-    appendMessageAgentEvents(pending.db, pending.messageId, pending.events);
+    const events = appendMessageAgentEvents(pending.db, pending.messageId, pending.events);
+    if (events) telemetry.persistedEventCount += events.length;
   } catch (err) {
+    telemetry.persistenceErrorCount += 1;
     console.warn('[runs] message event persistence failed', err);
+  } finally {
+    const durationMs = Math.max(0, performance.now() - startedAt);
+    telemetry.flushTotalMs += durationMs;
+    telemetry.flushMaxMs = Math.max(telemetry.flushMaxMs, durationMs);
+  }
+}
+
+export function finalizeRunMessageEvents(
+  db: SqliteDb,
+  run: ChatRunMessageState,
+): void {
+  flushRunMessageEvents(run);
+  if (!run.assistantMessageId) return;
+  const telemetry = ensureRunMessageEventPersistenceTelemetry(run);
+  if (finalizedInputEventCounts.get(run) === telemetry.inputEventCount) return;
+  telemetry.finalizeCount += 1;
+  const startedAt = performance.now();
+  try {
+    const events = finalizeMessageAgentEvents(db, run.assistantMessageId);
+    if (events) {
+      telemetry.persistedEventCount = events.length;
+      telemetry.finalEventCount = events.length;
+    }
+    finalizedInputEventCounts.set(run, telemetry.inputEventCount);
+  } catch (err) {
+    telemetry.persistenceErrorCount += 1;
+    console.warn('[runs] message event finalization failed', err);
+  } finally {
+    const durationMs = Math.max(0, performance.now() - startedAt);
+    telemetry.finalizeTotalMs += durationMs;
+    telemetry.finalizeMaxMs = Math.max(telemetry.finalizeMaxMs, durationMs);
   }
 }
 
@@ -135,6 +282,7 @@ export function persistRunFailureClassification(
   const failureDetail = run.failureDetail ?? null;
   if (!failureCategory && !failureDetail) return;
   try {
+    finalizeRunMessageEvents(db, run);
     const row = db
       .prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
       .get(run.assistantMessageId) as { eventsJson?: string } | undefined;
@@ -175,6 +323,9 @@ export function persistRunFailureClassification(
       JSON.stringify(events),
       run.assistantMessageId,
     );
+    const telemetry = ensureRunMessageEventPersistenceTelemetry(run);
+    telemetry.persistedEventCount = events.length;
+    telemetry.finalEventCount = events.length;
   } catch (err) {
     console.warn('[runs] failure classification persistence failed', err);
   }
@@ -487,6 +638,7 @@ export function pinAssistantMessageOnRunCreate(
       allowStaleActiveRebind ? 1 : 0,
     );
     if (result.changes === 0) return { ok: false, reason: 'active' as const };
+    if (!isSameRun) clearMessageAgentEventBatches(db, run.assistantMessageId!);
     opts?.beforeClaimCommit?.();
     return { ok: true };
   });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -125,6 +125,7 @@ import {
   daemonAgentPayloadToPersistedAgentEvent,
   persistRunEventToAssistantMessage,
   flushRunMessageEvents,
+  finalizeRunMessageEvents,
   persistRunFailureClassification,
   pinAssistantMessageOnRunCreate,
 } from './runtimes/chat-run-messages.js';
@@ -9719,7 +9720,7 @@ export async function startServer({
       run.clientRequestId = clientRequestId;
     if (typeof agentId === 'string' && agentId) run.agentId = agentId;
     const finishRun = (status, code = null, signal = null) => {
-      flushRunMessageEvents(run);
+      finalizeRunMessageEvents(db, run);
       return design.runs.finish(run, status, code, signal);
     };
     // Freeze the billing address once, before the first asynchronous setup

--- a/apps/daemon/src/transcript-export.ts
+++ b/apps/daemon/src/transcript-export.ts
@@ -56,6 +56,7 @@ import fs from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import path from 'node:path';
 import Database from 'better-sqlite3';
+import { listMessages } from './db.js';
 import { projectDir } from './projects.js';
 
 const SCHEMA_VERSION = 2;
@@ -239,6 +240,13 @@ export function exportProjectTranscript(
 
     for (const conv of conversations) {
       const rows = messageStmt.all(conv.id) as MessageRow[];
+      // Raw message columns are only a terminal snapshot now. During an
+      // active run, durable deltas live in message_event_batches; reuse the
+      // canonical read path so an on-demand export matches the transcript the
+      // chat UI can already reconstruct without forcing an early fold.
+      const materializedMessages = new Map(
+        listMessages(db, conv.id).map((message) => [String(message.id), message]),
+      );
       const messages: BuiltMessage[] = rows.map((row) => {
         const parsed = parseEvents(row.eventsJson);
         if (parsed.reason === 'malformed' || parsed.reason === 'not_array') {
@@ -251,9 +259,20 @@ export function exportProjectTranscript(
               `events_json is non-null but ${parsed.reason}; falling back to content.`,
           );
         }
-        const blocks = coalesceBlocks(parsed.events);
-        if (blocks.length === 0 && typeof row.content === 'string' && row.content.length > 0) {
-          blocks.push({ type: 'text', text: row.content });
+        const materialized = materializedMessages.get(row.id);
+        const materializedEvents = Array.isArray(materialized?.events)
+          ? materialized.events as PersistedAgentEvent[]
+          : parsed.events;
+        const materializedContent = typeof materialized?.content === 'string'
+          ? materialized.content
+          : row.content;
+        const blocks = coalesceBlocks(materializedEvents);
+        if (
+          blocks.length === 0 &&
+          typeof materializedContent === 'string' &&
+          materializedContent.length > 0
+        ) {
+          blocks.push({ type: 'text', text: materializedContent });
         }
 
         const attachments = parseAttachments(row.attachmentsJson);

--- a/apps/daemon/tests/db-message-events.test.ts
+++ b/apps/daemon/tests/db-message-events.test.ts
@@ -7,6 +7,7 @@ import {
   appendMessageAgentEvent,
   appendMessageStatusEvent,
   closeDatabase,
+  finalizeMessageAgentEvents,
   insertConversation,
   insertProject,
   listMessages,
@@ -181,6 +182,17 @@ describe('message event persistence', () => {
     });
     appendMessageAgentEvent(db, 'assistant-1', { kind: 'text', text: 'done.' });
 
+    const storedDuringRun = db.prepare(
+      `SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`,
+    ).get('assistant-1') as { content: string; eventsJson: string };
+    const batchCount = db.prepare(
+      `SELECT COUNT(*) AS count FROM message_event_batches WHERE message_id = ?`,
+    ).get('assistant-1') as { count: number };
+
+    expect(storedDuringRun.eventsJson).toBe('[]');
+    expect(storedDuringRun.content).toBe('');
+    expect(batchCount.count).toBe(3);
+
     const message = listMessages(db, 'conv-1')[0];
     expect(message?.content).toBe('Rendering done.');
     expect(message?.events).toEqual([
@@ -192,6 +204,130 @@ describe('message event persistence', () => {
         input: { command: 'od media generate' },
       },
       { kind: 'text', text: 'done.' },
+    ]);
+
+    // The browser periodically PUTs its live snapshot while the daemon owns
+    // the run. That snapshot must not be copied into events_json alongside
+    // the append-only batches, or the next read/finalize would double every
+    // event in the transcript.
+    upsertMessage(db, 'conv-1', {
+      ...message,
+      id: 'assistant-1',
+      role: 'assistant',
+      runId: 'agent-run-1',
+      runStatus: 'running',
+    });
+    expect(listMessages(db, 'conv-1')[0]?.events).toEqual(message?.events);
+    expect((db.prepare(
+      `SELECT events_json AS eventsJson FROM messages WHERE id = ?`,
+    ).get('assistant-1') as { eventsJson: string }).eventsJson).toBe('[]');
+
+    expect(finalizeMessageAgentEvents(db, 'assistant-1')).toEqual(message?.events);
+    expect(db.prepare(
+      `SELECT COUNT(*) AS count FROM message_event_batches WHERE message_id = ?`,
+    ).get('assistant-1')).toEqual({ count: 0 });
+    expect(JSON.parse((db.prepare(
+      `SELECT events_json AS eventsJson FROM messages WHERE id = ?`,
+    ).get('assistant-1') as { eventsJson: string }).eventsJson)).toEqual(message?.events);
+  });
+
+  it('lazily compacts a legacy terminal event snapshot after it is read', async () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-legacy',
+      name: 'Legacy stream project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-legacy',
+      projectId: 'proj-legacy',
+      title: 'Legacy stream run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-legacy', {
+      id: 'assistant-legacy',
+      role: 'assistant',
+      content: 'x'.repeat(20_000),
+      runId: 'legacy-run',
+      runStatus: 'succeeded',
+      events: [],
+      startedAt: now,
+      endedAt: now,
+    });
+    const legacyEvents = Array.from({ length: 20_000 }, () => ({
+      kind: 'thinking',
+      text: 'legacy-delta;',
+    }));
+    db.prepare(`UPDATE messages SET events_json = ? WHERE id = ?`).run(
+      JSON.stringify(legacyEvents),
+      'assistant-legacy',
+    );
+    closeDatabase();
+    const reopenedDb = openDatabase(tempDir, { dataDir: tempDir });
+    const beforeRead = reopenedDb.prepare(
+      `SELECT events_json AS eventsJson FROM messages WHERE id = ?`,
+    ).get('assistant-legacy') as { eventsJson: string };
+    expect(JSON.parse(beforeRead.eventsJson)).toHaveLength(20_000);
+
+    expect(listMessages(reopenedDb, 'conv-legacy')[0]?.events).toEqual([
+      { kind: 'thinking', text: 'legacy-delta;'.repeat(20_000) },
+    ]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const stored = reopenedDb.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-legacy') as { eventsJson: string };
+    expect(JSON.parse(stored.eventsJson)).toEqual([
+      { kind: 'thinking', text: 'legacy-delta;'.repeat(20_000) },
+    ]);
+  });
+
+  it('lazily finalizes append-only batches left behind by a terminal crash', async () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-recovery',
+      name: 'Recovered stream project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-recovery',
+      projectId: 'proj-recovery',
+      title: 'Recovered stream run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-recovery', {
+      id: 'assistant-recovery',
+      role: 'assistant',
+      content: '',
+      runId: 'recovery-run',
+      runStatus: 'running',
+      events: [],
+      startedAt: now,
+    });
+    appendMessageAgentEvent(db, 'assistant-recovery', {
+      kind: 'thinking',
+      text: 'Recovered reasoning',
+    });
+    db.prepare(`UPDATE messages SET run_status = 'failed', ended_at = ? WHERE id = ?`)
+      .run(now, 'assistant-recovery');
+
+    expect(listMessages(db, 'conv-recovery')[0]?.events).toEqual([
+      { kind: 'thinking', text: 'Recovered reasoning' },
+    ]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(db.prepare(
+      `SELECT COUNT(*) AS count FROM message_event_batches WHERE message_id = ?`,
+    ).get('assistant-recovery')).toEqual({ count: 0 });
+    const stored = db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
+      .get('assistant-recovery') as { eventsJson: string };
+    expect(JSON.parse(stored.eventsJson)).toEqual([
+      { kind: 'thinking', text: 'Recovered reasoning' },
     ]);
   });
 

--- a/apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts
+++ b/apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts
@@ -2,8 +2,11 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  finalizeRunMessageEvents,
   persistRunEventToAssistantMessage,
+  readRunMessageEventPersistenceTelemetry,
   RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS,
+  runMessageEventPersistenceAnalytics,
 } from '../../src/runtimes/chat-run-messages.js';
 
 function createDb(): Database.Database {
@@ -14,12 +17,25 @@ function createDb(): Database.Database {
       content TEXT NOT NULL DEFAULT '',
       events_json TEXT
     );
+    CREATE TABLE message_event_batches (
+      id INTEGER PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      events_json TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
     CREATE TABLE message_event_updates (count INTEGER NOT NULL DEFAULT 0);
     INSERT INTO message_event_updates (count) VALUES (0);
+    CREATE TABLE message_content_updates (count INTEGER NOT NULL DEFAULT 0);
+    INSERT INTO message_content_updates (count) VALUES (0);
     CREATE TRIGGER count_message_event_updates
       AFTER UPDATE OF events_json ON messages
       BEGIN
         UPDATE message_event_updates SET count = count + 1;
+      END;
+    CREATE TRIGGER count_message_content_updates
+      AFTER UPDATE OF content ON messages
+      BEGIN
+        UPDATE message_content_updates SET count = count + 1;
       END;
   `);
   return db;
@@ -34,7 +50,7 @@ describe('run message event persistence', () => {
     db = null;
   });
 
-  it('coalesces a high-volume delta stream before synchronously rewriting the message', () => {
+  it('coalesces a high-volume delta stream before one terminal fold', () => {
     db = createDb();
     db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
       .run('assistant-1');
@@ -48,6 +64,7 @@ describe('run message event persistence', () => {
       });
     }
     persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+    finalizeRunMessageEvents(db, run);
 
     const message = db.prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
       .get('assistant-1') as { content: string; eventsJson: string };
@@ -72,6 +89,7 @@ describe('run message event persistence', () => {
       });
     }
     persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+    finalizeRunMessageEvents(db, run);
 
     const message = db.prepare(`SELECT content, events_json AS eventsJson FROM messages WHERE id = ?`)
       .get('assistant-1') as { content: string; eventsJson: string };
@@ -84,6 +102,129 @@ describe('run message event persistence', () => {
       { kind: 'thinking', text: 'x'.repeat(50_000) },
     ]);
     expect(updates.count).toBeLessThanOrEqual(2);
+  });
+
+  it('reports persistence pressure without emitting a high-cardinality event per flush', () => {
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+
+    for (let index = 0; index < 1_500; index += 1) {
+      persistRunEventToAssistantMessage(db, run, 'agent', {
+        type: 'thinking_delta',
+        delta: 'x',
+      });
+    }
+    persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+    finalizeRunMessageEvents(db, run);
+
+    expect(readRunMessageEventPersistenceTelemetry(run)).toMatchObject({
+      storageMode: 'append_only',
+      inputEventCount: 1_500,
+      deltaEventCount: 1_500,
+      inputCharCount: 1_500,
+      flushCount: 1,
+      batchEventCount: 1,
+      persistedEventCount: 1,
+      pendingCharPeak: 1_500,
+      finalizeCount: 1,
+      finalEventCount: 1,
+      persistenceErrorCount: 0,
+    });
+    expect(runMessageEventPersistenceAnalytics(run)).toMatchObject({
+      message_event_storage_mode: 'append_only',
+      message_event_input_count: 1_500,
+      message_event_delta_count: 1_500,
+      message_event_input_char_count: 1_500,
+      message_event_flush_count: 1,
+      message_event_batch_event_count: 1,
+      message_event_persisted_count: 1,
+      message_event_pending_char_peak: 1_500,
+      message_event_finalize_count: 1,
+      message_event_final_event_count: 1,
+      message_event_persistence_error_count: 0,
+    });
+  });
+
+  it('bounds writes for a five-minute time-distributed 30,000-delta stream', async () => {
+    vi.useFakeTimers();
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+
+    const flushWindows = 1_200;
+    const deltasPerWindow = 25;
+    for (let window = 0; window < flushWindows; window += 1) {
+      for (let delta = 0; delta < deltasPerWindow; delta += 1) {
+        persistRunEventToAssistantMessage(db, run, 'agent', {
+          type: 'thinking_delta',
+          delta: 'x',
+        });
+      }
+      await vi.advanceTimersByTimeAsync(RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS);
+    }
+    const updates = db.prepare(`SELECT count FROM message_event_updates`).get() as { count: number };
+    const batches = db.prepare(`SELECT COUNT(*) AS count FROM message_event_batches`).get() as {
+      count: number;
+    };
+    expect(updates.count).toBe(0);
+    expect(batches.count).toBe(flushWindows);
+
+    persistRunEventToAssistantMessage(db, run, 'end', { status: 'succeeded' });
+    finalizeRunMessageEvents(db, run);
+
+    const finalizedUpdates = db.prepare(`SELECT count FROM message_event_updates`).get() as {
+      count: number;
+    };
+    const remainingBatches = db.prepare(`SELECT COUNT(*) AS count FROM message_event_batches`)
+      .get() as { count: number };
+    expect(finalizedUpdates.count).toBe(1);
+    expect(remainingBatches.count).toBe(0);
+    expect(readRunMessageEventPersistenceTelemetry(run)).toMatchObject({
+      inputEventCount: flushWindows * deltasPerWindow,
+      deltaEventCount: flushWindows * deltasPerWindow,
+      flushCount: flushWindows,
+      batchEventCount: flushWindows,
+      persistedEventCount: 1,
+      finalizeCount: 1,
+      finalEventCount: 1,
+      persistenceErrorCount: 0,
+    });
+  });
+
+  it('keeps time-distributed text append-only until the terminal fold', async () => {
+    vi.useFakeTimers();
+    db = createDb();
+    db.prepare(`INSERT INTO messages (id, content, events_json) VALUES (?, '', '[]')`)
+      .run('assistant-1');
+    const run = { id: 'run-1', assistantMessageId: 'assistant-1' };
+
+    const flushWindows = 100;
+    for (let window = 0; window < flushWindows; window += 1) {
+      persistRunEventToAssistantMessage(db, run, 'agent', {
+        type: 'text_delta',
+        delta: `window-${window};`,
+      });
+      await vi.advanceTimersByTimeAsync(RUN_MESSAGE_EVENT_FLUSH_INTERVAL_MS);
+    }
+
+    expect(db.prepare(`SELECT count FROM message_content_updates`).get())
+      .toEqual({ count: 0 });
+    expect(db.prepare(`SELECT content FROM messages WHERE id = ?`).get('assistant-1'))
+      .toEqual({ content: '' });
+
+    finalizeRunMessageEvents(db, run);
+
+    const expectedText = Array.from(
+      { length: flushWindows },
+      (_, window) => `window-${window};`,
+    ).join('');
+    expect(db.prepare(`SELECT count FROM message_content_updates`).get())
+      .toEqual({ count: 1 });
+    expect(db.prepare(`SELECT content FROM messages WHERE id = ?`).get('assistant-1'))
+      .toEqual({ content: expectedText });
   });
 
   it('flushes deltas on the interval boundary and semantic events immediately', async () => {
@@ -104,8 +245,10 @@ describe('run message event persistence', () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
       .get('assistant-1')).toEqual({
-      eventsJson: JSON.stringify([{ kind: 'text', text: 'hello' }]),
+      eventsJson: '[]',
     });
+    expect(db.prepare(`SELECT COUNT(*) AS count FROM message_event_batches`).get())
+      .toEqual({ count: 1 });
 
     persistRunEventToAssistantMessage(db, run, 'agent', {
       type: 'thinking_delta',
@@ -117,6 +260,10 @@ describe('run message event persistence', () => {
       name: 'Read',
       input: { file_path: 'brief.md' },
     });
+
+    expect(db.prepare(`SELECT COUNT(*) AS count FROM message_event_batches`).get())
+      .toEqual({ count: 2 });
+    finalizeRunMessageEvents(db, run);
 
     const message = db.prepare(`SELECT events_json AS eventsJson FROM messages WHERE id = ?`)
       .get('assistant-1') as { eventsJson: string };

--- a/apps/daemon/tests/transcript-export.test.ts
+++ b/apps/daemon/tests/transcript-export.test.ts
@@ -21,6 +21,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {
+  appendMessageAgentEvents,
   closeDatabase,
   insertConversation,
   insertProject,
@@ -214,6 +215,32 @@ describe('exportProjectTranscript', () => {
     const lines = readLines(exportProjectTranscript(db, projectsRoot, PROJECT_ID, { now: FIXED_NOW }).path);
     const msg = line(lines, 2);
     expect(msg.blocks).toEqual([{ type: 'text', text: 'hello world' }]);
+  });
+
+  it('includes append-only events from an active assistant run', () => {
+    const { db, projectsRoot } = setup();
+    seedConversation(db, { id: 'c1', createdAt: 100 });
+    upsertMessage(db, 'c1', {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      events: [],
+      runId: 'run-1',
+      runStatus: 'running',
+    });
+    appendMessageAgentEvents(db, 'm1', [
+      { kind: 'thinking', text: 'working' },
+      { kind: 'text', text: 'answer' },
+    ]);
+
+    const lines = readLines(
+      exportProjectTranscript(db, projectsRoot, PROJECT_ID, { now: FIXED_NOW }).path,
+    );
+
+    expect(line(lines, 2).blocks).toEqual([
+      { type: 'thinking', thinking: 'working' },
+      { type: 'text', text: 'answer' },
+    ]);
   });
 
   it('preserves tool_use and tool_result ordering interleaved with text', () => {

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -571,6 +571,29 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   agent_cli_version?: string;
   runtime_companion_name?: string;
   runtime_companion_version?: string;
+  /** Current assistant-message event persistence path for rollout comparison. */
+  message_event_storage_mode?: 'events_json_snapshot' | 'append_only';
+  /** Persistable agent events observed before batching or compaction. */
+  message_event_input_count?: number;
+  message_event_delta_count?: number;
+  /** Approximate UTF-16 character volume accepted by the persistence path. */
+  message_event_input_char_count?: number;
+  /** Synchronous message persistence batches attempted during this run. */
+  message_event_flush_count?: number;
+  /** Events handed to storage after in-memory adjacent-delta compaction. */
+  message_event_batch_event_count?: number;
+  /** Final compacted event count observed after the last successful flush. */
+  message_event_persisted_count?: number;
+  message_event_flush_total_ms?: number;
+  message_event_flush_max_ms?: number;
+  message_event_pending_char_peak?: number;
+  /** Number and cost of terminal append-only batch folds. */
+  message_event_finalize_count?: number;
+  message_event_finalize_total_ms?: number;
+  message_event_finalize_max_ms?: number;
+  /** Compacted event count in the terminal message snapshot. */
+  message_event_final_event_count?: number;
+  message_event_persistence_error_count?: number;
   retry_original_failure_category?: TrackingRunFailureCategory;
   retry_original_failure_detail?: TrackingRunFailureDetail;
   retry_original_failure_stage?: TrackingRunFailureStage;


### PR DESCRIPTION
## Why

A prerelease QA assessment found that long agent thinking streams still parsed and rewrote the complete messages.events_json snapshot on every 250 ms flush. A multi-minute DeepSeek Harness run could therefore keep the page busy and amplify SQLite work as the transcript grew. Existing giant snapshots also remained expensive on their first read.

This change keeps the visible streaming behavior while making persistence cost proportional to each new batch, and adds bounded rollout diagnostics without emitting telemetry per delta or flush.

## What users will see

Long agent runs continue to stream thinking and text as before, but conversation reloads remain responsive and completed runs no longer leave a growing message snapshot rewrite workload. Refreshing during an active run reconstructs the full transcript from durable batches and continues streaming.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [x] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: no UI surface changed.

## Bug fix verification

- Test paths: apps/daemon/tests/runtimes/chat-run-message-event-persistence.test.ts and apps/daemon/tests/db-message-events.test.ts
- Red on main: yes. The five-minute 30,000-delta spec observed 1,200 full events_json rewrites; the new terminal-fold and lazy-migration APIs were absent.
- Green on this branch: yes. The focused persistence, legacy migration, crash recovery, minimal-schema, and lightweight DB adapter coverage passes.

## Validation

- pnpm guard
- pnpm typecheck
- pnpm --filter @open-design/daemon typecheck
- pnpm --filter @open-design/daemon test — 669 files passed, 2 skipped; 8,524 tests passed, 6 skipped
- Focused post-rebase suite — 59 tests passed
- Real DeepSeek Harness E2E with isolated daemon/web data, Chrome, and Open Browser Use: approximately seven minutes and 39,686 persisted input events; active-run reload restored the full transcript and continued streaming; terminal fold completed in about 4 ms, produced 60 compacted events, and left zero pending batches; the HTML artifact was generated and previewed.