### PR TITLE
feat(standalone): preload shell-neutral product runtime

### DIFF
--- a/apps/standalone/AGENTS.md
+++ b/apps/standalone/AGENTS.md
@@ -1,0 +1,39 @@
+# apps/standalone
+
+Follow the root `AGENTS.md` and `apps/AGENTS.md` first. This app owns the deployable shell-neutral Open Design product composition.
+
+## Owns
+
+- The public Standalone application boundary and future executable entry.
+- The protocol-fixed `bootloader.mjs` handoff-once entry over `@open-design/standalone/protocol`.
+- Composition of Web and daemon adapters into one product closure.
+- Product lifecycle composition over semantic `@open-design/sidecar` launch/connect/stop operations.
+- Initial Closure discovery, layered local/remote resource resolution,
+  immutable Store verification, and prepared → Shell+Closure attempt →
+  lastSuccessful activation before the live handoff is exposed to a Shell.
+- Modern update routing from Closure metadata. Preparation is non-authoritative;
+  cold-start activation requires explicit authorization and health confirmation.
+- Product-facing exposure of common readiness, health, diagnostics, and shutdown.
+- Composition of validated Standalone-owned and attachment-local Shell updater provider ports into one opaque projection; it must not interpret provider action ids.
+- Serialization adapters that project attachment-local Shell capabilities and generation-shared Standalone body handles through the generic Sidecar control plane; transport-private service names stay out of standalone-proto.
+- The bundled `launcher.mjs` official-Node entry: decode one caller-fenced bootstrap, import one absolute body `bootloader.mjs`, attach the generation body service, and exit after the final attachment or stop request.
+- The bundled generation `bootloader.mjs`: run under the Shell-owned official Node, derive native and launcher paths from the three-component installation root, then enter the process bridge once. Keep these layout details inside this fossil wrapper rather than expanding the shared handoff protocol.
+
+## Does not own
+
+- Electron, Desktop IPC, windows, protocols, menus, or update UI.
+- Shell release discovery, Shell update UI, or Shell launch policy.
+- Raw stamps, IPC paths, transport selection, process matching, or packaged filesystem inference.
+- Codex Plugin installation or another shell's private state.
+
+## Rules
+
+- Consume body runtime behavior through launch specifications and semantic sidecar methods; do not import another app's private source tree.
+- Reuse the package-local `./runtime` subpath; do not duplicate its lifecycle state machine.
+- Keep the root `bootloader.mjs` fossil handoff-only: it may enter the adjacent
+  Standalone-owned baseline launcher once, but must not select a version,
+  interpret a component graph, or fall back to a second target. The baseline
+  launcher owns initial candidate resolution and Store preparation/activation.
+- Never infer or normalize product paths. The launcher adapter supplies already-resolved roots.
+- Always attempt shutdown in reverse startup order, even when one runtime fails to close.
+- Keep live handoff validation in `@open-design/standalone/protocol` and release candidate/integrity parsing in `@open-design/closure/protocol`.

--- a/apps/standalone/esbuild.config.ts
+++ b/apps/standalone/esbuild.config.ts
@@ -1,0 +1,88 @@
+import { build } from "esbuild";
+
+await build({
+  bundle: true,
+  entryPoints: [
+    "./src/index.ts",
+    "./src/bootloader.ts",
+    "./src/bootstrap.ts",
+    "./src/bootstrap-entry.ts",
+    "./src/fossil-bootloader.ts",
+    "./src/launcher-bootstrap.ts",
+    "./src/process-bridge.ts",
+    "./src/protocol/index.ts",
+    "./src/resource-handoff.ts",
+    "./src/resource-runtime.ts",
+    "./src/runtime/index.ts",
+    "./src/sidecars.ts",
+  ],
+  format: "esm",
+  outbase: "./src",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "external",
+  platform: "node",
+  target: "node24",
+});
+
+// Loaded only by an explicit ensureResource bridge call. Keeping the update
+// stack in a sibling bundle preserves the fossil launcher's cold-start floor.
+await build({
+  banner: {
+    js: 'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);',
+  },
+  bundle: true,
+  entryPoints: { "resource-provider": "./src/resource-provider.ts" },
+  format: "esm",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "bundle",
+  platform: "node",
+  target: "node24",
+});
+
+// launcher.mjs is the fossil-thin official-Node entry. Bundle every workspace
+// dependency so it does not depend on the body package graph it is about to
+// select and enter.
+await build({
+  bundle: true,
+  entryPoints: {
+    "generation-bootloader": "./src/generation-bootloader.ts",
+    launcher: "./src/launcher.ts",
+    "native-loader": "./src/native-loader.ts",
+  },
+  format: "esm",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "bundle",
+  platform: "node",
+  target: "node24",
+});
+
+// The Shell executes this fossil using its official Node. It must carry every
+// Standalone selection/Store dependency and never resolve modules from Shell.
+await build({
+  banner: {
+    js: 'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);',
+  },
+  bundle: true,
+  entryPoints: { launcher: "./src/bootstrap-entry.ts" },
+  format: "esm",
+  outdir: "./dist/bootstrap/baseline",
+  outExtension: { ".js": ".mjs" },
+  packages: "bundle",
+  platform: "node",
+  target: "node24",
+});
+
+await build({
+  bundle: true,
+  entryPoints: { bootloader: "./src/fossil-bootloader.ts" },
+  external: ["./baseline/launcher.mjs"],
+  format: "esm",
+  outdir: "./dist/bootstrap",
+  outExtension: { ".js": ".mjs" },
+  packages: "bundle",
+  platform: "node",
+  target: "node24",
+});

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@open-design/standalone",
+  "version": "0.19.2",
+  "private": true,
+  "type": "module",
+  "description": "Shell-neutral Open Design Web and daemon product lifecycle.",
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    },
+    "./protocol": {
+      "types": "./dist/protocol/index.d.ts",
+      "default": "./dist/protocol/index.mjs"
+    },
+    "./runtime": {
+      "types": "./dist/runtime/index.d.ts",
+      "default": "./dist/runtime/index.mjs"
+    },
+    "./bootloader": {
+      "types": "./dist/bootloader.d.ts",
+      "default": "./dist/bootloader.mjs"
+    },
+    "./bootstrap": {
+      "types": "./dist/bootstrap.d.ts",
+      "default": "./dist/bootstrap.mjs"
+    },
+    "./process-bridge": {
+      "types": "./dist/process-bridge.d.ts",
+      "default": "./dist/process-bridge.mjs"
+    },
+    "./resource-runtime": {
+      "types": "./dist/resource-runtime.d.ts",
+      "default": "./dist/resource-runtime.mjs"
+    },
+    "./sidecars": {
+      "types": "./dist/sidecars.d.ts",
+      "default": "./dist/sidecars.mjs"
+    }
+  },
+  "scripts": {
+    "build": "pnpm --filter @open-design/closure build && tsx ./esbuild.config.ts && tsc -p tsconfig.json --emitDeclarationOnly",
+    "test": "pnpm build && vitest run",
+    "typecheck": "pnpm --filter @open-design/closure build && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
+  },
+  "dependencies": {
+    "@open-design/closure": "workspace:*",
+    "@open-design/release": "workspace:*",
+    "@open-design/sidecar": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "esbuild": "0.28.0",
+    "jszip": "3.10.1",
+    "tsx": "4.22.3",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
+  },
+  "engines": {
+    "node": "~24"
+  }
+}

--- a/apps/standalone/src/bootloader.ts
+++ b/apps/standalone/src/bootloader.ts
@@ -1,0 +1,355 @@
+import {
+  compareStandaloneVersions,
+  sameStandaloneHandoffEnvelope,
+  validateStandaloneHandoffRequest,
+  validateStandaloneRuntimeCommandRequest,
+  validateStandaloneRuntimeCommandResult,
+  validateStandaloneRuntimeStatus,
+  validateStandaloneShellCapabilityRequest,
+  validateStandaloneShellCapabilityResult,
+  type StandaloneHandle,
+  type StandaloneHandoff,
+  type StandaloneHandoffRequest,
+  type StandaloneRuntimeCommandRequest,
+  type StandaloneRuntimeCommandResult,
+  type StandaloneRuntimeStatus,
+  type StandaloneRuntimeTerminalStatus,
+  type StandaloneShellCapabilityPort,
+  type StandaloneShellCapabilityRequest,
+} from "./protocol/index.js";
+
+export type StandaloneBootloaderErrorCode =
+  | "attachment-conflict"
+  | "body-invalid"
+  | "handoff-conflict"
+  | "shell-incompatible";
+
+export class StandaloneBootloaderError extends Error {
+  readonly code: StandaloneBootloaderErrorCode;
+
+  constructor(code: StandaloneBootloaderErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "StandaloneBootloaderError";
+    this.code = code;
+  }
+}
+
+export type StandaloneShellCompatibility = Readonly<Record<string, Readonly<{
+  version: Readonly<{ min: string }>;
+}>>>;
+
+export type CreateStandaloneBootloaderOptions = Readonly<{
+  shellCompatibility: StandaloneShellCompatibility;
+  start: StandaloneHandoff;
+  resolveRegisteredBootloader?: () => StandaloneHandoff | null;
+}>;
+
+function sharedRequestKey(request: StandaloneHandoffRequest): string {
+  return JSON.stringify({
+    descriptorDigest: request.handoff.descriptorDigest,
+    paths: request.paths,
+    scope: request.handoff.scope,
+  });
+}
+
+function attachmentKey(request: StandaloneHandoffRequest): string {
+  return JSON.stringify(request.attachment);
+}
+
+function requireCompatibleShell(
+  compatibility: StandaloneShellCompatibility,
+  request: StandaloneHandoffRequest,
+): void {
+  const minimum = compatibility[request.attachment.shell.type]?.version.min;
+  if (
+    minimum == null
+    || compareStandaloneVersions(request.attachment.shell.version, minimum) < 0
+  ) {
+    throw new StandaloneBootloaderError(
+      "shell-incompatible",
+      minimum == null
+        ? `Standalone does not support Shell ${request.attachment.shell.type}`
+        : `Standalone requires ${request.attachment.shell.type} Shell ${minimum} or newer`,
+    );
+  }
+}
+
+function validateCompatibility(value: StandaloneShellCompatibility): StandaloneShellCompatibility {
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    throw new StandaloneBootloaderError(
+      "body-invalid",
+      "Standalone shell compatibility must not be empty",
+    );
+  }
+  for (const [shellType, compatibility] of entries) {
+    if (!/^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/u.test(shellType)) {
+      throw new StandaloneBootloaderError(
+        "body-invalid",
+        `Standalone shell compatibility contains invalid type ${shellType}`,
+      );
+    }
+    compareStandaloneVersions(compatibility.version.min, compatibility.version.min);
+  }
+  return Object.freeze(Object.fromEntries(entries.map(([type, compatibility]) => [
+    type,
+    Object.freeze({ version: Object.freeze({ min: compatibility.version.min }) }),
+  ])));
+}
+
+type AttachmentSlot = {
+  closed: boolean;
+  key: string;
+  request: StandaloneHandoffRequest;
+  resolveTerminal: (status: StandaloneRuntimeTerminalStatus) => void;
+  task: Promise<StandaloneHandle> | null;
+  terminal: Promise<StandaloneRuntimeTerminalStatus>;
+  terminalStatus: StandaloneRuntimeTerminalStatus | null;
+};
+
+type BodyEntry = {
+  attachments: Map<string, AttachmentSlot>;
+  bodyTask: Promise<StandaloneHandle>;
+  key: string;
+  request: StandaloneHandoffRequest;
+};
+
+function attachmentTerminal(
+  status: StandaloneRuntimeStatus,
+): StandaloneRuntimeTerminalStatus {
+  if (status.state !== "running") return status;
+  return {
+    handoff: status.handoff,
+    pid: status.pid,
+    schemaVersion: status.schemaVersion,
+    state: "stopped",
+  };
+}
+
+function createCapabilityMultiplexer(entry: Pick<BodyEntry, "attachments" | "request">): StandaloneShellCapabilityPort {
+  return Object.freeze({
+    async invoke(value: StandaloneShellCapabilityRequest) {
+      const capabilityRequest = validateStandaloneShellCapabilityRequest(value, {
+        handoff: entry.request.handoff,
+      });
+      const attachment = entry.attachments.get(capabilityRequest.attachmentId);
+      if (attachment == null || attachment.closed) {
+        return validateStandaloneShellCapabilityResult({
+          attachmentId: capabilityRequest.attachmentId,
+          error: { code: "attachment-unavailable" },
+          handoff: entry.request.handoff,
+          outcome: "failed",
+          requestId: capabilityRequest.requestId,
+          schemaVersion: capabilityRequest.schemaVersion,
+        }, {
+          attachmentId: capabilityRequest.attachmentId,
+          capability: capabilityRequest.capability,
+          handoff: entry.request.handoff,
+          requestId: capabilityRequest.requestId,
+        });
+      }
+      const result = await attachment.request.capabilities.invoke(capabilityRequest);
+      return validateStandaloneShellCapabilityResult(result, {
+        attachmentId: capabilityRequest.attachmentId,
+        capability: capabilityRequest.capability,
+        handoff: entry.request.handoff,
+        requestId: capabilityRequest.requestId,
+      });
+    },
+  });
+}
+
+async function startBody(entry: Pick<BodyEntry, "attachments" | "request">, start: StandaloneHandoff): Promise<StandaloneHandle> {
+  const request = Object.freeze({
+    ...entry.request,
+    capabilities: createCapabilityMultiplexer(entry),
+  });
+  const rawHandle = await start(request);
+  try {
+    await rawHandle.readStatus().then((status) => validateStandaloneRuntimeStatus(status, {
+      handoff: request.handoff,
+      state: "running",
+    }));
+  } catch (error) {
+    await rawHandle.close().catch(() => undefined);
+    throw new StandaloneBootloaderError(
+      "body-invalid",
+      "Standalone did not report generation-bound running readiness",
+      { cause: error },
+    );
+  }
+  return rawHandle;
+}
+
+function resolveSlot(slot: AttachmentSlot, status: StandaloneRuntimeTerminalStatus): void {
+  if (slot.terminalStatus != null) return;
+  slot.terminalStatus = status;
+  slot.resolveTerminal(status);
+}
+
+function attachmentHandle(entry: BodyEntry, slot: AttachmentSlot, raw: StandaloneHandle): StandaloneHandle {
+  return Object.freeze({
+    async close() {
+      if (slot.terminalStatus != null) return slot.terminalStatus;
+      slot.closed = true;
+      entry.attachments.delete(slot.request.attachment.id);
+      if (entry.attachments.size === 0) {
+        const terminal = await raw.close();
+        resolveSlot(slot, validateStandaloneRuntimeStatus(terminal, {
+          handoff: slot.request.handoff,
+        }) as StandaloneRuntimeTerminalStatus);
+      } else {
+        const status = validateStandaloneRuntimeStatus(await raw.readStatus(), {
+          handoff: slot.request.handoff,
+        });
+        resolveSlot(slot, attachmentTerminal(status));
+      }
+      return slot.terminalStatus!;
+    },
+    async invoke(value: StandaloneRuntimeCommandRequest): Promise<StandaloneRuntimeCommandResult> {
+      const command = validateStandaloneRuntimeCommandRequest(value, {
+        attachmentId: slot.request.attachment.id,
+        handoff: slot.request.handoff,
+      });
+      if (slot.closed) {
+        return validateStandaloneRuntimeCommandResult({
+          attachmentId: command.attachmentId,
+          error: { code: "attachment-closed" },
+          handoff: slot.request.handoff,
+          outcome: "failed",
+          requestId: command.requestId,
+          schemaVersion: command.schemaVersion,
+        }, {
+          attachmentId: command.attachmentId,
+          handoff: slot.request.handoff,
+          requestId: command.requestId,
+        });
+      }
+      return validateStandaloneRuntimeCommandResult(await raw.invoke(command), {
+        attachmentId: command.attachmentId,
+        handoff: slot.request.handoff,
+        requestId: command.requestId,
+      });
+    },
+    async readStatus() {
+      if (slot.terminalStatus != null) return slot.terminalStatus;
+      return validateStandaloneRuntimeStatus(await raw.readStatus(), {
+        handoff: slot.request.handoff,
+      });
+    },
+    async waitForTerminal() {
+      return await slot.terminal;
+    },
+  });
+}
+
+function createSlot(request: StandaloneHandoffRequest): AttachmentSlot {
+  let resolveTerminal!: (status: StandaloneRuntimeTerminalStatus) => void;
+  const terminal = new Promise<StandaloneRuntimeTerminalStatus>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  return {
+    closed: false,
+    key: attachmentKey(request),
+    request,
+    resolveTerminal,
+    task: null,
+    terminal,
+    terminalStatus: null,
+  };
+}
+
+/**
+ * Create the fossil-compatible `bootloader.mjs` boundary. The root selects at
+ * most one inner bootloader and never falls back after that selection. The
+ * selected body is entered once per active generation, while compatible
+ * Shell attachments receive independent handles over the shared body.
+ */
+export function createStandaloneBootloader(
+  options: CreateStandaloneBootloaderOptions,
+): StandaloneHandoff {
+  const compatibility = validateCompatibility(options.shellCompatibility);
+  let selected: StandaloneHandoff | null | undefined;
+  let delegatedKey: string | null = null;
+  const delegated = new Map<string, Readonly<{ key: string; task: Promise<StandaloneHandle> }>>();
+  let entered: BodyEntry | null = null;
+
+  return async (value) => {
+    const request = validateStandaloneHandoffRequest(value);
+    requireCompatibleShell(compatibility, request);
+    const key = sharedRequestKey(request);
+
+    if (selected === undefined) {
+      selected = options.resolveRegisteredBootloader?.() ?? null;
+    }
+    if (selected != null) {
+      if (delegatedKey != null && delegatedKey !== key) {
+        throw new StandaloneBootloaderError(
+          "handoff-conflict",
+          "bootloader.mjs already entered a different Standalone generation",
+        );
+      }
+      delegatedKey = key;
+      const existing = delegated.get(request.attachment.id);
+      const nextAttachmentKey = attachmentKey(request);
+      if (existing != null) {
+        if (existing.key !== nextAttachmentKey) {
+          throw new StandaloneBootloaderError(
+            "attachment-conflict",
+            `Standalone attachment ${request.attachment.id} changed Shell identity`,
+          );
+        }
+        return await existing.task;
+      }
+      const task = selected(request);
+      delegated.set(request.attachment.id, Object.freeze({ key: nextAttachmentKey, task }));
+      return await task;
+    }
+
+    if (entered != null && (
+      entered.key !== key
+      || !sameStandaloneHandoffEnvelope(entered.request.handoff, request.handoff)
+    )) {
+      throw new StandaloneBootloaderError(
+        "handoff-conflict",
+        "bootloader.mjs already entered a different Standalone generation",
+      );
+    }
+    if (entered == null) {
+      const attachments = new Map<string, AttachmentSlot>();
+      const entry = {
+        attachments,
+        bodyTask: null as unknown as Promise<StandaloneHandle>,
+        key,
+        request,
+      };
+      const slot = createSlot(request);
+      attachments.set(request.attachment.id, slot);
+      entry.bodyTask = startBody(entry, options.start);
+      slot.task = entry.bodyTask.then((raw) => attachmentHandle(entry, slot, raw));
+      entered = entry;
+      void entry.bodyTask.then((raw) => raw.waitForTerminal()).then((terminal) => {
+        const validated = validateStandaloneRuntimeStatus(terminal, {
+          handoff: request.handoff,
+        }) as StandaloneRuntimeTerminalStatus;
+        for (const attachment of entry.attachments.values()) resolveSlot(attachment, validated);
+      }).catch(() => undefined);
+    }
+
+    const existing = entered.attachments.get(request.attachment.id);
+    const nextAttachmentKey = attachmentKey(request);
+    if (existing != null) {
+      if (existing.key !== nextAttachmentKey) {
+        throw new StandaloneBootloaderError(
+          "attachment-conflict",
+          `Standalone attachment ${request.attachment.id} changed Shell identity`,
+        );
+      }
+      return await existing.task!;
+    }
+    const slot = createSlot(request);
+    entered.attachments.set(request.attachment.id, slot);
+    slot.task = entered.bodyTask.then((raw) => attachmentHandle(entered!, slot, raw));
+    return await slot.task;
+  };
+}

--- a/apps/standalone/src/bootstrap-entry.ts
+++ b/apps/standalone/src/bootstrap-entry.ts
@@ -1,0 +1,53 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import {
+  STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+  validateStandaloneBootstrapDescriptor,
+  type StandaloneBootstrapProgress,
+  type StandaloneBootstrapResult,
+} from "./protocol/index.js";
+
+import { StandaloneBootstrapError, resolveStandaloneBootstrap } from "./bootstrap.js";
+
+export const STANDALONE_BOOTSTRAP_INPUT_ENV = "OD_STANDALONE_BOOTSTRAP_INPUT_V1" as const;
+export const STANDALONE_BOOTSTRAP_RESULT_ENV = "OD_STANDALONE_BOOTSTRAP_RESULT_V1" as const;
+
+export async function handoffOnce(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<StandaloneBootstrapResult> {
+  const inputPath = env[STANDALONE_BOOTSTRAP_INPUT_ENV];
+  const resultPath = env[STANDALONE_BOOTSTRAP_RESULT_ENV];
+  if (inputPath == null || resultPath == null) {
+    throw new Error("Standalone bootstrap input and result paths are required");
+  }
+  const descriptor = validateStandaloneBootstrapDescriptor(
+    JSON.parse(await readFile(inputPath, "utf8")) as unknown,
+  );
+  let result: StandaloneBootstrapResult;
+  const reportProgress = (progress: StandaloneBootstrapProgress): void => {
+    if (typeof process.send !== "function" || !process.connected) return;
+    try {
+      process.send(progress);
+    } catch {
+      // The JSON result file remains authoritative if the optional IPC channel closes.
+    }
+  };
+  try {
+    result = Object.freeze({
+      outcome: "resolved",
+      resolution: await resolveStandaloneBootstrap(descriptor, { onProgress: reportProgress }),
+      schemaVersion: STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+    });
+  } catch (error) {
+    result = Object.freeze({
+      error: Object.freeze({
+        code: error instanceof StandaloneBootstrapError ? error.code : "standalone-invalid",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+      outcome: "rejected",
+      schemaVersion: STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+    });
+  }
+  await writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  return result;
+}

--- a/apps/standalone/src/bootstrap.ts
+++ b/apps/standalone/src/bootstrap.ts
@@ -1,0 +1,504 @@
+import { join } from "node:path";
+
+import {
+  activatePreparedClosureBinding,
+  authorizePreparedClosureActivation,
+  beginActiveClosureBindingAttempt,
+  readClosureBindingDescriptor,
+  readStoredClosureDistributionManifest,
+  recoverInterruptedClosureBinding,
+  resolveClosureStorePaths,
+  sameShellBinding,
+  verifyStoredClosureDistributionGeneration,
+} from "@open-design/closure/store";
+import {
+  applyClosureDistributionUpdate,
+  ClosureInstallerRequiredError,
+  discoverClosureDistributionBootstrapCandidate,
+  discoverClosureDistributionVersionCandidate,
+  readClosureResourceRepositoryConfig,
+  repairActiveClosureDistribution,
+  resolveClosureShellMinimumVersion,
+  type ClosureDistributionReleaseCandidate,
+  type ClosureDistributionUpdateProgress,
+  type ClosureResourceRepositoryConfig,
+} from "@open-design/closure/update";
+import {
+  STANDALONE_PROTOCOL_VERSION,
+  STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION,
+  compareStandaloneVersions,
+  createStandaloneHandoffEnvelope,
+  validateStandaloneBootstrapDescriptor,
+  type StandaloneBootstrapDescriptor,
+  type StandaloneBootstrapErrorCode,
+  type StandaloneBootstrapProgress,
+  type StandaloneBootstrapResolution,
+} from "./protocol/index.js";
+import {
+  bootstrapSidecarLifecycle,
+  type SidecarTransitionCredential,
+} from "@open-design/sidecar/lifecycle";
+import { ensureStandaloneBootResources } from "./resource-runtime.js";
+import { VELA_RUNTIME_RESOURCE_ID } from "./tool-env.js";
+
+export class StandaloneBootstrapError extends Error {
+  readonly code: StandaloneBootstrapErrorCode;
+
+  constructor(code: StandaloneBootstrapErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "StandaloneBootstrapError";
+    this.code = code;
+  }
+}
+
+/**
+ * Resolve an unresolved Shell attachment into one attempted or last-successful
+ * generation. Existing bindings remain authoritative. Only an empty Store may
+ * discover a first-install release, which is then revalidated through its
+ * immutable version endpoint before any bytes are prepared.
+ */
+export async function resolveStandaloneBootstrap(
+  requestInput: StandaloneBootstrapDescriptor,
+  options: Readonly<{
+    fetch?: typeof globalThis.fetch;
+    onProgress?: (progress: StandaloneBootstrapProgress) => void;
+  }> = {},
+): Promise<StandaloneBootstrapResolution> {
+  const request = validateStandaloneBootstrapDescriptor(requestInput);
+  const paths = resolveClosureStorePaths({
+    channel: request.scope.channel,
+    namespace: request.scope.namespace,
+    root: request.paths.installationRoot,
+  });
+  const repository = await readClosureResourceRepositoryConfig({
+    OD_CLOSURE_RESOURCE_REPOSITORY_V1: request.repositoryConfigPath,
+  });
+  const lifecycle = bootstrapSidecarLifecycle({
+    controlRoot: request.paths.dataRoot,
+    scope: { channel: request.scope.channel, namespace: request.scope.namespace },
+  });
+  let descriptor = await readClosureBindingDescriptor(paths);
+  if (descriptor.attempt != null) {
+    const snapshot = await lifecycle.snapshot();
+    if (snapshot.transition != null) {
+      throw new StandaloneBootstrapError(
+        "standalone-occupied",
+        `Standalone activation is already active: ${snapshot.transition.kind}`,
+      );
+    }
+    await recoverInterruptedClosureBinding(paths);
+    descriptor = await readClosureBindingDescriptor(paths);
+  }
+  const initialLoad = descriptor.active == null;
+  const standaloneSubject = Object.freeze({
+    id: "standalone",
+    kind: "standalone" as const,
+    title: "Standalone",
+  });
+  const emitProgress = (
+    stage: StandaloneBootstrapProgress["stage"],
+    progress?: StandaloneBootstrapProgress["progress"],
+    subject: StandaloneBootstrapProgress["subject"] = standaloneSubject,
+  ): void => {
+    try {
+      options.onProgress?.(Object.freeze({
+        initialLoad,
+        ...(progress == null ? {} : { progress: Object.freeze(progress) }),
+        schemaVersion: STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION,
+        stage,
+        subject,
+      }));
+    } catch {
+      // Presentation telemetry cannot change bootstrap policy or authority.
+    }
+  };
+  const forwardDistributionProgress = (progress: ClosureDistributionUpdateProgress): void => {
+    if (progress.phase === "download") {
+      emitProgress("downloading", {
+        completed: progress.completedBytes,
+        total: progress.totalBytes,
+        unit: "bytes",
+      });
+      return;
+    }
+    emitProgress("materializing", {
+      completed: progress.completedComponents,
+      total: progress.totalComponents,
+      unit: "components",
+    });
+  };
+  emitProgress("checking");
+  let transition: SidecarTransitionCredential | null = null;
+  let transitionRenewal: ReturnType<typeof setInterval> | null = null;
+  let transitionRenewalError: Error | null = null;
+
+  const stopTransitionRenewal = (): void => {
+    if (transitionRenewal != null) clearInterval(transitionRenewal);
+    transitionRenewal = null;
+  };
+
+  const withTransition = async <TResult>(
+    kind: string,
+    operation: () => Promise<TResult>,
+  ): Promise<TResult> => {
+    if (transition == null) {
+      const acquired = await lifecycle.beginTransition({
+        kind,
+        leaseMs: 60_000,
+        owner: {
+          generation: descriptor.active?.standalone.generation ?? descriptor.nextGeneration,
+          incarnation: request.attachment.id,
+          key: `${request.attachment.shell.type}:${request.attachment.id}`,
+          projection: {
+            shellDigest: request.attachment.shell.digest,
+            shellVersion: request.attachment.shell.version,
+          },
+        },
+      });
+      if (acquired.state === "blocked") {
+        const occupants = acquired.occupants?.map((entry) => entry.owner.key).join(", ");
+        throw new StandaloneBootstrapError(
+          "standalone-occupied",
+          acquired.reason === "occupied"
+            ? `Standalone update is blocked by active Shell attachments: ${occupants || "unknown"}`
+            : `Standalone update is already active: ${acquired.transition?.kind ?? acquired.reason}`,
+        );
+      }
+      transition = acquired.credential;
+      transitionRenewal = setInterval(() => {
+        const credential = transition;
+        if (credential == null) return;
+        void lifecycle.renewTransition({ credential, leaseMs: 60_000 }).then((result) => {
+          if (result.state === "rejected") {
+            transitionRenewalError = new Error("Standalone lifecycle transition expired or was fenced");
+          }
+        }).catch((error: unknown) => {
+          transitionRenewalError = error instanceof Error ? error : new Error(String(error));
+        });
+      }, 20_000);
+      transitionRenewal.unref();
+    }
+    if (transitionRenewalError != null) throw transitionRenewalError;
+    const result = await operation();
+    if (transitionRenewalError != null) throw transitionRenewalError;
+    return result;
+  };
+
+  const discoverExact = async (version: string): Promise<ClosureDistributionReleaseCandidate> => {
+    emitProgress("discovering");
+    let candidate: ClosureDistributionReleaseCandidate | null;
+    try {
+      candidate = await discoverClosureDistributionVersionCandidate({
+        channel: request.scope.channel,
+        consumer: {
+          shellType: request.attachment.shell.type,
+          shellVersion: request.attachment.shell.version,
+        },
+        ...(options.fetch == null ? {} : { fetch: options.fetch }),
+        metadataUrl: request.discovery.metadataUrl,
+        repository,
+        target: request.discovery.target,
+        version,
+      });
+    } catch (error) {
+      if (error instanceof ClosureInstallerRequiredError) {
+        throw new StandaloneBootstrapError("installer-required", error.message, { cause: error });
+      }
+      throw error;
+    }
+    if (candidate == null) {
+      throw new StandaloneBootstrapError(
+        "no-standalone",
+        `Standalone ${version} is unavailable from Shell resources and the immutable release feed`,
+      );
+    }
+    return candidate;
+  };
+
+  const discoverInitial = async (): Promise<ClosureDistributionReleaseCandidate> => {
+    emitProgress("discovering");
+    let discovered: ClosureDistributionReleaseCandidate | null;
+    try {
+      discovered = await discoverClosureDistributionBootstrapCandidate({
+        channel: request.scope.channel,
+        consumer: {
+          shellType: request.attachment.shell.type,
+          shellVersion: request.attachment.shell.version,
+        },
+        ...(options.fetch == null ? {} : { fetch: options.fetch }),
+        metadataUrl: request.discovery.metadataUrl,
+        repository,
+        target: request.discovery.target,
+      });
+    } catch (error) {
+      if (error instanceof ClosureInstallerRequiredError) {
+        throw new StandaloneBootstrapError("installer-required", error.message, { cause: error });
+      }
+      throw error;
+    }
+    if (discovered == null) {
+      throw new StandaloneBootstrapError(
+        "no-standalone",
+        "Standalone is unavailable from Shell resources and the release feed",
+      );
+    }
+    const exact = await discoverExact(discovered.releaseVersion);
+    if (
+      exact.target !== discovered.target
+      || exact.manifest.identity.digest !== discovered.manifest.identity.digest
+    ) {
+      throw new StandaloneBootstrapError(
+        "standalone-invalid",
+        `Standalone ${discovered.releaseVersion} discovery conflicts with its immutable binding`,
+      );
+    }
+    return exact;
+  };
+
+  const assertCandidateSupportsShell = (candidate: ClosureDistributionReleaseCandidate): void => {
+    const minimum = resolveClosureShellMinimumVersion(
+      candidate.manifest,
+      request.attachment.shell.type,
+    );
+    if (minimum == null || compareStandaloneVersions(request.attachment.shell.version, minimum) < 0) {
+      throw new StandaloneBootstrapError(
+        "installer-required",
+        minimum == null
+          ? `Standalone does not support Shell ${request.attachment.shell.type}`
+          : `Standalone requires ${request.attachment.shell.type} Shell ${minimum} or newer`,
+      );
+    }
+  };
+
+  const prepareCandidate = async (candidate: ClosureDistributionReleaseCandidate): Promise<void> => {
+    assertCandidateSupportsShell(candidate);
+    const result = await applyClosureDistributionUpdate({
+      candidate,
+      ...(options.fetch == null ? {} : { fetch: options.fetch }),
+      onProgress: forwardDistributionProgress,
+      paths,
+      repository,
+      shellType: request.attachment.shell.type,
+      shellVersion: request.attachment.shell.version,
+    });
+    if (result.state === "retained" && result.reason === "shell-incompatible") {
+      throw new StandaloneBootstrapError("installer-required", "Standalone requires a newer Shell");
+    }
+    if (result.state !== "prepared" && result.reason !== "already-prepared") {
+      throw new StandaloneBootstrapError("standalone-invalid", `Standalone bootstrap could not prepare: ${result.reason}`);
+    }
+    descriptor = await readClosureBindingDescriptor(paths);
+  };
+
+  const prepareExact = async (version: string): Promise<void> => {
+    await prepareCandidate(await discoverExact(version));
+  };
+
+  type DistributionVerification = Awaited<ReturnType<typeof verifyStoredClosureDistributionGeneration>>;
+  let bootResourcesReady = false;
+  const ensureBootResources = async (verification: DistributionVerification): Promise<void> => {
+    try {
+      await ensureStandaloneBootResources({
+        ...(options.fetch == null ? {} : { fetch: options.fetch }),
+        manifest: verification.plan.manifest,
+        onProgress(resource, progress) {
+          const subject = Object.freeze({
+            id: resource.id,
+            kind: "resource" as const,
+            title: resource.id === VELA_RUNTIME_RESOURCE_ID ? "Local engine" : resource.title,
+          });
+          if (progress.phase === "copying" || progress.phase === "downloading") {
+            emitProgress(progress.phase, {
+              completed: progress.completedBytes,
+              total: progress.totalBytes,
+              unit: "bytes",
+            }, subject);
+            return;
+          }
+          emitProgress(progress.phase, undefined, subject);
+        },
+        paths,
+        repository,
+        target: verification.plan.target,
+      });
+      bootResourcesReady = true;
+    } catch (error) {
+      throw new StandaloneBootstrapError(
+        "resource-unavailable",
+        `Standalone startup resources could not be prepared: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  };
+
+  const activatePrepared = async (): Promise<DistributionVerification> => {
+    const prepared = descriptor.prepared;
+    if (prepared == null) throw new StandaloneBootstrapError("no-standalone", "Standalone prepared binding is missing");
+    let verification: DistributionVerification;
+    try {
+      emitProgress("verifying");
+      verification = await verifyStoredClosureDistributionGeneration(paths, prepared.standalone);
+    } catch (error) {
+      throw new StandaloneBootstrapError("standalone-invalid", "Prepared Standalone failed verification", { cause: error });
+    }
+    assertCandidateSupportsShell({
+      manifest: verification.plan.manifest,
+      releaseVersion: prepared.releaseVersion,
+      target: prepared.standalone.target,
+    });
+    await ensureBootResources(verification);
+    await withTransition("activate-standalone", async () => {
+      await activatePreparedClosureBinding(paths, prepared, request.attachment.shell);
+    });
+    descriptor = await readClosureBindingDescriptor(paths);
+    return verification;
+  };
+
+  try {
+    let verification: DistributionVerification | null = null;
+    if (descriptor.prepared != null && descriptor.activationIntent != null) {
+      verification = await activatePrepared();
+    } else if (descriptor.active == null) {
+      await withTransition("prepare-initial-standalone", async () => {
+        if (request.releaseIntent.kind === "exact") {
+          await prepareExact(request.releaseIntent.releaseVersion);
+        } else {
+          await prepareCandidate(await discoverInitial());
+        }
+        if (descriptor.prepared == null) {
+          throw new StandaloneBootstrapError("no-standalone", "Initial Standalone preparation is missing");
+        }
+        await authorizePreparedClosureActivation(paths, descriptor.prepared, "initial-bootstrap");
+        descriptor = await readClosureBindingDescriptor(paths);
+      });
+      verification = await activatePrepared();
+    }
+
+    let active = descriptor.active;
+    if (active == null) throw new StandaloneBootstrapError("no-standalone", "Standalone binding remained empty");
+    if (active.standalone.target !== request.discovery.target) {
+      throw new StandaloneBootstrapError(
+        "standalone-invalid",
+        `Active Standalone target ${active.standalone.target} does not match ${request.discovery.target}`,
+      );
+    }
+    if (verification == null) try {
+      emitProgress("verifying");
+      verification = await verifyStoredClosureDistributionGeneration(paths, active.standalone);
+    } catch (error) {
+      let candidate: ClosureDistributionReleaseCandidate;
+      try {
+        candidate = {
+          manifest: await readStoredClosureDistributionManifest(paths, active.standalone),
+          releaseVersion: active.releaseVersion,
+          target: active.standalone.target,
+        };
+      } catch (localError) {
+        candidate = await discoverExact(active.standalone.version).catch((discoveryError) => {
+          throw new StandaloneBootstrapError(
+            "standalone-invalid",
+            "Active Standalone failed verification and its exact repair candidate is unavailable",
+            { cause: new AggregateError([error, localError, discoveryError]) },
+          );
+        });
+      }
+      assertCandidateSupportsShell(candidate);
+      const repair = await withTransition("repair-standalone", async () => {
+        return await repairActiveClosureDistribution({
+          candidate,
+          ...(options.fetch == null ? {} : { fetch: options.fetch }),
+          onProgress: forwardDistributionProgress,
+          paths,
+          repository,
+          shellType: request.attachment.shell.type,
+          shellVersion: request.attachment.shell.version,
+        });
+      });
+      if (repair.state === "busy") {
+        throw new StandaloneBootstrapError(
+          "standalone-invalid",
+          "Active Standalone repair is already active",
+        );
+      }
+      if (repair.state !== "prepared") {
+        throw new StandaloneBootstrapError(
+          repair.reason === "shell-incompatible" ? "installer-required" : "standalone-invalid",
+          `Active Standalone repair could not prepare: ${repair.reason}`,
+        );
+      }
+      descriptor = await readClosureBindingDescriptor(paths);
+      if (descriptor.prepared == null) {
+        throw new StandaloneBootstrapError("standalone-invalid", "Standalone repair preparation is missing");
+      }
+      await authorizePreparedClosureActivation(paths, descriptor.prepared, "repair");
+      descriptor = await readClosureBindingDescriptor(paths);
+      verification = await activatePrepared();
+      active = descriptor.active;
+      if (active == null) throw new StandaloneBootstrapError("standalone-invalid", "Standalone repair did not activate");
+    }
+    if (verification == null) throw new StandaloneBootstrapError("standalone-invalid", "Standalone verification is unavailable");
+    const minimum = verification.plan.manifest.compatibility.shell[request.attachment.shell.type]?.version.min;
+    if (minimum == null || compareStandaloneVersions(request.attachment.shell.version, minimum) < 0) {
+      throw new StandaloneBootstrapError(
+        "installer-required",
+        minimum == null
+          ? `Standalone does not support Shell ${request.attachment.shell.type}`
+          : `Standalone requires ${request.attachment.shell.type} Shell ${minimum} or newer`,
+      );
+    }
+    if (descriptor.attempt == null && !sameShellBinding(active.shell, request.attachment.shell)) {
+      const currentActive = active;
+      await withTransition("activate-shell-combination", async () => {
+        await beginActiveClosureBindingAttempt(paths, currentActive, request.attachment.shell);
+      });
+      descriptor = await readClosureBindingDescriptor(paths);
+      active = descriptor.active;
+      if (active == null) {
+        throw new StandaloneBootstrapError("standalone-invalid", "Shell combination activation did not start");
+      }
+    }
+    if (!bootResourcesReady) await ensureBootResources(verification);
+    const handoff = Object.freeze({
+      attachment: request.attachment,
+      closure: Object.freeze({
+        repositoryConfigPath: request.repositoryConfigPath,
+        storeRoot: paths.root,
+        target: verification.plan.target,
+      }),
+      handoff: createStandaloneHandoffEnvelope({
+        descriptor: {
+          release: { version: active.releaseVersion },
+          standalone: {
+            digest: active.standalone.digest,
+            protocolVersion: STANDALONE_PROTOCOL_VERSION,
+            version: active.standalone.version,
+          },
+        },
+        scope: {
+          channel: paths.channel,
+          generation: active.standalone.generation,
+          namespace: paths.namespace,
+        },
+      }),
+      paths: Object.freeze({
+        cacheRoot: request.paths.cacheRoot,
+        dataRoot: request.paths.dataRoot,
+        installationRoot: verification.plan.installationRoot,
+        logsRoot: request.paths.logsRoot,
+        resourceRoot: paths.resourcesRoot,
+        runtimeRoot: request.paths.runtimeRoot,
+      }),
+      transition,
+    });
+    emitProgress("ready");
+    stopTransitionRenewal();
+    return Object.freeze({
+      bootloaderPath: verification.plan.required.launcher.resolvedHandoffPath,
+      handoff,
+    });
+  } catch (error) {
+    stopTransitionRenewal();
+    if (transition != null) await lifecycle.abortTransition(transition).catch(() => undefined);
+    throw error;
+  }
+}

--- a/apps/standalone/src/fossil-bootloader.ts
+++ b/apps/standalone/src/fossil-bootloader.ts
@@ -1,0 +1,18 @@
+export const STANDALONE_FOSSIL_HANDOFF_ENTRY = "./baseline/launcher.mjs" as const;
+
+/** Fossil rule: resolve one adjacent baseline entry and hand off at most once. */
+export async function handoff(): Promise<unknown> {
+  const target = new URL(STANDALONE_FOSSIL_HANDOFF_ENTRY, import.meta.url);
+  const module = await import(target.href) as Readonly<Record<string, unknown>>;
+  if (typeof module.handoffOnce !== "function") {
+    throw new Error("Standalone baseline launcher must export handoffOnce()");
+  }
+  return await module.handoffOnce();
+}
+
+if (process.env.OD_STANDALONE_BOOTSTRAP_INPUT_V1 != null) {
+  await handoff().catch((error: unknown) => {
+    process.stderr.write(`open-design standalone fossil handoff failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/standalone/src/generation-bootloader.ts
+++ b/apps/standalone/src/generation-bootloader.ts
@@ -1,0 +1,86 @@
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  cleanupClosureChannelGarbage,
+  resolveClosureStorePaths,
+} from "@open-design/closure/store";
+
+import {
+  validateStandaloneHandoffRequest,
+  type StandaloneHandoff,
+  type StandaloneHandoffRequest,
+} from "./protocol/index.js";
+
+import {
+  launchStandaloneBodyBridge,
+  type StandaloneBodyProcessLaunchSpec,
+} from "./process-bridge.js";
+import { bundledStandaloneToolEnv } from "./tool-env.js";
+import { prepareStandaloneResourceEnv } from "./resource-handoff.js";
+
+export type StandaloneGenerationLaunch = StandaloneBodyProcessLaunchSpec;
+
+/**
+ * Resolve the three-component generation layout inside the launcher fossil.
+ * The Shell-owned official Node executes this wrapper; native and launcher
+ * details remain private to the Closure-owned wrapper.
+ */
+export function resolveStandaloneGenerationLaunch(
+  requestInput: StandaloneHandoffRequest,
+  executable: string = process.env.OD_NODE_BIN ?? process.execPath,
+  resourceEnv: NodeJS.ProcessEnv = {},
+): StandaloneGenerationLaunch {
+  const request = validateStandaloneHandoffRequest(requestInput);
+  const installationRoot = request.paths.installationRoot;
+  const nativeRoot = join(installationRoot, "native");
+  const nativeLoader = pathToFileURL(join(installationRoot, "launcher", "native-loader.mjs")).href;
+  return Object.freeze({
+    cwd: join(installationRoot, "body"),
+    env: {
+      ...process.env,
+      ...bundledStandaloneToolEnv(request.paths.resourceRoot),
+      ...resourceEnv,
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, `--import=${nativeLoader}`].filter(Boolean).join(" "),
+      NODE_PATH: join(nativeRoot, "node_modules"),
+      OD_STANDALONE_NATIVE_ROOT: nativeRoot,
+    },
+    executable,
+    launcherPath: join(installationRoot, "launcher", "launcher.mjs"),
+    output: "inherit",
+  });
+}
+
+export const handoff: StandaloneHandoff = async (value) => {
+  const request = validateStandaloneHandoffRequest(value);
+  if (request.closure != null) {
+    void cleanupClosureChannelGarbage({
+      paths: resolveClosureStorePaths({
+        channel: request.handoff.scope.channel,
+        namespace: request.handoff.scope.namespace,
+        root: request.closure.storeRoot,
+      }),
+    }).catch((error: unknown) => {
+      process.stderr.write(
+        `open-design Standalone garbage cleanup was deferred: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+    });
+  }
+  const resourceEnv = await prepareStandaloneResourceEnv(request);
+  return await launchStandaloneBodyBridge({
+    capabilities: request.capabilities,
+    descriptor: {
+      attachment: request.attachment,
+      closure: request.closure,
+      handoff: request.handoff,
+      paths: request.paths,
+      transition: request.transition,
+    },
+    launch: resolveStandaloneGenerationLaunch(
+      request,
+      process.env.OD_NODE_BIN ?? process.execPath,
+      resourceEnv,
+    ),
+  });
+};
+
+export default handoff;

--- a/apps/standalone/src/index.ts
+++ b/apps/standalone/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./runtime/index.js";
+export * from "./bootstrap.js";
+export * from "./bootloader.js";
+export * from "./process-bridge.js";
+export * from "./sidecars.js";
+export * from "./update-runtime.js";

--- a/apps/standalone/src/launcher-bootstrap.ts
+++ b/apps/standalone/src/launcher-bootstrap.ts
@@ -1,0 +1,88 @@
+import { join } from "node:path";
+
+import {
+  STANDALONE_BOOTLOADER_ENTRY_PATH,
+  validateStandaloneHandoffDescriptor,
+  type StandaloneHandoffDescriptor,
+} from "./protocol/index.js";
+
+const STANDALONE_LAUNCHER_BOOTSTRAP_ENV = "OD_STANDALONE_LAUNCHER_BOOTSTRAP_V1";
+const STANDALONE_LAUNCHER_BOOTSTRAP_SCHEMA_VERSION = 1 as const;
+const STANDALONE_BODY_COMPONENT_DIRECTORY = "body" as const;
+
+export type StandaloneLauncherBootstrap = Readonly<{
+  descriptor: StandaloneHandoffDescriptor;
+  schemaVersion: typeof STANDALONE_LAUNCHER_BOOTSTRAP_SCHEMA_VERSION;
+}>;
+
+export function validateStandaloneLauncherBootstrap(
+  value: unknown,
+): StandaloneLauncherBootstrap {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    throw new Error("Standalone launcher bootstrap must be an object");
+  }
+  const bootstrap = value as Record<string, unknown>;
+  const unknownKeys = Object.keys(bootstrap).filter((key) => ![
+    "descriptor",
+    "schemaVersion",
+  ].includes(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `Standalone launcher bootstrap contains unsupported fields: ${unknownKeys.join(", ")}`,
+    );
+  }
+  if (bootstrap.schemaVersion !== STANDALONE_LAUNCHER_BOOTSTRAP_SCHEMA_VERSION) {
+    throw new Error("Standalone launcher bootstrap schemaVersion is unsupported");
+  }
+  return Object.freeze({
+    descriptor: validateStandaloneHandoffDescriptor(bootstrap.descriptor),
+    schemaVersion: STANDALONE_LAUNCHER_BOOTSTRAP_SCHEMA_VERSION,
+  });
+}
+
+export function resolveStandaloneBodyBootloaderPath(
+  descriptorInput: StandaloneHandoffDescriptor,
+): string {
+  const descriptor = validateStandaloneHandoffDescriptor(descriptorInput);
+  return join(
+    descriptor.paths.installationRoot,
+    STANDALONE_BODY_COMPONENT_DIRECTORY,
+    STANDALONE_BOOTLOADER_ENTRY_PATH,
+  );
+}
+
+export function encodeStandaloneLauncherBootstrap(
+  value: Omit<StandaloneLauncherBootstrap, "schemaVersion">,
+): string {
+  const bootstrap = validateStandaloneLauncherBootstrap({
+    ...value,
+    schemaVersion: STANDALONE_LAUNCHER_BOOTSTRAP_SCHEMA_VERSION,
+  });
+  return Buffer.from(JSON.stringify(bootstrap), "utf8").toString("base64url");
+}
+
+export function createStandaloneLauncherBootstrapEnv(
+  value: Omit<StandaloneLauncherBootstrap, "schemaVersion">,
+  env: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    [STANDALONE_LAUNCHER_BOOTSTRAP_ENV]: encodeStandaloneLauncherBootstrap(value),
+  };
+}
+
+export function readStandaloneLauncherBootstrap(
+  env: NodeJS.ProcessEnv = process.env,
+): StandaloneLauncherBootstrap {
+  const encoded = env[STANDALONE_LAUNCHER_BOOTSTRAP_ENV];
+  if (typeof encoded !== "string" || encoded.length === 0) {
+    throw new Error("Standalone launcher bootstrap is unavailable");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new Error("Standalone launcher bootstrap is invalid", { cause: error });
+  }
+  return validateStandaloneLauncherBootstrap(parsed);
+}

--- a/apps/standalone/src/launcher.ts
+++ b/apps/standalone/src/launcher.ts
@@ -1,0 +1,69 @@
+import { pathToFileURL } from "node:url";
+
+import {
+  STANDALONE_BOOTLOADER_EXPORT_NAME,
+  type StandaloneHandoff,
+} from "./protocol/index.js";
+
+import {
+  readStandaloneLauncherBootstrap,
+  resolveStandaloneBodyBootloaderPath,
+} from "./launcher-bootstrap.js";
+import { attachStandaloneBodyBridge } from "./process-bridge.js";
+
+type BootloaderModule = Readonly<Record<string, unknown>>;
+type ResourceProviderModule = Readonly<{
+  ensureStandaloneResource(input: Readonly<{
+    descriptor: ReturnType<typeof readStandaloneLauncherBootstrap>["descriptor"];
+    id: string;
+  }>): Promise<Readonly<{ id: string; path: string; reused: boolean; title: string }>>;
+}>;
+
+function bodyHandoff(module: BootloaderModule): StandaloneHandoff {
+  const handoff = module[STANDALONE_BOOTLOADER_EXPORT_NAME];
+  if (typeof handoff !== "function") {
+    throw new Error(
+      `Standalone body bootloader must export ${STANDALONE_BOOTLOADER_EXPORT_NAME}()`,
+    );
+  }
+  return handoff as StandaloneHandoff;
+}
+
+async function runStandaloneLauncher(): Promise<void> {
+  const bootstrap = readStandaloneLauncherBootstrap();
+  const bodyBootloaderPath = resolveStandaloneBodyBootloaderPath(bootstrap.descriptor);
+  const module = await import(pathToFileURL(bodyBootloaderPath).href) as BootloaderModule;
+  let resolveExit!: () => void;
+  const exitRequested = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+  const bridge = await attachStandaloneBodyBridge({
+    descriptor: bootstrap.descriptor,
+    async ensureResource(id) {
+      const providerUrl = new URL("./resource-provider.mjs", import.meta.url).href;
+      const provider = await import(providerUrl) as ResourceProviderModule;
+      return await provider.ensureStandaloneResource({ descriptor: bootstrap.descriptor, id });
+    },
+    handoff: bodyHandoff(module),
+    onExitRequested: resolveExit,
+  });
+  let closing: Promise<void> | null = null;
+  const close = async (): Promise<void> => {
+    if (closing == null) closing = bridge.close();
+    await closing;
+    resolveExit();
+  };
+  process.once("SIGINT", () => void close());
+  process.once("SIGTERM", () => void close());
+  await exitRequested;
+  await close();
+}
+
+await runStandaloneLauncher().catch((error: unknown) => {
+  process.stderr.write(
+    `open-design standalone launcher failed: ${
+      error instanceof Error ? error.message : String(error)
+    }\n`,
+  );
+  process.exitCode = 1;
+});

--- a/apps/standalone/src/native-loader.ts
+++ b/apps/standalone/src/native-loader.ts
@@ -1,0 +1,33 @@
+import { createRequire, registerHooks } from "node:module";
+import { isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const STANDALONE_NATIVE_ROOT_ENV = "OD_STANDALONE_NATIVE_ROOT" as const;
+
+const nativeRoot = process.env[STANDALONE_NATIVE_ROOT_ENV];
+if (nativeRoot == null || !isAbsolute(nativeRoot)) {
+  throw new Error(`${STANDALONE_NATIVE_ROOT_ENV} must point to the verified native component`);
+}
+const resolveNative = createRequire(join(nativeRoot, "resolver.cjs"));
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    try {
+      return nextResolve(specifier, context);
+    } catch (error) {
+      if (
+        specifier.startsWith(".")
+        || specifier.startsWith("/")
+        || specifier.startsWith("node:")
+      ) throw error;
+      try {
+        return {
+          shortCircuit: true,
+          url: pathToFileURL(resolveNative.resolve(specifier)).href,
+        };
+      } catch {
+        throw error;
+      }
+    }
+  },
+});

--- a/apps/standalone/src/process-bridge.ts
+++ b/apps/standalone/src/process-bridge.ts
@@ -1,0 +1,770 @@
+import { createHash } from "node:crypto";
+import {
+  cleanupClosureChannelGarbage,
+  confirmClosureBindingAttempt,
+  discardObsoleteClosureNamespaceEpochs,
+  resolveClosureStorePaths,
+  rollbackClosureBindingAttempt,
+} from "@open-design/closure/store";
+
+import {
+  SidecarControlError,
+  attachSidecar,
+  bootstrapControlPlane,
+  type AttachSidecarOptions,
+  type AttachedSidecar,
+  type SidecarControlClient,
+  type SidecarControlContext,
+  type SidecarControlPlane,
+  type SidecarMethod,
+} from "@open-design/sidecar/control";
+import {
+  bootstrapSidecarLifecycle,
+  type SidecarLifecyclePlane,
+  type SidecarTransitionCredential,
+} from "@open-design/sidecar/lifecycle";
+import {
+  validateStandaloneHandoffDescriptor,
+  validateStandaloneRuntimeCommandRequest,
+  validateStandaloneRuntimeCommandResult,
+  validateStandaloneRuntimeStatus,
+  validateStandaloneShellCapabilityRequest,
+  validateStandaloneShellCapabilityResult,
+  STANDALONE_BODY_BRIDGE_SERVICE,
+  type StandaloneHandle,
+  type StandaloneHandoff,
+  type StandaloneHandoffDescriptor,
+  type StandaloneLifecycleOccupant,
+  type StandaloneLifecyclePort,
+  type StandaloneLifecycleTransition,
+  type StandaloneProtocolJsonValue,
+  type StandalonePreparedResource,
+  type StandaloneResourceEnsureRequest,
+  type StandaloneRuntimeCommandRequest,
+  type StandaloneRuntimeCommandResult,
+  type StandaloneRuntimeStatus,
+  type StandaloneRuntimeTerminalStatus,
+  type StandaloneShellCapabilityPort,
+  type StandaloneShellCapabilityRequest,
+  type StandaloneShellCapabilityResult,
+  type StandaloneShellHandle,
+} from "./protocol/index.js";
+
+import { createStandaloneLauncherBootstrapEnv } from "./launcher-bootstrap.js";
+export { STANDALONE_BODY_BRIDGE_SERVICE } from "./protocol/index.js";
+
+type StandaloneShellBridgeMethods = {
+  invoke: SidecarMethod<StandaloneShellCapabilityRequest, StandaloneShellCapabilityResult>;
+};
+
+type StandaloneBodyAttachmentInput = Readonly<{
+  attachmentId: string;
+}>;
+
+type StandaloneBodyAttachInput = Readonly<{
+  descriptor: StandaloneHandoffDescriptor;
+  shellService: string;
+}>;
+
+export type StandaloneBodyBridgeMethods = {
+  attach: SidecarMethod<StandaloneBodyAttachInput, StandaloneRuntimeStatus>;
+  close: SidecarMethod<StandaloneBodyAttachmentInput, StandaloneRuntimeTerminalStatus>;
+  ensureResource: SidecarMethod<StandaloneResourceEnsureRequest, StandalonePreparedResource>;
+  invoke: SidecarMethod<StandaloneRuntimeCommandRequest, StandaloneRuntimeCommandResult>;
+  readStatus: SidecarMethod<StandaloneBodyAttachmentInput, StandaloneRuntimeStatus>;
+  waitForTerminal: SidecarMethod<StandaloneBodyAttachmentInput, StandaloneRuntimeTerminalStatus>;
+};
+
+type BodyAttachment = Readonly<{
+  descriptor: StandaloneHandoffDescriptor;
+  descriptorKey: string;
+  task: Promise<StandaloneHandle>;
+}>;
+
+type StandaloneShellBridgeExposure = Readonly<{
+  abortTransition(): Promise<void>;
+  completeTransition(): Promise<void>;
+  lifecycle: StandaloneLifecyclePort;
+  service: string;
+  sidecar: AttachedSidecar;
+}>;
+
+export type StandaloneBodyProcessLaunchSpec = Readonly<{
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  executable: string;
+  launcherPath: string;
+  output?: "ignore" | "inherit";
+  readyTimeoutMs?: number;
+  stopTimeoutMs?: number;
+}>;
+
+function descriptorControl(descriptorInput: StandaloneHandoffDescriptor): Readonly<{
+  control: SidecarControlPlane;
+  descriptor: StandaloneHandoffDescriptor;
+}> {
+  const descriptor = validateStandaloneHandoffDescriptor(descriptorInput);
+  const scope = descriptor.handoff.scope;
+  return {
+    control: bootstrapControlPlane({
+      projection: {
+        digest: descriptor.handoff.descriptorDigest,
+        value: descriptor.handoff.descriptor,
+      },
+      roots: {
+        dataRoot: descriptor.paths.dataRoot,
+        resourceRoot: descriptor.paths.resourceRoot,
+        runtimeRoot: descriptor.paths.runtimeRoot,
+      },
+      scope: {
+        channel: scope.channel,
+        generation: scope.generation,
+        namespace: scope.namespace,
+      },
+    }),
+    descriptor,
+  };
+}
+
+function descriptorKey(descriptor: StandaloneHandoffDescriptor): string {
+  return JSON.stringify({ closure: descriptor.closure, handoff: descriptor.handoff, paths: descriptor.paths });
+}
+
+function attachmentKey(descriptor: StandaloneHandoffDescriptor): string {
+  return JSON.stringify(descriptor.attachment);
+}
+
+export function resolveStandaloneShellBridgeService(
+  descriptorInput: StandaloneHandoffDescriptor,
+): string {
+  const descriptor = validateStandaloneHandoffDescriptor(descriptorInput);
+  const digest = createHash("sha256").update(attachmentKey(descriptor)).digest("hex").slice(0, 24);
+  return `standalone-shell-${digest}`;
+}
+
+export async function exposeStandaloneShellBridge(options: Readonly<{
+  capabilities: StandaloneShellCapabilityPort;
+  descriptor: StandaloneHandoffDescriptor;
+}>): Promise<StandaloneShellBridgeExposure> {
+  const { control, descriptor } = descriptorControl(options.descriptor);
+  const service = resolveStandaloneShellBridgeService(descriptor);
+  const lifecycle: SidecarLifecyclePlane = bootstrapSidecarLifecycle({
+    controlRoot: descriptor.paths.dataRoot,
+    scope: {
+      channel: descriptor.handoff.scope.channel,
+      namespace: descriptor.handoff.scope.namespace,
+    },
+  });
+  const owner = {
+    generation: descriptor.handoff.scope.generation,
+    incarnation: descriptor.attachment.id,
+    key: `${descriptor.attachment.shell.type}:${descriptor.attachment.id}`,
+    projection: {
+      shellDigest: descriptor.attachment.shell.digest,
+      shellVersion: descriptor.attachment.shell.version,
+    },
+  } as const;
+  const attached = await lifecycle.attach({
+    leaseMs: 60_000,
+    owner,
+    ...(descriptor.transition == null ? {} : { transition: descriptor.transition }),
+  });
+  if (attached.state === "blocked") {
+    throw new Error(`Standalone Shell attachment is blocked by transition ${attached.transition.kind}`);
+  }
+
+  let rawSidecar: AttachedSidecar;
+  try {
+    rawSidecar = await control.expose<StandaloneShellBridgeMethods>({
+      handlers: {
+        async invoke(value) {
+          const request = validateStandaloneShellCapabilityRequest(value, {
+            attachmentId: descriptor.attachment.id,
+            handoff: descriptor.handoff,
+          });
+          return validateStandaloneShellCapabilityResult(
+            await options.capabilities.invoke(request),
+            {
+              attachmentId: descriptor.attachment.id,
+              handoff: descriptor.handoff,
+              requestId: request.requestId,
+            },
+          );
+        },
+      },
+      service,
+    });
+  } catch (error) {
+    await lifecycle.detach(attached.credential).catch(() => undefined);
+    throw error;
+  }
+
+  let closed = false;
+  let transitionCompleted = descriptor.transition == null;
+  let activeTransition: SidecarTransitionCredential | null = null;
+  let activeTransitionHandle: StandaloneLifecycleTransition | null = null;
+  let heartbeat: NodeJS.Timeout;
+  const closurePaths = descriptor.closure == null
+    ? null
+    : resolveClosureStorePaths({
+        channel: descriptor.handoff.scope.channel,
+        namespace: descriptor.handoff.scope.namespace,
+        root: descriptor.closure.storeRoot,
+      });
+  const closurePointer = {
+    channel: descriptor.handoff.scope.channel,
+    digest: descriptor.handoff.descriptor.standalone.digest,
+    generation: descriptor.handoff.scope.generation,
+    namespace: descriptor.handoff.scope.namespace,
+    protocolVersion: descriptor.handoff.descriptor.standalone.protocolVersion,
+    target: descriptor.closure?.target ?? "unknown-unknown",
+    version: descriptor.handoff.descriptor.standalone.version,
+  } as const;
+  const releaseActiveTransition = async (): Promise<void> => {
+    const credential = activeTransition;
+    activeTransition = null;
+    activeTransitionHandle = null;
+    if (credential != null) await lifecycle.abortTransition(credential).catch(() => undefined);
+  };
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    clearInterval(heartbeat);
+    await releaseActiveTransition();
+    await lifecycle.detach(attached.credential).catch(() => undefined);
+    await rawSidecar.close();
+  };
+  heartbeat = setInterval(() => {
+    void (async () => {
+      const transition = activeTransition
+        ?? (transitionCompleted || descriptor.transition == null ? null : descriptor.transition);
+      if (activeTransition != null) {
+        const renewed = await lifecycle.renewTransition({
+          credential: activeTransition,
+          leaseMs: 60_000,
+        });
+        if (renewed.state === "rejected") return await close();
+      }
+      const result = await lifecycle.renewLease({
+        credential: attached.credential,
+        leaseMs: 60_000,
+        ...(transition == null ? {} : { transition }),
+      });
+      if (result.state === "rejected") await close();
+    })().catch(async () => await close());
+  }, 20_000);
+  heartbeat.unref();
+  const sidecar: AttachedSidecar = Object.freeze({ close, context: rawSidecar.context });
+
+  return {
+    async abortTransition() {
+      if (transitionCompleted || descriptor.transition == null) return;
+      await lifecycle.abortTransition(descriptor.transition).catch(() => undefined);
+      if (closurePaths != null) {
+        await rollbackClosureBindingAttempt(closurePaths, closurePointer).catch(() => undefined);
+      }
+    },
+    async completeTransition() {
+      if (transitionCompleted || descriptor.transition == null) return;
+      const result = await lifecycle.completeTransition({
+        lease: attached.credential,
+        transition: descriptor.transition,
+      });
+      if (result.state === "rejected") {
+        throw new Error(`Standalone transition completion was rejected: ${result.reason}`);
+      }
+      if (closurePaths != null) {
+        await confirmClosureBindingAttempt(closurePaths, closurePointer);
+        void discardObsoleteClosureNamespaceEpochs(closurePaths)
+          .then(async (result) => {
+            if (result.discarded > 0) await cleanupClosureChannelGarbage({ paths: closurePaths });
+          })
+          .catch(() => undefined);
+      }
+      transitionCompleted = true;
+    },
+    lifecycle: Object.freeze({
+      async beginTransition(kind: string) {
+        if (closed) return { occupants: [], reason: "unavailable", state: "blocked" } as const;
+        if (!transitionCompleted) {
+          return { occupants: [], reason: "transition-active", state: "blocked" } as const;
+        }
+        if (activeTransitionHandle != null) {
+          return { state: "acquired", transition: activeTransitionHandle } as const;
+        }
+        let acquired;
+        try {
+          acquired = await lifecycle.beginTransition({
+            kind,
+            leaseMs: 60_000,
+            owner,
+            requester: attached.credential,
+          });
+        } catch {
+          return { occupants: [], reason: "unavailable", state: "blocked" } as const;
+        }
+        if (acquired.state === "blocked") {
+          const occupants: StandaloneLifecycleOccupant[] = (acquired.occupants ?? []).map((entry) => ({
+            generation: entry.owner.generation,
+            incarnation: entry.owner.incarnation,
+            key: entry.owner.key,
+            ...(entry.owner.projection == null
+              ? {}
+              : { projection: entry.owner.projection as StandaloneProtocolJsonValue }),
+          }));
+          return {
+            occupants,
+            reason: acquired.reason === "occupied" ? "occupied" : "transition-active",
+            state: "blocked",
+          } as const;
+        }
+        activeTransition = acquired.credential;
+        const credential = acquired.credential;
+        activeTransitionHandle = Object.freeze({
+          async release() {
+            if (activeTransition?.id !== credential.id || activeTransition.fence !== credential.fence) return;
+            await releaseActiveTransition();
+          },
+        });
+        return { state: "acquired", transition: activeTransitionHandle } as const;
+      },
+    }),
+    service,
+    sidecar,
+  };
+}
+
+async function remoteCapabilityPort(
+  control: SidecarControlPlane,
+  descriptor: StandaloneHandoffDescriptor,
+  service: string,
+): Promise<StandaloneShellCapabilityPort> {
+  if (service !== resolveStandaloneShellBridgeService(descriptor)) {
+    throw new Error("Standalone body attach references the wrong Shell capability service");
+  }
+  const client = await control.connect<StandaloneShellBridgeMethods>(service);
+  return {
+    async invoke(value) {
+      const request = validateStandaloneShellCapabilityRequest(value, {
+        attachmentId: descriptor.attachment.id,
+        handoff: descriptor.handoff,
+      });
+      return validateStandaloneShellCapabilityResult(await client.call("invoke", request), {
+        attachmentId: descriptor.attachment.id,
+        handoff: descriptor.handoff,
+        requestId: request.requestId,
+      });
+    },
+  };
+}
+
+function attachment(
+  attachments: Map<string, BodyAttachment>,
+  attachmentId: string,
+): BodyAttachment {
+  const entry = attachments.get(attachmentId);
+  if (entry == null) throw new Error(`Standalone body attachment is unavailable: ${attachmentId}`);
+  return entry;
+}
+
+function validateTerminalStatus(
+  value: unknown,
+  descriptor: StandaloneHandoffDescriptor,
+): StandaloneRuntimeTerminalStatus {
+  const status = validateStandaloneRuntimeStatus(value, { handoff: descriptor.handoff });
+  if (status.state === "running") {
+    throw new Error("Standalone body returned a non-terminal status from a terminal operation");
+  }
+  return status;
+}
+
+export type StandaloneBodyBridgeHostOptions = Readonly<{
+  descriptor: StandaloneHandoffDescriptor;
+  ensureResource?: (id: string) => Promise<StandalonePreparedResource>;
+  handoff: StandaloneHandoff;
+  onExitRequested?: () => void;
+}>;
+
+function createStandaloneBodyBridgeHost(options: StandaloneBodyBridgeHostOptions): Readonly<{
+  attachOptions: AttachSidecarOptions<StandaloneBodyBridgeMethods>;
+  closeAttachments(): Promise<void>;
+}> {
+  const { control, descriptor: baseline } = descriptorControl(options.descriptor);
+  const lifecycle = bootstrapSidecarLifecycle({
+    controlRoot: baseline.paths.dataRoot,
+    scope: {
+      channel: baseline.handoff.scope.channel,
+      namespace: baseline.handoff.scope.namespace,
+    },
+  });
+  const baselineKey = descriptorKey(baseline);
+  const attachments = new Map<string, BodyAttachment>();
+  let exitScheduled = false;
+  let stopping = false;
+  const scheduleExitIfIdle = (): void => {
+    if (stopping || attachments.size > 0 || exitScheduled) return;
+    exitScheduled = true;
+    setImmediate(() => {
+      exitScheduled = false;
+      if (!stopping && attachments.size === 0) options.onExitRequested?.();
+    });
+  };
+  const removeAttachment = async (attachmentId: string, entry: BodyAttachment): Promise<void> => {
+    if (attachments.get(attachmentId) !== entry) return;
+    attachments.delete(attachmentId);
+    scheduleExitIfIdle();
+  };
+  const hasLiveShellLease = (
+    descriptor: StandaloneHandoffDescriptor,
+    leases: Awaited<ReturnType<SidecarLifecyclePlane["snapshot"]>>["leases"],
+  ): boolean => leases.some((lease) => {
+    const projection = lease.owner.projection;
+    if (projection == null || typeof projection !== "object" || Array.isArray(projection)) return false;
+    const shellProjection = projection as Readonly<Record<string, unknown>>;
+    return lease.owner.generation === descriptor.handoff.scope.generation
+      && lease.owner.incarnation === descriptor.attachment.id
+      && lease.owner.key === `${descriptor.attachment.shell.type}:${descriptor.attachment.id}`
+      && shellProjection.shellDigest === descriptor.attachment.shell.digest
+      && shellProjection.shellVersion === descriptor.attachment.shell.version;
+  });
+  let observing = false;
+  const reapExpiredShells = async (): Promise<void> => {
+    if (observing || stopping || attachments.size === 0) return;
+    observing = true;
+    try {
+      const snapshot = await lifecycle.snapshot();
+      await Promise.all([...attachments.entries()].map(async ([attachmentId, entry]) => {
+        if (hasLiveShellLease(entry.descriptor, snapshot.leases)) return;
+        await entry.task.then(async (handle) => await handle.close()).catch(() => undefined);
+        await removeAttachment(attachmentId, entry);
+      }));
+    } catch {
+      // Lifecycle truth becoming unreadable is not evidence of a live Shell.
+      // Fail closed so an unowned product body cannot consume data/resources.
+      await Promise.all([...attachments.entries()].map(async ([attachmentId, entry]) => {
+        await entry.task.then(async (handle) => await handle.close()).catch(() => undefined);
+        await removeAttachment(attachmentId, entry);
+      }));
+    } finally {
+      observing = false;
+    }
+  };
+  const observer = setInterval(() => void reapExpiredShells(), 1_000);
+  observer.unref();
+  const closeAttachments = async (): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    clearInterval(observer);
+    await Promise.all(
+      [...attachments.values()].map(async (entry) => {
+        await entry.task.then(async (handle) => await handle.close()).catch(() => undefined);
+      }),
+    );
+    attachments.clear();
+  };
+  const clientDescriptor = (value: StandaloneHandoffDescriptor): StandaloneHandoffDescriptor => {
+    const descriptor = validateStandaloneHandoffDescriptor(value);
+    if (descriptorKey(descriptor) !== baselineKey) {
+      throw new Error("Standalone body attach does not match its generation paths and handoff");
+    }
+    return descriptor;
+  };
+  return {
+    attachOptions: {
+      handlers: {
+        async attach(value) {
+          const descriptor = clientDescriptor(value.descriptor);
+          const key = attachmentKey(descriptor);
+          const existing = attachments.get(descriptor.attachment.id);
+          if (existing != null) {
+            if (existing.descriptorKey !== key) {
+              throw new Error("Standalone body attachment changed Shell identity");
+            }
+            return validateStandaloneRuntimeStatus(await (await existing.task).readStatus(), {
+              handoff: descriptor.handoff,
+            });
+          }
+          const snapshot = await lifecycle.snapshot();
+          if (!hasLiveShellLease(descriptor, snapshot.leases)) {
+            throw new Error("Standalone body attachment has no live Shell lifecycle lease");
+          }
+          const task = (async () => {
+            const capabilities = await remoteCapabilityPort(control, descriptor, value.shellService);
+            return await options.handoff({ ...descriptor, capabilities });
+          })();
+          const entry = { descriptor, descriptorKey: key, task };
+          attachments.set(descriptor.attachment.id, entry);
+          task.catch(() => {
+            void removeAttachment(descriptor.attachment.id, entry);
+          });
+          void task.then(async (handle) => await handle.waitForTerminal())
+            .then(async () => await removeAttachment(descriptor.attachment.id, entry))
+            .catch(async () => await removeAttachment(descriptor.attachment.id, entry));
+          return validateStandaloneRuntimeStatus(await (await task).readStatus(), {
+            handoff: descriptor.handoff,
+            state: "running",
+          });
+        },
+        async close({ attachmentId }) {
+          const entry = attachment(attachments, attachmentId);
+          const handle = await entry.task;
+          const terminal = validateTerminalStatus(await handle.close(), baseline);
+          await removeAttachment(attachmentId, entry);
+          return terminal;
+        },
+        async ensureResource({ id }) {
+          if (options.ensureResource == null) {
+            throw new Error("Standalone body does not expose Closure resource materialization");
+          }
+          return await options.ensureResource(id);
+        },
+        async invoke(value) {
+          const command = validateStandaloneRuntimeCommandRequest(value, {
+            attachmentId: value.attachmentId,
+            handoff: baseline.handoff,
+          });
+          return validateStandaloneRuntimeCommandResult(
+            await (await attachment(attachments, command.attachmentId).task).invoke(command),
+            {
+              attachmentId: command.attachmentId,
+              handoff: baseline.handoff,
+              requestId: command.requestId,
+            },
+          );
+        },
+        async readStatus({ attachmentId }) {
+          return validateStandaloneRuntimeStatus(
+            await (await attachment(attachments, attachmentId).task).readStatus(),
+            { handoff: baseline.handoff },
+          );
+        },
+        async waitForTerminal({ attachmentId }) {
+          const entry = attachment(attachments, attachmentId);
+          const terminal = validateTerminalStatus(
+            await (await entry.task).waitForTerminal(),
+            baseline,
+          );
+          await removeAttachment(attachmentId, entry);
+          return terminal;
+        },
+      },
+      async onStopRequested() {
+        await closeAttachments();
+        options.onExitRequested?.();
+      },
+    },
+    closeAttachments,
+  };
+}
+
+function wrapStandaloneBodySidecar(
+  sidecar: AttachedSidecar,
+  closeAttachments: () => Promise<void>,
+): AttachedSidecar {
+  return Object.freeze({
+    async close() {
+      await closeAttachments();
+      await sidecar.close();
+    },
+    context: sidecar.context,
+  });
+}
+
+function assertStandaloneBodyContext(
+  context: SidecarControlContext,
+  control: SidecarControlPlane,
+): void {
+  if (
+    context.identity.service !== STANDALONE_BODY_BRIDGE_SERVICE
+    || context.identity.channel !== control.scope.channel
+    || context.identity.namespace !== control.scope.namespace
+    || context.identity.generation !== control.scope.generation
+    || context.projection.digest !== control.projection.digest
+    || context.roots.dataRoot !== control.roots.dataRoot
+    || context.roots.resourceRoot !== control.roots.resourceRoot
+    || context.roots.runtimeRoot !== control.roots.runtimeRoot
+  ) {
+    throw new Error("Standalone launcher control metadata does not match its handoff descriptor");
+  }
+}
+
+/** Host a body bridge in the caller process for focused tests and embedders. */
+export async function exposeStandaloneBodyBridge(
+  options: StandaloneBodyBridgeHostOptions,
+): Promise<AttachedSidecar> {
+  const { control } = descriptorControl(options.descriptor);
+  const host = createStandaloneBodyBridgeHost(options);
+  return wrapStandaloneBodySidecar(
+    await control.expose<StandaloneBodyBridgeMethods>({
+      ...host.attachOptions,
+      service: STANDALONE_BODY_BRIDGE_SERVICE,
+    }),
+    host.closeAttachments,
+  );
+}
+
+/** Attach launcher.mjs to caller-supplied Sidecar launch metadata. */
+export async function attachStandaloneBodyBridge(
+  options: StandaloneBodyBridgeHostOptions,
+): Promise<AttachedSidecar> {
+  const { control } = descriptorControl(options.descriptor);
+  const host = createStandaloneBodyBridgeHost(options);
+  return wrapStandaloneBodySidecar(
+    await attachSidecar<StandaloneBodyBridgeMethods>({
+      ...host.attachOptions,
+      initialize(context) {
+        assertStandaloneBodyContext(context, control);
+      },
+    }),
+    host.closeAttachments,
+  );
+}
+
+function bodyClientHandle(
+  client: SidecarControlClient<StandaloneBodyBridgeMethods>,
+  descriptor: StandaloneHandoffDescriptor,
+  shell: StandaloneShellBridgeExposure,
+): StandaloneShellHandle {
+  const attachmentId = descriptor.attachment.id;
+  let closeTask: Promise<StandaloneRuntimeTerminalStatus> | null = null;
+  const closeShell = async (): Promise<void> => await shell.sidecar.close().catch(() => undefined);
+  return {
+    async close() {
+      if (closeTask == null) {
+        closeTask = client.call("close", { attachmentId }, { timeoutMs: null })
+          .then((status) => validateTerminalStatus(status, descriptor))
+          .finally(closeShell);
+      }
+      return await closeTask;
+    },
+    async invoke(value) {
+      const command = validateStandaloneRuntimeCommandRequest(value, {
+        attachmentId,
+        handoff: descriptor.handoff,
+      });
+      return validateStandaloneRuntimeCommandResult(await client.call("invoke", command, { timeoutMs: null }), {
+        attachmentId,
+        handoff: descriptor.handoff,
+        requestId: command.requestId,
+      });
+    },
+    lifecycle: shell.lifecycle,
+    async readStatus() {
+      return validateStandaloneRuntimeStatus(await client.call("readStatus", { attachmentId }), {
+        handoff: descriptor.handoff,
+      });
+    },
+    async waitForTerminal() {
+      try {
+        return validateTerminalStatus(
+          await client.call("waitForTerminal", { attachmentId }, { timeoutMs: null }),
+          descriptor,
+        );
+      } finally {
+        await closeShell();
+      }
+    },
+  };
+}
+
+async function attachShellToStandaloneBody(
+  client: SidecarControlClient<StandaloneBodyBridgeMethods>,
+  descriptor: StandaloneHandoffDescriptor,
+  shell: StandaloneShellBridgeExposure,
+): Promise<StandaloneShellHandle> {
+  try {
+    validateStandaloneRuntimeStatus(
+      // A cold attachment owns full Standalone acquisition (daemon + Web), so
+      // its lifecycle deadline belongs to the Shell/product policy rather than
+      // the sidecar transport's short request default. The body remains fenced
+      // by the exact generation descriptor and the caller can still terminate
+      // the owned launch if this operation rejects.
+      await client.call("attach", { descriptor, shellService: shell.service }, { timeoutMs: null }),
+      { handoff: descriptor.handoff, state: "running" },
+    );
+    await shell.completeTransition();
+    return bodyClientHandle(client, descriptor, shell);
+  } catch (error) {
+    await client.call("close", { attachmentId: descriptor.attachment.id }, { timeoutMs: null })
+      .catch(() => undefined);
+    await shell.abortTransition();
+    throw error;
+  }
+}
+
+function isUnavailableSidecar(error: unknown): boolean {
+  return error instanceof SidecarControlError && error.code === "peer-unavailable";
+}
+
+export async function connectStandaloneBodyBridge(options: Readonly<{
+  capabilities: StandaloneShellCapabilityPort;
+  descriptor: StandaloneHandoffDescriptor;
+}>): Promise<StandaloneShellHandle> {
+  const { control, descriptor } = descriptorControl(options.descriptor);
+  const shell = await exposeStandaloneShellBridge(options);
+  try {
+    const client = await control.connect<StandaloneBodyBridgeMethods>(STANDALONE_BODY_BRIDGE_SERVICE);
+    return await attachShellToStandaloneBody(client, descriptor, shell);
+  } catch (error) {
+    await shell.abortTransition();
+    await shell.sidecar.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+/**
+ * Shell-side cold/hot path. Reuse an existing generation body when present;
+ * otherwise launch official Node with the immutable launcher.mjs entry. A
+ * duplicate cold-start loser reconnects to the winner instead of replacing it.
+ */
+export async function launchStandaloneBodyBridge(options: Readonly<{
+  capabilities: StandaloneShellCapabilityPort;
+  descriptor: StandaloneHandoffDescriptor;
+  launch: StandaloneBodyProcessLaunchSpec;
+}>): Promise<StandaloneShellHandle> {
+  const { control, descriptor } = descriptorControl(options.descriptor);
+  const shell = await exposeStandaloneShellBridge(options);
+  const ownedLaunch: { stop: (() => Promise<unknown>) | null } = { stop: null };
+  try {
+    let client: SidecarControlClient<StandaloneBodyBridgeMethods>;
+    try {
+      client = await control.connect<StandaloneBodyBridgeMethods>(STANDALONE_BODY_BRIDGE_SERVICE);
+    } catch (connectError) {
+      if (!isUnavailableSidecar(connectError)) throw connectError;
+      try {
+        const launched = await control.launch<StandaloneBodyBridgeMethods>({
+          args: [options.launch.launcherPath],
+          ...(options.launch.cwd == null ? {} : { cwd: options.launch.cwd }),
+          env: createStandaloneLauncherBootstrapEnv({
+            descriptor,
+          }, options.launch.env),
+          executable: options.launch.executable,
+          ...(options.launch.output == null ? {} : { output: options.launch.output }),
+          ...(options.launch.readyTimeoutMs == null
+            ? {}
+            : { readyTimeoutMs: options.launch.readyTimeoutMs }),
+          service: STANDALONE_BODY_BRIDGE_SERVICE,
+          ...(options.launch.stopTimeoutMs == null
+            ? {}
+            : { stopTimeoutMs: options.launch.stopTimeoutMs }),
+        });
+        ownedLaunch.stop = async () => await launched.stop();
+        client = launched.client;
+      } catch (launchError) {
+        try {
+          client = await control.connect<StandaloneBodyBridgeMethods>(
+            STANDALONE_BODY_BRIDGE_SERVICE,
+          );
+        } catch {
+          throw launchError;
+        }
+      }
+    }
+    return await attachShellToStandaloneBody(client, descriptor, shell);
+  } catch (error) {
+    await shell.abortTransition();
+    await shell.sidecar.close().catch(() => undefined);
+    await ownedLaunch.stop?.().catch(() => undefined);
+    throw error;
+  }
+}

--- a/apps/standalone/src/protocol/core-validation.ts
+++ b/apps/standalone/src/protocol/core-validation.ts
@@ -1,0 +1,792 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, posix, win32 } from "node:path";
+
+import { isClosureChannel } from "@open-design/closure/protocol";
+
+import {
+  STANDALONE_PROTOCOL_VERSION,
+  STANDALONE_BOOTSTRAP_SCHEMA_VERSION,
+  STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION,
+  STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_BOOTLOADER_ENTRY_PATH,
+  StandaloneDigest,
+  StandaloneBootstrapScope,
+  StandaloneHandoffScope,
+  StandaloneRuntimeDescriptor,
+  StandaloneAttachmentDescriptor,
+  StandaloneHandoffEnvelope,
+  StandalonePaths,
+  StandaloneBootstrapDescriptor,
+  StandaloneBootstrapRequest,
+  StandaloneBootstrapResolution,
+  STANDALONE_BOOTSTRAP_PROGRESS_STAGES,
+  StandaloneBootstrapProgressStage,
+  StandaloneBootstrapProgress,
+  StandaloneLifecycleTransitionCredential,
+  STANDALONE_BOOTSTRAP_ERROR_CODES,
+  StandaloneBootstrapErrorCode,
+  StandaloneBootstrapResult,
+  StandaloneProtocolJsonValue,
+  StandaloneShellCapabilityPort,
+  STANDALONE_SHELL_CAPABILITIES,
+  StandaloneShellCapability,
+  StandaloneExportPdfInput,
+  StandaloneExportPdfResult,
+  StandaloneRenderSlidesInput,
+  StandaloneRenderSlidesErrorCode,
+  StandaloneRenderSlidesResult,
+  StandaloneExportArtifactInput,
+  StandaloneExportArtifactResult,
+  StandaloneShellCapabilityInput,
+  StandaloneShellCapabilityOutput,
+  StandaloneHandoffDescriptor,
+  StandaloneHandoffRequest,
+  StandaloneProtocolError,
+} from "./index.js";
+
+export function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new StandaloneProtocolError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function normalizeToken(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || !/^[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?$/u.test(value)
+  ) {
+    throw new StandaloneProtocolError(`${label} must be a lowercase protocol token`);
+  }
+  return value;
+}
+
+function normalizeNamespace(value: unknown): string {
+  if (
+    typeof value !== "string"
+    || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u.test(value)
+  ) {
+    throw new StandaloneProtocolError("standalone namespace must be a safe local token");
+  }
+  return value;
+}
+
+export function normalizeVersion(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value !== value.trim()
+    || !/^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u.test(value)
+  ) {
+    throw new StandaloneProtocolError(`${label} must be a comparable semantic version`);
+  }
+  return value;
+}
+
+function normalizeDigest(value: unknown): StandaloneDigest {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(value)) {
+    throw new StandaloneProtocolError("standalone digest must be a lowercase sha256 digest");
+  }
+  return value as StandaloneDigest;
+}
+
+function normalizePath(value: unknown, label: string): string {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || value !== value.trim()
+    || value.includes("\0")
+    || (!isAbsolute(value) && !posix.isAbsolute(value) && !win32.isAbsolute(value))
+  ) {
+    throw new StandaloneProtocolError(`${label} must be an absolute path`);
+  }
+  return value;
+}
+
+function normalizeNullableHttpUrl(value: unknown, label: string): string | null {
+  if (value == null) return null;
+  if (typeof value !== "string" || value.length === 0 || value !== value.trim()) {
+    throw new StandaloneProtocolError(`${label} must be null or an absolute http(s) URL`);
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("unsupported protocol");
+    return parsed.toString();
+  } catch {
+    throw new StandaloneProtocolError(`${label} must be null or an absolute http(s) URL`);
+  }
+}
+
+export function normalizeJsonValue(
+  value: unknown,
+  label: string,
+  seen: Set<object> = new Set(),
+): StandaloneProtocolJsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new StandaloneProtocolError(`${label} numbers must be finite`);
+    return value;
+  }
+  if (typeof value !== "object") {
+    throw new StandaloneProtocolError(`${label} must contain only JSON values`);
+  }
+  if (seen.has(value)) throw new StandaloneProtocolError(`${label} must not contain cycles`);
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry, index) => normalizeJsonValue(entry, `${label}[${index}]`, seen));
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new StandaloneProtocolError(`${label} objects must be plain JSON records`);
+    }
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+      key,
+      normalizeJsonValue(entry, `${label}.${key}`, seen),
+    ]));
+  } finally {
+    seen.delete(value);
+  }
+}
+
+export function requireKnownKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set(keys);
+  const extras = Object.keys(value).filter((key) => !allowed.has(key));
+  if (extras.length > 0) {
+    throw new StandaloneProtocolError(`${label} contains unsupported fields: ${extras.join(", ")}`);
+  }
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") throw new StandaloneProtocolError(`${label} must be a boolean`);
+  return value;
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "string") throw new StandaloneProtocolError(`${label} must be a string`);
+  return value;
+}
+
+export function requiredString(value: unknown, label: string): string {
+  const normalized = optionalString(value, label);
+  if (normalized == null || normalized.length === 0) {
+    throw new StandaloneProtocolError(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | undefined {
+  if (value == null) return undefined;
+  return requireBoolean(value, label);
+}
+
+function optionalPositiveNumber(value: unknown, label: string): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new StandaloneProtocolError(`${label} must be a positive number`);
+  }
+  return value;
+}
+
+function optionalNonNegativeInteger(value: unknown, label: string): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new StandaloneProtocolError(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function optionalStringArray(value: unknown, label: string): string[] | undefined {
+  if (value == null) return undefined;
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new StandaloneProtocolError(`${label} must be an array of strings`);
+  }
+  return [...value] as string[];
+}
+
+function validateExportPdfInput(value: unknown): StandaloneExportPdfInput {
+  const input = requireRecord(value, "standalone PDF export input");
+  requireKnownKeys(input, ["baseHref", "deck", "defaultFilename", "html", "title"], "standalone PDF export input");
+  return {
+    ...(input.baseHref == null ? {} : { baseHref: requiredString(input.baseHref, "standalone PDF export baseHref") }),
+    deck: requireBoolean(input.deck, "standalone PDF export deck"),
+    defaultFilename: requiredString(input.defaultFilename, "standalone PDF export defaultFilename"),
+    html: requiredString(input.html, "standalone PDF export html"),
+    title: requiredString(input.title, "standalone PDF export title"),
+  };
+}
+
+function validateExportPdfResult(value: unknown): StandaloneExportPdfResult {
+  const result = requireRecord(value, "standalone PDF export result");
+  requireKnownKeys(result, ["canceled", "error", "ok", "path"], "standalone PDF export result");
+  return {
+    ...(result.canceled == null ? {} : { canceled: requireBoolean(result.canceled, "standalone PDF export canceled") }),
+    ...(result.error == null ? {} : { error: optionalString(result.error, "standalone PDF export error")! }),
+    ok: requireBoolean(result.ok, "standalone PDF export ok"),
+    ...(result.path == null ? {} : { path: optionalString(result.path, "standalone PDF export path")! }),
+  };
+}
+
+function validateRenderSlidesInput(value: unknown): StandaloneRenderSlidesInput {
+  const input = requireRecord(value, "standalone slide render input");
+  requireKnownKeys(input, [
+    "baseHref", "deck", "editable", "height", "html", "index", "outputDir",
+    "pageImageFormat", "paginate", "stitch", "width",
+  ], "standalone slide render input");
+  const outputDir = input.outputDir == null
+    ? undefined
+    : requiredString(input.outputDir, "standalone slide render outputDir");
+  if (outputDir != null && !isAbsolute(outputDir) && !posix.isAbsolute(outputDir) && !win32.isAbsolute(outputDir)) {
+    throw new StandaloneProtocolError("standalone slide render outputDir must be an absolute path");
+  }
+  if (input.pageImageFormat != null && input.pageImageFormat !== "jpeg" && input.pageImageFormat !== "png") {
+    throw new StandaloneProtocolError("standalone slide render pageImageFormat must be jpeg or png");
+  }
+  return {
+    ...(input.baseHref == null ? {} : { baseHref: requiredString(input.baseHref, "standalone slide render baseHref") }),
+    ...(input.deck == null ? {} : { deck: optionalBoolean(input.deck, "standalone slide render deck")! }),
+    ...(input.editable == null ? {} : { editable: optionalBoolean(input.editable, "standalone slide render editable")! }),
+    ...(input.height == null ? {} : { height: optionalPositiveNumber(input.height, "standalone slide render height")! }),
+    html: requiredString(input.html, "standalone slide render html"),
+    ...(input.index == null ? {} : { index: optionalNonNegativeInteger(input.index, "standalone slide render index")! }),
+    ...(outputDir == null ? {} : { outputDir }),
+    ...(input.pageImageFormat == null ? {} : { pageImageFormat: input.pageImageFormat }),
+    ...(input.paginate == null ? {} : { paginate: optionalBoolean(input.paginate, "standalone slide render paginate")! }),
+    ...(input.stitch == null ? {} : { stitch: optionalBoolean(input.stitch, "standalone slide render stitch")! }),
+    ...(input.width == null ? {} : { width: optionalPositiveNumber(input.width, "standalone slide render width")! }),
+  };
+}
+
+function validateRenderSlidesResult(value: unknown): StandaloneRenderSlidesResult {
+  const result = requireRecord(value, "standalone slide render result");
+  requireKnownKeys(result, [
+    "error", "errorCode", "height", "mode", "ok", "pptxFile", "slideFiles", "slides", "width",
+  ], "standalone slide render result");
+  const errorCodes: readonly StandaloneRenderSlidesErrorCode[] = [
+    "NO_SLIDES", "PAGE_TOO_TALL", "RENDER_FAILED", "SLIDE_INDEX_OUT_OF_RANGE",
+  ];
+  if (result.errorCode != null && !errorCodes.includes(result.errorCode as StandaloneRenderSlidesErrorCode)) {
+    throw new StandaloneProtocolError("standalone slide render errorCode is unsupported");
+  }
+  if (result.mode != null && result.mode !== "deck" && result.mode !== "page") {
+    throw new StandaloneProtocolError("standalone slide render mode must be deck or page");
+  }
+  return {
+    ...(result.error == null ? {} : { error: optionalString(result.error, "standalone slide render error")! }),
+    ...(result.errorCode == null ? {} : { errorCode: result.errorCode as StandaloneRenderSlidesErrorCode }),
+    ...(result.height == null ? {} : { height: optionalPositiveNumber(result.height, "standalone slide render height")! }),
+    ...(result.mode == null ? {} : { mode: result.mode }),
+    ok: requireBoolean(result.ok, "standalone slide render ok"),
+    ...(result.pptxFile == null ? {} : { pptxFile: optionalString(result.pptxFile, "standalone slide render pptxFile")! }),
+    ...(result.slideFiles == null ? {} : { slideFiles: optionalStringArray(result.slideFiles, "standalone slide render slideFiles")! }),
+    ...(result.slides == null ? {} : { slides: optionalStringArray(result.slides, "standalone slide render slides")! }),
+    ...(result.width == null ? {} : { width: optionalPositiveNumber(result.width, "standalone slide render width")! }),
+  };
+}
+
+function validateExportArtifactInput(value: unknown): StandaloneExportArtifactInput {
+  const input = requireRecord(value, "standalone artifact export input");
+  requireKnownKeys(input, ["baseHref", "deck", "format", "height", "html", "imageFormat", "title", "width"], "standalone artifact export input");
+  if (input.format !== "image" && input.format !== "pdf") {
+    throw new StandaloneProtocolError("standalone artifact export format must be image or pdf");
+  }
+  if (input.imageFormat != null && input.imageFormat !== "jpeg" && input.imageFormat !== "png") {
+    throw new StandaloneProtocolError("standalone artifact export imageFormat must be jpeg or png");
+  }
+  return {
+    ...(input.baseHref == null ? {} : { baseHref: requiredString(input.baseHref, "standalone artifact export baseHref") }),
+    deck: requireBoolean(input.deck, "standalone artifact export deck"),
+    format: input.format,
+    ...(input.height == null ? {} : { height: optionalPositiveNumber(input.height, "standalone artifact export height")! }),
+    html: requiredString(input.html, "standalone artifact export html"),
+    ...(input.imageFormat == null ? {} : { imageFormat: input.imageFormat }),
+    title: requiredString(input.title, "standalone artifact export title"),
+    ...(input.width == null ? {} : { width: optionalPositiveNumber(input.width, "standalone artifact export width")! }),
+  };
+}
+
+function validateExportArtifactResult(value: unknown): StandaloneExportArtifactResult {
+  const result = requireRecord(value, "standalone artifact export result");
+  requireKnownKeys(result, ["bytes", "error", "mime", "ok", "path"], "standalone artifact export result");
+  return {
+    ...(result.bytes == null ? {} : { bytes: optionalNonNegativeInteger(result.bytes, "standalone artifact export bytes")! }),
+    ...(result.error == null ? {} : { error: optionalString(result.error, "standalone artifact export error")! }),
+    ...(result.mime == null ? {} : { mime: optionalString(result.mime, "standalone artifact export mime")! }),
+    ok: requireBoolean(result.ok, "standalone artifact export ok"),
+    ...(result.path == null ? {} : { path: optionalString(result.path, "standalone artifact export path")! }),
+  };
+}
+
+export function validateStandaloneShellCapabilityInput<
+  TCapability extends StandaloneShellCapability,
+>(
+  capability: TCapability,
+  value: unknown,
+): StandaloneShellCapabilityInput<TCapability> {
+  switch (capability) {
+    case STANDALONE_SHELL_CAPABILITIES.EXPORT_ARTIFACT:
+      return validateExportArtifactInput(value) as StandaloneShellCapabilityInput<TCapability>;
+    case STANDALONE_SHELL_CAPABILITIES.EXPORT_PDF:
+      return validateExportPdfInput(value) as StandaloneShellCapabilityInput<TCapability>;
+    case STANDALONE_SHELL_CAPABILITIES.RENDER_SLIDES:
+      return validateRenderSlidesInput(value) as StandaloneShellCapabilityInput<TCapability>;
+  }
+}
+
+export function validateStandaloneShellCapabilityOutput<
+  TCapability extends StandaloneShellCapability,
+>(
+  capability: TCapability,
+  value: unknown,
+): StandaloneShellCapabilityOutput<TCapability> {
+  switch (capability) {
+    case STANDALONE_SHELL_CAPABILITIES.EXPORT_ARTIFACT:
+      return validateExportArtifactResult(value) as StandaloneShellCapabilityOutput<TCapability>;
+    case STANDALONE_SHELL_CAPABILITIES.EXPORT_PDF:
+      return validateExportPdfResult(value) as StandaloneShellCapabilityOutput<TCapability>;
+    case STANDALONE_SHELL_CAPABILITIES.RENDER_SLIDES:
+      return validateRenderSlidesResult(value) as StandaloneShellCapabilityOutput<TCapability>;
+  }
+}
+
+export function validateStandaloneHandoffScope(value: unknown): StandaloneHandoffScope {
+  const scope = requireRecord(value, "standalone handoff scope");
+  if (!isClosureChannel(scope.channel)) {
+    throw new StandaloneProtocolError(`unsupported standalone channel: ${String(scope.channel)}`);
+  }
+  if (
+    typeof scope.generation !== "number"
+    || !Number.isSafeInteger(scope.generation)
+    || scope.generation < 0
+  ) {
+    throw new StandaloneProtocolError("standalone generation must be a non-negative safe integer");
+  }
+  return {
+    channel: scope.channel,
+    generation: scope.generation,
+    namespace: normalizeNamespace(scope.namespace),
+  };
+}
+
+export function validateStandaloneRuntimeDescriptor(value: unknown): StandaloneRuntimeDescriptor {
+  const descriptor = requireRecord(value, "standalone runtime descriptor");
+  const release = requireRecord(descriptor.release, "standalone release descriptor");
+  const standalone = requireRecord(descriptor.standalone, "standalone body descriptor");
+  if (standalone.protocolVersion !== STANDALONE_PROTOCOL_VERSION) {
+    throw new StandaloneProtocolError(
+      `unsupported standalone protocol version: ${String(standalone.protocolVersion)}`,
+    );
+  }
+  return {
+    release: {
+      version: normalizeVersion(release.version, "standalone release version"),
+    },
+    standalone: {
+      digest: normalizeDigest(standalone.digest),
+      protocolVersion: STANDALONE_PROTOCOL_VERSION,
+      version: normalizeVersion(standalone.version, "standalone body version"),
+    },
+  };
+}
+
+function descriptorJson(descriptor: StandaloneRuntimeDescriptor): string {
+  return JSON.stringify({
+    release: { version: descriptor.release.version },
+    standalone: {
+      digest: descriptor.standalone.digest,
+      protocolVersion: descriptor.standalone.protocolVersion,
+      version: descriptor.standalone.version,
+    },
+  });
+}
+
+export function validateStandaloneAttachmentDescriptor(
+  value: unknown,
+): StandaloneAttachmentDescriptor {
+  const attachment = requireRecord(value, "standalone attachment descriptor");
+  const shell = requireRecord(attachment.shell, "standalone attachment shell descriptor");
+  return {
+    id: normalizeToken(attachment.id, "standalone attachment id"),
+    shell: {
+      digest: normalizeDigest(shell.digest),
+      type: normalizeToken(shell.type, "standalone shell type"),
+      version: normalizeVersion(shell.version, "standalone shell version"),
+    },
+  };
+}
+
+export function validateStandaloneBootstrapScope(value: unknown): StandaloneBootstrapScope {
+  const scope = requireRecord(value, "standalone bootstrap scope");
+  requireKnownKeys(scope, ["channel", "namespace"], "standalone bootstrap scope");
+  if (!isClosureChannel(scope.channel)) {
+    throw new StandaloneProtocolError(`unsupported standalone channel: ${String(scope.channel)}`);
+  }
+  return Object.freeze({
+    channel: scope.channel,
+    namespace: normalizeNamespace(scope.namespace),
+  });
+}
+
+export function validateStandaloneBootstrapDescriptor(
+  value: unknown,
+): StandaloneBootstrapDescriptor {
+  const descriptor = requireRecord(value, "standalone bootstrap descriptor");
+  requireKnownKeys(
+    descriptor,
+    ["attachment", "discovery", "paths", "releaseIntent", "repositoryConfigPath", "schemaVersion", "scope"],
+    "standalone bootstrap descriptor",
+  );
+  if (descriptor.schemaVersion !== STANDALONE_BOOTSTRAP_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("standalone bootstrap schemaVersion is unsupported");
+  }
+  const discovery = requireRecord(descriptor.discovery, "standalone bootstrap discovery");
+  requireKnownKeys(discovery, ["metadataUrl", "target"], "standalone bootstrap discovery");
+  const releaseIntent = requireRecord(descriptor.releaseIntent, "standalone release intent");
+  if (releaseIntent.kind === "exact") {
+    requireKnownKeys(releaseIntent, ["kind", "releaseVersion"], "standalone exact release intent");
+  } else if (releaseIntent.kind === "resume-or-bootstrap") {
+    requireKnownKeys(releaseIntent, ["kind"], "standalone resume-or-bootstrap release intent");
+  } else {
+    throw new StandaloneProtocolError(`unsupported standalone release intent: ${String(releaseIntent.kind)}`);
+  }
+  return Object.freeze({
+    attachment: validateStandaloneAttachmentDescriptor(descriptor.attachment),
+    discovery: Object.freeze({
+      metadataUrl: normalizeNullableHttpUrl(discovery.metadataUrl, "standalone bootstrap metadataUrl"),
+      target: normalizeToken(discovery.target, "standalone bootstrap target"),
+    }),
+    paths: validateStandalonePaths(descriptor.paths),
+    releaseIntent: releaseIntent.kind === "exact"
+      ? Object.freeze({
+          kind: "exact" as const,
+          releaseVersion: normalizeVersion(
+            releaseIntent.releaseVersion,
+            "standalone requested release version",
+          ),
+        })
+      : Object.freeze({ kind: "resume-or-bootstrap" as const }),
+    repositoryConfigPath: normalizePath(
+      descriptor.repositoryConfigPath,
+      "standalone bootstrap repositoryConfigPath",
+    ),
+    schemaVersion: STANDALONE_BOOTSTRAP_SCHEMA_VERSION,
+    scope: validateStandaloneBootstrapScope(descriptor.scope),
+  });
+}
+
+export function validateStandaloneBootstrapRequest(value: unknown): StandaloneBootstrapRequest {
+  const request = requireRecord(value, "standalone bootstrap request");
+  requireKnownKeys(
+    request,
+    ["attachment", "capabilities", "discovery", "paths", "releaseIntent", "repositoryConfigPath", "schemaVersion", "scope"],
+    "standalone bootstrap request",
+  );
+  const descriptor = validateStandaloneBootstrapDescriptor({
+    attachment: request.attachment,
+    discovery: request.discovery,
+    paths: request.paths,
+    releaseIntent: request.releaseIntent,
+    repositoryConfigPath: request.repositoryConfigPath,
+    schemaVersion: request.schemaVersion,
+    scope: request.scope,
+  });
+  const capabilities = requireRecord(request.capabilities, "standalone bootstrap capabilities");
+  if (typeof capabilities.invoke !== "function") {
+    throw new StandaloneProtocolError("standalone bootstrap capabilities must provide invoke()");
+  }
+  return Object.freeze({ ...descriptor, capabilities: request.capabilities as StandaloneShellCapabilityPort });
+}
+
+export function validateStandaloneBootstrapResolution(
+  value: unknown,
+): StandaloneBootstrapResolution {
+  const resolution = requireRecord(value, "standalone bootstrap resolution");
+  requireKnownKeys(resolution, ["bootloaderPath", "handoff"], "standalone bootstrap resolution");
+  const bootloaderPath = normalizePath(resolution.bootloaderPath, "standalone bootstrap bootloaderPath");
+  if (!bootloaderPath.endsWith(`/${STANDALONE_BOOTLOADER_ENTRY_PATH}`)
+    && !bootloaderPath.endsWith(`\\${STANDALONE_BOOTLOADER_ENTRY_PATH}`)) {
+    throw new StandaloneProtocolError(
+      `standalone bootstrap bootloaderPath must end with ${STANDALONE_BOOTLOADER_ENTRY_PATH}`,
+    );
+  }
+  return Object.freeze({
+    bootloaderPath,
+    handoff: validateStandaloneHandoffDescriptor(resolution.handoff),
+  });
+}
+
+export function validateStandaloneBootstrapProgress(
+  value: unknown,
+): StandaloneBootstrapProgress {
+  const progress = requireRecord(value, "standalone bootstrap progress");
+  requireKnownKeys(
+    progress,
+    ["initialLoad", "progress", "schemaVersion", "stage", "subject"],
+    "standalone bootstrap progress",
+  );
+  if (progress.schemaVersion !== STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("standalone bootstrap progress schemaVersion is unsupported");
+  }
+  if (!STANDALONE_BOOTSTRAP_PROGRESS_STAGES.includes(
+    progress.stage as StandaloneBootstrapProgressStage,
+  )) {
+    throw new StandaloneProtocolError("standalone bootstrap progress stage is unsupported");
+  }
+  let normalizedProgress: StandaloneBootstrapProgress["progress"];
+  if (progress.progress != null) {
+    const quantitative = requireRecord(
+      progress.progress,
+      "standalone bootstrap quantitative progress",
+    );
+    requireKnownKeys(
+      quantitative,
+      ["completed", "total", "unit"],
+      "standalone bootstrap quantitative progress",
+    );
+    const completed = optionalNonNegativeInteger(
+      quantitative.completed,
+      "standalone bootstrap completed progress",
+    );
+    const total = optionalNonNegativeInteger(
+      quantitative.total,
+      "standalone bootstrap total progress",
+    );
+    if (completed == null || total == null || total === 0 || completed > total) {
+      throw new StandaloneProtocolError(
+        "standalone bootstrap quantitative progress must satisfy 0 <= completed <= total",
+      );
+    }
+    if (quantitative.unit !== "bytes" && quantitative.unit !== "components") {
+      throw new StandaloneProtocolError("standalone bootstrap progress unit is unsupported");
+    }
+    normalizedProgress = Object.freeze({ completed, total, unit: quantitative.unit });
+  }
+  const subject = requireRecord(progress.subject, "standalone bootstrap progress subject");
+  requireKnownKeys(subject, ["id", "kind", "title"], "standalone bootstrap progress subject");
+  if (subject.kind !== "resource" && subject.kind !== "standalone") {
+    throw new StandaloneProtocolError("standalone bootstrap progress subject kind is unsupported");
+  }
+  return Object.freeze({
+    initialLoad: requireBoolean(progress.initialLoad, "standalone bootstrap initialLoad"),
+    ...(normalizedProgress == null ? {} : { progress: normalizedProgress }),
+    schemaVersion: STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION,
+    stage: progress.stage as StandaloneBootstrapProgressStage,
+    subject: Object.freeze({
+      id: requiredString(subject.id, "standalone bootstrap progress subject id"),
+      kind: subject.kind,
+      title: requiredString(subject.title, "standalone bootstrap progress subject title"),
+    }),
+  });
+}
+
+export function validateStandaloneLifecycleTransitionCredential(
+  value: unknown,
+): StandaloneLifecycleTransitionCredential {
+  const credential = requireRecord(value, "standalone lifecycle transition credential");
+  requireKnownKeys(credential, ["fence", "id", "token"], "standalone lifecycle transition credential");
+  if (!Number.isSafeInteger(credential.fence) || Number(credential.fence) < 1) {
+    throw new StandaloneProtocolError("standalone lifecycle transition fence must be a positive integer");
+  }
+  return Object.freeze({
+    fence: credential.fence as number,
+    id: normalizeToken(credential.id, "standalone lifecycle transition id"),
+    token: normalizeToken(credential.token, "standalone lifecycle transition token"),
+  });
+}
+
+export function validateStandaloneBootstrapResult(
+  value: unknown,
+): StandaloneBootstrapResult {
+  const result = requireRecord(value, "standalone bootstrap result");
+  if (result.schemaVersion !== STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("standalone bootstrap result schemaVersion is unsupported");
+  }
+  if (result.outcome === "resolved") {
+    requireKnownKeys(
+      result,
+      ["outcome", "resolution", "schemaVersion"],
+      "standalone bootstrap result",
+    );
+    return Object.freeze({
+      outcome: "resolved",
+      resolution: validateStandaloneBootstrapResolution(result.resolution),
+      schemaVersion: STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+    });
+  }
+  if (result.outcome !== "rejected") {
+    throw new StandaloneProtocolError("standalone bootstrap result outcome is unsupported");
+  }
+  requireKnownKeys(
+    result,
+    ["error", "outcome", "schemaVersion"],
+    "standalone bootstrap result",
+  );
+  const error = requireRecord(result.error, "standalone bootstrap error");
+  requireKnownKeys(error, ["code", "message"], "standalone bootstrap error");
+  if (!STANDALONE_BOOTSTRAP_ERROR_CODES.includes(error.code as StandaloneBootstrapErrorCode)) {
+    throw new StandaloneProtocolError("standalone bootstrap error code is unsupported");
+  }
+  return Object.freeze({
+    error: Object.freeze({
+      code: error.code as StandaloneBootstrapErrorCode,
+      message: requiredString(error.message, "standalone bootstrap error message"),
+    }),
+    outcome: "rejected",
+    schemaVersion: STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION,
+  });
+}
+
+export function digestStandaloneRuntimeDescriptor(value: unknown): StandaloneDigest {
+  const descriptor = validateStandaloneRuntimeDescriptor(value);
+  return `sha256:${createHash("sha256").update(descriptorJson(descriptor)).digest("hex")}`;
+}
+
+export function sameStandaloneHandoffScope(
+  left: StandaloneHandoffScope,
+  right: StandaloneHandoffScope,
+): boolean {
+  return (
+    left.channel === right.channel
+    && left.generation === right.generation
+    && left.namespace === right.namespace
+  );
+}
+
+export function sameStandaloneHandoffEnvelope(
+  left: StandaloneHandoffEnvelope,
+  right: StandaloneHandoffEnvelope,
+): boolean {
+  return (
+    left.schemaVersion === right.schemaVersion
+    && left.descriptorDigest === right.descriptorDigest
+    && sameStandaloneHandoffScope(left.scope, right.scope)
+  );
+}
+
+export function createStandaloneHandoffEnvelope(
+  input: Readonly<{
+    descriptor: StandaloneRuntimeDescriptor;
+    scope: StandaloneHandoffScope;
+  }>,
+): StandaloneHandoffEnvelope {
+  const descriptor = validateStandaloneRuntimeDescriptor(input.descriptor);
+  return validateStandaloneHandoffEnvelope({
+    descriptor,
+    descriptorDigest: digestStandaloneRuntimeDescriptor(descriptor),
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    scope: input.scope,
+  });
+}
+
+export function validateStandaloneHandoffEnvelope(
+  value: unknown,
+  expected?: StandaloneHandoffEnvelope,
+): StandaloneHandoffEnvelope {
+  const envelope = requireRecord(value, "standalone handoff");
+  if (envelope.schemaVersion !== STANDALONE_HANDOFF_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError(
+      `unsupported standalone handoff schema version: ${String(envelope.schemaVersion)}`,
+    );
+  }
+  const descriptor = validateStandaloneRuntimeDescriptor(envelope.descriptor);
+  const descriptorDigest = normalizeDigest(envelope.descriptorDigest);
+  if (descriptorDigest !== digestStandaloneRuntimeDescriptor(descriptor)) {
+    throw new StandaloneProtocolError(
+      "standalone descriptorDigest does not match the runtime descriptor",
+    );
+  }
+  const normalized = {
+    descriptor,
+    descriptorDigest,
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    scope: validateStandaloneHandoffScope(envelope.scope),
+  } as const;
+  if (
+    expected != null
+    && (
+      !sameStandaloneHandoffEnvelope(normalized, expected)
+    )
+  ) {
+    throw new StandaloneProtocolError(
+      "standalone handoff does not match the active generation and descriptor",
+    );
+  }
+  return normalized;
+}
+
+export function validateStandalonePaths(value: unknown): StandalonePaths {
+  const paths = requireRecord(value, "standalone paths");
+  return {
+    cacheRoot: normalizePath(paths.cacheRoot, "standalone cacheRoot"),
+    dataRoot: normalizePath(paths.dataRoot, "standalone dataRoot"),
+    installationRoot: normalizePath(paths.installationRoot, "standalone installationRoot"),
+    logsRoot: normalizePath(paths.logsRoot, "standalone logsRoot"),
+    resourceRoot: normalizePath(paths.resourceRoot, "standalone resourceRoot"),
+    runtimeRoot: normalizePath(paths.runtimeRoot, "standalone runtimeRoot"),
+  };
+}
+
+export function validateStandaloneHandoffDescriptor(value: unknown): StandaloneHandoffDescriptor {
+  const request = requireRecord(value, "standalone handoff descriptor");
+  requireKnownKeys(
+    request,
+    ["attachment", "closure", "handoff", "paths", "transition"],
+    "standalone handoff descriptor",
+  );
+  return {
+    attachment: validateStandaloneAttachmentDescriptor(request.attachment),
+    ...(request.closure == null ? {} : {
+      closure: (() => {
+        const closure = requireRecord(request.closure, "standalone Closure resource context");
+        requireKnownKeys(
+          closure,
+          ["repositoryConfigPath", "storeRoot", "target"],
+          "standalone Closure resource context",
+        );
+        return Object.freeze({
+          repositoryConfigPath: normalizePath(
+            closure.repositoryConfigPath,
+            "standalone Closure repositoryConfigPath",
+          ),
+          storeRoot: normalizePath(closure.storeRoot, "standalone Closure storeRoot"),
+          target: normalizeToken(closure.target, "standalone Closure target"),
+        });
+      })(),
+    }),
+    handoff: validateStandaloneHandoffEnvelope(request.handoff),
+    paths: validateStandalonePaths(request.paths),
+    transition: request.transition == null
+      ? null
+      : validateStandaloneLifecycleTransitionCredential(request.transition),
+  };
+}
+
+export function validateStandaloneHandoffRequest(value: unknown): StandaloneHandoffRequest {
+  const request = requireRecord(value, "standalone handoff request");
+  requireKnownKeys(
+    request,
+    ["attachment", "capabilities", "closure", "handoff", "paths", "transition"],
+    "standalone handoff request",
+  );
+  const descriptor = validateStandaloneHandoffDescriptor({
+    attachment: request.attachment,
+    closure: request.closure,
+    handoff: request.handoff,
+    paths: request.paths,
+    transition: request.transition,
+  });
+  const capabilities = requireRecord(request.capabilities, "standalone shell capability port");
+  if (typeof capabilities.invoke !== "function") {
+    throw new StandaloneProtocolError("standalone shell capability port must expose invoke()");
+  }
+  return {
+    ...descriptor,
+    capabilities: request.capabilities as StandaloneShellCapabilityPort,
+  };
+}

--- a/apps/standalone/src/protocol/index.ts
+++ b/apps/standalone/src/protocol/index.ts
@@ -1,0 +1,559 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, posix, win32 } from "node:path";
+
+import type { ClosureChannel } from "@open-design/closure/protocol";
+
+export const STANDALONE_PROTOCOL_VERSION = 1 as const;
+export const STANDALONE_BOOTSTRAP_SCHEMA_VERSION = 2 as const;
+export const STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION = 2 as const;
+export const STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION = 1 as const;
+export const STANDALONE_HANDOFF_SCHEMA_VERSION = 1 as const;
+export const STANDALONE_UPDATER_SCHEMA_VERSION = 1 as const;
+export const STANDALONE_BOOTLOADER_ENTRY_PATH = "bootloader.mjs" as const;
+export const STANDALONE_BOOTLOADER_EXPORT_NAME = "handoff" as const;
+export const STANDALONE_BODY_BRIDGE_SERVICE = "standalone-body" as const;
+
+export type StandaloneDigest = `sha256:${string}`;
+
+export type StandaloneBootstrapScope = Readonly<{
+  channel: ClosureChannel;
+  namespace: string;
+}>;
+
+export type StandaloneHandoffScope = Readonly<{
+  channel: ClosureChannel;
+  generation: number;
+  namespace: string;
+}>;
+
+export type StandaloneRuntimeDescriptor = Readonly<{
+  release: Readonly<{
+    version: string;
+  }>;
+  standalone: Readonly<{
+    digest: StandaloneDigest;
+    protocolVersion: typeof STANDALONE_PROTOCOL_VERSION;
+    version: string;
+  }>;
+}>;
+
+export type StandaloneShellDescriptor = Readonly<{
+  digest: StandaloneDigest;
+  type: string;
+  version: string;
+}>;
+
+export type StandaloneAttachmentDescriptor = Readonly<{
+  id: string;
+  shell: StandaloneShellDescriptor;
+}>;
+
+export type StandaloneHandoffEnvelope = Readonly<{
+  descriptor: StandaloneRuntimeDescriptor;
+  descriptorDigest: StandaloneDigest;
+  schemaVersion: typeof STANDALONE_HANDOFF_SCHEMA_VERSION;
+  scope: StandaloneHandoffScope;
+}>;
+
+export type StandalonePaths = Readonly<{
+  cacheRoot: string;
+  dataRoot: string;
+  installationRoot: string;
+  logsRoot: string;
+  resourceRoot: string;
+  runtimeRoot: string;
+}>;
+
+export type StandaloneClosureResourceContext = Readonly<{
+  repositoryConfigPath: string;
+  storeRoot: string;
+  target: string;
+}>;
+
+export type StandaloneReleaseIntent =
+  | Readonly<{
+      kind: "exact";
+      releaseVersion: string;
+    }>
+  | Readonly<{
+      kind: "resume-or-bootstrap";
+    }>;
+
+export type StandaloneBootstrapDescriptor = Readonly<{
+  attachment: StandaloneAttachmentDescriptor;
+  discovery: Readonly<{
+    metadataUrl: string | null;
+    target: string;
+  }>;
+  paths: StandalonePaths;
+  /** Shell states intent; Standalone owns persisted binding and discovery policy. */
+  releaseIntent: StandaloneReleaseIntent;
+  repositoryConfigPath: string;
+  schemaVersion: typeof STANDALONE_BOOTSTRAP_SCHEMA_VERSION;
+  scope: StandaloneBootstrapScope;
+}>;
+
+export type StandaloneBootstrapRequest = StandaloneBootstrapDescriptor & Readonly<{
+  capabilities: StandaloneShellCapabilityPort;
+}>;
+
+export type StandaloneBootstrapResolution = Readonly<{
+  bootloaderPath: string;
+  handoff: StandaloneHandoffDescriptor;
+}>;
+
+export const STANDALONE_BOOTSTRAP_PROGRESS_STAGES = Object.freeze([
+  "checking",
+  "copying",
+  "discovering",
+  "downloading",
+  "materializing",
+  "verifying",
+  "ready",
+] as const);
+
+export type StandaloneBootstrapProgressStage =
+  (typeof STANDALONE_BOOTSTRAP_PROGRESS_STAGES)[number];
+
+export type StandaloneBootstrapProgress = Readonly<{
+  initialLoad: boolean;
+  progress?: Readonly<{
+    completed: number;
+    total: number;
+    unit: "bytes" | "components";
+  }>;
+  schemaVersion: typeof STANDALONE_BOOTSTRAP_PROGRESS_SCHEMA_VERSION;
+  stage: StandaloneBootstrapProgressStage;
+  subject: Readonly<{
+    id: string;
+    kind: "resource" | "standalone";
+    title: string;
+  }>;
+}>;
+
+/** Opaque sidecar-owned handoff-once capability. Product code never decodes it. */
+export type StandaloneLifecycleTransitionCredential = Readonly<{
+  fence: number;
+  id: string;
+  token: string;
+}>;
+
+export const STANDALONE_BOOTSTRAP_ERROR_CODES = Object.freeze([
+  "installer-required",
+  "no-standalone",
+  "resource-unavailable",
+  "standalone-occupied",
+  "standalone-invalid",
+] as const);
+
+export type StandaloneBootstrapErrorCode =
+  (typeof STANDALONE_BOOTSTRAP_ERROR_CODES)[number];
+
+export type StandaloneBootstrapResult =
+  | Readonly<{
+      outcome: "resolved";
+      resolution: StandaloneBootstrapResolution;
+      schemaVersion: typeof STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION;
+    }>
+  | Readonly<{
+      error: Readonly<{
+        code: StandaloneBootstrapErrorCode;
+        message: string;
+      }>;
+      outcome: "rejected";
+      schemaVersion: typeof STANDALONE_BOOTSTRAP_RESULT_SCHEMA_VERSION;
+    }>;
+
+export type StandaloneProtocolJsonValue =
+  | boolean
+  | null
+  | number
+  | string
+  | StandaloneProtocolJsonValue[]
+  | { [key: string]: StandaloneProtocolJsonValue };
+
+export const STANDALONE_RUNTIME_COMMANDS = Object.freeze({
+  PREPARE_UPDATE: "open-design.prepare-update.v2",
+  REGISTER_DESKTOP_AUTH: "open-design.register-desktop-auth.v1",
+} as const);
+
+export const STANDALONE_UPDATE_ACTIVATION_POLICIES = Object.freeze({
+  AUTHORIZE_SILENT: "authorize-silent",
+  AUTHORIZE_USER: "authorize-user",
+  REVOKE_SILENT: "revoke-silent",
+} as const);
+
+export type StandaloneUpdateActivationPolicy =
+  (typeof STANDALONE_UPDATE_ACTIVATION_POLICIES)[keyof typeof STANDALONE_UPDATE_ACTIVATION_POLICIES];
+
+export type StandalonePrepareUpdateCommandInput = Readonly<{
+  activationPolicy: StandaloneUpdateActivationPolicy;
+  metadata: Readonly<Record<string, StandaloneProtocolJsonValue>>;
+}>;
+
+export type StandaloneUpdatePreparation = Readonly<
+  | { architecture: "legacy" }
+  | { architecture: "standalone"; minimumShellVersion: string | null; route: "shell" }
+  | {
+      activationSource: "silent-policy" | "user-restart" | null;
+      architecture: "standalone";
+      releaseVersion: string;
+      route: "closure";
+      state: "current" | "prepared";
+    }
+>;
+
+export type StandaloneResourceEnsureRequest = Readonly<{ id: string }>;
+
+export type StandalonePreparedResource = Readonly<{
+  id: string;
+  path: string;
+  reused: boolean;
+  title: string;
+}>;
+
+export type StandaloneShellCapabilityExchange = Readonly<{
+  attachmentId: string;
+  handoff: StandaloneHandoffEnvelope;
+  requestId: string;
+  schemaVersion: typeof STANDALONE_HANDOFF_SCHEMA_VERSION;
+}>;
+
+export type StandaloneShellCapabilityRequest = StandaloneShellCapabilityExchange & Readonly<{
+  capability: string;
+  input: StandaloneProtocolJsonValue;
+}>;
+
+export type StandaloneShellCapabilityResult =
+  | (StandaloneShellCapabilityExchange & Readonly<{
+      outcome: "completed";
+      output: StandaloneProtocolJsonValue;
+    }>)
+  | (StandaloneShellCapabilityExchange & Readonly<{
+      outcome: "unsupported";
+    }>)
+  | (StandaloneShellCapabilityExchange & Readonly<{
+      error: Readonly<{ code: string }>;
+      outcome: "failed";
+    }>);
+
+export interface StandaloneShellCapabilityPort {
+  invoke(request: StandaloneShellCapabilityRequest): Promise<StandaloneShellCapabilityResult>;
+}
+
+export const STANDALONE_SHELL_CAPABILITIES = Object.freeze({
+  EXPORT_ARTIFACT: "open-design.export-artifact.v1",
+  EXPORT_PDF: "open-design.export-pdf.v1",
+  RENDER_SLIDES: "open-design.render-slides.v1",
+} as const);
+
+export type StandaloneShellCapability =
+  (typeof STANDALONE_SHELL_CAPABILITIES)[keyof typeof STANDALONE_SHELL_CAPABILITIES];
+
+export function isStandaloneShellCapability(value: unknown): value is StandaloneShellCapability {
+  return Object.values(STANDALONE_SHELL_CAPABILITIES).includes(value as StandaloneShellCapability);
+}
+
+export type StandaloneExportPdfInput = Readonly<{
+  baseHref?: string;
+  deck: boolean;
+  defaultFilename: string;
+  html: string;
+  title: string;
+}>;
+
+export type StandaloneExportPdfResult = Readonly<{
+  canceled?: boolean;
+  error?: string;
+  ok: boolean;
+  path?: string;
+}>;
+
+export type StandaloneRenderSlidesInput = Readonly<{
+  baseHref?: string;
+  deck?: boolean;
+  editable?: boolean;
+  height?: number;
+  html: string;
+  index?: number;
+  outputDir?: string;
+  pageImageFormat?: "jpeg" | "png";
+  paginate?: boolean;
+  stitch?: boolean;
+  width?: number;
+}>;
+
+export type StandaloneRenderSlidesErrorCode =
+  | "NO_SLIDES"
+  | "PAGE_TOO_TALL"
+  | "RENDER_FAILED"
+  | "SLIDE_INDEX_OUT_OF_RANGE";
+
+export type StandaloneRenderSlidesResult = Readonly<{
+  error?: string;
+  errorCode?: StandaloneRenderSlidesErrorCode;
+  height?: number;
+  mode?: "deck" | "page";
+  ok: boolean;
+  pptxFile?: string;
+  slideFiles?: string[];
+  slides?: string[];
+  width?: number;
+}>;
+
+export type StandaloneExportArtifactFormat = "image" | "pdf";
+export type StandaloneExportArtifactImageFormat = "jpeg" | "png";
+
+export type StandaloneExportArtifactInput = Readonly<{
+  baseHref?: string;
+  deck: boolean;
+  format: StandaloneExportArtifactFormat;
+  height?: number;
+  html: string;
+  imageFormat?: StandaloneExportArtifactImageFormat;
+  title: string;
+  width?: number;
+}>;
+
+export type StandaloneExportArtifactResult = Readonly<{
+  bytes?: number;
+  error?: string;
+  mime?: string;
+  ok: boolean;
+  path?: string;
+}>;
+
+export type StandaloneShellCapabilityContract = Readonly<{
+  [STANDALONE_SHELL_CAPABILITIES.EXPORT_ARTIFACT]: Readonly<{
+    input: StandaloneExportArtifactInput;
+    output: StandaloneExportArtifactResult;
+  }>;
+  [STANDALONE_SHELL_CAPABILITIES.EXPORT_PDF]: Readonly<{
+    input: StandaloneExportPdfInput;
+    output: StandaloneExportPdfResult;
+  }>;
+  [STANDALONE_SHELL_CAPABILITIES.RENDER_SLIDES]: Readonly<{
+    input: StandaloneRenderSlidesInput;
+    output: StandaloneRenderSlidesResult;
+  }>;
+}>;
+
+export type StandaloneShellCapabilityInput<TCapability extends StandaloneShellCapability> =
+  StandaloneShellCapabilityContract[TCapability]["input"];
+
+export type StandaloneShellCapabilityOutput<TCapability extends StandaloneShellCapability> =
+  StandaloneShellCapabilityContract[TCapability]["output"];
+
+export type StandaloneRuntimeCommandExchange = Readonly<{
+  attachmentId: string;
+  handoff: StandaloneHandoffEnvelope;
+  requestId: string;
+  schemaVersion: typeof STANDALONE_HANDOFF_SCHEMA_VERSION;
+}>;
+
+export type StandaloneRuntimeCommandRequest = StandaloneRuntimeCommandExchange & Readonly<{
+  command: string;
+  input: StandaloneProtocolJsonValue;
+}>;
+
+export type StandaloneRuntimeCommandResult =
+  | (StandaloneRuntimeCommandExchange & Readonly<{
+      outcome: "completed";
+      output: StandaloneProtocolJsonValue;
+    }>)
+  | (StandaloneRuntimeCommandExchange & Readonly<{
+      outcome: "unsupported";
+    }>)
+  | (StandaloneRuntimeCommandExchange & Readonly<{
+      error: Readonly<{ code: string }>;
+      outcome: "failed";
+    }>);
+
+export type StandaloneHandoffDescriptor = Readonly<{
+  attachment: StandaloneAttachmentDescriptor;
+  closure?: StandaloneClosureResourceContext;
+  handoff: StandaloneHandoffEnvelope;
+  paths: StandalonePaths;
+  transition?: StandaloneLifecycleTransitionCredential | null;
+}>;
+
+export type StandaloneHandoffRequest = StandaloneHandoffDescriptor & Readonly<{
+  capabilities: StandaloneShellCapabilityPort;
+}>;
+
+type StandaloneRuntimeStatusBase = Readonly<{
+  handoff: StandaloneHandoffEnvelope;
+  pid: number;
+  schemaVersion: typeof STANDALONE_HANDOFF_SCHEMA_VERSION;
+}>;
+
+export type StandaloneRuntimeRunningStatus = StandaloneRuntimeStatusBase & Readonly<{
+  daemonUrl: string;
+  state: "running";
+  webUrl: string;
+}>;
+
+export type StandaloneRuntimeStoppedStatus = StandaloneRuntimeStatusBase & Readonly<{
+  state: "stopped";
+}>;
+
+export type StandaloneRuntimeFailedStatus = StandaloneRuntimeStatusBase & Readonly<{
+  error: Readonly<{ code: string }>;
+  state: "failed";
+}>;
+
+export type StandaloneRuntimeTerminalStatus =
+  | StandaloneRuntimeStoppedStatus
+  | StandaloneRuntimeFailedStatus;
+
+export type StandaloneRuntimeStatus =
+  | StandaloneRuntimeRunningStatus
+  | StandaloneRuntimeTerminalStatus;
+
+type StandaloneUpdaterProviderBase = Readonly<{
+  handoff: StandaloneHandoffEnvelope;
+  incarnation: string;
+  providerId: string;
+  schemaVersion: typeof STANDALONE_UPDATER_SCHEMA_VERSION;
+}>;
+
+export type StandaloneUpdaterProviderDescriptor =
+  | (StandaloneUpdaterProviderBase & Readonly<{
+      owner: "standalone";
+    }>)
+  | (StandaloneUpdaterProviderBase & Readonly<{
+      attachmentId: string;
+      hostScope: string;
+      owner: "shell";
+    }>);
+
+export type StandaloneUpdaterActionPresentation = Readonly<{
+  detail?: string;
+  emphasis: "danger" | "primary" | "secondary";
+  id: string;
+  label: string;
+}>;
+
+export type StandaloneUpdaterState =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "ready"
+  | "applying"
+  | "handed-off"
+  | "failed";
+
+export type StandaloneUpdaterSnapshot = Readonly<{
+  actions: readonly StandaloneUpdaterActionPresentation[];
+  presentation: Readonly<{
+    detail?: string;
+    title: string;
+  }>;
+  progress?: Readonly<{
+    completed: number;
+    total: number;
+  }>;
+  provider: StandaloneUpdaterProviderDescriptor;
+  revision: number;
+  schemaVersion: typeof STANDALONE_UPDATER_SCHEMA_VERSION;
+  state: StandaloneUpdaterState;
+}>;
+
+export type StandaloneUpdaterWaitRequest = Readonly<{
+  afterRevision: number;
+  provider: StandaloneUpdaterProviderDescriptor;
+  schemaVersion: typeof STANDALONE_UPDATER_SCHEMA_VERSION;
+  timeoutMs: number;
+}>;
+
+export type StandaloneUpdaterActionRequest = Readonly<{
+  actionId: string;
+  provider: StandaloneUpdaterProviderDescriptor;
+  requestId: string;
+  schemaVersion: typeof STANDALONE_UPDATER_SCHEMA_VERSION;
+}>;
+
+type StandaloneUpdaterActionExchange = Readonly<{
+  actionId: string;
+  provider: StandaloneUpdaterProviderDescriptor;
+  requestId: string;
+  schemaVersion: typeof STANDALONE_UPDATER_SCHEMA_VERSION;
+}>;
+
+export type StandaloneUpdaterActionResult =
+  | (StandaloneUpdaterActionExchange & Readonly<{
+      operationId: string;
+      outcome: "accepted";
+    }>)
+  | (StandaloneUpdaterActionExchange & Readonly<{
+      outcome: "unsupported";
+    }>)
+  | (StandaloneUpdaterActionExchange & Readonly<{
+      error: Readonly<{ code: string }>;
+      outcome: "failed";
+    }>);
+
+export interface StandaloneUpdaterProviderPort {
+  invoke(request: StandaloneUpdaterActionRequest): Promise<StandaloneUpdaterActionResult>;
+  readSnapshot(): Promise<StandaloneUpdaterSnapshot>;
+  waitForChange(request: StandaloneUpdaterWaitRequest): Promise<StandaloneUpdaterSnapshot>;
+}
+
+export interface StandaloneHandle {
+  close(): Promise<StandaloneRuntimeTerminalStatus>;
+  invoke(request: StandaloneRuntimeCommandRequest): Promise<StandaloneRuntimeCommandResult>;
+  readStatus(): Promise<StandaloneRuntimeStatus>;
+  waitForTerminal(): Promise<StandaloneRuntimeTerminalStatus>;
+}
+
+export type StandaloneLifecycleOccupant = Readonly<{
+  generation: number;
+  incarnation: string;
+  key: string;
+  projection?: StandaloneProtocolJsonValue;
+}>;
+
+export interface StandaloneLifecycleTransition {
+  release(): Promise<void>;
+}
+
+export type StandaloneLifecycleTransitionResult =
+  | Readonly<{
+      state: "acquired";
+      transition: StandaloneLifecycleTransition;
+    }>
+  | Readonly<{
+      occupants: readonly StandaloneLifecycleOccupant[];
+      reason: "occupied" | "transition-active" | "unavailable";
+      state: "blocked";
+    }>;
+
+/**
+ * Shell-local semantic lifecycle port. Implementations keep sidecar paths,
+ * credentials and transport private; callers only select an opaque transition
+ * kind and receive non-secret occupant projections on a quick failure.
+ */
+export interface StandaloneLifecyclePort {
+  beginTransition(kind: string): Promise<StandaloneLifecycleTransitionResult>;
+}
+
+/** The validated outer Shell adapter; raw Standalone body handles stay smaller. */
+export interface StandaloneShellHandle extends StandaloneHandle {
+  lifecycle: StandaloneLifecyclePort;
+}
+
+export type StandaloneHandoff = (
+  request: StandaloneHandoffRequest,
+) => Promise<StandaloneHandle>;
+
+export class StandaloneProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StandaloneProtocolError";
+  }
+}
+
+
+export * from "./core-validation.js";
+export * from "./operations.js";

--- a/apps/standalone/src/protocol/operations.ts
+++ b/apps/standalone/src/protocol/operations.ts
@@ -1,0 +1,643 @@
+import { createHash } from "node:crypto";
+import { isAbsolute, posix, win32 } from "node:path";
+
+import {
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_UPDATE_ACTIVATION_POLICIES,
+  STANDALONE_UPDATER_SCHEMA_VERSION,
+  StandaloneHandoffEnvelope,
+  StandaloneProtocolJsonValue,
+  StandaloneShellCapabilityExchange,
+  StandaloneShellCapabilityRequest,
+  StandaloneShellCapabilityResult,
+  isStandaloneShellCapability,
+  StandaloneRuntimeCommandExchange,
+  StandaloneRuntimeCommandRequest,
+  StandaloneRuntimeCommandResult,
+  StandaloneRuntimeStatus,
+  StandaloneUpdaterProviderDescriptor,
+  StandaloneUpdaterState,
+  StandaloneUpdaterSnapshot,
+  StandaloneUpdaterWaitRequest,
+  StandaloneUpdaterActionRequest,
+  StandaloneUpdaterActionResult,
+  StandaloneProtocolError,
+  StandalonePrepareUpdateCommandInput,
+  StandaloneUpdateActivationPolicy,
+  StandaloneUpdatePreparation,
+} from "./index.js";
+import {
+  requireRecord,
+  normalizeToken,
+  normalizeVersion,
+  normalizeJsonValue,
+  requireKnownKeys,
+  requiredString,
+  validateStandaloneShellCapabilityInput,
+  validateStandaloneShellCapabilityOutput,
+  sameStandaloneHandoffEnvelope,
+  validateStandaloneHandoffEnvelope,
+} from "./core-validation.js";
+
+function validateCapabilityExchange(
+  value: Record<string, unknown>,
+  expected?: { attachmentId?: string; handoff?: StandaloneHandoffEnvelope; requestId?: string },
+): StandaloneShellCapabilityExchange {
+  if (value.schemaVersion !== STANDALONE_HANDOFF_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("unsupported standalone capability schema version");
+  }
+  const handoff = validateStandaloneHandoffEnvelope(value.handoff, expected?.handoff);
+  const attachmentId = normalizeToken(value.attachmentId, "standalone capability attachmentId");
+  if (expected?.attachmentId != null && attachmentId !== expected.attachmentId) {
+    throw new StandaloneProtocolError("standalone capability attachmentId does not match");
+  }
+  const requestId = normalizeToken(value.requestId, "standalone capability requestId");
+  if (expected?.requestId != null && requestId !== expected.requestId) {
+    throw new StandaloneProtocolError("standalone capability requestId does not match");
+  }
+  return { attachmentId, handoff, requestId, schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION };
+}
+
+function validateRuntimeCommandExchange(
+  value: Record<string, unknown>,
+  expected?: { attachmentId?: string; handoff?: StandaloneHandoffEnvelope; requestId?: string },
+): StandaloneRuntimeCommandExchange {
+  if (value.schemaVersion !== STANDALONE_HANDOFF_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("unsupported standalone runtime command schema version");
+  }
+  const handoff = validateStandaloneHandoffEnvelope(value.handoff, expected?.handoff);
+  const attachmentId = normalizeToken(value.attachmentId, "standalone runtime command attachmentId");
+  if (expected?.attachmentId != null && attachmentId !== expected.attachmentId) {
+    throw new StandaloneProtocolError("standalone runtime command attachmentId does not match");
+  }
+  const requestId = normalizeToken(value.requestId, "standalone runtime command requestId");
+  if (expected?.requestId != null && requestId !== expected.requestId) {
+    throw new StandaloneProtocolError("standalone runtime command requestId does not match");
+  }
+  return { attachmentId, handoff, requestId, schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION };
+}
+
+export function validateStandalonePrepareUpdateCommandInput(
+  value: unknown,
+): StandalonePrepareUpdateCommandInput {
+  const input = requireRecord(value, "standalone prepare-update command input");
+  requireKnownKeys(input, ["activationPolicy", "metadata"], "standalone prepare-update command input");
+  const activationPolicy = input.activationPolicy;
+  if (!Object.values(STANDALONE_UPDATE_ACTIVATION_POLICIES).includes(
+    activationPolicy as StandaloneUpdateActivationPolicy,
+  )) {
+    throw new StandaloneProtocolError("unsupported standalone update activation policy");
+  }
+  const metadata = requireRecord(input.metadata, "standalone prepare-update metadata");
+  return Object.freeze({
+    activationPolicy: activationPolicy as StandaloneUpdateActivationPolicy,
+    metadata: Object.freeze(
+      normalizeJsonValue(metadata, "standalone prepare-update metadata") as Record<string, StandaloneProtocolJsonValue>,
+    ),
+  });
+}
+
+export function createStandalonePrepareUpdateCommandInput(
+  metadata: Record<string, unknown>,
+  activationPolicy: StandaloneUpdateActivationPolicy,
+): StandalonePrepareUpdateCommandInput {
+  return validateStandalonePrepareUpdateCommandInput({ activationPolicy, metadata });
+}
+
+export function validateStandaloneUpdatePreparation(value: unknown): StandaloneUpdatePreparation {
+  const output = requireRecord(value, "standalone update preparation");
+  if (output.architecture === "legacy") {
+    requireKnownKeys(output, ["architecture"], "legacy standalone update preparation");
+    return Object.freeze({ architecture: "legacy" });
+  }
+  if (output.architecture !== "standalone") {
+    throw new StandaloneProtocolError("unsupported standalone update preparation architecture");
+  }
+  if (output.route === "shell") {
+    requireKnownKeys(
+      output,
+      ["architecture", "minimumShellVersion", "route"],
+      "Shell standalone update preparation",
+    );
+    if (output.minimumShellVersion !== null && typeof output.minimumShellVersion !== "string") {
+      throw new StandaloneProtocolError("standalone update minimum Shell version must be a string or null");
+    }
+    return Object.freeze({
+      architecture: "standalone",
+      minimumShellVersion: output.minimumShellVersion,
+      route: "shell",
+    });
+  }
+  if (output.route !== "closure") {
+    throw new StandaloneProtocolError("unsupported standalone update preparation route");
+  }
+  requireKnownKeys(
+    output,
+    ["activationSource", "architecture", "releaseVersion", "route", "state"],
+    "Closure standalone update preparation",
+  );
+  if (
+    output.activationSource !== null
+    && output.activationSource !== "silent-policy"
+    && output.activationSource !== "user-restart"
+  ) {
+    throw new StandaloneProtocolError("unsupported standalone update activation source");
+  }
+  if (output.state !== "current" && output.state !== "prepared") {
+    throw new StandaloneProtocolError("unsupported standalone update preparation state");
+  }
+  return Object.freeze({
+    activationSource: output.activationSource,
+    architecture: "standalone",
+    releaseVersion: normalizeVersion(output.releaseVersion, "standalone update release version"),
+    route: "closure",
+    state: output.state,
+  });
+}
+
+export function validateStandaloneShellCapabilityRequest(
+  value: unknown,
+  expected?: { attachmentId?: string; handoff?: StandaloneHandoffEnvelope },
+): StandaloneShellCapabilityRequest {
+  const request = requireRecord(value, "standalone shell capability request");
+  const capability = normalizeToken(request.capability, "standalone shell capability");
+  return {
+    ...validateCapabilityExchange(request, expected),
+    capability,
+    input: isStandaloneShellCapability(capability)
+      ? validateStandaloneShellCapabilityInput(capability, request.input) as StandaloneProtocolJsonValue
+      : normalizeJsonValue(request.input, "standalone shell capability input"),
+  };
+}
+
+export function validateStandaloneShellCapabilityResult(
+  value: unknown,
+  expected?: {
+    capability?: string;
+    attachmentId?: string;
+    handoff?: StandaloneHandoffEnvelope;
+    requestId?: string;
+  },
+): StandaloneShellCapabilityResult {
+  const result = requireRecord(value, "standalone shell capability result");
+  const exchange = validateCapabilityExchange(result, expected);
+  if (result.outcome === "completed") {
+    return {
+      ...exchange,
+      outcome: "completed",
+      output: expected?.capability != null && isStandaloneShellCapability(expected.capability)
+        ? validateStandaloneShellCapabilityOutput(expected.capability, result.output) as StandaloneProtocolJsonValue
+        : normalizeJsonValue(result.output, "standalone shell capability output"),
+    };
+  }
+  if (result.outcome === "unsupported") return { ...exchange, outcome: "unsupported" };
+  if (result.outcome === "failed") {
+    const error = requireRecord(result.error, "standalone shell capability error");
+    return {
+      ...exchange,
+      error: { code: normalizeToken(error.code, "standalone shell capability error code") },
+      outcome: "failed",
+    };
+  }
+  throw new StandaloneProtocolError(
+    `unsupported standalone shell capability outcome: ${String(result.outcome)}`,
+  );
+}
+
+export function validateStandaloneRuntimeCommandRequest(
+  value: unknown,
+  expected?: { attachmentId?: string; handoff?: StandaloneHandoffEnvelope },
+): StandaloneRuntimeCommandRequest {
+  const request = requireRecord(value, "standalone runtime command request");
+  return {
+    ...validateRuntimeCommandExchange(request, expected),
+    command: normalizeToken(request.command, "standalone runtime command"),
+    input: normalizeJsonValue(request.input, "standalone runtime command input"),
+  };
+}
+
+export function validateStandaloneRuntimeCommandResult(
+  value: unknown,
+  expected?: { attachmentId?: string; handoff?: StandaloneHandoffEnvelope; requestId?: string },
+): StandaloneRuntimeCommandResult {
+  const result = requireRecord(value, "standalone runtime command result");
+  const exchange = validateRuntimeCommandExchange(result, expected);
+  if (result.outcome === "completed") {
+    return {
+      ...exchange,
+      outcome: "completed",
+      output: normalizeJsonValue(result.output, "standalone runtime command output"),
+    };
+  }
+  if (result.outcome === "unsupported") return { ...exchange, outcome: "unsupported" };
+  if (result.outcome === "failed") {
+    const error = requireRecord(result.error, "standalone runtime command error");
+    return {
+      ...exchange,
+      error: { code: normalizeToken(error.code, "standalone runtime command error code") },
+      outcome: "failed",
+    };
+  }
+  throw new StandaloneProtocolError(
+    `unsupported standalone runtime command outcome: ${String(result.outcome)}`,
+  );
+}
+
+export function validateStandaloneRuntimeStatus(
+  value: unknown,
+  expected?: { handoff?: StandaloneHandoffEnvelope; state?: StandaloneRuntimeStatus["state"] },
+): StandaloneRuntimeStatus {
+  const status = requireRecord(value, "standalone runtime status");
+  if (status.schemaVersion !== STANDALONE_HANDOFF_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError("unsupported standalone runtime status schema version");
+  }
+  const handoff = validateStandaloneHandoffEnvelope(status.handoff, expected?.handoff);
+  if (
+    typeof status.pid !== "number"
+    || !Number.isSafeInteger(status.pid)
+    || status.pid <= 0
+  ) {
+    throw new StandaloneProtocolError("standalone runtime pid must be a positive safe integer");
+  }
+  if (expected?.state != null && status.state !== expected.state) {
+    throw new StandaloneProtocolError(
+      `standalone runtime state ${String(status.state)} does not match ${expected.state}`,
+    );
+  }
+  const base = {
+    handoff,
+    pid: status.pid,
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+  } as const;
+  if (status.state === "running") {
+    if (typeof status.daemonUrl !== "string" || !/^https?:\/\//u.test(status.daemonUrl)) {
+      throw new StandaloneProtocolError("running standalone status must contain an http(s) daemonUrl");
+    }
+    if (typeof status.webUrl !== "string" || !/^https?:\/\//u.test(status.webUrl)) {
+      throw new StandaloneProtocolError("running standalone status must contain an http(s) webUrl");
+    }
+    return { ...base, daemonUrl: status.daemonUrl, state: "running", webUrl: status.webUrl };
+  }
+  if (status.state === "stopped") return { ...base, state: "stopped" };
+  if (status.state === "failed") {
+    const error = requireRecord(status.error, "standalone runtime error");
+    return {
+      ...base,
+      error: { code: normalizeToken(error.code, "standalone runtime error code") },
+      state: "failed",
+    };
+  }
+  throw new StandaloneProtocolError(`unsupported standalone runtime state: ${String(status.state)}`);
+}
+
+function normalizeUpdaterSchemaVersion(value: unknown): typeof STANDALONE_UPDATER_SCHEMA_VERSION {
+  if (value !== STANDALONE_UPDATER_SCHEMA_VERSION) {
+    throw new StandaloneProtocolError(
+      `unsupported standalone updater schema version: ${String(value)}`,
+    );
+  }
+  return STANDALONE_UPDATER_SCHEMA_VERSION;
+}
+
+function normalizeRequiredNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new StandaloneProtocolError(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function normalizeRequiredPositiveInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new StandaloneProtocolError(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function sameUpdaterProvider(
+  left: StandaloneUpdaterProviderDescriptor,
+  right: StandaloneUpdaterProviderDescriptor,
+): boolean {
+  return (
+    left.owner === right.owner
+    && left.providerId === right.providerId
+    && left.incarnation === right.incarnation
+    && sameStandaloneHandoffEnvelope(left.handoff, right.handoff)
+    && (
+      left.owner === "standalone"
+      || (
+        right.owner === "shell"
+        && left.attachmentId === right.attachmentId
+        && left.hostScope === right.hostScope
+      )
+    )
+  );
+}
+
+export function validateStandaloneUpdaterProviderDescriptor(
+  value: unknown,
+  expected?: StandaloneUpdaterProviderDescriptor,
+): StandaloneUpdaterProviderDescriptor {
+  const provider = requireRecord(value, "standalone updater provider");
+  normalizeUpdaterSchemaVersion(provider.schemaVersion);
+  const base = {
+    handoff: validateStandaloneHandoffEnvelope(provider.handoff, expected?.handoff),
+    incarnation: normalizeToken(provider.incarnation, "standalone updater provider incarnation"),
+    providerId: normalizeToken(provider.providerId, "standalone updater provider id"),
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  } as const;
+  let normalized: StandaloneUpdaterProviderDescriptor;
+  if (provider.owner === "standalone") {
+    requireKnownKeys(
+      provider,
+      ["handoff", "incarnation", "owner", "providerId", "schemaVersion"],
+      "standalone-owned updater provider",
+    );
+    if (Object.hasOwn(provider, "attachmentId") || Object.hasOwn(provider, "hostScope")) {
+      throw new StandaloneProtocolError(
+        "standalone-owned updater provider must not contain Shell attachment fields",
+      );
+    }
+    normalized = { ...base, owner: "standalone" };
+  } else if (provider.owner === "shell") {
+    requireKnownKeys(
+      provider,
+      ["attachmentId", "handoff", "hostScope", "incarnation", "owner", "providerId", "schemaVersion"],
+      "standalone Shell updater provider",
+    );
+    normalized = {
+      ...base,
+      attachmentId: normalizeToken(
+        provider.attachmentId,
+        "standalone Shell updater attachmentId",
+      ),
+      hostScope: normalizeToken(provider.hostScope, "standalone Shell updater hostScope"),
+      owner: "shell",
+    };
+  } else {
+    throw new StandaloneProtocolError(
+      `unsupported standalone updater provider owner: ${String(provider.owner)}`,
+    );
+  }
+  if (expected != null && !sameUpdaterProvider(normalized, expected)) {
+    throw new StandaloneProtocolError(
+      "standalone updater provider does not match the expected provider incarnation",
+    );
+  }
+  return normalized;
+}
+
+export function validateStandaloneUpdaterSnapshot(
+  value: unknown,
+  expected?: { provider?: StandaloneUpdaterProviderDescriptor },
+): StandaloneUpdaterSnapshot {
+  const snapshot = requireRecord(value, "standalone updater snapshot");
+  requireKnownKeys(
+    snapshot,
+    ["actions", "presentation", "progress", "provider", "revision", "schemaVersion", "state"],
+    "standalone updater snapshot",
+  );
+  normalizeUpdaterSchemaVersion(snapshot.schemaVersion);
+  const provider = validateStandaloneUpdaterProviderDescriptor(snapshot.provider, expected?.provider);
+  const states: readonly StandaloneUpdaterState[] = [
+    "idle",
+    "checking",
+    "available",
+    "downloading",
+    "ready",
+    "applying",
+    "handed-off",
+    "failed",
+  ];
+  if (!states.includes(snapshot.state as StandaloneUpdaterState)) {
+    throw new StandaloneProtocolError(
+      `unsupported standalone updater state: ${String(snapshot.state)}`,
+    );
+  }
+  if (!Array.isArray(snapshot.actions)) {
+    throw new StandaloneProtocolError("standalone updater snapshot actions must be an array");
+  }
+  const actions = snapshot.actions.map((rawAction) => {
+    const action = requireRecord(rawAction, "standalone updater action presentation");
+    requireKnownKeys(
+      action,
+      ["detail", "emphasis", "id", "label"],
+      "standalone updater action presentation",
+    );
+    if (action.emphasis !== "primary" && action.emphasis !== "secondary" && action.emphasis !== "danger") {
+      throw new StandaloneProtocolError("standalone updater action emphasis is unsupported");
+    }
+    return {
+      ...(action.detail == null
+        ? {}
+        : { detail: requiredString(action.detail, "standalone updater action detail") }),
+      emphasis: action.emphasis,
+      id: normalizeToken(action.id, "standalone updater action id"),
+      label: requiredString(action.label, "standalone updater action label"),
+    } as const;
+  });
+  if (new Set(actions.map((action) => action.id)).size !== actions.length) {
+    throw new StandaloneProtocolError("standalone updater action ids must be unique");
+  }
+  const presentation = requireRecord(snapshot.presentation, "standalone updater presentation");
+  requireKnownKeys(presentation, ["detail", "title"], "standalone updater presentation");
+  const normalizedPresentation = {
+    ...(presentation.detail == null
+      ? {}
+      : { detail: requiredString(presentation.detail, "standalone updater presentation detail") }),
+    title: requiredString(presentation.title, "standalone updater presentation title"),
+  };
+  let progress: { completed: number; total: number } | undefined;
+  if (snapshot.progress != null) {
+    const rawProgress = requireRecord(snapshot.progress, "standalone updater progress");
+    requireKnownKeys(rawProgress, ["completed", "total"], "standalone updater progress");
+    const completed = normalizeRequiredNonNegativeInteger(
+      rawProgress.completed,
+      "standalone updater progress completed",
+    );
+    const total = normalizeRequiredPositiveInteger(
+      rawProgress.total,
+      "standalone updater progress total",
+    );
+    if (completed > total) {
+      throw new StandaloneProtocolError("standalone updater progress completed must not exceed total");
+    }
+    progress = { completed, total };
+  }
+  if (snapshot.state === "handed-off" && (actions.length > 0 || progress != null)) {
+    throw new StandaloneProtocolError(
+      "standalone updater handed-off state is terminal and must not expose actions or progress",
+    );
+  }
+  return {
+    actions,
+    presentation: normalizedPresentation,
+    ...(progress == null ? {} : { progress }),
+    provider,
+    revision: normalizeRequiredNonNegativeInteger(
+      snapshot.revision,
+      "standalone updater revision",
+    ),
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    state: snapshot.state as StandaloneUpdaterState,
+  };
+}
+
+export function validateStandaloneUpdaterWaitRequest(
+  value: unknown,
+  expected?: { provider?: StandaloneUpdaterProviderDescriptor },
+): StandaloneUpdaterWaitRequest {
+  const request = requireRecord(value, "standalone updater wait request");
+  requireKnownKeys(
+    request,
+    ["afterRevision", "provider", "schemaVersion", "timeoutMs"],
+    "standalone updater wait request",
+  );
+  normalizeUpdaterSchemaVersion(request.schemaVersion);
+  const timeoutMs = normalizeRequiredPositiveInteger(
+    request.timeoutMs,
+    "standalone updater wait timeoutMs",
+  );
+  if (timeoutMs > 30_000) {
+    throw new StandaloneProtocolError("standalone updater wait timeoutMs must not exceed 30000");
+  }
+  return {
+    afterRevision: normalizeRequiredNonNegativeInteger(
+      request.afterRevision,
+      "standalone updater wait afterRevision",
+    ),
+    provider: validateStandaloneUpdaterProviderDescriptor(request.provider, expected?.provider),
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    timeoutMs,
+  };
+}
+
+export function validateStandaloneUpdaterActionRequest(
+  value: unknown,
+  expected?: { provider?: StandaloneUpdaterProviderDescriptor },
+): StandaloneUpdaterActionRequest {
+  const request = requireRecord(value, "standalone updater action request");
+  requireKnownKeys(
+    request,
+    ["actionId", "provider", "requestId", "schemaVersion"],
+    "standalone updater action request",
+  );
+  normalizeUpdaterSchemaVersion(request.schemaVersion);
+  return {
+    actionId: normalizeToken(request.actionId, "standalone updater action id"),
+    provider: validateStandaloneUpdaterProviderDescriptor(request.provider, expected?.provider),
+    requestId: normalizeToken(request.requestId, "standalone updater action requestId"),
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  };
+}
+
+export function validateStandaloneUpdaterActionResult(
+  value: unknown,
+  expected?: {
+    actionId?: string;
+    provider?: StandaloneUpdaterProviderDescriptor;
+    requestId?: string;
+  },
+): StandaloneUpdaterActionResult {
+  const result = requireRecord(value, "standalone updater action result");
+  normalizeUpdaterSchemaVersion(result.schemaVersion);
+  const actionId = normalizeToken(result.actionId, "standalone updater action id");
+  if (expected?.actionId != null && actionId !== expected.actionId) {
+    throw new StandaloneProtocolError("standalone updater action id does not match");
+  }
+  const provider = validateStandaloneUpdaterProviderDescriptor(result.provider, expected?.provider);
+  const requestId = normalizeToken(result.requestId, "standalone updater action requestId");
+  if (expected?.requestId != null && requestId !== expected.requestId) {
+    throw new StandaloneProtocolError("standalone updater action requestId does not match");
+  }
+  const exchange = {
+    actionId,
+    provider,
+    requestId,
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  } as const;
+  if (result.outcome === "accepted") {
+    requireKnownKeys(
+      result,
+      ["actionId", "operationId", "outcome", "provider", "requestId", "schemaVersion"],
+      "standalone updater accepted action result",
+    );
+    return {
+      ...exchange,
+      operationId: normalizeToken(result.operationId, "standalone updater operationId"),
+      outcome: "accepted",
+    };
+  }
+  if (result.outcome === "unsupported") {
+    requireKnownKeys(
+      result,
+      ["actionId", "outcome", "provider", "requestId", "schemaVersion"],
+      "standalone updater unsupported action result",
+    );
+    return { ...exchange, outcome: "unsupported" };
+  }
+  if (result.outcome === "failed") {
+    requireKnownKeys(
+      result,
+      ["actionId", "error", "outcome", "provider", "requestId", "schemaVersion"],
+      "standalone updater failed action result",
+    );
+    const error = requireRecord(result.error, "standalone updater action error");
+    return {
+      ...exchange,
+      error: { code: normalizeToken(error.code, "standalone updater action error code") },
+      outcome: "failed",
+    };
+  }
+  throw new StandaloneProtocolError(
+    `unsupported standalone updater action outcome: ${String(result.outcome)}`,
+  );
+}
+
+type ComparableVersion = Readonly<{
+  core: readonly [number, number, number];
+  prerelease: string[];
+}>;
+
+function comparableVersion(value: string): ComparableVersion {
+  const validated = normalizeVersion(value, "standalone version");
+  const normalized = validated.replace(/^v/iu, "").split("+", 1)[0] ?? "";
+  const prereleaseSeparator = normalized.indexOf("-");
+  const core = prereleaseSeparator === -1 ? normalized : normalized.slice(0, prereleaseSeparator);
+  const prerelease = prereleaseSeparator === -1 ? "" : normalized.slice(prereleaseSeparator + 1);
+  const parts = core.split(".").map(Number);
+  return {
+    core: [parts[0]!, parts[1]!, parts[2]!],
+    prerelease: prerelease.length === 0 ? [] : prerelease.split("."),
+  };
+}
+
+function compareIdentifier(left: string, right: string): number {
+  const leftNumber = /^\d+$/u.test(left) ? Number(left) : null;
+  const rightNumber = /^\d+$/u.test(right) ? Number(right) : null;
+  if (leftNumber != null && rightNumber != null) return Math.sign(leftNumber - rightNumber);
+  if (leftNumber != null) return -1;
+  if (rightNumber != null) return 1;
+  return left.localeCompare(right);
+}
+
+export function compareStandaloneVersions(left: string, right: string): number {
+  const a = comparableVersion(left);
+  const b = comparableVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    const comparison = Math.sign((a.core[index] ?? 0) - (b.core[index] ?? 0));
+    if (comparison !== 0) return comparison;
+  }
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+  const count = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = a.prerelease[index];
+    const rightPart = b.prerelease[index];
+    if (leftPart == null) return -1;
+    if (rightPart == null) return 1;
+    const comparison = compareIdentifier(leftPart, rightPart);
+    if (comparison !== 0) return comparison;
+  }
+  return 0;
+}

--- a/apps/standalone/src/resource-garbage.ts
+++ b/apps/standalone/src/resource-garbage.ts
@@ -1,0 +1,117 @@
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import {
+  CLOSURE_STORE_EPOCH,
+  discardClosureStoreEntry,
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  readStoredClosureDistributionManifest,
+  resolveClosureStorePaths,
+  type ClosureStorePaths,
+} from "@open-design/closure/store";
+
+export type ClosureResourceDiscardResult = Readonly<{
+  discardedBlobs: number;
+  discardedResources: number;
+}>;
+
+const CONTENT_ADDRESS = /^[0-9a-f]{64}$/u;
+
+async function liveChannelReferences(paths: ClosureStorePaths): Promise<Readonly<{
+  blobs: ReadonlySet<string>;
+  resources: ReadonlySet<string>;
+}>> {
+  const blobs = new Set<string>();
+  const resources = new Set<string>();
+  const namespacesRoot = join(
+    paths.channelRoot,
+    "epochs",
+    String(CLOSURE_STORE_EPOCH),
+    "namespaces",
+  );
+  const namespaces = await readdir(namespacesRoot, { withFileTypes: true }).catch(() => []);
+  for (const entry of namespaces) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const namespacePaths = resolveClosureStorePaths({
+      channel: paths.channel,
+      namespace: entry.name,
+      root: paths.root,
+    });
+    const descriptor = await readClosureBindingDescriptor(namespacePaths);
+    const references = [
+      descriptor.active,
+      descriptor.attempt,
+      descriptor.lastSuccessful,
+      descriptor.prepared,
+    ].filter((binding) => binding != null);
+    const seen = new Set<string>();
+    for (const binding of references) {
+      const pointer = binding.standalone;
+      const key = `${pointer.generation}:${pointer.digest}:${pointer.target}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const manifest = await readStoredClosureDistributionManifest(namespacePaths, pointer);
+      const plan = planClosureDistributionGeneration(
+        namespacePaths,
+        pointer.generation,
+        manifest,
+        pointer.target,
+      );
+      for (const blobPath of plan.requiredBlobPaths) blobs.add(basename(blobPath));
+      for (const resource of plan.resources) {
+        blobs.add(basename(resource.blobPath));
+        resources.add(basename(resource.resourceRoot));
+      }
+    }
+  }
+  return Object.freeze({ blobs, resources });
+}
+
+async function discardUnreferencedRoot(input: Readonly<{
+  entriesAreDirectories: boolean;
+  live: ReadonlySet<string>;
+  paths: ClosureStorePaths;
+  root: string;
+}>): Promise<number> {
+  const entries = await readdir(input.root, { withFileTypes: true }).catch(() => []);
+  let discarded = 0;
+  for (const entry of entries) {
+    const expectedKind = input.entriesAreDirectories ? entry.isDirectory() : entry.isFile();
+    if (
+      !expectedKind
+      || entry.isSymbolicLink()
+      || !CONTENT_ADDRESS.test(entry.name)
+      || input.live.has(entry.name)
+    ) continue;
+    const result = await discardClosureStoreEntry({
+      paths: input.paths,
+      sourcePath: join(input.root, entry.name),
+    });
+    if (result.state === "discarded") discarded += 1;
+  }
+  return discarded;
+}
+
+/**
+ * Caller-owned conservative sweep. This runs under the channel maintenance
+ * lock; any unreadable retained graph aborts before the first discard.
+ */
+export async function discardUnreferencedClosureResources(
+  paths: ClosureStorePaths,
+): Promise<ClosureResourceDiscardResult> {
+  const live = await liveChannelReferences(paths);
+  const discardedResources = await discardUnreferencedRoot({
+    entriesAreDirectories: true,
+    live: live.resources,
+    paths,
+    root: paths.resourcesRoot,
+  });
+  const discardedBlobs = await discardUnreferencedRoot({
+    entriesAreDirectories: false,
+    live: live.blobs,
+    paths,
+    root: paths.blobsRoot,
+  });
+  return Object.freeze({ discardedBlobs, discardedResources });
+}

--- a/apps/standalone/src/resource-handoff.ts
+++ b/apps/standalone/src/resource-handoff.ts
@@ -1,0 +1,63 @@
+import {
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  readStoredClosureDistributionManifest,
+  resolveClosureStorePaths,
+} from "@open-design/closure/store";
+
+import {
+  validateStandaloneHandoffRequest,
+  type StandaloneHandoffRequest,
+} from "./protocol/index.js";
+import {
+  bundledStandaloneToolEnv,
+  lazyVelaRuntimeEnv,
+  standaloneResourceRootsEnv,
+  VELA_RUNTIME_RESOURCE_ID,
+} from "./tool-env.js";
+
+/** Project prepared blocking resources into the active body process. */
+export async function prepareStandaloneResourceEnv(
+  requestInput: StandaloneHandoffRequest,
+): Promise<NodeJS.ProcessEnv> {
+  const request = validateStandaloneHandoffRequest(requestInput);
+  if (request.closure == null) return bundledStandaloneToolEnv(request.paths.resourceRoot);
+  const paths = resolveClosureStorePaths({
+    channel: request.handoff.scope.channel,
+    namespace: request.handoff.scope.namespace,
+    root: request.closure.storeRoot,
+  });
+  const binding = await readClosureBindingDescriptor(paths);
+  const active = binding.active;
+  if (
+    active == null
+    || active.standalone.digest !== request.handoff.descriptor.standalone.digest
+    || active.standalone.target !== request.closure.target
+  ) {
+    throw new Error("Standalone resource context does not match the active Closure generation");
+  }
+  const manifest = await readStoredClosureDistributionManifest(paths, active.standalone);
+  const plan = planClosureDistributionGeneration(
+    paths,
+    active.standalone.generation,
+    manifest,
+    request.closure.target,
+  );
+  const resource = plan.resources.find((entry) => entry.id === VELA_RUNTIME_RESOURCE_ID);
+  const roots = new Map(
+    plan.resources
+      .filter((entry) => entry.startup === "blocking")
+      .map((entry) => [entry.id, entry.resourceRoot]),
+  );
+  return {
+    ...standaloneResourceRootsEnv(roots),
+    ...(process.env.VELA_BIN?.trim() && process.env.VELA_OPENCODE_BIN?.trim()
+      ? {}
+      : resource == null
+        ? bundledStandaloneToolEnv(request.paths.resourceRoot)
+        : lazyVelaRuntimeEnv(resource.resourceRoot)),
+  };
+}
+
+/** @deprecated Use prepareStandaloneResourceEnv. */
+export const prepareStandaloneVelaRuntime = prepareStandaloneResourceEnv;

--- a/apps/standalone/src/resource-provider.ts
+++ b/apps/standalone/src/resource-provider.ts
@@ -1,0 +1,1 @@
+export { ensureStandaloneResource } from "./resource-runtime.js";

--- a/apps/standalone/src/resource-runtime.ts
+++ b/apps/standalone/src/resource-runtime.ts
@@ -1,0 +1,122 @@
+import {
+  acquireClosureChannelLock,
+  planClosureDistributionGeneration,
+  readClosureBindingDescriptor,
+  readStoredClosureDistributionManifest,
+  releaseClosureChannelLock,
+  resolveClosureStorePaths,
+  type ClosureStorePaths,
+} from "@open-design/closure/store";
+import {
+  ensureClosureResource,
+  readClosureResourceRepositoryConfig,
+  type ClosureResourceEnsureProgress,
+  type ClosureResourceRepositoryConfig,
+} from "@open-design/closure/update";
+import type { ClosureDistributionManifest } from "@open-design/closure/protocol";
+
+import {
+  validateStandaloneHandoffDescriptor,
+  type StandaloneHandoffDescriptor,
+  type StandalonePreparedResource,
+} from "./protocol/index.js";
+import { VELA_RUNTIME_RESOURCE_ID } from "./tool-env.js";
+import { discardUnreferencedClosureResources } from "./resource-garbage.js";
+export {
+  prepareStandaloneResourceEnv,
+  prepareStandaloneVelaRuntime,
+} from "./resource-handoff.js";
+
+export type { StandalonePreparedResource } from "./protocol/index.js";
+
+/** Materialize one manifest-declared resource without joining the boot critical path. */
+export async function ensureStandaloneResource(input: Readonly<{
+  descriptor: StandaloneHandoffDescriptor;
+  fetch?: typeof globalThis.fetch;
+  id: string;
+}>): Promise<StandalonePreparedResource> {
+  const descriptor = validateStandaloneHandoffDescriptor(input.descriptor);
+  const id = input.id.trim();
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(id)) {
+    throw new Error(`Invalid Closure resource id: ${input.id}`);
+  }
+  if (descriptor.closure == null) {
+    throw new Error("Standalone handoff has no Closure resource context");
+  }
+  const paths = resolveClosureStorePaths({
+    channel: descriptor.handoff.scope.channel,
+    namespace: descriptor.handoff.scope.namespace,
+    root: descriptor.closure.storeRoot,
+  });
+  const binding = await readClosureBindingDescriptor(paths);
+  const active = binding.active;
+  if (
+    active == null
+    || active.standalone.digest !== descriptor.handoff.descriptor.standalone.digest
+    || active.standalone.generation !== descriptor.handoff.scope.generation
+    || active.standalone.target !== descriptor.closure.target
+  ) {
+    throw new Error("Standalone resource context does not match the active Closure generation");
+  }
+  const [manifest, repository] = await Promise.all([
+    readStoredClosureDistributionManifest(paths, active.standalone),
+    readClosureResourceRepositoryConfig({
+      OD_CLOSURE_RESOURCE_REPOSITORY_V1: descriptor.closure.repositoryConfigPath,
+    }),
+  ]);
+  const lock = await acquireClosureChannelLock(paths, { waitMs: 30_000 });
+  if (lock == null) throw new Error("Closure channel resources are busy");
+  try {
+    return await ensureClosureResource({
+      id,
+      manifest,
+      ...(input.fetch == null ? {} : { fetch: input.fetch }),
+      paths,
+      repository,
+      target: descriptor.closure.target,
+    });
+  } finally {
+    await releaseClosureChannelLock(lock);
+  }
+}
+
+export async function ensureStandaloneBootResources(input: Readonly<{
+  fetch?: typeof globalThis.fetch;
+  manifest: ClosureDistributionManifest;
+  onProgress?: (resource: Readonly<{ id: string; title: string }>, progress: ClosureResourceEnsureProgress) => void;
+  paths: ClosureStorePaths;
+  repository: ClosureResourceRepositoryConfig;
+  target: string;
+}>): Promise<readonly StandalonePreparedResource[]> {
+  const plan = planClosureDistributionGeneration(input.paths, 0, input.manifest, input.target);
+  const required = plan.resources.filter((entry) => (
+    entry.startup === "blocking"
+    && (
+      entry.id !== VELA_RUNTIME_RESOURCE_ID
+      || !(process.env.VELA_BIN?.trim() && process.env.VELA_OPENCODE_BIN?.trim())
+    )
+  ));
+  if (required.length === 0) return [];
+  const lock = await acquireClosureChannelLock(input.paths, { waitMs: 30_000 });
+  if (lock == null) throw new Error("Closure channel resources are busy");
+  try {
+    const prepared: StandalonePreparedResource[] = [];
+    for (const planned of required) {
+      prepared.push(await ensureClosureResource({
+        id: planned.id,
+        manifest: input.manifest,
+        ...(input.fetch == null ? {} : { fetch: input.fetch }),
+        ...(input.onProgress == null
+          ? {}
+          : { onProgress: (progress) => input.onProgress?.(planned, progress) }),
+        paths: input.paths,
+        repository: input.repository,
+        target: input.target,
+      }));
+    }
+    await discardUnreferencedClosureResources(input.paths).catch(() => undefined);
+    return Object.freeze(prepared);
+  } finally {
+    await releaseClosureChannelLock(lock);
+  }
+}

--- a/apps/standalone/src/runtime/index.ts
+++ b/apps/standalone/src/runtime/index.ts
@@ -1,0 +1,279 @@
+/** Shell-neutral lifecycle shared by the Standalone app and launcher adapters. */
+export const STANDALONE_PHASES = {
+  PREPARING: "preparing",
+  DAEMON_STARTING: "daemon-starting",
+  DAEMON_READY: "daemon-ready",
+  WEB_STARTING: "web-starting",
+  WEB_READY: "web-ready",
+  RUNNING: "running",
+  STOPPING: "stopping",
+  STOPPED: "stopped",
+  FAILED: "failed",
+} as const;
+
+export type StandalonePhase =
+  (typeof STANDALONE_PHASES)[keyof typeof STANDALONE_PHASES];
+
+/**
+ * Roots already resolved by a launcher for one local product namespace.
+ * Standalone deliberately preserves these values verbatim: path discovery and
+ * shell-specific storage policy belong to the launcher adapter.
+ */
+export interface StandalonePaths {
+  cacheRoot: string;
+  dataRoot: string;
+  installationRoot: string;
+  logsRoot: string;
+  resourceRoot: string;
+  runtimeRoot: string;
+}
+
+export interface StandaloneRuntimeStatus {
+  state: string;
+  url: string | null;
+}
+
+export interface StandaloneRuntimeHandle<
+  TStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  close(): Promise<void>;
+  readStatus(): Promise<TStatus>;
+  status: TStatus;
+}
+
+export interface StartStandaloneWebInput<
+  TDaemonStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  daemon: TDaemonStatus;
+  namespace: string;
+  paths: Readonly<StandalonePaths>;
+}
+
+export interface StandaloneDiagnostic {
+  daemonUrl: string | null;
+  error: string | null;
+  namespace: string;
+  paths: Readonly<StandalonePaths>;
+  phase: StandalonePhase;
+  webUrl: string | null;
+}
+
+export interface StandaloneHealth<
+  TDaemonStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+  TWebStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  daemon: TDaemonStatus | null;
+  issues: string[];
+  namespace: string;
+  state: "healthy" | "degraded" | "stopped";
+  web: TWebStatus | null;
+}
+
+export interface StandaloneDependencies<
+  TDaemonStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+  TWebStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  onDiagnostic?(diagnostic: StandaloneDiagnostic): void;
+  preparePaths(paths: Readonly<StandalonePaths>): Promise<void>;
+  registerWebUrl(input: {
+    daemon: TDaemonStatus;
+    webUrl: string;
+  }): Promise<void>;
+  startDaemon(input: {
+    namespace: string;
+    paths: Readonly<StandalonePaths>;
+  }): Promise<StandaloneRuntimeHandle<TDaemonStatus>>;
+  startWeb(
+    input: StartStandaloneWebInput<TDaemonStatus>,
+  ): Promise<StandaloneRuntimeHandle<TWebStatus>>;
+}
+
+export interface AcquireStandaloneOptions<
+  TDaemonStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+  TWebStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  dependencies: StandaloneDependencies<TDaemonStatus, TWebStatus>;
+  namespace: string;
+  paths: StandalonePaths;
+}
+
+export interface StandaloneHandle<
+  TDaemonStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+  TWebStatus extends StandaloneRuntimeStatus = StandaloneRuntimeStatus,
+> {
+  close(): Promise<void>;
+  readonly daemonUrl: string;
+  diagnostic(): StandaloneDiagnostic;
+  health(): Promise<StandaloneHealth<TDaemonStatus, TWebStatus>>;
+  readonly namespace: string;
+  readonly paths: Readonly<StandalonePaths>;
+  readonly webUrl: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function assertReadyUrl(runtime: "daemon" | "web", status: StandaloneRuntimeStatus): string {
+  if (status.state !== "running" || status.url == null || status.url.length === 0) {
+    throw new Error(
+      `${runtime} did not report a running status with a URL`,
+    );
+  }
+  return status.url;
+}
+
+function reportDiagnostic(
+  listener: StandaloneDependencies["onDiagnostic"],
+  diagnostic: StandaloneDiagnostic,
+): void {
+  try {
+    listener?.(diagnostic);
+  } catch {
+    // Product startup and shutdown must not depend on an observability sink.
+  }
+}
+
+export async function acquireStandalone<
+  TDaemonStatus extends StandaloneRuntimeStatus,
+  TWebStatus extends StandaloneRuntimeStatus,
+>(
+  options: AcquireStandaloneOptions<TDaemonStatus, TWebStatus>,
+): Promise<StandaloneHandle<TDaemonStatus, TWebStatus>> {
+  const { dependencies, namespace } = options;
+  if (namespace.trim().length === 0) {
+    throw new Error("standalone namespace must not be empty");
+  }
+
+  const paths = Object.freeze({ ...options.paths });
+  let phase: StandalonePhase = STANDALONE_PHASES.PREPARING;
+  let lastError: string | null = null;
+  let daemon: StandaloneRuntimeHandle<TDaemonStatus> | null = null;
+  let web: StandaloneRuntimeHandle<TWebStatus> | null = null;
+  let daemonUrl: string | null = null;
+  let webUrl: string | null = null;
+  let closeTask: Promise<void> | null = null;
+
+  const diagnostic = (): StandaloneDiagnostic => ({
+    daemonUrl,
+    error: lastError,
+    namespace,
+    paths,
+    phase,
+    webUrl,
+  });
+  const transition = (nextPhase: StandalonePhase): void => {
+    phase = nextPhase;
+    reportDiagnostic(dependencies.onDiagnostic, diagnostic());
+  };
+
+  const closeStartedRuntimes = async (): Promise<void> => {
+    const failures: unknown[] = [];
+    if (web != null) {
+      await web.close().catch((error: unknown) => failures.push(error));
+    }
+    if (daemon != null) {
+      await daemon.close().catch((error: unknown) => failures.push(error));
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        "failed to stop every standalone runtime",
+      );
+    }
+  };
+
+  try {
+    transition(STANDALONE_PHASES.PREPARING);
+    await dependencies.preparePaths(paths);
+
+    transition(STANDALONE_PHASES.DAEMON_STARTING);
+    daemon = await dependencies.startDaemon({ namespace, paths });
+    daemonUrl = assertReadyUrl("daemon", daemon.status);
+    transition(STANDALONE_PHASES.DAEMON_READY);
+
+    transition(STANDALONE_PHASES.WEB_STARTING);
+    web = await dependencies.startWeb({
+      daemon: daemon.status,
+      namespace,
+      paths,
+    });
+    webUrl = assertReadyUrl("web", web.status);
+    await dependencies.registerWebUrl({ daemon: daemon.status, webUrl });
+    transition(STANDALONE_PHASES.WEB_READY);
+    transition(STANDALONE_PHASES.RUNNING);
+  } catch (error) {
+    lastError = errorMessage(error);
+    await closeStartedRuntimes().catch(() => undefined);
+    transition(STANDALONE_PHASES.FAILED);
+    throw error;
+  }
+
+  const activeDaemon = daemon;
+  const activeWeb = web;
+  const activeWebUrl = webUrl;
+  const activeDaemonUrl = daemonUrl;
+  if (activeDaemon == null || activeDaemonUrl == null || activeWeb == null || activeWebUrl == null) {
+    throw new Error("standalone reached an impossible incomplete state");
+  }
+
+  return {
+    async close(): Promise<void> {
+      if (closeTask != null) return await closeTask;
+      transition(STANDALONE_PHASES.STOPPING);
+      closeTask = (async () => {
+        try {
+          await closeStartedRuntimes();
+          transition(STANDALONE_PHASES.STOPPED);
+        } catch (error) {
+          lastError = errorMessage(error);
+          transition(STANDALONE_PHASES.FAILED);
+          throw error;
+        }
+      })();
+      return await closeTask;
+    },
+    diagnostic,
+    async health(): Promise<StandaloneHealth<TDaemonStatus, TWebStatus>> {
+      if (
+        phase === STANDALONE_PHASES.STOPPED
+        || phase === STANDALONE_PHASES.STOPPING
+      ) {
+        return {
+          daemon: null,
+          issues: [],
+          namespace,
+          state: "stopped",
+          web: null,
+        };
+      }
+
+      const issues: string[] = [];
+      let daemonStatus: TDaemonStatus | null = null;
+      let webStatus: TWebStatus | null = null;
+      try {
+        daemonStatus = await activeDaemon.readStatus();
+        assertReadyUrl("daemon", daemonStatus);
+      } catch (error) {
+        issues.push(`daemon: ${errorMessage(error)}`);
+      }
+      try {
+        webStatus = await activeWeb.readStatus();
+        assertReadyUrl("web", webStatus);
+      } catch (error) {
+        issues.push(`web: ${errorMessage(error)}`);
+      }
+      return {
+        daemon: daemonStatus,
+        issues,
+        namespace,
+        state: issues.length === 0 ? "healthy" : "degraded",
+        web: webStatus,
+      };
+    },
+    daemonUrl: activeDaemonUrl,
+    namespace,
+    paths,
+    webUrl: activeWebUrl,
+  };
+}

--- a/apps/standalone/src/sidecars.ts
+++ b/apps/standalone/src/sidecars.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+
+import {
+  bootstrapControlPlane,
+  type SidecarLaunch,
+  type SidecarLaunchOptions,
+  type SidecarMethod,
+} from "@open-design/sidecar/control";
+import {
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_RUNTIME_COMMANDS,
+  validateStandalonePrepareUpdateCommandInput,
+  validateStandaloneHandoffRequest,
+  validateStandaloneRuntimeCommandRequest,
+  validateStandaloneUpdatePreparation,
+  type StandaloneHandle,
+  type StandaloneHandoffRequest,
+  type StandaloneRuntimeFailedStatus,
+  type StandaloneRuntimeCommandRequest,
+  type StandaloneRuntimeCommandResult,
+  type StandaloneProtocolJsonValue,
+  type StandaloneRuntimeStatus,
+  type StandaloneShellCapabilityResult,
+  type StandaloneRuntimeTerminalStatus,
+} from "./protocol/index.js";
+import {
+  acquireStandalone,
+  type StandaloneRuntimeHandle,
+} from "./runtime/index.js";
+import { hasModernClosureUpdateMetadata, prepareStandaloneUpdate } from "./update-runtime.js";
+
+type SidecarStatus = Readonly<{
+  pid: number;
+  state: "running" | "stopped";
+  url: string | null;
+}>;
+
+type StatusMethods = {
+  status: SidecarMethod<Record<string, never>, SidecarStatus>;
+};
+
+type DaemonMethods = StatusMethods & {
+  registerDesktopAuth: SidecarMethod<Readonly<{ secret: string }>, Readonly<{ accepted: true }>>;
+  registerWebUrl: SidecarMethod<Readonly<{ url: string }>, Readonly<{ accepted: true }>>;
+};
+
+type ShellCapabilityBridgeMethods = {
+  invoke: SidecarMethod<
+    Readonly<{ attachmentId: string; capability: string; input: StandaloneProtocolJsonValue }>,
+    StandaloneShellCapabilityResult
+  >;
+};
+
+export const STANDALONE_SHELL_CAPABILITY_SERVICE = "shell" as const;
+
+export type StandaloneSidecarLaunchSpec = Readonly<{
+  args?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  executable: string;
+  output?: "ignore" | "inherit";
+  readyTimeoutMs?: number;
+  stopTimeoutMs?: number;
+}>;
+
+export type StartSidecarStandaloneOptions = Readonly<{
+  daemon: StandaloneSidecarLaunchSpec;
+  web: StandaloneSidecarLaunchSpec;
+}>;
+
+function launchOptions(
+  service: "daemon" | "web",
+  spec: StandaloneSidecarLaunchSpec,
+  env?: NodeJS.ProcessEnv,
+): SidecarLaunchOptions {
+  const launchEnv = env ?? spec.env;
+  return {
+    executable: spec.executable,
+    service,
+    ...(spec.args == null ? {} : { args: spec.args }),
+    ...(spec.cwd == null ? {} : { cwd: spec.cwd }),
+    ...(launchEnv == null ? {} : { env: launchEnv }),
+    ...(spec.output == null ? {} : { output: spec.output }),
+    ...(spec.readyTimeoutMs == null ? {} : { readyTimeoutMs: spec.readyTimeoutMs }),
+    ...(spec.stopTimeoutMs == null ? {} : { stopTimeoutMs: spec.stopTimeoutMs }),
+  };
+}
+
+function runtimeHandle(
+  stop: () => Promise<unknown>,
+  readStatus: () => Promise<SidecarStatus>,
+  status: SidecarStatus,
+): StandaloneRuntimeHandle<SidecarStatus> {
+  return {
+    async close() {
+      await stop();
+    },
+    readStatus,
+    status,
+  };
+}
+
+function webDaemonPort(url: string): string {
+  const parsed = new URL(url);
+  const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+  if (!/^\d+$/u.test(port)) throw new Error("daemon URL does not contain a valid port");
+  return port;
+}
+
+/**
+ * Real Standalone composition over the normalized sidecar control plane.
+ * Product method catalogs remain local; packages/sidecar only sees opaque
+ * services, lifecycle mechanics and caller-owned launch commands.
+ */
+export async function startSidecarStandalone(
+  input: StandaloneHandoffRequest,
+  options: StartSidecarStandaloneOptions,
+): Promise<StandaloneHandle> {
+  const request = validateStandaloneHandoffRequest(input);
+  const scope = request.handoff.scope;
+  const control = bootstrapControlPlane({
+    projection: {
+      digest: request.handoff.descriptorDigest,
+      value: request.handoff.descriptor,
+    },
+    roots: {
+      dataRoot: request.paths.dataRoot,
+      resourceRoot: request.paths.resourceRoot,
+      runtimeRoot: request.paths.runtimeRoot,
+    },
+    scope: {
+      channel: scope.channel,
+      generation: scope.generation,
+      namespace: scope.namespace,
+    },
+  });
+  const launches: {
+    daemon?: SidecarLaunch<DaemonMethods>;
+    web?: SidecarLaunch<StatusMethods>;
+  } = {};
+
+  const shellCapabilities = await control.expose<ShellCapabilityBridgeMethods>({
+    handlers: {
+      async invoke({ attachmentId, capability, input: capabilityInput }) {
+        return await request.capabilities.invoke({
+          attachmentId,
+          capability,
+          handoff: request.handoff,
+          input: capabilityInput,
+          requestId: randomUUID(),
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        });
+      },
+    },
+    service: STANDALONE_SHELL_CAPABILITY_SERVICE,
+  });
+
+  const product = await acquireStandalone<SidecarStatus, SidecarStatus>({
+    dependencies: {
+      async preparePaths(paths) {
+        await Promise.all([
+          mkdir(paths.cacheRoot, { recursive: true }),
+          mkdir(paths.dataRoot, { recursive: true }),
+          mkdir(paths.logsRoot, { recursive: true }),
+          mkdir(paths.runtimeRoot, { recursive: true }),
+        ]);
+      },
+      async registerWebUrl({ webUrl }) {
+        if (launches.daemon == null) throw new Error("daemon sidecar is unavailable");
+        await launches.daemon.client.call("registerWebUrl", { url: webUrl });
+      },
+      async startDaemon() {
+        const launch = await control.launch<DaemonMethods>(launchOptions("daemon", options.daemon));
+        launches.daemon = launch;
+        const status = await launch.client.call("status", {});
+        return runtimeHandle(
+          async () => await launch.stop(),
+          async () => await launch.client.call("status", {}),
+          status,
+        );
+      },
+      async startWeb({ daemon }) {
+        const launch = await control.launch<StatusMethods>(launchOptions("web", options.web, {
+          ...options.web.env,
+          OD_PORT: webDaemonPort(daemon.url ?? ""),
+        }));
+        launches.web = launch;
+        const status = await launch.client.call("status", {});
+        return runtimeHandle(
+          async () => await launch.stop(),
+          async () => await launch.client.call("status", {}),
+          status,
+        );
+      },
+    },
+    namespace: scope.namespace,
+    paths: request.paths,
+  }).catch(async (error: unknown) => {
+    await shellCapabilities.close().catch(() => undefined);
+    throw error;
+  });
+
+  const closeProduct = async (): Promise<void> => {
+    let failure: unknown = null;
+    try {
+      await product.close();
+    } catch (error) {
+      failure = error;
+    }
+    try {
+      await shellCapabilities.close();
+    } catch (error) {
+      failure ??= error;
+    }
+    if (failure != null) throw failure;
+  };
+
+  let status: StandaloneRuntimeStatus = {
+    daemonUrl: product.daemonUrl,
+    handoff: request.handoff,
+    pid: process.pid,
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    state: "running",
+    webUrl: product.webUrl,
+  };
+  let closing = false;
+  let closeTask: Promise<StandaloneRuntimeTerminalStatus> | null = null;
+  let resolveTerminal!: (value: StandaloneRuntimeTerminalStatus) => void;
+  const terminal = new Promise<StandaloneRuntimeTerminalStatus>((resolve) => {
+    resolveTerminal = resolve;
+  });
+
+  const failFromExit = (service: "daemon" | "web"): void => {
+    if (closing || status.state !== "running") return;
+    closing = true;
+    const failed: StandaloneRuntimeFailedStatus = {
+      error: { code: `${service}-sidecar-exited` },
+      handoff: request.handoff,
+      pid: process.pid,
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      state: "failed",
+    };
+    status = failed;
+    void closeProduct().catch(() => undefined).finally(() => resolveTerminal(failed));
+  };
+  void launches.daemon?.exited.then(() => failFromExit("daemon"));
+  void launches.web?.exited.then(() => failFromExit("web"));
+
+  return Object.freeze({
+    async close() {
+      if (closeTask != null) return await closeTask;
+      if (status.state === "failed") return status;
+      closing = true;
+      closeTask = (async () => {
+        try {
+          await closeProduct();
+          const stopped = {
+            handoff: request.handoff,
+            pid: process.pid,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+            state: "stopped",
+          } as const;
+          status = stopped;
+          resolveTerminal(stopped);
+          return stopped;
+        } catch (error) {
+          const failed = {
+            error: { code: "sidecar-stop-failed" },
+            handoff: request.handoff,
+            pid: process.pid,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+            state: "failed",
+          } as const;
+          status = failed;
+          resolveTerminal(failed);
+          throw error;
+        }
+      })();
+      return await closeTask;
+    },
+    async invoke(value: StandaloneRuntimeCommandRequest): Promise<StandaloneRuntimeCommandResult> {
+      const command = validateStandaloneRuntimeCommandRequest(value, {
+        handoff: request.handoff,
+      });
+      if (command.command === STANDALONE_RUNTIME_COMMANDS.PREPARE_UPDATE) {
+        const input = validateStandalonePrepareUpdateCommandInput(command.input);
+        if (!hasModernClosureUpdateMetadata(input.metadata)) {
+          return {
+            attachmentId: command.attachmentId,
+            handoff: request.handoff,
+            outcome: "completed",
+            output: { architecture: "legacy" },
+            requestId: command.requestId,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+          };
+        }
+        if (request.closure == null) {
+          return {
+            attachmentId: command.attachmentId,
+            error: { code: "standalone-update-unavailable" },
+            handoff: request.handoff,
+            outcome: "failed",
+            requestId: command.requestId,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+          };
+        }
+        try {
+          const output = validateStandaloneUpdatePreparation(await prepareStandaloneUpdate({
+            activationPolicy: input.activationPolicy,
+            channel: request.handoff.scope.channel,
+            metadata: input.metadata,
+            namespace: request.handoff.scope.namespace,
+            repositoryConfigPath: request.closure.repositoryConfigPath,
+            shellType: request.attachment.shell.type,
+            shellVersion: request.attachment.shell.version,
+            storeRoot: request.closure.storeRoot,
+            target: request.closure.target,
+          }));
+          return {
+            attachmentId: command.attachmentId,
+            handoff: request.handoff,
+            outcome: "completed",
+            output,
+            requestId: command.requestId,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+          };
+        } catch {
+          return {
+            attachmentId: command.attachmentId,
+            error: { code: "standalone-update-prepare-failed" },
+            handoff: request.handoff,
+            outcome: "failed",
+            requestId: command.requestId,
+            schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+          };
+        }
+      }
+      if (command.command !== STANDALONE_RUNTIME_COMMANDS.REGISTER_DESKTOP_AUTH) {
+        return {
+          attachmentId: command.attachmentId,
+          handoff: request.handoff,
+          outcome: "unsupported",
+          requestId: command.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      }
+      const input = command.input;
+      if (
+        input == null
+        || typeof input !== "object"
+        || Array.isArray(input)
+        || typeof input.secret !== "string"
+        || !/^[A-Za-z0-9+/]+={0,2}$/u.test(input.secret)
+      ) {
+        return {
+          attachmentId: command.attachmentId,
+          error: { code: "invalid-desktop-auth-secret" },
+          handoff: request.handoff,
+          outcome: "failed",
+          requestId: command.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      }
+      if (launches.daemon == null) {
+        return {
+          attachmentId: command.attachmentId,
+          error: { code: "daemon-unavailable" },
+          handoff: request.handoff,
+          outcome: "failed",
+          requestId: command.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      }
+      await launches.daemon.client.call("registerDesktopAuth", { secret: input.secret });
+      return {
+        attachmentId: command.attachmentId,
+        handoff: request.handoff,
+        outcome: "completed",
+        output: { accepted: true },
+        requestId: command.requestId,
+        schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      };
+    },
+    async readStatus() {
+      return status;
+    },
+    async waitForTerminal() {
+      return await terminal;
+    },
+  });
+}

--- a/apps/standalone/src/tool-env.ts
+++ b/apps/standalone/src/tool-env.ts
@@ -1,0 +1,76 @@
+import { statSync } from "node:fs";
+import { join } from "node:path";
+
+export const VELA_RUNTIME_RESOURCE_ID = "vela-runtime" as const;
+export const VELA_RUNTIME_LAZY_ENV = "OD_VELA_RUNTIME_LAZY" as const;
+export const STANDALONE_RESOURCE_ROOTS_ENV = "OD_CLOSURE_RESOURCE_ROOTS_V1" as const;
+
+/** Known Closure resource groups the packaged daemon can project from isolated CAS roots. */
+export const STANDALONE_DAEMON_RESOURCE_IDS = Object.freeze([
+  "community-pets",
+  "craft",
+  "design-systems",
+  "design-templates",
+  "frames",
+  "plugin-previews",
+  "plugins",
+  "prompt-templates",
+  "skills",
+] as const);
+
+export type StandaloneDaemonResourceId = (typeof STANDALONE_DAEMON_RESOURCE_IDS)[number];
+
+export function standaloneResourceRootsEnv(
+  resources: ReadonlyMap<string, string>,
+): NodeJS.ProcessEnv {
+  const roots = Object.fromEntries(
+    STANDALONE_DAEMON_RESOURCE_IDS.flatMap((id) => {
+      const root = resources.get(id);
+      return root == null ? [] : [[id, root] as const];
+    }),
+  );
+  return Object.keys(roots).length === 0
+    ? {}
+    : { [STANDALONE_RESOURCE_ROOTS_ENV]: JSON.stringify(roots) };
+}
+
+export function bundledStandaloneToolEnv(resourceRoot: string): NodeJS.ProcessEnv {
+  const binaryName = process.platform === "win32" ? "vela.exe" : "vela";
+  const openCodeName = process.platform === "win32" ? "opencode.exe" : "opencode";
+  const candidates = {
+    VELA_BIN: join(resourceRoot, "bin", binaryName),
+    VELA_OPENCODE_BIN: join(resourceRoot, "bin", "libexec", "opencode", openCodeName),
+  } as const;
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, path] of Object.entries(candidates)) {
+    if (process.env[name]?.trim()) continue;
+    try {
+      if (statSync(path).isFile()) env[name] = path;
+    } catch {
+      // Non-strict development contributions may intentionally omit Vela.
+    }
+  }
+  return env;
+}
+
+export function lazyVelaRuntimeEnv(resourceRoot: string): NodeJS.ProcessEnv {
+  const binaryName = process.platform === "win32" ? "vela.exe" : "vela";
+  const openCodeName = process.platform === "win32" ? "opencode.exe" : "opencode";
+  return {
+    ...(process.env.VELA_BIN?.trim()
+      ? {}
+      : { VELA_BIN: join(resourceRoot, "bin", binaryName) }),
+    ...(process.env.VELA_OPENCODE_BIN?.trim()
+      ? {}
+      : {
+          VELA_OPENCODE_BIN: join(
+            resourceRoot,
+            "bin",
+            "libexec",
+            "opencode",
+            openCodeName,
+          ),
+        }),
+    [VELA_RUNTIME_LAZY_ENV]: "1",
+  };
+}

--- a/apps/standalone/src/update-runtime.ts
+++ b/apps/standalone/src/update-runtime.ts
@@ -1,0 +1,135 @@
+import {
+  authorizePreparedClosureActivation,
+  readClosureBindingDescriptor,
+  revokePreparedClosureActivation,
+  resolveClosureStorePaths,
+} from "@open-design/closure/store";
+import {
+  applyClosureDistributionUpdate,
+  compareClosureShellVersions,
+  readClosureResourceRepositoryConfig,
+  resolveClosureShellMinimumVersion,
+  selectClosureDistributionReleaseCandidate,
+} from "@open-design/closure/update";
+import type {
+  StandaloneUpdateActivationPolicy,
+  StandaloneUpdatePreparation,
+} from "./protocol/index.js";
+
+import { discardUnreferencedClosureResources } from "./resource-garbage.js";
+import { ensureStandaloneBootResources } from "./resource-runtime.js";
+
+/**
+ * The sole legacy discriminator is absence of the modern Closure envelope.
+ * Standalone never reads legacy control fields; Shell remains their owner.
+ */
+export function hasModernClosureUpdateMetadata(metadata: unknown): metadata is Record<string, unknown> {
+  return metadata != null
+    && typeof metadata === "object"
+    && !Array.isArray(metadata)
+    && Object.hasOwn(metadata, "closure");
+}
+
+export async function prepareStandaloneUpdate(input: Readonly<{
+  activationPolicy: StandaloneUpdateActivationPolicy;
+  channel: string;
+  fetch?: typeof globalThis.fetch;
+  metadata: unknown;
+  namespace: string;
+  repositoryConfigPath: string;
+  shellType: string;
+  shellVersion: string;
+  storeRoot: string;
+  target: string;
+}>): Promise<StandaloneUpdatePreparation> {
+  if (!hasModernClosureUpdateMetadata(input.metadata)) return { architecture: "legacy" };
+  const candidate = selectClosureDistributionReleaseCandidate(input.metadata, {
+    channel: input.channel,
+    target: input.target,
+  });
+  if (candidate == null) throw new Error("Modern Closure update metadata is invalid");
+  const minimumShellVersion = resolveClosureShellMinimumVersion(candidate.manifest, input.shellType);
+  if (
+    minimumShellVersion == null
+    || compareClosureShellVersions(input.shellVersion, minimumShellVersion) < 0
+  ) {
+    return { architecture: "standalone", minimumShellVersion, route: "shell" };
+  }
+  const paths = resolveClosureStorePaths({
+    channel: input.channel,
+    namespace: input.namespace,
+    root: input.storeRoot,
+  });
+  const repository = await readClosureResourceRepositoryConfig({
+    OD_CLOSURE_RESOURCE_REPOSITORY_V1: input.repositoryConfigPath,
+  });
+  const result = await applyClosureDistributionUpdate({
+    candidate,
+    ...(input.fetch == null ? {} : { fetch: input.fetch }),
+    paths,
+    repository,
+    shellType: input.shellType,
+    shellVersion: input.shellVersion,
+  });
+  if (result.state === "busy") throw new Error("Standalone update preparation is already active");
+  if (result.state === "retained") {
+    if (result.reason === "shell-incompatible") {
+      return { architecture: "standalone", minimumShellVersion, route: "shell" };
+    }
+    let descriptor = await readClosureBindingDescriptor(paths);
+    if (
+      input.activationPolicy !== "revoke-silent"
+      && result.reason === "already-prepared"
+      && descriptor.prepared != null
+    ) {
+      await authorizePreparedClosureActivation(
+        paths,
+        descriptor.prepared,
+        input.activationPolicy === "authorize-user" ? "user-restart" : "silent-policy",
+      );
+      descriptor = await readClosureBindingDescriptor(paths);
+    } else if (result.reason === "already-prepared") {
+      descriptor = await revokePreparedClosureActivation(paths, "silent-policy");
+    }
+    return {
+      architecture: "standalone",
+      activationSource: descriptor.activationIntent?.source === "silent-policy"
+        || descriptor.activationIntent?.source === "user-restart"
+        ? descriptor.activationIntent.source
+        : null,
+      releaseVersion: candidate.releaseVersion,
+      route: "closure",
+      state: result.reason === "already-prepared" ? "prepared" : "current",
+    };
+  }
+  await ensureStandaloneBootResources({
+    ...(input.fetch == null ? {} : { fetch: input.fetch }),
+    manifest: candidate.manifest,
+    paths,
+    repository,
+    target: candidate.target,
+  });
+  const descriptor = await readClosureBindingDescriptor(paths);
+  if (descriptor.prepared?.standalone.generation !== result.pointer.generation) {
+    throw new Error("Standalone prepared binding changed before resource completion");
+  }
+  if (input.activationPolicy !== "revoke-silent") {
+    await authorizePreparedClosureActivation(
+      paths,
+      descriptor.prepared,
+      input.activationPolicy === "authorize-user" ? "user-restart" : "silent-policy",
+    );
+  }
+  const preparedDescriptor = await readClosureBindingDescriptor(paths);
+  await discardUnreferencedClosureResources(paths).catch(() => undefined);
+  return {
+    architecture: "standalone",
+    activationSource: preparedDescriptor.activationIntent?.source === "silent-policy"
+      || preparedDescriptor.activationIntent?.source === "user-restart"
+      ? preparedDescriptor.activationIntent.source
+      : null,
+    releaseVersion: candidate.releaseVersion,
+    route: "closure",
+    state: "prepared",
+  };
+}

--- a/apps/standalone/tests/bootloader.test.ts
+++ b/apps/standalone/tests/bootloader.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_PROTOCOL_VERSION,
+  createStandaloneHandoffEnvelope,
+  type StandaloneHandle,
+  type StandaloneHandoffRequest,
+  type StandaloneRuntimeTerminalStatus,
+} from "@open-design/standalone/protocol";
+
+import { createStandaloneBootloader } from "../src/bootloader.js";
+
+const digest = `sha256:${"b".repeat(64)}` as const;
+const shellDigest = `sha256:${"c".repeat(64)}` as const;
+
+function request(overrides: {
+  attachmentId?: string;
+  generation?: number;
+  shellType?: string;
+  shellVersion?: string;
+} = {}): StandaloneHandoffRequest {
+  const handoff = createStandaloneHandoffEnvelope({
+    descriptor: {
+      release: { version: "0.18.0-beta.4" },
+      standalone: {
+        digest,
+        protocolVersion: STANDALONE_PROTOCOL_VERSION,
+        version: "0.18.0-beta.4",
+      },
+    },
+    scope: {
+      channel: "beta",
+      generation: overrides.generation ?? 3,
+      namespace: "release-beta",
+    },
+  });
+  return {
+    attachment: {
+      id: overrides.attachmentId ?? "electron-a",
+      shell: {
+        digest: shellDigest,
+        type: overrides.shellType ?? "electron",
+        version: overrides.shellVersion ?? "0.18.0-beta.4",
+      },
+    },
+    capabilities: {
+      async invoke(value) {
+        return {
+          attachmentId: value.attachmentId,
+          handoff: value.handoff,
+          outcome: "unsupported",
+          requestId: value.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      },
+    },
+    handoff,
+    paths: {
+      cacheRoot: "/open-design/cache",
+      dataRoot: "/open-design/data",
+      installationRoot: "/open-design/install",
+      logsRoot: "/open-design/logs",
+      resourceRoot: "/open-design/resources",
+      runtimeRoot: "/open-design/runtime",
+    },
+  };
+}
+
+function runningHandle(input: StandaloneHandoffRequest): StandaloneHandle {
+  const stopped: StandaloneRuntimeTerminalStatus = {
+    handoff: input.handoff,
+    pid: 42,
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    state: "stopped",
+  };
+  let resolveTerminal!: (status: StandaloneRuntimeTerminalStatus) => void;
+  const terminal = new Promise<StandaloneRuntimeTerminalStatus>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  return {
+    async close() {
+      resolveTerminal(stopped);
+      return stopped;
+    },
+    async invoke(value) {
+      return {
+        attachmentId: value.attachmentId,
+        handoff: input.handoff,
+        outcome: "unsupported",
+        requestId: value.requestId,
+        schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      };
+    },
+    async readStatus() {
+      return {
+        daemonUrl: "http://127.0.0.1:4100",
+        handoff: input.handoff,
+        pid: 42,
+        schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        state: "running",
+        webUrl: "http://127.0.0.1:4200",
+      };
+    },
+    async waitForTerminal() {
+      return await terminal;
+    },
+  };
+}
+
+function compatibility(min = "0.18.0-beta.1") {
+  return {
+    electron: { version: { min } },
+    "codex-plugin": { version: { min: "0.1.0" } },
+  };
+}
+
+describe("bootloader.mjs handoff-once", () => {
+  it("starts one body for repeated identical handoffs", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      start,
+    });
+    const input = request();
+
+    const [first, second] = await Promise.all([handoff(input), handoff(input)]);
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    await expect(first.readStatus()).resolves.toMatchObject({
+      handoff: input.handoff,
+      state: "running",
+    });
+  });
+
+  it("fails closed for a different active generation", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      start,
+    });
+
+    await handoff(request());
+    await expect(handoff(request({ generation: 4 }))).rejects.toMatchObject({
+      code: "handoff-conflict",
+    });
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces the shell floor before body startup", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility("0.18.0-beta.3"),
+      start,
+    });
+
+    await expect(handoff(request({ shellVersion: "0.18.0-beta.2" }))).rejects.toMatchObject({
+      code: "shell-incompatible",
+    });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("routes capabilities by attachment and stops the body after the final release", async () => {
+    let bodyRequest: StandaloneHandoffRequest | null = null;
+    let rawHandle: StandaloneHandle | null = null;
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => {
+      bodyRequest = input;
+      rawHandle = runningHandle(input);
+      rawHandle.close = vi.fn(rawHandle.close.bind(rawHandle));
+      return rawHandle;
+    });
+    const electron = request({ attachmentId: "electron-a" });
+    const plugin = request({
+      attachmentId: "codex-plugin-a",
+      shellType: "codex-plugin",
+      shellVersion: "0.1.0",
+    });
+    electron.capabilities.invoke = vi.fn(electron.capabilities.invoke);
+    plugin.capabilities.invoke = vi.fn(plugin.capabilities.invoke);
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      start,
+    });
+
+    const electronHandle = await handoff(electron);
+    const pluginHandle = await handoff(plugin);
+    expect(start).toHaveBeenCalledOnce();
+
+    await bodyRequest!.capabilities.invoke({
+      attachmentId: plugin.attachment.id,
+      capability: "open-design.fixture.v1",
+      handoff: plugin.handoff,
+      input: {},
+      requestId: "plugin-capability-1",
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    });
+    expect(plugin.capabilities.invoke).toHaveBeenCalledOnce();
+    expect(electron.capabilities.invoke).not.toHaveBeenCalled();
+
+    await expect(electronHandle.close()).resolves.toMatchObject({ state: "stopped" });
+    expect(rawHandle!.close).not.toHaveBeenCalled();
+    await expect(pluginHandle.readStatus()).resolves.toMatchObject({ state: "running" });
+    await expect(pluginHandle.close()).resolves.toMatchObject({ state: "stopped" });
+    expect(rawHandle!.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an undeclared shell before it acquires a body reference", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      start,
+    });
+
+    await expect(handoff(request({
+      attachmentId: "unknown-a",
+      shellType: "unknown-shell",
+    }))).rejects.toMatchObject({ code: "shell-incompatible" });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("fences shell capability results to the same request and generation", async () => {
+    const input = request();
+    const wrongHandoff = createStandaloneHandoffEnvelope({
+      descriptor: input.handoff.descriptor,
+      scope: {
+        ...input.handoff.scope,
+        generation: input.handoff.scope.generation + 1,
+      },
+    });
+    input.capabilities.invoke = async (value) => ({
+      attachmentId: value.attachmentId,
+      handoff: wrongHandoff,
+      outcome: "unsupported",
+      requestId: value.requestId,
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    });
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      async start(bound) {
+        await bound.capabilities.invoke({
+          attachmentId: bound.attachment.id,
+          capability: "open-external",
+          handoff: bound.handoff,
+          input: { url: "https://open-design.dev" },
+          requestId: "open-1",
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        });
+        return runningHandle(bound);
+      },
+    });
+
+    await expect(handoff(input)).rejects.toThrow(/active generation/);
+  });
+
+  it("rejects body readiness from another handoff", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => {
+      const wrong = request({ generation: input.handoff.scope.generation + 1 });
+      return runningHandle(wrong);
+    });
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      start,
+    });
+
+    await expect(handoff(request())).rejects.toMatchObject({ code: "body-invalid" });
+  });
+
+  it("hands off once to a registered inner bootloader", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const inner = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const resolveRegisteredBootloader = vi.fn(() => inner);
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      resolveRegisteredBootloader,
+      start,
+    });
+    const input = request();
+
+    const [first, second] = await Promise.all([handoff(input), handoff(input)]);
+
+    expect(resolveRegisteredBootloader).toHaveBeenCalledTimes(1);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+    expect(first).toBe(second);
+  });
+
+  it("treats an inner bootloader failure as terminal without body fallback", async () => {
+    const start = vi.fn(async (input: StandaloneHandoffRequest) => runningHandle(input));
+    const innerFailure = new Error("inner bootloader failed");
+    const inner = vi.fn(async () => await Promise.reject(innerFailure));
+    const handoff = createStandaloneBootloader({
+      shellCompatibility: compatibility(),
+      resolveRegisteredBootloader: () => inner,
+      start,
+    });
+
+    await expect(handoff(request())).rejects.toBe(innerFailure);
+    await expect(handoff(request())).rejects.toBe(innerFailure);
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(start).not.toHaveBeenCalled();
+  });
+});

--- a/apps/standalone/tests/bootstrap.test.ts
+++ b/apps/standalone/tests/bootstrap.test.ts
@@ -1,0 +1,696 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+  CLOSURE_PROTOCOL_VERSION,
+  createClosureComponentTreeDigest,
+  createClosureDistributionControl,
+  createClosureDistributionManifest,
+  type ClosureDistributionBlob,
+} from "@open-design/closure/protocol";
+import {
+  confirmClosureBindingAttempt,
+  readClosureBindingDescriptor,
+  resolveClosureStorePaths,
+} from "@open-design/closure/store";
+import { bootstrapSidecarLifecycle } from "@open-design/sidecar/lifecycle";
+import {
+  STANDALONE_BOOTSTRAP_SCHEMA_VERSION,
+  type StandaloneBootstrapProgress,
+} from "../src/protocol/index.js";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveStandaloneBootstrap } from "../src/bootstrap.js";
+import { discardUnreferencedClosureResources } from "../src/resource-garbage.js";
+import { prepareStandaloneResourceEnv } from "../src/resource-runtime.js";
+import { STANDALONE_RESOURCE_ROOTS_ENV } from "../src/tool-env.js";
+import { hasModernClosureUpdateMetadata, prepareStandaloneUpdate } from "../src/update-runtime.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+function digest(value: string | Buffer): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "od-standalone-bootstrap-"));
+  roots.push(root);
+  const zip = async (files: Array<readonly [string, string]>): Promise<Buffer> => {
+    const archive = new JSZip();
+    for (const [path, contents] of files) archive.file(path, contents, { date: new Date(0) });
+    return await archive.generateAsync({ compression: "DEFLATE", type: "nodebuffer" });
+  };
+  const source = {
+    body: [["bootloader.mjs", "export const body = true;\n"]],
+    launcher: [
+      ["bootloader.mjs", "export const handoff = true;\n"],
+      ["launcher.mjs", "export const launcher = true;\n"],
+    ],
+    native: [["addon.node", "native\n"]],
+    plugins: [
+      ["plugins/_official/sample/open-design.json", "{}\n"],
+      ["plugins/registry/index.json", "{}\n"],
+    ],
+    skills: [["skills/sample/SKILL.md", "# Sample\n"]],
+    vela: [
+      [`bin/libexec/opencode/${process.platform === "win32" ? "opencode.exe" : "opencode"}`, "opencode\n"],
+      [`bin/${process.platform === "win32" ? "vela.exe" : "vela"}`, "vela\n"],
+    ],
+  } satisfies Record<string, Array<readonly [string, string]>>;
+  const bytes = {
+    body: await zip(source.body),
+    launcher: await zip(source.launcher),
+    native: await zip(source.native),
+    plugins: await zip(source.plugins),
+    skills: await zip(source.skills),
+    vela: await zip(source.vela),
+  };
+  const artifact = (value: Buffer): ClosureDistributionBlob => ({
+    digest: digest(value),
+    mediaType: "application/zip",
+    size: value.byteLength,
+    url: `https://default.example.test/beta/blobs/${digest(value).slice("sha256:".length)}`,
+  });
+  const artifacts = {
+    body: artifact(bytes.body),
+    launcher: artifact(bytes.launcher),
+    native: artifact(bytes.native),
+    plugins: artifact(bytes.plugins),
+    skills: artifact(bytes.skills),
+    vela: artifact(bytes.vela),
+  };
+  const tree = (files: Array<readonly [string, string]>) => createClosureComponentTreeDigest(
+    files.map(([path, contents]) => ({ digest: digest(contents), path, size: Buffer.byteLength(contents) })),
+    digest,
+  );
+  const manifestFor = (version: string, minimumShellVersion = "0.19.0-beta.1") => (
+    createClosureDistributionManifest({
+      blobs: Object.fromEntries(Object.values(artifacts).map((entry) => [entry.digest, entry])),
+      compatibility: { shell: { electron: { version: { min: minimumShellVersion } } } },
+      identity: { channel: "beta", protocolVersion: CLOSURE_PROTOCOL_VERSION, version },
+      required: {
+        body: { blob: artifacts.body.digest, entryPath: "bootloader.mjs", treeDigest: tree(source.body) },
+        launcher: {
+          blob: artifacts.launcher.digest,
+          entryPath: "launcher.mjs",
+          handoffPath: "bootloader.mjs",
+          treeDigest: tree(source.launcher),
+        },
+        targets: {
+          "darwin-arm64": {
+            native: { blob: artifacts.native.digest, treeDigest: tree(source.native) },
+            resources: [{
+              blob: artifacts.vela.digest,
+              id: "vela-runtime",
+              startup: "blocking",
+              title: "Vela runtime",
+              treeDigest: tree(source.vela),
+            }],
+          },
+        },
+      },
+      resources: [
+        {
+          blob: artifacts.plugins.digest,
+          id: "plugins",
+          startup: "blocking",
+          title: "Plugin registry",
+          treeDigest: tree(source.plugins),
+        },
+        {
+          blob: artifacts.skills.digest,
+          id: "skills",
+          startup: "lazy",
+          title: "Skills",
+          treeDigest: tree(source.skills),
+        },
+      ],
+      schemaVersion: CLOSURE_DISTRIBUTION_SCHEMA_VERSION,
+    }, digest)
+  );
+  const manifests = {
+    "0.19.0-beta.1": manifestFor("0.19.0-beta.1"),
+    "0.19.0-beta.2": manifestFor("0.19.0-beta.2"),
+    "0.19.0-beta.3": manifestFor("0.19.0-beta.3", "0.19.0-beta.3"),
+  };
+  const manifest = manifests["0.19.0-beta.1"];
+  const metadataUrl = "https://releases.example.test/beta/latest/metadata.json";
+  const byUrl = new Map(Object.entries(bytes).map(([name, value]) => [artifacts[name as keyof typeof artifacts].url, value]));
+  const fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const versionMatch = /\/beta\/versions\/(0\.19\.0-beta\.[123])\/metadata\.json$/u.exec(url);
+    const selectedVersion = versionMatch?.[1] as keyof typeof manifests | undefined;
+    if (url === metadataUrl || selectedVersion != null) {
+      const version = selectedVersion ?? "0.19.0-beta.1";
+      return new Response(JSON.stringify({
+        channel: "beta",
+        closure: manifests[version],
+        closureControl: createClosureDistributionControl(manifests[version]),
+        releaseState: "complete",
+        releaseVersion: version,
+      }), { status: 200 });
+    }
+    const body = byUrl.get(url);
+    return body == null
+      ? new Response("not found", { status: 404 })
+      : new Response(body, { headers: { "content-length": String(body.byteLength) }, status: 200 });
+  }) as typeof globalThis.fetch;
+  const seedRoot = join(root, "seed");
+  await mkdir(join(seedRoot, "beta", "blobs"), { recursive: true });
+  const repositoryConfigPath = join(root, "repository.json");
+  await writeFile(repositoryConfigPath, JSON.stringify({ localSeeds: [{ root: seedRoot }], remoteOrigins: [], schemaVersion: 1 }));
+  const paths = {
+    cacheRoot: join(root, "cache"),
+    dataRoot: join(root, "data"),
+    installationRoot: join(root, "installation"),
+    logsRoot: join(root, "logs"),
+    resourceRoot: join(root, "legacy-resource-projection"),
+    runtimeRoot: join(root, "runtime"),
+  };
+  await mkdir(paths.installationRoot, { recursive: true });
+  return { artifacts, bytes, fetch, manifest, manifests, metadataUrl, paths, repositoryConfigPath, root, seedRoot };
+}
+
+function request(
+  value: Awaited<ReturnType<typeof fixture>>,
+  shellVersion: string,
+  metadataUrl: string | null = value.metadataUrl,
+  releaseIntent: { kind: "exact"; releaseVersion: string } | { kind: "resume-or-bootstrap" }
+    = { kind: "exact", releaseVersion: shellVersion },
+) {
+  return {
+    attachment: {
+      id: "electron-shell",
+      shell: { digest: `sha256:${"f".repeat(64)}` as const, type: "electron", version: shellVersion },
+    },
+    discovery: { metadataUrl, target: "darwin-arm64" },
+    paths: value.paths,
+    releaseIntent,
+    repositoryConfigPath: value.repositoryConfigPath,
+    schemaVersion: STANDALONE_BOOTSTRAP_SCHEMA_VERSION,
+    scope: { channel: "beta" as const, namespace: "release-beta" },
+  };
+}
+
+async function consumeTransition(
+  value: Awaited<ReturnType<typeof fixture>>,
+  resolution: Awaited<ReturnType<typeof resolveStandaloneBootstrap>>,
+): Promise<void> {
+  const transition = resolution.handoff.transition;
+  if (transition == null) return;
+  const lifecycle = bootstrapSidecarLifecycle({
+    controlRoot: value.paths.dataRoot,
+    scope: { channel: "beta", namespace: "release-beta" },
+  });
+  const attached = await lifecycle.attach({
+    leaseMs: 60_000,
+    owner: {
+      generation: resolution.handoff.handoff.scope.generation,
+      incarnation: resolution.handoff.attachment.id,
+      key: `electron:${resolution.handoff.attachment.id}`,
+    },
+    transition,
+  });
+  if (attached.state !== "attached") throw new Error("fixture transition attachment was blocked");
+  const completed = await lifecycle.completeTransition({
+    lease: attached.credential,
+    transition,
+  });
+  if (completed.state !== "completed") throw new Error("fixture transition completion was rejected");
+  const paths = resolveClosureStorePaths({
+    channel: "beta",
+    namespace: "release-beta",
+    root: value.paths.installationRoot,
+  });
+  const descriptor = await readClosureBindingDescriptor(paths);
+  if (descriptor.attempt != null) await confirmClosureBindingAttempt(paths, descriptor.attempt);
+  await lifecycle.detach(attached.credential);
+}
+
+describe("Standalone unresolved bootstrap", () => {
+  it("classifies legacy update metadata without consuming legacy fields", async () => {
+    const legacyMetadata = Object.defineProperty({}, "control", {
+      enumerable: true,
+      get: () => {
+        throw new Error("Standalone consumed a legacy control field");
+      },
+    });
+    const input = {
+      activationPolicy: "revoke-silent",
+      channel: "beta",
+      metadata: legacyMetadata,
+      namespace: "release-beta",
+      repositoryConfigPath: "/unused/repository.json",
+      shellType: "electron",
+      shellVersion: "0.19.4-beta.1",
+      storeRoot: "/unused/store",
+      target: "darwin-arm64",
+    } as const;
+
+    expect(hasModernClosureUpdateMetadata(legacyMetadata)).toBe(false);
+    await expect(prepareStandaloneUpdate(input)).resolves.toEqual({ architecture: "legacy" });
+    await expect(prepareStandaloneUpdate({ ...input, metadata: { closure: null } }))
+      .rejects.toThrow();
+  });
+
+  it("discovers mutable latest only for an empty Store and revalidates immutable metadata", async () => {
+    const value = await fixture();
+    const resolution = await resolveStandaloneBootstrap(request(
+      value,
+      "0.19.0-beta.1",
+      value.metadataUrl,
+      { kind: "resume-or-bootstrap" },
+    ), { fetch: value.fetch });
+
+    expect(resolution.handoff.handoff.descriptor.release.version).toBe("0.19.0-beta.1");
+    expect(vi.mocked(value.fetch).mock.calls.slice(0, 2).map(([url]) => String(url))).toEqual([
+      value.metadataUrl,
+      "https://releases.example.test/beta/versions/0.19.0-beta.1/metadata.json",
+    ]);
+  });
+
+  it("fails closed when mutable discovery and immutable metadata disagree", async () => {
+    const value = await fixture();
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.endsWith("/versions/0.19.0-beta.1/metadata.json")) {
+        return Response.json({
+          channel: "beta",
+          closure: value.manifests["0.19.0-beta.2"],
+          closureControl: createClosureDistributionControl(value.manifests["0.19.0-beta.2"]),
+          releaseState: "complete",
+          releaseVersion: "0.19.0-beta.2",
+        });
+      }
+      return await value.fetch(input, init);
+    }) as typeof globalThis.fetch;
+
+    await expect(resolveStandaloneBootstrap(request(
+      value,
+      "0.19.0-beta.1",
+      value.metadataUrl,
+      { kind: "resume-or-bootstrap" },
+    ), { fetch })).rejects.toThrow(/exact version 0\.19\.0-beta\.1/u);
+    const store = resolveClosureStorePaths({
+      channel: "beta",
+      namespace: "release-beta",
+      root: value.paths.installationRoot,
+    });
+    expect((await readClosureBindingDescriptor(store)).active).toBeNull();
+  });
+
+  it("discovers, commits, and resolves one immutable generation before handoff", async () => {
+    const value = await fixture();
+    const progress: StandaloneBootstrapProgress[] = [];
+    const resolution = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), {
+      fetch: value.fetch,
+      onProgress: (entry) => progress.push(entry),
+    });
+    await consumeTransition(value, resolution);
+
+    expect(resolution.bootloaderPath).toMatch(/installations[\\/].+[\\/]darwin-arm64[\\/]launcher[\\/]bootloader\.mjs$/u);
+    expect(resolution.handoff.handoff.scope).toEqual({ channel: "beta", generation: 0, namespace: "release-beta" });
+    expect(resolution.handoff.paths.resourceRoot).toMatch(/channels[\\/]beta[\\/]resources$/u);
+    expect(resolution.handoff.closure).toEqual({
+      repositoryConfigPath: value.repositoryConfigPath,
+      storeRoot: value.paths.installationRoot,
+      target: "darwin-arm64",
+    });
+    const store = resolveClosureStorePaths({ channel: "beta", namespace: "release-beta", root: value.paths.installationRoot });
+    expect((await readClosureBindingDescriptor(store)).active?.standalone.generation).toBe(0);
+    expect((await stat(join(store.blobsRoot, value.artifacts.plugins.digest.slice("sha256:".length)))).isFile())
+      .toBe(true);
+    expect(await stat(join(store.blobsRoot, value.artifacts.skills.digest.slice("sha256:".length))).catch(() => null))
+      .toBeNull();
+    expect(progress.map((entry) => entry.stage)).toEqual(expect.arrayContaining([
+      "checking", "discovering", "downloading", "materializing", "verifying", "ready",
+    ]));
+    expect(progress.every((entry) => entry.initialLoad)).toBe(true);
+    expect(progress.filter((entry) => entry.stage === "downloading").at(-1)?.progress)
+      .toMatchObject({ completed: expect.any(Number), unit: "bytes" });
+    expect(progress.filter((entry) => entry.subject.id === "vela-runtime").map((entry) => entry.stage))
+      .toEqual(["checking", "downloading", "downloading", "verifying", "materializing", "verifying", "ready"]);
+    expect(progress.filter((entry) => entry.subject.id === "plugins").map((entry) => entry.stage))
+      .toEqual(["checking", "downloading", "downloading", "verifying", "materializing", "verifying", "ready"]);
+    expect(progress.some((entry) => entry.subject.id === "skills")).toBe(false);
+
+    const callCount = vi.mocked(value.fetch).mock.calls.length;
+    const warmProgress: StandaloneBootstrapProgress[] = [];
+    await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1", null), {
+      fetch: value.fetch,
+      onProgress: (entry) => warmProgress.push(entry),
+    });
+    expect(vi.mocked(value.fetch).mock.calls).toHaveLength(callCount);
+    expect(warmProgress.map((entry) => [entry.subject.id, entry.stage])).toEqual([
+      ["standalone", "checking"],
+      ["standalone", "verifying"],
+      ["plugins", "checking"],
+      ["plugins", "ready"],
+      ["vela-runtime", "checking"],
+      ["vela-runtime", "ready"],
+      ["standalone", "ready"],
+    ]);
+  });
+
+  it("publishes readiness only after the target Vela resource is materialized", async () => {
+    const value = await fixture();
+    const resolution = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1"),
+      { fetch: value.fetch },
+    );
+    const env = await prepareStandaloneResourceEnv({
+      ...resolution.handoff,
+      capabilities: {
+        async invoke(exchange) {
+          return { ...exchange, outcome: "unsupported" as const };
+        },
+      },
+    });
+
+    expect(env.OD_VELA_RUNTIME_LAZY).toBe("1");
+    expect(env.VELA_BIN).toMatch(new RegExp(
+      `resources[\\\\/][0-9a-f]{64}[\\\\/]bin[\\\\/]vela${process.platform === "win32" ? "\\.exe" : ""}$`,
+      "u",
+    ));
+    const resourceRoots = JSON.parse(env[STANDALONE_RESOURCE_ROOTS_ENV]!) as Record<string, string>;
+    expect(resourceRoots.plugins).toMatch(/resources[\\/][0-9a-f]{64}$/u);
+    expect(resourceRoots.skills).toBeUndefined();
+    await vi.waitFor(async () => {
+      const materialized = await stat(env.VELA_BIN!).then((entry) => entry.isFile()).catch(() => false);
+      expect(materialized).toBe(true);
+      expect((await stat(join(resourceRoots.plugins!, "plugins", "_official", "sample", "open-design.json"))).isFile())
+        .toBe(true);
+    });
+  });
+
+  it("discards only unreferenced channel resources after committed graphs are readable", async () => {
+    const value = await fixture();
+    await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch });
+    const store = resolveClosureStorePaths({
+      channel: "beta",
+      namespace: "release-beta",
+      root: value.paths.installationRoot,
+    });
+    const obsoleteResource = "a".repeat(64);
+    const obsoleteBlob = "b".repeat(64);
+    await mkdir(join(store.resourcesRoot, obsoleteResource), { recursive: true });
+    await writeFile(join(store.resourcesRoot, obsoleteResource, "stale"), "stale");
+    await mkdir(store.blobsRoot, { recursive: true });
+    await writeFile(join(store.blobsRoot, obsoleteBlob), "stale");
+
+    const result = await discardUnreferencedClosureResources(store);
+
+    expect(result).toEqual({ discardedBlobs: 1, discardedResources: 1 });
+    expect(await stat(join(store.resourcesRoot, obsoleteResource)).catch(() => null)).toBeNull();
+    expect(await stat(join(store.blobsRoot, obsoleteBlob)).catch(() => null)).toBeNull();
+    expect(await readdir(store.garbageRoot)).toHaveLength(2);
+    expect((await stat(join(store.blobsRoot, value.artifacts.vela.digest.slice("sha256:".length)))).isFile())
+      .toBe(true);
+  });
+
+  it("rejects readiness with an actionable resource error when Vela is unavailable", async () => {
+    const value = await fixture();
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === value.artifacts.vela.url) return new Response("offline", { status: 503 });
+      return await value.fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const progress: StandaloneBootstrapProgress[] = [];
+
+    await expect(resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), {
+      fetch,
+      onProgress: (entry) => progress.push(entry),
+    })).rejects.toMatchObject({ code: "resource-unavailable" });
+    expect(progress.some((entry) => entry.subject.id === "standalone" && entry.stage === "ready"))
+      .toBe(false);
+    expect(progress.some((entry) => entry.subject.id === "vela-runtime" && entry.stage === "downloading"))
+      .toBe(true);
+  });
+
+  it("rejects readiness before daemon handoff when the plugin registry is unavailable", async () => {
+    const value = await fixture();
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === value.artifacts.plugins.url) return new Response("offline", { status: 503 });
+      return await value.fetch(input, init);
+    }) as typeof globalThis.fetch;
+    const progress: StandaloneBootstrapProgress[] = [];
+
+    await expect(resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), {
+      fetch,
+      onProgress: (entry) => progress.push(entry),
+    })).rejects.toMatchObject({ code: "resource-unavailable" });
+    expect(progress.some((entry) => entry.subject.id === "plugins" && entry.stage === "downloading"))
+      .toBe(true);
+    expect(progress.some((entry) => entry.subject.id === "standalone" && entry.stage === "ready"))
+      .toBe(false);
+  });
+
+  it("cold-starts offline from a version index and required local blobs", async () => {
+    const value = await fixture();
+    await mkdir(join(value.seedRoot, "beta", "blobs"), { recursive: true });
+    await writeFile(join(value.seedRoot, "beta", "baseline.json"), JSON.stringify({
+      channel: "beta",
+      closure: value.manifest,
+      releaseState: "complete",
+      releaseVersion: "0.19.0-beta.1",
+    }));
+    for (const [name, bytes] of Object.entries(value.bytes)) {
+      const artifact = value.artifacts[name as keyof typeof value.artifacts];
+      await writeFile(join(value.seedRoot, "beta", "blobs", artifact.digest.slice("sha256:".length)), bytes);
+    }
+    const fetch = vi.fn(async () => new Response("offline", { status: 503 })) as typeof globalThis.fetch;
+    const resolution = await resolveStandaloneBootstrap(request(
+      value,
+      "0.19.0-beta.1",
+      value.metadataUrl,
+      { kind: "resume-or-bootstrap" },
+    ), { fetch });
+    expect(resolution.handoff.handoff.scope.generation).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not reinterpret a newer Shell release binding as a Standalone update", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch }),
+    );
+    const resolution = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.2"), { fetch: value.fetch });
+    await consumeTransition(value, resolution);
+
+    expect(resolution.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
+    expect(resolution.handoff.handoff.scope.generation).toBe(0);
+  });
+
+  it("keeps prepared bytes inactive until silent activation is authorized", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch }),
+    );
+    const metadata = {
+      channel: "beta",
+      closure: value.manifests["0.19.0-beta.2"],
+      closureControl: createClosureDistributionControl(value.manifests["0.19.0-beta.2"]),
+      releaseState: "complete",
+      releaseVersion: "0.19.0-beta.2",
+    };
+    const updateInput = {
+      activationPolicy: "revoke-silent",
+      channel: "beta",
+      fetch: value.fetch,
+      metadata,
+      namespace: "release-beta",
+      repositoryConfigPath: value.repositoryConfigPath,
+      shellType: "electron",
+      shellVersion: "0.19.0-beta.1",
+      storeRoot: value.paths.installationRoot,
+      target: "darwin-arm64",
+    } as const;
+
+    await prepareStandaloneUpdate(updateInput);
+    const current = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1", null),
+      { fetch: value.fetch },
+    );
+    expect(current.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
+
+    await prepareStandaloneUpdate({ ...updateInput, activationPolicy: "authorize-silent" });
+    const revoked = await prepareStandaloneUpdate(updateInput);
+    expect(revoked).toMatchObject({ activationSource: null, state: "prepared" });
+    const stillCurrent = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1", null),
+      { fetch: value.fetch },
+    );
+    expect(stillCurrent.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
+
+    await prepareStandaloneUpdate({ ...updateInput, activationPolicy: "authorize-silent" });
+    const activated = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1", null),
+      { fetch: value.fetch },
+    );
+    expect(activated.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.2");
+    await consumeTransition(value, activated);
+  });
+
+  it("does not recover an attempt while its lifecycle transition is still owned", async () => {
+    const value = await fixture();
+    const first = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1"),
+      { fetch: value.fetch },
+    );
+
+    await expect(resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1"),
+      { fetch: value.fetch },
+    )).rejects.toMatchObject({ code: "standalone-occupied" });
+
+    const store = resolveClosureStorePaths({
+      channel: "beta",
+      namespace: "release-beta",
+      root: value.paths.installationRoot,
+    });
+    expect((await readClosureBindingDescriptor(store)).attempt?.standalone.generation).toBe(0);
+    const transition = first.handoff.transition;
+    if (transition != null) {
+      const lifecycle = bootstrapSidecarLifecycle({
+        controlRoot: value.paths.dataRoot,
+        scope: { channel: "beta", namespace: "release-beta" },
+      });
+      await lifecycle.abortTransition(transition);
+    }
+  });
+
+  it("keeps Shell identity independent from Standalone update discovery", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch }),
+    );
+    const resolution = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1", value.metadataUrl, {
+        kind: "exact",
+        releaseVersion: "0.19.0-beta.2",
+      }),
+      { fetch: value.fetch },
+    );
+    await consumeTransition(value, resolution);
+
+    expect(resolution.handoff.attachment.shell.version).toBe("0.19.0-beta.1");
+    expect(resolution.handoff.handoff.descriptor.release.version).toBe("0.19.0-beta.1");
+    expect(resolution.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.1");
+  });
+
+  it("keeps a newer compatible Standalone when an older Shell attaches", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.2"), { fetch: value.fetch }),
+    );
+    const fetchCount = vi.mocked(value.fetch).mock.calls.length;
+    const resolution = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1", null), { fetch: value.fetch });
+
+    expect(resolution.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.2");
+    expect(resolution.handoff.handoff.scope.generation).toBe(0);
+    expect(vi.mocked(value.fetch).mock.calls).toHaveLength(fetchCount);
+  });
+
+  it("quick-fails when a newer Standalone raises the Shell minimum", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.3"), { fetch: value.fetch }),
+    );
+
+    await expect(resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.2", null),
+      { fetch: value.fetch },
+    )).rejects.toMatchObject({ code: "installer-required" });
+  });
+
+  it("maps shallow metadata incompatibility to installer-required before graph consumption", async () => {
+    const value = await fixture();
+    await expect(resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.2", value.metadataUrl, {
+        kind: "exact",
+        releaseVersion: "0.19.0-beta.3",
+      }),
+      { fetch: value.fetch },
+    )).rejects.toMatchObject({ code: "installer-required" });
+  });
+
+  it("quick-fails a new Shell combination while another attachment owns the namespace", async () => {
+    const value = await fixture();
+    await consumeTransition(
+      value,
+      await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch }),
+    );
+    const lifecycle = bootstrapSidecarLifecycle({
+      controlRoot: value.paths.dataRoot,
+      scope: { channel: "beta", namespace: "release-beta" },
+    });
+    const occupant = await lifecycle.attach({
+      leaseMs: 60_000,
+      owner: {
+        generation: 0,
+        incarnation: "codex-plugin-a",
+        key: "codex-plugin:codex-plugin-a",
+      },
+    });
+    if (occupant.state !== "attached") throw new Error("occupant fixture was blocked");
+
+    await expect(resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.2"),
+      { fetch: value.fetch },
+    )).rejects.toMatchObject({
+      code: "standalone-occupied",
+      message: expect.stringContaining("codex-plugin:codex-plugin-a"),
+    });
+    await expect(lifecycle.snapshot()).resolves.toMatchObject({
+      leases: [{ owner: { key: "codex-plugin:codex-plugin-a" } }],
+      transition: null,
+    });
+  });
+
+  it("repairs the exact committed version into a fresh generation without downgrade", async () => {
+    const value = await fixture();
+    const first = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.2"), { fetch: value.fetch });
+    await consumeTransition(value, first);
+    await writeFile(first.bootloaderPath, "corrupt\n", "utf8");
+
+    const repaired = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.1"), { fetch: value.fetch });
+    await consumeTransition(value, repaired);
+    expect(repaired.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.2");
+    expect(repaired.handoff.handoff.scope.generation).toBe(1);
+    expect(await readFile(repaired.bootloaderPath, "utf8")).toContain("handoff = true");
+  });
+
+  it("repairs damaged materialized bytes offline from the committed manifest and blob Store", async () => {
+    const value = await fixture();
+    const first = await resolveStandaloneBootstrap(request(value, "0.19.0-beta.2"), { fetch: value.fetch });
+    await consumeTransition(value, first);
+    await writeFile(first.bootloaderPath, "corrupt\n", "utf8");
+    const fetchCount = vi.mocked(value.fetch).mock.calls.length;
+
+    const repaired = await resolveStandaloneBootstrap(
+      request(value, "0.19.0-beta.1", null),
+      { fetch: value.fetch },
+    );
+    await consumeTransition(value, repaired);
+
+    expect(repaired.handoff.handoff.descriptor.standalone.version).toBe("0.19.0-beta.2");
+    expect(repaired.handoff.handoff.scope.generation).toBe(1);
+    expect(await readFile(repaired.bootloaderPath, "utf8")).toContain("handoff = true");
+    expect(vi.mocked(value.fetch).mock.calls).toHaveLength(fetchCount);
+  });
+});

--- a/apps/standalone/tests/exports.test.ts
+++ b/apps/standalone/tests/exports.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { acquireStandalone } from "../src/index.js";
+
+describe("Standalone app boundary", () => {
+  it("exposes the shell-neutral product lifecycle", () => {
+    expect(acquireStandalone).toBeTypeOf("function");
+  });
+});

--- a/apps/standalone/tests/generation-bootloader.test.ts
+++ b/apps/standalone/tests/generation-bootloader.test.ts
@@ -1,0 +1,126 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_PROTOCOL_VERSION,
+  createStandaloneHandoffEnvelope,
+  type StandaloneHandoffRequest,
+} from "@open-design/standalone/protocol";
+
+import { resolveStandaloneGenerationLaunch } from "../src/generation-bootloader.js";
+
+function request(): StandaloneHandoffRequest {
+  return {
+    attachment: {
+      id: "electron-a",
+      shell: {
+        digest: `sha256:${"b".repeat(64)}`,
+        type: "electron",
+        version: "0.19.0-beta.10",
+      },
+    },
+    capabilities: {
+      async invoke(value) {
+        return {
+          attachmentId: value.attachmentId,
+          handoff: value.handoff,
+          outcome: "unsupported",
+          requestId: value.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      },
+    },
+    handoff: createStandaloneHandoffEnvelope({
+      descriptor: {
+        release: { version: "0.19.0-beta.10" },
+        standalone: {
+          digest: `sha256:${"a".repeat(64)}`,
+          protocolVersion: STANDALONE_PROTOCOL_VERSION,
+          version: "0.19.0-beta.10",
+        },
+      },
+      scope: { channel: "beta", generation: 3, namespace: "release-beta" },
+    }),
+    paths: {
+      cacheRoot: "/open-design/cache",
+      dataRoot: "/open-design/data",
+      installationRoot: "/open-design/generation-3",
+      logsRoot: "/open-design/logs",
+      resourceRoot: "/open-design/resources",
+      runtimeRoot: "/open-design/runtime",
+    },
+  };
+}
+
+describe("Standalone generation bootloader", () => {
+  it("reuses the Shell-owned official Node and derives native resolution from the generation root", () => {
+    const generationRoot = request().paths.installationRoot;
+    expect(resolveStandaloneGenerationLaunch(request(), "/shell/node")).toMatchObject({
+      cwd: join(generationRoot, "body"),
+      env: {
+        NODE_OPTIONS: `--import=${pathToFileURL(join(generationRoot, "launcher", "native-loader.mjs")).href}`,
+        NODE_PATH: join(generationRoot, "native", "node_modules"),
+        OD_STANDALONE_NATIVE_ROOT: join(generationRoot, "native"),
+      },
+      executable: "/shell/node",
+      launcherPath: join(generationRoot, "launcher", "launcher.mjs"),
+      output: "inherit",
+    });
+  });
+
+  it("projects target-native Vela and OpenCode binaries without replacing explicit overrides", async () => {
+    const generationRoot = await mkdtemp(join(tmpdir(), "od-generation-tools-"));
+    const resourceRoot = join(generationRoot, "shell-resources");
+    const velaPath = join(resourceRoot, "bin", process.platform === "win32" ? "vela.exe" : "vela");
+    const openCodePath = join(
+      resourceRoot,
+      "bin",
+      "libexec",
+      "opencode",
+      process.platform === "win32" ? "opencode.exe" : "opencode",
+    );
+    await mkdir(join(resourceRoot, "bin", "libexec", "opencode"), { recursive: true });
+    await writeFile(velaPath, "vela");
+    await writeFile(openCodePath, "opencode");
+    const input = {
+      ...request(),
+      paths: { ...request().paths, installationRoot: generationRoot, resourceRoot },
+    };
+    try {
+      expect(resolveStandaloneGenerationLaunch(input).env).toMatchObject({
+        VELA_BIN: velaPath,
+        VELA_OPENCODE_BIN: openCodePath,
+      });
+      const previous = process.env.VELA_BIN;
+      process.env.VELA_BIN = "/user/vela";
+      try {
+        expect(resolveStandaloneGenerationLaunch(input).env?.VELA_BIN).toBe("/user/vela");
+      } finally {
+        if (previous == null) delete process.env.VELA_BIN;
+        else process.env.VELA_BIN = previous;
+      }
+    } finally {
+      await rm(generationRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("defaults to the Node process executing the fossil bootloader", () => {
+    expect(resolveStandaloneGenerationLaunch(request()).executable).toBe(process.execPath);
+  });
+
+  it("consumes the Shell-projected official Node without learning Shell layout", () => {
+    const previous = process.env.OD_NODE_BIN;
+    process.env.OD_NODE_BIN = "/shell/resources/bin/node";
+    try {
+      expect(resolveStandaloneGenerationLaunch(request()).executable).toBe("/shell/resources/bin/node");
+    } finally {
+      if (previous == null) delete process.env.OD_NODE_BIN;
+      else process.env.OD_NODE_BIN = previous;
+    }
+  });
+});

--- a/apps/standalone/tests/process-bridge.test.ts
+++ b/apps/standalone/tests/process-bridge.test.ts
@@ -1,0 +1,651 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_PROTOCOL_VERSION,
+  createStandaloneHandoffEnvelope,
+  type StandaloneHandle,
+  type StandaloneHandoffDescriptor,
+  type StandaloneRuntimeStatus,
+  type StandaloneRuntimeTerminalStatus,
+  type StandaloneShellCapabilityRequest,
+} from "@open-design/standalone/protocol";
+import { bootstrapSidecarLifecycle } from "@open-design/sidecar/lifecycle";
+import { bootstrapControlPlane } from "@open-design/sidecar/control";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createStandaloneLauncherBootstrapEnv,
+  readStandaloneLauncherBootstrap,
+  resolveStandaloneBodyBootloaderPath,
+  validateStandaloneLauncherBootstrap,
+} from "../src/launcher-bootstrap.js";
+import {
+  STANDALONE_BODY_BRIDGE_SERVICE,
+  connectStandaloneBodyBridge,
+  exposeStandaloneBodyBridge,
+  launchStandaloneBodyBridge,
+  resolveStandaloneShellBridgeService,
+  type StandaloneBodyBridgeMethods,
+} from "../src/process-bridge.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+async function descriptor(
+  attachmentId = "electron-a",
+  generation = 3,
+): Promise<StandaloneHandoffDescriptor> {
+  const root = await mkdtemp(join(tmpdir(), "od-standalone-process-bridge-"));
+  roots.push(root);
+  return {
+    attachment: {
+      id: attachmentId,
+      shell: {
+        digest: `sha256:${(attachmentId === "electron-a" ? "b" : "c").repeat(64)}`,
+        type: "electron",
+        version: "0.19.0-beta.10",
+      },
+    },
+    handoff: createStandaloneHandoffEnvelope({
+      descriptor: {
+        release: { version: "0.19.0-beta.10" },
+        standalone: {
+          digest: `sha256:${"a".repeat(64)}`,
+          protocolVersion: STANDALONE_PROTOCOL_VERSION,
+          version: "0.19.0-beta.10",
+        },
+      },
+      scope: { channel: "beta", generation, namespace: "release-beta" },
+    }),
+    paths: {
+      cacheRoot: join(root, "cache"),
+      dataRoot: join(root, "data"),
+      installationRoot: join(root, "installation"),
+      logsRoot: join(root, "logs"),
+      resourceRoot: join(root, "resources"),
+      runtimeRoot: join(root, "runtime"),
+    },
+  };
+}
+
+function fakeHandle(descriptor: StandaloneHandoffDescriptor): StandaloneHandle {
+  let status: StandaloneRuntimeStatus = {
+    daemonUrl: "http://127.0.0.1:43101",
+    handoff: descriptor.handoff,
+    pid: process.pid,
+    schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    state: "running",
+    webUrl: "http://127.0.0.1:43102",
+  };
+  let resolveTerminal!: (status: StandaloneRuntimeTerminalStatus) => void;
+  const terminal = new Promise<StandaloneRuntimeTerminalStatus>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  return {
+    async close() {
+      if (status.state === "running") {
+        status = {
+          handoff: descriptor.handoff,
+          pid: process.pid,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+          state: "stopped",
+        };
+        resolveTerminal(status);
+      }
+      return status as StandaloneRuntimeTerminalStatus;
+    },
+    async invoke(request) {
+      return {
+        attachmentId: request.attachmentId,
+        handoff: request.handoff,
+        outcome: "completed",
+        output: request.input,
+        requestId: request.requestId,
+        schemaVersion: request.schemaVersion,
+      };
+    },
+    async readStatus() {
+      return status;
+    },
+    async waitForTerminal() {
+      return await terminal;
+    },
+  };
+}
+
+describe("Standalone process bridge", () => {
+  it("materializes lazy resources only when the body bridge is explicitly called", async () => {
+    const binding = await descriptor();
+    const requested: string[] = [];
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async ensureResource(id) {
+        requested.push(id);
+        return { id, path: join(binding.paths.resourceRoot, id), reused: false, title: "DSH" };
+      },
+      async handoff() {
+        return fakeHandle(binding);
+      },
+    });
+    try {
+      expect(requested).toEqual([]);
+      const client = await bootstrapControlPlane({
+        projection: {
+          digest: binding.handoff.descriptorDigest,
+          value: binding.handoff.descriptor,
+        },
+        roots: {
+          dataRoot: binding.paths.dataRoot,
+          resourceRoot: binding.paths.resourceRoot,
+          runtimeRoot: binding.paths.runtimeRoot,
+        },
+        scope: binding.handoff.scope,
+      }).connect<StandaloneBodyBridgeMethods>(STANDALONE_BODY_BRIDGE_SERVICE);
+      await expect(client.call(
+        "ensureResource",
+        { id: "dsh-runtime" },
+        { timeoutMs: null },
+      )).resolves.toEqual({
+        id: "dsh-runtime",
+        path: join(binding.paths.resourceRoot, "dsh-runtime"),
+        reused: false,
+        title: "DSH",
+      });
+      expect(requested).toEqual(["dsh-runtime"]);
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("round-trips a strict launcher bootstrap without Shell capabilities", async () => {
+    const binding = await descriptor();
+    const env = createStandaloneLauncherBootstrapEnv({
+      descriptor: binding,
+    });
+
+    expect(readStandaloneLauncherBootstrap(env)).toEqual({
+      descriptor: { ...binding, transition: null },
+      schemaVersion: 1,
+    });
+    expect(resolveStandaloneBodyBootloaderPath(binding)).toBe(
+      join(binding.paths.installationRoot, "body", "bootloader.mjs"),
+    );
+    expect(() => validateStandaloneLauncherBootstrap({
+      ...readStandaloneLauncherBootstrap(env),
+      capabilities: {},
+    })).toThrow(/unsupported fields/u);
+  });
+
+  it("round-trips Shell capabilities and body lifecycle through Sidecar methods", async () => {
+    const binding = await descriptor();
+    const capabilityInputs: unknown[] = [];
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async handoff(request) {
+        await request.capabilities.invoke({
+          attachmentId: request.attachment.id,
+          capability: "open-design.test-capability.v1",
+          handoff: request.handoff,
+          input: { value: "from-body" },
+          requestId: "capability-1",
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        });
+        return fakeHandle(binding);
+      },
+    });
+    try {
+      const handle = await connectStandaloneBodyBridge({
+        descriptor: binding,
+        capabilities: {
+          async invoke(request) {
+            capabilityInputs.push(request.input);
+            return {
+              attachmentId: request.attachmentId,
+              handoff: request.handoff,
+              outcome: "completed",
+              output: { accepted: true },
+              requestId: request.requestId,
+              schemaVersion: request.schemaVersion,
+            };
+          },
+        },
+      });
+
+      expect(capabilityInputs).toEqual([{ value: "from-body" }]);
+      await expect(handle.readStatus()).resolves.toMatchObject({ state: "running" });
+      await expect(handle.invoke({
+        attachmentId: binding.attachment.id,
+        command: "open-design.echo.v1",
+        handoff: binding.handoff,
+        input: { echoed: true },
+        requestId: "command-1",
+        schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      })).resolves.toMatchObject({ outcome: "completed", output: { echoed: true } });
+      const waiting = handle.waitForTerminal();
+      await expect(handle.close()).resolves.toMatchObject({ state: "stopped" });
+      await expect(waiting).resolves.toMatchObject({ state: "stopped" });
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("lets a cold body attachment outlive the generic sidecar request deadline", async () => {
+    const binding = await descriptor();
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async handoff() {
+        await new Promise((resolve) => setTimeout(resolve, 1_600));
+        return fakeHandle(binding);
+      },
+    });
+    try {
+      const handle = await connectStandaloneBodyBridge({
+        descriptor: binding,
+        capabilities: {
+          async invoke(request) {
+            return {
+              attachmentId: request.attachmentId,
+              handoff: request.handoff,
+              outcome: "unsupported" as const,
+              requestId: request.requestId,
+              schemaVersion: request.schemaVersion,
+            };
+          },
+        },
+      });
+
+      await expect(handle.readStatus()).resolves.toMatchObject({ state: "running" });
+      await expect(handle.close()).resolves.toMatchObject({ state: "stopped" });
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("keeps transition ownership in the Shell until the body reports running", async () => {
+    const baseline = await descriptor();
+    const lifecycle = bootstrapSidecarLifecycle({
+      controlRoot: baseline.paths.dataRoot,
+      scope: {
+        channel: baseline.handoff.scope.channel,
+        namespace: baseline.handoff.scope.namespace,
+      },
+    });
+    const transition = await lifecycle.beginTransition({
+      kind: "align-standalone-to-shell",
+      leaseMs: 60_000,
+      owner: {
+        generation: baseline.handoff.scope.generation,
+        incarnation: baseline.attachment.id,
+        key: `electron:${baseline.attachment.id}`,
+      },
+    });
+    if (transition.state !== "acquired") throw new Error("transition unexpectedly blocked");
+    const binding = { ...baseline, transition: transition.credential };
+    let releaseBody!: () => void;
+    const bodyReady = new Promise<void>((resolve) => {
+      releaseBody = resolve;
+    });
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async handoff() {
+        await bodyReady;
+        return fakeHandle(binding);
+      },
+    });
+    try {
+      const connecting = connectStandaloneBodyBridge({
+        descriptor: binding,
+        capabilities: {
+          async invoke(request) {
+            return {
+              attachmentId: request.attachmentId,
+              handoff: request.handoff,
+              outcome: "unsupported" as const,
+              requestId: request.requestId,
+              schemaVersion: request.schemaVersion,
+            };
+          },
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await expect(lifecycle.snapshot()).resolves.toMatchObject({
+        leases: [{ owner: { incarnation: binding.attachment.id } }],
+        transition: { id: transition.credential.id },
+      });
+
+      releaseBody();
+      const handle = await connecting;
+      await expect(lifecycle.snapshot()).resolves.toMatchObject({
+        leases: [{ owner: { incarnation: binding.attachment.id } }],
+        transition: null,
+      });
+      await handle.close();
+    } finally {
+      releaseBody();
+      await body.close();
+    }
+  });
+
+  it("aborts a transition and detaches the Shell lease when body startup fails", async () => {
+    const baseline = await descriptor();
+    const lifecycle = bootstrapSidecarLifecycle({
+      controlRoot: baseline.paths.dataRoot,
+      scope: {
+        channel: baseline.handoff.scope.channel,
+        namespace: baseline.handoff.scope.namespace,
+      },
+    });
+    const transition = await lifecycle.beginTransition({
+      kind: "repair-standalone",
+      leaseMs: 60_000,
+      owner: {
+        generation: baseline.handoff.scope.generation,
+        incarnation: baseline.attachment.id,
+        key: `electron:${baseline.attachment.id}`,
+      },
+    });
+    if (transition.state !== "acquired") throw new Error("transition unexpectedly blocked");
+    const binding = { ...baseline, transition: transition.credential };
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async handoff() {
+        throw new Error("body failed before running");
+      },
+    });
+    try {
+      await expect(connectStandaloneBodyBridge({
+        descriptor: binding,
+        capabilities: {
+          async invoke(request) {
+            return {
+              attachmentId: request.attachmentId,
+              handoff: request.handoff,
+              outcome: "unsupported" as const,
+              requestId: request.requestId,
+              schemaVersion: request.schemaVersion,
+            };
+          },
+        },
+      })).rejects.toThrow(/body failed before running/u);
+      await expect(lifecycle.snapshot()).resolves.toMatchObject({ leases: [], transition: null });
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("stops an unowned body attachment after its Shell lease disappears", async () => {
+    const binding = await descriptor();
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: binding,
+      async handoff() {
+        return fakeHandle(binding);
+      },
+    });
+    try {
+      const handle = await connectStandaloneBodyBridge({
+        descriptor: binding,
+        capabilities: {
+          async invoke(request) {
+            return {
+              attachmentId: request.attachmentId,
+              handoff: request.handoff,
+              outcome: "unsupported" as const,
+              requestId: request.requestId,
+              schemaVersion: request.schemaVersion,
+            };
+          },
+        },
+      });
+      const terminal = handle.waitForTerminal();
+      const lifecycleRoot = join(binding.paths.dataRoot, "sidecar-lifecycle");
+      const [stateName] = (await readdir(lifecycleRoot)).filter((name) => name.endsWith(".json"));
+      const statePath = join(lifecycleRoot, stateName!);
+      const state = JSON.parse(await readFile(statePath, "utf8")) as {
+        leases: Array<{ expiresAtMs: number }>;
+      };
+      for (const lease of state.leases) lease.expiresAtMs = 0;
+      await writeFile(statePath, `${JSON.stringify(state)}\n`, "utf8");
+
+      await expect(terminal).resolves.toMatchObject({ state: "stopped" });
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("coordinates update transitions across Shell attachments without exposing sidecar credentials", async () => {
+    const firstBinding = await descriptor("electron-a", 3);
+    const secondBinding = {
+      ...firstBinding,
+      attachment: (await descriptor("codex-plugin-a", 3)).attachment,
+    };
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: firstBinding,
+      async handoff(request) {
+        return fakeHandle({
+          attachment: request.attachment,
+          handoff: request.handoff,
+          paths: request.paths,
+        });
+      },
+    });
+    const capabilities = {
+      async invoke(request: StandaloneShellCapabilityRequest) {
+        return {
+          attachmentId: request.attachmentId,
+          handoff: request.handoff,
+          outcome: "unsupported" as const,
+          requestId: request.requestId,
+          schemaVersion: request.schemaVersion,
+        };
+      },
+    };
+    try {
+      const first = await connectStandaloneBodyBridge({ capabilities, descriptor: firstBinding });
+      const second = await connectStandaloneBodyBridge({ capabilities, descriptor: secondBinding });
+
+      await expect(first.lifecycle.beginTransition("apply-shell-update")).resolves.toEqual({
+        occupants: [{
+          generation: 3,
+          incarnation: "codex-plugin-a",
+          key: "electron:codex-plugin-a",
+          projection: {
+            shellDigest: secondBinding.attachment.shell.digest,
+            shellVersion: secondBinding.attachment.shell.version,
+          },
+        }],
+        reason: "occupied",
+        state: "blocked",
+      });
+
+      await second.close();
+      const acquired = await first.lifecycle.beginTransition("apply-shell-update");
+      expect(acquired.state).toBe("acquired");
+      if (acquired.state !== "acquired") throw new Error("update transition unexpectedly blocked");
+
+      const lifecycle = bootstrapSidecarLifecycle({
+        controlRoot: firstBinding.paths.dataRoot,
+        scope: {
+          channel: firstBinding.handoff.scope.channel,
+          namespace: firstBinding.handoff.scope.namespace,
+        },
+      });
+      await expect(lifecycle.snapshot()).resolves.toMatchObject({
+        leases: [{ owner: { incarnation: firstBinding.attachment.id } }],
+        transition: { kind: "apply-shell-update" },
+      });
+      await acquired.transition.release();
+      await expect(lifecycle.snapshot()).resolves.toMatchObject({
+        leases: [{ owner: { incarnation: firstBinding.attachment.id } }],
+        transition: null,
+      });
+      await first.close();
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("derives attachment-local services and fences a different generation", async () => {
+    const current = await descriptor("electron-a", 3);
+    const sibling = { ...current, attachment: (await descriptor("electron-b", 3)).attachment };
+    const stale = { ...current, handoff: (await descriptor("electron-a", 2)).handoff };
+    expect(resolveStandaloneShellBridgeService(current)).not.toBe(
+      resolveStandaloneShellBridgeService(sibling),
+    );
+
+    const body = await exposeStandaloneBodyBridge({
+      descriptor: current,
+      async handoff(request) {
+        return fakeHandle({
+          attachment: request.attachment,
+          handoff: request.handoff,
+          paths: request.paths,
+        });
+      },
+    });
+    try {
+      const unsupportedCapabilities = {
+        async invoke(request: StandaloneShellCapabilityRequest) {
+          return {
+            attachmentId: request.attachmentId,
+            handoff: request.handoff,
+            outcome: "unsupported" as const,
+            requestId: request.requestId,
+            schemaVersion: request.schemaVersion,
+          };
+        },
+      };
+      const first = await connectStandaloneBodyBridge({
+        capabilities: unsupportedCapabilities,
+        descriptor: current,
+      });
+      const second = await connectStandaloneBodyBridge({
+        capabilities: unsupportedCapabilities,
+        descriptor: sibling,
+      });
+      await expect(first.close()).resolves.toMatchObject({ state: "stopped" });
+      await expect(second.readStatus()).resolves.toMatchObject({ state: "running" });
+      await expect(second.close()).resolves.toMatchObject({ state: "stopped" });
+
+      await expect(connectStandaloneBodyBridge({
+        capabilities: unsupportedCapabilities,
+        descriptor: stale,
+      })).rejects.toThrow(/unavailable/u);
+    } finally {
+      await body.close();
+    }
+  });
+
+  it("launches the bundled launcher.mjs in a real Node body process", async () => {
+    const binding = await descriptor();
+    const bodyBootloaderPath = resolveStandaloneBodyBootloaderPath(binding);
+    await mkdir(join(binding.paths.installationRoot, "body"), { recursive: true });
+    await writeFile(bodyBootloaderPath, `
+export async function handoff(request) {
+  let terminalResolve;
+  const terminal = new Promise((resolve) => { terminalResolve = resolve; });
+  await request.capabilities.invoke({
+    attachmentId: request.attachment.id,
+    capability: "open-design.real-process.v1",
+    handoff: request.handoff,
+    input: { process: "body" },
+    requestId: "real-process-capability",
+    schemaVersion: 1,
+  });
+  let status = {
+    daemonUrl: "http://127.0.0.1:44101",
+    handoff: request.handoff,
+    pid: process.pid,
+    schemaVersion: 1,
+    state: "running",
+    webUrl: "http://127.0.0.1:44102",
+  };
+  return {
+    async close() {
+      if (status.state === "running") {
+        status = {
+          handoff: request.handoff,
+          pid: process.pid,
+          schemaVersion: 1,
+          state: "stopped",
+        };
+        terminalResolve(status);
+      }
+      return status;
+    },
+    async invoke(command) {
+      return {
+        attachmentId: command.attachmentId,
+        handoff: command.handoff,
+        outcome: "completed",
+        output: { bodyPid: process.pid },
+        requestId: command.requestId,
+        schemaVersion: command.schemaVersion,
+      };
+    },
+    async readStatus() { return status; },
+    async waitForTerminal() { return await terminal; },
+  };
+}
+`, "utf8");
+    const capabilityInputs: unknown[] = [];
+    const capabilities = {
+      async invoke(request: StandaloneShellCapabilityRequest) {
+        capabilityInputs.push(request.input);
+        return {
+          attachmentId: request.attachmentId,
+          handoff: request.handoff,
+          outcome: "completed" as const,
+          output: { accepted: true },
+          requestId: request.requestId,
+          schemaVersion: request.schemaVersion,
+        };
+      },
+    };
+    const launch = {
+      executable: process.execPath,
+      launcherPath: join(import.meta.dirname, "..", "dist", "launcher.mjs"),
+      readyTimeoutMs: 5_000,
+    };
+    const first = await launchStandaloneBodyBridge({
+      capabilities,
+      descriptor: binding,
+      launch,
+    });
+    const sibling = {
+      ...binding,
+      attachment: (await descriptor("electron-b", binding.handoff.scope.generation)).attachment,
+    };
+    const second = await launchStandaloneBodyBridge({
+      capabilities,
+      descriptor: sibling,
+      launch,
+    });
+
+    expect(capabilityInputs).toEqual([{ process: "body" }, { process: "body" }]);
+    const firstStatus = await first.readStatus();
+    const secondStatus = await second.readStatus();
+    expect(firstStatus).toMatchObject({ state: "running" });
+    expect(firstStatus.pid).not.toBe(process.pid);
+    expect(secondStatus.pid).toBe(firstStatus.pid);
+    await expect(first.invoke({
+      attachmentId: binding.attachment.id,
+      command: "open-design.real-process.v1",
+      handoff: binding.handoff,
+      input: null,
+      requestId: "real-process-command",
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    })).resolves.toMatchObject({
+      outcome: "completed",
+      output: { bodyPid: firstStatus.pid },
+    });
+    await expect(first.close()).resolves.toMatchObject({ state: "stopped" });
+    await expect(second.readStatus()).resolves.toMatchObject({ state: "running" });
+    await expect(second.close()).resolves.toMatchObject({ state: "stopped" });
+  });
+});

--- a/apps/standalone/tests/protocol.test.ts
+++ b/apps/standalone/tests/protocol.test.ts
@@ -1,0 +1,538 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STANDALONE_BOOTLOADER_ENTRY_PATH,
+  STANDALONE_HANDOFF_SCHEMA_VERSION,
+  STANDALONE_PROTOCOL_VERSION,
+  STANDALONE_RUNTIME_COMMANDS,
+  STANDALONE_SHELL_CAPABILITIES,
+  STANDALONE_UPDATER_SCHEMA_VERSION,
+  compareStandaloneVersions,
+  createStandalonePrepareUpdateCommandInput,
+  createStandaloneHandoffEnvelope,
+  validateStandaloneBootstrapDescriptor,
+  validateStandaloneBootstrapProgress,
+  validateStandaloneBootstrapResult,
+  validateStandaloneBootstrapRequest,
+  validateStandaloneBootstrapResolution,
+  validateStandaloneHandoffDescriptor,
+  validateStandaloneHandoffRequest,
+  validateStandaloneHandoffEnvelope,
+  validateStandaloneRuntimeStatus,
+  validateStandaloneRuntimeCommandRequest,
+  validateStandaloneRuntimeCommandResult,
+  validateStandalonePrepareUpdateCommandInput,
+  validateStandaloneShellCapabilityResult,
+  validateStandaloneShellCapabilityInput,
+  validateStandaloneShellCapabilityOutput,
+  validateStandaloneUpdatePreparation,
+  validateStandaloneUpdaterActionRequest,
+  validateStandaloneUpdaterActionResult,
+  validateStandaloneUpdaterProviderDescriptor,
+  validateStandaloneUpdaterSnapshot,
+  validateStandaloneUpdaterWaitRequest,
+  type StandaloneHandoffRequest,
+} from "../src/protocol/index.js";
+
+const digest = `sha256:${"a".repeat(64)}` as const;
+const shellDigest = `sha256:${"b".repeat(64)}` as const;
+
+function request(): StandaloneHandoffRequest {
+  return {
+    attachment: {
+      id: "electron-a",
+      shell: {
+        digest: shellDigest,
+        type: "electron",
+        version: "0.18.0-beta.1",
+      },
+    },
+    capabilities: {
+      async invoke(value) {
+        return {
+          attachmentId: value.attachmentId,
+          handoff: value.handoff,
+          outcome: "unsupported",
+          requestId: value.requestId,
+          schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+        };
+      },
+    },
+    handoff: createStandaloneHandoffEnvelope({
+      descriptor: {
+        release: { version: "0.18.0-beta.4" },
+        standalone: {
+          digest,
+          protocolVersion: STANDALONE_PROTOCOL_VERSION,
+          version: "0.18.0-beta.4",
+        },
+      },
+      scope: {
+        channel: "beta",
+        generation: 7,
+        namespace: "release-beta",
+      },
+    }),
+    paths: {
+      cacheRoot: "/open-design/cache",
+      dataRoot: "/open-design/data",
+      installationRoot: "/open-design/install",
+      logsRoot: "/open-design/logs",
+      resourceRoot: "/open-design/resources",
+      runtimeRoot: "/open-design/runtime",
+    },
+    transition: null,
+  };
+}
+
+describe("Standalone bootloader protocol", () => {
+  it("validates optional quantitative bootstrap progress without inventing percentages", () => {
+    expect(validateStandaloneBootstrapProgress({
+      initialLoad: true,
+      progress: { completed: 8, total: 16, unit: "bytes" },
+      schemaVersion: 2,
+      stage: "downloading",
+      subject: { id: "vela-runtime", kind: "resource", title: "Local engine" },
+    })).toEqual({
+      initialLoad: true,
+      progress: { completed: 8, total: 16, unit: "bytes" },
+      schemaVersion: 2,
+      stage: "downloading",
+      subject: { id: "vela-runtime", kind: "resource", title: "Local engine" },
+    });
+    expect(validateStandaloneBootstrapProgress({
+      initialLoad: false,
+      schemaVersion: 2,
+      stage: "verifying",
+      subject: { id: "standalone", kind: "standalone", title: "Standalone" },
+    })).not.toHaveProperty("progress");
+    expect(() => validateStandaloneBootstrapProgress({
+      initialLoad: true,
+      progress: { completed: 17, total: 16, unit: "bytes" },
+      schemaVersion: 2,
+      stage: "downloading",
+      subject: { id: "vela-runtime", kind: "resource", title: "Local engine" },
+    })).toThrow(/completed <= total/u);
+    expect(() => validateStandaloneBootstrapProgress({
+      initialLoad: true,
+      schemaVersion: 2,
+      stage: "guessing",
+      subject: { id: "standalone", kind: "standalone", title: "Standalone" },
+    })).toThrow(/stage/u);
+  });
+
+  it("separates unresolved discovery scope from the active generation handoff", () => {
+    const full = request();
+    const bootstrap = {
+      attachment: full.attachment,
+      capabilities: full.capabilities,
+      discovery: {
+        metadataUrl: "https://releases.example.test/beta/latest/metadata.json",
+        target: "darwin-arm64",
+      },
+      paths: full.paths,
+      releaseIntent: { kind: "exact", releaseVersion: "0.18.0-beta.4" },
+      repositoryConfigPath: "/shell/resources/repository.json",
+      schemaVersion: 2,
+      scope: { channel: "beta", namespace: "release-beta" },
+    };
+    expect(validateStandaloneBootstrapRequest(bootstrap)).toMatchObject({
+      discovery: { target: "darwin-arm64" },
+      scope: { channel: "beta", namespace: "release-beta" },
+    });
+    const { capabilities: _capabilities, ...descriptor } = bootstrap;
+    expect(validateStandaloneBootstrapDescriptor(descriptor)).toMatchObject({ schemaVersion: 2 });
+    expect(() => validateStandaloneBootstrapDescriptor({
+      ...descriptor,
+      releaseIntent: undefined,
+      releaseVersion: "0.18.0-beta.4",
+    })).toThrow(/unsupported fields|release intent/u);
+    expect(bootstrap).not.toHaveProperty("generation");
+    expect(bootstrap).not.toHaveProperty("handoff");
+    expect(validateStandaloneBootstrapResolution({
+      bootloaderPath: "/open-design/generation/launcher/bootloader.mjs",
+      handoff: {
+        attachment: full.attachment,
+        handoff: full.handoff,
+        paths: full.paths,
+        transition: null,
+      },
+    })).toMatchObject({ handoff: { handoff: { scope: { generation: 7 } } } });
+    expect(validateStandaloneBootstrapResult({
+      outcome: "rejected",
+      error: { code: "installer-required", message: "Install a newer Shell" },
+      schemaVersion: 1,
+    })).toMatchObject({ error: { code: "installer-required" }, outcome: "rejected" });
+    expect(() => validateStandaloneBootstrapResult({
+      outcome: "rejected",
+      error: { code: "retry-another-version", message: "unsafe fallback" },
+      schemaVersion: 1,
+    })).toThrow(/error code/u);
+  });
+
+  it("preserves the reserved local coordination domain across bootstrap and handoff", () => {
+    const full = request();
+    const localHandoff = createStandaloneHandoffEnvelope({
+      descriptor: {
+        release: { version: "0.19.1-local.1" },
+        standalone: {
+          digest,
+          protocolVersion: STANDALONE_PROTOCOL_VERSION,
+          version: "0.19.1-local.1",
+        },
+      },
+      scope: { channel: "local", generation: 0, namespace: "local-test" },
+    });
+
+    expect(validateStandaloneBootstrapDescriptor({
+      attachment: full.attachment,
+      discovery: { metadataUrl: null, target: "darwin-arm64" },
+      paths: full.paths,
+      releaseIntent: { kind: "resume-or-bootstrap" },
+      repositoryConfigPath: "/shell/resources/repository.json",
+      schemaVersion: 2,
+      scope: { channel: "local", namespace: "local-test" },
+    }).scope.channel).toBe("local");
+    expect(validateStandaloneHandoffEnvelope(localHandoff).scope.channel).toBe("local");
+  });
+
+  it("round-trips the transport-neutral handoff descriptor as JSON", () => {
+    const full = request();
+    const descriptor = validateStandaloneHandoffDescriptor({
+      attachment: full.attachment,
+      handoff: full.handoff,
+      paths: full.paths,
+    });
+
+    expect(validateStandaloneHandoffDescriptor(
+      JSON.parse(JSON.stringify(descriptor)),
+    )).toEqual(descriptor);
+    expect(descriptor).not.toHaveProperty("capabilities");
+    expect(() => validateStandaloneHandoffDescriptor({
+      ...descriptor,
+      capabilities: full.capabilities,
+    })).toThrow(/unsupported fields/u);
+  });
+
+  it("fixes the fossil entry while keeping channel and namespace independent", () => {
+    expect(STANDALONE_BOOTLOADER_ENTRY_PATH).toBe("bootloader.mjs");
+    expect(validateStandaloneHandoffRequest(request())).toMatchObject({
+      attachment: {
+        id: "electron-a",
+        shell: { type: "electron", version: "0.18.0-beta.1" },
+      },
+      handoff: {
+        descriptor: {
+          release: { version: "0.18.0-beta.4" },
+          standalone: { version: "0.18.0-beta.4" },
+        },
+        scope: {
+          channel: "beta",
+          namespace: "release-beta",
+          generation: 7,
+        },
+      },
+    });
+
+    expect(() => validateStandaloneHandoffRequest({
+      ...request(),
+      handoff: {
+        ...request().handoff,
+        scope: { ...request().handoff.scope, namespace: "Beta Namespace" },
+      },
+    })).toThrow(/namespace/);
+  });
+
+  it("compares shell floors without importing update policy", () => {
+    expect(compareStandaloneVersions("0.18.0-beta.4", "0.18.0-beta.3")).toBe(1);
+    expect(compareStandaloneVersions("0.18.0-beta.4", "0.18.0")).toBe(-1);
+    expect(compareStandaloneVersions("0.18.0", "0.18.0-beta.4")).toBe(1);
+  });
+
+  it("separates release presentation from Shell and Standalone compatibility truth", () => {
+    const handoff = request().handoff;
+    expect(handoff.descriptor).toEqual({
+      release: { version: "0.18.0-beta.4" },
+      standalone: {
+        digest,
+        protocolVersion: STANDALONE_PROTOCOL_VERSION,
+        version: "0.18.0-beta.4",
+      },
+    });
+    expect(() => validateStandaloneHandoffEnvelope({
+      ...handoff,
+      descriptor: {
+        ...handoff.descriptor,
+        release: { version: "0.18.0-beta.5" },
+      },
+    })).toThrow(/descriptorDigest/);
+  });
+
+  it("fences capability results and runtime status to the exact handoff", () => {
+    const handoff = request().handoff;
+    expect(validateStandaloneShellCapabilityResult({
+      attachmentId: request().attachment.id,
+      handoff,
+      outcome: "completed",
+      output: { path: "/tmp/export.pdf" },
+      requestId: "export-1",
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    }, {
+      attachmentId: request().attachment.id,
+      handoff,
+      requestId: "export-1",
+    })).toMatchObject({ outcome: "completed" });
+
+    expect(validateStandaloneRuntimeStatus({
+      handoff,
+      daemonUrl: "http://127.0.0.1:4100",
+      pid: 42,
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      state: "running",
+      webUrl: "http://127.0.0.1:4200",
+    }, { handoff, state: "running" })).toMatchObject({
+      daemonUrl: "http://127.0.0.1:4100",
+      state: "running",
+      webUrl: "http://127.0.0.1:4200",
+    });
+
+    const wrongHandoff = createStandaloneHandoffEnvelope({
+      descriptor: handoff.descriptor,
+      scope: {
+        ...handoff.scope,
+        generation: handoff.scope.generation + 1,
+      },
+    });
+    expect(() => validateStandaloneRuntimeStatus({
+      handoff: wrongHandoff,
+      pid: 42,
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+      state: "stopped",
+    }, { handoff })).toThrow(/active generation/);
+  });
+
+  it("owns the typed rendering capability payloads on both sides of the handoff", () => {
+    expect(validateStandaloneShellCapabilityInput(
+      STANDALONE_SHELL_CAPABILITIES.EXPORT_PDF,
+      {
+        deck: false,
+        defaultFilename: "artifact.pdf",
+        html: "<main>artifact</main>",
+        title: "Artifact",
+      },
+    )).toMatchObject({ deck: false, defaultFilename: "artifact.pdf" });
+    expect(() => validateStandaloneShellCapabilityInput(
+      STANDALONE_SHELL_CAPABILITIES.EXPORT_PDF,
+      { html: "<main>missing contract fields</main>" },
+    )).toThrow(/deck/);
+
+    expect(validateStandaloneShellCapabilityOutput(
+      STANDALONE_SHELL_CAPABILITIES.RENDER_SLIDES,
+      { ok: true, slides: ["data:image/png;base64,AA=="] },
+    )).toEqual({ ok: true, slides: ["data:image/png;base64,AA=="] });
+    expect(() => validateStandaloneShellCapabilityOutput(
+      STANDALONE_SHELL_CAPABILITIES.RENDER_SLIDES,
+      { ok: true, slides: [42] },
+    )).toThrow(/array of strings/);
+  });
+
+  it("fences Shell-to-Standalone commands to the active generation", () => {
+    const handoff = request().handoff;
+    const command = validateStandaloneRuntimeCommandRequest({
+      attachmentId: request().attachment.id,
+      command: "open-design.register-desktop-auth.v1",
+      handoff,
+      input: { secret: "dGVzdA==" },
+      requestId: "desktop-auth-1",
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    }, { attachmentId: request().attachment.id, handoff });
+    expect(validateStandaloneRuntimeCommandResult({
+      attachmentId: command.attachmentId,
+      handoff,
+      outcome: "completed",
+      output: { accepted: true },
+      requestId: command.requestId,
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    }, {
+      attachmentId: command.attachmentId,
+      handoff,
+      requestId: command.requestId,
+    })).toMatchObject({ outcome: "completed" });
+
+    expect(() => validateStandaloneRuntimeCommandResult({
+      attachmentId: command.attachmentId,
+      handoff,
+      outcome: "unsupported",
+      requestId: "other-request",
+      schemaVersion: STANDALONE_HANDOFF_SCHEMA_VERSION,
+    }, {
+      attachmentId: command.attachmentId,
+      handoff,
+      requestId: command.requestId,
+    })).toThrow(/requestId/);
+  });
+
+  it("owns one immutable v2 prepare-update dialect for both Shell and Standalone", () => {
+    expect(STANDALONE_RUNTIME_COMMANDS.PREPARE_UPDATE).toBe("open-design.prepare-update.v2");
+    expect(createStandalonePrepareUpdateCommandInput(
+      { channel: "beta", closure: { schemaVersion: 4 } },
+      "authorize-user",
+    )).toEqual({
+      activationPolicy: "authorize-user",
+      metadata: { channel: "beta", closure: { schemaVersion: 4 } },
+    });
+    expect(() => validateStandalonePrepareUpdateCommandInput({
+      activationPolicy: "authorize-user",
+      activationSource: "user-restart",
+      metadata: {},
+    })).toThrow(/unsupported fields/u);
+    expect(() => validateStandalonePrepareUpdateCommandInput({
+      activationPolicy: "future-policy",
+      metadata: {},
+    })).toThrow(/activation policy/u);
+
+    expect(validateStandaloneUpdatePreparation({
+      activationSource: "user-restart",
+      architecture: "standalone",
+      releaseVersion: "0.19.4-beta.38",
+      route: "closure",
+      state: "prepared",
+    })).toMatchObject({ activationSource: "user-restart", state: "prepared" });
+    expect(() => validateStandaloneUpdatePreparation({
+      activateOnRestart: true,
+      architecture: "standalone",
+      releaseVersion: "0.19.4-beta.38",
+      route: "closure",
+      state: "prepared",
+    })).toThrow(/unsupported fields/u);
+  });
+});
+
+describe("Standalone updater provider protocol", () => {
+  const handoff = request().handoff;
+  const standaloneProvider = {
+    handoff,
+    incarnation: "standalone-update-1",
+    owner: "standalone",
+    providerId: "standalone-update",
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  } as const;
+  const shellProvider = {
+    attachmentId: "electron-a",
+    handoff,
+    hostScope: "electron-updater-a",
+    incarnation: "electron-update-1",
+    owner: "shell",
+    providerId: "electron-update",
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  } as const;
+
+  it("separates namespace-shared Standalone and attachment-local Shell providers", () => {
+    expect(validateStandaloneUpdaterProviderDescriptor(standaloneProvider)).toEqual(standaloneProvider);
+    expect(validateStandaloneUpdaterProviderDescriptor(shellProvider)).toEqual(shellProvider);
+    expect(() => validateStandaloneUpdaterProviderDescriptor({
+      ...shellProvider,
+      attachmentId: undefined,
+    })).toThrow(/attachmentId/u);
+    expect(() => validateStandaloneUpdaterProviderDescriptor({
+      ...standaloneProvider,
+      attachmentId: "electron-a",
+    })).toThrow(/attachment/u);
+    expect(() => validateStandaloneUpdaterProviderDescriptor({
+      ...shellProvider,
+      installerPath: "/private/provider-state/OpenDesign.dmg",
+    })).toThrow(/unsupported fields/u);
+  });
+
+  it("projects progress and opaque presentation without exposing action semantics", () => {
+    const snapshot = validateStandaloneUpdaterSnapshot({
+      actions: [{
+        emphasis: "primary",
+        id: "apply-current-update",
+        label: "Install and restart",
+      }],
+      presentation: {
+        detail: "Open Design 0.19.1 is ready.",
+        title: "Update ready",
+      },
+      progress: { completed: 40, total: 100 },
+      provider: standaloneProvider,
+      revision: 4,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      state: "ready",
+    }, { provider: standaloneProvider });
+
+    expect(snapshot.actions[0]).toEqual({
+      emphasis: "primary",
+      id: "apply-current-update",
+      label: "Install and restart",
+    });
+    expect(snapshot.progress).toEqual({ completed: 40, total: 100 });
+    expect(snapshot).not.toHaveProperty("restart");
+    expect(snapshot).not.toHaveProperty("installerPath");
+  });
+
+  it("bounds wait-for-change and fences actions to one provider incarnation", () => {
+    expect(validateStandaloneUpdaterWaitRequest({
+      afterRevision: 4,
+      provider: shellProvider,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      timeoutMs: 30_000,
+    }, { provider: shellProvider })).toMatchObject({ afterRevision: 4, timeoutMs: 30_000 });
+    expect(() => validateStandaloneUpdaterWaitRequest({
+      afterRevision: 4,
+      provider: shellProvider,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      timeoutMs: 30_001,
+    })).toThrow(/timeoutMs/u);
+
+    const action = validateStandaloneUpdaterActionRequest({
+      actionId: "open-installer",
+      provider: shellProvider,
+      requestId: "update-action-1",
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    }, { provider: shellProvider });
+    expect(validateStandaloneUpdaterActionResult({
+      actionId: action.actionId,
+      operationId: "installer-handoff-1",
+      outcome: "accepted",
+      provider: shellProvider,
+      requestId: action.requestId,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    }, {
+      actionId: action.actionId,
+      provider: shellProvider,
+      requestId: action.requestId,
+    })).toMatchObject({ outcome: "accepted", operationId: "installer-handoff-1" });
+    expect(() => validateStandaloneUpdaterActionResult({
+      actionId: action.actionId,
+      outcome: "unsupported",
+      provider: { ...shellProvider, incarnation: "electron-update-2" },
+      requestId: action.requestId,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    }, {
+      actionId: action.actionId,
+      provider: shellProvider,
+      requestId: action.requestId,
+    })).toThrow(/provider/u);
+  });
+
+  it("treats handed-off as terminal after an accepted destructive action", () => {
+    expect(validateStandaloneUpdaterSnapshot({
+      actions: [],
+      presentation: { title: "Installer opened" },
+      provider: shellProvider,
+      revision: 5,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      state: "handed-off",
+    })).toMatchObject({ revision: 5, state: "handed-off" });
+    expect(() => validateStandaloneUpdaterSnapshot({
+      actions: [{ emphasis: "primary", id: "again", label: "Open again" }],
+      presentation: { title: "Installer opened" },
+      provider: shellProvider,
+      revision: 5,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      state: "handed-off",
+    })).toThrow(/terminal/u);
+  });
+});

--- a/apps/standalone/tests/runtime-lifecycle.test.ts
+++ b/apps/standalone/tests/runtime-lifecycle.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  acquireStandalone,
+  type StandaloneDependencies,
+  type StandalonePaths,
+  type StandaloneRuntimeHandle,
+  type StandaloneRuntimeStatus,
+} from "../src/runtime/index.js";
+
+type TestStatus = StandaloneRuntimeStatus & { pid: number };
+
+const paths: StandalonePaths = {
+  cacheRoot: "/channel/namespaces/release-beta/cache",
+  dataRoot: "/channel/namespaces/release-beta/data",
+  installationRoot: "/channel",
+  logsRoot: "/channel/namespaces/release-beta/logs",
+  resourceRoot: "/closure/resources",
+  runtimeRoot: "/channel/namespaces/release-beta/run",
+};
+
+function runtime(
+  status: TestStatus,
+  close: () => Promise<void>,
+): StandaloneRuntimeHandle<TestStatus> {
+  return {
+    close,
+    readStatus: async () => status,
+    status,
+  };
+}
+
+function fixture(options: { failWeb?: boolean } = {}) {
+  const events: string[] = [];
+  const daemonStatus: TestStatus = {
+    pid: 100,
+    state: "running",
+    url: "http://127.0.0.1:4100",
+  };
+  const webStatus: TestStatus = {
+    pid: 200,
+    state: "running",
+    url: "http://127.0.0.1:4200",
+  };
+  const dependencies: StandaloneDependencies<TestStatus, TestStatus> = {
+    onDiagnostic: (value) => events.push(`phase:${value.phase}`),
+    preparePaths: vi.fn(async (received) => {
+      events.push("prepare");
+      expect(received).toEqual(paths);
+    }),
+    registerWebUrl: vi.fn(async ({ daemon, webUrl }) => {
+      events.push(`register:${daemon.pid}:${webUrl}`);
+    }),
+    startDaemon: vi.fn(async ({ namespace, paths: received }) => {
+      events.push(`daemon:start:${namespace}`);
+      expect(received).toEqual(paths);
+      return runtime(daemonStatus, async () => {
+        events.push("daemon:close");
+      });
+    }),
+    startWeb: vi.fn(async ({ daemon, namespace, paths: received }) => {
+      events.push(`web:start:${namespace}:${daemon.pid}`);
+      expect(received).toEqual(paths);
+      if (options.failWeb === true) throw new Error("web boot failed");
+      return runtime(webStatus, async () => {
+        events.push("web:close");
+      });
+    }),
+  };
+  return { daemonStatus, dependencies, events, webStatus };
+}
+
+describe("acquireStandalone", () => {
+  it("owns ordered Web + daemon readiness and preserves launcher paths", async () => {
+    const { dependencies, events } = fixture();
+
+    const closure = await acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    });
+
+    expect(closure.webUrl).toBe("http://127.0.0.1:4200");
+    expect(closure.paths).toEqual(paths);
+    expect(closure.diagnostic()).toMatchObject({
+      daemonUrl: "http://127.0.0.1:4100",
+      error: null,
+      namespace: "release-beta",
+      phase: "running",
+      webUrl: "http://127.0.0.1:4200",
+    });
+    expect(events).toEqual([
+      "phase:preparing",
+      "prepare",
+      "phase:daemon-starting",
+      "daemon:start:release-beta",
+      "phase:daemon-ready",
+      "phase:web-starting",
+      "web:start:release-beta:100",
+      "register:100:http://127.0.0.1:4200",
+      "phase:web-ready",
+      "phase:running",
+    ]);
+  });
+
+  it("reports product health for both runtimes", async () => {
+    const { daemonStatus, dependencies, webStatus } = fixture();
+    const closure = await acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    });
+
+    await expect(closure.health()).resolves.toEqual({
+      daemon: daemonStatus,
+      issues: [],
+      namespace: "release-beta",
+      state: "healthy",
+      web: webStatus,
+    });
+  });
+
+  it("converges started children when Web startup fails", async () => {
+    const { dependencies, events } = fixture({ failWeb: true });
+
+    await expect(acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    })).rejects.toThrow("web boot failed");
+
+    expect(events.slice(-2)).toEqual(["daemon:close", "phase:failed"]);
+  });
+
+  it("closes Web and daemon when readiness publication fails", async () => {
+    const { dependencies, events } = fixture();
+    dependencies.registerWebUrl = vi.fn(async () => {
+      throw new Error("registration failed");
+    });
+
+    await expect(acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    })).rejects.toThrow("registration failed");
+
+    expect(events.slice(-3)).toEqual([
+      "web:close",
+      "daemon:close",
+      "phase:failed",
+    ]);
+  });
+
+  it("reports a degraded product when either runtime loses health", async () => {
+    const { dependencies } = fixture();
+    dependencies.startWeb = vi.fn(async () => ({
+      close: async () => undefined,
+      readStatus: async () => {
+        throw new Error("web status unavailable");
+      },
+      status: {
+        pid: 200,
+        state: "running",
+        url: "http://127.0.0.1:4200",
+      },
+    }));
+    const closure = await acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    });
+
+    await expect(closure.health()).resolves.toMatchObject({
+      issues: ["web: web status unavailable"],
+      state: "degraded",
+      web: null,
+    });
+  });
+
+  it("closes Web before daemon and makes shutdown idempotent", async () => {
+    const { dependencies, events } = fixture();
+    const closure = await acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    });
+
+    await Promise.all([closure.close(), closure.close()]);
+
+    expect(events.slice(-4)).toEqual([
+      "phase:stopping",
+      "web:close",
+      "daemon:close",
+      "phase:stopped",
+    ]);
+    await expect(closure.health()).resolves.toMatchObject({ state: "stopped" });
+  });
+
+  it("still closes daemon when Web shutdown fails", async () => {
+    const { dependencies, events } = fixture();
+    dependencies.startWeb = vi.fn(async () => runtime(
+      { pid: 200, state: "running", url: "http://127.0.0.1:4200" },
+      async () => {
+        events.push("web:close");
+        throw new Error("web close failed");
+      },
+    ));
+    const closure = await acquireStandalone({
+      dependencies,
+      namespace: "release-beta",
+      paths,
+    });
+
+    await expect(closure.close()).rejects.toThrow(
+      "failed to stop every standalone runtime",
+    );
+    expect(events).toContain("daemon:close");
+    expect(closure.diagnostic()).toMatchObject({ phase: "failed" });
+  });
+});

--- a/apps/standalone/tests/updater-contract.test.ts
+++ b/apps/standalone/tests/updater-contract.test.ts
@@ -1,0 +1,174 @@
+import {
+  STANDALONE_PROTOCOL_VERSION,
+  STANDALONE_UPDATER_SCHEMA_VERSION,
+  createStandaloneHandoffEnvelope,
+  validateStandaloneUpdaterActionRequest,
+  validateStandaloneUpdaterActionResult,
+  validateStandaloneUpdaterSnapshot,
+  validateStandaloneUpdaterWaitRequest,
+  type StandaloneUpdaterActionRequest,
+  type StandaloneUpdaterActionResult,
+  type StandaloneUpdaterProviderDescriptor,
+  type StandaloneUpdaterProviderPort,
+  type StandaloneUpdaterSnapshot,
+  type StandaloneUpdaterWaitRequest,
+} from "@open-design/standalone/protocol";
+import { describe, expect, it } from "vitest";
+
+const handoff = createStandaloneHandoffEnvelope({
+  descriptor: {
+    release: { version: "0.19.0-beta.10" },
+    standalone: {
+      digest: `sha256:${"a".repeat(64)}`,
+      protocolVersion: STANDALONE_PROTOCOL_VERSION,
+      version: "0.19.0-beta.10",
+    },
+  },
+  scope: { channel: "beta", generation: 3, namespace: "release-beta" },
+});
+
+function provider(
+  owner: "shell" | "standalone",
+  incarnation: string,
+): StandaloneUpdaterProviderDescriptor {
+  return owner === "shell"
+    ? {
+        attachmentId: "electron-a",
+        handoff,
+        hostScope: "electron-updater-a",
+        incarnation,
+        owner,
+        providerId: "electron-update",
+        schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      }
+    : {
+        handoff,
+        incarnation,
+        owner,
+        providerId: "standalone-update",
+        schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      };
+}
+
+class FakeUpdaterProvider implements StandaloneUpdaterProviderPort {
+  readonly receipts = new Map<string, StandaloneUpdaterActionResult>();
+  invocationCount = 0;
+  private readonly waiters = new Set<(snapshot: StandaloneUpdaterSnapshot) => void>();
+  private snapshot: StandaloneUpdaterSnapshot;
+
+  constructor(readonly descriptor: StandaloneUpdaterProviderDescriptor) {
+    this.snapshot = validateStandaloneUpdaterSnapshot({
+      actions: [{ emphasis: "primary", id: "apply", label: "Apply update" }],
+      presentation: { title: "Update ready" },
+      provider: descriptor,
+      revision: 1,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      state: "ready",
+    }, { provider: descriptor });
+  }
+
+  async readSnapshot(): Promise<StandaloneUpdaterSnapshot> {
+    return this.snapshot;
+  }
+
+  async waitForChange(raw: StandaloneUpdaterWaitRequest): Promise<StandaloneUpdaterSnapshot> {
+    const request = validateStandaloneUpdaterWaitRequest(raw, { provider: this.descriptor });
+    if (this.snapshot.revision > request.afterRevision) return this.snapshot;
+    return await new Promise<StandaloneUpdaterSnapshot>((resolve) => {
+      const onChange = (snapshot: StandaloneUpdaterSnapshot) => {
+        clearTimeout(timeout);
+        this.waiters.delete(onChange);
+        resolve(snapshot);
+      };
+      const timeout = setTimeout(() => {
+        this.waiters.delete(onChange);
+        resolve(this.snapshot);
+      }, request.timeoutMs);
+      this.waiters.add(onChange);
+    });
+  }
+
+  async invoke(raw: StandaloneUpdaterActionRequest): Promise<StandaloneUpdaterActionResult> {
+    const request = validateStandaloneUpdaterActionRequest(raw, { provider: this.descriptor });
+    const existing = this.receipts.get(request.requestId);
+    if (existing != null) return existing;
+    this.invocationCount += 1;
+    const result = validateStandaloneUpdaterActionResult({
+      actionId: request.actionId,
+      operationId: `${this.descriptor.providerId}-handoff`,
+      outcome: "accepted",
+      provider: this.descriptor,
+      requestId: request.requestId,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+    }, {
+      actionId: request.actionId,
+      provider: this.descriptor,
+      requestId: request.requestId,
+    });
+    this.receipts.set(request.requestId, result);
+    this.snapshot = validateStandaloneUpdaterSnapshot({
+      actions: [],
+      presentation: { title: "Update handed off" },
+      provider: this.descriptor,
+      revision: this.snapshot.revision + 1,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      state: "handed-off",
+    }, { provider: this.descriptor });
+    for (const notify of [...this.waiters]) notify(this.snapshot);
+    return result;
+  }
+}
+
+function action(
+  descriptor: StandaloneUpdaterProviderDescriptor,
+  requestId = "update-action-1",
+): StandaloneUpdaterActionRequest {
+  return {
+    actionId: "apply",
+    provider: descriptor,
+    requestId,
+    schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+  };
+}
+
+describe("updater provider contract demo", () => {
+  it("keeps Shell and Standalone providers independent while exposing one projection shape", async () => {
+    const shell = new FakeUpdaterProvider(provider("shell", "shell-incarnation-1"));
+    const standalone = new FakeUpdaterProvider(provider("standalone", "standalone-incarnation-1"));
+
+    await shell.invoke(action(shell.descriptor));
+
+    expect((await shell.readSnapshot()).state).toBe("handed-off");
+    expect((await standalone.readSnapshot()).state).toBe("ready");
+    expect(standalone.invocationCount).toBe(0);
+  });
+
+  it("wakes bounded waiters on revision change and deduplicates within one incarnation", async () => {
+    const shell = new FakeUpdaterProvider(provider("shell", "shell-incarnation-1"));
+    const waiting = shell.waitForChange({
+      afterRevision: 1,
+      provider: shell.descriptor,
+      schemaVersion: STANDALONE_UPDATER_SCHEMA_VERSION,
+      timeoutMs: 1_000,
+    });
+
+    const first = await shell.invoke(action(shell.descriptor));
+    const duplicate = await shell.invoke(action(shell.descriptor));
+
+    await expect(waiting).resolves.toMatchObject({ revision: 2, state: "handed-off" });
+    expect(duplicate).toEqual(first);
+    expect(shell.invocationCount).toBe(1);
+  });
+
+  it("fences stale providers and scopes request dedupe to the provider incarnation", async () => {
+    const previous = new FakeUpdaterProvider(provider("shell", "shell-incarnation-1"));
+    const current = new FakeUpdaterProvider(provider("shell", "shell-incarnation-2"));
+
+    await expect(current.invoke(action(previous.descriptor))).rejects.toThrow(/provider incarnation/u);
+    await previous.invoke(action(previous.descriptor));
+    await current.invoke(action(current.descriptor));
+
+    expect(previous.invocationCount).toBe(1);
+    expect(current.invocationCount).toBe(1);
+  });
+});

--- a/apps/standalone/tsconfig.json
+++ b/apps/standalone/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/standalone/tsconfig.tests.json
+++ b/apps/standalone/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,37 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  apps/standalone:
+    dependencies:
+      '@open-design/closure':
+        specifier: workspace:*
+        version: link:../../packages/closure
+      '@open-design/release':
+        specifier: workspace:*
+        version: link:../../packages/release
+      '@open-design/sidecar':
+        specifier: workspace:*
+        version: link:../../packages/sidecar
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      esbuild:
+        specifier: 0.28.0
+        version: 0.28.0
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+
   apps/web:
     dependencies:
       '@anthropic-ai/sdk':

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -22,6 +22,7 @@ const buildTargets = [
   "packages/launcher-proto",
   "packages/sidecar",
   "packages/closure",
+  "apps/standalone",
   "packages/diagnostics",
   "packages/dsh-runtime",
   "apps/daemon",


### PR DESCRIPTION
## Outcome

Registers the shell-neutral `@open-design/standalone` product runtime as an isolated workspace package. It contains the bootstrap, bootloader, process bridge, Closure handoff, resource runtime, sidecar orchestration, and public protocol needed by future shells.

## Transparency boundary

- No current application imports this package.
- No Electron shell or workflow changes are included.
- No existing packaged entrypoint, updater, or release path is switched.
- Registration only makes the package participate in normal install/build/test validation.

## Validation

- `pnpm install --frozen-lockfile` including all repository postinstall builds
- Standalone: 68 tests
- Standalone typecheck
