### PR TITLE
fix(web): only show artifact upsell for Cloud models

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5315,6 +5315,7 @@ function AppInner() {
       <TooltipLayer />
       <UpdateDialog />
       <AmrArtifactUpgradeGate
+        cloudModelSelected={config.mode === 'daemon' && config.agentId === 'amr'}
         homeVisible={route.kind === 'home' && route.view === 'home'}
         activeProjectId={route.kind === 'project' ? route.projectId : null}
         activeConversationId={

--- a/apps/web/src/components/AmrArtifactUpgradeGate.tsx
+++ b/apps/web/src/components/AmrArtifactUpgradeGate.tsx
@@ -14,6 +14,8 @@ import { isFreePlanTier } from '../collab/team-plan';
 import { AmrArtifactUpgradeDialog } from './AmrArtifactUpgradeDialog';
 
 interface Props {
+  /** Whether the currently selected chat model runs on Open Design Cloud. */
+  cloudModelSelected: boolean;
   /**
    * The resolved raw plan id (see `resolvePlanTier`), NOT vela's account-scoped
    * `account.plan` — a team member reads `free` there while their team holds a
@@ -70,6 +72,7 @@ function homeOfferForRoute(
 }
 
 export function AmrArtifactUpgradeGate({
+  cloudModelSelected,
   plan,
   planResolved,
   profile,
@@ -137,6 +140,7 @@ export function AmrArtifactUpgradeGate({
         !sessionKey
         || detail.source !== 'chat_send'
         || !eligibleSessionsRef.current.has(sessionKey)
+        || !cloudModelSelected
         || !planResolved
         || !isFreePlanTier(plan)
       ) {
@@ -159,7 +163,7 @@ export function AmrArtifactUpgradeGate({
     };
     window.addEventListener(AMR_ARTIFACT_UPGRADE_REQUEST_EVENT, handleRequest);
     return () => window.removeEventListener(AMR_ARTIFACT_UPGRADE_REQUEST_EVENT, handleRequest);
-  }, [plan, planResolved]);
+  }, [cloudModelSelected, plan, planResolved]);
 
   useEffect(() => {
     const pending = pendingSendRef.current;
@@ -167,7 +171,7 @@ export function AmrArtifactUpgradeGate({
 
     // Billing status can be unavailable while the Vela account remains
     // logged in. An unknown plan must never leave an intercepted Send hanging.
-    if (!planResolved || !isFreePlanTier(plan)) {
+    if (!cloudModelSelected || !planResolved || !isFreePlanTier(plan)) {
       pendingSendRef.current = null;
       pending.settle('proceed');
       return;
@@ -185,7 +189,7 @@ export function AmrArtifactUpgradeGate({
     promptedSessionsRef.current.add(pending.sessionKey);
     openRef.current = true;
     setDialogSessionKey(pending.sessionKey);
-  }, [pendingRevision, plan, planResolved]);
+  }, [cloudModelSelected, pendingRevision, plan, planResolved]);
 
   useEffect(() => {
     const previous = previousSurfaceRef.current;
@@ -210,24 +214,24 @@ export function AmrArtifactUpgradeGate({
 
   useEffect(() => {
     if (!pendingHomeOffer || !planResolved) return;
-    if (isFreePlanTier(plan) && !hasOpenModal()) {
+    if (cloudModelSelected && isFreePlanTier(plan) && !hasOpenModal()) {
       homeOfferedSessionsRef.current.add(pendingHomeOffer.sessionKey);
       promptedSessionsRef.current.add(pendingHomeOffer.sessionKey);
       onHomeOfferChange?.(pendingHomeOffer);
     }
     setPendingHomeOffer(null);
-  }, [onHomeOfferChange, pendingHomeOffer, plan, planResolved]);
+  }, [cloudModelSelected, onHomeOfferChange, pendingHomeOffer, plan, planResolved]);
 
   useEffect(() => {
-    if (!planResolved || isFreePlanTier(plan)) return;
+    if (cloudModelSelected && (!planResolved || isFreePlanTier(plan))) return;
     onHomeOfferChange?.(null);
     if (!dialogSessionKey) return;
     const pending = pendingSendRef.current;
     pendingSendRef.current = null;
-    pending?.settle('cancel');
+    pending?.settle(cloudModelSelected ? 'cancel' : 'proceed');
     openRef.current = false;
     setDialogSessionKey(null);
-  }, [dialogSessionKey, onHomeOfferChange, plan, planResolved]);
+  }, [cloudModelSelected, dialogSessionKey, onHomeOfferChange, plan, planResolved]);
 
   useEffect(() => () => {
     const pending = pendingSendRef.current;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1868,8 +1868,8 @@ export function ProjectView({
   // preflight context; they must never fall through to the Personal wallet.
   const projectRunPreflightContext =
     projectRunBillingContext ?? projectRunWorkspaceContext;
-  const projectRunRequiresWorkspaceScope =
-    config.mode === 'daemon' && config.agentId === 'amr';
+  const cloudModelSelected = config.mode === 'daemon' && config.agentId === 'amr';
+  const projectRunRequiresWorkspaceScope = cloudModelSelected;
   // An Open Design Cloud run needs a wallet, and the ONLY client-side veto is
   // "there is no billing principal at all". Either witness suffices: the
   // caller's own cloud identity, or a project scope that already names an
@@ -8106,11 +8106,7 @@ export function ProjectView({
       commentAttachments: ChatCommentAttachment[],
       meta?: ChatSendMeta,
     ): Promise<ChatSendOutcome> => {
-      if (
-        activeConversationId
-        && config.mode === 'daemon'
-        && config.agentId === 'amr'
-      ) {
+      if (activeConversationId && cloudModelSelected) {
         const decision = await requestAmrArtifactUpgrade({
           projectId: project.id,
           conversationId: activeConversationId,
@@ -8120,7 +8116,7 @@ export function ProjectView({
       }
       void handleSend(prompt, attachments, commentAttachments, meta);
     },
-    [activeConversationId, config.agentId, config.mode, handleSend, project.id],
+    [activeConversationId, cloudModelSelected, handleSend, project.id],
   );
 
   // Cancel every in-flight run for the current conversation (the user's own

--- a/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
+++ b/apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx
@@ -33,6 +33,7 @@ function requestSend(projectId = 'project-1', conversationId = 'conversation-1')
 }
 
 const BASE_PROPS = {
+  cloudModelSelected: true,
   profile: 'prod',
   metricsConsent: false,
   installationId: null,
@@ -85,6 +86,63 @@ describe('AmrArtifactUpgradeGate', () => {
 
     await expect(requestSend()).resolves.toBe('proceed');
     expect(screen.queryByTestId('amr-artifact-upgrade-dialog')).toBeNull();
+  });
+
+  it.each(['local CLI', 'BYOK'])('does not prompt when the selected model uses %s', async () => {
+    const onHomeOfferChange = vi.fn();
+    const view = render(
+      <AmrArtifactUpgradeGate
+        {...BASE_PROPS}
+        cloudModelSelected={false}
+        plan="free"
+        planResolved
+        onHomeOfferChange={onHomeOfferChange}
+      />,
+    );
+
+    act(() => publishFinishedRun());
+    await expect(requestSend()).resolves.toBe('proceed');
+    expect(screen.queryByTestId('amr-artifact-upgrade-dialog')).toBeNull();
+
+    view.rerender(
+      <AmrArtifactUpgradeGate
+        {...BASE_PROPS}
+        activeProjectId={null}
+        activeConversationId={null}
+        activeFileName={null}
+        cloudModelSelected={false}
+        homeVisible
+        plan="free"
+        planResolved
+        onHomeOfferChange={onHomeOfferChange}
+      />,
+    );
+    await waitFor(() => expect(onHomeOfferChange).toHaveBeenCalledWith(null));
+    expect(onHomeOfferChange).not.toHaveBeenCalledWith(expect.objectContaining({
+      sessionKey: JSON.stringify(['project-1', 'conversation-1']),
+    }));
+  });
+
+  it('releases a paused Send if the selected model switches away from Cloud', async () => {
+    const view = render(
+      <AmrArtifactUpgradeGate {...BASE_PROPS} plan="free" planResolved />,
+    );
+
+    act(() => publishFinishedRun());
+    const decision = requestSend();
+    await waitFor(() => expect(screen.getByTestId('amr-artifact-upgrade-dialog')).toBeTruthy());
+
+    view.rerender(
+      <AmrArtifactUpgradeGate
+        {...BASE_PROPS}
+        cloudModelSelected={false}
+        plan="free"
+        planResolved
+      />,
+    );
+
+    await expect(decision).resolves.toBe('proceed');
+    await waitFor(() => expect(screen.queryByTestId('amr-artifact-upgrade-dialog')).toBeNull());
   });
 
   it('does not prompt the same session again after the first decision', async () => {


### PR DESCRIPTION
## Why

This is a focused follow-up to #6760. While reproducing the reported upgrade prompt in the web app, we found that the artifact gate could still surface after a Cloud run even when the user's currently selected model was a local CLI or BYOK model. That interrupts local-provider workflows with an irrelevant paid-plan prompt.

The gate should follow the model selected for the current send: Open Design Cloud may show the upgrade experience, while CLI and BYOK sends must proceed without it.

## What users will see

- Local CLI and BYOK models no longer show the artifact upgrade dialog or Home upgrade offer.
- If a user switches away from Cloud while a send is paused by the dialog, the dialog closes and the send proceeds.
- The existing free-plan Cloud behavior is unchanged: eligible Cloud sessions can still show the upgrade prompt.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the reported paid-plan prompt could interrupt a local CLI/BYOK workflow. The Cloud positive-path dialog was also rechecked end to end to ensure it remains reachable.

<img width="813" height="577" alt="Reported paid-plan prompt" src="https://github.com/user-attachments/assets/d67ba41e-8c62-4231-bcd1-f8d8c8d617da" />

## Bug fix verification

- Test path: `apps/web/tests/components/AmrArtifactUpgradeGate.test.tsx`
- Red on `main`, green on this branch: yes. The new selected-model cases fail against the base behavior because the gate has no current-model guard; they pass on this branch (18/18 focused tests).
- End-to-end verification in the user's open Chrome against a local `tools-dev` service:
  - Claude CLI: generated an artifact, then sent again without an upgrade prompt.
  - Anthropic BYOK through OpenCode: sent without an upgrade prompt.
  - Free Open Design Cloud (`deepseek-v4-flash`): generated `index.html`, then showed the upgrade dialog on the next send.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/AmrArtifactUpgradeGate.test.tsx --maxWorkers=2` — 18/18 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
