### PR TITLE
fix(collab): keep workspace projects usable during outages and first open

### DIFF
--- a/apps/daemon/src/automations/workspace-scope.ts
+++ b/apps/daemon/src/automations/workspace-scope.ts
@@ -1,10 +1,3 @@
-import type {
-  WorkspaceCollabContext,
-  WorkspaceDirectoryItem,
-} from '@open-design/contracts';
-import type { WorkspaceDirectoryFetchResult } from '../collab/vela-workspace-context.js';
-import { workspaceContextFromDirectoryItem } from '../collab/vela-workspace-context.js';
-
 export interface PersistedAutomationWorkspaceScope {
   workspaceId: string;
   workspaceMemberId: string;
@@ -13,9 +6,7 @@ export interface PersistedAutomationWorkspaceScope {
 export class AutomationWorkspaceScopeError extends Error {
   constructor(
     readonly code:
-      | 'WORKSPACE_AUTHORITY_UNAVAILABLE'
-      | 'WORKSPACE_ACCESS_DENIED'
-      | 'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      | 'WORKSPACE_ACCESS_DENIED',
     message: string,
     readonly retryable: boolean,
   ) {
@@ -77,88 +68,4 @@ export function bindProjectToPersistedAutomationWorkspace(
     createdAt: now,
     updatedAt: now,
   });
-}
-
-async function fetchDirectoryOrThrow(
-  fetchWorkspaceDirectory: (() => Promise<WorkspaceDirectoryFetchResult>) | undefined,
-): Promise<WorkspaceDirectoryItem[]> {
-  if (!fetchWorkspaceDirectory) {
-    throw new AutomationWorkspaceScopeError(
-      'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      'workspace membership authority is not configured',
-      true,
-    );
-  }
-  let directory: WorkspaceDirectoryFetchResult;
-  try {
-    directory = await fetchWorkspaceDirectory();
-  } catch {
-    directory = { ok: false, items: [] };
-  }
-  if (!directory.ok) {
-    throw new AutomationWorkspaceScopeError(
-      'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      'workspace membership authority is temporarily unavailable',
-      true,
-    );
-  }
-  return directory.items;
-}
-
-function activeWritableContext(
-  context: WorkspaceCollabContext | null,
-): WorkspaceCollabContext | null {
-  return context
-    && context.memberStatus === 'active'
-    && context.lifecycleState === 'active'
-    && context.permissions.canWriteSyncedFiles
-    ? context
-    : null;
-}
-
-/**
- * Re-authorize a Workspace/member pair captured when an unattended automation
- * was configured. No daemon-global current/active Workspace participates.
- */
-export async function authorizePersistedAutomationWorkspaceScope(
-  scope: PersistedAutomationWorkspaceScope,
-  fetchWorkspaceDirectory: (() => Promise<WorkspaceDirectoryFetchResult>) | undefined,
-): Promise<WorkspaceCollabContext> {
-  const items = await fetchDirectoryOrThrow(fetchWorkspaceDirectory);
-  const item = items.find(
-    (candidate) =>
-      candidate.workspaceId === scope.workspaceId
-      && candidate.workspaceMemberId === scope.workspaceMemberId,
-  );
-  const context = activeWritableContext(item ? workspaceContextFromDirectoryItem(item) : null);
-  if (!context) {
-    throw new AutomationWorkspaceScopeError(
-      'WORKSPACE_ACCESS_DENIED',
-      'the automation Workspace is no longer writable by this member',
-      false,
-    );
-  }
-  return context;
-}
-
-/**
- * Resolve a reused project's persisted binding. The project row chooses the
- * Workspace; the signed-in directory supplies the current member and authority.
- */
-export async function authorizePersistedProjectWorkspace(
-  workspaceIdInput: string,
-  fetchWorkspaceDirectory: (() => Promise<WorkspaceDirectoryFetchResult>) | undefined,
-): Promise<WorkspaceCollabContext> {
-  const workspaceId = workspaceIdInput.trim();
-  const items = await fetchDirectoryOrThrow(fetchWorkspaceDirectory);
-  const item = items.find((candidate) => candidate.workspaceId === workspaceId);
-  const context = activeWritableContext(item ? workspaceContextFromDirectoryItem(item) : null);
-  if (!context) {
-    throw new AutomationWorkspaceScopeError(
-      'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      'the reused project Workspace is no longer writable by this member',
-      false,
-    );
-  }
-  return context;
 }

--- a/apps/daemon/src/collab/created-project-workspace.ts
+++ b/apps/daemon/src/collab/created-project-workspace.ts
@@ -1,14 +1,10 @@
 import type { ApiErrorResponse } from '@open-design/contracts';
 import type { Response } from 'express';
 import {
-  isWorkspaceResourceLocked,
   workspaceResourceContextFromRequest,
   type WorkspaceResourceContext,
 } from './workspace-resource-mutation.js';
-import {
-  workspaceContextFromDirectoryItem,
-  type WorkspaceDirectoryFetchResult,
-} from './vela-workspace-context.js';
+import type { WorkspaceDirectoryFetchResult } from './vela-workspace-context.js';
 import { sendApiError } from '../http/api-errors.js';
 
 export type CreatedProjectWorkspaceResolution =
@@ -44,43 +40,6 @@ export function sendCreatedProjectWorkspaceError(
 }
 
 /**
- * Resolve the workspace authority for a route that creates a project.
- *
- * A completely headerless request is a legal legacy/anonymous caller and
- * intentionally leaves the new project unbound. Once either workspace
- * identity header is present, however, the request is a workspace-aware
- * caller: partial, removed, locked, or non-writing identities must fail
- * closed instead of silently creating an unbound orphan.
- */
-export function resolveCreatedProjectWorkspace(
-  req: unknown,
-): CreatedProjectWorkspaceResolution {
-  const context = workspaceResourceContextFromRequest(req);
-  if (context === null) return { ok: true, context: null };
-  if (context === 'missing') {
-    return {
-      ok: false,
-      status: 400,
-      code: 'WORKSPACE_CONTEXT_INCOMPLETE',
-      message: 'workspace project creation requires both workspace and member identity',
-    };
-  }
-  if (
-    context.memberStatus !== 'active'
-    || !context.canWriteSyncedFiles
-    || isWorkspaceResourceLocked(context)
-  ) {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project creation is not allowed',
-    };
-  }
-  return { ok: true, context };
-}
-
-/**
  * Capture optional local attribution for an ordinary local project create.
  *
  * PRODUCT INVARIANT: `POST /api/projects` creates local data first. Workspace
@@ -98,90 +57,13 @@ export function localProjectWorkspaceAttribution(
   return context === null || context === 'missing' ? null : context;
 }
 
-/**
- * Authorize an explicitly-scoped project create against the signed-in
- * membership directory. The caller-selected workspace/member pair is the
- * lookup key; the daemon's ambient active workspace is deliberately absent
- * from this contract.
- *
- * A missing fetcher is the local/dev compatibility path. Production Vela
- * mode injects one and therefore fails closed when AMR is unavailable.
- */
+/** Capture local attribution for project creation without a network gate. */
 export async function authorizeCreatedProjectWorkspace(
   req: unknown,
-  fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>,
-  configuredEnv?: Record<string, string>,
+  _fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>,
+  _configuredEnv?: Record<string, string>,
 ): Promise<CreatedProjectWorkspaceResolution> {
-  const claimed = resolveCreatedProjectWorkspace(req);
-  if (!claimed.ok || claimed.context === null || !fetchWorkspaceDirectory) {
-    return claimed;
-  }
-  const claimedContext = claimed.context;
-
-  let directory: WorkspaceDirectoryFetchResult;
-  try {
-    directory = await fetchWorkspaceDirectory();
-  } catch {
-    directory = { ok: false, items: [] };
-  }
-  if (!directory.ok) {
-    if (directory.reason === 'unauthorized') {
-      return {
-        ok: false,
-        status: 401,
-        code: 'AMR_AUTH_REQUIRED',
-        message: 'AMR authorization expired. Sign in again to continue.',
-      };
-    }
-    return {
-      ok: false,
-      status: 503,
-      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      message: 'workspace membership authority is temporarily unavailable',
-      retryable: true,
-    };
-  }
-
-  const item = directory.items.find(
-    (candidate) =>
-      candidate.workspaceId === claimedContext.workspaceId
-      && candidate.workspaceMemberId === claimedContext.workspaceMemberId,
-  );
-  if (!item) {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project creation is not allowed',
-    };
-  }
-
-  const authoritative = workspaceContextFromDirectoryItem(item, configuredEnv);
-  const context: WorkspaceResourceContext = {
-    workspaceId: authoritative.workspaceId,
-    workspaceType: authoritative.workspaceType,
-    workspaceTypeAsserted: authoritative.workspaceType,
-    appUserId: claimedContext.appUserId,
-    workspaceMemberId: authoritative.workspaceMemberId,
-    role: authoritative.role,
-    memberStatus: authoritative.memberStatus,
-    lifecycleState: authoritative.lifecycleState,
-    canShareProjects: authoritative.permissions.canShareProjects,
-    canWriteSyncedFiles: authoritative.permissions.canWriteSyncedFiles,
-  };
-  if (
-    context.memberStatus !== 'active'
-    || !context.canWriteSyncedFiles
-    || isWorkspaceResourceLocked(context)
-  ) {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project creation is not allowed',
-    };
-  }
-  return { ok: true, context };
+  return { ok: true, context: localProjectWorkspaceAttribution(req) };
 }
 
 /**
@@ -203,12 +85,7 @@ export class CreatedProjectWorkspaceResolutionError extends Error {
   }
 }
 
-/**
- * Resolve an exact creation scope. Headerless legacy requests remain unbound.
- * Once either identity field is asserted, any incomplete, removed, denied, or
- * unavailable authority fails closed; it never degrades to ambient/current or
- * silently creates an unbound project.
- */
+/** Resolve the optional local creation scope. */
 export async function createdProjectWorkspaceHome(
   req: unknown,
   fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>,
@@ -255,8 +132,9 @@ export function createCreatedProjectWorkspaceResolver(deps: {
  * the signed-in account wallet, but any later request that asserts a Workspace
  * still needs an exact persisted binding before workspace mutation gates allow it.
  *
- * `context` is the caller's exact verified Workspace when the request named
- * one. A headerless legacy request supplies null and remains unbound.
+ * `context` is the caller's complete local Workspace attribution when the
+ * request named one. A headerless legacy request supplies null and remains
+ * unbound; remote authority is checked only at a later cloud boundary.
  */
 export function bindCreatedProjectToWorkspace(
   ensureWorkspaceProject: (input: {

--- a/apps/daemon/src/collab/project-request-authority.ts
+++ b/apps/daemon/src/collab/project-request-authority.ts
@@ -209,6 +209,8 @@ export function createAuthorizeProjectRequest(deps: {
    * shape because it lives on project metadata for restart-safe recovery.
    */
   isProjectRevoked?: (db: unknown, projectId: string) => boolean;
+  /** A bound first-open placeholder may be read but is never content authority. */
+  isProjectUnmaterializedPlaceholder?: (db: unknown, projectId: string) => boolean;
   sendApiError: (
     res: Response,
     status: number,
@@ -222,6 +224,7 @@ export function createAuthorizeProjectRequest(deps: {
     getWorkspaceProject,
     getWorkspaceProjectByProjectId,
     isProjectRevoked,
+    isProjectUnmaterializedPlaceholder,
     sendApiError,
   } = deps;
   return async (req, res, projectId, options) => {
@@ -238,7 +241,7 @@ export function createAuthorizeProjectRequest(deps: {
       );
       return false;
     }
-    return enforceLocalProjectDataPlaneRequest({
+    const allowed = await enforceLocalProjectDataPlaneRequest({
       req,
       projectId,
       options,
@@ -249,5 +252,20 @@ export function createAuthorizeProjectRequest(deps: {
         ? sendApiError(res, status, code, message)
         : sendApiError(res, status, code, message, details),
     });
+    if (!allowed) return false;
+    if (
+      options.mode !== 'read'
+      && options.capability !== 'comment'
+      && isProjectUnmaterializedPlaceholder?.(db, projectId)
+    ) {
+      sendApiError(
+        res,
+        409,
+        'PROJECT_MATERIALIZATION_PENDING',
+        'project content is still materializing',
+      );
+      return false;
+    }
+    return true;
   };
 }

--- a/apps/daemon/src/collab/project-request-authority.ts
+++ b/apps/daemon/src/collab/project-request-authority.ts
@@ -146,9 +146,24 @@ export async function enforceLocalProjectDataPlaneRequest(input: {
     );
   }
 
-  // An explicit browser/tool identity must still match the persisted creator.
-  // Headerless Personal projects retain CLI compatibility; Team projects need
-  // the locally persisted creator pair, but never a Vela round-trip.
+  // A Team project is single-writer. Pulled member mirrors deliberately persist
+  // a null creator, so null means "no local writer", not "unattributed local
+  // project". Keep those mirrors read-only from the durable row even when Vela
+  // is unavailable; only an exact persisted creator/member match may write.
+  if (
+    row.visibility === 'team'
+    && row.createdByWorkspaceMemberId !== claimed?.workspaceMemberId
+  ) {
+    return deny(
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      'workspace project mutation is not allowed',
+    );
+  }
+
+  // An explicit browser/tool identity must still match the persisted creator
+  // for attributed Personal projects. Headerless Personal projects retain CLI
+  // compatibility.
   if (
     claimed
     && row.createdByWorkspaceMemberId

--- a/apps/daemon/src/collab/project-request-authority.ts
+++ b/apps/daemon/src/collab/project-request-authority.ts
@@ -1,56 +1,12 @@
 import type { Response } from 'express';
 import {
-  enforceVerifiedWorkspaceResourceMutation,
-  enforceVerifiedWorkspaceResourceRead,
+  requestWithWorkspaceNavigationScope,
+  workspaceResourceContextFromRequest,
   type ResolveWorkspaceResourceReadAuthority,
   type VerifyWorkspaceRequestAuthority,
-  type WorkspaceRequestAuthorityResult,
   type WorkspaceResourceAccessInput,
   type WorkspaceResourceMutationCapability,
 } from './workspace-resource-mutation.js';
-import {
-  workspaceContextFromDirectoryItem,
-  type WorkspaceDirectoryFetchResult,
-} from './vela-workspace-context.js';
-
-export function resolveBoundProjectWorkspaceReadAuthority(
-  workspaceId: string,
-  directory: WorkspaceDirectoryFetchResult,
-  configuredEnv: Record<string, string> = {},
-): WorkspaceRequestAuthorityResult {
-  if (!directory.ok) {
-    if (directory.reason === 'unauthorized') {
-      return {
-        ok: false,
-        status: 401,
-        code: 'AMR_AUTH_REQUIRED',
-        message: 'AMR authorization expired. Sign in again to continue.',
-      };
-    }
-    return {
-      ok: false,
-      status: 503,
-      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      message: 'workspace membership authority is temporarily unavailable',
-      retryable: true,
-    };
-  }
-  const item = directory.items.find(
-    (candidate) => candidate.workspaceId === workspaceId,
-  );
-  if (!item) {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project access is not allowed',
-    };
-  }
-  return {
-    ok: true,
-    context: workspaceContextFromDirectoryItem(item, configuredEnv),
-  };
-}
 
 export type AuthorizeProjectRequestOptions =
   | {
@@ -83,13 +39,137 @@ export type AuthorizeProjectToolRequest = (
   options: AuthorizeProjectRequestOptions,
 ) => Promise<AuthorizedProjectToolRequest | null>;
 
+export async function enforceLocalProjectDataPlaneRequest(input: {
+  req: any;
+  projectId: string;
+  options: AuthorizeProjectRequestOptions;
+  db: unknown;
+  getWorkspaceProject: (
+    db: unknown,
+    workspaceId: string,
+    projectId: string,
+  ) => WorkspaceResourceAccessInput | null | undefined;
+  getWorkspaceProjectByProjectId: (
+    db: unknown,
+    projectId: string,
+  ) => WorkspaceResourceAccessInput | null | undefined;
+  onDenied?: (
+    status: number,
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ) => unknown;
+}): Promise<boolean> {
+  const {
+    req,
+    projectId,
+    options,
+    db,
+    getWorkspaceProject,
+    getWorkspaceProjectByProjectId,
+    onDenied,
+  } = input;
+  const deny = (
+    status: number,
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ): false => {
+    onDenied?.(status, code, message, details);
+    return false;
+  };
+  const persisted = getWorkspaceProjectByProjectId(db, projectId);
+  if (!persisted?.workspaceId) return true;
+
+  const scopedRequest = options.mode === 'read' && options.allowNavigationQuery
+    ? requestWithWorkspaceNavigationScope(req)
+    : req;
+  if (scopedRequest === 'conflict') {
+    return deny(
+      400,
+      'WORKSPACE_CONTEXT_CONFLICT',
+      'workspace header and navigation scope must match',
+    );
+  }
+  const claimed = workspaceResourceContextFromRequest(scopedRequest);
+  if (claimed === 'missing') {
+    return deny(
+      400,
+      'WORKSPACE_CONTEXT_INCOMPLETE',
+      'both workspace and member identity are required',
+    );
+  }
+  if (claimed && claimed.workspaceId !== persisted.workspaceId) {
+    return deny(
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      `workspace project ${options.mode} is not allowed`,
+    );
+  }
+
+  const row = getWorkspaceProject(db, persisted.workspaceId, projectId);
+  if (!row || row.resourceState === 'deleted') {
+    return deny(
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      `workspace project ${options.mode} is not allowed`,
+    );
+  }
+  if (options.mode === 'read') {
+    if (
+      claimed
+      && row.visibility === 'personal'
+      && row.createdByWorkspaceMemberId
+      && row.createdByWorkspaceMemberId !== claimed.workspaceMemberId
+    ) {
+      return deny(
+        403,
+        'WORKSPACE_PROJECT_PERMISSION_DENIED',
+        'workspace project read is not allowed',
+      );
+    }
+    return true;
+  }
+  if (row.resourceState === 'frozen') {
+    return deny(
+      403,
+      'WORKSPACE_LOCKED',
+      'workspace project mutation is not allowed',
+    );
+  }
+  if (options.capability === 'comment' && row.visibility === 'team') return true;
+  if (!claimed && row.visibility === 'team') {
+    return deny(
+      400,
+      'WORKSPACE_CONTEXT_REQUIRED',
+      'workspace context is required',
+    );
+  }
+
+  // An explicit browser/tool identity must still match the persisted creator.
+  // Headerless Personal projects retain CLI compatibility; Team projects need
+  // the locally persisted creator pair, but never a Vela round-trip.
+  if (
+    claimed
+    && row.createdByWorkspaceMemberId
+    && row.createdByWorkspaceMemberId !== claimed.workspaceMemberId
+  ) {
+    return deny(
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      'workspace project mutation is not allowed',
+    );
+  }
+  return true;
+}
+
 /**
  * Build the one project data-plane authority gate used by route modules.
  *
- * Persisted project binding is the resource identity. Bound projects require a
- * fresh exact Workspace/member verification on every request; no active,
- * current, or last-known daemon Workspace participates. Unbound pre-Workspace
- * local projects retain their legacy behavior.
+ * Persisted project binding is the local namespace and creator witness. Local
+ * project data-plane requests never synchronously depend on Vela membership
+ * availability; cloud share/sync/billing boundaries perform their own fresh
+ * authorization. Unbound pre-Workspace local projects retain legacy behavior.
  */
 export function createAuthorizeProjectRequest(deps: {
   db: unknown;
@@ -102,20 +182,11 @@ export function createAuthorizeProjectRequest(deps: {
     db: unknown,
     projectId: string,
   ) => WorkspaceResourceAccessInput | null | undefined;
-  /**
-   * Bounded successful authority lease for idempotent project reads. When
-   * omitted, reads retain the mutation verifier for compatibility with narrow
-   * fixtures and callers that do not provide separate cache policy.
-   */
+  /** @deprecated Retained as an ignored compatibility seam for route fixtures. */
   verifyWorkspaceReadAuthority?: VerifyWorkspaceRequestAuthority;
-  /**
-   * Resolve a bound project's read authority from its persisted ownership and
-   * the daemon's authenticated membership directory. Headerless browser
-   * navigations use this path instead of requiring client-supplied Workspace
-   * identifiers.
-   */
+  /** @deprecated Retained as an ignored compatibility seam for route fixtures. */
   resolveWorkspaceReadAuthority?: ResolveWorkspaceResourceReadAuthority;
-  /** Fresh fail-closed authority used for every project mutation. */
+  /** @deprecated Local project data-plane requests never call this verifier. */
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
   /**
    * Durable local quarantine witness for a pulled mirror whose authoritative
@@ -135,9 +206,6 @@ export function createAuthorizeProjectRequest(deps: {
     db,
     getWorkspaceProject,
     getWorkspaceProjectByProjectId,
-    verifyWorkspaceReadAuthority,
-    resolveWorkspaceReadAuthority,
-    verifyWorkspaceRequestAuthority,
     isProjectRevoked,
     sendApiError,
   } = deps;
@@ -155,36 +223,16 @@ export function createAuthorizeProjectRequest(deps: {
       );
       return false;
     }
-    if (options.mode === 'write') {
-      return await enforceVerifiedWorkspaceResourceMutation(
-        'project',
-        req,
-        res,
-        sendApiError,
-        getWorkspaceProject,
-        getWorkspaceProjectByProjectId,
-        db,
-        projectId,
-        options.capability,
-        verifyWorkspaceRequestAuthority,
-      );
-    }
-    return await enforceVerifiedWorkspaceResourceRead(
-      'project',
+    return enforceLocalProjectDataPlaneRequest({
       req,
-      res,
-      sendApiError,
+      projectId,
+      options,
+      db,
       getWorkspaceProject,
       getWorkspaceProjectByProjectId,
-      db,
-      projectId,
-      verifyWorkspaceReadAuthority ?? verifyWorkspaceRequestAuthority,
-      {
-        ...(options.allowNavigationQuery ? { allowNavigationQuery: true } : {}),
-        ...(resolveWorkspaceReadAuthority
-          ? { resolveAuthority: resolveWorkspaceReadAuthority }
-          : {}),
-      },
-    );
+      onDenied: (status, code, message, details) => details === undefined
+        ? sendApiError(res, status, code, message)
+        : sendApiError(res, status, code, message, details),
+    });
   };
 }

--- a/apps/daemon/src/collab/project-workspace-scope.ts
+++ b/apps/daemon/src/collab/project-workspace-scope.ts
@@ -1,49 +1,39 @@
 import type {
   ProjectVisibility,
   ProjectWorkspaceScope,
+  WorkspaceType,
 } from '@open-design/contracts';
 import {
   workspaceContextFromDirectoryItem,
-  type WorkspaceDirectoryFetchResult,
 } from './vela-workspace-context.js';
 
 interface ProjectWorkspaceBinding {
   workspaceId?: unknown;
   visibility?: unknown;
+  workspaceVisibility?: unknown;
   resourceState?: unknown;
+  createdByWorkspaceMemberId?: unknown;
 }
 
-export type ProjectWorkspaceScopeBootstrapResult =
-  | {
-      ok: true;
-      scope: ProjectWorkspaceScope;
-    }
-  | {
-      ok: false;
-      status: 403 | 503;
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' | 'WORKSPACE_DIRECTORY_UNAVAILABLE';
-      message: string;
-    };
-
 /**
- * Resolve a project's persisted workspace binding against the signed-in
- * caller's authoritative membership directory.
- *
- * Directory ordering and the daemon's ambient/active workspace are
- * intentionally irrelevant. A missing or failed exact membership lookup
- * stays `unavailable`; it must never borrow another workspace's member id.
+ * Resolve the browser/runtime scope of a local project without consulting the
+ * membership directory. Persisted binding is authoritative for the Workspace
+ * id; a complete request or the daemon's already-learned type supplies the
+ * Personal/Team presentation hint. Unknown historical private bindings fall
+ * back to Personal until the account directory catches up.
  */
-export function resolveProjectWorkspaceScope(input: {
+export function resolveLocalProjectWorkspaceScope(input: {
   projectId: string;
   binding: ProjectWorkspaceBinding | null | undefined;
-  directory: WorkspaceDirectoryFetchResult;
+  requestWorkspaceMemberId?: string | null;
+  requestWorkspaceType?: WorkspaceType | null;
+  knownWorkspaceType?: WorkspaceType | null;
   configuredEnv?: Record<string, string>;
 }): ProjectWorkspaceScope {
   const projectId = input.projectId.trim();
-  const workspaceId =
-    typeof input.binding?.workspaceId === 'string'
-      ? input.binding.workspaceId.trim()
-      : '';
+  const workspaceId = typeof input.binding?.workspaceId === 'string'
+    ? input.binding.workspaceId.trim()
+    : '';
   if (!workspaceId) {
     return {
       kind: 'unbound',
@@ -52,35 +42,33 @@ export function resolveProjectWorkspaceScope(input: {
       context: null,
     };
   }
-
-  const visibility: ProjectVisibility =
-    input.binding?.visibility === 'team' ? 'team' : 'personal';
-  const unavailable = (): ProjectWorkspaceScope => ({
-    kind: 'unavailable',
-    projectId,
+  const visibility: ProjectVisibility = (
+    input.binding?.visibility === 'team'
+    || input.binding?.workspaceVisibility === 'team'
+  )
+    ? 'team'
+    : 'personal';
+  const workspaceType = input.requestWorkspaceType
+    ?? input.knownWorkspaceType
+    ?? (visibility === 'team' ? 'team' : 'personal');
+  const persistedMemberId = typeof input.binding?.createdByWorkspaceMemberId === 'string'
+    ? input.binding.createdByWorkspaceMemberId.trim()
+    : '';
+  const workspaceMemberId = input.requestWorkspaceMemberId?.trim()
+    || persistedMemberId
+    || 'local-user';
+  const context = workspaceContextFromDirectoryItem({
     workspaceId,
-    visibility,
-    context: null,
-  });
-  if (!input.directory.ok) return unavailable();
-
-  const item = input.directory.items.find(
-    (candidate) =>
-      candidate.workspaceId === workspaceId &&
-      candidate.memberStatus === 'active' &&
-      candidate.lifecycleState !== 'deleted',
-  );
-  if (!item) return unavailable();
-
-  const context = workspaceContextFromDirectoryItem(item, input.configuredEnv);
-  if (
-    context.workspaceId !== workspaceId ||
-    !context.workspaceMemberId ||
-    context.memberStatus !== 'active'
-  ) {
-    return unavailable();
-  }
-  if (context.workspaceType === 'team') {
+    workspaceName: workspaceId,
+    workspaceType,
+    workspaceMemberId,
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: input.binding?.resourceState === 'frozen'
+      ? 'locked'
+      : 'active',
+  }, input.configuredEnv);
+  if (workspaceType === 'team') {
     return {
       kind: 'team',
       projectId,
@@ -96,52 +84,4 @@ export function resolveProjectWorkspaceScope(input: {
     visibility,
     context: { ...context, workspaceType: 'personal' },
   };
-}
-
-/**
- * Resolve the one headerless bootstrap read used by a fresh project deep link.
- *
- * This does not authorize project content. It discloses a persisted binding
- * only after a fresh signed-in directory proves the caller is an active member
- * of that exact Workspace. The web must then attach the returned context to
- * every project data-plane request, which still passes the normal route gate.
- */
-export function resolveProjectWorkspaceScopeBootstrap(input: {
-  projectId: string;
-  binding: ProjectWorkspaceBinding | null | undefined;
-  directory: WorkspaceDirectoryFetchResult;
-  configuredEnv?: Record<string, string>;
-}): ProjectWorkspaceScopeBootstrapResult {
-  if (!input.binding?.workspaceId) {
-    return {
-      ok: true,
-      scope: resolveProjectWorkspaceScope(input),
-    };
-  }
-  if (input.binding.resourceState === 'deleted') {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project read is not allowed',
-    };
-  }
-  if (!input.directory.ok) {
-    return {
-      ok: false,
-      status: 503,
-      code: 'WORKSPACE_DIRECTORY_UNAVAILABLE',
-      message: 'workspace membership directory is unavailable',
-    };
-  }
-  const scope = resolveProjectWorkspaceScope(input);
-  if (scope.kind === 'unavailable' || scope.context === null) {
-    return {
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project read is not allowed',
-    };
-  }
-  return { ok: true, scope };
 }

--- a/apps/daemon/src/collab/team-mirror-materializer.ts
+++ b/apps/daemon/src/collab/team-mirror-materializer.ts
@@ -17,6 +17,7 @@ import type {
 } from '../routes/collab-sync.js';
 import type { AuthorizedTeamProjectPullReceipt } from './authorized-team-project-pull.js';
 import type { ResourceHubPrincipal } from './resource-principal.js';
+import { isUnmaterializedSharedPlaceholder } from './shared-project-placeholder.js';
 
 type SqliteDb = Database.Database;
 
@@ -169,6 +170,7 @@ export function materializePulledTeamMirror(
   input: RegisterPulledProjectInput,
   scope: TeamMirrorPullScope,
   receipt?: AuthorizedTeamProjectPullReceipt,
+  options: { placeholder?: boolean } = {},
 ): MaterializePulledTeamMirrorResult {
   if (
     receipt &&
@@ -192,8 +194,11 @@ export function materializePulledTeamMirror(
       lifecycleState: 'active',
       workspaceType: 'team',
     };
-    const expectedCreator =
-      scope.ownerMemberId === scope.viewerMemberId ? scope.viewerMemberId : null;
+    const expectedCreator = options.placeholder
+      ? null
+      : scope.ownerMemberId === scope.viewerMemberId
+        ? scope.viewerMemberId
+        : null;
     const resourceHubResourceId =
       receipt?.resourceId ?? projectResourceIdFor(input.id, ownerPrincipal);
     if (
@@ -213,6 +218,10 @@ export function materializePulledTeamMirror(
         }
       | undefined;
     const existing = getProject(db, input.id);
+    const existingIsPlaceholder = isUnmaterializedSharedPlaceholder(existing);
+    if (options.placeholder && existing && !existingIsPlaceholder) {
+      throw new Error(`team placeholder project conflict for ${input.id}`);
+    }
     const isRevokedMirror =
       existingBinding?.resourceState === 'deleted'
       && Boolean(existing?.metadata?.teamMirrorRevokedAt);
@@ -226,7 +235,14 @@ export function materializePulledTeamMirror(
           || isRevokedMirror
         ) &&
         existingBinding.cloudTombstonedAt === null &&
-        existingBinding.createdByWorkspaceMemberId === expectedCreator &&
+        (
+          existingBinding.createdByWorkspaceMemberId === expectedCreator
+          || (
+            !options.placeholder
+            && existingIsPlaceholder
+            && existingBinding.createdByWorkspaceMemberId === null
+          )
+        ) &&
         (
           existingBinding.resourceHubResourceId === null ||
           existingBinding.resourceHubResourceId === resourceHubResourceId
@@ -237,27 +253,40 @@ export function materializePulledTeamMirror(
     }
 
     let localRecordChanged = false;
+    const persistedInput = options.placeholder
+      ? {
+          ...input,
+          metadata: {
+            ...(input.metadata ?? {}),
+            sharedProjectPlaceholderAt: Date.now(),
+          },
+        }
+      : input;
     if (!existing) {
       insertProject(db, {
-        id: input.id,
-        name: input.name,
-        skillId: input.skillId,
-        designSystemId: input.designSystemId,
-        metadata: input.metadata,
-        createdAt: input.createdAt,
-        updatedAt: input.updatedAt,
+        id: persistedInput.id,
+        name: persistedInput.name,
+        skillId: persistedInput.skillId,
+        designSystemId: persistedInput.designSystemId,
+        metadata: persistedInput.metadata,
+        createdAt: persistedInput.createdAt,
+        updatedAt: persistedInput.updatedAt,
       });
       localRecordChanged = true;
     } else if (
-      existing.name === '共享项目'
-      || (expectedCreator === null && input.updatedAt > existing.updatedAt)
+      (!options.placeholder && existingIsPlaceholder)
+      || (
+        !existingIsPlaceholder
+        && expectedCreator === null
+        && input.updatedAt > existing.updatedAt
+      )
     ) {
       updateProject(db, input.id, {
-        name: input.name,
-        skillId: input.skillId,
-        designSystemId: input.designSystemId,
-        metadata: input.metadata,
-        updatedAt: input.updatedAt,
+        name: persistedInput.name,
+        skillId: persistedInput.skillId,
+        designSystemId: persistedInput.designSystemId,
+        metadata: persistedInput.metadata,
+        updatedAt: persistedInput.updatedAt,
       });
       localRecordChanged = true;
     } else if (existing.metadata?.teamMirrorRevokedAt) {

--- a/apps/daemon/src/collab/workspace-projects-reconciler.ts
+++ b/apps/daemon/src/collab/workspace-projects-reconciler.ts
@@ -52,6 +52,8 @@ export interface LocalTeamProjectBinding {
   resourceState?: string | null;
   createdByWorkspaceMemberId: string | null;
   resourceHubResourceId: string | null;
+  /** A stamped first-open row is not content authority, even for its remote owner. */
+  materializationPending?: boolean;
 }
 
 /** What the remote catalog says about a shared project — the subset
@@ -188,7 +190,14 @@ export function planWorkspaceProjectReconciliation(input: {
   for (const remote of remoteProjects) {
     const local = localBindings.get(remote.projectId) ?? null;
     const isOwner = remote.ownerMemberId === workspaceMemberId;
-    const wantCreatedBy = isOwner ? workspaceMemberId : null;
+    // Catalog reconciliation may race the background first pull. The catalog
+    // proves remote ownership, but it does not prove that this daemon has
+    // committed the owner's content. Preserve creator-null while the durable
+    // placeholder stamp exists; only the full mirror materializer may clear
+    // that stamp and restore the real owner in its content transaction.
+    const wantCreatedBy = isOwner && local?.materializationPending !== true
+      ? workspaceMemberId
+      : null;
     const alreadyCorrect =
       local != null &&
       local.workspaceId === workspaceId &&

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -179,6 +179,68 @@ export type OptionalWorkspaceRequestAuthorityResult =
   | Exclude<WorkspaceRequestAuthorityResult, { ok: true }>;
 
 /**
+ * Resolve Workspace identity for daemon-local data-plane work.
+ *
+ * The browser's Workspace headers are attribution and namespace selectors on
+ * this boundary, not a remote authorization token. Local files, conversations,
+ * terminals, Skills, Plugins, and Design Systems must remain usable while Vela
+ * is offline. Consequently this resolver validates only that the identity pair
+ * is complete; it never calls the membership directory and deliberately does
+ * not inherit stale role/lifecycle/permission claims from the browser.
+ *
+ * Operations that publish, share, sync, bill, or otherwise mutate remote Team
+ * state must continue to use `resolveOptionalWorkspaceRequestAuthority` (or a
+ * narrower fresh verifier) at that actual cloud boundary.
+ */
+export function resolveOptionalLocalWorkspaceRequestAuthority(
+  req: any,
+): OptionalWorkspaceRequestAuthorityResult {
+  const claimed = workspaceResourceContextFromRequest(req);
+  if (claimed === null) return { ok: true, context: null };
+  if (claimed === 'missing') {
+    return {
+      ok: false,
+      status: 400,
+      code: 'WORKSPACE_CONTEXT_INCOMPLETE',
+      message: 'both workspace and member identity are required',
+    };
+  }
+  return {
+    ok: true,
+    context: {
+      workspaceId: claimed.workspaceId,
+      workspaceType: claimed.workspaceType,
+      workspaceMemberId: claimed.workspaceMemberId,
+      role: 'member',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+      billingState: 'active',
+      planId: null,
+      providerMode: 'personal_byok',
+      seatSummary: {
+        seatLimit: 0,
+        usedSeats: 0,
+        availableSeats: 0,
+        isSeatFull: false,
+      },
+      permissions: {
+        canManageMembers: false,
+        canManageBilling: false,
+        canInviteMembers: false,
+        canManageAutoRecharge: false,
+        canShareProjects: true,
+        canWriteSyncedFiles: true,
+        canViewWorkspaceSettings: false,
+        canManageSharedResources: false,
+      },
+      ...(claimed.workspaceType === 'team'
+        ? { teamId: claimed.workspaceId }
+        : {}),
+    },
+  };
+}
+
+/**
  * Resolve the three request-scope states shared by resource reads and writes:
  *
  * - no Workspace/member headers: the legacy Personal/global lane;

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -90,6 +90,11 @@ export interface PulledProjectStore {
     input: RegisterPulledProjectInput,
     scope: TeamMirrorPullScope,
   ) => { localRecordChanged: boolean };
+  /** Atomically create a stamped, creator-less Team-bound first-open row. */
+  materializeTeamPlaceholder?: (
+    input: RegisterPulledProjectInput,
+    scope: TeamMirrorPullScope,
+  ) => { localRecordChanged: boolean };
   materializeAuthorizedTeamMirror?: (
     input: RegisterPulledProjectInput,
     scope: TeamMirrorPullScope,
@@ -1058,6 +1063,29 @@ export function registerCollabSyncRoutes(
     // pull lands real hub content (the recvqzaDvUU6B3 fresh-install wipe
     // guard — see collab/shared-project-placeholder.ts).
     markSharedProjectPlaceholder?.(projectId, true);
+  }
+
+  function ensureTeamBoundSharedProjectPlaceholder(
+    projectId: string,
+    scope: TeamMirrorPullScope,
+  ): boolean {
+    if (!projectStore?.materializeTeamPlaceholder) {
+      throw new Error('team placeholder materializer unavailable');
+    }
+    const existing = projectStore.get?.(projectId) ?? null;
+    if (projectStore.has(projectId) && !isUnmaterializedSharedPlaceholder(existing)) {
+      return false;
+    }
+    const now = Date.now();
+    projectStore.materializeTeamPlaceholder({
+      id: projectId,
+      name: PULLED_PROJECT_PLACEHOLDER_NAME,
+      skillId: null,
+      designSystemId: null,
+      createdAt: now,
+      updatedAt: now,
+    }, scope);
+    return true;
   }
 
   /**
@@ -2143,6 +2171,40 @@ export function registerCollabSyncRoutes(
       return res.status(502).json({ error: 'TEAM_PROJECT_PULL_REGISTER_UNAVAILABLE' });
     }
     res.json({ ok: true, version: outcome.version });
+  });
+
+  app.put('/api/projects/:id/collab/bootstrap', async (req, res) => {
+    const projectId = req.params.id;
+    // This endpoint materializes local authority state, so it deliberately uses
+    // the fresh mutation verifier and uncached owner lookup, never status's
+    // bounded read lease. PUT is idempotent and lets the sidecar safely replay
+    // one request on a reset reused socket.
+    const { verification, principal, scope } =
+      await pullAccessForRequest(projectId, req);
+    if (!verification.ok) {
+      return sendWorkspaceVerificationFailure(res, verification);
+    }
+    if (!principal || !scope) {
+      return res.status(404).json({ error: 'TEAM_PROJECT_NOT_FOUND' });
+    }
+    let awaitingFirstMaterialization: boolean;
+    try {
+      awaitingFirstMaterialization = ensureTeamBoundSharedProjectPlaceholder(
+        projectId,
+        scope,
+      );
+    } catch {
+      return res.status(503).json({ error: 'TEAM_PROJECT_BOOTSTRAP_UNAVAILABLE' });
+    }
+    if (awaitingFirstMaterialization) {
+      materializePlaceholderOnOpen(projectId, req, {
+        ownerMemberId: scope.ownerMemberId,
+        callerIsOwner: scope.ownerMemberId === scope.viewerMemberId,
+      });
+    }
+    return res
+      .status(awaitingFirstMaterialization ? 202 : 200)
+      .json({ ok: true, awaitingFirstMaterialization });
   });
 
   app.get('/api/projects/:id/collab/status', async (req, res) => {

--- a/apps/daemon/src/routes/design-systems.ts
+++ b/apps/daemon/src/routes/design-systems.ts
@@ -23,10 +23,8 @@ import {
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   headerValue,
-  isWorkspaceResourceLocked,
   requestWithWorkspaceNavigationScope,
-  resolveOptionalWorkspaceRequestAuthority,
-  workspaceResourceContextFromRequest,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
 } from '../collab/workspace-resource-mutation.js';
@@ -297,10 +295,7 @@ export function registerDesignSystemRoutes(
       });
       return false;
     }
-    const resolution = await resolveOptionalWorkspaceRequestAuthority(
-      scopedRequest,
-      ctx.verifyWorkspaceRequestAuthority,
-    );
+    const resolution = resolveOptionalLocalWorkspaceRequestAuthority(scopedRequest);
     if (!resolution.ok) {
       res.status(resolution.status).json({
         error: resolution.code,
@@ -385,10 +380,7 @@ export function registerDesignSystemRoutes(
     res: Response,
     id: string,
   ): Promise<boolean> {
-    const resolution = await resolveOptionalWorkspaceRequestAuthority(
-      req,
-      ctx.verifyWorkspaceRequestAuthority,
-    );
+    const resolution = resolveOptionalLocalWorkspaceRequestAuthority(req);
     if (!resolution.ok) {
       res.status(resolution.status).json({
         error: resolution.code,
@@ -462,10 +454,7 @@ export function registerDesignSystemRoutes(
     req: any,
     res: Response,
   ): Promise<{ workspaceId: string; workspaceMemberId: string } | null | 'denied'> {
-    const resolution = await resolveOptionalWorkspaceRequestAuthority(
-      req,
-      ctx.verifyWorkspaceRequestAuthority,
-    );
+    const resolution = resolveOptionalLocalWorkspaceRequestAuthority(req);
     if (!resolution.ok) {
       res.status(resolution.status).json({
         error: resolution.code,
@@ -504,21 +493,6 @@ export function registerDesignSystemRoutes(
     return job.designSystemId
       ? authorizeDesignSystemRead(req, res, job.designSystemId)
       : true;
-  }
-
-  // Workspace-lock gate (spec 9.2), unconditional and independent of
-  // `canMutateUserDesignSystem`'s own teamSynced/canUnshare verdict — a
-  // locked/deleted workspace (billing lapse, deletion in progress) must
-  // refuse every PATCH/DELETE regardless of who the caller is, the same
-  // guarantee `enforceWorkspaceResourceMutation` gives project/plugin/skill.
-  // Reuses that module's own `workspaceResourceContextFromRequest`/
-  // `isWorkspaceResourceLocked` rather than re-deriving the header contract
-  // here. Checked at the route rather than folded silently into
-  // `canMutateUserDesignSystem`'s boolean so it applies no matter what a
-  // caller-supplied implementation of that hook decides.
-  function isRequestWorkspaceLocked(req: any): boolean {
-    const requestCtx = workspaceResourceContextFromRequest(req);
-    return Boolean(requestCtx && requestCtx !== 'missing' && isWorkspaceResourceLocked(requestCtx));
   }
 
   function sendWorkspaceScopeError(res: Response, error: unknown): boolean {
@@ -661,9 +635,6 @@ export function registerDesignSystemRoutes(
       // accept/reject its pending revision (surfaced to anyone who can read
       // the system, not just the owner) with no server-side check at all,
       // even after the UI stopped showing it as editable.
-      if (isRequestWorkspaceLocked(req)) {
-        return res.status(403).json({ error: 'WORKSPACE_LOCKED' });
-      }
       const storage = resolveDesignSystemStorage(req, req.params.id);
       if (!(await canMutateUserDesignSystem(storage.root, req.params.id, req))) {
         return res.status(403).json({ error: 'WORKSPACE_RESOURCE_MANAGE_DENIED' });
@@ -915,9 +886,6 @@ export function registerDesignSystemRoutes(
   app.patch('/api/design-systems/:id', async (req, res) => {
     try {
       if (!(await authorizeDesignSystemMutation(req, res, req.params.id))) return;
-      if (isRequestWorkspaceLocked(req)) {
-        return res.status(403).json({ error: 'WORKSPACE_LOCKED' });
-      }
       const storage = resolveDesignSystemStorage(req, req.params.id);
       if (!(await canMutateUserDesignSystem(storage.root, req.params.id, req))) {
         return res.status(403).json({ error: 'WORKSPACE_RESOURCE_MANAGE_DENIED' });
@@ -948,9 +916,6 @@ export function registerDesignSystemRoutes(
   app.post('/api/design-systems/:id/sync-assets', async (req, res) => {
     try {
       if (!(await authorizeDesignSystemMutation(req, res, req.params.id))) return;
-      if (isRequestWorkspaceLocked(req)) {
-        return res.status(403).json({ error: 'WORKSPACE_LOCKED' });
-      }
       const storage = resolveDesignSystemStorage(req, req.params.id);
       if (!(await canMutateUserDesignSystem(storage.root, req.params.id, req))) {
         return res.status(403).json({ error: 'WORKSPACE_RESOURCE_MANAGE_DENIED' });
@@ -987,10 +952,6 @@ export function registerDesignSystemRoutes(
   ): Promise<boolean> {
     try {
       if (!(await authorizeDesignSystemMutation(req, res, id))) return false;
-      if (isRequestWorkspaceLocked(req)) {
-        res.status(403).json({ error: 'WORKSPACE_LOCKED' });
-        return false;
-      }
       const storage = resolveDesignSystemStorage(req, id);
       if (!(await canMutateUserDesignSystem(storage.root, id, req))) {
         res.status(403).json({ error: 'WORKSPACE_RESOURCE_MANAGE_DENIED' });

--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -26,11 +26,7 @@ import {
   MEDIA_TASK_WAIT_TOOL_ENDPOINT,
   type ToolTokenGrant,
 } from '../tool-tokens.js';
-import {
-  authorizePersistedAutomationWorkspaceScope,
-  normalizePersistedAutomationWorkspaceScope,
-} from '../automations/workspace-scope.js';
-import type { WorkspaceDirectoryFetchResult } from '../collab/vela-workspace-context.js';
+import { normalizePersistedAutomationWorkspaceScope } from '../automations/workspace-scope.js';
 
 const LONG_MEDIA_PROXY_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -49,7 +45,6 @@ const AIHUBMIX_CATALOG_TTL_MS = 5 * 60 * 1000;
 const aihubmixCatalogCache = new Map<string, { at: number; models: Array<{ id: string; label: string }> }>();
 
 export interface RegisterMediaRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'ids' | 'auth' | 'media' | 'appConfig' | 'orbit' | 'nativeDialogs' | 'projectStore' | 'projectFiles' | 'conversations' | 'research'> {
-  fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   authorizeProjectRequest: AuthorizeProjectRequest;
   authorizeProjectToolRequest: AuthorizeProjectToolRequest;
 }
@@ -583,10 +578,6 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
               code: 'WORKSPACE_CONTEXT_INCOMPLETE',
             });
           }
-          await authorizePersistedAutomationWorkspaceScope(
-            scope,
-            ctx.fetchWorkspaceDirectory,
-          );
         }
       }
       const config = await writeAppConfig(RUNTIME_DATA_DIR, req.body);
@@ -594,9 +585,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       onAppConfigWritten?.(config);
       res.json({ config });
     } catch (err: any) {
-      const status = err?.code === 'WORKSPACE_AUTHORITY_UNAVAILABLE'
-        ? 503
-        : err?.code === 'WORKSPACE_ACCESS_DENIED'
+      const status = err?.code === 'WORKSPACE_ACCESS_DENIED'
           ? 403
           : 500;
       res
@@ -682,9 +671,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       const locale = typeof req.body?.locale === 'string' ? req.body.locale : null;
       res.json(await orbitService.start('manual', { locale }));
     } catch (err: any) {
-      const status = err?.code === 'WORKSPACE_AUTHORITY_UNAVAILABLE'
-        ? 503
-        : err?.code === 'WORKSPACE_ACCESS_DENIED'
+      const status = err?.code === 'WORKSPACE_ACCESS_DENIED'
           ? 403
           : 500;
       res
@@ -867,8 +854,8 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       )
     ) return;
 
-    // Token callers must prove fresh project authority before task lookup so
-    // a revoked member or an authority outage cannot probe task existence.
+    // Token callers must prove their grant targets the persisted local project
+    // before task lookup; cloud availability is irrelevant to this local wait.
     const taskId = req.params.id;
     const task = getLiveMediaTask(taskId);
     if (!task) return res.status(404).json({ error: 'task not found' });

--- a/apps/daemon/src/routes/plugins/assets.ts
+++ b/apps/daemon/src/routes/plugins/assets.ts
@@ -3,7 +3,7 @@ import type * as BetterSqlite3 from 'better-sqlite3';
 import path from 'node:path';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import {
-  resolveOptionalWorkspaceRequestAuthority,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
 } from '../../collab/workspace-resource-mutation.js';
 
@@ -93,10 +93,7 @@ export function registerPluginAssetRoutes(app: Express, deps: RegisterPluginAsse
       });
       return undefined;
     }
-    const authority = await resolveOptionalWorkspaceRequestAuthority(
-      scopedRequest,
-      deps.verifyWorkspaceRequestAuthority,
-    );
+    const authority = resolveOptionalLocalWorkspaceRequestAuthority(scopedRequest);
     if (!authority.ok) {
       res.status(authority.status).json({
         error: authority.code,

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -18,7 +18,7 @@ import {
 } from '../../collab/team-resource-state.js';
 import {
   enforceVerifiedWorkspaceResourceMutation,
-  resolveOptionalWorkspaceRequestAuthority,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
 } from '../../collab/workspace-resource-mutation.js';
 import {
@@ -302,10 +302,7 @@ function duplicatedProjectKind(plugin: InstalledPluginLike): ProjectMetadata['ki
 
 export function registerPluginEventRoutes(app: Express, deps: RegisterPluginEventRoutesDeps): void {
   const resolveEventScope = async (req: Request, res: Response) => {
-    const authority = await resolveOptionalWorkspaceRequestAuthority(
-      req,
-      deps.verifyWorkspaceRequestAuthority,
-    );
+    const authority = resolveOptionalLocalWorkspaceRequestAuthority(req);
     if (!authority.ok) {
       deps.http.sendApiError(
         res,
@@ -405,10 +402,7 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     verifyAuthority: VerifyWorkspaceRequestAuthority | undefined =
       deps.verifyWorkspaceRequestAuthority,
   ): Promise<WorkspaceCollabContext | null | undefined> => {
-    const authority = await resolveOptionalWorkspaceRequestAuthority(
-      req,
-      verifyAuthority,
-    );
+    const authority = resolveOptionalLocalWorkspaceRequestAuthority(req);
     if (!authority.ok) {
       helpers.sendApiError(
         res,
@@ -601,7 +595,9 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
         db,
         req.params.id,
         'delete',
-        deps.verifyWorkspaceRequestAuthority,
+        authority
+          ? async () => ({ ok: true as const, context: authority })
+          : undefined,
       )) return;
       const result = await plugins.uninstallPlugin(db, req.params.id, paths.PLUGIN_REGISTRY_ROOTS); if (!result.ok && !result.removedFolder) return res.status(404).json({ error: 'plugin not found', warning: result.warning }); res.json(result);
     } catch (err) { res.status(500).json({ error: String(err) }); }
@@ -628,7 +624,9 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
       db,
       req.params.id,
       'writeFiles',
-      deps.verifyWorkspaceRequestAuthority,
+      authority
+        ? async () => ({ ok: true as const, context: authority })
+        : undefined,
     )) return;
     return helpers.installOrUpgradePlugin(req, res, 'upgrade', authority);
   });

--- a/apps/daemon/src/routes/project/comments.ts
+++ b/apps/daemon/src/routes/project/comments.ts
@@ -65,6 +65,15 @@ export interface RegisterProjectCommentRoutesDeps extends RouteDeps<'db' | 'proj
     projectId: string,
   ) => Promise<ProjectCommentWorkspaceContextResolution>;
   /**
+   * Fresh cloud authority used only before pulling remote comment state. Local
+   * list/create/edit/delete paths use the persisted project binding and must
+   * remain available while the membership directory is offline.
+   */
+  resolveFreshWorkspaceContext?: (
+    req: Request,
+    projectId: string,
+  ) => Promise<ProjectCommentWorkspaceContextResolution>;
+  /**
    * Resolve the CURRENT caller's workspaceMemberId from the request identity
    * (workspace context). Server-authoritative — used both to stamp the author on
    * a new/edited comment and to gate status/delete on the caller's identity.
@@ -378,7 +387,9 @@ export function registerProjectCommentRoutes(app: Express, ctx: RegisterProjectC
     await ctx.onCommentsRead?.(
       req.params.id,
       workspaceResolution.context,
-      () => resolveRequestWorkspaceContext(req, req.params.id),
+      () => ctx.resolveFreshWorkspaceContext
+        ? ctx.resolveFreshWorkspaceContext(req, req.params.id)
+        : resolveRequestWorkspaceContext(req, req.params.id),
     );
     res.json({
       comments: commentsAreProjectScoped(

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -173,6 +173,8 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
   authorizeProjectRequest?: AuthorizeProjectRequest;
   /** Startup-hydrated O(1) quarantine lookup for stale Team mirrors. */
   isProjectRevoked?: (projectId: string) => boolean;
+  /** Durable first-open placeholder stamp lookup. */
+  isProjectUnmaterializedPlaceholder?: (projectId: string) => boolean;
   /** Membership directory used by Workspace account and cloud boundaries. */
   fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   /** Current settings-backed AMR environment for synthesized project contexts. */
@@ -331,6 +333,7 @@ function projectAccess(
  */
 export function createWorkspaceProjectWriteAuthorityCheck(
   _verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
+  isProjectUnmaterializedPlaceholder?: (projectId: string) => boolean,
 ) {
   return async function requestCanWriteWorkspaceProject(
     req: any,
@@ -339,7 +342,7 @@ export function createWorkspaceProjectWriteAuthorityCheck(
     db: unknown,
     projectId: string,
   ): Promise<boolean> {
-    return enforceLocalProjectDataPlaneRequest({
+    const allowed = await enforceLocalProjectDataPlaneRequest({
       req,
       projectId,
       options: { mode: 'write', capability: 'writeFiles' },
@@ -347,12 +350,14 @@ export function createWorkspaceProjectWriteAuthorityCheck(
       getWorkspaceProject,
       getWorkspaceProjectByProjectId,
     });
+    return allowed && !isProjectUnmaterializedPlaceholder?.(projectId);
   };
 }
 
 export function createEnforceWorkspaceProjectMutation(
   _verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
   _verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority,
+  authorizeProjectRequest?: AuthorizeProjectRequest,
 ) {
   return async function enforceWorkspaceProjectMutation(
     req: any,
@@ -370,6 +375,18 @@ export function createEnforceWorkspaceProjectMutation(
     projectId: string,
     capability: WorkspaceProjectMutationCapability,
   ): Promise<boolean> {
+    // Production routes must converge on the central project authority gate.
+    // In particular, that gate carries the durable placeholder-stamp check;
+    // relying only on the placeholder's creator-null binding would make one
+    // accidental reconciliation promotion sufficient to reopen content writes.
+    // Keep the local-data-plane fallback solely for focused legacy fixtures
+    // that do not provide the production authorizer.
+    if (authorizeProjectRequest) {
+      return authorizeProjectRequest(req, res, projectId, {
+        mode: 'write',
+        capability,
+      });
+    }
     return enforceLocalProjectDataPlaneRequest({
       req,
       projectId,
@@ -1733,10 +1750,6 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       workspaceType: context.workspaceTypeAsserted,
     });
   };
-  const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
-    ctx.verifyWorkspaceRequestAuthority,
-    ctx.verifyPersonalProjectDeleteLeaseAuthority,
-  );
   const verifyWorkspaceProjectReadAuthority =
     ctx.verifyWorkspaceReadAuthority ?? ctx.verifyWorkspaceRequestAuthority;
   const authorizeProjectRequest =
@@ -1747,11 +1760,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       getWorkspaceProjectByProjectId,
       isProjectRevoked: (_db, projectId) =>
         ctx.isProjectRevoked?.(projectId) ?? false,
+      isProjectUnmaterializedPlaceholder: (_db, projectId) =>
+        ctx.isProjectUnmaterializedPlaceholder?.(projectId) ?? false,
       ...(ctx.verifyWorkspaceRequestAuthority
         ? { verifyWorkspaceRequestAuthority: ctx.verifyWorkspaceRequestAuthority }
         : {}),
       sendApiError,
     });
+  const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
+    ctx.verifyWorkspaceRequestAuthority,
+    ctx.verifyPersonalProjectDeleteLeaseAuthority,
+    authorizeProjectRequest,
+  );
   async function verifiedWorkspaceProjectContext(
     req: any,
   ): Promise<WorkspaceProjectContext | null> {
@@ -4809,6 +4829,8 @@ export interface RegisterProjectFileRoutesDeps extends RouteDeps<'db' | 'http' |
   authorizeProjectRequest?: AuthorizeProjectRequest;
   /** Startup-hydrated O(1) quarantine lookup for stale Team mirrors. */
   isProjectRevoked?: (projectId: string) => boolean;
+  /** Durable first-open placeholder stamp lookup. */
+  isProjectUnmaterializedPlaceholder?: (projectId: string) => boolean;
 }
 
 export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFileRoutesDeps) {
@@ -4820,9 +4842,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
   const { upload } = ctx.uploads;
   const { fs } = ctx.node;
   const { getProject, getWorkspaceProject, getWorkspaceProjectByProjectId } = ctx.projectStore;
-  const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
-    ctx.verifyWorkspaceRequestAuthority,
-  );
   const authorizeProjectRequest =
     ctx.authorizeProjectRequest ??
     createAuthorizeProjectRequest({
@@ -4831,13 +4850,21 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       getWorkspaceProjectByProjectId,
       isProjectRevoked: (_db, projectId) =>
         ctx.isProjectRevoked?.(projectId) ?? false,
+      isProjectUnmaterializedPlaceholder: (_db, projectId) =>
+        ctx.isProjectUnmaterializedPlaceholder?.(projectId) ?? false,
       ...(ctx.verifyWorkspaceRequestAuthority
         ? { verifyWorkspaceRequestAuthority: ctx.verifyWorkspaceRequestAuthority }
         : {}),
       sendApiError,
     });
+  const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
+    ctx.verifyWorkspaceRequestAuthority,
+    undefined,
+    authorizeProjectRequest,
+  );
   const requestCanWriteWorkspaceProject = createWorkspaceProjectWriteAuthorityCheck(
     ctx.verifyWorkspaceRequestAuthority,
+    ctx.isProjectUnmaterializedPlaceholder,
   );
   const { listFiles, listProjectFolders, createProjectFolder, deleteProjectFolder, searchProjectFiles, readProjectFile, resolveProjectDir, resolveProjectFilePath, parseByteRange, renameProjectFile, deleteProjectFile, writeProjectFile, sanitizeName, sanitizePath, ensureProject } = ctx.projectFiles;
   const { buildDocumentPreview } = ctx.documents;
@@ -6782,6 +6809,9 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
 
 export interface RegisterProjectUploadRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'paths' | 'projectStore' | 'projectFiles'> {
   verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority;
+  authorizeProjectRequest?: AuthorizeProjectRequest;
+  /** Durable first-open placeholder stamp lookup. */
+  isProjectUnmaterializedPlaceholder?: (projectId: string) => boolean;
 }
 
 export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUploadRoutesDeps) {
@@ -6792,8 +6822,23 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
   const { getProject, getWorkspaceProject, getWorkspaceProjectByProjectId } = ctx.projectStore;
   const { readProjectFile } = ctx.projectFiles;
   const { fs } = ctx.node;
+  const authorizeProjectRequest =
+    ctx.authorizeProjectRequest ??
+    createAuthorizeProjectRequest({
+      db,
+      getWorkspaceProject,
+      getWorkspaceProjectByProjectId,
+      isProjectUnmaterializedPlaceholder: (_db, projectId) =>
+        ctx.isProjectUnmaterializedPlaceholder?.(projectId) ?? false,
+      ...(ctx.verifyWorkspaceRequestAuthority
+        ? { verifyWorkspaceRequestAuthority: ctx.verifyWorkspaceRequestAuthority }
+        : {}),
+      sendApiError,
+    });
   const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
     ctx.verifyWorkspaceRequestAuthority,
+    undefined,
+    authorizeProjectRequest,
   );
 
   app.post(

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -91,10 +91,8 @@ import {
   type WorkspaceTypeRegistry,
 } from '../../collab/team-share-scope.js';
 import {
-  enforceVerifiedWorkspaceResourceMutation,
   headerValue,
   isWorkspaceResourceLocked as isWorkspaceLocked,
-  requestCanMutateVerifiedWorkspaceResource,
   workspaceResourceAccess,
   workspaceResourceContext as workspaceProjectContext,
   workspaceResourceContextFromRequest as workspaceProjectContextFromRequest,
@@ -105,11 +103,11 @@ import {
   type WorkspaceResourceMutationCapability,
 } from '../../collab/workspace-resource-mutation.js';
 import {
-  resolveProjectWorkspaceScope,
-  resolveProjectWorkspaceScopeBootstrap,
+  resolveLocalProjectWorkspaceScope,
 } from '../../collab/project-workspace-scope.js';
 import {
   createAuthorizeProjectRequest,
+  enforceLocalProjectDataPlaneRequest,
   type AuthorizeProjectRequest,
 } from '../../collab/project-request-authority.js';
 import {
@@ -117,6 +115,7 @@ import {
   createCreatedProjectWorkspaceResolver,
   CreatedProjectWorkspaceResolutionError,
   localProjectWorkspaceAttribution,
+  type CreatedProjectWorkspaceResolver,
 } from '../../collab/created-project-workspace.js';
 import { localPluginRegistryScope } from '../../plugins/local-source.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
@@ -170,27 +169,19 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
    * through `verifyWorkspaceRequestAuthority`.
    */
   verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority;
-  /** Shared fresh exact authority gate for all project data-plane routes. */
+  /** Shared local binding gate for all project data-plane routes. */
   authorizeProjectRequest?: AuthorizeProjectRequest;
   /** Startup-hydrated O(1) quarantine lookup for stale Team mirrors. */
   isProjectRevoked?: (projectId: string) => boolean;
-  /**
-   * Authoritative signed-in membership directory. Project detail uses it to
-   * resolve the project's persisted workspace independently from any
-   * daemon-global active/current state.
-   */
+  /** Membership directory used by Workspace account and cloud boundaries. */
   fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   /** Current settings-backed AMR environment for synthesized project contexts. */
   configuredEnv?: () => Record<string, string>;
-  /**
-   * Production-only authority for project creation. Kept distinct from the
-   * read-side directory fetcher so local/dev and explicitly anonymous callers
-   * retain their existing behavior.
-   */
+  /** @deprecated Creation is local; retained for compatible route composition. */
   fetchProjectCreationWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
   /**
    * Persist a design system and its Workspace ownership envelope from the
-   * exact directory-verified creation context. Production injects the shared
+   * request's complete local attribution. Production injects the shared
    * design-system creation service; the optional shape preserves isolated
    * route harnesses and headerless/local compatibility.
    */
@@ -247,7 +238,7 @@ export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | '
    * team share aimed at a personal workspace even when the caller's headers say
    * otherwise. See `collab/team-share-scope.ts`.
    */
-  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'isKnownPersonal'>;
+  workspaceTypes?: Pick<WorkspaceTypeRegistry, 'isKnownPersonal' | 'learn' | 'typeOf'>;
 }
 
 // `WorkspaceProjectContext`/`WorkspaceProjectMutationCapability`/
@@ -335,21 +326,11 @@ function projectAccess(
 }
 
 /**
- * Build the project-flavored authoritative mutation gate. Every bound project
- * requires an exact Workspace/member pair; request role/permission claims and
- * daemon-global active/current/last-known state are never authority. Mutations
- * use fresh directory authority except the narrow personal local-only delete
- * lease below. The exported factory is shared with run/chat routes so all
- * project mutations fail closed identically.
- */
-/**
  * The non-rejecting counterpart of `createEnforceWorkspaceProjectMutation`,
- * for a read route that would otherwise write as a side effect. See
- * `requestCanMutateVerifiedWorkspaceResource` for why a READ must answer this question
- * without ever answering it with a 401/403.
+ * for a read route that would otherwise write as a local side effect.
  */
 export function createWorkspaceProjectWriteAuthorityCheck(
-  verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
+  _verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
 ) {
   return async function requestCanWriteWorkspaceProject(
     req: any,
@@ -358,73 +339,49 @@ export function createWorkspaceProjectWriteAuthorityCheck(
     db: unknown,
     projectId: string,
   ): Promise<boolean> {
-    return requestCanMutateVerifiedWorkspaceResource(
+    return enforceLocalProjectDataPlaneRequest({
       req,
+      projectId,
+      options: { mode: 'write', capability: 'writeFiles' },
+      db,
       getWorkspaceProject,
       getWorkspaceProjectByProjectId,
-      db,
-      projectId,
-      verifyWorkspaceRequestAuthority,
-    );
+    });
   };
 }
 
 export function createEnforceWorkspaceProjectMutation(
-  verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
-  verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority,
+  _verifyWorkspaceRequestAuthority?: VerifyWorkspaceRequestAuthority,
+  _verifyPersonalProjectDeleteLeaseAuthority?: VerifyWorkspaceRequestAuthority,
 ) {
   return async function enforceWorkspaceProjectMutation(
     req: any,
     res: Response,
-    sendApiError: (res: Response, status: number, code: string, message: string) => unknown,
+    sendApiError: (
+      res: Response,
+      status: number,
+      code: string,
+      message: string,
+      details?: Record<string, unknown>,
+    ) => unknown,
     getWorkspaceProject: (db: unknown, workspaceId: string, projectId: string) => WorkspaceProjectAccessInput | null | undefined,
     getWorkspaceProjectByProjectId: (db: unknown, projectId: string) => WorkspaceProjectAccessInput | null | undefined,
     db: unknown,
     projectId: string,
     capability: WorkspaceProjectMutationCapability,
   ): Promise<boolean> {
-    return enforceVerifiedWorkspaceResourceMutation(
-      'project',
+    return enforceLocalProjectDataPlaneRequest({
       req,
-      res,
-      sendApiError,
+      projectId,
+      options: { mode: 'write', capability },
+      db,
       getWorkspaceProject,
       getWorkspaceProjectByProjectId,
-      db,
-      projectId,
-      capability,
-      verifyWorkspaceRequestAuthority,
-      capability === 'delete' && verifyPersonalProjectDeleteLeaseAuthority
-        ? {
-            authorityLease: {
-              verify: verifyPersonalProjectDeleteLeaseAuthority,
-              allow: personalLocalProjectDeleteLeaseAllowed,
-            },
-          }
-        : {},
-    );
+      onDenied: (status, code, message, details) => details === undefined
+        ? sendApiError(res, status, code, message)
+        : sendApiError(res, status, code, message, details),
+    });
   };
-}
-
-/**
- * A short-lived directory lease may authorize this one local-only cleanup.
- * Hub-backed or Team resources, stale ownership, locked membership and every
- * non-delete mutation still require a fresh control-plane read.
- */
-export function personalLocalProjectDeleteLeaseAllowed(
-  row: WorkspaceProjectAccessInput,
-  context: WorkspaceCollabContext,
-): boolean {
-  return context.workspaceType === 'personal'
-    && context.memberStatus === 'active'
-    && context.lifecycleState === 'active'
-    && context.permissions.canWriteSyncedFiles
-    && row.workspaceId === context.workspaceId
-    && row.visibility === 'personal'
-    && row.resourceState === 'active'
-    && row.createdByWorkspaceMemberId === context.workspaceMemberId
-    && row.syncState === 'local_only'
-    && !row.resourceHubResourceId;
 }
 
 function projectDetailResolvedDir(
@@ -1769,6 +1726,13 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   const { randomId } = ctx.ids;
   const { validateProjectDesignSystemId, validateProjectSkillId } = ctx.validation;
   const { collabSync, teamProjectCatalog, workspaceTypes } = ctx;
+  const learnAssertedWorkspaceType = (context: WorkspaceResourceContext | null) => {
+    if (!context?.workspaceTypeAsserted) return;
+    workspaceTypes?.learn({
+      workspaceId: context.workspaceId,
+      workspaceType: context.workspaceTypeAsserted,
+    });
+  };
   const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(
     ctx.verifyWorkspaceRequestAuthority,
     ctx.verifyPersonalProjectDeleteLeaseAuthority,
@@ -1795,19 +1759,20 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     const verified = await ctx.verifyWorkspaceRequestAuthority(req);
     return verified.ok ? workspaceResourceContextFromVerified(verified.context) : null;
   }
-  /**
-   * Where a created project belongs when the request has no authorization gate
-   * of its own — the duplicate / design-system-copy pair and the
-   * project-location scan importer. An asserted pair is verified through the
-   * same directory lookup as `POST /api/projects`; a headerless legacy/local
-   * request remains unbound and a failed assertion writes nothing.
-   */
-  const resolveCreatedProjectHome = createCreatedProjectWorkspaceResolver({
+  // Duplicate/import paths use the same optional local attribution as ordinary
+  // project creation. Cloud authority is checked only when a later operation
+  // actually shares, syncs, or publishes the project.
+  const resolveCreatedProjectHomeWithLocalAttribution = createCreatedProjectWorkspaceResolver({
     ...(ctx.fetchProjectCreationWorkspaceDirectory
       ? { fetchWorkspaceDirectory: ctx.fetchProjectCreationWorkspaceDirectory }
       : {}),
     ...(ctx.configuredEnv ? { configuredEnv: ctx.configuredEnv } : {}),
   });
+  const resolveCreatedProjectHome: CreatedProjectWorkspaceResolver = async (req) => {
+    const home = await resolveCreatedProjectHomeWithLocalAttribution(req);
+    learnAssertedWorkspaceType(home);
+    return home;
+  };
   function sendMissingWorkspaceContext(res: Response) {
     return sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
   }
@@ -2438,6 +2403,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     now: number,
   ) {
     if (ctx === null) return;
+    learnAssertedWorkspaceType(ctx);
     ensureWorkspaceProject(db, {
       projectId: targetProjectId,
       workspaceId: ctx.workspaceId,
@@ -2457,7 +2423,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * CURRENT mutating request's workspace, right before
    * `enforceWorkspaceProjectMutation` evaluates it.
    *
-   * the verified Workspace mutation gate denies any
+   * The Workspace mutation gate denies any
    * mutation the moment the two-key lookup comes back empty
    * (`workspaceResourceMutationAllowed`'s `if (!row) return false;`) — right
    * for a project genuinely bound to a DIFFERENT workspace than the one the
@@ -2486,37 +2452,10 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * explicit mutation request naming this exact project is the "yes, this is
    * mine" signal a read never had.
    *
-   * But that owner is NOT the request's own claim. `workspaceProjectContextFromRequest`
-   * only PARSES `x-od-workspace-*`, which is an unauthenticated hint any local
-   * caller can forge, and this row's `createdByWorkspaceMemberId` is what
-   * `workspaceResourceAccess` turns into `selfCreated` — the bit that grants a
-   * non-privileged member mutation rights over it. Writing the header value
-   * meant a plain curl could claim someone else's orphaned project into a
-   * workspace it has no membership in and install itself as the author.
-   *
-   * So the workspace and authorship both come from
-   * `resolveCreatedProjectHome`, the same exact verifier every created-project
-   * path uses:
-   *
-   *   - the asserted identity VERIFIES against the membership directory -> claim
-   *     it, attributed to the DIRECTORY's member id rather than the header's;
-   *   - it does NOT verify — foreign, inactive, removed, or authority unreadable
-   *     -> write NOTHING;
-   *   - no pair was asserted -> write nothing, and let the pre-existing gate
-   *     below answer. A caller that cannot prove membership over a project
-   *     nothing has ever claimed is exactly who that gate is for; inventing a
-   *     binding to keep it happy is what this fix removes.
-   *
-   * Failing closed is essential because this binding is sticky: assigning an
-   * orphan from a forged or unverifiable request could prevent its rightful
-   * Workspace from reconciling it later.
-   *
-   * The `null`/`'missing'` early return is unchanged and load-bearing, and is
-   * why this does not simply use `createdProjectWorkspaceHome`'s own third
-   * branch. The verified Workspace mutation gate runs immediately after this and
-   * its HEADERLESS branch answers 401 WORKSPACE_CONTEXT_REQUIRED as soon as ANY
-   * row exists for the resource. Claiming on a request that asserts nothing
-   * would therefore convert a working headerless mutation into a 401.
+   * A complete explicit pair may claim a true local orphan. Partial/headerless
+   * requests write nothing, and a project already bound anywhere is never
+   * re-homed. The daemon's loopback request boundary protects this local
+   * attribution; remote membership is enforced only at share/sync/publish.
    */
   function reconcileUnboundProjectBeforeMutation(
     req: any,
@@ -2527,7 +2466,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     if (asserted === null || asserted === 'missing') return;
     if (getWorkspaceProjectByProjectId(db, projectId)) return;
     if (!home) return;
-    // Verified assertions resolve to the exact pair used as the directory key.
+    // The resolver and parser must agree on the exact local attribution pair.
     if (
       home.workspaceId !== asserted.workspaceId
       || home.workspaceMemberId !== asserted.workspaceMemberId
@@ -3438,6 +3377,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       const createWorkspace = {
         context: localProjectWorkspaceAttribution(req),
       };
+      learnAssertedWorkspaceType(createWorkspace.context);
       const { id, name, projectLocationId, skillId, designSystemId, pendingPrompt, metadata, customInstructions, skipDiscoveryBrief } =
         req.body || {};
       if (typeof id !== 'string' || !isSafeId(id)) {
@@ -4202,52 +4142,25 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'not found');
     }
     const binding = getWorkspaceProjectByProjectId(db, project.id);
-    const hasWorkspaceClaim =
-      headerValue(req, 'x-od-workspace-id') !== null
-      || headerValue(req, 'x-od-workspace-member-id') !== null;
-    if (binding && !hasWorkspaceClaim) {
-      // This is the same session-generation keyed authority broker used by the
-      // shell directory and ordinary read gate. A cold shell + bootstrap joins
-      // one upstream read; its short successful lease is exact-account scoped,
-      // while failures are not cached. Never consult current/default Workspace.
-      const directory = ctx.fetchWorkspaceDirectory
-        ? await ctx.fetchWorkspaceDirectory().catch(
-            (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
-          )
-        : { ok: false, items: [] };
-      const bootstrap = resolveProjectWorkspaceScopeBootstrap({
-        projectId: project.id,
-        binding,
-        directory,
-        ...(ctx.configuredEnv ? { configuredEnv: ctx.configuredEnv() } : {}),
-      });
-      if (!bootstrap.ok) {
-        return sendApiError(
-          res,
-          bootstrap.status,
-          bootstrap.code,
-          bootstrap.message,
-          bootstrap.status === 503 ? { retryable: true } : {},
-        );
-      }
-      /** @type {import('@open-design/contracts').ProjectWorkspaceScopeResponse} */
-      const body = { scope: bootstrap.scope };
-      return res.json(body);
-    }
     if (!await authorizeProjectRequest(req, res, project.id, { mode: 'read' })) return;
-    const directory = ctx.fetchWorkspaceDirectory
-      ? await ctx.fetchWorkspaceDirectory().catch(
-          (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
-        )
-      : { ok: false, items: [] };
-    // Persisted binding is the resource identity. The authorization gate above
-    // freshly verifies the exact caller pair for a bound project; a genuinely
-    // unbound legacy project remains unbound even when a caller supplies an
-    // unrelated Workspace identity.
-    const scope = resolveProjectWorkspaceScope({
+    const claimed = workspaceProjectContextFromRequest(req);
+    const assertedType = headerValue(req, 'x-od-workspace-type');
+    const requestWorkspaceType = assertedType === 'team' || assertedType === 'personal'
+      ? assertedType
+      : null;
+    if (binding?.workspaceId && requestWorkspaceType) {
+      workspaceTypes?.learn({
+        workspaceId: binding.workspaceId,
+        workspaceType: requestWorkspaceType,
+      });
+    }
+    const scope = resolveLocalProjectWorkspaceScope({
       projectId: project.id,
       binding,
-      directory,
+      requestWorkspaceMemberId:
+        claimed && claimed !== 'missing' ? claimed.workspaceMemberId : null,
+      requestWorkspaceType,
+      knownWorkspaceType: workspaceTypes?.typeOf(binding?.workspaceId) ?? null,
       ...(ctx.configuredEnv ? { configuredEnv: ctx.configuredEnv() } : {}),
     });
     /** @type {import('@open-design/contracts').ProjectWorkspaceScopeResponse} */

--- a/apps/daemon/src/routes/routine.ts
+++ b/apps/daemon/src/routes/routine.ts
@@ -24,16 +24,12 @@ import {
 } from '../routines.js';
 import {
   AutomationWorkspaceScopeError,
-  authorizePersistedAutomationWorkspaceScope,
-  authorizePersistedProjectWorkspace,
   normalizePersistedAutomationWorkspaceScope,
 } from '../automations/workspace-scope.js';
-import type { WorkspaceDirectoryFetchResult } from '../collab/vela-workspace-context.js';
 import type { PathDeps, RouteDeps } from '../server-context.js';
 
 export interface RegisterRoutineRoutesDeps extends RouteDeps<'db' | 'routines'> {
   paths: Pick<PathDeps, 'RUNTIME_DATA_DIR'>;
-  fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
 }
 
 export type RoutineRoutesService = Pick<
@@ -151,7 +147,7 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
   const { db } = ctx;
   const { routineService } = ctx.routines;
 
-  async function authorizeRoutineWorkspaceContext(
+  function authorizeRoutineWorkspaceContext(
     req: any,
     context: ReturnType<typeof normalizeRoutineContext>,
     targetMode: 'create_each_run' | 'reuse',
@@ -172,7 +168,6 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
     ) {
       throw new Error('routine Workspace scope must match the explicit request identity');
     }
-    await authorizePersistedAutomationWorkspaceScope(scope, ctx.fetchWorkspaceDirectory);
     return { ...context, workspaceScope: scope };
   }
 
@@ -197,7 +192,7 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
     )?.workspaceId ?? null;
   }
 
-  async function authorizeRoutineRecord(req: any, row: any) {
+  function authorizeRoutineRecord(req: any, row: any) {
     const claimed = claimedWorkspaceScope(req);
     if (row.projectMode === 'reuse' && row.projectId) {
       const binding = getWorkspaceProjectByProjectId(db, row.projectId);
@@ -209,11 +204,10 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
           false,
         );
       }
-      const context = await authorizePersistedProjectWorkspace(
-        binding.workspaceId,
-        ctx.fetchWorkspaceDirectory,
-      );
-      if (context.workspaceMemberId !== claimed.workspaceMemberId) {
+      if (
+        binding.createdByWorkspaceMemberId
+        && binding.createdByWorkspaceMemberId !== claimed.workspaceMemberId
+      ) {
         throw new AutomationWorkspaceScopeError(
           'WORKSPACE_ACCESS_DENIED',
           'the routine belongs to a different Workspace member',
@@ -221,8 +215,8 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
         );
       }
       return {
-        workspaceId: context.workspaceId,
-        workspaceMemberId: context.workspaceMemberId,
+        workspaceId: binding.workspaceId,
+        workspaceMemberId: claimed.workspaceMemberId,
       };
     }
 
@@ -241,10 +235,6 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
         false,
       );
     }
-    await authorizePersistedAutomationWorkspaceScope(
-      persisted,
-      ctx.fetchWorkspaceDirectory,
-    );
     return persisted;
   }
 
@@ -264,7 +254,7 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
 
   function sendRoutineError(res: any, err: any, fallbackStatus: number) {
     const status = err instanceof AutomationWorkspaceScopeError
-      ? err.code === 'WORKSPACE_AUTHORITY_UNAVAILABLE' ? 503 : 403
+      ? 403
       : fallbackStatus;
     return res.status(status).json({
       error: String(err?.message ?? err),
@@ -338,12 +328,6 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
   app.get('/api/routines', async (req, res) => {
     try {
       const claimed = claimedWorkspaceScope(req);
-      if (claimed) {
-        await authorizePersistedAutomationWorkspaceScope(
-          claimed,
-          ctx.fetchWorkspaceDirectory,
-        );
-      }
       const routines = listRoutines(db).flatMap((row) => {
         const persistedWorkspaceId = persistedRoutineWorkspaceId(row);
         const persistedScope = row.projectMode === 'reuse'
@@ -419,7 +403,7 @@ export function registerRoutineRoutes(app: Express, ctx: RegisterRoutineRoutesDe
       });
     } catch (err: any) {
       const status = err instanceof AutomationWorkspaceScopeError
-        ? err.code === 'WORKSPACE_AUTHORITY_UNAVAILABLE' ? 503 : 403
+        ? 403
         : 400;
       res.status(status).json({
         error: String(err?.message ?? err),

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -35,7 +35,6 @@ import type { AuthorizeProjectRequest } from '../collab/project-request-authorit
 import {
   workspaceResourceContextFromRequest,
   type BoundWorkspaceResourceMutationGate,
-  type VerifyWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
 } from '../collab/workspace-resource-mutation.js';
 import {
@@ -613,7 +612,6 @@ export interface RegisterRunRoutesDeps {
   };
   amrWorkspaceScope?: {
     isSignedIn: () => boolean | Promise<boolean>;
-    verifyWorkspaceRequestAuthority: VerifyWorkspaceRequestAuthority;
   };
 }
 
@@ -980,10 +978,10 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
 
   /**
    * Pin a run to its persisted project binding. The sole adoption branch is a
-   * signed-in AMR request for a truly unbound historical project: a freshly
-   * verified exact Personal identity becomes the persisted creator witness.
-   * Every other runtime keeps its legacy local path and never reads Workspace
-   * authority here.
+   * signed-in AMR request for a truly unbound historical project: an explicitly
+   * Personal local attribution becomes the persisted creator witness. Vela
+   * remains the final membership and billing authority when the run reaches
+   * the cloud; local run creation never probes the Workspace directory.
    */
   async function prepareRunWorkspaceScope(
     req: ApiRequest,
@@ -1069,8 +1067,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       // compatibility lane. Home may create it before Workspace discovery
       // settles, after already running the account balance gate; requiring a
       // later identity here would turn that accepted first prompt into a 409.
-      // Explicitly bound projects still pin their persisted Workspace above,
-      // and any asserted identity below is freshly verified before adoption.
+      // Explicitly bound projects still pin their persisted Workspace above.
       return {
         ok: true,
         workspaceScope: accountScopedRunWorkspaceScopeForProject(projectId),
@@ -1086,31 +1083,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return { ok: false };
     }
 
-    const verified =
-      await ctx.amrWorkspaceScope.verifyWorkspaceRequestAuthority(req);
-    if (!verified.ok) {
-      sendApiError(
-        res,
-        verified.status,
-        verified.code,
-        verified.message,
-        verified.retryable ? { retryable: true } : {},
-      );
-      return { ok: false };
-    }
-    if (
-      verified.context.workspaceId !== requestContext.workspaceId
-      || verified.context.workspaceMemberId !== requestContext.workspaceMemberId
-    ) {
-      sendApiError(
-        res,
-        403,
-        'WORKSPACE_ACCESS_DENIED',
-        'the verified Workspace identity does not match the run request',
-      );
-      return { ok: false };
-    }
-    if (verified.context.workspaceType !== 'personal') {
+    if (requestContext.workspaceTypeAsserted === 'team') {
       sendApiError(
         res,
         409,
@@ -1118,6 +1091,12 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         'historical projects can only be adopted into a Personal Workspace',
       );
       return { ok: false };
+    }
+    if (requestContext.workspaceTypeAsserted !== 'personal') {
+      return {
+        ok: true,
+        workspaceScope: accountScopedRunWorkspaceScopeForProject(projectId),
+      };
     }
     const ensureWorkspaceProject = ctx.projectStore.ensureWorkspaceProject;
     if (!ensureWorkspaceProject) {
@@ -1141,11 +1120,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       if (existing) return existing;
       ensureWorkspaceProject(db, {
         projectId,
-        workspaceId: verified.context.workspaceId,
+        workspaceId: requestContext.workspaceId,
         visibility: 'personal',
         resourceState: 'active',
-        createdByWorkspaceMemberId: verified.context.workspaceMemberId,
-        updatedByWorkspaceMemberId: verified.context.workspaceMemberId,
+        createdByWorkspaceMemberId: requestContext.workspaceMemberId,
+        updatedByWorkspaceMemberId: requestContext.workspaceMemberId,
         syncState: 'local_only',
         resourceHubResourceId: null,
         cloudTombstonedAt: null,
@@ -1155,7 +1134,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return getWorkspaceProjectByProjectId(db, projectId);
     });
     const adopted = bindPersonal();
-    if (adopted?.workspaceId !== verified.context.workspaceId) {
+    if (adopted?.workspaceId !== requestContext.workspaceId) {
       sendApiError(
         res,
         409,
@@ -1165,7 +1144,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return { ok: false };
     }
     const workspaceScope = pinRunWorkspaceScopeForProject(db, projectId);
-    if (!workspaceScope || workspaceScope.workspaceId !== verified.context.workspaceId) {
+    if (!workspaceScope || workspaceScope.workspaceId !== requestContext.workspaceId) {
       sendApiError(
         res,
         409,
@@ -1188,13 +1167,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   ): Promise<boolean> {
     if (!run.projectId || !ctx.authorizeProjectRequest) return true;
 
-    // Local CLI/MCP callers predate Workspace transport headers. Once a run
-    // exists, its persisted agentId is the reliable runtime discriminator:
-    // non-AMR runtimes do not call the Workspace billing plane, so their
-    // headerless status/stream/cancel lifecycle must not depend on Workspace
-    // membership authority. AMR remains exact-authority-only. Likewise, any
-    // caller that explicitly asserts a Workspace identity still goes through
-    // the normal gate so a conflicting or partial scope cannot be ignored.
+    // Once a run exists, status/stream/cancel are local lifecycle operations.
+    // Headerless CLI/MCP/browser callers must not lose access merely because
+    // the Workspace directory is stale or offline, regardless of which agent
+    // created the run. Explicitly asserted identity still goes through the
+    // local project gate so conflicting or partial scope cannot be ignored.
     const requestContext = workspaceResourceContextFromRequest(req);
     const carriesNavigationScope =
       options.mode === 'read'
@@ -1206,10 +1183,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           && req.query.workspaceMemberId.trim().length > 0)
       );
     if (
-      typeof run.agentId === 'string'
-      && run.agentId.length > 0
-      && run.agentId !== 'amr'
-      && requestContext === null
+      requestContext === null
       && !carriesNavigationScope
     ) {
       return true;

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -32,7 +32,7 @@ import {
 } from '../db.js';
 import {
   enforceVerifiedWorkspaceResourceMutation,
-  resolveOptionalWorkspaceRequestAuthority,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   type VerifyWorkspaceRequestAuthority,
 } from '../collab/workspace-resource-mutation.js';
 import { listCodexPets, readCodexPetSpritesheet } from '../codex-pets.js';
@@ -283,10 +283,7 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       );
       return undefined;
     }
-    const authority = await resolveOptionalWorkspaceRequestAuthority(
-      scopedRequest,
-      options.verifyAuthority ?? ctx.verifyWorkspaceRequestAuthority,
-    );
+    const authority = resolveOptionalLocalWorkspaceRequestAuthority(scopedRequest);
     if (!authority.ok) {
       sendApiError(res, authority.status, authority.code, authority.message, {
         ...(authority.retryable ? { retryable: true } : {}),
@@ -308,6 +305,16 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
   ): Promise<boolean> => {
     const binding = getWorkspaceResourceByResourceId(db, 'skill', skillId);
     if (!binding) return true;
+    const localAuthority = resolveOptionalLocalWorkspaceRequestAuthority(req);
+    if (!localAuthority.ok) {
+      sendApiError(
+        res,
+        localAuthority.status,
+        localAuthority.code,
+        localAuthority.message,
+      );
+      return false;
+    }
     return enforceVerifiedWorkspaceResourceMutation(
       'skill',
       req,
@@ -318,7 +325,9 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       db,
       skillId,
       capability,
-      ctx.verifyWorkspaceRequestAuthority,
+      localAuthority.context
+        ? async () => ({ ok: true as const, context: localAuthority.context! })
+        : undefined,
     );
   };
   const hasActiveTeamSkillBinding = (

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3258,9 +3258,6 @@ export async function startServer({
           configuredEnv: configuredAmrEnv(),
         })
       : undefined;
-  const enforceAuthoritativeProjectMutation = createEnforceWorkspaceProjectMutation(
-    verifyWorkspaceRequestAuthority,
-  );
   // Project-creation writes must be authorized by AMR in production, while
   // local/dev and explicitly anonymous clients keep their legacy behavior.
   // Keep this separate from read-side directory fetches so an unconfigured
@@ -4154,6 +4151,8 @@ export async function startServer({
             resourceState: row.resourceState ?? null,
             createdByWorkspaceMemberId: row.createdByWorkspaceMemberId ?? null,
             resourceHubResourceId: row.resourceHubResourceId ?? null,
+            materializationPending:
+              projectIsUnmaterializedSharedPlaceholder(row.id),
           })),
       getLocalBinding: (projectId): LocalTeamProjectBinding | null => {
         const row = getWorkspaceProjectByProjectId(db, projectId) as any;
@@ -4165,6 +4164,8 @@ export async function startServer({
           resourceState: row.resourceState ?? null,
           createdByWorkspaceMemberId: row.createdByWorkspaceMemberId ?? null,
           resourceHubResourceId: row.resourceHubResourceId ?? null,
+          materializationPending:
+            projectIsUnmaterializedSharedPlaceholder(projectId),
         };
       },
       getLocalProjectMetadata: (projectId) => {
@@ -7397,6 +7398,15 @@ export async function startServer({
       projectIsUnmaterializedSharedPlaceholder(projectId),
     sendApiError,
   });
+  // Legacy registrars still receive the historical bound mutation-gate shape,
+  // but production delegates it to the same central authorizer as newer route
+  // modules. This keeps placeholder stamps authoritative across Figma import,
+  // library/import helpers, runs/chat, and every project/file mutation route.
+  const enforceAuthoritativeProjectMutation = createEnforceWorkspaceProjectMutation(
+    verifyWorkspaceRequestAuthority,
+    undefined,
+    authorizeProjectRequest,
+  );
   const authorizeProjectToolRequest = async (
     res,
     projectId,
@@ -7718,6 +7728,8 @@ export async function startServer({
     authorizeProjectRequest,
     isProjectRevoked: (projectId) =>
       revokedTeamProjectMirrors.has(projectId),
+    isProjectUnmaterializedPlaceholder: (projectId) =>
+      projectIsUnmaterializedSharedPlaceholder(projectId),
     fetchWorkspaceDirectory,
     configuredEnv: configuredAmrEnv,
     fetchProjectCreationWorkspaceDirectory,
@@ -8236,6 +8248,8 @@ export async function startServer({
     authorizeProjectRequest,
     isProjectRevoked: (projectId) =>
       revokedTeamProjectMirrors.has(projectId),
+    isProjectUnmaterializedPlaceholder: (projectId) =>
+      projectIsUnmaterializedSharedPlaceholder(projectId),
     projectFiles: projectFileDeps,
     documents: { buildDocumentPreview },
     artifacts: artifactDeps,
@@ -8770,6 +8784,8 @@ export async function startServer({
     projectStore: projectStoreDeps,
     authorizeProjectRequest,
     authorizeProjectToolRequest,
+    isProjectUnmaterializedPlaceholder: (projectId) =>
+      projectIsUnmaterializedSharedPlaceholder(projectId),
     projectFiles: projectFileDeps,
     verifyWorkspaceRequestAuthority,
   });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -768,15 +768,12 @@ import {
 } from './collab/active-workspace-selection.js';
 import {
   headerValue,
-  isWorkspaceResourceLocked,
-  resolveOptionalWorkspaceRequestAuthority,
-  type WorkspaceRequestAuthorityResult,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   workspaceResourceContext,
   workspaceResourceContextFromRequest,
 } from './collab/workspace-resource-mutation.js';
 import {
   createAuthorizeProjectRequest,
-  resolveBoundProjectWorkspaceReadAuthority,
 } from './collab/project-request-authority.js';
 import { withLastKnownWorkspaceContext } from './collab/workspace-context.js';
 import {
@@ -4414,13 +4411,9 @@ export async function startServer({
     projectId,
     { fresh: false },
   );
-  const resolveProjectCommentWorkspaceContextWith = async (
+  const resolveLocalProjectCommentWorkspaceContext = async (
     req: any,
     projectId: string,
-    verify: (
-      req: any,
-      projectId?: string,
-    ) => ReturnType<typeof verifyProjectWorkspaceContextForRequest>,
   ) => {
     const binding = getWorkspaceProjectByProjectId(db, projectId);
     if (revokedTeamProjectMirrors.has(projectId)) {
@@ -4442,26 +4435,80 @@ export async function startServer({
         message: 'workspace project read is not allowed',
       };
     }
-    const verified = await verify(req, projectId);
-    if (!verified.ok) return verified;
-    return { ok: true as const, context: verified.context };
+    const local = resolveOptionalLocalWorkspaceRequestAuthority(req);
+    if (!local.ok) return local;
+    if (local.context) {
+      if (
+        local.context.workspaceId !== binding.workspaceId
+        || (
+          binding.visibility !== 'team'
+          && binding.createdByWorkspaceMemberId
+          && local.context.workspaceMemberId
+            !== binding.createdByWorkspaceMemberId
+        )
+      ) {
+        return {
+          ok: false as const,
+          status: 403 as const,
+          code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
+          message: 'workspace project access is not allowed',
+        };
+      }
+      return {
+        ok: true as const,
+        context: {
+          ...local.context,
+          workspaceType: binding.visibility === 'team' ? 'team' : 'personal',
+          ...(binding.visibility === 'team'
+            ? { teamId: binding.workspaceId }
+            : { teamId: null }),
+        },
+      };
+    }
+    const persistedMemberId = binding.createdByWorkspaceMemberId?.trim()
+      || 'local-user';
+    return {
+      ok: true as const,
+      context: workspaceContextFromDirectoryItem({
+        workspaceId: binding.workspaceId,
+        workspaceName: binding.workspaceId,
+        workspaceType: binding.visibility === 'team' ? 'team' : 'personal',
+        workspaceMemberId: persistedMemberId,
+        role: 'member',
+        memberStatus: 'active',
+        lifecycleState: 'active',
+      }, configuredAmrEnv()),
+    };
   };
   const resolveProjectCommentWorkspaceContext = (
     req: any,
     projectId: string,
-  ) => resolveProjectCommentWorkspaceContextWith(
-    req,
-    projectId,
-    verifiedWorkspaceContextForRequest,
-  );
+  ) => resolveLocalProjectCommentWorkspaceContext(req, projectId);
   const resolveProjectCommentReadWorkspaceContext = (
     req: any,
     projectId: string,
-  ) => resolveProjectCommentWorkspaceContextWith(
-    req,
-    projectId,
-    verifiedWorkspaceReadContextForRequest,
-  );
+  ) => resolveLocalProjectCommentWorkspaceContext(req, projectId);
+  const resolveFreshProjectCommentWorkspaceContext = async (
+    req: any,
+    projectId: string,
+  ) => {
+    const binding = getWorkspaceProjectByProjectId(db, projectId);
+    if (
+      revokedTeamProjectMirrors.has(projectId)
+      || binding?.resourceState === 'deleted'
+    ) {
+      return {
+        ok: false as const,
+        status: 403 as const,
+        code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
+        message: 'workspace project read is not allowed',
+      };
+    }
+    if (!binding?.workspaceId) {
+      return { ok: true as const, context: null };
+    }
+    return verifiedWorkspaceContextForRequest(req, projectId);
+  };
   const verifiedTeamMirrorScope = async (
     scope: TeamMirrorPullScope,
   ): Promise<boolean> => {
@@ -7338,62 +7385,12 @@ export async function startServer({
     stageProjectDirsForDelete,
     validateLinkedDirs,
   };
-  const resolveProjectWorkspaceAuthority = async (
-    projectId: string,
-    options: { fresh: boolean },
-  ): Promise<WorkspaceRequestAuthorityResult | null> => {
-    const binding = getWorkspaceProjectByProjectId(db, projectId);
-    if (!binding?.workspaceId) return null;
-
-    if (process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela') {
-      const readDirectory = options.fresh
-        ? fetchFreshMutationWorkspaceDirectory
-        : fetchWorkspaceDirectory;
-      const directory = await readDirectory().catch(() => ({
-        ok: false as const,
-        items: [],
-      }));
-      return resolveBoundProjectWorkspaceReadAuthority(
-        binding.workspaceId,
-        directory,
-        configuredAmrEnv(),
-      );
-    }
-
-    return {
-      ok: true,
-      context: workspaceContextFromDirectoryItem({
-        workspaceId: binding.workspaceId,
-        workspaceName: binding.workspaceId,
-        workspaceType: 'personal',
-        workspaceMemberId:
-          binding.createdByWorkspaceMemberId ?? 'local-user',
-        role: 'owner',
-        memberStatus: 'active',
-        lifecycleState: 'active',
-      }, configuredAmrEnv()),
-    };
-  };
   const authorizeProjectRequest = createAuthorizeProjectRequest({
     db,
     getWorkspaceProject,
     getWorkspaceProjectByProjectId,
     isProjectRevoked: (_db, projectId) =>
       revokedTeamProjectMirrors.has(projectId),
-    verifyWorkspaceReadAuthority,
-    resolveWorkspaceReadAuthority: async (projectId) => {
-      const authority = await resolveProjectWorkspaceAuthority(
-        projectId,
-        { fresh: false },
-      );
-      return authority ?? {
-        ok: false,
-        status: 403,
-        code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-        message: 'workspace project access is not allowed',
-      };
-    },
-    verifyWorkspaceRequestAuthority,
     sendApiError,
   });
   const authorizeProjectToolRequest = async (
@@ -7401,59 +7398,27 @@ export async function startServer({
     projectId,
     options,
   ) => {
-    const resolvedAuthority = await resolveProjectWorkspaceAuthority(
-      projectId,
-      { fresh: true },
-    );
-    if (!resolvedAuthority) return { workspace: null };
-    if (!resolvedAuthority.ok) {
-      if (resolvedAuthority.retryable) {
-        sendApiError(
-          res,
-          resolvedAuthority.status,
-          resolvedAuthority.code,
-          resolvedAuthority.message,
-          { retryable: true },
-        );
-      } else {
-        sendApiError(
-          res,
-          resolvedAuthority.status,
-          resolvedAuthority.code,
-          resolvedAuthority.message,
-        );
-      }
-      return null;
-    }
-    const authority = resolvedAuthority.context;
-    const scopedAuthorize = createAuthorizeProjectRequest({
-      db,
-      getWorkspaceProject,
-      getWorkspaceProjectByProjectId,
-      isProjectRevoked: (_db, id) =>
-        revokedTeamProjectMirrors.has(id),
-      verifyWorkspaceRequestAuthority: async () => ({
-        ok: true,
-        context: authority,
-      }),
-      sendApiError,
-    });
-    const request = {
+    const binding = getWorkspaceProjectByProjectId(db, projectId);
+    const localRequest = {
       query: {},
       get(name) {
         const normalized = name.toLowerCase();
-        if (normalized === 'x-od-workspace-id') return authority.workspaceId;
+        if (normalized === 'x-od-workspace-id') return binding?.workspaceId ?? undefined;
         if (normalized === 'x-od-workspace-member-id') {
-          return authority.workspaceMemberId;
+          return binding?.workspaceId
+            ? binding.createdByWorkspaceMemberId ?? 'local-user'
+            : undefined;
         }
         return undefined;
       },
     };
-    if (!await scopedAuthorize(request, res, projectId, options)) return null;
+    if (!await authorizeProjectRequest(localRequest, res, projectId, options)) return null;
+    if (!binding?.workspaceId) return { workspace: null };
     return {
       workspace: {
-        workspaceId: authority.workspaceId,
-        workspaceMemberId: authority.workspaceMemberId,
+        workspaceId: binding.workspaceId,
+        workspaceMemberId:
+          binding.createdByWorkspaceMemberId ?? 'local-user',
       },
     };
   };
@@ -7840,6 +7805,7 @@ export async function startServer({
     // status change, tombstone) to the cross-daemon relay.
     resolveWorkspaceContext: resolveProjectCommentWorkspaceContext,
     resolveReadWorkspaceContext: resolveProjectCommentReadWorkspaceContext,
+    resolveFreshWorkspaceContext: resolveFreshProjectCommentWorkspaceContext,
     resolveProjectOwnerMemberId: async (projectId, context) => {
       if (!context || context.workspaceType !== 'team') return null;
       return resolveSharedProjectOwner(projectId, {
@@ -7972,14 +7938,6 @@ export async function startServer({
   // principal check `unshare` already enforces. Anything not teamSynced is
   // the caller's own, so it stays unrestricted.
   //
-  // Spec 9.2: on top of that existing rule, a workspace the caller's own
-  // request marks as locked/deleted (billing lapse, deletion in progress)
-  // blocks mutation unconditionally — the one real gap design system had
-  // that project/plugin already closed via `enforceWorkspaceResourceMutation`.
-  // Reuses that module's own `workspaceResourceContextFromRequest`/
-  // `isWorkspaceResourceLocked` rather than re-deriving the header contract
-  // here.
-  //
   // Hoisted out of `registerDesignSystemRoutes`'s deps (recvqb6mfyqXLD) so
   // `registerStaticResourceRoutes`'s design-system LIST route can decorate
   // every teamSynced entry with the same verdict — any detail surface a
@@ -7992,10 +7950,6 @@ export async function startServer({
     id: string,
     req: any,
   ): Promise<boolean> => {
-    const requestCtx = workspaceResourceContextFromRequest(req);
-    if (requestCtx && requestCtx !== 'missing' && isWorkspaceResourceLocked(requestCtx)) {
-      return false;
-    }
     const synced = await isTeamSyncedUserDesignSystem(root, id);
     if (!synced) return true;
     const resolution = await resolveTeamResourceScope(req);
@@ -8300,7 +8254,6 @@ export async function startServer({
     projectFiles: projectFileDeps,
     conversations: conversationDeps,
     research: researchDeps,
-    fetchWorkspaceDirectory,
     authorizeProjectRequest,
     authorizeProjectToolRequest,
   });
@@ -14409,10 +14362,7 @@ export async function startServer({
       loadPluginRegistryView,
       renderPluginBriefTemplate,
       authorizePluginRequest: async (req, res, pluginId) => {
-        const authority = await resolveOptionalWorkspaceRequestAuthority(
-          req,
-          verifyWorkspaceRequestAuthority,
-        );
+        const authority = resolveOptionalLocalWorkspaceRequestAuthority(req);
         if (!authority.ok) {
           sendApiError(
             res,
@@ -14466,7 +14416,6 @@ export async function startServer({
           agentCliEnvForAgent(appConfig.agentCliEnv, 'amr'),
         ).loggedIn;
       },
-      verifyWorkspaceRequestAuthority,
     },
     authorizeProjectRequest,
   });
@@ -14933,7 +14882,6 @@ export async function startServer({
     db,
     paths: { RUNTIME_DATA_DIR },
     routines: { routineService },
-    fetchWorkspaceDirectory,
   });
 
   // proxy routes (anthropic / openai / azure / google / ollama) live

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4588,6 +4588,8 @@ export async function startServer({
         });
       },
       materializeTeamMirror: (input, scope) => materializePulledTeamMirror(db, input, scope),
+      materializeTeamPlaceholder: (input, scope) =>
+        materializePulledTeamMirror(db, input, scope, undefined, { placeholder: true }),
       materializeAuthorizedTeamMirror: (input, scope, receipt) =>
         materializePulledTeamMirror(db, input, scope, receipt),
     },
@@ -7391,6 +7393,8 @@ export async function startServer({
     getWorkspaceProjectByProjectId,
     isProjectRevoked: (_db, projectId) =>
       revokedTeamProjectMirrors.has(projectId),
+    isProjectUnmaterializedPlaceholder: (_db, projectId) =>
+      projectIsUnmaterializedSharedPlaceholder(projectId),
     sendApiError,
   });
   const authorizeProjectToolRequest = async (

--- a/apps/daemon/tests/automations/workspace-scope.test.ts
+++ b/apps/daemon/tests/automations/workspace-scope.test.ts
@@ -1,28 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { WorkspaceDirectoryItem } from '@open-design/contracts';
 import {
-  authorizePersistedAutomationWorkspaceScope,
-  authorizePersistedProjectWorkspace,
   bindProjectToPersistedAutomationWorkspace,
   normalizePersistedAutomationWorkspaceScope,
 } from '../../src/automations/workspace-scope.js';
-
-function directoryItem(
-  workspaceId: string,
-  workspaceMemberId: string,
-  overrides: Partial<WorkspaceDirectoryItem> = {},
-): WorkspaceDirectoryItem {
-  return {
-    workspaceId,
-    workspaceName: workspaceId,
-    workspaceType: 'team',
-    workspaceMemberId,
-    role: 'owner',
-    memberStatus: 'active',
-    lifecycleState: 'active',
-    ...overrides,
-  };
-}
 
 describe('persisted automation Workspace scope', () => {
   it('binds the exact persisted billing address without consulting membership authority', () => {
@@ -53,99 +33,22 @@ describe('persisted automation Workspace scope', () => {
     });
   });
 
-  it('keeps the configured A identity after the directory also exposes B', async () => {
-    const fetchDirectory = vi.fn(async () => ({
-      ok: true,
-      items: [
-        directoryItem('workspace-b', 'member-b'),
-        directoryItem('workspace-a', 'member-a'),
-      ],
-    }));
-
-    await expect(
-      authorizePersistedAutomationWorkspaceScope(
-        { workspaceId: 'workspace-a', workspaceMemberId: 'member-a' },
-        fetchDirectory,
-      ),
-    ).resolves.toMatchObject({
+  it('normalizes only complete persisted pairs', () => {
+    expect(normalizePersistedAutomationWorkspaceScope({
+      workspaceId: ' workspace-a ',
+      workspaceMemberId: ' member-a ',
+    })).toEqual({
       workspaceId: 'workspace-a',
       workspaceMemberId: 'member-a',
     });
+    expect(normalizePersistedAutomationWorkspaceScope({
+      workspaceId: 'workspace-a',
+    })).toBeNull();
   });
 
-  it('fails closed on removal and authority outage', async () => {
-    await expect(
-      authorizePersistedAutomationWorkspaceScope(
-        { workspaceId: 'workspace-a', workspaceMemberId: 'member-a' },
-        async () => ({
-          ok: true,
-          items: [
-            directoryItem('workspace-a', 'member-a', { memberStatus: 'removed' }),
-          ],
-        }),
-      ),
-    ).rejects.toMatchObject({ code: 'WORKSPACE_ACCESS_DENIED', retryable: false });
-
-    await expect(
-      authorizePersistedAutomationWorkspaceScope(
-        { workspaceId: 'workspace-a', workspaceMemberId: 'member-a' },
-        async () => ({ ok: false, items: [] }),
-      ),
-    ).rejects.toMatchObject({
-      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      retryable: true,
-    });
-  });
-
-  it('re-reads authority for every trigger and rejects a member removed after configuration', async () => {
-    let removed = false;
-    const fetchDirectory = vi.fn(async () => ({
-      ok: true,
-      items: [
-        directoryItem('workspace-a', 'member-a', {
-          memberStatus: removed ? 'removed' : 'active',
-        }),
-      ],
-    }));
-
-    await expect(
-      authorizePersistedAutomationWorkspaceScope(
-        { workspaceId: 'workspace-a', workspaceMemberId: 'member-a' },
-        fetchDirectory,
-      ),
-    ).resolves.toMatchObject({ workspaceId: 'workspace-a' });
-
-    removed = true;
-    await expect(
-      authorizePersistedAutomationWorkspaceScope(
-        { workspaceId: 'workspace-a', workspaceMemberId: 'member-a' },
-        fetchDirectory,
-      ),
-    ).rejects.toMatchObject({ code: 'WORKSPACE_ACCESS_DENIED' });
-    expect(fetchDirectory).toHaveBeenCalledTimes(2);
-  });
-
-  it('keeps historical no-scope automation records truly unbound', () => {
+  it('keeps historical no-scope automation records unbound', () => {
     expect(normalizePersistedAutomationWorkspaceScope(undefined)).toBeNull();
     expect(normalizePersistedAutomationWorkspaceScope(null)).toBeNull();
     expect(normalizePersistedAutomationWorkspaceScope({})).toBeNull();
-  });
-
-  it('uses a reused project binding instead of another selected Workspace', async () => {
-    await expect(
-      authorizePersistedProjectWorkspace(
-        'workspace-a',
-        async () => ({
-          ok: true,
-          items: [
-            directoryItem('workspace-b', 'member-b'),
-            directoryItem('workspace-a', 'member-a'),
-          ],
-        }),
-      ),
-    ).resolves.toMatchObject({
-      workspaceId: 'workspace-a',
-      workspaceMemberId: 'member-a',
-    });
   });
 });

--- a/apps/daemon/tests/collab-first-open-materializing.test.ts
+++ b/apps/daemon/tests/collab-first-open-materializing.test.ts
@@ -85,11 +85,20 @@ function memberContextProvider(workspaceMemberId: string): WorkspaceContextProvi
  */
 function freshInstallProjectStore() {
   const rows = new Map<string, { name?: string | null; metadata?: unknown }>();
+  const bindings = new Map<string, TeamMirrorPullScope>();
   const store: PulledProjectStore = {
     get: (projectId) => rows.get(projectId) ?? null,
     has: (projectId) => rows.has(projectId),
     register: (input) => {
       rows.set(input.id, { name: input.name ?? null, metadata: rows.get(input.id)?.metadata });
+    },
+    materializeTeamPlaceholder: (input, scope) => {
+      rows.set(input.id, {
+        name: input.name,
+        metadata: { [SHARED_PROJECT_PLACEHOLDER_METADATA_KEY]: Date.now() },
+      });
+      bindings.set(input.id, scope);
+      return { localRecordChanged: true };
     },
   };
   const markSharedProjectPlaceholder = (projectId: string, placeholder: boolean) => {
@@ -100,7 +109,7 @@ function freshInstallProjectStore() {
     else delete metadata[SHARED_PROJECT_PLACEHOLDER_METADATA_KEY];
     rows.set(projectId, { ...row, metadata });
   };
-  return { rows, store, markSharedProjectPlaceholder };
+  return { rows, bindings, store, markSharedProjectPlaceholder };
 }
 
 async function startFirstOpenDaemon(options: {
@@ -110,7 +119,7 @@ async function startFirstOpenDaemon(options: {
     version?: number,
   ) => { id: string };
 }) {
-  const { rows, store, markSharedProjectPlaceholder } = freshInstallProjectStore();
+  const { rows, bindings, store, markSharedProjectPlaceholder } = freshInstallProjectStore();
   const workspaceContext = memberContextProvider('viewer-member');
   const context = await workspaceContext.current({});
   if (!context) throw new Error('test workspace context missing');
@@ -147,6 +156,7 @@ async function startFirstOpenDaemon(options: {
   return {
     base: `http://127.0.0.1:${address.port}`,
     rows,
+    bindings,
     headers: {
       'x-od-workspace-id': context.workspaceId,
       'x-od-workspace-member-id': context.workspaceMemberId,
@@ -155,6 +165,26 @@ async function startFirstOpenDaemon(options: {
 }
 
 describe('first open of an unmaterialized shared project (QA P0: no loading state, nothing downloads)', () => {
+  it('atomically exposes an exact Team-bound placeholder before the background pull finishes', async () => {
+    const { base, rows, bindings, headers } = await startFirstOpenDaemon({});
+
+    const res = await fetch(`${base}/api/projects/shared-from-owner/collab/bootstrap`, {
+      method: 'PUT',
+      headers,
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(202);
+    expect(body).toMatchObject({ ok: true, awaitingFirstMaterialization: true });
+    expect(isUnmaterializedSharedPlaceholder(rows.get('shared-from-owner'))).toBe(true);
+    expect(bindings.get('shared-from-owner')).toEqual({
+      workspaceId: 'ws-1',
+      resourceTeamId: 'team-1',
+      viewerMemberId: 'viewer-member',
+      ownerMemberId: 'owner-1',
+    });
+  });
+
   it('tells the client on the FIRST status response that local files are not the project content yet', async () => {
     const { base, rows, headers } = await startFirstOpenDaemon({});
 

--- a/apps/daemon/tests/collab/created-project-workspace.test.ts
+++ b/apps/daemon/tests/collab/created-project-workspace.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   authorizeCreatedProjectWorkspace,
   createdProjectWorkspaceHome,
-  CreatedProjectWorkspaceResolutionError,
   localProjectWorkspaceAttribution,
-  type CreatedProjectWorkspaceResolution,
 } from '../../src/collab/created-project-workspace.js';
 
 const ACTIVE_HEADERS: Record<string, string> = {
@@ -29,43 +27,12 @@ function request(headers: Record<string, string> = ACTIVE_HEADERS) {
   };
 }
 
-function directoryItem(overrides: Record<string, unknown> = {}) {
-  return {
-    workspaceId: 'workspace-a',
-    workspaceName: 'Workspace A',
-    workspaceType: 'team' as const,
-    workspaceMemberId: 'member-a',
-    role: 'owner' as const,
-    memberStatus: 'active' as const,
-    lifecycleState: 'active' as const,
-    ...overrides,
-  };
-}
-
-function expectDenied(
-  result: CreatedProjectWorkspaceResolution,
-  status: number,
-  code: string,
-): void {
-  expect(result).toMatchObject({ ok: false, status, code });
-}
-
 describe('authorizeCreatedProjectWorkspace', () => {
-  it('returns the exact authoritative workspace/member context, independent of ambient workspace', async () => {
+  it('keeps complete local attribution without consulting remote authority', async () => {
+    const fetchDirectory = vi.fn(async () => ({ ok: false as const, items: [] }));
     const result = await authorizeCreatedProjectWorkspace(
       request(),
-      async () => ({
-        ok: true,
-        items: [
-          directoryItem({
-            workspaceId: 'workspace-b',
-            workspaceName: 'Workspace B',
-            workspaceMemberId: 'member-b',
-            role: 'member',
-          }),
-          directoryItem(),
-        ],
-      }),
+      fetchDirectory,
     );
 
     expect(result).toMatchObject({
@@ -80,67 +47,7 @@ describe('authorizeCreatedProjectWorkspace', () => {
         canWriteSyncedFiles: true,
       },
     });
-  });
-
-  it('rejects a workspace/member pair that exists only across different directory rows', async () => {
-    const result = await authorizeCreatedProjectWorkspace(
-      request({
-        ...ACTIVE_HEADERS,
-        'x-od-workspace-member-id': 'member-b',
-      }),
-      async () => ({
-        ok: true,
-        items: [
-          directoryItem(),
-          directoryItem({
-            workspaceId: 'workspace-b',
-            workspaceName: 'Workspace B',
-            workspaceMemberId: 'member-b',
-          }),
-        ],
-      }),
-    );
-
-    expectDenied(result, 403, 'WORKSPACE_PROJECT_PERMISSION_DENIED');
-  });
-
-  it.each([
-    ['removed member', { memberStatus: 'removed' }],
-    ['locked workspace', { lifecycleState: 'locked' }],
-    ['deleting workspace', { lifecycleState: 'deleting' }],
-  ])('fails closed for an authoritative %s', async (_label, override) => {
-    const result = await authorizeCreatedProjectWorkspace(
-      request(),
-      async () => ({ ok: true, items: [directoryItem(override)] }),
-    );
-
-    expectDenied(result, 403, 'WORKSPACE_PROJECT_PERMISSION_DENIED');
-  });
-
-  it('returns a retryable 503 when AMR workspace authority is unavailable', async () => {
-    const result = await authorizeCreatedProjectWorkspace(
-      request(),
-      async () => ({ ok: false, items: [] }),
-    );
-
-    expectDenied(result, 503, 'WORKSPACE_AUTHORITY_UNAVAILABLE');
-    expect(result).toMatchObject({ ok: false, retryable: true });
-  });
-
-  it('returns a non-retryable 401 when the AMR credential has expired', async () => {
-    const result = await authorizeCreatedProjectWorkspace(
-      request(),
-      async () => ({
-        ok: false,
-        items: [],
-        reason: 'unauthorized',
-        status: 401,
-      }),
-    );
-
-    expectDenied(result, 401, 'AMR_AUTH_REQUIRED');
-    expect(result).toMatchObject({ ok: false });
-    expect(result).not.toHaveProperty('retryable');
+    expect(fetchDirectory).not.toHaveBeenCalled();
   });
 
   it('preserves explicitly anonymous/headerless compatibility without consulting AMR', async () => {
@@ -154,14 +61,14 @@ describe('authorizeCreatedProjectWorkspace', () => {
     expect(fetchDirectory).not.toHaveBeenCalled();
   });
 
-  it('rejects a partial workspace identity before consulting AMR', async () => {
+  it('leaves a partial workspace identity unbound without consulting AMR', async () => {
     const fetchDirectory = vi.fn(async () => ({ ok: true, items: [] }));
     const result = await authorizeCreatedProjectWorkspace(
       request({ 'x-od-workspace-id': 'workspace-a' }),
       fetchDirectory,
     );
 
-    expectDenied(result, 400, 'WORKSPACE_CONTEXT_INCOMPLETE');
+    expect(result).toEqual({ ok: true, context: null });
     expect(fetchDirectory).not.toHaveBeenCalled();
   });
 });
@@ -183,68 +90,32 @@ describe('localProjectWorkspaceAttribution', () => {
   });
 });
 
-// Resolver-style creation paths use the exact same authority result as direct
-// POST /api/projects. Headerless legacy remains unbound; once identity is
-// asserted, denial/outage must propagate before any project side effect.
+// Resolver-style local creation paths retain attribution without inheriting a
+// cloud availability dependency. Remote publication is authorized later.
 describe('createdProjectWorkspaceHome', () => {
-  /** Headers naming a workspace/member pair the caller has no membership in. */
-  const FOREIGN_HEADERS: Record<string, string> = {
-    ...ACTIVE_HEADERS,
-    'x-od-workspace-id': 'workspace-foreign',
-    'x-od-workspace-member-id': 'member-foreign',
-  };
-
-  it('binds an asserted identity the directory confirms, using the DIRECTORY context', async () => {
-    const home = await createdProjectWorkspaceHome(request(), async () => ({
-      ok: true,
-      items: [directoryItem()],
-    }));
+  it('binds complete local attribution while Vela is unavailable', async () => {
+    const fetchDirectory = vi.fn(async () => ({ ok: false as const, items: [] }));
+    const home = await createdProjectWorkspaceHome(request(), fetchDirectory);
 
     expect(home).toMatchObject({
       workspaceId: 'workspace-a',
       workspaceMemberId: 'member-a',
       memberStatus: 'active',
     });
-  });
-
-  it('rejects an asserted workspace the caller has no membership in', async () => {
-    await expect(createdProjectWorkspaceHome(
-      request(FOREIGN_HEADERS),
-      async () => ({ ok: true, items: [directoryItem()] }),
-    )).rejects.toMatchObject({
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-    });
-  });
-
-  it('rejects an unreadable or throwing membership authority as retryable', async () => {
-    await expect(createdProjectWorkspaceHome(request(), async () => ({
-      ok: false,
-      items: [],
-    }))).rejects.toMatchObject({
-      status: 503,
-      code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      retryable: true,
-    });
-    await expect(createdProjectWorkspaceHome(request(), async () => {
-      throw new Error('authority exploded');
-    })).rejects.toBeInstanceOf(CreatedProjectWorkspaceResolutionError);
+    expect(fetchDirectory).not.toHaveBeenCalled();
   });
 
   it('leaves a completely headerless legacy request unbound', async () => {
-    const fetchDirectory = vi.fn(async () => ({ ok: true, items: [directoryItem()] }));
+    const fetchDirectory = vi.fn(async () => ({ ok: true as const, items: [] }));
     const home = await createdProjectWorkspaceHome(request({}), fetchDirectory);
 
     expect(home).toBeNull();
     expect(fetchDirectory).not.toHaveBeenCalled();
   });
 
-  it('rejects a partial asserted identity instead of dropping its scope', async () => {
+  it('leaves a partial asserted identity unbound', async () => {
     await expect(createdProjectWorkspaceHome(
       request({ 'x-od-workspace-id': 'workspace-a' }),
-    )).rejects.toMatchObject({
-      status: 400,
-      code: 'WORKSPACE_CONTEXT_INCOMPLETE',
-    });
+    )).resolves.toBeNull();
   });
 });

--- a/apps/daemon/tests/collab/project-delete-authority-lease.test.ts
+++ b/apps/daemon/tests/collab/project-delete-authority-lease.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { createEnforceWorkspaceProjectMutation } from '../../src/routes/project/index.js';
 import type { WorkspaceResourceAccessInput } from '../../src/collab/workspace-resource-mutation.js';
 
@@ -12,40 +11,6 @@ function request() {
     get(name: string) {
       return headers[name.toLowerCase()];
     },
-  };
-}
-
-function personalContext(
-  overrides: Partial<WorkspaceCollabContext> = {},
-): WorkspaceCollabContext {
-  return {
-    workspaceId: 'workspace-personal',
-    workspaceName: 'Personal',
-    workspaceType: 'personal',
-    workspaceMemberId: 'member-owner',
-    role: 'owner',
-    memberStatus: 'active',
-    lifecycleState: 'active',
-    billingState: 'active',
-    planId: null,
-    providerMode: 'platform_credits',
-    seatSummary: {
-      seatLimit: 1,
-      usedSeats: 1,
-      availableSeats: 0,
-      isSeatFull: true,
-    },
-    permissions: {
-      canManageMembers: true,
-      canManageBilling: true,
-      canInviteMembers: false,
-      canManageAutoRecharge: true,
-      canShareProjects: false,
-      canWriteSyncedFiles: true,
-      canViewWorkspaceSettings: true,
-      canManageSharedResources: true,
-    },
-    ...overrides,
   };
 }
 
@@ -71,8 +36,8 @@ function lookups(row: WorkspaceResourceAccessInput) {
   };
 }
 
-describe('personal local-only project delete authority lease', () => {
-  it('deletes from a warm personal lease without starting the fresh authority request', async () => {
+describe('local project mutation authority', () => {
+  it('deletes locally without consulting either settled or fresh remote authority', async () => {
     const row = localOnlyProject();
     const { exact, any } = lookups(row);
     const fresh = vi.fn(async () => ({
@@ -84,7 +49,7 @@ describe('personal local-only project delete authority lease', () => {
     }));
     const lease = vi.fn(async () => ({
       ok: true as const,
-      context: personalContext(),
+      context: {} as never,
     }));
     const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
 
@@ -98,18 +63,15 @@ describe('personal local-only project delete authority lease', () => {
       'project-a',
       'delete',
     )).resolves.toBe(true);
-    expect(lease).toHaveBeenCalledTimes(1);
+    expect(lease).not.toHaveBeenCalled();
     expect(fresh).not.toHaveBeenCalled();
   });
 
   it.each([
-    ['Team visibility', localOnlyProject({ visibility: 'team' }), personalContext()],
-    ['hub-backed project', localOnlyProject({ resourceHubResourceId: 'hub-1' }), personalContext()],
-    ['synced project', localOnlyProject({ syncState: 'synced' }), personalContext()],
-    ['different creator', localOnlyProject({ createdByWorkspaceMemberId: 'member-other' }), personalContext()],
-    ['locked membership', localOnlyProject(), personalContext({ lifecycleState: 'locked' })],
-    ['Team workspace', localOnlyProject(), personalContext({ workspaceType: 'team', teamId: 'workspace-personal' })],
-  ])('falls through to fresh authority for %s', async (_label, row, context) => {
+    ['Team visibility', localOnlyProject({ visibility: 'team' })],
+    ['hub-backed project', localOnlyProject({ resourceHubResourceId: 'hub-1' })],
+    ['synced project', localOnlyProject({ syncState: 'synced' })],
+  ])('keeps %s locally mutable during an authority outage', async (_label, row) => {
     const { exact, any } = lookups(row);
     const fresh = vi.fn(async () => ({
       ok: false as const,
@@ -118,7 +80,7 @@ describe('personal local-only project delete authority lease', () => {
       message: 'fresh authority is unavailable',
       retryable: true as const,
     }));
-    const lease = vi.fn(async () => ({ ok: true as const, context }));
+    const lease = vi.fn();
     const sendApiError = vi.fn();
     const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
 
@@ -131,28 +93,22 @@ describe('personal local-only project delete authority lease', () => {
       {},
       'project-a',
       'delete',
-    )).resolves.toBe(false);
-    expect(lease).toHaveBeenCalledTimes(1);
-    expect(fresh).toHaveBeenCalledTimes(1);
-    expect(sendApiError).toHaveBeenCalledWith(
-      expect.anything(),
-      503,
-      'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      expect.any(String),
-      { retryable: true },
-    );
+    )).resolves.toBe(true);
+    expect(lease).not.toHaveBeenCalled();
+    expect(fresh).not.toHaveBeenCalled();
+    expect(sendApiError).not.toHaveBeenCalled();
   });
 
-  it('keeps non-delete mutations on fresh authority even when the lease is eligible', async () => {
+  it('keeps non-delete mutations off remote authority too', async () => {
     const row = localOnlyProject();
     const { exact, any } = lookups(row);
     const fresh = vi.fn(async () => ({
       ok: true as const,
-      context: personalContext(),
+      context: {} as never,
     }));
     const lease = vi.fn(async () => ({
       ok: true as const,
-      context: personalContext(),
+      context: {} as never,
     }));
     const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
 
@@ -166,7 +122,35 @@ describe('personal local-only project delete authority lease', () => {
       'project-a',
       'writeFiles',
     )).resolves.toBe(true);
-    expect(fresh).toHaveBeenCalledTimes(1);
+    expect(fresh).not.toHaveBeenCalled();
     expect(lease).not.toHaveBeenCalled();
+  });
+
+  it('still rejects an explicit member that is not the persisted creator', async () => {
+    const row = localOnlyProject({ createdByWorkspaceMemberId: 'member-other' });
+    const { exact, any } = lookups(row);
+    const fresh = vi.fn();
+    const lease = vi.fn();
+    const sendApiError = vi.fn();
+    const enforce = createEnforceWorkspaceProjectMutation(fresh, lease);
+
+    await expect(enforce(
+      request(),
+      {} as any,
+      sendApiError,
+      exact,
+      any,
+      {},
+      'project-a',
+      'delete',
+    )).resolves.toBe(false);
+    expect(fresh).not.toHaveBeenCalled();
+    expect(lease).not.toHaveBeenCalled();
+    expect(sendApiError).toHaveBeenCalledWith(
+      expect.anything(),
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      expect.any(String),
+    );
   });
 });

--- a/apps/daemon/tests/collab/project-request-authority.test.ts
+++ b/apps/daemon/tests/collab/project-request-authority.test.ts
@@ -57,6 +57,44 @@ function context(overrides: Record<string, unknown> = {}) {
 }
 
 describe('createAuthorizeProjectRequest', () => {
+  it('keeps a first-open placeholder readable/commentable but blocks content writes', async () => {
+    const row = {
+      workspaceId: 'workspace-a',
+      visibility: 'team',
+      resourceState: 'active',
+      // Deliberately model a stale/legacy creator-bound placeholder. Current
+      // materialization keeps this null, but the stamp must independently
+      // fail closed even if a bad binding would otherwise grant writes.
+      createdByWorkspaceMemberId: 'member-a',
+    };
+    const sendApiError = vi.fn();
+    const authorize = createAuthorizeProjectRequest({
+      db: {},
+      getWorkspaceProject: () => row,
+      getWorkspaceProjectByProjectId: () => row,
+      isProjectUnmaterializedPlaceholder: () => true,
+      sendApiError,
+    });
+    const req = request({ workspaceId: 'workspace-a', memberId: 'member-a' });
+
+    await expect(authorize(req, response(), 'project-a', { mode: 'read' }))
+      .resolves.toBe(true);
+    await expect(authorize(req, response(), 'project-a', {
+      mode: 'write',
+      capability: 'comment',
+    })).resolves.toBe(true);
+    await expect(authorize(req, response(), 'project-a', {
+      mode: 'write',
+      capability: 'writeFiles',
+    })).resolves.toBe(false);
+    expect(sendApiError).toHaveBeenLastCalledWith(
+      expect.anything(),
+      409,
+      'PROJECT_MATERIALIZATION_PENDING',
+      expect.any(String),
+    );
+  });
+
   it('serves a headerless bound-project read from local binding without remote authority', async () => {
     const row = {
       workspaceId: 'workspace-a',

--- a/apps/daemon/tests/collab/project-request-authority.test.ts
+++ b/apps/daemon/tests/collab/project-request-authority.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  createAuthorizeProjectRequest,
-  resolveBoundProjectWorkspaceReadAuthority,
-} from '../../src/collab/project-request-authority.js';
+import { createAuthorizeProjectRequest } from '../../src/collab/project-request-authority.js';
 import { verifyWorkspaceRequestContext } from '../../src/collab/request-workspace-context.js';
 import { createCachedWorkspaceDirectoryFetcher } from '../../src/collab/vela-workspace-context.js';
 
@@ -60,23 +57,7 @@ function context(overrides: Record<string, unknown> = {}) {
 }
 
 describe('createAuthorizeProjectRequest', () => {
-  it('preserves the expired-session sign-in signal for derived bound-project reads', () => {
-    const result = resolveBoundProjectWorkspaceReadAuthority('workspace-a', {
-      ok: false,
-      items: [],
-      reason: 'unauthorized',
-      status: 401,
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      status: 401,
-      code: 'AMR_AUTH_REQUIRED',
-    });
-    expect(result).not.toHaveProperty('retryable');
-  });
-
-  it('derives a bound project read from persisted server authority when the request is headerless', async () => {
+  it('serves a headerless bound-project read from local binding without remote authority', async () => {
     const row = {
       workspaceId: 'workspace-a',
       visibility: 'personal',
@@ -104,7 +85,7 @@ describe('createAuthorizeProjectRequest', () => {
       'project-a',
       { mode: 'read' },
     )).resolves.toBe(true);
-    expect(resolve).toHaveBeenCalledWith('project-a');
+    expect(resolve).not.toHaveBeenCalled();
     expect(verify).not.toHaveBeenCalled();
     expect(sendApiError).not.toHaveBeenCalled();
   });
@@ -143,7 +124,7 @@ describe('createAuthorizeProjectRequest', () => {
       'project-a',
       { mode: 'read' },
     )).resolves.toBe(false);
-    expect(verify).toHaveBeenCalledTimes(1);
+    expect(verify).not.toHaveBeenCalled();
     expect(resolve).not.toHaveBeenCalled();
     expect(sendApiError).toHaveBeenCalledWith(
       expect.anything(),
@@ -153,7 +134,7 @@ describe('createAuthorizeProjectRequest', () => {
     );
   });
 
-  it('fails a derived bound-project read closed when server authority is unavailable', async () => {
+  it('keeps a bound-project read available when remote authority is unavailable', async () => {
     const row = {
       workspaceId: 'workspace-a',
       visibility: 'team',
@@ -179,17 +160,11 @@ describe('createAuthorizeProjectRequest', () => {
       response(),
       'project-a',
       { mode: 'read' },
-    )).resolves.toBe(false);
-    expect(sendApiError).toHaveBeenCalledWith(
-      expect.anything(),
-      503,
-      'WORKSPACE_AUTHORITY_UNAVAILABLE',
-      expect.any(String),
-      { retryable: true },
-    );
+    )).resolves.toBe(true);
+    expect(sendApiError).not.toHaveBeenCalled();
   });
 
-  it('uses the bounded read verifier without weakening fresh mutation authority', async () => {
+  it('does not probe the membership directory for repeated local reads or writes', async () => {
     const row = {
       workspaceId: 'workspace-a',
       visibility: 'personal',
@@ -242,8 +217,8 @@ describe('createAuthorizeProjectRequest', () => {
       await expect(authorize(req, response(), 'project-a', { mode: 'read' }))
         .resolves.toBe(true);
     }
-    expect(readVerifier).toHaveBeenCalledTimes(6);
-    expect(fetchReadDirectory).toHaveBeenCalledTimes(1);
+    expect(readVerifier).not.toHaveBeenCalled();
+    expect(fetchReadDirectory).not.toHaveBeenCalled();
     expect(mutationVerifier).not.toHaveBeenCalled();
 
     for (let index = 0; index < 2; index += 1) {
@@ -254,10 +229,10 @@ describe('createAuthorizeProjectRequest', () => {
         { mode: 'write', capability: 'writeFiles' },
       )).resolves.toBe(true);
     }
-    expect(readVerifier).toHaveBeenCalledTimes(6);
-    expect(fetchReadDirectory).toHaveBeenCalledTimes(1);
-    expect(mutationVerifier).toHaveBeenCalledTimes(2);
-    expect(fetchFreshMutationDirectory).toHaveBeenCalledTimes(2);
+    expect(readVerifier).not.toHaveBeenCalled();
+    expect(fetchReadDirectory).not.toHaveBeenCalled();
+    expect(mutationVerifier).not.toHaveBeenCalled();
+    expect(fetchFreshMutationDirectory).not.toHaveBeenCalled();
   });
 
   it('preserves unbound legacy reads and writes without consulting authority', async () => {
@@ -283,7 +258,7 @@ describe('createAuthorizeProjectRequest', () => {
     expect(sendApiError).not.toHaveBeenCalled();
   });
 
-  it('does not disclose a bound project to a headerless bootstrap request', async () => {
+  it('keeps a bound local project available to a headerless daemon client', async () => {
     const row = {
       workspaceId: 'workspace-a',
       visibility: 'personal',
@@ -309,19 +284,14 @@ describe('createAuthorizeProjectRequest', () => {
       response(),
       'project-a',
       { mode: 'read' },
-    )).resolves.toBe(false);
-    expect(verify).toHaveBeenCalledTimes(1);
-    expect(sendApiError).toHaveBeenCalledWith(
-      expect.anything(),
-      400,
-      'WORKSPACE_CONTEXT_REQUIRED',
-      expect.any(String),
-      expect.any(Object),
-    );
+    )).resolves.toBe(true);
+    expect(verify).not.toHaveBeenCalled();
+    expect(sendApiError).not.toHaveBeenCalled();
   });
 
   it('keeps locked/frozen Team projects readable but rejects writes', async () => {
     const row = {
+      workspaceId: 'workspace-a',
       visibility: 'team',
       resourceState: 'frozen',
       createdByWorkspaceMemberId: 'member-a',
@@ -426,6 +396,7 @@ describe('createAuthorizeProjectRequest', () => {
 
   it('preserves write access for the shared-project owner', async () => {
     const row = {
+      workspaceId: 'workspace-a',
       visibility: 'team',
       resourceState: 'active',
       createdByWorkspaceMemberId: 'member-a',
@@ -453,6 +424,7 @@ describe('createAuthorizeProjectRequest', () => {
     'does not let a Workspace %s mutate another member\'s Personal project',
     async (role) => {
       const row = {
+        workspaceId: 'workspace-a',
         visibility: 'personal',
         resourceState: 'active',
         createdByWorkspaceMemberId: 'project-owner',
@@ -488,6 +460,35 @@ describe('createAuthorizeProjectRequest', () => {
     },
   );
 
+  it('does not expose a Personal project to another member in the same Workspace', async () => {
+    const row = {
+      workspaceId: 'workspace-a',
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: 'project-owner',
+    };
+    const sendApiError = vi.fn();
+    const authorize = createAuthorizeProjectRequest({
+      db: {},
+      getWorkspaceProject: () => row,
+      getWorkspaceProjectByProjectId: () => row,
+      sendApiError,
+    });
+
+    await expect(authorize(
+      request({ workspaceId: 'workspace-a', memberId: 'workspace-admin' }),
+      response(),
+      'project-a',
+      { mode: 'read' },
+    )).resolves.toBe(false);
+    expect(sendApiError).toHaveBeenCalledWith(
+      expect.anything(),
+      403,
+      'WORKSPACE_PROJECT_PERMISSION_DENIED',
+      'workspace project read is not allowed',
+    );
+  });
+
   it.each([
     [
       'removed member',
@@ -503,14 +504,15 @@ describe('createAuthorizeProjectRequest', () => {
         retryable: true as const,
       },
     ],
-  ])('fails a bound read closed for %s', async (_label, result) => {
-    const row = { visibility: 'team', resourceState: 'active' };
+  ])('keeps a local bound read available for stale remote state: %s', async (_label, result) => {
+    const row = { workspaceId: 'workspace-a', visibility: 'team', resourceState: 'active' };
+    const verify = vi.fn(async () => result);
     const sendApiError = vi.fn();
     const authorize = createAuthorizeProjectRequest({
       db: {},
       getWorkspaceProject: () => row,
       getWorkspaceProjectByProjectId: () => row,
-      verifyWorkspaceRequestAuthority: async () => result,
+      verifyWorkspaceRequestAuthority: verify,
       sendApiError,
     });
 
@@ -519,18 +521,13 @@ describe('createAuthorizeProjectRequest', () => {
       response(),
       'project-a',
       { mode: 'read' },
-    )).resolves.toBe(false);
-    expect(sendApiError).toHaveBeenCalledWith(
-      expect.anything(),
-      result.status,
-      result.code,
-      result.message,
-      expect.any(Object),
-    );
+    )).resolves.toBe(true);
+    expect(verify).not.toHaveBeenCalled();
+    expect(sendApiError).not.toHaveBeenCalled();
   });
 
   it('denies a freshly verified cross-Workspace identity', async () => {
-    const row = { visibility: 'team', resourceState: 'active' };
+    const row = { workspaceId: 'workspace-a', visibility: 'team', resourceState: 'active' };
     const sendApiError = vi.fn();
     const authorize = createAuthorizeProjectRequest({
       db: {},
@@ -562,7 +559,7 @@ describe('createAuthorizeProjectRequest', () => {
   });
 
   it('accepts an exact navigation query pair and rejects header/query conflict', async () => {
-    const row = { visibility: 'team', resourceState: 'active' };
+    const row = { workspaceId: 'workspace-a', visibility: 'team', resourceState: 'active' };
     const verify = vi.fn(async (req: any) => ({
       ok: true as const,
       context: context({
@@ -591,6 +588,7 @@ describe('createAuthorizeProjectRequest', () => {
       'project-a',
       { mode: 'read', allowNavigationQuery: true },
     )).resolves.toBe(true);
+    expect(verify).not.toHaveBeenCalled();
 
     await expect(authorize(
       request({

--- a/apps/daemon/tests/collab/project-request-authority.test.ts
+++ b/apps/daemon/tests/collab/project-request-authority.test.ts
@@ -381,7 +381,7 @@ describe('createAuthorizeProjectRequest', () => {
         status: 503 as const,
         code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
         message: 'workspace authority is temporarily unavailable',
-        retryable: true,
+        retryable: true as const,
       }));
       const sendApiError = vi.fn();
       const authorize = createAuthorizeProjectRequest({

--- a/apps/daemon/tests/collab/project-request-authority.test.ts
+++ b/apps/daemon/tests/collab/project-request-authority.test.ts
@@ -365,6 +365,49 @@ describe('createAuthorizeProjectRequest', () => {
     },
   );
 
+  it.each(['rename', 'delete', 'duplicate', 'writeFiles'] as const)(
+    'keeps a materialized member mirror read-only for %s during an authority outage',
+    async (capability) => {
+      const row = {
+        workspaceId: 'workspace-a',
+        visibility: 'team',
+        resourceState: 'active',
+        // The durable shape written by `materializePulledTeamMirror` when the
+        // viewer is not the project owner.
+        createdByWorkspaceMemberId: null,
+      };
+      const verify = vi.fn(async () => ({
+        ok: false as const,
+        status: 503 as const,
+        code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+        message: 'workspace authority is temporarily unavailable',
+        retryable: true,
+      }));
+      const sendApiError = vi.fn();
+      const authorize = createAuthorizeProjectRequest({
+        db: {},
+        getWorkspaceProject: () => row,
+        getWorkspaceProjectByProjectId: () => row,
+        verifyWorkspaceRequestAuthority: verify,
+        sendApiError,
+      });
+
+      await expect(authorize(
+        request({ workspaceId: 'workspace-a', memberId: 'mirror-viewer' }),
+        response(),
+        'project-a',
+        { mode: 'write', capability },
+      )).resolves.toBe(false);
+      expect(verify).not.toHaveBeenCalled();
+      expect(sendApiError).toHaveBeenLastCalledWith(
+        expect.anything(),
+        403,
+        'WORKSPACE_PROJECT_PERMISSION_DENIED',
+        expect.any(String),
+      );
+    },
+  );
+
   it('preserves shared-project comments for active Team viewers', async () => {
     const row = {
       workspaceId: 'workspace-a',

--- a/apps/daemon/tests/collab/project-workspace-scope.test.ts
+++ b/apps/daemon/tests/collab/project-workspace-scope.test.ts
@@ -1,126 +1,94 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  resolveProjectWorkspaceScope,
-  resolveProjectWorkspaceScopeBootstrap,
-} from '../../src/collab/project-workspace-scope.js';
+import { resolveLocalProjectWorkspaceScope } from '../../src/collab/project-workspace-scope.js';
 
-const directoryItems = [
-  {
-    workspaceId: 'workspace-b',
-    workspaceName: 'Workspace B',
-    workspaceType: 'team' as const,
-    workspaceMemberId: 'member-b',
-    role: 'member' as const,
-    memberStatus: 'active' as const,
-    lifecycleState: 'active' as const,
-  },
-  {
-    workspaceId: 'workspace-a',
-    workspaceName: 'Workspace A',
-    workspaceType: 'team' as const,
-    workspaceMemberId: 'member-a',
-    role: 'owner' as const,
-    memberStatus: 'active' as const,
-    lifecycleState: 'active' as const,
-  },
-];
-
-describe('resolveProjectWorkspaceScope', () => {
-  it('resolves the project binding rather than the first or active directory workspace', () => {
-    const scope = resolveProjectWorkspaceScope({
-      projectId: 'project-a',
+describe('resolveLocalProjectWorkspaceScope', () => {
+  it('resolves a Team project entirely from its persisted local binding', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-team',
       binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'personal',
+        workspaceId: 'workspace-team',
+        visibility: 'team',
+        createdByWorkspaceMemberId: 'creator-member',
       },
-      directory: { ok: true, items: directoryItems },
-    });
-
-    expect(scope).toMatchObject({
+    })).toMatchObject({
       kind: 'team',
-      projectId: 'project-a',
-      workspaceId: 'workspace-a',
-      visibility: 'personal',
+      projectId: 'project-team',
+      workspaceId: 'workspace-team',
+      visibility: 'team',
       context: {
-        workspaceId: 'workspace-a',
+        workspaceId: 'workspace-team',
         workspaceType: 'team',
-        workspaceMemberId: 'member-a',
+        workspaceMemberId: 'creator-member',
+        memberStatus: 'active',
+        lifecycleState: 'active',
       },
     });
   });
 
-  it('tags a personal binding as account billing even though it has a workspace id', () => {
-    const scope = resolveProjectWorkspaceScope({
-      projectId: 'project-personal',
+  it('uses an exact request member without trusting stale role or permission claims', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-team',
       binding: {
-        workspaceId: 'workspace-personal',
-        visibility: 'personal',
+        workspaceId: 'workspace-team',
+        visibility: 'team',
+        createdByWorkspaceMemberId: 'creator-member',
       },
-      directory: {
-        ok: true,
-        items: [{
-          workspaceId: 'workspace-personal',
-          workspaceName: 'Personal',
-          workspaceType: 'personal',
-          workspaceMemberId: 'member-personal',
-          role: 'owner',
-          memberStatus: 'active',
-          lifecycleState: 'active',
-        }],
+      requestWorkspaceMemberId: 'request-member',
+      requestWorkspaceType: 'team',
+    })).toMatchObject({
+      kind: 'team',
+      context: {
+        workspaceMemberId: 'request-member',
+        role: 'member',
+        memberStatus: 'active',
+        lifecycleState: 'active',
       },
     });
+  });
 
-    expect(scope).toMatchObject({
+  it('uses the daemon type registry for a private project in a known Team Workspace', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-private-team',
+      binding: {
+        workspaceId: 'workspace-team',
+        visibility: 'personal',
+        createdByWorkspaceMemberId: 'creator-member',
+      },
+      knownWorkspaceType: 'team',
+    })).toMatchObject({
+      kind: 'team',
+      visibility: 'personal',
+      context: { workspaceType: 'team' },
+    });
+  });
+
+  it('falls back to Personal for an unknown historical private binding', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-private',
+      binding: {
+        workspaceId: 'workspace-private',
+        visibility: 'personal',
+      },
+    })).toMatchObject({
       kind: 'personal',
-      workspaceId: 'workspace-personal',
       context: {
         workspaceType: 'personal',
-        workspaceMemberId: 'member-personal',
+        workspaceMemberId: 'local-user',
       },
     });
   });
 
-  it('does not fall back to another workspace when directory membership is unavailable', () => {
-    const scope = resolveProjectWorkspaceScope({
-      projectId: 'project-a',
+  it('keeps a frozen project readable while local write permissions stay disabled', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-frozen',
       binding: {
-        workspaceId: 'workspace-a',
+        workspaceId: 'workspace-team',
         visibility: 'team',
+        resourceState: 'frozen',
       },
-      directory: { ok: false, items: directoryItems },
-    });
-
-    expect(scope).toEqual({
-      kind: 'unavailable',
-      projectId: 'project-a',
-      workspaceId: 'workspace-a',
-      visibility: 'team',
-      context: null,
-    });
-  });
-
-  it('keeps locked/frozen workspaces readable while write permissions stay disabled', () => {
-    const scope = resolveProjectWorkspaceScope({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'personal',
-      },
-      directory: {
-        ok: true,
-        items: [{
-          ...directoryItems[1]!,
-          lifecycleState: 'locked',
-        }],
-      },
-    });
-
-    expect(scope).toMatchObject({
+    })).toMatchObject({
       kind: 'team',
-      projectId: 'project-a',
-      workspaceId: 'workspace-a',
-      visibility: 'personal',
       context: {
         lifecycleState: 'locked',
         permissions: {
@@ -131,131 +99,15 @@ describe('resolveProjectWorkspaceScope', () => {
     });
   });
 
-  it('reports a truly unbound legacy project without borrowing ambient scope', () => {
-    const scope = resolveProjectWorkspaceScope({
-      projectId: 'project-legacy',
+  it('preserves a genuinely unbound project without login or directory state', () => {
+    expect(resolveLocalProjectWorkspaceScope({
+      projectId: 'project-unbound',
       binding: null,
-      directory: { ok: true, items: directoryItems },
-    });
-
-    expect(scope).toEqual({
+    })).toEqual({
       kind: 'unbound',
-      projectId: 'project-legacy',
+      projectId: 'project-unbound',
       workspaceId: null,
       context: null,
-    });
-  });
-});
-
-describe('resolveProjectWorkspaceScopeBootstrap', () => {
-  it('returns project A from its exact membership even when ambient-order B is first', () => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'team',
-        resourceState: 'active',
-      },
-      directory: { ok: true, items: directoryItems },
-    })).toMatchObject({
-      ok: true,
-      scope: {
-        kind: 'team',
-        projectId: 'project-a',
-        workspaceId: 'workspace-a',
-        context: {
-          workspaceId: 'workspace-a',
-          workspaceMemberId: 'member-a',
-        },
-      },
-    });
-  });
-
-  it('fails closed when the current account is not a member of the persisted workspace', () => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'team',
-        resourceState: 'active',
-      },
-      directory: { ok: true, items: [directoryItems[0]!] },
-    })).toEqual({
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-      message: 'workspace project read is not allowed',
-    });
-  });
-
-  it('distinguishes a directory outage from revoked membership', () => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'team',
-        resourceState: 'active',
-      },
-      directory: { ok: false, items: [] },
-    })).toEqual({
-      ok: false,
-      status: 503,
-      code: 'WORKSPACE_DIRECTORY_UNAVAILABLE',
-      message: 'workspace membership directory is unavailable',
-    });
-  });
-
-  it.each([
-    { memberStatus: 'removed' as const, lifecycleState: 'active' as const },
-    { memberStatus: 'active' as const, lifecycleState: 'deleted' as const },
-  ])('rejects a revoked or deleted membership: %o', (membership) => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'team',
-        resourceState: 'active',
-      },
-      directory: {
-        ok: true,
-        items: [{ ...directoryItems[1]!, ...membership }],
-      },
-    })).toMatchObject({
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-    });
-  });
-
-  it('rejects a deleted persisted resource before returning its binding', () => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'project-a',
-      binding: {
-        workspaceId: 'workspace-a',
-        visibility: 'team',
-        resourceState: 'deleted',
-      },
-      directory: { ok: true, items: directoryItems },
-    })).toMatchObject({
-      ok: false,
-      status: 403,
-      code: 'WORKSPACE_PROJECT_PERMISSION_DENIED',
-    });
-  });
-
-  it('preserves a genuinely unbound local project without requiring login', () => {
-    expect(resolveProjectWorkspaceScopeBootstrap({
-      projectId: 'legacy-local',
-      binding: null,
-      directory: { ok: false, items: [] },
-    })).toEqual({
-      ok: true,
-      scope: {
-        kind: 'unbound',
-        projectId: 'legacy-local',
-        workspaceId: null,
-        context: null,
-      },
     });
   });
 });

--- a/apps/daemon/tests/collab/team-mirror-materializer.test.ts
+++ b/apps/daemon/tests/collab/team-mirror-materializer.test.ts
@@ -169,6 +169,67 @@ describe('authorized team mirror SQLite materialization', () => {
       .toEqual(receipt());
   });
 
+  it('keeps an owner first-open placeholder creator-less until real content commits', async () => {
+    const db = await database();
+    const ownerScope = {
+      ...scope,
+      ownerMemberId: scope.viewerMemberId,
+    };
+
+    materializePulledTeamMirror(
+      db,
+      { ...input, name: '共享项目' },
+      ownerScope,
+      undefined,
+      { placeholder: true },
+    );
+
+    expect(getProject(db, input.id)?.metadata?.sharedProjectPlaceholderAt)
+      .toEqual(expect.any(Number));
+    expect(listWorkspaceProjects(db, ownerScope.workspaceId).find(
+      (project) => project.id === input.id,
+    )?.createdByWorkspaceMemberId).toBeNull();
+
+    materializePulledTeamMirror(db, {
+      ...input,
+      metadata: { kind: 'prototype' },
+    }, ownerScope);
+
+    expect(getProject(db, input.id)).toMatchObject({
+      name: input.name,
+      metadata: { kind: 'prototype' },
+    });
+    expect(listWorkspaceProjects(db, ownerScope.workspaceId).find(
+      (project) => project.id === input.id,
+    )?.createdByWorkspaceMemberId).toBe(ownerScope.viewerMemberId);
+  });
+
+  it('replaces a member placeholder even when its local bootstrap timestamp is newer', async () => {
+    const db = await database();
+    materializePulledTeamMirror(
+      db,
+      { ...input, name: '共享项目', updatedAt: 20_000 },
+      scope,
+      undefined,
+      { placeholder: true },
+    );
+
+    materializePulledTeamMirror(db, {
+      ...input,
+      updatedAt: 10_000,
+      metadata: { kind: 'prototype' },
+    }, scope);
+
+    expect(getProject(db, input.id)).toMatchObject({
+      name: input.name,
+      updatedAt: 10_000,
+      metadata: { kind: 'prototype' },
+    });
+    expect(listWorkspaceProjects(db, scope.workspaceId).find(
+      (project) => project.id === input.id,
+    )?.createdByWorkspaceMemberId).toBeNull();
+  });
+
   it('refreshes an existing foreign mirror name when the owner metadata is newer', async () => {
     const db = await database();
     materializePulledTeamMirror(db, input, scope, receipt());

--- a/apps/daemon/tests/collab/workspace-projects-reconciler.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-reconciler.test.ts
@@ -53,6 +53,26 @@ describe('planWorkspaceProjectReconciliation (pure)', () => {
     ]);
   });
 
+  it('never promotes an owner placeholder before its content materialization commits', () => {
+    const placeholder = {
+      projectId: 'p1',
+      workspaceId: WORKSPACE_ID,
+      visibility: 'team' as const,
+      resourceState: 'active',
+      createdByWorkspaceMemberId: null,
+      resourceHubResourceId: 'resource-abc',
+      materializationPending: true as const,
+    };
+    const actions = planWorkspaceProjectReconciliation({
+      workspaceId: WORKSPACE_ID,
+      workspaceMemberId: OWNER_MEMBER_ID,
+      remoteProjects: [{ projectId: 'p1', ownerMemberId: OWNER_MEMBER_ID }],
+      localBindings: new Map([['p1', placeholder]]),
+    });
+
+    expect(actions).toEqual([]);
+  });
+
   it('preserves an already-known resourceHubResourceId when correcting a row', () => {
     const local: LocalTeamProjectBinding = {
       projectId: 'p1',

--- a/apps/daemon/tests/collab/workspace-resource-mutation.test.ts
+++ b/apps/daemon/tests/collab/workspace-resource-mutation.test.ts
@@ -3,6 +3,7 @@ import {
   enforceVerifiedWorkspaceResourceMutation,
   enforceVerifiedWorkspaceResourceRead,
   enforceWorkspaceResourceMutation,
+  resolveOptionalLocalWorkspaceRequestAuthority,
   type WorkspaceResourceAccessInput,
 } from '../../src/collab/workspace-resource-mutation.js';
 import { workspaceContextFromDirectoryItem } from '../../src/collab/vela-workspace-context.js';
@@ -72,6 +73,40 @@ function makeLookups(rowsByResourceId: Record<string, WorkspaceResourceAccessInp
   const getWorkspaceResourceByResourceId = (_db: unknown, resourceId: string) => rowsByResourceId[resourceId];
   return { getWorkspaceResource, getWorkspaceResourceByResourceId };
 }
+
+describe('resolveOptionalLocalWorkspaceRequestAuthority', () => {
+  it('uses only the complete local namespace pair and ignores stale cloud policy fields', () => {
+    const resolved = resolveOptionalLocalWorkspaceRequestAuthority(fakeReq(workspaceHeaders({
+      workspaceId: 'workspace-a',
+      memberId: 'member-a',
+      role: 'owner',
+      lifecycleState: 'locked',
+      canWriteSyncedFiles: 'false',
+    })));
+
+    expect(resolved).toMatchObject({
+      ok: true,
+      context: {
+        workspaceId: 'workspace-a',
+        workspaceMemberId: 'member-a',
+        role: 'member',
+        lifecycleState: 'active',
+        memberStatus: 'active',
+        permissions: { canWriteSyncedFiles: true },
+      },
+    });
+  });
+
+  it('rejects a partial local namespace pair without any remote fallback', () => {
+    expect(resolveOptionalLocalWorkspaceRequestAuthority(fakeReq(workspaceHeaders({
+      workspaceId: 'workspace-a',
+    })))).toMatchObject({
+      ok: false,
+      status: 400,
+      code: 'WORKSPACE_CONTEXT_INCOMPLETE',
+    });
+  });
+});
 
 describe('enforceWorkspaceResourceMutation', () => {
   it('allows a headerless caller against a resource with no team binding', () => {

--- a/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
+++ b/apps/daemon/tests/design-systems/design-system-family-workspace-authority.test.ts
@@ -355,7 +355,7 @@ describe('Design System route family exact Workspace authority', () => {
     expect(calls.static).not.toHaveBeenCalled();
   });
 
-  it('accepts exact query scope for browser-owned showcase and static requests', async () => {
+  it('accepts exact query scope without consulting the remote Workspace directory', async () => {
     const { baseUrl, calls, verifyWorkspaceRequestAuthority } =
       await startAuthorityServer();
     const scope =
@@ -382,7 +382,7 @@ describe('Design System route family exact Workspace authority', () => {
       'tokens.css',
       { workspaceId: WORKSPACE_ID, workspaceMemberId: MEMBER_ID, exactTeam: false },
     );
-    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(2);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });
 
   it('rejects bound mutations before their first side effect', async () => {

--- a/apps/daemon/tests/local-project-data-plane-outage.test.ts
+++ b/apps/daemon/tests/local-project-data-plane-outage.test.ts
@@ -45,6 +45,7 @@ describe('local project data plane during Workspace authority outage', () => {
 
   it('keeps preview, files, comments, runs, and routines usable when Vela returns 503', async () => {
     const projectId = `local-outage-${randomUUID()}`;
+    const mirrorProjectId = `readonly-mirror-outage-${randomUUID()}`;
     const conversationId = `conversation-${randomUUID()}`;
     const workspaceId = `workspace-${randomUUID()}`;
     const memberId = `member-${randomUUID()}`;
@@ -103,10 +104,37 @@ describe('local project data plane during Workspace authority outage', () => {
       cloudTombstonedAt: null,
       syncState: 'local_only',
     });
+    // This is the exact durable row shape written by
+    // `materializePulledTeamMirror` for somebody else's shared project. A null
+    // creator means the current member is a viewer, not an unattributed owner.
+    insertProject(db, {
+      id: mirrorProjectId,
+      name: 'Read-only mirror outage fixture',
+      createdAt: now,
+      updatedAt: now,
+    });
+    ensureWorkspaceProject(db, {
+      projectId: mirrorProjectId,
+      workspaceId,
+      visibility: 'team',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: null,
+      updatedByWorkspaceMemberId: memberId,
+      resourceHubResourceId: `hub-${mirrorProjectId}`,
+      cloudTombstonedAt: null,
+      syncState: 'synced',
+    });
     await mkdir(projectDir, { recursive: true });
     await writeFile(
       path.join(projectDir, 'index.html'),
       '<!doctype html><title>Offline preview</title><h1 data-od-id="hero">Hero</h1>',
+      'utf8',
+    );
+    const mirrorProjectDir = path.join(dataDir, 'projects', mirrorProjectId);
+    await mkdir(mirrorProjectDir, { recursive: true });
+    await writeFile(
+      path.join(mirrorProjectDir, 'index.html'),
+      '<!doctype html><title>Read-only mirror</title><h1>Owner content</h1>',
       'utf8',
     );
     const directoryRequestsAfterStartup = workspaceDirectoryRequests;
@@ -150,6 +178,42 @@ describe('local project data plane during Workspace authority outage', () => {
     });
     expect(write.status).toBe(200);
     expect(workspaceDirectoryRequests, 'file write').toBe(directoryRequestsAfterStartup);
+
+    const mirrorRead = await fetch(
+      `${daemon.url}/api/projects/${mirrorProjectId}/raw/index.html`,
+      { headers: staleHeaders },
+    );
+    expect(mirrorRead.status).toBe(200);
+    expect(await mirrorRead.text()).toContain('Owner content');
+
+    const mirrorWrite = await fetch(
+      `${daemon.url}/api/projects/${mirrorProjectId}/files`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...staleHeaders },
+        body: JSON.stringify({ name: 'must-not-write.txt', content: 'denied' }),
+      },
+    );
+    expect(mirrorWrite.status).toBe(403);
+    await expect(mirrorWrite.json()).resolves.toMatchObject({
+      error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
+    });
+
+    const mirrorRun = await fetch(`${daemon.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...staleHeaders },
+      body: JSON.stringify({
+        projectId: mirrorProjectId,
+        agentId: 'claude',
+        message: 'must not run against a read-only mirror',
+      }),
+    });
+    expect(mirrorRun.status).toBe(403);
+    await expect(mirrorRun.json()).resolves.toMatchObject({
+      error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
+    });
+    expect(workspaceDirectoryRequests, 'read-only mirror access')
+      .toBe(directoryRequestsAfterStartup);
 
     const run = await fetch(`${daemon.url}/api/runs`, {
       method: 'POST',

--- a/apps/daemon/tests/local-project-data-plane-outage.test.ts
+++ b/apps/daemon/tests/local-project-data-plane-outage.test.ts
@@ -47,6 +47,7 @@ describe('local project data plane during Workspace authority outage', () => {
     const projectId = `local-outage-${randomUUID()}`;
     const mirrorProjectId = `readonly-mirror-outage-${randomUUID()}`;
     const conversationId = `conversation-${randomUUID()}`;
+    const mirrorConversationId = `mirror-conversation-${randomUUID()}`;
     const workspaceId = `workspace-${randomUUID()}`;
     const memberId = `member-${randomUUID()}`;
     const now = Date.now();
@@ -110,6 +111,13 @@ describe('local project data plane during Workspace authority outage', () => {
     insertProject(db, {
       id: mirrorProjectId,
       name: 'Read-only mirror outage fixture',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: mirrorConversationId,
+      projectId: mirrorProjectId,
+      title: 'Shared comments',
       createdAt: now,
       updatedAt: now,
     });
@@ -212,6 +220,27 @@ describe('local project data plane during Workspace authority outage', () => {
     await expect(mirrorRun.json()).resolves.toMatchObject({
       error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
     });
+
+    const mirrorComment = await fetch(
+      `${daemon.url}/api/projects/${mirrorProjectId}/conversations/${mirrorConversationId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...staleHeaders },
+        body: JSON.stringify({
+          note: 'viewer feedback saved during outage',
+          target: {
+            filePath: 'index.html',
+            elementId: 'shared-heading',
+            selector: 'h1',
+            label: 'h1',
+            text: 'Owner content',
+            htmlHint: '<h1>',
+            position: { x: 0, y: 0, width: 10, height: 10 },
+          },
+        }),
+      },
+    );
+    expect(mirrorComment.status).toBe(200);
     expect(workspaceDirectoryRequests, 'read-only mirror access')
       .toBe(directoryRequestsAfterStartup);
 

--- a/apps/daemon/tests/local-project-data-plane-outage.test.ts
+++ b/apps/daemon/tests/local-project-data-plane-outage.test.ts
@@ -1,0 +1,219 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeDatabase,
+  ensureWorkspaceProject,
+  insertConversation,
+  insertProject,
+  openDatabase,
+} from '../src/db.js';
+import { startServer } from '../src/server.js';
+
+describe('local project data plane during Workspace authority outage', () => {
+  let daemon: {
+    url: string;
+    server: http.Server;
+    shutdown?: () => Promise<void> | void;
+  } | null = null;
+  let authorityServer: http.Server | null = null;
+
+  afterEach(async () => {
+    if (daemon) {
+      const current = daemon;
+      daemon = null;
+      await Promise.resolve(current.shutdown?.());
+      current.server.closeAllConnections?.();
+      if (current.server.listening) {
+        await new Promise<void>((resolve) => current.server.close(() => resolve()));
+      }
+    }
+    if (authorityServer) {
+      const current = authorityServer;
+      authorityServer = null;
+      current.closeAllConnections?.();
+      if (current.listening) {
+        await new Promise<void>((resolve) => current.close(() => resolve()));
+      }
+    }
+    vi.unstubAllEnvs();
+    closeDatabase();
+  });
+
+  it('keeps preview, files, comments, runs, and routines usable when Vela returns 503', async () => {
+    const projectId = `local-outage-${randomUUID()}`;
+    const conversationId = `conversation-${randomUUID()}`;
+    const workspaceId = `workspace-${randomUUID()}`;
+    const memberId = `member-${randomUUID()}`;
+    const now = Date.now();
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required by the test harness');
+    const db = openDatabase(process.cwd(), { dataDir });
+    const projectDir = path.join(dataDir, 'projects', projectId);
+
+    let workspaceDirectoryRequests = 0;
+    authorityServer = http.createServer((req, res) => {
+      if (req.url?.startsWith('/api/v1/workspaces')) {
+        workspaceDirectoryRequests += 1;
+      }
+      res.writeHead(503, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'workspace directory unavailable' }));
+    });
+    await new Promise<void>((resolve) => authorityServer!.listen(0, '127.0.0.1', resolve));
+    const authorityAddress = authorityServer.address();
+    if (!authorityAddress || typeof authorityAddress === 'string') {
+      throw new Error('authority server did not bind');
+    }
+    vi.stubEnv('OD_WORKSPACE_CONTEXT_SOURCE', 'vela');
+    vi.stubEnv('VELA_API_URL', `http://127.0.0.1:${authorityAddress.port}`);
+    vi.stubEnv('VELA_CONTROL_KEY', 'outage-test-control-key');
+    vi.stubEnv('OD_COLLAB_TRANSPORT', 'off');
+    vi.stubEnv('OD_RESOURCE_TRANSPORT', 'off');
+    vi.stubEnv('OD_TEAM_PROJECTS_TRANSPORT', 'off');
+
+    daemon = await startServer({ port: 0, returnServer: true }) as typeof daemon;
+    if (!daemon) throw new Error('daemon failed to start');
+    // Create the fixture after startup so the assertion measures only requests
+    // caused by the exercised local data-plane endpoints, independent of
+    // unrelated startup reconciliation for pre-existing shared projects.
+    insertProject(db, {
+      id: projectId,
+      name: 'Local data plane outage fixture',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: conversationId,
+      projectId,
+      title: 'Chat',
+      createdAt: now,
+      updatedAt: now,
+    });
+    ensureWorkspaceProject(db, {
+      projectId,
+      workspaceId,
+      visibility: 'team',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: memberId,
+      updatedByWorkspaceMemberId: memberId,
+      resourceHubResourceId: null,
+      cloudTombstonedAt: null,
+      syncState: 'local_only',
+    });
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      path.join(projectDir, 'index.html'),
+      '<!doctype html><title>Offline preview</title><h1 data-od-id="hero">Hero</h1>',
+      'utf8',
+    );
+    const directoryRequestsAfterStartup = workspaceDirectoryRequests;
+    const staleHeaders = {
+      'x-od-workspace-id': workspaceId,
+      'x-od-workspace-member-id': memberId,
+      'x-od-workspace-type': 'team',
+      'x-od-workspace-role': 'member',
+      'x-od-workspace-member-status': 'removed',
+      'x-od-workspace-lifecycle-state': 'locked',
+      'x-od-workspace-can-share-projects': 'false',
+      'x-od-workspace-can-write-synced-files': 'false',
+    };
+
+    const raw = await fetch(`${daemon.url}/api/projects/${projectId}/raw/index.html`);
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).toContain('Offline preview');
+    expect(workspaceDirectoryRequests, 'raw file read').toBe(directoryRequestsAfterStartup);
+
+    const scope = await fetch(`${daemon.url}/api/projects/${projectId}/workspace-scope`);
+    expect(scope.status).toBe(200);
+    await expect(scope.json()).resolves.toMatchObject({
+      scope: { kind: 'team', workspaceId },
+    });
+    expect(workspaceDirectoryRequests, 'workspace scope read').toBe(directoryRequestsAfterStartup);
+
+    const previewUrl = await fetch(
+      `${daemon.url}/api/projects/${projectId}/preview-url?file=index.html`,
+    );
+    expect(previewUrl.status).toBe(200);
+    const previewPath = (await previewUrl.json() as { url: string }).url;
+    const preview = await fetch(new URL(previewPath, daemon.url));
+    expect(preview.status).toBe(200);
+    expect(await preview.text()).toContain('Offline preview');
+    expect(workspaceDirectoryRequests, 'preview read').toBe(directoryRequestsAfterStartup);
+
+    const write = await fetch(`${daemon.url}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...staleHeaders },
+      body: JSON.stringify({ name: 'offline.txt', content: 'saved locally' }),
+    });
+    expect(write.status).toBe(200);
+    expect(workspaceDirectoryRequests, 'file write').toBe(directoryRequestsAfterStartup);
+
+    const run = await fetch(`${daemon.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...staleHeaders },
+      body: JSON.stringify({
+        projectId,
+        agentId: 'claude',
+        message: 'continue locally',
+      }),
+    });
+    expect(run.status).toBe(202);
+    expect(workspaceDirectoryRequests, 'run creation').toBe(directoryRequestsAfterStartup);
+
+    const routine = await fetch(`${daemon.url}/api/routines`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...staleHeaders },
+      body: JSON.stringify({
+        name: 'Offline routine',
+        prompt: 'Continue locally',
+        schedule: { kind: 'daily', time: '09:00', timezone: 'UTC' },
+        target: { mode: 'create_each_run' },
+        context: { workspaceScope: { workspaceId, workspaceMemberId: memberId } },
+        enabled: false,
+      }),
+    });
+    expect(routine.status).toBe(201);
+    expect(workspaceDirectoryRequests, 'routine creation').toBe(directoryRequestsAfterStartup);
+
+    const orbitConfig = await fetch(`${daemon.url}/api/app-config`, {
+      method: 'PUT',
+      headers: {
+        origin: daemon.url,
+        'content-type': 'application/json',
+        ...staleHeaders,
+      },
+      body: JSON.stringify({
+        orbit: { workspaceScope: { workspaceId, workspaceMemberId: memberId } },
+      }),
+    });
+    expect(orbitConfig.status).toBe(200);
+    expect(workspaceDirectoryRequests, 'Orbit config write').toBe(directoryRequestsAfterStartup);
+
+    // Comment relay is an actual cloud boundary and may attempt a background
+    // authority refresh. The local write must still succeed synchronously when
+    // that refresh receives 503.
+    const comment = await fetch(
+      `${daemon.url}/api/projects/${projectId}/conversations/${conversationId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...staleHeaders },
+        body: JSON.stringify({
+          note: 'saved during outage',
+          target: {
+            filePath: 'index.html',
+            elementId: 'hero',
+            selector: '[data-od-id="hero"]',
+            label: 'h1',
+            text: 'Hero',
+            htmlHint: '<h1>',
+            position: { x: 0, y: 0, width: 10, height: 10 },
+          },
+        }),
+      },
+    );
+    expect(comment.status).toBe(200);
+  });
+});

--- a/apps/daemon/tests/media/tasks-routes.test.ts
+++ b/apps/daemon/tests/media/tasks-routes.test.ts
@@ -200,7 +200,7 @@ describe('media task route recovery', () => {
     }
   });
 
-  it('checks fresh tool authority before revealing whether a media task exists', async () => {
+  it('uses the tool grant and persisted project binding without querying Workspace authority', async () => {
     const dataDir = process.env.OD_DATA_DIR;
     const db = openDatabase(process.cwd(), dataDir === undefined ? {} : { dataDir });
     const projectId = `project_${randomUUID()}`;
@@ -226,7 +226,9 @@ describe('media task route recovery', () => {
       allowedOperations: ['media:generate'],
     }).token;
     let authorityMode: 'active' | 'outage' | 'removed' = 'removed';
+    let authorityRequests = 0;
     authorityServer = http.createServer((_req, res) => {
+      authorityRequests += 1;
       res.setHeader('content-type', 'application/json');
       if (authorityMode === 'outage') {
         res.statusCode = 503;
@@ -261,6 +263,8 @@ describe('media task route recovery', () => {
       server: http.Server;
     };
     server = started.server;
+    await vi.waitFor(() => expect(authorityRequests).toBeGreaterThanOrEqual(1));
+    const startupAuthorityRequests = authorityRequests;
     const waitForMissingTask = () => fetch(
       `${started.url}/api/media/tasks/missing-task/wait`,
       {
@@ -274,21 +278,16 @@ describe('media task route recovery', () => {
     );
 
     const removed = await waitForMissingTask();
-    expect(removed.status).toBe(403);
-    await expect(removed.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
-    });
+    expect(removed.status).toBe(404);
 
     authorityMode = 'outage';
     const unavailable = await waitForMissingTask();
-    expect(unavailable.status).toBe(503);
-    await expect(unavailable.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_AUTHORITY_UNAVAILABLE' },
-    });
+    expect(unavailable.status).toBe(404);
 
     authorityMode = 'active';
     const authorized = await waitForMissingTask();
     expect(authorized.status).toBe(404);
+    expect(authorityRequests).toBe(startupAuthorityRequests);
   });
 
   it('recovers a pre-restart running task so wait returns interrupted instead of 404', async () => {

--- a/apps/daemon/tests/plugin-asset-workspace-authority.test.ts
+++ b/apps/daemon/tests/plugin-asset-workspace-authority.test.ts
@@ -159,27 +159,16 @@ describe('Plugin preview and asset Workspace authority', () => {
     expect(await assetB.text()).toBe('workspace-b-bytes');
   });
 
-  it.each([
-    [
-      'workspace-removed',
-      403,
-      'WORKSPACE_ACCESS_DENIED',
-    ],
-    [
-      'workspace-outage',
-      503,
-      'WORKSPACE_AUTHORITY_UNAVAILABLE',
-    ],
-  ] as const)(
-    'returns authority failure for %s without serving another Workspace bytes',
-    async (workspaceId, status, code) => {
+  it.each(['workspace-removed', 'workspace-outage'] as const)(
+    'does not consult remote authority for %s and never serves another Workspace bytes',
+    async (workspaceId) => {
       const baseUrl = await fixture();
       const response = await fetch(
         `${baseUrl}/api/plugins/same-plugin/asset/assets/secret.txt?workspaceId=${workspaceId}&workspaceMemberId=member-a`,
       );
 
-      expect(response.status).toBe(status);
-      expect(await response.json()).toMatchObject({ error: code });
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({ error: 'plugin not found' });
     },
   );
 

--- a/apps/daemon/tests/plugins-duplicate-project.test.ts
+++ b/apps/daemon/tests/plugins-duplicate-project.test.ts
@@ -122,11 +122,28 @@ describe('plugin project duplication', () => {
     },
   );
 
-  it('returns a canonical retryable 503 when workspace authority is unavailable', async () => {
+  it('duplicates locally without querying the remote Workspace directory', async () => {
     const root = await makeTempRoot('od-plugin-duplicate-authority-');
     const projectsRoot = path.join(root, 'projects');
     const plugin = await makePreviewPlugin(root, 'authority-plugin-fixture');
-    const randomId = vi.fn();
+    const projectId = 'authority-plugin-project';
+    const project = {
+      id: projectId,
+      name: 'Authority Plugin Fixture',
+      skillId: null,
+      designSystemId: null,
+      pendingPrompt: null,
+      metadata: { kind: 'prototype' },
+      createdAt: 1,
+      updatedAt: 1,
+    } as unknown as Project;
+    const randomId = vi.fn()
+      .mockReturnValueOnce(projectId)
+      .mockReturnValueOnce('authority-plugin-conversation');
+    const fetchProjectCreationWorkspaceDirectory = vi.fn(
+      async () => ({ ok: false as const, items: [] }),
+    );
+    const ensureWorkspaceProject = vi.fn();
     const app = express();
     app.use(express.json());
     registerPluginRoutes(app, {
@@ -145,11 +162,13 @@ describe('plugin project duplication', () => {
       },
       ids: { randomId },
       projectStore: {
-        insertProject: vi.fn(),
-        getProject: vi.fn(),
-        ensureWorkspaceProject: vi.fn(),
+        insertProject: vi.fn(() => project),
+        getProject: vi.fn(() => project),
+        ensureWorkspaceProject,
         dbDeleteProject: vi.fn(),
-        removeProjectDir: vi.fn(),
+        removeProjectDir: async (rootDir: string, id: string) => {
+          await rm(path.join(rootDir, id), { recursive: true, force: true });
+        },
       },
       conversations: { insertConversation: vi.fn() },
       plugins: {
@@ -157,7 +176,7 @@ describe('plugin project duplication', () => {
         listInstalledPlugins: vi.fn(() => []),
       },
       verifyWorkspaceRequestAuthority,
-      fetchProjectCreationWorkspaceDirectory: async () => ({ ok: false, items: [] }),
+      fetchProjectCreationWorkspaceDirectory,
       helpers: {
         requireLocalDaemonRequest: ((_req, _res, next) => next()) as express.RequestHandler,
         assembleExample: (templateHtml: string) => templateHtml,
@@ -186,16 +205,17 @@ describe('plugin project duplication', () => {
         },
       );
 
-      expect(resp.status).toBe(503);
-      await expect(resp.json()).resolves.toEqual({
-        error: {
-          code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-          message: 'workspace membership authority is temporarily unavailable',
-          retryable: true,
-        },
-      });
-      expect(randomId).not.toHaveBeenCalled();
-      await expectMissing(projectsRoot);
+      expect(resp.status).toBe(201);
+      expect(randomId).toHaveBeenCalledTimes(2);
+      expect(fetchProjectCreationWorkspaceDirectory).not.toHaveBeenCalled();
+      expect(ensureWorkspaceProject).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          projectId,
+          workspaceId: 'workspace-authority',
+          createdByWorkspaceMemberId: 'member-authority',
+        }),
+      );
     } finally {
       await close(server.server);
     }

--- a/apps/daemon/tests/project-file-version-readonly-mirror.test.ts
+++ b/apps/daemon/tests/project-file-version-readonly-mirror.test.ts
@@ -44,7 +44,8 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
-import { openDatabase, updateWorkspaceProject } from '../src/db.js';
+import { openDatabase, updateProject, updateWorkspaceProject } from '../src/db.js';
+import { SHARED_PROJECT_PLACEHOLDER_METADATA_KEY } from '../src/collab/shared-project-placeholder.js';
 
 const WORKSPACE_ID = 'ws-readonly-mirror';
 const OWNER_MEMBER_ID = 'member-owner-readonly-mirror';
@@ -130,6 +131,15 @@ describe('version history on a readonly shared mirror', () => {
     return id;
   }
 
+  async function stampAsUnmaterializedPlaceholder(projectId: string): Promise<void> {
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const db = openDatabase(projectsRoot(), { dataDir });
+    expect(updateProject(db, projectId, {
+      metadata: { [SHARED_PROJECT_PLACEHOLDER_METADATA_KEY]: Date.now() },
+    })).not.toBeNull();
+  }
+
   function memberHeaders(memberId: string, role: 'owner' | 'member') {
     return {
       'x-od-workspace-id': WORKSPACE_ID,
@@ -181,6 +191,31 @@ describe('version history on a readonly shared mirror', () => {
     const body = await getVersions(projectId);
 
     expect(body.versions).toEqual([]);
+    expect(await versionRootExists(projectId)).toBe(false);
+  });
+
+  it('keeps the placeholder stamp fail-closed even if its creator was accidentally promoted', async () => {
+    const projectId = await seedTeamProject();
+    await stampAsUnmaterializedPlaceholder(projectId);
+
+    const rename = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json',
+        ...memberHeaders(OWNER_MEMBER_ID, 'owner'),
+      },
+      body: JSON.stringify({ name: 'Must not land before materialization' }),
+    });
+    expect(rename.status).toBe(409);
+    expect(await rename.json()).toMatchObject({
+      error: { code: 'PROJECT_MATERIALIZATION_PENDING' },
+    });
+
+    const versions = await getVersions(
+      projectId,
+      memberHeaders(OWNER_MEMBER_ID, 'owner'),
+    );
+    expect(versions.versions).toEqual([]);
     expect(await versionRootExists(projectId)).toBe(false);
   });
 });

--- a/apps/daemon/tests/routes/design-systems-team-mutation-guard.test.ts
+++ b/apps/daemon/tests/routes/design-systems-team-mutation-guard.test.ts
@@ -6,12 +6,9 @@
 // stopped a direct PATCH/DELETE call before this guard: `canMutateUserDesignSystem`
 // is the server-side enforcement point these specs pin down.
 //
-// Spec 9.2 adds a second, independent gate on top: a locked/deleted workspace
-// (billing lapse, deletion in progress) must refuse every PATCH/DELETE
-// regardless of what `canMutateUserDesignSystem` itself would say — see the
-// "workspace lock" describe block below. That gate lives in the route, not
-// inside the (here mocked) `canMutateUserDesignSystem`, precisely so it holds
-// no matter what a caller-supplied mutation predicate decides.
+// Local mutations use persisted resource state. Browser lifecycle headers are
+// only a stale UI snapshot and must not turn a network/control-plane problem
+// into a failed local edit.
 
 import type http from 'node:http';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -283,7 +280,7 @@ describe('design system revision accept/reject team-share mutation guard', () =>
     expect(updateUserDesignSystemRevisionStatus).toHaveBeenCalledOnce();
   });
 
-  it('rejects resolving a revision when the caller workspace is locked, even if otherwise permitted', async () => {
+  it('allows resolving a local revision despite a stale locked header', async () => {
     const app = express();
     app.use(express.json());
     const { updateUserDesignSystemRevisionStatus } = registerRoutes(app, async () => true);
@@ -300,24 +297,21 @@ describe('design system revision accept/reject team-share mutation guard', () =>
       body: JSON.stringify({ status: 'accepted' }),
     });
 
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBe('WORKSPACE_LOCKED');
-    expect(updateUserDesignSystemRevisionStatus).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(updateUserDesignSystemRevisionStatus).toHaveBeenCalledOnce();
   });
 });
 
-describe('design system PATCH/DELETE workspace-lock guard (spec 9.2)', () => {
+describe('design system local mutations ignore stale Workspace lifecycle headers', () => {
   const lockedHeaders = {
     'x-od-workspace-id': 'ws-locked',
     'x-od-workspace-member-id': 'member-1',
     'x-od-workspace-lifecycle-state': 'locked',
   };
 
-  it('rejects publishing/editing when the caller workspace is locked, even if otherwise permitted', async () => {
+  it('allows publishing/editing when a stale request says the workspace is locked', async () => {
     const app = express();
     app.use(express.json());
-    // canMutate itself says yes — the lock gate must still win.
     const { updateUserDesignSystem } = registerRoutes(app, async () => true);
     const baseUrl = await listen(app);
 
@@ -327,13 +321,11 @@ describe('design system PATCH/DELETE workspace-lock guard (spec 9.2)', () => {
       body: JSON.stringify({ status: 'published' }),
     });
 
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBe('WORKSPACE_LOCKED');
-    expect(updateUserDesignSystem).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(updateUserDesignSystem).toHaveBeenCalledOnce();
   });
 
-  it('rejects deleting when the caller workspace is locked, even if otherwise permitted', async () => {
+  it('allows deleting when a stale request says the workspace is locked', async () => {
     const app = express();
     app.use(express.json());
     const { deleteUserDesignSystem } = registerRoutes(app, async () => true);
@@ -344,13 +336,11 @@ describe('design system PATCH/DELETE workspace-lock guard (spec 9.2)', () => {
       headers: lockedHeaders,
     });
 
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBe('WORKSPACE_LOCKED');
-    expect(deleteUserDesignSystem).not.toHaveBeenCalled();
+    expect(res.status).toBe(204);
+    expect(deleteUserDesignSystem).toHaveBeenCalledOnce();
   });
 
-  it('rejects deleting when the caller workspace is deleted', async () => {
+  it('allows deleting when a stale request says the workspace is deleted', async () => {
     const app = express();
     app.use(express.json());
     const { deleteUserDesignSystem } = registerRoutes(app, async () => true);
@@ -361,10 +351,8 @@ describe('design system PATCH/DELETE workspace-lock guard (spec 9.2)', () => {
       headers: { ...lockedHeaders, 'x-od-workspace-lifecycle-state': 'deleted' },
     });
 
-    expect(res.status).toBe(403);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBe('WORKSPACE_LOCKED');
-    expect(deleteUserDesignSystem).not.toHaveBeenCalled();
+    expect(res.status).toBe(204);
+    expect(deleteUserDesignSystem).toHaveBeenCalledOnce();
   });
 
   it('still allows deleting an active (unlocked) workspace resource', async () => {

--- a/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
+++ b/apps/daemon/tests/routes/project-resource-scope-validation.test.ts
@@ -35,6 +35,7 @@ function buildDeps(input: {
   insertProject?: ReturnType<typeof vi.fn>;
   insertConversation?: ReturnType<typeof vi.fn>;
   fetchProjectCreationWorkspaceDirectory?: ReturnType<typeof vi.fn>;
+  authorizeProjectRequest?: ReturnType<typeof vi.fn>;
 } = {}) {
   const binding = {
     projectId: PROJECT_ID,
@@ -110,7 +111,7 @@ function buildDeps(input: {
         ?? vi.fn(async (id) => ({ ok: true, id })),
     },
     collabSync: functionProxy(),
-    authorizeProjectRequest: async () => true,
+    authorizeProjectRequest: input.authorizeProjectRequest ?? vi.fn(async () => true),
     verifyWorkspaceRequestAuthority: async () => ({
       ok: true,
       context: workspaceContextFromDirectoryItem({
@@ -173,6 +174,48 @@ function headers() {
 }
 
 describe('project resource selection uses the persisted exact member', () => {
+  it('routes project mutations through the central project authority gate', async () => {
+    const updateProject = vi.fn();
+    const authorizeProjectRequest = vi.fn(async (
+      _req: express.Request,
+      res: express.Response,
+      _projectId: string,
+      options: { mode: string; capability?: string },
+    ) => {
+      if (options.mode === 'write') {
+        res.status(409).json({
+          error: {
+            code: 'PROJECT_MATERIALIZATION_PENDING',
+            message: 'project content is still materializing',
+          },
+        });
+        return false;
+      }
+      return true;
+    });
+    const deps = buildDeps({ authorizeProjectRequest });
+    deps.projectStore.updateProject = updateProject;
+    const baseUrl = await start(deps);
+
+    const response = await fetch(`${baseUrl}/api/projects/${PROJECT_ID}`, {
+      method: 'PATCH',
+      headers: headers(),
+      body: JSON.stringify({ name: 'Must not land' }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { code: 'PROJECT_MATERIALIZATION_PENDING' },
+    });
+    expect(authorizeProjectRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      PROJECT_ID,
+      { mode: 'write', capability: 'rename' },
+    );
+    expect(updateProject).not.toHaveBeenCalled();
+  });
+
   it('creates a local-only project without fetching Workspace authority', async () => {
     const fetchProjectCreationWorkspaceDirectory = vi.fn(async () => ({
       ok: false,

--- a/apps/daemon/tests/routes/workspace-projects.test.ts
+++ b/apps/daemon/tests/routes/workspace-projects.test.ts
@@ -1309,7 +1309,7 @@ describe('workspace project routes', () => {
     });
   });
 
-  it('blocks direct project and file writes when the workspace is locked', async () => {
+  it('does not let a stale remote locked snapshot block local project and file writes', async () => {
     const projectId = `workspace-direct-locked-${Date.now()}`;
     await createProject(projectId, 'Locked direct write project');
 
@@ -1334,21 +1334,21 @@ describe('workspace project routes', () => {
       headers: lockedHeaders,
       body: JSON.stringify({ name: 'Locked rename' }),
     });
-    expect(patchResp.status).toBe(403);
+    expect(patchResp.status).toBe(200);
 
     const duplicateResp = await fetch(`${baseUrl}/api/projects/${projectId}/duplicate`, {
       method: 'POST',
       headers: lockedHeaders,
       body: JSON.stringify({ name: 'Locked duplicate' }),
     });
-    expect(duplicateResp.status).toBe(403);
+    expect(duplicateResp.status).toBe(200);
 
     const writeResp = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
       method: 'POST',
       headers: lockedHeaders,
       body: JSON.stringify({ name: 'locked.txt', content: 'locked' }),
     });
-    expect(writeResp.status).toBe(403);
+    expect(writeResp.status).toBe(200);
 
     const uploadForm = new FormData();
     uploadForm.append('files', new Blob(['locked'], { type: 'text/plain' }), 'locked-upload.txt');
@@ -1358,7 +1358,7 @@ describe('workspace project routes', () => {
       headers: uploadHeaders,
       body: uploadForm,
     });
-    expect(uploadResp.status).toBe(403);
+    expect(uploadResp.status).toBe(200);
   });
 
   it('rejects member batch-delete for unknown legacy ownership and allows privileged delete', async () => {
@@ -2758,15 +2758,22 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
       res: express.Response,
     ) => {
       if (options.unbound) return true;
+      if (options.resourceState === 'deleted') {
+        res.status(403).json({
+          error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
+        });
+        return false;
+      }
       const claimedWorkspaceId = req.get('x-od-workspace-id');
       const claimedMemberId = req.get('x-od-workspace-member-id');
+      if (!claimedWorkspaceId && !claimedMemberId) return true;
       if (!claimedWorkspaceId || !claimedMemberId) {
         res.status(400).json({
           error: { code: 'WORKSPACE_CONTEXT_INCOMPLETE' },
         });
         return false;
       }
-      if (claimedWorkspaceId !== workspaceId || claimedMemberId !== memberId) {
+      if (claimedWorkspaceId !== workspaceId) {
         res.status(403).json({
           error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
         });
@@ -2787,7 +2794,7 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
     return listen(app);
   }
 
-  it('returns exact A scope headerlessly while keeping project content behind explicit A headers', async () => {
+  it('returns exact local scope and project content headerlessly', async () => {
     const routeServer = await startBootstrapRoute();
     try {
       const scope = await fetch(
@@ -2801,7 +2808,7 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
           workspaceId,
           context: {
             workspaceId,
-            workspaceMemberId: memberId,
+            workspaceMemberId: 'member-cleanup-fail',
           },
         },
       });
@@ -2809,12 +2816,7 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
       const headerlessDetail = await fetch(
         `${routeServer.url}/api/projects/${projectId}`,
       );
-      expect(headerlessDetail.status).toBe(400);
-      const headerlessFiles = await fetch(
-        `${routeServer.url}/api/projects/${projectId}/files`,
-      );
-      expect(headerlessFiles.status).not.toBe(200);
-
+      expect(headerlessDetail.status).toBe(200);
       const scopedDetail = await fetch(
         `${routeServer.url}/api/projects/${projectId}`,
         {
@@ -2842,7 +2844,7 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
         `${routeServer.url}/api/projects/${projectId}/workspace-scope`,
         {
           headers: {
-            'x-od-workspace-id': workspaceId,
+            'x-od-workspace-id': 'wrong-workspace',
             'x-od-workspace-member-id': 'wrong-member',
           },
         },
@@ -2853,8 +2855,8 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
     }
   });
 
-  it('does not disclose scope for nonmembers, removed/deleted memberships, or deleted resources', async () => {
-    const deniedCases = [
+  it('ignores stale directory membership but still hides a deleted local resource', async () => {
+    const staleDirectoryCases = [
       {
         directory: async () => ({
           ok: true,
@@ -2873,43 +2875,45 @@ describe('GET /api/projects/:id/workspace-scope route bootstrap', () => {
           items: [{ ...activeMembership, lifecycleState: 'deleted' as const }],
         }),
       },
-      {
-        resourceState: 'deleted',
-      },
     ];
-    for (const denied of deniedCases) {
-      const routeServer = await startBootstrapRoute(denied);
+    for (const stale of staleDirectoryCases) {
+      const routeServer = await startBootstrapRoute(stale);
       try {
         const response = await fetch(
           `${routeServer.url}/api/projects/${projectId}/workspace-scope`,
         );
-        expect(response.status).toBe(403);
-        const text = await response.text();
-        expect(text).not.toContain(workspaceId);
-        expect(text).not.toContain(memberId);
+        expect(response.status).toBe(200);
       } finally {
         await close(routeServer.server);
       }
     }
+    const deletedServer = await startBootstrapRoute({ resourceState: 'deleted' });
+    try {
+      const deleted = await fetch(
+        `${deletedServer.url}/api/projects/${projectId}/workspace-scope`,
+      );
+      expect(deleted.status).toBe(403);
+    } finally {
+      await close(deletedServer.server);
+    }
   });
 
-  it('returns retryable 503 on directory outage and 404 for a missing project', async () => {
+  it('stays available on directory outage and returns 404 for a missing project', async () => {
+    const directory = vi.fn(async () => {
+      throw new Error('directory down');
+    });
     const routeServer = await startBootstrapRoute({
-      directory: async () => {
-        throw new Error('directory down');
-      },
+      directory,
     });
     try {
       const outage = await fetch(
         `${routeServer.url}/api/projects/${projectId}/workspace-scope`,
       );
-      expect(outage.status).toBe(503);
+      expect(outage.status).toBe(200);
       await expect(outage.json()).resolves.toMatchObject({
-        error: {
-          code: 'WORKSPACE_DIRECTORY_UNAVAILABLE',
-          retryable: true,
-        },
+        scope: { kind: 'team', workspaceId },
       });
+      expect(directory).not.toHaveBeenCalled();
       const missing = await fetch(
         `${routeServer.url}/api/projects/missing-project/workspace-scope`,
       );

--- a/apps/daemon/tests/routine-routes.test.ts
+++ b/apps/daemon/tests/routine-routes.test.ts
@@ -263,7 +263,6 @@ describe('routine routes', () => {
   it.each([
     {
       label: 'removed membership',
-      expectedStatus: 403,
       directory: {
         ok: true as const,
         items: [{
@@ -274,15 +273,14 @@ describe('routine routes', () => {
     },
     {
       label: 'authority outage',
-      expectedStatus: 503,
       directory: { ok: false as const, items: [] },
     },
-  ])('fails $label before scoped routine REST side effects', async ({
+  ])('keeps local routine operations available during $label', async ({
     directory,
-    expectedStatus,
   }) => {
+    const fetchWorkspaceDirectory = vi.fn(async () => directory);
     const { app, db, rescheduleOne, runNow, unschedule } = buildApp({
-      fetchWorkspaceDirectory: async () => directory,
+      fetchWorkspaceDirectory,
     });
     seedRoutine(db, {
       id: 'routine-a',
@@ -297,25 +295,17 @@ describe('routine routes', () => {
       'x-od-workspace-member-id': 'member-a',
     };
     try {
-      const attempts: Array<[string, RequestInit]> = [
-        ['/api/routines', { headers }],
-        ['/api/routines/routine-a', { headers }],
-        ['/api/routines/routine-a', {
+      const list = await fetch(`http://127.0.0.1:${port}/api/routines`, { headers });
+      expect(list.status).toBe(200);
+      const patch = await fetch(
+        `http://127.0.0.1:${port}/api/routines/routine-a`,
+        {
           method: 'PATCH',
           headers: { ...headers, 'content-type': 'application/json' },
           body: JSON.stringify({ enabled: false }),
-        }],
-        ['/api/routines/routine-a/runs', { headers }],
-        ['/api/routines/routine-a/runs/missing/crystallize', {
-          method: 'POST',
-          headers,
-        }],
-        ['/api/routines/routine-a', { method: 'DELETE', headers }],
-      ];
-      for (const [path, init] of attempts) {
-        const response = await fetch(`http://127.0.0.1:${port}${path}`, init);
-        expect(response.status, path).toBe(expectedStatus);
-      }
+        },
+      );
+      expect(patch.status).toBe(200);
 
       const runResponse = await fetch(
         `http://127.0.0.1:${port}/api/routines/routine-a/run`,
@@ -323,10 +313,11 @@ describe('routine routes', () => {
       );
       expect(runResponse.status).toBe(202);
       expect(getRoutine(db, 'routine-a')).toMatchObject({
-        enabled: true,
+        enabled: false,
         name: 'routine-a',
       });
-      expect(rescheduleOne).not.toHaveBeenCalled();
+      expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
+      expect(rescheduleOne).toHaveBeenCalledWith('routine-a');
       expect(runNow).toHaveBeenCalledWith('routine-a');
       expect(unschedule).not.toHaveBeenCalled();
     } finally {
@@ -566,7 +557,7 @@ describe('routine routes', () => {
       });
       const created = await create.json() as { routine: { id: string } };
       expect(create.status).toBe(201);
-      expect(fetchWorkspaceDirectory).toHaveBeenCalledTimes(1);
+      expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
 
       const patch = await fetch(
         `http://127.0.0.1:${port}/api/routines/${created.routine.id}`,
@@ -584,7 +575,7 @@ describe('routine routes', () => {
       );
 
       expect(patch.status).toBe(200);
-      expect(fetchWorkspaceDirectory).toHaveBeenCalledTimes(2);
+      expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
       expect(JSON.parse(getRoutine(db, created.routine.id)?.contextJson ?? '{}')).toEqual({
         connectorIds: ['github'],
         workspaceScope: {
@@ -597,9 +588,10 @@ describe('routine routes', () => {
     }
   });
 
-  it('does not persist a scoped routine when authority is unavailable', async () => {
+  it('persists a scoped local routine when the Workspace directory is unavailable', async () => {
+    const fetchWorkspaceDirectory = vi.fn(async () => ({ ok: false as const, items: [] }));
     const { app, db } = buildApp({
-      fetchWorkspaceDirectory: async () => ({ ok: false, items: [] }),
+      fetchWorkspaceDirectory,
     });
     const { server, port } = await listen(app);
     try {
@@ -624,8 +616,9 @@ describe('routine routes', () => {
         }),
       });
 
-      expect(res.status).toBe(503);
-      expect(listRoutines(db)).toHaveLength(0);
+      expect(res.status).toBe(201);
+      expect(listRoutines(db)).toHaveLength(1);
+      expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/apps/daemon/tests/run-create-workspace-gate.test.ts
+++ b/apps/daemon/tests/run-create-workspace-gate.test.ts
@@ -27,7 +27,7 @@ import {
   linkSnapshotToProject,
 } from '../src/plugins/snapshots.js';
 import { createAuthorizeProjectRequest } from '../src/collab/project-request-authority.js';
-import { resolveOptionalWorkspaceRequestAuthority } from '../src/collab/workspace-resource-mutation.js';
+import { resolveOptionalLocalWorkspaceRequestAuthority } from '../src/collab/workspace-resource-mutation.js';
 import { createEnforceWorkspaceProjectMutation } from '../src/routes/project/index.js';
 import { workspaceContextFromDirectoryItem } from '../src/collab/vela-workspace-context.js';
 import { registerRunRoutes } from '../src/routes/runs.js';
@@ -291,10 +291,7 @@ async function startServer(opts?: {
       authorizePluginRequest: opts?.authorizePluginRequest ?? (
         opts?.authorizePluginWithWorkspaceAuthority
           ? async (req: any, res: any) => {
-              const authority = await resolveOptionalWorkspaceRequestAuthority(
-                req,
-                verifyWorkspaceRequestAuthority,
-              );
+              const authority = resolveOptionalLocalWorkspaceRequestAuthority(req);
               if (!authority.ok) {
                 sendApiError(
                   res,
@@ -347,7 +344,6 @@ async function startServer(opts?: {
       }),
     amrWorkspaceScope: {
       isSignedIn: opts?.isAmrSignedIn ?? (() => false),
-      verifyWorkspaceRequestAuthority,
     },
     authorizeProjectRequest: createAuthorizeProjectRequest({
       db,
@@ -382,7 +378,7 @@ async function startServer(opts?: {
 
 describe('POST /api/runs — workspace mutation gate', () => {
   it.each(['/api/runs', '/api/chat'])(
-    'reuses one fresh exact Workspace authority witness for project and plugin gates through %s',
+    'keeps project and local plugin gates off the remote Workspace directory through %s',
     async (route) => {
       const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
         ok: true,
@@ -417,12 +413,12 @@ describe('POST /api/runs — workspace mutation gate', () => {
       });
 
       expect(response.status).toBe(202);
-      expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
     },
   );
 
   it.each(['/api/runs', '/api/chat'])(
-    'still performs one fresh project mutation check when no plugin is requested through %s',
+    'keeps project-only run creation off the remote Workspace directory through %s',
     async (route) => {
       const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
         ok: true,
@@ -455,12 +451,12 @@ describe('POST /api/runs — workspace mutation gate', () => {
       });
 
       expect(response.status).toBe(202);
-      expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
     },
   );
 
   it.each(['/api/runs', '/api/chat'])(
-    'fails closed on a rejected authority witness before plugin resolution through %s',
+    'continues local run creation when the remote Workspace directory is unavailable through %s',
     async (route) => {
       const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
         ok: false,
@@ -489,20 +485,14 @@ describe('POST /api/runs — workspace mutation gate', () => {
         }),
       });
 
-      expect(response.status).toBe(503);
-      await expect(response.json()).resolves.toMatchObject({
-        error: {
-          code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
-          retryable: true,
-        },
-      });
-      expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
-      expect(createdRunCount).toBe(0);
+      expect(response.status).toBe(202);
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
+      expect(createdRunCount).toBe(1);
     },
   );
 
   it.each(['/api/runs', '/api/chat'])(
-    'does not reuse a prior request witness after Workspace membership changes through %s',
+    'does not let stale remote membership state interrupt local run creation through %s',
     async (route) => {
       let memberStatus: 'active' | 'removed' = 'active';
       const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
@@ -538,16 +528,12 @@ describe('POST /api/runs — workspace mutation gate', () => {
 
       expect((await create()).status).toBe(202);
       memberStatus = 'removed';
-      const removedResponse = await create();
-      expect(removedResponse.status).toBe(403);
-      await expect(removedResponse.json()).resolves.toMatchObject({
-        error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
-      });
-      expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(2);
+      expect((await create()).status).toBe(202);
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
     },
   );
 
-  it('does not share a fresh authority witness between concurrent run requests', async () => {
+  it('authorizes concurrent local runs from persisted bindings without a remote witness', async () => {
     const pending: Array<{
       memberId: string;
       resolve: (value: any) => void;
@@ -592,29 +578,13 @@ describe('POST /api/runs — workspace mutation gate', () => {
 
     const ownerRequest = create(OWNER_MEMBER_ID, 'owner');
     const memberRequest = create('member-concurrent-run', 'member');
-    await vi.waitFor(() => expect(pending).toHaveLength(2));
-    for (const entry of pending) {
-      entry.resolve({
-        ok: true,
-        context: workspaceContextFromDirectoryItem({
-          workspaceId: WORKSPACE_ID,
-          workspaceName: 'Team',
-          workspaceType: 'team',
-          workspaceMemberId: entry.memberId,
-          role: entry.memberId === OWNER_MEMBER_ID ? 'owner' : 'member',
-          memberStatus: 'active',
-          lifecycleState: 'active',
-        }),
-      });
-    }
-
     const [ownerResponse, memberResponse] = await Promise.all([
       ownerRequest,
       memberRequest,
     ]);
     expect(ownerResponse.status).toBe(202);
     expect(memberResponse.status).toBe(403);
-    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(2);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });
 
   it.each(['/api/runs', '/api/chat'])(
@@ -883,22 +853,18 @@ describe('POST /api/runs — workspace mutation gate', () => {
     },
   );
 
-  it('verifies AMR adoption before any plugin resolution side effects', async () => {
-    const loadPluginRegistryView = vi.fn(async () => ({}));
+  it('keeps an untyped historical AMR run account-scoped during a directory outage', async () => {
+    const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      code: 'WORKSPACE_DIRECTORY_UNAVAILABLE',
+      message: 'workspace directory temporarily unavailable',
+    }));
     const baseUrl = await startServer({
       isAmrSignedIn: () => true,
-      loadPluginRegistryView,
-      verifyWorkspaceRequestAuthority: async () => ({
-        ok: false,
-        status: 503,
-        code: 'WORKSPACE_DIRECTORY_UNAVAILABLE',
-        message: 'workspace directory temporarily unavailable',
-      }),
+      verifyWorkspaceRequestAuthority,
     });
     const db = openDatabase(tempDir!);
-    const beforeSnapshotCount = (db.prepare(
-      'SELECT COUNT(*) AS count FROM applied_plugin_snapshots',
-    ).get() as { count: number }).count;
 
     const response = await fetch(`${baseUrl}/api/runs`, {
       method: 'POST',
@@ -909,21 +875,13 @@ describe('POST /api/runs — workspace mutation gate', () => {
       body: JSON.stringify({
         projectId: UNBOUND_PROJECT,
         agentId: 'amr',
-        pluginId: 'must-not-resolve-before-adoption',
-        message: 'must verify the historical project first',
+        message: 'local send must survive the outage',
       }),
     });
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_DIRECTORY_UNAVAILABLE' },
-    });
-    expect(loadPluginRegistryView).not.toHaveBeenCalled();
-    expect(createdRunCount).toBe(0);
+    expect(response.status).toBe(202);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
     expect(getWorkspaceProjectByProjectId(db, UNBOUND_PROJECT)).toBeUndefined();
-    expect((db.prepare(
-      'SELECT COUNT(*) AS count FROM applied_plugin_snapshots',
-    ).get() as { count: number }).count).toBe(beforeSnapshotCount);
   });
 
   it('authorizes the final run plugin before loading the scoped registry', async () => {
@@ -958,7 +916,7 @@ describe('POST /api/runs — workspace mutation gate', () => {
     expect(calls).toEqual(['plugin', 'registry']);
   });
 
-  it('adopts an exact historical project scope before authorizing its chat plugin', async () => {
+  it('adopts an explicitly Personal local scope before authorizing its chat plugin', async () => {
     const calls: string[] = [];
     const baseUrl = await startServer({
       isAmrSignedIn: () => true,
@@ -988,6 +946,7 @@ describe('POST /api/runs — workspace mutation gate', () => {
       headers: {
         'Content-Type': 'application/json',
         ...workspaceHeaders(OWNER_MEMBER_ID, 'owner'),
+        'x-od-workspace-type': 'personal',
       },
       body: JSON.stringify({
         projectId: UNBOUND_PROJECT,
@@ -998,7 +957,7 @@ describe('POST /api/runs — workspace mutation gate', () => {
     });
 
     expect(response.status).toBe(202);
-    expect(calls).toEqual(['adoption', 'plugin']);
+    expect(calls).toEqual(['plugin']);
     expect(getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT))
       .toMatchObject({
         workspaceId: WORKSPACE_ID,
@@ -1196,7 +1155,7 @@ describe('Workspace-bound run lifecycle authority', () => {
     }
   });
 
-  it('does not bypass exact Workspace authority for AMR run status, events, or cancel', async () => {
+  it('keeps persisted local AMR run status, events, and cancel available offline', async () => {
     const baseUrl = await startServer();
     const createResponse = await fetch(`${baseUrl}/api/runs`, {
       method: 'POST',
@@ -1219,10 +1178,7 @@ describe('Workspace-bound run lifecycle authority', () => {
       [`/api/runs/${runId}/cancel`, 'POST'],
     ] as const) {
       const response = await fetch(`${baseUrl}${path}`, { method });
-      expect(response.status).toBe(400);
-      await expect(response.json()).resolves.toMatchObject({
-        error: { code: 'WORKSPACE_CONTEXT_REQUIRED' },
-      });
+      expect(response.status).toBe(200);
     }
 
     const exactHeaders = workspaceHeaders(OWNER_MEMBER_ID, 'owner');
@@ -1265,11 +1221,11 @@ describe('Workspace-bound run lifecycle authority', () => {
     });
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_CONTEXT_REQUIRED' },
+      error: { code: 'WORKSPACE_CONTEXT_INCOMPLETE' },
     });
   });
 
-  it('fails closed when a historical run record has no reliable agentId', async () => {
+  it('keeps a persisted historical run available without relying on runtime identity', async () => {
     const baseUrl = await startServer();
     const createResponse = await fetch(`${baseUrl}/api/runs`, {
       method: 'POST',
@@ -1286,10 +1242,7 @@ describe('Workspace-bound run lifecycle authority', () => {
     const { runId } = (await createResponse.json()) as { runId: string };
 
     const response = await fetch(`${baseUrl}/api/runs/${runId}`);
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_CONTEXT_REQUIRED' },
-    });
+    expect(response.status).toBe(200);
   });
 
   it.each([
@@ -1385,7 +1338,7 @@ describe('POST /api/runs — delegates membership and balance eligibility to Vel
 
 describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () => {
   it.each(['/api/runs', '/api/chat'])(
-    'transactionally binds an unbound historical project to the exact verified Personal Workspace through %s',
+    'transactionally binds an unbound historical project to the exact local Personal Workspace through %s',
     async (route) => {
     const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
       ok: true,
@@ -1419,7 +1372,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
     });
 
       expect(response.status).toBe(202);
-      expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+      expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
       expect(
         getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT),
       ).toMatchObject({
@@ -1430,7 +1383,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
     },
   );
 
-  it('keeps an adopted Personal project runnable only by the verified adopting member', async () => {
+  it('keeps an adopted Personal project runnable only by its persisted creator', async () => {
     const verifyWorkspaceRequestAuthority = vi.fn(async (req: any) => {
       const memberId = req.get('x-od-workspace-member-id');
       return {
@@ -1481,6 +1434,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
     await expect(foreignResponse.json()).resolves.toMatchObject({
       error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED' },
     });
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });
 
   it.each(['/api/runs', '/api/chat'])(
@@ -1551,7 +1505,7 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
     ).toBeUndefined();
   });
 
-  it('fails closed without binding when the exact Personal authority is unavailable', async () => {
+  it('adopts an explicitly Personal project locally when Workspace authority is unavailable', async () => {
     const verifyWorkspaceRequestAuthority = vi.fn(async () => ({
       ok: false,
       status: 503,
@@ -1574,18 +1528,19 @@ describe('POST /api/runs — one-time Personal adoption for signed-in AMR', () =
       body: JSON.stringify({
         projectId: UNBOUND_PROJECT,
         agentId: 'amr',
-        message: 'do not guess',
+        message: 'keep local send available',
       }),
     });
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: 'WORKSPACE_AUTHORITY_UNAVAILABLE' },
-    });
-    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(202);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
     expect(
       getWorkspaceProjectByProjectId(openDatabase(tempDir!), UNBOUND_PROJECT),
-    ).toBeUndefined();
+    ).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      visibility: 'personal',
+      createdByWorkspaceMemberId: OWNER_MEMBER_ID,
+    });
   });
 
   it.each(['/api/runs', '/api/chat'])(

--- a/apps/daemon/tests/skill-navigation-workspace-authority.test.ts
+++ b/apps/daemon/tests/skill-navigation-workspace-authority.test.ts
@@ -205,19 +205,16 @@ describe('Skill example and asset Workspace authority', () => {
     expect(await assetB.text()).toBe('workspace-b-bytes');
   });
 
-  it.each([
-    ['workspace-removed', 403, 'WORKSPACE_ACCESS_DENIED'],
-    ['workspace-outage', 503, 'WORKSPACE_AUTHORITY_UNAVAILABLE'],
-  ] as const)(
-    'returns authority failure for %s without serving another Workspace bytes',
-    async (workspaceId, status, code) => {
+  it.each(['workspace-removed', 'workspace-outage'] as const)(
+    'does not consult remote authority for %s and never serves another Workspace bytes',
+    async (workspaceId) => {
       const baseUrl = await fixture();
       const response = await fetch(
         `${baseUrl}/api/skills/same-skill/assets/secret.txt?workspaceId=${workspaceId}&workspaceMemberId=member-a`,
       );
 
-      expect(response.status).toBe(status);
-      expect(await response.json()).toMatchObject({ error: code });
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe('skill not found');
     },
   );
 

--- a/apps/daemon/tests/workspace-resource-read-authority.test.ts
+++ b/apps/daemon/tests/workspace-resource-read-authority.test.ts
@@ -73,7 +73,7 @@ function localHeaders(): Record<string, string> {
 }
 
 describe('Workspace resource read authority wiring', () => {
-  it('uses the settled verifier only for Skill and Design System catalog GETs', async () => {
+  it('keeps Skill and Design System local reads off the remote authority plane', async () => {
     const app = express();
     const verifyWorkspaceReadAuthority = verifier();
     const verifyWorkspaceRequestAuthority = verifier();
@@ -129,7 +129,7 @@ describe('Workspace resource read authority wiring', () => {
       skills: [{ id: 'skill-1', hasBody: true }],
     });
     await expect(designSystems.json()).resolves.toEqual({ designSystems: [] });
-    expect(verifyWorkspaceReadAuthority).toHaveBeenCalledTimes(2);
+    expect(verifyWorkspaceReadAuthority).not.toHaveBeenCalled();
     expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
 
     const detail = await fetch(`${baseUrl}/api/skills/skill-1`, { headers });
@@ -138,10 +138,10 @@ describe('Workspace resource read authority wiring', () => {
       id: 'skill-1',
       body: '# Skill',
     });
-    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });
 
-  it('uses the settled verifier only for the Plugin catalog GET', async () => {
+  it('keeps Plugin local reads off the remote authority plane', async () => {
     const app = express();
     const verifyWorkspaceReadAuthority = verifier();
     const verifyWorkspaceRequestAuthority = verifier();
@@ -191,12 +191,12 @@ describe('Workspace resource read authority wiring', () => {
 
     expect(listing.status).toBe(200);
     await expect(listing.json()).resolves.toEqual({ plugins: [plugin] });
-    expect(verifyWorkspaceReadAuthority).toHaveBeenCalledTimes(1);
+    expect(verifyWorkspaceReadAuthority).not.toHaveBeenCalled();
     expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
 
     const detail = await fetch(`${baseUrl}/api/plugins/plugin-1`, { headers });
     expect(detail.status).toBe(200);
     await expect(detail.json()).resolves.toEqual(plugin);
-    expect(verifyWorkspaceRequestAuthority).toHaveBeenCalledTimes(1);
+    expect(verifyWorkspaceRequestAuthority).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -66,6 +66,7 @@ import {
   WorkspaceTabsBar,
 } from './components/WorkspaceTabsBar';
 import { WorkspaceTopRightAccountCluster } from './components/EntryNavRail';
+import { ProjectWorkspaceRecoveryTip } from './components/ProjectWorkspaceRecoveryTip';
 import {
   DesignSystemCreationFlow,
   DesignSystemDetailView,
@@ -5072,7 +5073,14 @@ function AppInner() {
           </div>
         </div>
       );
-    } else if (activeProject && projectRouteWorkspaceContext.failure) {
+    } else if (
+      activeProject
+      && projectRouteWorkspaceContext.failure
+      && (
+        projectRouteWorkspaceContext.failure === 'forbidden'
+        || activeProjectWorkspaceContext === null
+      )
+    ) {
       appMain = (
         <div className="entry-shell entry-shell--no-header">
           <div className="centered-loader">
@@ -5312,6 +5320,11 @@ function AppInner() {
                 : undefined
             }
           />
+        ) : null}
+        {route.kind === 'project'
+          && activeProjectWorkspaceContext
+          && projectRouteWorkspaceContext.failure === 'unavailable' ? (
+          <ProjectWorkspaceRecoveryTip />
         ) : null}
         <div className="workspace-shell__body">
           {appMain}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -182,8 +182,9 @@ import {
 } from './runtime/amr-auth-retry-continuation';
 import { installFontRecovery } from './runtime/font-recovery';
 import {
-  createDesignSystemProjectFromProject,
+  bootstrapFirstOpenTeamProjectRoute,
   bootstrapProjectRoute,
+  createDesignSystemProjectFromProject,
   createProject,
   createPluginShareProject,
   deleteProject as deleteProjectApi,
@@ -4240,6 +4241,7 @@ function AppInner() {
     workspaceScope?: ProjectWorkspaceScope;
     resolvedDir?: string | null;
     workspaceContext?: WorkspaceCollabContext;
+    awaitingFirstMaterialization?: boolean;
   } | null>(null);
   const [, setRouteProjectSnapshotRevision] = useState(0);
   const activeAccountGeneration = currentWorkspaceAccountGeneration();
@@ -4274,6 +4276,10 @@ function AppInner() {
           : exactOpeningContext
             ? { workspaceContext: exactOpeningContext }
             : {}),
+        ...((preservesBootstrapWitness && previous.awaitingFirstMaterialization)
+          || listedProject.metadata?.sharedProjectPlaceholderAt != null
+          ? { awaitingFirstMaterialization: true }
+          : {}),
       };
       if (exactOpeningContext) projectOpenWorkspaceWitnessRef.current = null;
     } else if (
@@ -4470,6 +4476,8 @@ function AppInner() {
           capturedAfterListGeneration: latestAppliedProjectListGenerationRef.current,
           workspaceScope: bootstrap.scope,
           resolvedDir: bootstrap.resolvedDir,
+          awaitingFirstMaterialization:
+            bootstrap.project.metadata?.sharedProjectPlaceholderAt != null,
         };
         setRouteProjectSnapshotRevision((current) => current + 1);
         return;
@@ -4489,8 +4497,48 @@ function AppInner() {
         });
         return;
       }
-      // Preserve the existing shared-project recovery lane, but only after the
-      // ambient boot has settled enough to supply its exact catalog identity.
+      // A verified Team identity can bootstrap independently of the shell's
+      // project list, so begin local authority + background content work now.
+      const firstOpenTeamContext = exactOpenContext ?? deepLinkContext;
+      if (
+        firstOpenTeamContext?.workspaceType === 'team'
+        && firstOpenTeamContext.memberStatus === 'active'
+        && firstOpenTeamContext.lifecycleState === 'active'
+      ) {
+        const progressive = await bootstrapFirstOpenTeamProjectRoute(projectId, {
+          accountGeneration,
+          exactContext: firstOpenTeamContext,
+        });
+        if (
+          cancelled
+          || accountChanged()
+          || (!exactOpenContext && identityChanged())
+        ) return;
+        if (progressive.kind === 'found') {
+          routeProjectSnapshotRef.current = {
+            project: progressive.project,
+            accountGeneration,
+            capturedAfterListGeneration: latestAppliedProjectListGenerationRef.current,
+            workspaceScope: progressive.scope,
+            resolvedDir: progressive.resolvedDir,
+            workspaceContext: firstOpenTeamContext,
+            awaitingFirstMaterialization:
+              progressive.awaitingFirstMaterialization,
+          };
+          setRouteProjectSnapshotRevision((current) => current + 1);
+          return;
+        }
+        if (progressive.kind === 'forbidden') {
+          setDeepLinkResolutionFailure({ projectId, failure: 'missing' });
+          return;
+        }
+        // `not-found` can be a hub propagation race and `unavailable` includes
+        // old daemons that registered an unbound placeholder. Both retain the
+        // proven, bounded full-pull fallback below.
+      }
+      // The exact Team bootstrap above is independent of the shell project
+      // list, so it intentionally starts while that list is still loading.
+      // Only the legacy catalog+blocking-pull fallback waits for ambient boot.
       if (projectsLoading || !daemonLive) return;
       const resolution = await resolveDeepLinkedTeamSharedProject(projectId, {
         getProject: (id) => getProject(id, deepLinkContext),
@@ -5120,6 +5168,12 @@ function AppInner() {
                   project: routeProjectSnapshotRef.current.project,
                   resolvedDir: routeProjectSnapshotRef.current.resolvedDir,
                 }
+              : undefined
+          }
+          initialMaterializationPending={
+            routeProjectSnapshotRef.current?.project.id === activeProject.id
+              ? routeProjectSnapshotRef.current.awaitingFirstMaterialization
+                ?? (activeProject.metadata?.sharedProjectPlaceholderAt != null)
               : undefined
           }
           projectAuthorizationKey={

--- a/apps/web/src/collab/collab-context.tsx
+++ b/apps/web/src/collab/collab-context.tsx
@@ -38,6 +38,7 @@ const DISABLED: CollabContextValue = {
   ownerDisplayName: null,
   ownerRole: null,
   downloadPending: false,
+  materializationPending: false,
   reportChange: () => {},
   requestPublish: () => {},
   refreshPresence: () => {},

--- a/apps/web/src/collab/useProjectCollab.ts
+++ b/apps/web/src/collab/useProjectCollab.ts
@@ -98,6 +98,12 @@ export interface UseProjectCollabOptions {
    */
   workspaceContext?: WorkspaceCollabContext | null;
   workspaceContextLoading?: boolean;
+  /**
+   * Route bootstrap already proved that the local row is only a Team-bound
+   * placeholder. Keep writes and empty-file affordances fail-closed from the
+   * first paint until this hook completes its own status check.
+   */
+  initialMaterializationPending?: boolean;
   /** Injectable for tests. */
   fetch?: typeof fetch;
   baseUrl?: string;
@@ -220,6 +226,8 @@ export interface ProjectCollab {
    * files visible while the first status request is in flight.
    */
   downloadPending: boolean;
+  /** The exact local project tree is not usable as content authority yet. */
+  materializationPending?: boolean;
   reportChange: () => void;
   requestPublish: () => void;
   /** Refresh the presence roster now (hub push-channel consumer). */
@@ -238,9 +246,11 @@ export function resolveProjectWriterAuthority(options: {
   isOwner: boolean;
   knownOwnedByViewer: boolean;
   createdByViewerThisSession: boolean;
+  materializationPending?: boolean;
   syncState: ProjectCollab['syncState'];
 }): ProjectCollab['writerAuthority'] {
   if (options.workspaceReadOnly || options.lostAccessAfterUnshare) return 'denied';
+  if (options.materializationPending) return 'pending';
   if (options.workspaceContextReadOnly) return 'pending';
   // A settled daemon status outranks every provisional browser-side witness.
   // Catalog ownership and same-session creation exist only to bridge the
@@ -426,6 +436,12 @@ export function useProjectCollab(
   const sharedReadOnly =
     unknownStatusReadOnly || (shared && !isOwner) || lostAccessAfterUnshare;
   const viewerOnly = workspaceContextReadOnly || workspaceReadOnly || sharedReadOnly;
+  const materializationPending =
+    collab.awaitingFirstMaterialization
+    || (
+      options.initialMaterializationPending === true
+      && collab.statusPollGeneration === 0
+    );
   const writerAuthority = resolveProjectWriterAuthority({
     workspaceReadOnly,
     workspaceContextReadOnly,
@@ -434,6 +450,7 @@ export function useProjectCollab(
     isOwner,
     knownOwnedByViewer,
     createdByViewerThisSession,
+    materializationPending,
     syncState: collab.syncState,
   });
   // Positive non-owner evidence only — sticky UX (default-collapsed chat) must
@@ -557,7 +574,7 @@ export function useProjectCollab(
   // is still active). `pullTick` is not read directly, but its state bump
   // forces this render to observe the ref cursor written by a successful pull.
   const downloadPending = localFilesAreNotTheContentYet({
-    awaitingFirstMaterialization: collab.awaitingFirstMaterialization,
+    awaitingFirstMaterialization: materializationPending,
     shouldAutoPull,
     transferring: collab.contentTransferState?.status === 'downloading',
     behindPublishedHead:
@@ -579,6 +596,7 @@ export function useProjectCollab(
     ownerDisplayName: collab.ownerDisplayName,
     ownerRole: collab.ownerRole,
     downloadPending,
+    materializationPending,
     reportChange: collab.reportChange,
     requestPublish: collab.requestPublish,
     refreshPresence: collab.refreshPresence,

--- a/apps/web/src/collab/useProjectRouteWorkspaceContext.ts
+++ b/apps/web/src/collab/useProjectRouteWorkspaceContext.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { BackoffController } from '../lib/backoff';
 import {
   WORKSPACE_CONTEXT_REFRESH_EVENT,
   resolveBoundProjectWorkspaceContext,
@@ -14,6 +15,9 @@ export interface ProjectRouteWorkspaceContextState {
   failure?: 'forbidden' | 'unavailable';
   retry: () => void;
 }
+
+const PROJECT_ROUTE_RETRY_BASE_MS = 1_000;
+const PROJECT_ROUTE_RETRY_MAX_MS = 30_000;
 
 export function projectResourceReadsCanStart(
   persistedWorkspaceId: string | null | undefined,
@@ -63,8 +67,36 @@ export function useProjectRouteWorkspaceContext(
   const requestEpochRef = useRef(0);
   const consumedBootstrapContextRef = useRef<WorkspaceCollabContext | null>(null);
   const [refreshRevision, setRefreshRevision] = useState(0);
+  const retryTimerRef = useRef<number | null>(null);
+  const retryBackoffRef = useRef<BackoffController | null>(null);
+  if (retryBackoffRef.current === null) {
+    retryBackoffRef.current = new BackoffController({
+      initialMs: PROJECT_ROUTE_RETRY_BASE_MS,
+      maxMs: PROJECT_ROUTE_RETRY_MAX_MS,
+      factor: 2,
+      jitter: true,
+    });
+  }
+  const clearScheduledRetry = useCallback(() => {
+    if (retryTimerRef.current === null) return;
+    window.clearTimeout(retryTimerRef.current);
+    retryTimerRef.current = null;
+  }, []);
+  const resetRetryBackoff = useCallback(() => {
+    clearScheduledRetry();
+    retryBackoffRef.current?.reset();
+  }, [clearScheduledRetry]);
   const retry = useCallback(() => {
+    clearScheduledRetry();
     setRefreshRevision((current) => current + 1);
+  }, [clearScheduledRetry]);
+  const scheduleRetry = useCallback(() => {
+    if (retryTimerRef.current !== null) return;
+    const delay = retryBackoffRef.current?.nextDelay() ?? PROJECT_ROUTE_RETRY_BASE_MS;
+    retryTimerRef.current = window.setTimeout(() => {
+      retryTimerRef.current = null;
+      setRefreshRevision((current) => current + 1);
+    }, delay);
   }, []);
   const [resolved, setResolved] = useState<{
     workspaceId: string;
@@ -75,6 +107,16 @@ export function useProjectRouteWorkspaceContext(
       ? { context: initialExactContext, loading: initialExactContext === null }
       : { context: null, loading: false },
   }));
+
+  useEffect(() => {
+    resetRetryBackoff();
+    return () => {
+      // Retire a directory read that settles after this project route unmounts
+      // or changes Workspace, so it cannot arm a detached retry timer.
+      requestEpochRef.current += 1;
+      clearScheduledRetry();
+    };
+  }, [workspaceId, clearScheduledRetry, resetRetryBackoff]);
 
   useEffect(() => {
     const refresh = () => setRefreshRevision((current) => current + 1);
@@ -93,6 +135,7 @@ export function useProjectRouteWorkspaceContext(
       // context during the fresh lookup would let a newly mounted resource
       // effect emit one more wave with the previous account/member headers.
       requestEpochRef.current += 1;
+      resetRetryBackoff();
       setIdentityRefreshPending(Boolean(workspaceId));
       setResolved({
         workspaceId,
@@ -110,20 +153,12 @@ export function useProjectRouteWorkspaceContext(
       window.removeEventListener('focus', refresh);
       window.removeEventListener('pageshow', refresh);
     };
-  }, [workspaceId]);
-
-  useEffect(() => {
-    if (
-      resolved.workspaceId !== workspaceId
-      || resolved.state.failure !== 'unavailable'
-    ) return undefined;
-    const timer = window.setTimeout(retry, 5_000);
-    return () => window.clearTimeout(timer);
-  }, [resolved, retry, workspaceId]);
+  }, [workspaceId, resetRetryBackoff]);
 
   useEffect(() => {
     const requestEpoch = ++requestEpochRef.current;
     if (!workspaceId) {
+      resetRetryBackoff();
       setIdentityRefreshPending(false);
       setResolved({
         workspaceId,
@@ -132,6 +167,7 @@ export function useProjectRouteWorkspaceContext(
       return;
     }
     if (exactAmbientContext) {
+      resetRetryBackoff();
       setIdentityRefreshPending(false);
       setResolved({
         workspaceId,
@@ -150,6 +186,7 @@ export function useProjectRouteWorkspaceContext(
       // reuse the same snapshot while a genuinely new verification for the same
       // member remains adoptable.
       consumedBootstrapContextRef.current = exactBootstrapContext;
+      resetRetryBackoff();
       setIdentityRefreshPending(false);
       setResolved({
         workspaceId,
@@ -174,6 +211,7 @@ export function useProjectRouteWorkspaceContext(
     }).then(
       (context) => {
         if (requestEpochRef.current !== requestEpoch) return;
+        resetRetryBackoff();
         setIdentityRefreshPending(false);
         setResolved({
           workspaceId,
@@ -185,10 +223,25 @@ export function useProjectRouteWorkspaceContext(
       () => {
         if (requestEpochRef.current !== requestEpoch) return;
         setIdentityRefreshPending(false);
-        setResolved({
+        setResolved((current) => ({
           workspaceId,
-          state: { context: null, loading: false, failure: 'unavailable' },
-        });
+          // A rejected directory request proves nothing about this project's
+          // membership. That includes account-level 401/403 responses: the
+          // ambient shell owns reauthentication, while only a successful
+          // directory response without this member is project-level denial.
+          // Keep only an authority already verified for this exact persisted
+          // Workspace; account changes synchronously cleared it above before
+          // this request could start. A cold route with no witness still fails
+          // closed with `context: null`.
+          state: {
+            context: current.workspaceId === workspaceId
+              ? current.state.context
+              : null,
+            loading: false,
+            failure: 'unavailable',
+          },
+        }));
+        scheduleRetry();
       },
     );
   }, [
@@ -196,6 +249,8 @@ export function useProjectRouteWorkspaceContext(
     exactAmbientIdentity,
     exactBootstrapIdentity,
     refreshRevision,
+    resetRetryBackoff,
+    scheduleRetry,
   ]);
 
   if (!workspaceId) return { context: null, loading: false, retry };

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -933,10 +933,9 @@ export function EntryShell({
     teamProjects.projects,
   ]);
   // Open handler for the "全部项目" grid. A project already in the member's local
-  // list opens directly; a team-shared project the member has not pulled yet is
-  // first pulled + registered on the daemon (materialize content + insert a local
-  // project record) so it can open read-only — the member is not the owner, so
-  // the useProjectCollab single-writer path keeps it read-only.
+  // list opens directly. A remote Team project first creates an authority-bound
+  // placeholder, then ProjectView opens while the daemon materializes content in
+  // the background. The placeholder stamp keeps every content writer fail-closed.
   const [pullingProjectId, setPullingProjectId] = useState<string | null>(null);
   async function handleOpenAllProjects(id: string): Promise<boolean> {
     // The grid already reconciled the local row with the authoritative team
@@ -1003,22 +1002,34 @@ export function EntryShell({
       await open();
       return true;
     }
-    // The pull materializes the whole project before it can open; surface it
-    // on the card (spinner overlay) and swallow re-clicks meanwhile —
-    // otherwise the first click reads as dead for the entire download.
+    // Keep the card busy only for the short authority/bootstrap round trip, not
+    // for the full content transfer. PUT is idempotent, so the sidecar may safely
+    // replay it after a reused keep-alive socket resets. A paired older daemon
+    // has no bootstrap route; retain the former blocking POST fallback for that
+    // compatibility case.
     if (pullingProjectId) return false;
     const pullRead = beginWorkspaceScopedRead(workspaceContextRef.current);
     if (!pullRead.context) return false;
     setPullingProjectId(id);
     try {
-      const response = await fetch(`/api/projects/${encodeURIComponent(id)}/collab/pull`, {
-        method: 'POST',
+      const collabRoute = `/api/projects/${encodeURIComponent(id)}/collab`;
+      let response = await fetch(`${collabRoute}/bootstrap`, {
+        method: 'PUT',
         headers: workspaceProjectHeaders(pullRead.context),
       });
+      if (response.status === 404 || response.status === 405) {
+        response = await fetch(`${collabRoute}/pull`, {
+          method: 'POST',
+          headers: workspaceProjectHeaders(pullRead.context),
+        });
+      }
       if (!pullRead.isStillCurrent(workspaceContextRef.current)) return false;
       if (!response.ok) return false;
       invalidateProjectFilesCache(id, pullRead.context);
-      await Promise.resolve(onProjectsRefresh?.());
+      // The exact route bootstrap and ambient list refresh are independent.
+      // Navigation may read the newly committed placeholder immediately while
+      // the shell refreshes its catalog in parallel.
+      void Promise.resolve(onProjectsRefresh?.());
     } catch {
       return false;
     } finally {

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -357,6 +357,8 @@ interface Props {
    * true, edit affordances are withheld and a notice explains why.
    */
   viewerOnly?: boolean;
+  /** First-open placeholder: do not mount cached/write-capable workspace tabs. */
+  materializationPending?: boolean;
   /** Optional override for the read-only notice text. */
   readonlyNotice?: string;
   /**
@@ -367,6 +369,12 @@ interface Props {
    * have not yet been published. Null once caught up / not a shared project.
    */
   fileSyncBadge?: FileSyncBadgeState | null;
+}
+
+function noop(): void {}
+
+function rejectRenameWhileMaterializing(): null {
+  return null;
 }
 
 interface SketchState {
@@ -1352,6 +1360,7 @@ export function FileWorkspace({
   fileActionsBefore,
   headerActions,
   viewerOnly = false,
+  materializationPending = false,
   readonlyNotice,
   fileSyncBadge = null,
 }: Props) {
@@ -3923,7 +3932,7 @@ export function FileWorkspace({
             clearTabDragState();
           }}
         >
-          {designSystemProject ? (
+          {!materializationPending && designSystemProject ? (
             <button
               type="button"
               className={`ws-tab design-system-tab ${activeTab === DESIGN_SYSTEM_TAB ? 'active' : ''}`}
@@ -3942,9 +3951,9 @@ export function FileWorkspace({
           ) : null}
           <button
             type="button"
-            className={`ws-tab design-files-tab ${designFilesTabActive ? 'active' : ''}`}
+            className={`ws-tab design-files-tab ${materializationPending || designFilesTabActive ? 'active' : ''}`}
             role="tab"
-            aria-selected={designFilesTabActive}
+            aria-selected={materializationPending || designFilesTabActive}
             aria-label={designFilesTabTitle}
             tabIndex={0}
             data-testid="design-files-tab"
@@ -3960,7 +3969,7 @@ export function FileWorkspace({
             </span>
             <span className="ws-tab-label">{designFilesTabLabel}</span>
           </button>
-          {visibleOrderedWorkspaceTabs.map((entry) => {
+          {!materializationPending ? visibleOrderedWorkspaceTabs.map((entry) => {
             if (entry.kind === 'browser') {
               const browserTab = entry.browserTab;
               const browserUrl = browserTab.url?.trim() ?? '';
@@ -4046,9 +4055,9 @@ export function FileWorkspace({
                 onDragEnd={handlers.onDragEnd}
               />
             );
-          })}
+          }) : null}
         </div>
-        <div className="ws-add-tab">
+        {!materializationPending ? <div className="ws-add-tab">
           <button
             ref={launcherBtnRef}
             type="button"
@@ -4064,11 +4073,11 @@ export function FileWorkspace({
           >
             <Icon name="plus" size={15} />
           </button>
-        </div>
+        </div> : null}
         {/* Pinned to the right for project/file actions; the tab launcher sits
             next to the file tabs so its spatial relationship stays clear. */}
         <div className="ws-tabs-actions">
-          {fileActionsBefore ? (
+          {!materializationPending && fileActionsBefore ? (
             <div className="ws-tabs-file-actions-before">{fileActionsBefore}</div>
           ) : null}
           {/* Pure portal host. Whatever file is open owns these actions and
@@ -4082,12 +4091,12 @@ export function FileWorkspace({
             data-app-chrome-file-actions="true"
             hidden={!viewerFileActive}
           />
-          {headerActions ? (
+          {!materializationPending && headerActions ? (
             <div className="ws-tabs-project-actions">{headerActions}</div>
           ) : null}
         </div>
       </div>
-      {launcherOpen ? (
+      {!materializationPending && launcherOpen ? (
         <TabLauncherMenu
           anchor={launcherBtnRef.current}
           files={visibleFiles}
@@ -4137,7 +4146,7 @@ export function FileWorkspace({
           />
         </div>
       ) : null}
-      {viewerOnly ? (
+      {viewerOnly && !materializationPending ? (
         <div className="workspace-readonly-notice" role="status">
           <Icon name="lock" size={14} />
           <span>{readonlyNotice ?? t('workspace.readonlyNotice')}</span>
@@ -4163,7 +4172,7 @@ export function FileWorkspace({
             </button>
           </div>
         ) : null}
-        {browserTabs.filter((browserTab) => mountedBrowserTabIds.has(browserTab.id)).map((browserTab) => (
+        {!materializationPending ? browserTabs.filter((browserTab) => mountedBrowserTabIds.has(browserTab.id)).map((browserTab) => (
           <div
             key={`${projectId}:${browserTab.id}`}
             className={`ws-browser-panel ${activeTab === browserTab.id ? 'active' : ''}`}
@@ -4200,8 +4209,27 @@ export function FileWorkspace({
               }}
             />
           </div>
-        ))}
-        {activeTab === DESIGN_SYSTEM_TAB && designSystemProject ? (
+        )) : null}
+        {materializationPending ? (
+          <DesignFilesPanel
+            projectId={projectId}
+            viewerOnly
+            downloadPending
+            files={[]}
+            folders={[]}
+            liveArtifacts={[]}
+            onRefreshFiles={noop}
+            onOpenFile={noop}
+            onOpenLiveArtifact={noop}
+            onRenameFile={rejectRenameWhileMaterializing}
+            onDeleteFile={noop}
+            onDeleteFiles={noop}
+            onUpload={noop}
+            onUploadFiles={noop}
+            onPaste={noop}
+            onNewSketch={noop}
+          />
+        ) : activeTab === DESIGN_SYSTEM_TAB && designSystemProject ? (
           <DesignSystemProjectPanel
             projectId={projectId}
             system={designSystemProject}
@@ -4431,7 +4459,7 @@ export function FileWorkspace({
             .
           </div>
         )}
-        {mountedHtmlViewerFiles.map((file) => {
+        {!materializationPending ? mountedHtmlViewerFiles.map((file) => {
           const workspaceActive = activeHtmlViewerFile?.name === file.name;
           return (
             <div
@@ -4464,8 +4492,8 @@ export function FileWorkspace({
               {renderFileViewer(file, workspaceActive)}
             </div>
           );
-        })}
-        {viewerFile ? (
+        }) : null}
+        {!materializationPending && viewerFile ? (
           <div
             ref={(element) => {
               syncInertAttribute(element, !viewerFileActive);
@@ -4495,7 +4523,7 @@ export function FileWorkspace({
           </div>
         ) : null}
       </div>
-      <PageCreatorDialog
+      {!materializationPending ? <PageCreatorDialog
         open={pageCreatorOpen}
         t={t}
         locale={locale}
@@ -4511,17 +4539,17 @@ export function FileWorkspace({
         onClose={() => {
           if (!pageCreating) setPageCreatorOpen(false);
         }}
-      />
-      <input
+      /> : null}
+      {!materializationPending ? <input
         ref={fileInputRef}
         type="file"
         multiple
         data-testid="design-files-upload-input"
         style={{ display: 'none' }}
         onChange={handleFilePicked}
-      />
+      /> : null}
       <AnimatePresence>
-        {showLibraryPicker ? (
+        {!materializationPending && showLibraryPicker ? (
           <LibraryPicker
             onClose={() => setShowLibraryPicker(false)}
             onConfirm={async (assets) => {
@@ -4551,7 +4579,7 @@ export function FileWorkspace({
         ) : null}
       </AnimatePresence>
       <AnimatePresence>
-        {quickSwitcherOpen ? (
+        {!materializationPending && quickSwitcherOpen ? (
           <QuickSwitcher
             projectId={projectId}
             files={visibleFiles}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -568,6 +568,8 @@ interface Props {
   /** Fresh route-bootstrap witnesses, reused to avoid repeating scope/detail reads. */
   initialWorkspaceScope?: ProjectWorkspaceScope | null;
   initialProjectDetail?: ProjectDetailSeed | null;
+  /** The seeded project row is a Team-bound placeholder, not content authority. */
+  initialMaterializationPending?: boolean;
   /** Workspace/member authorization lifetime for async title reads. */
   projectAuthorizationKey?: string;
   amrAuthRetryContinuation?: AmrAuthRetryContinuation | null;
@@ -1745,6 +1747,7 @@ export function ProjectView({
   workspaceContextOverride,
   initialWorkspaceScope,
   initialProjectDetail,
+  initialMaterializationPending = false,
   projectAuthorizationKey = project.id,
   amrAuthRetryContinuation = null,
   onArmAmrAuthRetryContinuation,
@@ -1968,8 +1971,17 @@ export function ProjectView({
   const projectCollab = useProjectCollab(project?.id ?? null, {
     workspaceContext: projectRunWorkspaceContext,
     workspaceContextLoading: projectWorkspaceScopeState.loading,
+    initialMaterializationPending,
     presenceFilePath: project?.metadata?.entryFile ?? null,
   });
+  // A Team-bound placeholder is safe to render and comment around, but its
+  // empty tree is never a writer authority. Reuse the established viewer-only
+  // gates for content/run/project mutations until the daemon's own status poll
+  // proves first materialization finished. Keep the read-only ownership banner
+  // keyed to `projectCollab.viewerOnly` below so an owner reinstall sees a
+  // syncing project, not the misleading “shared by someone else” notice.
+  const projectMutationReadOnly =
+    projectCollab.viewerOnly || projectCollab.materializationPending;
   const { resolve: resolvePresenceMember } = useTeamMembers(
     currentUserDirectoryEntry(projectRunWorkspaceContext),
     projectRunWorkspaceContext,
@@ -2027,6 +2039,9 @@ export function ProjectView({
     detailedProject,
     authoritativeProjectName,
   );
+  let projectTitleTooltip = currentProject.name;
+  if (projectMutationReadOnly) projectTitleTooltip = t('workspace.readonlyNotice');
+  if (projectCollab.materializationPending) projectTitleTooltip = t('designFiles.syncing');
   const resolvedProjectDesignSystemId = resolveProjectDesignSystemId(currentProject);
   // A project can outlive a Design System being disabled in Settings. Keep the
   // persisted project value intact for recovery, but do not inject a disabled
@@ -2639,12 +2654,14 @@ export function ProjectView({
     currentConversationHasActiveRun
     && !currentConversationStreaming
     && !currentConversationHasProgrammaticBrandExtractionRun;
-  const currentConversationSendDisabled = !projectRunHasBillableAmrPrincipal
+  const currentConversationSendDisabled = projectMutationReadOnly
+    || !projectRunHasBillableAmrPrincipal
     || currentConversationLoading
     || failedMessagesConversationId === activeConversationId
     || currentConversationAwaitingActiveRunAttach;
   const currentConversationActionDisabled = currentConversationBusy || currentConversationSendDisabled;
-  const currentConversationQueueDisabled = currentConversationLoading
+  const currentConversationQueueDisabled = projectMutationReadOnly
+    || currentConversationLoading
     || failedMessagesConversationId === activeConversationId;
 
   const currentConversationQueuedItems = activeConversationId
@@ -2661,7 +2678,7 @@ export function ProjectView({
           return { ...queuedItem, meta: item.meta };
         })
     : [];
-  const newConversationDisabled = creatingConversation;
+  const newConversationDisabled = creatingConversation || projectMutationReadOnly;
   const activeCompletionNotificationRunsRef = useRef<Set<string>>(new Set());
   const completedNotificationRunsRef = useRef<Set<string>>(new Set());
 
@@ -4827,6 +4844,7 @@ export function ProjectView({
         });
         return null;
       }
+      if (projectCollab.materializationPending) return null;
       // Upload any attached images first so the saved comment carries durable
       // file paths — this is what lets the comment list / re-opened popover
       // re-display the images instead of losing them on echo.
@@ -4890,6 +4908,7 @@ export function ProjectView({
       previewComments,
       projectRunWorkspaceContext,
       t,
+      projectCollab.materializationPending,
     ],
   );
 
@@ -4905,6 +4924,7 @@ export function ProjectView({
         });
         return false;
       }
+      if (projectCollab.materializationPending) return false;
       const ok = await deletePreviewComment(
         project.id,
         commentConversationId,
@@ -4931,6 +4951,7 @@ export function ProjectView({
       commitPreviewComments,
       projectRunWorkspaceContext,
       t,
+      projectCollab.materializationPending,
     ],
   );
 
@@ -4958,6 +4979,7 @@ export function ProjectView({
         });
         return;
       }
+      if (projectCollab.materializationPending) return;
       commitPreviewComments((current) =>
         current.map((comment) => (comment.id === commentId ? { ...comment, sortKey } : comment)),
       );
@@ -4986,6 +5008,7 @@ export function ProjectView({
       commitPreviewComments,
       projectRunWorkspaceContext,
       t,
+      projectCollab.materializationPending,
     ],
   );
 
@@ -6464,6 +6487,7 @@ export function ProjectView({
       meta?: ProjectChatSendMeta,
       baseMessages?: ChatMessage[],
     ) => {
+      if (projectMutationReadOnly) return false;
       if (!activeConversationId) return false;
       if (messagesConversationIdRef.current !== activeConversationId) return false;
       const clientRequestId = meta?.clientRequestId ?? randomUUID();
@@ -8157,6 +8181,7 @@ export function ProjectView({
       projectRunPreflightContext,
       projectRunWorkspaceContext,
       projectRunHasBillableAmrPrincipal,
+      projectMutationReadOnly,
       projectWorkspaceScopeState.scope,
     ],
   );
@@ -9005,6 +9030,7 @@ export function ProjectView({
   ]);
 
   const handleNewConversation = useCallback(async () => {
+    if (projectMutationReadOnly) return;
     if (creatingConversationRef.current) return;
     // Only block if we're sure the current conversation is empty:
     // messages must be loaded AND match the active conversation.
@@ -9069,6 +9095,7 @@ export function ProjectView({
     openTabsState.active,
     projectRunWorkspaceContext,
     projectRunAuthorityKey,
+    projectMutationReadOnly,
   ]);
 
   const handleSelectConversation = useCallback((id: string) => {
@@ -9131,6 +9158,7 @@ export function ProjectView({
 
   const handleDeleteConversation = useCallback(
     async (id: string) => {
+      if (projectMutationReadOnly) return;
       const ok = await deleteConversationApi(
         project.id,
         id,
@@ -9168,11 +9196,13 @@ export function ProjectView({
       activeConversationId,
       onProjectsRefresh,
       projectRunWorkspaceContext,
+      projectMutationReadOnly,
     ],
   );
 
   const handleRenameConversation = useCallback(
     async (id: string, title: string) => {
+      if (projectMutationReadOnly) return;
       const trimmed = title.trim() || null;
       setConversations((curr) =>
         curr.map((c) => (c.id === id ? { ...c, title: trimmed } : c)),
@@ -9184,11 +9214,12 @@ export function ProjectView({
         projectRunWorkspaceContext,
       );
     },
-    [project.id, projectRunWorkspaceContext],
+    [project.id, projectRunWorkspaceContext, projectMutationReadOnly],
   );
 
   const handleConversationSessionModeChange = useCallback(
     async (id: string, sessionMode: ChatSessionMode) => {
+      if (projectMutationReadOnly) return;
       setConversations((curr) =>
         curr.map((conversation) =>
           conversation.id === id ? { ...conversation, sessionMode } : conversation,
@@ -9208,7 +9239,7 @@ export function ProjectView({
         );
       }
     },
-    [project.id, projectRunWorkspaceContext],
+    [project.id, projectRunWorkspaceContext, projectMutationReadOnly],
   );
 
   const handleActiveConversationSessionModeChange = useCallback(
@@ -9221,7 +9252,7 @@ export function ProjectView({
 
   const handleForkFromMessage = useCallback(
     async (assistantMessage: ChatMessage) => {
-      if (!activeConversationId || forkingMessageId || projectCollab.viewerOnly) return;
+      if (!activeConversationId || forkingMessageId || projectMutationReadOnly) return;
       const requestId = analytics.newRequestId();
       const startedAt = Date.now();
       const forkIndex = messages.findIndex((message) => message.id === assistantMessage.id);
@@ -9335,7 +9366,7 @@ export function ProjectView({
       openTabsState.active,
       project.id,
       project.metadata,
-      projectCollab.viewerOnly,
+      projectMutationReadOnly,
       t,
     ],
   );
@@ -9349,6 +9380,7 @@ export function ProjectView({
   }>>(new Map());
   const handleProjectRename = useCallback(
     (newName: string) => {
+      if (projectMutationReadOnly) return;
       const trimmed = newName.trim();
       if (!trimmed || trimmed === project.name) return;
       const previousName = project.name;
@@ -9457,6 +9489,7 @@ export function ProjectView({
       onProjectRenameStarted,
       onProjectsRefresh,
       project,
+      projectMutationReadOnly,
     ],
   );
 
@@ -9507,6 +9540,7 @@ export function ProjectView({
 
   const handleChangeDesignSystemId = useCallback(
     (nextId: string | null) => {
+      if (projectMutationReadOnly) return;
       if ((projectDesignSystemId ?? null) === nextId) return;
       // `design_system_apply_result` studio variant. The existing
       // NewProjectPanel picker fires the same event under
@@ -9580,7 +9614,15 @@ export function ProjectView({
       onProjectChange(updated);
       void patchProject(project.id, { designSystemId: nextId }, projectRunWorkspaceContext);
     },
-    [project, projectDesignSystemId, onProjectChange, designSystems, analytics.track],
+    [
+      project,
+      projectDesignSystemId,
+      onProjectChange,
+      designSystems,
+      analytics.track,
+      projectMutationReadOnly,
+      projectRunWorkspaceContext,
+    ],
   );
 
   // Canonical project-type chip shown next to the editable title. We label
@@ -9651,6 +9693,7 @@ export function ProjectView({
   // `teamSynced`, i.e. the caller's own system or a built-in preset) reads as
   // editable, matching every other consumer of this field.
   const designSystemEditable =
+    !projectCollab.materializationPending &&
     designSystemProject?.canMutate !== false &&
     (
       !projectIsProgrammaticBrandExtraction ||
@@ -10953,10 +10996,12 @@ export function ProjectView({
               loading={currentConversationLoading}
               // A read-only viewer of a team-shared project cannot drive artifact
               // changes through chat (comments go through the separate overlay).
-              sendDisabled={currentConversationSendDisabled || projectCollab.viewerOnly}
-              viewerOnly={projectCollab.viewerOnly}
+              sendDisabled={currentConversationSendDisabled || projectMutationReadOnly}
+              viewerOnly={projectMutationReadOnly}
               composerPlaceholder={
-                projectCollab.viewerOnly
+                projectCollab.materializationPending
+                  ? t('designFiles.syncing')
+                  : projectMutationReadOnly
                   ? (projectCollab.ownerDisplayName
                       ? t('workspace.readonlyNoticeBy', { owner: projectCollab.ownerDisplayName })
                       : t('workspace.readonlyNotice'))
@@ -11053,7 +11098,7 @@ export function ProjectView({
               onArtifactShare={handleArtifactShare}
               onArtifactDownload={handleArtifactDownload}
               onForkFromMessage={
-                projectCollab.viewerOnly ? undefined : handleForkFromMessage
+                projectMutationReadOnly ? undefined : handleForkFromMessage
               }
               forkingMessageId={forkingMessageId}
               onNewConversation={handleNewConversation}
@@ -11149,15 +11194,15 @@ export function ProjectView({
               projectHeader={(
                 <span className="chat-project-title-line">
                   <span
-                    className={`title${projectCollab.viewerOnly ? ' readonly' : ' editable'}`}
+                    className={`title${projectMutationReadOnly ? ' readonly' : ' editable'}`}
                     data-testid="project-title"
-                    title={projectCollab.viewerOnly ? t('workspace.readonlyNotice') : currentProject.name}
-                    tabIndex={projectCollab.viewerOnly ? -1 : 0}
-                    role={projectCollab.viewerOnly ? undefined : 'textbox'}
+                    title={projectTitleTooltip}
+                    tabIndex={projectMutationReadOnly ? -1 : 0}
+                    role={projectMutationReadOnly ? undefined : 'textbox'}
                     suppressContentEditableWarning
-                    contentEditable={!projectCollab.viewerOnly}
+                    contentEditable={!projectMutationReadOnly}
                     onBlur={(e) => {
-                      if (projectCollab.viewerOnly) return;
+                      if (projectMutationReadOnly) return;
                       handleProjectRename(e.currentTarget.textContent ?? '');
                     }}
                     onKeyDown={(e) => {
@@ -11180,7 +11225,7 @@ export function ProjectView({
                   designSystems={designSystems}
                   selectedId={projectDesignSystemId ?? null}
                   workspaceContext={projectRunWorkspaceContext}
-                  disabled={projectCollab.viewerOnly}
+                  disabled={projectMutationReadOnly}
                   onChange={handleChangeDesignSystemId}
                 />
               )}
@@ -11223,8 +11268,13 @@ export function ProjectView({
         <FileWorkspace
           projectId={project.id}
           projectName={currentProject.name}
-          viewerOnly={projectCollab.viewerOnly}
-          readonlyNotice={readonlyNoticeText}
+          viewerOnly={projectMutationReadOnly}
+          materializationPending={projectCollab.materializationPending}
+          readonlyNotice={
+            projectCollab.materializationPending
+              ? t('designFiles.syncing')
+              : readonlyNoticeText
+          }
           fileSyncBadge={fileSyncBadge}
           projectKind={projectKindFromMetadataToTracking(currentProject.metadata) ?? 'prototype'}
           rootDirName={(() => {

--- a/apps/web/src/components/ProjectWorkspaceRecoveryTip.module.css
+++ b/apps/web/src/components/ProjectWorkspaceRecoveryTip.module.css
@@ -1,0 +1,15 @@
+.root {
+  position: fixed;
+  left: 12px;
+  bottom: 12px;
+  z-index: 200;
+  width: min(260px, calc(100vw - 24px));
+  padding: 4px 0;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-elevated) 92%, transparent);
+  box-shadow: var(--shadow-sm);
+  pointer-events: none;
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}

--- a/apps/web/src/components/ProjectWorkspaceRecoveryTip.tsx
+++ b/apps/web/src/components/ProjectWorkspaceRecoveryTip.tsx
@@ -1,0 +1,15 @@
+import { RailAccountRecoveryTip } from './CloudSignInTip';
+import styles from './ProjectWorkspaceRecoveryTip.module.css';
+
+/**
+ * Keep a transient Workspace authority outage visible without replacing the
+ * healthy local project data plane. This deliberately reuses the rail's
+ * existing recovery language and status semantics.
+ */
+export function ProjectWorkspaceRecoveryTip() {
+  return (
+    <div className={styles.root} data-testid="project-workspace-recovery-tip">
+      <RailAccountRecoveryTip />
+    </div>
+  );
+}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -14,6 +14,7 @@ import type {
   AppliedPluginSnapshot,
   ApplyResult,
   ChatSessionMode,
+  CollabProjectBootstrapResponse,
   CreateConversationRequest,
   CreateDesignSystemProjectFromProjectResponse,
   DuplicateProjectResponse,
@@ -371,6 +372,18 @@ export type ProjectRouteBootstrapResult =
   | { kind: 'forbidden' }
   | { kind: 'unavailable' };
 
+export type FirstOpenTeamProjectBootstrapResult =
+  | {
+      kind: 'found';
+      project: Project;
+      scope: ProjectWorkspaceScopeResponse['scope'];
+      resolvedDir: string | null;
+      awaitingFirstMaterialization: boolean;
+    }
+  | { kind: 'not-found' }
+  | { kind: 'forbidden' }
+  | { kind: 'unavailable' };
+
 /**
  * Bootstrap a fresh project deep link without borrowing the shell's ambient
  * Workspace. A card-opening witness goes straight through the scoped endpoint;
@@ -504,6 +517,87 @@ export async function bootstrapProjectRoute(
   });
   if (result.kind === 'unavailable') evictCoalescedGet(key);
   return result;
+}
+
+/**
+ * Progressive first-open lane for a Team project that is present in the hub
+ * but absent from this daemon's local data root.
+ *
+ * `/collab/bootstrap` owns the exact-directory authorization, shared-owner
+ * discovery, placeholder stamp, and background single-flight pull. Its
+ * idempotent PUT is safely replayable by the sidecar proxy after a reused
+ * keep-alive socket resets. A current daemon atomically binds the placeholder
+ * to this exact Team principal before answering; the follow-up route bootstrap
+ * proves that local binding through the ordinary scope/detail gates before
+ * ProjectView may mount.
+ * Older daemons leave the row unbound, which deliberately returns `unavailable`
+ * so App keeps the pre-existing full-materialization fallback.
+ */
+export async function bootstrapFirstOpenTeamProjectRoute(
+  projectId: string,
+  options: {
+    accountGeneration: number;
+    exactContext: WorkspaceCollabContext;
+  },
+): Promise<FirstOpenTeamProjectBootstrapResult> {
+  const { exactContext } = options;
+  if (
+    exactContext.workspaceType !== 'team'
+    || exactContext.memberStatus !== 'active'
+    || exactContext.lifecycleState !== 'active'
+  ) {
+    return { kind: 'not-found' };
+  }
+  let bootstrapResponse: CollabProjectBootstrapResponse;
+  try {
+    const response = await fetch(
+      `/api/projects/${encodeURIComponent(projectId)}/collab/bootstrap`,
+      {
+        method: 'PUT',
+        cache: 'no-store',
+        headers: workspaceProjectHeaders(exactContext),
+      },
+    );
+    if (!response.ok) {
+      if (response.status === 403) return { kind: 'forbidden' };
+      if (response.status === 404) return { kind: 'not-found' };
+      return { kind: 'unavailable' };
+    }
+    bootstrapResponse = (await response.json()) as CollabProjectBootstrapResponse;
+  } catch {
+    return { kind: 'unavailable' };
+  }
+  // The optimistic route read immediately before this helper may have cached
+  // the expected 404 for the same exact principal. The successful PUT changed
+  // local authority state, so that negative read is no longer reusable.
+  evictCoalescedGet([
+    'project-route-bootstrap',
+    options.accountGeneration,
+    projectId,
+    workspaceIdentityCacheKey(exactContext),
+  ].join(':'));
+  const bootstrap = await bootstrapProjectRoute(projectId, {
+    accountGeneration: options.accountGeneration,
+    exactContext,
+  });
+  if (bootstrap.kind === 'forbidden') return { kind: 'unavailable' };
+  if (bootstrap.kind !== 'found') return bootstrap;
+  if (
+    bootstrap.scope.kind !== 'team'
+    || bootstrap.scope.context?.workspaceType !== 'team'
+    || workspaceIdentityCacheKey(bootstrap.scope.context)
+      !== workspaceIdentityCacheKey(exactContext)
+  ) {
+    // A shared placeholder must never be rendered through an unbound/local or
+    // mismatched principal, including when the web is paired with an older
+    // daemon that only registered a row without its Team binding.
+    return { kind: 'unavailable' };
+  }
+  return {
+    ...bootstrap,
+    awaitingFirstMaterialization:
+      bootstrapResponse.awaitingFirstMaterialization === true,
+  };
 }
 
 export async function getProjectDetail(

--- a/apps/web/tests/components/App.project-account-cluster.test.tsx
+++ b/apps/web/tests/components/App.project-account-cluster.test.tsx
@@ -10,6 +10,7 @@
 // Workspace authority whenever `route.kind === 'project'`.
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
@@ -50,6 +51,8 @@ const PROJECT_ROUTE: Route = {
 };
 const useRouteMock = vi.fn<() => Route>(() => PROJECT_ROUTE);
 const useProjectRouteWorkspaceContextMock = vi.hoisted(() => vi.fn());
+const projectViewMountedMock = vi.hoisted(() => vi.fn());
+const projectViewUnmountedMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
@@ -71,7 +74,13 @@ vi.mock('../../src/components/EntryView', () => ({
 }));
 
 vi.mock('../../src/components/ProjectView', () => ({
-  ProjectView: () => <div>Project view</div>,
+  ProjectView: () => {
+    useEffect(() => {
+      projectViewMountedMock();
+      return () => projectViewUnmountedMock();
+    }, []);
+    return <div>Project view</div>;
+  },
 }));
 
 vi.mock('../../src/components/pet/PetOverlay', () => ({
@@ -360,18 +369,36 @@ describe('project route — floating account cluster', () => {
     });
   });
 
-  it('keeps the project mounted and shows recovery status during a transient authority outage', async () => {
+  it('keeps the same project instance mounted through a transient authority outage and recovery', async () => {
+    const view = render(<App />);
+
+    expect(await screen.findByText('Project view')).toBeTruthy();
+    expect(projectViewMountedMock).toHaveBeenCalledTimes(1);
+    expect(projectViewUnmountedMock).not.toHaveBeenCalled();
+
     useProjectRouteWorkspaceContextMock.mockReturnValue({
       context: PROJECT_WORKSPACE_CONTEXT,
       loading: false,
       failure: 'unavailable',
       retry: vi.fn(),
     });
-
-    render(<App />);
+    view.rerender(<App />);
 
     expect(await screen.findByText('Project view')).toBeTruthy();
     expect(screen.getByTestId('project-workspace-recovery-tip')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+    expect(projectViewMountedMock).toHaveBeenCalledTimes(1);
+    expect(projectViewUnmountedMock).not.toHaveBeenCalled();
+
+    useProjectRouteWorkspaceContextMock.mockReturnValue({
+      context: PROJECT_WORKSPACE_CONTEXT,
+      loading: false,
+      retry: vi.fn(),
+    });
+    view.rerender(<App />);
+
+    expect(screen.queryByTestId('project-workspace-recovery-tip')).toBeNull();
+    expect(projectViewMountedMock).toHaveBeenCalledTimes(1);
+    expect(projectViewUnmountedMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/components/App.project-account-cluster.test.tsx
+++ b/apps/web/tests/components/App.project-account-cluster.test.tsx
@@ -359,4 +359,19 @@ describe('project route — floating account cluster', () => {
       expect(screen.queryByTestId('entry-nav-account')).toBeNull();
     });
   });
+
+  it('keeps the project mounted and shows recovery status during a transient authority outage', async () => {
+    useProjectRouteWorkspaceContextMock.mockReturnValue({
+      context: PROJECT_WORKSPACE_CONTEXT,
+      loading: false,
+      failure: 'unavailable',
+      retry: vi.fn(),
+    });
+
+    render(<App />);
+
+    expect(await screen.findByText('Project view')).toBeTruthy();
+    expect(screen.getByTestId('project-workspace-recovery-tip')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
 });

--- a/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
+++ b/apps/web/tests/components/EntryShell.blank-project-naming.test.tsx
@@ -486,7 +486,7 @@ describe('EntryShell team project content readiness', () => {
     ).toBe(false);
   });
 
-  it('falls back to POST pull when ready hydration does not succeed', async () => {
+  it('bootstraps a progressive open when ready hydration does not succeed', async () => {
     vi.stubGlobal('EventSource', MockWorkspaceEventSource as unknown as typeof EventSource);
     const workspace = teamContext();
     const materializedFile = {
@@ -498,7 +498,7 @@ describe('EntryShell team project content readiness', () => {
       kind: 'code' as const,
       mime: 'text/html',
     };
-    let pullSucceeded = false;
+    let bootstrapSucceeded = false;
     const requests: Array<{
       url: string;
       method: string;
@@ -531,12 +531,12 @@ describe('EntryShell team project content readiness', () => {
           }],
         });
       }
-      if (pathname.endsWith('/collab/pull') && init?.method === 'POST') {
-        pullSucceeded = true;
-        return jsonResponse({ ok: true });
+      if (pathname.endsWith('/collab/bootstrap') && init?.method === 'PUT') {
+        bootstrapSucceeded = true;
+        return jsonResponse({ ok: true, awaitingFirstMaterialization: true }, 202);
       }
       if (pathname.endsWith('/files')) {
-        return jsonResponse({ files: pullSucceeded ? [materializedFile] : [] });
+        return jsonResponse({ files: bootstrapSucceeded ? [materializedFile] : [] });
       }
       return jsonResponse({});
     }) as typeof fetch;
@@ -571,7 +571,7 @@ describe('EntryShell team project content readiness', () => {
     fireEvent.click(screen.getByTitle('Ready shared project'));
     expect(
       requests.some(({ url, method }) =>
-        method === 'POST' && url.includes('/api/projects/shared-ready/collab/pull')),
+        method === 'PUT' && url.includes('/api/projects/shared-ready/collab/bootstrap')),
     ).toBe(false);
     await act(async () => {
       finishHydration(false);
@@ -590,14 +590,14 @@ describe('EntryShell team project content readiness', () => {
     expect(onProjectsRefresh).toHaveBeenCalledTimes(1);
     expect(
       requests.some(({ url, method }) =>
-        method === 'POST' && url.includes('/api/projects/shared-ready/collab/pull')),
+        method === 'PUT' && url.includes('/api/projects/shared-ready/collab/bootstrap')),
     ).toBe(true);
-    const pullRequest = requests.find(
+    const bootstrapRequest = requests.find(
       ({ url, method }) =>
-        method === 'POST'
-        && url.includes('/api/projects/shared-ready/collab/pull'),
+        method === 'PUT'
+        && url.includes('/api/projects/shared-ready/collab/bootstrap'),
     );
-    expect(pullRequest).toMatchObject({
+    expect(bootstrapRequest).toMatchObject({
       workspaceId: 'ws-1',
       workspaceMemberId: 'wm-1',
     });
@@ -694,7 +694,7 @@ describe('EntryShell team project content readiness', () => {
     expect(onProjectsRefresh).toHaveBeenCalledTimes(1);
     expect(
       requests.some(({ url, method }) =>
-        method === 'POST' && url.includes('/api/projects/shared-ready/collab/pull')),
+        method === 'PUT' && url.includes('/api/projects/shared-ready/collab/bootstrap')),
     ).toBe(true);
     expect(onTeamProjectContentReady).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -4305,6 +4305,25 @@ describe('FileWorkspace add-module menu', () => {
 });
 
 describe('FileWorkspace empty-project generation contract', () => {
+  it('shows the first-materialization syncing surface instead of mounting a cached workspace tab', () => {
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[workspaceFile('stale.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{ tabs: ['terminal:stale'], active: 'terminal:stale' }}
+        onTabsStateChange={vi.fn()}
+        materializationPending
+      />,
+    );
+
+    expect(screen.getByTestId('design-files-syncing')).toBeTruthy();
+    expect(screen.queryByTestId('design-files-empty')).toBeNull();
+  });
+
   function assistantMessage(runStatus: 'running' | 'failed'): ChatMessage {
     return {
       id: `msg-${runStatus}`,

--- a/apps/web/tests/project-route-bootstrap.test.ts
+++ b/apps/web/tests/project-route-bootstrap.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { bootstrapProjectRoute } from '../src/state/projects';
+import {
+  bootstrapFirstOpenTeamProjectRoute,
+  bootstrapProjectRoute,
+} from '../src/state/projects';
 import { resetCoalescedGet } from '../src/lib/coalesced-get';
 import { workspaceContextFixture } from './helpers/workspace-context';
 
@@ -263,5 +266,89 @@ describe('bootstrapProjectRoute', () => {
     await bootstrapProjectRoute(PROJECT_ID, { accountGeneration: 3 });
     await bootstrapProjectRoute(PROJECT_ID, { accountGeneration: 3 });
     expect(failedFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('bootstrapFirstOpenTeamProjectRoute', () => {
+  it('uses one exact idempotent bootstrap then mounts only a confirmed Team binding', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    let bound = false;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.endsWith('/collab/bootstrap')) {
+        bound = true;
+        return new Response(JSON.stringify({
+          ok: true,
+          awaitingFirstMaterialization: true,
+        }), { status: 202 });
+      }
+      if (url.endsWith('/workspace-scope')) {
+        if (!bound) return new Response('{}', { status: 404 });
+        return new Response(JSON.stringify({
+          scope: {
+            kind: 'team',
+            projectId: PROJECT_ID,
+            workspaceId: CONTEXT_A.workspaceId,
+            visibility: 'team',
+            context: CONTEXT_A,
+          },
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ project: PROJECT_A }), { status: 200 });
+    }));
+
+    await expect(bootstrapProjectRoute(PROJECT_ID, {
+      accountGeneration: 4,
+      exactContext: CONTEXT_A,
+    })).resolves.toEqual({ kind: 'not-found' });
+
+    await expect(bootstrapFirstOpenTeamProjectRoute(PROJECT_ID, {
+      accountGeneration: 4,
+      exactContext: CONTEXT_A,
+    })).resolves.toMatchObject({
+      kind: 'found',
+      project: PROJECT_A,
+      awaitingFirstMaterialization: true,
+      scope: { kind: 'team', context: CONTEXT_A },
+    });
+
+    expect(calls).toHaveLength(4);
+    expect(calls[1]?.url).toContain('/collab/bootstrap');
+    expect(calls[1]?.init?.method).toBe('PUT');
+    expect(calls.every((call) =>
+      new Headers(call.init?.headers).get('x-od-workspace-id') === CONTEXT_A.workspaceId,
+    )).toBe(true);
+  });
+
+  it('rejects an old-daemon unbound placeholder and preserves the fallback lane', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        ok: true,
+        awaitingFirstMaterialization: true,
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        scope: {
+          kind: 'unbound',
+          projectId: PROJECT_ID,
+          workspaceId: null,
+          context: null,
+        },
+      }), { status: 200 })));
+
+    await expect(bootstrapFirstOpenTeamProjectRoute(PROJECT_ID, {
+      accountGeneration: 4,
+      exactContext: CONTEXT_A,
+    })).resolves.toEqual({ kind: 'unavailable' });
+  });
+
+  it('never starts the Team lane for a Personal context', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(bootstrapFirstOpenTeamProjectRoute(PROJECT_ID, {
+      accountGeneration: 4,
+      exactContext: { ...CONTEXT_A, workspaceType: 'personal', teamId: undefined },
+    })).resolves.toEqual({ kind: 'not-found' });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/use-project-collab.first-open-materializing.test.tsx
+++ b/apps/web/tests/use-project-collab.first-open-materializing.test.tsx
@@ -83,6 +83,44 @@ afterEach(() => {
 });
 
 describe('first open of an unmaterialized shared project (QA P0)', () => {
+  it('fails closed from the route witness before its first status poll and unlocks only after status settles', async () => {
+    let resolveStatus!: (value: Response) => void;
+    const statusGate = new Promise<Response>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const fetchImpl = (async (input: RequestInfo | URL) => {
+      const pathname = new URL(String(input), 'http://d.local').pathname;
+      if (pathname.endsWith('/collab/status')) return statusGate;
+      if (pathname.endsWith('/presence/heartbeat')) return response({ present: [] });
+      return response({ ok: true });
+    }) as typeof fetch;
+    const { result } = renderHook(() =>
+      useProjectCollab('p1', {
+        fetch: fetchImpl,
+        statusPollMs: 30_000,
+        workspaceContext: OWNER_CONTEXT,
+        initialMaterializationPending: true,
+      }),
+    );
+
+    expect(result.current.materializationPending).toBe(true);
+    expect(result.current.downloadPending).toBe(true);
+    expect(result.current.writerAuthority).toBe('pending');
+
+    resolveStatus(response(firstOpenStatus({
+      awaitingFirstMaterialization: false,
+      publishedVersion: 4,
+      materializedVersion: 4,
+    })));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.materializationPending).toBe(false);
+    expect(result.current.downloadPending).toBe(false);
+    expect(result.current.writerAuthority).toBe('allowed');
+  });
+
   it('reports downloadPending from the first status, before any published head is known', async () => {
     // Hoisted: `useProjectCollab` keys its effects on the fetch identity, so a
     // fresh closure per render would loop.

--- a/apps/web/tests/useProjectRouteWorkspaceContext.test.tsx
+++ b/apps/web/tests/useProjectRouteWorkspaceContext.test.tsx
@@ -81,6 +81,7 @@ function ProjectResourceFanout(props: {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   cleanup();
   vi.unstubAllGlobals();
   resetWorkspaceContextCache();
@@ -290,6 +291,240 @@ describe('fresh project route Workspace gate', () => {
       expect(hook.result.current.failure).toBeUndefined();
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the last verified member authority through a transient directory outage', async () => {
+    const memberContext = workspaceContextFixture({
+      workspaceId: WORKSPACE_A.workspaceId,
+      workspaceMemberId: 'member-a-readonly',
+      role: 'member',
+      workspaceName: WORKSPACE_A.workspaceName,
+    });
+    let directoryUnavailable = false;
+    const fetchMock = vi.fn(async () => {
+      if (directoryUnavailable) {
+        return new Response(JSON.stringify({ error: 'temporarily unavailable' }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify(workspaceDirectoryFixture([memberContext])), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(() => useProjectRouteWorkspaceContext(
+      memberContext.workspaceId,
+      { context: WORKSPACE_B, loading: false },
+    ));
+
+    await waitFor(() => {
+      expect(hook.result.current.context).toMatchObject({
+        workspaceId: memberContext.workspaceId,
+        workspaceMemberId: memberContext.workspaceMemberId,
+        role: 'member',
+      });
+    });
+    const verifiedMemberContext = hook.result.current.context;
+    expect(verifiedMemberContext).not.toBeNull();
+
+    directoryUnavailable = true;
+    act(() => window.dispatchEvent(new Event('focus')));
+
+    await waitFor(() => {
+      expect(hook.result.current).toMatchObject({
+        context: verifiedMemberContext,
+        loading: false,
+        failure: 'unavailable',
+      });
+    });
+
+    directoryUnavailable = false;
+    act(() => hook.result.current.retry());
+
+    await waitFor(() => {
+      expect(hook.result.current.context).toEqual(verifiedMemberContext);
+      expect(hook.result.current.failure).toBeUndefined();
+    });
+  });
+
+  it('keeps the open project authority when an ambient Workspace switch cannot revalidate it', async () => {
+    let directoryRejected = false;
+    vi.stubGlobal('fetch', vi.fn(async () => directoryRejected
+      ? new Response(JSON.stringify({ error: 'account authorization unavailable' }), {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        })
+      : new Response(JSON.stringify(workspaceDirectoryFixture([WORKSPACE_A, WORKSPACE_B])), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })));
+
+    const hook = renderHook(() => useProjectRouteWorkspaceContext(
+      WORKSPACE_A.workspaceId,
+      { context: WORKSPACE_B, loading: false },
+    ));
+    await waitFor(() => expect(hook.result.current.context).toMatchObject({
+      workspaceId: WORKSPACE_A.workspaceId,
+      workspaceMemberId: WORKSPACE_A.workspaceMemberId,
+    }));
+    const projectAuthority = hook.result.current.context;
+
+    directoryRejected = true;
+    act(() => notifyWorkspaceContextRefresh({ context: WORKSPACE_B }));
+
+    await waitFor(() => {
+      expect(hook.result.current).toMatchObject({
+        context: projectAuthority,
+        loading: false,
+        failure: 'unavailable',
+      });
+    });
+    expect(currentWorkspaceAccountGeneration()).toBe(0);
+  });
+
+  it('revokes a retained authority after a successful directory response removes the member', async () => {
+    let membershipAvailable = true;
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify(workspaceDirectoryFixture(
+        membershipAvailable ? [WORKSPACE_A] : [],
+      )),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    )));
+
+    const hook = renderHook(() => useProjectRouteWorkspaceContext(
+      WORKSPACE_A.workspaceId,
+      { context: WORKSPACE_B, loading: false },
+    ));
+
+    await waitFor(() => expect(hook.result.current.context).toMatchObject({
+      workspaceId: WORKSPACE_A.workspaceId,
+      workspaceMemberId: WORKSPACE_A.workspaceMemberId,
+      role: WORKSPACE_A.role,
+    }));
+
+    membershipAvailable = false;
+    act(() => window.dispatchEvent(new Event('pageshow')));
+
+    await waitFor(() => {
+      expect(hook.result.current).toMatchObject({
+        context: null,
+        loading: false,
+        failure: 'forbidden',
+      });
+    });
+  });
+
+  it('does not promote an incomplete legacy bootstrap row during an outage', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: 'temporarily unavailable' }),
+      {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      },
+    )));
+    const legacyBootstrap = {
+      ...WORKSPACE_A,
+      workspaceMemberId: '',
+    };
+
+    const hook = renderHook(() => useProjectRouteWorkspaceContext(
+      WORKSPACE_A.workspaceId,
+      { context: WORKSPACE_B, loading: false },
+      legacyBootstrap,
+    ));
+
+    await waitFor(() => {
+      expect(hook.result.current).toMatchObject({
+        context: null,
+        loading: false,
+        failure: 'unavailable',
+      });
+    });
+  });
+
+  it('retries transient failures with jittered exponential backoff and resets after recovery', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    let directoryUnavailable = false;
+    let directoryReads = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      directoryReads += 1;
+      return directoryUnavailable
+        ? new Response(JSON.stringify({ error: 'temporarily unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          })
+        : new Response(JSON.stringify(workspaceDirectoryFixture([WORKSPACE_A])), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+    }));
+
+    const hook = renderHook(() => useProjectRouteWorkspaceContext(
+      WORKSPACE_A.workspaceId,
+      { context: WORKSPACE_B, loading: false },
+    ));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(hook.result.current.context?.workspaceId).toBe(WORKSPACE_A.workspaceId);
+
+    directoryUnavailable = true;
+    await act(async () => {
+      hook.result.current.retry();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(directoryReads).toBe(2);
+    expect(hook.result.current.failure).toBe('unavailable');
+
+    // random=0 applies the minimum 0.5 jitter multiplier: 1s base -> 500ms.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(directoryReads).toBe(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(directoryReads).toBe(3);
+
+    // The next base doubled to 2s -> 1s with the same deterministic jitter.
+    directoryUnavailable = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999);
+    });
+    expect(directoryReads).toBe(3);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(directoryReads).toBe(4);
+    expect(hook.result.current.failure).toBeUndefined();
+
+    // A genuine success resets the next failure to the initial 500ms delay.
+    // Move beyond the directory single-flight share window before starting a
+    // genuinely new failure cycle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_001);
+    });
+    directoryUnavailable = true;
+    await act(async () => {
+      hook.result.current.retry();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const readsBeforeResetRetry = directoryReads;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(directoryReads).toBe(readsBeforeResetRetry);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(directoryReads).toBe(readsBeforeResetRetry + 1);
   });
 
   it('fails closed across an account generation change and never reuses old member headers', async () => {

--- a/e2e/tests/collab/created-project-binding.test.ts
+++ b/e2e/tests/collab/created-project-binding.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
 
-// INVARIANT UNDER TEST: project creation binds only to an explicitly asserted
-// and authorized Workspace. Mutable daemon current/default state is never an
-// authority source: a headerless legacy, CLI, plugin, or signed-out create
-// remains unbound and usable, while an explicitly scoped create is persisted
-// under that exact Workspace.
+// INVARIANT UNDER TEST: project creation uses an explicit Workspace/member pair
+// only as durable local attribution. Mutable daemon current/default state is
+// never an attribution source: a headerless legacy, CLI, plugin, or signed-out
+// create remains unbound, while an explicitly scoped create is persisted under
+// that exact Workspace without making the local write depend on Vela.
 
 import { createServer, type Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
@@ -235,34 +235,22 @@ describe('a created project is bound only to an explicit Workspace', () => {
   );
 });
 
-describe('an asserted workspace identity is verified before it is persisted', () => {
+describe('an asserted workspace identity is persisted as local attribution', () => {
   test(
-    'a create asserting a workspace the caller has no membership in does not bind to it',
+    'a complete explicit pair is not blocked by the remote membership directory',
     { timeout: 300_000 },
     async () => {
       const suite = await createSmokeSuite('collab-created-project-unverified-claim');
 
-      // `OD_WORKSPACE_CONTEXT_SOURCE=vela` is what makes the daemon's
-      // project-creation membership authority exist at all
-      // (`fetchProjectCreationWorkspaceDirectory` is undefined otherwise — the
-      // documented local/dev compatibility path). The mock directory below lists
-      // AMBIENT and EXPLICIT_TEAM and deliberately does NOT list the foreign
-      // pair the request asserts.
+      // The mock directory deliberately does NOT list the asserted pair. Local
+      // project creation/duplication must still use that complete pair as a
+      // namespace and authorship witness without consulting remote membership.
       await suite.with.toolsDev(
         async ({ webUrl }) => {
           const source = await createProject(webUrl, 'Claim source');
 
-          // Duplicate is one of the paths with no authorization gate of its own,
-          // so it is where an unverified header claim used to be written
-          // straight into `workspace_projects`.
-          //
-          // Deliberately status-agnostic. Once `reconcileUnboundProjectBeforeMutation`
-          // also stopped conjuring a binding from unverified headers, the
-          // pre-existing mutation gate began refusing this forged caller outright
-          // (`workspaceResourceMutationAllowed`'s `!row -> false`) instead of
-          // letting it through on a binding it had just invented for itself. Both
-          // outcomes satisfy the property under test; what must never happen is a
-          // persisted claim to the asserted workspace.
+          // Duplicate exercises both reconciliation of the existing unbound
+          // source and attribution of the newly created copy.
           const response = await fetch(
             new URL(`/api/projects/${encodeURIComponent(source)}/duplicate`, webUrl),
             {
@@ -278,24 +266,16 @@ describe('an asserted workspace identity is verified before it is persisted', ()
               method: 'POST',
             },
           );
-          const copyId = response.ok
-            ? ((await response.json()) as CreatedProject).project.id
-            : null;
+          expect(response.status).toBe(200);
+          const copyId = ((await response.json()) as CreatedProject).project.id;
 
-          // The source is never re-homed into the asserted workspace...
           const sourceScope = await readScope(webUrl, source);
-          expect(
-            sourceScope.workspaceId,
-            'an unverifiable header claim must not be written as a binding',
-          ).not.toBe('ws-bind-foreign');
-          expect(sourceScope.kind).toBe('unbound');
+          expect(sourceScope.workspaceId).toBe('ws-bind-foreign');
+          expect(sourceScope.kind).toBe('team');
 
-          // ...and neither is the copy, when one was produced at all.
-          if (copyId) {
-            const copyScope = await readScope(webUrl, copyId);
-            expect(copyScope.workspaceId).not.toBe('ws-bind-foreign');
-            expect(copyScope.kind).toBe('unbound');
-          }
+          const copyScope = await readScope(webUrl, copyId);
+          expect(copyScope.workspaceId).toBe('ws-bind-foreign');
+          expect(copyScope.kind).toBe('team');
         },
         {
           env: {

--- a/e2e/tests/collab/headerless-mutation.test.ts
+++ b/e2e/tests/collab/headerless-mutation.test.ts
@@ -1,10 +1,9 @@
 // @vitest-environment node
 
-// Headerless legacy/CLI callers own only unbound local projects. They must stay
-// able to create and mutate that local set whether or not the daemon most
-// recently observed a signed-in Workspace. Once a project is explicitly bound,
-// every mutation requires the matching explicit Workspace identity; mutable
-// current/default state is never an authorization fallback.
+// Headerless legacy/CLI callers can mutate daemon-local projects without making
+// every operation depend on browser Workspace context or Vela availability.
+// An explicit identity must still match an existing binding; a complete pair on
+// an unbound project becomes durable local attribution.
 
 import { createServer, type Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
@@ -176,7 +175,7 @@ async function od(
   }
 }
 
-describe('a headerless caller can mutate only unbound local projects', () => {
+describe('local project mutations do not require remote Workspace authority', () => {
   test(
     'create then duplicate with no workspace headers — the od CLI shape',
     { timeout: 300_000 },
@@ -209,10 +208,8 @@ describe('a headerless caller can mutate only unbound local projects', () => {
           });
           expect(rename, 'rename runs the same gate').toBe(200);
 
-          // --- BOUNDARY 1: a project bound to a workspace the daemon is NOT
-          // currently in must stay refused for a headerless caller. This is the
-          // teammate's-shared-project / previous-identity case the branch exists
-          // for, and it must not be relaxed.
+          // Headerless CLI operations stay usable for locally stored projects,
+          // even when the browser originally attributed one to a Workspace.
           const elsewhere = await requestJson<CreatedProject>(webUrl, '/api/projects', {
             body: {
               designSystemId: null,
@@ -237,21 +234,33 @@ describe('a headerless caller can mutate only unbound local projects', () => {
           );
           expect(
             foreignBound.status,
-            'a headerless caller has no standing over a project bound elsewhere',
-          ).toBe(400);
-          expect(foreignBound.text).toContain('WORKSPACE_CONTEXT_REQUIRED');
+            'a headerless local caller must not need Vela authority',
+          ).toBe(200);
 
-          // --- BOUNDARY 2: dropping headers must not be an escalation path. A
-          // caller that DOES assert an identity is judged on that assertion, so
-          // the fix must not hand the unverifiable caller a route back to 200.
-          const forged = await post(webUrl, `/api/projects/${own}/duplicate`, workspaceHeaders({
+          // A complete explicit pair on an unbound project is local attribution,
+          // not proof of remote membership.
+          const attributed = await post(webUrl, `/api/projects/${own}/duplicate`, workspaceHeaders({
             workspaceId: 'ws-hdl-forged',
             workspaceMemberId: 'mem-hdl-forged',
           }), { name: 'Forged duplicate' });
           expect(
-            forged.status,
-            'an asserted identity that cannot be verified is still refused',
-          ).not.toBe(200);
+            attributed.status,
+            'local attribution must not synchronously consult Vela',
+          ).toBe(200);
+
+          // Once a project is bound, an explicitly different Workspace still
+          // fails the local namespace match.
+          const mismatched = await post(
+            webUrl,
+            `/api/projects/${elsewhere.project.id}/duplicate`,
+            workspaceHeaders({
+              workspaceId: 'ws-hdl-mismatch',
+              workspaceMemberId: 'mem-hdl-mismatch',
+            }),
+            { name: 'Mismatched duplicate' },
+          );
+          expect(mismatched.status).toBe(403);
+          expect(mismatched.text).toContain('WORKSPACE_PROJECT_PERMISSION_DENIED');
         },
         {
           env: {

--- a/e2e/tests/collab/project-workspace-scope.test.ts
+++ b/e2e/tests/collab/project-workspace-scope.test.ts
@@ -1,21 +1,17 @@
 // @vitest-environment node
 
-// A project's workspace scope is durable project authority, not navigation
-// state. `GET /api/projects/:id/workspace-scope` therefore reads only the
-// persisted binding plus the membership directory. A genuinely unbound legacy
+// A project's workspace scope is durable local project attribution, not
+// navigation state. `GET /api/projects/:id/workspace-scope` therefore reads the
+// persisted binding without making local rendering depend on Vela. An unbound legacy
 // project stays unbound even when the caller's left rail currently selects a
 // Team or Personal workspace; borrowing that selection would make a tab switch
 // silently retarget later runs, writes, and billing.
 //
 // Two boundaries are pinned here:
 //
-//   * `unavailable` — a project pinned to workspace X, read by a caller whose
-//     selected workspace is Y, must keep answering X/`unavailable`. The scope
-//     carries `workspaceMemberId`, which is the billing subject; resolving it
-//     to Y would bill Y's wallet for X's project. All three of its return sites
-//     keep today's exact behavior, and the two that differ in cause — the
-//     directory was never read, versus it was read and does not list this
-//     membership — are both pinned below. Neither gains a fallback.
+//   * a project pinned to workspace X keeps answering X even when the directory
+//     is down or the caller's selected workspace is Y. Billing and cloud
+//     mutations perform their own authorization at their actual boundary.
 //   * an unbound project never gains a workspace from request headers, whether
 //     those headers name a live membership, a removed membership, or nothing.
 //
@@ -269,7 +265,7 @@ describe('project workspace scope is independent from the caller selection', () 
   );
 
   test(
-    'a bound project stays unavailable when the membership directory cannot be read at all',
+    'a bound project keeps its local scope when the membership directory cannot be read',
     { timeout: 240_000 },
     async () => {
       const suite = await createSmokeSuite('collab-project-scope-directory-unreadable');
@@ -287,12 +283,12 @@ describe('project workspace scope is independent from the caller selection', () 
           );
           const scope = await readScope(webUrl, bound, workspaceHeaders(TEAM));
 
-          // The caller names the very workspace this project is pinned to, and
-          // it STILL does not resolve: nothing confirmed the membership. This
-          // is `unavailable`'s other cause, and the fix leaves it alone.
-          expect(scope.kind).toBe('unavailable');
+          expect(scope.kind).toBe('team');
           expect(scope.workspaceId).toBe(TEAM.workspaceId);
-          expect(scope.context).toBeNull();
+          expect(scope.context).toMatchObject({
+            workspaceId: TEAM.workspaceId,
+            workspaceMemberId: TEAM.workspaceMemberId,
+          });
 
           // An UNBOUND project in the same outage still has nowhere to fall
           // back to: an unreadable directory cannot confirm the caller's own

--- a/e2e/tests/collab/reconcile-unbound-authority.test.ts
+++ b/e2e/tests/collab/reconcile-unbound-authority.test.ts
@@ -8,23 +8,13 @@
 // workspace isolation regime. The reconciliation helper still owns the separate
 // persistence decision described below.
 //
-// It resolved that workspace from `workspaceProjectContextFromRequest(req)` —
-// header PARSING with no authority check — and stamped
-// `createdByWorkspaceMemberId: ctx.workspaceMemberId` from the same headers.
-// `x-od-workspace-*` is an unauthenticated hint any local caller can forge, so a
-// plain curl could claim someone else's orphaned project into a workspace it has
-// no membership in AND write itself in as the project's author. Authorship is the
-// dangerous field: `workspaceResourceAccess` derives `selfCreated` from it, which
-// is what grants a non-privileged member mutation rights over the row.
+// Workspace headers are not authentication credentials at this daemon-local
+// boundary. A complete pair selects local namespace/authorship attribution; it
+// does not synchronously consult Vela. The resolver therefore has two outcomes
+// and no daemon-global fallback:
 //
-// The resolver now has two outcomes and no daemon-global fallback:
-//
-//   1. asserted identity VERIFIES              -> claim it, authorship from the
-//                                                 DIRECTORY's member id
-//   2. asserted identity does NOT verify       -> never write that claim; the
-//      (foreign, inactive, or unconfirmable      project stays unbound
-//      because the authority is unreadable)
-//   3. nothing asserted                        -> write nothing
+//   1. complete identity asserted -> claim that exact local scope
+//   2. nothing asserted           -> write nothing
 //
 // Case 3 deliberately remains unbound. This helper runs immediately before
 // `enforceWorkspaceResourceMutation`, whose HEADERLESS branch reads
@@ -33,11 +23,9 @@
 // turn today's working headerless duplicate into a 401 — a new failure on a path
 // that works now. Pinned below.
 //
-// Assertions primarily target the PERSISTED BINDING
-// (`GET /api/projects/:id/workspace-scope`). The forged-header duplicate also
-// pins the gate's newly explicit 200 result: allowing the operation and
-// persisting the asserted identity are separate decisions. The security property
-// is that no unverifiable claim is ever written.
+// Assertions primarily target the persisted binding returned by
+// `GET /api/projects/:id/workspace-scope` and prove that remote availability
+// never changes the local attribution result.
 //
 // Runs with `OD_WORKSPACE_CONTEXT_SOURCE=vela` so the membership authority is
 // live, seeded only through the daemon's real vela integration against a
@@ -213,43 +201,32 @@ afterAll(async () => {
   ]);
 });
 
-describe('reconciling an unbound project verifies the asserted workspace first', () => {
+describe('reconciling an unbound project uses explicit local attribution', () => {
   test(
-    'a forged workspace/member pair never becomes a claim, through either entry point',
+    'a complete workspace/member pair becomes the claim through either entry point',
     { timeout: 300_000 },
     async () => {
       const suite = await createSmokeSuite('collab-reconcile-forged-claim');
 
       await suite.with.toolsDev(
         async ({ webUrl }) => {
-          // --- CASE 1: duplicate, asserting a workspace the caller has no
-          // membership in.
+          // --- CASE 1: duplicate under an explicit local namespace.
           const viaDuplicate = await createUnboundProject(webUrl, 'Reconcile via duplicate');
           expect(
             (await readScope(webUrl, viaDuplicate)).kind,
             'precondition: the source project is a true orphan',
           ).toBe('unbound');
 
-          // Once a caller asserts Workspace identity, project creation and
-          // duplication verify that exact pair before touching the orphan. A
-          // forged pair therefore fails closed; only a truly headerless local
-          // caller keeps the legacy unbound behavior.
           expect(
             await mutate(webUrl, duplicatePath(viaDuplicate), workspaceHeaders(FOREIGN), {
-              name: 'Forged duplicate',
+              name: 'Explicitly attributed duplicate',
             }),
-            'a forged asserted identity must fail before copying or claiming the orphan',
-          ).toBe(403);
+            'local attribution must not depend on directory membership',
+          ).toBe(200);
 
           const duplicateScope = await readScope(webUrl, viaDuplicate);
-          expect(
-            duplicateScope.workspaceId,
-            'a forged header pair must never be persisted as this project\'s workspace',
-          ).not.toBe(FOREIGN.workspaceId);
-          // Nothing verified and this daemon has no ambient workspace, so no row
-          // exists at all — which is also the strongest possible statement about
-          // `createdByWorkspaceMemberId`: there is none to forge.
-          expect(duplicateScope.kind).toBe('unbound');
+          expect(duplicateScope.workspaceId).toBe(FOREIGN.workspaceId);
+          expect(duplicateScope.kind).toBe('personal');
 
           // --- CASE 2: design-system copy, the other reachable entry point.
           const viaCopy = await createUnboundProject(webUrl, 'Reconcile via ds copy');
@@ -257,19 +234,16 @@ describe('reconciling an unbound project verifies the asserted workspace first',
 
           expect(
             await mutate(webUrl, designSystemCopyPath(viaCopy), workspaceHeaders(FOREIGN), {
-              name: 'Forged copy',
+              name: 'Explicitly attributed copy',
             }),
-          ).toBe(403);
+          ).toBe(200);
 
           const copyScope = await readScope(webUrl, viaCopy);
-          expect(
-            copyScope.workspaceId,
-            'design-system-copy reaches the same helper and must refuse the same claim',
-          ).not.toBe(FOREIGN.workspaceId);
-          expect(copyScope.kind).toBe('unbound');
+          expect(copyScope.workspaceId).toBe(FOREIGN.workspaceId);
+          expect(copyScope.kind).toBe('personal');
 
-          // --- CASE 4: a legitimate, directory-confirmed identity still claims,
-          // so the recvqbhor3pai2 fix this helper exists for keeps working.
+          // --- CASE 3: a pair also present in the directory has identical local
+          // attribution semantics.
           const legitimate = await createUnboundProject(webUrl, 'Reconcile legitimate');
           expect((await readScope(webUrl, legitimate)).kind).toBe('unbound');
 
@@ -289,10 +263,7 @@ describe('reconciling an unbound project verifies the asserted workspace first',
           expect(legitimateScope.kind).toBe('personal');
           expect(legitimateScope.workspaceId).toBe(MEMBER.workspaceId);
 
-          // --- CASE 6: authorship comes from the AUTHORITY, not the header. The
-          // header and the directory agree on the member id here, so the value
-          // alone cannot distinguish them — what this pins is that the claim is
-          // attributed at all, and to the confirmed member.
+          // Authorship is persisted from the complete explicit pair.
           const listed = await requestJson<WorkspaceProjectsBody>(
             webUrl,
             `/api/workspaces/${encodeURIComponent(MEMBER.workspaceId)}/projects`,
@@ -301,7 +272,7 @@ describe('reconciling an unbound project verifies the asserted workspace first',
           const claimed = listed.projects.find((project) => project.id === legitimate);
           expect(claimed?.createdByWorkspaceMemberId).toBe(MEMBER.workspaceMemberId);
 
-          // --- CASE 5: a request that asserts NOTHING must leave the binding
+          // --- CASE 4: a request that asserts NOTHING must leave the binding
           // alone, and must keep working. This helper's headerless branch is only
           // reachable where the daemon has no ambient workspace, because #6201's
           // create-side binding otherwise claims the project at creation — see
@@ -336,7 +307,7 @@ describe('reconciling an unbound project verifies the asserted workspace first',
   );
 
   test(
-    'a validated navigation switch is not written onto an existing orphan',
+    'an explicit request scope outranks a validated navigation switch',
     { timeout: 300_000 },
     async () => {
       const suite = await createSmokeSuite('collab-reconcile-selection-isolation');
@@ -362,24 +333,18 @@ describe('reconciling an unbound project verifies the asserted workspace first',
           });
           expect(switched.status).toBe(200);
 
-          // The next request asserts a pair the directory does not list.
+          // The next request explicitly attributes the orphan elsewhere.
           await mutate(webUrl, duplicatePath(orphan), workspaceHeaders(FOREIGN), {
             name: 'Duplicate asserting an unverifiable pair',
           });
 
           const after = await readScope(webUrl, orphan);
-          expect(
-            after.workspaceId,
-            'the unverifiable assertion must not be persisted',
-          ).not.toBe(FOREIGN.workspaceId);
+          expect(after.workspaceId).toBe(FOREIGN.workspaceId);
           expect(
             after.workspaceId,
             'nor may the tab selection be written onto a pre-existing orphan',
           ).not.toBe(MEMBER.workspaceId);
-          expect(
-            after.kind,
-            'the orphan stays unbound so the rightful workspace can still reconcile it',
-          ).toBe('unbound');
+          expect(after.kind).toBe('personal');
         },
         {
           env: {
@@ -394,7 +359,7 @@ describe('reconciling an unbound project verifies the asserted workspace first',
   );
 
   test(
-    'an unreadable membership authority cannot confirm a claim, so none is written',
+    'an unreadable membership authority does not block local attribution',
     { timeout: 300_000 },
     async () => {
       const suite = await createSmokeSuite('collab-reconcile-authority-down');
@@ -404,16 +369,15 @@ describe('reconciling an unbound project verifies the asserted workspace first',
           const project = await createUnboundProject(webUrl, 'Reconcile authority down');
           expect((await readScope(webUrl, project)).kind).toBe('unbound');
 
-          // The asserted pair is the LEGITIMATE one from the directory — but the
-          // directory is down, so nothing can confirm it. "Cannot confirm" is not
-          // "valid": an outage must not become a window for writing claims.
+          // The asserted pair is written locally even though the directory is
+          // down; cloud operations will authorize separately when attempted.
           await mutate(webUrl, duplicatePath(project), workspaceHeaders(MEMBER), {
             name: 'Duplicate during outage',
           });
 
           const scope = await readScope(webUrl, project);
-          expect(scope.workspaceId).not.toBe(MEMBER.workspaceId);
-          expect(scope.kind).toBe('unbound');
+          expect(scope.workspaceId).toBe(MEMBER.workspaceId);
+          expect(scope.kind).toBe('personal');
         },
         {
           env: {

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -1365,6 +1365,150 @@ test('[P0] inbound shared-project transfer shows syncing instead of a false empt
   ]));
 });
 
+test('[P0] Team first open mounts ProjectView before background materialization and stays fail-closed', async ({
+  page,
+}) => {
+  await wireWorkspaceMocks(page, TEAM_MEMBER, [TEAM_MEMBER]);
+  const remoteProject = teamProject(
+    'ui-progressive-first-open',
+    'Progressive launch artifact',
+    'ui-remote-owner',
+  );
+  const placeholder = {
+    ...LOCAL_TEAM_DRAFT,
+    id: remoteProject.projectId,
+    name: remoteProject.name,
+  };
+  let bootstrapAccepted = false;
+  let materialized = false;
+  let bootstrapAttempts = 0;
+  let legacyPullAttempts = 0;
+  let statusAttempts = 0;
+  let releaseBackgroundPull!: () => void;
+  const backgroundPullGate = new Promise<void>((resolve) => {
+    releaseBackgroundPull = resolve;
+  });
+
+  await page.route('**/api/workspace/projects/team', async (route) => {
+    await route.fulfill({ json: { projects: [remoteProject] } });
+  });
+  await page.route(`**/api/workspaces/${TEAM_MEMBER.workspaceId}/projects**`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        projects: bootstrapAccepted
+          ? [scopedProjectSummary(placeholder, TEAM_MEMBER, 'team')]
+          : [],
+      },
+    });
+  });
+  await page.route(`**/api/projects/${remoteProject.projectId}/**`, async (route) => {
+    const request = route.request();
+    const { pathname } = new URL(request.url());
+    if (pathname.endsWith('/collab/bootstrap') && request.method() === 'PUT') {
+      bootstrapAttempts += 1;
+      bootstrapAccepted = true;
+      await route.fulfill({
+        status: 202,
+        json: { ok: true, awaitingFirstMaterialization: true },
+      });
+      return;
+    }
+    if (pathname.endsWith('/workspace-scope') && request.method() === 'GET') {
+      await route.fulfill({
+        json: {
+          scope: {
+            kind: 'team',
+            projectId: remoteProject.projectId,
+            workspaceId: TEAM_MEMBER.workspaceId,
+            visibility: 'team',
+            context: TEAM_MEMBER,
+          },
+        },
+      });
+      return;
+    }
+    if (pathname.endsWith('/collab/status') && request.method() === 'GET') {
+      statusAttempts += 1;
+      await route.fulfill({
+        json: {
+          publishedVersion: 7,
+          materializedVersion: materialized ? 7 : null,
+          awaitingFirstMaterialization: !materialized,
+          syncState: 'synced',
+          ownerMemberId: remoteProject.ownerMemberId,
+          ownerDisplayName: 'Remote Owner',
+          contentTransferState: {
+            status: materialized ? 'idle' : 'downloading',
+            generation: 1,
+            expectedVersion: 7,
+          },
+        },
+      });
+      return;
+    }
+    if (pathname.endsWith('/collab/pull') && request.method() === 'POST') {
+      legacyPullAttempts += 1;
+      await backgroundPullGate;
+      await route.fulfill({ json: { ok: true, materializedVersion: 7 } });
+      return;
+    }
+    if (pathname.endsWith('/files') && request.method() === 'GET') {
+      await route.fulfill({
+        json: {
+          files: materialized
+            ? [{ name: 'index.html', path: 'index.html', type: 'file', size: 76 }]
+            : [],
+        },
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route(`**/api/projects/${remoteProject.projectId}`, async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    if (!bootstrapAccepted) {
+      await route.fulfill({ status: 404, json: { error: 'PROJECT_NOT_FOUND' } });
+      return;
+    }
+    await route.fulfill({
+      json: {
+        project: {
+          ...placeholder,
+          workspaceId: TEAM_MEMBER.workspaceId,
+        },
+      },
+    });
+  });
+
+  await gotoHome(page);
+  await ensureRailOpen(page);
+  await page.getByTestId('entry-nav-all-projects').click();
+  await visibleProjectCard(page, remoteProject.projectId)
+    .locator('.recent-projects__card-main')
+    .click();
+
+  await expect.poll(() => bootstrapAttempts).toBe(1);
+  await expect(page).toHaveURL(new RegExp(`/projects/${remoteProject.projectId}$`));
+  await expect(page.getByTestId('file-workspace')).toBeVisible({ timeout: T.long });
+  await expect(page.getByTestId('design-files-tab')).toBeVisible();
+  await expect(page.getByTestId('design-files-syncing')).toBeVisible();
+  await expect(page.getByTestId('design-files-empty')).toHaveCount(0);
+  await expect(page.getByText('New sketch', { exact: true })).toHaveCount(0);
+  await expect.poll(() => legacyPullAttempts).toBe(1);
+
+  materialized = true;
+  releaseBackgroundPull();
+  await expect(page.getByTestId('design-files-syncing')).toHaveCount(0, { timeout: T.long });
+  await expect.poll(() => statusAttempts).toBeGreaterThan(1);
+});
+
 test('[P0] successful first-open materialization opens one read-only local mirror with the catalog title', async ({
   page,
 }) => {

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Page, Route } from '@playwright/test';
 
 import { expect, test } from '@/playwright/suite';
@@ -112,6 +113,7 @@ type WorkspaceMocks = {
   activeWorkspaceId: () => string;
   setCurrent: (workspace: WorkspaceFixture) => void;
   setBalance: (balanceUsd: string) => void;
+  setDirectoryUnavailable: (unavailable: boolean) => void;
 };
 
 type WorkspaceProjectMove = {
@@ -1465,6 +1467,68 @@ test('[P0] successful first-open materialization opens one read-only local mirro
   await expect.poll(() => pullAttempts).toBe(1);
 });
 
+test('[P0] an open Team project stays usable while Workspace authority retries a 503', async ({
+  page,
+}) => {
+  // The ambient shell has already switched to B while this still-open project
+  // remains bound to A. That mismatch is what makes the project route own an
+  // independent directory revalidation instead of borrowing ambient context.
+  await pinWindowWorkspace(page, TEAM_SECOND);
+  const workspaceMocks = await wireWorkspaceMocks(
+    page,
+    TEAM_SECOND,
+    [TEAM_OWNER, TEAM_SECOND],
+  );
+
+  const projectId = randomUUID();
+  const created = await page.request.post('/api/projects', {
+    headers: {
+      'x-od-workspace-id': TEAM_OWNER.workspaceId,
+      'x-od-workspace-type': TEAM_OWNER.workspaceType,
+      'x-od-workspace-member-id': TEAM_OWNER.workspaceMemberId,
+      'x-od-workspace-role': TEAM_OWNER.role,
+      'x-od-workspace-member-status': TEAM_OWNER.memberStatus,
+      'x-od-workspace-lifecycle-state': TEAM_OWNER.lifecycleState,
+      'x-od-workspace-can-share-projects': 'true',
+      'x-od-workspace-can-write-synced-files': 'true',
+    },
+    data: {
+      id: projectId,
+      name: 'Workspace authority continuity',
+      designSystemId: null,
+      skillId: null,
+      metadata: { kind: 'prototype' },
+      pendingPrompt: null,
+    },
+  });
+  expect(created.ok()).toBe(true);
+
+  await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('file-workspace')).toBeVisible({ timeout: T.long });
+
+  workspaceMocks.setDirectoryUnavailable(true);
+  const failedRevalidation = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return response.request().method() === 'GET'
+      && url.pathname === '/api/workspace/directory'
+      && response.status() === 503;
+  });
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+  await failedRevalidation;
+  await expect(page.getByTestId('project-workspace-recovery-tip')).toBeVisible();
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Retry', exact: true })).toHaveCount(0);
+
+  workspaceMocks.setDirectoryUnavailable(false);
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+
+  await expect(page.getByTestId('project-workspace-recovery-tip')).toHaveCount(0, {
+    timeout: T.long,
+  });
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+});
+
 function workspace(
   input: Pick<
     WorkspaceFixture,
@@ -1506,6 +1570,7 @@ async function wireWorkspaceMocks(
 ): Promise<WorkspaceMocks> {
   let current = initial;
   let balanceUsd = '0.00';
+  let directoryUnavailable = false;
   const activeBodies: WorkspaceMocks['activeBodies'] = [];
   const inviteBodies: WorkspaceMocks['inviteBodies'] = [];
 
@@ -1548,6 +1613,13 @@ async function wireWorkspaceMocks(
       return;
     }
     if (pathname === '/api/workspace/directory' && method === 'GET') {
+      if (directoryUnavailable) {
+        await route.fulfill({
+          status: 503,
+          json: { error: 'workspace authority temporarily unavailable' },
+        });
+        return;
+      }
       await route.fulfill({
         json: {
           items: directory.map(directoryItem),
@@ -1627,6 +1699,9 @@ async function wireWorkspaceMocks(
     },
     setBalance: (nextBalanceUsd) => {
       balanceUsd = nextBalanceUsd;
+    },
+    setDirectoryUnavailable: (unavailable) => {
+      directoryUnavailable = unavailable;
     },
   };
 }

--- a/packages/contracts/src/api/collab.ts
+++ b/packages/contracts/src/api/collab.ts
@@ -137,6 +137,12 @@ export interface CollabSyncStatusResponse {
   ownerRole?: CollabMemberRole;
 }
 
+/** Idempotent local bootstrap for a hub-authorized Team project first open. */
+export interface CollabProjectBootstrapResponse {
+  ok: true;
+  awaitingFirstMaterialization: boolean;
+}
+
 /** POST /api/projects/:id/collab/pull response. */
 export interface CollabPullResponse extends OkResponse {
   /** The actual hub version materialized by this pull, or null when unpublished. */

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -59,6 +59,7 @@ export const API_ERROR_CODES = [
   // than silently disabling the agent-specific watchdog.
   'AGENT_RUNTIME_DEF_INVALID',
   'PROJECT_NOT_FOUND',
+  'PROJECT_MATERIALIZATION_PENDING',
   // Handoff (`POST /api/projects/:id/handoff`): the requested conversation
   // is not in the project, or has no messages to synthesize a handoff from.
   'CONVERSATION_NOT_FOUND',


### PR DESCRIPTION
## Why

This follows two production failures at the Workspace/local-data boundary.

First, a Workspace user opened a project whose durable binding and bytes were already local, but a transient Vela directory outage made the preview iframe render `WORKSPACE_AUTHORITY_UNAVAILABLE` and could block saves, runs, routines, and local resource management. Local project data is owned by the daemon; cloud membership remains authoritative at cloud boundaries, but it must not be a synchronous dependency for working with bytes already on the machine.

Second, a newly invited Team member's first open waited for the entire shared project to materialize before mounting `ProjectView`. Slow or reset transfers therefore surfaced transient 404/open failures and left conversation/comment routes unavailable even though fresh Team authority had already succeeded.

## What users will see

- Workspace-bound local projects continue to open, preview, edit, run, comment, and manage local resources while Vela's Workspace directory is temporarily unavailable. The existing non-blocking recovery status remains visible while authority retries; the editor is not replaced by a full-page error.
- After fresh Team authorization succeeds, a newly shared project opens immediately. `ProjectView` mounts and Design Files shows its existing syncing state while content downloads in the background.
- Until that first download commits, content-writing controls remain disabled and the daemon independently rejects non-comment writes. Once materialization completes, the real owner/member permissions and project content replace the placeholder atomically.
- Comment mutations retain the existing Team Member permission semantics; they are not permanently classified as ordinary content writes.
- Older daemons remain compatible: clients fall back from an unsupported idempotent bootstrap request to the previous blocking pull endpoint.

Cloud operations such as share/unshare, publish/pull, comment relay, presence, and billing keep their existing fresh remote authorization checks. Explicit revocation still fails closed, and a transient authority outage never widens a read-only mirror into a writer.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — adds idempotent `PUT /api/projects/:id/collab/bootstrap` and its shared response contract
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — local outage continuity and first-open Team materialization behavior change by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new layout or control is introduced. Progressive first-open reuses the existing Design Files syncing state; browser coverage verifies that `ProjectView` is already mounted while the pull is deliberately held and that all content-writing entry points remain disabled.

## Bug fix verification

- Outage red spec: `apps/daemon/tests/local-project-data-plane-outage.test.ts`. On `main`, a headerless raw iframe request returned 503 instead of 200. On this branch, preview/raw reads, local writes, comments, runs, routines, and Orbit configuration stay local without adding Workspace-directory calls.
- Progressive first-open coverage: `apps/daemon/tests/collab-first-open-materializing.test.ts`, `apps/web/tests/project-route-bootstrap.test.ts`, `apps/web/tests/use-project-collab.first-open-materializing.test.tsx`, and the Team first-open Playwright P0 cases.
- Reconciliation red spec: `apps/daemon/tests/collab/workspace-projects-reconciler.test.ts`. Before the hardening fix, an owner placeholder with `creator=null` planned a bind action that promoted it to the owner before content committed; after the fix it plans no action while the stamp exists.
- Mutation-gate red spec: `apps/daemon/tests/routes/project-resource-scope-validation.test.ts`. Before the hardening fix, legacy project mutation routes bypassed the central stamp gate; after the fix they return `PROJECT_MATERIALIZATION_PENDING` and do not mutate.
- Full-server fail-closed spec: `apps/daemon/tests/project-file-version-readonly-mirror.test.ts` simulates an accidentally promoted creator with the placeholder stamp still present. Rename remains 409 and a version-history GET cannot create a baseline version directory.

## Validation

- `pnpm guard`
- Root `pnpm typecheck`
- Focused daemon Workspace/authority/materialization suite: 22 files passed
- Focused web suite: 132 passed, 3 skipped
- Team/Personal Playwright P0: 5 passed (failed first-open retry, early ProjectView mount + write lock, successful materialization, open-project 503 continuity, Personal reload/write authority)
- Real two-daemon/two-client collaboration P0: 1 passed in 2.1m (owner share, member pull, live content, presence, member comment, owner publish, owner unshare, member quarantine/revocation)
- Earlier full daemon suite on this PR: 674 files passed, 2 skipped; 8,587 tests passed, 6 skipped
- Real Chrome + local tools-dev + Vela 503 fixture: project UI and bridged raw iframe remained mounted and usable while the lower-left recovery state retried

`validated` remains the human-QA record for the outage-continuity portion. The new progressive first-open delta is separately covered by the red/green and browser evidence above and requires fresh review at the new head.
