### PR TITLE
fix web list project menu placement near viewport edge

### DIFF
--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -7,7 +7,15 @@
 // surfaces (e.g. an in-project quick-switcher pane).
 
 import type { CSSProperties } from 'react';
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 
 const MOVE_CONFIRM_SKIP_KEY = 'od.projects.moveConfirmSkip';
@@ -203,6 +211,8 @@ const deckCoverCache = new Map<string, string>();
 const deckCoverInflight = new Map<string, Promise<string>>();
 const DEFAULT_RECENT_PROJECT_LIMIT = 6;
 const WIDE_RECENT_PROJECT_LIMIT = 7;
+const PROJECT_MENU_GAP = 6;
+const PROJECT_MENU_VIEWPORT_MARGIN = 24;
 // Card covers are background decoration. Browsers commonly allow only six
 // concurrent connections per origin, so an unbounded All Projects scan can
 // occupy every slot and queue the project file list/preview the user just
@@ -473,6 +483,7 @@ export function RecentProjectsStrip({
     Record<string, ProjectCoverOverride | null>
   >({});
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [menuPlacement, setMenuPlacement] = useState<'down' | 'up'>('down');
   const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
   const [renameInput, setRenameInput] = useState('');
   const [confirmTarget, setConfirmTarget] = useState<Project | null>(null);
@@ -549,6 +560,7 @@ export function RecentProjectsStrip({
     ],
   );
   const menuContainerRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const renameTitleId = useId();
   const confirmTitleId = useId();
   const moveTitleId = useId();
@@ -626,6 +638,48 @@ export function RecentProjectsStrip({
     }
     document.addEventListener('pointerdown', handlePointerDown);
     return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [menuOpenId]);
+
+  useLayoutEffect(() => {
+    if (!menuOpenId) return;
+    const anchor = menuContainerRef.current;
+    const menu = menuRef.current;
+    const trigger = anchor?.querySelector<HTMLElement>('.recent-projects__card-more');
+    if (!anchor || !menu || !trigger) return;
+
+    const measureMenuPlacement = () => {
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 720;
+      const scrollBoundary = anchor.closest<HTMLElement>('.entry-main--scroll');
+      const scrollRect = scrollBoundary?.getBoundingClientRect();
+      const visibleTop = Math.max(0, scrollRect?.top ?? 0);
+      const visibleBottom = Math.min(viewportHeight, scrollRect?.bottom ?? viewportHeight);
+      const triggerRect = trigger.getBoundingClientRect();
+      const menuHeight = menu.getBoundingClientRect().height;
+      const spaceBelow =
+        visibleBottom - triggerRect.bottom - PROJECT_MENU_GAP - PROJECT_MENU_VIEWPORT_MARGIN;
+      const spaceAbove =
+        triggerRect.top - visibleTop - PROJECT_MENU_GAP - PROJECT_MENU_VIEWPORT_MARGIN;
+      const nextPlacement =
+        spaceBelow < menuHeight && spaceAbove > spaceBelow ? 'up' : 'down';
+
+      setMenuPlacement((current) => (current === nextPlacement ? current : nextPlacement));
+    };
+
+    measureMenuPlacement();
+    window.addEventListener('resize', measureMenuPlacement);
+    window.addEventListener('scroll', measureMenuPlacement, true);
+    const observer = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(measureMenuPlacement);
+    if (observer) {
+      observer.observe(anchor);
+      observer.observe(menu);
+    }
+    return () => {
+      window.removeEventListener('resize', measureMenuPlacement);
+      window.removeEventListener('scroll', measureMenuPlacement, true);
+      observer?.disconnect();
+    };
   }, [menuOpenId]);
 
   // Cover fetching must key off the *set of project ids and their readiness*, not the
@@ -1873,6 +1927,8 @@ export function RecentProjectsStrip({
                   {menuOpenId === project.id ? (
                     <div
                       className="recent-projects__card-menu"
+                      data-placement={menuPlacement}
+                      ref={menuRef}
                       role="menu"
                       onClick={(event) => event.stopPropagation()}
                     >

--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -504,6 +504,10 @@
   background: var(--bg-panel);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
 }
+.recent-projects__card-menu[data-placement='up'] {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
 .recent-projects__card-menu button {
   appearance: none;
   display: flex;

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -555,6 +555,58 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+test('[P1] last project list row keeps its overflow menu inside the viewport', async ({ page }) => {
+  const recentProjects = Array.from({ length: 3 }, (_, index) => ({
+    id: `recent-list-menu-${index + 1}`,
+    name: `List Project ${index + 1}`,
+    skillId: null,
+    designSystemId: null,
+    createdAt: Date.now() - (index + 1) * 10_000,
+    updatedAt: Date.now() - (index + 1) * 5_000,
+    metadata: { kind: 'prototype', nameSource: 'user' },
+  }));
+  const lastProject = recentProjects.at(-1)!;
+
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { projects: recentProjects } });
+      return;
+    }
+    await route.continue();
+  });
+  await gotoEntryHome(page);
+
+  await page.getByRole('button', { name: 'List view' }).click();
+  const lastRow = page.locator(`[data-project-id="${lastProject.id}"]`);
+  await expect(lastRow).toBeVisible();
+  await page.evaluate((projectId) => {
+    const scroller = document.querySelector<HTMLElement>('.entry-main--scroll');
+    const row = document.querySelector<HTMLElement>(`[data-project-id="${projectId}"]`);
+    const trigger = row?.querySelector<HTMLElement>('.recent-projects__card-more');
+    if (!scroller || !row || !trigger) {
+      throw new Error('Recent project list-menu fixture is missing');
+    }
+
+    const desiredTop = scroller.getBoundingClientRect().bottom - 60;
+    scroller.scrollTop += trigger.getBoundingClientRect().top - desiredTop;
+  }, lastProject.id);
+
+  await lastRow.hover();
+  const trigger = lastRow.getByRole('button', { name: /more actions/i });
+  await trigger.click();
+
+  const menu = lastRow.getByRole('menu');
+  await expect(menu).toBeVisible();
+  await expect(menu.getByRole('menuitem', { name: 'Delete' })).toBeInViewport();
+
+  const triggerBox = await trigger.boundingBox();
+  const menuBox = await menu.boundingBox();
+  expect(triggerBox).not.toBeNull();
+  expect(menuBox).not.toBeNull();
+  expect((menuBox?.y ?? 0) + (menuBox?.height ?? 0)).toBeLessThan(triggerBox?.y ?? 0);
+});
+
 test('[P1] home left rail expands and collapses from the shell controls', async ({ page }) => {
   await gotoEntryHome(page);
 


### PR DESCRIPTION
Fixes #6970

## Why

While using Recent projects in list view on the Home page, opening the final row's overflow menu near the bottom of the visible scroll area placed its lower actions outside the viewport. Delete could not be seen or reached without changing the page position.

The root cause was the shared project menu's downward-only CSS anchor. It did not measure the rendered menu height or the visible boundary of the Home scroll container before choosing a direction.

PR #6917 remains open for the earlier grid-card report. This PR is independently based on current `main` and adds a list-view regression witness; the two reports share the same dropdown component, so their placement implementation overlaps.

## What users will see

In Recent projects list view, a menu near the bottom edge opens upward when there is not enough visible room below. It continues opening downward when space is available and recalculates after scrolling, resizing, or menu-size changes, keeping every action visible.

## Surface area

- [x] **UI** — Recent-project list-row overflow-menu placement on the Home page
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not included, following the prior request. The browser regression below covers the visible boundary behavior.

## Bug fix verification

- Test path: `e2e/ui/home-hero-rail.test.ts` (`[P1] last project list row keeps its overflow menu inside the viewport`)
- Red on `main`: yes — the Delete menu item had viewport ratio `0` because the downward menu was fully outside the viewport.
- Green on this branch: yes — the menu flips above the trigger and Delete remains inside the viewport.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir e2e typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx --maxWorkers=2` (33 passed)
- `pnpm exec playwright test -c playwright.config.ts ui/home-hero-rail.test.ts --grep "last project list row" --workers=1` (1 passed)
- `git diff --check`
