### PR TITLE
fix(deploy): ship data/ so Docker images keep their baked plugin previews

### DIFF
--- a/apps/daemon/src/plugins/plugin-preview-bakes.ts
+++ b/apps/daemon/src/plugins/plugin-preview-bakes.ts
@@ -46,9 +46,25 @@ export function resolvePluginPreviewsDir(projectRoot: string): string {
 
 let cache: { dir: string; mtimeMs: number; previews: Record<string, BakeEntry> } | null = null;
 
+// Absent-manifest notices are one-per-path: `loadManifest` runs on every plugin
+// listing, and a deployment that has no manifest has none on every call.
+const warnedMissing = new Set<string>();
+
 function loadManifest(dir: string): Record<string, BakeEntry> {
   const manifestPath = path.join(dir, 'manifest.json');
-  if (!existsSync(manifestPath)) return {};
+  if (!existsSync(manifestPath)) {
+    // Same reasoning as the malformed case below: with no manifest every baked
+    // preview is disabled and every plugin falls back to a live iframe, which
+    // looks like nothing more than a slower gallery. Say so once, so the cause
+    // is greppable instead of having to be inferred from the rendering path.
+    if (!warnedMissing.has(manifestPath)) {
+      warnedMissing.add(manifestPath);
+      console.warn(
+        `[plugin-preview-bakes] no manifest at ${manifestPath}; baked previews are disabled and every plugin will use the live preview path`,
+      );
+    }
+    return {};
+  }
   try {
     const mtimeMs = statSync(manifestPath).mtimeMs;
     if (cache && cache.dir === dir && cache.mtimeMs === mtimeMs) return cache.previews;

--- a/apps/daemon/tests/plugin-preview-bakes.test.ts
+++ b/apps/daemon/tests/plugin-preview-bakes.test.ts
@@ -202,4 +202,36 @@ describe('applyBakedPreviews', () => {
     });
     expect(out[1]).toBe(records[1]);
   });
+
+  it('says so when there is no manifest at all, instead of disabling bakes silently', async () => {
+    // A missing manifest disables every baked preview and sends every plugin to
+    // the live-iframe path, which presents as nothing worse than a slower
+    // gallery — the same "silently disable with no trace" failure the malformed
+    // branch already warns about. An image built without `data/` lands here, so
+    // the notice is what makes the cause greppable rather than inferred.
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'od-bakes-missing-'));
+    const emptyDir = tmpDir;
+    const records: PluginRecord[] = [
+      { id: 'html-plugin', manifest: { name: 'html-plugin', od: {} } },
+    ];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    };
+
+    try {
+      const out = applyBakedPreviews(records, emptyDir);
+      // Same directory twice: the notice is per-path, not per-call, so a
+      // deployment without a manifest does not reprint it on every listing.
+      applyBakedPreviews(records, emptyDir);
+      expect(out[0]).toBe(records[0]);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const matching = warnings.filter((line) => line.includes('plugin-preview-bakes'));
+    expect(matching).toHaveLength(1);
+    expect(matching[0]).toContain(path.join(emptyDir, "manifest.json"));
+  });
 });

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -76,6 +76,11 @@ COPY design-systems ./design-systems
 COPY craft ./craft
 COPY prompt-templates ./prompt-templates
 COPY assets ./assets
+# `data/plugin-previews/manifest.json` is committed by the bake pipeline and is
+# what `resolvePluginPreviewsDir()` looks for at runtime. Without it in the
+# image, `loadManifest()` returns `{}` and every plugin silently falls back to
+# the live-iframe preview path — the exact cost the bakes exist to avoid.
+COPY data ./data
 COPY plugins/_official ./plugins/_official
 
 FROM ${RUNTIME_IMAGE}
@@ -91,6 +96,7 @@ COPY --from=build --chown=open-design:open-design /app/skills ./skills
 COPY --from=build --chown=open-design:open-design /app/design-systems ./design-systems
 COPY --from=build --chown=open-design:open-design /app/craft ./craft
 COPY --from=build --chown=open-design:open-design /app/prompt-templates ./prompt-templates
+COPY --from=build --chown=open-design:open-design /app/data ./data
 COPY --from=build --chown=open-design:open-design /app/assets/frames ./assets/frames
 COPY --from=build --chown=open-design:open-design /app/assets/community-pets ./assets/community-pets
 # Plan §3.J4 / spec §23.3.5 — bundled atom plugins registered on

--- a/e2e/tests/docker-image-content-directories.test.ts
+++ b/e2e/tests/docker-image-content-directories.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+// The daemon resolves several content directories relative to the project root
+// at runtime. Anything it reads that way has to be COPYed into the image, in
+// both the build stage and the runtime stage, or the deployment loses that
+// content with no error — the daemon simply finds nothing and carries on.
+//
+// `data/plugin-previews/manifest.json` is the case that motivated this test: it
+// is committed by the bake pipeline and is what `resolvePluginPreviewsDir()`
+// looks for. Without it, `loadManifest()` returns `{}` and every plugin falls
+// back to the live-iframe preview path, which is exactly the GPU cost the bakes
+// exist to avoid.
+
+const dockerfile = new URL("../../deploy/Dockerfile", import.meta.url);
+
+function stageSections(content: string): { build: string; runtime: string } {
+  // The runtime stage is the last `FROM`; everything before it is the build.
+  const lastFrom = content.lastIndexOf("\nFROM ");
+  expect(lastFrom).toBeGreaterThan(0);
+  return { build: content.slice(0, lastFrom), runtime: content.slice(lastFrom) };
+}
+
+describe("deploy/Dockerfile content directories", () => {
+  it("copies every runtime-resolved content directory into both stages", async () => {
+    const content = await readFile(dockerfile, "utf8");
+    const { build, runtime } = stageSections(content);
+
+    // `assets` is copied wholesale in build but selectively in runtime, so it is
+    // matched loosely; the rest are whole-directory copies in both stages.
+    for (const dir of ["skills", "design-systems", "craft", "prompt-templates", "data"]) {
+      expect(build, `build stage should COPY ${dir}`).toMatch(
+        new RegExp(`^COPY ${dir} \\./${dir}$`, "m"),
+      );
+      expect(runtime, `runtime stage should COPY ${dir}`).toMatch(
+        new RegExp(`^COPY --from=build [^\\n]*/app/${dir} \\./${dir}$`, "m"),
+      );
+    }
+  });
+
+  it("ships the checked-in plugin preview manifest", async () => {
+    // Narrower than the directory check above and stated separately: this is the
+    // file whose absence is silent, so it is worth failing on its own terms
+    // rather than only as part of a directory list.
+    const content = await readFile(dockerfile, "utf8");
+    const { build, runtime } = stageSections(content);
+
+    expect(build).toMatch(/^COPY data \.\/data$/m);
+    expect(runtime).toMatch(/^COPY --from=build [^\n]*\/app\/data \.\/data$/m);
+  });
+});


### PR DESCRIPTION
Fixes #7018

## Why

I run a self-hosted Docker deployment. Chasing blank thumbnails in the home rail, I found that *no* plugin was using its baked preview — all 461 were rendering as live, scaled iframes, which `plugin-preview-bakes.ts` opens by noting is "GPU-expensive at scale" and is the whole reason the bakes exist.

The cause is one missing `COPY`. @lefarcen confirmed it in #7018 and labelled it `help wanted` / `good first issue`.

## What users will see

On Docker/self-hosted deployments, plugin cards in the home gallery show their baked poster and hover clip again instead of running a live iframe each. That is the same rendering the packaged app has always had; those users see no change.

Operators additionally get one log line if the manifest is ever missing again, instead of a gallery that is merely slower for no stated reason.

## The chain

`deploy/Dockerfile` copies `skills`, `design-systems`, `craft`, `prompt-templates`, `assets` and `plugins/_official`. `data/` is the one content directory missing from that list, and it holds the manifest CI commits for exactly this purpose:

```
$ docker exec <daemon> ls /app/data/plugin-previews
ls: /app/data/plugin-previews: No such file or directory
```

From there everything degrades quietly:

- `resolvePluginPreviewsDir()` defaults to `<projectRoot>/data/plugin-previews`
- `loadManifest()` finds no `manifest.json` and returns `{}`
- `applyBakedPreviews()` early-returns the records untouched, so nothing gets an `od.bakedPreview`
- `inferPluginPreview(record, { preferBaked: true })` falls through to the live-HTML branch

Measured on 0.19.2 with 461 registered plugins: the checked-in manifest has **176** entries, and **0** records carried `od.bakedPreview`. With `data/` present the same daemon reports 176 — deck 79, prototype 79, video 10, scenario 4, image 1, audio 1, template 2.

The packaged app reaches the manifest through its own packaging path, which is why this only bites Docker/self-hosted deployments and why it has gone unreported.

## The second change

`loadManifest()` now warns once per path when the manifest is absent. That is not scope creep so much as finishing a thought already in the file — the malformed branch carries this comment:

> `// A malformed/unreadable manifest would otherwise silently disable every baked preview with no trace; surface it so it's diagnosable.`

…and warns accordingly, while the *absent* branch returned `{}` with no message. Same failure, same lack of trace. The notice is deduplicated per path because `loadManifest` runs on every plugin listing.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — packaging fix plus a diagnostic log line and their regression specs.

## Screenshots

n/a — no UI surface. The visible effect is which of two existing render paths a card takes, and the counts above measure that directly.

## Bug fix verification

- Test paths: `e2e/tests/docker-image-content-directories.test.ts`, `apps/daemon/tests/plugin-preview-bakes.test.ts`
- Red on `main`, green on this branch: **yes**

Pre-fix output:

```
× copies every runtime-resolved content directory into both stages
    AssertionError: build stage should COPY data: expected 'ARG NODE_IMAGE=docker.io/library/node…' to match /^COPY data \.\/data$/
× ships the checked-in plugin preview manifest
× says so when there is no manifest at all, instead of disabling bakes silently
    AssertionError: expected [] to have a length of 1 but got +0
```

The Dockerfile assertion lives in `e2e/tests/` per the root `AGENTS.md` rule that repository-resource consistency checks belong there. It covers the other four runtime-resolved directories too, not just `data/`, so the next one to go missing fails on the way in rather than in someone's deployment. `assets` is deliberately excluded: the runtime stage copies it selectively (`assets/frames`, `assets/community-pets`), so a whole-directory assertion would be wrong.

The daemon spec calls `applyBakedPreviews` twice against the same manifest-less directory, so it pins the dedup as well as the notice.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/plugin-preview-bakes.test.ts` — 6 passed
- `pnpm --filter @open-design/e2e exec vitest run tests/docker-image-content-directories.test.ts` — 2 passed
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm guard` — pass

I have not built the image in CI here; the Dockerfile change is two `COPY` lines mirroring the ones directly above them, and the spec asserts both stages.

## Not addressed here

#7019 is the rendering bug this one exposes — with no manifest, every card lands on the live-iframe path, and deck tiles there position outside their frame. Separate PR (#7026). Fixing this issue hides that symptom for deck (79 of 80 are baked) but does not resolve it: 285 of the 461 bundled plugins have no bake at all, and user-installed plugins never do.
