### PR TITLE
fix project update-ready rocket

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -56,6 +56,7 @@ import { AmrArtifactUpgradeGate } from './components/AmrArtifactUpgradeGate';
 import { AmrArtifactUpgradeHomeCard } from './components/AmrArtifactUpgradeHomeCard';
 import { TooltipLayer } from './components/TooltipLayer';
 import { UpdateDialog } from './components/UpdateDialog';
+import { UpdaterPopup } from './components/UpdaterPopup';
 import {
   openWorkspaceTab,
   removeWorkspaceProjectTabs,
@@ -5297,6 +5298,13 @@ function AppInner() {
           <WorkspaceTopRightAccountCluster
             onOpenSettings={openSettings}
             onSignedOut={handleActiveCloudSignOut}
+            updaterSlot={
+              <UpdaterPopup
+                allowSilentUpdates={config.allowSilentUpdates}
+                silentUpdatePreferenceReady={daemonAppConfigReady}
+                onAllowSilentUpdatesChange={handleSilentUpdatePreferenceChange}
+              />
+            }
             workspaceContextOverride={
               activeProject?.workspaceId
                 ? activeProjectWorkspaceContext

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -1127,11 +1127,14 @@ export function EntryTopRightCluster({
 export function WorkspaceTopRightAccountCluster({
   onOpenSettings,
   onSignedOut,
+  updaterSlot,
   workspaceContextOverride,
   workspaceContextLoading,
 }: {
   onOpenSettings?: (section?: EntrySettingsSection) => void;
   onSignedOut?: () => void | Promise<void>;
+  /** Keep the project-detail account cluster on the same updater surface as Home. */
+  updaterSlot?: ReactNode;
   workspaceContextOverride?: WorkspaceCollabContext | null;
   workspaceContextLoading?: boolean;
 }) {
@@ -1157,6 +1160,7 @@ export function WorkspaceTopRightAccountCluster({
       context={context}
       billing={billing}
       balanceUsd={balanceUsd}
+      updaterSlot={updaterSlot}
       onOpenSettings={onOpenSettings}
       onSignedOut={onSignedOut}
     />

--- a/apps/web/tests/components/App.project-account-cluster.test.tsx
+++ b/apps/web/tests/components/App.project-account-cluster.test.tsx
@@ -342,10 +342,13 @@ describe('project route — floating account cluster', () => {
     expect(open.mock.calls[0]?.[0]).toContain('/dashboard?workspaceId=ws-project');
   });
 
-  it('renders no cluster while signed out (context resolves to null)', async () => {
+  it.each([
+    ['signed out', false],
+    ['workspace identity is still loading', true],
+  ])('renders no cluster when %s', async (_state, loading) => {
     useProjectRouteWorkspaceContextMock.mockReturnValue({
       context: null,
-      loading: false,
+      loading,
       retry: vi.fn(),
     });
     vi.stubGlobal(
@@ -354,9 +357,12 @@ describe('project route — floating account cluster', () => {
     );
     render(<App />);
 
-    await screen.findByText('Project view');
+    await screen.findByText(loading ? 'Loading workspace…' : 'Project view');
     await waitFor(() => {
+      expect(document.querySelector('.entry-top-right-cluster')).toBeNull();
+      expect(screen.queryByTestId('entry-top-right-github')).toBeNull();
       expect(screen.queryByTestId('entry-nav-account')).toBeNull();
+      expect(screen.queryByTestId('entry-nav-account-updater')).toBeNull();
     });
   });
 });

--- a/apps/web/tests/components/App.update-dialog.test.tsx
+++ b/apps/web/tests/components/App.update-dialog.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import type { ReactNode } from 'react';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -23,9 +24,21 @@ import { fetchDaemonConfig, loadConfig, mergeDaemonConfig } from '../../src/stat
 import { listProjects, listTemplates } from '../../src/state/projects';
 import type { AppConfig } from '../../src/types';
 
+const routeState = vi.hoisted(() => ({
+  current: { kind: 'home' as const, view: 'home' as const } as
+    | { kind: 'home'; view: 'home' }
+    | { kind: 'project'; projectId: string },
+}));
+
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
-  useRoute: () => ({ kind: 'home' as const, view: 'home' as const }),
+  useRoute: () => routeState.current,
+}));
+
+vi.mock('../../src/components/EntryNavRail', () => ({
+  WorkspaceTopRightAccountCluster: ({ updaterSlot }: { updaterSlot?: ReactNode }) => (
+    <div data-testid="project-top-right-account-cluster">{updaterSlot}</div>
+  ),
 }));
 
 vi.mock('../../src/components/EntryView', () => ({
@@ -174,6 +187,7 @@ describe('App updater dialog integration', () => {
   let restoreHost: (() => void) | null = null;
 
   beforeEach(() => {
+    routeState.current = { kind: 'home', view: 'home' };
     mockedDaemonIsLive.mockResolvedValue(true);
     mockedFetchAgentsStream.mockResolvedValue([]);
     mockedFetchSkills.mockResolvedValue([]);
@@ -255,5 +269,26 @@ describe('App updater dialog integration', () => {
 
     unmount();
     expect(unsubscribeOpenDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the update-ready rocket in the project-detail account cluster', async () => {
+    routeState.current = { kind: 'project', projectId: 'project-1' };
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => idleStatus({
+            availableVersion: '1.2.4',
+            downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+            state: 'downloaded',
+          })),
+        },
+      },
+    });
+
+    render(<App />);
+
+    expect(await screen.findByTestId('project-top-right-account-cluster')).toBeTruthy();
+    expect(await screen.findByTestId('entry-nav-updater')).toBeTruthy();
+    expect(screen.getByTestId('updater-rocket-glyph')).toBeTruthy();
   });
 });

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -25,7 +25,11 @@ import type { OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
 import { installMockOpenDesignHost } from '@open-design/host/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import {
+  EntryNavRail,
+  resetWorkspaceDirectoryCache,
+  WorkspaceTopRightAccountCluster,
+} from '../../src/components/EntryNavRail';
 import { UpdaterPopup } from '../../src/components/UpdaterPopup';
 import { I18nProvider } from '../../src/i18n';
 
@@ -130,6 +134,22 @@ async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null
 }
 
 describe('updater rocket placement after the account avatar', () => {
+  it('keeps the project-detail updater slot in the shared account row', () => {
+    render(
+      <I18nProvider initial="zh-CN">
+        <WorkspaceTopRightAccountCluster
+          workspaceContextOverride={teamContext()}
+          updaterSlot={<span data-testid="project-updater-slot-content" />}
+        />
+      </I18nProvider>,
+    );
+
+    const trigger = screen.getByTestId('entry-nav-account');
+    const slot = screen.getByTestId('entry-nav-account-updater');
+    expect(screen.getByTestId('project-updater-slot-content')).toBeTruthy();
+    expect(trigger.nextElementSibling).toBe(slot);
+  });
+
   it('renders the rocket inline immediately after the avatar chip', async () => {
     await renderWithDownloadedUpdate();
 


### PR DESCRIPTION
Fixes #7003

## Why

A packaged desktop update can be ready while the user is working inside a project. Home already shows the update-ready rocket beside the account avatar, but opening a project unmounted Home's updater host and the project-owned account cluster did not replace it. That made the available update disappear from the active work surface and forced users to return Home to discover or install it.

The root cause was a missing composition seam: `WorkspaceTopRightAccountCluster` reused Home's account presentation, but `App` did not pass the shared `UpdaterPopup` into its updater slot.

## What users will see

When an update is ready, project detail now shows the same green rocket immediately after the account avatar as Home. Clicking it opens the same install/restart panel and uses the same silent-update preference behavior. Idle updater states remain visually unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Omitted per requester. The fix reuses the existing Home `UpdaterPopup` and the existing avatar-following account slot without changing styles.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/components/App.update-dialog.test.tsx`
  - `apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx`
- Red/green: yes. The project-route integration failed on `main` because `entry-nav-updater` was absent, then passed after wiring the shared updater slot.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/lib/updater.test.ts tests/update-surface-real-data.test.ts tests/components/App.update-dialog.test.tsx tests/components/EntryNavRail.updater-after-avatar.test.tsx --maxWorkers=2` (23 passed)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
