### PR TITLE
fix(web): show only delivered files in result summary

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -633,13 +633,13 @@ function AssistantMessageImpl({
     () => turnFileOps.filter((entry) => entry.ops.includes('write') || entry.ops.includes('edit')),
     [turnFileOps],
   );
-  // Same artifacts-not-inputs rule, applied to the #5517 summary source. The
-  // summary row is fed by `fileOps` (produced files stay their own flat block
-  // below), so it needs its own read-only filter rather than reusing
-  // `turnArtifactOps`, which is derived from the produced-file merge.
+  // Same artifacts-not-inputs rule, applied to the #5517 summary source. Once
+  // the daemon has attached an authoritative produced-file list, the result
+  // card must describe that delivered set rather than every attempted tool
+  // path. Failed attempts remain visible in the execution disclosure.
   const summaryArtifactOps = useMemo(
-    () => fileOps.filter((entry) => entry.ops.includes('write') || entry.ops.includes('edit')),
-    [fileOps],
+    () => summaryArtifactOpsForProducedFiles(fileOps, produced),
+    [fileOps, produced],
   );
   // The single artifact the "next step" affordance anchors to: prefer the HTML
   // produced by THIS turn; if the final turn emitted none (a summary / continue
@@ -1258,6 +1258,60 @@ function mergeProducedFilesIntoFileOps(
     });
   }
   return merged;
+}
+
+function summaryArtifactOpsForProducedFiles(
+  fileOps: FileOpEntry[],
+  produced: ProjectFile[],
+): FileOpEntry[] {
+  const artifactOps = fileOps.filter(
+    (entry) => entry.ops.includes('write') || entry.ops.includes('edit'),
+  );
+  if (artifactOps.length === 0 || produced.length === 0) return artifactOps;
+
+  const unused = new Set(artifactOps);
+  return produced.map((file) => {
+    const candidates = [...unused]
+      .map((entry) => ({ entry, score: producedFileOpMatchScore(entry, file) }))
+      .filter(({ score }) => score > 0)
+      .sort((left, right) => {
+        const statusDelta =
+          Number(right.entry.status === 'done') - Number(left.entry.status === 'done');
+        return statusDelta || right.score - left.score;
+      });
+    const matched = candidates[0]?.entry;
+    if (matched) {
+      unused.delete(matched);
+      return {
+        ...matched,
+        path: file.name,
+        status: 'done' as const,
+      };
+    }
+
+    const fullPath = file.path || file.localPath || file.name;
+    return {
+      path: file.name,
+      fullPath,
+      ops: ['write'],
+      opCounts: { read: 0, write: 1, edit: 0, delete: 0 },
+      total: 1,
+      status: 'done',
+    };
+  });
+}
+
+function producedFileOpMatchScore(entry: FileOpEntry, file: ProjectFile): number {
+  const entryFullPath = normalizeTouchedPath(entry.fullPath);
+  const entryPath = normalizeTouchedPath(entry.path);
+  const filePaths = [file.path, file.localPath, file.name]
+    .filter((path): path is string => Boolean(path))
+    .map(normalizeTouchedPath);
+
+  if (filePaths.includes(entryFullPath)) return 3;
+  if (filePaths.some((path) => entryFullPath.endsWith(`/${path}`))) return 2;
+  if (filePaths.includes(entryPath)) return 1;
+  return 0;
 }
 
 function normalizeTouchedPath(path: string): string {

--- a/apps/web/tests/components/AssistantMessage.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.test.tsx
@@ -1382,6 +1382,53 @@ describe('AssistantMessage recovered produced files', () => {
     expect(hasProducedFiles).toBe(false);
   });
 
+  it('lists only the authoritative artifact when an earlier edit targeted a wrong project path', () => {
+    const fileName = 'opendesign-b2b-sales-deck.html';
+    const failedPath = `/workspace/projects/wrong-project/${fileName}`;
+    const deliveredPath = `/workspace/projects/project-1/${fileName}`;
+    const file = producedFile(fileName);
+
+    render(
+      <AssistantMessage
+        message={baseMessage({
+          events: [
+            {
+              kind: 'tool_use',
+              id: 'failed-edit',
+              name: 'Edit',
+              input: { file_path: failedPath },
+            } as ChatMessage['events'][number],
+            {
+              kind: 'tool_result',
+              toolUseId: 'failed-edit',
+              content: `File ${failedPath} not found`,
+              isError: true,
+            } as ChatMessage['events'][number],
+            {
+              kind: 'tool_use',
+              id: 'successful-edit',
+              name: 'Edit',
+              input: { file_path: deliveredPath },
+            } as ChatMessage['events'][number],
+            {
+              kind: 'tool_result',
+              toolUseId: 'successful-edit',
+              content: 'Updated successfully.',
+              isError: false,
+            } as ChatMessage['events'][number],
+          ],
+          producedFiles: [file],
+        })}
+        streaming={false}
+        projectId="project-1"
+        projectFiles={[file]}
+      />,
+    );
+
+    expect(screen.getAllByTestId(`file-ops-row-${fileName}`)).toHaveLength(1);
+    expect(screen.queryByTestId('file-ops-toggle')).toBeNull();
+  });
+
   it('shows project files mentioned as plain filenames in the assistant summary', () => {
     const content = '文件列表：\n- browser-war-deck-outline.md';
     render(


### PR DESCRIPTION
## Why

A stable-app diagnostics bundle showed a completed turn whose run metadata contained one delivered HTML artifact, while the chat result card listed the same filename twice. The turn first attempted an Edit against a mistyped project path (failed), then edited the real project path successfully. Treating both tool paths as delivered artifacts makes the result summary contradict the actual filesystem and undermines trust in the output.

## What users will see

Completed assistant turns now list the authoritative delivered files once. Failed or superseded Write/Edit attempts remain available in the execution disclosure, but no longer appear as extra produced files.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The bug is a result-card data mismatch rather than a new visual surface. The diagnostics reproduction shows two identical rows before the fix; the regression test asserts the completed card has exactly one row and no multi-file header after the fix.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/AssistantMessage.test.tsx` — “lists only the authoritative artifact when an earlier edit targeted a wrong project path”
- Did the test go red on `main` and green on this branch? yes
  - Red: expected 1 produced-file row, received 2
  - Green: 1 produced-file row; all 52 AssistantMessage tests pass

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/components/AssistantMessage.test.tsx --maxWorkers=1` (52 passed)
