### PR TITLE
fix(web): default Home creation type to prototype

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -744,18 +744,26 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     );
   }, [activeExamplePlugins, activeChipId, selectedSubcategory, pluginOptions]);
 
-  // First-run guide, beat 1: pulse the Prototype chip for brand-new users.
+  // First-run guide, beat 1: pulse the Prototype chip for brand-new users only
+  // when Home could not bind a default type. A successfully seeded default has
+  // already completed that choice, so skip the redundant pulse and let beat 2
+  // guide the user to its first example card.
   // The settle delay lets the hero finish its entrance before the sheen.
   useEffect(() => {
     if (firstRunGuide !== true) return;
     if (readHomeGuideStage() !== 'chip') return;
+    if (activeChipId) {
+      writeHomeGuideStage('card');
+      setGuidePulseChipId(null);
+      return;
+    }
     const arm = window.setTimeout(() => setGuidePulseChipId('prototype'), 900);
     const disarm = window.setTimeout(() => setGuidePulseChipId(null), 3600);
     return () => {
       window.clearTimeout(arm);
       window.clearTimeout(disarm);
     };
-  }, [firstRunGuide]);
+  }, [firstRunGuide, activeChipId]);
 
   // Users with existing projects never see the trail — complete ANY
   // unfinished stage silently. A chip pick during the loading window can

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -1806,7 +1806,7 @@ export function HomeView({
   }, [pendingChipRestore, pluginsLoading, plugins, active, pendingPluginUseHandoff]);
 
   // Default creation type (per product): a fresh Home composer starts on
-  // 幻灯片 (the `deck` chip) instead of typeless. One-shot per mount, decided
+  // 原型 (the `prototype` chip) instead of typeless. One-shot per mount, decided
   // from the MOUNT-time draft state — if a persisted chip draft exists, the
   // restore effect above owns the composer and this seed must never race its
   // async resolution, so it is skipped outright. Explicitly clearing the chip
@@ -1817,10 +1817,10 @@ export function HomeView({
   // `pickChip` itself so no synthetic chat_composer click lands in analytics.
   const defaultChipSeededRef = useRef(pendingChipRestore !== null);
   // Keep Send locked during the one effect turn between a cold plugin-catalog
-  // load and the default deck binding. The heavier Home chrome can otherwise
+  // load and the default prototype binding. The heavier Home chrome can otherwise
   // make that turn user-visible: the composer accepts a click while `active`
   // is still null and routes the prompt through the generic fallback even
-  // though Slide deck becomes selected immediately afterwards.
+  // though Prototype becomes selected immediately afterwards.
   const [defaultChipSeedPending, setDefaultChipSeedPending] = useState(
     pendingChipRestore === null,
   );
@@ -1828,7 +1828,7 @@ export function HomeView({
     if (defaultChipSeededRef.current) return;
     if (pluginsLoading || pendingPluginUseHandoff || pendingChipRestore) return;
     // A live hand-off or another explicit intent may have bound a plugin in
-    // the same catalog-resolution turn. It supersedes the default deck and is
+    // the same catalog-resolution turn. It supersedes the default prototype and is
     // just as ready to submit.
     if (active) {
       defaultChipSeededRef.current = true;
@@ -1836,22 +1836,22 @@ export function HomeView({
       return;
     }
     defaultChipSeededRef.current = true;
-    const deckChip = findChip('deck');
-    const deckAction = deckChip?.action;
-    if (!deckChip || !deckAction || deckAction.kind !== 'apply-scenario') {
+    const prototypeChip = findChip('prototype');
+    const prototypeAction = prototypeChip?.action;
+    if (!prototypeChip || !prototypeAction || prototypeAction.kind !== 'apply-scenario') {
       setDefaultChipSeedPending(false);
       return;
     }
-    const record = plugins.find((plugin) => plugin.id === deckAction.pluginId);
+    const record = plugins.find((plugin) => plugin.id === prototypeAction.pluginId);
     if (!record) {
       setDefaultChipSeedPending(false);
       return;
     }
     void usePlugin(record, undefined, {
-      projectKind: deckAction.projectKind,
-      chipId: deckChip.id,
-      inputs: deckAction.inputs,
-      projectMetadata: deckAction.projectMetadata ?? null,
+      projectKind: prototypeAction.projectKind,
+      chipId: prototypeChip.id,
+      inputs: prototypeAction.inputs,
+      projectMetadata: prototypeAction.projectMetadata ?? null,
       suppressPromptUpdate: true,
       deferApply: true,
     });
@@ -2811,10 +2811,10 @@ export function HomeView({
   // centers vertically instead of hugging the top, and the strip is skipped.
   const recentProjectsEmpty = !projectsLoading && projects.length === 0;
   // A deliberate resource/plugin selection already gives submit an exact
-  // route, so it must not remain behind the fresh-home default-deck barrier.
+  // route, so it must not remain behind the fresh-home default-prototype barrier.
   // Keep the barrier for a plain prompt: that is the only lane where sending
   // before the catalog settles could incorrectly fall back to the generic
-  // scenario immediately before Slide deck binds.
+  // scenario immediately before Prototype binds.
   const hasExplicitSubmitRoute = Boolean(
     active
     || activeSkill

--- a/apps/web/src/components/home-hero/firstRunGuide.ts
+++ b/apps/web/src/components/home-hero/firstRunGuide.ts
@@ -1,10 +1,11 @@
 // First-run Home guidance cascade.
 //
 // A brand-new user (no projects yet) gets a three-beat trail of sheen
-// pulses pointing at the happy path: the Prototype type chip → the first
-// example-prompt card → the Send button (the send pulse ships separately
-// and fires on every pick). Each beat advances a persisted stage so the
-// trail plays at most once per install:
+// pulses pointing at the happy path: the Prototype type chip when Home has no
+// default selection → the first example-prompt card → the Send button (the
+// send pulse ships separately and fires on every pick). A successfully bound
+// default type skips the redundant chip pulse. Each beat advances a persisted
+// stage so the trail plays at most once per install:
 //
 //   'chip' (fresh) → user picks a type chip → 'card' → first preset card
 //   pulses once → 'done'

--- a/apps/web/tests/components/HomeView.first-run-guide.test.tsx
+++ b/apps/web/tests/components/HomeView.first-run-guide.test.tsx
@@ -3,8 +3,9 @@
 // First-run guidance trail (home-hero/firstRunGuide.ts).
 //
 // A brand-new user (no projects, fresh storage) gets a sheen pulse on the
-// Prototype type chip; picking any type chip advances the persisted stage
-// so the first example card can pulse next, and the trail never replays.
+// Prototype type chip when no type can be selected automatically; a default
+// type skips that redundant beat so the first example card can pulse next,
+// and the trail never replays.
 // Users with existing projects have the trail completed silently.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -148,7 +149,7 @@ describe('Home first-run guide trail', () => {
     });
   });
 
-  it('carries beat 2 through the static prompt-example fallback', async () => {
+  it('carries a default prototype straight to beat 2 through the static prompt-example fallback', async () => {
     // The chip's default plugin exists (so the chip binds) but nothing
     // matches the example filter — the chip renders static prompt-example
     // cards, and the guide's beat 2 must land on the first of those.
@@ -181,9 +182,6 @@ describe('Home first-run guide trail', () => {
       throw new Error(`unexpected fetch ${url}`);
     }));
     renderHome([]);
-
-    await pickHomeTemplate('prototype');
-    expect(readHomeGuideStage()).toBe('card');
 
     const exampleCards = await screen.findAllByTestId('home-hero-prompt-example');
     await waitFor(

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -541,7 +541,7 @@ describe('HomeView prompt handoff', () => {
     expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('false');
   });
 
-  it('keeps Send locked until the fresh-home default deck binding is ready', async () => {
+  it('keeps Send locked until the fresh-home default prototype binding is ready', async () => {
     let resolvePlugins: (response: Response) => void = () => undefined;
     const pluginsResponse = new Promise<Response>((resolve) => {
       resolvePlugins = resolve;
@@ -567,7 +567,7 @@ describe('HomeView prompt handoff', () => {
     expect(submit.disabled).toBe(true);
 
     await act(async () => {
-      resolvePlugins(new Response(JSON.stringify({ plugins: [SIMPLE_DECK_PLUGIN] }), {
+      resolvePlugins(new Response(JSON.stringify({ plugins: [WEB_PROTOTYPE_PLUGIN] }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       }));
@@ -575,7 +575,7 @@ describe('HomeView prompt handoff', () => {
     });
 
     await waitFor(() => expect(submit.disabled).toBe(false));
-    expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Slide deck');
+    expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('UI Mockup');
   });
 
   it('keeps creation types actionable while an expired plugin cache refreshes after a project round trip', async () => {

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -1083,7 +1083,7 @@ test('[P1] rail destinations navigate and Home keeps its composer execution pill
   await expect(page.getByTestId('inline-model-switcher-popover')).toHaveCount(0);
 });
 
-test('[P0] @critical home composer routes free-form prompts through the default deck scenario', async ({ page }) => {
+test('[P0] @critical home composer routes free-form prompts through the default prototype scenario', async ({ page }) => {
   await gotoEntryHome(page);
 
   await expect(page.getByTestId('composer-mode-trigger')).toHaveAttribute('aria-label', 'Mode: Design');
@@ -1105,12 +1105,12 @@ test('[P0] @critical home composer routes free-form prompts through the default 
     pluginInputs?: Record<string, unknown>;
     metadata?: { kind?: string };
   };
-  expect(body.name).toBe('Write an Operating Review like a Disciplined COO');
+  expect(body.name).toBe('Web Prototype');
   expect(body.pendingPrompt).toBe(prompt);
   expect(body.conversationMode).toBe('design');
-  expect(body.pluginId).toBe('example-simple-deck');
-  expect(body.pluginInputs).toMatchObject({ deckType: 'pitch deck' });
-  expect(body.metadata?.kind).toBe('deck');
+  expect(body.pluginId).toBe('example-web-prototype');
+  expect(body.pluginInputs).toMatchObject({ artifactKind: 'web prototype' });
+  expect(body.metadata?.kind).toBe('prototype');
 });
 
 test('[P0] @critical home working directory creates the project with linked dirs instead of importing files', async ({ page }) => {
@@ -1316,12 +1316,12 @@ test('[P0] @critical home hero attachment input stages files, enables submit, an
 
   const input = page.getByTestId('home-hero-file-input');
   const submit = page.getByTestId('home-hero-submit');
-  // Fresh Home now locks submit until its default deck route has resolved.
+  // Fresh Home locks submit until its default prototype route has resolved.
   // Under the grouped CI pool that catalogue binding can outlive Playwright's
   // default assertion timeout, so wait on the user-visible routed state before
   // checking the attachment lifecycle rather than racing the seed effect.
   await expect(page.getByTestId('home-hero-template-trigger')).toContainText(
-    /Slide deck|幻灯片|投影片/i,
+    /UI Mockup|原型/i,
     { timeout: T.long },
   );
   await expect(submit).toBeEnabled({ timeout: T.long });

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -308,6 +308,40 @@ const HOME_PLUGINS = [
 ];
 
 const APPLY_RESPONSES: Record<string, unknown> = {
+  'example-web-prototype': {
+    query: 'Build a high-fidelity web prototype for product evaluators.',
+    contextItems: [],
+    inputs: [],
+    assets: [],
+    mcpServers: [],
+    trust: 'bundled',
+    capabilitiesGranted: ['prompt:inject'],
+    capabilitiesRequired: ['prompt:inject'],
+    appliedPlugin: {
+      snapshotId: 'snap-web-prototype',
+      pluginId: 'example-web-prototype',
+      pluginVersion: '0.1.0',
+      manifestSourceDigest: 'c'.repeat(64),
+      inputs: {
+        artifactKind: 'web prototype',
+        fidelity: 'high-fidelity',
+        audience: 'product evaluators',
+        designSystem: 'the active project design system',
+        template: 'the bundled web prototype seed',
+      },
+      resolvedContext: { items: [] },
+      capabilitiesGranted: ['prompt:inject'],
+      capabilitiesRequired: ['prompt:inject'],
+      assetsStaged: [],
+      taskKind: 'new-generation',
+      appliedAt: 0,
+      connectorsRequired: [],
+      connectorsResolved: [],
+      mcpServers: [],
+      status: 'fresh',
+    },
+    projectMetadata: {},
+  },
   'example-live-dashboard': {
     query: 'Build a Notion-style team dashboard with live KPIs.',
     contextItems: [],
@@ -1174,8 +1208,8 @@ test('[P0] empty home composer submits the active placeholder suggestion with te
   };
 
   expect(body.pendingPrompt?.trim()).toBeTruthy();
-  expect(typeof body.pluginId).toBe('string');
-  expect(typeof body.metadata?.kind).toBe('string');
+  expect(body.pluginId).toBe('example-web-prototype');
+  expect(body.metadata?.kind).toBe('prototype');
   await expect(page).toHaveURL(/\/projects\//);
 });
 

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1383,29 +1383,30 @@ test('[P2] zh-CN home smoke exposes the localized creation type, design system, 
   await expect(page.getByTestId('home-hero-submit')).toHaveAccessibleName('运行');
 });
 
-test('[P1] home template picker switches the seeded deck to another type without a clear action', async ({ page }) => {
+test('[P1] home template picker switches the seeded prototype to another type without a clear action', async ({ page }) => {
   await gotoEntryHome(page);
   // Wait for the fresh-home default binding before opening its menu. Otherwise
   // the binding's reconciliation legitimately replaces the open menu tree
   // while Playwright is trying to act on one of its rows.
   await expect(page.getByTestId('home-hero-template-trigger')).toContainText(
-    /Slide deck|幻灯片|投影片/i,
+    /UI Mockup|原型/i,
   );
 
   const menu = await openHomeTemplateMenu(page);
   await expect(menu.getByTestId('home-hero-template-wedge-prototype')).toBeVisible();
   await expect(menu.getByTestId('home-hero-template-wedge-deck')).toBeVisible();
 
-  // Deck is already the fresh-Home default. Switch to a different item so the
-  // test exercises a real selection instead of racing the async deck binding
+  // Prototype is already the fresh-Home default. Switch to a different item so the
+  // test exercises a real selection instead of racing the async default binding
   // by clicking the active menu row while it is being reconciled.
-  await menu.getByTestId('home-hero-template-wedge-prototype').click();
-  await expect(page.getByTestId('home-hero-template-trigger')).toContainText(/Prototype|原型|UI Mockup/i);
+  await menu.getByTestId('home-hero-template-wedge-deck').click();
+  await expect(page.getByTestId('home-hero-template-trigger')).toContainText(/Slide deck|幻灯片|投影片/i);
 
   // Clearing was removed, so switching is the only exit from a chosen type:
-  // the pill follows the new one and deck-only footer chrome drops away.
+  // the pill follows the new one while deferred artifact settings stay out of
+  // the footer for both prototype and deck.
   await expect(page.getByTestId('home-hero-footer-option-speakerNotes')).toHaveCount(0);
-  await expect(page.getByTestId('home-hero-template-trigger')).toContainText(/Prototype|原型|UI Mockup/i);
+  await expect(page.getByTestId('home-hero-template-trigger')).toContainText(/Slide deck|幻灯片|投影片/i);
 });
 
 // "Blank project" no longer has a Home entry: the "…or create a blank project"


### PR DESCRIPTION
## Why

The Home composer currently cold-starts on Slide deck, so a free-form prompt with no saved selection is routed through the deck scenario. The requested primary creation path is Prototype, while saved user choices and explicit handoffs still need to keep their existing priority.

## What users will see

On a fresh Home composer with no saved creation type, Prototype (UI Mockup) is selected by default. Free-form submissions use the `example-web-prototype` scenario. Returning users keep their saved creation type, and explicit handoffs still win.

For first-run users, when Prototype is already bound by default, the guide skips the redundant “choose Prototype” pulse and moves directly to the first example prompt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this changes the selected state of the existing Home creation-type control and adds no new UI surface. The default state and submit routing are covered by component and Playwright regressions below.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/HomeView.prefill.test.tsx`
  - `apps/web/tests/components/HomeView.first-run-guide.test.tsx`
  - `e2e/ui/entry-chrome-flows.test.ts`
  - `e2e/ui/home-hero-rail.test.ts`
- Red/green: yes. The default-prototype component spec failed before the source change because no prototype was selected. The first-run guide spec then reproduced the redundant active-type beat and went green after the guide advanced directly to the example beat.

## Validation

- `pnpm --filter @open-design/web test` — 621 files passed; 6,513 tests passed, 1 expected failure, 11 skipped
- Focused Playwright scenarios in `entry-chrome-flows.test.ts` and `home-hero-rail.test.ts` — passed
- `pnpm --filter @open-design/web typecheck`
- `cd e2e && pnpm typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
