### PR TITLE
add od lint — CLI half of the artifact lint endpoint

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -18,6 +18,7 @@ import { resolveDaemonUrl } from './daemon-url.js';
 import { requestJsonIpc } from '@open-design/sidecar';
 import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
 import { EXPORT_FORMATS, EXPORT_IMAGE_FORMATS } from '@open-design/contracts';
+import type { ArtifactLintFinding, LintArtifactCliResultEnvelope, LintArtifactResponse, LintFailOn } from '@open-design/contracts';
 import { buildExportCliRequestBody, buildExportCliResultEnvelope, resolveExportCliDeckMode } from './export-cli-request.js';
 import { exportRoutePath } from './export-cli-routing.js';
 import {
@@ -407,6 +408,7 @@ const SUBCOMMAND_MAP = {
   craft: runCraft,
   diagnostics: runDiagnostics,
   export: runExport,
+  lint: runLint,
   status: runStatus,
   version: runVersion,
   'whats-new': runWhatsNew,
@@ -605,6 +607,121 @@ async function runExport(args) {
     );
   }
   console.log(`wrote ${out} (${buffer.length} bytes)`);
+}
+
+const LINT_STRING_FLAGS = new Set(['daemon-url', 'file', 'html-file', 'fail-on']);
+const LINT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'agent-message']);
+const LINT_FAIL_ON_VALUES = ['p0', 'p1', 'p2', 'none'];
+
+function printLintHelp() {
+  console.log(`Usage:
+  od lint <file.html|-> [options]
+
+Run the daemon's anti-slop artifact linter (the same checks applied on
+artifact save) against an HTML file, or stdin when the file is \`-\`.
+Runs without model/agent calls; works against a headless daemon.
+
+Exit codes: 0 clean at threshold · 1 findings at/above --fail-on ·
+2 usage · 3 daemon unreachable.
+
+Options:
+  --file, --html-file <p>  Input path (alternative to the positional; \`-\` = stdin)
+  --fail-on <sev>          p0 | p1 | p2 | none — exit 1 threshold (default p0)
+  --agent-message          Also print the <artifact-lint> block for agent splicing
+  --json                   Print a machine-readable result envelope
+  --daemon-url <url>       Override daemon URL
+
+Examples:
+  od lint artifact.html
+  od lint - < artifact.html --json
+  od lint report.html --fail-on p1 --agent-message`);
+}
+
+// CLI half of POST /api/artifacts/lint. The endpoint has been live since the
+// linter landed, but without a subcommand it was unreachable from external
+// agents — the exact gap the dual-track rule in AGENTS.md exists to prevent.
+async function runLint(args) {
+  if (args.length === 0 || args[0] === 'help' || args.includes('--help') || args.includes('-h')) {
+    printLintHelp();
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+  let flags;
+  try {
+    flags = parseFlags(args, { string: LINT_STRING_FLAGS, boolean: LINT_BOOLEAN_FLAGS });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+  const pos = positionalArgs(args, LINT_STRING_FLAGS);
+  const file = flags.file || flags['html-file'] || pos[0];
+  if (!file) {
+    printLintHelp();
+    process.exit(2);
+  }
+  const failOn = (flags['fail-on'] || 'p0') as LintFailOn;
+  if (!LINT_FAIL_ON_VALUES.includes(failOn)) {
+    console.error(`invalid --fail-on: ${failOn} (expected ${LINT_FAIL_ON_VALUES.join(' | ')})`);
+    process.exit(2);
+  }
+  let html;
+  try {
+    if (file === '-') {
+      const chunks = [];
+      for await (const chunk of process.stdin) chunks.push(chunk);
+      html = Buffer.concat(chunks).toString('utf8');
+    } else {
+      const { readFile } = await import('node:fs/promises');
+      html = await readFile(file, 'utf8');
+    }
+  } catch (err) {
+    console.error(`cannot read ${file}: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+  if (html.length === 0) {
+    console.error(`empty input: ${file}`);
+    process.exit(2);
+  }
+  const base = await cliDaemonBaseUrl(flags);
+  let resp;
+  try {
+    resp = await fetch(`${base}/api/artifacts/lint`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ html }),
+    });
+  } catch (err) {
+    surfaceFetchError(err, base);
+    process.exit(3);
+  }
+  if (!resp.ok) return structuredHttpFailure(resp);
+  const { findings, agentMessage } = (await resp.json()) as LintArtifactResponse;
+  const counts = { p0: 0, p1: 0, p2: 0 };
+  for (const f of findings) {
+    if (f.severity === 'P0') counts.p0 += 1;
+    else if (f.severity === 'P1') counts.p1 += 1;
+    else counts.p2 += 1;
+  }
+  const failed =
+    failOn === 'p0' ? counts.p0 > 0
+    : failOn === 'p1' ? counts.p0 + counts.p1 > 0
+    : failOn === 'p2' ? findings.length > 0
+    : false;
+  if (flags.json) {
+    const envelope: LintArtifactCliResultEnvelope = {
+      ok: !failed, file, failOn, counts, findings, agentMessage,
+    };
+    process.stdout.write(JSON.stringify(envelope, null, 2) + '\n');
+  } else {
+    for (const f of findings as ArtifactLintFinding[]) {
+      console.log(`[${f.severity}] ${f.id} — ${f.message}`);
+      if (f.snippet) console.log(`      ${f.snippet}`);
+      console.log(`      fix: ${f.fix}`);
+    }
+    const summary = `${findings.length} finding${findings.length === 1 ? '' : 's'} (P0 ${counts.p0} · P1 ${counts.p1} · P2 ${counts.p2})`;
+    console.log(findings.length ? summary : `clean — ${summary}`);
+    if (flags['agent-message'] && agentMessage) console.log(`\n${agentMessage}`);
+  }
+  if (failed) process.exitCode = 1;
 }
 
 if (argv[0] === 'mcp' && argv[1] === 'live-artifacts') {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -923,6 +923,11 @@ function printRootHelp() {
       (no model/agent calls). Mirrors the web Download menu; rasterization uses
       the desktop runtime's bundled Chromium.
 
+  od lint <file.html|-> [--fail-on <p0|p1|p2|none>] [--json]
+      Run the daemon's anti-slop artifact linter against an HTML file or stdin
+      (no model/agent calls; headless-safe). Exits 1 when findings meet the
+      --fail-on threshold, so it can gate cron/CI render pipelines.
+
   "$OD_NODE_BIN" "$OD_BIN" tools ...
       Recommended agent-runtime form; avoids relying on user PATH for od or node.
 

--- a/apps/daemon/src/lint-artifact.ts
+++ b/apps/daemon/src/lint-artifact.ts
@@ -17,15 +17,15 @@
  * surface badges next to each saved artifact.
  */
 
-type LintSeverity = 'P0' | 'P1' | 'P2';
+import type { ArtifactLintFinding, ArtifactLintSeverity } from '@open-design/contracts';
 
-export type LintFinding = {
-  severity: LintSeverity;
-  id: string;
-  message: string;
-  fix: string;
-  snippet?: string;
-};
+// The shared wire contract in @open-design/contracts is the authority for
+// the finding shape; the legacy names alias it so existing importers keep
+// compiling while incompatible producer changes now fail compilation here
+// rather than drifting silently behind a consumer-side assertion.
+type LintSeverity = ArtifactLintSeverity;
+
+export type LintFinding = ArtifactLintFinding;
 
 type CssDeclaration = { prop: string; value: string };
 type CssTokenScope = {

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import type { Express, Request, Response } from 'express';
+import type { LintArtifactRequest, LintArtifactResponse } from '@open-design/contracts';
 import {
   PREVIEW_OBSERVABILITY_BRIDGE_MARKER,
   buildPreviewObservabilityBridge,
@@ -4864,17 +4865,20 @@ export function registerProjectArtifactRoutes(app: Express, ctx: RegisterProject
   // Standalone lint endpoint — POST raw HTML, get findings back.
   // The chat layer uses this to lint streamed-in artifacts without writing
   // them to disk first, so a P0 issue can be surfaced before save.
+  // Request/response are typed against the shared contract so a producer
+  // change that breaks the wire shape fails compilation here.
   app.post('/api/artifacts/lint', (req, res) => {
     try {
-      const { html } = req.body || {};
+      const { html } = (req.body ?? {}) as Partial<LintArtifactRequest>;
       if (typeof html !== 'string' || html.length === 0) {
         return res.status(400).json({ error: 'html required' });
       }
       const findings = lintArtifact(html);
-      res.json({
+      const payload: LintArtifactResponse = {
         findings,
         agentMessage: renderFindingsForAgent(findings),
-      });
+      };
+      res.json(payload);
     } catch (err: any) {
       res.status(500).json({ error: String(err) });
     }

--- a/apps/daemon/tests/cli-lint.test.ts
+++ b/apps/daemon/tests/cli-lint.test.ts
@@ -1,0 +1,293 @@
+// Contract test for the `od lint` CLI surface. Keeps the UI / API / CLI
+// triple wired together (AGENTS.md "Capability exposure"): the CLI must
+// drive the same POST /api/artifacts/lint endpoint the web layer uses,
+// with --json support for headless agents.
+//
+// Same stub-server process harness as cli-templates.test.ts /
+// cli-deploy.test.ts: we prove SUBCOMMAND_MAP routes `lint`, parseFlags
+// accepts the documented flags, the right HTTP call is emitted, and the
+// exit code follows the --fail-on threshold — without booting the daemon.
+
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { ArtifactLintFinding } from '@open-design/contracts';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = pathResolve(__dirname, '..');
+const REPO_ROOT = pathResolve(__dirname, '../../..');
+const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
+const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+const P0_FINDING: ArtifactLintFinding = {
+  severity: 'P0',
+  id: 'ai-default-indigo',
+  message: 'Found a default LLM accent color (#6366f1).',
+  fix: 'Replace with var(--accent).',
+  snippet: '#6366f1',
+};
+const P1_FINDING: ArtifactLintFinding = {
+  severity: 'P1',
+  id: 'slide-rhythm',
+  message: 'Three same-theme slides in a row.',
+  fix: 'Swap the middle slide theme.',
+};
+const P2_FINDING: ArtifactLintFinding = {
+  severity: 'P2',
+  id: 'advisory-example',
+  message: 'Advisory finding.',
+  fix: 'Optional.',
+};
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface StubServer {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  setResponder: (
+    fn: (req: CapturedRequest) => { status: number; body: unknown } | null,
+  ) => void;
+  close: () => Promise<void>;
+}
+
+async function startStubServer(): Promise<StubServer> {
+  const requests: CapturedRequest[] = [];
+  let responder:
+    | ((req: CapturedRequest) => { status: number; body: unknown } | null)
+    | null = null;
+
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      const captured: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        body: raw,
+      };
+      requests.push(captured);
+      const response = responder?.(captured) ?? { status: 200, body: { findings: [], agentMessage: '' } };
+      res.statusCode = response.status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(response.body));
+    });
+  });
+
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    baseUrl,
+    requests,
+    setResponder: (fn) => {
+      responder = fn;
+    },
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((err) => (err ? rejectClose(err) : resolveClose()));
+      }),
+  };
+}
+
+async function runCli(
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv; stdin?: string } = {},
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...options.env,
+  };
+  delete env.NODE_OPTIONS;
+  return await new Promise((resolveRun) => {
+    const child = execFile(
+      process.execPath,
+      [TSX_CLI, CLI_SRC, ...args],
+      {
+        cwd: DAEMON_ROOT,
+        env,
+        timeout: 15_000,
+        maxBuffer: 4 * 1024 * 1024,
+      },
+      (err, stdout, stderr) => {
+        const failed = err as { code?: number | null } | null;
+        resolveRun({
+          stdout: stdout ?? '',
+          stderr: stderr ?? '',
+          code: failed ? failed.code ?? 1 : 0,
+        });
+      },
+    );
+    if (options.stdin != null) {
+      child.stdin?.write(options.stdin);
+    }
+    child.stdin?.end();
+  });
+}
+
+// Reserve a port the OS says is free, then close it, so connections fail
+// with ECONNREFUSED (same rationale as cli-templates.test.ts #2428 fix:
+// a `port + 1` heuristic can silently hit an unrelated server).
+async function reserveAndReleasePort(): Promise<number> {
+  return new Promise((resolveListen, rejectListen) => {
+    const probe = http.createServer();
+    probe.unref();
+    probe.once('error', rejectListen);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      if (!addr || typeof addr === 'string') {
+        probe.close();
+        rejectListen(new Error('probe server has no address'));
+        return;
+      }
+      const { port } = addr;
+      probe.close((err) => (err ? rejectListen(err) : resolveListen(port)));
+    });
+  });
+}
+
+describe('od lint CLI entrypoint', () => {
+  let stub: StubServer;
+  let fixtureDir: string;
+  let cleanFile: string;
+
+  beforeAll(async () => {
+    stub = await startStubServer();
+    fixtureDir = mkdtempSync(join(tmpdir(), 'od-cli-lint-'));
+    cleanFile = join(fixtureDir, 'clean.html');
+    writeFileSync(cleanFile, '<main><p>Hello</p></main>');
+  });
+
+  afterAll(async () => {
+    await stub.close();
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('POSTs the file body to /api/artifacts/lint and exits 0 on clean', async () => {
+    stub.setResponder(() => ({ status: 200, body: { findings: [], agentMessage: '' } }));
+    const before = stub.requests.length;
+    const run = await runCli(['lint', cleanFile, '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain('clean — 0 findings');
+    const req = stub.requests[before];
+    expect(req?.method).toBe('POST');
+    expect(req?.url).toBe('/api/artifacts/lint');
+    expect(JSON.parse(req?.body ?? '{}')).toEqual({ html: '<main><p>Hello</p></main>' });
+  });
+
+  it('reads stdin when the file is `-` and sends it verbatim', async () => {
+    stub.setResponder(() => ({ status: 200, body: { findings: [], agentMessage: '' } }));
+    const before = stub.requests.length;
+    const run = await runCli(['lint', '-', '--daemon-url', stub.baseUrl], {
+      stdin: '<p>from stdin</p>',
+    });
+    expect(run.code).toBe(0);
+    expect(JSON.parse(stub.requests[before]?.body ?? '{}')).toEqual({ html: '<p>from stdin</p>' });
+  });
+
+  it('exits 1 on a P0 finding at the default threshold and prints it', async () => {
+    stub.setResponder(() => ({
+      status: 200,
+      body: { findings: [P0_FINDING], agentMessage: '<artifact-lint>x</artifact-lint>' },
+    }));
+    const run = await runCli(['lint', cleanFile, '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(1);
+    expect(run.stdout).toContain('[P0] ai-default-indigo');
+    expect(run.stdout).toContain('fix: Replace with var(--accent).');
+  });
+
+  it('exits 0 on a P1-only response at the default p0 threshold', async () => {
+    stub.setResponder(() => ({ status: 200, body: { findings: [P1_FINDING], agentMessage: '' } }));
+    const run = await runCli(['lint', cleanFile, '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain('[P1] slide-rhythm');
+  });
+
+  it('honors --fail-on p1 and p2 thresholds', async () => {
+    stub.setResponder(() => ({ status: 200, body: { findings: [P1_FINDING], agentMessage: '' } }));
+    expect((await runCli(['lint', cleanFile, '--fail-on', 'p1', '--daemon-url', stub.baseUrl])).code).toBe(1);
+
+    stub.setResponder(() => ({ status: 200, body: { findings: [P2_FINDING], agentMessage: '' } }));
+    expect((await runCli(['lint', cleanFile, '--fail-on', 'p1', '--daemon-url', stub.baseUrl])).code).toBe(0);
+    expect((await runCli(['lint', cleanFile, '--fail-on', 'p2', '--daemon-url', stub.baseUrl])).code).toBe(1);
+  });
+
+  it('honors --fail-on none even with P0 findings', async () => {
+    stub.setResponder(() => ({ status: 200, body: { findings: [P0_FINDING], agentMessage: '' } }));
+    const run = await runCli(['lint', cleanFile, '--fail-on', 'none', '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(0);
+  });
+
+  it('prints a machine envelope with --json (counts, findings, agentMessage)', async () => {
+    stub.setResponder(() => ({
+      status: 200,
+      body: { findings: [P0_FINDING, P1_FINDING], agentMessage: '<artifact-lint>m</artifact-lint>' },
+    }));
+    const run = await runCli(['lint', cleanFile, '--json', '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(1);
+    const envelope = JSON.parse(run.stdout);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failOn).toBe('p0');
+    expect(envelope.counts).toEqual({ p0: 1, p1: 1, p2: 0 });
+    expect(envelope.findings).toHaveLength(2);
+    expect(envelope.agentMessage).toContain('<artifact-lint>');
+  });
+
+  it('appends the agent block to human output only with --agent-message', async () => {
+    stub.setResponder(() => ({
+      status: 200,
+      body: { findings: [P0_FINDING], agentMessage: '<artifact-lint>block</artifact-lint>' },
+    }));
+    const withFlag = await runCli(['lint', cleanFile, '--agent-message', '--daemon-url', stub.baseUrl]);
+    expect(withFlag.stdout).toContain('<artifact-lint>block</artifact-lint>');
+    const withoutFlag = await runCli(['lint', cleanFile, '--daemon-url', stub.baseUrl]);
+    expect(withoutFlag.stdout).not.toContain('<artifact-lint>');
+  });
+
+  it('exits 2 on usage errors: unknown flag, bad --fail-on, missing file, empty input', async () => {
+    expect((await runCli(['lint', cleanFile, '--bogus', '--daemon-url', stub.baseUrl])).code).toBe(2);
+    expect((await runCli(['lint', cleanFile, '--fail-on', 'p9', '--daemon-url', stub.baseUrl])).code).toBe(2);
+    expect((await runCli(['lint'])).code).toBe(2);
+    const missing = await runCli(['lint', join(fixtureDir, 'nope.html'), '--daemon-url', stub.baseUrl]);
+    expect(missing.code).toBe(2);
+    expect(missing.stderr).toContain('cannot read');
+    const empty = join(fixtureDir, 'empty.html');
+    writeFileSync(empty, '');
+    const emptyRun = await runCli(['lint', empty, '--daemon-url', stub.baseUrl]);
+    expect(emptyRun.code).toBe(2);
+    expect(emptyRun.stderr).toContain('empty input');
+  });
+
+  it('surfaces an HTTP failure as a structured nonzero exit', async () => {
+    stub.setResponder(() => ({ status: 500, body: { error: 'boom' } }));
+    const run = await runCli(['lint', cleanFile, '--daemon-url', stub.baseUrl]);
+    expect(run.code).toBe(64);
+    expect(`${run.stdout}${run.stderr}`).toContain('boom');
+  });
+
+  it('exits 3 when the daemon is unreachable', async () => {
+    const port = await reserveAndReleasePort();
+    const run = await runCli(['lint', cleanFile, '--daemon-url', `http://127.0.0.1:${port}`]);
+    expect(run.code).toBe(3);
+  });
+
+  it('is discoverable from the root help output', async () => {
+    const run = await runCli(['--help']);
+    expect(run.stdout).toContain('od lint <file.html|->');
+    expect(run.stdout).toContain('--fail-on');
+  });
+});

--- a/packages/contracts/src/api/artifact-lint.ts
+++ b/packages/contracts/src/api/artifact-lint.ts
@@ -1,0 +1,53 @@
+// Artifact lint — the anti-slop linter's wire contract.
+//
+// The daemon has served POST /api/artifacts/lint (and returned the same
+// findings inline from POST /api/artifacts/save) since the linter landed,
+// but the shape only ever existed as a private type in
+// apps/daemon/src/lint-artifact.ts. This file makes it a shared DTO so the
+// CLI (`od lint`) and web surfaces parse one contract instead of
+// re-declaring the daemon's internals.
+
+export type ArtifactLintSeverity = 'P0' | 'P1' | 'P2';
+
+export interface ArtifactLintFinding {
+  severity: ArtifactLintSeverity;
+  /** Stable rule id, e.g. `purple-gradient`, `invented-metric`. */
+  id: string;
+  message: string;
+  /** Actionable remediation, phrased for the generating agent. */
+  fix: string;
+  /** Offending excerpt when the rule can isolate one. */
+  snippet?: string;
+}
+
+export interface LintArtifactRequest {
+  html: string;
+}
+
+export interface LintArtifactResponse {
+  findings: ArtifactLintFinding[];
+  /**
+   * Findings pre-rendered as an `<artifact-lint>` block, formatted to be
+   * spliced into the generating agent's next turn for self-correction.
+   */
+  agentMessage: string;
+}
+
+/** Severity threshold for `od lint`'s exit code. `none` never fails. */
+export type LintFailOn = 'p0' | 'p1' | 'p2' | 'none';
+
+export interface LintArtifactCliCounts {
+  p0: number;
+  p1: number;
+  p2: number;
+}
+
+/** Machine envelope printed by `od lint --json`. */
+export interface LintArtifactCliResultEnvelope {
+  ok: boolean;
+  file: string;
+  failOn: LintFailOn;
+  counts: LintArtifactCliCounts;
+  findings: ArtifactLintFinding[];
+  agentMessage: string;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from './api/amrWallet.js';
 export * from './api/amr-auth.js';
 export * from './api/automations.js';
 export * from './api/artifacts.js';
+export * from './api/artifact-lint.js';
 export * from './api/brands.js';
 export * from './api/brief.js';
 export * from './api/chat.js';


### PR DESCRIPTION
Part of #6958 — first slice of the proposal there (this PR does not close it; the figure-ledger and export-disclosure pieces are held for the scope discussion in that thread).

## Why

**Use case:** we drive Open Design headlessly — hermes-agent calling `od` subcommands as a render backend, no human at the web UI. Building a render gate (generate → lint → export, all model-free), we found the lint step is the one capability in the chain with no CLI verb: `POST /api/artifacts/lint` is live, but `od lint` returns `unknown command`.

**Pain:** AGENTS.md's capability-exposure section names this exact failure mode — "If a capability is UI-only, it cannot be composed into those external agents." External agents cannot reach the anti-slop linter at all, so the self-correction loop (`<artifact-lint>` block → agent re-emits) only exists for web-driven runs.

## What users will see

- New `od lint <file.html|->` subcommand (also `--file`/`--html-file`): runs the same checks as artifact save, prints findings with fixes, and exits 1 when findings meet `--fail-on` (default `p0`; `p1|p2|none` available).
- `--json` prints a machine envelope (counts, findings, and the `<artifact-lint>` block); `-` reads stdin; `--agent-message` appends the agent block to human output.
- Runs against a headless daemon with zero model/agent calls, so it can sit in cron or CI.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — new `od lint` subcommand with `--fail-on`, `--agent-message`, `--json`, `--daemon-url`
- [x] **API / contract** — no endpoint changes; adds shared DTOs in `packages/contracts` (`ArtifactLintFinding`, `LintArtifactRequest/Response`, CLI envelope) for a response shape that previously existed only as a private type in `apps/daemon/src/lint-artifact.ts`
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — none: new verb, existing endpoint untouched
- [ ] **None**

**On the unchecked UI box:** the lint capability's UI half already exists (P0/P1 badges on artifact save; findings spliced into the chat layer). This PR adds the missing CLI half of that existing capability, per the dual-track rule.

## Screenshots

N/A — no UI surface touched. CLI output, paired controls:

```
$ od lint clean.html
clean — 0 findings (P0 0 · P1 0 · P2 0)            # exit 0

$ od lint slop.html
[P0] ai-default-indigo — Found a default LLM accent color (#6366f1) …
[P0] invented-metric — Suspected invented metric: "99.9% uptime" …
2 findings (P0 2 · P1 0 · P2 0)                     # exit 1

$ od lint - < slop.html --json                      # stdin + machine envelope
{ "ok": false, "failOn": "p0", "counts": { "p0": 2, … }, "agentMessage": "<artifact-lint>…" }

$ od lint slop.html --fail-on none                  # exit 0 — threshold honored
```

## Bug fix verification

Not a bug fix (parity-gap closure); section skipped per template.

## Validation

On this branch exactly:

- `pnpm guard` — clean
- `tsc --noEmit` for both `apps/daemon` and `packages/contracts`, src and tests configs — clean
- `pnpm --filter @open-design/contracts build` and `--filter @open-design/daemon build` — clean
- Paired CLI controls against a live headless daemon: a clean fixture exits 0 printing `clean — 0 findings`; the same fixture with a seeded `#6366f1` accent and an invented metric exits 1 naming both (`ai-default-indigo`, `invented-metric`); `--fail-on none` returns exit 0 on the same failing file; stdin (`-`) and `--json` verified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
