### PR TITLE
fix: handle SOCKS-only system proxy for Claude Code

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -204,7 +204,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
     'OPENCODE_TEST_HOME',
   ])],
   ['aider', new Set(['AIDER_BIN'])],
-  ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'MMD_MODEL_ROUTES_FILE'])],
+  ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'MMD_MODEL_ROUTES_FILE', 'HTTP_PROXY', 'HTTPS_PROXY'])],
   ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'CODEX_API_KEY', 'OPENAI_API_KEY'])],
   ['copilot', new Set(['COPILOT_BIN'])],
   ['cursor-agent', new Set(['CURSOR_AGENT_BIN'])],

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
+import { isSocksOnlyProxyEnv, mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
 import { readAppConfigSync } from '../app-config.js';
 import { resolveProjectRelativePath } from '../home-expansion.js';
 import { expandConfiguredEnv } from './paths.js';
@@ -132,6 +132,25 @@ export function spawnEnvForAgent(
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'claude') {
+    // Claude Code does not support SOCKS proxies. If the system proxy is
+    // SOCKS-only (ALL_PROXY=socks://... with no HTTP_PROXY/HTTPS_PROXY),
+    // strip ALL_PROXY so Claude can reach the API directly. Users can
+    // configure an HTTP(S) forward proxy via agentCliEnv.
+    if (isSocksOnlyProxyEnv(env)) {
+      for (const key of Object.keys(env)) {
+        if (key.toLowerCase() === 'all_proxy') delete env[key];
+      }
+      // Also drop NODE_USE_ENV_PROXY if no HTTP/HTTPS proxy remains.
+      const hasHttpOrHttps = Object.keys(env).some((k) => {
+        const lk = k.toLowerCase();
+        return (lk === 'http_proxy' || lk === 'https_proxy') && (env[k] || '').trim().length > 0;
+      });
+      if (!hasHttpOrHttps) {
+        for (const key of Object.keys(env)) {
+          if (key.toLowerCase() === 'node_use_env_proxy') delete env[key];
+        }
+      }
+    }
     return finalizeRuntimeEnv(env, sandboxRuntime);
   }
   if (agentId === 'codex') {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -937,6 +937,18 @@ const AGENT_CLI_ENV_FIELDS = [
     placeholder: 'Paste OPENAI_API_KEY',
     secret: true,
   },
+  {
+    agentId: 'claude',
+    envKey: 'HTTP_PROXY',
+    labelKey: 'settings.cliEnvClaudeHttpProxy',
+    placeholder: 'http://proxy.example.com:8080',
+  },
+  {
+    agentId: 'claude',
+    envKey: 'HTTPS_PROXY',
+    labelKey: 'settings.cliEnvClaudeHttpsProxy',
+    placeholder: 'http://proxy.example.com:8080',
+  },
 ] as const;
 
 function defaultApiProtocolConfig(protocol: ApiProtocol): ApiProtocolConfig {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -608,6 +608,8 @@ export const en: Dict = {
   'settings.cliEnvClaudeConfigDir': 'Claude Code config directory',
   'settings.cliEnvClaudeBaseUrl': 'Claude proxy base URL',
   'settings.cliEnvClaudeApiKey': 'Claude CLI API key',
+  'settings.cliEnvClaudeHttpProxy': 'HTTP_PROXY (for Claude Code)',
+  'settings.cliEnvClaudeHttpsProxy': 'HTTPS_PROXY (for Claude Code)',
   'settings.cliEnvCodexHome': 'Codex home',
   'settings.cliEnvCodexBin': 'Codex executable path',
   'settings.cliEnvCodexBaseUrl': 'Codex/OpenAI proxy base URL',

--- a/packages/platform/src/proxy-env.ts
+++ b/packages/platform/src/proxy-env.ts
@@ -365,6 +365,33 @@ export function parseWindowsInternetSettingsProxyOutput(
  * @param options - Optional platform override and command runner (for testing).
  * @returns A normalized proxy environment, or `{}` when no proxy is configured.
  */
+
+/**
+ * Check whether a proxy environment is SOCKS-only — has a SOCKS ALL_PROXY
+ * value but no HTTP or HTTPS proxy. Agents like Claude Code that do not
+ * support SOCKS can use this to avoid passing an unusable ALL_PROXY.
+ */
+export function isSocksOnlyProxyEnv(
+  env: NodeJS.ProcessEnv,
+): boolean {
+  let hasAllProxy = false;
+  let hasHttpProxy = false;
+  let hasHttpsProxy = false;
+  for (const [key, value] of Object.entries(env)) {
+    const lowerKey = key.toLowerCase();
+    const trimmed = (value || '').trim();
+    if (!trimmed) continue;
+    if (lowerKey === 'all_proxy') {
+      hasAllProxy = trimmed.startsWith('socks');
+    } else if (lowerKey === 'http_proxy') {
+      hasHttpProxy = true;
+    } else if (lowerKey === 'https_proxy') {
+      hasHttpsProxy = true;
+    }
+  }
+  return hasAllProxy && !hasHttpProxy && !hasHttpsProxy;
+}
+
 export function resolveSystemProxyEnv(options: ResolveSystemProxyEnvOptions = {}): NodeJS.ProcessEnv {
   const platform = options.platform ?? process.platform;
   const runCommand = options.runCommand ?? defaultSystemProxyCommandRunner;


### PR DESCRIPTION
## Summary

Fixes #6969. When Open Design detects a macOS system proxy that is **SOCKS-only** (only `SOCKSEnable: 1` with no HTTP/HTTPS proxy), it currently passes `ALL_PROXY=socks5://...` unchanged to Claude Code. Claude Code does not support SOCKS proxies, so this creates a dead end for users on SOCKS-only networks.

## Changes

### 1. `packages/platform/src/proxy-env.ts`
- Added `isSocksOnlyProxyEnv()` — checks whether an env object has `ALL_PROXY` with a `socks://` scheme but no `HTTP_PROXY` or `HTTPS_PROXY`.

### 2. `apps/daemon/src/runtimes/env.ts`
- In `spawnEnvForAgent('claude')`, detect SOCKS-only proxy env and strip the unusable `ALL_PROXY` and `NODE_USE_ENV_PROXY` from the Claude launch environment. The agent can still reach the API directly.

### 3. `apps/daemon/src/app-config.ts`
- Added `HTTP_PROXY` and `HTTPS_PROXY` to the per-agent `AGENT_CLI_ENV_KEYS` allowlist for claude. Users can now configure an HTTP forward proxy via Settings → Local CLI → Advanced: proxy & custom paths.

### 4. `apps/web/src/components/SettingsDialog.tsx`
- Added `HTTP_PROXY` and `HTTPS_PROXY` fields to the Settings UI for Claude Code.

### 5. `apps/web/src/i18n/locales/en.ts`
- Added English translations for the new settings fields.

## Testing

- `spawnEnvForAgent('claude', ...)` with a SOCKS-only system proxy → `ALL_PROXY` is stripped, `NODE_USE_ENV_PROXY` is removed
- `spawnEnvForAgent('claude', ...)` with `HTTP_PROXY` configured via agentCliEnv → `ALL_PROXY` is kept (since `HTTP_PROXY` is present)
- `spawnEnvForAgent('claude', ...)` with normal HTTP/HTTPS proxy → no change in behavior
- Existing tests for `spawnEnvForAgent` continue to pass