### PR TITLE
fix(web): show full descriptions for expanded skills

### DIFF
--- a/apps/web/src/styles/viewer/templates-plugins.css
+++ b/apps/web/src/styles/viewer/templates-plugins.css
@@ -1698,6 +1698,9 @@
   padding: 8px 10px 8px 14px;
   min-width: 0;
 }
+.settings-skills .skills-row-expanded .skills-row-head {
+  align-items: flex-start;
+}
 .settings-skills .skills-row-summary-btn {
   flex: 1;
   min-width: 0;
@@ -1712,6 +1715,10 @@
   cursor: pointer;
   color: inherit;
   font: inherit;
+}
+.settings-skills .skills-row-expanded .skills-row-summary-btn {
+  align-items: flex-start;
+  height: auto;
 }
 .settings-skills .skills-row-summary-btn:hover .skills-row-summary-name {
   color: var(--accent);
@@ -1795,6 +1802,12 @@
   font-size: 12px;
   color: var(--text-muted);
   line-height: 1.4;
+}
+.settings-skills .skills-row-expanded .skills-row-summary-desc {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 .settings-skills .skills-row-chevron {
   display: inline-flex;

--- a/apps/web/tests/styles/settings-polish.test.ts
+++ b/apps/web/tests/styles/settings-polish.test.ts
@@ -55,6 +55,36 @@ describe('settings polish CSS', () => {
     expect(ruleValue(content, 'z-index')).toBe('1');
   });
 
+  it('shows the full skill description when its row is expanded', () => {
+    const collapsed = cssBlock(
+      expandedIndexCss,
+      '.settings-skills .skills-row-summary-desc',
+    );
+    const expandedHead = cssBlock(
+      expandedIndexCss,
+      '.settings-skills .skills-row-expanded .skills-row-head',
+    );
+    const expandedButton = cssBlock(
+      expandedIndexCss,
+      '.settings-skills .skills-row-expanded .skills-row-summary-btn',
+    );
+    const expanded = cssBlock(
+      expandedIndexCss,
+      '.settings-skills .skills-row-expanded .skills-row-summary-desc',
+    );
+
+    expect(ruleValue(collapsed, 'overflow')).toBe('hidden');
+    expect(ruleValue(collapsed, 'text-overflow')).toBe('ellipsis');
+    expect(ruleValue(collapsed, 'white-space')).toBe('nowrap');
+    expect(ruleValue(expandedHead, 'align-items')).toBe('flex-start');
+    expect(ruleValue(expandedButton, 'align-items')).toBe('flex-start');
+    expect(ruleValue(expandedButton, 'height')).toBe('auto');
+    expect(ruleValue(expanded, 'overflow')).toBe('visible');
+    expect(ruleValue(expanded, 'text-overflow')).toBe('clip');
+    expect(ruleValue(expanded, 'white-space')).toBe('normal');
+    expect(ruleValue(expanded, 'overflow-wrap')).toBe('anywhere');
+  });
+
   it('keeps the silent-update checkbox native-sized and aligned horizontally', () => {
     const row = cssBlock(artifactsCss, '.settings-about-diagnostics > .settings-about-toggle');
     const checkbox = cssBlock(artifactsCss, '.settings-about-toggle input');


### PR DESCRIPTION
Fixes #7031

## Why

I hit this while reviewing a skill with a long description in Integrations > Skills. Expanding the row reveals its SKILL.md content and bundled files, but the collapsed row's single-line ellipsis styles continue to constrain the summary description. The fixed-height summary control also cannot grow with wrapped text, which can make the summary overlap the detail content.

## What users will see

Collapsed skill rows keep the current compact one-line ellipsis. Expanded rows wrap the complete description, grow with the content, and keep the SKILL.md detail below the summary without overlap.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

See the before/after comparison in [this PR comment](https://github.com/nexu-io/open-design/pull/7032#issuecomment-5325151475).

## Bug fix verification

- Test path: `apps/web/tests/styles/settings-polish.test.ts`
- The regression test went red before the source change and green afterward.
- The initial red spec failed because the expanded-description override was missing.
- Follow-up red assertions caught the fixed-height summary layout before the auto-height and top-alignment rules were added.
- Browser QA confirmed that the complete `brand-extract` description wraps without horizontal clipping or overlap with the SKILL.md detail.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/settings-polish.test.ts --maxWorkers=2`
- `pnpm --filter @open-design/web test` — 624 test files passed, 6562 tests passed, 1 expected failure, 11 skipped
- `pnpm --filter @open-design/web build`
- `git diff --check`
- Browser QA in Integrations > Skills using the `brand-extract` skill