### PR TITLE
fix(web): recover aborted srcdoc previews

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -624,6 +624,8 @@ const MAX_CACHED_PREVIEW_CONTENT_WIDTHS = 128;
 const PREVIEW_CONTENT_WIDTH_CACHE_VERSION = 2;
 const SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS = 1500;
 const SRC_DOC_READY_PROBE_TIMEOUT_MS = 1500;
+const SRC_DOC_PARSING_RECHECK_MS = 1500;
+const SRC_DOC_PARSING_COMPLETION_TIMEOUT_MS = 10_000;
 let previewContentMeasurementDocumentEpochSequence = 0;
 let previewContentMeasurementHostInstanceSequence = 0;
 let previewTransportGenerationSequence = 0;
@@ -10215,6 +10217,10 @@ function HtmlViewer({
     probeId: string;
     recoverOnFailure: boolean;
   } | null>(null);
+  const srcDocParsingGraceRef = useRef<{
+    generation: string;
+    deadline: number;
+  } | null>(null);
   const replayPreviewBridgeModes = useCallback((target: HTMLIFrameElement | null) => {
     if (!workspaceActive) return;
     const win = target?.contentWindow;
@@ -10349,6 +10355,7 @@ function HtmlViewer({
       timeoutMs: signal === 'probe_timeout' ? SRC_DOC_READY_PROBE_TIMEOUT_MS : undefined,
     });
     pendingSrcDocTransportProbeRef.current = null;
+    srcDocParsingGraceRef.current = null;
     verifiedSrcDocTransportRef.current = null;
     readySrcDocTransportRef.current = null;
     activatedSrcDocTransportHtmlRef.current = null;
@@ -10494,6 +10501,7 @@ function HtmlViewer({
         && data.bodyComplete === true
       ) {
         pendingSrcDocTransportProbeRef.current = null;
+        srcDocParsingGraceRef.current = null;
         verifiedSrcDocTransportRef.current = { frame, generation: data.generation };
       } else if (
         typeof data.probeId === 'string'
@@ -10503,6 +10511,42 @@ function HtmlViewer({
         && pending.probeId === data.probeId
         && pending.recoverOnFailure
       ) {
+        if (data.documentReadyState === 'loading') {
+          // A healthy parser can remain in `loading` while it waits on an
+          // authored parser-blocking resource. The head bridge is responsive,
+          // so keep challenging this generation without remounting and risk
+          // running earlier authored side effects twice. A bounded grace
+          // period still recovers Chromium's permanently-aborted half-document.
+          pendingSrcDocTransportProbeRef.current = null;
+          const now = Date.now();
+          const currentGrace = srcDocParsingGraceRef.current;
+          const grace = currentGrace?.generation === data.generation
+            ? currentGrace
+            : {
+                generation: data.generation,
+                deadline: now + SRC_DOC_PARSING_COMPLETION_TIMEOUT_MS,
+              };
+          srcDocParsingGraceRef.current = grace;
+          if (now >= grace.deadline) {
+            recoverUnacknowledgedSrcDocTransport(data.generation, 'body_incomplete', {
+              readyState: 'loading',
+              bodyPresent: typeof data.bodyPresent === 'boolean' ? data.bodyPresent : undefined,
+              bodyChildCount: typeof data.bodyChildCount === 'number' ? data.bodyChildCount : undefined,
+              documentElementChildCount:
+                typeof data.documentElementChildCount === 'number'
+                  ? data.documentElementChildCount
+                  : undefined,
+            });
+            return;
+          }
+          window.setTimeout(() => {
+            if (expectedSrcDocTransportGenerationRef.current !== data.generation) return;
+            const verified = verifiedSrcDocTransportRef.current;
+            if (verified?.frame === frame && verified.generation === data.generation) return;
+            probeSrcDocTransport(data.generation, true);
+          }, Math.min(SRC_DOC_PARSING_RECHECK_MS, grace.deadline - now));
+          return;
+        }
         // The exact challenged head bridge answered, but it could not observe
         // the inert marker placed after all authored body content. This is the
         // characteristic half-document state from an aborted about:srcdoc;
@@ -10531,7 +10575,12 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [recoverUnacknowledgedSrcDocTransport, replayPreviewBridgeModes, workspaceActive]);
+  }, [
+    probeSrcDocTransport,
+    recoverUnacknowledgedSrcDocTransport,
+    replayPreviewBridgeModes,
+    workspaceActive,
+  ]);
   // React can commit a fresh `srcdoc` attribute while Chromium aborts the
   // corresponding about:srcdoc navigation. The injected head bridge may run
   // and announce eagerly before that abort, so a plain generation ACK is not a

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -40,8 +40,11 @@ import { deployErrorCode } from '../analytics/deploy-error-code';
 import { publishErrorCode } from '../analytics/publish-error-code';
 import {
   reportPreviewIframeMessage,
+  reportPreviewTransportRecovery,
   subscribePreviewIframeMessages,
   trackIframeLoad,
+  type PreviewTransportDocumentState,
+  type PreviewTransportRecoverySignal,
 } from '../observability/iframe-error';
 import { notifyExportSucceeded } from './experience-survey-trigger';
 import {
@@ -10312,7 +10315,11 @@ function HtmlViewer({
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
   const srcDocRecoveryAttemptedGenerationRef = useRef<string | null>(null);
   const [srcDocRecoveryGeneration, setSrcDocRecoveryGeneration] = useState<string | null>(null);
-  const recoverUnacknowledgedSrcDocTransport = useCallback((generation: string) => {
+  const recoverUnacknowledgedSrcDocTransport = useCallback((
+    generation: string,
+    signal: PreviewTransportRecoverySignal,
+    documentState?: PreviewTransportDocumentState,
+  ) => {
     if (
       !workspaceActiveRef.current
       || expectedSrcDocTransportGenerationRef.current !== generation
@@ -10324,6 +10331,23 @@ function HtmlViewer({
     if (frame && verified?.frame === frame && verified.generation === generation) return;
     if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
     srcDocRecoveryAttemptedGenerationRef.current = generation;
+    const ready = readySrcDocTransportRef.current;
+    reportPreviewTransportRecovery({
+      surface: 'artifact_preview',
+      renderMode: 'srcdoc',
+      artifactId: anonymizeArtifactId({ projectId, fileName: file.name }),
+      artifactKind:
+        handoffArtifactKind
+        ?? artifactKindToTracking({ fileKind: file.kind ?? null }),
+      projectId,
+      signal,
+      activationAcknowledged:
+        ready?.frame === frame && ready.generation === generation,
+      documentState,
+      viewportWidth: frame?.clientWidth,
+      viewportHeight: frame?.clientHeight,
+      timeoutMs: signal === 'probe_timeout' ? SRC_DOC_READY_PROBE_TIMEOUT_MS : undefined,
+    });
     pendingSrcDocTransportProbeRef.current = null;
     verifiedSrcDocTransportRef.current = null;
     readySrcDocTransportRef.current = null;
@@ -10331,7 +10355,7 @@ function HtmlViewer({
     setSrcDocShellReady(false);
     setSrcDocRecoveryGeneration(generation);
     setSrcDocTransportResetKey((key) => key + 1);
-  }, []);
+  }, [file.kind, file.name, handoffArtifactKind, projectId]);
   const probeSrcDocTransport = useCallback((
     generation: string,
     recoverOnFailure: boolean,
@@ -10363,8 +10387,9 @@ function HtmlViewer({
     };
     // An eager acknowledgement from the injected head bridge is provisional:
     // Chromium can still abort the about:srcdoc navigation after it was sent.
-    // Only this exact challenge response proves the current browsing context is
-    // alive after the navigation had a chance to commit.
+    // Only this exact challenge response, together with the body-end witness,
+    // proves the current browsing context is alive and fully parsed after the
+    // navigation had a chance to commit.
     verifiedSrcDocTransportRef.current = null;
     frame.contentWindow?.postMessage({
       type: 'od:srcdoc-transport-ready-probe',
@@ -10382,7 +10407,9 @@ function HtmlViewer({
         return;
       }
       pendingSrcDocTransportProbeRef.current = null;
-      if (pending.recoverOnFailure) recoverUnacknowledgedSrcDocTransport(generation);
+      if (pending.recoverOnFailure) {
+        recoverUnacknowledgedSrcDocTransport(generation, 'probe_timeout');
+      }
     }, SRC_DOC_READY_PROBE_TIMEOUT_MS);
   }, [recoverUnacknowledgedSrcDocTransport]);
   // Sticky once the srcDoc iframe has materialized the real artifact for the
@@ -10443,6 +10470,11 @@ function HtmlViewer({
         type?: unknown;
         generation?: unknown;
         probeId?: unknown;
+        bodyComplete?: unknown;
+        documentReadyState?: unknown;
+        bodyPresent?: unknown;
+        bodyChildCount?: unknown;
+        documentElementChildCount?: unknown;
       } | null;
       const pending = pendingSrcDocTransportProbeRef.current;
       if (
@@ -10459,21 +10491,54 @@ function HtmlViewer({
         && pending.frame === frame
         && pending.generation === data.generation
         && pending.probeId === data.probeId
+        && data.bodyComplete === true
       ) {
         pendingSrcDocTransportProbeRef.current = null;
         verifiedSrcDocTransportRef.current = { frame, generation: data.generation };
+      } else if (
+        typeof data.probeId === 'string'
+        && pending
+        && pending.frame === frame
+        && pending.generation === data.generation
+        && pending.probeId === data.probeId
+        && pending.recoverOnFailure
+      ) {
+        // The exact challenged head bridge answered, but it could not observe
+        // the inert marker placed after all authored body content. This is the
+        // characteristic half-document state from an aborted about:srcdoc;
+        // recover immediately instead of waiting for the probe timeout.
+        recoverUnacknowledgedSrcDocTransport(data.generation, 'body_incomplete', {
+          readyState:
+            typeof data.documentReadyState === 'string'
+              ? data.documentReadyState
+              : undefined,
+          bodyPresent:
+            typeof data.bodyPresent === 'boolean'
+              ? data.bodyPresent
+              : undefined,
+          bodyChildCount:
+            typeof data.bodyChildCount === 'number'
+              ? data.bodyChildCount
+              : undefined,
+          documentElementChildCount:
+            typeof data.documentElementChildCount === 'number'
+              ? data.documentElementChildCount
+              : undefined,
+        });
+        return;
       }
       if (frame === iframeRef.current) replayPreviewBridgeModes(frame);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [replayPreviewBridgeModes, workspaceActive]);
+  }, [recoverUnacknowledgedSrcDocTransport, replayPreviewBridgeModes, workspaceActive]);
   // React can commit a fresh `srcdoc` attribute while Chromium aborts the
   // corresponding about:srcdoc navigation. The injected head bridge may run
   // and announce eagerly before that abort, so a plain generation ACK is not a
   // committed-document witness. Challenge the current browsing context after
-  // the navigation had time to settle and require the exact probe token back;
-  // otherwise retry through the small lazy shell automatically. Chromium can
+  // the navigation had time to settle and require both the exact probe token
+  // and an inert body-end marker; otherwise retry through the small lazy shell
+  // automatically. Chromium can
   // commit that shell even when it aborts a large direct srcDoc navigation,
   // after which the existing ready handshake safely document.write's the
   // latest HTML. One fallback per generation avoids a loop when an authored

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -164,6 +164,8 @@ export function reportPreviewIframeMessage(
       visible_element_count: boundedNumber(message.visible_element_count),
       viewport_width: boundedNumber(message.viewport_width),
       viewport_height: boundedNumber(message.viewport_height),
+      blank_observation_count: boundedNumber(message.blank_observation_count),
+      sample_interval_ms: boundedNumber(message.sample_interval_ms),
     });
     return true;
   }

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -38,6 +38,26 @@ export interface PreviewIframeReportOptions {
   projectId?: string;
 }
 
+export type PreviewTransportRecoverySignal =
+  | 'body_incomplete'
+  | 'probe_timeout';
+
+export interface PreviewTransportDocumentState {
+  readyState?: string;
+  bodyPresent?: boolean;
+  bodyChildCount?: number;
+  documentElementChildCount?: number;
+}
+
+export interface PreviewTransportRecoveryOptions extends PreviewIframeReportOptions {
+  signal: PreviewTransportRecoverySignal;
+  activationAcknowledged: boolean;
+  documentState?: PreviewTransportDocumentState;
+  viewportWidth?: number;
+  viewportHeight?: number;
+  timeoutMs?: number;
+}
+
 interface BufferedPreviewMessage {
   source: MessageEventSource | null;
   data: PreviewObservabilityMessage;
@@ -168,6 +188,52 @@ export function reportPreviewIframeMessage(
     column: boundedNumber(message.column),
   });
   return true;
+}
+
+/**
+ * Report a host-observed blank preview that the iframe-local paint detector
+ * cannot reliably see. In particular, Chromium may execute the injected head
+ * bridge and then abort the rest of an about:srcdoc navigation. Recovery
+ * replaces that half-document before its five-second white-screen timer can
+ * fire, so the host records the transport witness that caused the remount.
+ *
+ * This deliberately reuses client_preview_white_screen: it is operational
+ * safety telemetry, not a new product analytics event. Only bounded state is
+ * attached; no authored DOM text or source content leaves the client.
+ */
+export function reportPreviewTransportRecovery(
+  options: PreviewTransportRecoveryOptions,
+): void {
+  const transportStage = options.signal === 'body_incomplete'
+    ? 'head_bridge_alive_body_tail_missing'
+    : options.activationAcknowledged
+      ? 'head_bridge_lost_after_eager_ack'
+      : 'no_head_bridge_ack';
+  reportSafetyEvent('client_preview_white_screen', {
+    surface: options.surface,
+    render_mode: options.renderMode,
+    artifact_id: options.artifactId,
+    artifact_kind: options.artifactKind,
+    project_id: options.projectId,
+    reason: 'srcdoc_transport_unverified',
+    transport_signal: options.signal,
+    transport_stage: transportStage,
+    activation_acknowledged: options.activationAcknowledged,
+    body_complete: options.signal === 'body_incomplete' ? false : undefined,
+    frame_ready_state: boundedText(options.documentState?.readyState, 32),
+    frame_body_present: options.documentState?.bodyPresent,
+    frame_body_child_count: boundedNumber(options.documentState?.bodyChildCount),
+    frame_document_element_child_count: boundedNumber(
+      options.documentState?.documentElementChildCount,
+    ),
+    recovery_attempted: true,
+    recovery_path: 'lazy_shell_remount',
+    host_visibility_state:
+      typeof document === 'undefined' ? undefined : document.visibilityState,
+    viewport_width: boundedNumber(options.viewportWidth),
+    viewport_height: boundedNumber(options.viewportHeight),
+    timeout_ms: boundedNumber(options.timeoutMs),
+  });
 }
 
 function boundedText(value: unknown, limit: number): string | undefined {

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -143,9 +143,8 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   // and each `var(--slide-bg)` resolves to transparent, painting nothing over
   // the near-black thumbnail host (black thumbnails). Comments are inert, so
   // removing them changes only which selectors the rewrites can see.
-  const styleWithImports = Array.from(doc.querySelectorAll('style'))
-    .map((el) => el.textContent || '')
-    .join('\n');
+  const styleBlocks = Array.from(doc.querySelectorAll('style')).map((el) => el.textContent || '');
+  const styleWithImports = styleBlocks.join('\n');
   if (!styleWithImports.trim()) return unrenderable('no-styles');
 
   // Constructable stylesheets ignore @import, so leaving an approved webfont
@@ -153,12 +152,16 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   // shadow thumbnail. Lift approved font imports into the host alongside
   // <link> fonts; any other import may contain layout CSS we cannot reproduce
   // safely, so use the isolated iframe fallback instead.
-  const imported = extractStylesheetImports(styleWithImports);
-  if (imported.unsafe) return unrenderable('external-stylesheet');
-  for (const href of imported.fontLinks) {
-    if (!fontLinks.includes(href)) fontLinks.push(href);
+  const importedBlocks = styleBlocks.map(extractStylesheetImports);
+  if (importedBlocks.some((imported) => imported.unsafe)) {
+    return unrenderable('external-stylesheet');
   }
-  const rawStyle = stripCssComments(imported.css);
+  for (const imported of importedBlocks) {
+    for (const href of imported.fontLinks) {
+      if (!fontLinks.includes(href)) fontLinks.push(href);
+    }
+  }
+  const rawStyle = stripCssComments(importedBlocks.map((imported) => imported.css).join('\n'));
   if (!rawStyle.trim()) return unrenderable('no-styles');
 
   const designSize = resolveDesignSize(doc, rawStyle);
@@ -385,6 +388,7 @@ function extractStylesheetImports(css: string): StylesheetImportExtraction {
   let quote: '"' | "'" | null = null;
   let escaped = false;
   let inComment = false;
+  let importPreludeOpen = true;
 
   for (let i = 0; i < css.length; i += 1) {
     const char = css[i]!;
@@ -409,6 +413,7 @@ function extractStylesheetImports(css: string): StylesheetImportExtraction {
     }
     if (char === '"' || char === "'") {
       quote = char;
+      if (braceDepth === 0) importPreludeOpen = false;
       continue;
     }
     if (char === '{') {
@@ -424,10 +429,11 @@ function extractStylesheetImports(css: string): StylesheetImportExtraction {
       css.slice(i, i + '@import'.length).toLowerCase() !== '@import' ||
       isCssIdentifierChar(css[i + '@import'.length])
     ) {
+      if (braceDepth === 0 && !/\s/.test(char)) importPreludeOpen = false;
       continue;
     }
 
-    if (braceDepth !== 0) {
+    if (braceDepth !== 0 || !importPreludeOpen) {
       unsafe = true;
       continue;
     }
@@ -439,7 +445,8 @@ function extractStylesheetImports(css: string): StylesheetImportExtraction {
     const statement = css.slice(i, end);
     const match = CSS_IMPORT_HREF_RE.exec(statement);
     const href = match?.slice(1).find((value): value is string => typeof value === 'string')?.trim() ?? '';
-    if (!href || !isApprovedFontHref(href)) unsafe = true;
+    const condition = match ? statement.slice(match[0].length, -1).trim() : '';
+    if (!href || condition || !isApprovedFontHref(href)) unsafe = true;
     else if (!fontLinks.includes(href)) fontLinks.push(href);
 
     chunks.push(css.slice(chunkStart, i));

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -143,11 +143,9 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   // and each `var(--slide-bg)` resolves to transparent, painting nothing over
   // the near-black thumbnail host (black thumbnails). Comments are inert, so
   // removing them changes only which selectors the rewrites can see.
-  const styleWithImports = stripCssComments(
-    Array.from(doc.querySelectorAll('style'))
-      .map((el) => el.textContent || '')
-      .join('\n'),
-  );
+  const styleWithImports = Array.from(doc.querySelectorAll('style'))
+    .map((el) => el.textContent || '')
+    .join('\n');
   if (!styleWithImports.trim()) return unrenderable('no-styles');
 
   // Constructable stylesheets ignore @import, so leaving an approved webfont
@@ -160,7 +158,7 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   for (const href of imported.fontLinks) {
     if (!fontLinks.includes(href)) fontLinks.push(href);
   }
-  const rawStyle = imported.css;
+  const rawStyle = stripCssComments(imported.css);
   if (!rawStyle.trim()) return unrenderable('no-styles');
 
   const designSize = resolveDesignSize(doc, rawStyle);
@@ -330,44 +328,127 @@ interface StylesheetImportExtraction {
   unsafe: boolean;
 }
 
-// CSS imports may contain semicolons inside a quoted URL (Google Fonts uses
-// this for axis tuples), so the URL alternatives consume their quoted or
-// parenthesized payload before matching the statement terminator.
-const CSS_IMPORT_RE = /@import\s+(?:url\(\s*(?:"([^"]*)"|'([^']*)'|([^'"\s][^)]*))\s*\)|"([^"]*)"|'([^']*)')\s*[^;]*;/gi;
+const CSS_IMPORT_HREF_RE =
+  /^@import\s+(?:url\(\s*(?:"([^"]*)"|'([^']*)'|([^'"\s][^)]*))\s*\)|"([^"]*)"|'([^']*)')/i;
+
+function isCssIdentifierChar(char: string | undefined): boolean {
+  return !!char && /[\w-]/.test(char);
+}
+
+function findCssImportEnd(css: string, start: number): number | null {
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let inComment = false;
+  let parenDepth = 0;
+
+  for (let i = start + '@import'.length; i < css.length; i += 1) {
+    const char = css[i]!;
+    const next = css[i + 1];
+    if (inComment) {
+      if (char === '*' && next === '/') {
+        inComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      inComment = true;
+      i += 1;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      parenDepth += 1;
+    } else if (char === ')') {
+      if (parenDepth === 0) return null;
+      parenDepth -= 1;
+    } else if (char === ';' && parenDepth === 0) {
+      return i + 1;
+    } else if (char === '{' && parenDepth === 0) {
+      return null;
+    }
+  }
+  return null;
+}
 
 function extractStylesheetImports(css: string): StylesheetImportExtraction {
   const fontLinks: string[] = [];
   let unsafe = false;
-  const stripped = css.replace(
-    CSS_IMPORT_RE,
-    (
-      _statement,
-      doubleQuotedUrl?: string,
-      singleQuotedUrl?: string,
-      bareUrl?: string,
-      doubleQuotedHref?: string,
-      singleQuotedHref?: string,
-    ) => {
-      const href = [
-        doubleQuotedUrl,
-        singleQuotedUrl,
-        bareUrl,
-        doubleQuotedHref,
-        singleQuotedHref,
-      ].find((value): value is string => typeof value === 'string')?.trim() ?? '';
-      if (!href || !isApprovedFontHref(href)) {
-        unsafe = true;
-        return '';
+  const chunks: string[] = [];
+  let chunkStart = 0;
+  let braceDepth = 0;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let inComment = false;
+
+  for (let i = 0; i < css.length; i += 1) {
+    const char = css[i]!;
+    const next = css[i + 1];
+    if (inComment) {
+      if (char === '*' && next === '/') {
+        inComment = false;
+        i += 1;
       }
-      if (!fontLinks.includes(href)) fontLinks.push(href);
-      return '';
-    },
-  );
-  // A malformed or unsupported @import form must not leak into the app-origin
-  // shadow stylesheet. Falling back is safer and more faithful than pretending
-  // the imported layout rules do not exist.
-  if (/@import\b/i.test(stripped)) unsafe = true;
-  return { css: stripped, fontLinks, unsafe };
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      inComment = true;
+      i += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '{') {
+      braceDepth += 1;
+      continue;
+    }
+    if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+    if (
+      char !== '@' ||
+      css.slice(i, i + '@import'.length).toLowerCase() !== '@import' ||
+      isCssIdentifierChar(css[i + '@import'.length])
+    ) {
+      continue;
+    }
+
+    if (braceDepth !== 0) {
+      unsafe = true;
+      continue;
+    }
+    const end = findCssImportEnd(css, i);
+    if (end === null) {
+      unsafe = true;
+      continue;
+    }
+    const statement = css.slice(i, end);
+    const match = CSS_IMPORT_HREF_RE.exec(statement);
+    const href = match?.slice(1).find((value): value is string => typeof value === 'string')?.trim() ?? '';
+    if (!href || !isApprovedFontHref(href)) unsafe = true;
+    else if (!fontLinks.includes(href)) fontLinks.push(href);
+
+    chunks.push(css.slice(chunkStart, i));
+    chunkStart = end;
+    i = end - 1;
+  }
+
+  chunks.push(css.slice(chunkStart));
+  return { css: chunks.join(''), fontLinks, unsafe };
 }
 
 // Rewrite `:root`/`html` to `:host`, so document-level variables inherit into

--- a/apps/web/src/runtime/deck-thumbnail-parser.ts
+++ b/apps/web/src/runtime/deck-thumbnail-parser.ts
@@ -13,9 +13,9 @@
 //
 // It is intentionally pure and synchronous (DOMParser only) so it memoizes on
 // the source string and is unit-testable. Decks it cannot faithfully render
-// statically (external layout CSS, viewport-unit slides, script-built content)
-// report `renderable: false` with a reason, and the caller keeps the old
-// iframe thumbnail for that deck.
+// statically (external layout CSS or script-built content) report
+// `renderable: false` with a reason, and the caller keeps the old iframe
+// thumbnail for that deck.
 
 import DOMPurify from 'dompurify';
 
@@ -143,11 +143,24 @@ export function parseDeckThumbnails(html: string, baseHref?: string): ParsedDeck
   // and each `var(--slide-bg)` resolves to transparent, painting nothing over
   // the near-black thumbnail host (black thumbnails). Comments are inert, so
   // removing them changes only which selectors the rewrites can see.
-  const rawStyle = stripCssComments(
+  const styleWithImports = stripCssComments(
     Array.from(doc.querySelectorAll('style'))
       .map((el) => el.textContent || '')
       .join('\n'),
   );
+  if (!styleWithImports.trim()) return unrenderable('no-styles');
+
+  // Constructable stylesheets ignore @import, so leaving an approved webfont
+  // import in styleText silently changes typography and line wrapping in the
+  // shadow thumbnail. Lift approved font imports into the host alongside
+  // <link> fonts; any other import may contain layout CSS we cannot reproduce
+  // safely, so use the isolated iframe fallback instead.
+  const imported = extractStylesheetImports(styleWithImports);
+  if (imported.unsafe) return unrenderable('external-stylesheet');
+  for (const href of imported.fontLinks) {
+    if (!fontLinks.includes(href)) fontLinks.push(href);
+  }
+  const rawStyle = imported.css;
   if (!rawStyle.trim()) return unrenderable('no-styles');
 
   const designSize = resolveDesignSize(doc, rawStyle);
@@ -309,6 +322,52 @@ function matchPxLength(body: string, prop: 'width' | 'height'): number | null {
 // and deck CSS effectively never puts comment markers inside string values.
 function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+interface StylesheetImportExtraction {
+  css: string;
+  fontLinks: string[];
+  unsafe: boolean;
+}
+
+// CSS imports may contain semicolons inside a quoted URL (Google Fonts uses
+// this for axis tuples), so the URL alternatives consume their quoted or
+// parenthesized payload before matching the statement terminator.
+const CSS_IMPORT_RE = /@import\s+(?:url\(\s*(?:"([^"]*)"|'([^']*)'|([^'"\s][^)]*))\s*\)|"([^"]*)"|'([^']*)')\s*[^;]*;/gi;
+
+function extractStylesheetImports(css: string): StylesheetImportExtraction {
+  const fontLinks: string[] = [];
+  let unsafe = false;
+  const stripped = css.replace(
+    CSS_IMPORT_RE,
+    (
+      _statement,
+      doubleQuotedUrl?: string,
+      singleQuotedUrl?: string,
+      bareUrl?: string,
+      doubleQuotedHref?: string,
+      singleQuotedHref?: string,
+    ) => {
+      const href = [
+        doubleQuotedUrl,
+        singleQuotedUrl,
+        bareUrl,
+        doubleQuotedHref,
+        singleQuotedHref,
+      ].find((value): value is string => typeof value === 'string')?.trim() ?? '';
+      if (!href || !isApprovedFontHref(href)) {
+        unsafe = true;
+        return '';
+      }
+      if (!fontLinks.includes(href)) fontLinks.push(href);
+      return '';
+    },
+  );
+  // A malformed or unsupported @import form must not leak into the app-origin
+  // shadow stylesheet. Falling back is safer and more faithful than pretending
+  // the imported layout rules do not exist.
+  if (/@import\b/i.test(stripped)) unsafe = true;
+  return { css: stripped, fontLinks, unsafe };
 }
 
 // Rewrite `:root`/`html` to `:host`, so document-level variables inherit into

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -536,15 +536,44 @@ export function canActivateSrcDocTransport(state: SrcDocActivationInputs): boole
 
 function injectSrcdocTransportActivationBridge(doc: string, generation: string): string {
   const encodedGeneration = JSON.stringify(generation);
+  const markerGeneration = generation
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
   const script = `<script data-od-srcdoc-transport-activation>(function(){
   var generation = ${encodedGeneration};
+  var bodyComplete = false;
+  function containsCompletionMarker(node){
+    if (!node || node.nodeType !== 1) return false;
+    if (node.tagName === 'TEMPLATE' && node.getAttribute('data-od-srcdoc-transport-body-complete') === generation) return true;
+    var candidates = node.querySelectorAll ? node.querySelectorAll('template[data-od-srcdoc-transport-body-complete]') : [];
+    for (var i = 0; i < candidates.length; i += 1) {
+      if (candidates[i].getAttribute('data-od-srcdoc-transport-body-complete') === generation) return true;
+    }
+    return false;
+  }
+  var completionObserver = typeof MutationObserver === 'function' ? new MutationObserver(function(records){
+    if (bodyComplete) return;
+    for (var i = 0; i < records.length; i += 1) {
+      var added = records[i].addedNodes || [];
+      for (var j = 0; j < added.length; j += 1) {
+        if (!containsCompletionMarker(added[j])) continue;
+        bodyComplete = true;
+        completionObserver.disconnect();
+        return;
+      }
+    }
+  }) : null;
+  if (completionObserver && document.documentElement) {
+    completionObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
   function announceReady(probeId){
     if (!generation) return;
     try {
       if (window.parent && window.parent !== window) {
         var message = { type: 'od:srcdoc-transport-activated', generation: generation };
         if (typeof probeId === 'string' && probeId) message.probeId = probeId;
-        var bodyComplete = !!document.querySelector('template[data-od-srcdoc-transport-body-complete]');
         message.bodyComplete = bodyComplete;
         message.documentReadyState = document.readyState;
         message.bodyPresent = !!document.body;
@@ -573,12 +602,12 @@ function injectSrcdocTransportActivationBridge(doc: string, generation: string):
   // missing-ACK recovery indistinguishable from a genuinely aborted
   // `about:srcdoc` navigation. Placing the bridge first also runs it before an
   // authored meta CSP can disable later inline scripts.
-  // The inert tail marker distinguishes a fully parsed artifact from the
+  // The generation-specific inert tail marker distinguishes a fully parsed artifact from the
   // half-document Chromium can leave behind after aborting about:srcdoc. The
-  // head bridge remains alive in that state and can answer a host probe, but
-  // it cannot see a marker the parser never reached. A template is used so the
-  // witness executes no script and remains compatible with authored CSPs.
-  const bodyCompleteMarker = '<template data-od-srcdoc-transport-body-complete></template>';
+  // head bridge latches its insertion permanently, so later authored DOM
+  // replacement cannot erase the parser witness. A template is inert and
+  // remains compatible with authored CSPs.
+  const bodyCompleteMarker = `<template data-od-srcdoc-transport-body-complete="${markerGeneration}"></template>`;
   return injectBeforeBodyEnd(injectAfterHeadOpen(doc, script), bodyCompleteMarker);
 }
 

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -544,6 +544,12 @@ function injectSrcdocTransportActivationBridge(doc: string, generation: string):
       if (window.parent && window.parent !== window) {
         var message = { type: 'od:srcdoc-transport-activated', generation: generation };
         if (typeof probeId === 'string' && probeId) message.probeId = probeId;
+        var bodyComplete = !!document.querySelector('template[data-od-srcdoc-transport-body-complete]');
+        message.bodyComplete = bodyComplete;
+        message.documentReadyState = document.readyState;
+        message.bodyPresent = !!document.body;
+        message.bodyChildCount = document.body ? document.body.children.length : 0;
+        message.documentElementChildCount = document.documentElement ? document.documentElement.children.length : 0;
         window.parent.postMessage(message, '*');
       }
     } catch (_) { /* sandboxed parent */ }
@@ -567,7 +573,13 @@ function injectSrcdocTransportActivationBridge(doc: string, generation: string):
   // missing-ACK recovery indistinguishable from a genuinely aborted
   // `about:srcdoc` navigation. Placing the bridge first also runs it before an
   // authored meta CSP can disable later inline scripts.
-  return injectAfterHeadOpen(doc, script);
+  // The inert tail marker distinguishes a fully parsed artifact from the
+  // half-document Chromium can leave behind after aborting about:srcdoc. The
+  // head bridge remains alive in that state and can answer a host probe, but
+  // it cannot see a marker the parser never reached. A template is used so the
+  // witness executes no script and remains compatible with authored CSPs.
+  const bodyCompleteMarker = '<template data-od-srcdoc-transport-body-complete></template>';
+  return injectBeforeBodyEnd(injectAfterHeadOpen(doc, script), bodyCompleteMarker);
 }
 
 function injectSnapshotBridge(doc: string): string {

--- a/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FileViewer } from '../../src/components/FileViewer';
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
 import type { ProjectFile } from '../../src/types';
 
 function htmlFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
@@ -41,8 +45,17 @@ function transportGeneration(frame: HTMLIFrameElement): string {
   return generation;
 }
 
+beforeEach(() => {
+  setExceptionTrackingContext({
+    apiKey: 'phc_preview_test',
+    host: 'https://posthog.test',
+    distinctId: 'preview-test-user',
+  });
+});
+
 afterEach(() => {
   cleanup();
+  clearExceptionTrackingContext();
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -139,6 +152,7 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
           type: 'od:srcdoc-transport-activated',
           generation: transportGeneration(refreshedFrame),
           probeId: probe!.probeId,
+          bodyComplete: true,
         },
       }));
       vi.runAllTimers();
@@ -185,6 +199,7 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
           type: 'od:srcdoc-transport-activated',
           generation: firstProbe!.generation,
           probeId: firstProbe!.probeId,
+          bodyComplete: true,
         },
       }));
       vi.runAllTimers();
@@ -225,6 +240,86 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
     const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     expect(recoveredFrame).not.toBe(abortedFrame);
     expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+  });
+
+  it('recovers when a partial head bridge answers the probe before the body completed', () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => new Response('', {
+      status: String(input).includes('/i/v0/e/') ? 200 : 404,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('partial-document')}
+      />,
+    );
+
+    const partialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(partialFrame.contentWindow!, 'postMessage');
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+    const probe = postMessage.mock.calls.find(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    )?.[0] as { generation?: string; probeId?: string } | undefined;
+    expect(probe?.probeId).toBeTruthy();
+
+    act(() => {
+      // Chromium can leave the head bridge alive after aborting the rest of
+      // about:srcdoc. It can answer the challenge, but it has not observed the
+      // body-end marker and therefore must remain provisional.
+      window.dispatchEvent(new MessageEvent('message', {
+        source: partialFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: probe!.generation,
+          probeId: probe!.probeId,
+          bodyComplete: false,
+          documentReadyState: 'loading',
+          bodyPresent: true,
+          bodyChildCount: 2,
+          documentElementChildCount: 2,
+        },
+      }));
+    });
+
+    const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(recoveredFrame).not.toBe(partialFrame);
+    expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
+
+    const postHogCalls = fetchMock.mock.calls.filter(([input]) =>
+      String(input).includes('/i/v0/e/'));
+    expect(postHogCalls).toHaveLength(1);
+    const [, postHogInit] = postHogCalls[0]!;
+    expect(postHogInit).toBeDefined();
+    const payload = JSON.parse(
+      String(postHogInit?.body),
+    ) as { event?: string; properties?: Record<string, unknown> };
+    expect(payload).toMatchObject({
+      event: 'client_preview_white_screen',
+      properties: {
+        reason: 'srcdoc_transport_unverified',
+        transport_signal: 'body_incomplete',
+        transport_stage: 'head_bridge_alive_body_tail_missing',
+        activation_acknowledged: true,
+        body_complete: false,
+        frame_ready_state: 'loading',
+        frame_body_present: true,
+        frame_body_child_count: 2,
+        frame_document_element_child_count: 2,
+        recovery_attempted: true,
+        recovery_path: 'lazy_shell_remount',
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain('partial-document');
   });
 
   it('revalidates an early activation acknowledgement after the frame load completes', () => {

--- a/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx
@@ -242,7 +242,7 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
     expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
   });
 
-  it('recovers when a partial head bridge answers the probe before the body completed', () => {
+  it('recovers when a settled partial document answers the probe without completing its body', () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn(async (
       input: RequestInfo | URL,
@@ -283,7 +283,7 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
           generation: probe!.generation,
           probeId: probe!.probeId,
           bodyComplete: false,
-          documentReadyState: 'loading',
+          documentReadyState: 'complete',
           bodyPresent: true,
           bodyChildCount: 2,
           documentElementChildCount: 2,
@@ -311,7 +311,7 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
         transport_stage: 'head_bridge_alive_body_tail_missing',
         activation_acknowledged: true,
         body_complete: false,
-        frame_ready_state: 'loading',
+        frame_ready_state: 'complete',
         frame_body_present: true,
         frame_body_child_count: 2,
         frame_document_element_child_count: 2,
@@ -320,6 +320,122 @@ describe('FileViewer srcDoc file-watch refresh recovery', () => {
       },
     });
     expect(JSON.stringify(payload)).not.toContain('partial-document');
+  });
+
+  it('does not remount a healthy document while a parser-blocking script is still loading', () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => new Response('', { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={`<html><body>
+          <script>window.previewBootCount = (window.previewBootCount || 0) + 1;</script>
+          <script src="https://slow.example/parser-blocking.js"></script>
+          <main>Delayed but healthy</main>
+        </body></html>`}
+      />,
+    );
+
+    const parsingFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(parsingFrame.contentWindow!, 'postMessage');
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+    const firstProbe = postMessage.mock.calls.find(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    )?.[0] as { generation?: string; probeId?: string } | undefined;
+    expect(firstProbe?.probeId).toBeTruthy();
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: parsingFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: firstProbe!.generation,
+          probeId: firstProbe!.probeId,
+          bodyComplete: false,
+          documentReadyState: 'loading',
+        },
+      }));
+    });
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(parsingFrame);
+
+    fireEvent.load(parsingFrame);
+    const probes = postMessage.mock.calls.filter(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    );
+    const completionProbe = probes.at(-1)?.[0] as { generation?: string; probeId?: string };
+    expect(completionProbe.probeId).not.toBe(firstProbe!.probeId);
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: parsingFrame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: completionProbe.generation,
+          probeId: completionProbe.probeId,
+          bodyComplete: true,
+          documentReadyState: 'complete',
+        },
+      }));
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(parsingFrame);
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes('/i/v0/e/'))).toBe(false);
+  });
+
+  it('recovers when a truncated document stays loading through the parsing grace period', () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlFile()}
+        filesRefreshKey={0}
+        liveHtml={srcDocHtml('stuck-loading-document')}
+      />,
+    );
+
+    const partialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(partialFrame.contentWindow!, 'postMessage');
+    act(() => {
+      vi.advanceTimersByTime(1_500);
+    });
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const probes = postMessage.mock.calls.filter(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      );
+      const probe = probes.at(-1)?.[0] as { generation?: string; probeId?: string };
+      expect(probe.probeId).toBeTruthy();
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: partialFrame.contentWindow,
+          data: {
+            type: 'od:srcdoc-transport-activated',
+            generation: probe.generation,
+            probeId: probe.probeId,
+            bodyComplete: false,
+            documentReadyState: 'loading',
+          },
+        }));
+        if (attempt < 7) vi.advanceTimersByTime(1_500);
+      });
+    }
+
+    const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(recoveredFrame).not.toBe(partialFrame);
+    expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
   });
 
   it('revalidates an early activation acknowledgement after the frame load completes', () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -2717,6 +2717,7 @@ describe('FileViewer SVG artifacts', () => {
           type: 'od:srcdoc-transport-activated',
           generation: readinessProbe!.generation,
           probeId: readinessProbe!.probeId,
+          bodyComplete: true,
         },
       }));
     });
@@ -7362,6 +7363,7 @@ describe('FileViewer tweaks toolbar', () => {
             type: 'od:srcdoc-transport-activated',
             generation: initialGeneration,
             probeId: initialProbe!.probeId,
+            bodyComplete: true,
           },
         }));
       });
@@ -7799,6 +7801,7 @@ describe('FileViewer tweaks toolbar', () => {
           type: 'od:srcdoc-transport-activated',
           generation: probe.generation,
           probeId: probe.probeId,
+          bodyComplete: true,
         },
       }));
     });

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../src/analytics/error-tracking', () => ({ reportSafetyEvent }));
 import {
   installPreviewIframeMessageObserver,
   reportPreviewIframeMessage,
+  reportPreviewTransportRecovery,
   subscribePreviewIframeMessages,
 } from '../../src/observability/iframe-error';
 
@@ -83,6 +84,78 @@ describe('preview iframe observability', () => {
       viewport_width: 1440,
     }));
   });
+
+  it('reports host-observed incomplete srcDoc recovery without authored content', () => {
+    reportPreviewTransportRecovery({
+      surface: 'artifact_preview',
+      renderMode: 'srcdoc',
+      artifactId: 'anon-artifact',
+      artifactKind: 'slide_deck',
+      projectId: 'project-1',
+      signal: 'body_incomplete',
+      activationAcknowledged: true,
+      documentState: {
+        readyState: 'loading',
+        bodyPresent: true,
+        bodyChildCount: 2,
+        documentElementChildCount: 2,
+      },
+      viewportWidth: 1280,
+      viewportHeight: 720,
+    });
+
+    expect(reportSafetyEvent).toHaveBeenCalledWith(
+      'client_preview_white_screen',
+      {
+        surface: 'artifact_preview',
+        render_mode: 'srcdoc',
+        artifact_id: 'anon-artifact',
+        artifact_kind: 'slide_deck',
+        project_id: 'project-1',
+        reason: 'srcdoc_transport_unverified',
+        transport_signal: 'body_incomplete',
+        transport_stage: 'head_bridge_alive_body_tail_missing',
+        activation_acknowledged: true,
+        body_complete: false,
+        frame_ready_state: 'loading',
+        frame_body_present: true,
+        frame_body_child_count: 2,
+        frame_document_element_child_count: 2,
+        recovery_attempted: true,
+        recovery_path: 'lazy_shell_remount',
+        host_visibility_state: 'visible',
+        viewport_width: 1280,
+        viewport_height: 720,
+        timeout_ms: undefined,
+      },
+    );
+  });
+
+  it.each([
+    [true, 'head_bridge_lost_after_eager_ack'],
+    [false, 'no_head_bridge_ack'],
+  ])(
+    'classifies a probe timeout from activation state %s',
+    (activationAcknowledged, transportStage) => {
+      reportPreviewTransportRecovery({
+        surface: 'artifact_preview',
+        renderMode: 'srcdoc',
+        signal: 'probe_timeout',
+        activationAcknowledged,
+        timeoutMs: 1_500,
+      });
+
+      expect(reportSafetyEvent).toHaveBeenCalledWith(
+        'client_preview_white_screen',
+        expect.objectContaining({
+          transport_signal: 'probe_timeout',
+          transport_stage: transportStage,
+          activation_acknowledged: activationAcknowledged,
+          timeout_ms: 1_500,
+        }),
+      );
+    },
+  );
 
   it('deduplicates repeated failures from one preview', () => {
     const seen = new Set<string>();

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -72,6 +72,8 @@ describe('preview iframe observability', () => {
       visible_element_count: 0,
       viewport_width: 1440,
       viewport_height: 900,
+      blank_observation_count: 2,
+      sample_interval_ms: 1_500,
     }, { surface: 'artifact_preview', renderMode: 'srcdoc' });
 
     expect(reportSafetyEvent).toHaveBeenNthCalledWith(1, 'client_preview_resource_error', expect.objectContaining({
@@ -82,6 +84,8 @@ describe('preview iframe observability', () => {
       reason: 'no_visible_paint_after_timeout',
       visible_element_count: 0,
       viewport_width: 1440,
+      blank_observation_count: 2,
+      sample_interval_ms: 1_500,
     }));
   });
 

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -458,7 +458,7 @@ describe('parseDeckThumbnails', () => {
 
   it('lifts a top-level import with a directly quoted URL', () => {
     const fontHref = 'https://fonts.googleapis.com/css2?family=Inter';
-    const deck = frameworkDeck(1).replace('<style>', `<style>@import "${fontHref}" screen;`);
+    const deck = frameworkDeck(1).replace('<style>', `<style>@import "${fontHref}";`);
 
     const parsed = parseDeckThumbnails(deck);
 
@@ -472,6 +472,38 @@ describe('parseDeckThumbnails', () => {
     ['a non-font import', '@import url("https://cdn.example.com/layout.css");'],
   ])('falls back for %s', (_case, importRule) => {
     const deck = frameworkDeck(1).replace('<style>', `<style>${importRule}`);
+
+    const parsed = parseDeckThumbnails(deck);
+
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('external-stylesheet');
+  });
+
+  it.each([
+    ['print media', '@import url("https://fonts.googleapis.com/css2?family=Inter") print;'],
+    [
+      'a true supports condition',
+      '@import url("https://fonts.googleapis.com/css2?family=Inter") supports(display: grid);',
+    ],
+    [
+      'a false supports condition',
+      '@import url("https://fonts.googleapis.com/css2?family=Inter") supports(display: unknown-value);',
+    ],
+    ['a named layer', '@import url("https://fonts.googleapis.com/css2?family=Inter") layer(deck-fonts);'],
+  ])('falls back rather than changing the semantics of %s', (_case, importRule) => {
+    const deck = frameworkDeck(1).replace('<style>', `<style>${importRule}`);
+
+    const parsed = parseDeckThumbnails(deck);
+
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('external-stylesheet');
+  });
+
+  it('falls back for an import after a normal rule', () => {
+    const deck = frameworkDeck(1).replace(
+      '</style>',
+      '@import url("https://fonts.googleapis.com/css2?family=Inter");</style>',
+    );
 
     const parsed = parseDeckThumbnails(deck);
 

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -439,6 +439,46 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.styleText).not.toContain('@import');
   });
 
+  it.each([
+    ['quoted content', `.deck-stage::after { content: "@import url('https://fonts.googleapis.com/css2?family=Fake');"; }`],
+    ['a quoted custom property', `.deck-stage { --example: "@import url('https://fonts.googleapis.com/css2?family=Fake');"; }`],
+  ])('does not treat @import text inside %s as a stylesheet import', (_case, declaration) => {
+    const deck = frameworkDeck(1).replace(
+      '.deck-stage { width: 1920px; height: 1080px; background: var(--bg); }',
+      `${declaration}\n.deck-stage { width: 1920px; height: 1080px; background: var(--bg); }`,
+    );
+
+    const parsed = parseDeckThumbnails(deck);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.fontLinks).toEqual([]);
+    expect(parsed.styleText).toContain('@import url');
+    expect(parsed.styleText).toContain('.deck-stage { width: 1920px');
+  });
+
+  it('lifts a top-level import with a directly quoted URL', () => {
+    const fontHref = 'https://fonts.googleapis.com/css2?family=Inter';
+    const deck = frameworkDeck(1).replace('<style>', `<style>@import "${fontHref}" screen;`);
+
+    const parsed = parseDeckThumbnails(deck);
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.fontLinks).toContain(fontHref);
+    expect(parsed.styleText).not.toContain('@import');
+  });
+
+  it.each([
+    ['a malformed import', '@import url("https://fonts.googleapis.com/css2?family=Inter";'],
+    ['a non-font import', '@import url("https://cdn.example.com/layout.css");'],
+  ])('falls back for %s', (_case, importRule) => {
+    const deck = frameworkDeck(1).replace('<style>', `<style>${importRule}`);
+
+    const parsed = parseDeckThumbnails(deck);
+
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('external-stylesheet');
+  });
+
   it('falls back when a slide-nested style imports unapproved CSS', () => {
     const deck = [
       '<!doctype html><html><head><style>.deck-stage { width: 1920px; height: 1080px; }</style></head><body>',

--- a/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
+++ b/apps/web/tests/runtime/deck-thumbnail-parser.test.ts
@@ -421,7 +421,25 @@ describe('parseDeckThumbnails', () => {
     expect(parsed.fontLinks).toContain('https://fonts.googleapis.com/css2?family=Inter');
   });
 
-  it('drops a slide-nested <style> element from the sanitized slide body', () => {
+  it('lifts an approved font @import into the host so thumbnail typography matches', () => {
+    const fontHref = 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,700&display=swap';
+    const deck = [
+      '<!doctype html><html><head><style>',
+      `  @import url('${fontHref}');`,
+      '  .deck-stage { width: 1920px; height: 1080px; }',
+      '</style></head><body>',
+      '  <div class="deck-stage" id="deck-stage"><section class="slide active"><h1>Title</h1></section></div>',
+      '</body></html>',
+    ].join('\n');
+
+    const parsed = parseDeckThumbnails(deck, '/api/projects/p1/raw/');
+
+    expect(parsed.renderable).toBe(true);
+    expect(parsed.fontLinks).toContain(fontHref);
+    expect(parsed.styleText).not.toContain('@import');
+  });
+
+  it('falls back when a slide-nested style imports unapproved CSS', () => {
     const deck = [
       '<!doctype html><html><head><style>.deck-stage { width: 1920px; height: 1080px; }</style></head><body>',
       '  <div class="deck-stage" id="deck-stage">',
@@ -433,18 +451,11 @@ describe('parseDeckThumbnails', () => {
       '</body></html>',
     ].join('\n');
     const parsed = parseDeckThumbnails(deck, '/api/projects/p1/raw/');
-    expect(parsed.renderable).toBe(true);
-    const slide = parsed.slides[0] ?? '';
-    // DOMPurify removes the <style> element from the slide body markup.
-    expect(slide).not.toMatch(/<style/i);
-    expect(slide).not.toContain('evil.example');
-    expect(slide).toContain('Title');
-    // Note the deferred gap: parseDeckThumbnails harvests every <style> in the
-    // document into styleText independently of this DOMPurify pass, so the
-    // nested rule's CSS (including its @import) still lands in styleText. CSS
-    // @import stripping is intentionally left to the CSS-tokenizer follow-up,
-    // so this stays unchanged from main and is asserted here, not silently
-    // assumed closed.
-    expect(parsed.styleText).toContain('evil.example');
+    // Every style block contributes to the shadow stylesheet, including one
+    // nested inside a slide before the markup sanitizer removes that element.
+    // An unapproved import therefore makes static rendering unsafe/incomplete
+    // and must use the isolated iframe fallback.
+    expect(parsed.renderable).toBe(false);
+    expect(parsed.reason).toBe('external-stylesheet');
   });
 });

--- a/apps/web/tests/runtime/preview-observability-bridge.test.ts
+++ b/apps/web/tests/runtime/preview-observability-bridge.test.ts
@@ -1,0 +1,195 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  PREVIEW_OBSERVABILITY_MESSAGE_TYPE,
+  buildPreviewObservabilityBridge,
+  type PreviewObservabilityMessage,
+} from '@open-design/contracts/runtime/preview-observability';
+
+interface ScheduledTask {
+  at: number;
+  callback: () => void;
+  id: number;
+}
+
+interface BridgeHarness {
+  advanceBy: (durationMs: number) => void;
+  close: () => void;
+  events: PreviewObservabilityMessage[];
+  setViewport: (width: number, height: number) => void;
+  setVisibility: (value: DocumentVisibilityState) => void;
+  window: JSDOM['window'];
+}
+
+function bridgeScriptBody(): string {
+  return buildPreviewObservabilityBridge()
+    .replace(/^<script[^>]*>/, '')
+    .replace(/<\/script>$/, '');
+}
+
+function createBridgeHarness(body = ''): BridgeHarness {
+  const dom = new JSDOM(`<!doctype html><html><body>${body}</body></html>`, {
+    pretendToBeVisual: true,
+    runScripts: 'outside-only',
+    url: 'http://preview.test/',
+  });
+  const events: PreviewObservabilityMessage[] = [];
+  const tasks: ScheduledTask[] = [];
+  let nextTaskId = 0;
+  let now = 0;
+  let visibility: DocumentVisibilityState = 'visible';
+  let viewportWidth = 1280;
+  let viewportHeight = 720;
+  const win = dom.window;
+
+  Object.defineProperties(win.document, {
+    readyState: { configurable: true, get: () => 'complete' },
+    visibilityState: { configurable: true, get: () => visibility },
+  });
+  Object.defineProperties(win, {
+    innerHeight: { configurable: true, get: () => viewportHeight },
+    innerWidth: { configurable: true, get: () => viewportWidth },
+  });
+  win.postMessage = ((data: unknown) => {
+    if (
+      data
+      && typeof data === 'object'
+      && (data as { type?: unknown }).type === PREVIEW_OBSERVABILITY_MESSAGE_TYPE
+    ) {
+      events.push(data as PreviewObservabilityMessage);
+    }
+  }) as typeof win.postMessage;
+  win.setTimeout = ((callback: TimerHandler, delay = 0) => {
+    nextTaskId += 1;
+    tasks.push({
+      at: now + Number(delay),
+      callback: () => {
+        if (typeof callback === 'function') callback();
+      },
+      id: nextTaskId,
+    });
+    return nextTaskId;
+  }) as typeof win.setTimeout;
+  win.clearTimeout = ((id: number) => {
+    const index = tasks.findIndex((task) => task.id === id);
+    if (index >= 0) tasks.splice(index, 1);
+  }) as typeof win.clearTimeout;
+
+  win.eval(bridgeScriptBody());
+
+  return {
+    advanceBy(durationMs) {
+      const target = now + durationMs;
+      while (true) {
+        tasks.sort((left, right) => left.at - right.at || left.id - right.id);
+        const task = tasks[0];
+        if (!task || task.at > target) break;
+        tasks.shift();
+        now = task.at;
+        task.callback();
+      }
+      now = target;
+    },
+    close: () => dom.window.close(),
+    events,
+    setViewport(width, height) {
+      viewportWidth = width;
+      viewportHeight = height;
+      win.dispatchEvent(new win.Event('resize'));
+    },
+    setVisibility(value) {
+      visibility = value;
+      win.document.dispatchEvent(new win.Event('visibilitychange'));
+    },
+    window: win,
+  };
+}
+
+const harnesses: BridgeHarness[] = [];
+
+afterEach(() => {
+  for (const harness of harnesses.splice(0)) harness.close();
+});
+
+describe('preview observability white-screen bridge', () => {
+  it('does not report while the host tab is hidden, then samples after it becomes visible', () => {
+    const harness = createBridgeHarness();
+    harnesses.push(harness);
+    harness.setVisibility('hidden');
+
+    harness.advanceBy(20_000);
+    expect(harness.events).toEqual([]);
+
+    harness.setVisibility('visible');
+    harness.advanceBy(6_500);
+    expect(harness.events).toEqual([
+      expect.objectContaining({
+        event: 'white_screen',
+        visibility_state: 'visible',
+      }),
+    ]);
+  });
+
+  it('does not report a zero-sized preview and retries after the viewport becomes measurable', () => {
+    const harness = createBridgeHarness();
+    harnesses.push(harness);
+    harness.setViewport(0, 0);
+
+    harness.advanceBy(20_000);
+    expect(harness.events).toEqual([]);
+
+    harness.setViewport(1280, 720);
+    harness.advanceBy(6_500);
+    expect(harness.events).toEqual([
+      expect.objectContaining({
+        event: 'white_screen',
+        viewport_width: 1280,
+        viewport_height: 720,
+      }),
+    ]);
+  });
+
+  it('nudges layout once and suppresses the report when visible paint recovers', () => {
+    const harness = createBridgeHarness('<main>Rendered after resize</main>');
+    harnesses.push(harness);
+    let layoutNudged = false;
+    const main = harness.window.document.querySelector('main');
+    if (!main) throw new Error('missing preview fixture');
+    main.getBoundingClientRect = () => ({
+      bottom: layoutNudged ? 100 : 0,
+      height: layoutNudged ? 100 : 0,
+      left: 0,
+      right: layoutNudged ? 100 : 0,
+      top: 0,
+      width: layoutNudged ? 100 : 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    harness.window.addEventListener('resize', () => {
+      layoutNudged = true;
+    });
+
+    harness.advanceBy(20_000);
+
+    expect(layoutNudged).toBe(true);
+    expect(harness.events).toEqual([]);
+  });
+
+  it('reports only after two blank observations and includes confirmation metadata', () => {
+    const harness = createBridgeHarness();
+    harnesses.push(harness);
+
+    harness.advanceBy(5_000);
+    expect(harness.events).toEqual([]);
+
+    harness.advanceBy(1_500);
+    expect(harness.events).toEqual([
+      expect.objectContaining({
+        event: 'white_screen',
+        blank_observation_count: 2,
+        sample_interval_ms: 1_500,
+      }),
+    ]);
+  });
+});

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -116,10 +116,90 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain("data.type === 'od:srcdoc-transport-ready-probe'");
     expect(srcdoc).toContain('announceReady(data.probeId)');
     expect(srcdoc).toContain('message.probeId = probeId');
-    expect(srcdoc).toContain('data-od-srcdoc-transport-body-complete');
+    expect(srcdoc).toContain('data-od-srcdoc-transport-body-complete="generation-42"');
+    expect(srcdoc).toContain('var bodyComplete = false');
+    expect(srcdoc).toContain('new MutationObserver(function(records)');
     expect(srcdoc).toContain('message.bodyComplete = bodyComplete');
+    expect(srcdoc).not.toContain("document.querySelector('template[data-od-srcdoc-transport-body-complete]')");
     expect(srcdoc).toContain('message.documentReadyState = document.readyState');
     expect(srcdoc).toContain('message.bodyChildCount = document.body ? document.body.children.length : 0');
+  });
+
+  it('keeps parser completion latched after authored code removes the completed body', async () => {
+    const messages: Array<Record<string, unknown>> = [];
+    const generation = 'generation-remove-body';
+    const srcdoc = buildSrcdoc(
+      `<html><head></head><body><main>Ready</main><script>
+        window.addEventListener('DOMContentLoaded', function(){ document.body.remove(); });
+      </script></body></html>`,
+      { transportActivationGeneration: generation },
+    );
+    const dom = new JSDOM(srcdoc, {
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        Object.defineProperty(window, 'parent', {
+          value: { postMessage: (message: Record<string, unknown>) => messages.push(message) },
+        });
+      },
+    });
+    await new Promise<void>((resolve) => dom.window.addEventListener('load', () => resolve()));
+    await new Promise<void>((resolve) => dom.window.queueMicrotask(resolve));
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: {
+        type: 'od:srcdoc-transport-ready-probe',
+        generation,
+        probeId: 'probe-after-body-removal',
+      },
+    }));
+
+    expect(dom.window.document.body).toBeNull();
+    expect(messages).toContainEqual(expect.objectContaining({
+      type: 'od:srcdoc-transport-activated',
+      generation,
+      probeId: 'probe-after-body-removal',
+      bodyComplete: true,
+    }));
+    dom.window.close();
+  });
+
+  it('does not accept an authored lookalike before a truncated injected tail', async () => {
+    const messages: Array<Record<string, unknown>> = [];
+    const generation = 'generation-truncated-tail';
+    const completeSrcdoc = buildSrcdoc(
+      '<html><head></head><body><template data-od-srcdoc-transport-body-complete></template><main>Partial</main></body></html>',
+      { transportActivationGeneration: generation },
+    );
+    const injectedMarker = `<template data-od-srcdoc-transport-body-complete="${generation}"></template>`;
+    const markerIndex = completeSrcdoc.indexOf(injectedMarker);
+    expect(markerIndex).toBeGreaterThan(-1);
+    const srcdoc = completeSrcdoc.slice(0, markerIndex);
+    const dom = new JSDOM(srcdoc, {
+      runScripts: 'dangerously',
+      beforeParse(window) {
+        Object.defineProperty(window, 'parent', {
+          value: { postMessage: (message: Record<string, unknown>) => messages.push(message) },
+        });
+      },
+    });
+    await new Promise<void>((resolve) => dom.window.addEventListener('load', () => resolve()));
+    await new Promise<void>((resolve) => dom.window.queueMicrotask(resolve));
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: {
+        type: 'od:srcdoc-transport-ready-probe',
+        generation,
+        probeId: 'probe-truncated-tail',
+      },
+    }));
+
+    expect(messages).toContainEqual(expect.objectContaining({
+      type: 'od:srcdoc-transport-activated',
+      generation,
+      probeId: 'probe-truncated-tail',
+      bodyComplete: false,
+    }));
+    dom.window.close();
   });
 
   it('paints an opaque background before drawing so empty rasters never flatten to black', () => {

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -116,6 +116,10 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain("data.type === 'od:srcdoc-transport-ready-probe'");
     expect(srcdoc).toContain('announceReady(data.probeId)');
     expect(srcdoc).toContain('message.probeId = probeId');
+    expect(srcdoc).toContain('data-od-srcdoc-transport-body-complete');
+    expect(srcdoc).toContain('message.bodyComplete = bodyComplete');
+    expect(srcdoc).toContain('message.documentReadyState = document.readyState');
+    expect(srcdoc).toContain('message.bodyChildCount = document.body ? document.body.children.length : 0');
   });
 
   it('paints an opaque background before drawing so empty rasters never flatten to black', () => {

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -381,12 +381,12 @@ async function selectComposerSessionMode(page: Page, modeTitle: 'Ask mode' | 'Pl
 }
 
 async function openDesignFile(page: Page, fileName: string) {
-  const preview = page.getByTestId('artifact-preview-frame');
-  if (await preview.isVisible()) return;
-
   const fileTab = page.getByRole('tab', { name: new RegExp(fileName.replace(/\./g, '\\.'), 'i') });
   if (await fileTab.isVisible()) {
-    await fileTab.click();
+    if (await fileTab.getAttribute('aria-selected') !== 'true') {
+      await fileTab.click();
+    }
+    await expect(fileTab).toHaveAttribute('aria-selected', 'true');
     return;
   }
 

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -6,10 +6,19 @@ import type { Locator, Page, Request } from '@playwright/test';
 import { automatedUiScenarios } from '@/playwright/resources';
 import type { UiScenario } from '@/playwright/resources';
 import { T } from '@/timeouts';
+import {
+  PREVIEW_WHITE_SCREEN_CONFIRMATION_MS,
+  PREVIEW_WHITE_SCREEN_TIMEOUT_MS,
+} from '@open-design/contracts/runtime/preview-observability';
 
 const STORAGE_KEY = 'open-design:config';
 const TINY_PNG_B64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
+
+interface CapturedSafetyEvent {
+  event?: string;
+  properties?: Record<string, unknown>;
+}
 
 test.describe.configure({ timeout: T.xlong });
 
@@ -41,6 +50,78 @@ async function routeMockAgents(page: Page) {
       models: [{ id: 'default', label: 'Default' }],
     },
   ]);
+}
+
+async function captureSafetyTelemetry(page: Page): Promise<CapturedSafetyEvent[]> {
+  const events: CapturedSafetyEvent[] = [];
+  await page.unroute('**/api/app-config').catch(() => {});
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+        privacyDecisionAt: 1,
+        telemetry: { metrics: true, content: false, artifactManifest: false },
+      }),
+    );
+  }, STORAGE_KEY);
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          privacyDecisionAt: 1,
+          telemetry: { metrics: true, content: false, artifactManifest: false },
+        },
+      },
+    });
+  });
+  await page.route('**/api/analytics/config', async (route) => {
+    await route.fulfill({
+      json: {
+        enabled: true,
+        env: 'e2e',
+        key: 'phc_e2e',
+        host: 'https://analytics.open-design.test',
+        installationId: 'e2e-installation',
+      },
+    });
+  });
+  await page.route('https://analytics.open-design.test/**', async (route) => {
+    const body = route.request().postData();
+    if (body) {
+      try {
+        events.push(JSON.parse(body) as CapturedSafetyEvent);
+      } catch {
+        // posthog-js can use non-JSON batch encodings; this witness owns only
+        // the direct JSON safety-telemetry transport.
+      }
+    }
+    await route.fulfill({ status: 200, json: { status: 1 } });
+  });
+  return events;
+}
+
+function capturedWhiteScreenEvents(
+  events: CapturedSafetyEvent[],
+): CapturedSafetyEvent[] {
+  return events.filter((event) => event.event === 'client_preview_white_screen');
 }
 
 for (const entry of automatedUiScenarios().filter((scenario) => designFileFlows.has(scenario.flow ?? ''))) {
@@ -927,6 +1008,84 @@ test('[P0] @critical file workspace restores HTML preview after switching throug
     name: 'Risk Dashboard',
   })).toBeVisible();
   await expect(page.getByTestId('file-workspace')).toBeVisible();
+});
+
+test('[P0] @critical white-screen monitoring recovers layout stalls and confirms persistent blanks', async ({ page }) => {
+  const safetyEvents = await captureSafetyTelemetry(page);
+  await routeMockAgents(page);
+
+  const projectId = await createProjectViaApi(page, 'Preview white-screen monitoring');
+  await seedHtmlArtifact(
+    page,
+    projectId,
+    'recoverable-blank.html',
+    `<!doctype html>
+      <html>
+        <head><style>main { display: none; }</style></head>
+        <body data-monitor-fixture="recoverable" data-monitor-recovered="false">
+          <main><h1>Recovered preview paint</h1></main>
+          <script>
+            window.__monitorFixtureStartedAt = performance.now();
+            window.addEventListener('resize', function () {
+              if (performance.now() - window.__monitorFixtureStartedAt < 4500) return;
+              document.querySelector('main').style.display = 'block';
+              document.body.dataset.monitorRecovered = 'true';
+            });
+          </script>
+        </body>
+      </html>`,
+  );
+  await seedHtmlArtifact(
+    page,
+    projectId,
+    'persistent-blank.html',
+    `<!doctype html>
+      <html>
+        <body data-monitor-fixture="persistent">
+          <script>window.__monitorFixtureReady = true;</script>
+        </body>
+      </html>`,
+  );
+
+  await page.goto(`/projects/${projectId}?forceInline=1`, { waitUntil: 'domcontentloaded' });
+  await expectWorkspaceReady(page);
+  await openDesignFile(page, 'recoverable-blank.html');
+
+  const activePreview = page.frameLocator('[data-testid="artifact-preview-frame"]');
+  const recoverableBody = activePreview.locator('body[data-monitor-fixture="recoverable"]');
+  const recoverableMain = recoverableBody.locator('main');
+  await expect(recoverableBody).toBeVisible();
+  await expect(recoverableBody).toHaveAttribute('data-monitor-recovered', 'true', {
+    timeout: PREVIEW_WHITE_SCREEN_TIMEOUT_MS + T.short,
+  });
+  await expect(recoverableMain).toHaveCSS('display', 'block', {
+    timeout: PREVIEW_WHITE_SCREEN_TIMEOUT_MS + T.short,
+  });
+  await page.waitForTimeout(PREVIEW_WHITE_SCREEN_CONFIRMATION_MS + 100);
+  expect(capturedWhiteScreenEvents(safetyEvents)).toEqual([]);
+
+  await openAllProjectFiles(page);
+  const persistentRow = await revealDesignFileRow(page, 'persistent-blank.html');
+  await persistentRow.getByRole('button').first().click();
+  await expect(page.getByRole('tab', { name: /persistent-blank\.html/i }))
+    .toHaveAttribute('aria-selected', 'true');
+  const persistentBody = activePreview.locator('body[data-monitor-fixture="persistent"]');
+  await expect(persistentBody).toBeAttached();
+
+  await page.waitForTimeout(PREVIEW_WHITE_SCREEN_TIMEOUT_MS - 500);
+  expect(capturedWhiteScreenEvents(safetyEvents)).toEqual([]);
+
+  await expect.poll(
+    () => capturedWhiteScreenEvents(safetyEvents).length,
+    { timeout: PREVIEW_WHITE_SCREEN_CONFIRMATION_MS + T.short },
+  ).toBe(1);
+  const [whiteScreen] = capturedWhiteScreenEvents(safetyEvents);
+  expect(whiteScreen?.properties).toMatchObject({
+    blank_observation_count: 2,
+    sample_interval_ms: PREVIEW_WHITE_SCREEN_CONFIRMATION_MS,
+    visible_element_count: 0,
+    visibility_state: 'visible',
+  });
 });
 
 test('[P0] @critical HTML file list and previews stay stable across repeated switches', async ({ page }) => {

--- a/packages/contracts/src/runtime/preview-observability.ts
+++ b/packages/contracts/src/runtime/preview-observability.ts
@@ -12,6 +12,7 @@ export const PREVIEW_OBSERVABILITY_MESSAGE_TYPE = 'od:preview-observability';
 export const PREVIEW_OBSERVABILITY_PROTOCOL_VERSION = 1;
 export const PREVIEW_OBSERVABILITY_BRIDGE_MARKER = 'data-od-preview-observability';
 export const PREVIEW_WHITE_SCREEN_TIMEOUT_MS = 5_000;
+export const PREVIEW_WHITE_SCREEN_CONFIRMATION_MS = 1_500;
 
 export type PreviewObservabilityEvent =
   | 'runtime_error'
@@ -38,6 +39,8 @@ export interface PreviewObservabilityMessage {
   visible_element_count?: number;
   viewport_width?: number;
   viewport_height?: number;
+  blank_observation_count?: number;
+  sample_interval_ms?: number;
 }
 
 const EVENT_NAMES = new Set<PreviewObservabilityEvent>([
@@ -75,7 +78,9 @@ type PreviewNumberField =
   | 'body_child_count'
   | 'visible_element_count'
   | 'viewport_width'
-  | 'viewport_height';
+  | 'viewport_height'
+  | 'blank_observation_count'
+  | 'sample_interval_ms';
 
 const NUMBER_FIELDS: readonly PreviewNumberField[] = [
   'line',
@@ -84,6 +89,8 @@ const NUMBER_FIELDS: readonly PreviewNumberField[] = [
   'visible_element_count',
   'viewport_width',
   'viewport_height',
+  'blank_observation_count',
+  'sample_interval_ms',
 ];
 
 const MAX_PREVIEW_OBSERVABILITY_NUMBER = 10_000_000;
@@ -137,6 +144,7 @@ export function buildPreviewObservabilityBridge(): string {
   var TYPE = ${JSON.stringify(PREVIEW_OBSERVABILITY_MESSAGE_TYPE)};
   var VERSION = ${PREVIEW_OBSERVABILITY_PROTOCOL_VERSION};
   var WHITE_SCREEN_TIMEOUT = ${PREVIEW_WHITE_SCREEN_TIMEOUT_MS};
+  var WHITE_SCREEN_CONFIRMATION_DELAY = ${PREVIEW_WHITE_SCREEN_CONFIRMATION_MS};
   var MAX_EVENTS = 12;
   var sentCount = 0;
   var sent = Object.create(null);
@@ -254,24 +262,58 @@ export function buildPreviewObservabilityBridge(): string {
     }
     return count;
   }
-  var whiteScreenChecked = false;
-  function checkWhiteScreen(){
-    if (whiteScreenChecked) return;
-    whiteScreenChecked = true;
+  var whiteScreenReported = false;
+  var whiteScreenCheckTimer = null;
+  var whiteScreenConfirmationTimer = null;
+  function whiteScreenCheckEligible(){
+    return document.readyState === 'complete' &&
+      document.visibilityState === 'visible' &&
+      (window.innerWidth || 0) > 1 &&
+      (window.innerHeight || 0) > 1;
+  }
+  function scheduleWhiteScreenCheck(delay){
+    if (whiteScreenReported || whiteScreenCheckTimer !== null || whiteScreenConfirmationTimer !== null) return;
+    whiteScreenCheckTimer = setTimeout(function(){
+      whiteScreenCheckTimer = null;
+      checkWhiteScreen();
+    }, delay);
+  }
+  function nudgePreviewLayout(){
+    try { document.documentElement && document.documentElement.getBoundingClientRect(); } catch (_) {}
+    try { window.dispatchEvent(new Event('resize')); } catch (_) {}
+  }
+  function confirmWhiteScreen(){
+    whiteScreenConfirmationTimer = null;
+    if (whiteScreenReported || !whiteScreenCheckEligible()) return;
     var visible = visiblePaintCount();
     if (visible > 0) return;
+    whiteScreenReported = true;
     send('white_screen', {
       ready_state: text(document.readyState, 32),
       visibility_state: text(document.visibilityState, 32),
       body_child_count: document.body ? document.body.children.length : 0,
       visible_element_count: visible,
       viewport_width: Math.max(0, Math.round(window.innerWidth || 0)),
-      viewport_height: Math.max(0, Math.round(window.innerHeight || 0))
+      viewport_height: Math.max(0, Math.round(window.innerHeight || 0)),
+      blank_observation_count: 2,
+      sample_interval_ms: WHITE_SCREEN_CONFIRMATION_DELAY
     });
   }
-  if (document.readyState === 'complete') setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT);
-  else window.addEventListener('load', function(){ setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT); }, { once: true });
-  setTimeout(checkWhiteScreen, WHITE_SCREEN_TIMEOUT * 2);
+  function checkWhiteScreen(){
+    if (whiteScreenReported || whiteScreenConfirmationTimer !== null || !whiteScreenCheckEligible()) return;
+    var visible = visiblePaintCount();
+    if (visible > 0) return;
+    whiteScreenConfirmationTimer = setTimeout(confirmWhiteScreen, WHITE_SCREEN_CONFIRMATION_DELAY);
+    nudgePreviewLayout();
+  }
+  function scheduleWhiteScreenCheckWhenEligible(){
+    if (whiteScreenCheckEligible()) scheduleWhiteScreenCheck(WHITE_SCREEN_TIMEOUT);
+  }
+  if (document.readyState === 'complete') scheduleWhiteScreenCheck(WHITE_SCREEN_TIMEOUT);
+  else window.addEventListener('load', scheduleWhiteScreenCheckWhenEligible, { once: true });
+  document.addEventListener('visibilitychange', scheduleWhiteScreenCheckWhenEligible);
+  window.addEventListener('resize', scheduleWhiteScreenCheckWhenEligible);
+  setTimeout(scheduleWhiteScreenCheckWhenEligible, WHITE_SCREEN_TIMEOUT * 2);
 })();
 </script>`;
 }

--- a/packages/contracts/tests/runtime/preview-observability.test.ts
+++ b/packages/contracts/tests/runtime/preview-observability.test.ts
@@ -52,6 +52,8 @@ describe('preview observability contract', () => {
       stack: 'line one\nline two',
       line: 12.6,
       viewport_width: 20_000_000,
+      blank_observation_count: 2,
+      sample_interval_ms: 1_500,
       ignored: 'not part of the protocol',
     });
 
@@ -61,6 +63,8 @@ describe('preview observability contract', () => {
       stack: 'line one line two',
       line: 13,
       viewport_width: 10_000_000,
+      blank_observation_count: 2,
+      sample_interval_ms: 1_500,
     });
     expect(parsed).not.toHaveProperty('ignored');
   });


### PR DESCRIPTION
## Why

Community template remixes and existing HTML artifacts could intermittently open as a blank file preview in packaged clients. We reproduced the issue against the original incident artifact and a colleague's diagnostics from stable 0.19.2: Electron repeatedly aborted the `about:srcdoc` subframe with `ERR_ABORTED (-3)`, while the injected head bridge could still answer readiness probes. That let a half-parsed document look healthy, leaving users to toggle Code and Preview to force a remount.

The same investigation found that deck thumbnails ignored approved `@import` webfonts, and that the existing white-screen detector treated hidden tabs, zero-sized preview frames, and one transient blank sample as confirmed failures. Historical PostHog events therefore mixed real blank previews with recoverable layout stalls and false positives.

## What users will see

- An interrupted HTML preview now retries through the lazy shell and renders without requiring a Code/Preview toggle.
- Deck thumbnails preserve approved imported webfonts; unsafe or malformed layout imports fall back to the isolated iframe renderer.
- A first blank observation performs one bounded layout/resize nudge. If paint recovers, no white-screen event is emitted.
- Hidden tabs and zero-sized previews wait until they are visible and measurable. A blank preview is reported only after a second observation 1.5 seconds later.
- Confirmed blank-preview events include bounded sampling and transport metadata without authored DOM text.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — the internal preview-observability wire shape in `packages/contracts` adds bounded confirmation metadata
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes automatic preview recovery and white-screen reporting
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI chrome changed. The behavior was verified in real Chrome across initial load, Code → Preview toggling, cold reload, background/foreground transitions, and forced blank/half-document fixtures.

## Bug fix verification

- Red-spec paths:
  - `apps/web/tests/components/FileViewer.srcdoc-refresh-recovery.test.tsx`
  - `apps/web/tests/runtime/preview-observability-bridge.test.ts`
- Red on the previous implementation, green on this branch: yes.
  - An eager head-bridge acknowledgement could survive after the document body was aborted; the recovery tests require the body-tail completion witness and remount when it is absent.
  - The previous detector's four new behavioral tests all failed: hidden tab, zero viewport, recoverable layout stall, and one-sample reporting. All four pass on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- White-screen regression group: 7 Web test files, 411 tests passed
- Preview observability contract: 4 tests passed
- Real Chrome + Open Browser Use on the final head:
  - hidden tab remained silent beyond the previous timeout
  - foreground layout stall recovered after one resize nudge without reporting
  - confirmed blank preview emitted one event after two observations with `blank_observation_count=2` and `sample_interval_ms=1500`
  - original srcdoc recovery paths remain covered by the unchanged eight-case recovery suite
- Live PostHog dashboard: https://us.posthog.com/project/420348/dashboard/2007098
