### PR TITLE
feat(daemon): add Gemini 3.6/3.7 Flash to Antigravity model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added] Antigravity model picker now exposes Gemini 3.6 Flash and Gemini 3.7 Flash (High/Medium/Low) in the static fallback list, matching agy's current Switch-Model labels.
 - [Fixed] Long speaker notes are now scrollable inside the presenter view instead of being clipped when notes push the layout past the viewport. (#6271)
 
 ## [0.9.0] - 2026-05-29

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -34,10 +34,11 @@ import type { RuntimeAgentDef } from '../types.js';
 // `availableModels` cache miss + empty print-mode output, which surfaces
 // to the user as a generic "empty response" error.
 //
-// The 8 model labels mirror what `Switch Model` in agy's TUI lists for
-// consumer-tier accounts as of 2026-05-28. The set is small and stable
-// enough to ship statically until upstream adds a programmatic
-// `agy models` subcommand (also tracked under issue #35).
+// The 14 model labels mirror what `Switch Model` in agy's TUI lists for
+// consumer-tier accounts as of 2026-08-18 (Gemini 3.6 Flash and Gemini
+// 3.7 Flash shipped in August 2026). The set is small and stable enough
+// to ship statically until upstream adds a programmatic `agy models`
+// subcommand (also tracked under issue #35).
 const ANTIGRAVITY_SETTINGS_PATH = join(
   homedir(),
   '.gemini',
@@ -178,6 +179,12 @@ export const antigravityAgentDef = {
     { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
     { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
     { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' },
+    { id: 'Gemini 3.6 Flash (High)', label: 'Gemini 3.6 Flash (High)' },
+    { id: 'Gemini 3.6 Flash (Medium)', label: 'Gemini 3.6 Flash (Medium)' },
+    { id: 'Gemini 3.6 Flash (Low)', label: 'Gemini 3.6 Flash (Low)' },
+    { id: 'Gemini 3.7 Flash (High)', label: 'Gemini 3.7 Flash (High)' },
+    { id: 'Gemini 3.7 Flash (Medium)', label: 'Gemini 3.7 Flash (Medium)' },
+    { id: 'Gemini 3.7 Flash (Low)', label: 'Gemini 3.7 Flash (Low)' },
     {
       id: 'Claude Sonnet 4.6 (Thinking)',
       label: 'Claude Sonnet 4.6 (Thinking)',

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -587,7 +587,7 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);
 
-  // Picker exposes the synthetic Default + the 8 labels agy's TUI
+  // Picker exposes the synthetic Default + the 14 labels agy's TUI
   // Switch-Model surfaces for consumer-tier accounts. The set is small
   // enough to ship statically; revisit when upstream adds an `agy
   // models` subcommand (also tracked under issue #35).
@@ -600,6 +600,12 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
       'Gemini 3.5 Flash (High)',
       'Gemini 3.5 Flash (Medium)',
       'Gemini 3.5 Flash (Low)',
+      'Gemini 3.6 Flash (High)',
+      'Gemini 3.6 Flash (Medium)',
+      'Gemini 3.6 Flash (Low)',
+      'Gemini 3.7 Flash (High)',
+      'Gemini 3.7 Flash (Medium)',
+      'Gemini 3.7 Flash (Low)',
       'Claude Sonnet 4.6 (Thinking)',
       'Claude Opus 4.6 (Thinking)',
       'GPT-OSS 120B (Medium)',


### PR DESCRIPTION
## Summary

The Antigravity runtime's static `fallbackModels` list was snapshotted on 2026-05-28 and still only contained Gemini 3.1 Pro / 3.5 Flash / Claude / GPT-OSS labels. Google shipped **Gemini 3.6 Flash** and **Gemini 3.7 Flash** in August 2026 and both are now available to all Antigravity plans (see [Antigravity Models docs](https://antigravity.google/docs/models)), but Open Design's model picker could not show them, forcing users to fall back to the `Default` + manual `/model` switch in `agy`.

This PR adds the six new labels (`Gemini 3.6 Flash (High/Medium/Low)` and `Gemini 3.7 Flash (High/Medium/Low)`) to the static fallback list so they appear directly in the Open Design model picker.

## Changes

- `apps/daemon/src/runtimes/defs/antigravity.ts`: add the 6 new labels to `fallbackModels` and update the snapshot comment (8 → 14 labels, dated 2026-08-18).
- `apps/daemon/tests/runtimes/agent-args.test.ts`: update the pinned `fallbackModels` ids assertion.
- `CHANGELOG.md`: add an Unreleased entry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

Note: the only user-visible effect is that the existing Antigravity model picker in Settings now offers the six additional model options; no UI/CLI/API/contract code changed — this is purely the daemon's static model catalog.

## Verification

- `vitest run agent-args antigravity-model-lock` → 54/54 tests pass
- daemon typecheck (`tsc -p tsconfig.json --noEmit` + `tsc -p tsconfig.tests.json --noEmit`) passes

The labels match the exact display strings agy's Switch-Model TUI uses (`<Model> (<High|Medium|Low>)`), consistent with the existing 3.5 Flash entries and the requirement that unrecognized labels produce silent empty responses.
