### PR TITLE
fix(web): prevent double-scaled HTML card thumbnails

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useAnalytics } from '../analytics/provider';
 import { trackFileManagerClick } from '../analytics/events';
 import { useT } from '../i18n';
@@ -2069,17 +2069,19 @@ function HtmlCardThumbnail({
     url,
   ]);
 
-  // Track the host width so the fixed-layout iframe scales with the card.
-  // Environments without ResizeObserver (jsdom) fall back to an unscaled
-  // fill-the-box iframe.
-  useEffect(() => {
+  // Track the host width before paint so the iframe's first rendered viewport
+  // is the fixed desktop layout, then only its outer transform follows the
+  // card. This prevents responsive decks from fitting once to the card-sized
+  // iframe and then being scaled a second time after ResizeObserver runs.
+  useLayoutEffect(() => {
     const host = hostRef.current;
-    if (!host || typeof ResizeObserver === 'undefined') return;
+    if (!host) return;
     const update = () => {
       const width = host.clientWidth;
       if (width > 0) setScale(width / PAGE_THUMB_LAYOUT_WIDTH);
     };
     update();
+    if (typeof ResizeObserver === 'undefined') return;
     const observer = new ResizeObserver(update);
     observer.observe(host);
     return () => observer.disconnect();
@@ -2095,16 +2097,16 @@ function HtmlCardThumbnail({
           srcDoc={srcDoc}
           sandbox="allow-scripts allow-downloads"
           loading="lazy"
-          style={
-            scale
+          style={{
+            width: PAGE_THUMB_LAYOUT_WIDTH,
+            height: PAGE_THUMB_LAYOUT_HEIGHT,
+            ...(scale
               ? {
-                  width: PAGE_THUMB_LAYOUT_WIDTH,
-                  height: PAGE_THUMB_LAYOUT_HEIGHT,
                   transform: `scale(${scale})`,
                   transformOrigin: '0 0',
                 }
-              : undefined
-          }
+              : {}),
+          }}
         />
       )}
     </div>

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -686,6 +686,30 @@ describe("DesignFilesPanel page thumbnails", () => {
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("mounts a cached HTML thumbnail with the desktop layout viewport on its first render", () => {
+    const cachedFile = file({
+      name: "deck.html",
+      kind: "html",
+      mime: "text/html",
+      size: 16 * 1024,
+      mtime: 1700000000001,
+    });
+    setHtmlSourceSnapshot({
+      authorizationScopeKey: "local",
+      projectId: "test-project",
+      fileName: cachedFile.name,
+      refreshKey: `${cachedFile.mtime}:${cachedFile.size}:8`,
+      source: "<!doctype html><html><body><main>Deck</main></body></html>",
+    });
+
+    const { container } = renderPanel([cachedFile], { filesRefreshKey: 8 });
+    const iframe = container.querySelector<HTMLIFrameElement>(".df-card-thumb iframe");
+
+    expect(iframe).toBeTruthy();
+    expect(iframe?.style.width).toBe("1200px");
+    expect(iframe?.style.height).toBe("675px");
+  });
 });
 
 describe("DesignFilesPanel directory navigation", () => {


### PR DESCRIPTION
## Why

A stable-app diagnostics report showed an HTML slide deck whose Design Files card rendered the slide at a tiny fraction of the thumbnail area even though the full file preview was valid. The thumbnail iframe could first mount at the card's responsive width, allowing the deck to fit itself to that small viewport, and only later switch to the 1200px layout plus an outer scale. For responsive deck runtimes this applies the fit twice.

## What users will see

HTML and deck cards in Design Files now load at a stable 1200×675 desktop viewport from their first render, then scale that viewport once to the card. Deck thumbnails fill the card as intended instead of appearing as a tiny slide in the corner.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The diagnostics reproduction shows the before state: a 16:9 deck card with the slide rendered at roughly one-fifth scale in the top-left corner. This draft uses a DOM viewport regression as the after evidence; no new UI entry point or styling is introduced.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignFilesPanel.test.tsx` — “mounts a cached HTML thumbnail with the desktop layout viewport on its first render”
- Did the test go red on `main` and green on this branch? yes
  - Red: first-render iframe width was empty/CSS-driven instead of `1200px`
  - Green: first-render iframe is `1200×675`
- Additional regression: `apps/web/tests/design-files-lazy-render.test.tsx` (7 passed)

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/components/DesignFilesPanel.test.tsx --maxWorkers=1` (45 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/design-files-lazy-render.test.tsx --maxWorkers=1` (7 passed)
