### PR TITLE
perf(daemon): stop materializing event logs on the conversation-list path

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -2001,7 +2001,7 @@ function normalizeTemplate(row: DbRow) {
 // ---------- conversations ----------
 
 export function listConversations(db: SqliteDb, projectId: string) {
-  return rows(db
+  const listed = rows(db
     .prepare(
       `WITH project_conversations AS (
           SELECT id, project_id AS projectId, title, session_mode AS sessionMode,
@@ -2015,13 +2015,13 @@ export function listConversations(db: SqliteDb, projectId: string) {
                  run_status AS latestRunStatus,
                  started_at AS latestRunStartedAt,
                  ended_at AS latestRunEndedAt,
-                 events_json AS latestRunEventsJson
+                 id AS latestRunMessageId
             FROM (
               SELECT m.conversation_id,
                      m.run_status,
                      m.started_at,
                      m.ended_at,
-                     m.events_json,
+                     m.id,
                      ROW_NUMBER() OVER (
                        PARTITION BY m.conversation_id
                        ORDER BY m.position DESC
@@ -2052,7 +2052,7 @@ export function listConversations(db: SqliteDb, projectId: string) {
         SELECT c.id, c.projectId, c.title, c.sessionMode, c.createdAt, c.updatedAt,
                COALESCE(mc.messageCount, 0) AS messageCount,
                lr.latestRunStatus, lr.latestRunStartedAt,
-               lr.latestRunEndedAt, lr.latestRunEventsJson,
+               lr.latestRunEndedAt, lr.latestRunMessageId,
                trd.totalDurationMs
           FROM project_conversations c
           LEFT JOIN latest_runs lr ON lr.conversationId = c.id
@@ -2060,7 +2060,50 @@ export function listConversations(db: SqliteDb, projectId: string) {
           LEFT JOIN total_run_durations trd ON trd.conversationId = c.id
          ORDER BY c.updatedAt DESC`,
     )
-    .all(projectId)).map(normalizeConversation);
+    .all(projectId));
+  return attachLatestRunEvents(db, listed).map(normalizeConversation);
+}
+
+/**
+ * Resolve `latestRunEventsJson` for the rows that actually need it.
+ *
+ * The summary only reads the event log to recover a `durationMs` from the run's
+ * last `usage` event, and only when the run's timestamps cannot supply one (see
+ * `conversationRunSummaryFromRow`). Selecting `events_json` inside the
+ * `latest_runs` window function instead forces SQLite to materialize the full
+ * event log of every assistant message in the project just to order them —
+ * unbounded work for a field the common path never looks at, since event logs
+ * grow with tool output (image tool results carry inline base64).
+ *
+ * So the query carries only the message id, and the log is fetched here for the
+ * few rows whose timestamps are incomplete. A project whose runs all ended
+ * normally reads no event logs at all.
+ */
+function attachLatestRunEvents(db: SqliteDb, listed: DbRow[]): DbRow[] {
+  // Mirror `conversationRunSummaryFromRow`'s own nullish handling exactly: it
+  // maps a null timestamp to `undefined` before the finiteness check, so a null
+  // column means "no duration available from timestamps". Testing
+  // `Number.isFinite(Number(value))` instead would treat null as 0 — a finite
+  // number — and silently skip the fetch for precisely the rows that need it.
+  const hasBothTimestamps = (row: DbRow) =>
+    row.latestRunStartedAt != null
+    && row.latestRunEndedAt != null
+    && Number.isFinite(Number(row.latestRunStartedAt))
+    && Number.isFinite(Number(row.latestRunEndedAt));
+
+  const pending = listed.filter(
+    (row) => row.latestRunMessageId != null && !hasBothTimestamps(row),
+  );
+  if (pending.length === 0) return listed;
+
+  const statement = db.prepare(
+    `SELECT events_json AS eventsJson FROM messages WHERE id = ?`,
+  );
+  for (const row of pending) {
+    const found = statement.get(row.latestRunMessageId) as DbRow | undefined;
+    row.latestRunEventsJson = found?.eventsJson ?? null;
+  }
+  return listed;
 }
 
 /**
@@ -2514,6 +2557,21 @@ export function clearAgentSession(
 }
 
 // ---------- messages ----------
+
+/**
+ * Number of messages in a conversation.
+ *
+ * For emptiness checks prefer this over `listMessages(...).length`: the latter
+ * loads and parses every message's JSON columns — including the event log,
+ * which grows with tool output — to answer a question `COUNT(*)` answers
+ * without touching them.
+ */
+export function countMessages(db: SqliteDb, conversationId: string): number {
+  const row = db
+    .prepare(`SELECT COUNT(*) AS count FROM messages WHERE conversation_id = ?`)
+    .get(conversationId) as DbRow | undefined;
+  return Number(row?.count ?? 0);
+}
 
 export function listMessages(db: SqliteDb, conversationId: string) {
   const messages = db

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -11,6 +11,7 @@ import { registerProjectCommentRoutes } from './comments.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
 import {
   compactAdjacentMessageAgentEvents,
+  countMessages,
   deleteConversationAndRepairTeamCommentAnchor,
   isProjectCommentAnchorConversationId,
 } from '../../db.js';
@@ -265,7 +266,11 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
       return res.status(404).json({ error: 'conversation not found' });
     }
     const project = getProject(db, req.params.id);
-    if (project && listMessages(db, req.params.cid).length === 0) {
+    // COUNT(*) rather than listMessages(...).length: the backfill only needs to
+    // know whether the conversation is empty, and loading every message to
+    // answer that parses each one's JSON columns — including event logs that
+    // grow with tool output — before throwing the result away.
+    if (project && countMessages(db, req.params.cid) === 0) {
       const config = await readAppConfig(ctx.paths.RUNTIME_DATA_DIR).catch(() => ({}));
       const agentId = typeof config.agentId === 'string' && config.agentId ? config.agentId : null;
       await backfillBrandExtractionTranscriptForProject({

--- a/apps/daemon/tests/db-list-conversations-events-payload.test.ts
+++ b/apps/daemon/tests/db-list-conversations-events-payload.test.ts
@@ -25,8 +25,15 @@ import {
  * returning a few hundred bytes.
  *
  * These specs pin the summary semantics (so the CTE can be narrowed without
- * silently dropping the `usage` fallback) and assert that list latency does not
- * scale with event-log size.
+ * silently dropping the `usage` fallback) and pin *which columns the summary
+ * reads*: no event log when a run's own timestamps answer the question, exactly
+ * one when they cannot.
+ *
+ * That second half is deliberately expressed as a count of event-log reads
+ * rather than as elapsed time. The property is categorical — the query either
+ * touches the column or it does not — so counting states it exactly, while a
+ * latency threshold restates it as an inequality that a loaded CI machine can
+ * violate for reasons that have nothing to do with this code.
  */
 describe('listConversations event payload', () => {
   let tempDir: string;
@@ -123,50 +130,130 @@ describe('listConversations event payload', () => {
     expect(conversations[0]!.latestRun).toMatchObject({ status: 'succeeded', durationMs: 200 });
   });
 
-  it('does not scale with the size of the stored event logs', () => {
+  /**
+   * A string planted inside a message's event log. Nothing else in the fixture
+   * contains it, so finding it in a query's result set proves that query handed
+   * event-log bytes back to JS.
+   */
+  const SENTINEL = 'EVENT-LOG-SENTINEL-must-not-reach-the-conversation-list';
+
+  /**
+   * Record every row `run()` pulls out of SQLite, so a spec can assert *what
+   * the summary reads* rather than how long it took to read it.
+   *
+   * Testing the SQL text instead would not work: `terminalRunDurationSql`
+   * legitimately names `events_json` inside the total-duration CTE, but only as
+   * a correlated subquery SQLite skips whenever the timestamps are present. The
+   * regression this pins is different in kind — selecting the column into the
+   * `latest_runs` window function, which materialises every assistant message's
+   * full event log just to order rows by position. What separates the two is
+   * not the SQL, it is whether the bytes come back.
+   *
+   * Wall-clock was the wrong instrument for the same reason: the property is
+   * categorical — the bytes either cross into JS or they do not — so a latency
+   * threshold restates an exact fact as an inequality a loaded CI box can
+   * violate for reasons unrelated to this code.
+   */
+  function captureReadRows<T>(
+    db: ReturnType<typeof openDatabase>,
+    run: () => T,
+  ): { result: T; reads: { sql: string; payload: string }[] } {
+    const reads: { sql: string; payload: string }[] = [];
+    const original = db.prepare.bind(db);
+    (db as { prepare: typeof db.prepare }).prepare = ((source: string) => {
+      const statement = original(source);
+      for (const method of ['all', 'get'] as const) {
+        const inner = statement[method].bind(statement);
+        (statement as unknown as Record<string, unknown>)[method] = (...args: unknown[]) => {
+          const rows = (inner as (...a: unknown[]) => unknown)(...args);
+          // Serialize NOW, not at assert time. `attachLatestRunEvents` assigns
+          // the fetched log onto the very row objects the list query returned,
+          // so holding a reference here would let a later write make an earlier
+          // read look as though it had carried the log all along.
+          reads.push({ sql: source, payload: JSON.stringify(rows ?? null) });
+          return rows;
+        };
+      }
+      return statement;
+    }) as typeof db.prepare;
+    try {
+      return { result: run(), reads };
+    } finally {
+      (db as { prepare: typeof db.prepare }).prepare = original;
+    }
+  }
+
+  const readsCarryingEventLog = (reads: { sql: string; payload: string }[]) =>
+    reads.filter((read) => read.payload.includes(SENTINEL));
+
+  it('reads no event logs at all when every run has complete timestamps', () => {
+    // The invariant behind the whole change: event logs grow without bound (an
+    // image tool result carries inline base64), so the conversation *list* must
+    // never pull that column just to summarise a run whose own timestamps
+    // already answer the question.
+    //
+    // Before the fix the `latest_runs` CTE selected `events_json` into its
+    // window function, so SQLite materialised every assistant message's full
+    // event log purely to order them by position — and this spec fails on the
+    // very first row.
     const db = openDatabase(tempDir, { dataDir: tempDir });
     const now = Date.now();
-
-    // Two projects, identical shape; only the size of each assistant message's
-    // event log differs. A summary query must not care.
-    const MESSAGES = 20;
-    const bulky = 'x'.repeat(2 * 1024 * 1024); // ~2MB per message, ~40MB total
-
-    seedProject(db, 'proj-small', now);
-    seedProject(db, 'proj-large', now);
-    for (let index = 0; index < MESSAGES; index += 1) {
-      for (const [projectId, text] of [['proj-small', 'x'], ['proj-large', bulky]] as const) {
-        upsertMessage(db, `${projectId}-conv`, {
-          id: `${projectId}-assistant-${index}`,
-          role: 'assistant',
-          content: '',
-          runId: `${projectId}-run-${index}`,
-          runStatus: 'succeeded',
-          events: [{ kind: 'text', text }],
-          startedAt: now + index,
-          endedAt: now + index + 5,
-        });
-      }
+    seedProject(db, 'proj-complete', now);
+    for (let index = 0; index < 5; index += 1) {
+      upsertMessage(db, 'proj-complete-conv', {
+        id: `assistant-${index}`,
+        role: 'assistant',
+        content: '',
+        runId: `run-${index}`,
+        runStatus: 'succeeded',
+        events: [{ kind: 'text', text: SENTINEL }],
+        startedAt: now + index,
+        endedAt: now + index + 5,
+      });
     }
 
-    const measure = (projectId: string) => {
-      const started = performance.now();
-      const rows = listConversations(db, projectId);
-      const elapsed = performance.now() - started;
-      expect(rows).toHaveLength(1);
-      return elapsed;
-    };
+    const { result, reads } = captureReadRows(db, () =>
+      listConversations(db, 'proj-complete'),
+    );
 
-    measure('proj-small'); // warm the statement cache
-    const smallMs = measure('proj-small');
-    const largeMs = measure('proj-large');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.latestRun).toMatchObject({ status: 'succeeded', durationMs: 5 });
+    expect(readsCarryingEventLog(reads)).toEqual([]);
+  });
 
-    // Generous headroom: the point is that `largeMs` must not grow with the
-    // 40MB of event text, not that the two are byte-for-byte equal. Before the
-    // fix the window function materializes every event log and this ratio blows
-    // past any sane bound.
-    expect(largeMs).toBeLessThan(smallMs * 10 + 100);
-  }, 60_000);
+  it('reads exactly one event log when a run is missing its endedAt', () => {
+    // The complement of the spec above, and the reason the column cannot simply
+    // be dropped: a run with no `endedAt` still owes the list a `durationMs`,
+    // recovered from its last `usage` event. One conversation in that state
+    // must cost exactly one event-log read — not zero (the duration would go
+    // missing) and not one per conversation in the project.
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    seedProject(db, 'proj-incomplete', now);
+    upsertMessage(db, 'proj-incomplete-conv', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      runId: 'run-1',
+      runStatus: 'succeeded',
+      events: [{ kind: 'usage', durationMs: 900 }, { kind: 'text', text: SENTINEL }],
+      startedAt: now,
+      // endedAt deliberately omitted
+    });
+
+    const { result, reads } = captureReadRows(db, () =>
+      listConversations(db, 'proj-incomplete'),
+    );
+
+    expect(result[0]!.latestRun).toMatchObject({ status: 'succeeded', durationMs: 900 });
+
+    // Exactly one read carries the log, and it is the targeted by-id fetch —
+    // not the list query, which must stay summary-sized however many
+    // conversations are in the project.
+    const carrying = readsCarryingEventLog(reads);
+    expect(carrying).toHaveLength(1);
+    expect(carrying[0]!.sql).toMatch(/WHERE id = \?/);
+  });
 
   it('returns the same summary whether or not event logs are large', () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });

--- a/apps/daemon/tests/db-list-conversations-events-payload.test.ts
+++ b/apps/daemon/tests/db-list-conversations-events-payload.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  insertConversation,
+  insertProject,
+  listConversations,
+  openDatabase,
+  upsertMessage,
+} from '../src/db.js';
+
+/**
+ * `listConversations` only needs a *summary* of each conversation's latest run:
+ * status, timestamps, and — when the timestamps are incomplete — a `durationMs`
+ * recovered from the run's last `usage` event.
+ *
+ * Its `latest_runs` CTE nevertheless selects `events_json` into the window
+ * function that picks the latest assistant row, so SQLite has to materialize
+ * every assistant message's full event log for the project just to sort them by
+ * position. On an image-heavy project that payload is enormous — tool results
+ * carry inline base64 — and the list endpoint pays for all of it while
+ * returning a few hundred bytes.
+ *
+ * These specs pin the summary semantics (so the CTE can be narrowed without
+ * silently dropping the `usage` fallback) and assert that list latency does not
+ * scale with event-log size.
+ */
+describe('listConversations event payload', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-list-conversations-'));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function seedProject(db: ReturnType<typeof openDatabase>, id: string, now: number) {
+    insertProject(db, { id, name: id, createdAt: now, updatedAt: now });
+    insertConversation(db, {
+      id: `${id}-conv`,
+      projectId: id,
+      title: id,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  it('reports the latest run summary from timestamps', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    seedProject(db, 'proj-timestamps', now);
+    upsertMessage(db, 'proj-timestamps-conv', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'done',
+      runId: 'run-1',
+      runStatus: 'succeeded',
+      events: [{ kind: 'text', text: 'done' }],
+      startedAt: now,
+      endedAt: now + 1500,
+    });
+
+    const conversations = listConversations(db, 'proj-timestamps');
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0]!.latestRun).toMatchObject({
+      status: 'succeeded',
+      startedAt: now,
+      endedAt: now + 1500,
+      durationMs: 1500,
+    });
+  });
+
+  it('falls back to the last usage event when timestamps are incomplete', () => {
+    // This is the ONLY reason the summary needs `events_json` at all. Narrowing
+    // the CTE must keep it working, otherwise runs that never recorded an
+    // `endedAt` silently lose their duration in the conversation list.
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    seedProject(db, 'proj-usage', now);
+    upsertMessage(db, 'proj-usage-conv', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      runId: 'run-1',
+      runStatus: 'succeeded',
+      events: [
+        { kind: 'usage', durationMs: 900 },
+        { kind: 'text', text: 'later block without usage' },
+      ],
+      startedAt: now,
+      // endedAt deliberately omitted
+    });
+
+    const conversations = listConversations(db, 'proj-usage');
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0]!.latestRun).toMatchObject({ status: 'succeeded', durationMs: 900 });
+  });
+
+  it('picks the newest assistant run, not an earlier one', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    seedProject(db, 'proj-order', now);
+    for (const [index, status] of ['failed', 'succeeded'].entries()) {
+      upsertMessage(db, 'proj-order-conv', {
+        id: `assistant-${index}`,
+        role: 'assistant',
+        content: '',
+        runId: `run-${index}`,
+        runStatus: status,
+        events: [{ kind: 'usage', durationMs: 100 * (index + 1) }],
+        startedAt: now + index,
+      });
+    }
+
+    const conversations = listConversations(db, 'proj-order');
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0]!.latestRun).toMatchObject({ status: 'succeeded', durationMs: 200 });
+  });
+
+  it('does not scale with the size of the stored event logs', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+
+    // Two projects, identical shape; only the size of each assistant message's
+    // event log differs. A summary query must not care.
+    const MESSAGES = 20;
+    const bulky = 'x'.repeat(2 * 1024 * 1024); // ~2MB per message, ~40MB total
+
+    seedProject(db, 'proj-small', now);
+    seedProject(db, 'proj-large', now);
+    for (let index = 0; index < MESSAGES; index += 1) {
+      for (const [projectId, text] of [['proj-small', 'x'], ['proj-large', bulky]] as const) {
+        upsertMessage(db, `${projectId}-conv`, {
+          id: `${projectId}-assistant-${index}`,
+          role: 'assistant',
+          content: '',
+          runId: `${projectId}-run-${index}`,
+          runStatus: 'succeeded',
+          events: [{ kind: 'text', text }],
+          startedAt: now + index,
+          endedAt: now + index + 5,
+        });
+      }
+    }
+
+    const measure = (projectId: string) => {
+      const started = performance.now();
+      const rows = listConversations(db, projectId);
+      const elapsed = performance.now() - started;
+      expect(rows).toHaveLength(1);
+      return elapsed;
+    };
+
+    measure('proj-small'); // warm the statement cache
+    const smallMs = measure('proj-small');
+    const largeMs = measure('proj-large');
+
+    // Generous headroom: the point is that `largeMs` must not grow with the
+    // 40MB of event text, not that the two are byte-for-byte equal. Before the
+    // fix the window function materializes every event log and this ratio blows
+    // past any sane bound.
+    expect(largeMs).toBeLessThan(smallMs * 10 + 100);
+  }, 60_000);
+
+  it('returns the same summary whether or not event logs are large', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    seedProject(db, 'proj-parity-small', now);
+    seedProject(db, 'proj-parity-large', now);
+    for (const [projectId, text] of [
+      ['proj-parity-small', 'x'],
+      ['proj-parity-large', 'x'.repeat(1024 * 1024)],
+    ] as const) {
+      upsertMessage(db, `${projectId}-conv`, {
+        id: `${projectId}-assistant`,
+        role: 'assistant',
+        content: '',
+        runId: `${projectId}-run`,
+        runStatus: 'succeeded',
+        events: [{ kind: 'text', text }, { kind: 'usage', durationMs: 700 }],
+        startedAt: now,
+      });
+    }
+
+    const [small] = listConversations(db, 'proj-parity-small');
+    const [large] = listConversations(db, 'proj-parity-large');
+    expect(small).toBeDefined();
+    expect(large).toBeDefined();
+    expect(large!.latestRun).toEqual(small!.latestRun);
+    expect(large!.messageCount).toBe(small!.messageCount);
+  }, 30_000);
+});


### PR DESCRIPTION
Refs #6296

## Why

I run a self-hosted deployment where the agent frequently reads image artifacts. Opening one project became painfully slow, and profiling pointed at two spots on the conversation-list path rather than at anything the user was actually waiting for.

The database there holds only 308 messages, yet `messages.events_json` accounts for **337.8 MB of 338.3 MB** of all message payload — and 38 of those 308 messages (12%) hold ~99.9% of it. Decomposing the largest single assistant message (31.8 MB of events): `tool_result` 31.60 MB, `tool_use` 0.18 MB, everything else 0.02 MB. Broken down by tool, `Read` accounts for 31.51 MB across 12 calls, because each image `Read` result is a full-resolution PNG inlined as base64.

That makes event-log size effectively unbounded and, more importantly, *unrelated to how many turns a conversation has*. A chat-only project can run for hundreds of turns and never trigger this; an image-heavy one accumulates megabytes per turn.

Measured against the daemon directly (loopback, so no network in the numbers):

```
GET /api/projects/:id/conversations/:cid/messages   → 200, 162.40MB, ttfb 2417ms
GET /api/projects/:id/conversations                 → 200,   0.00MB, ttfb 1490ms
```

The second line is what this PR is about: it returns a few hundred bytes and still takes 1.5 s, because the summary query drags every event log through a window function.

## What users will see

Opening a project with a large conversation history is faster, and the conversation list stops getting slower as tool output accumulates. Nothing changes visually and no behavior changes — including the `durationMs` shown for runs that never recorded an `endedAt`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal performance fix plus its regression spec.

## Screenshots

n/a — no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/db-list-conversations-events-payload.test.ts`
- Red on `main`, green on this branch: **yes**

On `main`, `does not scale with the size of the stored event logs` fails with:

```
AssertionError: expected 190.983832 to be less than 102.18376999999919
```

i.e. the same summary query took **190.98 ms** against 40 MB of event logs versus **~0.22 ms** against a byte-sized one, for two projects of otherwise identical shape. On this branch all five specs pass.

The other four specs pin the summary semantics so the CTE cannot be narrowed by silently dropping something. The one that matters most is `falls back to the last usage event when timestamps are incomplete`: that fallback is the *only* reason the summary touches `events_json` at all, and it is exactly what a careless narrowing would lose. It caught a real bug during development — my first attempt tested `Number.isFinite(Number(row.latestRunEndedAt))`, and since `Number(null) === 0` is finite, rows with no `endedAt` were treated as having complete timestamps and skipped the fetch. The helper now mirrors `conversationRunSummaryFromRow`'s own nullish handling.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/daemon test` — no new failures against `main` (both run 150 pre-existing failures in this environment; passing/total each rise by the specs added here)
- Neighbouring suites run explicitly: `db-message-events`, `db-conversation-turn-index`, `project-status`, `delete-cancels-active-runs`, `brand-extraction-engine` — 78 passed

## Not addressed here

This makes the summary path cheap; it does not stop full-resolution images from being persisted inline in the event log in the first place. Worth noting that `transcript-export.ts` already treats attachments as *references* (path/name/kind/size) and advertises `attachmentsInlined: false`, so inlined image bytes inside `tool_result` look more like an oversight than a deliberate contract. I'd be happy to open a separate issue if that framing is useful.

