### PR TITLE
fix: keep AMR environment switching consistent

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -82,7 +82,7 @@ interface VelaWorkspaceContextOptions {
   /** Injectable for tests; defaults to reading ~/.amr/config.json + env. */
   readSession?: typeof readVelaControlApiContext;
   /** Settings-backed AMR environment used by the daemon's agent launcher. */
-  configuredEnv?: Record<string, string>;
+  configuredEnv?: Record<string, string> | (() => Record<string, string>);
   /**
    * Legacy default for no-argument `current()` and fresh-account bootstrap.
    * Exact request resolution never reads it.
@@ -115,7 +115,10 @@ interface VelaWorkspaceContextOptions {
  * Returns null when a required field is missing or an enum is out of range —
  * collab then stays dormant rather than acting on a malformed context.
  */
-export function mapVelaWorkspaceContext(input: unknown): WorkspaceCollabContext | null {
+export function mapVelaWorkspaceContext(
+  input: unknown,
+  configuredEnv: Record<string, string> = {},
+): WorkspaceCollabContext | null {
   if (!input || typeof input !== 'object') return null;
   const raw = input as Record<string, unknown>;
 
@@ -160,6 +163,8 @@ export function mapVelaWorkspaceContext(input: unknown): WorkspaceCollabContext 
   const settingsUrl = resolveWorkspaceSettingsUrl(
     workspaceId,
     (raw as { workspaceSettingsUrl?: unknown }).workspaceSettingsUrl,
+    process.env,
+    configuredEnv,
   );
   if (settingsUrl) context.workspaceSettingsUrl = settingsUrl;
 
@@ -227,6 +232,9 @@ export function createVelaWorkspaceContextProvider(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   type VelaSession = NonNullable<ReturnType<typeof readVelaControlApiContext>>;
   let lastBootstrapFailureAt = 0;
+  const configuredEnv = () => typeof options.configuredEnv === 'function'
+    ? options.configuredEnv()
+    : (options.configuredEnv ?? {});
 
   /**
    * Read the context for the workspace THIS daemon is pinned to.
@@ -339,10 +347,12 @@ export function createVelaWorkspaceContextProvider(
   async function resolvePinnedWorkspace(
     session: VelaSession,
     workspaceId: string,
+    selectedEnv: Record<string, string>,
   ): Promise<WorkspaceCollabContext | null> {
     const result = await fetchVelaWorkspaceDirectory({
       fetch: fetchImpl,
       readSession: () => session,
+      configuredEnv: selectedEnv,
       timeoutMs,
     });
     if (!result.ok) return null; // B unreachable — preserve the pin, confirm nothing.
@@ -352,7 +362,7 @@ export function createVelaWorkspaceContextProvider(
         entry.memberStatus === 'active' &&
         entry.lifecycleState !== 'deleted',
     );
-    if (item) return workspaceContextFromDirectoryItem(item);
+    if (item) return workspaceContextFromDirectoryItem(item, selectedEnv);
     // Confirmed stale: the directory answered and this workspace no longer
     // has the caller as an active member. Purge the pin before anything else
     // reads it, then recover exactly like the fresh-account bootstrap.
@@ -360,13 +370,14 @@ export function createVelaWorkspaceContextProvider(
     const fallback = await pickDefaultWorkspace(session, result);
     if (!fallback) return null;
     await options.setLocalSelection?.(fallback.workspaceId);
-    return workspaceContextFromDirectoryItem(fallback);
+    return workspaceContextFromDirectoryItem(fallback, selectedEnv);
   }
 
   async function resolveCurrent(
     req: WorkspaceContextRequest,
   ): Promise<WorkspaceCollabContext | null> {
-      const session = readSession();
+      const selectedEnv = configuredEnv();
+      const session = readSession(process.env, selectedEnv);
       if (!session || !session.controlKey || !session.apiUrl) return null;
       try {
         const explicitSelection = req.workspaceId?.trim() || undefined;
@@ -381,14 +392,17 @@ export function createVelaWorkspaceContextProvider(
         const response = await fetchCurrent(session, localSelection);
         if (response.ok) {
           const body: unknown = await response.json();
-          const mapped = mapVelaWorkspaceContext(body);
+          const mapped = mapVelaWorkspaceContext(body, selectedEnv);
           if (mapped && (!localSelection || mapped.workspaceId === localSelection)) {
             return withUserIdentity(mapped, session);
           }
           if (localSelection) {
             // Server disagrees with the pinned scope → synthesize from the
             // membership directory instead of silently following the server.
-            return withUserIdentity(await resolvePinnedWorkspace(session, localSelection), session);
+            return withUserIdentity(
+              await resolvePinnedWorkspace(session, localSelection, selectedEnv),
+              session,
+            );
           }
           return null;
         }
@@ -399,7 +413,10 @@ export function createVelaWorkspaceContextProvider(
         if (localSelection) {
           // The pinned workspace could not be read from current — resolve it
           // from the directory (clears the pin only on a CONFIRMED removal).
-          return withUserIdentity(await resolvePinnedWorkspace(session, localSelection), session);
+          return withUserIdentity(
+            await resolvePinnedWorkspace(session, localSelection, selectedEnv),
+            session,
+          );
         }
         if (missingPrincipal) {
           // Fresh account: B has no current workspace and the client has no
@@ -407,7 +424,7 @@ export function createVelaWorkspaceContextProvider(
           const picked = await pickDefaultWorkspace(session);
           if (!picked) return null;
           await options.setLocalSelection?.(picked.workspaceId);
-          return withUserIdentity(workspaceContextFromDirectoryItem(picked), session);
+          return withUserIdentity(workspaceContextFromDirectoryItem(picked, selectedEnv), session);
         }
         return null;
       } catch {
@@ -420,13 +437,14 @@ export function createVelaWorkspaceContextProvider(
   async function resolveExact(
     req: WorkspaceContextRequest & { workspaceId: string },
   ): Promise<WorkspaceCollabContext | null> {
-    const session = readSession();
+    const selectedEnv = configuredEnv();
+    const session = readSession(process.env, selectedEnv);
     const workspaceId = req.workspaceId.trim();
     if (!session || !session.controlKey || !session.apiUrl || !workspaceId) return null;
     try {
       const response = await fetchCurrent(session, workspaceId);
       if (response.ok) {
-        const mapped = mapVelaWorkspaceContext(await response.json());
+        const mapped = mapVelaWorkspaceContext(await response.json(), selectedEnv);
         if (mapped?.workspaceId === workspaceId) {
           return withUserIdentity(mapped, session);
         }
@@ -436,6 +454,7 @@ export function createVelaWorkspaceContextProvider(
       const directory = await fetchVelaWorkspaceDirectory({
         fetch: fetchImpl,
         readSession: () => session,
+        configuredEnv: selectedEnv,
         timeoutMs,
       });
       if (!directory.ok) return null;
@@ -446,7 +465,7 @@ export function createVelaWorkspaceContextProvider(
           && entry.lifecycleState !== 'deleted',
       );
       return item
-        ? withUserIdentity(workspaceContextFromDirectoryItem(item), session)
+        ? withUserIdentity(workspaceContextFromDirectoryItem(item, selectedEnv), session)
         : null;
     } catch {
       return null;
@@ -477,6 +496,7 @@ async function responseIsMissingPrincipal(response: Response): Promise<boolean> 
  */
 export function workspaceContextFromDirectoryItem(
   item: WorkspaceDirectoryItem,
+  configuredEnv: Record<string, string> = {},
 ): WorkspaceCollabContext {
   const context: WorkspaceCollabContext = {
     workspaceId: item.workspaceId,
@@ -495,7 +515,12 @@ export function workspaceContextFromDirectoryItem(
       memberStatus: item.memberStatus,
     }),
   };
-  const settingsUrl = resolveWorkspaceSettingsUrl(item.workspaceId, undefined);
+  const settingsUrl = resolveWorkspaceSettingsUrl(
+    item.workspaceId,
+    undefined,
+    process.env,
+    configuredEnv,
+  );
   if (settingsUrl) context.workspaceSettingsUrl = settingsUrl;
   if (item.workspaceName) context.workspaceName = item.workspaceName;
   if (item.workspaceType === 'team') {
@@ -960,7 +985,10 @@ export async function fetchVelaWorkspaceDirectory(
   const fetchImpl = options.fetch ?? fetch;
   const readSession = options.readSession ?? readVelaControlApiContext;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const session = readSession(process.env, options.configuredEnv ?? {});
+  const configuredEnv = typeof options.configuredEnv === 'function'
+    ? options.configuredEnv()
+    : (options.configuredEnv ?? {});
+  const session = readSession(process.env, configuredEnv);
   // No local Vela session is an authoritative signed-out identity, not an
   // authority outage. Returning a successful empty directory lets clients
   // clear a previously cached Team selection instead of preserving it forever.
@@ -976,7 +1004,7 @@ export async function fetchVelaWorkspaceDirectory(
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
         if (!options.readSession) {
-          markVelaAuthorizationExpired(process.env, options.configuredEnv ?? {});
+          markVelaAuthorizationExpired(process.env, configuredEnv);
         }
         return {
           ok: false,
@@ -1016,7 +1044,7 @@ export function createWorkspaceContextProviderFromEnv(
   env: NodeJS.ProcessEnv = process.env,
   options: Pick<
     VelaWorkspaceContextOptions,
-    'getActiveWorkspaceId' | 'setLocalSelection' | 'clearLocalSelection'
+    'configuredEnv' | 'getActiveWorkspaceId' | 'setLocalSelection' | 'clearLocalSelection'
   > = {},
 ): WorkspaceContextProvider {
   if (env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela') {

--- a/apps/daemon/src/collab/workspace-context.ts
+++ b/apps/daemon/src/collab/workspace-context.ts
@@ -11,6 +11,7 @@ import type {
   WorkspaceProviderMode,
   WorkspaceType,
 } from '@open-design/contracts';
+import { resolveEffectiveVelaConsoleOrigin } from '../integrations/vela-console-origin.js';
 
 // The daemon's single B-integration point . Presence + sync need the
 // caller's workspace identity (workspaceMemberId + role + lifecycle). In
@@ -192,6 +193,7 @@ export function resolveWorkspaceSettingsUrl(
   workspaceId: string,
   explicit: unknown,
   env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
 ): string | undefined {
   // B's web console supports workspace deep links (?workspaceId=…): the target
   // page opens directly when it matches the account's Active Workspace, and
@@ -204,7 +206,7 @@ export function resolveWorkspaceSettingsUrl(
   if (typeof explicit === 'string' && explicit.trim()) {
     return withWorkspaceDeepLink(explicit.trim(), workspaceId);
   }
-  const base = env.OD_VELA_WEB_URL?.trim();
+  const base = resolveEffectiveVelaConsoleOrigin(env, configuredEnv);
   if (!base) return undefined;
   return withWorkspaceDeepLink(`${base.replace(/\/$/, '')}/settings`, workspaceId);
 }

--- a/apps/daemon/src/integrations/vela-console-origin.ts
+++ b/apps/daemon/src/integrations/vela-console-origin.ts
@@ -1,0 +1,64 @@
+import { resolveAmrProfile } from './vela-profile.js';
+
+type EnvMap = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+// Publicly named console origins already used by the web client. feature-test
+// remains build-injected because its deployment hostname is intentionally not
+// part of the public repository.
+const PUBLIC_ORIGINS: Partial<Record<string, string>> = {
+  prod: 'https://open-design.ai/cloud',
+  test: 'https://vela.powerformer.net',
+  local: 'http://localhost:5173',
+};
+
+function normalizedOrigin(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const origin = value.trim().replace(/\/+$/, '');
+  return origin.length > 0 ? origin : undefined;
+}
+
+function originsByProfile(env: EnvMap): Record<string, string> {
+  const raw = env.OD_VELA_WEB_URLS?.trim();
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const result: Record<string, string> = {};
+    for (const profile of ['prod', 'test', 'feature-test', 'local'] as const) {
+      const origin = normalizedOrigin((parsed as Record<string, unknown>)[profile]);
+      if (origin) result[profile] = origin;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the console origin for the AMR profile selected in app settings.
+ *
+ * `OD_VELA_WEB_URL` describes only the profile baked into the package. It is
+ * safe as a compatibility fallback while that same profile remains selected,
+ * but must never leak across a runtime profile switch. New packages also carry
+ * `OD_VELA_WEB_URLS`, a build-time-injected profile map that makes switching
+ * links deterministic without checking internal deployment names into source.
+ */
+export function resolveEffectiveVelaConsoleOrigin(
+  env: EnvMap = process.env,
+  configuredEnv: EnvMap = {},
+): string | undefined {
+  const packagedProfile = resolveAmrProfile(env);
+  const selectedProfile = resolveAmrProfile({ ...env, ...configuredEnv });
+  const mapped = originsByProfile(env)[selectedProfile];
+  if (mapped) return mapped;
+  if (selectedProfile === packagedProfile) {
+    const packagedOrigin = normalizedOrigin(env.OD_VELA_WEB_URL);
+    if (packagedOrigin) return packagedOrigin;
+  }
+  const hasRuntimeSelection = Boolean(
+    configuredEnv.OPEN_DESIGN_AMR_PROFILE?.trim() || configuredEnv.VELA_PROFILE?.trim(),
+  );
+  const publicOrigin = hasRuntimeSelection ? PUBLIC_ORIGINS[selectedProfile] : undefined;
+  if (publicOrigin) return publicOrigin;
+  return undefined;
+}

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -22,6 +22,7 @@ import { resolveAgentLaunch } from '../runtimes/launch.js';
 import { spawnEnvForAgent } from '../runtimes/env.js';
 import { getAgentDef } from '../runtimes/registry.js';
 import { resolveAmrProfile } from './vela-profile.js';
+import { resolveEffectiveVelaConsoleOrigin } from './vela-console-origin.js';
 
 export { resolveAmrProfile } from './vela-profile.js';
 
@@ -290,15 +291,15 @@ export interface VelaLoginStatus {
  * Non-prod AMR environments are internal deployments, so their hostnames are
  * not literals in this public repository: packaging injects the origin from a
  * CI secret and the packaged runtime forwards it as `OD_VELA_WEB_URL`. Reporting
- * it on the login status is how the web client learns which console to link to
- * without needing a hostname table of its own. Undefined for prod and fork
- * builds, where the client falls back to the public product console.
+ * it on the login status is how the web client learns which console to link to.
+ * The resolver combines that packaged origin with the settings-selected AMR
+ * profile, so a runtime switch cannot keep linking to the package's backend.
  */
 export function resolveVelaConsoleOrigin(
   env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
 ): string | undefined {
-  const origin = env.OD_VELA_WEB_URL?.trim().replace(/\/+$/, '') ?? '';
-  return origin.length > 0 ? origin : undefined;
+  return resolveEffectiveVelaConsoleOrigin(env, configuredEnv);
 }
 
 export interface VelaLoginAuthStage {

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -529,9 +529,10 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
       const status = readVelaLoginStatus(mergeVelaEnv(env, configuredEnv));
       // Reported on every response, signed in or not: the client builds console
       // links (wallet, plans, upgrade) from it and must not have to carry a
-      // hostname table for internal AMR environments. Absent for prod/fork
-      // builds, where the client keeps using the public product console.
-      const consoleOrigin = resolveVelaConsoleOrigin(env);
+      // hostname table for internal AMR environments. The resolver also sees
+      // the settings-selected profile, so this cannot retain the package's
+      // console origin after an environment switch.
+      const consoleOrigin = resolveVelaConsoleOrigin(env, configuredEnv);
       if (consoleOrigin) status.consoleOrigin = consoleOrigin;
       if (status.loggedIn && status.sessionState === 'authenticated') {
         // Key the live-account cache by the full credential revision (not just

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3416,6 +3416,7 @@ export async function startServer({
   // verify the exact Workspace/member carried by each request.
   const workspaceContext = withLastKnownWorkspaceContext(
     createWorkspaceContextProviderFromEnv(process.env, {
+      configuredEnv: configuredAmrEnv,
       getActiveWorkspaceId: () => activeWorkspace.get(),
       setLocalSelection: (workspaceId: string) => activeWorkspace.set(workspaceId),
       // Only called after the membership directory CONFIRMS the pinned

--- a/apps/daemon/tests/collab/workspace-settings-url.test.ts
+++ b/apps/daemon/tests/collab/workspace-settings-url.test.ts
@@ -38,6 +38,19 @@ describe('resolveWorkspaceSettingsUrl', () => {
     ).toBeUndefined();
     expect(resolveWorkspaceSettingsUrl('ws-1', 'not-a-url')).toBe('not-a-url');
   });
+
+  it('builds the link from the selected AMR profile origin', () => {
+    expect(resolveWorkspaceSettingsUrl('ws-1', undefined, {
+      OPEN_DESIGN_AMR_PROFILE: 'prod',
+      OD_VELA_WEB_URL: 'https://prod.example',
+      OD_VELA_WEB_URLS: JSON.stringify({
+        prod: 'https://prod.example',
+        test: 'https://test.example',
+      }),
+    }, {
+      OPEN_DESIGN_AMR_PROFILE: 'test',
+    })).toBe('https://test.example/settings?workspaceId=ws-1&source=open_design');
+  });
 });
 
 describe('parseWorkspaceCollabContext', () => {

--- a/apps/daemon/tests/vela-console-origin.test.ts
+++ b/apps/daemon/tests/vela-console-origin.test.ts
@@ -20,4 +20,28 @@ describe('resolveVelaConsoleOrigin', () => {
     expect(resolveVelaConsoleOrigin({})).toBeUndefined();
     expect(resolveVelaConsoleOrigin({ OD_VELA_WEB_URL: '   ' })).toBeUndefined();
   });
+
+  it('uses the selected profile origin instead of the packaged profile origin', () => {
+    const packagedEnv = {
+      OPEN_DESIGN_AMR_PROFILE: 'test',
+      OD_VELA_WEB_URL: 'https://test.example.invalid',
+      OD_VELA_WEB_URLS: JSON.stringify({
+        prod: 'https://prod.example.invalid',
+        test: 'https://test.example.invalid',
+      }),
+    };
+
+    expect(resolveVelaConsoleOrigin(packagedEnv, {
+      OPEN_DESIGN_AMR_PROFILE: 'prod',
+    })).toBe('https://prod.example.invalid');
+  });
+
+  it('never reuses the packaged origin after switching to an unmapped profile', () => {
+    expect(resolveVelaConsoleOrigin({
+      OPEN_DESIGN_AMR_PROFILE: 'test',
+      OD_VELA_WEB_URL: 'https://test.example.invalid',
+    }, {
+      OPEN_DESIGN_AMR_PROFILE: 'feature-test',
+    })).toBeUndefined();
+  });
 });

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -945,6 +945,28 @@ describe('createVelaWorkspaceContextProvider', () => {
     expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
   });
 
+  it('reads the current configured AMR environment on every workspace request', async () => {
+    let profile = 'prod';
+    const readSession = vi.fn((
+      _env?: NodeJS.ProcessEnv,
+      _configuredEnv?: Record<string, string>,
+    ) => SESSION as ReturnType<typeof readVelaControlApiContext>);
+    const provider = createVelaWorkspaceContextProvider({
+      fetch: (async () => jsonResponse(200, B_TEAM_CONTEXT)) as unknown as typeof fetch,
+      configuredEnv: () => ({ OPEN_DESIGN_AMR_PROFILE: profile }),
+      readSession,
+    });
+
+    await provider.current({});
+    profile = 'test';
+    await provider.current({});
+
+    expect(readSession.mock.calls.map((call) => call[1])).toEqual([
+      { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+      { OPEN_DESIGN_AMR_PROFILE: 'test' },
+    ]);
+  });
+
   it('degrades to null on a 401 (signed out) or a network error', async () => {
     const unauthorized = createVelaWorkspaceContextProvider({
       fetch: (async () => jsonResponse(401, { error: 'unauthenticated' })) as unknown as typeof fetch,

--- a/apps/packaged/src/config.ts
+++ b/apps/packaged/src/config.ts
@@ -21,6 +21,7 @@ export const PACKAGED_WEB_OUTPUT_MODE_ENV = "OD_WEB_OUTPUT_MODE";
 
 export type PackagedWebOutputMode = "server" | "standalone";
 export type PackagedAmrProfile = "prod" | "test" | "feature-test" | "local";
+export type PackagedVelaWebUrls = Partial<Record<PackagedAmrProfile, string>>;
 
 export type RawPackagedConfig = {
   amrProfile?: string;
@@ -50,6 +51,7 @@ export type RawPackagedConfig = {
   // checked in because the non-prod AMR environments are internal deployments
   // and this repository is public; absent for prod and fork builds.
   velaWebUrl?: string;
+  velaWebUrls?: Partial<Record<PackagedAmrProfile, string>>;
   webSidecarEntryRelative?: string;
   webStandaloneRoot?: string;
   webOutputMode?: string;
@@ -69,6 +71,7 @@ export type PackagedConfig = {
   posthogKey: string | null;
   posthogHost: string | null;
   velaWebUrl: string | null;
+  velaWebUrls?: PackagedVelaWebUrls;
   webSidecarEntry: string | null;
   webStandaloneRoot: string | null;
   webOutputMode: PackagedWebOutputMode;
@@ -128,6 +131,17 @@ function cleanOptionalString(value: string | undefined): string | null {
   if (value == null) return null;
   const trimmed = value.trim();
   return trimmed.length === 0 ? null : trimmed;
+}
+
+function cleanVelaWebUrls(
+  value: Partial<Record<PackagedAmrProfile, string>> | undefined,
+): PackagedVelaWebUrls {
+  const result: PackagedVelaWebUrls = {};
+  for (const profile of ['prod', 'test', 'feature-test', 'local'] as const) {
+    const origin = cleanOptionalString(value?.[profile]);
+    if (origin) result[profile] = origin.replace(/\/+$/, '');
+  }
+  return result;
 }
 
 function resolvePackagedWebOutputMode(value: string | undefined): PackagedWebOutputMode {
@@ -216,6 +230,7 @@ export async function readPackagedConfig(): Promise<PackagedConfig> {
     posthogKey: cleanOptionalString(raw.posthogKey),
     posthogHost: cleanOptionalString(raw.posthogHost),
     velaWebUrl: cleanOptionalString(raw.velaWebUrl),
+    velaWebUrls: cleanVelaWebUrls(raw.velaWebUrls),
     webSidecarEntry,
     webStandaloneRoot,
     webOutputMode,

--- a/apps/packaged/src/headless-runtime.ts
+++ b/apps/packaged/src/headless-runtime.ts
@@ -233,6 +233,7 @@ export async function runPackagedHeadless(
         posthogKey: activeConfig.posthogKey,
         posthogHost: activeConfig.posthogHost,
         velaWebUrl: activeConfig.velaWebUrl,
+        velaWebUrls: activeConfig.velaWebUrls,
         // PR #974 round-5 (lefarcen P2): headless packaged mode uses the signed
         // Electron entry as a lifecycle owner, but creates no BrowserWindow and
         // exposes no privileged shell.openPath surface.

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -64,6 +64,13 @@ function resolveHeadlessConfig(): PackagedConfig {
     posthogKey: process.env.POSTHOG_KEY?.trim() || null,
     posthogHost: process.env.POSTHOG_HOST?.trim() || null,
     velaWebUrl: process.env.OD_VELA_WEB_URL?.trim() || null,
+    velaWebUrls: (() => {
+      try {
+        return JSON.parse(process.env.OD_VELA_WEB_URLS ?? '{}') as Record<string, string>;
+      } catch {
+        return {};
+      }
+    })(),
     webSidecarEntry: null,
     webStandaloneRoot: null,
     webOutputMode: "server",

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -257,6 +257,7 @@ async function main(): Promise<void> {
     posthogKey: activeConfig.posthogKey,
     posthogHost: activeConfig.posthogHost,
     velaWebUrl: activeConfig.velaWebUrl,
+    velaWebUrls: activeConfig.velaWebUrls,
     // PR #974 round-5 (lefarcen P2): the Electron entry runs desktop
     // main alongside the daemon, so the import-folder gate must be
     // pinned ON from request 0. See `apps/packaged/src/headless-runtime.ts`

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -672,6 +672,7 @@ export type PackagedDaemonSpawnEnvOptions = {
    * the workspace-team gate — see {@link workspaceTeamTransportEnv}.
    */
   velaWebUrl?: string | null;
+  velaWebUrls?: Record<string, string>;
 };
 
 /**
@@ -707,6 +708,9 @@ export function buildPackagedDaemonSpawnEnv(
       ? {}
       : { OPEN_DESIGN_AMR_PROFILE: options.amrProfile }),
     ...workspaceTeamTransportEnv(options.amrProfile, options.velaWebUrl),
+    ...(options.velaWebUrls == null || Object.keys(options.velaWebUrls).length === 0
+      ? {}
+      : { OD_VELA_WEB_URLS: JSON.stringify(options.velaWebUrls) }),
     ...(options.appVersion == null ? {} : { OD_APP_VERSION: options.appVersion }),
     ...(options.mcpBootstrapCommand == null
       || options.mcpBootstrapCommand.length === 0
@@ -883,6 +887,7 @@ export async function startPackagedSidecars(
     posthogKey: string | null;
     posthogHost: string | null;
     velaWebUrl: string | null;
+    velaWebUrls?: Record<string, string>;
     /**
      * PR #974 round-5 (lefarcen P2): caller asserts whether a desktop
      * runtime is being started in this packaged process group. The
@@ -962,6 +967,7 @@ export async function startPackagedSidecars(
         posthogKey: options.posthogKey,
         posthogHost: options.posthogHost,
         velaWebUrl: options.velaWebUrl,
+        velaWebUrls: options.velaWebUrls,
       }),
       electronNodeCommand: options.electronNodeCommand,
       nodeCommand: options.nodeCommand,

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -594,6 +594,25 @@ describe('buildPackagedDaemonSpawnEnv', () => {
     expect(env.OPEN_DESIGN_AMR_PROFILE).toBe('test');
   });
 
+  it('forwards the per-profile Vela console origins to the daemon', () => {
+    const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      amrProfile: 'prod',
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      requireDesktopAuth: true,
+      velaWebUrl: 'https://prod.example.invalid',
+      velaWebUrls: {
+        prod: 'https://prod.example.invalid',
+        test: 'https://test.example.invalid',
+      },
+    });
+    expect(JSON.parse(env.OD_VELA_WEB_URLS ?? '{}')).toEqual({
+      prod: 'https://prod.example.invalid',
+      test: 'https://test.example.invalid',
+    });
+  });
+
   it.each(['feature-test', 'test'] as const)(
     'enables the vela-cli workspace-team transport for a %s build with an injected vela web origin',
     (amrProfile) => {

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -19,6 +19,7 @@ export type ToolPackBuildOutput = "all" | "app" | "appimage" | "dir" | "dmg" | "
 export type ToolPackMacCompression = "store" | "normal" | "maximum";
 export type ToolPackWebOutputMode = "server" | "standalone";
 export type ToolPackAmrProfile = "prod" | "test" | "feature-test" | "local";
+export type ToolPackVelaWebUrls = Partial<Record<ToolPackAmrProfile, string>>;
 
 export type ToolPackCliOptions = {
   appVersion?: string;
@@ -113,6 +114,13 @@ export type ToolPackConfig = {
    * simply omit it, which leaves workspace-team dormant.
    */
   velaWebUrl?: string;
+  /**
+   * Optional per-profile origins used by the runtime profile switcher. Read
+   * from `OD_VELA_WEB_URL_PROD`, `_TEST`, `_FEATURE_TEST`, and `_LOCAL` so an
+   * official or local build can enable cross-profile links without checking
+   * deployment-specific hostnames into source.
+   */
+  velaWebUrls?: ToolPackVelaWebUrls;
   /**
    * Personal API key (`phx_...`) used by the @posthog/cli sourcemap helper to
    * upload browser sourcemaps to PostHog after `next build` and before the
@@ -243,6 +251,21 @@ function resolveToolPackVelaWebUrl(value: string | undefined): string | undefine
     throw new Error(`OD_VELA_WEB_URL must be http(s): ${value}`);
   }
   return normalized.replace(/\/+$/, "");
+}
+
+function resolveToolPackVelaWebUrls(env: NodeJS.ProcessEnv): ToolPackVelaWebUrls | undefined {
+  const candidates: ReadonlyArray<[ToolPackAmrProfile, string | undefined]> = [
+    ['prod', env.OD_VELA_WEB_URL_PROD],
+    ['test', env.OD_VELA_WEB_URL_TEST],
+    ['feature-test', env.OD_VELA_WEB_URL_FEATURE_TEST],
+    ['local', env.OD_VELA_WEB_URL_LOCAL],
+  ];
+  const result: ToolPackVelaWebUrls = {};
+  for (const [profile, value] of candidates) {
+    const origin = resolveToolPackVelaWebUrl(value);
+    if (origin) result[profile] = origin;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function resolveToolPackPosthogCliApiKey(value: string | undefined): string | undefined {
@@ -397,6 +420,7 @@ export function resolveToolPackConfig(
     posthogKey: resolveToolPackPosthogKey(process.env.POSTHOG_KEY),
     posthogHost: resolveToolPackPosthogHost(process.env.POSTHOG_HOST),
     velaWebUrl: resolveToolPackVelaWebUrl(process.env.OD_VELA_WEB_URL),
+    velaWebUrls: resolveToolPackVelaWebUrls(process.env),
     posthogCliApiKey: resolveToolPackPosthogCliApiKey(
       process.env.POSTHOG_CLI_API_KEY ?? process.env.POSTHOG_PERSONAL_API_KEY,
     ),

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -598,6 +598,7 @@ async function writeAssembledApp(
         ...(config.posthogKey == null ? {} : { posthogKey: config.posthogKey }),
         ...(config.posthogHost == null ? {} : { posthogHost: config.posthogHost }),
         ...(config.velaWebUrl == null ? {} : { velaWebUrl: config.velaWebUrl }),
+        ...(config.velaWebUrls == null ? {} : { velaWebUrls: config.velaWebUrls }),
         ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
       },
       null,

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -174,6 +174,7 @@ export function renderMacPackagedConfig(options: {
       ...(options.config.posthogKey == null ? {} : { posthogKey: options.config.posthogKey }),
       ...(options.config.posthogHost == null ? {} : { posthogHost: options.config.posthogHost }),
       ...(options.config.velaWebUrl == null ? {} : { velaWebUrl: options.config.velaWebUrl }),
+      ...(options.config.velaWebUrls == null ? {} : { velaWebUrls: options.config.velaWebUrls }),
       ...(options.usePrebundledStandaloneWeb ? { webSidecarEntryRelative: MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH } : {}),
       webOutputMode: options.config.webOutputMode,
       ...(options.config.portable ? {} : { namespaceBaseRoot: options.config.roots.runtime.namespaceBaseRoot }),

--- a/tools/pack/src/win/manifest.ts
+++ b/tools/pack/src/win/manifest.ts
@@ -31,6 +31,7 @@ function createPackagedConfig(
     ...(config.posthogKey == null ? {} : { posthogKey: config.posthogKey }),
     ...(config.posthogHost == null ? {} : { posthogHost: config.posthogHost }),
     ...(config.velaWebUrl == null ? {} : { velaWebUrl: config.velaWebUrl }),
+    ...(config.velaWebUrls == null ? {} : { velaWebUrls: config.velaWebUrls }),
     webOutputMode: config.webOutputMode,
     ...(config.portable ? {} : { namespaceBaseRoot: config.roots.runtime.namespaceBaseRoot }),
   };

--- a/tools/pack/tests/config.test.ts
+++ b/tools/pack/tests/config.test.ts
@@ -8,6 +8,8 @@ const savedPosthogKey = process.env.POSTHOG_KEY;
 const savedPosthogHost = process.env.POSTHOG_HOST;
 const savedAmrProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
 const savedVelaWebUrl = process.env.OD_VELA_WEB_URL;
+const savedVelaWebUrlProd = process.env.OD_VELA_WEB_URL_PROD;
+const savedVelaWebUrlTest = process.env.OD_VELA_WEB_URL_TEST;
 
 afterEach(() => {
   if (savedVelaWebUrl == null) {
@@ -15,6 +17,10 @@ afterEach(() => {
   } else {
     process.env.OD_VELA_WEB_URL = savedVelaWebUrl;
   }
+  if (savedVelaWebUrlProd == null) delete process.env.OD_VELA_WEB_URL_PROD;
+  else process.env.OD_VELA_WEB_URL_PROD = savedVelaWebUrlProd;
+  if (savedVelaWebUrlTest == null) delete process.env.OD_VELA_WEB_URL_TEST;
+  else process.env.OD_VELA_WEB_URL_TEST = savedVelaWebUrlTest;
   if (savedTelemetryRelayUrl == null) {
     delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
   } else {
@@ -189,6 +195,16 @@ describe("resolveToolPackConfig PostHog analytics", () => {
 // secret keyed by AMR profile, exactly like POSTHOG_KEY, and flows on into
 // open-design-config.json -> the packaged daemon spawn env (OD_VELA_WEB_URL).
 describe("resolveToolPackConfig vela web origin", () => {
+  it("bakes every supplied profile origin for runtime environment switching", () => {
+    process.env.OD_VELA_WEB_URL_PROD = "https://prod.example.invalid";
+    process.env.OD_VELA_WEB_URL_TEST = "https://test.example.invalid/";
+    const config = resolveToolPackConfig("mac", { namespace: "vela-web-test" });
+    expect(config.velaWebUrls).toEqual({
+      prod: "https://prod.example.invalid",
+      test: "https://test.example.invalid",
+    });
+  });
+
   it("bakes OD_VELA_WEB_URL into packaged config when set at build time", () => {
     process.env.OD_VELA_WEB_URL = "https://vela.example.invalid";
     const config = resolveToolPackConfig("mac", { namespace: "vela-web-test" });


### PR DESCRIPTION
## Summary

- resolve the Vela console and Workspace settings origin from the AMR profile selected in app settings instead of always reusing the package's build-time origin
- make the Workspace context provider read the current configured AMR environment on every request, so profile switches affect Workspace API reads without restarting the app
- carry optional per-profile Vela console origins through packaged configuration while retaining safe public fallbacks for prod, test, and local
- fail closed when a switched profile has no trusted console origin rather than linking to the wrong environment

## Root cause

The profile switcher updated `OPEN_DESIGN_AMR_PROFILE` in app settings, which correctly changed AMR CLI and billing requests. However, console links still used the raw `OD_VELA_WEB_URL` injected by the package, and the main Workspace context provider did not receive the settings-backed AMR environment. This allowed data requests, Workspace reads, and external links to point at different environments after a switch.

## User impact

Switching between prod and test now keeps balances, Workspace context, upgrade links, and Workspace settings links on the same environment. A new app restart is not required for Workspace reads to pick up the selected profile.

## Validation

- `@open-design/daemon`: 57 focused tests passed
- `@open-design/tools-pack`: 44 focused tests passed
- `@open-design/packaged`: 56 focused tests passed
- daemon, tools-pack, and packaged typechecks passed
- `git diff --check` passed
- repository `pnpm guard` remains blocked by existing baseline issues: missing `apps/telemetry-worker/package.json` and unallowlisted vendor JavaScript under `apps/landing-page/public/enhancers`
