### PR TITLE
test(e2e): freeze motion in visual captures

### DIFF
--- a/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
+++ b/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
@@ -7,6 +7,7 @@ import {
   initialTypewriterState,
   type PlaceholderScenario,
 } from './placeholderScenarios';
+import { isVisualStabilityMode } from '../../utils/visualStability';
 
 // Reports the OS "reduce motion" preference, live. SSR/jsdom without
 // matchMedia falls back to false (animate) — the animation is purely
@@ -50,6 +51,7 @@ interface Props {
 // the frequent re-renders stay confined here and never touch the editor.
 export function PlaceholderCarousel({ scenarios, active, paused = false, onScenarioChange }: Props) {
   const reducedMotion = usePrefersReducedMotion();
+  const visualStabilityMode = isVisualStabilityMode();
   const [state, setState] = useState(initialTypewriterState);
   const onChangeRef = useRef(onScenarioChange);
   onChangeRef.current = onScenarioChange;
@@ -88,7 +90,7 @@ export function PlaceholderCarousel({ scenarios, active, paused = false, onScena
   // state re-runs this effect, whose cleanup clears the prior timer — so the
   // chain self-sustains without overlapping timers (StrictMode-safe).
   useEffect(() => {
-    if (!active || paused || scenarios.length === 0) return;
+    if (!active || paused || visualStabilityMode || scenarios.length === 0) return;
     const scenario = scenarios[state.index % scenarios.length];
     const length = scenario?.text.length ?? 0;
     const { state: nextState, delayMs } = advanceTypewriter(
@@ -100,12 +102,14 @@ export function PlaceholderCarousel({ scenarios, active, paused = false, onScena
     );
     const timer = window.setTimeout(() => setState(nextState), Math.max(16, delayMs));
     return () => window.clearTimeout(timer);
-  }, [active, paused, state, scenarios, reducedMotion]);
+  }, [active, paused, state, scenarios, reducedMotion, visualStabilityMode]);
 
   if (!active || paused || scenarios.length === 0) return null;
   const scenario = scenarios[state.index % scenarios.length];
   if (!scenario) return null;
-  const visible = reducedMotion ? scenario.text : scenario.text.slice(0, state.charCount);
+  const visible = reducedMotion || visualStabilityMode
+    ? scenario.text
+    : scenario.text.slice(0, state.charCount);
   return (
     <div className="home-hero__carousel" aria-hidden="true" data-testid="home-hero-carousel">
       <span className="home-hero__carousel-text">{visible}</span>

--- a/apps/web/tests/components/PlaceholderCarousel.test.tsx
+++ b/apps/web/tests/components/PlaceholderCarousel.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlaceholderCarousel } from '../../src/components/home-hero/PlaceholderCarousel';
+import { DEFAULT_TYPEWRITER_TIMING } from '../../src/components/home-hero/placeholderScenarios';
+import { VISUAL_STABILITY_STORAGE_KEY } from '../../src/utils/visualStability';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  window.localStorage.clear();
+});
+
+describe('PlaceholderCarousel', () => {
+  it('pins the first full scenario without scheduling carousel advances in visual stability mode', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('matchMedia', vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })));
+    window.localStorage.setItem(VISUAL_STABILITY_STORAGE_KEY, '1');
+    const onScenarioChange = vi.fn();
+
+    render(
+      <PlaceholderCarousel
+        active
+        scenarios={[
+          { id: 'first', text: 'Pinned first scenario', chipId: 'document' },
+          { id: 'second', text: 'Second scenario', chipId: 'deck' },
+        ]}
+        onScenarioChange={onScenarioChange}
+      />,
+    );
+
+    expect(screen.getByTestId('home-hero-carousel').textContent).toContain('Pinned first scenario');
+    expect(onScenarioChange).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEFAULT_TYPEWRITER_TIMING.holdMs * 2);
+    });
+
+    expect(screen.getByTestId('home-hero-carousel').textContent).toContain('Pinned first scenario');
+    expect(onScenarioChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -263,6 +263,11 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
   const config = { ...VISUAL_CONFIG, ...(options.config ?? {}) };
   const agents = options.agents ?? [MOCK_AGENT];
 
+  // Screenshot-level `animations: 'disabled'` only fast-forwards CSS motion.
+  // The home wordmark and placeholder carousel are driven by requestAnimationFrame
+  // and timers, so make them take the product's deterministic static fallback too.
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+
   // Visual coverage is a web rendering contract, not a daemon behavior lane.
   // Register these first so the narrower fixtures below win; every other
   // daemon-owned request terminates at a deterministic browser-side boundary.


### PR DESCRIPTION
## Why

While reviewing the visual regression report on #7023, I found eight changed screenshots across unrelated Home, workspace, and topbar surfaces. The product diff only changed composer placeholder wrapping, but the screenshots captured different frames of two decorative animations: the WebGL pixel-scan wordmark and the timer-driven placeholder typewriter.

Playwright's screenshot-level `animations: 'disabled'` option only fast-forwards CSS animations and transitions. It does not freeze `requestAnimationFrame` canvas rendering or JavaScript timers, so unrelated PRs can receive noisy visual regression reports.

## What users will see

No product behavior changes. Visual regression captures now render the existing reduced-motion fallbacks, keeping the logo and placeholder text deterministic between the base and PR runs.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this only stabilizes the test harness.

## Bug fix verification

- Test path: `e2e/ui/visual-entry.test.ts` through `configureVisualPage` in `e2e/lib/playwright/visual.ts`
- Before the fix, #7023 reported animation-frame drift in eight otherwise unrelated captures.
- After the fix, two independent focused Home capture runs produced byte-identical PNGs.

## Validation

- `pnpm --filter @open-design/e2e typecheck`
- Focused `visual-home` capture twice; both runs passed and produced the same SHA-256.
- Full validation intentionally left to CI.
