### PR TITLE
fix(community): make deck remix previews reliable

### DIFF
--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -281,6 +281,25 @@ export interface RegisterPluginRoutesDeps {
   helpers: PluginRouteHelpers;
 }
 
+function duplicatedProjectKind(plugin: InstalledPluginLike): ProjectMetadata['kind'] {
+  const od = plugin.manifest?.['od'];
+  const mode = od && typeof od === 'object'
+    ? (od as { mode?: unknown }).mode
+    : null;
+  switch (mode) {
+    case 'deck':
+    case 'image':
+    case 'video':
+    case 'audio':
+    case 'brand':
+    case 'template':
+    case 'prototype':
+      return mode;
+    default:
+      return 'prototype';
+  }
+}
+
 export function registerPluginEventRoutes(app: Express, deps: RegisterPluginEventRoutesDeps): void {
   const resolveEventScope = async (req: Request, res: Response) => {
     const authority = await resolveOptionalWorkspaceRequestAuthority(
@@ -719,7 +738,11 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
       const conversationId = ids.randomId();
       cleanupProjectId = projectId;
       const metadata: ProjectMetadata = {
-        kind: 'prototype',
+        // Preserve the plugin's artifact contract. Treating every duplicate as
+        // a prototype made deck behavior depend on the copied HTML happening
+        // to match the viewer's heuristic; fixed-canvas/vertical deck examples
+        // then opened without slide chrome or a thumbnail rail.
+        kind: duplicatedProjectKind(plugin),
         templateId: `plugin:${plugin.id}`,
         templateLabel: plugin.title || plugin.id,
         duplicatedFromPluginId: plugin.id,

--- a/apps/daemon/tests/plugins-duplicate-project.test.ts
+++ b/apps/daemon/tests/plugins-duplicate-project.test.ts
@@ -205,6 +205,7 @@ describe('plugin project duplication', () => {
     const root = await makeTempRoot('od-plugin-duplicate-workspace-');
     const projectsRoot = path.join(root, 'projects');
     const plugin = await makePreviewPlugin(root, 'workspace-plugin-fixture');
+    (plugin.manifest.od as { mode?: string }).mode = 'deck';
     const projectId = 'workspace-plugin-project';
     const project = {
       id: projectId,
@@ -234,6 +235,10 @@ describe('plugin project duplication', () => {
       transactionSteps.push('workspace:bind');
       return input;
     });
+    const insertProjectMock = vi.fn(() => {
+      transactionSteps.push('project:insert');
+      return project;
+    });
     const app = express();
     app.use(express.json());
     registerPluginRoutes(app, {
@@ -249,10 +254,7 @@ describe('plugin project duplication', () => {
           .mockReturnValueOnce('workspace-plugin-conversation'),
       },
       projectStore: {
-        insertProject: vi.fn(() => {
-          transactionSteps.push('project:insert');
-          return project;
-        }),
+        insertProject: insertProjectMock,
         getProject: vi.fn(() => project),
         ensureWorkspaceProject,
         dbDeleteProject: vi.fn(),
@@ -298,6 +300,12 @@ describe('plugin project duplication', () => {
         },
       );
       expect(resp.status).toBe(201);
+      expect(insertProjectMock).toHaveBeenCalledWith(
+        db,
+        expect.objectContaining({
+          metadata: expect.objectContaining({ kind: 'deck' }),
+        }),
+      );
       expect(ensureWorkspaceProject).toHaveBeenCalledWith(
         db,
         expect.objectContaining({

--- a/apps/web/src/components/CommunityView.tsx
+++ b/apps/web/src/components/CommunityView.tsx
@@ -5,15 +5,14 @@ import { useI18n } from '../i18n';
 import { listPlugins } from '../state/projects';
 import {
   buildCommunityTemplates,
-  copyTemplatePrompt,
   isPromptArtifact,
-  templateActionLabel,
   TEMPLATE_TYPE_LABEL_KEY,
   TEMPLATE_TYPE_ORDER,
   type TemplateDemo,
   type TemplateType,
 } from './CommunityTemplatePreview';
 import { MediaSurface } from './plugins-home/cards/MediaSurface';
+import { canDuplicatePluginPreview } from './plugins-home/duplicate';
 import { PluginDetailsModal } from './PluginDetailsModal';
 import type { PluginUseAction } from './plugins-home/useActions';
 import { useInView } from './plugins-home/useInView';
@@ -102,9 +101,9 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
   const [detailsRecord, setDetailsRecord] = useState<InstalledPluginRecord | null>(null);
   const [activeType, setActiveType] = useState<TemplateType>('Slides');
   const [activeSubtype, setActiveSubtype] = useState('All');
-  // Remix (and the prompt-artifact copy path it shares) hands off to a
-  // fire-and-forget parent callback (`onRemixTemplate`/`onUsePrompt` return
-  // void) that kicks off a real POST /api/projects — nothing here observes
+  // Remix hands off to a fire-and-forget parent callback
+  // (`onRemixTemplate` returns void) that kicks off a real POST /api/projects
+  // — nothing here observes
   // when it settles. Without a guard, N rapid clicks before the resulting
   // navigation actually leaves this view fired N separate creates,
   // duplicating the project N times ("Community 的模板 remix 点击多次会复制
@@ -147,6 +146,10 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
     () => buildCommunityTemplates(plugins, locale, t, workspaceContext),
     [plugins, locale, t, workspaceContext],
   );
+  const pluginById = useMemo(
+    () => new Map(plugins.map((record) => [record.id, record])),
+    [plugins],
+  );
   const typeOptions = TEMPLATE_TYPE_ORDER.filter((type) =>
     templates.some((template) => template.type === type),
   );
@@ -165,19 +168,6 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
     return sourceKind === 'bundled' || sourceKind === 'marketplace' ? 'official' as const : 'personal' as const;
   };
   const handleTemplateAction = (template: TemplateDemo) => {
-    if (isPromptArtifact(template)) {
-      trackCommunityTemplateClick(analytics.track, {
-        page_name: 'community',
-        area: 'community_templates',
-        element: 'copy_prompt',
-        template_key: template.id,
-        template_type: template.type,
-        resource_scope: templateScope(template.id),
-        ...workspaceDimensions,
-      });
-      void copyTemplatePrompt(template);
-      return;
-    }
     // Synchronous check-and-set on the ref: this is what actually decides
     // whether a request goes out. See the remixingIdRef comment above for
     // why the state flag alone cannot gate this.
@@ -194,6 +184,28 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
     remixingIdRef.current = template.id;
     setRemixingId(template.id);
     onRemixTemplate?.({ templateId: template.id, prompt: template.prompt });
+  };
+  const handleCardUse = (template: TemplateDemo) => {
+    const target = templateUseTarget(template);
+    trackCommunityTemplateClick(analytics.track, {
+      page_name: 'community',
+      area: 'community_templates',
+      element: 'use_prompt',
+      template_key: template.id,
+      template_type: template.type,
+      resource_scope: templateScope(template.id),
+      ...workspaceDimensions,
+    });
+    const record = pluginById.get(template.id);
+    if (record && onUsePlugin) {
+      onUsePlugin(record, 'use-with-query', target);
+      return;
+    }
+    onUsePrompt?.(target);
+  };
+  const canRemixTemplate = (template: TemplateDemo) => {
+    const record = pluginById.get(template.id);
+    return !isPromptArtifact(template) && Boolean(record && canDuplicatePluginPreview(record));
   };
   const templateById = useCallback(
     (id: string) => templates.find((template) => template.id === id) ?? null,
@@ -217,7 +229,7 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
   /** The detail modal's Use split action. Shells that own a Home hand-off
    *  route the plugin as the composer's active driver; without one, fall back
    *  to seeding the composer with the template's prompt (same destination the
-   *  card's own prompt button uses). */
+   *  card's own Use button uses). */
   const handleDetailsUse = (record: InstalledPluginRecord, action: PluginUseAction) => {
     setDetailsRecord(null);
     const template = templateById(record.id);
@@ -330,7 +342,7 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
             onClick={() => openTemplateDetails(template)}
           >
             <div
-              className="community-template-card__preview"
+              className={`community-template-card__preview${template.type === 'Slides' ? ' is-deck' : ''}`}
               style={{ '--template-accent': template.accent } as CSSProperties}
               aria-hidden
             >
@@ -339,34 +351,27 @@ export function CommunityView({ onRemixTemplate, onUsePrompt, onUsePlugin }: Com
             <footer className="community-template-card__foot">
               <span>{template.meta}</span>
               <div className="community-template-card__actions">
-                <button
-                  type="button"
-                  disabled={remixingId === template.id}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleTemplateAction(template);
-                  }}
-                >
-                  {remixingId === template.id ? t('common.loading') : templateActionLabel(template)}
-                </button>
+                {canRemixTemplate(template) ? (
+                  <button
+                    type="button"
+                    disabled={remixingId === template.id}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleTemplateAction(template);
+                    }}
+                  >
+                    {remixingId === template.id ? t('common.loading') : 'Remix'}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="community-template-card__prompt-btn"
                   onClick={(event) => {
                     event.stopPropagation();
-                    trackCommunityTemplateClick(analytics.track, {
-                      page_name: 'community',
-                      area: 'community_templates',
-                      element: 'use_prompt',
-                      template_key: template.id,
-                      template_type: template.type,
-                      resource_scope: templateScope(template.id),
-                      ...workspaceDimensions,
-                    });
-                    onUsePrompt?.(templateUseTarget(template));
+                    handleCardUse(template);
                   }}
                 >
-                  {t('community.usePrompt')}
+                  {t('pluginCard.use')}
                 </button>
               </div>
             </footer>

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -44,7 +44,7 @@ export interface ParsedDeckThumbnails {
   reason?: DeckThumbnailFallbackReason;
   /** `outerHTML` of each slide, in document order. */
   slides: string[];
-  /** Concatenated deck stylesheets, `:root`/`html`/`body` rewritten to `:host`,
+  /** Concatenated deck stylesheets, root selectors rewritten for shadow DOM,
    *  `@font-face` stripped (see `fontFaces`), relative `url()` absolutized. */
   styleText: string;
   /** `@font-face` blocks lifted out of `styleText` — must live in the host
@@ -240,8 +240,23 @@ interface DesignSize {
 // Design canvas size (viewport-unit decks are already excluded upstream):
 // explicit `<deck-stage width height>`, then an explicit px `width`+`height` on
 // a stage/slide rule, else the 1920×1080 default.
-const STAGE_SIZE_SELECTOR_RE =
-  /(?:\bdeck-stage\b|\.deck-stage\b|\.canvas\b|#deck\b|\.deck\b|\.slide\b|\.ppt-slide\b|\.deck-slide\b|\[data-screen-label\])/i;
+const STAGE_SIZE_TARGET_RE =
+  /(?:^|[^\w-])(?:deck-stage|\.deck-stage|\.canvas|#deck|\.deck|\.slide|\.ppt-slide|\.deck-slide|\[data-screen-label(?:[\s~|^$*]?=[^\]]+)?\])(?![\w-])/i;
+
+// A size declaration only describes the design canvas when the rule's TARGET
+// is a stage/slide. Merely mentioning `.slide` in an ancestor is insufficient:
+// real decks commonly contain rules such as `.slide .kicker-line { width:72px;
+// height:6px }`. Treating that decoration as the canvas collapses the whole
+// thumbnail into a 72x6 strip.
+function selectorTargetsStageOrSlide(selectorList: string): boolean {
+  return selectorList.split(',').some((selector) => {
+    const trimmed = selector.trim();
+    if (!trimmed || /::(?:before|after)\b/i.test(trimmed)) return false;
+    const compounds = trimmed.split(/\s+|[>+~]/).filter(Boolean);
+    const target = compounds.at(-1) ?? '';
+    return STAGE_SIZE_TARGET_RE.test(target);
+  });
+}
 
 function resolveDesignSize(doc: Document, css: string): DesignSize {
   const stage = doc.querySelector('deck-stage[width][height]');
@@ -254,7 +269,7 @@ function resolveDesignSize(doc: Document, css: string): DesignSize {
   }
 
   for (const block of iterateRuleBlocks(css)) {
-    if (!STAGE_SIZE_SELECTOR_RE.test(block.selector)) continue;
+    if (!selectorTargetsStageOrSlide(block.selector)) continue;
     const width = matchPxLength(block.body, 'width');
     const height = matchPxLength(block.body, 'height');
     if (width && height) return { width, height };
@@ -296,13 +311,19 @@ function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-// Rewrite `:root`, `html`, and `body` (as standalone selectors in a selector
-// list) to `:host`, so the deck's custom properties, base font, and base color
-// land on the shadow host and inherit into the re-parented slide. Compound
-// selectors like `body.dark` are left untouched (they'd match nothing, but
-// forcing them onto `:host` risks unwanted rules).
+// Rewrite `:root`/`html` to `:host`, so document-level variables inherit into
+// the reconstructed slide. Body rules belong on the design canvas itself: host
+// page styles intentionally own the shadow host's dark thumbnail frame and win
+// over ordinary `:host` declarations, which used to hide transparent slides on
+// that dark frame. Applying body paint/layout to `.od-thumb-canvas` preserves
+// the source deck's paper/background inside the frame. Compound selectors like
+// `body.dark` are left untouched.
 function rewriteRootSelectors(css: string): string {
-  return css.replace(/(^|[{};,])(\s*)(:root|html|body)(\s*)(?=[,{])/g, '$1$2:host$4');
+  return css.replace(
+    /(^|[{};,])(\s*)(:root|html|body)(\s*)(?=[,{])/g,
+    (_whole, prefix: string, whitespace: string, selector: string, trailing: string) =>
+      `${prefix}${whitespace}${selector.toLowerCase() === 'body' ? '.od-thumb-canvas' : ':host'}${trailing}`,
+  );
 }
 
 // Lift `@font-face` blocks out; they're ignored inside a shadow root and must be

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -241,7 +241,7 @@ interface DesignSize {
 // explicit `<deck-stage width height>`, then an explicit px `width`+`height` on
 // a stage/slide rule, else the 1920×1080 default.
 const STAGE_SIZE_TARGET_RE =
-  /(?:^|[^\w-])(?:deck-stage|\.deck-stage|\.canvas|#deck|\.deck|\.slide|\.ppt-slide|\.deck-slide|\[data-screen-label(?:[\s~|^$*]?=[^\]]+)?\])(?![\w-])/i;
+  /(?:^|[^\w-])deck-stage(?![\w-])|(?:\.deck-stage|\.canvas|#deck|\.deck|\.slide|\.ppt-slide|\.deck-slide|\[data-screen-label(?:[\s~|^$*]?=[^\]]+)?\])(?![\w-])/i;
 
 // A size declaration only describes the design canvas when the rule's TARGET
 // is a stage/slide. Merely mentioning `.slide` in an ancestor is insufficient:

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -241,7 +241,7 @@ interface DesignSize {
 // explicit `<deck-stage width height>`, then an explicit px `width`+`height` on
 // a stage/slide rule, else the 1920×1080 default.
 const STAGE_SIZE_TARGET_RE =
-  /(?:^|[^\w-])deck-stage(?![\w-])|(?:\.deck-stage|\.canvas|#deck|\.deck|\.slide|\.ppt-slide|\.deck-slide|\[data-screen-label(?:[\s~|^$*]?=[^\]]+)?\])(?![\w-])/i;
+  /(?:^|[^\w-])deck-stage(?![\w-])|(?:\.deck-stage|\.canvas|#deck|\.deck|\.slide|\.slide-frame|\.ppt-slide|\.deck-slide|\[data-screen-label(?:[\s~|^$*]?=[^\]]+)?\])(?![\w-])/i;
 
 // A size declaration only describes the design canvas when the rule's TARGET
 // is a stage/slide. Merely mentioning `.slide` in an ancestor is insufficient:

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3033,7 +3033,21 @@ function injectDeckBridge(
     add(document.body);
     return targets;
   }
-  function maxScrollOffset(axis){
+  function nestedScrollTargets(list){
+    var targets = [];
+    if (!list || !list.length) return targets;
+    var node = list[0] && list[0].parentElement;
+    while (node && !isRootScrollContainer(node)) {
+      var containsAll = true;
+      for (var i=1; i<list.length; i++) {
+        if (!node.contains(list[i])) { containsAll = false; break; }
+      }
+      if (containsAll) targets.push(node);
+      node = node.parentElement;
+    }
+    return targets;
+  }
+  function maxRootScrollOffset(axis){
     var targets = scrollTargets();
     var value = axis === 'y'
       ? Number(window.scrollY || window.pageYOffset || 0)
@@ -3043,30 +3057,35 @@ function injectDeckBridge(
     }
     return value;
   }
-  function hasHorizontalScroll(){
-    var targets = scrollTargets();
-    for (var i=0; i<targets.length; i++) {
-      if (targets[i].scrollWidth > targets[i].clientWidth + 1) return true;
-    }
-    return false;
-  }
-  function scrollDeckAxis(){
-    var targets = scrollTargets();
+  function scrollDeckTarget(list){
     var axes = ['x', 'y'];
+    var nested = nestedScrollTargets(list);
+    for (var n=0; n<nested.length; n++) {
+      for (var a=0; a<axes.length; a++) {
+        var nestedAxis = axes[a];
+        if (scrollOverflow(nested[n], nestedAxis) <= 1) continue;
+        if (isScrollableOverflowMode(overflowMode(nested[n], nestedAxis))) {
+          return { axis: nestedAxis, element: nested[n], root: false };
+        }
+      }
+    }
+    var targets = scrollTargets();
     for (var a=0; a<axes.length; a++) {
       var axis = axes[a];
       for (var i=0; i<targets.length; i++) {
         var candidate = targets[i];
         if (scrollOverflow(candidate, axis) <= 1) continue;
         var mode = overflowMode(candidate, axis);
-        if (isScrollableOverflowMode(mode)) return axis;
-        if (isRootScrollContainer(candidate) && !isClippedOverflowMode(mode) && !rootScrollerClipped(axis)) return axis;
+        if (isScrollableOverflowMode(mode)) return { axis: axis, element: candidate, root: true };
+        if (!isClippedOverflowMode(mode) && !rootScrollerClipped(axis)) {
+          return { axis: axis, element: candidate, root: true };
+        }
       }
     }
-    return '';
+    return null;
   }
-  function isScrollDeck(){
-    return !!scrollDeckAxis();
+  function isScrollDeck(list){
+    return !!scrollDeckTarget(list || slides());
   }
   function findActiveByClass(list){
     for (var i=0; i<list.length; i++) {
@@ -3084,7 +3103,15 @@ function injectDeckBridge(
     }
     return -1;
   }
-  function activeIndexFromScrollRects(list, axis){
+  function activeIndexFromScrollRects(list, scrollTarget){
+    var axis = scrollTarget.axis;
+    var origin = 0;
+    if (!scrollTarget.root) {
+      try {
+        var containerRect = scrollTarget.element.getBoundingClientRect();
+        origin = Number(axis === 'y' ? containerRect.top : containerRect.left) || 0;
+      } catch (_) {}
+    }
     var best = -1;
     var distance = Infinity;
     var firstPosition = null;
@@ -3092,7 +3119,7 @@ function injectDeckBridge(
     for (var i=0; i<list.length; i++) {
       try {
         var rect = list[i].getBoundingClientRect();
-        var position = Number(axis === 'y' ? rect.top : rect.left) || 0;
+        var position = (Number(axis === 'y' ? rect.top : rect.left) || 0) - origin;
         if (firstPosition === null) firstPosition = position;
         else if (Math.abs(position - firstPosition) > 1) hasDistinctPosition = true;
         var value = Math.abs(position);
@@ -3107,12 +3134,18 @@ function injectDeckBridge(
     if (forcedScrollPageIndex >= 0) {
       return Math.max(0, Math.min(list.length - 1, forcedScrollPageIndex));
     }
-    var axis = scrollDeckAxis();
-    if (axis) {
-      var byRect = activeIndexFromScrollRects(list, axis);
+    var scrollTarget = scrollDeckTarget(list);
+    if (scrollTarget) {
+      var byRect = activeIndexFromScrollRects(list, scrollTarget);
       if (byRect >= 0) return byRect;
-      var span = Math.max(1, axis === 'y' ? window.innerHeight : window.innerWidth);
-      return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollOffset(axis) / span)));
+      var axis = scrollTarget.axis;
+      var span = Math.max(1, scrollTarget.root
+        ? (axis === 'y' ? window.innerHeight : window.innerWidth)
+        : (axis === 'y' ? scrollTarget.element.clientHeight : scrollTarget.element.clientWidth));
+      var offset = scrollTarget.root
+        ? maxRootScrollOffset(axis)
+        : scrollOffsetOf(scrollTarget.element, axis);
+      return Math.max(0, Math.min(list.length - 1, Math.round(offset / span)));
     }
     var byDeckStage = activeIndexFromDeckStage(list);
     if (byDeckStage >= 0) return byDeckStage;
@@ -3292,7 +3325,7 @@ function injectDeckBridge(
     report();
     return true;
   }
-  function forceScrollDeckPage(list, target){
+  function forceScrollDeckPage(list, target, scrollTarget){
     forcedScrollPageIndex = target;
     var activeClass = activeClassName(list);
     for (var i=0; i<list.length; i++) {
@@ -3312,38 +3345,68 @@ function injectDeckBridge(
     for (var r=0; r<roots.length; r++) {
       try { roots[r].scrollLeft = 0; roots[r].scrollTop = 0; } catch (_) {}
     }
+    if (scrollTarget && !scrollTarget.root) {
+      try { scrollTarget.element.scrollLeft = 0; scrollTarget.element.scrollTop = 0; } catch (_) {}
+    }
     updateDeckChrome(target, list.length);
     report(target);
   }
   function scrollGo(i){
     var list = slides();
     var next = Math.max(0, Math.min(list.length - 1, i));
-    var axis = scrollDeckAxis() || 'x';
-    var offset = next * (axis === 'y' ? window.innerHeight : window.innerWidth);
+    var scrollTarget = scrollDeckTarget(list);
+    if (!scrollTarget) return;
+    var axis = scrollTarget.axis;
+    var span = Math.max(1, scrollTarget.root
+      ? (axis === 'y' ? window.innerHeight : window.innerWidth)
+      : (axis === 'y' ? scrollTarget.element.clientHeight : scrollTarget.element.clientWidth));
+    var offset = next * span;
+    try {
+      var firstRect = list[0].getBoundingClientRect();
+      var targetRect = list[next].getBoundingClientRect();
+      var firstPosition = Number(axis === 'y' ? firstRect.top : firstRect.left) || 0;
+      var targetPosition = Number(axis === 'y' ? targetRect.top : targetRect.left) || 0;
+      if (Math.abs(targetPosition - firstPosition) > 1) {
+        var current = scrollTarget.root
+          ? maxRootScrollOffset(axis)
+          : scrollOffsetOf(scrollTarget.element, axis);
+        var containerOrigin = 0;
+        if (!scrollTarget.root) {
+          var containerRect = scrollTarget.element.getBoundingClientRect();
+          containerOrigin = Number(axis === 'y' ? containerRect.top : containerRect.left) || 0;
+        }
+        offset = current + targetPosition - containerOrigin;
+      }
+    } catch (_) {}
     var position = axis === 'y'
       ? { top: offset, behavior: 'smooth' }
       : { left: offset, behavior: 'smooth' };
-    // Root scrolling is browser-special: setting scrollLeft/scrollTop on body
-    // or documentElement is not reliable when body owns overflow (common in
-    // horizontally paged decks). Drive the viewport as well as both root
-    // elements. This also makes vertically stacked/scrolling deck templates
-    // navigable through the same thumbnail rail.
-    try {
-      list[next].scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' });
-    } catch (_) {}
-    try {
-      window.scrollTo(position);
-    } catch (_) {
-      try { window.scrollTo(axis === 'y' ? 0 : offset, axis === 'y' ? offset : 0); } catch (__) {}
-    }
-    var targets = scrollTargets();
-    for (var t=0; t<targets.length; t++) {
+    if (scrollTarget.root) {
+      // Root scrolling is browser-special: setting scrollLeft/scrollTop on
+      // body or documentElement is not reliable when body owns overflow.
       try {
-        targets[t].scrollTo(position);
+        window.scrollTo(position);
+      } catch (_) {
+        try { window.scrollTo(axis === 'y' ? 0 : offset, axis === 'y' ? offset : 0); } catch (__) {}
+      }
+      var targets = scrollTargets();
+      for (var t=0; t<targets.length; t++) {
+        try {
+          targets[t].scrollTo(position);
+        } catch (_) {
+          try {
+            if (axis === 'y') targets[t].scrollTop = offset;
+            else targets[t].scrollLeft = offset;
+          } catch (__) {}
+        }
+      }
+    } else {
+      try {
+        scrollTarget.element.scrollTo(position);
       } catch (_) {
         try {
-          if (axis === 'y') targets[t].scrollTop = offset;
-          else targets[t].scrollLeft = offset;
+          if (axis === 'y') scrollTarget.element.scrollTop = offset;
+          else scrollTarget.element.scrollLeft = offset;
         } catch (__) {}
       }
     }
@@ -3359,7 +3422,7 @@ function injectDeckBridge(
       // but ignore every root scrolling API. Fall back to a single-visible-page
       // presentation so Remix never leaves the main canvas on page one while
       // the host rail claims another page is active.
-      forceScrollDeckPage(list, next);
+      forceScrollDeckPage(list, next, scrollTarget);
     }, 420);
   }
   function targetFor(action, list){
@@ -3484,7 +3547,7 @@ function injectDeckBridge(
     var list = slides();
     if (!list.length) return;
     if (navigateViaDeckStage(list, action)) return;
-    if (isScrollDeck()) {
+    if (isScrollDeck(list)) {
       scrollGo(Math.max(0, Math.min(list.length - 1, targetFor(action, list))));
       return;
     }
@@ -3505,7 +3568,7 @@ function injectDeckBridge(
     if (!list.length) return;
     var target = Math.max(0, Math.min(list.length - 1, i));
     if (navigateViaDeckStage(list, 'go', target)) return;
-    if (isScrollDeck()) { scrollGo(target); return; }
+    if (isScrollDeck(list)) { scrollGo(target); return; }
     if (activeIndex(list) === target) { report(); return; }
     stepToIndexViaKeys(target, function(stepped){
       if (stepped) { report(); return; }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3057,8 +3057,27 @@ function injectDeckBridge(
     }
     return value;
   }
+  function deckAxisOrder(list){
+    var minX = Infinity;
+    var maxX = -Infinity;
+    var minY = Infinity;
+    var maxY = -Infinity;
+    for (var i=0; list && i<list.length; i++) {
+      try {
+        var rect = list[i].getBoundingClientRect();
+        var x = Number(rect.left);
+        var y = Number(rect.top);
+        if (Number.isFinite(x)) { minX = Math.min(minX, x); maxX = Math.max(maxX, x); }
+        if (Number.isFinite(y)) { minY = Math.min(minY, y); maxY = Math.max(maxY, y); }
+      } catch (_) {}
+    }
+    var xSpan = Number.isFinite(minX) && Number.isFinite(maxX) ? maxX - minX : 0;
+    var ySpan = Number.isFinite(minY) && Number.isFinite(maxY) ? maxY - minY : 0;
+    if (ySpan > 1 && ySpan > xSpan) return ['y', 'x'];
+    return ['x', 'y'];
+  }
   function scrollDeckTarget(list){
-    var axes = ['x', 'y'];
+    var axes = deckAxisOrder(list);
     var nested = nestedScrollTargets(list);
     for (var n=0; n<nested.length; n++) {
       for (var a=0; a<axes.length; a++) {

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3340,12 +3340,13 @@ function injectDeckBridge(
         if (i === target) list[i].classList.add(activeClass);
       }
     }
-    try { window.scrollTo(0, 0); } catch (_) {}
-    var roots = scrollTargets();
-    for (var r=0; r<roots.length; r++) {
-      try { roots[r].scrollLeft = 0; roots[r].scrollTop = 0; } catch (_) {}
-    }
-    if (scrollTarget && !scrollTarget.root) {
+    if (!scrollTarget || scrollTarget.root) {
+      try { window.scrollTo(0, 0); } catch (_) {}
+      var roots = scrollTargets();
+      for (var r=0; r<roots.length; r++) {
+        try { roots[r].scrollLeft = 0; roots[r].scrollTop = 0; } catch (_) {}
+      }
+    } else {
       try { scrollTarget.element.scrollLeft = 0; scrollTarget.element.scrollTop = 0; } catch (_) {}
     }
     updateDeckChrome(target, list.length);

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2981,14 +2981,17 @@ function injectDeckBridge(
       return false;
     }
   }
-  function scrollOverflow(el){
+  function scrollOverflow(el, axis){
     if (!el) return 0;
-    return Math.max(0, (el.scrollWidth || 0) - (el.clientWidth || 0));
+    return axis === 'y'
+      ? Math.max(0, (el.scrollHeight || 0) - (el.clientHeight || 0))
+      : Math.max(0, (el.scrollWidth || 0) - (el.clientWidth || 0));
   }
-  function overflowMode(el){
+  function overflowMode(el, axis){
     if (!el || !window.getComputedStyle) return '';
     try {
-      return String(window.getComputedStyle(el).overflowX || '').toLowerCase();
+      var style = window.getComputedStyle(el);
+      return String(axis === 'y' ? style.overflowY : style.overflowX || '').toLowerCase();
     } catch (_) {
       return '';
     }
@@ -3006,14 +3009,14 @@ function injectDeckBridge(
       el === document.body
     );
   }
-  function rootScrollerClipped(){
-    return isClippedOverflowMode(overflowMode(document.documentElement)) ||
-      isClippedOverflowMode(overflowMode(document.body));
+  function rootScrollerClipped(axis){
+    return isClippedOverflowMode(overflowMode(document.documentElement, axis)) ||
+      isClippedOverflowMode(overflowMode(document.body, axis));
   }
-  function scrollLeftOf(el){
+  function scrollOffsetOf(el, axis){
     if (!el) return 0;
     try {
-      return Number(el.scrollLeft) || 0;
+      return Number(axis === 'y' ? el.scrollTop : el.scrollLeft) || 0;
     } catch (_) {
       return 0;
     }
@@ -3030,11 +3033,13 @@ function injectDeckBridge(
     add(document.body);
     return targets;
   }
-  function maxScrollLeft(){
+  function maxScrollOffset(axis){
     var targets = scrollTargets();
-    var value = 0;
+    var value = axis === 'y'
+      ? Number(window.scrollY || window.pageYOffset || 0)
+      : Number(window.scrollX || window.pageXOffset || 0);
     for (var i=0; i<targets.length; i++) {
-      value = Math.max(value, Number(targets[i].scrollLeft || 0));
+      value = Math.max(value, scrollOffsetOf(targets[i], axis));
     }
     return value;
   }
@@ -3045,16 +3050,23 @@ function injectDeckBridge(
     }
     return false;
   }
-  function isScrollDeck(){
+  function scrollDeckAxis(){
     var targets = scrollTargets();
-    for (var i=0; i<targets.length; i++) {
-      var candidate = targets[i];
-      if (scrollOverflow(candidate) <= 1) continue;
-      var mode = overflowMode(candidate);
-      if (isScrollableOverflowMode(mode)) return true;
-      if (isRootScrollContainer(candidate) && !isClippedOverflowMode(mode) && !rootScrollerClipped()) return true;
+    var axes = ['x', 'y'];
+    for (var a=0; a<axes.length; a++) {
+      var axis = axes[a];
+      for (var i=0; i<targets.length; i++) {
+        var candidate = targets[i];
+        if (scrollOverflow(candidate, axis) <= 1) continue;
+        var mode = overflowMode(candidate, axis);
+        if (isScrollableOverflowMode(mode)) return axis;
+        if (isRootScrollContainer(candidate) && !isClippedOverflowMode(mode) && !rootScrollerClipped(axis)) return axis;
+      }
     }
-    return false;
+    return '';
+  }
+  function isScrollDeck(){
+    return !!scrollDeckAxis();
   }
   function findActiveByClass(list){
     for (var i=0; i<list.length; i++) {
@@ -3072,11 +3084,35 @@ function injectDeckBridge(
     }
     return -1;
   }
+  function activeIndexFromScrollRects(list, axis){
+    var best = -1;
+    var distance = Infinity;
+    var firstPosition = null;
+    var hasDistinctPosition = false;
+    for (var i=0; i<list.length; i++) {
+      try {
+        var rect = list[i].getBoundingClientRect();
+        var position = Number(axis === 'y' ? rect.top : rect.left) || 0;
+        if (firstPosition === null) firstPosition = position;
+        else if (Math.abs(position - firstPosition) > 1) hasDistinctPosition = true;
+        var value = Math.abs(position);
+        if (value < distance) { distance = value; best = i; }
+      } catch (_) {}
+    }
+    return hasDistinctPosition ? best : -1;
+  }
+  var forcedScrollPageIndex = -1;
   function activeIndex(list){
     if (!list || !list.length) return 0;
-    if (isScrollDeck()) {
-      var w = Math.max(1, window.innerWidth);
-      return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollLeft() / w)));
+    if (forcedScrollPageIndex >= 0) {
+      return Math.max(0, Math.min(list.length - 1, forcedScrollPageIndex));
+    }
+    var axis = scrollDeckAxis();
+    if (axis) {
+      var byRect = activeIndexFromScrollRects(list, axis);
+      if (byRect >= 0) return byRect;
+      var span = Math.max(1, axis === 'y' ? window.innerHeight : window.innerWidth);
+      return Math.max(0, Math.min(list.length - 1, Math.round(maxScrollOffset(axis) / span)));
     }
     var byDeckStage = activeIndexFromDeckStage(list);
     if (byDeckStage >= 0) return byDeckStage;
@@ -3193,10 +3229,22 @@ function injectDeckBridge(
   function updateDeckChrome(i, count){
     var cur = document.getElementById('deck-cur');
     var total = document.getElementById('deck-total');
+    var simpleCounter = document.getElementById('counter');
+    var simpleCounterParts = simpleCounter ? String(simpleCounter.textContent || '').split('/') : [];
     var prev = document.getElementById('deck-prev');
     var next = document.getElementById('deck-next');
     if (cur) cur.textContent = pad2(i + 1);
     if (total) total.textContent = pad2(count);
+    if (
+      simpleCounter &&
+      simpleCounterParts.length === 2 &&
+      simpleCounterParts[0].trim() !== '' &&
+      simpleCounterParts[1].trim() !== '' &&
+      Number.isFinite(Number(simpleCounterParts[0])) &&
+      Number.isFinite(Number(simpleCounterParts[1]))
+    ) {
+      simpleCounter.textContent = (i + 1) + ' / ' + count;
+    }
     if (prev) prev.toggleAttribute('disabled', i <= 0);
     if (next) next.toggleAttribute('disabled', i >= count - 1);
   }
@@ -3204,6 +3252,7 @@ function injectDeckBridge(
     var list = slides();
     if (!list.length) return false;
     var target = Math.max(0, Math.min(list.length - 1, i));
+    if (forcedScrollPageIndex >= 0) forcedScrollPageIndex = target;
     var activeClass = activeClassName(list);
     var usesInlineDisplay = false;
     var usesInlineVisibility = false;
@@ -3243,19 +3292,75 @@ function injectDeckBridge(
     report();
     return true;
   }
+  function forceScrollDeckPage(list, target){
+    forcedScrollPageIndex = target;
+    var activeClass = activeClassName(list);
+    for (var i=0; i<list.length; i++) {
+      if (!list[i].hasAttribute('data-od-scroll-original-display')) {
+        list[i].setAttribute('data-od-scroll-original-display', list[i].style.display || '');
+      }
+      list[i].style.display = i === target
+        ? (list[i].getAttribute('data-od-scroll-original-display') || '')
+        : 'none';
+      if (list[i].classList) {
+        list[i].classList.remove('active', 'is-active', 'current');
+        if (i === target) list[i].classList.add(activeClass);
+      }
+    }
+    try { window.scrollTo(0, 0); } catch (_) {}
+    var roots = scrollTargets();
+    for (var r=0; r<roots.length; r++) {
+      try { roots[r].scrollLeft = 0; roots[r].scrollTop = 0; } catch (_) {}
+    }
+    updateDeckChrome(target, list.length);
+    report(target);
+  }
   function scrollGo(i){
     var list = slides();
     var next = Math.max(0, Math.min(list.length - 1, i));
-    var left = next * window.innerWidth;
+    var axis = scrollDeckAxis() || 'x';
+    var offset = next * (axis === 'y' ? window.innerHeight : window.innerWidth);
+    var position = axis === 'y'
+      ? { top: offset, behavior: 'smooth' }
+      : { left: offset, behavior: 'smooth' };
+    // Root scrolling is browser-special: setting scrollLeft/scrollTop on body
+    // or documentElement is not reliable when body owns overflow (common in
+    // horizontally paged decks). Drive the viewport as well as both root
+    // elements. This also makes vertically stacked/scrolling deck templates
+    // navigable through the same thumbnail rail.
+    try {
+      list[next].scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'start' });
+    } catch (_) {}
+    try {
+      window.scrollTo(position);
+    } catch (_) {
+      try { window.scrollTo(axis === 'y' ? 0 : offset, axis === 'y' ? offset : 0); } catch (__) {}
+    }
     var targets = scrollTargets();
     for (var t=0; t<targets.length; t++) {
       try {
-        targets[t].scrollTo({ left: left, behavior: 'smooth' });
+        targets[t].scrollTo(position);
       } catch (_) {
-        try { targets[t].scrollLeft = left; } catch (__) {}
+        try {
+          if (axis === 'y') targets[t].scrollTop = offset;
+          else targets[t].scrollLeft = offset;
+        } catch (__) {}
       }
     }
-    setTimeout(report, 380);
+    // A body-owned scroller can visually move while its offset remains absent
+    // from document.scrollingElement (notably in sandboxed iframes). Preserve
+    // the requested index for the host state instead of immediately snapping
+    // the rail back to page one; ordinary scroll events still call report()
+    // without an override and track subsequent manual movement.
+    report(next);
+    setTimeout(function(){
+      if (activeIndex(list) === next) { report(); return; }
+      // Some sandboxed Chromium documents expose a wide/tall root scrollWidth
+      // but ignore every root scrolling API. Fall back to a single-visible-page
+      // presentation so Remix never leaves the main canvas on page one while
+      // the host rail claims another page is active.
+      forceScrollDeckPage(list, next);
+    }, 420);
   }
   function targetFor(action, list){
     var i = activeIndex(list);
@@ -3453,10 +3558,13 @@ function injectDeckBridge(
     }, true);
   }
   var lastCommentTargetSlideIndex = -1;
-  function report(){
+  function report(forcedIndex){
     try {
       var list = slides();
-      var i = activeIndex(list);
+      var measured = activeIndex(list);
+      var i = Number.isFinite(forcedIndex)
+        ? Math.max(0, Math.min(list.length - 1, Math.floor(forcedIndex)))
+        : measured;
       var count = list.length;
       var progressWidth = count ? ((i + 1) / count * 100) + '%' : '0';
       updateDeckChrome(i, count);

--- a/apps/web/src/styles/home/plugin-marketplace-demo.css
+++ b/apps/web/src/styles/home/plugin-marketplace-demo.css
@@ -1510,6 +1510,15 @@
   user-select: none;
 }
 
+/* Deck bakes are 16:9. Centre legacy 1.31-aspect bakes while the versioned
+   preview pipeline replaces them, so any captured outer canvas is cropped
+   symmetrically instead of leaving a thick black strip along one edge. */
+.community-template-card__preview.is-deck .community-template-thumb__image,
+.community-template-card__preview.is-deck .plugins-home__media-img,
+.community-template-card__preview.is-deck .plugins-home__media-video {
+  object-position: center;
+}
+
 .community-template-card__foot {
   display: flex;
   align-items: center;

--- a/apps/web/tests/community-view.test.tsx
+++ b/apps/web/tests/community-view.test.tsx
@@ -242,6 +242,13 @@ describe('CommunityView catalogue source', () => {
 });
 
 describe('CommunityView previews', () => {
+  it('centres deck media in the 16:9 preview crop while legacy bakes are being replaced', async () => {
+    await renderCommunity();
+
+    expect(renderedCards()[0]!.querySelector('.community-template-card__preview.is-deck'))
+      .not.toBeNull();
+  });
+
   it('shows the plugin\'s own poster on the card and its live page in the full details modal', async () => {
     await renderCommunity();
 
@@ -323,6 +330,37 @@ describe('CommunityView previews', () => {
 });
 
 describe('CommunityView remix', () => {
+  it('shows Remix + Use for duplicable decks, but only Use for prompt-driven media', async () => {
+    await renderCommunity();
+
+    expect(Array.from(
+      renderedCards()[0]!.querySelectorAll<HTMLButtonElement>('.community-template-card__actions button'),
+    ).map((button) => button.textContent?.trim())).toEqual(['Remix', 'Use']);
+
+    fireEvent.click(readFacets().find((facet) => facet.label === 'Image')!.tab);
+    expect(Array.from(
+      renderedCards()[0]!.querySelectorAll<HTMLButtonElement>('.community-template-card__actions button'),
+    ).map((button) => button.textContent?.trim())).toEqual(['Use']);
+    expect(screen.queryByRole('button', { name: 'Copy prompt' })).toBeNull();
+  });
+
+  it('applies a media template as the active composer driver when Use is clicked', async () => {
+    const onUsePlugin = vi.fn();
+    const onUsePrompt = vi.fn();
+    await renderCommunity({ onUsePlugin, onUsePrompt });
+
+    fireEvent.click(readFacets().find((facet) => facet.label === 'Image')!.tab);
+    fireEvent.click(screen.getByRole('button', { name: 'Use' }));
+
+    expect(onUsePlugin).toHaveBeenCalledWith(IMAGE_TEMPLATE, 'use-with-query', {
+      templateId: 'image-template-poster',
+      prompt: 'A typography-led key art poster.',
+      chipId: 'image',
+      projectKind: 'image',
+    });
+    expect(onUsePrompt).not.toHaveBeenCalled();
+  });
+
   it('threads the real plugin id + its curated seed prompt into onRemixTemplate', async () => {
     // The primary "Remix" CTA must not drop the selected template, and it must
     // hand over the plugin's own curated seed rather than a synthesized
@@ -414,11 +452,11 @@ describe('CommunityView remix', () => {
 });
 
 describe('CommunityView use handoff', () => {
-  it('carries the selected Community type with the card prompt action', async () => {
+  it('carries the selected Community type with the card Use action', async () => {
     const onUsePrompt = vi.fn();
     await renderCommunity({ onUsePrompt });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Prompt' })[0]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Use' })[0]!);
 
     expect(onUsePrompt).toHaveBeenCalledWith({
       templateId: 'example-fundraising-deck',

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -258,6 +258,21 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.designHeight).toBe(1200);
   });
 
+  it('reads the design size from the shared slide-frame marker', () => {
+    const html = `<!doctype html><html><head><style>
+      .slide-frame { width: 1280px; height: 720px; }
+    </style></head><body><main class="deck">
+      <section class="slide-frame" data-screen-label="01 Cover">A</section>
+      <section class="slide-frame" data-screen-label="02 Detail">B</section>
+    </main></body></html>`;
+
+    const parsed = parseDeckThumbnails(html);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.designWidth).toBe(1280);
+    expect(parsed.designHeight).toBe(720);
+  });
+
   it('falls back when the deck depends on an external layout stylesheet', () => {
     const html = frameworkDeck(1).replace(
       '</head>',

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -228,6 +228,36 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.designHeight).toBe(1080);
   });
 
+  it('reads a 4:3 canvas size from a tag-prefixed slide class selector', () => {
+    const html = `<!doctype html><html><head><style>
+      section.slide { width: 1200px; height: 900px; }
+    </style></head><body><main class="deck">
+      <section class="slide">A</section>
+      <section class="slide">B</section>
+    </main></body></html>`;
+
+    const parsed = parseDeckThumbnails(html);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.designWidth).toBe(1200);
+    expect(parsed.designHeight).toBe(900);
+  });
+
+  it('reads a portrait canvas size from a tag-prefixed screen-label selector', () => {
+    const html = `<!doctype html><html><head><style>
+      section[data-screen-label] { width: 900px; height: 1200px; }
+    </style></head><body><main class="deck">
+      <section data-screen-label="01 Cover">A</section>
+      <section data-screen-label="02 Detail">B</section>
+    </main></body></html>`;
+
+    const parsed = parseDeckThumbnails(html);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.designWidth).toBe(900);
+    expect(parsed.designHeight).toBe(1200);
+  });
+
   it('falls back when the deck depends on an external layout stylesheet', () => {
     const html = frameworkDeck(1).replace(
       '</head>',

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -43,10 +43,10 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.ancestors[1]!.attributes).toContainEqual(['id', 'deck-stage']);
   });
 
-  it('rewrites :root / html / body selectors to :host', () => {
+  it('rewrites root selectors to :host and body selectors to the thumbnail canvas', () => {
     const parsed = parseDeckThumbnails(frameworkDeck(1));
     expect(parsed.styleText).toContain(':host { --bg: #fff');
-    expect(parsed.styleText).toContain(':host { background: var(--shell)');
+    expect(parsed.styleText).toContain(':host, .od-thumb-canvas { background: var(--shell)');
     expect(parsed.styleText).not.toMatch(/:root\s*\{/);
     // Compound selectors are left alone.
     expect(parsed.styleText).toContain('.deck-stage {');
@@ -210,6 +210,22 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.designWidth).toBe(1920);
     // Percent sizing is left untouched — it already resolves to the canvas.
     expect(parsed.styleText).toContain('width: 100%');
+  });
+
+  it('does not mistake a slide descendant decoration for the design canvas', () => {
+    const html = `<!doctype html><html><head><style>
+      body { display: flex; width: 200vw; height: 100vh; }
+      .slide { width: 100vw; height: 100vh; flex: none; }
+      .slide .kicker-line { width: 72px; height: 6px; }
+      .slide::before { width: 40px; height: 40px; }
+    </style></head><body>
+      <section class="slide"><span class="kicker-line">A</span></section>
+      <section class="slide">B</section>
+    </body></html>`;
+    const parsed = parseDeckThumbnails(html);
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.designWidth).toBe(1920);
+    expect(parsed.designHeight).toBe(1080);
   });
 
   it('falls back when the deck depends on an external layout stylesheet', () => {

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts
@@ -35,6 +35,7 @@ function setupDeckBridge(bodyHtml: string) {
     pretendToBeVisual: true,
   });
   const win = dom.window;
+  win.scrollTo = vi.fn() as typeof win.scrollTo;
   const parentPostMessage = vi.fn();
   // jsdom defaults `window.parent` to `window` itself for top-level
   // documents; replace it with a stub that has a spied postMessage so
@@ -96,6 +97,36 @@ describe('deck bridge — nested slide markup (#1530)', () => {
       '<main><section data-screen-label="01 Cover">One</section>' +
       '<section data-screen-label="02 Agenda">Two</section></main>',
     );
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 2 });
+  });
+
+  it('counts persisted deck pages that use data-screen-label instead of .slide', async () => {
+    // Runtime-managed decks persist this marker even when their generated
+    // page classes do not include `.slide`. The thumbnail parser already
+    // recognises it; the iframe bridge must use the same contract or Remix
+    // opens with an empty left preview rail.
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <main class="deck-stage">
+        <section data-screen-label="Intro">One</section>
+        <section data-screen-label="Plan">Two</section>
+      </main>
+    `);
+
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
+
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 0, count: 2 });
+  });
+
+  it('counts fixed-canvas slide-frame pages once a remixed project is declared as a deck', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <main>
+        <section class="slide-frame">One</section>
+        <section class="slide-frame">Two</section>
+      </main>
+    `);
 
     await new Promise<void>((resolve) => win.setTimeout(resolve, 350));
 
@@ -283,6 +314,80 @@ describe('deck bridge — nested slide markup (#1530)', () => {
 
     expect(bodyScrollTo).toHaveBeenCalledWith({ left: 1000, behavior: 'smooth' });
     expect(htmlScrollTo).toHaveBeenCalledWith({ left: 1000, behavior: 'smooth' });
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('navigates vertically stacked deck pages through the thumbnail bridge', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <style>
+        html, body { margin: 0; width: 100%; }
+        body { overflow-x: hidden; overflow-y: auto; scroll-snap-type: y mandatory; }
+        .slide { width: 100vw; height: 100vh; scroll-snap-align: start; }
+      </style>
+      <section class="slide">One</section>
+      <section class="slide">Two</section>
+      <section class="slide">Three</section>
+    `);
+    Object.defineProperty(win, 'innerHeight', { configurable: true, value: 700 });
+    Object.defineProperties(win.document.body, {
+      scrollHeight: { configurable: true, value: 2100 },
+      clientHeight: { configurable: true, value: 700 },
+    });
+    Object.defineProperties(win.document.documentElement, {
+      scrollHeight: { configurable: true, value: 2100 },
+      clientHeight: { configurable: true, value: 700 },
+    });
+    const bodyScrollTo = vi.fn();
+    const htmlScrollTo = vi.fn((options?: ScrollToOptions | number) => {
+      const top = typeof options === 'number' ? 0 : Number(options?.top || 0);
+      win.document.documentElement.scrollTop = top;
+    });
+    win.scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+      const top = typeof options === 'number' ? 0 : Number(options?.top || 0);
+      win.document.documentElement.scrollTop = top;
+    }) as typeof win.scrollTo;
+    win.document.body.scrollTo = bodyScrollTo;
+    win.document.documentElement.scrollTo = htmlScrollTo;
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(win.scrollTo).toHaveBeenCalledWith({ top: 700, behavior: 'smooth' });
+    expect(htmlScrollTo).toHaveBeenCalledWith({ top: 700, behavior: 'smooth' });
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('falls back to one visible page when a sandbox ignores root scrolling APIs', async () => {
+    const { win, parentPostMessage } = setupDeckBridge(`
+      <style>
+        body { display: flex; overflow-x: auto; overflow-y: hidden; }
+        .slide { flex: 0 0 100vw; width: 100vw; height: 100vh; }
+      </style>
+      <section class="slide">One</section>
+      <section class="slide">Two</section>
+      <section class="slide">Three</section>
+      <div id="counter">1 / 3</div>
+    `);
+    Object.defineProperty(win, 'innerWidth', { configurable: true, value: 1000 });
+    Object.defineProperties(win.document.body, {
+      scrollWidth: { configurable: true, value: 3000 },
+      clientWidth: { configurable: true, value: 1000 },
+    });
+    Object.defineProperties(win.document.documentElement, {
+      scrollWidth: { configurable: true, value: 3000 },
+      clientWidth: { configurable: true, value: 1000 },
+    });
+    win.scrollTo = vi.fn() as typeof win.scrollTo;
+    win.document.body.scrollTo = vi.fn();
+    win.document.documentElement.scrollTo = vi.fn();
+
+    postSlide(win, 'next');
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 500));
+
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    expect(slides[0]!.style.display).toBe('none');
+    expect(slides[1]!.style.display).toBe('');
+    expect(win.document.getElementById('counter')?.textContent).toBe('2 / 3');
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
   });
 

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -35,6 +35,7 @@ describe('deck bridge - scroll container fallback', () => {
       pretendToBeVisual: true,
     });
     const win = dom.window;
+    win.scrollTo = vi.fn() as typeof win.scrollTo;
     const parentPostMessage = vi.fn();
     Object.defineProperty(win, 'parent', {
       configurable: true,
@@ -125,6 +126,7 @@ describe('deck bridge - scroll container fallback', () => {
       pretendToBeVisual: true,
     });
     const win = dom.window;
+    win.scrollTo = vi.fn() as typeof win.scrollTo;
     const parentPostMessage = vi.fn();
     Object.defineProperty(win, 'parent', {
       configurable: true,

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -303,5 +303,23 @@ describe('deck bridge - scroll container fallback', () => {
     expect(windowScrollTo).not.toHaveBeenCalled();
     expect(scrollIntoView).not.toHaveBeenCalled();
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+
+    // If the nested scroller ignores a later smooth-scroll request, the bridge
+    // falls back to one visible page. That fallback must reset only the nested
+    // element; touching window/root scroll would jump the surrounding workspace
+    // to the top.
+    Object.defineProperty(container, 'scrollTo', {
+      configurable: true,
+      value: () => {},
+    });
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(container.scrollTop).toBe(0);
+    expect(win.scrollY).toBe(37);
+    expect(windowScrollTo).not.toHaveBeenCalled();
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
   });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -206,4 +206,102 @@ describe('deck bridge - scroll container fallback', () => {
     expect(win.document.documentElement.scrollLeft).toBe(2000);
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
   });
+
+  it('drives a nested vertical slide scroller without moving the outer document', async () => {
+    const bodyHtml = `
+      <style>
+        html, body { overflow: hidden; }
+        .slides-container { height: 800px; overflow-y: scroll; }
+        .slide { height: 800px; }
+      </style>
+      <div class="slides-container">
+        <section class="slide">One</section>
+        <section class="slide">Two</section>
+        <section class="slide">Three</section>
+      </div>
+    `;
+    const srcdoc = buildSrcdoc(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      deck: true,
+    });
+    const script = extractDeckBridgeScript(srcdoc);
+    const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+      runScripts: 'outside-only',
+      pretendToBeVisual: true,
+    });
+    const win = dom.window;
+    const windowScrollTo = vi.fn();
+    win.scrollTo = windowScrollTo as typeof win.scrollTo;
+    Object.defineProperty(win, 'scrollY', { configurable: true, value: 37 });
+    const parentPostMessage = vi.fn();
+    Object.defineProperty(win, 'parent', {
+      configurable: true,
+      value: { postMessage: parentPostMessage },
+    });
+
+    const container = win.document.querySelector<HTMLElement>('.slides-container')!;
+    const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 800 });
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
+    Object.defineProperty(container, 'clientWidth', { configurable: true, value: 1200 });
+    Object.defineProperty(container, 'scrollWidth', { configurable: true, value: 1200 });
+    let containerScrollTop = 0;
+    Object.defineProperty(container, 'scrollTop', {
+      configurable: true,
+      get: () => containerScrollTop,
+      set: (value: number) => { containerScrollTop = value; },
+    });
+    Object.defineProperty(container, 'scrollTo', {
+      configurable: true,
+      value: ({ top }: { top?: number }) => {
+        if (typeof top === 'number') containerScrollTop = top;
+      },
+    });
+    container.getBoundingClientRect = () => ({
+      x: 0,
+      y: 50,
+      top: 50,
+      left: 0,
+      right: 1200,
+      bottom: 850,
+      width: 1200,
+      height: 800,
+      toJSON: () => ({}),
+    });
+    slides.forEach((slide, index) => {
+      slide.getBoundingClientRect = () => {
+        const top = 50 + index * 800 - containerScrollTop;
+        return {
+          x: 0,
+          y: top,
+          top,
+          left: 0,
+          right: 1200,
+          bottom: top + 800,
+          width: 1200,
+          height: 800,
+          toJSON: () => ({}),
+        };
+      };
+    });
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(slides[1], 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    const evaluate = new win.Function(script);
+    evaluate.call(win);
+    win.dispatchEvent(new win.Event('load'));
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 1 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 450));
+
+    expect(container.scrollTop).toBe(800);
+    expect(win.scrollY).toBe(37);
+    expect(windowScrollTo).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 1, count: 3 });
+  });
 });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-scroll-container.test.ts
@@ -207,7 +207,7 @@ describe('deck bridge - scroll container fallback', () => {
     expect(lastSlideState(parentPostMessage)).toMatchObject({ active: 2, count: 3 });
   });
 
-  it('drives a nested vertical slide scroller without moving the outer document', async () => {
+  it('uses vertical slide geometry when a nested scroller also has horizontal overflow', async () => {
     const bodyHtml = `
       <style>
         html, body { overflow: hidden; }
@@ -243,7 +243,10 @@ describe('deck bridge - scroll container fallback', () => {
     Object.defineProperty(container, 'clientHeight', { configurable: true, value: 800 });
     Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 2400 });
     Object.defineProperty(container, 'clientWidth', { configurable: true, value: 1200 });
-    Object.defineProperty(container, 'scrollWidth', { configurable: true, value: 1200 });
+    // A classic scrollbar or slightly over-wide child can make overflow-x
+    // compute to auto with a small real overflow. Slide geometry, not the
+    // first overflowing axis, must still identify this as a vertical deck.
+    Object.defineProperty(container, 'scrollWidth', { configurable: true, value: 1210 });
     let containerScrollTop = 0;
     Object.defineProperty(container, 'scrollTop', {
       configurable: true,

--- a/e2e/tests/scripts/bake-plugin-previews.test.ts
+++ b/e2e/tests/scripts/bake-plugin-previews.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+const originalGetComputedStyle = globalThis.getComputedStyle;
+
+afterEach(() => {
+  Object.assign(globalThis, {
+    document: originalDocument,
+    window: originalWindow,
+    getComputedStyle: originalGetComputedStyle,
+  });
+});
+
+describe('bake-plugin-previews vertical deck driver', () => {
+  it('[P1] advances Daisy Days-style slides through their nested scroller', async () => {
+    const scriptUrl = new URL('../../../scripts/bake-plugin-previews.mjs', import.meta.url).href;
+    const { verticalDeckState } = await import(/* @vite-ignore */ scriptUrl) as {
+      verticalDeckState: (
+        selector: string,
+        action: 'probe' | 'advance',
+      ) => { hasStack: boolean; moved: boolean };
+    };
+
+    let scrollTop = 0;
+    const body = { scrollTop: 0 };
+    const html = { scrollTop: 0 };
+    const container = {
+      parentElement: body,
+      clientHeight: 800,
+      clientWidth: 1200,
+      scrollHeight: 2400,
+      scrollWidth: 1200,
+      scrollLeft: 0,
+      get scrollTop() { return scrollTop; },
+      set scrollTop(value: number) { scrollTop = value; },
+      contains: (slide: unknown) => (slides as unknown[]).includes(slide),
+      getBoundingClientRect: () => ({ top: 40 }),
+      scrollTo: ({ top }: { top: number }) => { scrollTop = top; },
+    };
+    const slides = Array.from({ length: 3 }, (_, index) => ({
+      parentElement: container,
+      getBoundingClientRect: () => ({
+        width: 1200,
+        height: 800,
+        top: 40 + index * 800 - scrollTop,
+      }),
+    }));
+    const windowScrollTo = vi.fn();
+    Object.assign(globalThis, {
+      document: {
+        body,
+        documentElement: html,
+        scrollingElement: html,
+        querySelectorAll: () => slides,
+      },
+      window: {
+        innerHeight: 800,
+        scrollX: 0,
+        scrollY: 19,
+        pageYOffset: 19,
+        scrollTo: windowScrollTo,
+        __odBakeVerticalSlideIndex: 0,
+      },
+      getComputedStyle: (element: unknown) => ({
+        display: 'block',
+        visibility: 'visible',
+        overflowY: element === container ? 'scroll' : 'visible',
+      }),
+    });
+
+    expect(verticalDeckState('.slide', 'probe')).toEqual({ hasStack: true, moved: false });
+    expect(verticalDeckState('.slide', 'advance')).toEqual({ hasStack: true, moved: true });
+    expect(scrollTop).toBe(800);
+    expect(verticalDeckState('.slide', 'advance')).toEqual({ hasStack: true, moved: true });
+    expect(scrollTop).toBe(1600);
+    expect(windowScrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/contracts/src/runtime/deck-stage-fallback.ts
+++ b/packages/contracts/src/runtime/deck-stage-fallback.ts
@@ -12,11 +12,13 @@ const DECK_SLIDE_MARKERS = [
   '[data-screen-label]',
   '.deck-slide',
   '.ppt-slide',
+  '.slide-frame',
 ] as const;
 const DECK_EXPLICIT_SLIDE_MARKERS = [
   '.slide',
   '.deck-slide',
   '.ppt-slide',
+  '.slide-frame',
 ] as const;
 const DECK_SLIDE_CONTAINERS = [
   'deck-stage',

--- a/packages/contracts/tests/deck-stage-fallback.test.ts
+++ b/packages/contracts/tests/deck-stage-fallback.test.ts
@@ -14,13 +14,13 @@ import {
 
 describe('deck-stage fallback runtime injection', () => {
   it('publishes one selector contract for legacy, modern, and imported slide markers', () => {
-    expect(DECK_SLIDE_SELECTOR).toBe('.slide, [data-screen-label], .deck-slide, .ppt-slide');
-    expect(DECK_EXPLICIT_SLIDE_SELECTOR).toBe('.slide, .deck-slide, .ppt-slide');
+    expect(DECK_SLIDE_SELECTOR).toBe('.slide, [data-screen-label], .deck-slide, .ppt-slide, .slide-frame');
+    expect(DECK_EXPLICIT_SLIDE_SELECTOR).toBe('.slide, .deck-slide, .ppt-slide, .slide-frame');
     expect(DECK_SCREEN_SLIDE_SELECTOR).toBe('[data-screen-label]');
     expect(DECK_LEGACY_SCREEN_SLIDE_SELECTOR).toBe('section[data-screen-label]');
     expect(new RegExp(DECK_LEGACY_SCREEN_LABEL_RE_SOURCE).test('01 Cover')).toBe(true);
     for (const container of ['deck-stage', '.deck', '.deck-stage', '.deck-shell', '#deck']) {
-      for (const marker of ['.slide', '[data-screen-label]', '.deck-slide', '.ppt-slide']) {
+      for (const marker of ['.slide', '[data-screen-label]', '.deck-slide', '.ppt-slide', '.slide-frame']) {
         expect(DECK_STRUCTURED_SLIDE_SELECTOR).toContain(`${container} > ${marker}`);
       }
     }

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -34,12 +34,12 @@
 // Uploading <out> to R2 + committing the manifest is the CI step's job; this
 // script only renders + encodes so it stays runnable locally and in CI alike.
 
-import puppeteer from 'puppeteer-core';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { mkdirSync, rmSync, writeFileSync, readFileSync, statSync, existsSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 // Bump when the bake recipe changes (capture geometry, timing, encoder, waits…)
 // so every plugin re-bakes even though its page content is byte-identical.
@@ -262,33 +262,78 @@ function deckSignal(cap) {
       parts.push(getComputedStyle(el).transform);
     }
     if (el.scrollWidth > el.clientWidth + 4) parts.push(`sl${el.scrollLeft}`);
+    if (el.scrollHeight > el.clientHeight + 4) parts.push(`st${el.scrollTop}`);
   }
   const a = document.querySelector('.active,.is-active,[aria-current="true"],[data-active="true"]');
   if (a) parts.push((a.id || '') + (a.className || ''));
   return parts.join('|').slice(0, 4000);
 }
 
+// Locate and optionally advance a vertically stacked deck. Some templates keep
+// html/body fixed and put the actual slide rail in an inner overflow-y
+// container, so window.scrollY alone cannot describe or drive them. Runs in the
+// page; must stay self-contained.
+export function verticalDeckState(selector, action) {
+  const slides = Array.from(document.querySelectorAll(selector)).filter((el) => {
+    const rect = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    return rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
+  });
+  if (slides.length < 2) return { hasStack: false, moved: false };
+
+  const isRoot = (el) => el === document.scrollingElement || el === document.documentElement || el === document.body;
+  let scroller = null;
+  let node = slides[0].parentElement;
+  while (node && !isRoot(node)) {
+    const containsAll = slides.every((slide) => node.contains(slide));
+    const overflowY = String(getComputedStyle(node).overflowY || '').toLowerCase();
+    if (
+      containsAll &&
+      node.scrollHeight > node.clientHeight + 1 &&
+      (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay')
+    ) {
+      scroller = node;
+      break;
+    }
+    node = node.parentElement;
+  }
+
+  const root = !scroller;
+  scroller ||= document.scrollingElement || document.documentElement || document.body;
+  const current = root
+    ? Math.max(
+      Number(window.scrollY || window.pageYOffset || 0),
+      Number(document.documentElement?.scrollTop || 0),
+      Number(document.body?.scrollTop || 0),
+    )
+    : Number(scroller.scrollTop || 0);
+  const origin = root ? 0 : Number(scroller.getBoundingClientRect().top || 0);
+  const tops = slides.map((el) => current + Number(el.getBoundingClientRect().top || 0) - origin);
+  const span = Math.max(1, root ? window.innerHeight : scroller.clientHeight);
+  const hasStack = Math.max(...tops) - Math.min(...tops) > span * 0.5;
+  if (!hasStack || action !== 'advance') return { hasStack, moved: false };
+
+  const currentIndex = Number(window.__odBakeVerticalSlideIndex || 0);
+  const nextIndex = currentIndex + 1;
+  if (nextIndex >= slides.length) return { hasStack, moved: false };
+  const top = tops[nextIndex];
+  window.__odBakeVerticalSlideIndex = nextIndex;
+  if (root) {
+    window.scrollTo({ left: window.scrollX, top, behavior: 'auto' });
+  } else {
+    try {
+      scroller.scrollTo({ left: scroller.scrollLeft, top, behavior: 'auto' });
+    } catch {
+      scroller.scrollTop = top;
+    }
+  }
+  return { hasStack, moved: true };
+}
+
 async function driveDeck(page, driver) {
   if (driver === 'vertical') {
-    return page.evaluate((selector) => {
-      const slides = Array.from(document.querySelectorAll(selector)).filter((el) => {
-        const rect = el.getBoundingClientRect();
-        const style = getComputedStyle(el);
-        return rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
-      });
-      const current = Number(window.__odBakeVerticalSlideIndex || 0);
-      const next = current + 1;
-      if (next >= slides.length) return false;
-      const target = slides[next];
-      const rect = target.getBoundingClientRect();
-      window.__odBakeVerticalSlideIndex = next;
-      window.scrollTo({
-        left: window.scrollX + rect.left,
-        top: window.scrollY + rect.top,
-        behavior: 'auto',
-      });
-      return true;
-    }, DECK_CAPTURE_SELECTOR);
+    const state = await page.evaluate(verticalDeckState, DECK_CAPTURE_SELECTOR, 'advance');
+    return state.moved;
   }
   if (driver === 'arrow') { await page.keyboard.press('ArrowRight'); return; }
   if (driver === 'wheel') {
@@ -342,17 +387,8 @@ async function probeDeckDriver(page) {
   await driveDeck(page, 'wheel');
   await sleep(900);
   if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) return 'wheel';
-  const hasVerticalSlideStack = await page.evaluate((selector) => {
-    const slides = Array.from(document.querySelectorAll(selector)).filter((el) => {
-      const rect = el.getBoundingClientRect();
-      const style = getComputedStyle(el);
-      return rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
-    });
-    if (slides.length < 2) return false;
-    const tops = slides.map((el) => el.getBoundingClientRect().top + window.scrollY);
-    return Math.max(...tops) - Math.min(...tops) > window.innerHeight * 0.5;
-  }, DECK_CAPTURE_SELECTOR);
-  if (hasVerticalSlideStack) return 'vertical';
+  const verticalState = await page.evaluate(verticalDeckState, DECK_CAPTURE_SELECTOR, 'probe');
+  if (verticalState.hasStack) return 'vertical';
   return null;
 }
 
@@ -687,6 +723,8 @@ async function bakeOne(browser, id, hash, motion) {
 }
 
 // ---- main -----------------------------------------------------------------
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+const { default: puppeteer } = await import('puppeteer-core');
 mkdirSync(OUT, { recursive: true });
 const ids = await discoverIds();
 const motionMap = await loadMotionMap();
@@ -837,3 +875,4 @@ await Promise.all([process.stdout, process.stderr].map(
   (stream) => new Promise((resolve) => stream.write('', resolve)),
 ));
 process.exit(strictFail ? 1 : 0);
+}

--- a/scripts/bake-plugin-previews.mjs
+++ b/scripts/bake-plugin-previews.mjs
@@ -61,19 +61,23 @@ import path from 'node:path';
 //       of skipping them forever. Bumped so every entry's metadata is
 //       corrected in one sweep (23 entries carried holdMs > real duration,
 //       5 static-page entries could never refresh at all).
-const BAKE_VERSION = 5;
+//   v6: capture decks in their native 16:9 frame so the gallery does not bake
+//       the outer black canvas into posters/clips; a plugin declared with
+//       `od.mode: deck` now takes the slide-walk path by default instead of
+//       being misclassified as a vertically scrolling page.
+const BAKE_VERSION = 6;
 
 // ---- config ---------------------------------------------------------------
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:17579';
 const RENDER_W = 1440;          // pages lay out at their desktop width
 const VIEW_H = 1099;            // 1.31-aspect window showing the FULL width (no clip)
-// Decks (PPT/slideshow: a fixed 100vh page navigated by arrow keys or the wheel,
-// NOT vertical scroll) are captured at the SAME 1.31 tile aspect as everything
-// else — so the clip fills the card with no crop or letterbox — but at a larger
-// width. At the normal 1440 width decks hit a width breakpoint and collapse into
-// a compact variant (hero headline -> condensed strip); 1760 clears it.
+// Decks are authored and displayed at 16:9. Capture that frame directly rather
+// than the old 1.31 page viewport, which recorded the stage's outer black canvas
+// above/beside the slide. The wider viewport still avoids compact breakpoints.
 const DECK_W = 1760;
-const DECK_H = 1344;            // 1760/1344 = 1.31, the tile aspect
+const DECK_H = 990;             // 1760/990 = 16:9, the slide/card aspect
+const DECK_CAPTURE_SELECTOR =
+  '.slide, [data-screen-label], .deck-slide, .ppt-slide, .slide-frame';
 const SLIDE_MS = 1150;          // deck per-slide dwell: ~.9s CSS transition + settle
 const MAX_SLIDES = 6;           // advance budget; HOLD + slides stays ~<=9s
 const MAX_WALK_MS = 8000;       // hard wall-time cap on the walk: even when signal
@@ -212,8 +216,10 @@ async function discoverIds() {
 }
 
 // Authors can declare how their preview should be captured via
-// `od.preview.motion` ('scroll' | 'deck' | 'static'); we honor it and only
-// auto-detect when it's absent. Returns an id -> motion map (missing => null).
+// `od.preview.motion` ('scroll' | 'deck' | 'static'); we honor it first. When
+// absent, an `od.mode: deck` declaration is authoritative — vertically stacked
+// deck DOM must still be walked page-by-page, not recorded as one long scroll.
+// Everything else remains auto-detected. Returns id -> motion (missing => null).
 async function loadMotionMap() {
   const map = {};
   try {
@@ -224,7 +230,12 @@ async function loadMotionMap() {
       if (!it || typeof it !== 'object') continue;
       const id = it.id || it.slug;
       const m = it.manifest?.od?.preview?.motion;
-      if (id && (m === 'scroll' || m === 'deck' || m === 'static')) map[id] = m;
+      if (!id) continue;
+      if (m === 'scroll' || m === 'deck' || m === 'static') {
+        map[id] = m;
+      } else if (it.manifest?.od?.mode === 'deck') {
+        map[id] = 'deck';
+      }
     }
   } catch {}
   return map;
@@ -258,6 +269,27 @@ function deckSignal(cap) {
 }
 
 async function driveDeck(page, driver) {
+  if (driver === 'vertical') {
+    return page.evaluate((selector) => {
+      const slides = Array.from(document.querySelectorAll(selector)).filter((el) => {
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        return rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
+      });
+      const current = Number(window.__odBakeVerticalSlideIndex || 0);
+      const next = current + 1;
+      if (next >= slides.length) return false;
+      const target = slides[next];
+      const rect = target.getBoundingClientRect();
+      window.__odBakeVerticalSlideIndex = next;
+      window.scrollTo({
+        left: window.scrollX + rect.left,
+        top: window.scrollY + rect.top,
+        behavior: 'auto',
+      });
+      return true;
+    }, DECK_CAPTURE_SELECTOR);
+  }
   if (driver === 'arrow') { await page.keyboard.press('ArrowRight'); return; }
   if (driver === 'wheel') {
     await page.evaluate(() => {
@@ -283,6 +315,12 @@ async function walkSlides(page, driver) {
   const t0 = Date.now();
   for (let s = 0; s < MAX_SLIDES; s += 1) {
     if (Date.now() - t0 > MAX_WALK_MS) break; // backstop so the clip never runs long
+    if (driver === 'vertical') {
+      if (!(await driveDeck(page, driver))) break;
+      await sleep(SLIDE_MS);
+      moved += 1;
+      continue;
+    }
     const before = await page.evaluate(deckSignal, DECK_SCAN_CAP);
     await driveDeck(page, driver);
     await sleep(SLIDE_MS);
@@ -304,7 +342,68 @@ async function probeDeckDriver(page) {
   await driveDeck(page, 'wheel');
   await sleep(900);
   if ((await page.evaluate(deckSignal, DECK_SCAN_CAP)) !== sig0) return 'wheel';
+  const hasVerticalSlideStack = await page.evaluate((selector) => {
+    const slides = Array.from(document.querySelectorAll(selector)).filter((el) => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      return rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
+    });
+    if (slides.length < 2) return false;
+    const tops = slides.map((el) => el.getBoundingClientRect().top + window.scrollY);
+    return Math.max(...tops) - Math.min(...tops) > window.innerHeight * 0.5;
+  }, DECK_CAPTURE_SELECTOR);
+  if (hasVerticalSlideStack) return 'vertical';
   return null;
+}
+
+// Size and position the screencast viewport against the authored slide itself,
+// not the surrounding stage/body. This is what removes baked-in black canvas:
+// matching only the slide's aspect ratio is insufficient when the page adds
+// padding or renders a fixed 1280×720 canvas at a smaller CSS transform.
+async function cropDeckViewportToSlide(page, fallbackW, fallbackH) {
+  const measured = await page.evaluate((selector) => {
+    const slides = Array.from(document.querySelectorAll(selector));
+    const candidates = slides.map((el, index) => {
+      const rect = el.getBoundingClientRect();
+      const style = getComputedStyle(el);
+      const active = el.matches('.active,.is-active,[aria-current="true"],[data-active="true"],[data-od-deck-active]');
+      const visible = rect.width > 1 && rect.height > 1 && style.display !== 'none' && style.visibility !== 'hidden';
+      const onscreen = rect.right > 0 && rect.bottom > 0 && rect.left < innerWidth && rect.top < innerHeight;
+      return { index, active, visible, onscreen, width: rect.width, height: rect.height };
+    });
+    return candidates.find((item) => item.active && item.visible)
+      || candidates.find((item) => item.visible && item.onscreen)
+      || candidates.find((item) => item.visible)
+      || null;
+  }, DECK_CAPTURE_SELECTOR);
+  if (!measured) return { width: fallbackW, height: fallbackH };
+
+  const width = Math.max(320, Math.min(2560, Math.round(measured.width)));
+  const height = Math.max(180, Math.min(1440, Math.round(measured.height)));
+  const aspect = width / height;
+  if (!Number.isFinite(aspect) || aspect < 1.2 || aspect > 2.4) {
+    return { width: fallbackW, height: fallbackH };
+  }
+
+  if (width !== fallbackW || height !== fallbackH) {
+    await page.setViewport({ width, height, deviceScaleFactor: 1 });
+    await sleep(250);
+  }
+  await page.evaluate(({ selector, index }) => {
+    document.documentElement.style.setProperty('overflow', 'auto', 'important');
+    document.body.style.setProperty('overflow', 'visible', 'important');
+    const target = document.querySelectorAll(selector)[index];
+    if (!target) return;
+    const rect = target.getBoundingClientRect();
+    window.__odBakeVerticalSlideIndex = 0;
+    window.scrollTo({
+      left: window.scrollX + rect.left,
+      top: window.scrollY + rect.top,
+      behavior: 'auto',
+    });
+  }, { selector: DECK_CAPTURE_SELECTOR, index: measured.index });
+  await sleep(100);
+  return { width, height };
 }
 
 // ---- render + encode one plugin -------------------------------------------
@@ -423,6 +522,12 @@ async function bakeOne(browser, id, hash, motion) {
     }, 12000);
   } catch {}
   await sleep(600);
+
+  if (isDeck) {
+    const crop = await cropDeckViewportToSlide(page, capW, capH);
+    capW = crop.width;
+    capH = crop.height;
+  }
 
   const frameDir = path.join(OUT, `.frames-${id}`);
   rmSync(frameDir, { recursive: true, force: true }); mkdirSync(frameDir, { recursive: true });


### PR DESCRIPTION
## Why

QA found three related failures in Community: baked deck previews included the black stage around the slide, vertically-authored decks could Remix into projects with an empty thumbnail rail, and prompt-driven artifact cards exposed duplicate prompt actions that did not consistently carry the selected template into Home.

This fixes the end-to-end template handoff and deck preview pipeline so Community cards behave like real reusable templates instead of prompt-copy shortcuts.

## What users will see

- Community cards expose one localized **Use** action; media templates no longer show a separate Copy prompt button, and Use activates the selected plugin/template context in Home.
- Duplicable Slide templates retain **Remix**. Remixed projects preserve deck kind, recognize horizontal, vertical-scroll, `data-screen-label`, and `.slide-frame` layouts, and populate/navigate the left thumbnail rail.
- Newly baked deck posters and preview videos crop to the slide itself instead of recording the surrounding black stage. Bake version 6 schedules existing catalog previews for regeneration.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- Community entry point and remixed-deck navigation were captured from the live local branch in real Chrome.
- GitHub's file chooser bridge blocked the automated binary attachment; the capture is retained for local reviewer/user handoff.

## Bug fix verification

- Red specs: [Community action semantics](https://github.com/nexu-io/open-design/blob/e51c1bd08396923b7c29ddb638fd99c3d0df184a/apps/web/tests/community-view.test.tsx#L333), [persisted/slide-frame deck discovery](https://github.com/nexu-io/open-design/blob/e51c1bd08396923b7c29ddb638fd99c3d0df184a/apps/web/tests/runtime/srcdoc-deck-bridge-nested-slides.test.ts#L106-L137), and [duplicated deck project kind](https://github.com/nexu-io/open-design/blob/e51c1bd08396923b7c29ddb638fd99c3d0df184a/apps/daemon/tests/plugins-duplicate-project.test.ts#L280-L310).
- These tests were run red against the pre-fix baseline and are green on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- Web focused suite: 5 files, 96 tests passed
- Daemon duplicate-project suite: 6 tests passed
- Contracts deck-stage fallback suite: 7 tests passed
- `node --check scripts/bake-plugin-previews.mjs`
- `git diff --check`
- Real Chrome E2E: Image Use activated the selected template context; horizontal and vertical-scroll Slide Remix both populated the thumbnail rail and navigated to page 2; representative deck posters/videos were baked without surrounding black canvas.

## Adjacent issues

- None; the change is limited to the reported Community template actions, deck duplication/navigation, and preview baking path.
