### PR TITLE
fix(landing): restore DeepSeek curated plugin detail routes

### DIFF
--- a/apps/landing-page/app/pages/[locale]/plugins/deepseek-harness-genui/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/deepseek-harness-genui/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/deepseek-harness-genui/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/[locale]/plugins/dsh-annotate/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/dsh-annotate/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/dsh-annotate/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/[locale]/plugins/dsh-diagram/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/dsh-diagram/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/dsh-diagram/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/[locale]/plugins/dsh-hyperframes/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/dsh-hyperframes/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/dsh-hyperframes/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/[locale]/plugins/dsh-vision-router/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/dsh-vision-router/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/dsh-vision-router/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/[locale]/plugins/dsh-web-preview/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/dsh-web-preview/index.astro
@@ -1,0 +1,12 @@
+---
+import DeepseekSkillPage from '../../../plugins/dsh-web-preview/index.astro';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../i18n';
+
+export function getStaticPaths() {
+  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).map(
+    (locale) => ({ params: { locale: locale.code } }),
+  );
+}
+---
+
+<DeepseekSkillPage />

--- a/apps/landing-page/app/pages/plugins/deepseek-harness-genui/index.astro
+++ b/apps/landing-page/app/pages/plugins/deepseek-harness-genui/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/deepseek-harness-genui/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('deepseek-harness-genui')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/app/pages/plugins/dsh-annotate/index.astro
+++ b/apps/landing-page/app/pages/plugins/dsh-annotate/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/dsh-annotate/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('dsh-annotate')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/app/pages/plugins/dsh-diagram/index.astro
+++ b/apps/landing-page/app/pages/plugins/dsh-diagram/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/dsh-diagram/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('dsh-diagram')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/app/pages/plugins/dsh-hyperframes/index.astro
+++ b/apps/landing-page/app/pages/plugins/dsh-hyperframes/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/dsh-hyperframes/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('dsh-hyperframes')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/app/pages/plugins/dsh-vision-router/index.astro
+++ b/apps/landing-page/app/pages/plugins/dsh-vision-router/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/dsh-vision-router/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('dsh-vision-router')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/app/pages/plugins/dsh-web-preview/index.astro
+++ b/apps/landing-page/app/pages/plugins/dsh-web-preview/index.astro
@@ -1,0 +1,15 @@
+---
+/*
+ * /plugins/dsh-web-preview/ — curated DeepSeek Harness design plugin, filed flat in the
+ * plugin library. A static route wins over the bundled `[slug]` catalogue
+ * route, which keeps that SEO-critical file untouched;
+ * `assertNoCuratedSlugCollision` fails the build if another /plugins/ route
+ * ever claims the same slug.
+ */
+import DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro';
+import { getDeepseekSkill } from '../../../_lib/deepseek-design';
+
+const skill = getDeepseekSkill('dsh-web-preview')!;
+---
+
+<DeepseekSkillDetail skill={skill} />

--- a/apps/landing-page/tests/deepseek-plugin-routes.test.ts
+++ b/apps/landing-page/tests/deepseek-plugin-routes.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+import { DEEPSEEK_SKILLS } from '../app/_lib/deepseek-design';
+import { DEFAULT_LOCALE, LANDING_LOCALES } from '../app/i18n';
+
+interface StaticPath {
+  params: { locale: string };
+}
+
+async function readRoute(url: URL): Promise<string | undefined> {
+  try {
+    return await readFile(url, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}
+
+function localizedStaticPaths(source: string): StaticPath[] {
+  const frontmatter = source.match(/^---\n([\s\S]*?)\n---/)?.[1];
+  assert.ok(frontmatter, 'localized wrapper must have Astro frontmatter');
+
+  const executable = frontmatter
+    .replace(/^import .*;$/gm, '')
+    .replace('export function getStaticPaths()', 'function getStaticPaths()');
+  const evaluate = new Function(
+    'LANDING_LOCALES',
+    'DEFAULT_LOCALE',
+    `${executable}\nreturn getStaticPaths();`,
+  ) as (locales: typeof LANDING_LOCALES, defaultLocale: string) => StaticPath[];
+
+  return evaluate(LANDING_LOCALES, DEFAULT_LOCALE);
+}
+
+test('every curated DeepSeek plugin has canonical and localized detail wrappers', async () => {
+  const routeIssues: string[] = [];
+
+  for (const { slug } of DEEPSEEK_SKILLS) {
+    const canonical = await readRoute(
+      new URL(`../app/pages/plugins/${slug}/index.astro`, import.meta.url),
+    );
+    const localized = await readRoute(
+      new URL(`../app/pages/[locale]/plugins/${slug}/index.astro`, import.meta.url),
+    );
+
+    if (!canonical) {
+      routeIssues.push(`/plugins/${slug}/: missing canonical wrapper`);
+    } else {
+      if (!canonical.includes("DeepseekSkillDetail from '../../../_components/deepseek-skill-detail.astro'")) {
+        routeIssues.push(`/plugins/${slug}/: canonical wrapper uses the wrong detail component`);
+      }
+      if (!canonical.includes(`getDeepseekSkill('${slug}')!`)) {
+        routeIssues.push(`/plugins/${slug}/: canonical wrapper is not bound to ${slug}`);
+      }
+    }
+
+    if (!localized) {
+      routeIssues.push(`/{locale}/plugins/${slug}/: missing localized wrapper`);
+    } else {
+      if (!localized.includes(`../../../plugins/${slug}/index.astro`)) {
+        routeIssues.push(`/{locale}/plugins/${slug}/: localized wrapper is not bound to ${slug}`);
+      }
+      const expectedPaths = LANDING_LOCALES
+        .filter((locale) => locale.code !== DEFAULT_LOCALE)
+        .map((locale) => ({ params: { locale: locale.code } }));
+      try {
+        assert.deepEqual(localizedStaticPaths(localized), expectedPaths);
+      } catch {
+        routeIssues.push(`/{locale}/plugins/${slug}/: localized wrapper emits the wrong active locales`);
+      }
+    }
+  }
+
+  assert.deepEqual(routeIssues, []);
+});


### PR DESCRIPTION
Fixes #6973

## Why

The curated DeepSeek Harness collection now advertises six additional plugins, but their canonical and localized detail routes were never added. On staging, clicking any of those cards resolves to a 404 across all 11 active locales (66 advertised URLs in total).

The static build did not catch the omission because the collection data and card links can exist without matching Astro route wrappers. This change restores the missing routes and adds a data-driven contract test so future `DEEPSEEK_SKILLS` additions fail CI when either wrapper is absent or incorrectly bound.

## What users will see

The six affected DeepSeek Harness cards now open their existing detail pages in English and every active localized route. There are no visual, copy, or interaction changes to the detail template itself.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — landing-page route availability and regression coverage only; none of the listed product surfaces apply

## Screenshots

N/A — this restores routes to the existing detail-page template without changing its rendered design. The static-output audit covers all 66 generated pages.

## Bug fix verification

- Test path that reproduces the bug: `apps/landing-page/tests/deepseek-plugin-routes.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** Before adding production wrappers it failed with exactly 12 missing contracts (canonical + localized for each of the six slugs); the same focused command now passes 1/1.
- The regression enumerates `DEEPSEEK_SKILLS`, verifies canonical component/slug binding, verifies localized canonical binding, and executes each localized wrapper's `getStaticPaths()` against the active locale matrix.

## Validation

- `pnpm --filter @open-design/landing-page exec node --import tsx --test tests/deepseek-plugin-routes.test.ts` — 1/1 passed
- `pnpm --filter @open-design/landing-page test` — 146/146 passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed; landing Astro check: 596 files, 0 errors, 0 warnings
- `pnpm --filter @open-design/landing-page build:static` — 6,697 pages built
- Static-output audit — all 6 slugs × 11 active locales passed: 66 canonical URLs, 66 complete hreflang sets plus `x-default`, 66 H1s, 66 upstream source links, and 66 cover images
