### PR TITLE
feat(standalone): preload Closure runtime foundation

### DIFF
--- a/packages/closure/AGENTS.md
+++ b/packages/closure/AGENTS.md
@@ -1,0 +1,20 @@
+# packages/closure
+
+Follow the root `AGENTS.md` and `packages/AGENTS.md` first.
+
+This package is the shell-neutral Standalone Closure boundary. Its public API is
+split into `./protocol`, `./store`, and `./update`.
+
+- `protocol` owns Closure identities, manifests, validation, and canonical digests.
+- `store` owns immutable content materialization and the
+  prepared/attempt/active/lastSuccessful channel binding transaction; runtime
+  bindings include the exact Shell identity that passed health confirmation.
+- `update` owns release discovery, resumable download, repair, and preparation.
+
+The protocol subpath must not import Store or update implementation modules. Store
+must not discover releases or launch processes. Update must not update a Shell,
+render UI, infer Shell-private paths, or own runtime process identity.
+
+Launcher is a required Closure component. Node remains Shell bootstrap/carrier
+material and is not a Closure component.
+

--- a/packages/closure/esbuild.config.ts
+++ b/packages/closure/esbuild.config.ts
@@ -2,16 +2,17 @@ import { build } from "esbuild";
 
 await build({
   bundle: true,
-  entryPoints: {
-    index: "./src/index.ts",
-    protocol: "./src/protocol.ts",
-    "control/index": "./src/control/index.ts",
-    "lifecycle/index": "./src/lifecycle/index.ts",
-  },
+  entryPoints: [
+    "./src/protocol/index.ts",
+    "./src/store/index.ts",
+    "./src/update/index.ts",
+  ],
   format: "esm",
+  outbase: "./src",
   outdir: "./dist",
   outExtension: { ".js": ".mjs" },
   packages: "external",
   platform: "node",
   target: "node24",
 });
+

--- a/packages/closure/fixtures/distribution-v4.json
+++ b/packages/closure/fixtures/distribution-v4.json
@@ -1,0 +1,89 @@
+{
+  "blobs": {
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+      "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mediaType": "application/zip",
+      "size": 1024,
+      "url": "https://releases.open-design.ai/beta/blobs/sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": {
+      "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "mediaType": "application/zip",
+      "size": 1024,
+      "url": "https://releases.open-design.ai/beta/blobs/sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": {
+      "digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "mediaType": "application/zip",
+      "size": 1024,
+      "url": "https://releases.open-design.ai/beta/blobs/sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    },
+    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "mediaType": "application/zip",
+      "size": 1024,
+      "url": "https://releases.open-design.ai/beta/blobs/sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    },
+    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+      "digest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "mediaType": "application/zip",
+      "size": 1024,
+      "url": "https://releases.open-design.ai/beta/blobs/sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  },
+  "compatibility": {
+    "shell": {
+      "electron": {
+        "version": {
+          "min": "0.19.0-beta.4"
+        }
+      }
+    }
+  },
+  "identity": {
+    "channel": "beta",
+    "protocolVersion": 1,
+    "version": "0.19.0-beta.10",
+    "digest": "sha256:9ba00f0bc814419397bb0056fa764a3e0b75a4692644e85820f1a1edba83d912"
+  },
+  "required": {
+    "body": {
+      "blob": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "entryPath": "bootloader.mjs",
+      "treeDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "launcher": {
+      "blob": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "entryPath": "launcher.mjs",
+      "handoffPath": "bootloader.mjs",
+      "treeDigest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "targets": {
+      "darwin-arm64": {
+        "native": {
+          "blob": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "treeDigest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        },
+        "resources": []
+      },
+      "win32-x64": {
+        "native": {
+          "blob": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+          "treeDigest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        },
+        "resources": []
+      }
+    }
+  },
+  "resources": [
+    {
+      "blob": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "id": "design-system-core",
+      "startup": "lazy",
+      "title": "Open Design Core",
+      "treeDigest": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  ],
+  "schemaVersion": 4
+}
+

--- a/packages/closure/package.json
+++ b/packages/closure/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@open-design/closure",
+  "version": "0.19.2",
+  "type": "module",
+  "exports": {
+    "./protocol": {
+      "types": "./dist/protocol/index.d.ts",
+      "default": "./dist/protocol/index.mjs"
+    },
+    "./store": {
+      "types": "./dist/store/index.d.ts",
+      "default": "./dist/store/index.mjs"
+    },
+    "./update": {
+      "types": "./dist/update/index.d.ts",
+      "default": "./dist/update/index.mjs"
+    },
+    "./fixtures/*": "./fixtures/*"
+  },
+  "scripts": {
+    "build": "tsx ./esbuild.config.ts && tsc -p tsconfig.json --emitDeclarationOnly",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
+  },
+  "dependencies": {
+    "@open-design/download": "workspace:*",
+    "@open-design/platform": "workspace:*",
+    "@open-design/release": "workspace:*",
+    "@open-design/sidecar": "workspace:*",
+    "extract-zip": "2.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "esbuild": "0.28.0",
+    "jszip": "3.10.1",
+    "tsx": "4.22.3",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
+  }
+}

--- a/packages/closure/src/protocol/distribution.ts
+++ b/packages/closure/src/protocol/distribution.ts
@@ -1,0 +1,732 @@
+import {
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION,
+  CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_PROTOCOL_VERSION,
+  CLOSURE_ARCHIVE_ENTRY_PATH,
+  CLOSURE_LAUNCHER_ENTRY_PATH,
+  CLOSURE_LAUNCHER_HANDOFF_PATH,
+  CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES,
+  ClosureDigest,
+  ClosureShellCompatibility,
+  ClosureDistributionBlob,
+  ClosureDistributionComponent,
+  ClosureDistributionEntrypointComponent,
+  ClosureDistributionLauncherComponent,
+  ClosureDistributionTarget,
+  ClosureDistributionResource,
+  ClosureDistributionManifestDraft,
+  ClosureDistributionManifest,
+  ClosureDistributionSharedContribution,
+  ClosureDistributionTargetContribution,
+  ClosureDistributionDigest,
+  ClosureDistributionColdStartBudget,
+  ClosureDistributionControl,
+  ClosureChannel,
+  ResolvedClosureDistributionTarget,
+  ClosureProtocolError,
+  requireRecord,
+  requireKnownKeys,
+  normalizeChannel,
+  normalizeVersion,
+  normalizeDigest,
+  normalizePlatform,
+  normalizeShellType,
+  normalizePositiveInteger,
+  compareCanonicalStrings,
+  normalizeProtocolToken,
+  normalizeDisplayTitle,
+  normalizeMediaType,
+  normalizeRelativePath,
+  normalizeProtocolVersion,
+  normalizeHttpUrl,
+} from "./index.js";
+
+/**
+ * Stable shallow envelope read before a consumer opens the versioned graph.
+ * Keep this schema small: future distribution schemas must remain gateable by
+ * an older Shell without asking that Shell to parse their payload shape.
+ */
+export function createClosureDistributionControl(
+  manifest: ClosureDistributionManifest,
+): ClosureDistributionControl {
+  return {
+    distribution: {
+      digest: manifest.identity.digest,
+      protocolVersion: manifest.identity.protocolVersion,
+      schemaVersion: manifest.schemaVersion,
+    },
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION,
+    shellCompatibility: manifest.compatibility.shell,
+  };
+}
+
+export function validateClosureDistributionControl(value: unknown): ClosureDistributionControl {
+  const control = requireRecord(value, "closure distribution control");
+  if (control.schemaVersion !== CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure distribution control schema version: ${String(control.schemaVersion)}`,
+    );
+  }
+  const distribution = requireRecord(control.distribution, "closure distribution control payload");
+  const schemaVersion = normalizePositiveInteger(
+    distribution.schemaVersion,
+    "closure distribution control payload schema version",
+  );
+  return {
+    distribution: {
+      digest: normalizeDigest(distribution.digest),
+      protocolVersion: normalizeProtocolVersion(distribution.protocolVersion),
+      schemaVersion,
+    },
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION,
+    shellCompatibility: normalizeDistributionShellCompatibility({
+      shell: control.shellCompatibility,
+    }),
+  };
+}
+
+function normalizeDistributionShellCompatibility(value: unknown): ClosureShellCompatibility {
+  const compatibility = requireRecord(value, "closure distribution compatibility");
+  requireKnownKeys(compatibility, ["shell"], "closure distribution compatibility");
+  const shell = requireRecord(compatibility.shell, "closure distribution shell compatibility");
+  const entries = Object.entries(shell).sort(([left], [right]) => compareCanonicalStrings(left, right));
+  if (entries.length === 0) {
+    throw new ClosureProtocolError("closure distribution shell compatibility must declare at least one shell");
+  }
+  return Object.fromEntries(entries.map(([shellType, rawCompatibility]) => {
+    const normalizedType = normalizeShellType(shellType);
+    const shellCompatibility = requireRecord(
+      rawCompatibility,
+      `closure distribution ${normalizedType} shell compatibility`,
+    );
+    requireKnownKeys(
+      shellCompatibility,
+      ["version"],
+      `closure distribution ${normalizedType} shell compatibility`,
+    );
+    const version = requireRecord(
+      shellCompatibility.version,
+      `closure distribution ${normalizedType} shell compatibility version`,
+    );
+    requireKnownKeys(
+      version,
+      ["min"],
+      `closure distribution ${normalizedType} shell compatibility version`,
+    );
+    return [normalizedType, {
+      version: {
+        min: normalizeVersion(
+          version.min,
+          `closure distribution ${normalizedType} minimum shell version`,
+        ),
+      },
+    }];
+  }));
+}
+
+function normalizeDistributionBlob(value: unknown, label: string): ClosureDistributionBlob {
+  const blob = requireRecord(value, label);
+  requireKnownKeys(blob, ["digest", "mediaType", "size", "url"], label);
+  return {
+    digest: normalizeDigest(blob.digest),
+    mediaType: normalizeMediaType(blob.mediaType),
+    size: normalizePositiveInteger(blob.size, `${label} size`),
+    url: normalizeHttpUrl(blob.url),
+  };
+}
+
+function normalizeDistributionBlobs(value: unknown): Record<string, ClosureDistributionBlob> {
+  const blobs = requireRecord(value, "closure distribution blobs");
+  const entries = Object.entries(blobs).sort(([left], [right]) => compareCanonicalStrings(left, right));
+  if (entries.length === 0) {
+    throw new ClosureProtocolError("closure distribution must declare at least one blob");
+  }
+  return Object.fromEntries(entries.map(([key, rawBlob]) => {
+    const digest = normalizeDigest(key);
+    const blob = normalizeDistributionBlob(rawBlob, `closure distribution blob ${digest}`);
+    if (blob.digest !== digest) {
+      throw new ClosureProtocolError(`closure distribution blob ${digest} must repeat its map digest`);
+    }
+    return [digest, blob];
+  }));
+}
+
+function normalizeDistributionComponent(
+  value: unknown,
+  label: string,
+): ClosureDistributionComponent {
+  const component = requireRecord(value, label);
+  requireKnownKeys(component, ["blob", "treeDigest"], label);
+  return {
+    blob: normalizeDigest(component.blob),
+    treeDigest: normalizeDigest(component.treeDigest),
+  };
+}
+
+function normalizeResourceStartup(value: unknown): "blocking" | "lazy" {
+  if (value !== "blocking" && value !== "lazy") {
+    throw new ClosureProtocolError("closure distribution resource startup must be blocking or lazy");
+  }
+  return value;
+}
+
+function normalizeDistributionEntrypointComponent(
+  value: unknown,
+  label: string,
+): ClosureDistributionEntrypointComponent {
+  const component = requireRecord(value, label);
+  requireKnownKeys(component, ["blob", "entryPath", "treeDigest"], label);
+  return {
+    blob: normalizeDigest(component.blob),
+    entryPath: normalizeRelativePath(component.entryPath, `${label} entry path`),
+    treeDigest: normalizeDigest(component.treeDigest),
+  };
+}
+
+function normalizeDistributionLauncherComponent(
+  value: unknown,
+  label: string,
+): ClosureDistributionLauncherComponent {
+  const component = requireRecord(value, label);
+  requireKnownKeys(component, ["blob", "entryPath", "handoffPath", "treeDigest"], label);
+  const normalized = {
+    blob: normalizeDigest(component.blob),
+    entryPath: normalizeRelativePath(component.entryPath, `${label} entry path`),
+    handoffPath: normalizeRelativePath(component.handoffPath, `${label} handoff path`),
+    treeDigest: normalizeDigest(component.treeDigest),
+  };
+  if (normalized.handoffPath !== CLOSURE_LAUNCHER_HANDOFF_PATH) {
+    throw new ClosureProtocolError(
+      `closure distribution launcher handoff path must be ${CLOSURE_LAUNCHER_HANDOFF_PATH}`,
+    );
+  }
+  return normalized as ClosureDistributionLauncherComponent;
+}
+
+function normalizeDistributionResources(value: unknown): ClosureDistributionResource[] {
+  if (!Array.isArray(value)) {
+    throw new ClosureProtocolError("closure distribution resources must be an array");
+  }
+  const resources = value.map((rawResource) => {
+    const resource = requireRecord(rawResource, "closure distribution resource");
+    requireKnownKeys(resource, ["blob", "id", "startup", "title", "treeDigest"], "closure distribution resource");
+    return {
+      blob: normalizeDigest(resource.blob),
+      id: normalizeProtocolToken(resource.id, "closure distribution resource id"),
+      startup: normalizeResourceStartup(resource.startup),
+      title: normalizeDisplayTitle(resource.title, "closure distribution resource title"),
+      treeDigest: normalizeDigest(resource.treeDigest),
+    };
+  }).sort((left, right) => compareCanonicalStrings(left.id, right.id));
+  for (let index = 1; index < resources.length; index += 1) {
+    if (resources[index - 1]?.id === resources[index]?.id) {
+      throw new ClosureProtocolError("closure distribution resource ids must be unique");
+    }
+  }
+  return resources;
+}
+
+function normalizeDistributionTargets(value: unknown): Record<string, ClosureDistributionTarget> {
+  const targets = requireRecord(value, "closure distribution targets");
+  const entries = Object.entries(targets).sort(([left], [right]) => compareCanonicalStrings(left, right));
+  if (entries.length === 0) {
+    throw new ClosureProtocolError("closure distribution must declare at least one target");
+  }
+  return Object.fromEntries(entries.map(([rawTarget, rawComponents]) => {
+    const target = normalizePlatform(rawTarget);
+    const components = requireRecord(rawComponents, `closure distribution target ${target}`);
+    requireKnownKeys(
+      components,
+      ["native", "resources"],
+      `closure distribution target ${target}`,
+    );
+    return [target, {
+      native: normalizeDistributionComponent(
+        components.native,
+        `closure distribution target ${target} native component`,
+      ),
+      resources: normalizeDistributionResources(components.resources ?? []),
+    }];
+  }));
+}
+
+function normalizeClosureDistributionManifestDraft(value: unknown): ClosureDistributionManifestDraft {
+  const manifest = requireRecord(value, "closure distribution manifest");
+  requireKnownKeys(
+    manifest,
+    ["blobs", "compatibility", "identity", "required", "resources", "schemaVersion"],
+    "closure distribution manifest",
+  );
+  if (manifest.schemaVersion !== CLOSURE_DISTRIBUTION_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure distribution schema version: ${String(manifest.schemaVersion)}`,
+    );
+  }
+  if (Object.hasOwn(manifest, "namespace")) {
+    throw new ClosureProtocolError("closure distribution manifest must not contain a local namespace");
+  }
+  const identity = requireRecord(manifest.identity, "closure distribution identity");
+  requireKnownKeys(
+    identity,
+    ["channel", "digest", "protocolVersion", "version"],
+    "closure distribution identity",
+  );
+  if (Object.hasOwn(identity, "namespace") || Object.hasOwn(identity, "platform")) {
+    throw new ClosureProtocolError(
+      "closure distribution identity must remain namespace-neutral and target-neutral",
+    );
+  }
+  const required = requireRecord(manifest.required, "closure distribution required components");
+  requireKnownKeys(
+    required,
+    ["body", "launcher", "targets"],
+    "closure distribution required components",
+  );
+  const body = normalizeDistributionEntrypointComponent(
+    required.body,
+    "closure distribution body component",
+  );
+  if (body.entryPath !== CLOSURE_ARCHIVE_ENTRY_PATH) {
+    throw new ClosureProtocolError(
+      `closure distribution body entry path must be ${CLOSURE_ARCHIVE_ENTRY_PATH}`,
+    );
+  }
+  const launcher = normalizeDistributionLauncherComponent(
+    required.launcher,
+    "closure distribution launcher component",
+  );
+  if (launcher.entryPath !== CLOSURE_LAUNCHER_ENTRY_PATH) {
+    throw new ClosureProtocolError(
+      `closure distribution launcher entry path must be ${CLOSURE_LAUNCHER_ENTRY_PATH}`,
+    );
+  }
+  const normalized: ClosureDistributionManifestDraft = {
+    blobs: normalizeDistributionBlobs(manifest.blobs),
+    compatibility: {
+      shell: normalizeDistributionShellCompatibility(manifest.compatibility),
+    },
+    identity: {
+      channel: normalizeChannel(identity.channel),
+      protocolVersion: normalizeProtocolVersion(identity.protocolVersion),
+      version: normalizeVersion(identity.version, "closure distribution version"),
+    },
+    required: {
+      body,
+      launcher,
+      targets: normalizeDistributionTargets(required.targets),
+    },
+    resources: normalizeDistributionResources(manifest.resources),
+    schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  };
+
+  const referenced = new Set<ClosureDigest>([
+    normalized.required.body.blob,
+    normalized.required.launcher.blob,
+    ...normalized.resources.map((resource) => resource.blob),
+    ...Object.values(normalized.required.targets).map((target) => target.native.blob),
+    ...Object.values(normalized.required.targets).flatMap((target) => (
+      target.resources.map((resource) => resource.blob)
+    )),
+  ]);
+  for (const digest of referenced) {
+    if (normalized.blobs[digest] == null) {
+      throw new ClosureProtocolError(`closure distribution component references unknown blob ${digest}`);
+    }
+  }
+  for (const digest of Object.keys(normalized.blobs)) {
+    if (!referenced.has(digest as ClosureDigest)) {
+      throw new ClosureProtocolError(`closure distribution contains unused blob ${digest}`);
+    }
+  }
+  for (const [target, targetComponents] of Object.entries(normalized.required.targets)) {
+    const componentEntries = [
+      ["body", normalized.required.body.blob],
+      ["launcher", normalized.required.launcher.blob],
+      ["native", targetComponents.native.blob],
+    ] as const;
+    const required = new Set(componentEntries.map(([, blob]) => blob));
+    const requiredBytes = [...required].reduce((total, blob) => total + normalized.blobs[blob]!.size, 0);
+    if (requiredBytes >= CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES) {
+      const components = componentEntries
+        .map(([name, blob]) => `${name}=${normalized.blobs[blob]!.size}`)
+        .join(", ");
+      throw new ClosureProtocolError(
+        `closure distribution ${target} cold-start bytes ${components}, unique=${requiredBytes}, `
+        + `budget<${CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES}`,
+      );
+    }
+  }
+  return normalized;
+}
+
+function computeClosureDistributionDigest(
+  draft: ClosureDistributionManifestDraft,
+  digest: ClosureDistributionDigest,
+): ClosureDigest {
+  return normalizeDigest(digest(`${JSON.stringify(draft)}\n`));
+}
+
+export function serializeClosureDistributionManifestForDigest(value: unknown): string {
+  return `${JSON.stringify(normalizeClosureDistributionManifestDraft(value))}\n`;
+}
+
+export function createClosureDistributionManifest(
+  value: unknown,
+  digest: ClosureDistributionDigest,
+): ClosureDistributionManifest {
+  const draft = normalizeClosureDistributionManifestDraft(value);
+  return {
+    ...draft,
+    identity: {
+      ...draft.identity,
+      digest: computeClosureDistributionDigest(draft, digest),
+    },
+  };
+}
+
+export function validateClosureDistributionManifest(
+  value: unknown,
+  digest: ClosureDistributionDigest,
+): ClosureDistributionManifest {
+  const manifest = requireRecord(value, "closure distribution manifest");
+  const rawIdentity = requireRecord(manifest.identity, "closure distribution identity");
+  const actualDigest = normalizeDigest(rawIdentity.digest);
+  const draft = normalizeClosureDistributionManifestDraft(manifest);
+  const expectedDigest = computeClosureDistributionDigest(draft, digest);
+  if (actualDigest !== expectedDigest) {
+    throw new ClosureProtocolError(
+      `closure distribution canonical digest ${actualDigest} does not match ${expectedDigest}`,
+    );
+  }
+  return {
+    ...draft,
+    identity: {
+      ...draft.identity,
+      digest: actualDigest,
+    },
+  };
+}
+
+function validateContributionIdentity(value: Record<string, unknown>): {
+  channel: ClosureChannel;
+  protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+  version: string;
+} {
+  if (value.schemaVersion !== CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure distribution contribution schema version: ${String(value.schemaVersion)}`,
+    );
+  }
+  return {
+    channel: normalizeChannel(value.channel),
+    protocolVersion: normalizeProtocolVersion(value.protocolVersion),
+    version: normalizeVersion(value.version, "closure distribution contribution version"),
+  };
+}
+
+function normalizeContributionArtifact(value: unknown, label: string): ClosureDistributionBlob {
+  return normalizeDistributionBlob(value, `${label} artifact`);
+}
+
+/** Parse the once-built launcher/body/resource declaration crossing job boundaries. */
+export function validateClosureDistributionSharedContribution(
+  value: unknown,
+): ClosureDistributionSharedContribution {
+  const contribution = requireRecord(value, "closure distribution shared contribution");
+  requireKnownKeys(
+    contribution,
+    [
+      "body",
+      "channel",
+      "launcher",
+      "protocolVersion",
+      "resources",
+      "schemaVersion",
+      "shellCompatibility",
+      "version",
+    ],
+    "closure distribution shared contribution",
+  );
+  const identity = validateContributionIdentity(contribution);
+  const body = requireRecord(contribution.body, "closure distribution shared body");
+  requireKnownKeys(body, ["artifact", "entryPath", "treeDigest"], "closure distribution shared body");
+  if (body.entryPath !== CLOSURE_ARCHIVE_ENTRY_PATH) {
+    throw new ClosureProtocolError(
+      `closure distribution shared body entry path must be ${CLOSURE_ARCHIVE_ENTRY_PATH}`,
+    );
+  }
+  const launcher = requireRecord(contribution.launcher, "closure distribution shared launcher");
+  requireKnownKeys(
+    launcher,
+    ["artifact", "entryPath", "handoffPath", "treeDigest"],
+    "closure distribution shared launcher",
+  );
+  if (
+    launcher.entryPath !== CLOSURE_LAUNCHER_ENTRY_PATH
+    || launcher.handoffPath !== CLOSURE_LAUNCHER_HANDOFF_PATH
+  ) {
+    throw new ClosureProtocolError("closure distribution shared launcher entries are invalid");
+  }
+  if (!Array.isArray(contribution.resources)) {
+    throw new ClosureProtocolError("closure distribution shared resources must be an array");
+  }
+  const resources = contribution.resources.map((value) => {
+    const resource = requireRecord(value, "closure distribution shared resource");
+    requireKnownKeys(
+      resource,
+      ["artifact", "id", "startup", "title", "treeDigest"],
+      "closure distribution shared resource",
+    );
+    return {
+      artifact: normalizeContributionArtifact(resource.artifact, "closure distribution shared resource"),
+      id: normalizeProtocolToken(resource.id, "closure distribution shared resource id"),
+      startup: normalizeResourceStartup(resource.startup),
+      title: normalizeDisplayTitle(resource.title, "closure distribution shared resource title"),
+      treeDigest: normalizeDigest(resource.treeDigest),
+    };
+  }).sort((left, right) => compareCanonicalStrings(left.id, right.id));
+  for (let index = 1; index < resources.length; index += 1) {
+    if (resources[index - 1]?.id === resources[index]?.id) {
+      throw new ClosureProtocolError("closure distribution shared resource ids must be unique");
+    }
+  }
+  return {
+    body: {
+      artifact: normalizeContributionArtifact(body.artifact, "closure distribution shared body"),
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      treeDigest: normalizeDigest(body.treeDigest),
+    },
+    ...identity,
+    launcher: {
+      artifact: normalizeContributionArtifact(launcher.artifact, "closure distribution shared launcher"),
+      entryPath: CLOSURE_LAUNCHER_ENTRY_PATH,
+      handoffPath: CLOSURE_LAUNCHER_HANDOFF_PATH,
+      treeDigest: normalizeDigest(launcher.treeDigest),
+    },
+    resources,
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+    shellCompatibility: normalizeDistributionShellCompatibility({
+      shell: contribution.shellCompatibility,
+    }),
+  };
+}
+
+/** Parse one platform-owned native declaration crossing job boundaries. */
+export function validateClosureDistributionTargetContribution(
+  value: unknown,
+): ClosureDistributionTargetContribution {
+  const contribution = requireRecord(value, "closure distribution target contribution");
+  requireKnownKeys(
+    contribution,
+    ["channel", "native", "protocolVersion", "resources", "schemaVersion", "target", "version"],
+    "closure distribution target contribution",
+  );
+  const identity = validateContributionIdentity(contribution);
+  const native = requireRecord(contribution.native, "closure distribution target native");
+  requireKnownKeys(native, ["artifact", "treeDigest"], "closure distribution target native");
+  if (contribution.resources != null && !Array.isArray(contribution.resources)) {
+    throw new ClosureProtocolError("closure distribution target resources must be an array");
+  }
+  const resources = (contribution.resources ?? []).map((value) => {
+    const resource = requireRecord(value, "closure distribution target resource");
+    requireKnownKeys(
+      resource,
+      ["artifact", "id", "startup", "title", "treeDigest"],
+      "closure distribution target resource",
+    );
+    return {
+      artifact: normalizeContributionArtifact(resource.artifact, "closure distribution target resource"),
+      id: normalizeProtocolToken(resource.id, "closure distribution target resource id"),
+      startup: normalizeResourceStartup(resource.startup),
+      title: normalizeDisplayTitle(resource.title, "closure distribution target resource title"),
+      treeDigest: normalizeDigest(resource.treeDigest),
+    };
+  }).sort((left, right) => compareCanonicalStrings(left.id, right.id));
+  for (let index = 1; index < resources.length; index += 1) {
+    if (resources[index - 1]?.id === resources[index]?.id) {
+      throw new ClosureProtocolError("closure distribution target resource ids must be unique");
+    }
+  }
+  return {
+    ...identity,
+    native: {
+      artifact: normalizeContributionArtifact(native.artifact, "closure distribution target native"),
+      treeDigest: normalizeDigest(native.treeDigest),
+    },
+    resources,
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+    target: normalizePlatform(contribution.target),
+  };
+}
+
+function insertContributionBlob(
+  blobs: Record<string, ClosureDistributionBlob>,
+  blob: ClosureDistributionBlob,
+): void {
+  const current = blobs[blob.digest];
+  if (current != null && JSON.stringify(current) !== JSON.stringify(blob)) {
+    throw new ClosureProtocolError(`closure distribution blob metadata conflicts for ${blob.digest}`);
+  }
+  blobs[blob.digest] = blob;
+}
+
+/** Merge validated cross-job declarations into the sole canonical release graph. */
+export function mergeClosureDistributionContributions(
+  sharedInput: unknown,
+  targetInputs: readonly unknown[],
+  digest: ClosureDistributionDigest,
+): ClosureDistributionManifest {
+  const shared = validateClosureDistributionSharedContribution(sharedInput);
+  if (targetInputs.length === 0) {
+    throw new ClosureProtocolError("closure distribution requires target contributions");
+  }
+  const blobs: Record<string, ClosureDistributionBlob> = {};
+  const targets: Record<string, ClosureDistributionTarget> = {};
+  for (const artifact of [
+    shared.launcher.artifact,
+    shared.body.artifact,
+    ...shared.resources.map((resource) => resource.artifact),
+  ]) insertContributionBlob(blobs, artifact);
+  for (const input of targetInputs) {
+    const contribution = validateClosureDistributionTargetContribution(input);
+    if (
+      contribution.channel !== shared.channel
+      || contribution.protocolVersion !== shared.protocolVersion
+      || contribution.version !== shared.version
+    ) {
+      throw new ClosureProtocolError(
+        "closure target contributions must describe one release identity",
+      );
+    }
+    if (targets[contribution.target] != null) {
+      throw new ClosureProtocolError(
+        `duplicate closure target contribution: ${contribution.target}`,
+      );
+    }
+    insertContributionBlob(blobs, contribution.native.artifact);
+    for (const resource of contribution.resources) insertContributionBlob(blobs, resource.artifact);
+    const sharedResourceIds = new Set(shared.resources.map((resource) => resource.id));
+    const duplicateResource = contribution.resources.find((resource) => sharedResourceIds.has(resource.id));
+    if (duplicateResource != null) {
+      throw new ClosureProtocolError(
+        `closure target resource conflicts with shared resource: ${duplicateResource.id}`,
+      );
+    }
+    targets[contribution.target] = {
+      native: {
+        blob: contribution.native.artifact.digest,
+        treeDigest: contribution.native.treeDigest,
+      },
+      resources: contribution.resources.map((resource) => ({
+        blob: resource.artifact.digest,
+        id: resource.id,
+        startup: resource.startup,
+        title: resource.title,
+        treeDigest: resource.treeDigest,
+      })),
+    };
+  }
+  return createClosureDistributionManifest({
+    blobs,
+    compatibility: { shell: shared.shellCompatibility },
+    identity: {
+      channel: shared.channel,
+      protocolVersion: shared.protocolVersion,
+      version: shared.version,
+    },
+    required: {
+      body: {
+        blob: shared.body.artifact.digest,
+        entryPath: shared.body.entryPath,
+        treeDigest: shared.body.treeDigest,
+      },
+      launcher: {
+        blob: shared.launcher.artifact.digest,
+        entryPath: shared.launcher.entryPath,
+        handoffPath: shared.launcher.handoffPath,
+        treeDigest: shared.launcher.treeDigest,
+      },
+      targets,
+    },
+    resources: shared.resources.map((resource) => ({
+      blob: resource.artifact.digest,
+      id: resource.id,
+      startup: resource.startup,
+      title: resource.title,
+      treeDigest: resource.treeDigest,
+    })),
+    schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  }, digest);
+}
+
+export function resolveClosureDistributionTarget(
+  manifest: ClosureDistributionManifest,
+  value: string,
+): ResolvedClosureDistributionTarget {
+  const target = normalizePlatform(value);
+  const targetComponents = manifest.required.targets[target];
+  if (targetComponents == null) {
+    throw new ClosureProtocolError(`closure distribution does not contain target ${target}`);
+  }
+  const required = {
+    body: manifest.required.body,
+    launcher: manifest.required.launcher,
+    native: targetComponents.native,
+  };
+  const requiredDigests = new Set<ClosureDigest>([
+    required.body.blob,
+    required.launcher.blob,
+    required.native.blob,
+  ]);
+  const requiredBlobs = [...requiredDigests]
+    .sort()
+    .map((blobDigest) => {
+      const blob = manifest.blobs[blobDigest];
+      if (blob == null) {
+        throw new ClosureProtocolError(`closure distribution target references unknown blob ${blobDigest}`);
+      }
+      return blob;
+    });
+  return {
+    required,
+    requiredBlobs,
+    resources: [...manifest.resources, ...targetComponents.resources]
+      .sort((left, right) => compareCanonicalStrings(left.id, right.id))
+      .map((resource) => {
+      const artifact = manifest.blobs[resource.blob];
+      if (artifact == null) {
+        throw new ClosureProtocolError(
+          `closure distribution resource references unknown blob ${resource.blob}`,
+        );
+      }
+      return { ...resource, artifact };
+      }),
+    target,
+  };
+}
+
+export function resolveClosureDistributionColdStartBudget(
+  manifest: ClosureDistributionManifest,
+  value: string,
+): ClosureDistributionColdStartBudget {
+  const resolved = resolveClosureDistributionTarget(manifest, value);
+  const component = (digest: ClosureDigest): ClosureDistributionBlob => {
+    const artifact = manifest.blobs[digest];
+    if (artifact == null) {
+      throw new ClosureProtocolError(`closure distribution target references unknown blob ${digest}`);
+    }
+    return artifact;
+  };
+  return {
+    budgetBytes: CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES,
+    components: {
+      body: component(resolved.required.body.blob),
+      launcher: component(resolved.required.launcher.blob),
+      native: component(resolved.required.native.blob),
+    },
+    requiredBytes: resolved.requiredBlobs.reduce((total, artifact) => total + artifact.size, 0),
+    target: resolved.target,
+  };
+}
+

--- a/packages/closure/src/protocol/index.ts
+++ b/packages/closure/src/protocol/index.ts
@@ -1,0 +1,600 @@
+import { isReleaseChannel, type ReleaseChannel } from "@open-design/release";
+import { normalizeNamespace } from "@open-design/sidecar/protocol";
+
+export const CLOSURE_SCHEMA_VERSION = 1 as const;
+export const CLOSURE_DISTRIBUTION_SCHEMA_VERSION = 4 as const;
+export const CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION = 1 as const;
+export const CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION = 3 as const;
+export const CLOSURE_PROTOCOL_VERSION = 1 as const;
+export const CLOSURE_INVENTORY_SCHEMA_VERSION = 1 as const;
+export const CLOSURE_SIGNATURE_SCHEMA_VERSION = 1 as const;
+export const CLOSURE_ARCHIVE_MEDIA_TYPE = "application/vnd.open-design.closure.zip-v1" as const;
+export const CLOSURE_ARCHIVE_ENTRY_PATH = "bootloader.mjs" as const;
+export const CLOSURE_LAUNCHER_ENTRY_PATH = "launcher.mjs" as const;
+export const CLOSURE_LAUNCHER_HANDOFF_PATH = CLOSURE_ARCHIVE_ENTRY_PATH;
+export const CLOSURE_SIGNATURE_ALGORITHM = "ed25519" as const;
+export const CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES = 30_000_000 as const;
+
+/** Reserved coordination domain for transactional local builds. */
+export type ClosureChannel = ReleaseChannel | "local";
+
+export type ClosureDigest = `sha256:${string}`;
+
+export type ClosureCandidateIdentity = {
+  channel: ClosureChannel;
+  digest: ClosureDigest;
+  platform: string;
+  protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+  version: string;
+};
+
+export type ClosureBindingIdentity = ClosureCandidateIdentity & {
+  namespace: string;
+};
+
+export type ClosureArtifactDescriptor = {
+  digest: ClosureDigest;
+  entryPath: typeof CLOSURE_ARCHIVE_ENTRY_PATH;
+  inventoryDigest: ClosureDigest;
+  mediaType: typeof CLOSURE_ARCHIVE_MEDIA_TYPE;
+  size: number;
+  url: string;
+};
+
+export type ClosureShellCompatibility = Record<string, {
+  version: {
+    min: string;
+  };
+}>;
+
+export type ClosureCandidateManifest = {
+  artifact: ClosureArtifactDescriptor;
+  compatibility: {
+    shell: ClosureShellCompatibility;
+  };
+  identity: ClosureCandidateIdentity;
+  schemaVersion: typeof CLOSURE_SCHEMA_VERSION;
+};
+
+export type ClosureFileInventoryEntry = {
+  digest: ClosureDigest;
+  path: string;
+  size: number;
+};
+
+export type ClosureFileInventory = {
+  files: ClosureFileInventoryEntry[];
+  schemaVersion: typeof CLOSURE_INVENTORY_SCHEMA_VERSION;
+};
+
+/** Detached signature over serializeClosureCandidateManifestForSigning(). */
+export type ClosureCandidateSignature = {
+  algorithm: typeof CLOSURE_SIGNATURE_ALGORITHM;
+  keyId: string;
+  schemaVersion: typeof CLOSURE_SIGNATURE_SCHEMA_VERSION;
+  value: string;
+};
+
+export type ClosureDistributionBlob = {
+  digest: ClosureDigest;
+  mediaType: string;
+  size: number;
+  url: string;
+};
+
+export type ClosureDistributionComponent = {
+  blob: ClosureDigest;
+  treeDigest: ClosureDigest;
+};
+
+export type ClosureDistributionEntrypointComponent = ClosureDistributionComponent & {
+  entryPath: string;
+};
+
+export type ClosureDistributionLauncherComponent = ClosureDistributionEntrypointComponent & {
+  handoffPath: typeof CLOSURE_LAUNCHER_HANDOFF_PATH;
+};
+
+export type ClosureDistributionTarget = {
+  native: ClosureDistributionComponent;
+  resources: ClosureDistributionResource[];
+};
+
+export type ClosureDistributionResource = ClosureDistributionComponent & {
+  id: string;
+  startup: "blocking" | "lazy";
+  title: string;
+};
+
+export type ClosureDistributionIdentityDraft = {
+  channel: ClosureChannel;
+  protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+  version: string;
+};
+
+export type ClosureDistributionIdentity = ClosureDistributionIdentityDraft & {
+  digest: ClosureDigest;
+};
+
+export type ClosureDistributionManifestDraft = {
+  blobs: Record<string, ClosureDistributionBlob>;
+  compatibility: {
+    shell: ClosureShellCompatibility;
+  };
+  identity: ClosureDistributionIdentityDraft;
+  required: {
+    body: ClosureDistributionEntrypointComponent;
+    launcher: ClosureDistributionLauncherComponent;
+    targets: Record<string, ClosureDistributionTarget>;
+  };
+  resources: ClosureDistributionResource[];
+  schemaVersion: typeof CLOSURE_DISTRIBUTION_SCHEMA_VERSION;
+};
+
+export type ClosureDistributionManifest = Omit<ClosureDistributionManifestDraft, "identity"> & {
+  identity: ClosureDistributionIdentity;
+};
+
+export type ClosureDistributionControl = {
+  distribution: {
+    digest: ClosureDigest;
+    protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+    schemaVersion: number;
+  };
+  schemaVersion: typeof CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION;
+  shellCompatibility: ClosureShellCompatibility;
+};
+
+export type ClosureDistributionSharedContribution = {
+  body: {
+    artifact: ClosureDistributionBlob;
+    entryPath: typeof CLOSURE_ARCHIVE_ENTRY_PATH;
+    treeDigest: ClosureDigest;
+  };
+  channel: ClosureChannel;
+  launcher: {
+    artifact: ClosureDistributionBlob;
+    entryPath: typeof CLOSURE_LAUNCHER_ENTRY_PATH;
+    handoffPath: typeof CLOSURE_LAUNCHER_HANDOFF_PATH;
+    treeDigest: ClosureDigest;
+  };
+  protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+  resources: Array<{
+    artifact: ClosureDistributionBlob;
+    id: string;
+    startup: "blocking" | "lazy";
+    title: string;
+    treeDigest: ClosureDigest;
+  }>;
+  schemaVersion: typeof CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION;
+  shellCompatibility: ClosureShellCompatibility;
+  version: string;
+};
+
+export type ClosureDistributionTargetContribution = {
+  channel: ClosureChannel;
+  native: { artifact: ClosureDistributionBlob; treeDigest: ClosureDigest };
+  protocolVersion: typeof CLOSURE_PROTOCOL_VERSION;
+  resources: Array<{
+    artifact: ClosureDistributionBlob;
+    id: string;
+    startup: "blocking" | "lazy";
+    title: string;
+    treeDigest: ClosureDigest;
+  }>;
+  schemaVersion: typeof CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION;
+  target: string;
+  version: string;
+};
+
+export type ClosureDistributionDigest = (canonicalManifest: string) => ClosureDigest;
+
+export type ClosureComponentTreeFile = ClosureFileInventoryEntry;
+
+export type ResolvedClosureDistributionTarget = {
+  required: {
+    body: ClosureDistributionEntrypointComponent;
+    launcher: ClosureDistributionLauncherComponent;
+    native: ClosureDistributionComponent;
+  };
+  requiredBlobs: ClosureDistributionBlob[];
+  resources: Array<ClosureDistributionResource & Readonly<{
+    artifact: ClosureDistributionBlob;
+  }>>;
+  target: string;
+};
+
+export type ClosureDistributionColdStartBudget = {
+  budgetBytes: typeof CLOSURE_DISTRIBUTION_MAX_REQUIRED_BYTES;
+  components: {
+    body: ClosureDistributionBlob;
+    launcher: ClosureDistributionBlob;
+    native: ClosureDistributionBlob;
+  };
+  requiredBytes: number;
+  target: string;
+};
+
+export class ClosureProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClosureProtocolError";
+  }
+}
+
+export function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ClosureProtocolError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function requireKnownKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set(keys);
+  const extras = Object.keys(value).filter((key) => !allowed.has(key));
+  if (extras.length > 0) {
+    throw new ClosureProtocolError(`${label} contains unsupported fields: ${extras.join(", ")}`);
+  }
+}
+
+export function isClosureChannel(value: unknown): value is ClosureChannel {
+  return value === "local" || isReleaseChannel(value);
+}
+
+export function normalizeChannel(value: unknown): ClosureChannel {
+  if (!isClosureChannel(value)) {
+    throw new ClosureProtocolError(`unsupported closure channel: ${String(value)}`);
+  }
+  return value;
+}
+
+export function normalizeVersion(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ClosureProtocolError(`${label} must be a non-empty string`);
+  }
+  if (value !== value.trim()) {
+    throw new ClosureProtocolError(`${label} must not contain leading or trailing whitespace`);
+  }
+  if (value.includes("\0") || /[\\/]/u.test(value) || value === "." || value === ".." || value.includes("..")) {
+    throw new ClosureProtocolError(`${label} must be a safe version identifier`);
+  }
+  return value;
+}
+
+export function normalizeDigest(value: unknown): ClosureDigest {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new ClosureProtocolError("closure digest must be a lowercase sha256 digest");
+  }
+  return value as ClosureDigest;
+}
+
+export function normalizePlatform(value: unknown): string {
+  if (typeof value !== "string" || !/^[a-z0-9]+(?:-[a-z0-9]+)+$/u.test(value)) {
+    throw new ClosureProtocolError("closure platform must be a lowercase os-arch identifier");
+  }
+  return value;
+}
+
+export function normalizeShellType(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/u.test(value)
+  ) {
+    throw new ClosureProtocolError("closure shell type must be a lowercase protocol token");
+  }
+  return value;
+}
+
+export function normalizePositiveInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new ClosureProtocolError(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function normalizeNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new ClosureProtocolError(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function normalizeKeyId(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,127})$/u.test(value)) {
+    throw new ClosureProtocolError("closure signature keyId must be a safe token");
+  }
+  return value;
+}
+
+function normalizeSignatureValue(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new ClosureProtocolError("closure signature value must be unpadded base64url");
+  }
+  return value;
+}
+
+export function compareCanonicalStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function normalizeProtocolToken(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !/^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/u.test(value)
+  ) {
+    throw new ClosureProtocolError(`${label} must be a lowercase protocol token`);
+  }
+  return value;
+}
+
+export function normalizeDisplayTitle(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim() || value.includes("\0")) {
+    throw new ClosureProtocolError(`${label} must be a non-empty trimmed string`);
+  }
+  return value;
+}
+
+export function normalizeMediaType(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/u.test(value)
+  ) {
+    throw new ClosureProtocolError("closure blob mediaType must be a lowercase media type");
+  }
+  return value;
+}
+
+export function normalizeRelativePath(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ClosureProtocolError(`${label} must be a non-empty string`);
+  }
+  if (
+    value.startsWith("/")
+    || value.includes("\\")
+    || value.includes("\0")
+    || value.split("/").some((component) => component.length === 0 || component === "." || component === "..")
+  ) {
+    throw new ClosureProtocolError(`${label} must be a safe relative POSIX path: ${value}`);
+  }
+  return value;
+}
+
+function normalizeInventoryPath(value: unknown): string {
+  return normalizeRelativePath(value, "closure inventory path");
+}
+
+export function normalizeProtocolVersion(value: unknown): typeof CLOSURE_PROTOCOL_VERSION {
+  const protocolVersion = normalizePositiveInteger(value, "closure protocol version");
+  if (protocolVersion !== CLOSURE_PROTOCOL_VERSION) {
+    throw new ClosureProtocolError(`unsupported closure protocol version: ${protocolVersion}`);
+  }
+  return protocolVersion;
+}
+
+function normalizeProductNamespace(value: unknown): string {
+  try {
+    return normalizeNamespace(value);
+  } catch (error) {
+    throw new ClosureProtocolError(
+      `invalid closure product namespace: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export function normalizeHttpUrl(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ClosureProtocolError("closure artifact URL must be a non-empty string");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new ClosureProtocolError("closure artifact URL must be an absolute URL");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new ClosureProtocolError("closure artifact URL must use http or https");
+  }
+  return parsed.toString();
+}
+
+function normalizeCandidateFields(value: Record<string, unknown>): ClosureCandidateIdentity {
+  return {
+    channel: normalizeChannel(value.channel),
+    digest: normalizeDigest(value.digest),
+    platform: normalizePlatform(value.platform),
+    protocolVersion: normalizeProtocolVersion(value.protocolVersion),
+    version: normalizeVersion(value.version, "closure version"),
+  };
+}
+
+export function validateClosureCandidateIdentity(value: unknown): ClosureCandidateIdentity {
+  const candidate = requireRecord(value, "closure candidate identity");
+  if (Object.hasOwn(candidate, "namespace")) {
+    throw new ClosureProtocolError("closure candidate identity must not contain a local namespace");
+  }
+  return normalizeCandidateFields(candidate);
+}
+
+export function bindClosureCandidateIdentity(
+  candidate: ClosureCandidateIdentity,
+  namespace: string,
+): ClosureBindingIdentity {
+  return {
+    ...validateClosureCandidateIdentity(candidate),
+    namespace: normalizeProductNamespace(namespace),
+  };
+}
+
+export function validateClosureBindingIdentity(
+  value: unknown,
+  expected?: { channel: string; namespace: string },
+): ClosureBindingIdentity {
+  const binding = requireRecord(value, "closure binding identity");
+  const normalized: ClosureBindingIdentity = {
+    ...normalizeCandidateFields(binding),
+    namespace: normalizeProductNamespace(binding.namespace),
+  };
+  if (expected != null) {
+    const channel = normalizeChannel(expected.channel);
+    const namespace = normalizeProductNamespace(expected.namespace);
+    if (normalized.channel !== channel) {
+      throw new ClosureProtocolError(
+        `closure binding channel ${normalized.channel} does not match expected channel ${channel}`,
+      );
+    }
+    if (normalized.namespace !== namespace) {
+      throw new ClosureProtocolError(
+        `closure binding namespace ${normalized.namespace} does not match expected namespace ${namespace}`,
+      );
+    }
+  }
+  return normalized;
+}
+
+export function validateClosureCandidateManifest(value: unknown): ClosureCandidateManifest {
+  const manifest = requireRecord(value, "closure candidate manifest");
+  if (Object.hasOwn(manifest, "namespace")) {
+    throw new ClosureProtocolError("closure candidate manifest must not contain a local namespace");
+  }
+  if (manifest.schemaVersion !== CLOSURE_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure manifest schema version: ${String(manifest.schemaVersion)}`,
+    );
+  }
+  const identity = validateClosureCandidateIdentity(manifest.identity);
+  const artifact = requireRecord(manifest.artifact, "closure artifact");
+  const digest = normalizeDigest(artifact.digest);
+  const inventoryDigest = normalizeDigest(artifact.inventoryDigest);
+  if (digest !== identity.digest) {
+    throw new ClosureProtocolError("closure artifact digest must match candidate identity digest");
+  }
+  if (artifact.mediaType !== CLOSURE_ARCHIVE_MEDIA_TYPE) {
+    throw new ClosureProtocolError(`unsupported closure artifact media type: ${String(artifact.mediaType)}`);
+  }
+  if (artifact.entryPath !== CLOSURE_ARCHIVE_ENTRY_PATH) {
+    throw new ClosureProtocolError(`unsupported closure artifact entry path: ${String(artifact.entryPath)}`);
+  }
+  const compatibility = requireRecord(manifest.compatibility, "closure compatibility");
+  const shell = requireRecord(compatibility.shell, "closure shell compatibility");
+  const shellEntries = Object.entries(shell).sort(([left], [right]) => compareCanonicalStrings(left, right));
+  if (shellEntries.length === 0) {
+    throw new ClosureProtocolError("closure shell compatibility must declare at least one shell");
+  }
+  const normalizedShell = Object.fromEntries(shellEntries.map(([shellType, value]) => {
+    const normalizedType = normalizeShellType(shellType);
+    const shellCompatibility = requireRecord(
+      value,
+      `closure ${normalizedType} shell compatibility`,
+    );
+    const version = requireRecord(
+      shellCompatibility.version,
+      `closure ${normalizedType} shell compatibility version`,
+    );
+    return [normalizedType, {
+      version: {
+        min: normalizeVersion(
+          version.min,
+          `closure ${normalizedType} minimum shell version`,
+        ),
+      },
+    }];
+  }));
+  return {
+    artifact: {
+      digest,
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      inventoryDigest,
+      mediaType: CLOSURE_ARCHIVE_MEDIA_TYPE,
+      size: normalizePositiveInteger(artifact.size, "closure artifact size"),
+      url: normalizeHttpUrl(artifact.url),
+    },
+    compatibility: {
+      shell: normalizedShell,
+    },
+    identity,
+    schemaVersion: CLOSURE_SCHEMA_VERSION,
+  };
+}
+
+export function validateClosureFileInventory(value: unknown): ClosureFileInventory {
+  const inventory = requireRecord(value, "closure file inventory");
+  if (inventory.schemaVersion !== CLOSURE_INVENTORY_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure inventory schema version: ${String(inventory.schemaVersion)}`,
+    );
+  }
+  if (!Array.isArray(inventory.files)) {
+    throw new ClosureProtocolError("closure inventory files must be an array");
+  }
+  const files = normalizeClosureComponentTreeFiles(inventory.files);
+  if (!files.some((file) => file.path === CLOSURE_ARCHIVE_ENTRY_PATH)) {
+    throw new ClosureProtocolError(`closure inventory must contain ${CLOSURE_ARCHIVE_ENTRY_PATH}`);
+  }
+  return { files, schemaVersion: CLOSURE_INVENTORY_SCHEMA_VERSION };
+}
+
+function normalizeClosureComponentTreeFiles(value: unknown): ClosureComponentTreeFile[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ClosureProtocolError("closure component tree files must be a non-empty array");
+  }
+  const files = value.map((entry) => {
+    const file = requireRecord(entry, "closure inventory file");
+    requireKnownKeys(file, ["digest", "path", "size"], "closure inventory file");
+    return {
+      digest: normalizeDigest(file.digest),
+      path: normalizeInventoryPath(file.path),
+      size: normalizeNonNegativeInteger(file.size, "closure inventory file size"),
+    };
+  });
+  for (let index = 1; index < files.length; index += 1) {
+    const previous = files[index - 1];
+    const current = files[index];
+    if (previous == null || current == null || previous.path >= current.path) {
+      throw new ClosureProtocolError("closure inventory paths must be strictly sorted and unique");
+    }
+  }
+  return files;
+}
+
+export function serializeClosureComponentTreeForDigest(value: unknown): string {
+  return `${JSON.stringify(normalizeClosureComponentTreeFiles(value))}\n`;
+}
+
+export function createClosureComponentTreeDigest(
+  value: unknown,
+  digest: ClosureDistributionDigest,
+): ClosureDigest {
+  return normalizeDigest(digest(serializeClosureComponentTreeForDigest(value)));
+}
+
+export function validateClosureCandidateSignature(value: unknown): ClosureCandidateSignature {
+  const signature = requireRecord(value, "closure candidate signature");
+  if (signature.schemaVersion !== CLOSURE_SIGNATURE_SCHEMA_VERSION) {
+    throw new ClosureProtocolError(
+      `unsupported closure signature schema version: ${String(signature.schemaVersion)}`,
+    );
+  }
+  if (signature.algorithm !== CLOSURE_SIGNATURE_ALGORITHM) {
+    throw new ClosureProtocolError(
+      `unsupported closure signature algorithm: ${String(signature.algorithm)}`,
+    );
+  }
+  return {
+    algorithm: CLOSURE_SIGNATURE_ALGORITHM,
+    keyId: normalizeKeyId(signature.keyId),
+    schemaVersion: CLOSURE_SIGNATURE_SCHEMA_VERSION,
+    value: normalizeSignatureValue(signature.value),
+  };
+}
+
+export function serializeClosureCandidateManifestForSigning(value: unknown): string {
+  return `${JSON.stringify(validateClosureCandidateManifest(value))}\n`;
+}
+
+
+export * from "./distribution.js";
+

--- a/packages/closure/src/store/binding.ts
+++ b/packages/closure/src/store/binding.ts
@@ -1,0 +1,544 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { isAbsolute, join, resolve, sep } from "node:path";
+
+import {
+  isClosureChannel,
+  normalizeDigest,
+  validateClosureBindingIdentity,
+  type ClosureBindingIdentity,
+  type ClosureCandidateManifest,
+  type ClosureChannel,
+  type ClosureDigest,
+  type ClosureFileInventory,
+} from "../protocol/index.js";
+import { normalizeNamespace } from "@open-design/sidecar/protocol";
+
+export const CLOSURE_BINDING_SCHEMA_VERSION = 4 as const;
+export const CLOSURE_ACTIVATION_INTENT_SCHEMA_VERSION = 1 as const;
+const TRANSITIONAL_CLOSURE_BINDING_SCHEMA_VERSION = 5 as const;
+export const CLOSURE_STORE_EPOCH = 4 as const;
+
+export type ClosureStoreRequest = {
+  channel: string;
+  namespace: string;
+  root: string;
+};
+
+export type ClosureStorePaths = {
+  activationIntentPath: string;
+  bindingPath: string;
+  blobsRoot: string;
+  channel: ClosureChannel;
+  channelRoot: string;
+  closureRoot: string;
+  garbageRoot: string;
+  installationsRoot: string;
+  namespace: string;
+  namespaceRoot: string;
+  resourcesRoot: string;
+  root: string;
+  stagingRoot: string;
+  stateRoot: string;
+  versionsRoot: string;
+};
+
+export type ClosureStoreVersionPaths = ClosureStorePaths & {
+  archivePath: string;
+  digest: string;
+  inventoryPath: string;
+  manifestPath: string;
+  payloadRoot: string;
+  version: string;
+  versionRoot: string;
+};
+
+export type ClosureRuntimePointer = Omit<ClosureBindingIdentity, "platform"> & {
+  generation: number;
+  target: string;
+};
+
+export type ClosureReleaseBinding = {
+  releaseVersion: string;
+  standalone: ClosureRuntimePointer;
+};
+
+export type ClosureShellBinding = {
+  digest: ClosureDigest;
+  type: string;
+  version: string;
+};
+
+export type ClosureRuntimeBinding = ClosureReleaseBinding & {
+  shell: ClosureShellBinding;
+};
+
+export type ClosureActivationSource =
+  | "initial-bootstrap"
+  | "repair"
+  | "silent-policy"
+  | "user-restart";
+
+export type ClosureActivationIntent = ClosureReleaseBinding & {
+  source: ClosureActivationSource;
+};
+
+export type ClosureBindingDescriptor = {
+  active: ClosureRuntimeBinding | null;
+  attempt: ClosureRuntimeBinding | null;
+  activationIntent: ClosureActivationIntent | null;
+  channel: ClosureChannel;
+  lastSuccessful: ClosureRuntimeBinding | null;
+  namespace: string;
+  nextGeneration: number;
+  prepared: ClosureReleaseBinding | null;
+  schemaVersion: typeof CLOSURE_BINDING_SCHEMA_VERSION;
+  updatedAt: string;
+};
+
+export type ClosureActivationIntentDescriptor = {
+  channel: ClosureChannel;
+  intent: ClosureActivationIntent;
+  namespace: string;
+  schemaVersion: typeof CLOSURE_ACTIVATION_INTENT_SCHEMA_VERSION;
+  updatedAt: string;
+};
+
+export type StoredClosureVerification = {
+  binding: ClosureBindingIdentity;
+  inventory: ClosureFileInventory;
+  inventoryDigest: string;
+  manifest: ClosureCandidateManifest;
+  paths: ClosureStoreVersionPaths;
+};
+
+export class ClosureStoreError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ClosureStoreError";
+  }
+}
+
+function normalizeRoot(value: string): string {
+  if (value.length === 0 || value.includes("\0") || !isAbsolute(value)) {
+    throw new ClosureStoreError(`Closure store root must be a non-empty absolute path: ${value}`);
+  }
+  return resolve(value);
+}
+
+function normalizeChannel(value: string): ClosureChannel {
+  if (!isClosureChannel(value)) throw new ClosureStoreError(`unsupported Closure store channel: ${value}`);
+  return value;
+}
+
+function normalizeStoreNamespace(value: string): string {
+  try {
+    return normalizeNamespace(value);
+  } catch (error) {
+    throw new ClosureStoreError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function assertUnderRoot(root: string, target: string): string {
+  const normalized = resolve(target);
+  if (normalized !== root && !normalized.startsWith(`${root}${sep}`)) {
+    throw new ClosureStoreError(`Closure store path escapes root: ${normalized}`);
+  }
+  return normalized;
+}
+
+export function resolveClosureStorePaths(request: ClosureStoreRequest): ClosureStorePaths {
+  const root = normalizeRoot(request.root);
+  const channel = normalizeChannel(request.channel);
+  const namespace = normalizeStoreNamespace(request.namespace);
+  const closureRoot = assertUnderRoot(root, join(root, "closure"));
+  const channelRoot = assertUnderRoot(root, join(closureRoot, "channels", channel));
+  const namespaceRoot = assertUnderRoot(root, join(channelRoot, "epochs", String(CLOSURE_STORE_EPOCH), "namespaces", namespace));
+  const stateRoot = assertUnderRoot(root, join(namespaceRoot, "state"));
+  return {
+    activationIntentPath: assertUnderRoot(root, join(stateRoot, "activation-intent.json")),
+    bindingPath: assertUnderRoot(root, join(stateRoot, "binding.json")),
+    blobsRoot: assertUnderRoot(root, join(channelRoot, "blobs")),
+    channel,
+    channelRoot,
+    closureRoot,
+    garbageRoot: assertUnderRoot(root, join(channelRoot, "garbage")),
+    installationsRoot: assertUnderRoot(root, join(namespaceRoot, "installations")),
+    namespace,
+    namespaceRoot,
+    resourcesRoot: assertUnderRoot(root, join(channelRoot, "resources")),
+    root,
+    stagingRoot: assertUnderRoot(root, join(namespaceRoot, "staging")),
+    stateRoot,
+    versionsRoot: assertUnderRoot(root, join(namespaceRoot, "versions")),
+  };
+}
+
+export function resolveClosureActivationIntentPath(
+  paths: Pick<ClosureStorePaths, "root" | "stateRoot">,
+): string {
+  return assertUnderRoot(paths.root, join(paths.stateRoot, "activation-intent.json"));
+}
+
+export function sameBinding(left: ClosureBindingIdentity, right: ClosureBindingIdentity): boolean {
+  return left.channel === right.channel
+    && left.namespace === right.namespace
+    && left.platform === right.platform
+    && left.protocolVersion === right.protocolVersion
+    && left.version === right.version
+    && left.digest === right.digest;
+}
+
+export function normalizeGeneration(value: unknown): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new ClosureStoreError(`Closure generation must be a non-negative safe integer: ${String(value)}`);
+  }
+  return value;
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ClosureStoreError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertExactKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const extras = Object.keys(value).filter((key) => !allowed.includes(key));
+  if (extras.length > 0) throw new ClosureStoreError(`${label} contains unsupported fields: ${extras.join(", ")}`);
+}
+
+function normalizeIsoString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || Number.isNaN(Date.parse(value))) {
+    throw new ClosureStoreError(`${label} must be an ISO timestamp`);
+  }
+  return value;
+}
+
+export function normalizeReleaseVersion(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new ClosureStoreError("Closure release version must be a non-empty trimmed string");
+  }
+  return value;
+}
+
+export function normalizePointer(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureRuntimePointer {
+  const pointer = requireRecord(value, "Closure runtime pointer");
+  assertExactKeys(pointer, [
+    "channel",
+    "digest",
+    "generation",
+    "namespace",
+    "protocolVersion",
+    "target",
+    "version",
+  ], "Closure runtime pointer");
+  const binding = validateClosureBindingIdentity({
+    ...pointer,
+    platform: pointer.target,
+  }, expected);
+  return {
+    channel: binding.channel,
+    digest: binding.digest,
+    generation: normalizeGeneration(pointer.generation),
+    namespace: binding.namespace,
+    protocolVersion: binding.protocolVersion,
+    target: binding.platform,
+    version: binding.version,
+  };
+}
+
+export function closureBindingIdentityFromRuntimePointer(
+  pointer: ClosureRuntimePointer,
+): ClosureBindingIdentity {
+  return validateClosureBindingIdentity({
+    channel: pointer.channel,
+    digest: pointer.digest,
+    namespace: pointer.namespace,
+    platform: pointer.target,
+    protocolVersion: pointer.protocolVersion,
+    version: pointer.version,
+  });
+}
+
+function normalizeReleaseBinding(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureReleaseBinding {
+  const binding = requireRecord(value, "Closure release binding");
+  assertExactKeys(binding, ["releaseVersion", "standalone"], "Closure release binding");
+  return {
+    releaseVersion: normalizeReleaseVersion(binding.releaseVersion),
+    standalone: normalizePointer(binding.standalone, expected),
+  };
+}
+
+export function normalizeShellBinding(value: unknown): ClosureShellBinding {
+  const shell = requireRecord(value, "Closure Shell binding");
+  assertExactKeys(shell, ["digest", "type", "version"], "Closure Shell binding");
+  const type = typeof shell.type === "string" ? shell.type : "";
+  const version = typeof shell.version === "string" ? shell.version : "";
+  if (type.length === 0 || type !== type.trim() || version.length === 0 || version !== version.trim()) {
+    throw new ClosureStoreError("Closure Shell type and version must be non-empty trimmed strings");
+  }
+  return { digest: normalizeDigest(shell.digest), type, version };
+}
+
+function normalizeRuntimeBinding(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureRuntimeBinding {
+  const binding = requireRecord(value, "Closure runtime binding");
+  assertExactKeys(binding, ["releaseVersion", "shell", "standalone"], "Closure runtime binding");
+  return {
+    releaseVersion: normalizeReleaseVersion(binding.releaseVersion),
+    shell: normalizeShellBinding(binding.shell),
+    standalone: normalizePointer(binding.standalone, expected),
+  };
+}
+
+export function sameReleaseBinding(
+  left: ClosureReleaseBinding,
+  right: ClosureReleaseBinding,
+): boolean {
+  return left.releaseVersion === right.releaseVersion
+    && left.standalone.generation === right.standalone.generation
+    && left.standalone.channel === right.standalone.channel
+    && left.standalone.namespace === right.standalone.namespace
+    && left.standalone.protocolVersion === right.standalone.protocolVersion
+    && left.standalone.target === right.standalone.target
+    && left.standalone.version === right.standalone.version
+    && left.standalone.digest === right.standalone.digest;
+}
+
+export function sameRuntimeBinding(
+  left: ClosureRuntimeBinding,
+  right: ClosureRuntimeBinding,
+): boolean {
+  return sameReleaseBinding(left, right)
+    && left.shell.digest === right.shell.digest
+    && left.shell.type === right.shell.type
+    && left.shell.version === right.shell.version;
+}
+
+export function sameShellBinding(
+  left: ClosureShellBinding,
+  right: ClosureShellBinding,
+): boolean {
+  return left.digest === right.digest
+    && left.type === right.type
+    && left.version === right.version;
+}
+
+export function validateClosureBindingDescriptor(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureBindingDescriptor {
+  const descriptor = requireRecord(value, "Closure binding descriptor");
+  const transitional = descriptor.schemaVersion === TRANSITIONAL_CLOSURE_BINDING_SCHEMA_VERSION;
+  assertExactKeys(descriptor, transitional ? [
+    "active",
+    "attempt",
+    "activationIntent",
+    "channel",
+    "lastSuccessful",
+    "namespace",
+    "nextGeneration",
+    "prepared",
+    "schemaVersion",
+    "updatedAt",
+  ] : [
+    "active",
+    "attempt",
+    "activationAuthorized",
+    "channel",
+    "lastSuccessful",
+    "namespace",
+    "nextGeneration",
+    "prepared",
+    "schemaVersion",
+    "updatedAt",
+  ], "Closure binding descriptor");
+  if (!transitional && descriptor.schemaVersion !== CLOSURE_BINDING_SCHEMA_VERSION) {
+    throw new ClosureStoreError(`unsupported Closure binding schema: ${String(descriptor.schemaVersion)}`);
+  }
+  const channel = normalizeChannel(String(descriptor.channel));
+  const namespace = normalizeStoreNamespace(String(descriptor.namespace));
+  if (channel !== expected.channel || namespace !== expected.namespace) {
+    throw new ClosureStoreError("Closure binding descriptor does not match its channel/namespace store");
+  }
+  const active = descriptor.active == null ? null : normalizeRuntimeBinding(descriptor.active, expected);
+  const attempt = descriptor.attempt == null ? null : normalizeRuntimeBinding(descriptor.attempt, expected);
+  const lastSuccessful = descriptor.lastSuccessful == null
+    ? null
+    : normalizeRuntimeBinding(descriptor.lastSuccessful, expected);
+  const prepared = descriptor.prepared == null
+    ? null
+    : normalizeReleaseBinding(descriptor.prepared, expected);
+  if (!transitional && typeof descriptor.activationAuthorized !== "boolean") {
+    throw new ClosureStoreError("Closure activation authorization flag must be boolean");
+  }
+  const activationIntent = !transitional || descriptor.activationIntent == null
+    ? null
+    : normalizeActivationIntent(descriptor.activationIntent, expected);
+  if (activationIntent != null && (
+    prepared == null || !sameReleaseBinding(activationIntent, prepared)
+  )) throw new ClosureStoreError("Closure activation intent must match the prepared binding");
+  const nextGeneration = normalizeGeneration(descriptor.nextGeneration);
+  const retained = [active, attempt, lastSuccessful, prepared].filter(
+    (binding): binding is ClosureReleaseBinding => binding != null,
+  );
+  if (retained.some((binding) => binding.standalone.generation >= nextGeneration)) {
+    throw new ClosureStoreError("Closure nextGeneration must be greater than every retained generation");
+  }
+  if (attempt != null && (active == null || !sameRuntimeBinding(active, attempt))) {
+    throw new ClosureStoreError("Closure attempt must match the active binding");
+  }
+  if (attempt == null && active != null && (
+    lastSuccessful == null || !sameRuntimeBinding(active, lastSuccessful)
+  )) {
+    throw new ClosureStoreError("Closure active binding must be the pending attempt or last successful binding");
+  }
+  return {
+    active,
+    attempt,
+    activationIntent,
+    channel,
+    lastSuccessful,
+    namespace,
+    nextGeneration,
+    prepared,
+    schemaVersion: CLOSURE_BINDING_SCHEMA_VERSION,
+    updatedAt: normalizeIsoString(descriptor.updatedAt, "Closure binding updatedAt"),
+  };
+}
+
+export function validateClosureActivationIntentDescriptor(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureActivationIntentDescriptor {
+  const descriptor = requireRecord(value, "Closure activation intent descriptor");
+  assertExactKeys(descriptor, [
+    "channel",
+    "intent",
+    "namespace",
+    "schemaVersion",
+    "updatedAt",
+  ], "Closure activation intent descriptor");
+  if (descriptor.schemaVersion !== CLOSURE_ACTIVATION_INTENT_SCHEMA_VERSION) {
+    throw new ClosureStoreError(
+      `unsupported Closure activation intent schema: ${String(descriptor.schemaVersion)}`,
+    );
+  }
+  const channel = normalizeChannel(String(descriptor.channel));
+  const namespace = normalizeStoreNamespace(String(descriptor.namespace));
+  if (channel !== expected.channel || namespace !== expected.namespace) {
+    throw new ClosureStoreError("Closure activation intent does not match its channel/namespace store");
+  }
+  return {
+    channel,
+    intent: normalizeActivationIntent(descriptor.intent, expected),
+    namespace,
+    schemaVersion: CLOSURE_ACTIVATION_INTENT_SCHEMA_VERSION,
+    updatedAt: normalizeIsoString(descriptor.updatedAt, "Closure activation intent updatedAt"),
+  };
+}
+
+export function persistedClosureBindingDescriptor(
+  descriptor: ClosureBindingDescriptor,
+): Record<string, unknown> {
+  const { activationIntent: _activationIntent, ...binding } = descriptor;
+  return {
+    ...binding,
+    activationAuthorized: descriptor.activationIntent != null,
+    schemaVersion: CLOSURE_BINDING_SCHEMA_VERSION,
+  };
+}
+
+export function persistedClosureActivationIntentDescriptor(
+  descriptor: ClosureBindingDescriptor,
+): ClosureActivationIntentDescriptor | null {
+  if (descriptor.activationIntent == null) return null;
+  return {
+    channel: descriptor.channel,
+    intent: descriptor.activationIntent,
+    namespace: descriptor.namespace,
+    schemaVersion: CLOSURE_ACTIVATION_INTENT_SCHEMA_VERSION,
+    updatedAt: descriptor.updatedAt,
+  };
+}
+
+function normalizeActivationIntent(
+  value: unknown,
+  expected: Pick<ClosureStorePaths, "channel" | "namespace">,
+): ClosureActivationIntent {
+  const intent = requireRecord(value, "Closure activation intent");
+  assertExactKeys(intent, ["releaseVersion", "source", "standalone"], "Closure activation intent");
+  const sources: readonly ClosureActivationSource[] = [
+    "initial-bootstrap",
+    "repair",
+    "silent-policy",
+    "user-restart",
+  ];
+  if (!sources.includes(intent.source as ClosureActivationSource)) {
+    throw new ClosureStoreError(`unsupported Closure activation source: ${String(intent.source)}`);
+  }
+  const { source: _source, ...binding } = intent;
+  return {
+    ...normalizeReleaseBinding(binding, expected),
+    source: intent.source as ClosureActivationSource,
+  };
+}
+
+export function resolveClosureStoreVersionPaths(
+  paths: ClosureStorePaths,
+  binding: ClosureBindingIdentity,
+): ClosureStoreVersionPaths {
+  const identity = validateClosureBindingIdentity(binding, paths);
+  const digest = identity.digest.slice("sha256:".length);
+  const versionRoot = assertUnderRoot(paths.root, join(paths.versionsRoot, identity.version, digest));
+  return {
+    ...paths,
+    archivePath: assertUnderRoot(paths.root, join(versionRoot, "closure.zip")),
+    digest,
+    inventoryPath: assertUnderRoot(paths.root, join(versionRoot, "inventory.json")),
+    manifestPath: assertUnderRoot(paths.root, join(versionRoot, "manifest.json")),
+    payloadRoot: assertUnderRoot(paths.root, join(versionRoot, "payload")),
+    version: identity.version,
+    versionRoot,
+  };
+}
+
+export async function readRequiredJson(path: string, label: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  } catch (error) {
+    throw new ClosureStoreError(`${label} is missing or unreadable at ${path}: ${
+      error instanceof Error ? error.message : String(error)
+    }`);
+  }
+}
+
+export async function readOptionalJson(path: string, label: string): Promise<unknown | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as unknown;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new ClosureStoreError(`${label} is unreadable at ${path}: ${
+      error instanceof Error ? error.message : String(error)
+    }`);
+  }
+}
+
+export async function digestFile(path: string): Promise<{ digest: string; size: number }> {
+  const metadata = await stat(path).catch(() => null);
+  if (metadata == null || !metadata.isFile()) throw new ClosureStoreError(`Closure file is missing: ${path}`);
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer);
+  return { digest: `sha256:${hash.digest("hex")}`, size: metadata.size };
+}
+

--- a/packages/closure/src/store/channel-lock.ts
+++ b/packages/closure/src/store/channel-lock.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { isProcessAlive } from "@open-design/platform";
+
+import { assertUnderRoot, type ClosureStorePaths } from "./binding.js";
+
+export const INCOMPLETE_CLOSURE_CHANNEL_LOCK_GRACE_MS = 30_000;
+
+export type ClosureChannelLock = Readonly<{
+  path: string;
+  token: string;
+}>;
+
+type ClosureChannelLockRecord = Readonly<{
+  createdAt: string;
+  pid: number;
+  token: string;
+}>;
+
+function errorCode(error: unknown): string | null {
+  if (error == null || typeof error !== "object" || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return code == null ? null : String(code);
+}
+
+function lockPath(paths: ClosureStorePaths): string {
+  return assertUnderRoot(paths.channelRoot, join(paths.channelRoot, "maintenance.lock"));
+}
+
+function isLockRecord(value: unknown): value is ClosureChannelLockRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Partial<ClosureChannelLockRecord>;
+  return typeof record.createdAt === "string"
+    && !Number.isNaN(Date.parse(record.createdAt))
+    && typeof record.pid === "number"
+    && Number.isSafeInteger(record.pid)
+    && record.pid > 0
+    && typeof record.token === "string"
+    && record.token.length > 0;
+}
+
+async function readLock(path: string): Promise<ClosureChannelLockRecord | null> {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as unknown;
+    return isLockRecord(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Serialize all mutations of channel-shared blobs and resource indices. */
+export async function acquireClosureChannelLock(
+  paths: ClosureStorePaths,
+  options: Readonly<{ waitMs?: number }> = {},
+): Promise<ClosureChannelLock | null> {
+  const path = lockPath(paths);
+  const waitMs = options.waitMs ?? 0;
+  const deadline = Date.now() + waitMs;
+  if (!Number.isSafeInteger(waitMs) || waitMs < 0) {
+    throw new TypeError("Closure channel lock waitMs must be a non-negative safe integer");
+  }
+  await mkdir(paths.channelRoot, { recursive: true });
+  let recovered = false;
+  while (true) {
+    const record: ClosureChannelLockRecord = Object.freeze({
+      createdAt: new Date().toISOString(),
+      pid: process.pid,
+      token: randomUUID(),
+    });
+    try {
+      await writeFile(path, `${JSON.stringify(record)}\n`, { flag: "wx" });
+      return Object.freeze({ path, token: record.token });
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+      const existing = await readLock(path);
+      const metadata = existing == null ? await stat(path).catch(() => null) : null;
+      const incompleteIsStale = metadata != null
+        && Date.now() - metadata.mtimeMs >= INCOMPLETE_CLOSURE_CHANNEL_LOCK_GRACE_MS;
+      if (!recovered && ((existing == null && incompleteIsStale) || (existing != null && !isProcessAlive(existing.pid)))) {
+        recovered = true;
+        await rm(path, { force: true }).catch(() => undefined);
+        continue;
+      }
+      if (Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, Math.min(25, deadline - Date.now())));
+        continue;
+      }
+      return null;
+    }
+  }
+}
+
+export async function releaseClosureChannelLock(lock: ClosureChannelLock): Promise<void> {
+  const current = await readLock(lock.path);
+  if (current?.token === lock.token) await rm(lock.path, { force: true }).catch(() => undefined);
+}
+

--- a/packages/closure/src/store/distribution/index.ts
+++ b/packages/closure/src/store/distribution/index.ts
@@ -1,0 +1,489 @@
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readdir, rename, rm } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+
+import {
+  createClosureComponentTreeDigest,
+  resolveClosureDistributionTarget,
+  validateClosureDistributionManifest,
+  type ClosureComponentTreeFile,
+  type ClosureDigest,
+  type ClosureDistributionBlob,
+  type ClosureDistributionEntrypointComponent,
+  type ClosureDistributionIdentity,
+  type ClosureDistributionLauncherComponent,
+  type ClosureDistributionManifest,
+  type ClosureChannel,
+  type ResolvedClosureDistributionTarget,
+} from "../../protocol/index.js";
+import {
+  ClosureStoreError,
+  assertUnderRoot,
+  digestFile,
+  normalizeGeneration,
+  normalizePointer,
+  readRequiredJson,
+  type ClosureBindingDescriptor,
+  type ClosureRuntimePointer,
+  type ClosureStorePaths,
+  type ClosureReleaseBinding,
+} from "../binding.js";
+import { compareName, readClosureBindingDescriptor } from "../legacy-candidate.js";
+import { publishPreparedClosureBinding } from "../runtime.js";
+import { resolveDistributionInstallationRoot } from "./paths.js";
+
+export type ClosureDistributionComponentPlan = Readonly<{
+  artifact: ClosureDistributionBlob;
+  blobPath: string;
+  componentRoot: string;
+  treeDigest: ClosureDigest;
+}>;
+
+export type ClosureDistributionEntrypointPlan = ClosureDistributionComponentPlan & Readonly<{
+  entryPath: string;
+  resolvedEntryPath: string;
+}>;
+
+export type ClosureDistributionLauncherPlan = ClosureDistributionEntrypointPlan & Readonly<{
+  handoffPath: string;
+  resolvedHandoffPath: string;
+}>;
+
+export type ClosureDistributionResourcePlan = Readonly<{
+  artifact: ClosureDistributionBlob;
+  blobPath: string;
+  id: string;
+  resourceRoot: string;
+  startup: "blocking" | "lazy";
+  title: string;
+  treeDigest: ClosureDigest;
+}>;
+
+export type ClosureDistributionGenerationPlan = Readonly<{
+  channel: ClosureChannel;
+  generation: number;
+  storeRoot: string;
+  identity: ClosureDistributionIdentity;
+  installationRoot: string;
+  manifest: ClosureDistributionManifest;
+  manifestPath: string;
+  namespace: string;
+  required: Readonly<{
+    body: ClosureDistributionEntrypointPlan;
+    launcher: ClosureDistributionLauncherPlan;
+    native: ClosureDistributionComponentPlan;
+  }>;
+  requiredBlobPaths: readonly string[];
+  resources: readonly ClosureDistributionResourcePlan[];
+  target: string;
+}>;
+
+export type StoredClosureDistributionVerification = Readonly<{
+  materializedRoot: string;
+  plan: ClosureDistributionGenerationPlan;
+}>;
+
+function sha256CanonicalDistribution(value: string): ClosureDigest {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+/**
+ * Consume one sealed distribution graph without selecting a release or
+ * exposing Store layout. Materialization may stage the returned target, but a
+ * later Store preparation still publishes the generation atomically.
+ */
+export function consumeClosureDistributionTarget(
+  value: unknown,
+  target: string,
+): {
+  manifest: ClosureDistributionManifest;
+  target: ResolvedClosureDistributionTarget;
+} {
+  const manifest = validateClosureDistributionManifest(value, sha256CanonicalDistribution);
+  return {
+    manifest,
+    target: resolveClosureDistributionTarget(manifest, target),
+  };
+}
+
+function resolveDistributionBlobPath(paths: ClosureStorePaths, digest: ClosureDigest): string {
+  return assertUnderRoot(paths.root, join(paths.blobsRoot, digest.slice("sha256:".length)));
+}
+
+export function createClosureResourceIndexKey(
+  title: string,
+  treeDigest: ClosureDigest,
+): string {
+  if (title.trim().length === 0 || title !== title.trim()) {
+    throw new ClosureStoreError("Closure resource title must be non-empty and trimmed");
+  }
+  if (!/^sha256:[0-9a-f]{64}$/u.test(treeDigest)) {
+    throw new ClosureStoreError("Closure resource treeDigest must be a lowercase sha256 digest");
+  }
+  const digest = treeDigest;
+  return createHash("sha256").update(JSON.stringify({ title, treeDigest: digest })).digest("hex");
+}
+
+function planDistributionComponent(
+  paths: ClosureStorePaths,
+  storeRoot: string,
+  componentName: "native",
+  component: Readonly<{ blob: ClosureDigest; treeDigest: ClosureDigest }>,
+  manifest: ClosureDistributionManifest,
+): ClosureDistributionComponentPlan;
+function planDistributionComponent(
+  paths: ClosureStorePaths,
+  storeRoot: string,
+  componentName: "launcher",
+  component: ClosureDistributionLauncherComponent,
+  manifest: ClosureDistributionManifest,
+): ClosureDistributionLauncherPlan;
+function planDistributionComponent(
+  paths: ClosureStorePaths,
+  storeRoot: string,
+  componentName: "body",
+  component: ClosureDistributionEntrypointComponent,
+  manifest: ClosureDistributionManifest,
+): ClosureDistributionEntrypointPlan;
+function planDistributionComponent(
+  paths: ClosureStorePaths,
+  storeRoot: string,
+  componentName: "body" | "launcher" | "native",
+  component: Readonly<{
+    blob: ClosureDigest;
+    entryPath?: string;
+    handoffPath?: string;
+    treeDigest: ClosureDigest;
+  }>,
+  manifest: ClosureDistributionManifest,
+): ClosureDistributionComponentPlan | ClosureDistributionEntrypointPlan | ClosureDistributionLauncherPlan {
+  const artifact = manifest.blobs[component.blob];
+  if (artifact == null) {
+    throw new ClosureStoreError(`Closure distribution component ${componentName} references an unknown blob`);
+  }
+  const componentRoot = assertUnderRoot(paths.root, join(storeRoot, componentName));
+  const common = {
+    artifact,
+    blobPath: resolveDistributionBlobPath(paths, component.blob),
+    componentRoot,
+    treeDigest: component.treeDigest,
+  };
+  if (component.entryPath == null) return common;
+  const entrypoint = {
+    ...common,
+    entryPath: component.entryPath,
+    resolvedEntryPath: assertUnderRoot(paths.root, join(componentRoot, component.entryPath)),
+  };
+  if (component.handoffPath == null) return entrypoint;
+  return {
+    ...entrypoint,
+    handoffPath: component.handoffPath,
+    resolvedHandoffPath: assertUnderRoot(paths.root, join(componentRoot, component.handoffPath)),
+  };
+}
+
+/** Resolve one content-addressed installation; generation is only a runtime fence. */
+export function planClosureDistributionGeneration(
+  paths: ClosureStorePaths,
+  generationInput: number,
+  value: unknown,
+  targetInput: string,
+): ClosureDistributionGenerationPlan {
+  const generation = normalizeGeneration(generationInput);
+  const consumed = consumeClosureDistributionTarget(value, targetInput);
+  if (consumed.manifest.identity.channel !== paths.channel) {
+    throw new ClosureStoreError("Closure distribution channel does not match its Store");
+  }
+  const storeRoot = resolveDistributionInstallationRoot({
+    digest: consumed.manifest.identity.digest,
+    installationsRoot: paths.installationsRoot,
+    root: paths.root,
+    target: consumed.target.target,
+    version: consumed.manifest.identity.version,
+  });
+  const required = {
+    body: planDistributionComponent(
+      paths,
+      storeRoot,
+      "body",
+      consumed.target.required.body,
+      consumed.manifest,
+    ),
+    launcher: planDistributionComponent(
+      paths,
+      storeRoot,
+      "launcher",
+      consumed.target.required.launcher,
+      consumed.manifest,
+    ),
+    native: planDistributionComponent(
+      paths,
+      storeRoot,
+      "native",
+      consumed.target.required.native,
+      consumed.manifest,
+    ),
+  };
+  return Object.freeze({
+    channel: paths.channel,
+    generation,
+    storeRoot,
+    identity: consumed.manifest.identity,
+    installationRoot: storeRoot,
+    manifest: consumed.manifest,
+    manifestPath: assertUnderRoot(paths.root, join(storeRoot, "closure.json")),
+    namespace: paths.namespace,
+    required: Object.freeze(required),
+    requiredBlobPaths: Object.freeze(
+      consumed.target.requiredBlobs.map((blob) => resolveDistributionBlobPath(paths, blob.digest)),
+    ),
+    resources: Object.freeze(consumed.target.resources.map((resource) => Object.freeze({
+      artifact: resource.artifact,
+      blobPath: resolveDistributionBlobPath(paths, resource.blob),
+      id: resource.id,
+      resourceRoot: assertUnderRoot(paths.root, join(
+        paths.resourcesRoot,
+        createClosureResourceIndexKey(resource.title, resource.treeDigest),
+      )),
+      startup: resource.startup,
+      title: resource.title,
+      treeDigest: resource.treeDigest,
+    }))),
+    target: consumed.target.target,
+  });
+}
+
+export async function verifyClosureDistributionBlob(
+  paths: ClosureStorePaths,
+  artifact: ClosureDistributionBlob,
+): Promise<string> {
+  const blobPath = resolveDistributionBlobPath(paths, artifact.digest);
+  const actual = await digestFile(blobPath);
+  if (actual.digest !== artifact.digest || actual.size !== artifact.size) {
+    throw new ClosureStoreError("Closure distribution blob does not match its manifest");
+  }
+  return blobPath;
+}
+
+function assertDistributionPlanMatchesStore(
+  paths: ClosureStorePaths,
+  plan: ClosureDistributionGenerationPlan,
+): void {
+  if (plan.channel !== paths.channel || plan.namespace !== paths.namespace) {
+    throw new ClosureStoreError("Closure distribution plan does not match its channel/namespace Store");
+  }
+  const expectedRoot = resolveDistributionInstallationRoot({
+    digest: plan.identity.digest, installationsRoot: paths.installationsRoot, root: paths.root,
+    target: plan.target, version: plan.identity.version,
+  });
+  if (plan.storeRoot !== expectedRoot || plan.installationRoot !== expectedRoot) {
+    throw new ClosureStoreError("Closure distribution plan does not match its content-addressed Store root");
+  }
+  if (plan.manifestPath !== join(expectedRoot, "closure.json")) {
+    throw new ClosureStoreError("Closure distribution plan manifest path is invalid");
+  }
+}
+
+async function inspectMaterializedComponentTree(
+  root: string,
+  label: string,
+): Promise<ClosureComponentTreeFile[]> {
+  const pending = [root];
+  const files: ClosureComponentTreeFile[] = [];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    const metadata = await lstat(current).catch(() => null);
+    if (metadata == null || !metadata.isDirectory()) {
+      throw new ClosureStoreError(`materialized Closure ${label} component is missing`);
+    }
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const entryPath = join(current, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new ClosureStoreError(`materialized Closure ${label} component contains a symlink`);
+      }
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isFile()) {
+        const inspected = await digestFile(entryPath);
+        files.push({
+          digest: inspected.digest as ClosureDigest,
+          path: relative(root, entryPath).split(sep).join("/"),
+          size: inspected.size,
+        });
+      } else {
+        throw new ClosureStoreError(`materialized Closure ${label} component contains an unsupported entry`);
+      }
+    }
+  }
+  if (files.length === 0) {
+    throw new ClosureStoreError(`materialized Closure ${label} component is empty`);
+  }
+  return files.sort((left, right) => compareName(left.path, right.path));
+}
+
+async function assertMaterializedEntrypoint(path: string, label: string): Promise<void> {
+  const metadata = await lstat(path).catch(() => null);
+  if (metadata == null || !metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new ClosureStoreError(`materialized Closure ${label} entry is missing`);
+  }
+}
+
+/** Verify a private staging tree and every required channel CAS blob. */
+export async function verifyMaterializedClosureDistributionGeneration(
+  paths: ClosureStorePaths,
+  plan: ClosureDistributionGenerationPlan,
+  materializedRootInput: string,
+): Promise<StoredClosureDistributionVerification> {
+  assertDistributionPlanMatchesStore(paths, plan);
+  const materializedRoot = assertUnderRoot(paths.stagingRoot, materializedRootInput);
+  if (materializedRoot === paths.stagingRoot) {
+    throw new ClosureStoreError("materialized Closure generation must use an isolated staging child");
+  }
+  return await verifyClosureDistributionGenerationRoot(paths, plan, materializedRoot);
+}
+
+async function verifyClosureDistributionGenerationRoot(
+  paths: ClosureStorePaths,
+  plan: ClosureDistributionGenerationPlan,
+  materializedRoot: string,
+): Promise<StoredClosureDistributionVerification> {
+  const expectedTopLevel = ["body", "closure.json", "launcher", "native"];
+  const topLevel = (await readdir(materializedRoot, { withFileTypes: true }).catch(() => []))
+    .map((entry) => entry.name)
+    .sort(compareName);
+  if (JSON.stringify(topLevel) !== JSON.stringify(expectedTopLevel)) {
+    throw new ClosureStoreError("materialized Closure generation has an invalid top-level shape");
+  }
+
+  const normalizedManifest = validateClosureDistributionManifest(
+    await readRequiredJson(join(materializedRoot, "closure.json"), "Closure distribution manifest"),
+    sha256CanonicalDistribution,
+  );
+  if (JSON.stringify(normalizedManifest) !== JSON.stringify(plan.manifest)) {
+    throw new ClosureStoreError("materialized Closure distribution manifest does not match its generation plan");
+  }
+
+  const required = Object.entries(plan.required) as Array<[
+    keyof ClosureDistributionGenerationPlan["required"],
+    ClosureDistributionComponentPlan | ClosureDistributionEntrypointPlan,
+  ]>;
+  const verifiedDigests = new Set<string>();
+  for (const [name, component] of required) {
+    const expectedBlobPath = resolveDistributionBlobPath(paths, component.artifact.digest);
+    if (component.blobPath !== expectedBlobPath) {
+      throw new ClosureStoreError(`Closure distribution ${name} blob path is invalid`);
+    }
+    if (!verifiedDigests.has(component.artifact.digest)) {
+      try {
+        await verifyClosureDistributionBlob(paths, component.artifact);
+      } catch (error) {
+        throw new ClosureStoreError(`Closure distribution ${name} blob does not match its manifest`, {
+          cause: error,
+        });
+      }
+      verifiedDigests.add(component.artifact.digest);
+    }
+    const componentRoot = join(materializedRoot, name);
+    const files = await inspectMaterializedComponentTree(componentRoot, name);
+    const treeDigest = createClosureComponentTreeDigest(files, sha256CanonicalDistribution);
+    if (treeDigest !== component.treeDigest) {
+      throw new ClosureStoreError(`materialized Closure ${name} component tree does not match its manifest`);
+    }
+    if ("entryPath" in component) {
+      await assertMaterializedEntrypoint(join(componentRoot, component.entryPath), name);
+    }
+    if ("handoffPath" in component && typeof component.handoffPath === "string") {
+      await assertMaterializedEntrypoint(join(componentRoot, component.handoffPath), `${name} handoff`);
+    }
+  }
+  if (verifiedDigests.size !== new Set(plan.requiredBlobPaths).size) {
+    throw new ClosureStoreError("Closure distribution required blob set does not match its components");
+  }
+  return Object.freeze({ materializedRoot, plan });
+}
+
+/** Read the digest-bound manifest even when its materialized components need repair. */
+export async function readStoredClosureDistributionManifest(
+  paths: ClosureStorePaths, pointerInput: ClosureRuntimePointer,
+): Promise<ClosureDistributionManifest> {
+  const pointer = normalizePointer(pointerInput, paths);
+  const storeRoot = resolveDistributionInstallationRoot({
+    digest: pointer.digest, installationsRoot: paths.installationsRoot, root: paths.root, target: pointer.target,
+    version: pointer.version,
+  });
+  const manifest = validateClosureDistributionManifest(
+    await readRequiredJson(join(storeRoot, "closure.json"), "Closure distribution manifest"), sha256CanonicalDistribution,
+  );
+  const plan = planClosureDistributionGeneration(paths, pointer.generation, manifest, pointer.target);
+  if (
+    plan.identity.channel !== pointer.channel
+    || plan.identity.digest !== pointer.digest
+    || plan.identity.protocolVersion !== pointer.protocolVersion
+    || plan.identity.version !== pointer.version
+  ) {
+    throw new ClosureStoreError("stored Closure distribution identity does not match its installation");
+  }
+  return manifest;
+}
+
+/** Verify the immutable installation identity named by the runtime pointer. */
+export async function verifyStoredClosureDistributionGeneration(
+  paths: ClosureStorePaths, pointerInput: ClosureRuntimePointer,
+): Promise<StoredClosureDistributionVerification> {
+  const pointer = normalizePointer(pointerInput, paths);
+  const manifest = await readStoredClosureDistributionManifest(paths, pointer);
+  const plan = planClosureDistributionGeneration(paths, pointer.generation, manifest, pointer.target);
+  const storeRoot = resolveDistributionInstallationRoot({
+    digest: pointer.digest, installationsRoot: paths.installationsRoot, root: paths.root,
+    target: pointer.target, version: pointer.version,
+  });
+  return await verifyClosureDistributionGenerationRoot(paths, plan, storeRoot);
+}
+
+export async function hasStoredClosureDistributionGeneration(
+  paths: ClosureStorePaths, pointerInput: ClosureRuntimePointer,
+): Promise<boolean> {
+  const pointer = normalizePointer(pointerInput, paths);
+  const manifestPath = join(resolveDistributionInstallationRoot({
+    digest: pointer.digest, installationsRoot: paths.installationsRoot, root: paths.root,
+    target: pointer.target, version: pointer.version,
+  }), "closure.json");
+  const metadata = await lstat(manifestPath).catch(() => null);
+  return metadata?.isFile() === true && !metadata.isSymbolicLink();
+}
+
+/** Publish verified bytes as a prepared generation without changing launch authority. */
+export async function prepareVerifiedClosureDistributionGeneration(
+  paths: ClosureStorePaths,
+  verification: StoredClosureDistributionVerification,
+  releaseVersion: string,
+): Promise<{
+  prepared: ClosureReleaseBinding;
+  descriptor: ClosureBindingDescriptor;
+  verification: StoredClosureDistributionVerification;
+}> {
+  assertDistributionPlanMatchesStore(paths, verification.plan);
+  const materializedRoot = assertUnderRoot(paths.stagingRoot, verification.materializedRoot);
+  const current = await readClosureBindingDescriptor(paths);
+  if (verification.plan.generation !== current.nextGeneration) {
+    throw new ClosureStoreError("verified Closure generation is stale");
+  }
+  await rm(verification.plan.storeRoot, { force: true, recursive: true });
+  await mkdir(dirname(verification.plan.storeRoot), { recursive: true });
+  await rename(materializedRoot, verification.plan.storeRoot);
+
+  const pointer: ClosureRuntimePointer = {
+    channel: paths.channel,
+    digest: verification.plan.identity.digest,
+    generation: verification.plan.generation,
+    namespace: paths.namespace,
+    protocolVersion: verification.plan.identity.protocolVersion,
+    target: verification.plan.target,
+    version: verification.plan.identity.version,
+  };
+  const descriptor = await publishPreparedClosureBinding(paths, pointer, releaseVersion);
+  const prepared = descriptor.prepared;
+  if (prepared == null) throw new ClosureStoreError("prepared Closure binding was not published");
+  return { prepared, descriptor, verification };
+}
+

--- a/packages/closure/src/store/distribution/paths.ts
+++ b/packages/closure/src/store/distribution/paths.ts
@@ -1,0 +1,30 @@
+import { resolve, sep } from "node:path";
+
+import type { ClosureDigest } from "../../protocol/index.js";
+
+function segment(value: string, label: string): string {
+  if (value.length === 0 || value === "." || value === ".." || /[\\/\0]/u.test(value)) {
+    throw new Error(`invalid Closure ${label} path segment: ${value}`);
+  }
+  return value;
+}
+
+export function resolveDistributionInstallationRoot(input: Readonly<{
+  digest: ClosureDigest;
+  installationsRoot: string;
+  root: string;
+  target: string;
+  version: string;
+}>): string {
+  const digest = input.digest.slice("sha256:".length);
+  const path = resolve(
+    input.installationsRoot,
+    segment(input.version, "version"),
+    segment(digest, "distribution digest"),
+    segment(input.target, "target"),
+  );
+  const root = resolve(input.root);
+  if (!path.startsWith(`${root}${sep}`)) throw new Error("Closure installation path escapes its Store");
+  return path;
+}
+

--- a/packages/closure/src/store/garbage.ts
+++ b/packages/closure/src/store/garbage.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, sep } from "node:path";
+
+import { isProcessAlive } from "@open-design/platform";
+
+import {
+  CLOSURE_STORE_EPOCH,
+  ClosureStoreError,
+  assertUnderRoot,
+  sameRuntimeBinding,
+  type ClosureStorePaths,
+} from "./binding.js";
+import { readClosureBindingDescriptor } from "./legacy-candidate.js";
+
+export const CLOSURE_GARBAGE_CLEANUP_MAX_ENTRIES = 16 as const;
+export const CLOSURE_GARBAGE_CLEANUP_MAX_DURATION_MS = 250 as const;
+
+export type ClosureGarbageCleanupResult = Readonly<{
+  attempted: number;
+  busy: boolean;
+  durationMs: number;
+  remaining: number;
+  removed: number;
+}>;
+
+export type ClosureObsoleteEpochDiscardResult = Readonly<{
+  discarded: number;
+  state: "deferred" | "discarded";
+}>;
+
+type CleanupLockRecord = Readonly<{
+  createdAt: string;
+  pid: number;
+  token: string;
+}>;
+
+function errorCode(error: unknown): string | null {
+  if (error == null || typeof error !== "object" || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return code == null ? null : String(code);
+}
+
+function strictChannelChild(paths: ClosureStorePaths, input: string): string {
+  const source = assertUnderRoot(paths.channelRoot, input);
+  const child = relative(paths.channelRoot, source);
+  if (child.length === 0 || child.startsWith("..")) {
+    throw new ClosureStoreError("Closure garbage source must be a channel child");
+  }
+  const garbageRelative = relative(paths.garbageRoot, source);
+  if (
+    garbageRelative === ""
+    || (
+      garbageRelative !== ".."
+      && !garbageRelative.startsWith(`..${sep}`)
+      && !isAbsolute(garbageRelative)
+    )
+  ) {
+    throw new ClosureStoreError("Closure garbage source is already inside the channel garbage root");
+  }
+  return source;
+}
+
+/** Transfer one caller-owned Store entry into the opaque channel black hole. */
+export async function discardClosureStoreEntry(input: Readonly<{
+  paths: ClosureStorePaths;
+  sourcePath: string;
+}>): Promise<Readonly<{ garbagePath: string; state: "discarded" | "missing" }>> {
+  const sourcePath = strictChannelChild(input.paths, input.sourcePath);
+  await mkdir(input.paths.garbageRoot, { recursive: true });
+  const garbagePath = assertUnderRoot(
+    input.paths.garbageRoot,
+    join(input.paths.garbageRoot, `${Date.now()}-${process.pid}-${randomUUID()}`),
+  );
+  try {
+    await rename(sourcePath, garbagePath);
+    return Object.freeze({ garbagePath, state: "discarded" });
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return Object.freeze({ garbagePath, state: "missing" });
+    throw error;
+  }
+}
+
+/** Discard this namespace's obsolete epochs only after its current binding is confirmed. */
+export async function discardObsoleteClosureNamespaceEpochs(
+  paths: ClosureStorePaths,
+): Promise<ClosureObsoleteEpochDiscardResult> {
+  const descriptor = await readClosureBindingDescriptor(paths);
+  if (
+    descriptor.active == null
+    || descriptor.lastSuccessful == null
+    || !sameRuntimeBinding(descriptor.active, descriptor.lastSuccessful)
+    || descriptor.attempt != null
+    || descriptor.prepared != null
+    || descriptor.activationIntent != null
+  ) {
+    return Object.freeze({ discarded: 0, state: "deferred" });
+  }
+
+  const epochsRoot = assertUnderRoot(paths.channelRoot, join(paths.channelRoot, "epochs"));
+  const entries = await readdir(epochsRoot, { withFileTypes: true }).catch(() => []);
+  let discarded = 0;
+  for (const entry of entries) {
+    if (
+      !entry.isDirectory()
+      || entry.isSymbolicLink()
+      || entry.name === String(CLOSURE_STORE_EPOCH)
+    ) continue;
+    const sourcePath = assertUnderRoot(
+      paths.channelRoot,
+      join(epochsRoot, entry.name, "namespaces", paths.namespace),
+    );
+    const result = await discardClosureStoreEntry({ paths, sourcePath });
+    if (result.state === "discarded") discarded += 1;
+  }
+  return Object.freeze({ discarded, state: "discarded" });
+}
+
+function cleanupLockPath(paths: ClosureStorePaths): string {
+  return assertUnderRoot(paths.channelRoot, join(paths.channelRoot, "garbage-cleanup.lock"));
+}
+
+function isCleanupLockRecord(value: unknown): value is CleanupLockRecord {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Partial<CleanupLockRecord>;
+  return typeof record.createdAt === "string"
+    && !Number.isNaN(Date.parse(record.createdAt))
+    && typeof record.pid === "number"
+    && Number.isSafeInteger(record.pid)
+    && record.pid > 0
+    && typeof record.token === "string"
+    && record.token.length > 0;
+}
+
+async function readCleanupLock(path: string): Promise<CleanupLockRecord | null> {
+  try {
+    const value = JSON.parse(await readFile(path, "utf8")) as unknown;
+    return isCleanupLockRecord(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+async function acquireCleanupLock(paths: ClosureStorePaths): Promise<CleanupLockRecord | null> {
+  const path = cleanupLockPath(paths);
+  await mkdir(paths.channelRoot, { recursive: true });
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const record = Object.freeze({
+      createdAt: new Date().toISOString(),
+      pid: process.pid,
+      token: randomUUID(),
+    });
+    try {
+      await writeFile(path, `${JSON.stringify(record)}\n`, { flag: "wx" });
+      return record;
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+      const existing = await readCleanupLock(path);
+      if (attempt === 0 && (existing == null || !isProcessAlive(existing.pid))) {
+        await rm(path, { force: true }).catch(() => undefined);
+        continue;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+async function releaseCleanupLock(paths: ClosureStorePaths, lock: CleanupLockRecord): Promise<void> {
+  const path = cleanupLockPath(paths);
+  const current = await readCleanupLock(path);
+  if (current?.token === lock.token) await rm(path, { force: true }).catch(() => undefined);
+}
+
+/** Best-effort, structure-agnostic draining of opaque channel garbage entries. */
+export async function cleanupClosureChannelGarbage(input: Readonly<{
+  maxDurationMs?: number;
+  maxEntries?: number;
+  paths: ClosureStorePaths;
+}>): Promise<ClosureGarbageCleanupResult> {
+  const startedAt = Date.now();
+  const maxDurationMs = input.maxDurationMs ?? CLOSURE_GARBAGE_CLEANUP_MAX_DURATION_MS;
+  const maxEntries = input.maxEntries ?? CLOSURE_GARBAGE_CLEANUP_MAX_ENTRIES;
+  if (!Number.isSafeInteger(maxDurationMs) || maxDurationMs < 0) {
+    throw new ClosureStoreError("Closure garbage cleanup maxDurationMs must be a non-negative safe integer");
+  }
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 0) {
+    throw new ClosureStoreError("Closure garbage cleanup maxEntries must be a non-negative safe integer");
+  }
+  const lock = await acquireCleanupLock(input.paths);
+  if (lock == null) {
+    return Object.freeze({ attempted: 0, busy: true, durationMs: Date.now() - startedAt, remaining: 0, removed: 0 });
+  }
+  let attempted = 0;
+  let removed = 0;
+  try {
+    const entries = await readdir(input.paths.garbageRoot).catch(() => []);
+    for (const name of entries) {
+      if (attempted >= maxEntries || Date.now() - startedAt >= maxDurationMs) break;
+      attempted += 1;
+      const path = assertUnderRoot(input.paths.garbageRoot, join(input.paths.garbageRoot, name));
+      try {
+        await rm(path, { force: true, recursive: true });
+        removed += 1;
+      } catch {
+        // The black hole keeps failed entries for a future best-effort pass.
+      }
+    }
+    const remaining = await readdir(input.paths.garbageRoot).then((value) => value.length, () => 0);
+    return Object.freeze({
+      attempted,
+      busy: false,
+      durationMs: Date.now() - startedAt,
+      remaining,
+      removed,
+    });
+  } finally {
+    await releaseCleanupLock(input.paths, lock);
+  }
+}
+

--- a/packages/closure/src/store/index.ts
+++ b/packages/closure/src/store/index.ts
@@ -1,0 +1,7 @@
+export * from "./binding.js";
+export * from "./channel-lock.js";
+export * from "./distribution/index.js";
+export * from "./garbage.js";
+export * from "./legacy-candidate.js";
+export * from "./runtime.js";
+

--- a/packages/closure/src/store/legacy-candidate.ts
+++ b/packages/closure/src/store/legacy-candidate.ts
@@ -1,0 +1,307 @@
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, rename, rm, stat } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+import {
+  CLOSURE_ARCHIVE_ENTRY_PATH,
+  bindClosureCandidateIdentity,
+  validateClosureBindingIdentity,
+  validateClosureCandidateManifest,
+  validateClosureFileInventory,
+  type ClosureBindingIdentity,
+  type ClosureCandidateManifest,
+  type ClosureFileInventory,
+} from "../protocol/index.js";
+import { writeJsonFile } from "@open-design/sidecar";
+
+import {
+  CLOSURE_BINDING_SCHEMA_VERSION,
+  ClosureStoreError,
+  assertUnderRoot,
+  digestFile,
+  normalizeReleaseVersion,
+  persistedClosureActivationIntentDescriptor,
+  persistedClosureBindingDescriptor,
+  readOptionalJson,
+  readRequiredJson,
+  resolveClosureActivationIntentPath,
+  resolveClosureStoreVersionPaths,
+  sameBinding,
+  sameReleaseBinding,
+  validateClosureBindingDescriptor,
+  validateClosureActivationIntentDescriptor,
+  type ClosureBindingDescriptor,
+  type ClosureRuntimePointer,
+  type ClosureStorePaths,
+  type ClosureStoreVersionPaths,
+  type ClosureReleaseBinding,
+  type StoredClosureVerification,
+} from "./binding.js";
+
+export function compareName(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+const CLOSURE_VERIFY_IO_CONCURRENCY = 16;
+
+async function collectPayloadFiles(root: string): Promise<ClosureFileInventory["files"]> {
+  const directories = [root];
+  const discovered: Array<{ absolutePath: string; archivePath: string }> = [];
+
+  // Traverse in bounded batches: Windows Closure payloads contain thousands
+  // of directories, so serial readdir/lstat turns Defender latency into a
+  // multi-minute cold start. Dirent still rejects links and special files; the
+  // queue only changes I/O scheduling, not the verified inventory contract.
+  while (directories.length > 0) {
+    const batch = directories.splice(0, CLOSURE_VERIFY_IO_CONCURRENCY);
+    const batches = await Promise.all(batch.map(async (current) => {
+      const entries = await readdir(current, { withFileTypes: true }).catch((error) => {
+        throw new ClosureStoreError(`Closure payload is missing or unreadable at ${current}: ${
+          error instanceof Error ? error.message : String(error)
+        }`);
+      });
+      return { current, entries: entries.sort((left, right) => compareName(left.name, right.name)) };
+    }));
+    for (const { current, entries } of batches) {
+      for (const entry of entries) {
+        const absolutePath = join(current, entry.name);
+        const archivePath = relative(root, absolutePath).split(sep).join("/");
+        if (entry.isSymbolicLink()) {
+          throw new ClosureStoreError(`Closure payload contains a symlink: ${archivePath}`);
+        }
+        if (entry.isDirectory()) {
+          directories.push(absolutePath);
+          continue;
+        }
+        if (!entry.isFile()) {
+          const metadata = await lstat(absolutePath);
+          if (metadata.isSymbolicLink()) {
+            throw new ClosureStoreError(`Closure payload contains a symlink: ${archivePath}`);
+          }
+          if (metadata.isDirectory()) {
+            directories.push(absolutePath);
+            continue;
+          }
+          if (!metadata.isFile()) {
+            throw new ClosureStoreError(`Closure payload contains an unsupported entry: ${archivePath}`);
+          }
+        }
+        discovered.push({ absolutePath, archivePath });
+      }
+    }
+  }
+
+  discovered.sort((left, right) => compareName(left.archivePath, right.archivePath));
+  const files = new Array<ClosureFileInventory["files"][number]>(discovered.length);
+  let nextIndex = 0;
+  const workers = Array.from(
+    { length: Math.min(CLOSURE_VERIFY_IO_CONCURRENCY, discovered.length) },
+    async () => {
+      while (nextIndex < discovered.length) {
+        const index = nextIndex++;
+        const file = discovered[index]!;
+        const identity = await digestFile(file.absolutePath);
+        files[index] = {
+          digest: identity.digest as `sha256:${string}`,
+          path: file.archivePath,
+          size: identity.size,
+        };
+      }
+    },
+  );
+  await Promise.all(workers);
+  return files;
+}
+
+function inventoryDigest(inventory: ClosureFileInventory): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(inventory.files)).digest("hex")}`;
+}
+
+export async function verifyStoredClosureCandidate(
+  paths: ClosureStorePaths,
+  expectedBinding: ClosureBindingIdentity,
+): Promise<StoredClosureVerification> {
+  const binding = validateClosureBindingIdentity(expectedBinding, paths);
+  const versionPaths = resolveClosureStoreVersionPaths(paths, binding);
+  return await verifyMaterializedClosureCandidate(paths, binding, versionPaths);
+}
+
+export async function verifyMaterializedClosureCandidate(
+  paths: ClosureStorePaths,
+  expectedBinding: ClosureBindingIdentity,
+  materializedPaths: ClosureStoreVersionPaths,
+): Promise<StoredClosureVerification> {
+  const binding = validateClosureBindingIdentity(expectedBinding, paths);
+  if (
+    materializedPaths.root !== paths.root
+    || materializedPaths.channel !== paths.channel
+    || materializedPaths.namespace !== paths.namespace
+    || materializedPaths.version !== binding.version
+    || materializedPaths.digest !== binding.digest.slice("sha256:".length)
+  ) {
+    throw new ClosureStoreError("materialized Closure paths do not match their Store binding");
+  }
+  const versionPaths: ClosureStoreVersionPaths = {
+    ...materializedPaths,
+    archivePath: assertUnderRoot(paths.root, materializedPaths.archivePath),
+    inventoryPath: assertUnderRoot(paths.root, materializedPaths.inventoryPath),
+    manifestPath: assertUnderRoot(paths.root, materializedPaths.manifestPath),
+    payloadRoot: assertUnderRoot(paths.root, materializedPaths.payloadRoot),
+    versionRoot: assertUnderRoot(paths.root, materializedPaths.versionRoot),
+  };
+  const manifest = validateClosureCandidateManifest(
+    await readRequiredJson(versionPaths.manifestPath, "Closure candidate manifest"),
+  );
+  const manifestBinding = bindClosureCandidateIdentity(manifest.identity, paths.namespace);
+  if (!sameBinding(binding, manifestBinding)) {
+    throw new ClosureStoreError("stored Closure manifest does not match the requested binding");
+  }
+  const archive = await digestFile(versionPaths.archivePath);
+  if (archive.digest !== manifest.artifact.digest || archive.size !== manifest.artifact.size) {
+    throw new ClosureStoreError("stored Closure archive does not match its manifest digest and size");
+  }
+  const inventory = validateClosureFileInventory(
+    await readRequiredJson(versionPaths.inventoryPath, "Closure file inventory"),
+  );
+  const expectedInventoryDigest = inventoryDigest(inventory);
+  if (expectedInventoryDigest !== manifest.artifact.inventoryDigest) {
+    throw new ClosureStoreError("stored Closure inventory does not match its manifest digest");
+  }
+  const actualFiles = (await collectPayloadFiles(versionPaths.payloadRoot)).sort(
+    (left, right) => compareName(left.path, right.path),
+  );
+  if (JSON.stringify(actualFiles) !== JSON.stringify(inventory.files)) {
+    throw new ClosureStoreError("materialized Closure payload does not match its inventory");
+  }
+  if (!(await stat(join(versionPaths.payloadRoot, CLOSURE_ARCHIVE_ENTRY_PATH)).catch(() => null))?.isFile()) {
+    throw new ClosureStoreError(`materialized Closure entry is missing: ${CLOSURE_ARCHIVE_ENTRY_PATH}`);
+  }
+  return {
+    binding,
+    inventory,
+    inventoryDigest: expectedInventoryDigest,
+    manifest,
+    paths: versionPaths,
+  };
+}
+
+function emptyBinding(paths: ClosureStorePaths, now: string): ClosureBindingDescriptor {
+  return {
+    active: null,
+    attempt: null,
+    activationIntent: null,
+    channel: paths.channel,
+    lastSuccessful: null,
+    namespace: paths.namespace,
+    nextGeneration: 0,
+    prepared: null,
+    schemaVersion: CLOSURE_BINDING_SCHEMA_VERSION,
+    updatedAt: now,
+  };
+}
+
+export async function readClosureBindingDescriptor(paths: ClosureStorePaths): Promise<ClosureBindingDescriptor> {
+  const raw = await readOptionalJson(paths.bindingPath, "Closure binding descriptor");
+  if (raw == null) return emptyBinding(paths, new Date(0).toISOString());
+  let descriptor = validateClosureBindingDescriptor(raw, paths);
+  const activationIntentPath = resolveClosureActivationIntentPath(paths);
+  const physical = raw as Record<string, unknown>;
+  const transitional = physical.schemaVersion === 5;
+  let revokeOrphanedAuthorization = false;
+  if (!transitional && physical.activationAuthorized === true) {
+    const rawIntent = await readOptionalJson(activationIntentPath, "Closure activation intent").catch(() => null);
+    if (rawIntent != null) {
+      const intent = (() => {
+        try {
+          return validateClosureActivationIntentDescriptor(rawIntent, paths).intent;
+        } catch {
+          return null;
+        }
+      })();
+      if (intent != null && descriptor.prepared != null && sameReleaseBinding(intent, descriptor.prepared)) {
+        descriptor = { ...descriptor, activationIntent: intent };
+      } else revokeOrphanedAuthorization = true;
+    } else {
+      revokeOrphanedAuthorization = true;
+    }
+  }
+  if (transitional) {
+    const intent = persistedClosureActivationIntentDescriptor(descriptor);
+    if (intent != null) await writeJsonFile(activationIntentPath, intent);
+    await writeJsonFile(paths.bindingPath, persistedClosureBindingDescriptor(descriptor));
+    if (intent == null) await rm(activationIntentPath, { force: true });
+  } else if (revokeOrphanedAuthorization) {
+    await writeJsonFile(paths.bindingPath, persistedClosureBindingDescriptor(descriptor));
+    await rm(activationIntentPath, { force: true });
+  }
+  return descriptor;
+}
+
+export async function prepareStoredClosureCandidate(
+  paths: ClosureStorePaths,
+  binding: ClosureBindingIdentity,
+  releaseVersion: string,
+): Promise<{
+  prepared: ClosureReleaseBinding;
+  descriptor: ClosureBindingDescriptor;
+  verification: StoredClosureVerification;
+}> {
+  const verification = await verifyStoredClosureCandidate(paths, binding);
+  return await prepareVerifiedStoredClosureCandidate(paths, verification, releaseVersion);
+}
+
+/**
+ * Prepare a candidate whose exact materialized bytes were already verified.
+ *
+ * Fresh update staging verifies every inventory entry before an atomic rename
+ * into the Store. Carrying that proof across the rename avoids hashing a large
+ * Windows Closure two more times while preserving the one full byte-level
+ * verification before the binding becomes visible.
+ */
+export async function prepareVerifiedStoredClosureCandidate(
+  paths: ClosureStorePaths,
+  verification: StoredClosureVerification,
+  releaseVersion: string,
+): Promise<{
+  prepared: ClosureReleaseBinding;
+  descriptor: ClosureBindingDescriptor;
+  verification: StoredClosureVerification;
+}> {
+  const binding = validateClosureBindingIdentity(verification.binding, paths);
+  const expectedPaths = resolveClosureStoreVersionPaths(paths, binding);
+  if (
+    verification.paths.versionRoot !== expectedPaths.versionRoot
+    || verification.paths.archivePath !== expectedPaths.archivePath
+    || verification.paths.inventoryPath !== expectedPaths.inventoryPath
+    || verification.paths.manifestPath !== expectedPaths.manifestPath
+    || verification.paths.payloadRoot !== expectedPaths.payloadRoot
+  ) {
+    throw new ClosureStoreError("verified Closure paths do not match the prepared Store location");
+  }
+  const current = await readClosureBindingDescriptor(paths);
+  const generation = current.nextGeneration;
+  const pointer: ClosureRuntimePointer = {
+    channel: binding.channel,
+    digest: binding.digest,
+    generation,
+    namespace: binding.namespace,
+    protocolVersion: binding.protocolVersion,
+    target: binding.platform,
+    version: binding.version,
+  };
+  const prepared: ClosureReleaseBinding = {
+    releaseVersion: normalizeReleaseVersion(releaseVersion),
+    standalone: pointer,
+  };
+  const descriptor: ClosureBindingDescriptor = {
+    ...current,
+    activationIntent: null,
+    prepared,
+    nextGeneration: generation + 1,
+    updatedAt: new Date().toISOString(),
+  };
+  await writeJsonFile(paths.bindingPath, persistedClosureBindingDescriptor(descriptor));
+  await rm(resolveClosureActivationIntentPath(paths), { force: true });
+  return { prepared, descriptor, verification };
+}
+

--- a/packages/closure/src/store/runtime.ts
+++ b/packages/closure/src/store/runtime.ts
@@ -1,0 +1,192 @@
+import { rm } from "node:fs/promises";
+
+import { writeJsonFile } from "@open-design/sidecar";
+
+import {
+  ClosureStoreError,
+  normalizeReleaseVersion,
+  normalizeShellBinding,
+  persistedClosureActivationIntentDescriptor,
+  persistedClosureBindingDescriptor,
+  resolveClosureActivationIntentPath,
+  sameReleaseBinding,
+  sameShellBinding,
+  type ClosureBindingDescriptor,
+  type ClosureActivationSource,
+  type ClosureReleaseBinding,
+  type ClosureRuntimeBinding,
+  type ClosureRuntimePointer,
+  type ClosureShellBinding,
+  type ClosureStorePaths,
+} from "./binding.js";
+import { readClosureBindingDescriptor } from "./legacy-candidate.js";
+
+async function writeDescriptor(
+  paths: ClosureStorePaths,
+  descriptor: ClosureBindingDescriptor,
+): Promise<ClosureBindingDescriptor> {
+  const next = { ...descriptor, updatedAt: new Date().toISOString() };
+  const activationIntentPath = resolveClosureActivationIntentPath(paths);
+  const intent = persistedClosureActivationIntentDescriptor(next);
+  if (intent != null) await writeJsonFile(activationIntentPath, intent);
+  await writeJsonFile(paths.bindingPath, persistedClosureBindingDescriptor(next));
+  if (intent == null) await rm(activationIntentPath, { force: true });
+  return next;
+}
+
+function expectedBinding(
+  actual: ClosureReleaseBinding | null,
+  expected: ClosureReleaseBinding | ClosureRuntimePointer,
+  label: string,
+): ClosureReleaseBinding {
+  if (actual == null) throw new ClosureStoreError(`Closure ${label} binding is missing`);
+  const pointer = "standalone" in expected ? expected.standalone : expected;
+  if (
+    actual.standalone.generation !== pointer.generation
+    || actual.standalone.digest !== pointer.digest
+    || actual.standalone.version !== pointer.version
+    || actual.standalone.target !== pointer.target
+  ) {
+    throw new ClosureStoreError(`Closure ${label} binding changed concurrently`);
+  }
+  return actual;
+}
+
+export async function publishPreparedClosureBinding(
+  paths: ClosureStorePaths,
+  pointer: ClosureRuntimePointer,
+  releaseVersion: string,
+): Promise<ClosureBindingDescriptor> {
+  const current = await readClosureBindingDescriptor(paths);
+  if (pointer.generation !== current.nextGeneration) {
+    throw new ClosureStoreError("prepared Closure generation is stale");
+  }
+  const prepared: ClosureReleaseBinding = {
+    releaseVersion: normalizeReleaseVersion(releaseVersion),
+    standalone: pointer,
+  };
+  return await writeDescriptor(paths, {
+    ...current,
+    activationIntent: null,
+    nextGeneration: current.nextGeneration + 1,
+    prepared,
+  });
+}
+
+export async function authorizePreparedClosureActivation(
+  paths: ClosureStorePaths,
+  expected: ClosureReleaseBinding | ClosureRuntimePointer,
+  source: ClosureActivationSource,
+): Promise<ClosureReleaseBinding> {
+  const current = await readClosureBindingDescriptor(paths);
+  const prepared = expectedBinding(current.prepared, expected, "prepared");
+  await writeDescriptor(paths, {
+    ...current,
+    activationIntent: { ...prepared, source },
+  });
+  return prepared;
+}
+
+export async function revokePreparedClosureActivation(
+  paths: ClosureStorePaths,
+  source?: ClosureActivationSource,
+): Promise<ClosureBindingDescriptor> {
+  const current = await readClosureBindingDescriptor(paths);
+  if (current.activationIntent == null || (
+    source != null && current.activationIntent.source !== source
+  )) return current;
+  return await writeDescriptor(paths, {
+    ...current,
+    activationIntent: null,
+  });
+}
+
+export async function activatePreparedClosureBinding(
+  paths: ClosureStorePaths,
+  expected: ClosureReleaseBinding | ClosureRuntimePointer,
+  shell: ClosureShellBinding,
+): Promise<ClosureRuntimeBinding> {
+  const current = await readClosureBindingDescriptor(paths);
+  if (current.attempt != null) {
+    throw new ClosureStoreError("Closure activation is blocked by an unfinished attempt");
+  }
+  const prepared = expectedBinding(current.prepared, expected, "prepared");
+  const attempt: ClosureRuntimeBinding = { ...prepared, shell: normalizeShellBinding(shell) };
+  await writeDescriptor(paths, {
+    ...current,
+    active: attempt,
+    attempt,
+    activationIntent: null,
+    prepared: null,
+  });
+  return attempt;
+}
+
+export async function beginActiveClosureBindingAttempt(
+  paths: ClosureStorePaths,
+  expected: ClosureReleaseBinding | ClosureRuntimePointer,
+  shellInput: ClosureShellBinding,
+): Promise<ClosureRuntimeBinding> {
+  const current = await readClosureBindingDescriptor(paths);
+  if (current.attempt != null) {
+    throw new ClosureStoreError("Closure activation is blocked by an unfinished attempt");
+  }
+  const active = expectedBinding(current.active, expected, "active");
+  if (current.active == null) throw new ClosureStoreError("Closure active binding is missing");
+  const shell = normalizeShellBinding(shellInput);
+  if (sameShellBinding(current.active.shell, shell)) return current.active;
+  const attempt: ClosureRuntimeBinding = { ...active, shell };
+  await writeDescriptor(paths, { ...current, active: attempt, attempt });
+  return attempt;
+}
+
+export async function confirmClosureBindingAttempt(
+  paths: ClosureStorePaths,
+  expected: ClosureReleaseBinding | ClosureRuntimePointer,
+): Promise<ClosureRuntimeBinding> {
+  const current = await readClosureBindingDescriptor(paths);
+  expectedBinding(current.attempt, expected, "attempt");
+  const attempt = current.attempt;
+  if (attempt == null) throw new ClosureStoreError("Closure attempt binding is missing");
+  await writeDescriptor(paths, {
+    ...current,
+    active: attempt,
+    attempt: null,
+    lastSuccessful: attempt,
+  });
+  return attempt;
+}
+
+export async function rollbackClosureBindingAttempt(
+  paths: ClosureStorePaths,
+  expected?: ClosureReleaseBinding | ClosureRuntimePointer,
+): Promise<ClosureRuntimeBinding | null> {
+  const current = await readClosureBindingDescriptor(paths);
+  if (current.attempt == null) return current.lastSuccessful;
+  if (expected != null) expectedBinding(current.attempt, expected, "attempt");
+  await writeDescriptor(paths, {
+    ...current,
+    active: current.lastSuccessful,
+    attempt: null,
+    activationIntent: null,
+    prepared: null,
+  });
+  return current.lastSuccessful;
+}
+
+export async function recoverInterruptedClosureBinding(
+  paths: ClosureStorePaths,
+): Promise<ClosureRuntimeBinding | null> {
+  const descriptor = await readClosureBindingDescriptor(paths);
+  return descriptor.attempt == null
+    ? descriptor.active
+    : await rollbackClosureBindingAttempt(paths, descriptor.attempt);
+}
+
+export function isCurrentClosureBinding(
+  current: ClosureReleaseBinding | null,
+  expected: ClosureReleaseBinding,
+): boolean {
+  return current != null && sameReleaseBinding(current, expected);
+}
+

--- a/packages/closure/src/update/apply.ts
+++ b/packages/closure/src/update/apply.ts
@@ -1,0 +1,512 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+
+import {
+  bindClosureCandidateIdentity,
+  validateClosureCandidateManifest,
+  validateClosureDistributionManifest,
+  validateClosureFileInventory,
+  type ClosureCandidateManifest,
+  type ClosureDistributionManifest,
+} from "../protocol/index.js";
+import type { ClosureBindingDescriptor } from "../store/index.js";
+import {
+  acquireClosureChannelLock,
+  prepareVerifiedClosureDistributionGeneration,
+  prepareVerifiedStoredClosureCandidate,
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  resolveClosureStoreVersionPaths,
+  verifyMaterializedClosureCandidate,
+  verifyMaterializedClosureDistributionGeneration,
+  verifyStoredClosureCandidate,
+  releaseClosureChannelLock,
+  type ClosureRuntimePointer,
+  type ClosureStorePaths,
+  type ClosureStoreVersionPaths,
+  type StoredClosureVerification,
+} from "../store/index.js";
+import { downloadCopyAndClear } from "@open-design/download";
+import {
+  compareReleaseVersions,
+  isReleaseChannel,
+  type ReleaseChannel,
+} from "@open-design/release";
+import extractZip from "extract-zip";
+
+
+import {
+  ClosureReleaseCandidate,
+  ClosureDistributionReleaseCandidate,
+  ClosureResourceRepositoryConfig,
+  ApplyClosureUpdateResult,
+  ApplyClosureDistributionUpdateResult,
+  ClosureDistributionUpdateProgress,
+  reportDistributionProgress,
+  ApplyClosureReleaseUpdateResult,
+  requireHttpUrl,
+  selectClosureReleaseCandidate,
+  selectClosureDistributionReleaseCandidate,
+  compareClosureShellVersions,
+  resolveClosureShellMinimumVersion,
+  decideClosureUpdate,
+  decideClosureDistributionUpdate,
+} from "./index.js";
+import { ClosureUpdateError } from "./errors.js";
+import { ensureDistributionBlob } from "./resource.js";
+
+function errorCode(error: unknown): string | null {
+  if (error == null || typeof error !== "object" || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return code == null ? null : String(code);
+}
+
+function sameCandidate(
+  pointer: Pick<ClosureRuntimePointer, "channel" | "digest" | "namespace" | "protocolVersion" | "target" | "version">,
+  binding: ReturnType<typeof bindClosureCandidateIdentity>,
+): boolean {
+  return pointer.channel === binding.channel
+    && pointer.digest === binding.digest
+    && pointer.namespace === binding.namespace
+    && pointer.target === binding.platform
+    && pointer.protocolVersion === binding.protocolVersion
+    && pointer.version === binding.version;
+}
+
+export async function fetchJsonDocument(
+  url: string,
+  label: string,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<unknown> {
+  const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+  if (!response.ok) {
+    const requestUrl = new URL(url);
+    const requestLocation = `${requestUrl.origin}${requestUrl.pathname}`;
+    throw new ClosureUpdateError(
+      `${label} request to ${requestLocation} returned HTTP ${response.status}`,
+    );
+  }
+  const text = await response.text();
+  if (Buffer.byteLength(text) > 16 * 1024 * 1024) {
+    throw new ClosureUpdateError(`${label} exceeds the 16 MiB metadata limit`);
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new ClosureUpdateError(
+      `${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function inventoryDigest(files: ReturnType<typeof validateClosureFileInventory>["files"]): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(files)).digest("hex")}`;
+}
+
+async function fetchCandidateDocuments(
+  candidate: ClosureReleaseCandidate,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<{
+  inventory: ReturnType<typeof validateClosureFileInventory>;
+  manifest: ClosureCandidateManifest;
+}> {
+  const [manifestValue, inventoryValue] = await Promise.all([
+    fetchJsonDocument(candidate.assets.manifest, "Closure manifest", fetchImpl),
+    fetchJsonDocument(candidate.assets.inventory, "Closure inventory", fetchImpl),
+  ]);
+  const manifest = validateClosureCandidateManifest(manifestValue);
+  if (JSON.stringify(manifest) !== JSON.stringify(candidate.manifest)) {
+    throw new ClosureUpdateError("downloaded Closure manifest does not match release metadata");
+  }
+  const inventory = validateClosureFileInventory(inventoryValue);
+  if (inventoryDigest(inventory.files) !== manifest.artifact.inventoryDigest) {
+    throw new ClosureUpdateError("downloaded Closure inventory does not match its manifest digest");
+  }
+  return { inventory, manifest };
+}
+
+function stagedVersionPaths(
+  finalPaths: ClosureStoreVersionPaths,
+  stageRoot: string,
+): ClosureStoreVersionPaths {
+  return {
+    ...finalPaths,
+    archivePath: join(stageRoot, "closure.zip"),
+    inventoryPath: join(stageRoot, "inventory.json"),
+    manifestPath: join(stageRoot, "manifest.json"),
+    payloadRoot: join(stageRoot, "payload"),
+    versionRoot: stageRoot,
+  };
+}
+
+function candidateIsReferenced(
+  descriptor: ClosureBindingDescriptor,
+  binding: ReturnType<typeof bindClosureCandidateIdentity>,
+): boolean {
+  return [descriptor.active, descriptor.attempt, descriptor.lastSuccessful, descriptor.prepared]
+    .some((reference) => reference != null && sameCandidate(reference.standalone, binding));
+}
+
+async function ensureCandidateMaterialized(input: {
+  candidate: ClosureReleaseCandidate;
+  descriptor: ClosureBindingDescriptor;
+  fetchImpl: typeof globalThis.fetch;
+  paths: ClosureStorePaths;
+}): Promise<StoredClosureVerification> {
+  const binding = bindClosureCandidateIdentity(input.candidate.manifest.identity, input.paths.namespace);
+  const finalPaths = resolveClosureStoreVersionPaths(input.paths, binding);
+  const existing = await stat(finalPaths.versionRoot).catch(() => null);
+  if (existing != null) {
+    try {
+      return await verifyStoredClosureCandidate(input.paths, binding);
+    } catch (error) {
+      if (candidateIsReferenced(input.descriptor, binding)) throw error;
+      await rm(finalPaths.versionRoot, { force: true, recursive: true });
+    }
+  }
+
+  const stageRoot = join(
+    input.paths.stagingRoot,
+    `${binding.version}-${binding.digest.slice("sha256:".length)}-${randomUUID()}`,
+  );
+  const stagePaths = stagedVersionPaths(finalPaths, stageRoot);
+  await mkdir(stagePaths.payloadRoot, { recursive: true });
+  try {
+    const documents = await fetchCandidateDocuments(input.candidate, input.fetchImpl);
+    await Promise.all([
+      writeFile(stagePaths.manifestPath, `${JSON.stringify(documents.manifest, null, 2)}\n`, "utf8"),
+      writeFile(stagePaths.inventoryPath, `${JSON.stringify(documents.inventory, null, 2)}\n`, "utf8"),
+      downloadCopyAndClear({
+        basePath: join(input.paths.stagingRoot, "downloads"),
+        bucket: "closure",
+        fetch: input.fetchImpl,
+        fileName: `${binding.digest.slice("sha256:".length)}.zip`,
+        outputPath: stagePaths.archivePath,
+        payload: {
+          checksum: {
+            algorithm: "sha256",
+            value: binding.digest.slice("sha256:".length),
+          },
+          url: input.candidate.assets.archive,
+        },
+      }),
+    ]);
+    await extractZip(stagePaths.archivePath, { dir: stagePaths.payloadRoot });
+    const stagedVerification = await verifyMaterializedClosureCandidate(input.paths, binding, stagePaths);
+    await mkdir(dirname(finalPaths.versionRoot), { recursive: true });
+    try {
+      await rename(stageRoot, finalPaths.versionRoot);
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST" && errorCode(error) !== "ENOTEMPTY") throw error;
+      return await verifyStoredClosureCandidate(input.paths, binding);
+    }
+    return { ...stagedVerification, paths: finalPaths };
+  } finally {
+    await rm(stageRoot, { force: true, recursive: true }).catch(() => undefined);
+  }
+}
+
+async function stageClosureDistributionGeneration(input: {
+  candidate: ClosureDistributionReleaseCandidate;
+  descriptor: ClosureBindingDescriptor;
+  fetchImpl: typeof globalThis.fetch;
+  onProgress?: (progress: ClosureDistributionUpdateProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+}) {
+  const plan = planClosureDistributionGeneration(
+    input.paths,
+    input.descriptor.nextGeneration,
+    input.candidate.manifest,
+    input.candidate.target,
+  );
+  const components = Object.entries(plan.required);
+  const uniqueComponents = [...new Map(
+    components.map(([, component]) => [component.artifact.digest, component] as const),
+  ).values()];
+  const totalBytes = uniqueComponents.reduce(
+    (total, component) => total + component.artifact.size,
+    0,
+  );
+  let completedBytes = 0;
+  reportDistributionProgress(input.onProgress, { completedBytes, phase: "download", totalBytes });
+  for (const component of uniqueComponents) {
+    let reportedArtifactBytes = 0;
+    await ensureDistributionBlob({
+      artifact: component.artifact,
+      fetchImpl: input.fetchImpl,
+      onProgress(progress) {
+        const artifactBytes = progress.phase === "copying" || progress.phase === "downloading"
+          ? progress.completedBytes
+          : progress.phase === "ready" ? component.artifact.size : reportedArtifactBytes;
+        reportedArtifactBytes = Math.max(
+          reportedArtifactBytes,
+          Math.min(artifactBytes, component.artifact.size),
+        );
+        reportDistributionProgress(input.onProgress, {
+          completedBytes: completedBytes + reportedArtifactBytes,
+          phase: "download",
+          totalBytes,
+        });
+      },
+      paths: input.paths,
+      ...(input.repository == null ? {} : { repository: input.repository }),
+    });
+    completedBytes += component.artifact.size;
+    reportDistributionProgress(input.onProgress, { completedBytes, phase: "download", totalBytes });
+  }
+
+  const stageRoot = join(
+    input.paths.stagingRoot,
+    `generation-${plan.generation}-${plan.identity.digest.slice("sha256:".length)}-${randomUUID()}`,
+  );
+  await mkdir(stageRoot, { recursive: true });
+  try {
+    let completedComponents = 0;
+    reportDistributionProgress(input.onProgress, {
+      completedComponents,
+      phase: "materialize",
+      totalComponents: components.length,
+    });
+    await Promise.all(components.map(async ([name, component]) => {
+      const componentRoot = join(stageRoot, name);
+      await mkdir(componentRoot, { recursive: true });
+      await extractZip(component.blobPath, { dir: componentRoot });
+      completedComponents += 1;
+      reportDistributionProgress(input.onProgress, {
+        completedComponents,
+        phase: "materialize",
+        totalComponents: components.length,
+      });
+    }));
+    await writeFile(
+      join(stageRoot, "closure.json"),
+      `${JSON.stringify(plan.manifest, null, 2)}\n`,
+      "utf8",
+    );
+    return await verifyMaterializedClosureDistributionGeneration(
+      input.paths,
+      plan,
+      stageRoot,
+    );
+  } catch (error) {
+    await rm(stageRoot, { force: true, recursive: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+/** Apply one already-selected v2 distribution graph to the local Store. */
+export async function applyClosureDistributionUpdate(input: {
+  candidate: ClosureDistributionReleaseCandidate;
+  fetch?: typeof globalThis.fetch;
+  onProgress?: (progress: ClosureDistributionUpdateProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+  shellType: string;
+  shellVersion: string;
+}): Promise<ApplyClosureDistributionUpdateResult> {
+  const lock = await acquireClosureChannelLock(input.paths, { waitMs: 250 });
+  if (lock == null) {
+    return { candidate: input.candidate, reason: "another-updater-active", state: "busy" };
+  }
+  try {
+    const descriptor = await readClosureBindingDescriptor(input.paths);
+    const decision = decideClosureDistributionUpdate({
+      candidate: input.candidate,
+      descriptor,
+      shellType: input.shellType,
+      shellVersion: input.shellVersion,
+    });
+    if (decision.action === "retain") {
+      return { candidate: input.candidate, reason: decision.reason, state: "retained" };
+    }
+    const verification = await stageClosureDistributionGeneration({
+      candidate: input.candidate,
+      descriptor,
+      fetchImpl: input.fetch ?? globalThis.fetch,
+      ...(input.onProgress == null ? {} : { onProgress: input.onProgress }),
+      paths: input.paths,
+      ...(input.repository == null ? {} : { repository: input.repository }),
+    });
+    try {
+      const prepared = await prepareVerifiedClosureDistributionGeneration(
+        input.paths,
+        verification,
+        input.candidate.releaseVersion,
+      );
+      return {
+        candidate: input.candidate,
+        pointer: prepared.prepared.standalone,
+        reason: decision.reason,
+        state: "prepared",
+      };
+    } finally {
+      await rm(verification.materializedRoot, { force: true, recursive: true }).catch(() => undefined);
+    }
+  } finally {
+    await releaseClosureChannelLock(lock);
+  }
+}
+
+/**
+ * Re-materialize the exact content identity and advance only the runtime fence.
+ */
+export async function repairActiveClosureDistribution(input: {
+  candidate: ClosureDistributionReleaseCandidate;
+  fetch?: typeof globalThis.fetch;
+  onProgress?: (progress: ClosureDistributionUpdateProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+  shellType: string;
+  shellVersion: string;
+}): Promise<ApplyClosureDistributionUpdateResult> {
+  const lock = await acquireClosureChannelLock(input.paths, { waitMs: 250 });
+  if (lock == null) {
+    return { candidate: input.candidate, reason: "another-updater-active", state: "busy" };
+  }
+  try {
+    const descriptor = await readClosureBindingDescriptor(input.paths);
+    const active = descriptor.active;
+    if (active == null) {
+      throw new ClosureUpdateError("Closure repair requires an active binding");
+    }
+    const minimum = resolveClosureShellMinimumVersion(input.candidate.manifest, input.shellType);
+    if (minimum == null || compareClosureShellVersions(input.shellVersion, minimum) < 0) {
+      return { candidate: input.candidate, reason: "shell-incompatible", state: "retained" };
+    }
+    if (
+      input.candidate.releaseVersion !== active.releaseVersion
+      || input.candidate.manifest.identity.version !== active.standalone.version
+      || input.candidate.manifest.identity.digest !== active.standalone.digest
+      || input.candidate.target !== active.standalone.target
+    ) {
+      throw new ClosureUpdateError("Closure repair candidate does not match the active immutable binding");
+    }
+    const verification = await stageClosureDistributionGeneration({
+      candidate: input.candidate,
+      descriptor,
+      fetchImpl: input.fetch ?? globalThis.fetch,
+      ...(input.onProgress == null ? {} : { onProgress: input.onProgress }),
+      paths: input.paths,
+      ...(input.repository == null ? {} : { repository: input.repository }),
+    });
+    try {
+      const repaired = await prepareVerifiedClosureDistributionGeneration(
+        input.paths,
+        verification,
+        input.candidate.releaseVersion,
+      );
+      return {
+        candidate: input.candidate,
+        pointer: repaired.prepared.standalone,
+        reason: "repair-active-closure",
+        state: "prepared",
+      };
+    } finally {
+      await rm(verification.materializedRoot, { force: true, recursive: true }).catch(() => undefined);
+    }
+  } finally {
+    await releaseClosureChannelLock(lock);
+  }
+}
+
+export async function applyClosureUpdate(input: {
+  candidate: ClosureReleaseCandidate;
+  fetch?: typeof globalThis.fetch;
+  paths: ClosureStorePaths;
+  shellType: string;
+  shellVersion: string;
+}): Promise<ApplyClosureUpdateResult> {
+  const lock = await acquireClosureChannelLock(input.paths, { waitMs: 250 });
+  if (lock == null) {
+    return { candidate: input.candidate, reason: "another-updater-active", state: "busy" };
+  }
+  try {
+    const descriptor = await readClosureBindingDescriptor(input.paths);
+    const decision = decideClosureUpdate({
+      candidate: input.candidate,
+      descriptor,
+      shellType: input.shellType,
+      shellVersion: input.shellVersion,
+    });
+    if (decision.action === "retain") {
+      return { candidate: input.candidate, reason: decision.reason, state: "retained" };
+    }
+    const verification = await ensureCandidateMaterialized({
+      candidate: input.candidate,
+      descriptor,
+      fetchImpl: input.fetch ?? globalThis.fetch,
+      paths: input.paths,
+    });
+
+    const currentDescriptor = await readClosureBindingDescriptor(input.paths);
+    const currentDecision = decideClosureUpdate({
+      candidate: input.candidate,
+      descriptor: currentDescriptor,
+      shellType: input.shellType,
+      shellVersion: input.shellVersion,
+    });
+    if (currentDecision.action === "retain") {
+      return { candidate: input.candidate, reason: currentDecision.reason, state: "retained" };
+    }
+    const prepared = await prepareVerifiedStoredClosureCandidate(
+      input.paths,
+      verification,
+      input.candidate.releaseVersion,
+    );
+    return {
+      candidate: input.candidate,
+      pointer: prepared.prepared.standalone,
+      reason: currentDecision.reason,
+      state: "prepared",
+    };
+  } finally {
+    await releaseClosureChannelLock(lock);
+  }
+}
+
+export async function updateClosureFromRelease(input: {
+  channel: string;
+  fetch?: typeof globalThis.fetch;
+  metadataUrl: string;
+  paths: ClosureStorePaths;
+  platform: string;
+  releaseTarget: string;
+  repository?: ClosureResourceRepositoryConfig;
+  shellType: string;
+  shellVersion: string;
+}): Promise<ApplyClosureReleaseUpdateResult> {
+  const fetchImpl = input.fetch ?? globalThis.fetch;
+  const metadataUrl = requireHttpUrl(input.metadataUrl, "Closure release metadata URL");
+  const metadata = await fetchJsonDocument(metadataUrl, "Closure release metadata", fetchImpl);
+  const distribution = selectClosureDistributionReleaseCandidate(metadata, {
+    channel: input.channel,
+    target: input.platform,
+  });
+  if (distribution != null) {
+    return await applyClosureDistributionUpdate({
+      candidate: distribution,
+      fetch: fetchImpl,
+      paths: input.paths,
+      ...(input.repository == null ? {} : { repository: input.repository }),
+      shellType: input.shellType,
+      shellVersion: input.shellVersion,
+    });
+  }
+  const candidate = selectClosureReleaseCandidate(metadata, input);
+  return await applyClosureUpdate({
+    candidate,
+    fetch: fetchImpl,
+    paths: input.paths,
+    shellType: input.shellType,
+    shellVersion: input.shellVersion,
+  });
+}
+

--- a/packages/closure/src/update/errors.ts
+++ b/packages/closure/src/update/errors.ts
@@ -1,0 +1,17 @@
+export class ClosureUpdateError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ClosureUpdateError";
+  }
+}
+
+export class ClosureInstallerRequiredError extends ClosureUpdateError {
+  readonly minimumShellVersion: string | null;
+
+  constructor(message: string, minimumShellVersion: string | null = null) {
+    super(message);
+    this.name = "ClosureInstallerRequiredError";
+    this.minimumShellVersion = minimumShellVersion;
+  }
+}
+

--- a/packages/closure/src/update/index.ts
+++ b/packages/closure/src/update/index.ts
@@ -1,0 +1,780 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+
+import {
+  bindClosureCandidateIdentity,
+  CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION,
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_PROTOCOL_VERSION,
+  createClosureDistributionControl,
+  createClosureComponentTreeDigest,
+  isClosureChannel,
+  validateClosureDistributionControl,
+  validateClosureCandidateManifest,
+  validateClosureDistributionManifest,
+  validateClosureFileInventory,
+  type ClosureCandidateManifest,
+  type ClosureDistributionBlob,
+  type ClosureDistributionManifest,
+  type ClosureDistributionControl,
+} from "../protocol/index.js";
+import type { ClosureBindingDescriptor } from "../store/index.js";
+import {
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  resolveClosureStoreVersionPaths,
+  verifyClosureDistributionBlob,
+  verifyMaterializedClosureCandidate,
+  verifyMaterializedClosureDistributionGeneration,
+  verifyStoredClosureCandidate,
+  type ClosureRuntimePointer,
+  type ClosureStorePaths,
+  type ClosureStoreVersionPaths,
+  type StoredClosureVerification,
+} from "../store/index.js";
+import { isProcessAlive } from "@open-design/platform";
+import {
+  compareReleaseVersions,
+  isReleaseChannel,
+  type ReleaseChannel,
+} from "@open-design/release";
+import extractZip from "extract-zip";
+
+import { fetchJsonDocument } from "./apply.js";
+import {
+  ClosureInstallerRequiredError,
+  ClosureUpdateError,
+} from "./errors.js";
+import { parseClosureImmutableMetadataVersion } from "./metadata-url.js";
+
+export {
+  ClosureInstallerRequiredError,
+  ClosureUpdateError,
+} from "./errors.js";
+export {
+  parseClosureImmutableMetadataVersion,
+  resolveClosureImmutableMetadataVersion,
+} from "./metadata-url.js";
+
+export type ClosureReleaseAssetUrls = {
+  archive: string;
+  inventory: string;
+  manifest: string;
+  provenance: string | null;
+};
+
+export type ClosureReleaseCandidate = {
+  assets: ClosureReleaseAssetUrls;
+  manifest: ClosureCandidateManifest;
+  releaseTarget: string;
+  releaseVersion: string;
+};
+
+export type ClosureDistributionReleaseCandidate = Readonly<{
+  manifest: ClosureDistributionManifest;
+  releaseVersion: string;
+  target: string;
+}>;
+
+export type ClosureDistributionConsumer = Readonly<{
+  shellType: string;
+  shellVersion: string;
+}>;
+
+export type ClosureUpdatePrepareReason =
+  | "newer-release-binding"
+  | "no-active-closure"
+  | "repair-active-closure";
+
+export type ClosureUpdateRetainReason =
+  | "already-active"
+  | "already-prepared"
+  | "candidate-not-newer"
+  | "runtime-attempt-pending"
+  | "shell-incompatible";
+
+export type ClosureUpdateDecision =
+  | {
+      action: "prepare";
+      candidate: ClosureReleaseCandidate;
+      reason: ClosureUpdatePrepareReason;
+    }
+  | {
+      action: "retain";
+      candidate: ClosureReleaseCandidate;
+      reason: ClosureUpdateRetainReason;
+    };
+
+export const CLOSURE_RESOURCE_REPOSITORY_ENV = "OD_CLOSURE_RESOURCE_REPOSITORY_V1" as const;
+export const CLOSURE_RESOURCE_REPOSITORY_SCHEMA_VERSION = 1 as const;
+
+export type ClosureResourceRepositoryConfig = Readonly<{
+  localSeeds: readonly Readonly<{ root: string }>[];
+  remoteOrigins: readonly string[];
+  schemaVersion: typeof CLOSURE_RESOURCE_REPOSITORY_SCHEMA_VERSION;
+}>;
+
+export function validateClosureResourceRepositoryConfig(
+  value: unknown,
+  options: Readonly<{ baseRoot?: string }> = {},
+): ClosureResourceRepositoryConfig {
+  const config = requireRecord(value, "Closure resource repository config");
+  const extras = Object.keys(config).filter((key) => !["localSeeds", "remoteOrigins", "schemaVersion"].includes(key));
+  if (extras.length > 0) throw new ClosureUpdateError(`Closure resource repository config contains unsupported fields: ${extras.join(", ")}`);
+  if (config.schemaVersion !== CLOSURE_RESOURCE_REPOSITORY_SCHEMA_VERSION) {
+    throw new ClosureUpdateError("Closure resource repository config schemaVersion is unsupported");
+  }
+  if (!Array.isArray(config.localSeeds) || !Array.isArray(config.remoteOrigins)) {
+    throw new ClosureUpdateError("Closure resource repository config sources must be arrays");
+  }
+  const localSeeds = config.localSeeds.map((entry, index) => {
+    const seed = requireRecord(entry, `Closure local seed ${index}`);
+    if (Object.keys(seed).some((key) => key !== "root")) throw new ClosureUpdateError(`Closure local seed ${index} contains unsupported fields`);
+    const configuredRoot = requireString(seed.root, `Closure local seed ${index} root`);
+    const root = isAbsolute(configuredRoot)
+      ? configuredRoot
+      : options.baseRoot == null ? configuredRoot : join(options.baseRoot, configuredRoot);
+    if (!isAbsolute(root)) throw new ClosureUpdateError(`Closure local seed ${index} root must resolve absolute`);
+    return Object.freeze({ root });
+  });
+  const remoteOrigins = config.remoteOrigins.map((origin, index) => {
+    const normalized = requireHttpUrl(origin, `Closure remote origin ${index}`);
+    return normalized.replace(/\/+$/u, "");
+  });
+  return Object.freeze({
+    localSeeds: Object.freeze(localSeeds),
+    remoteOrigins: Object.freeze(remoteOrigins),
+    schemaVersion: CLOSURE_RESOURCE_REPOSITORY_SCHEMA_VERSION,
+  });
+}
+
+export async function readClosureResourceRepositoryConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ClosureResourceRepositoryConfig> {
+  const path = env[CLOSURE_RESOURCE_REPOSITORY_ENV];
+  if (path == null || path.length === 0 || !isAbsolute(path)) {
+    throw new ClosureUpdateError(`${CLOSURE_RESOURCE_REPOSITORY_ENV} must point to an absolute config file`);
+  }
+  const bytes = await readFile(path);
+  if (bytes.byteLength > 1024 * 1024) throw new ClosureUpdateError("Closure resource repository config exceeds 1 MiB");
+  try {
+    return validateClosureResourceRepositoryConfig(
+      JSON.parse(bytes.toString("utf8")) as unknown,
+      { baseRoot: dirname(path) },
+    );
+  } catch (error) {
+    if (error instanceof ClosureUpdateError) throw error;
+    throw new ClosureUpdateError(`Closure resource repository config is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export type ApplyClosureUpdateResult =
+  | {
+      candidate: ClosureReleaseCandidate;
+      pointer: ClosureRuntimePointer;
+      reason: ClosureUpdatePrepareReason;
+      state: "prepared";
+    }
+  | {
+      candidate: ClosureReleaseCandidate;
+      reason: ClosureUpdateRetainReason;
+      state: "retained";
+    }
+  | {
+      candidate: ClosureReleaseCandidate;
+      reason: "another-updater-active";
+      state: "busy";
+    };
+
+export type ApplyClosureDistributionUpdateResult =
+  | {
+      candidate: ClosureDistributionReleaseCandidate;
+      pointer: ClosureRuntimePointer;
+      reason: ClosureUpdatePrepareReason;
+      state: "prepared";
+    }
+  | {
+      candidate: ClosureDistributionReleaseCandidate;
+      reason: ClosureUpdateRetainReason;
+      state: "retained";
+    }
+  | {
+      candidate: ClosureDistributionReleaseCandidate;
+      reason: "another-updater-active";
+      state: "busy";
+    };
+
+export type ClosureDistributionUpdateProgress =
+  | Readonly<{
+      completedBytes: number;
+      phase: "download";
+      totalBytes: number;
+    }>
+  | Readonly<{
+      completedComponents: number;
+      phase: "materialize";
+      totalComponents: number;
+    }>;
+
+export function reportDistributionProgress(
+  observer: ((progress: ClosureDistributionUpdateProgress) => void) | undefined,
+  progress: ClosureDistributionUpdateProgress,
+): void {
+  try {
+    observer?.(Object.freeze(progress));
+  } catch {
+    // Progress is optional presentation telemetry and must never change update authority.
+  }
+}
+
+export type ApplyClosureReleaseUpdateResult =
+  | ApplyClosureDistributionUpdateResult
+  | ApplyClosureUpdateResult;
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ClosureUpdateError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value !== value.trim()) {
+    throw new ClosureUpdateError(`${label} must be a non-empty trimmed string`);
+  }
+  return value;
+}
+
+export function requireHttpUrl(value: unknown, label: string): string {
+  const normalized = requireString(value, label);
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("unsupported protocol");
+    return parsed.toString();
+  } catch {
+    throw new ClosureUpdateError(`${label} must be an absolute http(s) URL`);
+  }
+}
+
+function assetUrl(assets: Record<string, unknown>, name: string, required = true): string | null {
+  const asset = assets[name];
+  if (asset == null && !required) return null;
+  const record = requireRecord(asset, `Closure ${name} asset`);
+  return requireHttpUrl(record.url, `Closure ${name} asset URL`);
+}
+
+export function selectClosureReleaseCandidate(
+  metadata: unknown,
+  input: {
+    channel: string;
+    platform: string;
+    releaseTarget: string;
+  },
+): ClosureReleaseCandidate {
+  if (!isReleaseChannel(input.channel)) {
+    throw new ClosureUpdateError(`unsupported Closure update channel: ${input.channel}`);
+  }
+  const root = requireRecord(metadata, "release metadata");
+  if (root.channel !== input.channel) {
+    throw new ClosureUpdateError(
+      `release metadata channel ${String(root.channel)} does not match ${input.channel}`,
+    );
+  }
+  if (root.releaseState !== "complete") {
+    throw new ClosureUpdateError(`release metadata is not complete: ${String(root.releaseState)}`);
+  }
+  const releaseVersion = requireString(root.releaseVersion, "release metadata version");
+  const targets = requireRecord(root.releaseTargets, "release metadata targets");
+  const target = requireRecord(targets[input.releaseTarget], `release target ${input.releaseTarget}`);
+  if (target.status !== "published" || target.enabled !== true) {
+    throw new ClosureUpdateError(`release target ${input.releaseTarget} is not published and enabled`);
+  }
+  const closure = requireRecord(target.closure, `release target ${input.releaseTarget} Closure`);
+  let manifest: ClosureCandidateManifest;
+  try {
+    manifest = validateClosureCandidateManifest(closure.manifest);
+  } catch (error) {
+    throw new ClosureUpdateError(
+      `release target ${input.releaseTarget} Closure manifest is invalid: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (manifest.identity.channel !== input.channel) {
+    throw new ClosureUpdateError("Closure candidate channel does not match its release metadata");
+  }
+  if (manifest.identity.platform !== input.platform) {
+    throw new ClosureUpdateError(
+      `Closure candidate platform ${manifest.identity.platform} does not match ${input.platform}`,
+    );
+  }
+  const assets = requireRecord(closure.assets, "Closure release assets");
+  const archive = assetUrl(assets, "archive")!;
+  if (archive !== new URL(manifest.artifact.url).toString()) {
+    throw new ClosureUpdateError("Closure archive asset URL does not match the candidate manifest");
+  }
+  return {
+    assets: {
+      archive,
+      inventory: assetUrl(assets, "inventory")!,
+      manifest: assetUrl(assets, "manifest")!,
+      provenance: assetUrl(assets, "provenance", false),
+    },
+    manifest,
+    releaseTarget: input.releaseTarget,
+    releaseVersion,
+  };
+}
+
+export async function discoverClosureReleaseCandidate(input: {
+  channel: string;
+  fetch?: typeof globalThis.fetch;
+  metadataUrl: string;
+  platform: string;
+  releaseTarget: string;
+}): Promise<ClosureReleaseCandidate> {
+  const metadataUrl = requireHttpUrl(input.metadataUrl, "Closure release metadata URL");
+  const metadata = await fetchJsonDocument(
+    metadataUrl,
+    "Closure release metadata",
+    input.fetch ?? globalThis.fetch,
+  );
+  return selectClosureReleaseCandidate(metadata, input);
+}
+
+/** Select the sole version-wide v2 graph without consulting platform subtrees. */
+export function selectClosureDistributionReleaseCandidate(
+  metadata: unknown,
+  input: Readonly<{ channel: string; consumer?: ClosureDistributionConsumer; target: string }>,
+): ClosureDistributionReleaseCandidate | null {
+  if (!isClosureChannel(input.channel)) {
+    throw new ClosureUpdateError(`unsupported Closure update channel: ${input.channel}`);
+  }
+  const root = requireRecord(metadata, "release metadata");
+  if (root.channel !== input.channel) {
+    throw new ClosureUpdateError(
+      `release metadata channel ${String(root.channel)} does not match ${input.channel}`,
+    );
+  }
+  if (root.releaseState !== "complete") {
+    throw new ClosureUpdateError(`release metadata is not complete: ${String(root.releaseState)}`);
+  }
+  if (root.closure == null) return null;
+  const releaseVersion = requireString(root.releaseVersion, "release metadata version");
+  let control: ClosureDistributionControl | null = null;
+  if (root.closureControl != null) {
+    const rawControl = requireRecord(root.closureControl, "closure distribution control");
+    if (rawControl.schemaVersion !== CLOSURE_DISTRIBUTION_CONTROL_SCHEMA_VERSION) {
+      throw new ClosureInstallerRequiredError("Standalone metadata requires a newer Shell control protocol");
+    }
+    try {
+      control = validateClosureDistributionControl(rawControl);
+    } catch (error) {
+      throw new ClosureUpdateError(
+        `release metadata Closure control is invalid: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (
+      control.distribution.schemaVersion !== CLOSURE_DISTRIBUTION_SCHEMA_VERSION
+      || control.distribution.protocolVersion !== CLOSURE_PROTOCOL_VERSION
+    ) {
+      throw new ClosureInstallerRequiredError(
+        `Standalone distribution protocol ${control.distribution.protocolVersion}/schema ${control.distribution.schemaVersion} requires a newer Shell`,
+      );
+    }
+    if (input.consumer != null) {
+      const minimum = control.shellCompatibility[input.consumer.shellType]?.version.min ?? null;
+      if (minimum == null || compareClosureShellVersions(input.consumer.shellVersion, minimum) < 0) {
+        throw new ClosureInstallerRequiredError(
+          minimum == null
+            ? `Standalone does not support Shell ${input.consumer.shellType}`
+            : `Standalone requires ${input.consumer.shellType} Shell ${minimum} or newer`,
+          minimum,
+        );
+      }
+    }
+  }
+  let manifest: ClosureDistributionManifest;
+  try {
+    manifest = validateClosureDistributionManifest(root.closure, (canonical) => (
+      `sha256:${createHash("sha256").update(canonical).digest("hex")}`
+    ));
+  } catch (error) {
+    throw new ClosureUpdateError(
+      `release metadata Closure distribution is invalid: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (manifest.identity.channel !== input.channel) {
+    throw new ClosureUpdateError("Closure distribution channel does not match its release metadata");
+  }
+  if (control != null) {
+    const expected = createClosureDistributionControl(manifest);
+    if (JSON.stringify(control) !== JSON.stringify(expected)) {
+      throw new ClosureUpdateError("Closure distribution control does not match its manifest");
+    }
+  }
+  if (manifest.required.targets[input.target] == null) {
+    throw new ClosureUpdateError(`Closure distribution does not contain target ${input.target}`);
+  }
+  return { manifest, releaseVersion, target: input.target };
+}
+
+export async function discoverClosureDistributionReleaseCandidate(input: Readonly<{
+  channel: string;
+  consumer?: ClosureDistributionConsumer;
+  fetch?: typeof globalThis.fetch;
+  metadataUrl: string;
+  target: string;
+}>): Promise<ClosureDistributionReleaseCandidate | null> {
+  if (!isReleaseChannel(input.channel)) {
+    throw new ClosureUpdateError(`unsupported public Closure update channel: ${input.channel}`);
+  }
+  const metadataUrl = requireHttpUrl(input.metadataUrl, "Closure release metadata URL");
+  const metadata = await fetchJsonDocument(
+    metadataUrl,
+    "Closure release metadata",
+    input.fetch ?? globalThis.fetch,
+  );
+  return selectClosureDistributionReleaseCandidate(metadata, input);
+}
+
+/**
+ * Resolve the first-install candidate without granting the Shell any version
+ * selection policy. A seed exposes one conventional baseline index; if it is
+ * absent or invalid, Standalone may consult the caller-provided release feed.
+ */
+export async function discoverClosureDistributionBootstrapCandidate(input: Readonly<{
+  channel: string;
+  consumer?: ClosureDistributionConsumer;
+  fetch?: typeof globalThis.fetch;
+  metadataUrl: string | null;
+  repository: ClosureResourceRepositoryConfig;
+  target: string;
+}>): Promise<ClosureDistributionReleaseCandidate | null> {
+  let localError: unknown = null;
+  for (const seed of input.repository.localSeeds) {
+    const path = join(seed.root, input.channel, "baseline.json");
+    try {
+      const bytes = await readFile(path);
+      if (bytes.byteLength > 4 * 1024 * 1024) {
+        throw new ClosureUpdateError("Closure baseline index exceeds 4 MiB");
+      }
+      return selectClosureDistributionReleaseCandidate(
+        JSON.parse(bytes.toString("utf8")) as unknown,
+        input,
+      );
+    } catch (error) {
+      localError = error;
+    }
+  }
+  if (input.metadataUrl != null) {
+    return await discoverClosureDistributionReleaseCandidate({
+      channel: input.channel,
+      ...(input.consumer == null ? {} : { consumer: input.consumer }),
+      ...(input.fetch == null ? {} : { fetch: input.fetch }),
+      metadataUrl: input.metadataUrl,
+      target: input.target,
+    });
+  }
+  if (localError != null) {
+    throw new ClosureUpdateError("Closure baseline index is unusable", { cause: localError });
+  }
+  return null;
+}
+
+function versionMetadataUrl(latestMetadataUrl: string, version: string): string {
+  const latest = new URL(requireHttpUrl(latestMetadataUrl, "Closure release metadata URL"));
+  const immutableVersion = parseClosureImmutableMetadataVersion(latest.toString());
+  if (immutableVersion != null) {
+    if (immutableVersion !== version) {
+      throw new ClosureUpdateError(
+        `Closure release metadata URL describes ${immutableVersion}, not exact version ${version}`,
+      );
+    }
+    latest.search = "";
+    latest.hash = "";
+    return latest.toString();
+  }
+  const suffix = "/latest/metadata.json";
+  if (!latest.pathname.endsWith(suffix)) {
+    throw new ClosureUpdateError(
+      "Closure release metadata URL cannot resolve an immutable version endpoint",
+    );
+  }
+  latest.pathname = `${latest.pathname.slice(0, -suffix.length)}/versions/${encodeURIComponent(version)}/metadata.json`;
+  latest.search = "";
+  latest.hash = "";
+  return latest.toString();
+}
+
+function isExactDistributionCandidate(
+  candidate: ClosureDistributionReleaseCandidate,
+  version: string,
+): boolean {
+  return candidate.releaseVersion === version && candidate.manifest.identity.version === version;
+}
+
+/**
+ * Resolve one exact product version for cold-start alignment or repair. Local
+ * Shell resources remain candidates rather than launch authority; a mismatched
+ * baseline is skipped before consulting the immutable version feed.
+ */
+export async function discoverClosureDistributionVersionCandidate(input: Readonly<{
+  channel: string;
+  consumer?: ClosureDistributionConsumer;
+  fetch?: typeof globalThis.fetch;
+  metadataUrl: string | null;
+  repository: ClosureResourceRepositoryConfig;
+  target: string;
+  version: string;
+}>): Promise<ClosureDistributionReleaseCandidate | null> {
+  let localError: unknown = null;
+  for (const seed of input.repository.localSeeds) {
+    const path = join(seed.root, input.channel, "baseline.json");
+    try {
+      const bytes = await readFile(path);
+      if (bytes.byteLength > 4 * 1024 * 1024) {
+        throw new ClosureUpdateError("Closure baseline index exceeds 4 MiB");
+      }
+      const candidate = selectClosureDistributionReleaseCandidate(
+        JSON.parse(bytes.toString("utf8")) as unknown,
+        input,
+      );
+      if (candidate != null && isExactDistributionCandidate(candidate, input.version)) {
+        return candidate;
+      }
+    } catch (error) {
+      localError = error;
+    }
+  }
+  if (input.metadataUrl != null) {
+    const candidate = await discoverClosureDistributionReleaseCandidate({
+      channel: input.channel,
+      ...(input.consumer == null ? {} : { consumer: input.consumer }),
+      ...(input.fetch == null ? {} : { fetch: input.fetch }),
+      metadataUrl: versionMetadataUrl(input.metadataUrl, input.version),
+      target: input.target,
+    });
+    if (candidate == null || !isExactDistributionCandidate(candidate, input.version)) {
+      throw new ClosureUpdateError(
+        `Closure immutable version metadata does not describe exact version ${input.version}`,
+      );
+    }
+    return candidate;
+  }
+  if (localError != null) {
+    throw new ClosureUpdateError("Closure baseline index is unusable", { cause: localError });
+  }
+  return null;
+}
+
+type ComparableVersion = {
+  core: readonly [number, number, number];
+  prerelease: string[];
+};
+
+function comparableVersion(value: string): ComparableVersion {
+  const normalized = value.trim().replace(/^v/iu, "").split("+", 1)[0] ?? "";
+  const prereleaseSeparator = normalized.indexOf("-");
+  const core = prereleaseSeparator === -1 ? normalized : normalized.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? "" : normalized.slice(prereleaseSeparator + 1);
+  const parts = core.split(".");
+  const numbers = parts.map((part) => Number(part));
+  if (
+    parts.length !== 3
+    || numbers.some((part) => !Number.isSafeInteger(part) || part < 0)
+  ) {
+    throw new ClosureUpdateError(`shell version is not comparable: ${value}`);
+  }
+  return {
+    core: [numbers[0]!, numbers[1]!, numbers[2]!],
+    prerelease: prerelease.length === 0 ? [] : prerelease.split("."),
+  };
+}
+
+function compareIdentifier(left: string, right: string): number {
+  const leftNumber = /^\d+$/u.test(left) ? Number(left) : null;
+  const rightNumber = /^\d+$/u.test(right) ? Number(right) : null;
+  if (leftNumber != null && rightNumber != null) return Math.sign(leftNumber - rightNumber);
+  if (leftNumber != null) return -1;
+  if (rightNumber != null) return 1;
+  return left.localeCompare(right);
+}
+
+export function compareClosureShellVersions(left: string, right: string): number {
+  const a = comparableVersion(left);
+  const b = comparableVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    const comparison = Math.sign((a.core[index] ?? 0) - (b.core[index] ?? 0));
+    if (comparison !== 0) return comparison;
+  }
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+  const count = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = a.prerelease[index];
+    const rightPart = b.prerelease[index];
+    if (leftPart == null) return -1;
+    if (rightPart == null) return 1;
+    const comparison = compareIdentifier(leftPart, rightPart);
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}
+
+export function resolveClosureShellMinimumVersion(
+  manifest: Pick<ClosureCandidateManifest, "compatibility">,
+  shellType: string,
+): string | null {
+  return manifest.compatibility.shell[shellType]?.version.min ?? null;
+}
+
+export function decideClosureUpdate(input: {
+  candidate: ClosureReleaseCandidate;
+  descriptor: ClosureBindingDescriptor;
+  shellType: string;
+  shellVersion: string;
+}): ClosureUpdateDecision {
+  const { candidate } = input;
+  if (candidate.manifest.identity.channel !== input.descriptor.channel) {
+    throw new ClosureUpdateError("Closure candidate channel does not match the local Store");
+  }
+  const minimumShellVersion = resolveClosureShellMinimumVersion(
+    candidate.manifest,
+    input.shellType,
+  );
+  if (
+    minimumShellVersion == null
+    ||
+    compareClosureShellVersions(
+      input.shellVersion,
+      minimumShellVersion,
+    ) < 0
+  ) {
+    return { action: "retain", candidate, reason: "shell-incompatible" };
+  }
+  if (input.descriptor.attempt != null) {
+    return { action: "retain", candidate, reason: "runtime-attempt-pending" };
+  }
+  const prepared = input.descriptor.prepared;
+  if (
+    prepared?.standalone.version === candidate.manifest.identity.version
+    && prepared.standalone.digest === candidate.manifest.identity.digest
+    && prepared.releaseVersion === candidate.releaseVersion
+  ) {
+    return { action: "retain", candidate, reason: "already-prepared" };
+  }
+  const activeBinding = input.descriptor.active;
+  if (activeBinding == null) {
+    return { action: "prepare", candidate, reason: "no-active-closure" };
+  }
+  const active = activeBinding.standalone;
+  if (
+    active.version === candidate.manifest.identity.version
+    && active.digest === candidate.manifest.identity.digest
+    && activeBinding.releaseVersion === candidate.releaseVersion
+  ) {
+    return { action: "retain", candidate, reason: "already-active" };
+  }
+  const channel = candidate.manifest.identity.channel as ReleaseChannel;
+  const comparison = compareReleaseVersions(candidate.releaseVersion, activeBinding.releaseVersion, channel);
+  if (comparison === 0) {
+    throw new ClosureUpdateError(
+      `Closure release ${activeBinding.releaseVersion} has conflicting immutable bindings`,
+    );
+  }
+  return comparison > 0
+    ? { action: "prepare", candidate, reason: "newer-release-binding" }
+    : { action: "retain", candidate, reason: "candidate-not-newer" };
+}
+
+export type ClosureDistributionUpdateDecision =
+  | {
+      action: "prepare";
+      candidate: ClosureDistributionReleaseCandidate;
+      reason: ClosureUpdatePrepareReason;
+    }
+  | {
+      action: "retain";
+      candidate: ClosureDistributionReleaseCandidate;
+      reason: ClosureUpdateRetainReason;
+    };
+
+export function decideClosureDistributionUpdate(input: {
+  candidate: ClosureDistributionReleaseCandidate;
+  descriptor: ClosureBindingDescriptor;
+  shellType: string;
+  shellVersion: string;
+}): ClosureDistributionUpdateDecision {
+  const { candidate } = input;
+  if (candidate.manifest.identity.channel !== input.descriptor.channel) {
+    throw new ClosureUpdateError("Closure distribution channel does not match the local Store");
+  }
+  if (candidate.manifest.required.targets[candidate.target] == null) {
+    throw new ClosureUpdateError(`Closure distribution does not contain target ${candidate.target}`);
+  }
+  const minimumShellVersion = resolveClosureShellMinimumVersion(candidate.manifest, input.shellType);
+  if (
+    minimumShellVersion == null
+    || compareClosureShellVersions(input.shellVersion, minimumShellVersion) < 0
+  ) {
+    return { action: "retain", candidate, reason: "shell-incompatible" };
+  }
+  if (input.descriptor.attempt != null) {
+    return { action: "retain", candidate, reason: "runtime-attempt-pending" };
+  }
+  const prepared = input.descriptor.prepared;
+  if (
+    prepared?.standalone.version === candidate.manifest.identity.version
+    && prepared.standalone.digest === candidate.manifest.identity.digest
+    && prepared.standalone.target === candidate.target
+    && prepared.releaseVersion === candidate.releaseVersion
+  ) {
+    return { action: "retain", candidate, reason: "already-prepared" };
+  }
+  const activeBinding = input.descriptor.active;
+  if (activeBinding == null) {
+    return { action: "prepare", candidate, reason: "no-active-closure" };
+  }
+  const active = activeBinding.standalone;
+  if (
+    active.version === candidate.manifest.identity.version
+    && active.digest === candidate.manifest.identity.digest
+    && active.target === candidate.target
+    && activeBinding.releaseVersion === candidate.releaseVersion
+  ) {
+    return { action: "retain", candidate, reason: "already-active" };
+  }
+  const channel = candidate.manifest.identity.channel;
+  const comparison = compareReleaseVersions(
+    candidate.releaseVersion,
+    activeBinding.releaseVersion,
+    channel,
+  );
+  if (comparison === 0) {
+    throw new ClosureUpdateError(
+      `Closure release ${activeBinding.releaseVersion} has conflicting immutable distribution bindings`,
+    );
+  }
+  return comparison > 0
+    ? { action: "prepare", candidate, reason: "newer-release-binding" }
+    : { action: "retain", candidate, reason: "candidate-not-newer" };
+}
+
+export * from "./apply.js";
+export * from "./resource.js";
+

--- a/packages/closure/src/update/metadata-url.ts
+++ b/packages/closure/src/update/metadata-url.ts
@@ -1,0 +1,41 @@
+import { ClosureUpdateError } from "./errors.js";
+
+function immutableMetadataVersion(metadataUrl: URL): string | null {
+  const match = metadataUrl.pathname.match(/\/versions\/([^/]+)\/metadata\.json$/u);
+  if (match == null) return null;
+  try {
+    const version = decodeURIComponent(match[1]!).trim();
+    if (version.length === 0) throw new Error("empty version");
+    return version;
+  } catch {
+    throw new ClosureUpdateError(
+      "Closure release metadata URL contains an invalid immutable version endpoint",
+    );
+  }
+}
+
+/** Parse a valid metadata URL without requiring it to be an immutable endpoint. */
+export function parseClosureImmutableMetadataVersion(metadataUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(metadataUrl);
+  } catch {
+    throw new ClosureUpdateError("Closure release metadata URL must be an absolute http(s) URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ClosureUpdateError("Closure release metadata URL must be an absolute http(s) URL");
+  }
+  return immutableMetadataVersion(parsed);
+}
+
+/** Resolve first-install launch authority only from an immutable exact metadata endpoint. */
+export function resolveClosureImmutableMetadataVersion(metadataUrl: string): string {
+  const version = parseClosureImmutableMetadataVersion(metadataUrl);
+  if (version == null) {
+    throw new ClosureUpdateError(
+      "Closure first-install release binding requires an immutable /versions/<version>/metadata.json URL",
+    );
+  }
+  return version;
+}
+

--- a/packages/closure/src/update/resource.ts
+++ b/packages/closure/src/update/resource.ts
@@ -1,0 +1,308 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants as fsConstants, createReadStream } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readdir,
+  rename,
+  rm,
+  stat,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+  createClosureComponentTreeDigest,
+  type ClosureDistributionBlob,
+  type ClosureDistributionManifest,
+} from "../protocol/index.js";
+import {
+  discardClosureStoreEntry,
+  planClosureDistributionGeneration,
+  verifyClosureDistributionBlob,
+  type ClosureStorePaths,
+} from "../store/index.js";
+import { downloadCopyAndClear } from "@open-design/download";
+import extractZip from "extract-zip";
+
+import type { ClosureResourceRepositoryConfig } from "./index.js";
+import { ClosureUpdateError } from "./errors.js";
+
+export type ClosureBlobEnsureProgress =
+  | Readonly<{ phase: "checking" | "verifying" | "ready" }>
+  | Readonly<{ completedBytes: number; phase: "copying" | "downloading"; totalBytes: number }>;
+
+export type ClosureResourceEnsureProgress =
+  | Readonly<{ phase: "checking" | "materializing" | "verifying" | "ready" }>
+  | Readonly<{
+      completedBytes: number;
+      phase: "copying" | "downloading";
+      totalBytes: number;
+    }>;
+
+function report<T>(observer: ((progress: T) => void) | undefined, progress: T): void {
+  try {
+    observer?.(Object.freeze(progress));
+  } catch {
+    // Resource progress is presentation-only and cannot change Store policy.
+  }
+}
+
+function errorCode(error: unknown): string | null {
+  if (error == null || typeof error !== "object" || !("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return code == null ? null : String(code);
+}
+
+async function cloneOrCopy(source: string, destination: string): Promise<void> {
+  try {
+    await copyFile(source, destination, fsConstants.COPYFILE_FICLONE);
+  } catch {
+    await rm(destination, { force: true });
+    await copyFile(source, destination);
+  }
+}
+
+export async function ensureDistributionBlob(input: Readonly<{
+  artifact: ClosureDistributionBlob;
+  fetchImpl: typeof globalThis.fetch;
+  onProgress?: (progress: ClosureBlobEnsureProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+}>): Promise<string> {
+  if (input.artifact.mediaType !== "application/zip") {
+    throw new ClosureUpdateError(
+      `unsupported Closure distribution blob media type: ${input.artifact.mediaType}`,
+    );
+  }
+  report(input.onProgress, { phase: "checking" });
+  try {
+    const verified = await verifyClosureDistributionBlob(input.paths, input.artifact);
+    report(input.onProgress, { phase: "ready" });
+    return verified;
+  } catch {
+    const digest = input.artifact.digest.slice("sha256:".length);
+    const outputPath = join(input.paths.blobsRoot, digest);
+    const accept = async (candidatePath: string): Promise<string> => {
+      report(input.onProgress, { phase: "verifying" });
+      const metadata = await stat(candidatePath);
+      if (metadata.size !== input.artifact.size) {
+        throw new ClosureUpdateError("Closure blob candidate size mismatch");
+      }
+      const hash = createHash("sha256");
+      for await (const chunk of createReadStream(candidatePath)) hash.update(chunk as Buffer);
+      if (`sha256:${hash.digest("hex")}` !== input.artifact.digest) {
+        throw new ClosureUpdateError("Closure blob candidate digest mismatch");
+      }
+      await mkdir(input.paths.blobsRoot, { recursive: true });
+      try {
+        await rename(candidatePath, outputPath);
+      } catch (error) {
+        if (!["EEXIST", "ENOTEMPTY", "EPERM"].includes(errorCode(error) ?? "")) throw error;
+        try {
+          const verified = await verifyClosureDistributionBlob(input.paths, input.artifact);
+          report(input.onProgress, { phase: "ready" });
+          return verified;
+        } catch {
+          await rm(outputPath, { force: true });
+          await rename(candidatePath, outputPath);
+        }
+      }
+      const verified = await verifyClosureDistributionBlob(input.paths, input.artifact);
+      report(input.onProgress, { phase: "ready" });
+      return verified;
+    };
+    const candidatePath = () => join(
+      input.paths.stagingRoot,
+      "blob-downloads",
+      `${digest}-${randomUUID()}.zip`,
+    );
+
+    for (const seed of input.repository?.localSeeds ?? []) {
+      const temporaryPath = candidatePath();
+      try {
+        await mkdir(dirname(temporaryPath), { recursive: true });
+        const sourcePath = join(seed.root, input.paths.channel, "blobs", digest);
+        const sourceMetadata = await stat(sourcePath);
+        if (!sourceMetadata.isFile() || sourceMetadata.size !== input.artifact.size) {
+          throw new ClosureUpdateError("Closure local seed blob size mismatch");
+        }
+        report(input.onProgress, {
+          completedBytes: 0,
+          phase: "copying",
+          totalBytes: input.artifact.size,
+        });
+        await cloneOrCopy(sourcePath, temporaryPath);
+        report(input.onProgress, {
+          completedBytes: input.artifact.size,
+          phase: "copying",
+          totalBytes: input.artifact.size,
+        });
+        return await accept(temporaryPath);
+      } catch {
+        await rm(temporaryPath, { force: true }).catch(() => undefined);
+      }
+    }
+
+    const artifactPath = new URL(input.artifact.url).pathname.replace(/^\/+/, "");
+    const configuredUrls = (input.repository?.remoteOrigins ?? []).map((origin) => {
+      const base = new URL(origin);
+      if (!base.pathname.endsWith("/")) base.pathname += "/";
+      return new URL(artifactPath, base).toString();
+    });
+    const urls = [...new Set([...configuredUrls, input.artifact.url])];
+    let lastError: unknown = null;
+    for (const url of urls) {
+      const temporaryPath = candidatePath();
+      try {
+        report(input.onProgress, {
+          completedBytes: 0,
+          phase: "downloading",
+          totalBytes: input.artifact.size,
+        });
+        await downloadCopyAndClear({
+          basePath: join(input.paths.stagingRoot, "downloads"),
+          bucket: "closure-blobs",
+          fetch: input.fetchImpl,
+          fileName: `${digest}.zip`,
+          outputPath: temporaryPath,
+          onProgress(progress) {
+            report(input.onProgress, {
+              completedBytes: Math.min(progress.receivedBytes, input.artifact.size),
+              phase: "downloading",
+              totalBytes: input.artifact.size,
+            });
+          },
+          payload: {
+            checksum: { algorithm: "sha256", value: digest },
+            url,
+          },
+        });
+        return await accept(temporaryPath);
+      } catch (error) {
+        lastError = error;
+        await rm(temporaryPath, { force: true }).catch(() => undefined);
+      }
+    }
+    const detail = lastError instanceof Error ? `: ${lastError.message}` : "";
+    throw new ClosureUpdateError(`Closure blob is unavailable from every configured source${detail}`, {
+      cause: lastError,
+    });
+  }
+}
+
+export async function ensureClosureDistributionBlob(input: Readonly<{
+  artifact: ClosureDistributionBlob;
+  fetch?: typeof globalThis.fetch;
+  onProgress?: (progress: ClosureBlobEnsureProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+}>): Promise<string> {
+  return await ensureDistributionBlob({
+    artifact: input.artifact,
+    fetchImpl: input.fetch ?? globalThis.fetch,
+    ...(input.onProgress == null ? {} : { onProgress: input.onProgress }),
+    paths: input.paths,
+    ...(input.repository == null ? {} : { repository: input.repository }),
+  });
+}
+
+async function inspectResourceFiles(root: string, current = root): Promise<Array<{
+  digest: `sha256:${string}`;
+  path: string;
+  size: number;
+}>> {
+  const files: Array<{ digest: `sha256:${string}`; path: string; size: number }> = [];
+  for (const entry of await readdir(current, { withFileTypes: true })) {
+    const path = join(current, entry.name);
+    if (entry.isSymbolicLink()) throw new ClosureUpdateError("Closure resource must not contain symlinks");
+    if (entry.isDirectory()) files.push(...await inspectResourceFiles(root, path));
+    else if (entry.isFile()) {
+      const metadata = await stat(path);
+      const hash = createHash("sha256");
+      for await (const chunk of createReadStream(path)) hash.update(chunk as Buffer);
+      files.push({
+        digest: `sha256:${hash.digest("hex")}`,
+        path: path.slice(root.length + 1).split("\\").join("/"),
+        size: metadata.size,
+      });
+    } else throw new ClosureUpdateError("Closure resource contains an unsupported entry");
+  }
+  return files.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+}
+
+async function verifyResourceRoot(root: string, expected: `sha256:${string}`): Promise<void> {
+  const files = await inspectResourceFiles(root);
+  if (files.length === 0) throw new ClosureUpdateError("Closure resource is empty");
+  const actual = createClosureComponentTreeDigest(files, (canonical) => (
+    `sha256:${createHash("sha256").update(canonical).digest("hex")}`
+  ));
+  if (actual !== expected) throw new ClosureUpdateError("Closure resource tree does not match its manifest");
+}
+
+export async function ensureClosureResource(input: Readonly<{
+  fetch?: typeof globalThis.fetch;
+  id: string;
+  manifest: ClosureDistributionManifest;
+  onProgress?: (progress: ClosureResourceEnsureProgress) => void;
+  paths: ClosureStorePaths;
+  repository?: ClosureResourceRepositoryConfig;
+  target: string;
+}>): Promise<Readonly<{ id: string; path: string; reused: boolean; title: string }>> {
+  const plan = planClosureDistributionGeneration(input.paths, 0, input.manifest, input.target);
+  const resource = plan.resources.find((entry) => entry.id === input.id);
+  if (resource == null) throw new ClosureUpdateError(`Closure resource is not locked by this version: ${input.id}`);
+  report(input.onProgress, { phase: "checking" });
+  try {
+    await verifyResourceRoot(resource.resourceRoot, resource.treeDigest);
+    report(input.onProgress, { phase: "ready" });
+    return Object.freeze({ id: resource.id, path: resource.resourceRoot, reused: true, title: resource.title });
+  } catch {
+    // Continue through the same repository resolver as required components.
+  }
+  const blobPath = await ensureClosureDistributionBlob({
+    artifact: resource.artifact,
+    ...(input.fetch == null ? {} : { fetch: input.fetch }),
+    ...(input.onProgress == null ? {} : {
+      onProgress(progress) {
+        if (progress.phase === "copying" || progress.phase === "downloading") {
+          report(input.onProgress, progress);
+        } else if (progress.phase === "verifying") {
+          report(input.onProgress, { phase: "verifying" });
+        }
+      },
+    }),
+    paths: input.paths,
+    ...(input.repository == null ? {} : { repository: input.repository }),
+  });
+  const stageRoot = join(input.paths.stagingRoot, `resource-${resource.id}-${randomUUID()}`);
+  try {
+    report(input.onProgress, { phase: "materializing" });
+    await mkdir(stageRoot, { recursive: true });
+    await extractZip(blobPath, { dir: stageRoot });
+    report(input.onProgress, { phase: "verifying" });
+    await verifyResourceRoot(stageRoot, resource.treeDigest);
+    await mkdir(dirname(resource.resourceRoot), { recursive: true });
+    try {
+      await verifyResourceRoot(resource.resourceRoot, resource.treeDigest);
+      report(input.onProgress, { phase: "ready" });
+      return Object.freeze({ id: resource.id, path: resource.resourceRoot, reused: true, title: resource.title });
+    } catch {
+      // The existing root is still absent or damaged; replace it transactionally.
+    }
+    await discardClosureStoreEntry({
+      paths: input.paths,
+      sourcePath: resource.resourceRoot,
+    });
+    try {
+      await rename(stageRoot, resource.resourceRoot);
+    } catch (error) {
+      if (!["EEXIST", "ENOTEMPTY", "EPERM"].includes(errorCode(error) ?? "")) throw error;
+      await verifyResourceRoot(resource.resourceRoot, resource.treeDigest);
+    }
+    report(input.onProgress, { phase: "ready" });
+    return Object.freeze({ id: resource.id, path: resource.resourceRoot, reused: false, title: resource.title });
+  } finally {
+    await rm(stageRoot, { force: true, recursive: true }).catch(() => undefined);
+  }
+}
+

--- a/packages/closure/tests/protocol.test.ts
+++ b/packages/closure/tests/protocol.test.ts
@@ -1,0 +1,621 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CLOSURE_ARCHIVE_ENTRY_PATH,
+  CLOSURE_ARCHIVE_MEDIA_TYPE,
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_INVENTORY_SCHEMA_VERSION,
+  CLOSURE_LAUNCHER_ENTRY_PATH,
+  CLOSURE_LAUNCHER_HANDOFF_PATH,
+  CLOSURE_PROTOCOL_VERSION,
+  CLOSURE_SCHEMA_VERSION,
+  CLOSURE_SIGNATURE_ALGORITHM,
+  CLOSURE_SIGNATURE_SCHEMA_VERSION,
+  ClosureProtocolError,
+  bindClosureCandidateIdentity,
+  createClosureComponentTreeDigest,
+  createClosureDistributionControl,
+  createClosureDistributionManifest,
+  mergeClosureDistributionContributions,
+  resolveClosureDistributionColdStartBudget,
+  resolveClosureDistributionTarget,
+  serializeClosureCandidateManifestForSigning,
+  validateClosureBindingIdentity,
+  validateClosureCandidateIdentity,
+  validateClosureCandidateManifest,
+  validateClosureCandidateSignature,
+  validateClosureDistributionManifest,
+  validateClosureDistributionControl,
+  validateClosureDistributionSharedContribution,
+  validateClosureDistributionTargetContribution,
+  validateClosureFileInventory,
+  type ClosureCandidateIdentity,
+  type ClosureCandidateManifest,
+  type ClosureDigest,
+  type ClosureDistributionManifestDraft,
+} from "../src/protocol/index.js";
+
+const digest = `sha256:${"a".repeat(64)}` as const;
+
+function digestCanonical(value: string) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}` as const;
+}
+
+const candidate: ClosureCandidateIdentity = {
+  channel: "beta",
+  digest,
+  platform: "darwin-arm64",
+  protocolVersion: CLOSURE_PROTOCOL_VERSION,
+  version: "0.19.0-beta.1",
+};
+
+const manifest: ClosureCandidateManifest = {
+  artifact: {
+    digest,
+    entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+    inventoryDigest: digest,
+    mediaType: CLOSURE_ARCHIVE_MEDIA_TYPE,
+    size: 1024,
+    url: "https://releases.open-design.ai/beta/closure/darwin-arm64/runtime.zip",
+  },
+  compatibility: {
+    shell: {
+      electron: { version: { min: "0.18.1" } },
+    },
+  },
+  identity: candidate,
+  schemaVersion: CLOSURE_SCHEMA_VERSION,
+};
+
+const distributionDigests = {
+  body: `sha256:${"b".repeat(64)}`,
+  launcher: `sha256:${"c".repeat(64)}`,
+  nativeMac: `sha256:${"d".repeat(64)}`,
+  nativeWin: `sha256:${"e".repeat(64)}`,
+  resource: `sha256:${"f".repeat(64)}`,
+  velaMac: `sha256:${"1".repeat(64)}`,
+  velaWin: `sha256:${"2".repeat(64)}`,
+} as const;
+
+function blob(digestValue: ClosureDigest, mediaType = "application/zip") {
+  return {
+    digest: digestValue,
+    mediaType,
+    size: 1024,
+    url: `https://releases.open-design.ai/beta/blobs/${digestValue}`,
+  };
+}
+
+const distributionDraft: ClosureDistributionManifestDraft = {
+  blobs: Object.fromEntries(Object.values(distributionDigests).map((value) => [value, blob(value)])),
+  compatibility: {
+    shell: {
+      electron: { version: { min: "0.19.0-beta.4" } },
+    },
+  },
+  identity: {
+    channel: "beta",
+    protocolVersion: CLOSURE_PROTOCOL_VERSION,
+    version: "0.19.0-beta.10",
+  },
+  required: {
+    body: {
+      blob: distributionDigests.body,
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      treeDigest: distributionDigests.body,
+    },
+    launcher: {
+      blob: distributionDigests.launcher,
+      entryPath: CLOSURE_LAUNCHER_ENTRY_PATH,
+      handoffPath: CLOSURE_LAUNCHER_HANDOFF_PATH,
+      treeDigest: distributionDigests.launcher,
+    },
+    targets: {
+      "win32-x64": {
+        native: { blob: distributionDigests.nativeWin, treeDigest: distributionDigests.nativeWin },
+        resources: [{
+          blob: distributionDigests.velaWin,
+          id: "vela-runtime",
+          startup: "blocking",
+          title: "Vela runtime",
+          treeDigest: distributionDigests.velaWin,
+        }],
+      },
+      "darwin-arm64": {
+        native: { blob: distributionDigests.nativeMac, treeDigest: distributionDigests.nativeMac },
+        resources: [{
+          blob: distributionDigests.velaMac,
+          id: "vela-runtime",
+          startup: "blocking",
+          title: "Vela runtime",
+          treeDigest: distributionDigests.velaMac,
+        }],
+      },
+    },
+  },
+  resources: [{
+    blob: distributionDigests.resource,
+    id: "design-system-core",
+    startup: "lazy",
+    title: "Open Design Core",
+    treeDigest: distributionDigests.resource,
+  }],
+  schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+};
+
+describe("closure candidate identity", () => {
+  it("validates a namespace-neutral platform candidate", () => {
+    expect(validateClosureCandidateIdentity(candidate)).toEqual(candidate);
+  });
+
+  it("rejects a public candidate that is already bound to a local namespace", () => {
+    expect(() => validateClosureCandidateIdentity({
+      ...candidate,
+      namespace: "release-beta",
+    })).toThrowError(new ClosureProtocolError(
+      "closure candidate identity must not contain a local namespace",
+    ));
+  });
+
+  it.each([
+    ["digest", `sha256:${"A".repeat(64)}`],
+    ["platform", "darwin_arm64"],
+    ["protocolVersion", 0],
+    ["protocolVersion", 2],
+    ["version", "../0.19.0-beta.1"],
+  ])("rejects an invalid %s", (field, value) => {
+    expect(() => validateClosureCandidateIdentity({
+      ...candidate,
+      [field]: value,
+    })).toThrow(ClosureProtocolError);
+  });
+});
+
+describe("closure local binding", () => {
+  it("binds an explicit product namespace only during local activation", () => {
+    const binding = bindClosureCandidateIdentity(candidate, "release-beta");
+
+    expect(binding).toEqual({
+      ...candidate,
+      namespace: "release-beta",
+    });
+    expect(validateClosureBindingIdentity(binding, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toEqual(binding);
+  });
+
+  it("rejects a binding from another coordination domain", () => {
+    const binding = bindClosureCandidateIdentity(candidate, "release-beta");
+
+    expect(() => validateClosureBindingIdentity(binding, {
+      channel: "stable",
+      namespace: "release-beta",
+    })).toThrow(/does not match expected channel/u);
+    expect(() => validateClosureBindingIdentity(binding, {
+      channel: "beta",
+      namespace: "release-preview",
+    })).toThrow(/does not match expected namespace/u);
+    expect(() => bindClosureCandidateIdentity(candidate, "../release-beta")).toThrowError(ClosureProtocolError);
+  });
+});
+
+describe("closure candidate manifest", () => {
+  it("validates an immutable artifact and its minimum shell version", () => {
+    expect(validateClosureCandidateManifest(manifest)).toEqual(manifest);
+  });
+
+  it("rejects artifact identity drift", () => {
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      artifact: {
+        ...manifest.artifact,
+        digest: `sha256:${"b".repeat(64)}`,
+      },
+    })).toThrow(/digest must match/u);
+  });
+
+  it("rejects a manifest that is already bound to a local namespace", () => {
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      namespace: "release-beta",
+    })).toThrow(/must not contain a local namespace/u);
+  });
+
+  it.each([
+    ["entryPath", "standalone.mjs"],
+    ["inventoryDigest", "sha256:invalid"],
+    ["size", 0],
+    ["url", "file:///tmp/runtime.zip"],
+    ["mediaType", "application/zip"],
+  ])("rejects an invalid artifact %s", (field, value) => {
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      artifact: {
+        ...manifest.artifact,
+        [field]: value,
+      },
+    })).toThrow(ClosureProtocolError);
+  });
+
+  it("rejects an unsafe minimum shell version", () => {
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      compatibility: {
+        shell: {
+          electron: { version: { min: "../0.18.1" } },
+        },
+      },
+    })).toThrow(/minimum shell version/u);
+  });
+
+  it("normalizes compatibility independently for every shell type", () => {
+    expect(validateClosureCandidateManifest({
+      ...manifest,
+      compatibility: {
+        shell: {
+          electron: { version: { min: "0.19.0-beta.1" } },
+          "codex-plugin": { version: { min: "0.1.0" } },
+        },
+      },
+    }).compatibility.shell).toEqual({
+      "codex-plugin": { version: { min: "0.1.0" } },
+      electron: { version: { min: "0.19.0-beta.1" } },
+    });
+  });
+
+  it("rejects an empty or malformed shell compatibility map", () => {
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      compatibility: { shell: {} },
+    })).toThrow(/at least one shell/u);
+    expect(() => validateClosureCandidateManifest({
+      ...manifest,
+      compatibility: {
+        shell: { "Electron Shell": { version: { min: "0.19.0-beta.1" } } },
+      },
+    })).toThrow(/shell type/u);
+  });
+});
+
+describe("closure file inventory", () => {
+  const inventory = {
+    files: [
+      { digest, path: "bootloader.mjs", size: 12 },
+      { digest, path: "web/server.js", size: 0 },
+    ],
+    schemaVersion: CLOSURE_INVENTORY_SCHEMA_VERSION,
+  };
+
+  it("validates a sorted, namespace-neutral payload inventory", () => {
+    expect(validateClosureFileInventory(inventory)).toEqual(inventory);
+    expect(createClosureComponentTreeDigest(inventory.files, digestCanonical))
+      .toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+
+  it.each([
+    ["absolute", "/bootloader.mjs"],
+    ["parent", "../bootloader.mjs"],
+    ["windows", "web\\server.js"],
+  ])("rejects an unsafe %s path", (_label, path) => {
+    expect(() => validateClosureFileInventory({
+      ...inventory,
+      files: [{ digest, path, size: 1 }],
+    })).toThrow(ClosureProtocolError);
+  });
+
+  it("rejects duplicate or unsorted paths", () => {
+    expect(() => validateClosureFileInventory({
+      ...inventory,
+      files: [...inventory.files].reverse(),
+    })).toThrow(/strictly sorted/u);
+    expect(() => createClosureComponentTreeDigest([], digestCanonical)).toThrow(/non-empty/u);
+  });
+});
+
+describe("closure candidate signatures", () => {
+  it("validates a detached Ed25519 signature descriptor", () => {
+    expect(validateClosureCandidateSignature({
+      algorithm: CLOSURE_SIGNATURE_ALGORITHM,
+      keyId: "release-root-2026",
+      schemaVersion: CLOSURE_SIGNATURE_SCHEMA_VERSION,
+      value: "ZmFrZS1zaWduYXR1cmU",
+    })).toEqual({
+      algorithm: "ed25519",
+      keyId: "release-root-2026",
+      schemaVersion: 1,
+      value: "ZmFrZS1zaWduYXR1cmU",
+    });
+  });
+
+  it("serializes the normalized v1 manifest deterministically", () => {
+    expect(serializeClosureCandidateManifestForSigning({
+      ...manifest,
+      ignoredFutureField: true,
+    })).toBe(`${JSON.stringify(manifest)}\n`);
+  });
+
+  it.each([
+    ["algorithm", "rsa"],
+    ["keyId", "../release-root"],
+    ["value", "not+padded="],
+    ["schemaVersion", 2],
+  ])("rejects an invalid signature %s", (field, value) => {
+    expect(() => validateClosureCandidateSignature({
+      algorithm: CLOSURE_SIGNATURE_ALGORITHM,
+      keyId: "release-root-2026",
+      schemaVersion: CLOSURE_SIGNATURE_SCHEMA_VERSION,
+      value: "ZmFrZS1zaWduYXR1cmU",
+      [field]: value,
+    })).toThrow(ClosureProtocolError);
+  });
+});
+
+describe("layered Closure distribution manifest", () => {
+  it("accepts the reserved local coordination domain inside Closure only", () => {
+    const localDraft: ClosureDistributionManifestDraft = {
+      ...distributionDraft,
+      identity: {
+        ...distributionDraft.identity,
+        channel: "local",
+        version: "0.19.1-local.1",
+      },
+    };
+    const produced = createClosureDistributionManifest(localDraft, digestCanonical);
+
+    expect(validateClosureDistributionManifest(produced, digestCanonical).identity).toMatchObject({
+      channel: "local",
+      version: "0.19.1-local.1",
+    });
+  });
+
+  it("projects a stable shallow compatibility envelope", () => {
+    const produced = createClosureDistributionManifest(distributionDraft, digestCanonical);
+    const control = createClosureDistributionControl(produced);
+    expect(validateClosureDistributionControl(control)).toEqual(control);
+    expect(control).toMatchObject({
+      distribution: {
+        digest: produced.identity.digest,
+        protocolVersion: CLOSURE_PROTOCOL_VERSION,
+        schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+      },
+      schemaVersion: 1,
+      shellCompatibility: produced.compatibility.shell,
+    });
+  });
+
+  it("lets an independent producer seal one version across multiple targets", () => {
+    const produced = createClosureDistributionManifest(distributionDraft, digestCanonical);
+
+    expect(produced.identity).toMatchObject({
+      channel: "beta",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      version: "0.19.0-beta.10",
+    });
+    expect(produced.identity.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    expect(Object.keys(produced.required.targets)).toEqual(["darwin-arm64", "win32-x64"]);
+    expect(validateClosureDistributionManifest(produced, digestCanonical)).toEqual(produced);
+  });
+
+  it("lets a target consumer resolve the complete cold-start set and lazy resources", () => {
+    const produced = createClosureDistributionManifest(distributionDraft, digestCanonical);
+    const target = resolveClosureDistributionTarget(produced, "darwin-arm64");
+
+    expect(target.required).toEqual({
+      body: produced.required.body,
+      launcher: produced.required.launcher,
+      native: produced.required.targets["darwin-arm64"]?.native,
+    });
+    expect(target.resources).toEqual([
+      ...produced.resources,
+      ...produced.required.targets["darwin-arm64"]!.resources,
+    ].sort((left, right) => left.id.localeCompare(right.id)).map((resource) => ({
+      ...resource,
+      artifact: produced.blobs[resource.blob],
+    })));
+    expect(target.requiredBlobs.map((entry) => entry.digest)).toEqual([
+      distributionDigests.body,
+      distributionDigests.launcher,
+      distributionDigests.nativeMac,
+    ].sort());
+    expect(target.requiredBlobs.map((entry) => entry.digest)).not.toContain(distributionDigests.resource);
+    expect(target.requiredBlobs.map((entry) => entry.digest)).not.toContain(distributionDigests.velaMac);
+    expect(target.resources.some((resource) => resource.blob === distributionDigests.velaWin)).toBe(false);
+    expect(resolveClosureDistributionColdStartBudget(produced, "darwin-arm64")).toEqual({
+      budgetBytes: 30_000_000,
+      components: {
+        body: produced.blobs[distributionDigests.body],
+        launcher: produced.blobs[distributionDigests.launcher],
+        native: produced.blobs[distributionDigests.nativeMac],
+      },
+      requiredBytes: 3_072,
+      target: "darwin-arm64",
+    });
+  });
+
+  it("enforces the strict 30 MB unique cold-start component budget", () => {
+    const oversized = {
+      ...distributionDraft,
+      blobs: Object.fromEntries(Object.entries(distributionDraft.blobs).map(([key, value]) => [
+        key,
+        [distributionDigests.body, distributionDigests.launcher, distributionDigests.nativeMac].includes(key as ClosureDigest)
+          ? { ...value, size: 10_000_000 }
+          : value,
+      ])),
+    };
+    expect(() => createClosureDistributionManifest(oversized, digestCanonical))
+      .toThrow(
+        /darwin-arm64 cold-start bytes body=10000000, launcher=10000000, native=10000000, unique=30000000, budget<30000000/u,
+      );
+  });
+
+  it("counts a shared cold-start blob once while preserving named component diagnostics", () => {
+    const sharedNative = {
+      ...distributionDraft,
+      blobs: Object.fromEntries(
+        Object.entries(distributionDraft.blobs).filter(([digest]) => digest !== distributionDigests.nativeMac),
+      ),
+      required: {
+        ...distributionDraft.required,
+        targets: {
+          ...distributionDraft.required.targets,
+          "darwin-arm64": {
+            native: {
+              blob: distributionDigests.launcher,
+              treeDigest: distributionDigests.launcher,
+            },
+            resources: distributionDraft.required.targets["darwin-arm64"]!.resources,
+          },
+        },
+      },
+    };
+    const produced = createClosureDistributionManifest(sharedNative, digestCanonical);
+    const budget = resolveClosureDistributionColdStartBudget(produced, "darwin-arm64");
+    expect(budget.components.native).toEqual(budget.components.launcher);
+    expect(budget.requiredBytes).toBe(2_048);
+  });
+
+  it("keeps resource identity content-addressed across release versions", () => {
+    const first = createClosureDistributionManifest(distributionDraft, digestCanonical);
+    const second = createClosureDistributionManifest({
+      ...distributionDraft,
+      identity: { ...distributionDraft.identity, version: "0.19.1-beta.1" },
+    }, digestCanonical);
+
+    expect(first.identity.digest).not.toBe(second.identity.digest);
+    expect(first.resources[0]?.blob).toBe(second.resources[0]?.blob);
+  });
+
+  it("rejects graph drift, dangling blobs and target ambiguity", () => {
+    const produced = createClosureDistributionManifest(distributionDraft, digestCanonical);
+    expect(() => validateClosureDistributionManifest({
+      ...produced,
+      identity: { ...produced.identity, version: "0.19.0-beta.11" },
+    }, digestCanonical)).toThrow(/canonical digest/u);
+    expect(() => createClosureDistributionManifest({
+      ...distributionDraft,
+      required: {
+        ...distributionDraft.required,
+        body: { ...distributionDraft.required.body, blob: `sha256:${"9".repeat(64)}` },
+      },
+    }, digestCanonical)).toThrow(/unknown blob/u);
+    expect(() => resolveClosureDistributionTarget(produced, "darwin-x64")).toThrow(/target/u);
+  });
+
+  it("rejects unused blob mappings and non-canonical entry paths", () => {
+    expect(() => createClosureDistributionManifest({
+      ...distributionDraft,
+      blobs: {
+        ...distributionDraft.blobs,
+        [`sha256:${"3".repeat(64)}`]: blob(`sha256:${"3".repeat(64)}`),
+      },
+    }, digestCanonical)).toThrow(/unused blob/u);
+    expect(() => createClosureDistributionManifest({
+      ...distributionDraft,
+      required: {
+        ...distributionDraft.required,
+        launcher: { ...distributionDraft.required.launcher, entryPath: "standalone-launcher.mjs" },
+      },
+    }, digestCanonical)).toThrow(/launcher entry path/u);
+  });
+
+  it("rejects unknown fields instead of silently dropping local or Shell-owned state", () => {
+    expect(() => createClosureDistributionManifest({
+      ...distributionDraft,
+      shellBytes: { electron: "not-part-of-closure" },
+    }, digestCanonical)).toThrow(/unsupported fields: shellBytes/u);
+    expect(() => createClosureDistributionManifest({
+      ...distributionDraft,
+      required: {
+        ...distributionDraft.required,
+        launcher: {
+          ...distributionDraft.required.launcher,
+          namespace: "release-beta",
+        },
+      },
+    }, digestCanonical)).toThrow(/unsupported fields: namespace/u);
+  });
+});
+
+describe("layered Closure cross-job contributions", () => {
+  const artifact = (digestValue: ClosureDigest) => blob(digestValue);
+  const shared = {
+    body: {
+      artifact: artifact(distributionDigests.body),
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      treeDigest: distributionDigests.body,
+    },
+    channel: "beta",
+    launcher: {
+      artifact: artifact(distributionDigests.launcher),
+      entryPath: CLOSURE_LAUNCHER_ENTRY_PATH,
+      handoffPath: CLOSURE_LAUNCHER_HANDOFF_PATH,
+      treeDigest: distributionDigests.launcher,
+    },
+    protocolVersion: CLOSURE_PROTOCOL_VERSION,
+    resources: [{
+      artifact: artifact(distributionDigests.resource),
+      id: "design-system-core",
+      startup: "lazy",
+      title: "Open Design Core",
+      treeDigest: distributionDigests.resource,
+    }],
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+    shellCompatibility: distributionDraft.compatibility.shell,
+    version: "0.19.0-beta.10",
+  } as const;
+  const mac = {
+    channel: "beta",
+    native: {
+      artifact: artifact(distributionDigests.nativeMac),
+      treeDigest: distributionDigests.nativeMac,
+    },
+    protocolVersion: CLOSURE_PROTOCOL_VERSION,
+    resources: [{
+      artifact: artifact(distributionDigests.velaMac),
+      id: "vela-runtime",
+      startup: "blocking",
+      title: "Vela runtime",
+      treeDigest: distributionDigests.velaMac,
+    }],
+    schemaVersion: CLOSURE_DISTRIBUTION_CONTRIBUTION_SCHEMA_VERSION,
+    target: "darwin-arm64",
+    version: "0.19.0-beta.10",
+  } as const;
+
+  it("parses both declarations and seals the same canonical graph", () => {
+    expect(validateClosureDistributionSharedContribution(shared)).toEqual(shared);
+    expect(validateClosureDistributionTargetContribution(mac)).toEqual(mac);
+    const merged = mergeClosureDistributionContributions(shared, [mac], digestCanonical);
+    expect(merged.required.targets["darwin-arm64"]).toEqual({
+      native: distributionDraft.required.targets["darwin-arm64"]?.native,
+      resources: distributionDraft.required.targets["darwin-arm64"]?.resources,
+    });
+    expect(merged.resources[0]?.blob).toBe(distributionDigests.resource);
+  });
+
+  it("fails closed on drift, duplicates, and undeclared job fields", () => {
+    expect(() => mergeClosureDistributionContributions(shared, [mac, mac], digestCanonical))
+      .toThrow(/duplicate/u);
+    expect(() => mergeClosureDistributionContributions(shared, [{
+      ...mac,
+      version: "0.19.0-beta.11",
+    }], digestCanonical)).toThrow(/one release identity/u);
+    expect(() => validateClosureDistributionTargetContribution({
+      ...mac,
+      localArtifactPath: "/tmp/node.zip",
+    })).toThrow(/unsupported fields/u);
+    expect(() => validateClosureDistributionTargetContribution({
+      ...mac,
+      runtime: { entryPath: "bin/node" },
+    })).toThrow(/unsupported fields/u);
+    expect(() => validateClosureDistributionSharedContribution({
+      ...shared,
+      namespace: "release-beta",
+    })).toThrow(/unsupported fields/u);
+  });
+});
+

--- a/packages/closure/tests/store.test.ts
+++ b/packages/closure/tests/store.test.ts
@@ -1,0 +1,757 @@
+import { createHash } from "node:crypto";
+import { cp, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  CLOSURE_ARCHIVE_ENTRY_PATH,
+  CLOSURE_ARCHIVE_MEDIA_TYPE,
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_INVENTORY_SCHEMA_VERSION,
+  CLOSURE_PROTOCOL_VERSION,
+  CLOSURE_SCHEMA_VERSION,
+  bindClosureCandidateIdentity,
+  createClosureComponentTreeDigest,
+  createClosureDistributionManifest,
+  type ClosureBindingIdentity,
+  type ClosureCandidateManifest,
+  type ClosureDistributionBlob,
+} from "@open-design/closure/protocol";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CLOSURE_BINDING_SCHEMA_VERSION,
+  activatePreparedClosureBinding,
+  authorizePreparedClosureActivation,
+  beginActiveClosureBindingAttempt,
+  confirmClosureBindingAttempt,
+  prepareStoredClosureCandidate,
+  prepareVerifiedClosureDistributionGeneration,
+  prepareVerifiedStoredClosureCandidate,
+  recoverInterruptedClosureBinding,
+  cleanupClosureChannelGarbage,
+  consumeClosureDistributionTarget,
+  discardObsoleteClosureNamespaceEpochs,
+  discardClosureStoreEntry,
+  hasStoredClosureDistributionGeneration,
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  revokePreparedClosureActivation,
+  resolveClosureStorePaths,
+  resolveClosureStoreVersionPaths,
+  verifyMaterializedClosureCandidate,
+  verifyMaterializedClosureDistributionGeneration,
+  verifyStoredClosureCandidate,
+  verifyStoredClosureDistributionGeneration,
+  type ClosureStorePaths,
+} from "../src/store/index.js";
+
+const roots: string[] = [];
+const shellBinding = {
+  digest: `sha256:${"f".repeat(64)}` as const,
+  type: "electron",
+  version: "0.19.0-beta.1",
+};
+const distributionFixturePath = fileURLToPath(
+  new URL("../fixtures/distribution-v4.json", import.meta.url),
+);
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+function digest(bytes: string | Buffer): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+async function createStore(namespace = "release-beta"): Promise<ClosureStorePaths> {
+  const root = await mkdtemp(join(tmpdir(), "od-closure-store-"));
+  roots.push(root);
+  return resolveClosureStorePaths({ channel: "beta", namespace, root });
+}
+
+async function materializeCandidate(
+  paths: ClosureStorePaths,
+  version: string,
+): Promise<{ binding: ClosureBindingIdentity; manifest: ClosureCandidateManifest }> {
+  const archive = Buffer.from(`archive:${version}`, "utf8");
+  const archiveDigest = digest(archive);
+  const runtime = "export const ready = true;\n";
+  const web = "console.log('web');\n";
+  const inventory = {
+    files: [
+      { digest: digest(runtime), path: CLOSURE_ARCHIVE_ENTRY_PATH, size: Buffer.byteLength(runtime) },
+      { digest: digest(web), path: "web/server.js", size: Buffer.byteLength(web) },
+    ],
+    schemaVersion: CLOSURE_INVENTORY_SCHEMA_VERSION,
+  };
+  const inventoryDigest = digest(JSON.stringify(inventory.files));
+  const manifest: ClosureCandidateManifest = {
+    artifact: {
+      digest: archiveDigest,
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      inventoryDigest,
+      mediaType: CLOSURE_ARCHIVE_MEDIA_TYPE,
+      size: archive.byteLength,
+      url: `https://releases.open-design.ai/beta/closure/darwin-arm64/versions/${version}/closure.zip`,
+    },
+    compatibility: { shell: { electron: { version: { min: "0.16.2" } } } },
+    identity: {
+      channel: "beta",
+      digest: archiveDigest,
+      platform: "darwin-arm64",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      version,
+    },
+    schemaVersion: CLOSURE_SCHEMA_VERSION,
+  };
+  const binding = bindClosureCandidateIdentity(manifest.identity, paths.namespace);
+  const versionPaths = resolveClosureStoreVersionPaths(paths, binding);
+  await mkdir(join(versionPaths.payloadRoot, "web"), { recursive: true });
+  await writeFile(versionPaths.archivePath, archive);
+  await writeFile(versionPaths.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeFile(join(versionPaths.payloadRoot, CLOSURE_ARCHIVE_ENTRY_PATH), runtime);
+  await writeFile(join(versionPaths.payloadRoot, "web", "server.js"), web);
+  await writeFile(versionPaths.inventoryPath, `${JSON.stringify(inventory, null, 2)}\n`);
+  return { binding, manifest };
+}
+
+async function materializeDistributionGeneration(
+  paths: ClosureStorePaths,
+  generation: number,
+) {
+  const sources = {
+    body: Buffer.from("body-archive"),
+    launcher: Buffer.from("launcher-archive"),
+    native: Buffer.from("native-archive"),
+    resource: Buffer.from("resource-archive"),
+  };
+  const blob = (bytes: Buffer): ClosureDistributionBlob => {
+    const value = digest(bytes);
+    return {
+      digest: value,
+      mediaType: "application/zip",
+      size: bytes.byteLength,
+      url: `https://releases.open-design.test/beta/blobs/${value.slice("sha256:".length)}`,
+    };
+  };
+  const artifacts = Object.fromEntries(
+    Object.entries(sources).map(([name, bytes]) => [name, blob(bytes)]),
+  ) as Record<keyof typeof sources, ClosureDistributionBlob>;
+  const tree = (path: string, contents: string) => createClosureComponentTreeDigest([{
+    digest: digest(contents),
+    path,
+    size: Buffer.byteLength(contents),
+  }], digest);
+  const launcherFiles = [
+    ["bootloader.mjs", "export const handoff = true;\n"],
+    ["launcher.mjs", "export const launcher = true;\n"],
+  ] as const;
+  const trees = {
+    body: tree("bootloader.mjs", "export const body = true;\n"),
+    launcher: createClosureComponentTreeDigest(launcherFiles.map(([path, contents]) => ({
+      digest: digest(contents),
+      path,
+      size: Buffer.byteLength(contents),
+    })), digest),
+    native: tree("addon.node", "native\n"),
+    resource: tree("skills/sample/SKILL.md", "resource\n"),
+  };
+  const manifest = createClosureDistributionManifest({
+    blobs: Object.fromEntries(Object.values(artifacts).map((artifact) => [artifact.digest, artifact])),
+    compatibility: { shell: { electron: { version: { min: "0.19.0" } } } },
+    identity: {
+      channel: "beta",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      version: "0.19.0-beta.10",
+    },
+    required: {
+      body: { blob: artifacts.body.digest, entryPath: "bootloader.mjs", treeDigest: trees.body },
+      launcher: {
+        blob: artifacts.launcher.digest,
+        entryPath: "launcher.mjs",
+        handoffPath: "bootloader.mjs",
+        treeDigest: trees.launcher,
+      },
+      targets: {
+        "darwin-arm64": {
+          native: { blob: artifacts.native.digest, treeDigest: trees.native },
+        },
+      },
+    },
+    resources: [{
+      blob: artifacts.resource.digest,
+      id: "skills",
+      startup: "lazy",
+      title: "Skills",
+      treeDigest: trees.resource,
+    }],
+    schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  }, digest);
+  const plan = planClosureDistributionGeneration(paths, generation, manifest, "darwin-arm64");
+  await mkdir(paths.blobsRoot, { recursive: true });
+  for (const [name, bytes] of Object.entries(sources)) {
+    if (name === "resource") continue;
+    await writeFile(join(paths.blobsRoot, artifacts[name as keyof typeof sources].digest.slice("sha256:".length)), bytes);
+  }
+  const stageRoot = join(paths.stagingRoot, `generation-${generation}`);
+  await mkdir(join(stageRoot, "body"), { recursive: true });
+  await mkdir(join(stageRoot, "launcher"), { recursive: true });
+  await mkdir(join(stageRoot, "native"), { recursive: true });
+  await writeFile(join(stageRoot, "body", "bootloader.mjs"), "export const body = true;\n");
+  await writeFile(join(stageRoot, "launcher", "launcher.mjs"), "export const launcher = true;\n");
+  await writeFile(join(stageRoot, "launcher", "bootloader.mjs"), "export const handoff = true;\n");
+  await writeFile(join(stageRoot, "native", "addon.node"), "native\n");
+  await writeFile(join(stageRoot, "closure.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  return { artifacts, manifest, plan, stageRoot };
+}
+
+describe("Closure store paths", () => {
+  it("isolates state by channel and namespace without transport identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-store-paths-"));
+    roots.push(root);
+    const beta = resolveClosureStorePaths({ channel: "beta", namespace: "release-beta", root });
+    const preview = resolveClosureStorePaths({ channel: "preview", namespace: "release-preview", root });
+
+    expect(beta.namespaceRoot).toBe(join(root, "closure", "channels", "beta", "epochs", "4", "namespaces", "release-beta"));
+    expect(preview.namespaceRoot).not.toBe(beta.namespaceRoot);
+    expect(JSON.stringify(beta)).not.toMatch(/port/iu);
+  });
+
+  it("isolates the reserved local coordination domain from public channels", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-store-local-paths-"));
+    roots.push(root);
+    const local = resolveClosureStorePaths({ channel: "local", namespace: "local-transactional", root });
+    const beta = resolveClosureStorePaths({ channel: "beta", namespace: "local-transactional", root });
+
+    expect(local.channelRoot).toBe(join(root, "closure", "channels", "local"));
+    expect(local.namespaceRoot).not.toBe(beta.namespaceRoot);
+  });
+
+  it("rejects relative roots and unsafe namespaces", () => {
+    expect(() => resolveClosureStorePaths({ channel: "beta", namespace: "release-beta", root: ".tmp" }))
+      .toThrow(/absolute path/u);
+    expect(() => resolveClosureStorePaths({ channel: "beta", namespace: "../beta", root: "/tmp/od" }))
+      .toThrow();
+  });
+});
+
+describe("Closure channel garbage black hole", () => {
+  it("atomically transfers an arbitrary channel entry without preserving its structure", async () => {
+    const paths = await createStore();
+    const sourcePath = join(paths.resourcesRoot, "resource-key", "nested");
+    await mkdir(sourcePath, { recursive: true });
+    await writeFile(join(sourcePath, "payload.bin"), "garbage");
+
+    const discarded = await discardClosureStoreEntry({ paths, sourcePath });
+
+    expect(discarded.state).toBe("discarded");
+    await expect(stat(sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(discarded.garbagePath, "payload.bin"), "utf8")).resolves.toBe("garbage");
+    expect(dirname(discarded.garbagePath)).toBe(paths.garbageRoot);
+    expect(discarded.garbagePath).not.toContain("resource-key");
+    await expect(discardClosureStoreEntry({ paths, sourcePath: discarded.garbagePath }))
+      .rejects.toThrow(/already inside/u);
+  });
+
+  it("drains opaque files and directories within a bounded number of entries", async () => {
+    const paths = await createStore();
+    await mkdir(join(paths.garbageRoot, "directory"), { recursive: true });
+    await writeFile(join(paths.garbageRoot, "directory", "nested"), "nested");
+    await writeFile(join(paths.garbageRoot, "file"), "file");
+
+    const first = await cleanupClosureChannelGarbage({
+      maxDurationMs: 10_000,
+      maxEntries: 1,
+      paths,
+    });
+    expect(first).toMatchObject({ attempted: 1, busy: false, remaining: 1, removed: 1 });
+
+    const second = await cleanupClosureChannelGarbage({
+      maxDurationMs: 10_000,
+      maxEntries: 16,
+      paths,
+    });
+    expect(second).toMatchObject({ attempted: 1, busy: false, remaining: 0, removed: 1 });
+  });
+
+  it("discards obsolete namespace epochs only after the current binding is confirmed", async () => {
+    const paths = await createStore();
+    const obsoleteNamespaceRoot = join(paths.channelRoot, "epochs", "3", "namespaces", paths.namespace);
+    await mkdir(obsoleteNamespaceRoot, { recursive: true });
+    await writeFile(join(obsoleteNamespaceRoot, "obsolete.bin"), "obsolete");
+
+    expect(await discardObsoleteClosureNamespaceEpochs(paths)).toEqual({
+      discarded: 0,
+      state: "deferred",
+    });
+    const candidate = await materializeCandidate(paths, "0.19.0-beta.1");
+    const prepared = await prepareStoredClosureCandidate(paths, candidate.binding, "0.19.0-beta.1");
+    await authorizePreparedClosureActivation(paths, prepared.prepared, "user-restart");
+    await activatePreparedClosureBinding(paths, prepared.prepared, shellBinding);
+    await confirmClosureBindingAttempt(paths, prepared.prepared);
+
+    expect(await discardObsoleteClosureNamespaceEpochs(paths)).toEqual({
+      discarded: 1,
+      state: "discarded",
+    });
+    await expect(stat(obsoleteNamespaceRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    const garbageEntries = await readdir(paths.garbageRoot);
+    expect(garbageEntries).toHaveLength(1);
+    await expect(readFile(join(paths.garbageRoot, garbageEntries[0]!, "obsolete.bin"), "utf8"))
+      .resolves.toBe("obsolete");
+  });
+});
+
+describe("layered Closure distribution consumer", () => {
+  it("accepts the producer fixture and resolves only one target's cold-start set", async () => {
+    const fixture = JSON.parse(await readFile(distributionFixturePath, "utf8")) as unknown;
+    const consumed = consumeClosureDistributionTarget(fixture, "win32-x64");
+
+    expect(consumed.manifest.identity).toMatchObject({
+      channel: "beta",
+      version: "0.19.0-beta.10",
+    });
+    expect(consumed.target.required.native).toEqual(
+      consumed.manifest.required.targets["win32-x64"]?.native,
+    );
+    expect(consumed.target.resources).toEqual([
+      expect.objectContaining({ id: "design-system-core", title: "Open Design Core" }),
+    ]);
+    expect(consumed.target.requiredBlobs).toHaveLength(3);
+    expect(consumed.target.requiredBlobs.map((blob) => blob.digest)).not.toContain(
+      consumed.target.resources[0]?.blob,
+    );
+  });
+
+  it("rejects a valid-looking graph whose sealed identity was mutated", async () => {
+    const fixture = JSON.parse(await readFile(distributionFixturePath, "utf8")) as {
+      identity: Record<string, unknown>;
+    };
+
+    expect(() => consumeClosureDistributionTarget({
+      ...fixture,
+      identity: { ...fixture.identity, version: "0.19.0-beta.11" },
+    }, "win32-x64")).toThrow(/canonical digest/u);
+  });
+
+  it("plans one active generation view while resources remain lazy channel blobs", async () => {
+    const fixture = JSON.parse(await readFile(distributionFixturePath, "utf8")) as unknown;
+    const root = await mkdtemp(join(tmpdir(), "od-closure-store-plan-"));
+    roots.push(root);
+    const left = resolveClosureStorePaths({ channel: "beta", namespace: "team-a", root });
+    const right = resolveClosureStorePaths({ channel: "beta", namespace: "team-b", root });
+
+    const leftPlan = planClosureDistributionGeneration(left, 7, fixture, "darwin-arm64");
+    const rightPlan = planClosureDistributionGeneration(right, 2, fixture, "darwin-arm64");
+
+    expect(leftPlan.installationRoot).toBe(join(
+      left.installationsRoot,
+      leftPlan.identity.version,
+      leftPlan.identity.digest.slice("sha256:".length),
+      leftPlan.target,
+    ));
+    expect(leftPlan.required.body.resolvedEntryPath).toBe(
+      join(leftPlan.installationRoot, "body", "bootloader.mjs"),
+    );
+    expect(leftPlan.required.launcher.resolvedEntryPath).toBe(
+      join(leftPlan.installationRoot, "launcher", "launcher.mjs"),
+    );
+    expect(leftPlan.required.native.componentRoot).toBe(join(leftPlan.installationRoot, "native"));
+    expect(leftPlan.requiredBlobPaths).toHaveLength(3);
+    expect(leftPlan.resources).toEqual([
+      expect.objectContaining({ id: "design-system-core", title: "Open Design Core" }),
+    ]);
+    expect(leftPlan.requiredBlobPaths).not.toContain(leftPlan.resources[0]?.blobPath);
+    expect(leftPlan.resources[0]?.blobPath).toBe(rightPlan.resources[0]?.blobPath);
+    expect(leftPlan.required.body.blobPath).toBe(rightPlan.required.body.blobPath);
+    expect(leftPlan.installationRoot).not.toBe(rightPlan.installationRoot);
+  });
+
+  it("rejects a distribution from another channel before planning local paths", async () => {
+    const fixture = JSON.parse(await readFile(distributionFixturePath, "utf8")) as unknown;
+    const paths = resolveClosureStorePaths({
+      channel: "preview",
+      namespace: "release-preview",
+      root: "/tmp/open-design-closure-plan",
+    });
+
+    expect(() => planClosureDistributionGeneration(paths, 0, fixture, "darwin-arm64"))
+      .toThrow(/channel does not match/u);
+    expect(() => planClosureDistributionGeneration(paths, -1, fixture, "darwin-arm64"))
+      .toThrow(/non-negative safe integer/u);
+  });
+});
+
+describe("layered Closure generation preparation", () => {
+  it("publishes exactly one verified generation while lazy resources stay outside the cold view", async () => {
+    const paths = await createStore();
+    const staged = await materializeDistributionGeneration(paths, 0);
+
+    const verification = await verifyMaterializedClosureDistributionGeneration(
+      paths,
+      staged.plan,
+      staged.stageRoot,
+    );
+    const result = await prepareVerifiedClosureDistributionGeneration(
+      paths,
+      verification,
+      "0.19.0-beta.10",
+    );
+
+    expect(result.prepared.standalone).toEqual({
+      channel: "beta",
+      digest: staged.manifest.identity.digest,
+      generation: 0,
+      namespace: "release-beta",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      target: "darwin-arm64",
+      version: "0.19.0-beta.10",
+    });
+    expect(result.descriptor.schemaVersion).toBe(CLOSURE_BINDING_SCHEMA_VERSION);
+    expect((await stat(staged.plan.required.body.resolvedEntryPath)).isFile()).toBe(true);
+    expect(await stat(staged.stageRoot).catch(() => null)).toBeNull();
+    expect(await stat(staged.plan.resources[0]!.blobPath).catch(() => null)).toBeNull();
+    expect(await readClosureBindingDescriptor(paths)).toEqual(result.descriptor);
+
+    const stored = await verifyStoredClosureDistributionGeneration(
+      paths,
+      result.prepared.standalone,
+    );
+    expect(stored.materializedRoot).toBe(staged.plan.storeRoot);
+    expect(stored.plan.required.native.componentRoot).toBe(
+      join(staged.plan.storeRoot, "native"),
+    );
+    await expect(hasStoredClosureDistributionGeneration(
+      paths,
+      result.prepared.standalone,
+    )).resolves.toBe(true);
+  });
+
+  it("rejects a prepared pointer whose content-addressed installation drifted", async () => {
+    const paths = await createStore();
+    const staged = await materializeDistributionGeneration(paths, 0);
+    const verification = await verifyMaterializedClosureDistributionGeneration(
+      paths,
+      staged.plan,
+      staged.stageRoot,
+    );
+    const result = await prepareVerifiedClosureDistributionGeneration(
+      paths,
+      verification,
+      "0.19.0-beta.10",
+    );
+    await writeFile(join(staged.plan.required.native.componentRoot, "addon.node"), "tampered-native");
+
+    await expect(verifyStoredClosureDistributionGeneration(
+      paths,
+      result.prepared.standalone,
+    )).rejects.toThrow(/native/u);
+  });
+
+  it("fails closed before rename when a required CAS blob or view shape drifts", async () => {
+    const paths = await createStore();
+    const staged = await materializeDistributionGeneration(paths, 0);
+    await writeFile(staged.plan.required.native.blobPath, "corrupt-native");
+
+    await expect(verifyMaterializedClosureDistributionGeneration(
+      paths,
+      staged.plan,
+      staged.stageRoot,
+    )).rejects.toThrow(/native blob does not match/u);
+    expect((await readClosureBindingDescriptor(paths)).prepared).toBeNull();
+
+    await writeFile(staged.plan.required.native.blobPath, Buffer.from("native-archive"));
+    await mkdir(join(staged.stageRoot, "resources"));
+    await expect(verifyMaterializedClosureDistributionGeneration(
+      paths,
+      staged.plan,
+      staged.stageRoot,
+    )).rejects.toThrow(/top-level shape/u);
+    expect((await readClosureBindingDescriptor(paths)).prepared).toBeNull();
+  });
+});
+
+describe("stored Closure verification", () => {
+  it("verifies archive identity and every materialized payload file", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const { platform, ...pointerIdentity } = binding;
+    await expect(hasStoredClosureDistributionGeneration(paths, {
+      ...pointerIdentity,
+      generation: 0,
+      target: platform,
+    })).resolves.toBe(false);
+
+    const verified = await verifyStoredClosureCandidate(paths, binding);
+
+    expect(verified.binding).toEqual(binding);
+    expect(verified.inventory.files.map((file) => file.path)).toEqual([
+      CLOSURE_ARCHIVE_ENTRY_PATH,
+      "web/server.js",
+    ]);
+    expect(verified.inventoryDigest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+  });
+
+  it("verifies an isolated staging tree before it becomes a version root", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const finalPaths = resolveClosureStoreVersionPaths(paths, binding);
+    const stageRoot = join(paths.stagingRoot, "candidate");
+    const stagedPaths = {
+      ...finalPaths,
+      archivePath: join(stageRoot, "closure.zip"),
+      inventoryPath: join(stageRoot, "inventory.json"),
+      manifestPath: join(stageRoot, "manifest.json"),
+      payloadRoot: join(stageRoot, "payload"),
+      versionRoot: stageRoot,
+    };
+    await mkdir(paths.stagingRoot, { recursive: true });
+    await cp(finalPaths.versionRoot, stageRoot, { recursive: true });
+
+    const verified = await verifyMaterializedClosureCandidate(paths, binding, stagedPaths);
+
+    expect(verified.paths.versionRoot).toBe(stageRoot);
+    expect(verified.binding).toEqual(binding);
+  });
+
+  it("refuses archive or payload drift before activation", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const versionPaths = resolveClosureStoreVersionPaths(paths, binding);
+
+    await writeFile(versionPaths.archivePath, "corrupt");
+    await expect(prepareStoredClosureCandidate(paths, binding, "0.18.0-beta.1")).rejects.toThrow(/archive does not match/u);
+
+    await writeFile(versionPaths.archivePath, "archive:0.18.0-beta.1");
+    await writeFile(join(versionPaths.payloadRoot, CLOSURE_ARCHIVE_ENTRY_PATH), "mutated");
+    await expect(prepareStoredClosureCandidate(paths, binding, "0.18.0-beta.1")).rejects.toThrow(/payload does not match/u);
+  });
+
+  it("refuses a self-consistent replacement inventory not bound by the manifest", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const versionPaths = resolveClosureStoreVersionPaths(paths, binding);
+    const replacement = "replacement payload\n";
+    await writeFile(join(versionPaths.payloadRoot, CLOSURE_ARCHIVE_ENTRY_PATH), replacement);
+    const inventory = JSON.parse(await readFile(versionPaths.inventoryPath, "utf8")) as {
+      files: Array<{ digest: string; path: string; size: number }>;
+      schemaVersion: number;
+    };
+    const entry = inventory.files.find((file) => file.path === CLOSURE_ARCHIVE_ENTRY_PATH);
+    if (entry == null) throw new Error("test inventory entry missing");
+    entry.digest = digest(replacement);
+    entry.size = Buffer.byteLength(replacement);
+    await writeFile(versionPaths.inventoryPath, `${JSON.stringify(inventory, null, 2)}\n`);
+
+    await expect(prepareStoredClosureCandidate(paths, binding, "0.18.0-beta.1")).rejects.toThrow(/inventory does not match/u);
+  });
+});
+
+describe("Closure prepared binding", () => {
+  it("ignores legacy boolean authorization and binds new intent to the prepared candidate", async () => {
+    const paths = await createStore();
+    await mkdir(paths.stateRoot, { recursive: true });
+    await writeFile(paths.bindingPath, `${JSON.stringify({
+      active: null,
+      activationAuthorized: true,
+      attempt: null,
+      channel: paths.channel,
+      lastSuccessful: null,
+      namespace: paths.namespace,
+      nextGeneration: 0,
+      prepared: null,
+      schemaVersion: 4,
+      updatedAt: new Date().toISOString(),
+    })}\n`);
+
+    const legacy = await readClosureBindingDescriptor(paths);
+    expect(legacy.activationIntent).toBeNull();
+    expect(JSON.parse(await readFile(paths.bindingPath, "utf8"))).toMatchObject({
+      activationAuthorized: false,
+      schemaVersion: 4,
+    });
+
+    const candidate = await materializeCandidate(paths, "0.18.0-beta.1");
+    const prepared = await prepareStoredClosureCandidate(paths, candidate.binding, "0.19.0-beta.1");
+    await authorizePreparedClosureActivation(paths, prepared.prepared, "silent-policy");
+    expect((await readClosureBindingDescriptor(paths)).activationIntent).toEqual({
+      ...prepared.prepared,
+      source: "silent-policy",
+    });
+    expect(JSON.parse(await readFile(paths.bindingPath, "utf8"))).toMatchObject({
+      activationAuthorized: true,
+      schemaVersion: 4,
+    });
+    expect(await readFile(paths.bindingPath, "utf8")).not.toContain("activationIntent");
+    expect(JSON.parse(await readFile(paths.activationIntentPath, "utf8"))).toMatchObject({
+      intent: { ...prepared.prepared, source: "silent-policy" },
+      schemaVersion: 1,
+    });
+    await revokePreparedClosureActivation(paths, "silent-policy");
+    expect((await readClosureBindingDescriptor(paths)).activationIntent).toBeNull();
+    await expect(readFile(paths.activationIntentPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("repairs the transitional schema before an immutable schema-4 launcher reads it", async () => {
+    const paths = await createStore();
+    const candidate = await materializeCandidate(paths, "0.18.0-beta.1");
+    const prepared = await prepareStoredClosureCandidate(paths, candidate.binding, "0.19.0-beta.10");
+    const intent = { ...prepared.prepared, source: "user-restart" as const };
+    await writeFile(paths.bindingPath, `${JSON.stringify({
+      ...prepared.descriptor,
+      activationIntent: intent,
+      schemaVersion: 5,
+    })}\n`);
+
+    expect((await readClosureBindingDescriptor(paths)).activationIntent).toEqual(intent);
+
+    const repaired = JSON.parse(await readFile(paths.bindingPath, "utf8")) as Record<string, unknown>;
+    expect(repaired).toMatchObject({ activationAuthorized: true, schemaVersion: 4 });
+    expect(repaired).not.toHaveProperty("activationIntent");
+    expect(Object.keys(repaired).sort()).toEqual([
+      "activationAuthorized",
+      "active",
+      "attempt",
+      "channel",
+      "lastSuccessful",
+      "namespace",
+      "nextGeneration",
+      "prepared",
+      "schemaVersion",
+      "updatedAt",
+    ]);
+    expect(JSON.parse(await readFile(paths.activationIntentPath, "utf8"))).toMatchObject({
+      intent,
+      schemaVersion: 1,
+    });
+  });
+
+  it("confirms a healthy attempt and rolls an interrupted attempt back to it", async () => {
+    const paths = await createStore();
+    const first = await materializeCandidate(paths, "0.18.0-beta.1");
+    const second = await materializeCandidate(paths, "0.18.0-beta.2");
+    const initial = await prepareStoredClosureCandidate(paths, first.binding, "0.19.0-beta.1");
+
+    await authorizePreparedClosureActivation(paths, initial.prepared, "user-restart");
+    await activatePreparedClosureBinding(paths, initial.prepared, shellBinding);
+    await confirmClosureBindingAttempt(paths, initial.prepared);
+
+    await beginActiveClosureBindingAttempt(paths, initial.prepared, {
+      ...shellBinding,
+      version: "0.19.0-beta.2",
+    });
+    await recoverInterruptedClosureBinding(paths);
+
+    const update = await prepareStoredClosureCandidate(paths, second.binding, "0.19.0-beta.2");
+    await authorizePreparedClosureActivation(paths, update.prepared, "silent-policy");
+    await activatePreparedClosureBinding(paths, update.prepared, shellBinding);
+    await recoverInterruptedClosureBinding(paths);
+
+    const descriptor = await readClosureBindingDescriptor(paths);
+    expect(descriptor.active).toEqual({ ...initial.prepared, shell: shellBinding });
+    expect(descriptor.lastSuccessful).toEqual({ ...initial.prepared, shell: shellBinding });
+    expect(descriptor.attempt).toBeNull();
+    expect(descriptor.prepared).toBeNull();
+    expect(descriptor.activationIntent).toBeNull();
+  });
+
+  it("atomically prepares one release-to-Standalone binding", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+
+    const result = await prepareStoredClosureCandidate(paths, binding, "0.19.0-beta.1");
+
+    expect(result.prepared).toEqual({
+      releaseVersion: "0.19.0-beta.1",
+      standalone: {
+        channel: binding.channel,
+        digest: binding.digest,
+        generation: 0,
+        namespace: binding.namespace,
+        protocolVersion: binding.protocolVersion,
+        target: binding.platform,
+        version: binding.version,
+      },
+    });
+    expect(await readClosureBindingDescriptor(paths)).toEqual(result.descriptor);
+    expect(paths.bindingPath).toMatch(/binding\.json$/u);
+  });
+
+  it("prepares an atomically promoted candidate from its existing verification proof", async () => {
+    const paths = await createStore();
+    const { binding } = await materializeCandidate(paths, "0.18.0-beta.1");
+    const verification = await verifyStoredClosureCandidate(paths, binding);
+
+    const result = await prepareVerifiedStoredClosureCandidate(paths, verification, "0.19.0-beta.1");
+
+    expect(result.prepared.standalone).toEqual({
+      channel: binding.channel,
+      digest: binding.digest,
+      generation: 0,
+      namespace: binding.namespace,
+      protocolVersion: binding.protocolVersion,
+      target: binding.platform,
+      version: binding.version,
+    });
+    await expect(prepareVerifiedStoredClosureCandidate(paths, {
+      ...verification,
+      paths: { ...verification.paths, versionRoot: join(paths.stagingRoot, "candidate") },
+    }, "0.19.0-beta.1")).rejects.toThrow(/verified Closure paths/u);
+  });
+
+  it("replaces the prepared binding without changing launch history", async () => {
+    const paths = await createStore();
+    const first = await materializeCandidate(paths, "0.18.0-beta.1");
+    const second = await materializeCandidate(paths, "0.18.0-beta.2");
+
+    const firstCommit = await prepareStoredClosureCandidate(paths, first.binding, "0.19.0-beta.1");
+    const secondCommit = await prepareStoredClosureCandidate(paths, second.binding, "0.19.0-beta.2");
+
+    expect(firstCommit.prepared.standalone.generation).toBe(0);
+    expect(secondCommit.prepared.standalone.generation).toBe(1);
+    expect(secondCommit.descriptor.active).toBeNull();
+    expect(secondCommit.descriptor.lastSuccessful).toBeNull();
+  });
+
+  it("fails closed on transport fields or corrupt persisted state", async () => {
+    const paths = await createStore();
+    await mkdir(paths.stateRoot, { recursive: true });
+    await writeFile(paths.bindingPath, `${JSON.stringify({
+      channel: paths.channel,
+      active: null,
+      attempt: null,
+      activationAuthorized: false,
+      lastSuccessful: null,
+      namespace: paths.namespace,
+      nextGeneration: 0,
+      port: 7456,
+      prepared: null,
+      schemaVersion: 4,
+      updatedAt: new Date().toISOString(),
+    })}\n`);
+
+    await expect(readClosureBindingDescriptor(paths)).rejects.toThrow(/unsupported fields: port/u);
+
+    await writeFile(paths.bindingPath, "{not-json");
+    await expect(readClosureBindingDescriptor(paths)).rejects.toThrow(/unreadable/u);
+  });
+
+  it("keeps namespaces independent under one product root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-store-shared-"));
+    roots.push(root);
+    const left = resolveClosureStorePaths({ channel: "beta", namespace: "team-a", root });
+    const right = resolveClosureStorePaths({ channel: "beta", namespace: "team-b", root });
+    const leftCandidate = await materializeCandidate(left, "0.18.0-beta.1");
+    const rightCandidate = await materializeCandidate(right, "0.18.0-beta.2");
+
+    await prepareStoredClosureCandidate(left, leftCandidate.binding, "0.19.0-beta.1");
+    await prepareStoredClosureCandidate(right, rightCandidate.binding, "0.19.0-beta.2");
+
+    expect((await readClosureBindingDescriptor(left)).prepared?.standalone.version).toBe("0.18.0-beta.1");
+    expect((await readClosureBindingDescriptor(right)).prepared?.standalone.version).toBe("0.18.0-beta.2");
+    expect(await readFile(left.bindingPath, "utf8")).not.toContain("team-b");
+  });
+});
+

--- a/packages/closure/tests/update.test.ts
+++ b/packages/closure/tests/update.test.ts
@@ -1,0 +1,966 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CLOSURE_ARCHIVE_ENTRY_PATH,
+  CLOSURE_ARCHIVE_MEDIA_TYPE,
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_INVENTORY_SCHEMA_VERSION,
+  CLOSURE_PROTOCOL_VERSION,
+  CLOSURE_SCHEMA_VERSION,
+  createClosureComponentTreeDigest,
+  createClosureDistributionControl,
+  createClosureDistributionManifest,
+  type ClosureCandidateManifest,
+  type ClosureDistributionBlob,
+} from "@open-design/closure/protocol";
+import {
+  CLOSURE_BINDING_SCHEMA_VERSION,
+  readClosureBindingDescriptor,
+  resolveClosureStorePaths,
+  verifyStoredClosureCandidate,
+  type ClosureStorePaths,
+} from "@open-design/closure/store";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ClosureBindingDescriptor,
+  ClosureRuntimePointer,
+} from "@open-design/closure/store";
+
+import {
+  ClosureInstallerRequiredError,
+  ClosureUpdateError,
+  applyClosureDistributionUpdate,
+  applyClosureUpdate,
+  compareClosureShellVersions,
+  decideClosureUpdate,
+  discoverClosureDistributionReleaseCandidate,
+  discoverClosureReleaseCandidate,
+  ensureClosureDistributionBlob,
+  ensureClosureResource,
+  discoverClosureDistributionBootstrapCandidate,
+  discoverClosureDistributionVersionCandidate,
+  parseClosureImmutableMetadataVersion,
+  readClosureResourceRepositoryConfig,
+  resolveClosureImmutableMetadataVersion,
+  selectClosureDistributionReleaseCandidate,
+  selectClosureReleaseCandidate,
+  updateClosureFromRelease,
+  type ClosureReleaseCandidate,
+  type ClosureDistributionReleaseCandidate,
+} from "../src/update/index.js";
+
+const DIGEST = `sha256:${"a".repeat(64)}` as const;
+const OTHER_DIGEST = `sha256:${"b".repeat(64)}` as const;
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+function digest(bytes: string | Buffer): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+describe("Closure resource repository", () => {
+  it("loads and freezes source policy without accepting a version map", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-resource-config-"));
+    roots.push(root);
+    const configPath = join(root, "repository.json");
+    await writeFile(configPath, JSON.stringify({
+      localSeeds: [{ root: "seed" }],
+      remoteOrigins: ["https://mirror.example.test/open-design/"],
+      schemaVersion: 1,
+    }));
+    const config = await readClosureResourceRepositoryConfig({
+      OD_CLOSURE_RESOURCE_REPOSITORY_V1: configPath,
+    });
+    expect(config).toEqual({
+      localSeeds: [{ root: join(root, "seed") }],
+      remoteOrigins: ["https://mirror.example.test/open-design"],
+      schemaVersion: 1,
+    });
+    expect(Object.isFrozen(config)).toBe(true);
+    await writeFile(configPath, JSON.stringify({
+      localSeeds: [],
+      remoteOrigins: [],
+      schemaVersion: 1,
+      versions: {},
+    }));
+    await expect(readClosureResourceRepositoryConfig({
+      OD_CLOSURE_RESOURCE_REPOSITORY_V1: configPath,
+    })).rejects.toThrow(/unsupported fields/u);
+  });
+
+  it("prefers a valid local seed and falls through corrupt seed and remote mirror", async () => {
+    const paths = await createStore();
+    const validRoot = join(paths.root, "valid-seed");
+    const corruptRoot = join(paths.root, "corrupt-seed");
+    const bytes = Buffer.from("closure-resource-blob");
+    const artifact: ClosureDistributionBlob = {
+      digest: digest(bytes),
+      mediaType: "application/zip",
+      size: bytes.byteLength,
+      url: "https://default.example.test/beta/blobs/default",
+    };
+    const name = artifact.digest.slice("sha256:".length);
+    await mkdir(join(validRoot, "beta", "blobs"), { recursive: true });
+    await mkdir(join(corruptRoot, "beta", "blobs"), { recursive: true });
+    await writeFile(join(validRoot, "beta", "blobs", name), bytes);
+    await writeFile(join(corruptRoot, "beta", "blobs", name), "corrupt");
+    const fetch = vi.fn(async () => new Response("network must not run", { status: 500 })) as typeof globalThis.fetch;
+
+    await expect(ensureClosureDistributionBlob({
+      artifact,
+      fetch,
+      paths,
+      repository: {
+        localSeeds: [{ root: corruptRoot }, { root: validRoot }],
+        remoteOrigins: ["https://mirror.example.test"],
+        schemaVersion: 1,
+      },
+    })).resolves.toBe(join(paths.blobsRoot, name));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("materializes one isolated resource lazily and reuses title plus content across versions", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableDistribution();
+    const progress: string[] = [];
+    const first = await ensureClosureResource({
+      fetch: fixture.fetch,
+      id: "skills",
+      manifest: fixture.candidate.manifest,
+      onProgress: (entry) => progress.push(entry.phase),
+      paths,
+      target: "darwin-arm64",
+    });
+    expect(first).toMatchObject({ id: "skills", reused: false, title: "Skills" });
+    await expect(readFile(join(first.path, "skills", "SKILL.md"), "utf8")).resolves.toBe("# Skill\n");
+    expect(progress[0]).toBe("checking");
+    expect(progress).toEqual(expect.arrayContaining(["downloading", "materializing", "verifying"]));
+    expect(progress.at(-1)).toBe("ready");
+    const calls = vi.mocked(fixture.fetch).mock.calls.length;
+
+    const nextVersion = createClosureDistributionManifest({
+      ...fixture.candidate.manifest,
+      identity: {
+        channel: "beta",
+        protocolVersion: CLOSURE_PROTOCOL_VERSION,
+        version: "0.19.1-beta.0",
+      },
+      schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+    }, digest);
+    const second = await ensureClosureResource({
+      fetch: fixture.fetch,
+      id: "skills",
+      manifest: nextVersion,
+      paths,
+      target: "darwin-arm64",
+    });
+    expect(second).toEqual({ ...first, reused: true });
+    expect(vi.mocked(fixture.fetch).mock.calls).toHaveLength(calls);
+
+    await writeFile(join(first.path, "skills", "SKILL.md"), "corrupt\n");
+    const repaired = await ensureClosureResource({
+      fetch: fixture.fetch,
+      id: "skills",
+      manifest: nextVersion,
+      paths,
+      target: "darwin-arm64",
+    });
+    expect(repaired).toEqual({ ...first, reused: false });
+    await expect(readFile(join(first.path, "skills", "SKILL.md"), "utf8")).resolves.toBe("# Skill\n");
+    expect(await readdir(paths.garbageRoot)).toHaveLength(1);
+    expect(vi.mocked(fixture.fetch).mock.calls).toHaveLength(calls);
+
+    await expect(ensureClosureResource({
+      fetch: fixture.fetch,
+      id: "missing",
+      manifest: nextVersion,
+      paths,
+      target: "darwin-arm64",
+    })).rejects.toThrow(/not locked/u);
+  });
+});
+
+async function createStore(): Promise<ClosureStorePaths> {
+  const root = await mkdtemp(join(tmpdir(), "od-closure-update-"));
+  roots.push(root);
+  return resolveClosureStorePaths({ channel: "beta", namespace: "release-beta", root });
+}
+
+function metadata(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const version = "0.18.0-beta.4";
+  const archiveUrl = `https://releases.open-design.test/beta/closure/darwin-arm64/versions/${version}/closure.zip`;
+  return {
+    channel: "beta",
+    releaseState: "complete",
+    releaseTargets: {
+      mac_arm64: {
+        closure: {
+          assets: {
+            archive: { url: archiveUrl },
+            inventory: { url: `${archiveUrl}.inventory.json` },
+            manifest: { url: `${archiveUrl}.manifest.json` },
+            provenance: { url: `${archiveUrl}.provenance.json` },
+          },
+          manifest: {
+            artifact: {
+              digest: DIGEST,
+              entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+              inventoryDigest: OTHER_DIGEST,
+              mediaType: "application/vnd.open-design.closure.zip-v1",
+              size: 123,
+              url: archiveUrl,
+            },
+            compatibility: { shell: { electron: { version: { min: "0.16.2" } } } },
+            identity: {
+              channel: "beta",
+              digest: DIGEST,
+              platform: "darwin-arm64",
+              protocolVersion: 1,
+              version,
+            },
+            schemaVersion: 1,
+          },
+        },
+        enabled: true,
+        status: "published",
+      },
+    },
+    releaseVersion: version,
+    ...overrides,
+  };
+}
+
+function select(value: unknown = metadata()): ClosureReleaseCandidate {
+  return selectClosureReleaseCandidate(value, {
+    channel: "beta",
+    platform: "darwin-arm64",
+    releaseTarget: "mac_arm64",
+  });
+}
+
+function pointer(version: string, digest = DIGEST): ClosureRuntimePointer {
+  return {
+    channel: "beta",
+    digest,
+    generation: 0,
+    namespace: "release-beta",
+    protocolVersion: 1,
+    target: "darwin-arm64",
+    version,
+  };
+}
+
+function descriptor(
+  standalone: ClosureRuntimePointer | null,
+  releaseVersion = standalone?.version ?? "0.18.0-beta.0",
+): ClosureBindingDescriptor {
+  const active = standalone == null ? null : {
+    releaseVersion,
+    shell: {
+      digest: `sha256:${"f".repeat(64)}` as const,
+      type: "electron",
+      version: "0.19.0-beta.1",
+    },
+    standalone,
+  };
+  return {
+    active,
+    attempt: null,
+    activationIntent: null,
+    channel: "beta",
+    lastSuccessful: active,
+    namespace: "release-beta",
+    nextGeneration: standalone == null ? 0 : 1,
+    prepared: null,
+    schemaVersion: CLOSURE_BINDING_SCHEMA_VERSION,
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+async function downloadableCandidate(): Promise<{
+  archive: Buffer;
+  candidate: ClosureReleaseCandidate;
+  fetch: typeof globalThis.fetch;
+}> {
+  const runtimeBytes = "export const ready = true;\n";
+  const zip = new JSZip();
+  zip.file(CLOSURE_ARCHIVE_ENTRY_PATH, runtimeBytes);
+  const archive = await zip.generateAsync({ compression: "DEFLATE", type: "nodebuffer" });
+  const archiveDigest = digest(archive);
+  const version = "0.18.0-beta.4";
+  const baseUrl = `https://releases.open-design.test/beta/closure/darwin-arm64/versions/${version}`;
+  const inventory = {
+    files: [{
+      digest: digest(runtimeBytes),
+      path: CLOSURE_ARCHIVE_ENTRY_PATH,
+      size: Buffer.byteLength(runtimeBytes),
+    }],
+    schemaVersion: CLOSURE_INVENTORY_SCHEMA_VERSION,
+  };
+  const manifest: ClosureCandidateManifest = {
+    artifact: {
+      digest: archiveDigest,
+      entryPath: CLOSURE_ARCHIVE_ENTRY_PATH,
+      inventoryDigest: digest(JSON.stringify(inventory.files)),
+      mediaType: CLOSURE_ARCHIVE_MEDIA_TYPE,
+      size: archive.byteLength,
+      url: `${baseUrl}/closure.zip`,
+    },
+    compatibility: { shell: { electron: { version: { min: "0.16.2" } } } },
+    identity: {
+      channel: "beta",
+      digest: archiveDigest,
+      platform: "darwin-arm64",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      version,
+    },
+    schemaVersion: CLOSURE_SCHEMA_VERSION,
+  };
+  const candidate: ClosureReleaseCandidate = {
+    assets: {
+      archive: manifest.artifact.url,
+      inventory: `${baseUrl}/inventory.json`,
+      manifest: `${baseUrl}/manifest.json`,
+      provenance: null,
+    },
+    manifest,
+    releaseTarget: "mac_arm64",
+    releaseVersion: version,
+  };
+  const fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url === candidate.assets.manifest) {
+      return new Response(JSON.stringify(manifest), { status: 200 });
+    }
+    if (url === candidate.assets.inventory) {
+      return new Response(JSON.stringify(inventory), { status: 200 });
+    }
+    if (url === candidate.assets.archive) {
+      return new Response(archive, {
+        headers: { "content-length": String(archive.byteLength) },
+        status: 200,
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof globalThis.fetch;
+  return { archive, candidate, fetch };
+}
+
+async function downloadableDistribution(): Promise<{
+  candidate: ClosureDistributionReleaseCandidate;
+  fetch: typeof globalThis.fetch;
+  resourceUrl: string;
+}> {
+  const zip = async (...files: Array<readonly [string, string]>): Promise<Buffer> => {
+    const archive = new JSZip();
+    for (const [path, contents] of files) archive.file(path, contents, { date: new Date(0) });
+    return await archive.generateAsync({ compression: "DEFLATE", type: "nodebuffer" });
+  };
+  const launcherFiles = [
+    ["bootloader.mjs", "export const handoff = true;\n"],
+    ["launcher.mjs", "export const launcher = true;\n"],
+  ] as const;
+  const archives = {
+    body: await zip(["bootloader.mjs", "export const body = true;\n"]),
+    launcher: await zip(...launcherFiles),
+    native: await zip(["addon.node", "native\n"]),
+    resource: await zip(["skills/SKILL.md", "# Skill\n"]),
+  };
+  const artifact = (bytes: Buffer): ClosureDistributionBlob => {
+    const value = digest(bytes);
+    return {
+      digest: value,
+      mediaType: "application/zip",
+      size: bytes.byteLength,
+      url: `https://releases.open-design.test/beta/blobs/${value.slice("sha256:".length)}`,
+    };
+  };
+  const artifacts = Object.fromEntries(
+    Object.entries(archives).map(([name, bytes]) => [name, artifact(bytes)]),
+  ) as Record<keyof typeof archives, ClosureDistributionBlob>;
+  const tree = (path: string, contents: string) => createClosureComponentTreeDigest([{
+    digest: digest(contents),
+    path,
+    size: Buffer.byteLength(contents),
+  }], digest);
+  const trees = {
+    body: tree("bootloader.mjs", "export const body = true;\n"),
+    launcher: createClosureComponentTreeDigest(launcherFiles.map(([path, contents]) => ({
+      digest: digest(contents),
+      path,
+      size: Buffer.byteLength(contents),
+    })), digest),
+    native: tree("addon.node", "native\n"),
+    resource: tree("skills/SKILL.md", "# Skill\n"),
+  };
+  const manifest = createClosureDistributionManifest({
+    blobs: Object.fromEntries(Object.values(artifacts).map((value) => [value.digest, value])),
+    compatibility: { shell: { electron: { version: { min: "0.19.0" } } } },
+    identity: {
+      channel: "beta",
+      protocolVersion: CLOSURE_PROTOCOL_VERSION,
+      version: "0.19.0-beta.10",
+    },
+    required: {
+      body: { blob: artifacts.body.digest, entryPath: "bootloader.mjs", treeDigest: trees.body },
+      launcher: {
+        blob: artifacts.launcher.digest,
+        entryPath: "launcher.mjs",
+        handoffPath: "bootloader.mjs",
+        treeDigest: trees.launcher,
+      },
+      targets: {
+        "darwin-arm64": {
+          native: { blob: artifacts.native.digest, treeDigest: trees.native },
+        },
+      },
+    },
+    resources: [{
+      blob: artifacts.resource.digest,
+      id: "skills",
+      startup: "lazy",
+      title: "Skills",
+      treeDigest: trees.resource,
+    }],
+    schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  }, digest);
+  const bytesByUrl = new Map(Object.entries(archives).map(([name, bytes]) => [
+    artifacts[name as keyof typeof archives].url,
+    bytes,
+  ]));
+  const fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const bytes = bytesByUrl.get(url);
+    return bytes == null
+      ? new Response("not found", { status: 404 })
+      : new Response(bytes, {
+          headers: { "content-length": String(bytes.byteLength) },
+          status: 200,
+        });
+  }) as typeof globalThis.fetch;
+  return {
+    candidate: { manifest, releaseVersion: "0.19.0-beta.10", target: "darwin-arm64" },
+    fetch,
+    resourceUrl: artifacts.resource.url,
+  };
+}
+
+describe("Closure baseline discovery", () => {
+  it("projects first-install authority only from an immutable metadata URL", () => {
+    expect(parseClosureImmutableMetadataVersion(
+      "https://releases.example.test/beta/latest/metadata.json",
+    )).toBeNull();
+    expect(resolveClosureImmutableMetadataVersion(
+      "https://releases.example.test/beta/versions/0.19.4-beta.2/metadata.json",
+    )).toBe("0.19.4-beta.2");
+    expect(() => resolveClosureImmutableMetadataVersion(
+      "https://releases.example.test/beta/latest/metadata.json",
+    )).toThrow(/requires an immutable/u);
+  });
+
+  it("prefers the conventional local index before release discovery", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-bootstrap-index-"));
+    roots.push(root);
+    const seedRoot = join(root, "seed");
+    await mkdir(join(seedRoot, "beta"), { recursive: true });
+    const { candidate } = await downloadableDistribution();
+    await writeFile(join(seedRoot, "beta", "baseline.json"), JSON.stringify({
+      channel: "beta",
+      closure: candidate.manifest,
+      releaseState: "complete",
+      releaseVersion: candidate.releaseVersion,
+    }));
+    const fetch = vi.fn(async () => new Response("must not fetch", { status: 500 })) as typeof globalThis.fetch;
+    await expect(discoverClosureDistributionBootstrapCandidate({
+      channel: "beta",
+      fetch,
+      metadataUrl: "https://releases.example.test/beta/latest/metadata.json",
+      repository: { localSeeds: [{ root: seedRoot }], remoteOrigins: [], schemaVersion: 1 },
+      target: "darwin-arm64",
+    })).resolves.toMatchObject({ releaseVersion: candidate.releaseVersion });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts an already immutable exact-version metadata endpoint", async () => {
+    const fixture = await downloadableDistribution();
+    const metadataUrl = "https://releases.example.test/beta/versions/0.19.0-beta.10/metadata.json?cache=miss#ignored";
+    const fetch = vi.fn(async (input: string | URL | Request) => new Response(JSON.stringify({
+      channel: "beta",
+      closure: fixture.candidate.manifest,
+      releaseState: "complete",
+      releaseVersion: fixture.candidate.releaseVersion,
+    }), { status: 200 })) as typeof globalThis.fetch;
+
+    await expect(discoverClosureDistributionVersionCandidate({
+      channel: "beta",
+      fetch,
+      metadataUrl,
+      repository: { localSeeds: [], remoteOrigins: [], schemaVersion: 1 },
+      target: "darwin-arm64",
+      version: fixture.candidate.releaseVersion,
+    })).resolves.toMatchObject({ releaseVersion: fixture.candidate.releaseVersion });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://releases.example.test/beta/versions/0.19.0-beta.10/metadata.json",
+      expect.anything(),
+    );
+  });
+
+  it("rejects an immutable metadata endpoint for a different version", async () => {
+    const fetch = vi.fn() as typeof globalThis.fetch;
+    await expect(discoverClosureDistributionVersionCandidate({
+      channel: "beta",
+      fetch,
+      metadataUrl: "https://releases.example.test/beta/versions/0.19.0-beta.9/metadata.json",
+      repository: { localSeeds: [], remoteOrigins: [], schemaVersion: 1 },
+      target: "darwin-arm64",
+      version: "0.19.0-beta.10",
+    })).rejects.toThrow(/not exact version/u);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("Closure release update selection", () => {
+  it("selects the platform Closure independently from shell artifacts", () => {
+    const candidate = select();
+
+    expect(candidate.releaseTarget).toBe("mac_arm64");
+    expect(candidate.releaseVersion).toBe("0.18.0-beta.4");
+    expect(candidate.manifest.identity).toMatchObject({
+      channel: "beta",
+      platform: "darwin-arm64",
+      version: "0.18.0-beta.4",
+    });
+    expect(candidate.assets.archive).toBe(candidate.manifest.artifact.url);
+  });
+
+  it("selects a Closure version independently from the shell release version", () => {
+    const candidate = select(metadata({ releaseVersion: "0.18.0-beta.3" }));
+
+    expect(candidate.manifest.identity.version).toBe("0.18.0-beta.4");
+    expect(candidate.releaseVersion).toBe("0.18.0-beta.3");
+  });
+
+  it("discovers the Closure from the combined release metadata endpoint", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify(metadata()), { status: 200 })) as typeof globalThis.fetch;
+
+    const candidate = await discoverClosureReleaseCandidate({
+      channel: "beta",
+      fetch,
+      metadataUrl: "https://releases.open-design.test/beta/metadata.json",
+      platform: "darwin-arm64",
+      releaseTarget: "mac_arm64",
+    });
+
+    expect(candidate.releaseTarget).toBe("mac_arm64");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://releases.open-design.test/beta/metadata.json",
+      { headers: { accept: "application/json" } },
+    );
+  });
+
+  it("rejects incomplete, cross-channel, and cross-platform metadata", () => {
+    expect(() => select(metadata({ releaseState: "partial" }))).toThrow(/not complete/u);
+    expect(() => select(metadata({ channel: "preview" }))).toThrow(/does not match beta/u);
+    expect(() => selectClosureReleaseCandidate(metadata(), {
+      channel: "beta",
+      platform: "win32-x64",
+      releaseTarget: "mac_arm64",
+    })).toThrow(/does not match win32-x64/u);
+  });
+
+  it("uses shell compatibility and the independent active release binding", () => {
+    const candidate = select();
+
+    expect(decideClosureUpdate({
+      candidate,
+      descriptor: descriptor(null),
+      shellType: "electron",
+      shellVersion: "0.16.2",
+    })).toMatchObject({ action: "prepare", reason: "no-active-closure" });
+    expect(decideClosureUpdate({
+      candidate,
+      descriptor: descriptor(pointer("0.18.0-beta.3", OTHER_DIGEST)),
+      shellType: "electron",
+      shellVersion: "0.18.0-beta.4",
+    })).toMatchObject({ action: "prepare", reason: "newer-release-binding" });
+    expect(decideClosureUpdate({
+      candidate,
+      descriptor: descriptor(pointer("0.18.0-beta.5", OTHER_DIGEST)),
+      shellType: "electron",
+      shellVersion: "0.18.0-beta.4",
+    })).toMatchObject({ action: "retain", reason: "candidate-not-newer" });
+    expect(decideClosureUpdate({
+      candidate,
+      descriptor: descriptor(null),
+      shellType: "electron",
+      shellVersion: "0.16.1",
+    })).toMatchObject({ action: "retain", reason: "shell-incompatible" });
+  });
+
+  it("rejects equivocation within one release binding", () => {
+    const candidate = select();
+    expect(() => decideClosureUpdate({
+      candidate,
+      descriptor: descriptor(pointer("0.18.0-beta.4", OTHER_DIGEST)),
+      shellType: "electron",
+      shellVersion: "0.18.0-beta.4",
+    })).toThrowError(new ClosureUpdateError(
+      "Closure release 0.18.0-beta.4 has conflicting immutable bindings",
+    ));
+  });
+
+  it("compares release and prerelease shell versions deterministically", () => {
+    expect(compareClosureShellVersions("0.16.2", "0.16.2")).toBe(0);
+    expect(compareClosureShellVersions("0.18.0-beta.4", "0.16.2")).toBe(1);
+    expect(compareClosureShellVersions("0.18.0-beta.4", "0.18.0-beta.3")).toBe(1);
+    expect(compareClosureShellVersions("0.18.0-beta-internal.2", "0.18.0-beta-internal.1")).toBe(1);
+    expect(compareClosureShellVersions("0.18.0-beta.3", "0.18.0")).toBe(-1);
+  });
+});
+
+describe("version-wide Closure distribution selection", () => {
+  it("selects the sole root graph for the requested target", async () => {
+    const fixture = await downloadableDistribution();
+    const value = metadata({
+      closure: fixture.candidate.manifest,
+      releaseVersion: fixture.candidate.releaseVersion,
+    });
+
+    expect(selectClosureDistributionReleaseCandidate(value, {
+      channel: "beta",
+      target: "darwin-arm64",
+    })).toEqual(fixture.candidate);
+  });
+
+  it("uses absence as the only legacy fallback signal", async () => {
+    const fixture = await downloadableDistribution();
+    expect(selectClosureDistributionReleaseCandidate(metadata(), {
+      channel: "beta",
+      target: "darwin-arm64",
+    })).toBeNull();
+
+    const invalid = {
+      ...fixture.candidate.manifest,
+      identity: {
+        ...fixture.candidate.manifest.identity,
+        version: "0.19.0-beta.11",
+      },
+    };
+    expect(() => selectClosureDistributionReleaseCandidate(metadata({ closure: invalid }), {
+      channel: "beta",
+      target: "darwin-arm64",
+    })).toThrow(/distribution is invalid/u);
+    expect(() => selectClosureDistributionReleaseCandidate(metadata({
+      closure: fixture.candidate.manifest,
+    }), {
+      channel: "beta",
+      target: "win32-x64",
+    })).toThrow(/does not contain target win32-x64/u);
+  });
+
+  it("gates unsupported schemas and Shell versions before parsing the graph", async () => {
+    const fixture = await downloadableDistribution();
+    const control = createClosureDistributionControl(fixture.candidate.manifest);
+    const invalidGraph = { schemaVersion: 999 };
+    expect(() => selectClosureDistributionReleaseCandidate(metadata({
+      closure: invalidGraph,
+      closureControl: {
+        ...control,
+        distribution: { ...control.distribution, schemaVersion: 5 },
+      },
+      releaseVersion: fixture.candidate.releaseVersion,
+    }), {
+      channel: "beta",
+      consumer: { shellType: "electron", shellVersion: "0.19.1-beta.16" },
+      target: "darwin-arm64",
+    })).toThrow(ClosureInstallerRequiredError);
+
+    expect(() => selectClosureDistributionReleaseCandidate(metadata({
+      closure: invalidGraph,
+      closureControl: {
+        ...control,
+        shellCompatibility: { electron: { version: { min: "0.19.1-beta.17" } } },
+      },
+      releaseVersion: fixture.candidate.releaseVersion,
+    }), {
+      channel: "beta",
+      consumer: { shellType: "electron", shellVersion: "0.19.1-beta.16" },
+      target: "darwin-arm64",
+    })).toThrow(/requires electron Shell 0\.19\.1-beta\.17/u);
+  });
+
+  it("rejects a shallow control projection that drifts from the validated graph", async () => {
+    const fixture = await downloadableDistribution();
+    const control = createClosureDistributionControl(fixture.candidate.manifest);
+    expect(() => selectClosureDistributionReleaseCandidate(metadata({
+      closure: fixture.candidate.manifest,
+      closureControl: {
+        ...control,
+        distribution: { ...control.distribution, digest: OTHER_DIGEST },
+      },
+      releaseVersion: fixture.candidate.releaseVersion,
+    }), {
+      channel: "beta",
+      consumer: { shellType: "electron", shellVersion: "0.19.1-beta.16" },
+      target: "darwin-arm64",
+    })).toThrow(/control does not match/u);
+  });
+
+  it("discovers the root graph from the combined metadata endpoint", async () => {
+    const fixture = await downloadableDistribution();
+    const metadataUrl = "https://releases.open-design.test/beta/metadata.json";
+    const fetch = vi.fn(async () => new Response(JSON.stringify(metadata({
+      closure: fixture.candidate.manifest,
+      releaseVersion: fixture.candidate.releaseVersion,
+    })), { status: 200 })) as typeof globalThis.fetch;
+
+    await expect(discoverClosureDistributionReleaseCandidate({
+      channel: "beta",
+      fetch,
+      metadataUrl,
+      target: "darwin-arm64",
+    })).resolves.toEqual(fixture.candidate);
+    expect(fetch).toHaveBeenCalledWith(metadataUrl, { headers: { accept: "application/json" } });
+  });
+});
+
+describe("Closure release update application", () => {
+  it("downloads, verifies, and atomically prepares a candidate", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableCandidate();
+
+    const result = await applyClosureUpdate({
+      candidate: fixture.candidate,
+      fetch: fixture.fetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.16.2",
+    });
+
+    expect(result).toMatchObject({ reason: "no-active-closure", state: "prepared" });
+    const binding = await readClosureBindingDescriptor(paths);
+    expect(binding.prepared).toMatchObject({
+      releaseVersion: fixture.candidate.releaseVersion,
+      standalone: {
+        channel: fixture.candidate.manifest.identity.channel,
+        digest: fixture.candidate.manifest.identity.digest,
+        protocolVersion: fixture.candidate.manifest.identity.protocolVersion,
+        target: fixture.candidate.manifest.identity.platform,
+        version: fixture.candidate.manifest.identity.version,
+      },
+    });
+    const verified = await verifyStoredClosureCandidate(paths, {
+      ...fixture.candidate.manifest.identity,
+      namespace: paths.namespace,
+    });
+    expect(await readFile(verified.paths.archivePath)).toEqual(fixture.archive);
+
+    const fetchCount = vi.mocked(fixture.fetch).mock.calls.length;
+    const retained = await applyClosureUpdate({
+      candidate: fixture.candidate,
+      fetch: fixture.fetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.16.2",
+    });
+    expect(retained).toMatchObject({ reason: "already-prepared", state: "retained" });
+    expect(vi.mocked(fixture.fetch).mock.calls).toHaveLength(fetchCount);
+  });
+
+  it("does not mutate runtime state when the archive fails verification", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableCandidate();
+    const corruptFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === fixture.candidate.assets.archive) {
+        return new Response("corrupt archive", {
+          headers: { "content-length": "15" },
+          status: 200,
+        });
+      }
+      return await fixture.fetch(input, init);
+    }) as typeof globalThis.fetch;
+
+    await expect(applyClosureUpdate({
+      candidate: fixture.candidate,
+      fetch: corruptFetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.16.2",
+    })).rejects.toThrow(/checksum/u);
+
+    expect((await readClosureBindingDescriptor(paths)).prepared).toBeNull();
+  });
+
+  it("leaves an active updater lock untouched", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableCandidate();
+    const lockPath = join(paths.channelRoot, "maintenance.lock");
+    await mkdir(paths.stateRoot, { recursive: true });
+    await writeFile(lockPath, `${JSON.stringify({
+      createdAt: new Date().toISOString(),
+      pid: process.pid,
+      token: "live-updater",
+    })}\n`);
+
+    await expect(applyClosureUpdate({
+      candidate: fixture.candidate,
+      fetch: fixture.fetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.16.2",
+    })).resolves.toMatchObject({ reason: "another-updater-active", state: "busy" });
+    expect(await readFile(lockPath, "utf8")).toContain("live-updater");
+    expect(vi.mocked(fixture.fetch)).not.toHaveBeenCalled();
+  });
+});
+
+describe("layered Closure distribution application", () => {
+  it("discovers and prepares the root graph without consulting the legacy target", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableDistribution();
+    const metadataUrl = "https://releases.open-design.test/beta/metadata.json";
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === metadataUrl) {
+        return new Response(JSON.stringify({
+          channel: "beta",
+          closure: fixture.candidate.manifest,
+          releaseState: "complete",
+          releaseVersion: fixture.candidate.releaseVersion,
+        }), { status: 200 });
+      }
+      return await fixture.fetch(input, init);
+    }) as typeof globalThis.fetch;
+
+    const result = await updateClosureFromRelease({
+      channel: "beta",
+      fetch,
+      metadataUrl,
+      paths,
+      platform: "darwin-arm64",
+      releaseTarget: "missing-on-purpose",
+      shellType: "electron",
+      shellVersion: "0.19.0",
+    });
+
+    expect(result).toMatchObject({ reason: "no-active-closure", state: "prepared" });
+    expect((await readClosureBindingDescriptor(paths)).prepared?.standalone).toMatchObject({
+      digest: fixture.candidate.manifest.identity.digest,
+      target: "darwin-arm64",
+      version: "0.19.0-beta.10",
+    });
+  });
+
+  it("downloads only required blobs, extracts the fixed view, and reuses channel CAS", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableDistribution();
+    const progress: Array<Record<string, unknown>> = [];
+
+    const result = await applyClosureDistributionUpdate({
+      candidate: fixture.candidate,
+      fetch: fixture.fetch,
+      onProgress: (entry) => progress.push(entry),
+      paths,
+      shellType: "electron",
+      shellVersion: "0.19.0",
+    });
+
+    expect(result).toMatchObject({ reason: "no-active-closure", state: "prepared" });
+    if (result.state !== "prepared") throw new Error("distribution was not prepared");
+    const storeRoot = join(
+      paths.installationsRoot,
+      result.pointer.version,
+      result.pointer.digest.slice("sha256:".length),
+      result.pointer.target,
+    );
+    expect(await readFile(join(storeRoot, "body", "bootloader.mjs"), "utf8"))
+      .toContain("body = true");
+    expect(await readFile(join(storeRoot, "launcher", "launcher.mjs"), "utf8"))
+      .toContain("launcher = true");
+    expect(vi.mocked(fixture.fetch).mock.calls.map(([input]) => String(input)))
+      .not.toContain(fixture.resourceUrl);
+    expect(vi.mocked(fixture.fetch)).toHaveBeenCalledTimes(3);
+    const downloads = progress.filter((entry) => entry.phase === "download");
+    const materializations = progress.filter((entry) => entry.phase === "materialize");
+    expect(downloads.at(0)).toMatchObject({ completedBytes: 0, phase: "download" });
+    expect(downloads.at(-1)).toMatchObject({
+      completedBytes: downloads.at(-1)?.totalBytes,
+      phase: "download",
+    });
+    expect(materializations).toEqual([
+      { completedComponents: 0, phase: "materialize", totalComponents: 3 },
+      expect.objectContaining({ completedComponents: 1, totalComponents: 3 }),
+      expect.objectContaining({ completedComponents: 2, totalComponents: 3 }),
+      { completedComponents: 3, phase: "materialize", totalComponents: 3 },
+    ]);
+
+    const retained = await applyClosureDistributionUpdate({
+      candidate: fixture.candidate,
+      fetch: fixture.fetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.19.0",
+    });
+    expect(retained).toMatchObject({ reason: "already-prepared", state: "retained" });
+    expect(vi.mocked(fixture.fetch)).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps the binding empty when any required blob fails checksum", async () => {
+    const paths = await createStore();
+    const fixture = await downloadableDistribution();
+    const originalFetch = fixture.fetch;
+    const corruptFetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const call = vi.mocked(originalFetch).mock.calls.length;
+      if (call === 0) {
+        return new Response("corrupt", {
+          headers: { "content-length": "7" },
+          status: 200,
+        });
+      }
+      return await originalFetch(input, init);
+    }) as typeof globalThis.fetch;
+
+    await expect(applyClosureDistributionUpdate({
+      candidate: fixture.candidate,
+      fetch: corruptFetch,
+      paths,
+      shellType: "electron",
+      shellVersion: "0.19.0",
+    })).rejects.toThrow(/checksum/u);
+    expect((await readClosureBindingDescriptor(paths)).prepared).toBeNull();
+  });
+
+  it("lets independent namespaces converge on the same immutable channel CAS", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-closure-update-shared-cas-"));
+    roots.push(root);
+    const left = resolveClosureStorePaths({ channel: "beta", namespace: "team-a", root });
+    const right = resolveClosureStorePaths({ channel: "beta", namespace: "team-b", root });
+    const fixture = await downloadableDistribution();
+
+    const results = await Promise.all([left, right].map(async (paths) => (
+      await applyClosureDistributionUpdate({
+        candidate: fixture.candidate,
+        fetch: fixture.fetch,
+        paths,
+        shellType: "electron",
+        shellVersion: "0.19.0",
+      })
+    )));
+
+    expect(results.map((result) => result.state)).toEqual(["prepared", "prepared"]);
+    expect(left.blobsRoot).toBe(right.blobsRoot);
+    expect((await readClosureBindingDescriptor(left)).prepared?.standalone.namespace).toBe("team-a");
+    expect((await readClosureBindingDescriptor(right)).prepared?.standalone.namespace).toBe("team-b");
+  });
+});
+

--- a/packages/closure/tsconfig.json
+++ b/packages/closure/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}
+

--- a/packages/closure/tsconfig.tests.json
+++ b/packages/closure/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}
+

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -176,6 +176,27 @@ export function compareReleaseBaseVersions(left: ReleaseBaseVersionTuple, right:
   return 0;
 }
 
+export function compareReleaseVersions(
+  left: string,
+  right: string,
+  channel: ReleaseChannel,
+): number {
+  const parsedLeft = parseReleaseVersion(left, channel);
+  const parsedRight = parseReleaseVersion(right, channel);
+  const leftBase = parseReleaseBaseVersion(parsedLeft.baseVersion);
+  const rightBase = parseReleaseBaseVersion(parsedRight.baseVersion);
+  if (leftBase == null || rightBase == null) {
+    throw new Error(`release version base could not be compared: ${left} vs ${right}`);
+  }
+  const baseComparison = compareReleaseBaseVersions(leftBase, rightBase);
+  if (baseComparison !== 0) return baseComparison;
+  if (!("number" in parsedLeft) && !("number" in parsedRight)) return 0;
+  if (!("number" in parsedLeft) || !("number" in parsedRight)) {
+    throw new Error(`release channel mismatch while comparing ${left} and ${right}`);
+  }
+  return Math.sign(parsedLeft.number - parsedRight.number);
+}
+
 export function parseReleaseVersion(value: string, channel: ReleaseChannel): ParsedReleaseVersion {
   if (channel === "stable") {
     const parsed = parseStableReleaseVersion(value);

--- a/packages/release/tests/index.test.ts
+++ b/packages/release/tests/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatReleaseVersion,
   compareReleaseBaseVersions,
+  compareReleaseVersions,
   parseReleaseBaseVersion,
   parseReleaseVersion,
   releaseChannelDescriptor,
@@ -31,6 +32,13 @@ describe("@open-design/release", () => {
     expect(compareReleaseBaseVersions([1, 2, 4], [1, 2, 3])).toBe(1);
     expect(compareReleaseBaseVersions([1, 2, 3], [1, 2, 3])).toBe(0);
     expect(compareReleaseBaseVersions([1, 2, 3], [1, 3, 0])).toBe(-1);
+  });
+
+  it("orders complete release versions within one channel", () => {
+    expect(compareReleaseVersions("1.2.4-beta.1", "1.2.3-beta.99", "beta")).toBe(1);
+    expect(compareReleaseVersions("1.2.3-beta.10", "1.2.3-beta.9", "beta")).toBe(1);
+    expect(compareReleaseVersions("1.2.3-beta.9", "1.2.3-beta.9", "beta")).toBe(0);
+    expect(compareReleaseVersions("1.2.3", "1.2.4", "stable")).toBe(-1);
   });
 
   it("derives metadata fields from the channel descriptor", () => {

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -12,6 +12,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.mjs"
+    },
+    "./control": {
+      "types": "./dist/control/index.d.ts",
+      "default": "./dist/control/index.mjs"
+    },
+    "./lifecycle": {
+      "types": "./dist/lifecycle/index.d.ts",
+      "default": "./dist/lifecycle/index.mjs"
+    },
+    "./protocol": {
+      "types": "./dist/protocol.d.ts",
+      "default": "./dist/protocol.mjs"
     }
   },
   "scripts": {
@@ -19,9 +31,13 @@
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
+  "dependencies": {
+    "@open-design/release": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "24.12.2",
     "esbuild": "0.28.0",
+    "tsx": "4.22.3",
     "typescript": "6.0.3",
     "vitest": "4.1.6"
   },

--- a/packages/sidecar/src/control/body.ts
+++ b/packages/sidecar/src/control/body.ts
@@ -1,0 +1,175 @@
+import { readJsonFile, removeFile, writeJsonFile } from "../json-file.js";
+import { createJsonIpcServer } from "../json-ipc.js";
+import { SidecarControlError } from "./error.js";
+import {
+  privateControlPaths,
+  privateResponse,
+  readPrivateLaunchMetadata,
+  sameControlIdentity,
+  type PrivateControlRequest,
+  type PrivateControlResponse,
+  type PrivateLaunchMetadata,
+  type PrivateReadyDescriptor,
+} from "./private-protocol.js";
+import type {
+  AttachedSidecar,
+  AttachSidecarOptions,
+  SidecarControlContext,
+  SidecarMethodHandlers,
+  SidecarProbeResult,
+  SidecarStopResult,
+} from "./public-types.js";
+
+function requestFailure(
+  request: PrivateControlRequest,
+  metadata: PrivateLaunchMetadata,
+  code: "method-unavailable" | "peer-mismatch" | "request-failed",
+  message: string,
+): PrivateControlResponse {
+  return privateResponse(request, metadata, { error: { code, message }, status: "error" });
+}
+
+function normalizeIncomingRequest(value: unknown): PrivateControlRequest | null {
+  if (typeof value !== "object" || value == null) return null;
+  const request = value as Partial<PrivateControlRequest>;
+  if (
+    request.schemaVersion !== 1 ||
+    typeof request.requestId !== "string" ||
+    typeof request.incarnation !== "string" ||
+    typeof request.operation !== "object" ||
+    request.operation == null
+  ) {
+    return null;
+  }
+  return request as PrivateControlRequest;
+}
+
+export async function attachSidecar<TMethods>({
+  ...options
+}: AttachSidecarOptions<TMethods>): Promise<AttachedSidecar> {
+  return await attachSidecarWithMetadata(readPrivateLaunchMetadata(), options);
+}
+
+/** @internal Attach a caller-hosted semantic service to validated control metadata. */
+export async function attachSidecarWithMetadata<TMethods>(
+  metadata: PrivateLaunchMetadata,
+  {
+    handlers,
+    initialize,
+    onStopRequested,
+  }: AttachSidecarOptions<TMethods>,
+): Promise<AttachedSidecar> {
+  const context: SidecarControlContext = Object.freeze({
+    identity: metadata.identity,
+    projection: metadata.projection,
+    roots: metadata.roots,
+  });
+  let closing: Promise<void> | null = null;
+  let stopRequested = false;
+  let closeServerAndDescriptor: () => Promise<void> = async () => undefined;
+
+  try {
+    await initialize?.(context);
+  } catch (error) {
+    await Promise.resolve().then(() => onStopRequested?.()).catch(() => undefined);
+    throw error;
+  }
+
+  const server = await createJsonIpcServer({
+    socketPath: metadata.endpointPath,
+    async handler(value) {
+      const request = normalizeIncomingRequest(value);
+      if (request == null) {
+        throw new SidecarControlError("invalid-input", "invalid sidecar control request");
+      }
+      if (
+        !sameControlIdentity(request.identity, metadata.identity) ||
+        request.incarnation !== metadata.incarnation
+      ) {
+        return requestFailure(
+          request,
+          metadata,
+          "peer-mismatch",
+          "stale sidecar peer rejected by control fencing",
+        );
+      }
+
+      if (request.operation.kind === "probe") {
+        return privateResponse(request, metadata, {
+          result: {
+            identity: metadata.identity,
+            projection: metadata.projection,
+          } satisfies SidecarProbeResult,
+          status: "ok",
+        });
+      }
+
+      if (request.operation.kind === "request-stop") {
+        if (!stopRequested) {
+          stopRequested = true;
+          queueMicrotask(() => {
+            void Promise.resolve()
+              .then(() => onStopRequested?.())
+              .catch(() => undefined)
+              .finally(() => closeServerAndDescriptor());
+          });
+        }
+        return privateResponse(request, metadata, {
+          result: { accepted: true } satisfies SidecarStopResult,
+          status: "ok",
+        });
+      }
+
+      const method = request.operation.method as keyof TMethods;
+      const handler = (handlers as SidecarMethodHandlers<TMethods>)[method];
+      if (typeof handler !== "function") {
+        return requestFailure(
+          request,
+          metadata,
+          "method-unavailable",
+          `sidecar method is unavailable: ${request.operation.method}`,
+        );
+      }
+      try {
+        const result = await handler(request.operation.input as never, context);
+        return privateResponse(request, metadata, { result, status: "ok" });
+      } catch (error) {
+        return requestFailure(
+          request,
+          metadata,
+          "request-failed",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    },
+  }).catch(async (error: unknown) => {
+    await Promise.resolve().then(() => onStopRequested?.()).catch(() => undefined);
+    throw error;
+  });
+
+  const { descriptorPath } = privateControlPaths(metadata.identity, metadata.roots);
+  closeServerAndDescriptor = async () => {
+    if (closing != null) return await closing;
+    closing = (async () => {
+      await server.close();
+      const current = await readJsonFile<Partial<PrivateReadyDescriptor>>(descriptorPath);
+      if (current?.incarnation === metadata.incarnation) await removeFile(descriptorPath);
+    })();
+    return await closing;
+  };
+  try {
+    await writeJsonFile(descriptorPath, metadata);
+  } catch (error) {
+    await server.close();
+    await Promise.resolve().then(() => onStopRequested?.()).catch(() => undefined);
+    throw error;
+  }
+
+  return Object.freeze({
+    async close() {
+      await closeServerAndDescriptor();
+    },
+    context,
+  });
+}
+

--- a/packages/sidecar/src/control/controller.ts
+++ b/packages/sidecar/src/control/controller.ts
@@ -1,0 +1,330 @@
+import { spawn } from "node:child_process";
+import { watch, type FSWatcher } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { readJsonFile, removeFile } from "../json-file.js";
+import { isWindowsNamedPipePath } from "../ipc-path.js";
+import { requestJsonIpc } from "../json-ipc.js";
+import { SidecarControlError } from "./error.js";
+import { attachSidecarWithMetadata } from "./body.js";
+import {
+  assertPrivateResponse,
+  createPrivateLaunchEnv,
+  createPrivateLaunchMetadata,
+  createPrivateRequest,
+  normalizeControlIdentity,
+  normalizeControlRoots,
+  normalizeControlScope,
+  normalizeControlProjection,
+  normalizePrivateReadyDescriptor,
+  privateControlPaths,
+  sameControlIdentity,
+  sameControlProjection,
+  sameControlRoots,
+  type PrivateControlResponse,
+  type PrivateLaunchMetadata,
+  type PrivateReadyDescriptor,
+} from "./private-protocol.js";
+import type {
+  BootstrapControlPlaneOptions,
+  SidecarControlClient,
+  SidecarControlIdentity,
+  SidecarControlPlane,
+  SidecarExit,
+  SidecarExposeOptions,
+  SidecarLaunch,
+  SidecarLaunchOptions,
+  SidecarProbeResult,
+  SidecarStopResult,
+} from "./public-types.js";
+
+const SEMANTIC_CALL_TIMEOUT_MS = 600_000;
+
+function peerUnavailable(identity: SidecarControlIdentity): SidecarControlError {
+  return new SidecarControlError(
+    "peer-unavailable",
+    `sidecar peer is unavailable: ${identity.channel}/${identity.namespace}/${identity.generation}/${identity.service}`,
+  );
+}
+
+async function readCurrentDescriptor(
+  identity: SidecarControlIdentity,
+  roots: BootstrapControlPlaneOptions["roots"],
+  projection: BootstrapControlPlaneOptions["projection"],
+): Promise<PrivateReadyDescriptor> {
+  const { descriptorPath } = privateControlPaths(identity, roots);
+  const raw = await readJsonFile(descriptorPath);
+  if (raw == null) throw peerUnavailable(identity);
+  let descriptor: PrivateReadyDescriptor;
+  try {
+    descriptor = normalizePrivateReadyDescriptor(raw);
+  } catch (error) {
+    throw new SidecarControlError("peer-unavailable", "sidecar peer descriptor is invalid", {
+      cause: error,
+    });
+  }
+  if (
+    !sameControlIdentity(descriptor.identity, identity)
+    || !sameControlRoots(descriptor.roots, roots)
+    || !sameControlProjection(descriptor.projection, projection)
+  ) {
+    throw peerUnavailable(identity);
+  }
+  return descriptor;
+}
+
+function normalizeTimeout(value: number | undefined, fallback: number, label: string): number {
+  const timeout = value ?? fallback;
+  if (!Number.isSafeInteger(timeout) || timeout <= 0) {
+    throw new SidecarControlError("invalid-input", `${label} must be a positive safe integer`);
+  }
+  return timeout;
+}
+
+function childExit(child: ReturnType<typeof spawn>): Promise<SidecarExit> {
+  return new Promise<SidecarExit>((resolveExit, rejectExit) => {
+    child.once("error", rejectExit);
+    child.once("exit", (code, signal) => resolveExit({ code, signal }));
+  });
+}
+
+function createClient<TMethods>(descriptor: PrivateReadyDescriptor): SidecarControlClient<TMethods> {
+  const invoke = async (
+    operation: Parameters<typeof createPrivateRequest>[1],
+    timeoutMs?: number | null,
+  ): Promise<unknown> => {
+    const request = createPrivateRequest(descriptor, operation);
+    let response: PrivateControlResponse;
+    try {
+      response = await requestJsonIpc<PrivateControlResponse>(
+        descriptor.endpointPath,
+        request,
+        timeoutMs === undefined ? {} : { timeoutMs },
+      );
+    } catch (error) {
+      throw new SidecarControlError("peer-unavailable", "sidecar peer request failed", { cause: error });
+    }
+    return assertPrivateResponse(request, response);
+  };
+
+  return Object.freeze({
+    async call(method, input, options) {
+      const timeoutMs = options?.timeoutMs === undefined
+        ? SEMANTIC_CALL_TIMEOUT_MS
+        : options.timeoutMs;
+      return (await invoke({ kind: "call", input, method }, timeoutMs)) as never;
+    },
+    identity: descriptor.identity,
+    async probe() {
+      return (await invoke({ kind: "probe" })) as SidecarProbeResult;
+    },
+    async requestStop() {
+      return (await invoke({ kind: "request-stop" })) as SidecarStopResult;
+    },
+  });
+}
+
+async function convergeExitedLaunch(descriptor: PrivateLaunchMetadata): Promise<void> {
+  const { descriptorPath, endpointPath } = privateControlPaths(descriptor.identity, descriptor.roots);
+  const current = await readJsonFile<Partial<PrivateReadyDescriptor>>(descriptorPath);
+  if (current?.incarnation !== descriptor.incarnation) return;
+  if (!isWindowsNamedPipePath(endpointPath)) await removeFile(endpointPath);
+  await removeFile(descriptorPath);
+}
+
+async function waitForLaunchedClient<TMethods>(input: {
+  descriptor: PrivateLaunchMetadata;
+  exited: Promise<SidecarExit>;
+  timeoutMs: number;
+}): Promise<SidecarControlClient<TMethods>> {
+  const { descriptorPath } = privateControlPaths(input.descriptor.identity, input.descriptor.roots);
+  const descriptorRoot = dirname(descriptorPath);
+  await mkdir(descriptorRoot, { recursive: true });
+
+  return await new Promise<SidecarControlClient<TMethods>>((resolveReady, rejectReady) => {
+    let checking = false;
+    let checkAgain = false;
+    let poll: NodeJS.Timeout | null = null;
+    let settled = false;
+    let timeout: NodeJS.Timeout | null = null;
+    let watcher: FSWatcher | null = null;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeout != null) clearTimeout(timeout);
+      if (poll != null) clearInterval(poll);
+      watcher?.close();
+      callback();
+    };
+    const check = async () => {
+      if (settled) return;
+      if (checking) {
+        checkAgain = true;
+        return;
+      }
+      checking = true;
+      try {
+        const descriptor = await readCurrentDescriptor(
+          input.descriptor.identity,
+          input.descriptor.roots,
+          input.descriptor.projection,
+        );
+        if (descriptor.incarnation !== input.descriptor.incarnation) return;
+        const client = createClient<TMethods>(descriptor);
+        await client.probe();
+        settle(() => resolveReady(client));
+      } catch {
+        // Descriptor creation and socket readiness are separate writes. A later
+        // filesystem event, child exit, or the deadline gives the next signal.
+      } finally {
+        checking = false;
+        if (checkAgain && !settled) {
+          checkAgain = false;
+          void check();
+        }
+      }
+    };
+    watcher = watch(descriptorRoot, () => void check());
+    watcher.once("error", (error) => settle(() => rejectReady(error)));
+    // fs.watch can coalesce or drop a Windows directory event while an async
+    // descriptor probe is already in flight. The coalesced retry above closes
+    // that window; this bounded poll is the backstop for an event the OS never
+    // delivers at all. Both paths still require an exact fenced descriptor and
+    // a successful peer probe before readiness resolves.
+    poll = setInterval(() => void check(), 100);
+    timeout = setTimeout(() => {
+      settle(() =>
+        rejectReady(
+          new SidecarControlError(
+            "peer-unavailable",
+            `sidecar ${input.descriptor.identity.service} launch readiness timed out after ${input.timeoutMs}ms`,
+          ),
+        ),
+      );
+    }, input.timeoutMs);
+    void input.exited.then(
+      (exit) => {
+        settle(() =>
+          rejectReady(
+            new SidecarControlError(
+              "peer-unavailable",
+              `sidecar exited before readiness: code=${String(exit.code)} signal=${String(exit.signal)}`,
+            ),
+          ),
+        );
+      },
+      (error) => settle(() => rejectReady(error)),
+    );
+    void check();
+  });
+}
+
+async function awaitExitOrTerminate(input: {
+  child: ReturnType<typeof spawn>;
+  exited: Promise<SidecarExit>;
+  timeoutMs: number;
+}): Promise<SidecarExit> {
+  let timeout: NodeJS.Timeout | null = null;
+  try {
+    return await Promise.race([
+      input.exited,
+      new Promise<SidecarExit>((resolveExit) => {
+        timeout = setTimeout(() => {
+          input.child.kill("SIGKILL");
+          void input.exited.then(resolveExit);
+        }, input.timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
+  }
+}
+
+export function bootstrapControlPlane({
+  projection: projectionInput,
+  roots: rootsInput,
+  scope: scopeInput,
+}: BootstrapControlPlaneOptions): SidecarControlPlane {
+  const roots = normalizeControlRoots(rootsInput);
+  const projection = normalizeControlProjection(projectionInput);
+  const scope = normalizeControlScope(scopeInput);
+  const connect = async <TMethods>(service: string): Promise<SidecarControlClient<TMethods>> => {
+    const identity = normalizeControlIdentity({ ...scope, service });
+    const client = createClient<TMethods>(await readCurrentDescriptor(identity, roots, projection));
+    await client.probe();
+    return client;
+  };
+  const launch = async <TMethods>(options: SidecarLaunchOptions): Promise<SidecarLaunch<TMethods>> => {
+    if (typeof options.executable !== "string" || options.executable.length === 0) {
+      throw new SidecarControlError("invalid-input", "sidecar executable must be present");
+    }
+    const readyTimeoutMs = normalizeTimeout(options.readyTimeoutMs, 5_000, "readyTimeoutMs");
+    const stopTimeoutMs = normalizeTimeout(options.stopTimeoutMs, 1_500, "stopTimeoutMs");
+    const descriptor = createPrivateLaunchMetadata({
+      projection,
+      roots,
+      scope,
+      service: options.service,
+    });
+    const child = spawn(options.executable, [...(options.args ?? [])], {
+      cwd: options.cwd,
+      env: createPrivateLaunchEnv(descriptor, options.env),
+      stdio: options.output ?? "ignore",
+      // Sidecars are background services. Without this, a packaged Windows
+      // Shell that inherits stdio from the generation bootloader receives a
+      // visible conhost window for the lifetime of the daemon/web child.
+      windowsHide: true,
+    });
+    const exited = childExit(child).then(async (exit) => {
+      await convergeExitedLaunch(descriptor);
+      return exit;
+    });
+    let client: SidecarControlClient<TMethods>;
+    try {
+      client = await waitForLaunchedClient<TMethods>({ descriptor, exited, timeoutMs: readyTimeoutMs });
+    } catch (error) {
+      child.kill("SIGKILL");
+      await exited.catch(() => undefined);
+      throw error;
+    }
+    let stopping: Promise<SidecarExit> | null = null;
+    return Object.freeze({
+      client,
+      exited,
+      identity: descriptor.identity,
+      async stop() {
+        if (stopping != null) return await stopping;
+        stopping = (async () => {
+          await client.requestStop().catch(() => undefined);
+          return await awaitExitOrTerminate({ child, exited, timeoutMs: stopTimeoutMs });
+        })();
+        return await stopping;
+      },
+    });
+  };
+
+  return Object.freeze({
+    connect,
+    async expose<TMethods>(options: SidecarExposeOptions<TMethods>) {
+      const metadata = createPrivateLaunchMetadata({
+        projection,
+        roots,
+        scope,
+        service: options.service,
+      });
+      return await attachSidecarWithMetadata(metadata, options);
+    },
+    launch,
+    projection,
+    roots,
+    scope,
+    async probe(service) {
+      return await (await connect(service)).probe();
+    },
+    async requestStop(service) {
+      return await (await connect(service)).requestStop();
+    },
+  });
+}
+

--- a/packages/sidecar/src/control/error.ts
+++ b/packages/sidecar/src/control/error.ts
@@ -1,0 +1,17 @@
+export type SidecarControlErrorCode =
+  | "invalid-input"
+  | "method-unavailable"
+  | "peer-mismatch"
+  | "peer-unavailable"
+  | "request-failed";
+
+export class SidecarControlError extends Error {
+  readonly code: SidecarControlErrorCode;
+
+  constructor(code: SidecarControlErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SidecarControlError";
+    this.code = code;
+  }
+}
+

--- a/packages/sidecar/src/control/index.ts
+++ b/packages/sidecar/src/control/index.ts
@@ -1,0 +1,25 @@
+export { SidecarControlError } from "./error.js";
+export { attachSidecar } from "./body.js";
+export { bootstrapControlPlane } from "./controller.js";
+export type {
+  AttachedSidecar,
+  AttachSidecarOptions,
+  BootstrapControlPlaneOptions,
+  SidecarControlClient,
+  SidecarControlContext,
+  SidecarControlIdentity,
+  SidecarControlJsonValue,
+  SidecarControlPlane,
+  SidecarControlProjection,
+  SidecarControlRoots,
+  SidecarControlScope,
+  SidecarExit,
+  SidecarExposeOptions,
+  SidecarLaunch,
+  SidecarLaunchOptions,
+  SidecarMethod,
+  SidecarMethodHandlers,
+  SidecarProbeResult,
+  SidecarStopResult,
+} from "./public-types.js";
+

--- a/packages/sidecar/src/control/private-protocol.ts
+++ b/packages/sidecar/src/control/private-protocol.ts
@@ -1,0 +1,352 @@
+import { createHash, randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+import { SidecarControlError, type SidecarControlErrorCode } from "./error.js";
+import type {
+  SidecarControlIdentity,
+  SidecarControlJsonValue,
+  SidecarControlProjection,
+  SidecarControlRoots,
+  SidecarControlScope,
+} from "./public-types.js";
+
+const CONTROL_SCHEMA_VERSION = 1 as const;
+const CONTROL_BOOTSTRAP_ENV = "OD_SIDECAR_CONTROL_BOOTSTRAP_V1";
+const CONTROL_TOKEN = /^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/;
+
+export type PrivateLaunchMetadata = Readonly<{
+  endpointPath: string;
+  identity: SidecarControlIdentity;
+  incarnation: string;
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+  schemaVersion: typeof CONTROL_SCHEMA_VERSION;
+}>;
+
+export type PrivateControlOperation =
+  | Readonly<{ kind: "call"; input: unknown; method: string }>
+  | Readonly<{ kind: "probe" }>
+  | Readonly<{ kind: "request-stop" }>;
+
+export type PrivateControlRequest = Readonly<{
+  identity: SidecarControlIdentity;
+  incarnation: string;
+  operation: PrivateControlOperation;
+  requestId: string;
+  schemaVersion: typeof CONTROL_SCHEMA_VERSION;
+}>;
+
+export type PrivateControlResponse = Readonly<{
+  error?: Readonly<{ code: SidecarControlErrorCode; message: string }>;
+  identity: SidecarControlIdentity;
+  incarnation: string;
+  requestId: string;
+  result?: unknown;
+  schemaVersion: typeof CONTROL_SCHEMA_VERSION;
+  status: "error" | "ok";
+}>;
+
+export type PrivateReadyDescriptor = PrivateLaunchMetadata;
+
+function invalid(label: string, detail: string): never {
+  throw new SidecarControlError("invalid-input", `${label} ${detail}`);
+}
+
+function normalizeToken(value: unknown, label: string): string {
+  if (typeof value !== "string") invalid(label, "must be a string");
+  if (!CONTROL_TOKEN.test(value)) invalid(label, "must be a lowercase control token");
+  return value;
+}
+
+function normalizeRoot(value: unknown, label: string): string {
+  if (typeof value !== "string") invalid(label, "must be a string");
+  if (value.length === 0 || value.trim() !== value || value.includes("\0")) {
+    invalid(label, "must be a non-empty canonical path");
+  }
+  if (!isAbsolute(value)) invalid(label, "must be absolute");
+  return resolve(value);
+}
+
+export function normalizeControlScope(value: SidecarControlScope): SidecarControlScope {
+  if (!Number.isSafeInteger(value.generation) || value.generation < 0) {
+    invalid("sidecar generation", "must be a non-negative safe integer");
+  }
+  return Object.freeze({
+    channel: normalizeToken(value.channel, "sidecar channel"),
+    generation: value.generation,
+    namespace: normalizeToken(value.namespace, "sidecar namespace"),
+  });
+}
+
+export function normalizeControlIdentity(value: SidecarControlIdentity): SidecarControlIdentity {
+  return Object.freeze({
+    ...normalizeControlScope(value),
+    service: normalizeToken(value.service, "sidecar service"),
+  });
+}
+
+export function normalizeControlRoots(value: SidecarControlRoots): SidecarControlRoots {
+  return Object.freeze({
+    dataRoot: normalizeRoot(value.dataRoot, "sidecar dataRoot"),
+    resourceRoot: normalizeRoot(value.resourceRoot, "sidecar resourceRoot"),
+    runtimeRoot: normalizeRoot(value.runtimeRoot, "sidecar runtimeRoot"),
+  });
+}
+
+function normalizeJsonValue(value: unknown, label: string, seen = new Set<object>()): SidecarControlJsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) invalid(label, "must contain only finite JSON numbers");
+    return value;
+  }
+  if (typeof value !== "object") invalid(label, "must contain only JSON values");
+  if (seen.has(value)) invalid(label, "must not contain cycles");
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return Object.freeze(value.map((entry, index) =>
+        normalizeJsonValue(entry, `${label}[${index}]`, seen),
+      ));
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      invalid(label, "objects must be plain JSON records");
+    }
+    return Object.freeze(Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeJsonValue(entry, `${label}.${key}`, seen)]),
+    ));
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function canonicalJson(value: SidecarControlJsonValue): string {
+  return JSON.stringify(value);
+}
+
+export function normalizeControlProjection(value: SidecarControlProjection): SidecarControlProjection {
+  if (typeof value !== "object" || value == null) invalid("sidecar projection", "must be present");
+  const normalizedValue = normalizeJsonValue(value.value, "sidecar projection value");
+  if (typeof value.digest !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value.digest)) {
+    invalid("sidecar projection digest", "must be a lowercase sha256 digest");
+  }
+  const digest = `sha256:${createHash("sha256").update(canonicalJson(normalizedValue)).digest("hex")}` as const;
+  if (value.digest !== digest) invalid("sidecar projection digest", "does not match its value");
+  return Object.freeze({ digest, value: normalizedValue });
+}
+
+export function sameControlProjection(
+  left: SidecarControlProjection,
+  right: SidecarControlProjection,
+): boolean {
+  return left.digest === right.digest;
+}
+
+export function sameControlIdentity(
+  left: SidecarControlIdentity,
+  right: SidecarControlIdentity,
+): boolean {
+  return (
+    left.channel === right.channel &&
+    left.namespace === right.namespace &&
+    left.generation === right.generation &&
+    left.service === right.service
+  );
+}
+
+export function sameControlRoots(left: SidecarControlRoots, right: SidecarControlRoots): boolean {
+  return (
+    left.dataRoot === right.dataRoot &&
+    left.resourceRoot === right.resourceRoot &&
+    left.runtimeRoot === right.runtimeRoot
+  );
+}
+
+function controlKey(identity: SidecarControlIdentity, roots: SidecarControlRoots): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        identity.channel,
+        identity.namespace,
+        identity.generation,
+        identity.service,
+        roots.runtimeRoot,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function privateControlPaths(
+  identity: SidecarControlIdentity,
+  roots: SidecarControlRoots,
+): Readonly<{ descriptorPath: string; endpointPath: string }> {
+  const key = controlKey(identity, roots);
+  const controlRoot = join(roots.runtimeRoot, ".sidecar-control");
+  return {
+    descriptorPath: join(controlRoot, `${key}.json`),
+    endpointPath:
+      process.platform === "win32"
+        ? `\\\\.\\pipe\\open-design-sidecar-${key}`
+        : join(tmpdir(), `od-sidecar-${key}.sock`),
+  };
+}
+
+export function createPrivateLaunchMetadata(input: {
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+  scope: SidecarControlScope;
+  service: string;
+}): PrivateLaunchMetadata {
+  const roots = normalizeControlRoots(input.roots);
+  const identity = normalizeControlIdentity({
+    ...normalizeControlScope(input.scope),
+    service: input.service,
+  });
+  return Object.freeze({
+    endpointPath: privateControlPaths(identity, roots).endpointPath,
+    identity,
+    incarnation: randomUUID(),
+    projection: normalizeControlProjection(input.projection),
+    roots,
+    schemaVersion: CONTROL_SCHEMA_VERSION,
+  });
+}
+
+export function encodePrivateLaunchMetadata(metadata: PrivateLaunchMetadata): string {
+  return Buffer.from(JSON.stringify(metadata), "utf8").toString("base64url");
+}
+
+export function decodePrivateLaunchMetadata(value: unknown): PrivateLaunchMetadata {
+  if (typeof value !== "string" || value.length === 0) {
+    invalid("sidecar launch metadata", "is unavailable");
+  }
+  let parsed: Partial<PrivateLaunchMetadata>;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as Partial<PrivateLaunchMetadata>;
+  } catch (error) {
+    throw new SidecarControlError("invalid-input", "sidecar launch metadata is invalid", { cause: error });
+  }
+  if (parsed.schemaVersion !== CONTROL_SCHEMA_VERSION) {
+    invalid("sidecar launch metadata schemaVersion", "is unsupported");
+  }
+  if (typeof parsed.identity !== "object" || parsed.identity == null) {
+    invalid("sidecar launch identity", "must be present");
+  }
+  if (typeof parsed.roots !== "object" || parsed.roots == null) {
+    invalid("sidecar launch roots", "must be present");
+  }
+  if (typeof parsed.projection !== "object" || parsed.projection == null) {
+    invalid("sidecar launch projection", "must be present");
+  }
+  if (typeof parsed.incarnation !== "string" || parsed.incarnation.length === 0) {
+    invalid("sidecar launch incarnation", "must be present");
+  }
+  const identity = normalizeControlIdentity(parsed.identity as SidecarControlIdentity);
+  const projection = normalizeControlProjection(parsed.projection as SidecarControlProjection);
+  const roots = normalizeControlRoots(parsed.roots as SidecarControlRoots);
+  const expectedEndpoint = privateControlPaths(identity, roots).endpointPath;
+  if (parsed.endpointPath !== expectedEndpoint) {
+    invalid("sidecar launch endpoint", "does not match the normalized identity");
+  }
+  return Object.freeze({
+    endpointPath: expectedEndpoint,
+    identity,
+    incarnation: parsed.incarnation,
+    projection,
+    roots,
+    schemaVersion: CONTROL_SCHEMA_VERSION,
+  });
+}
+
+export function readPrivateLaunchMetadata(env: NodeJS.ProcessEnv = process.env): PrivateLaunchMetadata {
+  return decodePrivateLaunchMetadata(env[CONTROL_BOOTSTRAP_ENV]);
+}
+
+export function installPrivateLaunchMetadata(
+  metadata: PrivateLaunchMetadata,
+  env: NodeJS.ProcessEnv = process.env,
+): () => void {
+  const previous = env[CONTROL_BOOTSTRAP_ENV];
+  env[CONTROL_BOOTSTRAP_ENV] = encodePrivateLaunchMetadata(metadata);
+  return () => {
+    if (previous == null) delete env[CONTROL_BOOTSTRAP_ENV];
+    else env[CONTROL_BOOTSTRAP_ENV] = previous;
+  };
+}
+
+export function createPrivateLaunchEnv(
+  metadata: PrivateLaunchMetadata,
+  extraEnv: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...extraEnv,
+    [CONTROL_BOOTSTRAP_ENV]: encodePrivateLaunchMetadata(metadata),
+  };
+}
+
+export function createPrivateRequest(
+  metadata: PrivateReadyDescriptor,
+  operation: PrivateControlOperation,
+): PrivateControlRequest {
+  return {
+    identity: metadata.identity,
+    incarnation: metadata.incarnation,
+    operation,
+    requestId: randomUUID(),
+    schemaVersion: CONTROL_SCHEMA_VERSION,
+  };
+}
+
+export function privateResponse(
+  request: PrivateControlRequest,
+  metadata: PrivateLaunchMetadata,
+  value:
+    | Readonly<{ error: Readonly<{ code: SidecarControlErrorCode; message: string }>; status: "error" }>
+    | Readonly<{ result: unknown; status: "ok" }>,
+): PrivateControlResponse {
+  return {
+    ...value,
+    identity: metadata.identity,
+    incarnation: metadata.incarnation,
+    requestId: request.requestId,
+    schemaVersion: CONTROL_SCHEMA_VERSION,
+  };
+}
+
+export function normalizePrivateReadyDescriptor(value: unknown): PrivateReadyDescriptor {
+  const descriptor = decodePrivateLaunchMetadata(
+    typeof value === "object" && value != null
+      ? Buffer.from(JSON.stringify(value), "utf8").toString("base64url")
+      : value,
+  );
+  return descriptor;
+}
+
+export function assertPrivateResponse(
+  request: PrivateControlRequest,
+  response: PrivateControlResponse,
+): unknown {
+  if (
+    typeof response !== "object" ||
+    response == null ||
+    response.schemaVersion !== CONTROL_SCHEMA_VERSION ||
+    response.requestId !== request.requestId ||
+    !sameControlIdentity(response.identity, request.identity) ||
+    response.incarnation !== request.incarnation
+  ) {
+    throw new SidecarControlError("peer-mismatch", "stale sidecar peer rejected by control fencing");
+  }
+  if (response.status === "error") {
+    throw new SidecarControlError(
+      response.error?.code ?? "request-failed",
+      response.error?.message ?? "sidecar control request failed",
+    );
+  }
+  return response.result;
+}
+

--- a/packages/sidecar/src/control/private-testing.ts
+++ b/packages/sidecar/src/control/private-testing.ts
@@ -1,0 +1,69 @@
+import { access } from "node:fs/promises";
+
+import { isWindowsNamedPipePath } from "../ipc-path.js";
+import {
+  createPrivateRequest,
+  createPrivateLaunchMetadata,
+  installPrivateLaunchMetadata,
+  privateControlPaths,
+  type PrivateLaunchMetadata,
+  type PrivateControlOperation,
+  type PrivateControlResponse,
+} from "./private-protocol.js";
+import { requestJsonIpc } from "../json-ipc.js";
+import type {
+  SidecarControlIdentity,
+  SidecarControlProjection,
+  SidecarControlRoots,
+  SidecarControlScope,
+} from "./public-types.js";
+
+export function createPrivateLaunchForTest(input: {
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+  scope: SidecarControlScope;
+  service: string;
+}): PrivateLaunchMetadata {
+  return createPrivateLaunchMetadata(input);
+}
+
+export function installPrivateLaunchForTest(metadata: PrivateLaunchMetadata): () => void {
+  return installPrivateLaunchMetadata(metadata);
+}
+
+export async function sendPrivateRequestForTest(
+  metadata: PrivateLaunchMetadata,
+  input: {
+    identity?: SidecarControlIdentity;
+    operation: PrivateControlOperation;
+  },
+): Promise<PrivateControlResponse> {
+  const request = {
+    ...createPrivateRequest(metadata, input.operation),
+    identity: input.identity ?? metadata.identity,
+  };
+  return await requestJsonIpc<PrivateControlResponse>(metadata.endpointPath, request);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function privateLaunchStateForTest(metadata: PrivateLaunchMetadata): Promise<{
+  descriptorExists: boolean;
+  endpointExists: boolean;
+}> {
+  const paths = privateControlPaths(metadata.identity, metadata.roots);
+  return {
+    descriptorExists: await pathExists(paths.descriptorPath),
+    endpointExists: isWindowsNamedPipePath(paths.endpointPath)
+      ? false
+      : await pathExists(paths.endpointPath),
+  };
+}
+

--- a/packages/sidecar/src/control/public-types.ts
+++ b/packages/sidecar/src/control/public-types.ts
@@ -1,0 +1,151 @@
+export type SidecarControlScope = Readonly<{
+  channel: string;
+  generation: number;
+  namespace: string;
+}>;
+
+export type SidecarControlIdentity = SidecarControlScope &
+  Readonly<{
+    service: string;
+  }>;
+
+export type SidecarControlRoots = Readonly<{
+  dataRoot: string;
+  resourceRoot: string;
+  runtimeRoot: string;
+}>;
+
+export type SidecarControlJsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | readonly SidecarControlJsonValue[]
+  | Readonly<{ [key: string]: SidecarControlJsonValue }>;
+
+/**
+ * Caller-owned, immutable truth projected through the control plane. Sidecar
+ * validates and fences the digest but never interprets the value.
+ */
+export type SidecarControlProjection = Readonly<{
+  digest: `sha256:${string}`;
+  value: SidecarControlJsonValue;
+}>;
+
+export type SidecarControlContext = Readonly<{
+  identity: SidecarControlIdentity;
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+}>;
+
+export type SidecarMethod<Input, Output> = Readonly<{
+  input: Input;
+  output: Output;
+}>;
+
+type MethodInput<TMethods, TMethod extends keyof TMethods> = TMethods[TMethod] extends SidecarMethod<
+  infer Input,
+  unknown
+>
+  ? Input
+  : never;
+
+type MethodOutput<TMethods, TMethod extends keyof TMethods> = TMethods[TMethod] extends SidecarMethod<
+  unknown,
+  infer Output
+>
+  ? Output
+  : never;
+
+export type SidecarMethodHandlers<TMethods> = {
+  [TMethod in keyof TMethods]: (
+    input: MethodInput<TMethods, TMethod>,
+    context: SidecarControlContext,
+  ) => MethodOutput<TMethods, TMethod> | Promise<MethodOutput<TMethods, TMethod>>;
+};
+
+export type SidecarProbeResult = Readonly<{
+  identity: SidecarControlIdentity;
+  projection: SidecarControlProjection;
+}>;
+
+export type SidecarStopResult = Readonly<{
+  accepted: true;
+}>;
+
+export type SidecarCallOptions = Readonly<{
+  /** `null` is reserved for lifecycle calls whose response is the terminal event itself. */
+  timeoutMs?: number | null;
+}>;
+
+export type SidecarControlClient<TMethods> = Readonly<{
+  identity: SidecarControlIdentity;
+  call<TMethod extends Extract<keyof TMethods, string>>(
+    method: TMethod,
+    input: MethodInput<TMethods, TMethod>,
+    options?: SidecarCallOptions,
+  ): Promise<MethodOutput<TMethods, TMethod>>;
+  probe(): Promise<SidecarProbeResult>;
+  requestStop(): Promise<SidecarStopResult>;
+}>;
+
+export type SidecarControlPlane = Readonly<{
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+  scope: SidecarControlScope;
+  connect<TMethods>(service: string): Promise<SidecarControlClient<TMethods>>;
+  expose<TMethods>(options: SidecarExposeOptions<TMethods>): Promise<AttachedSidecar>;
+  launch<TMethods>(options: SidecarLaunchOptions): Promise<SidecarLaunch<TMethods>>;
+  probe(service: string): Promise<SidecarProbeResult>;
+  requestStop(service: string): Promise<SidecarStopResult>;
+}>;
+
+export type SidecarExposeOptions<TMethods> = AttachSidecarOptions<TMethods> & Readonly<{
+  service: string;
+}>;
+
+export type SidecarLaunchOptions = Readonly<{
+  args?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  executable: string;
+  output?: "ignore" | "inherit";
+  readyTimeoutMs?: number;
+  service: string;
+  stopTimeoutMs?: number;
+}>;
+
+export type SidecarExit = Readonly<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}>;
+
+export type SidecarLaunch<TMethods> = Readonly<{
+  client: SidecarControlClient<TMethods>;
+  exited: Promise<SidecarExit>;
+  identity: SidecarControlIdentity;
+  stop(): Promise<SidecarExit>;
+}>;
+
+export type AttachSidecarOptions<TMethods> = Readonly<{
+  handlers: SidecarMethodHandlers<TMethods>;
+  /**
+   * Complete body-owned startup after the package has decoded and validated
+   * caller identity/roots, but before the ready descriptor becomes visible.
+   * This is the only bootstrap seam a real Web/daemon body needs.
+   */
+  initialize?: (context: SidecarControlContext) => void | Promise<void>;
+  onStopRequested?: () => void | Promise<void>;
+}>;
+
+export type AttachedSidecar = Readonly<{
+  context: SidecarControlContext;
+  close(): Promise<void>;
+}>;
+
+export type BootstrapControlPlaneOptions = Readonly<{
+  projection: SidecarControlProjection;
+  roots: SidecarControlRoots;
+  scope: SidecarControlScope;
+}>;
+

--- a/packages/sidecar/src/desktop-protocol.ts
+++ b/packages/sidecar/src/desktop-protocol.ts
@@ -1,0 +1,489 @@
+import { RELEASE_CHANNELS, type ReleaseChannel } from "@open-design/release";
+
+type StandaloneRuntimeStatusSnapshot = Readonly<{
+  state: "failed" | "running" | "stopped";
+  [field: string]: unknown;
+}>;
+
+export const SIDECAR_MESSAGES = Object.freeze({
+  CLICK: "click",
+  CONSOLE: "console",
+  EVAL: "eval",
+  EXPORT_ARTIFACT: "export-artifact",
+  EXPORT_PDF: "export-pdf",
+  MINT_IMPORT_TOKEN: "mint-import-token",
+  REGISTER_DESKTOP_AUTH: "register-desktop-auth",
+  REGISTER_WEB_URL: "register-web-url",
+  RENDER_SLIDES: "render-slides",
+  SCREENSHOT: "screenshot",
+  SHUTDOWN: "shutdown",
+  SHOW: "show",
+  STATUS: "status",
+  UPDATE: "update",
+} as const);
+
+export const DESKTOP_UPDATE_ACTIONS = Object.freeze({
+  CHECK: "check",
+  CLEAR_CACHE: "clear-cache",
+  DOWNLOAD: "download",
+  INSTALL: "install",
+  STATUS: "status",
+} as const);
+
+export type DesktopUpdateAction = (typeof DESKTOP_UPDATE_ACTIONS)[keyof typeof DESKTOP_UPDATE_ACTIONS];
+
+export const DESKTOP_UPDATE_MODES = Object.freeze({
+  JS_INCREMENTAL: "js-incremental",
+  PACKAGE_LAUNCHER: "package-launcher",
+} as const);
+
+export type DesktopUpdateMode = (typeof DESKTOP_UPDATE_MODES)[keyof typeof DESKTOP_UPDATE_MODES];
+
+export const DESKTOP_UPDATE_CHANNELS = Object.freeze({
+  BETA: RELEASE_CHANNELS.BETA,
+  PRERELEASE: RELEASE_CHANNELS.PRERELEASE,
+  STABLE: RELEASE_CHANNELS.STABLE,
+} as const);
+
+export type DesktopUpdateChannel = ReleaseChannel;
+
+export const DESKTOP_UPDATE_STATES = Object.freeze({
+  AVAILABLE: "available",
+  CHECKING: "checking",
+  DOWNLOADED: "downloaded",
+  DOWNLOADING: "downloading",
+  ERROR: "error",
+  IDLE: "idle",
+  INSTALLING: "installing",
+  NOT_AVAILABLE: "not-available",
+  UNSUPPORTED: "unsupported",
+} as const);
+
+export type DesktopUpdateState = (typeof DESKTOP_UPDATE_STATES)[keyof typeof DESKTOP_UPDATE_STATES];
+export type DesktopRuntimeState = "idle" | "running" | "unknown";
+
+export type DesktopStatusSnapshot = {
+  pid?: number | null;
+  standalone?: StandaloneRuntimeStatusSnapshot;
+  standaloneStatusError?: string;
+  state: DesktopRuntimeState;
+  title?: string | null;
+  update?: DesktopUpdateStatusSnapshot;
+  updateStatusError?: string;
+  updatedAt?: string;
+  url?: string | null;
+  windowVisible?: boolean;
+};
+
+export type DesktopEvalInput = {
+  expression: string;
+};
+
+export type DesktopEvalResult = {
+  error?: string;
+  ok: boolean;
+  value?: unknown;
+};
+
+export type DesktopScreenshotInput = {
+  path: string;
+};
+
+export type DesktopScreenshotResult = {
+  path: string;
+};
+
+export type DesktopConsoleEntry = {
+  level: string;
+  text: string;
+  timestamp: string;
+};
+
+export type DesktopConsoleResult = {
+  entries: DesktopConsoleEntry[];
+};
+
+export type DesktopClickInput = {
+  selector: string;
+};
+
+export type DesktopClickResult = {
+  clicked: boolean;
+  found: boolean;
+};
+
+export type DesktopExportPdfInput = {
+  baseHref?: string;
+  deck: boolean;
+  defaultFilename: string;
+  html: string;
+  title: string;
+};
+
+export type DesktopExportPdfResult = {
+  canceled?: boolean;
+  error?: string;
+  ok: boolean;
+  path?: string;
+};
+
+// Renders an HTML deck (every `<section class="slide">`) to one pixel-perfect
+// PNG per slide using the desktop's Electron Chromium, so screenshot-based
+// PPTX/PDF export reuses the already-bundled browser instead of shipping a
+// second headless engine. `slides` are `data:image/png;base64,...` URLs in
+// slide order; `width`/`height` are the captured pixel dimensions.
+export type DesktopRenderSlidesInput = {
+  baseHref?: string;
+  html: string;
+  // Explicit page-vs-deck signal from the caller (the web side knows whether the
+  // artifact is a deck). `true` forces deck slide capture, `false` forces a
+  // single full-page capture even if the page happens to contain `.slide`
+  // elements (carousels, testimonials). When omitted, the renderer falls back to
+  // the `.slide`-count heuristic.
+  deck?: boolean;
+  // When true, produce an editable .pptx (native PowerPoint shapes/text via the
+  // vendored dom-to-pptx engine) instead of screenshot images. Writes one .pptx
+  // into `outputDir` and returns `pptxFile`.
+  editable?: boolean;
+  // When set, render only the slide at this index (deck mode) — used by image
+  // export to capture the single slide the user is viewing.
+  index?: number;
+  // Encoding for the full-document `page` mode: `jpeg` (small, for PDF) or `png`
+  // (lossless source, for image export). Deck slides are always PNG. Default png.
+  pageImageFormat?: "png" | "jpeg";
+  // Deck only: render every slide and stitch them top-to-bottom into a single
+  // tall image (used by image export of a deck). Ignored for ordinary pages.
+  stitch?: boolean;
+  // Page mode only: split an ordinary (non-deck) page into one image PER
+  // VIEWPORT, top to bottom, instead of a single full-page capture — used by
+  // the PDF path so a long scrolling page becomes a multi-page PDF (one screen
+  // per page). Ignored in deck mode (decks already paginate per slide).
+  paginate?: boolean;
+  // Optional requested render viewport/stage size in CSS px. Omitted dimensions
+  // fall back to renderer defaults.
+  width?: number;
+  height?: number;
+  // When set, the renderer writes each rendered image to a file inside this
+  // directory and returns the file paths in `slideFiles` instead of base64
+  // data URLs in `slides`. The daemon (which owns the data root) creates and
+  // owns this directory and reads/deletes the files afterwards — this avoids
+  // pushing tens of MB of base64 through the JSON IPC channel for large images.
+  // desktop only writes to the absolute path it is given; it never derives it.
+  outputDir?: string;
+};
+
+// `mode` reports what the renderer found: `deck` = one PNG per 1920x1080 slide;
+// `page` = a single full-document PNG at natural size (the artifact has no
+// `.slide` sections, e.g. an ordinary website).
+// When the request set `outputDir`, the images are returned as absolute file
+// paths in `slideFiles` (binary on disk, no base64); otherwise as base64 data
+// URLs in `slides`.
+export type DesktopRenderSlidesErrorCode =
+  | "NO_SLIDES"
+  | "PAGE_TOO_TALL"
+  | "RENDER_FAILED"
+  | "SLIDE_INDEX_OUT_OF_RANGE";
+
+export type DesktopRenderSlidesResult = {
+  error?: string;
+  errorCode?: DesktopRenderSlidesErrorCode;
+  height?: number;
+  mode?: "deck" | "page";
+  ok: boolean;
+  // Absolute path to the written editable .pptx (set when the request was
+  // `editable` with an `outputDir`).
+  pptxFile?: string;
+  slideFiles?: string[];
+  slides?: string[];
+  width?: number;
+};
+
+export type DesktopExportArtifactFormat = "pdf" | "image";
+// Electron's `nativeImage` (the off-screen renderer the programmatic exporter
+// uses) can only encode PNG and JPEG. WebP is deliberately excluded so a caller
+// asking for it gets a clear validation error instead of a silent PNG downgrade.
+// (The in-app web Download menu encodes WebP client-side via canvas.toBlob and
+// is unaffected by this list.)
+export type DesktopExportArtifactImageFormat = "png" | "jpeg";
+
+// Generic programmatic export (PDF / image). The desktop renderer writes
+// the result to a temporary file and returns its path; the daemon streams those
+// bytes to the HTTP caller (the `od export` CLI), then removes the temp file.
+export type DesktopExportArtifactInput = {
+  baseHref?: string;
+  deck: boolean;
+  format: DesktopExportArtifactFormat;
+  html: string;
+  imageFormat?: DesktopExportArtifactImageFormat;
+  title: string;
+  width?: number;
+  height?: number;
+};
+
+export type DesktopExportArtifactResult = {
+  bytes?: number;
+  error?: string;
+  mime?: string;
+  ok: boolean;
+  path?: string;
+};
+
+export type DesktopUpdateCapabilitySet = {
+  canApplyInPlace: boolean;
+  canDownload: boolean;
+  canOpenInstaller: boolean;
+  requiresManualInstall: boolean;
+};
+
+export type DesktopUpdatePathSnapshot = {
+  downloadRoot?: string;
+  launcherRoot?: string;
+  launcherRuntimePath?: string;
+  manifestPath?: string;
+};
+
+export type DesktopUpdateChecksumSnapshot = {
+  algorithm: "sha256" | "sha512";
+  url?: string;
+  value?: string;
+};
+
+export type DesktopUpdateArtifactSnapshot = {
+  name?: string;
+  platformKey?: string;
+  size?: number;
+  type?: string;
+  url: string;
+};
+
+export type DesktopUpdateProgressSnapshot = {
+  receivedBytes: number;
+  totalBytes?: number;
+};
+
+export type DesktopUpdateErrorSnapshot = {
+  code: string;
+  details?: unknown;
+  message: string;
+};
+
+export type DesktopUpdateInstallResult = {
+  activeVersion?: string;
+  artifactPath?: string;
+  dryRun?: boolean;
+  helperLogPath?: string;
+  launcherRuntimePath?: string;
+  launchPath?: string;
+  openedAt: string;
+  path: string;
+};
+
+export type DesktopUpdateReleaseSnapshot = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  checksum: DesktopUpdateChecksumSnapshot;
+  channel: DesktopUpdateChannel;
+  downloadedAt: string;
+  key: string;
+  metadata?: Record<string, unknown>;
+  path: string;
+  platformKey: string;
+  version: string;
+};
+
+export type DesktopUpdateIncomingSnapshot = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  channel: DesktopUpdateChannel;
+  key?: string;
+  metadata?: Record<string, unknown>;
+  progress?: DesktopUpdateProgressSnapshot;
+  startedAt: string;
+  version: string;
+};
+
+export type DesktopUpdateCacheLifecycleTrigger = "cold-start" | "manual" | "next-version-ready";
+
+export type DesktopUpdateReleaseLifecycleState =
+  | "cleanup-deferred"
+  | "cleanup-removed"
+  | "deprecated"
+  | "retained"
+  | "unknown";
+
+export type DesktopUpdateCacheLifecycleSummary = {
+  lastRunAt?: string;
+  lastTrigger?: DesktopUpdateCacheLifecycleTrigger;
+  platform: string;
+  releases: {
+    cleanupDeferred: number;
+    cleanupRemoved: number;
+    deprecated: number;
+    errors: number;
+    retained: number;
+    total: number;
+    unknown: number;
+  };
+};
+
+export type DesktopUpdateCacheSnapshot = {
+  lifecycle?: DesktopUpdateCacheLifecycleSummary;
+};
+
+export const DESKTOP_UPDATE_REINSTALL_REASONS = Object.freeze({
+  LAUNCHER_SCHEMA: "launcher-schema",
+  OUTER_BELOW_MIN: "outer-below-min",
+  OUTER_VERSION_UNREADABLE: "outer-version-unreadable",
+} as const);
+
+export type DesktopUpdateReinstallReason =
+  (typeof DESKTOP_UPDATE_REINSTALL_REASONS)[keyof typeof DESKTOP_UPDATE_REINSTALL_REASONS];
+
+/**
+ * Present on a status snapshot when the release feed requires a full installer
+ * reinstall instead of an in-place payload update. `installedVersion` is the
+ * physically installed outer package version (not the running payload version);
+ * it is omitted when the outer bundle config could not be read. `url` is an
+ * optional operator-supplied explanation link from
+ * `control.shell.installation.version.url`.
+ */
+export type DesktopUpdateReinstallSnapshot = {
+  installedVersion?: string;
+  minVersion?: string;
+  reason: DesktopUpdateReinstallReason;
+  url?: string;
+};
+
+export type DesktopStandaloneUpdateSnapshot = {
+  activationSource: "silent-policy" | "user-restart" | null;
+  releaseVersion: string;
+  state: "current" | "prepared";
+};
+
+export type DesktopUpdateStatusSnapshot = {
+  active?: DesktopUpdateReleaseSnapshot;
+  arch: string;
+  artifact?: DesktopUpdateArtifactSnapshot;
+  artifactUrl?: string;
+  availableVersion?: string;
+  cache?: DesktopUpdateCacheSnapshot;
+  capabilities: DesktopUpdateCapabilitySet;
+  channel: DesktopUpdateChannel;
+  checksum?: DesktopUpdateChecksumSnapshot;
+  currentVersion: string;
+  downloadPath?: string;
+  enabled: boolean;
+  error?: DesktopUpdateErrorSnapshot;
+  incoming?: DesktopUpdateIncomingSnapshot;
+  installResult?: DesktopUpdateInstallResult;
+  lastCheckedAt?: string;
+  metadata?: Record<string, unknown>;
+  mode: DesktopUpdateMode;
+  paths?: DesktopUpdatePathSnapshot;
+  platform: string;
+  progress?: DesktopUpdateProgressSnapshot;
+  reinstall?: DesktopUpdateReinstallSnapshot;
+  standalone?: DesktopStandaloneUpdateSnapshot;
+  state: DesktopUpdateState;
+  supported: boolean;
+};
+
+export type DesktopUpdateInput = {
+  action: DesktopUpdateAction;
+};
+
+export type DesktopUpdateResult = DesktopUpdateStatusSnapshot;
+
+export type SidecarStatusMessage = { type: typeof SIDECAR_MESSAGES.STATUS };
+export type SidecarShutdownMessage = { type: typeof SIDECAR_MESSAGES.SHUTDOWN };
+export type DesktopEvalMessage = { input: DesktopEvalInput; type: typeof SIDECAR_MESSAGES.EVAL };
+export type DesktopScreenshotMessage = { input: DesktopScreenshotInput; type: typeof SIDECAR_MESSAGES.SCREENSHOT };
+export type DesktopConsoleMessage = { type: typeof SIDECAR_MESSAGES.CONSOLE };
+export type DesktopShowInput = {
+  deeplinkUrl?: string;
+};
+export type DesktopShowMessage = { input?: DesktopShowInput; type: typeof SIDECAR_MESSAGES.SHOW };
+export type DesktopClickMessage = { input: DesktopClickInput; type: typeof SIDECAR_MESSAGES.CLICK };
+export type DesktopExportPdfMessage = { input: DesktopExportPdfInput; type: typeof SIDECAR_MESSAGES.EXPORT_PDF };
+export type DesktopRenderSlidesMessage = { input: DesktopRenderSlidesInput; type: typeof SIDECAR_MESSAGES.RENDER_SLIDES };
+export type DesktopExportArtifactMessage = { input: DesktopExportArtifactInput; type: typeof SIDECAR_MESSAGES.EXPORT_ARTIFACT };
+export type DesktopUpdateMessage = { input: DesktopUpdateInput; type: typeof SIDECAR_MESSAGES.UPDATE };
+
+// Sent by the desktop main process to the daemon over its sidecar IPC at
+// startup, before the BrowserWindow is created. The base64 string is a
+// freshly generated 32-byte secret that both processes will share for the
+// lifetime of the daemon. The daemon uses this secret to verify HMAC tokens
+// minted by the desktop main process for `POST /api/import/folder` calls
+// (PR #974: closes the renderer→arbitrary-baseDir→openPath bypass chain).
+// When the secret is registered, daemon's import-folder route requires a
+// valid per-path token; when it isn't (web-only deployments), the route
+// behaves as before.
+export type RegisterDesktopAuthInput = {
+  secret: string;
+};
+
+export type RegisterDesktopAuthMessage = {
+  input: RegisterDesktopAuthInput;
+  type: typeof SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH;
+};
+
+export type RegisterDesktopAuthResult = {
+  accepted: true;
+};
+
+export type MintImportTokenInput = {
+  baseDir: string;
+};
+
+export type MintImportTokenMessage = {
+  input: MintImportTokenInput;
+  type: typeof SIDECAR_MESSAGES.MINT_IMPORT_TOKEN;
+};
+
+export type MintImportTokenResult =
+  | { ok: true; expiresAt: string; token: string }
+  | { ok: false; code: "DESKTOP_AUTH_INACTIVE"; message: string; retryable: false }
+  | { ok: false; code: "DESKTOP_AUTH_PENDING"; message: string; retryable: true };
+
+/**
+ * Registers the browser-facing URL after a packaged web sidecar has bound its
+ * dynamic port. The message travels over the namespace-scoped daemon IPC, so
+ * it cannot accidentally update another packaged runtime.
+ */
+export type RegisterWebUrlInput = {
+  url: string;
+};
+
+export type RegisterWebUrlMessage = {
+  input: RegisterWebUrlInput;
+  type: typeof SIDECAR_MESSAGES.REGISTER_WEB_URL;
+};
+
+export type RegisterWebUrlResult = {
+  accepted: true;
+};
+
+export type DaemonSidecarMessage =
+  | SidecarStatusMessage
+  | SidecarShutdownMessage
+  | RegisterDesktopAuthMessage
+  | MintImportTokenMessage
+  | RegisterWebUrlMessage;
+export type WebSidecarMessage = SidecarStatusMessage | SidecarShutdownMessage;
+export type DesktopSidecarMessage =
+  | SidecarStatusMessage
+  | SidecarShutdownMessage
+  | DesktopEvalMessage
+  | DesktopScreenshotMessage
+  | DesktopConsoleMessage
+  | DesktopShowMessage
+  | DesktopClickMessage
+  | DesktopExportPdfMessage
+  | DesktopRenderSlidesMessage
+  | DesktopExportArtifactMessage
+  | DesktopUpdateMessage;
+
+export type ShutdownResult = {
+  accepted: true;
+};
+

--- a/packages/sidecar/src/index.ts
+++ b/packages/sidecar/src/index.ts
@@ -48,3 +48,43 @@ export { bootstrapSidecarRuntime, createSidecarLaunchEnv } from "./bootstrap.js"
 export { allocatePort } from "./port.js";
 export { readJsonFile, removeFile, removePointerIfCurrent, writeJsonFile } from "./json-file.js";
 export { createJsonIpcServer, requestJsonIpc } from "./json-ipc.js";
+export { SidecarControlError, attachSidecar, bootstrapControlPlane } from "./control/index.js";
+export type {
+  AttachedSidecar,
+  AttachSidecarOptions,
+  BootstrapControlPlaneOptions,
+  SidecarControlClient,
+  SidecarControlContext,
+  SidecarControlIdentity,
+  SidecarControlJsonValue,
+  SidecarControlPlane,
+  SidecarControlProjection,
+  SidecarControlRoots,
+  SidecarControlScope,
+  SidecarExit,
+  SidecarLaunch,
+  SidecarLaunchOptions,
+  SidecarMethod,
+  SidecarMethodHandlers,
+  SidecarProbeResult,
+  SidecarStopResult,
+} from "./control/index.js";
+export { SidecarLifecycleError, bootstrapSidecarLifecycle } from "./lifecycle/index.js";
+export type {
+  BootstrapSidecarLifecycleOptions,
+  SidecarAbortTransitionResult,
+  SidecarAttachResult,
+  SidecarBeginTransitionResult,
+  SidecarCompleteTransitionResult,
+  SidecarLeaseCredential,
+  SidecarLeaseView,
+  SidecarLifecycleOwner,
+  SidecarLifecyclePlane,
+  SidecarLifecycleScope,
+  SidecarLifecycleSnapshot,
+  SidecarRenewLeaseResult,
+  SidecarRenewTransitionResult,
+  SidecarTakeoverTransitionResult,
+  SidecarTransitionCredential,
+  SidecarTransitionView,
+} from "./lifecycle/index.js";

--- a/packages/sidecar/src/json-ipc.ts
+++ b/packages/sidecar/src/json-ipc.ts
@@ -30,7 +30,6 @@ function jsonIpcTraceEnabled(): boolean {
   const value = process.env.OD_JSON_IPC_TRACE;
   return value === "1" || value === "true" || value === "yes";
 }
-
 /**
  * @internal Allocate a per-connection trace id.
  */
@@ -280,7 +279,7 @@ export async function createJsonIpcServer({
 export async function requestJsonIpc<T = any>(
   socketPath: string,
   payload: unknown,
-  { timeoutMs = 1500 }: { timeoutMs?: number } = {},
+  { timeoutMs = 1500 }: { timeoutMs?: number | null } = {},
 ): Promise<T> {
   return await new Promise<T>((resolveRequest, rejectRequest) => {
     const socket = createConnection(socketPath);
@@ -296,20 +295,22 @@ export async function requestJsonIpc<T = any>(
     const settle = (callback: () => void) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeout);
+      if (timeout != null) clearTimeout(timeout);
       callback();
     };
-    const timeout = setTimeout(() => {
-      traceJsonIpc("client.timeout", {
-        durationMs: jsonIpcTraceDurationMs(startedAt),
-        message: messageSummary,
-        socketPath,
-        timeoutMs,
-        traceId,
-      });
-      socket.destroy();
-      settle(() => rejectRequest(new Error(`IPC request timed out: ${socketPath}`)));
-    }, timeoutMs);
+    const timeout = timeoutMs == null
+      ? null
+      : setTimeout(() => {
+          traceJsonIpc("client.timeout", {
+            durationMs: jsonIpcTraceDurationMs(startedAt),
+            message: messageSummary,
+            socketPath,
+            timeoutMs,
+            traceId,
+          });
+          socket.destroy();
+          settle(() => rejectRequest(new Error(`IPC request timed out: ${socketPath}`)));
+        }, timeoutMs);
 
     socket.on("connect", () => {
       traceJsonIpc("client.connected", {

--- a/packages/sidecar/src/lifecycle/error.ts
+++ b/packages/sidecar/src/lifecycle/error.ts
@@ -1,0 +1,16 @@
+export type SidecarLifecycleErrorCode =
+  | "guard-busy"
+  | "invalid-input"
+  | "state-corrupt"
+  | "state-unavailable";
+
+export class SidecarLifecycleError extends Error {
+  readonly code: SidecarLifecycleErrorCode;
+
+  constructor(code: SidecarLifecycleErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SidecarLifecycleError";
+    this.code = code;
+  }
+}
+

--- a/packages/sidecar/src/lifecycle/index.ts
+++ b/packages/sidecar/src/lifecycle/index.ts
@@ -1,0 +1,21 @@
+export { SidecarLifecycleError } from "./error.js";
+export { bootstrapSidecarLifecycle } from "./plane.js";
+export type {
+  BootstrapSidecarLifecycleOptions,
+  SidecarAbortTransitionResult,
+  SidecarAttachResult,
+  SidecarBeginTransitionResult,
+  SidecarCompleteTransitionResult,
+  SidecarLeaseCredential,
+  SidecarLeaseView,
+  SidecarLifecycleOwner,
+  SidecarLifecyclePlane,
+  SidecarLifecycleScope,
+  SidecarLifecycleSnapshot,
+  SidecarRenewLeaseResult,
+  SidecarRenewTransitionResult,
+  SidecarTakeoverTransitionResult,
+  SidecarTransitionCredential,
+  SidecarTransitionView,
+} from "./public-types.js";
+

--- a/packages/sidecar/src/lifecycle/plane.ts
+++ b/packages/sidecar/src/lifecycle/plane.ts
@@ -1,0 +1,406 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import { SidecarLifecycleError } from "./error.js";
+import type {
+  BootstrapSidecarLifecycleOptions,
+  SidecarAbortTransitionResult,
+  SidecarAttachResult,
+  SidecarBeginTransitionResult,
+  SidecarCompleteTransitionResult,
+  SidecarLeaseCredential,
+  SidecarLeaseView,
+  SidecarLifecycleOwner,
+  SidecarLifecyclePlane,
+  SidecarLifecycleScope,
+  SidecarLifecycleSnapshot,
+  SidecarRenewLeaseResult,
+  SidecarRenewTransitionResult,
+  SidecarTakeoverTransitionResult,
+  SidecarTransitionCredential,
+  SidecarTransitionView,
+} from "./public-types.js";
+
+const STATE_SCHEMA_VERSION = 1;
+const DEFAULT_MAX_LEASE_MS = 60_000;
+const DEFAULT_GUARD_SPIN_MS = 300;
+const DEFAULT_GUARD_STALE_MS = 2_000;
+
+type LeaseRecord = SidecarLeaseView & Readonly<{ token: string }>;
+type TransitionRecord = SidecarTransitionView & Readonly<{ token: string }>;
+type LifecycleState = {
+  leases: LeaseRecord[];
+  nextFence: number;
+  observedAtMs: number;
+  schemaVersion: 1;
+  scope: SidecarLifecycleScope;
+  transition: TransitionRecord | null;
+};
+
+function fail(code: ConstructorParameters<typeof SidecarLifecycleError>[0], message: string, cause?: unknown): never {
+  throw new SidecarLifecycleError(code, message, cause == null ? undefined : { cause });
+}
+
+function assertSegment(value: string, field: string): string {
+  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(value)) {
+    fail("invalid-input", `${field} must be a lowercase filesystem-safe segment`);
+  }
+  return value;
+}
+
+function assertOwner(owner: SidecarLifecycleOwner): SidecarLifecycleOwner {
+  if (!owner || typeof owner !== "object") fail("invalid-input", "owner is required");
+  if (!Number.isSafeInteger(owner.generation) || owner.generation < 0) {
+    fail("invalid-input", "owner.generation must be a non-negative integer");
+  }
+  for (const [field, value] of [["owner.key", owner.key], ["owner.incarnation", owner.incarnation]] as const) {
+    if (typeof value !== "string" || value.length === 0 || value.length > 256) {
+      fail("invalid-input", `${field} must be a non-empty string of at most 256 characters`);
+    }
+  }
+  return owner;
+}
+
+function assertDuration(value: number, maxLeaseMs: number): number {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maxLeaseMs) {
+    fail("invalid-input", `leaseMs must be an integer between 1 and ${maxLeaseMs}`);
+  }
+  return value;
+}
+
+function leaseView(record: LeaseRecord): SidecarLeaseView {
+  return { expiresAtMs: record.expiresAtMs, id: record.id, owner: record.owner };
+}
+
+function transitionView(record: TransitionRecord): SidecarTransitionView {
+  return {
+    expiresAtMs: record.expiresAtMs,
+    fence: record.fence,
+    id: record.id,
+    kind: record.kind,
+    owner: record.owner,
+  };
+}
+
+function credentialMatches(
+  record: Readonly<{ id: string; token: string }>,
+  credential: Readonly<{ id: string; token: string }>,
+): boolean {
+  return record.id === credential.id && record.token === credential.token;
+}
+
+function transitionCredentialMatches(
+  record: TransitionRecord,
+  credential: SidecarTransitionCredential,
+): boolean {
+  return credentialMatches(record, credential) && record.fence === credential.fence;
+}
+
+function isOwner(value: unknown): value is SidecarLifecycleOwner {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const owner = value as Partial<SidecarLifecycleOwner>;
+  return Number.isSafeInteger(owner.generation) && Number(owner.generation) >= 0
+    && typeof owner.incarnation === "string" && owner.incarnation.length > 0
+    && typeof owner.key === "string" && owner.key.length > 0;
+}
+
+function decodeState(value: unknown, expectedScope: SidecarLifecycleScope): LifecycleState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("state-corrupt", "sidecar lifecycle state is not an object");
+  }
+  const state = value as Partial<LifecycleState>;
+  if (state.schemaVersion !== STATE_SCHEMA_VERSION) {
+    fail("state-corrupt", `unsupported sidecar lifecycle schema: ${String(state.schemaVersion)}`);
+  }
+  if (state.scope?.channel !== expectedScope.channel || state.scope.namespace !== expectedScope.namespace) {
+    fail("state-corrupt", "sidecar lifecycle state scope does not match the requested scope");
+  }
+  if (!Number.isFinite(state.observedAtMs) || !Number.isSafeInteger(state.nextFence) || Number(state.nextFence) < 1) {
+    fail("state-corrupt", "sidecar lifecycle state counters are invalid");
+  }
+  if (!Array.isArray(state.leases) || !state.leases.every((lease) =>
+    lease && typeof lease.id === "string" && typeof lease.token === "string"
+      && Number.isFinite(lease.expiresAtMs) && isOwner(lease.owner))) {
+    fail("state-corrupt", "sidecar lifecycle leases are invalid");
+  }
+  const transition = state.transition;
+  if (transition !== null && (!transition || typeof transition.id !== "string"
+    || typeof transition.token !== "string" || typeof transition.kind !== "string"
+    || !Number.isFinite(transition.expiresAtMs) || !Number.isSafeInteger(transition.fence)
+    || !isOwner(transition.owner))) {
+    fail("state-corrupt", "sidecar lifecycle transition is invalid");
+  }
+  return state as LifecycleState;
+}
+
+function initialState(scope: SidecarLifecycleScope, nowMs: number): LifecycleState {
+  return {
+    leases: [],
+    nextFence: 1,
+    observedAtMs: nowMs,
+    schemaVersion: STATE_SCHEMA_VERSION,
+    scope,
+    transition: null,
+  };
+}
+
+function prune(state: LifecycleState, nowMs: number): void {
+  state.observedAtMs = Math.max(state.observedAtMs, nowMs);
+  state.leases = state.leases.filter((lease) => lease.expiresAtMs > state.observedAtMs);
+  if (state.transition && state.transition.expiresAtMs <= state.observedAtMs) state.transition = null;
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
+}
+
+export function bootstrapSidecarLifecycle(options: BootstrapSidecarLifecycleOptions): SidecarLifecyclePlane {
+  const scope = {
+    channel: assertSegment(options.scope.channel, "scope.channel"),
+    namespace: assertSegment(options.scope.namespace, "scope.namespace"),
+  };
+  const controlRoot = resolve(options.controlRoot);
+  const maxLeaseMs = options.maxLeaseMs ?? DEFAULT_MAX_LEASE_MS;
+  const guardSpinMs = options.guardSpinMs ?? DEFAULT_GUARD_SPIN_MS;
+  const guardStaleMs = options.guardStaleMs ?? DEFAULT_GUARD_STALE_MS;
+  const clock = options.now ?? Date.now;
+  if (!Number.isSafeInteger(maxLeaseMs) || maxLeaseMs <= 0 || maxLeaseMs > DEFAULT_MAX_LEASE_MS) {
+    fail("invalid-input", `maxLeaseMs must be between 1 and ${DEFAULT_MAX_LEASE_MS}`);
+  }
+  if (!Number.isSafeInteger(guardSpinMs) || guardSpinMs < 0 || guardSpinMs > 2_000) {
+    fail("invalid-input", "guardSpinMs must be between 0 and 2000");
+  }
+  if (!Number.isSafeInteger(guardStaleMs) || guardStaleMs < 500 || guardStaleMs > 10_000) {
+    fail("invalid-input", "guardStaleMs must be between 500 and 10000");
+  }
+
+  const scopeDigest = createHash("sha256")
+    .update(`${scope.channel}\0${scope.namespace}`)
+    .digest("hex")
+    .slice(0, 24);
+  const statePath = join(controlRoot, "sidecar-lifecycle", `${scopeDigest}.json`);
+  const guardPath = `${statePath}.guard`;
+
+  async function acquireGuard(): Promise<void> {
+    await mkdir(dirname(guardPath), { mode: 0o700, recursive: true });
+    await chmod(dirname(guardPath), 0o700);
+    const deadline = Date.now() + guardSpinMs;
+    while (true) {
+      try {
+        await mkdir(guardPath, { mode: 0o700 });
+        return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+          fail("state-unavailable", "sidecar lifecycle guard is unavailable", error);
+        }
+      }
+
+      try {
+        const guardStat = await stat(guardPath);
+        if (Date.now() - guardStat.mtimeMs >= guardStaleMs) {
+          await rm(guardPath, { recursive: true });
+          continue;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        fail("state-unavailable", "sidecar lifecycle guard cannot be inspected", error);
+      }
+
+      if (Date.now() >= deadline) {
+        fail("guard-busy", "sidecar lifecycle guard is busy; retry the operation");
+      }
+      await wait(Math.min(20, Math.max(1, deadline - Date.now())));
+    }
+  }
+
+  async function readState(): Promise<LifecycleState> {
+    let source: string;
+    try {
+      source = await readFile(statePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return initialState(scope, clock());
+      fail("state-unavailable", "sidecar lifecycle state cannot be read", error);
+    }
+    try {
+      return decodeState(JSON.parse(source), scope);
+    } catch (error) {
+      if (error instanceof SidecarLifecycleError) throw error;
+      fail("state-corrupt", "sidecar lifecycle state is not valid JSON", error);
+    }
+  }
+
+  async function writeState(state: LifecycleState): Promise<void> {
+    await mkdir(dirname(statePath), { mode: 0o700, recursive: true });
+    await chmod(dirname(statePath), 0o700);
+    const temporaryPath = `${statePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await rename(temporaryPath, statePath);
+    } catch (error) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+      fail("state-unavailable", "sidecar lifecycle state cannot be committed", error);
+    }
+  }
+
+  async function mutate<TResult>(operation: (state: LifecycleState) => TResult | Promise<TResult>): Promise<TResult> {
+    await acquireGuard();
+    try {
+      const state = await readState();
+      prune(state, clock());
+      const result = await operation(state);
+      await writeState(state);
+      return result;
+    } finally {
+      await rm(guardPath, { recursive: true }).catch(() => undefined);
+    }
+  }
+
+  return {
+    scope,
+    async attach({ leaseMs, owner, transition }): Promise<SidecarAttachResult> {
+      assertOwner(owner);
+      assertDuration(leaseMs, maxLeaseMs);
+      return mutate((state) => {
+        if (state.transition && (!transition || !transitionCredentialMatches(state.transition, transition))) {
+          return { reason: "transition-active", state: "blocked", transition: transitionView(state.transition) };
+        }
+        const credential = { id: randomUUID(), token: randomUUID() };
+        const lease: LeaseRecord = {
+          expiresAtMs: state.observedAtMs + leaseMs,
+          id: credential.id,
+          owner,
+          token: credential.token,
+        };
+        state.leases.push(lease);
+        return { credential, lease: leaseView(lease), state: "attached" };
+      });
+    },
+    async renewLease({ credential, leaseMs, transition }): Promise<SidecarRenewLeaseResult> {
+      assertDuration(leaseMs, maxLeaseMs);
+      return mutate((state) => {
+        if (state.transition && (!transition || !transitionCredentialMatches(state.transition, transition))) {
+          return {
+            reason: "transition-active",
+            state: "rejected",
+            transition: transitionView(state.transition),
+          };
+        }
+        const lease = state.leases.find((candidate) => credentialMatches(candidate, credential));
+        if (!lease) return { reason: "expired-or-fenced", state: "rejected" };
+        const renewed: LeaseRecord = { ...lease, expiresAtMs: state.observedAtMs + leaseMs };
+        state.leases = state.leases.map((candidate) => candidate.id === lease.id ? renewed : candidate);
+        return { lease: leaseView(renewed), state: "renewed" };
+      });
+    },
+    async detach(credential): Promise<Readonly<{ detached: boolean }>> {
+      return mutate((state) => {
+        const before = state.leases.length;
+        state.leases = state.leases.filter((lease) => !credentialMatches(lease, credential));
+        return { detached: state.leases.length !== before };
+      });
+    },
+    async beginTransition({ kind, leaseMs, owner, requester }): Promise<SidecarBeginTransitionResult> {
+      assertOwner(owner);
+      assertDuration(leaseMs, maxLeaseMs);
+      if (typeof kind !== "string" || kind.length === 0 || kind.length > 128) {
+        fail("invalid-input", "transition kind must be a non-empty string of at most 128 characters");
+      }
+      return mutate((state) => {
+        if (state.transition) {
+          return {
+            reason: "transition-active",
+            state: "blocked",
+            transition: transitionView(state.transition),
+          };
+        }
+        let requesterRecord: LeaseRecord | undefined;
+        if (requester) {
+          requesterRecord = state.leases.find((lease) => credentialMatches(lease, requester));
+          if (!requesterRecord) return { reason: "requester-expired-or-fenced", state: "blocked" };
+        }
+        const occupants = state.leases.filter((lease) => lease !== requesterRecord);
+        if (occupants.length > 0) {
+          return { occupants: occupants.map(leaseView), reason: "occupied", state: "blocked" };
+        }
+        const credential = { fence: state.nextFence, id: randomUUID(), token: randomUUID() };
+        state.nextFence += 1;
+        const transition: TransitionRecord = {
+          expiresAtMs: state.observedAtMs + leaseMs,
+          fence: credential.fence,
+          id: credential.id,
+          kind,
+          owner,
+          token: credential.token,
+        };
+        state.transition = transition;
+        return { credential, state: "acquired", transition: transitionView(transition) };
+      });
+    },
+    async renewTransition({ credential, leaseMs }): Promise<SidecarRenewTransitionResult> {
+      assertDuration(leaseMs, maxLeaseMs);
+      return mutate((state) => {
+        if (!state.transition || !transitionCredentialMatches(state.transition, credential)) {
+          return { reason: "expired-or-fenced", state: "rejected" };
+        }
+        state.transition = { ...state.transition, expiresAtMs: state.observedAtMs + leaseMs };
+        return { state: "renewed", transition: transitionView(state.transition) };
+      });
+    },
+    async takeoverTransition({ credential, leaseMs, owner }): Promise<SidecarTakeoverTransitionResult> {
+      assertOwner(owner);
+      assertDuration(leaseMs, maxLeaseMs);
+      return mutate((state) => {
+        if (!state.transition || !transitionCredentialMatches(state.transition, credential)) {
+          return { reason: "expired-or-fenced", state: "rejected" };
+        }
+        const nextCredential = { fence: state.nextFence, id: state.transition.id, token: randomUUID() };
+        state.nextFence += 1;
+        state.transition = {
+          ...state.transition,
+          expiresAtMs: state.observedAtMs + leaseMs,
+          fence: nextCredential.fence,
+          owner,
+          token: nextCredential.token,
+        };
+        return {
+          credential: nextCredential,
+          state: "acquired",
+          transition: transitionView(state.transition),
+        };
+      });
+    },
+    async abortTransition(credential): Promise<SidecarAbortTransitionResult> {
+      return mutate((state) => {
+        if (!state.transition || !transitionCredentialMatches(state.transition, credential)) {
+          return { reason: "expired-or-fenced", state: "rejected" };
+        }
+        state.transition = null;
+        return { state: "aborted" };
+      });
+    },
+    async completeTransition({ lease, transition }): Promise<SidecarCompleteTransitionResult> {
+      return mutate((state) => {
+        if (!state.transition || !transitionCredentialMatches(state.transition, transition)) {
+          return { reason: "transition-expired-or-fenced", state: "rejected" };
+        }
+        if (!state.leases.some((candidate) => credentialMatches(candidate, lease))) {
+          return { reason: "lease-expired-or-fenced", state: "rejected" };
+        }
+        state.transition = null;
+        return { state: "completed" };
+      });
+    },
+    async snapshot(): Promise<SidecarLifecycleSnapshot> {
+      return mutate((state) => ({
+        leases: state.leases.map(leaseView),
+        scope,
+        transition: state.transition ? transitionView(state.transition) : null,
+      }));
+    },
+  };
+}
+

--- a/packages/sidecar/src/lifecycle/public-types.ts
+++ b/packages/sidecar/src/lifecycle/public-types.ts
@@ -1,0 +1,150 @@
+import type { SidecarControlJsonValue } from "../control/public-types.js";
+
+export type SidecarLifecycleScope = Readonly<{
+  channel: string;
+  namespace: string;
+}>;
+
+/** Caller-owned identity. Sidecar stores and returns it, but never interprets it. */
+export type SidecarLifecycleOwner = Readonly<{
+  generation: number;
+  incarnation: string;
+  key: string;
+  projection?: SidecarControlJsonValue;
+}>;
+
+export type SidecarLeaseCredential = Readonly<{
+  id: string;
+  token: string;
+}>;
+
+export type SidecarTransitionCredential = Readonly<{
+  fence: number;
+  id: string;
+  token: string;
+}>;
+
+export type SidecarLeaseView = Readonly<{
+  expiresAtMs: number;
+  id: string;
+  owner: SidecarLifecycleOwner;
+}>;
+
+export type SidecarTransitionView = Readonly<{
+  expiresAtMs: number;
+  fence: number;
+  id: string;
+  kind: string;
+  owner: SidecarLifecycleOwner;
+}>;
+
+export type SidecarLifecycleSnapshot = Readonly<{
+  leases: readonly SidecarLeaseView[];
+  scope: SidecarLifecycleScope;
+  transition: SidecarTransitionView | null;
+}>;
+
+export type SidecarAttachResult =
+  | Readonly<{
+      credential: SidecarLeaseCredential;
+      lease: SidecarLeaseView;
+      state: "attached";
+    }>
+  | Readonly<{
+      reason: "transition-active";
+      state: "blocked";
+      transition: SidecarTransitionView;
+    }>;
+
+export type SidecarRenewLeaseResult =
+  | Readonly<{ lease: SidecarLeaseView; state: "renewed" }>
+  | Readonly<{
+      reason: "expired-or-fenced" | "transition-active";
+      state: "rejected";
+      transition?: SidecarTransitionView;
+    }>;
+
+export type SidecarBeginTransitionResult =
+  | Readonly<{
+      credential: SidecarTransitionCredential;
+      state: "acquired";
+      transition: SidecarTransitionView;
+    }>
+  | Readonly<{
+      occupants?: readonly SidecarLeaseView[];
+      reason: "occupied" | "requester-expired-or-fenced" | "transition-active";
+      state: "blocked";
+      transition?: SidecarTransitionView;
+    }>;
+
+export type SidecarRenewTransitionResult =
+  | Readonly<{ state: "renewed"; transition: SidecarTransitionView }>
+  | Readonly<{ reason: "expired-or-fenced"; state: "rejected" }>;
+
+export type SidecarTakeoverTransitionResult =
+  | Readonly<{
+      credential: SidecarTransitionCredential;
+      state: "acquired";
+      transition: SidecarTransitionView;
+    }>
+  | Readonly<{ reason: "expired-or-fenced"; state: "rejected" }>;
+
+export type SidecarCompleteTransitionResult =
+  | Readonly<{ state: "completed" }>
+  | Readonly<{
+      reason: "lease-expired-or-fenced" | "transition-expired-or-fenced";
+      state: "rejected";
+    }>;
+
+export type SidecarAbortTransitionResult =
+  | Readonly<{ state: "aborted" }>
+  | Readonly<{ reason: "expired-or-fenced"; state: "rejected" }>;
+
+export type SidecarLifecyclePlane = Readonly<{
+  scope: SidecarLifecycleScope;
+  attach(options: Readonly<{
+    leaseMs: number;
+    owner: SidecarLifecycleOwner;
+    transition?: SidecarTransitionCredential;
+  }>): Promise<SidecarAttachResult>;
+  renewLease(options: Readonly<{
+    credential: SidecarLeaseCredential;
+    leaseMs: number;
+    transition?: SidecarTransitionCredential;
+  }>): Promise<SidecarRenewLeaseResult>;
+  detach(credential: SidecarLeaseCredential): Promise<Readonly<{ detached: boolean }>>;
+  beginTransition(options: Readonly<{
+    kind: string;
+    leaseMs: number;
+    owner: SidecarLifecycleOwner;
+    requester?: SidecarLeaseCredential;
+  }>): Promise<SidecarBeginTransitionResult>;
+  renewTransition(options: Readonly<{
+    credential: SidecarTransitionCredential;
+    leaseMs: number;
+  }>): Promise<SidecarRenewTransitionResult>;
+  takeoverTransition(options: Readonly<{
+    credential: SidecarTransitionCredential;
+    leaseMs: number;
+    owner: SidecarLifecycleOwner;
+  }>): Promise<SidecarTakeoverTransitionResult>;
+  abortTransition(
+    credential: SidecarTransitionCredential,
+  ): Promise<SidecarAbortTransitionResult>;
+  completeTransition(options: Readonly<{
+    lease: SidecarLeaseCredential;
+    transition: SidecarTransitionCredential;
+  }>): Promise<SidecarCompleteTransitionResult>;
+  snapshot(): Promise<SidecarLifecycleSnapshot>;
+}>;
+
+export type BootstrapSidecarLifecycleOptions = Readonly<{
+  /** Stable namespace control root, outside an app generation or temporary directory. */
+  controlRoot: string;
+  guardSpinMs?: number;
+  guardStaleMs?: number;
+  maxLeaseMs?: number;
+  now?: () => number;
+  scope: SidecarLifecycleScope;
+}>;
+

--- a/packages/sidecar/src/protocol.ts
+++ b/packages/sidecar/src/protocol.ts
@@ -1,0 +1,637 @@
+
+
+import {
+  SIDECAR_MESSAGES,
+  DESKTOP_UPDATE_ACTIONS,
+  DesktopUpdateAction,
+  DESKTOP_UPDATE_MODES,
+  DesktopUpdateMode,
+  DESKTOP_UPDATE_CHANNELS,
+  DesktopUpdateChannel,
+  DESKTOP_UPDATE_STATES,
+  DesktopUpdateState,
+  DesktopRuntimeState,
+  DesktopStatusSnapshot,
+  DesktopEvalInput,
+  DesktopEvalResult,
+  DesktopScreenshotInput,
+  DesktopScreenshotResult,
+  DesktopConsoleEntry,
+  DesktopConsoleResult,
+  DesktopClickInput,
+  DesktopClickResult,
+  DesktopExportPdfInput,
+  DesktopExportPdfResult,
+  DesktopRenderSlidesInput,
+  DesktopRenderSlidesErrorCode,
+  DesktopRenderSlidesResult,
+  DesktopExportArtifactFormat,
+  DesktopExportArtifactImageFormat,
+  DesktopExportArtifactInput,
+  DesktopExportArtifactResult,
+  DesktopUpdateCapabilitySet,
+  DesktopUpdatePathSnapshot,
+  DesktopUpdateChecksumSnapshot,
+  DesktopUpdateArtifactSnapshot,
+  DesktopUpdateProgressSnapshot,
+  DesktopUpdateErrorSnapshot,
+  DesktopUpdateInstallResult,
+  DesktopUpdateReleaseSnapshot,
+  DesktopUpdateIncomingSnapshot,
+  DesktopUpdateCacheLifecycleTrigger,
+  DesktopUpdateReleaseLifecycleState,
+  DesktopUpdateCacheLifecycleSummary,
+  DesktopUpdateCacheSnapshot,
+  DESKTOP_UPDATE_REINSTALL_REASONS,
+  DesktopUpdateReinstallReason,
+  DesktopUpdateReinstallSnapshot,
+  DesktopUpdateStatusSnapshot,
+  DesktopUpdateInput,
+  DesktopUpdateResult,
+  SidecarStatusMessage,
+  SidecarShutdownMessage,
+  DesktopEvalMessage,
+  DesktopScreenshotMessage,
+  DesktopConsoleMessage,
+  DesktopShowInput,
+  DesktopShowMessage,
+  DesktopClickMessage,
+  DesktopExportPdfMessage,
+  DesktopRenderSlidesMessage,
+  DesktopExportArtifactMessage,
+  DesktopUpdateMessage,
+  RegisterDesktopAuthInput,
+  RegisterDesktopAuthMessage,
+  RegisterDesktopAuthResult,
+  MintImportTokenInput,
+  MintImportTokenMessage,
+  MintImportTokenResult,
+  RegisterWebUrlInput,
+  RegisterWebUrlMessage,
+  RegisterWebUrlResult,
+  DaemonSidecarMessage,
+  WebSidecarMessage,
+  DesktopSidecarMessage,
+  ShutdownResult,
+} from "./desktop-protocol.js";
+export * from "./desktop-protocol.js";
+
+export const APP_KEYS = Object.freeze({
+  DAEMON: "daemon",
+  DESKTOP: "desktop",
+  WEB: "web",
+} as const);
+
+export type AppKey = (typeof APP_KEYS)[keyof typeof APP_KEYS];
+
+export const SIDECAR_MODES = Object.freeze({
+  DEV: "dev",
+  RUNTIME: "runtime",
+} as const);
+
+export type SidecarMode = (typeof SIDECAR_MODES)[keyof typeof SIDECAR_MODES];
+
+export const SIDECAR_SOURCES = Object.freeze({
+  PACKAGED: "packaged",
+  TOOLS_DEV: "tools-dev",
+  TOOLS_PACK: "tools-pack",
+} as const);
+
+export type SidecarSource = (typeof SIDECAR_SOURCES)[keyof typeof SIDECAR_SOURCES];
+
+export const SIDECAR_ENV = Object.freeze({
+  BASE: "OD_SIDECAR_BASE",
+  DAEMON_CLI_PATH: "OD_DAEMON_CLI_PATH",
+  DAEMON_PORT: "OD_PORT",
+  IPC_BASE: "OD_SIDECAR_IPC_BASE",
+  IPC_PATH: "OD_SIDECAR_IPC_PATH",
+  NAMESPACE: "OD_SIDECAR_NAMESPACE",
+  SOURCE: "OD_SIDECAR_SOURCE",
+  TOOLS_DEV_PARENT_PID: "OD_TOOLS_DEV_PARENT_PID",
+  WEB_DIST_DIR: "OD_WEB_DIST_DIR",
+  WEB_PORT: "OD_WEB_PORT",
+  WEB_TSCONFIG_PATH: "OD_WEB_TSCONFIG_PATH",
+} as const);
+
+export const SIDECAR_RUNTIME_ENV = Object.freeze({
+  base: SIDECAR_ENV.BASE,
+  ipcBase: SIDECAR_ENV.IPC_BASE,
+  ipcPath: SIDECAR_ENV.IPC_PATH,
+  namespace: SIDECAR_ENV.NAMESPACE,
+  source: SIDECAR_ENV.SOURCE,
+} as const);
+
+export const SIDECAR_STAMP_FLAGS = Object.freeze({
+  app: "--od-stamp-app",
+  ipc: "--od-stamp-ipc",
+  mode: "--od-stamp-mode",
+  namespace: "--od-stamp-namespace",
+  source: "--od-stamp-source",
+} as const);
+
+export const STAMP_APP_FLAG = SIDECAR_STAMP_FLAGS.app;
+export const STAMP_IPC_FLAG = SIDECAR_STAMP_FLAGS.ipc;
+export const STAMP_MODE_FLAG = SIDECAR_STAMP_FLAGS.mode;
+export const STAMP_NAMESPACE_FLAG = SIDECAR_STAMP_FLAGS.namespace;
+export const STAMP_SOURCE_FLAG = SIDECAR_STAMP_FLAGS.source;
+
+export const SIDECAR_STAMP_FIELDS = ["app", "mode", "namespace", "ipc", "source"] as const;
+
+export const SIDECAR_DEFAULTS = Object.freeze({
+  host: "127.0.0.1",
+  ipcBase: "/tmp/open-design/ipc",
+  namespace: "default",
+  projectTmpDirName: ".tmp",
+  windowsPipePrefix: "open-design",
+} as const);
+
+export const OPEN_DESIGN_PRODUCT_NAME = "Open Design";
+
+export function resolveWindowsReleaseNamespaceToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-");
+}
+
+export function resolveWindowsUninstallRegistryKey(namespace: string): string {
+  const namespaceToken = resolveWindowsReleaseNamespaceToken(namespace);
+  return `Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\${OPEN_DESIGN_PRODUCT_NAME}-${namespaceToken}`;
+}
+
+export const SIDECAR_ERROR_CODES = Object.freeze({
+  INVALID_MESSAGE: "SIDECAR_INVALID_MESSAGE",
+  UNKNOWN_MESSAGE: "SIDECAR_UNKNOWN_MESSAGE",
+} as const);
+
+export type SidecarErrorCode = (typeof SIDECAR_ERROR_CODES)[keyof typeof SIDECAR_ERROR_CODES];
+
+export class SidecarContractError extends Error {
+  readonly code: SidecarErrorCode;
+
+  constructor(code: SidecarErrorCode, message: string) {
+    super(message);
+    this.name = "SidecarContractError";
+    this.code = code;
+  }
+}
+
+export type ServiceRuntimeState = "idle" | "running" | "starting" | "stopped" | "unknown";
+
+export type DaemonStatusSnapshot = {
+  pid?: number | null;
+  state: ServiceRuntimeState;
+  trustedWebOriginPort?: number | null;
+  updatedAt?: string;
+  url: string | null;
+  /**
+   * PR #974 round 6 (mrcfps): true when the daemon's
+   * `/api/import/folder` route refuses tokenless requests. Surfaced
+   * over IPC so `tools-dev start desktop` can detect a daemon that
+   * was spawned without `OD_REQUIRE_DESKTOP_AUTH=1` (the split-start
+   * dev flow `start daemon` -> `start desktop`) and restart it
+   * before launching desktop main, instead of letting a renderer
+   * race the registration handshake. Mirrors
+   * `apps/daemon/src/server.ts#isDesktopAuthGateActive()` at the
+   * moment the STATUS request was answered.
+   */
+  desktopAuthGateActive: boolean;
+};
+
+export type WebStatusSnapshot = {
+  pid?: number | null;
+  state: ServiceRuntimeState;
+  updatedAt?: string;
+  url: string | null;
+};
+
+export type SidecarStamp = {
+  app: AppKey;
+  ipc: string;
+  mode: SidecarMode;
+  namespace: string;
+  source: SidecarSource;
+};
+
+export type SidecarStampInput = Partial<Record<(typeof SIDECAR_STAMP_FIELDS)[number], unknown>>;
+export type SidecarStampCriteria = Partial<SidecarStamp>;
+
+export type OpenDesignSidecarContract = {
+  appKeys: typeof APP_KEYS;
+  defaults: typeof SIDECAR_DEFAULTS;
+  env: typeof SIDECAR_RUNTIME_ENV;
+  errorCodes: typeof SIDECAR_ERROR_CODES;
+  messages: typeof SIDECAR_MESSAGES;
+  modes: typeof SIDECAR_MODES;
+  normalizeApp: typeof normalizeAppKey;
+  normalizeNamespace: typeof normalizeNamespace;
+  normalizeSource: typeof normalizeSidecarSource;
+  normalizeStamp: typeof normalizeSidecarStamp;
+  normalizeStampCriteria: typeof normalizeSidecarStampCriteria;
+  sources: typeof SIDECAR_SOURCES;
+  stampFields: typeof SIDECAR_STAMP_FIELDS;
+  stampFlags: typeof SIDECAR_STAMP_FLAGS;
+  updateActions: typeof DESKTOP_UPDATE_ACTIONS;
+  updateChannels: typeof DESKTOP_UPDATE_CHANNELS;
+  updateModes: typeof DESKTOP_UPDATE_MODES;
+  updateStates: typeof DESKTOP_UPDATE_STATES;
+};
+
+function assertObject(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertKnownKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const allowedSet = new Set<string>(allowed);
+  const unexpected = Object.keys(value).filter((key) => !allowedSet.has(key));
+  if (unexpected.length > 0) {
+    throw new Error(`${label} contains unsupported fields: ${unexpected.join(", ")}`);
+  }
+}
+
+function normalizeNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== "string") throw new Error(`${label} must be a string`);
+  if (value.length === 0) throw new Error(`${label} must not be empty`);
+  return value;
+}
+
+export function normalizeNamespace(namespace: unknown): string {
+  if (typeof namespace !== "string") throw new Error("namespace must be a string");
+  const value = namespace.trim();
+  if (value.length === 0) throw new Error("namespace must not be empty");
+  if (value !== namespace) throw new Error("namespace must not contain leading or trailing whitespace");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) {
+    throw new Error(`namespace contains unsupported characters: ${value}`);
+  }
+  if (/[\\/]/.test(value)) throw new Error(`namespace must not contain path separators: ${value}`);
+  return value;
+}
+
+export function isSidecarMode(value: unknown): value is SidecarMode {
+  return Object.values(SIDECAR_MODES).includes(value as SidecarMode);
+}
+
+export function normalizeSidecarMode(mode: unknown): SidecarMode {
+  if (!isSidecarMode(mode)) {
+    throw new Error("sidecar mode must be dev or runtime");
+  }
+  return mode;
+}
+
+export function isAppKey(value: unknown): value is AppKey {
+  return Object.values(APP_KEYS).includes(value as AppKey);
+}
+
+export function normalizeAppKey(app: unknown): AppKey {
+  if (!isAppKey(app)) throw new Error(`unsupported sidecar app: ${String(app)}`);
+  return app;
+}
+
+export function isSidecarSource(value: unknown): value is SidecarSource {
+  return Object.values(SIDECAR_SOURCES).includes(value as SidecarSource);
+}
+
+export function normalizeSidecarSource(source: unknown): SidecarSource {
+  if (!isSidecarSource(source)) {
+    throw new Error(`unsupported sidecar source: ${String(source)}`);
+  }
+  return source;
+}
+
+export function isWindowsNamedPipePath(value: unknown): boolean {
+  return typeof value === "string" && value.startsWith("\\\\.\\pipe\\");
+}
+
+export function normalizeIpcPath(ipc: unknown): string {
+  if (typeof ipc !== "string") throw new Error("sidecar ipc path must be a string");
+  if (ipc.length === 0) throw new Error("sidecar ipc path must not be empty");
+  if (ipc.trim() !== ipc) throw new Error("sidecar ipc path must not contain leading or trailing whitespace");
+  if (ipc.includes("\0")) throw new Error("sidecar ipc path must not contain null bytes");
+  if (isWindowsNamedPipePath(ipc)) return ipc;
+  if (!ipc.startsWith("/") && !/^[A-Za-z]:[\\/]/.test(ipc)) {
+    throw new Error(`sidecar ipc path must be absolute: ${ipc}`);
+  }
+  return ipc;
+}
+
+function assertKnownStampKeys(value: Record<string, unknown>, label: string): void {
+  assertKnownKeys(value, SIDECAR_STAMP_FIELDS, label);
+}
+
+export function normalizeSidecarStamp(input: unknown): SidecarStamp {
+  const value = assertObject(input, "sidecar stamp");
+  assertKnownStampKeys(value, "sidecar stamp");
+  return {
+    app: normalizeAppKey(value.app),
+    ipc: normalizeIpcPath(value.ipc),
+    mode: normalizeSidecarMode(value.mode),
+    namespace: normalizeNamespace(value.namespace),
+    source: normalizeSidecarSource(value.source),
+  };
+}
+
+export function normalizeSidecarStampCriteria(input: unknown = {}): SidecarStampCriteria {
+  const value = assertObject(input, "sidecar stamp criteria");
+  assertKnownStampKeys(value, "sidecar stamp criteria");
+  return {
+    ...(value.app == null ? {} : { app: normalizeAppKey(value.app) }),
+    ...(value.ipc == null ? {} : { ipc: normalizeIpcPath(value.ipc) }),
+    ...(value.mode == null ? {} : { mode: normalizeSidecarMode(value.mode) }),
+    ...(value.namespace == null ? {} : { namespace: normalizeNamespace(value.namespace) }),
+    ...(value.source == null ? {} : { source: normalizeSidecarSource(value.source) }),
+  };
+}
+
+export function assertSidecarStamp(input: unknown): asserts input is SidecarStamp {
+  normalizeSidecarStamp(input);
+}
+
+function normalizeDesktopEvalInput(input: unknown): DesktopEvalInput {
+  const value = assertObject(input, "desktop eval input");
+  assertKnownKeys(value, ["expression"], "desktop eval input");
+  return { expression: normalizeNonEmptyString(value.expression, "desktop eval expression") };
+}
+
+function normalizeDesktopScreenshotInput(input: unknown): DesktopScreenshotInput {
+  const value = assertObject(input, "desktop screenshot input");
+  assertKnownKeys(value, ["path"], "desktop screenshot input");
+  return { path: normalizeNonEmptyString(value.path, "desktop screenshot path") };
+}
+
+function normalizeDesktopClickInput(input: unknown): DesktopClickInput {
+  const value = assertObject(input, "desktop click input");
+  assertKnownKeys(value, ["selector"], "desktop click input");
+  return { selector: normalizeNonEmptyString(value.selector, "desktop click selector") };
+}
+
+function normalizeRegisterDesktopAuthInput(input: unknown): RegisterDesktopAuthInput {
+  const value = assertObject(input, "register-desktop-auth input");
+  assertKnownKeys(value, ["secret"], "register-desktop-auth input");
+  const secret = normalizeNonEmptyString(value.secret, "register-desktop-auth secret");
+  // Reject anything that isn't base64-shaped — the wire format is a
+  // base64-encoded random buffer minted by the desktop main process. The
+  // daemon decodes it back to bytes for HMAC. Loose validation here, not
+  // length-pinned, so the encoding (base64 vs base64url) stays caller-driven.
+  if (!/^[A-Za-z0-9+/_=-]+$/.test(secret)) {
+    throw new Error("register-desktop-auth secret must be base64-encoded");
+  }
+  return { secret };
+}
+
+function normalizeMintImportTokenInput(input: unknown): MintImportTokenInput {
+  const value = assertObject(input, "mint-import-token input");
+  assertKnownKeys(value, ["baseDir"], "mint-import-token input");
+  return { baseDir: normalizeNonEmptyString(value.baseDir, "mint-import-token baseDir") };
+}
+
+function normalizeRegisterWebUrlInput(input: unknown): RegisterWebUrlInput {
+  const value = assertObject(input, "register-web-url input");
+  assertKnownKeys(value, ["url"], "register-web-url input");
+  const raw = normalizeNonEmptyString(value.url, "register-web-url url");
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("register-web-url url must be an absolute URL");
+  }
+  if (parsed.protocol !== "http:") {
+    throw new Error("register-web-url url must use HTTP");
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname !== "127.0.0.1" && hostname !== "localhost" && hostname !== "[::1]") {
+    throw new Error("register-web-url url must use a loopback host");
+  }
+  const port = Number(parsed.port);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error("register-web-url url must include a valid explicit port");
+  }
+  if (
+    parsed.username
+    || parsed.password
+    || parsed.pathname !== "/"
+    || parsed.search
+    || parsed.hash
+  ) {
+    throw new Error("register-web-url url must be a bare origin");
+  }
+  return { url: parsed.origin };
+}
+
+function normalizeBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${label} must be a boolean`);
+  return value;
+}
+
+function normalizeDesktopExportPdfInput(input: unknown): DesktopExportPdfInput {
+  const value = assertObject(input, "desktop PDF export input");
+  assertKnownKeys(value, ["baseHref", "deck", "defaultFilename", "html", "title"], "desktop PDF export input");
+  return {
+    ...(value.baseHref == null ? {} : { baseHref: normalizeNonEmptyString(value.baseHref, "desktop PDF export baseHref") }),
+    deck: normalizeBoolean(value.deck, "desktop PDF export deck"),
+    defaultFilename: normalizeNonEmptyString(value.defaultFilename, "desktop PDF export defaultFilename"),
+    html: normalizeNonEmptyString(value.html, "desktop PDF export html"),
+    title: normalizeNonEmptyString(value.title, "desktop PDF export title"),
+  };
+}
+
+function normalizeDesktopRenderSlidesInput(input: unknown): DesktopRenderSlidesInput {
+  const value = assertObject(input, "desktop render slides input");
+  assertKnownKeys(value, ["baseHref", "deck", "editable", "height", "html", "index", "outputDir", "pageImageFormat", "stitch", "paginate", "width"], "desktop render slides input");
+  if (value.deck != null && typeof value.deck !== "boolean") {
+    throw new Error("desktop render slides deck must be a boolean");
+  }
+  if (value.editable != null && typeof value.editable !== "boolean") {
+    throw new Error("desktop render slides editable must be a boolean");
+  }
+  if (value.index != null && (typeof value.index !== "number" || !Number.isInteger(value.index) || value.index < 0)) {
+    throw new Error("desktop render slides index must be a non-negative integer");
+  }
+  if (value.pageImageFormat != null && value.pageImageFormat !== "png" && value.pageImageFormat !== "jpeg") {
+    throw new Error("desktop render slides pageImageFormat must be 'png' or 'jpeg'");
+  }
+  if (value.stitch != null && typeof value.stitch !== "boolean") {
+    throw new Error("desktop render slides stitch must be a boolean");
+  }
+  if (value.paginate != null && typeof value.paginate !== "boolean") {
+    throw new Error("desktop render slides paginate must be a boolean");
+  }
+  if (value.outputDir != null) {
+    const dir = normalizeNonEmptyString(value.outputDir, "desktop render slides outputDir");
+    // outputDir is a daemon-owned absolute scratch path; reject relative values
+    // so a malformed request can't make desktop main write outside it. Accepts
+    // POSIX (`/…`), Windows drive (`C:\…` / `C:/…`), and UNC (`\\…`) absolutes.
+    if (!/^(\/|[A-Za-z]:[\\/]|\\\\)/.test(dir)) {
+      throw new Error("desktop render slides outputDir must be an absolute path");
+    }
+  }
+  return {
+    ...(value.baseHref == null ? {} : { baseHref: normalizeNonEmptyString(value.baseHref, "desktop render slides baseHref") }),
+    ...(value.deck == null ? {} : { deck: value.deck }),
+    ...(value.editable == null ? {} : { editable: value.editable }),
+    html: normalizeNonEmptyString(value.html, "desktop render slides html"),
+    ...(value.index == null ? {} : { index: value.index }),
+    ...(value.outputDir == null ? {} : { outputDir: normalizeNonEmptyString(value.outputDir, "desktop render slides outputDir") }),
+    ...(value.pageImageFormat == null ? {} : { pageImageFormat: value.pageImageFormat }),
+    ...(value.stitch == null ? {} : { stitch: value.stitch }),
+    ...(value.paginate == null ? {} : { paginate: value.paginate }),
+    ...(value.width == null ? {} : { width: normalizeOptionalPositiveNumber(value.width, "desktop render slides width") }),
+    ...(value.height == null ? {} : { height: normalizeOptionalPositiveNumber(value.height, "desktop render slides height") }),
+  };
+}
+
+function normalizeOptionalPositiveNumber(value: unknown, label: string): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive number`);
+  }
+  return value;
+}
+
+const DESKTOP_EXPORT_ARTIFACT_FORMATS: readonly DesktopExportArtifactFormat[] = ["pdf", "image"];
+const DESKTOP_EXPORT_ARTIFACT_IMAGE_FORMATS: readonly DesktopExportArtifactImageFormat[] = ["png", "jpeg"];
+
+function normalizeDesktopExportArtifactInput(input: unknown): DesktopExportArtifactInput {
+  const value = assertObject(input, "desktop artifact export input");
+  assertKnownKeys(value, ["baseHref", "deck", "format", "html", "imageFormat", "title", "width", "height"], "desktop artifact export input");
+  if (!DESKTOP_EXPORT_ARTIFACT_FORMATS.includes(value.format as DesktopExportArtifactFormat)) {
+    throw new Error(`unsupported artifact export format: ${String(value.format)}`);
+  }
+  if (value.imageFormat != null && !DESKTOP_EXPORT_ARTIFACT_IMAGE_FORMATS.includes(value.imageFormat as DesktopExportArtifactImageFormat)) {
+    throw new Error(`unsupported artifact export image format: ${String(value.imageFormat)}`);
+  }
+  return {
+    ...(value.baseHref == null ? {} : { baseHref: normalizeNonEmptyString(value.baseHref, "desktop artifact export baseHref") }),
+    deck: normalizeBoolean(value.deck, "desktop artifact export deck"),
+    format: value.format as DesktopExportArtifactFormat,
+    html: normalizeNonEmptyString(value.html, "desktop artifact export html"),
+    ...(value.imageFormat == null ? {} : { imageFormat: value.imageFormat as DesktopExportArtifactImageFormat }),
+    title: normalizeNonEmptyString(value.title, "desktop artifact export title"),
+    ...(value.width == null ? {} : { width: normalizeOptionalPositiveNumber(value.width, "desktop artifact export width")! }),
+    ...(value.height == null ? {} : { height: normalizeOptionalPositiveNumber(value.height, "desktop artifact export height")! }),
+  };
+}
+
+export function isDesktopUpdateAction(value: unknown): value is DesktopUpdateAction {
+  return Object.values(DESKTOP_UPDATE_ACTIONS).includes(value as DesktopUpdateAction);
+}
+
+function normalizeDesktopUpdateInput(input: unknown): DesktopUpdateInput {
+  const value = assertObject(input, "desktop update input");
+  assertKnownKeys(value, ["action"], "desktop update input");
+  if (!isDesktopUpdateAction(value.action)) {
+    throw new Error(`unsupported desktop update action: ${String(value.action)}`);
+  }
+  return { action: value.action };
+}
+
+function normalizeDesktopShowInput(input: unknown): DesktopShowInput {
+  const value = assertObject(input, "desktop show input");
+  assertKnownKeys(value, ["deeplinkUrl"], "desktop show input");
+  if (value.deeplinkUrl == null) return {};
+  const deeplinkUrl = normalizeNonEmptyString(value.deeplinkUrl, "desktop show deeplinkUrl");
+  if (!deeplinkUrl.startsWith("opendesign://")) {
+    throw new Error("desktop show deeplinkUrl must use the opendesign scheme");
+  }
+  return { deeplinkUrl };
+}
+
+function normalizeMessageType(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new SidecarContractError(SIDECAR_ERROR_CODES.INVALID_MESSAGE, `${label} type must be a non-empty string`);
+  }
+  return value;
+}
+
+export function normalizeDaemonSidecarMessage(input: unknown): DaemonSidecarMessage {
+  const value = assertObject(input, "daemon sidecar message");
+  const type = normalizeMessageType(value.type, "daemon sidecar message");
+  if (type === SIDECAR_MESSAGES.STATUS || type === SIDECAR_MESSAGES.SHUTDOWN) {
+    assertKnownKeys(value, ["type"], "daemon sidecar message");
+    return { type };
+  }
+  if (type === SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH) {
+    assertKnownKeys(value, ["input", "type"], "daemon sidecar message");
+    return { input: normalizeRegisterDesktopAuthInput(value.input), type };
+  }
+  if (type === SIDECAR_MESSAGES.MINT_IMPORT_TOKEN) {
+    assertKnownKeys(value, ["input", "type"], "daemon sidecar message");
+    return { input: normalizeMintImportTokenInput(value.input), type };
+  }
+  if (type === SIDECAR_MESSAGES.REGISTER_WEB_URL) {
+    assertKnownKeys(value, ["input", "type"], "daemon sidecar message");
+    return { input: normalizeRegisterWebUrlInput(value.input), type };
+  }
+  throw new SidecarContractError(SIDECAR_ERROR_CODES.UNKNOWN_MESSAGE, `unknown daemon sidecar message: ${type}`);
+}
+
+export function normalizeWebSidecarMessage(input: unknown): WebSidecarMessage {
+  const value = assertObject(input, "web sidecar message");
+  const type = normalizeMessageType(value.type, "web sidecar message");
+  if (type === SIDECAR_MESSAGES.STATUS || type === SIDECAR_MESSAGES.SHUTDOWN) {
+    assertKnownKeys(value, ["type"], "web sidecar message");
+    return { type };
+  }
+  throw new SidecarContractError(SIDECAR_ERROR_CODES.UNKNOWN_MESSAGE, `unknown web sidecar message: ${type}`);
+}
+
+export function normalizeDesktopSidecarMessage(input: unknown): DesktopSidecarMessage {
+  const value = assertObject(input, "desktop sidecar message");
+  const type = normalizeMessageType(value.type, "desktop sidecar message");
+  switch (type) {
+    case SIDECAR_MESSAGES.STATUS:
+    case SIDECAR_MESSAGES.SHUTDOWN:
+    case SIDECAR_MESSAGES.CONSOLE:
+      assertKnownKeys(value, ["type"], "desktop sidecar message");
+      return { type };
+    case SIDECAR_MESSAGES.SHOW:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return value.input == null
+        ? { type }
+        : { input: normalizeDesktopShowInput(value.input), type };
+    case SIDECAR_MESSAGES.EVAL:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopEvalInput(value.input), type };
+    case SIDECAR_MESSAGES.SCREENSHOT:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopScreenshotInput(value.input), type };
+    case SIDECAR_MESSAGES.CLICK:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopClickInput(value.input), type };
+    case SIDECAR_MESSAGES.EXPORT_PDF:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopExportPdfInput(value.input), type };
+    case SIDECAR_MESSAGES.RENDER_SLIDES:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopRenderSlidesInput(value.input), type };
+    case SIDECAR_MESSAGES.EXPORT_ARTIFACT:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopExportArtifactInput(value.input), type };
+    case SIDECAR_MESSAGES.UPDATE:
+      assertKnownKeys(value, ["input", "type"], "desktop sidecar message");
+      return { input: normalizeDesktopUpdateInput(value.input), type };
+    default:
+      throw new SidecarContractError(SIDECAR_ERROR_CODES.UNKNOWN_MESSAGE, `unknown desktop sidecar message: ${type}`);
+  }
+}
+
+export const OPEN_DESIGN_SIDECAR_CONTRACT = Object.freeze({
+  appKeys: APP_KEYS,
+  defaults: SIDECAR_DEFAULTS,
+  env: SIDECAR_RUNTIME_ENV,
+  errorCodes: SIDECAR_ERROR_CODES,
+  messages: SIDECAR_MESSAGES,
+  modes: SIDECAR_MODES,
+  normalizeApp: normalizeAppKey,
+  normalizeNamespace,
+  normalizeSource: normalizeSidecarSource,
+  normalizeStamp: normalizeSidecarStamp,
+  normalizeStampCriteria: normalizeSidecarStampCriteria,
+  sources: SIDECAR_SOURCES,
+  stampFields: SIDECAR_STAMP_FIELDS,
+  stampFlags: SIDECAR_STAMP_FLAGS,
+  updateActions: DESKTOP_UPDATE_ACTIONS,
+  updateChannels: DESKTOP_UPDATE_CHANNELS,
+  updateModes: DESKTOP_UPDATE_MODES,
+  updateStates: DESKTOP_UPDATE_STATES,
+} as const satisfies OpenDesignSidecarContract);
+

--- a/packages/sidecar/tests/control-plane.test.ts
+++ b/packages/sidecar/tests/control-plane.test.ts
@@ -1,0 +1,434 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import * as publicControl from "../src/control/index.js";
+import {
+  createPrivateLaunchForTest,
+  installPrivateLaunchForTest,
+  privateLaunchStateForTest,
+  sendPrivateRequestForTest,
+} from "../src/control/private-testing.js";
+import { attachDemoBody } from "./fixtures/control-body.js";
+import {
+  createDemoController,
+  demoProjection,
+  type DemoMethods,
+} from "./fixtures/control-controller.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), "open-design-sidecar-control-"));
+  cleanups.push(() => rm(root, { force: true, recursive: true }));
+  return {
+    roots: {
+      dataRoot: join(root, "data"),
+      resourceRoot: join(root, "resources"),
+      runtimeRoot: join(root, "runtime"),
+    },
+    scope: {
+      channel: "beta",
+      generation: 7,
+      namespace: "release-beta",
+    },
+  } as const;
+}
+
+describe("sidecar control public boundary", () => {
+  it("exports semantic control operations without raw transport or incarnation helpers", () => {
+    expect(Object.keys(publicControl).sort()).toEqual([
+      "SidecarControlError",
+      "attachSidecar",
+      "bootstrapControlPlane",
+    ]);
+
+    const publicNames = Object.keys(publicControl).join(" ").toLowerCase();
+    expect(publicNames).not.toMatch(/endpoint|incarnation|ipc|process|stamp|transport/);
+  });
+});
+
+describe("sidecar control identity", () => {
+  it("keeps channel, namespace, generation and service independent", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+
+    expect(controller.scope).toEqual(scope);
+    expect(controller.roots).toEqual(roots);
+    expect(() =>
+      createDemoController({ ...scope, channel: "release/beta" }, roots),
+    ).toThrow(/channel/);
+    expect(() =>
+      createDemoController({ ...scope, namespace: "Beta Namespace" }, roots),
+    ).toThrow(/namespace/);
+    expect(() => createDemoController({ ...scope, generation: -1 }, roots)).toThrow(
+      /generation/,
+    );
+  });
+});
+
+describe("independent sidecar controller and body", () => {
+  it("exposes a caller-hosted semantic service through the same fenced control plane", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+    const hosted = await controller.expose<DemoMethods>({
+      handlers: {
+        context(_input, context) {
+          return context;
+        },
+        echo(input) {
+          return { value: `hosted:${input.value}` };
+        },
+      },
+      service: "shell",
+    });
+    cleanups.push(() => hosted.close());
+
+    const client = await controller.connect<DemoMethods>("shell");
+    await expect(client.call("echo", { value: "capability" })).resolves.toEqual({
+      value: "hosted:capability",
+    });
+    await expect(client.call("context", {})).resolves.toEqual({
+      identity: { ...scope, service: "shell" },
+      projection: demoProjection,
+      roots,
+    });
+
+    await hosted.close();
+    await expect(controller.connect("shell")).rejects.toThrow(/unavailable/);
+  });
+
+  it("gives semantic calls a long default deadline while preserving caller overrides", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+    let contextCalls = 0;
+    const hosted = await controller.expose<DemoMethods>({
+      handlers: {
+        async context(_input, context) {
+          contextCalls += 1;
+          await new Promise((resolve) => setTimeout(resolve, contextCalls === 1 ? 1_600 : 25));
+          return context;
+        },
+        echo(input) {
+          return input;
+        },
+      },
+      service: "shell",
+    });
+    cleanups.push(() => hosted.close());
+
+    const client = await controller.connect<DemoMethods>("shell");
+    await expect(client.call("context", {})).resolves.toMatchObject({
+      identity: { ...scope, service: "shell" },
+    });
+    await expect(client.call("context", {}, { timeoutMs: 5 })).rejects.toMatchObject({
+      code: "peer-unavailable",
+    });
+    await expect(client.call("context", {}, { timeoutMs: null })).resolves.toMatchObject({
+      identity: { ...scope, service: "shell" },
+    });
+  });
+
+  it("initializes the body from validated roots before publishing readiness", async () => {
+    const { roots, scope } = await createFixture();
+    const launch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "web",
+    });
+    const restoreLaunch = installPrivateLaunchForTest(launch);
+    cleanups.push(restoreLaunch);
+    let initialized = false;
+    const body = await publicControl.attachSidecar<DemoMethods>({
+      handlers: {
+        context(_input, context) {
+          expect(initialized).toBe(true);
+          return context;
+        },
+        echo(input) {
+          expect(initialized).toBe(true);
+          return { value: input.value };
+        },
+      },
+      initialize(context) {
+        expect(context).toEqual({
+          identity: { ...scope, service: "web" },
+          projection: demoProjection,
+          roots,
+        });
+        initialized = true;
+      },
+    });
+    cleanups.push(() => body.close());
+
+    const client = await createDemoController(scope, roots).connect<DemoMethods>("web");
+    await expect(client.call("echo", { value: "ready-after-body" })).resolves.toEqual({
+      value: "ready-after-body",
+    });
+  });
+
+  it("cleans up body startup when initialization fails", async () => {
+    const { roots, scope } = await createFixture();
+    const launch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "web",
+    });
+    const restoreLaunch = installPrivateLaunchForTest(launch);
+    cleanups.push(restoreLaunch);
+    let stopped = false;
+
+    await expect(publicControl.attachSidecar<DemoMethods>({
+      handlers: {
+        context(_input, context) {
+          return context;
+        },
+        echo(input) {
+          return { value: input.value };
+        },
+      },
+      initialize() {
+        throw new Error("body startup failed");
+      },
+      onStopRequested() {
+        stopped = true;
+      },
+    })).rejects.toThrow("body startup failed");
+
+    expect(stopped).toBe(true);
+    await expect(createDemoController(scope, roots).connect("web")).rejects.toThrow(
+      /unavailable/,
+    );
+  });
+
+  it("launches and stops a real body without exposing launch metadata to it", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+    const childEntry = join(import.meta.dirname, "fixtures", "control-child.ts");
+    const launch = await controller.launch<DemoMethods>({
+      args: ["--import", "tsx", childEntry],
+      executable: process.execPath,
+      readyTimeoutMs: 5_000,
+      service: "daemon",
+    });
+    cleanups.push(async () => {
+      await launch.stop();
+    });
+
+    await expect(launch.client.call("echo", { value: "real-child" })).resolves.toEqual({
+      value: "real-child",
+    });
+    await expect(launch.client.call("context", {})).resolves.toEqual({
+      identity: { ...scope, service: "daemon" },
+      projection: demoProjection,
+      roots,
+    });
+    await expect(launch.stop()).resolves.toMatchObject({ code: 0, signal: null });
+    await expect(controller.connect("daemon")).rejects.toThrow(/unavailable/);
+  });
+
+  it("force-terminates an uncooperative body and converges its control state", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+    const childEntry = join(import.meta.dirname, "fixtures", "control-uncooperative-child.ts");
+    const launch = await controller.launch<DemoMethods>({
+      args: ["--import", "tsx", childEntry],
+      executable: process.execPath,
+      service: "daemon",
+      stopTimeoutMs: 50,
+    });
+    cleanups.push(async () => {
+      await launch.stop();
+    });
+
+    await expect(launch.stop()).resolves.toMatchObject({ code: null });
+    await expect(controller.connect("daemon")).rejects.toThrow(/unavailable/);
+    const privateState = await privateLaunchStateForTest(
+      createPrivateLaunchForTest({
+        projection: demoProjection,
+        roots,
+        scope,
+        service: "daemon",
+      }),
+    );
+    expect(privateState).toEqual({ descriptorExists: false, endpointExists: false });
+  });
+
+  it("does not replace a live peer when a duplicate launch loses endpoint ownership", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+    const childEntry = join(import.meta.dirname, "fixtures", "control-child.ts");
+    const first = await controller.launch<DemoMethods>({
+      args: ["--import", "tsx", childEntry],
+      executable: process.execPath,
+      service: "daemon",
+    });
+    cleanups.push(async () => {
+      await first.stop();
+    });
+
+    await expect(
+      controller.launch<DemoMethods>({
+        args: ["--import", "tsx", childEntry],
+        executable: process.execPath,
+        readyTimeoutMs: 2_000,
+        service: "daemon",
+      }),
+    ).rejects.toThrow(/exited before readiness/);
+    await expect(first.client.call("echo", { value: "still-owner" })).resolves.toEqual({
+      value: "still-owner",
+    });
+  });
+
+  it("agree on normalized identity, roots and caller-owned methods", async () => {
+    const { roots, scope } = await createFixture();
+    const launch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "daemon",
+    });
+    const restoreLaunch = installPrivateLaunchForTest(launch);
+    cleanups.push(restoreLaunch);
+    let observedContext: unknown = null;
+    const body = await attachDemoBody((context) => {
+      observedContext = context;
+    });
+    cleanups.push(() => body.close());
+
+    const controller = createDemoController(scope, roots);
+    const client = await controller.connect<DemoMethods>("daemon");
+
+    await expect(client.probe()).resolves.toEqual({
+      identity: { ...scope, service: "daemon" },
+      projection: demoProjection,
+    });
+    await expect(client.call("echo", { value: "江湖" })).resolves.toEqual({
+      value: "江湖",
+    });
+    expect(observedContext).toEqual({
+      identity: { ...scope, service: "daemon" },
+      projection: demoProjection,
+      roots,
+    });
+  });
+
+  it("fences a delayed client after a same-generation restart", async () => {
+    const { roots, scope } = await createFixture();
+    const controller = createDemoController(scope, roots);
+
+    const firstLaunch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "web",
+    });
+    const restoreFirst = installPrivateLaunchForTest(firstLaunch);
+    const firstBody = await attachDemoBody(() => undefined);
+    const staleClient = await controller.connect<DemoMethods>("web");
+    await firstBody.close();
+    restoreFirst();
+
+    const secondLaunch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "web",
+    });
+    expect(secondLaunch.identity).toEqual(firstLaunch.identity);
+    expect(secondLaunch.incarnation).not.toBe(firstLaunch.incarnation);
+    const restoreSecond = installPrivateLaunchForTest(secondLaunch);
+    cleanups.push(restoreSecond);
+    const secondBody = await attachDemoBody(() => undefined);
+    cleanups.push(() => secondBody.close());
+
+    await expect(staleClient.call("echo", { value: "late" })).rejects.toThrow(
+      /stale sidecar peer/,
+    );
+
+    const currentClient = await controller.connect<DemoMethods>("web");
+    await expect(currentClient.call("echo", { value: "current" })).resolves.toEqual({
+      value: "current",
+    });
+  });
+
+  it("does not let a wrong scope satisfy or stop the requested peer", async () => {
+    const { roots, scope } = await createFixture();
+    const launch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "daemon",
+    });
+    const restoreLaunch = installPrivateLaunchForTest(launch);
+    cleanups.push(restoreLaunch);
+    const body = await attachDemoBody(() => undefined);
+    cleanups.push(() => body.close());
+
+    const wrongChannel = createDemoController({ ...scope, channel: "stable" }, roots);
+    const wrongNamespace = createDemoController({ ...scope, namespace: "release-stable" }, roots);
+    const wrongGeneration = createDemoController({ ...scope, generation: 8 }, roots);
+
+    await expect(wrongChannel.connect("daemon")).rejects.toThrow(/unavailable/);
+    await expect(wrongNamespace.connect("daemon")).rejects.toThrow(/unavailable/);
+    await expect(wrongGeneration.requestStop("daemon")).rejects.toThrow(/unavailable/);
+
+    for (const identity of [
+      { ...launch.identity, channel: "stable" },
+      { ...launch.identity, namespace: "release-stable" },
+      { ...launch.identity, generation: 8 },
+    ]) {
+      await expect(
+        sendPrivateRequestForTest(launch, {
+          identity,
+          operation: { kind: "request-stop" },
+        }),
+      ).resolves.toMatchObject({
+        error: { code: "peer-mismatch" },
+        status: "error",
+      });
+    }
+
+    const currentClient = await createDemoController(scope, roots).connect<DemoMethods>("daemon");
+    await expect(currentClient.call("echo", { value: "still-running" })).resolves.toEqual({
+      value: "still-running",
+    });
+  });
+
+  it("does not attach a controller with a different caller-owned projection", async () => {
+    const { roots, scope } = await createFixture();
+    const launch = createPrivateLaunchForTest({
+      projection: demoProjection,
+      roots,
+      scope,
+      service: "daemon",
+    });
+    const restoreLaunch = installPrivateLaunchForTest(launch);
+    cleanups.push(restoreLaunch);
+    const body = await attachDemoBody(() => undefined);
+    cleanups.push(() => body.close());
+
+    const value = { releaseVersion: "0.18.0-beta.5" } as const;
+    const wrongProjection = {
+      digest: `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}` as const,
+      value,
+    };
+    const wrongController = publicControl.bootstrapControlPlane({
+      projection: wrongProjection,
+      roots,
+      scope,
+    });
+
+    await expect(wrongController.connect("daemon")).rejects.toThrow(/unavailable/);
+    await expect(createDemoController(scope, roots).connect("daemon")).resolves.toBeDefined();
+  });
+});
+

--- a/packages/sidecar/tests/fixtures/control-body.ts
+++ b/packages/sidecar/tests/fixtures/control-body.ts
@@ -1,0 +1,24 @@
+import {
+  attachSidecar,
+  type AttachedSidecar,
+  type SidecarControlContext,
+} from "../../src/control/index.js";
+
+import type { DemoMethods } from "./control-controller.js";
+
+export async function attachDemoBody(
+  observeContext: (context: SidecarControlContext) => void,
+): Promise<AttachedSidecar> {
+  return await attachSidecar<DemoMethods>({
+    handlers: {
+      context(_input, context) {
+        return context;
+      },
+      echo(input, context) {
+        observeContext(context);
+        return { value: input.value };
+      },
+    },
+  });
+}
+

--- a/packages/sidecar/tests/fixtures/control-child.ts
+++ b/packages/sidecar/tests/fixtures/control-child.ts
@@ -1,0 +1,15 @@
+import { attachSidecar } from "../../src/control/index.js";
+
+import type { DemoMethods } from "./control-controller.js";
+
+await attachSidecar<DemoMethods>({
+  handlers: {
+    context(_input, context) {
+      return context;
+    },
+    echo(input) {
+      return { value: input.value };
+    },
+  },
+});
+

--- a/packages/sidecar/tests/fixtures/control-controller.ts
+++ b/packages/sidecar/tests/fixtures/control-controller.ts
@@ -1,0 +1,43 @@
+import { createHash } from "node:crypto";
+
+import {
+  bootstrapControlPlane,
+  type SidecarControlPlane,
+  type SidecarControlRoots,
+  type SidecarControlScope,
+} from "../../src/control/index.js";
+
+const demoProjectionValue = Object.freeze({ releaseVersion: "0.18.0-beta.4" });
+export const demoProjection = Object.freeze({
+  digest: `sha256:${createHash("sha256")
+    .update(JSON.stringify(demoProjectionValue))
+    .digest("hex")}` as const,
+  value: demoProjectionValue,
+});
+
+export type DemoMethods = {
+  context: {
+    input: Record<string, never>;
+    output: {
+      identity: {
+        channel: string;
+        generation: number;
+        namespace: string;
+        service: string;
+      };
+      roots: SidecarControlRoots;
+    };
+  };
+  echo: {
+    input: { value: string };
+    output: { value: string };
+  };
+};
+
+export function createDemoController(
+  scope: SidecarControlScope,
+  roots: SidecarControlRoots,
+): SidecarControlPlane {
+  return bootstrapControlPlane({ projection: demoProjection, roots, scope });
+}
+

--- a/packages/sidecar/tests/fixtures/control-uncooperative-child.ts
+++ b/packages/sidecar/tests/fixtures/control-uncooperative-child.ts
@@ -1,0 +1,18 @@
+import { attachSidecar } from "../../src/control/index.js";
+
+import type { DemoMethods } from "./control-controller.js";
+
+await attachSidecar<DemoMethods>({
+  handlers: {
+    context(_input, context) {
+      return context;
+    },
+    echo(input) {
+      return { value: input.value };
+    },
+  },
+  async onStopRequested() {
+    await new Promise<never>(() => undefined);
+  },
+});
+

--- a/packages/sidecar/tests/ipc-path.test.ts
+++ b/packages/sidecar/tests/ipc-path.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { isWindowsNamedPipePath, normalizeIpcPath } from "../src/protocol.js";
+
+describe("normalizeIpcPath", () => {
+  it("returns absolute POSIX paths unchanged", () => {
+    expect(normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock")).toBe("/tmp/open-design/ipc/ns/web.sock");
+  });
+
+  it("returns Windows named-pipe paths unchanged without absolute-path checking", () => {
+    expect(normalizeIpcPath("\\\\.\\pipe\\open-design-ns-web")).toBe("\\\\.\\pipe\\open-design-ns-web");
+  });
+
+  it("returns drive-letter absolute Windows paths unchanged", () => {
+    expect(normalizeIpcPath("C:\\Users\\ipc\\web.sock")).toBe("C:\\Users\\ipc\\web.sock");
+  });
+
+  it("throws when the ipc path is not a string", () => {
+    expect(() => normalizeIpcPath(42)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(null)).toThrow(/must be a string/);
+    expect(() => normalizeIpcPath(undefined)).toThrow(/must be a string/);
+  });
+
+  it("throws on the empty string", () => {
+    expect(() => normalizeIpcPath("")).toThrow(/must not be empty/);
+  });
+
+  it("throws when the path has leading or trailing whitespace", () => {
+    expect(() => normalizeIpcPath(" /tmp/open-design/ipc/ns/web.sock")).toThrow(/whitespace/);
+    expect(() => normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock\n")).toThrow(/whitespace/);
+  });
+
+  it("throws when the path contains a null byte", () => {
+    expect(() => normalizeIpcPath("/tmp/open-design/ipc/ns/web.sock\0extra")).toThrow(/null bytes/);
+  });
+
+  it("throws when a POSIX path is not absolute", () => {
+    expect(() => normalizeIpcPath("relative/path.sock")).toThrow(/must be absolute/);
+    expect(() => normalizeIpcPath("./web.sock")).toThrow(/must be absolute/);
+  });
+});
+
+describe("isWindowsNamedPipePath", () => {
+  it("returns true for paths starting with \\\\.\\pipe\\", () => {
+    expect(isWindowsNamedPipePath("\\\\.\\pipe\\open-design-ns-web")).toBe(true);
+    expect(isWindowsNamedPipePath("\\\\.\\pipe\\")).toBe(true);
+  });
+
+  it("returns false for POSIX, drive-letter, or non-string inputs", () => {
+    expect(isWindowsNamedPipePath("/tmp/open-design/ipc/ns/web.sock")).toBe(false);
+    expect(isWindowsNamedPipePath("C:\\Users\\ipc\\web.sock")).toBe(false);
+    expect(isWindowsNamedPipePath("\\\\.\\Pipe\\open-design")).toBe(false);
+    expect(isWindowsNamedPipePath(null)).toBe(false);
+    expect(isWindowsNamedPipePath(undefined)).toBe(false);
+    expect(isWindowsNamedPipePath(123)).toBe(false);
+  });
+});
+

--- a/packages/sidecar/tests/lifecycle.test.ts
+++ b/packages/sidecar/tests/lifecycle.test.ts
@@ -1,0 +1,270 @@
+import { mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  bootstrapSidecarLifecycle,
+  type SidecarLifecycleOwner,
+  type SidecarLifecyclePlane,
+} from "../src/lifecycle/index.js";
+
+const cleanups: Array<() => void | Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+});
+
+async function createFixture(options: Readonly<{ maxLeaseMs?: number }> = {}) {
+  const root = await mkdtemp(join(tmpdir(), "open-design-sidecar-lifecycle-"));
+  cleanups.push(() => rm(root, { force: true, recursive: true }));
+  let nowMs = 1_000;
+  const plane = bootstrapSidecarLifecycle({
+    controlRoot: root,
+    maxLeaseMs: options.maxLeaseMs ?? 60_000,
+    now: () => nowMs,
+    scope: { channel: "beta", namespace: "release-beta" },
+  });
+  return {
+    advance(milliseconds: number) {
+      nowMs += milliseconds;
+    },
+    plane,
+    root,
+  };
+}
+
+function owner(key: string, generation = 1): SidecarLifecycleOwner {
+  return {
+    generation,
+    incarnation: `${key}-incarnation`,
+    key,
+    projection: { label: key },
+  };
+}
+
+async function attach(plane: SidecarLifecyclePlane, key: string, generation = 1) {
+  const result = await plane.attach({ leaseMs: 60_000, owner: owner(key, generation) });
+  expect(result.state).toBe("attached");
+  if (result.state !== "attached") throw new Error("attachment unexpectedly blocked");
+  return result;
+}
+
+describe("namespace lifecycle leases", () => {
+  it("uses caller heartbeats as bounded evidence and never revives an expired lease", async () => {
+    const { advance, plane } = await createFixture();
+    const first = await attach(plane, "electron-a", 7);
+
+    advance(20_000);
+    await expect(plane.renewLease({ credential: first.credential, leaseMs: 60_000 })).resolves.toMatchObject({
+      state: "renewed",
+    });
+    advance(60_001);
+    await expect(plane.renewLease({ credential: first.credential, leaseMs: 60_000 })).resolves.toEqual({
+      reason: "expired-or-fenced",
+      state: "rejected",
+    });
+
+    const second = await attach(plane, "electron-a", 7);
+    expect(second.credential).not.toEqual(first.credential);
+    await expect(plane.detach(first.credential)).resolves.toEqual({ detached: false });
+    await expect(plane.detach(second.credential)).resolves.toEqual({ detached: true });
+    await expect(plane.detach(second.credential)).resolves.toEqual({ detached: false });
+  });
+
+  it("enforces the protocol-wide one minute lease ceiling", async () => {
+    const { plane } = await createFixture();
+    await expect(plane.attach({ leaseMs: 60_001, owner: owner("electron") })).rejects.toMatchObject({
+      code: "invalid-input",
+    });
+  });
+});
+
+describe("namespace transition", () => {
+  it("atomically prunes, checks occupants and lets only the requester stay live inside the transition", async () => {
+    const { plane } = await createFixture();
+    const requester = await attach(plane, "electron-a", 3);
+    const occupant = await attach(plane, "codex-plugin", 2);
+
+    await expect(plane.beginTransition({
+      kind: "apply-shell-update",
+      leaseMs: 60_000,
+      owner: owner("electron-a", 3),
+      requester: requester.credential,
+    })).resolves.toMatchObject({
+      occupants: [{ owner: { key: "codex-plugin" } }],
+      reason: "occupied",
+      state: "blocked",
+    });
+
+    await plane.detach(occupant.credential);
+    const acquired = await plane.beginTransition({
+      kind: "apply-shell-update",
+      leaseMs: 60_000,
+      owner: owner("electron-a", 3),
+      requester: requester.credential,
+    });
+    expect(acquired.state).toBe("acquired");
+    if (acquired.state !== "acquired") throw new Error("transition unexpectedly blocked");
+
+    await expect(plane.renewLease({ credential: requester.credential, leaseMs: 60_000 })).resolves.toMatchObject({
+      reason: "transition-active",
+      state: "rejected",
+    });
+    await expect(plane.renewLease({
+      credential: requester.credential,
+      leaseMs: 60_000,
+      transition: acquired.credential,
+    })).resolves.toMatchObject({ state: "renewed" });
+    await expect(plane.snapshot()).resolves.toMatchObject({
+      leases: [{ owner: { key: "electron-a" } }],
+      transition: { id: acquired.credential.id },
+    });
+    await expect(plane.attach({ leaseMs: 60_000, owner: owner("old-generation", 3) })).resolves.toMatchObject({
+      reason: "transition-active",
+      state: "blocked",
+    });
+  });
+
+  it("fences handoff-once credentials and only completes with an attached target", async () => {
+    const { plane } = await createFixture();
+    const acquired = await plane.beginTransition({
+      kind: "install-standalone",
+      leaseMs: 60_000,
+      owner: owner("old-electron", 4),
+    });
+    if (acquired.state !== "acquired") throw new Error("transition unexpectedly blocked");
+
+    const helper = await plane.takeoverTransition({
+      credential: acquired.credential,
+      leaseMs: 60_000,
+      owner: owner("installer-helper", 4),
+    });
+    expect(helper.state).toBe("acquired");
+    if (helper.state !== "acquired") throw new Error("transition handoff unexpectedly rejected");
+    expect(helper.credential.fence).toBeGreaterThan(acquired.credential.fence);
+
+    await expect(plane.renewTransition({ credential: acquired.credential, leaseMs: 60_000 })).resolves.toEqual({
+      reason: "expired-or-fenced",
+      state: "rejected",
+    });
+    await expect(plane.attach({
+      leaseMs: 60_000,
+      owner: owner("new-electron", 5),
+      transition: acquired.credential,
+    })).resolves.toMatchObject({ reason: "transition-active", state: "blocked" });
+
+    const target = await plane.attach({
+      leaseMs: 60_000,
+      owner: owner("new-electron", 5),
+      transition: helper.credential,
+    });
+    if (target.state !== "attached") throw new Error("target attachment unexpectedly blocked");
+    await expect(plane.renewLease({
+      credential: target.credential,
+      leaseMs: 60_000,
+      transition: helper.credential,
+    })).resolves.toMatchObject({ state: "renewed" });
+    await expect(plane.renewLease({
+      credential: target.credential,
+      leaseMs: 60_000,
+      transition: acquired.credential,
+    })).resolves.toMatchObject({ reason: "transition-active", state: "rejected" });
+    await expect(plane.completeTransition({
+      lease: { id: "missing", token: "missing" },
+      transition: helper.credential,
+    })).resolves.toEqual({ reason: "lease-expired-or-fenced", state: "rejected" });
+    await expect(plane.completeTransition({
+      lease: target.credential,
+      transition: helper.credential,
+    })).resolves.toEqual({ state: "completed" });
+
+    await expect(plane.snapshot()).resolves.toMatchObject({
+      leases: [{ owner: { generation: 5, key: "new-electron" } }],
+      transition: null,
+    });
+  });
+
+  it("recovers after a crashed transition only when its bounded lease expires", async () => {
+    const { advance, plane } = await createFixture();
+    const acquired = await plane.beginTransition({
+      kind: "install-standalone",
+      leaseMs: 1_000,
+      owner: owner("crashed-helper"),
+    });
+    expect(acquired.state).toBe("acquired");
+    await expect(plane.attach({ leaseMs: 60_000, owner: owner("electron") })).resolves.toMatchObject({
+      reason: "transition-active",
+      state: "blocked",
+    });
+
+    advance(1_001);
+    await expect(plane.attach({ leaseMs: 60_000, owner: owner("electron") })).resolves.toMatchObject({
+      state: "attached",
+    });
+  });
+
+  it("lets the current fenced owner abort a failed transition without touching a successor", async () => {
+    const { plane } = await createFixture();
+    const acquired = await plane.beginTransition({
+      kind: "repair-standalone",
+      leaseMs: 60_000,
+      owner: owner("electron"),
+    });
+    if (acquired.state !== "acquired") throw new Error("transition unexpectedly blocked");
+    const helper = await plane.takeoverTransition({
+      credential: acquired.credential,
+      leaseMs: 60_000,
+      owner: owner("helper"),
+    });
+    if (helper.state !== "acquired") throw new Error("transition handoff unexpectedly rejected");
+
+    await expect(plane.abortTransition(acquired.credential)).resolves.toEqual({
+      reason: "expired-or-fenced",
+      state: "rejected",
+    });
+    await expect(plane.abortTransition(helper.credential)).resolves.toEqual({ state: "aborted" });
+    await expect(plane.snapshot()).resolves.toMatchObject({ transition: null });
+  });
+});
+
+describe("lifecycle persistence failures", () => {
+  it("keeps opaque lifecycle credentials private on disk", async () => {
+    const { plane, root } = await createFixture();
+    await attach(plane, "electron");
+    const stateDirectory = join(root, "sidecar-lifecycle");
+    const [stateFile] = (await readdir(stateDirectory)).filter((entry) => entry.endsWith(".json"));
+
+    if (process.platform !== "win32") {
+      expect((await stat(stateDirectory)).mode & 0o777).toBe(0o700);
+      expect((await stat(join(stateDirectory, stateFile!))).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("quick-fails corrupt state instead of deleting history and continuing", async () => {
+    const { plane, root } = await createFixture();
+    await plane.snapshot();
+    const stateDirectory = join(root, "sidecar-lifecycle");
+    const [stateFile] = (await readdir(stateDirectory)).filter((entry) => entry.endsWith(".json"));
+    await writeFile(join(stateDirectory, stateFile!), "{ broken", "utf8");
+
+    await expect(plane.snapshot()).rejects.toMatchObject({ code: "state-corrupt" });
+  });
+
+  it("bounds filesystem guard spin and returns a structured quick failure", async () => {
+    const { root } = await createFixture();
+    const plane = bootstrapSidecarLifecycle({
+      controlRoot: root,
+      guardSpinMs: 0,
+      scope: { channel: "beta", namespace: "release-beta" },
+    });
+    await plane.snapshot();
+    const stateDirectory = join(root, "sidecar-lifecycle");
+    const [stateFile] = (await readdir(stateDirectory)).filter((entry) => entry.endsWith(".json"));
+    await mkdir(join(stateDirectory, `${stateFile}.guard`));
+
+    await expect(plane.snapshot()).rejects.toMatchObject({ code: "guard-busy" });
+  });
+});
+

--- a/packages/sidecar/tests/protocol.test.ts
+++ b/packages/sidecar/tests/protocol.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  APP_KEYS,
+  DESKTOP_UPDATE_ACTIONS,
+  DESKTOP_UPDATE_CHANNELS,
+  DESKTOP_UPDATE_MODES,
+  DESKTOP_UPDATE_STATES,
+  normalizeDaemonSidecarMessage,
+  normalizeDesktopSidecarMessage,
+  normalizeNamespace,
+  normalizeSidecarStamp,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MESSAGES,
+  SIDECAR_SOURCES,
+  SIDECAR_STAMP_FIELDS,
+  STAMP_APP_FLAG,
+  STAMP_IPC_FLAG,
+  STAMP_MODE_FLAG,
+  STAMP_NAMESPACE_FLAG,
+  STAMP_SOURCE_FLAG,
+  type DaemonStatusSnapshot,
+} from "../src/protocol.js";
+
+const validStamp = {
+  app: APP_KEYS.WEB,
+  ipc: "/tmp/open-design/ipc/contract-check/web.sock",
+  mode: "dev" as const,
+  namespace: "contract-check",
+  source: SIDECAR_SOURCES.TOOLS_DEV,
+};
+
+describe("open-design sidecar contract", () => {
+  it("exports the canonical five-field stamp descriptor", () => {
+    expect(SIDECAR_STAMP_FIELDS).toEqual(["app", "mode", "namespace", "ipc", "source"]);
+    expect(OPEN_DESIGN_SIDECAR_CONTRACT.stampFlags).toEqual({
+      app: STAMP_APP_FLAG,
+      ipc: STAMP_IPC_FLAG,
+      mode: STAMP_MODE_FLAG,
+      namespace: STAMP_NAMESPACE_FLAG,
+      source: STAMP_SOURCE_FLAG,
+    });
+    expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateActions).toBe(DESKTOP_UPDATE_ACTIONS);
+    expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateChannels).toBe(DESKTOP_UPDATE_CHANNELS);
+    expect(Object.values(DESKTOP_UPDATE_CHANNELS)).toEqual(["beta", "prerelease", "stable"]);
+    expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateModes).toBe(DESKTOP_UPDATE_MODES);
+    expect(OPEN_DESIGN_SIDECAR_CONTRACT.updateStates).toBe(DESKTOP_UPDATE_STATES);
+  });
+
+  it("accepts the explicit namespace contract", () => {
+    expect(normalizeNamespace("contract-check_1.alpha")).toBe("contract-check_1.alpha");
+  });
+
+  it("rejects path-like or whitespace namespaces", () => {
+    expect(() => normalizeNamespace("../other")).toThrow();
+    expect(() => normalizeNamespace(" contract-check")).toThrow();
+    expect(() => normalizeNamespace("contract check")).toThrow();
+  });
+
+  it("accepts exactly app, mode, namespace, ipc, and source", () => {
+    expect(normalizeSidecarStamp(validStamp)).toEqual(validStamp);
+  });
+
+  it("rejects legacy or extra stamp fields", () => {
+    expect(() => normalizeSidecarStamp({ ...validStamp, runtimeToken: "legacy" })).toThrow();
+    expect(() => normalizeSidecarStamp({ ...validStamp, role: "web-sidecar" })).toThrow();
+  });
+
+  it("rejects non-contract sidecar sources", () => {
+    expect(() => normalizeSidecarStamp({ ...validStamp, source: "custom-script" })).toThrow();
+  });
+
+  it("validates daemon IPC messages", () => {
+    expect(normalizeDaemonSidecarMessage({ type: SIDECAR_MESSAGES.STATUS })).toEqual({ type: "status" });
+    expect(normalizeDaemonSidecarMessage({ type: SIDECAR_MESSAGES.SHUTDOWN })).toEqual({ type: "shutdown" });
+    expect(() => normalizeDaemonSidecarMessage({ input: {}, type: SIDECAR_MESSAGES.EVAL })).toThrow();
+  });
+
+  it("accepts a base64 register-desktop-auth payload", () => {
+    const message = {
+      input: { secret: "AAECAwQFBgcICQoLDA0ODw==" },
+      type: SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH,
+    };
+    expect(normalizeDaemonSidecarMessage(message)).toEqual(message);
+  });
+
+  it("accepts a mint-import-token payload with a baseDir", () => {
+    const message = {
+      input: { baseDir: "/Users/u/project" },
+      type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+    };
+    expect(normalizeDaemonSidecarMessage(message)).toEqual(message);
+  });
+
+  it("accepts only loopback HTTP origins for packaged web registration", () => {
+    const message = {
+      input: { url: "http://127.0.0.1:64248" },
+      type: SIDECAR_MESSAGES.REGISTER_WEB_URL,
+    };
+    expect(normalizeDaemonSidecarMessage(message)).toEqual(message);
+
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { url: "https://open-design.ai" },
+        type: SIDECAR_MESSAGES.REGISTER_WEB_URL,
+      }),
+    ).toThrow(/loopback|http/i);
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { url: "http://127.0.0.1:64248/projects/project-1" },
+        type: SIDECAR_MESSAGES.REGISTER_WEB_URL,
+      }),
+    ).toThrow(/origin/i);
+  });
+
+  it("rejects malformed mint-import-token payloads", () => {
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { baseDir: "" },
+        type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+      }),
+    ).toThrow(/baseDir/i);
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { baseDir: "/Users/u/project", extra: true },
+        type: SIDECAR_MESSAGES.MINT_IMPORT_TOKEN,
+      }),
+    ).toThrow(/extra/i);
+  });
+
+  it("rejects register-desktop-auth payloads that are not base64-shaped", () => {
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { secret: "not base64!" },
+        type: SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH,
+      }),
+    ).toThrow(/base64/i);
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: { secret: "" },
+        type: SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDaemonSidecarMessage({
+        input: {},
+        type: SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH,
+      }),
+    ).toThrow();
+  });
+
+  it("validates desktop IPC message inputs", () => {
+    expect(normalizeDesktopSidecarMessage({ type: SIDECAR_MESSAGES.SHOW })).toEqual({ type: "show" });
+    expect(normalizeDesktopSidecarMessage({
+      input: { deeplinkUrl: "opendesign://workspace/invite/continue?nonce=hot" },
+      type: SIDECAR_MESSAGES.SHOW,
+    })).toEqual({
+      input: { deeplinkUrl: "opendesign://workspace/invite/continue?nonce=hot" },
+      type: "show",
+    });
+    expect(() => normalizeDesktopSidecarMessage({
+      input: { deeplinkUrl: "https://example.com/invite" },
+      type: SIDECAR_MESSAGES.SHOW,
+    })).toThrow(/opendesign scheme/);
+    expect(normalizeDesktopSidecarMessage({ input: { expression: "location.href" }, type: SIDECAR_MESSAGES.EVAL })).toEqual({
+      input: { expression: "location.href" },
+      type: "eval",
+    });
+    expect(() => normalizeDesktopSidecarMessage({ input: { expression: 42 }, type: SIDECAR_MESSAGES.EVAL })).toThrow();
+    expect(() => normalizeDesktopSidecarMessage({ input: { selector: "" }, type: SIDECAR_MESSAGES.CLICK })).toThrow();
+  });
+
+  it("requires DaemonStatusSnapshot to carry desktopAuthGateActive (PR #974 round 6)", () => {
+    // The TS compiler enforces that `desktopAuthGateActive: boolean` is
+    // present on every constructed snapshot — tools-dev's split-start
+    // hardening relies on the daemon STATUS IPC carrying this field so
+    // `start desktop` can detect an ungated already-running daemon and
+    // restart it before launching desktop main. Removing the field, or
+    // softening it to optional, must fail this build.
+    const armed: DaemonStatusSnapshot = {
+      state: "running",
+      url: "http://127.0.0.1:7456",
+      desktopAuthGateActive: true,
+    };
+    const dormant: DaemonStatusSnapshot = {
+      state: "running",
+      url: "http://127.0.0.1:7456",
+      desktopAuthGateActive: false,
+    };
+    expect(armed.desktopAuthGateActive).toBe(true);
+    expect(dormant.desktopAuthGateActive).toBe(false);
+  });
+
+  it("validates desktop PDF export IPC message inputs", () => {
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: {
+          baseHref: "http://127.0.0.1:7456/api/projects/proj/raw/deck/",
+          deck: true,
+          defaultFilename: "Seed Deck.pdf",
+          html: "<!doctype html><section class=\"slide\">One</section>",
+          title: "Seed Deck",
+        },
+        type: SIDECAR_MESSAGES.EXPORT_PDF,
+      }),
+    ).toEqual({
+      input: {
+        baseHref: "http://127.0.0.1:7456/api/projects/proj/raw/deck/",
+        deck: true,
+        defaultFilename: "Seed Deck.pdf",
+        html: "<!doctype html><section class=\"slide\">One</section>",
+        title: "Seed Deck",
+      },
+      type: "export-pdf",
+    });
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { deck: true, defaultFilename: "x.pdf", html: "", title: "x" },
+        type: SIDECAR_MESSAGES.EXPORT_PDF,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { deck: "yes", defaultFilename: "x.pdf", html: "<p>x</p>", title: "x" },
+        type: SIDECAR_MESSAGES.EXPORT_PDF,
+      }),
+    ).toThrow();
+  });
+
+  it("validates desktop render-slides IPC message inputs", () => {
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: {
+          baseHref: "http://127.0.0.1:7456/api/projects/proj/raw/deck/",
+          deck: true,
+          editable: true,
+          html: "<!doctype html><section class=\"slide\">One</section>",
+          outputDir: "/data/export-render/abc123",
+          pageImageFormat: "jpeg",
+          stitch: true,
+          paginate: true,
+          width: 1280,
+          height: 720,
+        },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toEqual({
+      input: {
+        baseHref: "http://127.0.0.1:7456/api/projects/proj/raw/deck/",
+        deck: true,
+        editable: true,
+        html: "<!doctype html><section class=\"slide\">One</section>",
+        outputDir: "/data/export-render/abc123",
+        pageImageFormat: "jpeg",
+        stitch: true,
+        paginate: true,
+        width: 1280,
+        height: 720,
+      },
+      type: "render-slides",
+    });
+    // `deck: false` round-trips (explicit page mode) and a non-boolean is rejected.
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", deck: false },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toEqual({ input: { html: "<p>x</p>", deck: false }, type: "render-slides" });
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", deck: "yes" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", editable: "yes" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+    // outputDir must be absolute — a relative path is rejected so a malformed
+    // request can't make desktop write outside the daemon scratch dir.
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", outputDir: "export-render/abc" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow(/absolute path/);
+    // index: a non-negative integer round-trips; negative / fractional / non-number reject.
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", index: 1 },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toEqual({ input: { html: "<p>x</p>", index: 1 }, type: "render-slides" });
+    for (const badIndex of [-1, 1.5, Number.NaN, "0"]) {
+      expect(() =>
+        normalizeDesktopSidecarMessage({
+          input: { html: "<p>x</p>", index: badIndex },
+          type: SIDECAR_MESSAGES.RENDER_SLIDES,
+        }),
+      ).toThrow();
+    }
+    // Minimal input (only html) round-trips with nothing extra.
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toEqual({ input: { html: "<p>x</p>" }, type: "render-slides" });
+    // Invalid: empty html, bad enum, non-boolean stitch, unknown key.
+    expect(() =>
+      normalizeDesktopSidecarMessage({ input: { html: "" }, type: SIDECAR_MESSAGES.RENDER_SLIDES }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", pageImageFormat: "webp" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", stitch: "yes" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", paginate: "yes" },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { html: "<p>x</p>", bogus: 1 },
+        type: SIDECAR_MESSAGES.RENDER_SLIDES,
+      }),
+    ).toThrow();
+  });
+
+  it("accepts PNG/JPEG artifact image export and rejects WebP up front", () => {
+    // The off-screen Electron renderer (nativeImage) can only encode PNG/JPEG.
+    for (const imageFormat of ["png", "jpeg"] as const) {
+      expect(
+        normalizeDesktopSidecarMessage({
+          input: { deck: false, format: "image", html: "<p>x</p>", imageFormat, title: "Shot" },
+          type: SIDECAR_MESSAGES.EXPORT_ARTIFACT,
+        }),
+      ).toEqual({
+        input: { deck: false, format: "image", html: "<p>x</p>", imageFormat, title: "Shot" },
+        type: "export-artifact",
+      });
+    }
+    // WebP must fail fast with a clear error rather than silently downgrade to PNG.
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { deck: false, format: "image", html: "<p>x</p>", imageFormat: "webp", title: "Shot" },
+        type: SIDECAR_MESSAGES.EXPORT_ARTIFACT,
+      }),
+    ).toThrow(/unsupported artifact export image format/);
+  });
+
+  it("validates desktop update IPC message inputs", () => {
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: { action: DESKTOP_UPDATE_ACTIONS.CHECK },
+        type: SIDECAR_MESSAGES.UPDATE,
+      }),
+    ).toEqual({
+      input: { action: "check" },
+      type: "update",
+    });
+    expect(
+      normalizeDesktopSidecarMessage({
+        input: { action: DESKTOP_UPDATE_ACTIONS.INSTALL },
+        type: SIDECAR_MESSAGES.UPDATE,
+      }),
+    ).toEqual({
+      input: { action: "install" },
+      type: "update",
+    });
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { action: "apply" },
+        type: SIDECAR_MESSAGES.UPDATE,
+      }),
+    ).toThrow(/unsupported desktop update action/);
+    expect(() =>
+      normalizeDesktopSidecarMessage({
+        input: { action: "status", path: "/tmp/update.dmg" },
+        type: SIDECAR_MESSAGES.UPDATE,
+      }),
+    ).toThrow(/unsupported fields/);
+  });
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,43 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(jsdom@29.1.1)(vite@7.3.3(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/closure:
+    dependencies:
+      '@open-design/download':
+        specifier: workspace:*
+        version: link:../download
+      '@open-design/platform':
+        specifier: workspace:*
+        version: link:../platform
+      '@open-design/release':
+        specifier: workspace:*
+        version: link:../release
+      '@open-design/sidecar':
+        specifier: workspace:*
+        version: link:../sidecar
+      extract-zip:
+        specifier: 2.0.1
+        version: 2.0.1
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      esbuild:
+        specifier: 0.28.0
+        version: 0.28.0
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/components:
     devDependencies:
       '@testing-library/react':
@@ -757,6 +794,10 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/sidecar:
+    dependencies:
+      '@open-design/release':
+        specifier: workspace:*
+        version: link:../release
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -764,6 +805,9 @@ importers:
       esbuild:
         specifier: 0.28.0
         version: 0.28.0
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -21,6 +21,7 @@ const buildTargets = [
   "packages/sidecar-proto",
   "packages/launcher-proto",
   "packages/sidecar",
+  "packages/closure",
   "packages/diagnostics",
   "packages/dsh-runtime",
   "apps/daemon",


### PR DESCRIPTION
## Outcome

Adds the shell-neutral runtime primitives needed by standalone delivery without wiring any product or release entrypoint to them:

- `@open-design/closure`: protocol, immutable store/binding transaction, update preparation/application, resource delivery, and cleanup
- `@open-design/sidecar`: normalized control plane, lifecycle plane, and shared desktop protocol surfaces
- `@open-design/release`: channel-aware complete-version comparison used by Closure

## Transparency boundary

- No workflow consumes these APIs.
- No existing packaged application entrypoint is switched.
- Existing `sidecar-proto` and `launcher-proto` packages remain intact for current consumers.
- Closure is only registered as a normal workspace/postinstall build target.

## Validation

- `pnpm install --frozen-lockfile` including all repository postinstall builds
- Closure: 94 tests + typecheck
- Sidecar: 59 tests + typecheck
- Release primitives: 7 tests + typecheck
