### PR TITLE
fix(web): restore message center close button

### DIFF
--- a/apps/web/src/components/MessageCenter.module.css
+++ b/apps/web/src/components/MessageCenter.module.css
@@ -78,6 +78,29 @@
   line-height: 1.45;
 }
 
+.close.close {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  padding: 0;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-subtle);
+  color: var(--text);
+  transition:
+    background 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.close.close:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--bg-muted);
+  color: var(--text-strong);
+}
+
+.close.close:focus-visible,
 .filter:focus-visible,
 .markAll:focus-visible,
 .syncStatus button:focus-visible,

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -248,7 +248,7 @@ export function MessageCenter({
       <Icon name="bell" size={17} />{unreadCount > 0 ? <span className={styles.badge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}
     </button>}
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
-      <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div></header>
+      <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><Button size="icon" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={18} strokeWidth={2}/></Button></header>
       <div className={styles.controls}><div className={styles.filters} role="group" aria-label={t('messageCenter.title')}>{FILTERS.map((item) => <button key={item.id} type="button" className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`} aria-pressed={filter === item.id} onClick={() => setFilter(item.id)}>{t(item.label)}{item.id === 'unread' && unreadCount > 0 ? <span className={styles.filterBadge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}</button>)}</div><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncState('error'))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
       <div className={styles.list} aria-live="polite">
         {syncState === 'error' && messages.length > 0 ? (

--- a/apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx
@@ -80,7 +80,7 @@ afterEach(() => {
 });
 
 describe('EntryNavRail message-center openers', () => {
-  it('returns focus to the account trigger when the panel closes with Escape', async () => {
+  it('returns focus to the account trigger when the panel close button is clicked', async () => {
     renderRail(teamContext());
     const accountTrigger = screen.getByTestId('entry-nav-account');
 
@@ -88,7 +88,7 @@ describe('EntryNavRail message-center openers', () => {
     fireEvent.click(screen.getByTestId('account-menu-message-center'));
     await waitFor(() => expect(screen.getByTestId('message-center-dialog')).toBeTruthy());
 
-    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.click(screen.getByRole('button', { name: '关闭消息中心' }));
 
     expect(screen.queryByTestId('message-center-dialog')).toBeNull();
     expect(document.activeElement).toBe(accountTrigger);

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -494,4 +494,15 @@ describe('MessageCenter', () => {
     expect(screen.queryByTestId('message-center-dialog')).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });
+
+  it('shows a close button and restores trigger focus when it is clicked', async () => {
+    renderMessageCenter();
+    const trigger = screen.getByTestId('message-center-trigger');
+    const dialog = await openCenter();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close message center' }));
+
+    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
 });


### PR DESCRIPTION
## Why

While checking the message center from the signed-in account entry, the panel had no visible close control in its upper-right corner. A workspace redesign removed both the close button node and its styles, leaving Escape and backdrop clicks as the only dismissal paths.

This restores the discoverable mouse, touch, and keyboard dismissal affordance and protects it from being dropped again.

## What users will see

The message center once again shows a visible close icon in its upper-right corner. Clicking it closes the panel and returns keyboard focus to the control that opened the message center.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this Draft. The regression is covered at both the message-center component boundary and the signed-in account-entry integration boundary.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/components/MessageCenter.test.tsx`
  - `apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** The red spec failed because no accessible “Close message center” button existed; it passes after restoring the control.

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/components/MessageCenter.test.tsx tests/components/EntryNavRail.message-center-entry.test.tsx --maxWorkers=1` — 25 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
