### PR TITLE
fix(release): validate nested Windows updater status

### DIFF
--- a/e2e/specs/win/lib/context.ts
+++ b/e2e/specs/win/lib/context.ts
@@ -281,6 +281,14 @@ export type DesktopStatus = {
   standalone?: unknown;
   state?: string;
   title?: string | null;
+  update?: {
+    channel: string;
+    currentVersion: string;
+    enabled: boolean;
+    mode: string;
+    supported: boolean;
+  };
+  updateStatusError?: string;
   url?: string | null;
   windowVisible?: boolean;
 };

--- a/e2e/specs/win/shell-lifecycle.spec.ts
+++ b/e2e/specs/win/shell-lifecycle.spec.ts
@@ -197,7 +197,16 @@ winDescribe('packaged windows runtime smoke', () => {
           });
         }
         expect(firstRunInspect.status?.state).toBe('running');
-        if (verifyPublicImmutableArtifacts) expect(firstRunInspect.update?.enabled).toBe(true);
+        if (verifyPublicImmutableArtifacts) {
+          expect(firstRunInspect.status?.updateStatusError).toBeUndefined();
+          expect(firstRunInspect.status?.update).toMatchObject({
+            channel: releaseChannel,
+            currentVersion: releaseVersion,
+            enabled: true,
+            mode: 'package-launcher',
+            supported: true,
+          });
+        }
         if (!firstRunInspect.desktopIpcUnavailable) {
           const firstRunPhase = await measureSmokeStep(timings, 'ensure first-run app shell', async () =>
             runPackagedAppShellPhase({

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -3001,6 +3001,8 @@ process.stdin.on("end", () => {
     expect(winSpec).toContain("resolveNativeAcceptanceUpdateMetadataUrl()");
     expect(winSpec).toContain("${process.env.RELEASE_PUBLIC_ORIGIN}/${updateScenario.channel}/latest/metadata.json");
     expect(winSpec).toContain("acceptance/runs/[0-9]+-[0-9]+/latest/metadata\\\\.json$");
+    expect(winSpec).toContain("firstRunInspect.status?.update");
+    expect(winSpec).not.toContain("firstRunInspect.update?.enabled");
     expect(winSpec).not.toContain("function resolveNativeAcceptanceMetadataUrl");
   });
 

--- a/tools/pack/tests/win-lifecycle.test.ts
+++ b/tools/pack/tests/win-lifecycle.test.ts
@@ -456,7 +456,18 @@ describe("inspectPackedWinApp", () => {
         if (payload.type === SIDECAR_MESSAGES.STATUS) {
           if (ipc.includes("daemon")) return { state: "running", url: "http://127.0.0.1:1234" };
           if (ipc.includes("web")) return { state: "running", url: "http://127.0.0.1:5678" };
-          return { pid: 12345, state: "running", url: "od://app/" };
+          return {
+            pid: 12345,
+            state: "running",
+            update: {
+              channel: "beta",
+              currentVersion: "0.10.0-beta.1",
+              enabled: true,
+              mode: "package-launcher",
+              supported: true,
+            },
+            url: "od://app/",
+          };
         }
         if (payload.type === SIDECAR_MESSAGES.EVAL) {
           return {
@@ -477,7 +488,18 @@ describe("inspectPackedWinApp", () => {
         timeoutMs: 1000,
       });
 
-      expect(result.status).toEqual({ pid: 12345, state: "running", url: "od://app/" });
+      expect(result.status).toEqual({
+        pid: 12345,
+        state: "running",
+        update: {
+          channel: "beta",
+          currentVersion: "0.10.0-beta.1",
+          enabled: true,
+          mode: "package-launcher",
+          supported: true,
+        },
+        url: "od://app/",
+      });
       expect(result.eval?.ok).toBe(true);
       expect(result.wait.attempts).toBe(1);
       expect(result.wait.intervalMs).toBe(1);


### PR DESCRIPTION
## Why

Two consecutive release-beta runs built, installed, launched, and reached a healthy Windows Desktop, but public acceptance failed because the spec read the optional top-level updater action result instead of the updater snapshot nested in Desktop status.

## What users will see

No product UI change. Windows release acceptance now validates the updater state reported by the running installed application and no longer rejects a healthy public immutable build because of a response projection mismatch.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `shells/electron` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/packaged-smoke-workflow.test.ts`
- The contract assertion failed on `feat/standalone-closure` and passed after the source change.
- `tools/pack/tests/win-lifecycle.test.ts` also proves that a one-process healthy wait preserves the nested Desktop updater snapshot.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts` in `e2e` — 75 passed
- `pnpm exec vitest run tests/win-lifecycle.test.ts` in `tools/pack` — 15 passed
- `pnpm --filter @open-design/e2e typecheck` — passed
- `pnpm --filter @open-design/tools-pack typecheck` — passed
- `pnpm typecheck` — blocked by pre-existing duplicate imports and removed `@open-design/closure-proto` reference in `tools/serve/tests/updater-fixture.test.ts`
- `pnpm guard` — blocked by pre-existing cross-app import in `apps/daemon/src/sidecar/standalone-control.ts`
