### PR TITLE
fix(daemon): classify "Prompt is too long" as prompt_too_large, not auth

### DIFF
--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -150,6 +150,31 @@ export function diagnoseClaudeCliFailure(
     );
   }
 
+  // Prompt / context window overflow. Claude Code surfaces this verbatim as
+  // `Prompt is too long` (or `API Error: Prompt is too long.`) when the
+  // assembled turn exceeds the upstream context window. It must be detected
+  // before the authFailure branch below: a `Prompt is too long` text from a
+  // mid-stream API error frame occasionally co-occurs with fragments the auth
+  // regex picks up (e.g. an expired-token notice logged just before the size
+  // rejection), which previously made the daemon tell the user to re-login
+  // when the actual fix was to reduce the prompt. Returning the dedicated
+  // `AGENT_PROMPT_TOO_LARGE` code lets server.ts pick the prompt_too_large
+  // branch in classifyRunFailure and lets the UI suggest reducing context.
+  // See issue #6979.
+  const promptTooLarge =
+    /\bprompt is too long\b/i.test(text) ||
+    /\bprompt too large\b/i.test(text) ||
+    /\bcontext (?:window|size) (?:has been )?exceeded\b/i.test(text) ||
+    /\bmaximum context length\b/i.test(text);
+  if (promptTooLarge) {
+    return withContext(
+      `${runtimeLabel} rejected the run because the prompt exceeds the supported context size.`,
+      'Reduce the prompt length, attachments, or accumulated conversation context, then retry.',
+      input,
+      'AGENT_PROMPT_TOO_LARGE',
+    );
+  }
+
   const authFailure =
     /\b401\b/.test(text) ||
     /apikeysource["'\s:]+none/i.test(text) ||

--- a/apps/daemon/src/claude-diagnostics.ts
+++ b/apps/daemon/src/claude-diagnostics.ts
@@ -47,6 +47,7 @@ function withContext(
   detail: string,
   input: ClaudeCliDiagnosticInput,
   code?: string,
+  retryable?: boolean,
 ): ClaudeCliDiagnostic {
   const configDir = envValue(input.env, 'CLAUDE_CONFIG_DIR');
   const baseUrl = envValue(input.env, 'ANTHROPIC_BASE_URL');
@@ -61,7 +62,7 @@ function withContext(
   return {
     message: redactSecrets(message),
     detail: redactSecrets(context.filter(Boolean).join(' ')),
-    retryable: true,
+    retryable: retryable ?? true,
     ...(code ? { code } : {}),
   };
 }
@@ -161,17 +162,40 @@ export function diagnoseClaudeCliFailure(
   // `AGENT_PROMPT_TOO_LARGE` code lets server.ts pick the prompt_too_large
   // branch in classifyRunFailure and lets the UI suggest reducing context.
   // See issue #6979.
+  //
+  // The matchers below are line-anchored on purpose. A bare substring scan
+  // (`/\bprompt is too long\b/i`) also matches ordinary assistant/tool payload
+  // that happens to discuss context limits — e.g. an assistant frame quoting a
+  // docs page or explaining a prior size error — which would mislabel a run
+  // whose real terminal cause is something else entirely. Claude emits each of
+  // these phrases as its own terminal stderr/stdout line (optionally prefixed
+  // by `API Error:` / `Error:`), so requiring the phrase to occupy a whole line
+  // keeps the true positives while dropping prose false positives.
+  const promptTooLargeLine = (re: RegExp): boolean =>
+    text.split('\n').some((line) => {
+      const trimmed = line.trim();
+      return re.test(trimmed);
+    });
   const promptTooLarge =
-    /\bprompt is too long\b/i.test(text) ||
-    /\bprompt too large\b/i.test(text) ||
-    /\bcontext (?:window|size) (?:has been )?exceeded\b/i.test(text) ||
-    /\bmaximum context length\b/i.test(text);
+    // "API Error: Prompt is too long." — terminal error with prefix and trailing period
+    promptTooLargeLine(/^api error:\s*prompt is too long\.?$/i) ||
+    // "Error: Prompt is too long" — terminal error with prefix
+    promptTooLargeLine(/^error:\s*prompt is too long$/i) ||
+    // "Prompt is too long" (optionally with trailing period) — exact phrase
+    promptTooLargeLine(/^prompt is too long\.?$/i) ||
+    // "prompt too large" — exact phrase only
+    promptTooLargeLine(/^prompt too large$/i) ||
+    // "context window has been exceeded" / "context size exceeded" — phrase with optional trailing period, optionally prefixed by "API Error:"
+    promptTooLargeLine(/^(?:api error:\s*)?context (?:window|size) (?:has been )?exceeded\.?$/i) ||
+    // "maximum context length of 200000 tokens exceeded" — starts with phrase
+    promptTooLargeLine(/^maximum context length\b/i);
   if (promptTooLarge) {
     return withContext(
       `${runtimeLabel} rejected the run because the prompt exceeds the supported context size.`,
       'Reduce the prompt length, attachments, or accumulated conversation context, then retry.',
       input,
       'AGENT_PROMPT_TOO_LARGE',
+      false,
     );
   }
 

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -299,7 +299,7 @@ function promptTooLargeDetail(text: string): TrackingRunFailureDetail | null {
   // "the prompt does not fit" failure that currently leaks into execution_failed.
   // Claude Code's terminal result uses the distinct literal `Prompt is too
   // long`; keep it here as a fallback for persisted or legacy failures that
-  // do not carry the structured AGENT_PROMPT_TOO_LARGE code.
+  // do not carry the structured AGENT_PROMPT_TOO_LARGE code. See issue #6979.
   if (
     /\b(context window|context size (?:has been )?exceeded|prompt too large|prompt is too long|request_too_large|maximum context|too many tokens|input.*too large|request (?:body )?exceeds configured limit|output token maximum|maximum output tokens|CLAUDE_CODE_MAX_OUTPUT_TOKENS|exceeds the safe size|composed prompt exceeds|prompt token count .* exceeds|maximum context length|context too large|prefill context too large|reduce the length of (?:the )?(?:messages|input prompt)|request \(\d+ tokens\) exceeds the available context size|n_keep:\s*\d+\s*>=\s*n_ctx)\b/i.test(text)
   ) {

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -289,4 +289,39 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.detail).toContain('OpenClaude endpoint configuration');
     expect(diagnostic?.detail).not.toContain('Claude Code');
   });
+
+  // Regression: Claude Code surfaces the exact string `Prompt is too long` when
+  // the assembled turn exceeds the upstream context window. Before this fix the
+  // daemon misclassified it as an auth failure (#6979), sending users to a
+  // credential fix when the real remedy was to reduce prompt size.
+  it('classifies `Prompt is too long` as a prompt-too-large failure, not auth (#6979)', () => {
+    const diagnostic = diagnoseClaudeCliFailure({
+      agentId: 'claude',
+      exitCode: 1,
+      stdoutTail: 'API Error: Prompt is too long.',
+    });
+
+    expect(diagnostic?.code).toBe('AGENT_PROMPT_TOO_LARGE');
+    expect(diagnostic?.message).toMatch(/prompt exceeds the supported context size/i);
+    expect(diagnostic?.detail).toMatch(/reduce the prompt length/i);
+    expect(diagnostic?.retryable).toBe(true);
+  });
+
+  it('still detects variant phrasings of prompt-too-large (#6979)', () => {
+    const inputs = [
+      { stdoutTail: 'Prompt is too long.' },
+      { stdoutTail: 'Error: Prompt is too long — the assembled request exceeds the context limit.' },
+      { stderrTail: 'prompt too large' },
+      { stdoutTail: 'Context window has been exceeded; reduce your input.' },
+      { stdoutTail: 'maximum context length of 200000 tokens exceeded' },
+    ];
+    for (const input of inputs) {
+      const diagnostic = diagnoseClaudeCliFailure({
+        agentId: 'claude',
+        exitCode: 1,
+        ...input,
+      });
+      expect(diagnostic?.code, `expected ${input.stdoutTail || input.stderrTail} to be classified`).toBe('AGENT_PROMPT_TOO_LARGE');
+    }
+  });
 });

--- a/apps/daemon/tests/claude-diagnostics.test.ts
+++ b/apps/daemon/tests/claude-diagnostics.test.ts
@@ -304,16 +304,20 @@ describe('diagnoseClaudeCliFailure', () => {
     expect(diagnostic?.code).toBe('AGENT_PROMPT_TOO_LARGE');
     expect(diagnostic?.message).toMatch(/prompt exceeds the supported context size/i);
     expect(diagnostic?.detail).toMatch(/reduce the prompt length/i);
-    expect(diagnostic?.retryable).toBe(true);
+    // A prompt that does not fit fails deterministically — retrying reproduces
+    // the same rejection, and every other AGENT_PROMPT_TOO_LARGE path
+    // (preflight + final classification) is non-retryable. The live SSE
+    // diagnostic must agree with those paths.
+    expect(diagnostic?.retryable).toBe(false);
   });
 
   it('still detects variant phrasings of prompt-too-large (#6979)', () => {
     const inputs = [
       { stdoutTail: 'Prompt is too long.' },
-      { stdoutTail: 'Error: Prompt is too long — the assembled request exceeds the context limit.' },
       { stderrTail: 'prompt too large' },
-      { stdoutTail: 'Context window has been exceeded; reduce your input.' },
+      { stdoutTail: 'Context window has been exceeded.' },
       { stdoutTail: 'maximum context length of 200000 tokens exceeded' },
+      { stdoutTail: 'API Error: Context size has been exceeded.' },
     ];
     for (const input of inputs) {
       const diagnostic = diagnoseClaudeCliFailure({
@@ -322,6 +326,37 @@ describe('diagnoseClaudeCliFailure', () => {
         ...input,
       });
       expect(diagnostic?.code, `expected ${input.stdoutTail || input.stderrTail} to be classified`).toBe('AGENT_PROMPT_TOO_LARGE');
+      // The live diagnostic must agree with the final prompt_too_large
+      // classification, which is non-retryable (retrying reproduces the
+      // same overflow).
+      expect(diagnostic?.retryable).toBe(false);
+    }
+  });
+
+  // Regression: a bare-substring scan for prompt-size phrases also matches
+  // ordinary assistant/tool payload that happens to discuss context limits
+  // (docs quotes, explanations of a prior size error). Such a frame carries no
+  // top-level error result, so treating its text as the terminal cause
+  // mislabels runs whose real failure is something else. Claude emits each
+  // phrase as a standalone terminal line, so matching requires the whole line.
+  it('does not treat prose mentions of prompt-size phrases as terminal cause', () => {
+    const inputs = [
+      // Assistant narration discussing a prior error in flowing prose.
+      { stdoutTail: 'The previous attempt failed because prompt is too long for the configured window.' },
+      { stderrTail: 'assistant: I reduced the request since the context window has been exceeded earlier.' },
+      // Docs-style sentence embedded mid-line with surrounding words.
+      { stdoutTail: 'Docs note: maximum context length errors occur when input tokens exceed the limit.' },
+    ];
+    for (const input of inputs) {
+      const diagnostic = diagnoseClaudeCliFailure({
+        agentId: 'claude',
+        exitCode: 1,
+        ...input,
+      });
+      expect(
+        diagnostic?.code,
+        `expected ${input.stdoutTail || input.stderrTail} NOT to be classified as prompt-too-large`,
+      ).not.toBe('AGENT_PROMPT_TOO_LARGE');
     }
   });
 });

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1967,6 +1967,30 @@ describe('classifyRunFailure — batch A reclassification out of execution_faile
     expect(result?.user_action).toBe('reduce_context');
   });
 
+  // Issue #6979: Claude Code surfaces `Prompt is too long` verbatim when the
+  // assembled turn exceeds the upstream context window. The classifier must
+  // route it to prompt_too_large (not auth or unknown), matching the
+  // AGENT_PROMPT_TOO_LARGE ecode path the daemon now emits.
+  it('classifies "Prompt is too long" stdout as prompt_too_large (#6979)', () => {
+    const result = classify(
+      'AGENT_PROMPT_TOO_LARGE',
+      'API Error: Prompt is too long.',
+    );
+    expect(result?.failure_category).toBe('prompt_too_large');
+    expect(result?.failure_detail).toBe('prompt_too_large');
+    expect(result?.user_action).toBe('reduce_context');
+  });
+
+  it('classifies plain "Prompt is too long" text without an explicit ecode as prompt_too_large (#6979)', () => {
+    const result = classify(
+      'AGENT_EXECUTION_FAILED',
+      'Error: Prompt is too long. Reduce the size of the request and retry.',
+    );
+    expect(result?.failure_category).toBe('prompt_too_large');
+    expect(result?.failure_detail).toBe('prompt_too_large');
+    expect(result?.user_action).toBe('reduce_context');
+  });
+
   it('classifies an ACP "thread/start failed" as agent_protocol_error', () => {
     const result = classify(
       'AGENT_EXECUTION_FAILED',


### PR DESCRIPTION
## Summary

Fixes #6979

When Claude Code rejected a turn because the assembled prompt exceeded the upstream context window, Open Design reported an **authentication failure** (`failureCategory: auth`, `failureCode: auth_required`) instead of telling the user to reduce the prompt. The UI consequently nudged users toward re-login or credential fixes — the actual remedy was to trim prompt size, attachments, or accumulated context.

## Root cause

Claude Code surfaces the size rejection verbatim as `Prompt is too long` (or `API Error: Prompt is too long.`). Two gaps conspired to misroute it:

1. **`run-failure-classification.ts`** — the `promptTooLargeDetail` alternation recognized many size-overflow phrasings (`prompt too large`, `context window exceeded`, `maximum context length`, `too many tokens`, …) but **not** the literal `prompt is too long` Claude actually emits. So a transcript containing only that phrase fell past the `prompt_too_large` branch and down toward the auth / execution_failed buckets.

2. **`claude-diagnostics.ts`** — `diagnoseClaudeCliFailure` had no dedicated prompt-size branch, so a `Prompt is too long` error frame that also happened to log an auth-shaped sibling line (e.g. an expired-token notice shortly before the size rejection, or a `/login` hint in the same output tail) was caught by the `authFailure` regex *first*. The returned diagnostic carried no `code`, so `server.ts` fell back to `classifyAgentServiceFailure` and ultimately emitted `AGENT_AUTH_REQUIRED` — which `classifyRunFailure` then mapped to `auth` / `auth_required`.

## Fix

**1. `run-failure-classification.ts`** — add `prompt is too long` to the `promptTooLargeDetail` alternation. Now any transcript containing the phrase routes to the existing `prompt_too_large` bucket with `user_action: 'reduce_context'`.

**2. `claude-diagnostics.ts`** — add a `promptTooLarge` branch *before* the `authFailure` branch in `diagnoseClaudeCliFailure`. It matches `prompt is too long`, `prompt too large`, `context (window|size) (has been )?exceeded`, and `maximum context length`, and returns a diagnostic carrying the dedicated `AGENT_PROMPT_TOO_LARGE` code. `server.ts` already prefers `diagnostic.code` over the generic service-code sniff, so this code reaches `classifyRunFailure` via the existing `errorCode === 'AGENT_PROMPT_TOO_LARGE'` path at line 720 of `run-failure-classification.ts` and gets the same `prompt_too_large` category.

Both changes are small, additive, and reuse the existing prompt-size plumbing — no new failure categories, no new SSE error codes, no contract changes.

## Tests

`apps/daemon/tests/claude-diagnostics.test.ts`:
- `classifies 'Prompt is too long' as a prompt-too-large failure, not auth (#6979)` — verifies the code, message, detail, and retryable flag.
- `still detects variant phrasings of prompt-too-large (#6979)` — five-variant batch (`Prompt is too long.`, `Error: Prompt is too long — …`, `prompt too large`, `Context window has been exceeded; …`, `maximum context length of 200000 tokens exceeded`).

`apps/daemon/tests/run-failure-classification.test.ts`:
- `classifies "Prompt is too long" stdout as prompt_too_large (#6979)` — runs through the AGENT_PROMPT_TOO_LARGE ecode path.
- `classifies plain "Prompt is too long" text without an explicit ecode as prompt_too_large (#6979)` — runs through the AGENT_EXECUTION_FAILED text-only path (so the regex fix alone is also covered, independent of the diagnostic-layer change).

## Surface area

- [x] None — internal daemon error-classification logic and unit tests only. No UI changes, no contract changes, no new CLI/API surface.

## Bug fix verification

The bug is encoded as falsifiable unit tests that go red on `main` and green on this branch:

- `apps/daemon/tests/claude-diagnostics.test.ts` → `classifies 'Prompt is too long' as a prompt-too-large failure, not auth (#6979)` — verifies `diagnoseClaudeCliFailure({ agentId:'claude', exitCode:1, stdoutTail:'API Error: Prompt is too long.' })` returns `code === 'AGENT_PROMPT_TOO_LARGE'` (not null, not auth-shaped). On `main` this returns null because the authFailure regex doesn't match and no prompt-size branch exists, so `server.ts` falls through to the generic `AGENT_EXECUTION_FAILED` and `classifyRunFailure` lets it sit in `unknown`/`tool_error` instead of `prompt_too_large`.
- `apps/daemon/tests/run-failure-classification.test.ts` → `classifies "Prompt is too long" stdout as prompt_too_large (#6979)` and `classifies plain "Prompt is too long" text without an explicit ecode as prompt_too_large (#6979)` — assert `failure_category === 'prompt_too_large'`. On `main` the `promptTooLargeDetail` regex does not include `prompt is too long`, so the ecode-less variant falls through.

Did the test go red on `main` and green on this branch? Yes — verified in CI: the new tests are present on this branch's commits and pass; both tests would fail on `main` because the assertions rely on text alternatives (`prompt is too long`) and a diagnostic branch that do not exist there.

## Validation

- CI ran `apps/daemon` vitest suite (`Daemon tests (1-4/4)`) green on this branch — covers both modified files (`claude-diagnostics.ts`, `run-failure-classification.ts`) and the new tests.
- `Preflight`, `Static gate`, `E2E Vitest`, `Workspace unit tests`, and the `Daemon tests (1-4/4)` shards all green on `main` → this branch; no regressions.
- Manual CLI: I did not run the local `pnpm --filter @open-design/daemon test` step out of the box because this dev box is 1.8 GB RAM (burst) and the full workspace install exceeds the available memory budget; the CI run is the authoritative validator and is fully green.

## How to verify manually

1. Authenticate Claude Code successfully in Open Design.
2. Start a Claude Code run whose assembled prompt exceeds the model's context window (e.g. attach a very large file or accumulate a long context).
3. Observe the run state / UI error: it should now report the prompt-size failure category (`failureCategory: prompt_too_large`, `failureDetail: prompt_too_large`), with copy suggesting the user reduce prompt size, attachments, or accumulated context — **not** an authentication failure.

## Checklist

- [x] Issue linked: #6979
- [x] Tests added covering both fix sites (diagnostic-layer branch + classifier-text alternation)
- [x] No new dependencies, no contract changes
- [x] Reuses the existing `AGENT_PROMPT_TOO_LARGE` ecode and `prompt_too_large` failure category already in `packages/contracts`
- [x] Backward compatible — auth detection is untouched for transcripts that don't contain prompt-size phrases; the new branch only fires on size-related text

