### PR TITLE
fix(web): wrap the composer placeholder instead of truncating it

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1468,20 +1468,34 @@
   min-height: clamp(150px, 20vh, 210px);
 }
 /* Lexical placeholder — absolutely positioned over the empty editor. The
-   editor adds/removes its sibling automatically; we style by class. */
+   editor adds/removes its sibling automatically; we style by class.
+
+   Wraps rather than truncating (#5370): several placeholders are full
+   sentences (the design-system flow's, for one), and on a single nowrap line
+   an ellipsis hid most of the text with no way to read the rest.
+
+   The inset matches the editable's own 8px/9px padding, so the placeholder
+   occupies exactly the text box it stands in for. Taking the height from
+   `bottom` rather than a max-height literal is what keeps it inside the
+   composer instead of merely trading ellipsis for overflow: the containing
+   block is `.composer-input-editor`, so the bound tracks whichever height that
+   element currently has — the default `min(184px, 34vh)`, active-file mode's
+   taller box, or a manually dragged `--composer-manual-h` — with no value
+   repeated here to fall out of sync. `overflow: hidden` clips a placeholder
+   longer than that box; it cannot push the composer taller. */
 .composer-input-placeholder {
   position: absolute;
-  top: 8px;
-  left: 9px;
+  inset: 8px 9px;
   pointer-events: none;
   user-select: none;
   color: var(--text-faint);
   font-size: 13px;
   line-height: 1.6;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: calc(100% - 8px);
+  text-overflow: clip;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .composer-input-wrap .home-hero__carousel {
   position: absolute;

--- a/apps/web/tests/styles/composer-input-placeholder.test.ts
+++ b/apps/web/tests/styles/composer-input-placeholder.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// #5370 — the composer placeholder truncated to one ellipsised line, which hid
+// most of the longer placeholders (the design-system flow's is a full
+// sentence). The fix wraps it instead, and the constraint that came with the
+// scope was that it must wrap *inside* the composer rather than trading an
+// ellipsis for overflow. Both halves are pinned here, plus the one thing the
+// fix must NOT touch: the home-page prompt carousel is single-line on purpose.
+
+const chatCss = readFileSync(new URL('../../src/styles/chat.css', import.meta.url), 'utf8');
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const matches = [...block.matchAll(new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`, 'g'))];
+  const match = matches.at(-1);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('#5370 — composer placeholder shows its full text', () => {
+  const placeholder = cssDeclarations(chatCss, '.composer-input-placeholder');
+
+  it('wraps instead of truncating to one line', () => {
+    expect(ruleValue(placeholder, 'white-space')).toBe('pre-wrap');
+    expect(ruleValue(placeholder, 'text-overflow')).toBe('clip');
+    // The two properties that produced the reported behaviour. Asserted as
+    // absent rather than only asserting the replacements, because either one
+    // coming back re-truncates the placeholder on its own.
+    expect(placeholder).not.toMatch(/white-space:\s*nowrap/);
+    expect(placeholder).not.toMatch(/text-overflow:\s*ellipsis/);
+    // Long unbroken tokens (a pasted path or URL in a placeholder) must break
+    // rather than push a single line past the fold.
+    expect(ruleValue(placeholder, 'overflow-wrap')).toBe('anywhere');
+    expect(ruleValue(placeholder, 'word-break')).toBe('break-word');
+  });
+
+  it('stays inside the editor box rather than trading ellipsis for overflow', () => {
+    // The height bound comes from the inset's `bottom`, so it is whatever
+    // `.composer-input-editor` currently is — the default max-height,
+    // active-file mode's taller box, or a manually dragged height. A
+    // max-height literal here would be a second copy of that number, free to
+    // drift from the three rules that actually set it.
+    const inset = ruleValue(placeholder, 'inset');
+    expect(inset).toBe('8px 9px');
+    expect(ruleValue(placeholder, 'position')).toBe('absolute');
+    // Wrapping without this would let a long placeholder spill out of the
+    // composer, which is the failure mode the scope explicitly ruled out.
+    expect(ruleValue(placeholder, 'overflow')).toBe('hidden');
+    // The bound is only meaningful while the editor is the containing block.
+    expect(ruleValue(cssDeclarations(chatCss, '.composer-input-editor'), 'position')).toBe('relative');
+  });
+
+  it('leaves the home-page prompt carousel single-line', () => {
+    // Deliberately NOT part of this fix: the carousel is a typewriter
+    // animation that reads as one line by design. It is a sibling of the
+    // placeholder and easy to sweep up in a "make placeholders wrap" change.
+    const carousel = cssDeclarations(chatCss, '.composer-input-wrap .home-hero__carousel');
+    expect(ruleValue(carousel, 'white-space')).toBe('nowrap');
+    expect(ruleValue(carousel, 'overflow')).toBe('hidden');
+  });
+});


### PR DESCRIPTION
Fixes #5370

## Why

Picked this up from the community queue after @lefarcen reopened it on Aug 18. The diagnosis and the scope here are @Kameti77's — they were the one who established that typed input wraps fine and that the problem is the placeholder overlay, and their PR #5491 was closed by the inactivity bot on Jul 26 without merging rather than because anything was wrong with it.

The pain: several placeholders are full sentences — the design-system flow's is one — and on a single `nowrap` line the ellipsis hid most of the text with no way to read the rest. Measured on `main` at the default composer width, that string lays out **519px wide inside a 414px box**, so about 20% of it is cut.

## What users will see

A placeholder that is longer than one line now wraps and shows in full, instead of ending in `…`. It wraps inside the composer's existing box — the composer does not grow, and nothing spills outside it.

The home page's rotating prompt carousel is unchanged: it is a separate element with its own rule and stays on one line by design.

## Surface area

- [x] **UI** — composer placeholder rendering in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Chromium, default composer width, showing the design-system flow's placeholder string (`dsFlow.composerPlaceholder`):

![Before and after](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-5370/composer-placeholder-before-after.png)

Disclosure on how these were produced: the string was written into the placeholder node in a throwaway Playwright spec rather than by navigating the whole design-system flow, so the capture exercises the shipped rule on the shipped element without the navigation in the way. Two placeholder nodes render stacked at that spot, so the text was set on both — setting only the first is what made my earlier captures show two overlapping strings.

## Bug fix verification

- Test path: `apps/web/tests/styles/composer-input-placeholder.test.ts`
- Red on `main`, green on this branch: **yes**. Reverted each part of the change separately, one at a time:
  - restore `white-space: nowrap` → only *"wraps instead of truncating to one line"* fails
  - restore `text-overflow: ellipsis` → same single test fails
  - put back `top`/`left` + `max-width` in place of `inset` → only *"stays inside the editor box…"* fails
  - also switch the carousel to `pre-wrap` (simulating the change spilling into the forbidden neighbour) → only *"leaves the home-page prompt carousel single-line"* fails

A CSS-level test cannot show that the placeholder actually stays inside the composer, so I measured that in the browser as well (Playwright, chromium, default width). `scrollHeight` vs the element's own height is the "is any of it cut" signal; the placeholder box vs the editor box is the "did it stay inside" signal:

| Case | Lines | Placeholder box | Editor box | Reading |
|---|---|---|---|---|
| `main`, real string | 1 | h 20.8 (589–609.8) | 581–653 | `scrollWidth` 519 vs `clientWidth` 414 → ~20% cut |
| this branch, real string | 3 | h 56 (589–645) | 581–653 | `scrollHeight == height` → nothing cut, fully inside |
| this branch, string ×6 | 8 | h **56** (589–645, clamped) | 581–653 | content wants `scrollHeight` 166, box stays 56, `bottom` 645 < 653 → clipped, does not spill |
| `main`, string ×6 | 1 | h 20.8 | 581–653 | `scrollWidth` 3132 vs 414 |

The third row is the one that answers the "don't just trade ellipsis for overflow" constraint directly.

Incidental finding while measuring, in case it is useful for reproducing: while the typewriter carousel owns an empty composer the placeholder node carries no text at all, which is consistent with the ellipsis showing up in the design-system flow (no carousel) rather than in the home composer.

## Validation

- `pnpm --filter @open-design/web test` — 6552 passed / 0 failed / 11 skipped
- `pnpm --filter @open-design/web exec tsc --noEmit` — clean
- `pnpm guard` — clean

## Design note

The scope @lefarcen set was that the placeholder must wrap *inside* the composer rather than trade an ellipsis for overflow. #5491 removed the two truncating properties; the piece I added is the bound.

Rather than repeating a `max-height` literal, the placeholder takes its box from the editable's own 8px/9px inset:

```css
.composer-input-placeholder {
  position: absolute;
  inset: 8px 9px;
  overflow: hidden;
  text-overflow: clip;
  white-space: pre-wrap;
  overflow-wrap: anywhere;
  word-break: break-word;
}
```

Deriving the height from `bottom` means the containing block — `.composer-input-editor` — supplies it, so the bound tracks whichever height that element currently has: the default `min(184px, 34vh)`, active-file mode's `min(300px, 32vh)`, or a manually dragged `--composer-manual-h`. A literal here would be a fourth copy of a number that three other rules already set, free to drift from all of them.

One consequence worth flagging for review: `.composer.composer-readonly .composer-input-placeholder` still carries `max-width: none`, which is now a no-op since the base rule no longer sets `max-width`. I left it rather than widen the diff into a rule this issue does not cover — happy to drop it if you would rather it went.
