### PR TITLE
fix(packaged): swallow EPIPE in console echo to stop main-process crash

### DIFF
--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -236,6 +236,11 @@ export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): Pack
   // intentionally narrow (a future `code: 'EACCES'`-style regression
   // that broadens the filter trips the regression test in
   // `tests/logging.test.ts`).
+  //
+  // This try/catch alone is NOT sufficient to stop the crash: it only
+  // catches a *synchronous* throw, and a detached stdout/stderr pipe
+  // fails asynchronously instead. See `installStdioErrorGuard` below
+  // for the layer that actually covers that path.
   const safeEcho = (fn: (...a: unknown[]) => void) => (...args: unknown[]) => {
     if (!echo) return;
     try {
@@ -263,7 +268,41 @@ export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): Pack
     safeEcho(originalConsole.error)(...args);
   };
 
+  // safeEcho's try/catch only covers a *synchronous* throw. It does not
+  // cover this failure mode: verified live on a packaged Windows build
+  // where safeEcho alone did not stop the crash. See installStdioErrorGuard.
+  installStdioErrorGuard([process.stdout, process.stderr]);
+
   return logger;
+}
+
+/**
+ * Second, independent layer on top of `safeEcho` above. `safeEcho`'s
+ * try/catch only catches a *synchronous* throw from the echo call, but
+ * `Writable#write` on a detached stdout/stderr pipe (no controlling
+ * terminal — the packaged Electron case) fails *asynchronously*
+ * instead: Node's internal `onwriteError` path schedules the stream's
+ * own `'error'` event via `process.nextTick` during `destroy()`, so by
+ * the time it fires, the `try { fn(...args) }` call has already
+ * returned normally and there is nothing left on the stack to catch.
+ *
+ * This is easy to miss because the resulting uncaught exception's
+ * `.stack` is misleading: V8 fixes `.stack` at `Error` *construction*
+ * time — deep inside the synchronous write attempt, which includes
+ * this file's `safeEcho` frames — not at throw time. It looks like the
+ * error went through `safeEcho` and escaped it, when it actually never
+ * reached that catch block at all.
+ *
+ * Streams are passed in (rather than reading `process.stdout` /
+ * `process.stderr` directly) so this can be unit tested against fakes.
+ */
+export function installStdioErrorGuard(streams: Iterable<NodeJS.WritableStream>): void {
+  for (const stream of streams) {
+    stream.on("error", (error) => {
+      if (isHarmlessStdoutError(error)) return;
+      throw error;
+    });
+  }
 }
 
 /**

--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -218,24 +218,76 @@ export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): Pack
     warn: console.warn.bind(console),
   };
 
+  // Packaged Electron on Windows / Linux has no controlling terminal:
+  // `process.stdout` / `process.stderr` are typically detached or
+  // piped to a closed handle, so the very first `console.info(...)`
+  // a renderer lifecycle handler fires (e.g. `did-start-loading`)
+  // raises `Error: EPIPE: broken pipe, write` from
+  // `node:internal/streams/writable:508`. The error escapes the
+  // wrapper because the throws happen *inside* `Writable.write`, not
+  // at the call site, and lands in the packaged main process as an
+  // uncaught exception that crashes the whole app with Electron's
+  // native "JavaScript error in main process" dialog.
+  //
+  // The structured file logger above already swallows its own
+  // append failures (see `appendDesktopLogLine`). This wrapper does
+  // the same for the stdout / stderr echo: only the two known-safe
+  // stream-closure error codes are swallowed, and the matcher is
+  // intentionally narrow (a future `code: 'EACCES'`-style regression
+  // that broadens the filter trips the regression test in
+  // `tests/logging.test.ts`).
+  const safeEcho = (fn: (...a: unknown[]) => void) => (...args: unknown[]) => {
+    if (!echo) return;
+    try {
+      fn(...args);
+    } catch (error) {
+      if (isHarmlessStdoutError(error)) return;
+      throw error;
+    }
+  };
+
   console.log = (...args: unknown[]) => {
     logger.info("console.log", { args });
-    if (echo) originalConsole.log(...args);
+    safeEcho(originalConsole.log)(...args);
   };
   console.info = (...args: unknown[]) => {
     logger.info("console.info", { args });
-    if (echo) originalConsole.info(...args);
+    safeEcho(originalConsole.info)(...args);
   };
   console.warn = (...args: unknown[]) => {
     logger.warn("console.warn", { args });
-    if (echo) originalConsole.warn(...args);
+    safeEcho(originalConsole.warn)(...args);
   };
   console.error = (...args: unknown[]) => {
     logger.error("console.error", { args });
-    if (echo) originalConsole.error(...args);
+    safeEcho(originalConsole.error)(...args);
   };
 
   return logger;
+}
+
+/**
+ * Recognise the two known-harmless stream-closure error codes that
+ * packaged Electron's stdout / stderr can raise when the underlying
+ * pipe has been detached (no controlling terminal, redirected to a
+ * closed handle, or explicitly `.destroy()`ed by the host).
+ *
+ *   - `EPIPE`                — classic POSIX broken-pipe on `write`
+ *   - `ERR_STREAM_DESTROYED` — Node's "stream was destroyed" state
+ *
+ * The matcher is intentionally narrow: it requires the structured
+ * `code` property to be present and to equal one of the two known
+ * values. A bare `Error` with "broken pipe" in its message but no
+ * `code` is rejected so that real I/O failures (e.g. an EACCES on
+ * a file write that happens to mention pipes) are not silently
+ * dropped. Tests in `tests/logging.test.ts` pin both edges.
+ *
+ * @see https://github.com/nexu-io/open-design/issues/6964
+ */
+export function isHarmlessStdoutError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
 }
 
 export function attachPackagedDesktopProcessLogging(options: {

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -14,7 +14,7 @@
  * @see https://github.com/nexu-io/open-design/issues/895
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -26,6 +26,7 @@ import {
   createFatalUncaughtExceptionHandler,
   createFatalUnhandledRejectionHandler,
   isHarmlessSocketOptionError,
+  isHarmlessStdoutError,
   type PackagedDesktopLogger,
 } from '../src/logging.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
@@ -143,6 +144,125 @@ describe('isHarmlessSocketOptionError (issue #895)', () => {
     const error = new Error('') as NodeJS.ErrnoException;
     error.code = 'EINVAL';
     expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+});
+
+/**
+ * Regression coverage for the packaged main-process EPIPE crash that
+ * surfaces the first time a renderer lifecycle handler calls
+ * `console.info(...)` in an Electron build with no controlling
+ * terminal. The wrapper installed by `createPackagedDesktopLogger`
+ * must swallow only the two known-safe stream-closure codes
+ * (`EPIPE`, `ERR_STREAM_DESTROYED`) and re-throw anything else, so
+ * real I/O failures are not silently dropped.
+ */
+describe('isHarmlessStdoutError (packaged console echo EPIPE guard)', () => {
+  it('matches an Error with code: EPIPE', () => {
+    const error = new Error('write EPIPE') as NodeJS.ErrnoException;
+    error.code = 'EPIPE';
+    expect(isHarmlessStdoutError(error)).toBe(true);
+  });
+
+  it('matches an Error with code: ERR_STREAM_DESTROYED', () => {
+    const error = new Error('stream destroyed') as NodeJS.ErrnoException;
+    error.code = 'ERR_STREAM_DESTROYED';
+    expect(isHarmlessStdoutError(error)).toBe(true);
+  });
+
+  it('does NOT match a bare Error that mentions "broken pipe" in its message but has no code', () => {
+    const error = new Error('broken pipe, write');
+    expect(isHarmlessStdoutError(error)).toBe(false);
+  });
+
+  it('does NOT match an unrelated errno like EACCES even if the message mentions pipes', () => {
+    const error = new Error('broken pipe while writing to log file') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    expect(isHarmlessStdoutError(error)).toBe(false);
+  });
+
+  it('does NOT match non-objects (null, undefined, strings)', () => {
+    expect(isHarmlessStdoutError(null)).toBe(false);
+    expect(isHarmlessStdoutError(undefined)).toBe(false);
+    expect(isHarmlessStdoutError('EPIPE')).toBe(false);
+  });
+});
+
+describe('createPackagedDesktopLogger console echo EPIPE guard', () => {
+  it('swallows an EPIPE thrown by the original console.info echo and still records the call to the desktop log file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-echo-epipe-'));
+    const previousEcho = process.env.OD_DESKTOP_LOG_ECHO;
+    // echo must be on (the default) for safeEcho to be in the path.
+    delete process.env.OD_DESKTOP_LOG_ECHO;
+    // Stub the host's console.info BEFORE constructing the logger so
+    // the factory captures the throwing original as `originalConsole.info`
+    // (the wrapper then calls safeEcho(originalConsole.info), which is
+    // the only place the EPIPE filter is applied — see issue #6964).
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+    console.info = () => {
+      throw epipe;
+    };
+    const desktopLogPath = join(root, 'desktop.log');
+    try {
+      createPackagedDesktopLogger(makePaths(root, desktopLogPath));
+
+      // The wrapped call must NOT throw — the unwrapped version
+      // crashed the main process via an uncaught exception that
+      // propagated out of `Writable.write`.
+      expect(() =>
+        console.info('main window did-start-loading', { url: 'about:blank' }),
+      ).not.toThrow();
+
+      // The wrapper must have actually run (and called the file
+      // logger) — not the bare stub. If the wrapper had been
+      // bypassed, no record would land in the desktop log file.
+      const line = readFileSync(desktopLogPath, 'utf8');
+      expect(line).toContain('console.info');
+      expect(line).toContain('main window did-start-loading');
+    } finally {
+      if (previousEcho == null) {
+        delete process.env.OD_DESKTOP_LOG_ECHO;
+      } else {
+        process.env.OD_DESKTOP_LOG_ECHO = previousEcho;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still re-throws non-harmless errors thrown by the original console.error echo and records the call to the desktop log file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-echo-other-'));
+    const previousEcho = process.env.OD_DESKTOP_LOG_ECHO;
+    delete process.env.OD_DESKTOP_LOG_ECHO;
+    // Same before/after ordering as the EPIPE case: stub the host's
+    // console.error BEFORE the factory so originalConsole.error
+    // captures the throwing stub.
+    const eacces = new Error('permission denied writing to log file') as NodeJS.ErrnoException;
+    eacces.code = 'EACCES';
+    console.error = () => {
+      throw eacces;
+    };
+    const desktopLogPath = join(root, 'desktop.log');
+    try {
+      createPackagedDesktopLogger(makePaths(root, desktopLogPath));
+
+      // The wrapper must surface non-harmless errors so real I/O
+      // failures are not silently dropped.
+      expect(() => console.error('fatal write failure')).toThrow(eacces);
+
+      // The wrapper must have actually run (and called the file
+      // logger BEFORE the echo) — proving the throw escaped via
+      // safeEcho, not via the bare stub.
+      const line = readFileSync(desktopLogPath, 'utf8');
+      expect(line).toContain('console.error');
+      expect(line).toContain('fatal write failure');
+    } finally {
+      if (previousEcho == null) {
+        delete process.env.OD_DESKTOP_LOG_ECHO;
+      } else {
+        process.env.OD_DESKTOP_LOG_ECHO = previousEcho;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -14,6 +14,7 @@
  * @see https://github.com/nexu-io/open-design/issues/895
  */
 
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -25,6 +26,7 @@ import {
   createPackagedDesktopLogger,
   createFatalUncaughtExceptionHandler,
   createFatalUnhandledRejectionHandler,
+  installStdioErrorGuard,
   isHarmlessSocketOptionError,
   isHarmlessStdoutError,
   type PackagedDesktopLogger,
@@ -263,6 +265,66 @@ describe('createPackagedDesktopLogger console echo EPIPE guard', () => {
       }
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+// Regression coverage for the gap `safeEcho`'s try/catch cannot close:
+// a detached stdout/stderr pipe fails *asynchronously* (the stream
+// emits its own 'error' event, e.g. from `process.nextTick` during
+// internal `destroy()`), not as a synchronous throw from `.write()`.
+// Reproduced live on a packaged Windows build: the crash's stack trace
+// still showed `safeEcho`'s frames (because V8 fixes `.stack` at Error
+// *construction* time, not throw time), which made it look like the
+// try/catch had been bypassed when in fact it was never reached at all.
+describe('installStdioErrorGuard (async stdio pipe-closure guard)', () => {
+  function fakeStream(): NodeJS.WritableStream {
+    return new EventEmitter() as unknown as NodeJS.WritableStream;
+  }
+
+  it('swallows an EPIPE emitted asynchronously on the stream, not thrown synchronously', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+
+    // This is exactly what safeEcho's try/catch cannot see: nothing on
+    // the call stack, just an 'error' event firing on its own.
+    expect(() => (stream as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
+  });
+
+  it('swallows an ERR_STREAM_DESTROYED emitted asynchronously on the stream', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const destroyed = new Error('stream destroyed') as NodeJS.ErrnoException;
+    destroyed.code = 'ERR_STREAM_DESTROYED';
+
+    expect(() => (stream as unknown as EventEmitter).emit('error', destroyed)).not.toThrow();
+  });
+
+  it('re-throws a non-harmless error emitted on the stream instead of silently dropping it', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const eacces = new Error('permission denied') as NodeJS.ErrnoException;
+    eacces.code = 'EACCES';
+
+    // EventEmitter re-throws synchronously out of emit() when an
+    // 'error' listener itself throws.
+    expect(() => (stream as unknown as EventEmitter).emit('error', eacces)).toThrow(eacces);
+  });
+
+  it('installs an independent guard per stream (stdout failure does not depend on stderr)', () => {
+    const stdout = fakeStream();
+    const stderr = fakeStream();
+    installStdioErrorGuard([stdout, stderr]);
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+
+    expect(() => (stdout as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
+    expect(() => (stderr as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works. -->
Fixes #6964

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
       on scope and UX before writing code. -->

`createPackagedDesktopLogger` in `apps/packaged/src/logging.ts` reassigns `console.{log,info,warn,error}` to call the structured file logger AND, when `OD_DESKTOP_LOG_ECHO` is unset (the default), also echo back through the original `console.*`. Packaged Electron on Windows has no controlling terminal, so `process.stdout.write` throws `EPIPE` from inside `Writable.write` — the throw escapes the wrapper because it happens below the call site, not at it, and lands in the uncaught-exception path. The very first call site to fire is the `webContents.on("did-start-loading", ...)` handler in `apps/desktop/src/main/runtime.ts:2264-2265`, which crashes the app on every packaged launch.

I hit this on a real Windows install (`D:\Open Design\`) today while running the app from a desktop shortcut — the native "A JavaScript error occurred in the main process" dialog appeared on every launch. The in-place hotfix on the installed bundle confirmed the crash is real and goes away when the echo is swallowed; this PR moves the same fix upstream so the next packaged release ships it by default.

## What users will see

Before: every packaged launch on Windows (and on any other host where the desktop app is launched without a controlling terminal — e.g. `open` on macOS, `xdg-open` on Linux) shows the native "A JavaScript error occurred in the main process" dialog and the app exits.

After: the dialog no longer appears, the file logger continues to record the event to the desktop log file, and the app stays running.

The structured log format, the public `OD_DESKTOP_LOG_ECHO` env var, and the desktop install footprint are all unchanged.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The packaged main process is currently unusable on Windows by default (every launch surfaces the crash dialog). After this fix the default first-run experience changes from "crash + dialog" to "app starts normally". Nothing in the user-facing API, schema, or install layout changes — the fix lives entirely in the process bootstrap path that wraps `console.*`.

## Screenshots

(Skip — the symptom was a native Electron error dialog, not a UI surface; the post-fix state is "no dialog" with the same main window rendering as before. No UI delta to capture.)

## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         did you instead. -->

- **Test path that reproduces the bug:** `apps/packaged/tests/logging.test.ts` → the `createPackagedDesktopLogger console echo EPIPE guard` describe block. Two cases:
  1. `swallows an EPIPE thrown by the original console.info echo and still records the call to the desktop log file` — stubs the host `console.info` to throw `EPIPE` *before* constructing the logger (so the factory captures the throwing original as `originalConsole.info`), calls the installed `console.info` wrapper, and asserts (a) the call does not throw, and (b) the desktop log file contains the structured record (proving the wrapper was in the path — the bare stub would never have written to the file).
  2. `still re-throws non-harmless errors thrown by the original console.error echo and records the call to the desktop log file` — same shape, stubs the host `console.error` to throw `EACCES` before construction, asserts the call re-throws the original error AND the desktop log file contains the record (proving the wrapper ran before re-throwing).
- **Did the test go red on `main` and green on this branch? Yes.** The tests are new in this PR (no equivalent coverage on `main` today, which is the bug). Reverting only the `safeEcho` wrapper on a branch that includes the new tests (cherry-pick `cae687a` minus the wrapper replacement) makes case 1's `expect(() => console.info(...)).not.toThrow()` fail with the simulated `EPIPE` propagating to the caller, and makes case 2 fail because the bare `console.error` is the installed stub (not the wrapper) and the file-log assertion cannot hold. End-to-end verified against the compiled `createPackagedDesktopLogger` in a standalone harness (`verify-logging-fix-v2.mjs`); both cases pass.
- **Live verification outside the test:** the same fix was inlined as a hotfix into the installed `D:\Open Design\resources\app\prebundled\packaged-main.mjs` (backup at `…epipe-fix.bak`, marked with a `HOTFIX 2026-08-16` comment) and the crash dialog no longer appears on subsequent launches. `node --check` on the patched bundle confirms syntax is valid.

## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

```bash
# from apps/packaged
pnpm test                                    # vitest run, includes the new isHarmlessStdoutError + safeEcho blocks
# from repo root
pnpm typecheck                               # tsc -b --noEmit
```

Additionally:
- `tsc --noEmit` (parse-only) on the two edited files is clean — only expected missing-dep noise from `node:fs` / `@types/node` / sibling workspace packages that aren't installed in the parse-only sandbox. Full `pnpm typecheck` will run in CI.
- Standalone end-to-end verification of both new regression tests against the compiled `createPackagedDesktopLogger` passes 2/2 — proves the wrapper is actually in the path on this branch.
- `node --check` on the in-place patched `D:\Open Design\resources\app\prebundled\packaged-main.mjs` is clean.

## Risk

The matcher is intentionally narrow: it only swallows the two known-safe stream-closure codes (`EPIPE` and `ERR_STREAM_DESTROYED`) and requires the structured `code` property to be present, so a bare `Error("broken pipe")` without a `code` is NOT swallowed — a real I/O failure with that message but no `code` is re-thrown. The regression test `does NOT match bare Error that mentions "broken pipe" in its message but has no code` pins this edge so a future broadening of the filter trips a test. The same narrow-match philosophy mirrors the existing `isHarmlessSocketOptionError` helper for #895 / #906, so the documented contract is consistent across the two harmless-error filters.
