### PR TITLE
fix(web): keep the deck preview tile inside its card

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2718,11 +2718,23 @@
    width-fit scale letterboxes top/bottom with the card bg and never clips. */
 .home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__html-iframe {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  inset: auto;
+  /* Anchor with the `inset` shorthand ALONE — no `top`/`left` longhands beside
+     it. This rule previously carried `inset: auto` after `top: 50%; left: 50%`,
+     and since `inset` is the top/right/bottom/left shorthand it reset both back
+     to `auto`, dropping the iframe to its static position: for a 1280px box in
+     a ~206px flex frame that lands several hundred pixels outside the tile,
+     which the frame's `overflow: hidden` renders as an empty card. Ordering the
+     two correctly would also work, but stating the anchor once removes the
+     shorthand/longhand hazard instead of relying on the next editor to preserve
+     the order. */
+  inset: 50% auto auto 50%;
   width: 1280px;
   height: 720px;
+  /* The base `.plugins-home__html-iframe` rule sets `transform-origin: 0 0`,
+     but the -50%/-50% centering idiom is only correct about the element's
+     centre; inheriting the corner origin offsets the tile by half its
+     *unscaled* 1280x720. Restate the origin rather than rely on the base. */
+  transform-origin: 50% 50%;
   transform: translate(-50%, -50%) scale(var(--deck-preview-scale));
 }
 

--- a/apps/web/tests/styles/deck-preview-tile-position.test.ts
+++ b/apps/web/tests/styles/deck-preview-tile-position.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+// The deck override for the home rail's example-prompt tiles renders the
+// preview iframe at a fixed 1280x720 logical viewport and scales it down to the
+// tile. Where the scaled box lands is load-bearing and easy to lose to a
+// plausible-looking edit, so the rule's anchoring is pinned here.
+//
+// Measured on a 206x150 tile before this was fixed: the iframe kept its correct
+// visual size (206x115.9 = 1280x720 x 0.1609) but sat at (-1158, -45), entirely
+// outside the tile — which the frame's `overflow: hidden` renders as an empty
+// card.
+//
+// The behavioural counterpart is `[P1] home hero deck preview keeps its scaled
+// slide inside the tile` (e2e/ui/home-hero-rail.test.ts), which measures the
+// rendered geometry rather than the stylesheet. It is kept in addition to, not
+// instead of, this spec: `uiP0Groups['entry-settings']` greps `\[P0\]`, so a
+// P1 UI spec does not run on PR CI, while this file runs in the Web workspace
+// lane on every PR that touches the stylesheet it guards.
+
+const homeHeroCss = readFileSync(new URL('../../src/styles/home/home-hero.css', import.meta.url), 'utf8');
+
+const DECK_IFRAME_SELECTOR = '.home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__html-iframe';
+
+function cssDeclarations(css: string, selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+describe('deck preview tile position', () => {
+  it('anchors with `inset` alone, never alongside `top`/`left` longhands', () => {
+    // `inset` is the shorthand for all four longhands, so the two forms cannot
+    // safely coexist: the rule shipped as `top: 50%; left: 50%; inset: auto`,
+    // where the trailing shorthand reset both back to `auto` and dropped the
+    // absolutely-positioned iframe to its static position. Ordering them the
+    // other way also works, but only until the next edit reorders them —
+    // stating the anchor once removes the hazard rather than documenting it.
+    const block = cssDeclarations(homeHeroCss, DECK_IFRAME_SELECTOR);
+
+    expect(block, 'the deck override should anchor via the `inset` shorthand').toMatch(
+      /(?:^|[;\n])\s*inset\s*:/,
+    );
+    expect(block, '`top` longhand alongside `inset` is the shipped regression').not.toMatch(
+      /(?:^|[;\n])\s*top\s*:/,
+    );
+    expect(block, '`left` longhand alongside `inset` is the shipped regression').not.toMatch(
+      /(?:^|[;\n])\s*left\s*:/,
+    );
+  });
+
+  it('restates `transform-origin` instead of inheriting the base rule corner origin', () => {
+    // `.plugins-home__html-iframe` (plugins-home.css) sets `transform-origin: 0 0`
+    // for its own top-left scaling. The deck override centres with
+    // `translate(-50%, -50%)`, which is only correct about the element's centre;
+    // with the corner origin it shifts by half the *unscaled* 1280x720.
+    const block = cssDeclarations(homeHeroCss, DECK_IFRAME_SELECTOR);
+
+    expect(block).toMatch(/transform-origin\s*:\s*(?:50%\s+50%|center)/);
+    expect(block, 'the centering transform is what depends on the origin').toMatch(
+      /transform\s*:\s*translate\(-50%,\s*-50%\)/,
+    );
+  });
+});

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -150,6 +150,12 @@ const HOME_PLUGINS = [
       od: {
         kind: 'scenario',
         taskKind: 'new-generation',
+        // `mode` drives the card's `data-od-mode`, and an html preview is what
+        // puts a scaled iframe in the tile — both are needed for the deck
+        // preview-positioning spec below to exercise the deck override at all.
+        mode: 'deck',
+        surface: 'web',
+        preview: { type: 'html', entry: './example.html' },
         useCase: {
           query:
             'Create a {{deckType}} for {{audience}} about {{topic}} with {{slideCount}}. Speaker notes: {{speakerNotes}}. Use {{designSystem}}.',
@@ -1873,6 +1879,81 @@ test('[P1] home hero deck example preset updates the composer input', async ({ p
   await expect(input).toHaveText(
     'Create a pitch deck for decision makers about quarterly review with 10-15 pages. Speaker notes: include speaker notes. Use the active project design system.',
   );
+});
+
+test('[P1] home hero deck preview keeps its scaled slide inside the tile', async ({ page }) => {
+  // The deck override renders the slide at a fixed 1280x720 logical viewport
+  // and scales it down to the tile. Two ways of writing that rule have already
+  // gone wrong: an `inset` shorthand ordered after the `top`/`left` longhands
+  // reset the anchor, and a `transform-origin` inherited from the base rule
+  // offsets the box by half its *unscaled* size. Both put the iframe outside
+  // the tile, where `overflow: hidden` renders it as an empty card.
+  //
+  // Assert the two properties the rule exists to provide rather than the
+  // declarations that happen to provide them, so a different-but-correct
+  // anchoring still passes:
+  //   1. the scaled slide is inside its frame (not a blank card);
+  //   2. the leftover slack is split evenly, since the cell is taller than 16:9
+  //      and the rule's contract is to letterbox top/bottom (see the frame's
+  //      `align-items: center` and the comment above the override).
+  await page.route('**/api/plugins/example-simple-deck/preview*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><html><body style="margin:0"><main style="width:1280px;height:720px">Deck preview</main></body></html>',
+    });
+  });
+
+  await gotoEntryHome(page);
+  await pickHomeTemplate(page, 'deck');
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+
+  const card = page.locator(
+    '[data-testid="home-hero-plugin-preset"][data-plugin-id="example-simple-deck"]',
+  );
+  await expect(card).toBeVisible();
+
+  const iframe = card.locator('.plugins-home__html-iframe');
+  await expect(iframe).toBeVisible();
+
+  const metrics = await iframe.evaluate((element) => {
+    const frame = element.closest('.plugins-home__html-frame');
+    if (!(frame instanceof HTMLElement)) throw new Error('Deck preview frame not found');
+    const slide = element.getBoundingClientRect();
+    const cell = frame.getBoundingClientRect();
+    return {
+      width: slide.width,
+      height: slide.height,
+      frameWidth: cell.width,
+      frameHeight: cell.height,
+      gapTop: slide.top - cell.top,
+      gapBottom: cell.bottom - slide.bottom,
+      gapLeft: slide.left - cell.left,
+      gapRight: cell.right - slide.right,
+    };
+  });
+
+  // A scale that collapsed to zero would satisfy every containment check below.
+  expect(metrics.width).toBeGreaterThan(0);
+  expect(metrics.height).toBeGreaterThan(0);
+
+  for (const [edge, gap] of Object.entries({
+    top: metrics.gapTop,
+    bottom: metrics.gapBottom,
+    left: metrics.gapLeft,
+    right: metrics.gapRight,
+  })) {
+    // Negative means the slide hangs off that edge and is clipped away.
+    expect(gap, `slide should not overhang the ${edge} edge (got ${gap}px)`).toBeGreaterThanOrEqual(
+      -1,
+    );
+  }
+
+  expect(
+    Math.abs(metrics.gapTop - metrics.gapBottom),
+    `letterbox should be even: ${metrics.gapTop}px top vs ${metrics.gapBottom}px bottom`,
+  ).toBeLessThanOrEqual(1);
+  expect(Math.abs(metrics.gapLeft - metrics.gapRight)).toBeLessThanOrEqual(1);
 });
 
 test('[P1] home hero prompt example cards fill the composer for fallback modes', async ({ page }) => {


### PR DESCRIPTION
Fixes #7019

## Why

I run a self-hosted deployment, where no plugin has a baked preview, so every home-rail tile takes the live-iframe path. On that path the deck tiles render as empty cards — the category that is otherwise the best-baked one, and therefore the one nobody sees this on.

@lefarcen confirmed the analysis in #7019 and invited a PR for the scoped CSS fix, which is what this is.

## What users will see

Deck templates in the home rail's example-prompt tiles show their first slide again, centered and letterboxed, instead of an empty card. Nothing else moves: the tile keeps its size, its scale, and its place in the rail.

Anyone whose deployment has baked previews never saw the bug and will see no change — those tiles render through `MediaSurface`, not this rule.

## The two causes

The iframe was scaled correctly the whole time. Measured on a 206×150 tile, its visual box was 206×115.9 — exactly 1280×720 × 0.1609, matching the resolved `--deck-preview-scale`. It was simply somewhere else.

1. **`inset: auto` came after `top`/`left`.** `inset` is the shorthand for all four longhands, so declaring it afterwards resets both back to `auto` and the absolutely-positioned iframe falls back to its static position — for a 1280px box in a ~206px flex frame, several hundred pixels outside the tile.
2. **The rule inherited `transform-origin: 0 0`** from the base `.plugins-home__html-iframe` rule in `plugins-home.css`. The `translate(-50%, -50%)` centering idiom is only correct about the element's own centre; from the corner it offsets by half the *unscaled* 1280×720.

Isolated in headless Chrome, same markup, one declaration changed at a time (position relative to the cell):

| variant | x | y | inside the cell |
|---|---|---|---|
| as shipped | −594 | −306 | ✗ |
| `inset` order fixed only | −537 | −285 | ✗ |
| **both fixed** | **0** | **17** | **✓** |

`y = 17` is `(150 − 116) / 2` — the letterboxing the rule's own comment describes. Fixing either cause alone leaves the tile outside the card, which is why both are in this patch.

Worth noting the built CSS collapses the result to `inset: 50% auto auto 50%`, so the ordering hazard disappears entirely rather than being re-introducible by a future reorder.

## Surface area

- [x] **UI** — deck tiles in the home example-prompt rail
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**

## Screenshots

Not attached, and I want to be straight about why: reproducing the *before* state requires a deployment with no baked previews, so a screenshot pair from my environment would differ from yours in ways unrelated to this change. The measured rects above are the same evidence in a form that does not depend on my setup, and the spec below pins it without a browser at all.

## Bug fix verification

- Test path: `apps/web/tests/styles/deck-preview-tile-position.test.ts`
- Red on `main`, green on this branch: **yes**

Pre-fix output, both specs failing for their own reason:

```
× clears `inset` before setting the `top`/`left` it depends on
    AssertionError: `inset` must precede `top`, otherwise it resets it to auto: expected 46 to be less than 21
× restates `transform-origin` instead of inheriting the base rule corner origin
    AssertionError: expected '\n  position: absolute;\n  top: 50%;\…' to match /transform-origin\s*:\s*(?:50%\s+50%|c…/
```

It asserts the stylesheet rather than rendered geometry, following the existing `apps/web/tests/styles/` pattern. That is a deliberate trade: a headless-render assertion would cover more but would bring a browser into a unit suite for two declarations, and these two are the whole failure. The measurements above are what established *which* declarations to pin; the spec keeps them pinned.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/styles/` — 35 files, 84 tests, all pass
- `pnpm --filter @open-design/web typecheck` — pass

## Not addressed here

The reason this path runs at all for a whole deployment is #7018 — Docker images ship without `data/plugin-previews/manifest.json`, so every plugin falls back to the live iframe. That is a separate PR. This one is still worth having after it: unbaked bundled plugins (285 of 461) and user-installed plugins stay on this path regardless.
