### PR TITLE
fix(updater): unify check activation policy

### DIFF
--- a/apps/standalone/src/sidecars.ts
+++ b/apps/standalone/src/sidecars.ts
@@ -318,10 +318,11 @@ export async function startSidecarStandalone(
         }
         try {
           const output = await prepareStandaloneUpdate({
-            ...(command.input.activationSource === "silent-policy"
-              || command.input.activationSource === "user-restart"
-              ? { activationSource: command.input.activationSource }
-              : {}),
+            activationPolicy: command.input.activationSource === "silent-policy"
+              ? "authorize-silent"
+              : command.input.activationSource === "user-restart"
+                ? "authorize-user"
+                : "revoke-silent",
             channel: request.handoff.scope.channel,
             metadata: command.input.metadata,
             namespace: request.handoff.scope.namespace,

--- a/apps/standalone/src/update-runtime.ts
+++ b/apps/standalone/src/update-runtime.ts
@@ -27,6 +27,11 @@ export type StandaloneUpdatePreparation = Readonly<
     }
 >;
 
+export type StandaloneUpdateActivationPolicy =
+  | "authorize-silent"
+  | "authorize-user"
+  | "revoke-silent";
+
 /**
  * The sole legacy discriminator is absence of the modern Closure envelope.
  * Standalone never reads legacy control fields; Shell remains their owner.
@@ -39,7 +44,7 @@ export function hasModernClosureUpdateMetadata(metadata: unknown): metadata is R
 }
 
 export async function prepareStandaloneUpdate(input: Readonly<{
-  activationSource?: "silent-policy" | "user-restart";
+  activationPolicy: StandaloneUpdateActivationPolicy;
   channel: string;
   fetch?: typeof globalThis.fetch;
   metadata: unknown;
@@ -86,11 +91,15 @@ export async function prepareStandaloneUpdate(input: Readonly<{
     }
     let descriptor = await readClosureBindingDescriptor(paths);
     if (
-      input.activationSource != null
+      input.activationPolicy !== "revoke-silent"
       && result.reason === "already-prepared"
       && descriptor.prepared != null
     ) {
-      await authorizePreparedClosureActivation(paths, descriptor.prepared, input.activationSource);
+      await authorizePreparedClosureActivation(
+        paths,
+        descriptor.prepared,
+        input.activationPolicy === "authorize-user" ? "user-restart" : "silent-policy",
+      );
       descriptor = await readClosureBindingDescriptor(paths);
     } else if (result.reason === "already-prepared") {
       descriptor = await revokePreparedClosureActivation(paths, "silent-policy");
@@ -117,8 +126,12 @@ export async function prepareStandaloneUpdate(input: Readonly<{
   if (descriptor.prepared?.standalone.generation !== result.pointer.generation) {
     throw new Error("Standalone prepared binding changed before resource completion");
   }
-  if (input.activationSource != null) {
-    await authorizePreparedClosureActivation(paths, descriptor.prepared, input.activationSource);
+  if (input.activationPolicy !== "revoke-silent") {
+    await authorizePreparedClosureActivation(
+      paths,
+      descriptor.prepared,
+      input.activationPolicy === "authorize-user" ? "user-restart" : "silent-policy",
+    );
   }
   const preparedDescriptor = await readClosureBindingDescriptor(paths);
   await discardUnreferencedClosureResources(paths).catch(() => undefined);

--- a/apps/standalone/tests/bootstrap.test.ts
+++ b/apps/standalone/tests/bootstrap.test.ts
@@ -245,6 +245,7 @@ describe("Standalone unresolved bootstrap", () => {
       },
     });
     const input = {
+      activationPolicy: "revoke-silent",
       channel: "beta",
       metadata: legacyMetadata,
       namespace: "release-beta",
@@ -505,6 +506,7 @@ describe("Standalone unresolved bootstrap", () => {
       releaseVersion: "0.19.0-beta.2",
     };
     const updateInput = {
+      activationPolicy: "revoke-silent",
       channel: "beta",
       fetch: value.fetch,
       metadata,
@@ -523,7 +525,7 @@ describe("Standalone unresolved bootstrap", () => {
     );
     expect(current.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
 
-    await prepareStandaloneUpdate({ ...updateInput, activationSource: "silent-policy" });
+    await prepareStandaloneUpdate({ ...updateInput, activationPolicy: "authorize-silent" });
     const revoked = await prepareStandaloneUpdate(updateInput);
     expect(revoked).toMatchObject({ activationSource: null, state: "prepared" });
     const stillCurrent = await resolveStandaloneBootstrap(
@@ -532,7 +534,7 @@ describe("Standalone unresolved bootstrap", () => {
     );
     expect(stillCurrent.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
 
-    await prepareStandaloneUpdate({ ...updateInput, activationSource: "silent-policy" });
+    await prepareStandaloneUpdate({ ...updateInput, activationPolicy: "authorize-silent" });
     const activated = await resolveStandaloneBootstrap(
       request(value, "0.19.0-beta.1", null),
       { fetch: value.fetch },

--- a/docs/testing/updater-lifecycle.md
+++ b/docs/testing/updater-lifecycle.md
@@ -31,6 +31,7 @@ spec (`e2e/specs/mac.spec.ts` / `win.spec.ts` via `release-smoke.ts`),
 | Metadata fetch/parse/channel match, per-channel version fields | U, P, F | desktop unit; specs; real beta feed loop |
 | not-available / available / downloaded-stays-visible | U, P | desktop unit; specs |
 | Silent startup payload update (allowSilentUpdates) | U, P | desktop unit silent group; mac/win spec `applies a downloaded payload silently on the next cold start` |
+| Shared check activation policy (renderer, scheduler, inspect/sidecar) | U, P | desktop check-policy + host-boundary unit; mac silent-update convergence issues an inspect check between Shell and Closure cold starts |
 | Modern route: Shell min decides Shell vs Closure; legacy floor is isolated | U | Closure update tests; desktop modern-metadata routing test |
 | Artifact selection (payload vs installer, context validity) | U, P | desktop unit routing group; specs |
 | Installer-reinstall floor (`control.shell.installation.version.min`): three reasons, same-version offer, clamp | U, P | desktop unit reseed group; spec recovery segment |

--- a/e2e/specs/mac/lib/context.ts
+++ b/e2e/specs/mac/lib/context.ts
@@ -244,6 +244,11 @@ export type MacInspectResult = {
       reason: string;
       url?: string;
     };
+    standalone?: {
+      activationSource: 'silent-policy' | 'user-restart' | null;
+      releaseVersion: string;
+      state: 'current' | 'prepared';
+    };
     state: string;
     supported?: boolean;
   };

--- a/e2e/specs/mac/shell-silent-update.spec.ts
+++ b/e2e/specs/mac/shell-silent-update.spec.ts
@@ -124,6 +124,19 @@ macShellDescribe('packaged mac Shell silent update', () => {
       );
       expect(terminal.update?.currentVersion).toBe(updateScenario.expectedCurrentVersion);
 
+      // Exercise the operator/inspect entry while the target Shell is still
+      // paired with the previous Closure. Manual and scheduled checks must use
+      // the same preference-backed atom, so this cannot disarm the prepared
+      // compatible Closure before the convergence restart.
+      const manualCheck = await runToolsPackJson<MacInspectResult>(
+        'inspect',
+        ['--update-action', 'check'],
+      );
+      expect(manualCheck.update?.standalone).toMatchObject({
+        activationSource: 'silent-policy',
+        state: 'prepared',
+      });
+
       // The target Closure requires the target Shell. The first cold start
       // therefore advances only the Shell while retaining the last successful
       // Closure; the next cold start commits the now-compatible Closure graph.

--- a/e2e/tests/packaged-launcher-update-loop.test.ts
+++ b/e2e/tests/packaged-launcher-update-loop.test.ts
@@ -29,7 +29,11 @@ type PackagedConfigLike = {
 
 type DesktopUpdaterModule = {
   createDesktopUpdater: (config: Record<string, unknown>, deps?: Record<string, unknown>) => {
-    checkForUpdates: () => Promise<{
+    checkForUpdates: (options: {
+      activationPolicy: "authorize-silent" | "revoke-silent";
+      autoDownload?: boolean;
+      trigger: "download" | "manual" | "scheduler" | "sidecar" | "test";
+    }) => Promise<{
       artifact?: { type?: string };
       availableVersion?: string;
       reinstall?: {
@@ -404,7 +408,10 @@ describe("packaged launcher payload update loop", () => {
         now: () => new Date("2026-06-06T00:00:00.000Z"),
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates({
+        activationPolicy: "revoke-silent",
+        trigger: "test",
+      });
       expect(checked.state).toBe(UPDATE_DOWNLOADED);
       expect(checked.artifact?.type).toBe("payload");
       expect(checked.availableVersion).toBe(testCase.promotedVersion);
@@ -929,7 +936,10 @@ async function checkPackagedUpdate(scenario: FloorScenario): Promise<{
       now: () => new Date("2026-07-28T00:00:00.000Z"),
     });
 
-    const snapshot = await updater.checkForUpdates();
+    const snapshot = await updater.checkForUpdates({
+      activationPolicy: "revoke-silent",
+      trigger: "test",
+    });
     const runtimeJson = JSON.parse(
       await readFile(runtime.launcherPaths.runtimePath, "utf8"),
     ) as { active?: { generation: number; version: string } };

--- a/shells/electron/src/main/index.ts
+++ b/shells/electron/src/main/index.ts
@@ -6,6 +6,7 @@ import { BrowserWindow, Menu, app, dialog, globalShortcut, shell, type MenuItemC
 
 import {
   APP_KEYS,
+  DESKTOP_UPDATE_ACTIONS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
@@ -24,6 +25,7 @@ import {
   type SidecarStamp,
   type WebStatusSnapshot,
 } from "@open-design/sidecar/protocol";
+import type { StandaloneUpdateActivationPolicy } from "@open-design/standalone";
 import type { StandaloneLifecyclePort, StandaloneRuntimeStatus } from "@open-design/standalone/protocol";
 import type { DesktopStandaloneUpdatePreparation } from "./updater.js";
 import { dirname, join } from "node:path";
@@ -64,6 +66,7 @@ import {
   type DesktopUpdaterScheduler,
 } from "./updater.js";
 import { ensureSilentUpdatePreference } from "./updater/silent-policy.js";
+import { checkDesktopUpdatesWithPolicy } from "./updater/check-policy.js";
 import { DesktopUpdateTransitionOwner } from "./update-preflight.js";
 import {
   exportDiagnosticsToFile,
@@ -218,7 +221,7 @@ export type DesktopMainOptions = {
     launcherRuntimePath?: string | null;
     prepareStandaloneUpdate?: (
       metadata: Record<string, unknown>,
-      options?: { activationSource?: "silent-policy" | "user-restart" },
+      options: { activationPolicy: StandaloneUpdateActivationPolicy },
     ) => Promise<DesktopStandaloneUpdatePreparation>;
   };
 };
@@ -996,7 +999,25 @@ export async function runDesktopMain(
           case SIDECAR_MESSAGES.EXPORT_ARTIFACT:
             return await activeDesktop.exportArtifact(request.input as DesktopExportArtifactInput);
           case SIDECAR_MESSAGES.UPDATE:
-            return await updater.handle((request.input as DesktopUpdateInput).action);
+            switch ((request.input as DesktopUpdateInput).action) {
+              case DESKTOP_UPDATE_ACTIONS.STATUS:
+                return await updater.status();
+              case DESKTOP_UPDATE_ACTIONS.CHECK:
+                return await checkDesktopUpdatesWithPolicy({
+                  onPreferenceError: (error) => {
+                    console.warn("[open-design updater] sidecar check could not resolve silent update preference; revoking activation", error);
+                  },
+                  resolveSilentActivation: ensureUpdaterSilentPreference,
+                  trigger: "sidecar",
+                  updater,
+                });
+              case DESKTOP_UPDATE_ACTIONS.CLEAR_CACHE:
+                return await updater.clearCache();
+              case DESKTOP_UPDATE_ACTIONS.DOWNLOAD:
+                return await updater.downloadUpdate();
+              case DESKTOP_UPDATE_ACTIONS.INSTALL:
+                return await updater.installUpdate();
+            }
         }
       } catch (error) {
         console.error("[open-design desktop] desktop IPC request failed", {

--- a/shells/electron/src/main/runtime.ts
+++ b/shells/electron/src/main/runtime.ts
@@ -49,6 +49,7 @@ export {
 } from "./splash-progress.js";
 import type { PrintReadyPdfOptions } from "./pdf-export.js";
 import type { DesktopUpdater } from "./updater.js";
+import { checkDesktopUpdatesWithPolicy } from "./updater/check-policy.js";
 import { parseDesktopUpdateMenuLabels } from "./update-menu.js";
 import {
   DesktopUpdateTransitionOwner,
@@ -2365,11 +2366,18 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   });
   ipcMain.handle("od:update:check", async (event, updaterOptions: unknown) => {
     requireMainWindowSender(event);
-    const silent = await options.ensureSilentUpdatePreference?.().catch(() => false) ?? false;
-    const status = await (options.updater?.checkForUpdates({
-      ...checkOptionsFromHost(updaterOptions),
-      ...(silent ? { activationSource: "silent-policy" as const } : {}),
-    }) ?? unavailableUpdaterStatus());
+    const checkOptions = checkOptionsFromHost(updaterOptions);
+    const status = options.updater == null
+      ? unavailableUpdaterStatus()
+      : await checkDesktopUpdatesWithPolicy({
+          ...checkOptions,
+          onPreferenceError: (error) => {
+            console.warn("[open-design updater] manual check could not resolve silent update preference; revoking activation", error);
+          },
+          resolveSilentActivation: options.ensureSilentUpdatePreference ?? (async () => false),
+          trigger: "manual",
+          updater: options.updater,
+        });
     sendUpdaterStatus(status);
     return status;
   });

--- a/shells/electron/src/main/updater.ts
+++ b/shells/electron/src/main/updater.ts
@@ -27,13 +27,11 @@ import { createProcessStampArgs } from "@open-design/platform";
 import { resolveAppIpcPath } from "@open-design/sidecar";
 import {
   APP_KEYS,
-  DESKTOP_UPDATE_ACTIONS,
   DESKTOP_UPDATE_MODES,
   DESKTOP_UPDATE_STATES,
   OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_MODES,
   SIDECAR_SOURCES,
-  type DesktopUpdateAction,
   type DesktopUpdateCacheLifecycleSummary,
   type DesktopUpdateChecksumSnapshot,
   type DesktopUpdateErrorSnapshot,
@@ -94,6 +92,10 @@ import {
   type DesktopStandaloneUpdatePreparation,
   type StandaloneUpdatePreparationPort,
 } from "./updater/standalone.js";
+import type {
+  DesktopUpdateCheckActivationPolicy,
+  DesktopUpdateCheckTrigger,
+} from "./updater/check-policy.js";
 
 export type { DesktopStandaloneUpdatePreparation } from "./updater/standalone.js";
 
@@ -172,16 +174,16 @@ export type LoadedRelease = {
 };
 
 type ActionOptions = {
-  activationSource?: "silent-policy" | "user-restart";
+  activationPolicy: DesktopUpdateCheckActivationPolicy;
   autoDownload?: boolean;
+  trigger: DesktopUpdateCheckTrigger;
 };
 
 export type DesktopUpdater = {
-  checkForUpdates(options?: ActionOptions): Promise<DesktopUpdateStatusSnapshot>;
+  checkForUpdates(options: ActionOptions): Promise<DesktopUpdateStatusSnapshot>;
   clearCache(): Promise<DesktopUpdateStatusSnapshot>;
   config: DesktopUpdaterConfig;
   downloadUpdate(): Promise<DesktopUpdateStatusSnapshot>;
-  handle(action: DesktopUpdateAction): Promise<DesktopUpdateStatusSnapshot>;
   installUpdate(): Promise<DesktopUpdateStatusSnapshot>;
   shouldAutoCheck(): boolean;
   snapshot(): DesktopUpdateStatusSnapshot;
@@ -761,7 +763,7 @@ export function createDesktopUpdater(
     return opened.root;
   }
 
-  async function checkForCandidate(options: ActionOptions = {}): Promise<DesktopUpdateStatusSnapshot> {
+  async function checkForCandidate(options: ActionOptions): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
     if (installFrozen || installResult != null) return snapshot();
@@ -771,7 +773,7 @@ export function createDesktopUpdater(
       if (installFrozen || installResult != null) return snapshot();
     }
     if (
-      options.activationSource == null
+      options.activationPolicy === "revoke-silent"
       && standaloneStatus?.architecture === "standalone"
       && standaloneStatus.route === "closure"
       && standaloneStatus.state === "prepared"
@@ -779,6 +781,7 @@ export function createDesktopUpdater(
       && metadata != null
     ) {
       const reconciled = await resolveStandaloneMetadataPreparation({
+        activationPolicy: "revoke-silent",
         metadata,
         ...(deps.prepareStandaloneUpdate == null ? {} : { prepare: deps.prepareStandaloneUpdate }),
       });
@@ -787,7 +790,11 @@ export function createDesktopUpdater(
     const keepDownloadedVisible = activeRelease != null;
     if (!keepDownloadedVisible) setState(DESKTOP_UPDATE_STATES.CHECKING);
     try {
-      logUpdateEvent("check-start", { metadataUrl: config.metadataUrl });
+      logUpdateEvent("check-start", {
+        activationPolicy: options.activationPolicy,
+        metadataUrl: config.metadataUrl,
+        trigger: options.trigger,
+      });
       const body = await fetchJson(fetchImpl, config.metadataUrl);
       lastCheckedAt = now().toISOString();
       metadata = body;
@@ -797,7 +804,7 @@ export function createDesktopUpdater(
       }));
       if (root != null) scheduleBackCleanup(root.realRoot, logger);
       const standaloneRoute = await resolveStandaloneMetadataPreparation({
-        ...(options.activationSource == null ? {} : { activationSource: options.activationSource }),
+        activationPolicy: options.activationPolicy,
         metadata: body,
         ...(deps.prepareStandaloneUpdate == null ? {} : { prepare: deps.prepareStandaloneUpdate }),
       });
@@ -930,7 +937,11 @@ export function createDesktopUpdater(
     if (unsupported != null) return unsupported;
     if (installFrozen || installResult != null) return snapshot();
     if (candidate == null) {
-      const checked = await checkForCandidate({ autoDownload: false });
+      const checked = await checkForCandidate({
+        activationPolicy: "revoke-silent",
+        autoDownload: false,
+        trigger: "download",
+      });
       if (checked.state !== DESKTOP_UPDATE_STATES.AVAILABLE || candidate == null) return checked;
     }
     if (activeRelease != null && releaseMatchesCandidate(activeRelease.ref, candidate)) {
@@ -1212,7 +1223,7 @@ export function createDesktopUpdater(
       && metadata != null
     ) {
       const authorized = await resolveStandaloneMetadataPreparation({
-        activationSource: "user-restart",
+        activationPolicy: "authorize-user",
         metadata,
         ...(deps.prepareStandaloneUpdate == null ? {} : { prepare: deps.prepareStandaloneUpdate }),
       });
@@ -1440,20 +1451,6 @@ export function createDesktopUpdater(
     clearCache: () => serialized(clearCacheAndResetState),
     config,
     downloadUpdate: () => serialized(downloadUpdate),
-    handle(action) {
-      switch (action) {
-        case DESKTOP_UPDATE_ACTIONS.STATUS:
-          return this.status();
-        case DESKTOP_UPDATE_ACTIONS.CHECK:
-          return this.checkForUpdates();
-        case DESKTOP_UPDATE_ACTIONS.CLEAR_CACHE:
-          return this.clearCache();
-        case DESKTOP_UPDATE_ACTIONS.DOWNLOAD:
-          return this.downloadUpdate();
-        case DESKTOP_UPDATE_ACTIONS.INSTALL:
-          return this.installUpdate();
-      }
-    },
     installUpdate: () => serialized(installUpdate),
     shouldAutoCheck: () => config.enabled && config.autoCheck,
     snapshot,

--- a/shells/electron/src/main/updater/check-policy.ts
+++ b/shells/electron/src/main/updater/check-policy.ts
@@ -1,0 +1,33 @@
+import type { DesktopUpdater } from "../updater.js";
+
+export const DESKTOP_UPDATE_CHECK_ACTIVATION_POLICIES = {
+  AUTHORIZE_SILENT: "authorize-silent",
+  REVOKE_SILENT: "revoke-silent",
+} as const;
+
+export type DesktopUpdateCheckActivationPolicy =
+  typeof DESKTOP_UPDATE_CHECK_ACTIVATION_POLICIES[keyof typeof DESKTOP_UPDATE_CHECK_ACTIVATION_POLICIES];
+
+export type DesktopUpdateCheckTrigger = "download" | "manual" | "scheduler" | "sidecar" | "test";
+
+export async function checkDesktopUpdatesWithPolicy(input: Readonly<{
+  autoDownload?: boolean;
+  onPreferenceError?: (error: unknown) => void;
+  resolveSilentActivation: () => Promise<boolean>;
+  trigger: DesktopUpdateCheckTrigger;
+  updater: DesktopUpdater;
+}>) {
+  let silent = false;
+  try {
+    silent = await input.resolveSilentActivation();
+  } catch (error) {
+    input.onPreferenceError?.(error);
+  }
+  return await input.updater.checkForUpdates({
+    activationPolicy: silent
+      ? DESKTOP_UPDATE_CHECK_ACTIVATION_POLICIES.AUTHORIZE_SILENT
+      : DESKTOP_UPDATE_CHECK_ACTIVATION_POLICIES.REVOKE_SILENT,
+    ...(input.autoDownload == null ? {} : { autoDownload: input.autoDownload }),
+    trigger: input.trigger,
+  });
+}

--- a/shells/electron/src/main/updater/scheduler.ts
+++ b/shells/electron/src/main/updater/scheduler.ts
@@ -5,6 +5,7 @@ import {
 
 import type { DesktopUpdater, DesktopUpdaterLogger } from "../updater.js";
 import type { DesktopUpdateTransitionOwner } from "../update-preflight.js";
+import { checkDesktopUpdatesWithPolicy } from "./check-policy.js";
 
 /**
  * @module updater-scheduler
@@ -36,7 +37,7 @@ export function createDesktopUpdaterScheduler(
     initialDelayMs: number;
     intervalMs: number;
     logger?: DesktopUpdaterLogger;
-  silentStandaloneActivation?: () => Promise<boolean>;
+    silentStandaloneActivation?: () => Promise<boolean>;
     startupSilentPayloadUpdate?: StartupSilentPayloadUpdateOptions;
   },
 ): DesktopUpdaterScheduler {
@@ -105,9 +106,13 @@ export function createDesktopUpdaterScheduler(
       const startupReady = startupTick && options.startupSilentPayloadUpdate != null
         ? await updater.status()
         : null;
-      const silentActivationEnabled = await options.silentStandaloneActivation?.().catch(() => false) ?? false;
-      status = await updater.checkForUpdates({
-        ...(silentActivationEnabled ? { activationSource: "silent-policy" as const } : {}),
+      status = await checkDesktopUpdatesWithPolicy({
+        onPreferenceError: (error) => {
+          logger.warn("[open-design updater] scheduled check could not resolve silent update preference; revoking activation", error);
+        },
+        resolveSilentActivation: options.silentStandaloneActivation ?? (async () => false),
+        trigger: "scheduler",
+        updater,
       });
       if (
         startupTick

--- a/shells/electron/src/main/updater/standalone.ts
+++ b/shells/electron/src/main/updater/standalone.ts
@@ -1,3 +1,5 @@
+import type { StandaloneUpdateActivationPolicy } from "@open-design/standalone";
+
 import { hasStandaloneDistributionMetadata } from "./feed.js";
 
 export type DesktopStandaloneUpdatePreparation =
@@ -13,11 +15,11 @@ export type DesktopStandaloneUpdatePreparation =
 
 export type StandaloneUpdatePreparationPort = (
   metadata: Record<string, unknown>,
-  options: { activationSource?: "silent-policy" | "user-restart" },
+  options: { activationPolicy: StandaloneUpdateActivationPolicy },
 ) => Promise<DesktopStandaloneUpdatePreparation>;
 
 export async function resolveStandaloneMetadataPreparation(input: Readonly<{
-  activationSource?: "silent-policy" | "user-restart";
+  activationPolicy: StandaloneUpdateActivationPolicy;
   metadata: Record<string, unknown>;
   prepare?: StandaloneUpdatePreparationPort;
 }>): Promise<Readonly<{
@@ -27,8 +29,6 @@ export async function resolveStandaloneMetadataPreparation(input: Readonly<{
   const modern = hasStandaloneDistributionMetadata(input.metadata);
   const preparation = input.prepare == null
     ? (modern ? null : { architecture: "legacy" as const })
-    : await input.prepare(input.metadata, {
-        ...(input.activationSource == null ? {} : { activationSource: input.activationSource }),
-      });
+    : await input.prepare(input.metadata, { activationPolicy: input.activationPolicy });
   return Object.freeze({ modern, preparation });
 }

--- a/shells/electron/src/standalone-commands.ts
+++ b/shells/electron/src/standalone-commands.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import type { StandaloneUpdateActivationPolicy } from "@open-design/standalone";
 import {
   STANDALONE_HANDOFF_SCHEMA_VERSION,
   type StandaloneHandle,
@@ -56,16 +57,20 @@ export function createStandaloneUpdatePreparation(input: Readonly<{
   requestId?: () => string;
 }>): (
   metadata: Record<string, unknown>,
-  options?: { activationSource?: "silent-policy" | "user-restart" },
+  options: { activationPolicy: StandaloneUpdateActivationPolicy },
 ) => Promise<StandaloneUpdatePreparation> {
   const requestId = input.requestId ?? randomUUID;
-  return async (metadata, options = {}) => {
+  return async (metadata, options) => {
     const result = await input.handle.invoke({
       attachmentId: input.attachmentId,
       command: OPEN_DESIGN_PREPARE_UPDATE_COMMAND,
       handoff: input.handoff,
       input: {
-        ...(options.activationSource == null ? {} : { activationSource: options.activationSource }),
+        ...(options.activationPolicy === "authorize-silent"
+          ? { activationSource: "silent-policy" }
+          : options.activationPolicy === "authorize-user"
+            ? { activationSource: "user-restart" }
+            : {}),
         metadata,
       } as StandaloneProtocolJsonValue,
       requestId: requestId(),

--- a/shells/electron/tests/main/updater-check-policy.test.ts
+++ b/shells/electron/tests/main/updater-check-policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DesktopUpdater } from "../../src/main/updater.js";
+import { checkDesktopUpdatesWithPolicy } from "../../src/main/updater/check-policy.js";
+
+describe("desktop updater check policy", () => {
+  it.each([
+    { expected: "authorize-silent", preference: true },
+    { expected: "revoke-silent", preference: false },
+  ] as const)("maps preference=$preference to $expected", async ({ expected, preference }) => {
+    const snapshot = { state: "not-available" };
+    const checkForUpdates = vi.fn(async () => snapshot);
+
+    await expect(checkDesktopUpdatesWithPolicy({
+      autoDownload: false,
+      resolveSilentActivation: async () => preference,
+      trigger: "manual",
+      updater: { checkForUpdates } as unknown as DesktopUpdater,
+    })).resolves.toBe(snapshot);
+
+    expect(checkForUpdates).toHaveBeenCalledWith({
+      activationPolicy: expected,
+      autoDownload: false,
+      trigger: "manual",
+    });
+  });
+
+  it("fails closed when the preference cannot be resolved", async () => {
+    const checkForUpdates = vi.fn(async () => ({ state: "not-available" }));
+    const onPreferenceError = vi.fn();
+
+    await checkDesktopUpdatesWithPolicy({
+      onPreferenceError,
+      resolveSilentActivation: async () => {
+        throw new Error("app config unavailable");
+      },
+      trigger: "sidecar",
+      updater: { checkForUpdates } as unknown as DesktopUpdater,
+    });
+
+    expect(checkForUpdates).toHaveBeenCalledWith({
+      activationPolicy: "revoke-silent",
+      trigger: "sidecar",
+    });
+    expect(onPreferenceError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "app config unavailable",
+    }));
+  });
+});

--- a/shells/electron/tests/main/updater-host-boundary.test.ts
+++ b/shells/electron/tests/main/updater-host-boundary.test.ts
@@ -23,8 +23,18 @@ describe("desktop updater host boundary", () => {
     expect(runtime).toContain("UPDATER_STATUS_EVENT");
     expect(runtime).toContain("event.sender !== window.webContents");
     expect(runtime).toContain("ensureSilentUpdatePreference");
-    expect(runtime).toContain('activationSource: "silent-policy"');
+    expect(runtime).toContain("checkDesktopUpdatesWithPolicy");
     expect(runtime).not.toContain("activateOnRestart");
+  });
+
+  it("routes renderer, scheduler, and sidecar checks through one policy atom", () => {
+    const main = source("src/main/index.ts");
+    const runtime = source("src/main/runtime.ts");
+    const scheduler = source("src/main/updater/scheduler.ts");
+    expect(runtime).toContain('trigger: "manual"');
+    expect(scheduler).toContain('trigger: "scheduler"');
+    expect(main).toContain('trigger: "sidecar"');
+    expect(main).not.toContain("updater.handle(");
   });
 
   it("lists every registered od:update:* handler in the teardown channel table", () => {
@@ -85,7 +95,9 @@ describe("desktop updater host boundary", () => {
     expect(main).toContain("desktop updater status timed out after ${timeoutMs}ms");
     expect(main).toContain("update: updater.snapshot()");
     expect(main).toContain("return await desktopStatusSnapshot(activeDesktop)");
-    expect(main).not.toContain("return await updater.status()");
+    const snapshotStart = main.indexOf("async function snapshotUpdateForStatus()");
+    const snapshotEnd = main.indexOf("async function snapshotStandaloneForStatus()", snapshotStart);
+    expect(main.slice(snapshotStart, snapshotEnd)).not.toContain("return await updater.status()");
   });
 
   it("adds updater access to the macOS app menu without changing the Windows File menu", () => {

--- a/shells/electron/tests/main/updater.test.ts
+++ b/shells/electron/tests/main/updater.test.ts
@@ -48,6 +48,11 @@ type FixtureServer = {
 type FixturePlatform = "mac" | "win";
 type FixtureChannel = ReleaseChannel;
 
+const TEST_REVOKE_CHECK = Object.freeze({
+  activationPolicy: "revoke-silent",
+  trigger: "test",
+} as const);
+
 function prereleaseCounterParts(version: string): { baseVersion: string; number: number } | null {
   const prerelease = /^(\d+\.\d+\.\d+)-.+\.(\d+)$/.exec(version);
   if (prerelease?.[1] != null && prerelease[2] != null) {
@@ -346,10 +351,12 @@ describe("desktop updater", () => {
       controlInstallationVersionMin: "9.9.9",
       standaloneMetadata: { schemaVersion: 4 },
     });
-    const prepareStandaloneUpdate = vi.fn(async (_metadata: unknown, options?: {
-      activationSource?: "silent-policy" | "user-restart";
+    const prepareStandaloneUpdate = vi.fn(async (_metadata: unknown, options: {
+      activationPolicy: "authorize-silent" | "authorize-user" | "revoke-silent";
     }) => ({
-      activationSource: options?.activationSource ?? null,
+      activationSource: options.activationPolicy === "authorize-silent"
+        ? "silent-policy" as const
+        : options.activationPolicy === "authorize-user" ? "user-restart" as const : null,
       architecture: "standalone" as const,
       releaseVersion: "1.0.1",
       route: "closure" as const,
@@ -365,8 +372,9 @@ describe("desktop updater", () => {
       }, { prepareStandaloneUpdate });
 
       const status = await updater.checkForUpdates({
-        activationSource: "silent-policy",
+        activationPolicy: "authorize-silent",
         autoDownload: false,
+        trigger: "test",
       });
 
       expect(status.state).toBe(DESKTOP_UPDATE_STATES.NOT_AVAILABLE);
@@ -379,7 +387,7 @@ describe("desktop updater", () => {
       expect(status.reinstall).toBeUndefined();
       expect(prepareStandaloneUpdate).toHaveBeenCalledWith(
         expect.objectContaining({ closure: { schemaVersion: 4 } }),
-        { activationSource: "silent-policy" },
+        { activationPolicy: "authorize-silent" },
       );
 
       const authorized = await updater.installUpdate();
@@ -390,7 +398,7 @@ describe("desktop updater", () => {
       });
       expect(prepareStandaloneUpdate).toHaveBeenLastCalledWith(
         expect.objectContaining({ closure: { schemaVersion: 4 } }),
-        { activationSource: "user-restart" },
+        { activationPolicy: "authorize-user" },
       );
     } finally {
       await fixture.close();
@@ -407,10 +415,12 @@ describe("desktop updater", () => {
       if (fetchCount > 1) throw new Error("offline");
       return await globalThis.fetch(input, init);
     };
-    const prepareStandaloneUpdate = vi.fn(async (_metadata: unknown, options?: {
-      activationSource?: "silent-policy" | "user-restart";
+    const prepareStandaloneUpdate = vi.fn(async (_metadata: unknown, options: {
+      activationPolicy: "authorize-silent" | "authorize-user" | "revoke-silent";
     }) => ({
-      activationSource: options?.activationSource ?? null,
+      activationSource: options.activationPolicy === "authorize-silent"
+        ? "silent-policy" as const
+        : options.activationPolicy === "authorize-user" ? "user-restart" as const : null,
       architecture: "standalone" as const,
       releaseVersion: "1.0.1",
       route: "closure" as const,
@@ -424,15 +434,15 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.PACKAGED,
       }, { fetch: fetchImpl, prepareStandaloneUpdate });
 
-      await updater.checkForUpdates({ activationSource: "silent-policy", autoDownload: false });
-      const offline = await updater.checkForUpdates({ autoDownload: false });
+      await updater.checkForUpdates({ activationPolicy: "authorize-silent", trigger: "test", autoDownload: false });
+      const offline = await updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
 
       expect(offline.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(offline.standalone?.activationSource).toBeNull();
       expect(prepareStandaloneUpdate).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ closure: { schemaVersion: 4 } }),
-        {},
+        { activationPolicy: "revoke-silent" },
       );
     } finally {
       await fixture.close();
@@ -471,7 +481,7 @@ describe("desktop updater", () => {
         },
       );
 
-      await updater.checkForUpdates({ autoDownload: false });
+      await updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
 
       expect(logger.info).toHaveBeenCalledWith("[open-design updater] lifecycle", expect.objectContaining({
         enabled: true,
@@ -505,7 +515,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.STABLE);
       expect(checked.availableVersion).toBe("1.0.1");
@@ -541,7 +551,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.platform).toBe("win32");
       expect(checked.supported).toBe(true);
@@ -576,7 +586,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.PACKAGED,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("installer");
@@ -629,7 +639,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.PACKAGED,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("installer");
@@ -720,7 +730,7 @@ describe("desktop updater", () => {
         processPid: 4242,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("payload");
@@ -859,7 +869,7 @@ describe("desktop updater", () => {
       })}\n`);
 
       const lockedUpdater = createUpdater(failLauncherPayloadRemovalForVersion("1.0.0-beta.0"));
-      const checked = await lockedUpdater.checkForUpdates();
+      const checked = await lockedUpdater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.error).toBeUndefined();
@@ -887,7 +897,7 @@ describe("desktop updater", () => {
         state: "cleanup-removed",
       });
 
-      const rechecked = await lockedUpdater.checkForUpdates();
+      const rechecked = await lockedUpdater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(rechecked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(rechecked.error).toBeUndefined();
       expect(extractCount).toBe(1);
@@ -969,7 +979,7 @@ describe("desktop updater", () => {
         removeLauncherPayloadRoot: failLauncherPayloadRemovalForVersion("1.0.0-beta.0"),
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       await mkdir(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload"), { recursive: true });
       await writeFile(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload", "opencode.exe"), "locked");
@@ -1095,7 +1105,7 @@ describe("desktop updater", () => {
       processPid: 4242,
     };
     const updater = createDesktopUpdater(updaterInput, updaterDeps);
-    const snapshot = await updater.checkForUpdates();
+    const snapshot = await updater.checkForUpdates(TEST_REVOKE_CHECK);
     const restartedSnapshot = harnessOptions.restart === true
       ? await createDesktopUpdater(updaterInput, updaterDeps).status()
       : undefined;
@@ -1294,7 +1304,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       const installed = await updater.installUpdate();
       expect(installed.installResult?.dryRun).toBe(true);
@@ -1313,7 +1323,7 @@ describe("desktop updater", () => {
       expect(await readdir(join(root, "releases"))).toEqual([]);
 
       // Install freeze is gone: a fresh check re-offers and re-downloads.
-      const rechecked = await updater.checkForUpdates();
+      const rechecked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(rechecked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(rechecked.downloadPath).toEqual(expect.any(String));
     } finally {
@@ -1332,7 +1342,7 @@ describe("desktop updater", () => {
         env: updaterEnv(fixture.metadataUrl),
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       await mkdir(join(root, "state", "lock"), { recursive: true });
       await writeFile(join(root, "state", "lock", "owner.json"), JSON.stringify({
@@ -1664,7 +1674,7 @@ describe("desktop updater", () => {
         processPid: 4242,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("payload");
@@ -1748,7 +1758,7 @@ describe("desktop updater", () => {
         },
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("launcher-payload-prepare-failed");
@@ -1806,7 +1816,7 @@ describe("desktop updater", () => {
         processExecPath: "C:\\Users\\runneradmin\\AppData\\Roaming\\Open Design Beta\\launcher\\channels\\beta\\namespaces\\release-beta-win\\versions\\1.0.0-beta.1\\payload\\Open Design.exe",
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.artifact?.type).toBe("installer");
@@ -1895,7 +1905,7 @@ describe("desktop updater", () => {
         processPid: 4243,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.artifact?.type).toBe("payload");
       expect(checked.capabilities.canApplyInPlace).toBe(true);
       expect(checked.capabilities.canOpenInstaller).toBe(false);
@@ -2022,7 +2032,7 @@ describe("desktop updater", () => {
         processPid: 4244,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.PRERELEASE);
       expect(checked.artifact?.type).toBe("payload");
@@ -2142,7 +2152,7 @@ describe("desktop updater", () => {
         processPid: 4244,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.artifact?.type).toBe("payload");
       expect(checked.capabilities.canApplyInPlace).toBe(true);
       expect(checked.capabilities.canOpenInstaller).toBe(false);
@@ -2252,7 +2262,7 @@ describe("desktop updater", () => {
         processPid: 4246,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.artifact?.type).toBe("payload");
       await rm(launcherLaunchPath, { force: true });
 
@@ -2364,7 +2374,7 @@ describe("desktop updater", () => {
         },
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
 
       expect(installed.error).toBeUndefined();
@@ -2496,7 +2506,7 @@ describe("desktop updater", () => {
         spawnDetached: () => child as never,
       });
 
-      await updater.checkForUpdates();
+      await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
 
       expect(installed.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
@@ -2573,7 +2583,7 @@ describe("desktop updater", () => {
         },
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("launcher-payload-prepare-failed");
@@ -2609,7 +2619,7 @@ describe("desktop updater", () => {
         { logger },
       );
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.error).toBeUndefined();
@@ -2639,7 +2649,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("download-failed");
@@ -2678,7 +2688,7 @@ describe("desktop updater", () => {
         } },
       );
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
       const flowIds = await readdir(observationRoot);
       const summary = JSON.parse(await readFile(join(observationRoot, flowIds[0] ?? "", "summary.json"), "utf8")) as Record<string, unknown>;
@@ -2733,7 +2743,7 @@ describe("desktop updater", () => {
         } },
       );
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const first = await updater.installUpdate();
       const second = await updater.installUpdate();
 
@@ -2772,7 +2782,7 @@ describe("desktop updater", () => {
         },
       );
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
 
       expect(installed.installResult?.path).toBe(checked.downloadPath);
@@ -2823,7 +2833,7 @@ describe("desktop updater", () => {
         },
       );
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
 
       expect(installed.installResult?.path).toBe(checked.downloadPath);
@@ -2894,12 +2904,12 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const first = await updater.checkForUpdates();
+      const first = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(first.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(first.downloadPath).toEqual(expect.any(String));
       expect(fixture.artifactRequests()).toBe(1);
 
-      const second = await updater.checkForUpdates();
+      const second = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(second.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(second.downloadPath).toBe(first.downloadPath);
       expect(second.availableVersion).toBe(first.availableVersion);
@@ -2921,7 +2931,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const first = await updater.checkForUpdates();
+      const first = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(first.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(first.downloadPath).toEqual(expect.any(String));
       expect(fixture.artifactRequests()).toBe(1);
@@ -2937,7 +2947,7 @@ describe("desktop updater", () => {
         env: updaterEnv(fixture.metadataUrl),
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
-      const restored = await restarted.checkForUpdates();
+      const restored = await restarted.checkForUpdates(TEST_REVOKE_CHECK);
       const metadata = JSON.parse(await readFile(join(root, "metadata.json"), "utf8")) as Record<string, unknown>;
 
       expect(restored.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
@@ -2963,12 +2973,12 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const downloaded = await updater.checkForUpdates();
+      const downloaded = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(downloaded.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       await fixture.close();
       fixtureClosed = true;
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.downloadPath).toBe(downloaded.downloadPath);
@@ -3032,12 +3042,12 @@ describe("desktop updater", () => {
         { fetch: fetchImpl },
       );
 
-      const downloaded = await updater.checkForUpdates();
+      const downloaded = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(downloaded.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
 
       version = "1.0.2";
       failArtifact = true;
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.downloadPath).toBe(downloaded.downloadPath);
@@ -3084,7 +3094,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.NOT_AVAILABLE);
       expect(checked.downloadPath).toBeUndefined();
     } finally {
@@ -3107,7 +3117,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(checked.availableVersion).toBe("1.0.1-beta.2");
@@ -3128,7 +3138,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.STABLE);
       expect(checked.error?.code).toBe("metadata-channel-mismatch");
@@ -3153,7 +3163,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(checked.error?.code).toBe("metadata-channel-mismatch");
@@ -3178,7 +3188,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.BETA);
       expect(checked.availableVersion).toBe("1.0.1-beta-internal.2");
@@ -3202,7 +3212,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe(DESKTOP_UPDATE_CHANNELS.PRERELEASE);
       expect(checked.availableVersion).toBe("1.0.1-prerelease.2");
@@ -3226,7 +3236,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.channel).toBe("preview");
       expect(checked.availableVersion).toBe("1.0.1-preview.2");
@@ -3247,7 +3257,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       await writeFile(checked.downloadPath ?? "", "tampered", "utf8");
 
@@ -3283,9 +3293,9 @@ describe("desktop updater", () => {
         { fetch: fetchImpl },
       );
 
-      const first = updater.checkForUpdates({ autoDownload: false });
-      const second = updater.checkForUpdates({ autoDownload: false });
-      const third = updater.checkForUpdates({ autoDownload: false });
+      const first = updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
+      const second = updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
+      const third = updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
 
       await waitForRequestCount(requests, 1);
       expect(requests).toHaveLength(1);
@@ -3367,7 +3377,7 @@ describe("desktop updater", () => {
         },
         { fetch: fetchImpl },
       );
-      await updater.checkForUpdates({ autoDownload: false });
+      await updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
       fetchImpl.mockClear();
       vi.useFakeTimers();
       const scheduler = createDesktopUpdaterScheduler(updater, {
@@ -3416,7 +3426,7 @@ describe("desktop updater", () => {
         },
         { fetch: fetchImpl },
       );
-      await updater.checkForUpdates({ autoDownload: false });
+      await updater.checkForUpdates({ ...TEST_REVOKE_CHECK, autoDownload: false });
       blockScheduledFetch = true;
       vi.useFakeTimers();
       const scheduler = createDesktopUpdaterScheduler(updater, {
@@ -3458,13 +3468,13 @@ describe("desktop updater", () => {
         intervalMs: 100,
       });
 
-      await updater.checkForUpdates();
+      await updater.checkForUpdates(TEST_REVOKE_CHECK);
       scheduler.start();
       expect(scheduler.isRunning()).toBe(true);
       await updater.installUpdate();
       expect(scheduler.isRunning()).toBe(false);
       const requestsBeforeFrozenCheck = fixture.artifactRequests();
-      await updater.checkForUpdates();
+      await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(fixture.artifactRequests()).toBe(requestsBeforeFrozenCheck);
     } finally {
       await fixture.close();
@@ -3483,7 +3493,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const downloaded = await updater.checkForUpdates();
+      const downloaded = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
       expect(installed.installResult?.path).toBe(downloaded.downloadPath);
       const metadataRequestsBeforeRestart = fixture.metadataRequests();
@@ -3494,7 +3504,7 @@ describe("desktop updater", () => {
         env: updaterEnv(fixture.metadataUrl),
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
-      const checked = await restarted.checkForUpdates();
+      const checked = await restarted.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.installResult?.path).toBe(downloaded.downloadPath);
@@ -3516,7 +3526,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const downloaded = await updater.checkForUpdates();
+      const downloaded = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const installed = await updater.installUpdate();
       expect(installed.installResult?.path).toBe(downloaded.downloadPath);
 
@@ -3540,7 +3550,7 @@ describe("desktop updater", () => {
       expect(store.installFrozen).toBeUndefined();
       expect(store.installResult).toBeUndefined();
 
-      const checked = await restarted.checkForUpdates();
+      const checked = await restarted.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.NOT_AVAILABLE);
       expect(checked.installResult).toBeUndefined();
     } finally {
@@ -3603,7 +3613,7 @@ describe("desktop updater", () => {
         launchAppAfterQuit: async () => ({ helperLogPath: join(root, "updates", "helpers", "relaunch.log") }),
       };
       const updater = createDesktopUpdater(updaterInput, updaterDeps);
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       const installed = await updater.installUpdate();
       expect(installed.installResult?.activeVersion).toBe("1.0.0-beta.2");
@@ -3622,7 +3632,7 @@ describe("desktop updater", () => {
 
       // Checks are alive again: the updater re-derives the offer instead of
       // returning the frozen snapshot.
-      const rechecked = await restarted.checkForUpdates();
+      const rechecked = await restarted.checkForUpdates(TEST_REVOKE_CHECK);
       expect(rechecked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(rechecked.installResult).toBeUndefined();
     } finally {
@@ -3708,7 +3718,7 @@ describe("desktop updater", () => {
       await writeReleaseFixture(root, "1.0.0-beta.1-win-x64-old1", "beta", "1.0.0-beta.1");
       await writeReleaseFixture(root, "1.0.0-beta.2-win-x64-current", "beta", "1.0.0-beta.2");
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       const cleanup = JSON.parse(await readFile(join(root, "state", "cleanup.json"), "utf8")) as {
         releases: Array<{ deprecatedAt?: string; key: string; state: string; version?: string }>;
       };
@@ -3750,7 +3760,7 @@ describe("desktop updater", () => {
       await updater.status();
       await mkdir(join(root, "releases", "missing-metadata-release"), { recursive: true });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.cache?.lifecycle?.releases.unknown).toBe(1);
@@ -3991,7 +4001,7 @@ describe("desktop updater", () => {
       await updater.status();
       await writeReleaseFixture(root, "1.0.0-beta.1-mac-arm64-old1", "beta", "1.0.0-beta.1");
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
 
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.cache?.lifecycle).toMatchObject({
@@ -4019,7 +4029,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("no-compatible-artifact");
       expect(checked.error?.message).toContain("macIntel");
@@ -4042,7 +4052,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("update-root-not-owned");
       expect(existsSync(alienFile)).toBe(true);
@@ -4067,7 +4077,7 @@ describe("desktop updater", () => {
         source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("update-root-not-owned");
       expect(existsSync(join(realRoot, ".open-design-updater-root.json"))).toBe(false);
@@ -4094,7 +4104,7 @@ describe("desktop updater", () => {
       await updater.status();
       symlinkSync(outside, join(root, "staging"), "dir");
 
-      const checked = await updater.checkForUpdates();
+      const checked = await updater.checkForUpdates(TEST_REVOKE_CHECK);
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
       expect(checked.error?.code).toBe("update-store-invalid-shape");
       expect(existsSync(outsideMarker)).toBe(true);

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -114,17 +114,15 @@ describe("release workflow topology", () => {
     expect(distribution).toContain("uses: ./.github/actions/release/platform/mac/exact");
     expect(distribution).toContain("uses: ./.github/actions/release/platform/win/exact");
     expect(distribution).toContain("channel: ${{ inputs.exact_name }}");
-    expect(mac).toContain('prefix: tools-pack-mac-v2-${{ runner.os }}-${{ inputs.arch }}-');
-    expect(mac).not.toContain('prefix: tools-pack-mac-v2-${{ inputs.channel }}-');
+    expect(mac).toContain('prefix: tools-pack-mac-v3-${{ inputs.channel }}-${{ runner.os }}-${{ inputs.arch }}-');
     expect(mac).toContain("uses: ./.github/actions/release/closure/target/mac");
     expect(mac).toContain("channel: ${{ inputs.channel }}");
-    expect(win).toContain('prefix: tools-pack-win-v2-${{ runner.os }}-${{ runner.arch }}-');
-    expect(win).not.toContain('prefix: tools-pack-win-v2-${{ inputs.channel }}-');
+    expect(win).toContain('prefix: tools-pack-win-v3-${{ inputs.channel }}-${{ runner.os }}-${{ runner.arch }}-');
     expect(win).toContain('"release-${{ inputs.channel }}-win"');
     expect(mac).toContain("uses: ./.github/actions/release/platform/cache/save");
     expect(win).toContain("uses: ./.github/actions/release/platform/cache/save");
-    expect(standardMac).toContain('prefix: tools-pack-mac-v2-${{ runner.os }}-${{ steps.platform.outputs.arch }}-');
-    expect(standardWin).toContain('prefix: tools-pack-win-v2-${{ runner.os }}-${{ runner.arch }}-');
+    expect(standardMac).toContain('prefix: tools-pack-mac-v3-${{ inputs.channel }}-${{ runner.os }}-${{ steps.platform.outputs.arch }}-');
+    expect(standardWin).toContain('prefix: tools-pack-win-v3-${{ inputs.channel }}-${{ runner.os }}-${{ runner.arch }}-');
     for (const action of [mac, win, standardMac, standardWin]) {
       expect(action).not.toContain("hashFiles(");
     }


### PR DESCRIPTION
## Summary
- route renderer, scheduler, and inspect/sidecar update checks through one preference-backed policy atom
- make Standalone activation authorization explicit internally while preserving the legacy Shell-to-Closure wire shape
- fail closed and log when silent-update preference resolution fails
- cover the old Closure + new Shell convergence window with an inspect-triggered manual check

## Validation
- pnpm --filter @open-design/standalone typecheck
- pnpm --filter @open-design/shell-electron typecheck
- pnpm --filter @open-design/e2e typecheck
- Standalone tests: 67 passed
- Electron Shell tests: 627 passed, 1 skipped
- mac silent-update spec collected successfully; packaged scenario remains environment-gated