### PR TITLE
fix(daemon): classify Claude prompt-too-long errors

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -282,8 +282,11 @@ function promptTooLargeDetail(text: string): TrackingRunFailureDetail | null {
   }
   // `prefill context too large` is the local-runtime (MLX) shape of the same
   // "the prompt does not fit" failure that currently leaks into execution_failed.
+  // Claude Code's terminal result uses the distinct literal `Prompt is too
+  // long`; keep it here as a fallback for persisted or legacy failures that
+  // do not carry the structured AGENT_PROMPT_TOO_LARGE code.
   if (
-    /\b(context window|context size (?:has been )?exceeded|prompt too large|request_too_large|maximum context|too many tokens|input.*too large|request (?:body )?exceeds configured limit|output token maximum|maximum output tokens|CLAUDE_CODE_MAX_OUTPUT_TOKENS|exceeds the safe size|composed prompt exceeds|prompt token count .* exceeds|maximum context length|context too large|prefill context too large|reduce the length of (?:the )?(?:messages|input prompt)|request \(\d+ tokens\) exceeds the available context size|n_keep:\s*\d+\s*>=\s*n_ctx)\b/i.test(text)
+    /\b(context window|context size (?:has been )?exceeded|prompt too large|prompt is too long|request_too_large|maximum context|too many tokens|input.*too large|request (?:body )?exceeds configured limit|output token maximum|maximum output tokens|CLAUDE_CODE_MAX_OUTPUT_TOKENS|exceeds the safe size|composed prompt exceeds|prompt token count .* exceeds|maximum context length|context too large|prefill context too large|reduce the length of (?:the )?(?:messages|input prompt)|request \(\d+ tokens\) exceeds the available context size|n_keep:\s*\d+\s*>=\s*n_ctx)\b/i.test(text)
   ) {
     return 'prompt_too_large';
   }

--- a/apps/daemon/src/runtimes/claude-stream.ts
+++ b/apps/daemon/src/runtimes/claude-stream.ts
@@ -520,10 +520,15 @@ export function createClaudeStreamHandler(
         ...(isError ? { isError: true } : {}),
       });
       if (isError) {
+        const message = errorResultMessage(obj);
         onEvent({
           type: 'error',
-          message: errorResultMessage(obj),
-          code: typeof obj.subtype === 'string' && obj.subtype ? obj.subtype : 'result_error',
+          message,
+          code: isPromptTooLongResult(message)
+            ? 'AGENT_PROMPT_TOO_LARGE'
+            : typeof obj.subtype === 'string' && obj.subtype
+              ? obj.subtype
+              : 'result_error',
           // Marks this as the run's terminal error (the CLI is exiting), not an
           // in-stream hiccup. Consumers with their own result-frame
           // classification (connection test #4501) skip terminal errors.
@@ -544,6 +549,10 @@ export function createClaudeStreamHandler(
     if (typeof obj.result === 'string' && obj.result.trim()) return obj.result;
     if (typeof obj.subtype === 'string' && obj.subtype) return `Claude run failed: ${obj.subtype}`;
     return 'Claude run failed';
+  }
+
+  function isPromptTooLongResult(message: string): boolean {
+    return /^(?:API Error:\s*)?Prompt is too long\.?$/i.test(message.trim());
   }
 
   function assistantText(content: unknown[]): string {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13196,6 +13196,19 @@ export async function startServer({
             agentStderrTail,
           ].join('\n');
           clearInactivityWatchdog();
+          // A parsed terminal Claude result has stronger provenance than text
+          // sniffing across the combined stdout/stderr tail. In particular,
+          // Claude can log `apiKeySource: none` alongside an upstream
+          // `Prompt is too long` result; letting the broad auth diagnostic see
+          // that tail first sends users to /login instead of reducing context.
+          // Only accept the stable code emitted by claude-stream for this
+          // terminal result shape; other Claude errors keep the existing
+          // diagnostic/service fallback behavior.
+          const structuredCode =
+            (ev as any).terminal === true &&
+            (ev as any).code === 'AGENT_PROMPT_TOO_LARGE'
+              ? 'AGENT_PROMPT_TOO_LARGE'
+              : null;
           // Claude surfaces a connection drop / reset as an in-stream `error`
           // frame (assistant `error:"unknown"` + the raw SDK string), which
           // would otherwise reach the UI verbatim as a non-retryable
@@ -13203,25 +13216,33 @@ export async function startServer({
           // child-exit so this path emits the specific class
           // (AGENT_CONNECTION_DROPPED) — retryable, with copy the web can
           // localize and triage can count by code.
-          const diagnostic = diagnoseClaudeCliFailure({
-            agentId: def.id,
-            exitCode: 1,
-            stderrTail: agentStderrTail,
-            stdoutTail: failureText,
-            env: spawnedAgentEnv,
-            resolvedBin: agentLaunch.selectedPath,
-          });
-          const serviceCode = classifyAgentServiceFailure(failureText);
-          agentStreamError = diagnostic?.message
-            ?? rewriteKnownAgentStreamError(agentId, message, failureText);
+          const diagnostic = structuredCode
+            ? null
+            : diagnoseClaudeCliFailure({
+                agentId: def.id,
+                exitCode: 1,
+                stderrTail: agentStderrTail,
+                stdoutTail: failureText,
+                env: spawnedAgentEnv,
+                resolvedBin: agentLaunch.selectedPath,
+              });
+          const serviceCode = structuredCode
+            ? null
+            : classifyAgentServiceFailure(failureText);
+          agentStreamError = structuredCode
+            ? message
+            : diagnostic?.message
+              ?? rewriteKnownAgentStreamError(agentId, message, failureText);
           agentStreamErrorObservedBeforeCancellation = true;
           run.runtimeFailureObservedBeforeCancellation = true;
           send('error', createSseErrorPayload(
-            diagnostic?.code ?? serviceCode ?? 'AGENT_EXECUTION_FAILED',
+            structuredCode ?? diagnostic?.code ?? serviceCode ?? 'AGENT_EXECUTION_FAILED',
             agentStreamError,
             {
-              retryable: diagnostic?.retryable
-                ?? (serviceCode === 'AGENT_AUTH_REQUIRED' || serviceCode === 'RATE_LIMITED'),
+              retryable: structuredCode
+                ? false
+                : diagnostic?.retryable
+                  ?? (serviceCode === 'AGENT_AUTH_REQUIRED' || serviceCode === 'RATE_LIMITED'),
               ...(diagnostic ? { details: { detail: diagnostic.detail } } : {}),
             },
           ));

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -3040,6 +3040,108 @@ process.exit(1);
     );
   });
 
+  it('prefers a terminal Claude prompt-length error over auth-shaped stderr (#6979)', async () => {
+    await withFakeAgent(
+      'claude',
+      `
+console.error(JSON.stringify({ apiKeySource: 'none' }));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'error_during_execution',
+  is_error: true,
+  result: 'Prompt is too long',
+  stop_reason: null,
+}));
+process.exit(1);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'claude',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: error');
+        eventsController.abort();
+        await waitForRunStatus(baseUrl, runId);
+        const statusResponse = await fetch(`${baseUrl}/api/runs/${runId}`);
+        const statusBody = await statusResponse.json() as {
+          status: string;
+          failureCategory: string | null;
+          failureDetail: string | null;
+        };
+
+        expect(eventsBody).toContain('AGENT_PROMPT_TOO_LARGE');
+        expect(eventsBody).toContain('Prompt is too long');
+        expect(eventsBody).toContain('"retryable":false');
+        expect(eventsBody).not.toContain('could not authenticate');
+        expect(statusBody).toMatchObject({
+          status: 'failed',
+          failureCategory: 'prompt_too_large',
+          failureDetail: 'prompt_too_large',
+        });
+      },
+    );
+  });
+
+  it('does not treat prompt-length text in an assistant payload as the terminal cause (#6979)', async () => {
+    await withFakeAgent(
+      'claude',
+      `
+console.log(JSON.stringify({
+  type: 'assistant',
+  parent_tool_use_id: null,
+  message: {
+    id: 'msg-prompt-text',
+    content: [{ type: 'text', text: 'The upstream phrase was: Prompt is too long.' }],
+    stop_reason: 'end_turn',
+  },
+}));
+console.log(JSON.stringify({
+  type: 'result',
+  subtype: 'error_during_execution',
+  is_error: true,
+  result: 'A different terminal failure',
+  stop_reason: null,
+}));
+process.exit(1);
+`,
+      async () => {
+        const createResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'claude',
+            message: 'hello',
+          }),
+        });
+        expect(createResponse.status).toBe(202);
+        const { runId } = await createResponse.json() as { runId: string };
+
+        const eventsController = new AbortController();
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${runId}/events`, {
+          signal: eventsController.signal,
+        });
+        const eventsBody = await readSseUntil(eventsResponse, 'event: error');
+        eventsController.abort();
+        await waitForRunStatus(baseUrl, runId);
+
+        expect(eventsBody).toContain('AGENT_EXECUTION_FAILED');
+        expect(eventsBody).toContain('A different terminal failure');
+        expect(eventsBody).not.toContain('AGENT_PROMPT_TOO_LARGE');
+      },
+    );
+  });
+
   it('caps oversized inactivity overrides so Node does not fire the timer immediately', async () => {
     const previous = process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS;
     process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '10000000000';

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1739,6 +1739,18 @@ describe('classifyRunFailure — batch A reclassification out of execution_faile
     expect(result?.failure_detail).toBe('prompt_too_large');
   });
 
+  it('classifies a text-only Claude "Prompt is too long" failure as prompt_too_large (#6979)', () => {
+    const result = classify(
+      'AGENT_EXECUTION_FAILED',
+      'API Error: Prompt is too long.',
+    );
+
+    expect(result?.failure_category).toBe('prompt_too_large');
+    expect(result?.failure_detail).toBe('prompt_too_large');
+    expect(result?.retryable).toBe(false);
+    expect(result?.user_action).toBe('reduce_context');
+  });
+
   it('classifies AMR request body limits as prompt_too_large', () => {
     const result = classify(
       'AGENT_EXECUTION_FAILED',

--- a/apps/daemon/tests/runtimes/structured-streams.test.ts
+++ b/apps/daemon/tests/runtimes/structured-streams.test.ts
@@ -949,6 +949,29 @@ describe('structured agent stream fixtures', () => {
     expect(String(error?.message)).toContain('No conversation found with session ID');
   });
 
+  it('marks a terminal prompt-length result with the stable prompt-too-large code (#6979)', () => {
+    const events: Array<Record<string, unknown>> = [];
+    const handler = createClaudeStreamHandler((event: unknown) => {
+      events.push(event as Record<string, unknown>);
+    });
+
+    handler.feed(`${JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      result: 'Prompt is too long',
+      stop_reason: null,
+    })}\n`);
+    handler.flush();
+
+    expect(events.find((event) => event.type === 'error')).toMatchObject({
+      type: 'error',
+      message: 'Prompt is too long',
+      code: 'AGENT_PROMPT_TOO_LARGE',
+      terminal: true,
+    });
+  });
+
   it('does not flag a successful result as an error', () => {
     const events: Array<Record<string, unknown>> = [];
     const handler = createClaudeStreamHandler((event: unknown) => {


### PR DESCRIPTION
Fixes #6979

## Why

Claude Code can terminate with `Prompt is too long` while its captured diagnostics also contain `apiKeySource: none`. Open Design previously ran the authentication heuristic first, so users were told to authenticate even though their credentials were unrelated to the failure.

This change makes the trustworthy terminal Claude result authoritative and keeps the text-only fallback for legacy failure paths. It also addresses the provenance and retryability concerns raised on #6988: arbitrary assistant/tool payload text is not scanned, and automatic retry is disabled until the user reduces context.

## What users will see

When Claude rejects an oversized prompt, Open Design reports the prompt/context-limit failure and recommends reducing context instead of showing a Claude Code authentication error. The failure remains manually retryable after the prompt is shortened, but is not automatically retried unchanged.

## Surface area

- [ ] UI
- [ ] CLI
- [ ] HTTP API / contracts
- [ ] Agent runtime flags or prompt behavior
- [ ] Environment variables or persisted settings
- [ ] `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [ ] i18n keys
- [ ] New root dependency
- [x] None

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Red: the Claude stream parser emitted the generic `error_during_execution` code for a terminal `Prompt is too long` result.
- Red: with `apiKeySource: none` in stderr, the chat route emitted `AGENT_EXECUTION_FAILED`, authentication guidance, and `retryable: true`.
- Red: the text-only classifier categorized `API Error: Prompt is too long.` as `process_exit`.
- Green: the terminal result now emits `AGENT_PROMPT_TOO_LARGE`, wins over the auth heuristic, persists `prompt_too_large`, and is non-retryable for automatic retry.
- Negative regression: the same phrase inside an ordinary assistant payload does not change an unrelated terminal failure's classification.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/chat-route.test.ts tests/runtimes/structured-streams.test.ts tests/run-failure-classification.test.ts tests/claude-diagnostics.test.ts` — 231 passed
- `corepack pnpm --filter @open-design/daemon test` — 8,611 passed, 6 skipped
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check origin/main...HEAD`
