### PR TITLE
fix(daemon): route trace object authority through Vela

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -25,6 +25,7 @@ import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-r
 import {
   deriveLangfuseDeliveryState,
   readFeedbackTelemetrySinkConfig,
+  readRunTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
   type AgentEventSummary,
@@ -1126,13 +1127,14 @@ export async function reportRunCompletedFromDaemon(
         traceObjectFilesRaw,
         uploaded: finalManifests,
       }),
+      traceRunId = run.id,
     ): ReportContext => ({
       installationId,
       projectId: run.projectId ?? '',
       conversationId: run.conversationId ?? '',
       ...(run.agentId ? { agentId: run.agentId } : {}),
       run: {
-        runId: run.id,
+        runId: traceRunId,
         status,
         startedAt,
         endedAt,
@@ -1186,26 +1188,81 @@ export async function reportRunCompletedFromDaemon(
       ...objectManifestOptions,
       uploadMode: 'manifest-only',
     });
-    if (registrationManifests) {
-      await reportRunCompleted(
-        buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
-        {
-          config: objectRegistrationTelemetryConfig(),
-          deliveryPurpose: 'object-registration',
-          ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
-        },
-      );
+    const finalTelemetryConfig = readRunTelemetrySinkConfig(
+      process.env,
+      configuredAmrEnv,
+    );
+    const registrationTelemetryConfig = objectRegistrationTelemetryConfig();
+    let uploadedManifests: TraceObjectUploadManifests | undefined;
+    let finalObjectManifests = registrationManifests;
+
+    if (registrationManifests && finalTelemetryConfig) {
+      if (finalTelemetryConfig.kind === 'vela') {
+        // Vela owns the canonical Langfuse trace id. Ask it for that identity
+        // before registering object authority so the content-free relay event
+        // updates the same trace instead of creating a permanent raw-id shell.
+        const registrationDelivery = await reportRunCompleted(
+          buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
+          {
+            config: finalTelemetryConfig,
+            deliveryPurpose: 'object-registration',
+            ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+          },
+        );
+        const receipt = registrationDelivery.velaReceipt;
+        const scopedTraceId = receipt?.clientTraceId === run.id
+          ? receipt.scopedTraceId
+          : null;
+        if (scopedTraceId && registrationTelemetryConfig) {
+          const scopedObjectManifestOptions = {
+            ...objectManifestOptions,
+            runId: scopedTraceId,
+          };
+          const scopedRegistrationManifests = await buildTraceObjectManifests({
+            ...scopedObjectManifestOptions,
+            uploadMode: 'manifest-only',
+          });
+          if (scopedRegistrationManifests) {
+            await reportRunCompleted(
+              buildContext(
+                mergeTraceSafeManifests(manifests, scopedRegistrationManifests),
+                undefined,
+                scopedTraceId,
+              ),
+              {
+                config: registrationTelemetryConfig,
+                deliveryPurpose: 'object-registration',
+                ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+              },
+            );
+            uploadedManifests = await buildTraceObjectManifests(
+              scopedObjectManifestOptions,
+            );
+            finalObjectManifests = uploadedManifests ?? scopedRegistrationManifests;
+          }
+        }
+      } else if (registrationTelemetryConfig) {
+        await reportRunCompleted(
+          buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
+          {
+            config: registrationTelemetryConfig,
+            deliveryPurpose: 'object-registration',
+            ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+          },
+        );
+        uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
+        finalObjectManifests = uploadedManifests ?? registrationManifests;
+      }
     }
 
-    const uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
-    const finalManifests = mergeTraceSafeManifests(manifests, uploadedManifests);
+    const finalManifests = mergeTraceSafeManifests(manifests, finalObjectManifests);
     return await reportRunCompleted(
       buildContext(finalManifests, buildTraceObjectSummary({
         traceObjectFilesRaw,
         ...(uploadedManifests ? { uploaded: uploadedManifests } : {}),
       })),
       {
-        configuredEnv: configuredAmrEnv,
+        config: finalTelemetryConfig,
         ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
       },
     );

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1127,14 +1127,13 @@ export async function reportRunCompletedFromDaemon(
         traceObjectFilesRaw,
         uploaded: finalManifests,
       }),
-      traceRunId = run.id,
     ): ReportContext => ({
       installationId,
       projectId: run.projectId ?? '',
       conversationId: run.conversationId ?? '',
       ...(run.agentId ? { agentId: run.agentId } : {}),
       run: {
-        runId: traceRunId,
+        runId: run.id,
         status,
         startedAt,
         endedAt,
@@ -1192,56 +1191,18 @@ export async function reportRunCompletedFromDaemon(
       process.env,
       configuredAmrEnv,
     );
-    const registrationTelemetryConfig = objectRegistrationTelemetryConfig();
     let uploadedManifests: TraceObjectUploadManifests | undefined;
     let finalObjectManifests = registrationManifests;
 
-    if (registrationManifests && finalTelemetryConfig) {
-      if (finalTelemetryConfig.kind === 'vela') {
-        // Vela owns the canonical Langfuse trace id. Ask it for that identity
-        // before registering object authority so the content-free relay event
-        // updates the same trace instead of creating a permanent raw-id shell.
-        const registrationDelivery = await reportRunCompleted(
-          buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
-          {
-            config: finalTelemetryConfig,
-            deliveryPurpose: 'object-registration',
-            ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
-          },
-        );
-        const receipt = registrationDelivery.velaReceipt;
-        const scopedTraceId = receipt?.clientTraceId === run.id
-          ? receipt.scopedTraceId
-          : null;
-        if (scopedTraceId && registrationTelemetryConfig) {
-          const scopedObjectManifestOptions = {
-            ...objectManifestOptions,
-            runId: scopedTraceId,
-          };
-          const scopedRegistrationManifests = await buildTraceObjectManifests({
-            ...scopedObjectManifestOptions,
-            uploadMode: 'manifest-only',
-          });
-          if (scopedRegistrationManifests) {
-            await reportRunCompleted(
-              buildContext(
-                mergeTraceSafeManifests(manifests, scopedRegistrationManifests),
-                undefined,
-                scopedTraceId,
-              ),
-              {
-                config: registrationTelemetryConfig,
-                deliveryPurpose: 'object-registration',
-                ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
-              },
-            );
-            uploadedManifests = await buildTraceObjectManifests(
-              scopedObjectManifestOptions,
-            );
-            finalObjectManifests = uploadedManifests ?? scopedRegistrationManifests;
-          }
-        }
-      } else if (registrationTelemetryConfig) {
+    if (registrationManifests) {
+      // Authenticated runs register object authority through Vela's signed
+      // service path. Anonymous/direct runs retain the legacy relay boundary.
+      // The authority worker handles registration_only without writing a
+      // content-free Langfuse trace.
+      const registrationTelemetryConfig = finalTelemetryConfig?.kind === 'vela'
+        ? finalTelemetryConfig
+        : objectRegistrationTelemetryConfig();
+      if (registrationTelemetryConfig) {
         await reportRunCompleted(
           buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
           {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -2455,7 +2455,9 @@ export async function reportRunCompleted(
         ? postRelayBatch(fallback, serialized, fetchImpl)
         : postLangfuseBatch(fallback, batch, fetchImpl);
     }
-    return postVelaBatch(config, batch, installationId, fetchImpl);
+    return postVelaBatch(config, batch, installationId, fetchImpl, {
+      allowAnonymousAuthFallback: opts.deliveryPurpose !== 'object-registration',
+    });
   }
   if (config.kind === 'relay') {
     return postRelayBatch(config, serialized, fetchImpl);

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -92,16 +92,6 @@ export interface LangfuseDeliveryState {
   langfuse_drop_reason?: LangfuseDropReason;
 }
 
-export interface VelaTelemetryReceipt {
-  clientTraceId: string;
-  scopedTraceId: string;
-}
-
-export interface RunTelemetryDeliveryResult extends LangfuseDeliveryState {
-  /** Server-owned trace identity; used internally for Vela-scoped object authority. */
-  velaReceipt?: VelaTelemetryReceipt;
-}
-
 export type TelemetrySinkConfig =
   | {
       kind: 'relay';
@@ -2162,7 +2152,7 @@ async function postVelaBatch(
   installationId: string,
   fetchImpl: typeof fetch,
   opts: { allowAnonymousAuthFallback?: boolean } = {},
-): Promise<RunTelemetryDeliveryResult> {
+): Promise<LangfuseDeliveryState> {
   // Completed-run batches may fall back to the anonymous relay when Vela
   // rejects auth (expired Control Key, etc.). Score-only feedback must not:
   // the matching trace is account-scoped on Vela, so anonymous delivery would
@@ -2189,12 +2179,9 @@ async function postVelaBatch(
         },
       );
       if (response.status === 202) {
-        const responseBody = await response.json().catch(() => null);
-        const receipt = parseVelaTelemetryReceipt(responseBody);
         return {
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
-          ...(receipt ? { velaReceipt: receipt } : {}),
         };
       }
 
@@ -2247,26 +2234,6 @@ async function postVelaBatch(
     langfuse_expected: true,
     langfuse_delivery_status: 'failed',
     langfuse_drop_reason: 'network_error',
-  };
-}
-
-function parseVelaTelemetryReceipt(value: unknown): VelaTelemetryReceipt | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const receipt = (value as { receipt?: unknown }).receipt;
-  if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt)) return null;
-  const clientTraceId = (receipt as { clientTraceId?: unknown }).clientTraceId;
-  const scopedTraceId = (receipt as { scopedTraceId?: unknown }).scopedTraceId;
-  if (
-    typeof clientTraceId !== 'string' ||
-    clientTraceId.trim().length === 0 ||
-    typeof scopedTraceId !== 'string' ||
-    scopedTraceId.trim().length === 0
-  ) {
-    return null;
-  }
-  return {
-    clientTraceId: clientTraceId.trim(),
-    scopedTraceId: scopedTraceId.trim(),
   };
 }
 
@@ -2422,7 +2389,7 @@ function objectRegistrationBatch(batch: unknown[]): unknown[] {
 export async function reportRunCompleted(
   ctx: ReportContext,
   opts: ReportRunOpts = {},
-): Promise<RunTelemetryDeliveryResult> {
+): Promise<LangfuseDeliveryState> {
   const notExpected = deriveLangfuseDeliveryState(ctx.prefs, null);
   if (ctx.prefs.metrics !== true) return notExpected;
   if (ctx.prefs.content !== true) return notExpected;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -92,6 +92,16 @@ export interface LangfuseDeliveryState {
   langfuse_drop_reason?: LangfuseDropReason;
 }
 
+export interface VelaTelemetryReceipt {
+  clientTraceId: string;
+  scopedTraceId: string;
+}
+
+export interface RunTelemetryDeliveryResult extends LangfuseDeliveryState {
+  /** Server-owned trace identity; used internally for Vela-scoped object authority. */
+  velaReceipt?: VelaTelemetryReceipt;
+}
+
 export type TelemetrySinkConfig =
   | {
       kind: 'relay';
@@ -347,7 +357,7 @@ export interface ReportRunOpts {
   fetchImpl?: typeof fetch;
   /** App-config AMR env used only when resolving the completed-run Vela sink. */
   configuredEnv?: Record<string, string>;
-  /** Keep object-authority registration anonymous and content-free. */
+  /** Emit only the content-free object-authority trace projection. */
   deliveryPurpose?: 'final' | 'object-registration';
 }
 
@@ -2109,12 +2119,12 @@ function asVelaSourceEvents(batch: unknown[]): VelaSourceEvent[] {
 }
 
 function stableVelaEventId(event: VelaSourceEvent): string {
-  const bodyId =
-    typeof event.body.id === 'string' && event.body.id.trim()
-      ? event.body.id.trim()
-      : JSON.stringify(event.body);
+  // Retries and deterministic rebuilds of the same event keep one id, while
+  // a later upsert of the same trace/observation with richer data gets a new
+  // ingestion id and cannot be mistaken for the earlier registration event.
+  const canonicalBody = JSON.stringify(event.body);
   return `od-${createHash('sha256')
-    .update(`${event.type}\n${bodyId}`, 'utf8')
+    .update(`${event.type}\n${canonicalBody}`, 'utf8')
     .digest('hex')}`;
 }
 
@@ -2152,7 +2162,7 @@ async function postVelaBatch(
   installationId: string,
   fetchImpl: typeof fetch,
   opts: { allowAnonymousAuthFallback?: boolean } = {},
-): Promise<LangfuseDeliveryState> {
+): Promise<RunTelemetryDeliveryResult> {
   // Completed-run batches may fall back to the anonymous relay when Vela
   // rejects auth (expired Control Key, etc.). Score-only feedback must not:
   // the matching trace is account-scoped on Vela, so anonymous delivery would
@@ -2179,9 +2189,12 @@ async function postVelaBatch(
         },
       );
       if (response.status === 202) {
+        const responseBody = await response.json().catch(() => null);
+        const receipt = parseVelaTelemetryReceipt(responseBody);
         return {
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
+          ...(receipt ? { velaReceipt: receipt } : {}),
         };
       }
 
@@ -2234,6 +2247,26 @@ async function postVelaBatch(
     langfuse_expected: true,
     langfuse_delivery_status: 'failed',
     langfuse_drop_reason: 'network_error',
+  };
+}
+
+function parseVelaTelemetryReceipt(value: unknown): VelaTelemetryReceipt | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const receipt = (value as { receipt?: unknown }).receipt;
+  if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt)) return null;
+  const clientTraceId = (receipt as { clientTraceId?: unknown }).clientTraceId;
+  const scopedTraceId = (receipt as { scopedTraceId?: unknown }).scopedTraceId;
+  if (
+    typeof clientTraceId !== 'string' ||
+    clientTraceId.trim().length === 0 ||
+    typeof scopedTraceId !== 'string' ||
+    scopedTraceId.trim().length === 0
+  ) {
+    return null;
+  }
+  return {
+    clientTraceId: clientTraceId.trim(),
+    scopedTraceId: scopedTraceId.trim(),
   };
 }
 
@@ -2389,7 +2422,7 @@ function objectRegistrationBatch(batch: unknown[]): unknown[] {
 export async function reportRunCompleted(
   ctx: ReportContext,
   opts: ReportRunOpts = {},
-): Promise<LangfuseDeliveryState> {
+): Promise<RunTelemetryDeliveryResult> {
   const notExpected = deriveLangfuseDeliveryState(ctx.prefs, null);
   if (ctx.prefs.metrics !== true) return notExpected;
   if (ctx.prefs.content !== true) return notExpected;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -2443,6 +2443,13 @@ export async function reportRunCompleted(
   if (config.kind === 'vela') {
     const installationId = ctx.installationId?.trim() ?? '';
     if (!installationId) {
+      if (opts.deliveryPurpose === 'object-registration') {
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'failed',
+          langfuse_drop_reason: 'missing_sink_config',
+        };
+      }
       const fallback = readTelemetrySinkConfig();
       if (!fallback) {
         return {

--- a/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
+++ b/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
@@ -4,6 +4,7 @@ const readAppConfigMock = vi.fn();
 const agentCliEnvForAgentMock = vi.fn();
 const listMessagesMock = vi.fn();
 const reportRunCompletedMock = vi.fn();
+const readRunTelemetrySinkConfigMock = vi.fn();
 
 vi.mock('../src/app-config.js', () => ({
   agentCliEnvForAgent: agentCliEnvForAgentMock,
@@ -17,6 +18,7 @@ vi.mock('../src/db.js', () => ({
 vi.mock('../src/langfuse-trace.js', () => ({
   INPUT_MAX_BYTES: 64 * 1024,
   readFeedbackTelemetrySinkConfig: vi.fn(() => ({ kind: 'langfuse' })),
+  readRunTelemetrySinkConfig: readRunTelemetrySinkConfigMock,
   reportRunCompleted: reportRunCompletedMock,
   reportRunFeedback: vi.fn(),
 }));
@@ -81,9 +83,17 @@ describe('langfuse-bridge non-blocking behavior', () => {
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
     });
+    readRunTelemetrySinkConfigMock.mockReset();
+    readRunTelemetrySinkConfigMock.mockReturnValue({
+      kind: 'vela',
+      apiUrl: 'https://vela.example.test',
+      controlKey: 'ck_profile',
+      timeoutMs: 1_000,
+      retries: 0,
+    });
   });
 
-  it('passes configured AMR env only to the completed-run reporter', async () => {
+  it('resolves the completed-run sink once from the configured AMR env', async () => {
     const configuredEnv = {
       VELA_CONTROL_KEY: 'ck_profile',
       VELA_API_URL: 'https://vela.example.test',
@@ -99,9 +109,15 @@ describe('langfuse-bridge non-blocking behavior', () => {
     });
 
     expect(agentCliEnvForAgentMock).toHaveBeenCalledWith(undefined, 'amr');
+    expect(readRunTelemetrySinkConfigMock).toHaveBeenCalledWith(process.env, configuredEnv);
     expect(reportRunCompletedMock).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ configuredEnv }),
+      expect.objectContaining({
+        config: expect.objectContaining({
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+        }),
+      }),
     );
   });
 

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -949,6 +949,188 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
   });
 
+  it('uses the Vela-scoped trace id for object authority while final telemetry stays on Vela', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const projectDir = path.join(dataDir, 'projects', 'proj-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
+
+    const velaEnvelopes: any[] = [];
+    const relayRegistrations: any[][] = [];
+    const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url === 'https://vela.example.test/api/v1/open-design/telemetry') {
+        const envelope = JSON.parse(init.body as string);
+        velaEnvelopes.push(envelope);
+        return new Response(JSON.stringify({
+          ok: true,
+          idempotencyKey: `vela-key-${velaEnvelopes.length}`,
+          receipt: {
+            clientTraceId: 'run-id-1',
+            scopedTraceId: 'scoped-run-id-1',
+          },
+        }), { status: 202 });
+      }
+      if (url === 'https://telemetry.open-design.ai/api/langfuse') {
+        relayRegistrations.push(JSON.parse(init.body as string).batch);
+        return new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 });
+      }
+      if (url === 'https://telemetry.open-design.ai/api/objects/authorize') {
+        const parsed = JSON.parse(init.body as string) as {
+          run_id: string;
+          objects: Array<{ storage_ref: string }>;
+        };
+        expect(parsed.run_id).toBe('scoped-run-id-1');
+        expect(parsed.objects[0]?.storage_ref).toContain('/runs/scoped-run-id-1/');
+        return new Response(JSON.stringify({ upload_token: 'upload-token' }), { status: 200 });
+      }
+      if (url === 'https://telemetry.open-design.ai/api/objects/batch') {
+        const parsed = JSON.parse(init.body as string) as {
+          run_id: string;
+          objects: Array<{ storage_ref: string; content_base64: string }>;
+        };
+        expect(parsed.run_id).toBe('scoped-run-id-1');
+        expect(parsed.objects[0]?.storage_ref).toContain('/runs/scoped-run-id-1/');
+        return new Response(JSON.stringify({
+          objects: parsed.objects.map((object) => ({
+            storage_ref: object.storage_ref,
+            status: 'available',
+            size_bytes: Buffer.from(object.content_base64, 'base64').byteLength,
+            sha256: 'sha256:uploaded-artifact',
+          })),
+        }), { status: 200 });
+      }
+      throw new Error(`unexpected telemetry request: ${url}`);
+    });
+
+    const velaTelemetryEnabled = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    const velaControlKey = process.env.VELA_CONTROL_KEY;
+    const velaApiUrl = process.env.VELA_API_URL;
+    process.env.OPEN_DESIGN_VELA_TELEMETRY = 'on';
+    process.env.VELA_CONTROL_KEY = 'ck_test';
+    process.env.VELA_API_URL = 'https://vela.example.test';
+    process.env.OPEN_DESIGN_OBJECT_RELAY_URL =
+      'https://telemetry.open-design.ai/api/objects/batch';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            { id: 'user-1', role: 'user', content: 'Build it.' },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'done',
+              producedFiles: [{ name: 'index.html', kind: 'html', size: 35 }],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun() as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      if (velaTelemetryEnabled === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = velaTelemetryEnabled;
+      if (velaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+      else process.env.VELA_CONTROL_KEY = velaControlKey;
+      if (velaApiUrl === undefined) delete process.env.VELA_API_URL;
+      else process.env.VELA_API_URL = velaApiUrl;
+      delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(velaEnvelopes).toHaveLength(2);
+    expect(relayRegistrations).toHaveLength(1);
+
+    const velaRegistrationEvent = velaEnvelopes[0].events.find(
+      (event: { kind: string }) => event.kind === 'trace',
+    );
+    const velaRegistrationTrace = velaRegistrationEvent.data;
+    expect(velaRegistrationTrace.id).toBe('run-id-1');
+    expect(velaRegistrationTrace.metadata.registration_only).toBe(true);
+    expect(velaRegistrationTrace).not.toHaveProperty('input');
+    expect(velaRegistrationTrace).not.toHaveProperty('output');
+
+    const relayRegistrationTrace = relayRegistrations[0]![0].body;
+    expect(relayRegistrationTrace.id).toBe('scoped-run-id-1');
+    expect(relayRegistrationTrace.metadata.artifact_manifest[0].storage_ref).toContain(
+      '/runs/scoped-run-id-1/',
+    );
+
+    const velaFinalEvent = velaEnvelopes[1].events.find(
+      (event: { kind: string }) => event.kind === 'trace',
+    );
+    const velaFinalTrace = velaFinalEvent.data;
+    expect(velaFinalEvent.id).not.toBe(velaRegistrationEvent.id);
+    expect(velaFinalTrace.id).toBe('run-id-1');
+    expect(velaFinalTrace).toHaveProperty('input');
+    expect(velaFinalTrace).toHaveProperty('output');
+    expect(velaFinalTrace.metadata.artifact_manifest[0]).toMatchObject({
+      storage_ref: expect.stringContaining('/runs/scoped-run-id-1/'),
+      status: 'ok',
+      stored_in_open_design: true,
+    });
+  });
+
+  it('does not create a raw-id relay trace when Vela omits the scoped receipt', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const projectDir = path.join(dataDir, 'projects', 'proj-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url !== 'https://vela.example.test/api/v1/open-design/telemetry') {
+        throw new Error(`unexpected non-Vela request: ${url}`);
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 202 });
+    });
+
+    const velaTelemetryEnabled = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    const velaControlKey = process.env.VELA_CONTROL_KEY;
+    const velaApiUrl = process.env.VELA_API_URL;
+    process.env.OPEN_DESIGN_VELA_TELEMETRY = 'on';
+    process.env.VELA_CONTROL_KEY = 'ck_test';
+    process.env.VELA_API_URL = 'https://vela.example.test';
+    process.env.OPEN_DESIGN_OBJECT_RELAY_URL =
+      'https://telemetry.open-design.ai/api/objects/batch';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            { id: 'user-1', role: 'user', content: 'Build it.' },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'done',
+              producedFiles: [{ name: 'index.html', kind: 'html', size: 35 }],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun() as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      if (velaTelemetryEnabled === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = velaTelemetryEnabled;
+      if (velaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+      else process.env.VELA_CONTROL_KEY = velaControlKey;
+      if (velaApiUrl === undefined) delete process.env.VELA_API_URL;
+      else process.env.VELA_API_URL = velaApiUrl;
+      delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
+      'https://vela.example.test/api/v1/open-design/telemetry',
+      'https://vela.example.test/api/v1/open-design/telemetry',
+    ]);
+  });
+
   it('uploads modified existing files from traceObjectFiles and records object summary metadata', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -949,7 +949,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
   });
 
-  it('uses the Vela-scoped trace id for object authority while final telemetry stays on Vela', async () => {
+  it('registers object authority through Vela without an anonymous trace shell', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true, artifactManifest: true },
@@ -959,31 +959,19 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
 
     const velaEnvelopes: any[] = [];
-    const relayRegistrations: any[][] = [];
     const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
       if (url === 'https://vela.example.test/api/v1/open-design/telemetry') {
         const envelope = JSON.parse(init.body as string);
         velaEnvelopes.push(envelope);
-        return new Response(JSON.stringify({
-          ok: true,
-          idempotencyKey: `vela-key-${velaEnvelopes.length}`,
-          receipt: {
-            clientTraceId: 'run-id-1',
-            scopedTraceId: 'scoped-run-id-1',
-          },
-        }), { status: 202 });
-      }
-      if (url === 'https://telemetry.open-design.ai/api/langfuse') {
-        relayRegistrations.push(JSON.parse(init.body as string).batch);
-        return new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 });
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
       }
       if (url === 'https://telemetry.open-design.ai/api/objects/authorize') {
         const parsed = JSON.parse(init.body as string) as {
           run_id: string;
           objects: Array<{ storage_ref: string }>;
         };
-        expect(parsed.run_id).toBe('scoped-run-id-1');
-        expect(parsed.objects[0]?.storage_ref).toContain('/runs/scoped-run-id-1/');
+        expect(parsed.run_id).toBe('run-id-1');
+        expect(parsed.objects[0]?.storage_ref).toContain('/runs/run-id-1/');
         return new Response(JSON.stringify({ upload_token: 'upload-token' }), { status: 200 });
       }
       if (url === 'https://telemetry.open-design.ai/api/objects/batch') {
@@ -991,8 +979,8 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
           run_id: string;
           objects: Array<{ storage_ref: string; content_base64: string }>;
         };
-        expect(parsed.run_id).toBe('scoped-run-id-1');
-        expect(parsed.objects[0]?.storage_ref).toContain('/runs/scoped-run-id-1/');
+        expect(parsed.run_id).toBe('run-id-1');
+        expect(parsed.objects[0]?.storage_ref).toContain('/runs/run-id-1/');
         return new Response(JSON.stringify({
           objects: parsed.objects.map((object) => ({
             storage_ref: object.storage_ref,
@@ -1040,9 +1028,11 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
     }
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
     expect(velaEnvelopes).toHaveLength(2);
-    expect(relayRegistrations).toHaveLength(1);
+    expect(fetchSpy.mock.calls.map((call) => call[0])).not.toContain(
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
 
     const velaRegistrationEvent = velaEnvelopes[0].events.find(
       (event: { kind: string }) => event.kind === 'trace',
@@ -1050,14 +1040,12 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const velaRegistrationTrace = velaRegistrationEvent.data;
     expect(velaRegistrationTrace.id).toBe('run-id-1');
     expect(velaRegistrationTrace.metadata.registration_only).toBe(true);
+    expect(velaRegistrationTrace.metadata.artifact_manifest[0]).toMatchObject({
+      run_id: 'run-id-1',
+      storage_ref: expect.stringContaining('/runs/run-id-1/'),
+    });
     expect(velaRegistrationTrace).not.toHaveProperty('input');
     expect(velaRegistrationTrace).not.toHaveProperty('output');
-
-    const relayRegistrationTrace = relayRegistrations[0]![0].body;
-    expect(relayRegistrationTrace.id).toBe('scoped-run-id-1');
-    expect(relayRegistrationTrace.metadata.artifact_manifest[0].storage_ref).toContain(
-      '/runs/scoped-run-id-1/',
-    );
 
     const velaFinalEvent = velaEnvelopes[1].events.find(
       (event: { kind: string }) => event.kind === 'trace',
@@ -1068,67 +1056,11 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(velaFinalTrace).toHaveProperty('input');
     expect(velaFinalTrace).toHaveProperty('output');
     expect(velaFinalTrace.metadata.artifact_manifest[0]).toMatchObject({
-      storage_ref: expect.stringContaining('/runs/scoped-run-id-1/'),
+      run_id: 'run-id-1',
+      storage_ref: expect.stringContaining('/runs/run-id-1/'),
       status: 'ok',
       stored_in_open_design: true,
     });
-  });
-
-  it('does not create a raw-id relay trace when Vela omits the scoped receipt', async () => {
-    await writeAppCfg({
-      installationId: 'install-uuid-1',
-      telemetry: { metrics: true, content: true, artifactManifest: true },
-    });
-    const projectDir = path.join(dataDir, 'projects', 'proj-1');
-    await mkdir(projectDir, { recursive: true });
-    await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
-    const fetchSpy = vi.fn(async (url: string) => {
-      if (url !== 'https://vela.example.test/api/v1/open-design/telemetry') {
-        throw new Error(`unexpected non-Vela request: ${url}`);
-      }
-      return new Response(JSON.stringify({ ok: true }), { status: 202 });
-    });
-
-    const velaTelemetryEnabled = process.env.OPEN_DESIGN_VELA_TELEMETRY;
-    const velaControlKey = process.env.VELA_CONTROL_KEY;
-    const velaApiUrl = process.env.VELA_API_URL;
-    process.env.OPEN_DESIGN_VELA_TELEMETRY = 'on';
-    process.env.VELA_CONTROL_KEY = 'ck_test';
-    process.env.VELA_API_URL = 'https://vela.example.test';
-    process.env.OPEN_DESIGN_OBJECT_RELAY_URL =
-      'https://telemetry.open-design.ai/api/objects/batch';
-    try {
-      await reportRunCompletedFromDaemon({
-        db: makeDbWithListMessages({
-          'conv-1': [
-            { id: 'user-1', role: 'user', content: 'Build it.' },
-            {
-              id: 'msg-1',
-              role: 'assistant',
-              content: 'done',
-              producedFiles: [{ name: 'index.html', kind: 'html', size: 35 }],
-            },
-          ],
-        }),
-        dataDir,
-        run: makeRun() as any,
-        fetchImpl: fetchSpy as any,
-      });
-    } finally {
-      if (velaTelemetryEnabled === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
-      else process.env.OPEN_DESIGN_VELA_TELEMETRY = velaTelemetryEnabled;
-      if (velaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
-      else process.env.VELA_CONTROL_KEY = velaControlKey;
-      if (velaApiUrl === undefined) delete process.env.VELA_API_URL;
-      else process.env.VELA_API_URL = velaApiUrl;
-      delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
-    }
-
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
-    expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
-      'https://vela.example.test/api/v1/open-design/telemetry',
-      'https://vela.example.test/api/v1/open-design/telemetry',
-    ]);
   });
 
   it('uploads modified existing files from traceObjectFiles and records object summary metadata', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2028,6 +2028,39 @@ describe('reportRunCompleted', () => {
     },
   );
 
+  it('fails object registration closed when the Vela installation identity is missing', async () => {
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const result = await reportRunCompleted(
+      makeCtx({
+        installationId: null,
+        prefs: { metrics: true, content: true, artifactManifest: true },
+      }),
+      {
+        config: {
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+          controlKey: 'ck_secret',
+          timeoutMs: 1_000,
+          retries: 0,
+        },
+        deliveryPurpose: 'object-registration',
+        fetchImpl: fetchSpy as any,
+      },
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'missing_sink_config',
+    });
+  });
+
   it('does not anonymously overwrite a throttled Vela delivery', async () => {
     vi.stubEnv(
       'OPEN_DESIGN_TELEMETRY_RELAY_URL',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1875,7 +1875,14 @@ describe('reportRunCompleted', () => {
       timeoutMs: 1_000,
       retries: 0,
     };
-    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      idempotencyKey: 'vela-key-1',
+      receipt: {
+        clientTraceId: 'run-1',
+        scopedTraceId: 'scoped-run-1',
+      },
+    }), { status: 202 }));
 
     const result = await reportRunCompleted(
       makeCtx({
@@ -1900,6 +1907,35 @@ describe('reportRunCompleted', () => {
       'span',
     ]);
     expect(envelope.events.every((event: any) => event.kind !== 'score')).toBe(true);
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+      velaReceipt: {
+        clientTraceId: 'run-1',
+        scopedTraceId: 'scoped-run-1',
+      },
+    });
+  });
+
+  it('accepts a Vela 202 response without a trace receipt', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: {
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+          controlKey: 'ck_secret',
+          timeoutMs: 1_000,
+          retries: 0,
+        },
+        fetchImpl: fetchSpy as any,
+      },
+    );
+
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1991,6 +1991,43 @@ describe('reportRunCompleted', () => {
     expect(result.langfuse_delivery_status).toBe('accepted');
   });
 
+  it.each([401, 403])(
+    'fails object registration closed when Vela rejects auth with %i',
+    async (status) => {
+      vi.stubEnv(
+        'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status }));
+
+      const result = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: true },
+        }),
+        {
+          config: {
+            kind: 'vela',
+            apiUrl: 'https://vela.example.test',
+            controlKey: 'ck_expired',
+            timeoutMs: 1_000,
+            retries: 0,
+          },
+          deliveryPurpose: 'object-registration',
+          fetchImpl: fetchSpy as any,
+        },
+      );
+
+      expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
+        'https://vela.example.test/api/v1/open-design/telemetry',
+      ]);
+      expect(result).toEqual({
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: `vela_${status}`,
+      });
+    },
+  );
+
   it('does not anonymously overwrite a throttled Vela delivery', async () => {
     vi.stubEnv(
       'OPEN_DESIGN_TELEMETRY_RELAY_URL',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1875,14 +1875,7 @@ describe('reportRunCompleted', () => {
       timeoutMs: 1_000,
       retries: 0,
     };
-    const fetchSpy = vi.fn().mockResolvedValue(new Response(JSON.stringify({
-      ok: true,
-      idempotencyKey: 'vela-key-1',
-      receipt: {
-        clientTraceId: 'run-1',
-        scopedTraceId: 'scoped-run-1',
-      },
-    }), { status: 202 }));
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
 
     const result = await reportRunCompleted(
       makeCtx({
@@ -1907,35 +1900,6 @@ describe('reportRunCompleted', () => {
       'span',
     ]);
     expect(envelope.events.every((event: any) => event.kind !== 'score')).toBe(true);
-    expect(result).toEqual({
-      langfuse_expected: true,
-      langfuse_delivery_status: 'accepted',
-      velaReceipt: {
-        clientTraceId: 'run-1',
-        scopedTraceId: 'scoped-run-1',
-      },
-    });
-  });
-
-  it('accepts a Vela 202 response without a trace receipt', async () => {
-    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
-
-    const result = await reportRunCompleted(
-      makeCtx({
-        prefs: { metrics: true, content: true, artifactManifest: false },
-      }),
-      {
-        config: {
-          kind: 'vela',
-          apiUrl: 'https://vela.example.test',
-          controlKey: 'ck_secret',
-          timeoutMs: 1_000,
-          retries: 0,
-        },
-        fetchImpl: fetchSpy as any,
-      },
-    );
-
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',


### PR DESCRIPTION
Related: [OPEND-1962](https://plane.powerformer.net/open-design/browse/OPEND-1962)

## Why

While investigating OPEND-1962, I reproduced the duplicate empty rows shown in Langfuse. Open Design first sent a content-free object-authority registration directly to the anonymous telemetry relay, then sent the real completed-run trace through Vela. Vela account-scopes the Langfuse trace ID, so those two writes had different identities and the registration survived as a separate trace with empty input, output, and observations.

The earlier single-repository workaround tried to reuse a scoped trace ID returned by Vela. That put the Worker-owned account identity into object storage references and still required a second anonymous relay write. Object upload authority and Langfuse trace identity are different contracts and should not be coupled.

## What users will see

For new Vela-backed completed runs, Langfuse receives only the real trace with input, output, and observations. The preliminary object-authority command also goes through Vela, but the telemetry Worker consumes it without forwarding it to Langfuse. Artifact and attachment uploads continue to use the original Open Design run namespace.

Anonymous/direct telemetry retains its existing registration path. Existing historical empty traces are not deleted by this change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — Vela-backed object authority no longer creates an anonymous content-free Langfuse trace
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this changes daemon telemetry delivery and has no UI entry point.

## Bug fix verification

- Test path: `apps/daemon/tests/langfuse-bridge.test.ts`
- Red spec: `registers object authority through Vela without an anonymous trace shell`
- Did the test go red on `main` and green on this branch? **Yes.** With only the test applied, the previous implementation attempted the anonymous `/api/langfuse` registration and could not complete the asserted Vela-only four-step flow. The branch proves two distinct signed Vela events, no anonymous Langfuse call, original-run object authorization/upload, and a final trace containing input/output plus uploaded manifest status.
- Sink-resolution coverage: `apps/daemon/tests/langfuse-bridge-nonblocking.test.ts` proves the configured Vela sink is resolved once and reused for registration and final delivery.
- Companion Worker red/green coverage is in [core/open-design-telemetry-worker#9](https://code.powerformer.net/core/open-design-telemetry-worker/pulls/9).

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/langfuse-bridge.test.ts tests/langfuse-bridge-nonblocking.test.ts tests/langfuse-trace.test.ts` — 3 files, 127 tests passed
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

## Rollout dependency

The telemetry Worker companion must be merged and deployed before this Open Design change is released. The old Worker would forward `registration_only` to Langfuse and would not register the original run namespace. No production deployment is included in this PR.
