### PR TITLE
feat(shell): preload shared contracts and Electron boundary

### DIFF
--- a/packages/shell/AGENTS.md
+++ b/packages/shell/AGENTS.md
@@ -1,0 +1,27 @@
+# packages/shell
+
+Follow the root `AGENTS.md` and `packages/AGENTS.md` first.
+
+This package owns Shell persistence contracts shared across artifact tooling
+and Shell runtime consumption.
+
+## Owns
+
+- The `./update` subpath: launcher payload pointers and
+  `runtime/attempt/handoff/cleanup` descriptor schemas.
+- The `./launch-context` subpath: transactional, leased local debug routing
+  shared by tools-pack and Shell startup.
+- Validation of those persisted descriptors.
+- Deterministic channel/namespace/version layout below an explicit root.
+
+## Does not own
+
+- Electron processes, argv protocols, target selection, fallback execution,
+  updater lifecycle, IPC, menus, or UI projection.
+- Artifact construction, release publication, installer behavior, or signing.
+- Standalone Closure selection, storage, or update policy.
+- Renderer-facing host capabilities.
+
+Keep serialized schema versions, filenames, and layout stable unless an
+explicit migration is designed and accepted across every producer and
+consumer.

--- a/packages/shell/esbuild.config.ts
+++ b/packages/shell/esbuild.config.ts
@@ -1,0 +1,13 @@
+import { build } from "esbuild";
+
+await build({
+  bundle: true,
+  entryPoints: ["./src/launch-context/index.ts", "./src/update/index.ts"],
+  format: "esm",
+  outbase: "./src",
+  outdir: "./dist",
+  outExtension: { ".js": ".mjs" },
+  packages: "external",
+  platform: "node",
+  target: "node24",
+});

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@open-design/shell",
+  "version": "0.19.2",
+  "private": true,
+  "type": "module",
+  "description": "Shared Open Design Shell update persistence contract and deterministic layout.",
+  "exports": {
+    "./launch-context": {
+      "types": "./dist/launch-context/index.d.ts",
+      "default": "./dist/launch-context/index.mjs"
+    },
+    "./update": {
+      "types": "./dist/update/index.d.ts",
+      "default": "./dist/update/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsx ./esbuild.config.ts && tsc -p tsconfig.json --emitDeclarationOnly",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
+  },
+  "dependencies": {
+    "@open-design/release": "workspace:*",
+    "@open-design/sidecar": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "24.12.2",
+    "esbuild": "0.28.0",
+    "tsx": "4.22.3",
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
+  },
+  "engines": {
+    "node": "~24"
+  }
+}

--- a/packages/shell/src/launch-context/index.ts
+++ b/packages/shell/src/launch-context/index.ts
@@ -1,0 +1,384 @@
+import { randomUUID, createHash } from "node:crypto";
+import { access, mkdir, open, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+export const PACKAGED_LAUNCH_CONTEXT_FILE = "open-design-launch-context.json";
+export const PACKAGED_LAUNCH_CONTEXT_SCHEMA_VERSION = 2;
+export const DEFAULT_LAUNCH_CONTEXT_TTL_MS = 6 * 60 * 60 * 1_000;
+
+export type LaunchContextOwner = {
+  pid: number;
+  startedAt: string;
+};
+
+export type LaunchContextTarget = {
+  namespace: string;
+  namespaceBaseRoot: string;
+};
+
+type LaunchContextSnapshot = {
+  bodyBase64: string;
+  sha256: string;
+};
+
+export type PackagedLaunchContext = {
+  createdAt: string;
+  expiresAt: string;
+  owner: LaunchContextOwner;
+  previous: LaunchContextSnapshot | null;
+  schemaVersion: 2;
+  sessionId: string;
+  state: "active" | "pending" | "relaunchable";
+  target: LaunchContextTarget;
+  updatedAt: string;
+};
+
+export type LaunchContextRuntime = {
+  isProcessAlive?: (pid: number) => boolean;
+  now?: () => Date;
+  pathExists?: (path: string) => Promise<boolean>;
+};
+
+type ParsedContext = { body: string; context: PackagedLaunchContext };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  if (!Number.isSafeInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function defaultPathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeDefaults(runtime: LaunchContextRuntime) {
+  return {
+    isProcessAlive: runtime.isProcessAlive ?? defaultIsProcessAlive,
+    now: runtime.now ?? (() => new Date()),
+    pathExists: runtime.pathExists ?? defaultPathExists,
+  };
+}
+
+function sha256(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function parseIso(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseOwner(value: unknown): LaunchContextOwner | null {
+  if (!isRecord(value) || !Number.isSafeInteger(value.pid) || Number(value.pid) < 1) return null;
+  if (parseIso(value.startedAt) == null) return null;
+  return { pid: Number(value.pid), startedAt: String(value.startedAt) };
+}
+
+export function createLaunchContextTarget(input: {
+  namespace?: string;
+  namespaceBaseRoot?: string;
+}): LaunchContextTarget | null {
+  const namespace = input.namespace?.trim();
+  const namespaceBaseRoot = input.namespaceBaseRoot?.trim();
+  if (!namespace || !namespaceBaseRoot) return null;
+  return { namespace, namespaceBaseRoot: resolve(namespaceBaseRoot) };
+}
+
+export function parsePackagedLaunchContext(value: unknown): PackagedLaunchContext | null {
+  if (!isRecord(value) || value.schemaVersion !== PACKAGED_LAUNCH_CONTEXT_SCHEMA_VERSION) return null;
+  const owner = parseOwner(value.owner);
+  const target = isRecord(value.target) ? createLaunchContextTarget(value.target) : null;
+  const state = value.state;
+  if (
+    owner == null
+    || target == null
+    || typeof value.sessionId !== "string"
+    || value.sessionId.length < 8
+    || (state !== "active" && state !== "pending" && state !== "relaunchable")
+    || parseIso(value.createdAt) == null
+    || parseIso(value.updatedAt) == null
+    || parseIso(value.expiresAt) == null
+  ) return null;
+
+  let previous: LaunchContextSnapshot | null = null;
+  if (value.previous != null) {
+    if (
+      !isRecord(value.previous)
+      || typeof value.previous.bodyBase64 !== "string"
+      || !/^[0-9a-f]{64}$/.test(String(value.previous.sha256))
+    ) return null;
+    const body = Buffer.from(value.previous.bodyBase64, "base64").toString("utf8");
+    if (sha256(body) !== value.previous.sha256) return null;
+    previous = { bodyBase64: value.previous.bodyBase64, sha256: String(value.previous.sha256) };
+  }
+
+  return {
+    createdAt: String(value.createdAt),
+    expiresAt: String(value.expiresAt),
+    owner,
+    previous,
+    schemaVersion: PACKAGED_LAUNCH_CONTEXT_SCHEMA_VERSION,
+    sessionId: value.sessionId,
+    state,
+    target,
+    updatedAt: String(value.updatedAt),
+  };
+}
+
+async function readContext(path: string): Promise<ParsedContext | null> {
+  try {
+    const body = await readFile(path, "utf8");
+    const context = parsePackagedLaunchContext(JSON.parse(body) as unknown);
+    return context == null ? null : { body, context };
+  } catch {
+    return null;
+  }
+}
+
+async function atomicWrite(path: string, body: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, body, { encoding: "utf8", mode: 0o600 });
+  await rename(temporaryPath, path);
+}
+
+async function writeContext(path: string, context: PackagedLaunchContext): Promise<void> {
+  await atomicWrite(path, `${JSON.stringify(context, null, 2)}\n`);
+}
+
+async function restoreSnapshot(path: string, snapshot: LaunchContextSnapshot | null): Promise<void> {
+  if (snapshot == null) {
+    await rm(path, { force: true });
+    return;
+  }
+  const body = Buffer.from(snapshot.bodyBase64, "base64").toString("utf8");
+  if (sha256(body) !== snapshot.sha256) throw new Error("launch context previous snapshot digest mismatch");
+  await atomicWrite(path, body);
+}
+
+async function acquireLock(path: string, runtime: ReturnType<typeof runtimeDefaults>): Promise<() => Promise<void>> {
+  const lockPath = `${path}.lock`;
+  await mkdir(dirname(lockPath), { recursive: true });
+  const deadline = Date.now() + 2_000;
+  while (true) {
+    try {
+      const handle = await open(lockPath, "wx", 0o600);
+      await handle.writeFile(`${JSON.stringify({ createdAt: runtime.now().toISOString(), pid: process.pid })}\n`);
+      await handle.close();
+      return async () => await rm(lockPath, { force: true });
+    } catch (error) {
+      const code = isRecord(error) && typeof error.code === "string" ? error.code : null;
+      if (code !== "EEXIST") throw error;
+      let stale = false;
+      try {
+        const lock = JSON.parse(await readFile(lockPath, "utf8")) as unknown;
+        stale = !isRecord(lock)
+          || !Number.isSafeInteger(lock.pid)
+          || !runtime.isProcessAlive(Number(lock.pid))
+          || (parseIso(lock.createdAt) ?? 0) < runtime.now().getTime() - 30_000;
+      } catch {
+        stale = true;
+      }
+      if (stale) {
+        await rm(lockPath, { force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error(`launch context is locked: ${path}`);
+      await new Promise((resolveWait) => setTimeout(resolveWait, 25));
+    }
+  }
+}
+
+async function withLock<T>(path: string, input: LaunchContextRuntime, operation: (runtime: ReturnType<typeof runtimeDefaults>) => Promise<T>): Promise<T> {
+  const runtime = runtimeDefaults(input);
+  const release = await acquireLock(path, runtime);
+  try {
+    return await operation(runtime);
+  } finally {
+    await release();
+  }
+}
+
+function isExpired(context: PackagedLaunchContext, now: Date): boolean {
+  return Date.parse(context.expiresAt) <= now.getTime();
+}
+
+async function isUsable(context: PackagedLaunchContext, runtime: ReturnType<typeof runtimeDefaults>): Promise<boolean> {
+  return !isExpired(context, runtime.now()) && await runtime.pathExists(context.target.namespaceBaseRoot);
+}
+
+async function recoverUnlocked(path: string, runtime: ReturnType<typeof runtimeDefaults>): Promise<"absent" | "recovered" | "valid"> {
+  let rawExists = true;
+  try {
+    await access(path);
+  } catch {
+    rawExists = false;
+  }
+  if (!rawExists) return "absent";
+
+  const parsed = await readContext(path);
+  if (parsed == null) {
+    await rm(path, { force: true });
+    return "recovered";
+  }
+  const { context } = parsed;
+  const ownerRequired = context.state === "active" || context.state === "pending";
+  if (
+    !await isUsable(context, runtime)
+    || (ownerRequired && !runtime.isProcessAlive(context.owner.pid))
+  ) {
+    await restoreSnapshot(path, context.previous);
+    return "recovered";
+  }
+  return "valid";
+}
+
+export async function recoverPackagedLaunchContext(
+  path: string,
+  input: LaunchContextRuntime = {},
+): Promise<"absent" | "recovered" | "valid"> {
+  return await withLock(path, input, async (runtime) => await recoverUnlocked(path, runtime));
+}
+
+export async function beginPackagedLaunchContext(input: {
+  owner?: LaunchContextOwner;
+  path: string;
+  runtime?: LaunchContextRuntime;
+  sessionId?: string;
+  target: LaunchContextTarget;
+  ttlMs?: number;
+}): Promise<PackagedLaunchContext> {
+  return await withLock(input.path, input.runtime ?? {}, async (runtime) => {
+    const recovery = await recoverUnlocked(input.path, runtime);
+    if (recovery === "valid") throw new Error(`launch context transaction is already active: ${input.path}`);
+    const now = runtime.now();
+    const ttlMs = input.ttlMs ?? DEFAULT_LAUNCH_CONTEXT_TTL_MS;
+    if (!Number.isSafeInteger(ttlMs) || ttlMs < 1_000) throw new Error("launch context ttlMs must be at least 1000");
+    if (!await runtime.pathExists(input.target.namespaceBaseRoot)) {
+      throw new Error(`launch context namespace base root does not exist: ${input.target.namespaceBaseRoot}`);
+    }
+    const owner = input.owner ?? { pid: process.pid, startedAt: now.toISOString() };
+    const context: PackagedLaunchContext = {
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+      owner,
+      previous: null,
+      schemaVersion: PACKAGED_LAUNCH_CONTEXT_SCHEMA_VERSION,
+      sessionId: input.sessionId ?? randomUUID(),
+      state: "pending",
+      target: createLaunchContextTarget(input.target)!,
+      updatedAt: now.toISOString(),
+    };
+    await writeContext(input.path, context);
+    return context;
+  });
+}
+
+/** Re-arm a parked transaction so an external launcher can hand it to the next process. */
+export async function rearmPackagedLaunchContext(input: {
+  owner?: LaunchContextOwner;
+  path: string;
+  runtime?: LaunchContextRuntime;
+  target: LaunchContextTarget;
+}): Promise<PackagedLaunchContext | null> {
+  return await withLock(input.path, input.runtime ?? {}, async (runtime) => {
+    const parsed = await readContext(input.path);
+    if (parsed == null || !await isUsable(parsed.context, runtime)) return null;
+    const context = parsed.context;
+    const target = createLaunchContextTarget(input.target);
+    if (
+      context.state !== "relaunchable"
+      || target == null
+      || context.target.namespace !== target.namespace
+      || context.target.namespaceBaseRoot !== target.namespaceBaseRoot
+    ) return null;
+    const now = runtime.now();
+    const rearmed = {
+      ...context,
+      owner: input.owner ?? { pid: process.pid, startedAt: now.toISOString() },
+      state: "pending" as const,
+      updatedAt: now.toISOString(),
+    };
+    await writeContext(input.path, rearmed);
+    return rearmed;
+  });
+}
+
+export async function claimPackagedLaunchContext(input: {
+  owner?: LaunchContextOwner;
+  path: string;
+  runtime?: LaunchContextRuntime;
+  sessionId?: string;
+}): Promise<PackagedLaunchContext | null> {
+  return await withLock(input.path, input.runtime ?? {}, async (runtime) => {
+    const parsed = await readContext(input.path);
+    if (parsed == null || !await isUsable(parsed.context, runtime)) {
+      if (parsed != null) await restoreSnapshot(input.path, parsed.context.previous);
+      else await rm(input.path, { force: true });
+      return null;
+    }
+    const context = parsed.context;
+    if (input.sessionId != null && context.sessionId !== input.sessionId) return null;
+    if (context.state === "active" && runtime.isProcessAlive(context.owner.pid)) {
+      return context;
+    }
+    if (context.state !== "pending" && context.state !== "relaunchable") {
+      await restoreSnapshot(input.path, context.previous);
+      return null;
+    }
+    const now = runtime.now();
+    const owner = input.owner ?? { pid: process.pid, startedAt: now.toISOString() };
+    const claimed = { ...context, owner, state: "active" as const, updatedAt: now.toISOString() };
+    await writeContext(input.path, claimed);
+    return claimed;
+  });
+}
+
+export async function markPackagedLaunchContextRelaunchable(input: {
+  ownerPid?: number;
+  path: string;
+  runtime?: LaunchContextRuntime;
+  sessionId?: string;
+}): Promise<boolean> {
+  return await withLock(input.path, input.runtime ?? {}, async (runtime) => {
+    const parsed = await readContext(input.path);
+    if (parsed == null) return false;
+    const context = parsed.context;
+    if (input.sessionId != null && context.sessionId !== input.sessionId) return false;
+    if (input.ownerPid != null && context.owner.pid !== input.ownerPid) return false;
+    const updated = { ...context, state: "relaunchable" as const, updatedAt: runtime.now().toISOString() };
+    await writeContext(input.path, updated);
+    return true;
+  });
+}
+
+export async function restorePackagedLaunchContext(input: {
+  path: string;
+  runtime?: LaunchContextRuntime;
+  sessionId?: string;
+}): Promise<boolean> {
+  return await withLock(input.path, input.runtime ?? {}, async () => {
+    const parsed = await readContext(input.path);
+    if (parsed == null) {
+      await rm(input.path, { force: true });
+      return false;
+    }
+    if (input.sessionId != null && parsed.context.sessionId !== input.sessionId) return false;
+    await restoreSnapshot(input.path, parsed.context.previous);
+    return true;
+  });
+}

--- a/packages/shell/src/update/index.ts
+++ b/packages/shell/src/update/index.ts
@@ -1,0 +1,493 @@
+import { isAbsolute, join, resolve, sep } from "node:path";
+
+import { isReleaseChannel, RELEASE_CHANNELS, type ReleaseChannel } from "@open-design/release";
+import { normalizeNamespace } from "@open-design/sidecar/protocol";
+
+export const LAUNCHER_SCHEMA_VERSION = 1 as const;
+
+export const LAUNCHER_CHANNELS = Object.freeze({
+  BETA: RELEASE_CHANNELS.BETA,
+  LOCAL: "local",
+  PRERELEASE: RELEASE_CHANNELS.PRERELEASE,
+  STABLE: RELEASE_CHANNELS.STABLE,
+} as const);
+
+export type LauncherChannel = ReleaseChannel | "local";
+
+export type LauncherRootRequest = {
+  channel: string;
+  namespace: string;
+  root: string;
+};
+
+export type LauncherVersionRequest = LauncherRootRequest & {
+  version: string;
+};
+
+export type LauncherPaths = {
+  attemptsPath: string;
+  channel: LauncherChannel;
+  channelRoot: string;
+  cleanupPath: string;
+  downloadsRoot: string;
+  handoffPath: string;
+  installPath: string;
+  launcherPath: string;
+  lockRoot: string;
+  logsRoot: string;
+  namespace: string;
+  namespaceRoot: string;
+  releasesRoot: string;
+  root: string;
+  runtimePath: string;
+  stagingRoot: string;
+  stateRoot: string;
+  updatesRoot: string;
+  versionsRoot: string;
+};
+
+export type LauncherVersionPaths = LauncherPaths & {
+  manifestPath: string;
+  payloadRoot: string;
+  version: string;
+  versionRoot: string;
+};
+
+export type LauncherVersionPointer = {
+  generation: number;
+  version: string;
+};
+
+export type LauncherRuntimeDescriptor = {
+  active: LauncherVersionPointer | null;
+  channel: LauncherChannel;
+  lastSuccessful: LauncherVersionPointer | null;
+  namespace: string;
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+  updatedAt?: string;
+};
+
+export type LauncherAttemptDescriptor = {
+  channel: LauncherChannel;
+  generation: number;
+  namespace: string;
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+  startedAt?: string;
+  version: string;
+};
+
+export type LauncherDesktopHandoffDescriptor = {
+  channel: LauncherChannel;
+  createdAt: string;
+  handoffId: string;
+  namespace: string;
+  outer: {
+    executablePath: string;
+    pid: number;
+  };
+  payloadExecutablePath: string;
+  previous: LauncherVersionPointer;
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+  source: LauncherVersionPointer;
+  state: "armed" | "confirmed" | "prepared";
+  target?: LauncherVersionPointer;
+  updatedAt: string;
+};
+
+export type LauncherCleanupState = "cleanup-deferred" | "cleanup-removed" | "deprecated" | "retained";
+
+export type LauncherCleanupReason =
+  | "cleanup-failed"
+  | "current-bound-package"
+  | "older-than-bound-package";
+
+export type LauncherCleanupEntry = {
+  error?: {
+    code: string;
+    message: string;
+  };
+  generation: number;
+  reason: LauncherCleanupReason;
+  removedAt?: string;
+  state: LauncherCleanupState;
+  updatedAt: string;
+  version: string;
+};
+
+export type LauncherCleanupDescriptor = {
+  channel: LauncherChannel;
+  currentVersion?: string;
+  namespace: string;
+  updatedAt: string;
+  version: typeof LAUNCHER_SCHEMA_VERSION;
+  versions: LauncherCleanupEntry[];
+};
+
+export class LauncherProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LauncherProtocolError";
+  }
+}
+
+export function normalizeLauncherChannel(value: unknown): LauncherChannel {
+  if (typeof value !== "string") throw new LauncherProtocolError("launcher channel must be a string");
+  const channel = value.trim();
+  if (channel !== value) throw new LauncherProtocolError("launcher channel must not contain leading or trailing whitespace");
+  if (channel !== "local" && !isReleaseChannel(channel)) {
+    throw new LauncherProtocolError(`unsupported launcher channel: ${value}`);
+  }
+  return channel as LauncherChannel;
+}
+
+export function normalizeLauncherVersion(value: unknown): string {
+  if (typeof value !== "string") throw new LauncherProtocolError("launcher version must be a string");
+  if (value.length === 0) throw new LauncherProtocolError("launcher version must not be empty");
+  if (value !== value.trim()) throw new LauncherProtocolError("launcher version must not contain leading or trailing whitespace");
+  if (value.includes("\0")) throw new LauncherProtocolError("launcher version must not contain null bytes");
+  if (/[\\/]/.test(value)) throw new LauncherProtocolError(`launcher version must not contain path separators: ${value}`);
+  if (value === "." || value === ".." || value.includes("..")) {
+    throw new LauncherProtocolError(`launcher version must not contain relative path segments: ${value}`);
+  }
+  if (isAbsolute(value)) throw new LauncherProtocolError(`launcher version must not be absolute: ${value}`);
+  return value;
+}
+
+function normalizePositiveInteger(value: unknown, label: string): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new LauncherProtocolError(`${label} must be a positive safe integer`);
+  }
+  return parsed;
+}
+
+export function normalizeLauncherHandoffId(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9_-]{15,127}$/.test(value)) {
+    throw new LauncherProtocolError("launcher handoff id must be 16-128 URL-safe characters");
+  }
+  return value;
+}
+
+export function normalizeLauncherGeneration(value: unknown): number {
+  const generation = typeof value === "string" && value.length > 0 ? Number(value) : value;
+  if (typeof generation !== "number" || !Number.isSafeInteger(generation) || generation < 0) {
+    throw new LauncherProtocolError(`launcher generation must be a non-negative safe integer: ${String(value)}`);
+  }
+  return generation;
+}
+
+export function normalizeLauncherNamespace(value: unknown): string {
+  try {
+    return normalizeNamespace(value);
+  } catch (error) {
+    throw new LauncherProtocolError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function normalizeRoot(root: string): string {
+  if (root.length === 0) throw new LauncherProtocolError("launcher root must not be empty");
+  if (root.includes("\0")) throw new LauncherProtocolError("launcher root must not contain null bytes");
+  if (!isAbsolute(root)) throw new LauncherProtocolError(`launcher root must be absolute: ${root}`);
+  return resolve(root);
+}
+
+function assertUnderRoot(root: string, target: string): string {
+  const normalizedRoot = resolve(root);
+  const normalizedTarget = resolve(target);
+  if (normalizedTarget !== normalizedRoot && !normalizedTarget.startsWith(`${normalizedRoot}${sep}`)) {
+    throw new LauncherProtocolError(`launcher path escapes root: ${normalizedTarget}`);
+  }
+  return normalizedTarget;
+}
+
+export function resolveLauncherPaths(request: LauncherRootRequest): LauncherPaths {
+  const root = normalizeRoot(request.root);
+  const channel = normalizeLauncherChannel(request.channel);
+  const namespace = normalizeLauncherNamespace(request.namespace);
+  const launcherPath = assertUnderRoot(root, join(root, "launcher"));
+  const channelRoot = assertUnderRoot(root, join(launcherPath, "channels", channel));
+  const namespaceRoot = assertUnderRoot(root, join(channelRoot, "namespaces", namespace));
+  const stateRoot = assertUnderRoot(root, join(namespaceRoot, "state"));
+  const updatesRoot = assertUnderRoot(root, join(namespaceRoot, "updates"));
+
+  return {
+    attemptsPath: assertUnderRoot(root, join(stateRoot, "attempt.json")),
+    channel,
+    channelRoot,
+    cleanupPath: assertUnderRoot(root, join(stateRoot, "cleanup.json")),
+    downloadsRoot: assertUnderRoot(root, join(updatesRoot, "downloads")),
+    handoffPath: assertUnderRoot(root, join(stateRoot, "desktop-handoff.json")),
+    installPath: assertUnderRoot(root, join(namespaceRoot, "install.json")),
+    launcherPath,
+    lockRoot: assertUnderRoot(root, join(stateRoot, "lock")),
+    logsRoot: assertUnderRoot(root, join(namespaceRoot, "logs")),
+    namespace,
+    namespaceRoot,
+    releasesRoot: assertUnderRoot(root, join(updatesRoot, "releases")),
+    root,
+    runtimePath: assertUnderRoot(root, join(namespaceRoot, "runtime.json")),
+    stagingRoot: assertUnderRoot(root, join(updatesRoot, "staging")),
+    stateRoot,
+    updatesRoot,
+    versionsRoot: assertUnderRoot(root, join(namespaceRoot, "versions")),
+  };
+}
+
+export function resolveLauncherVersionPaths(request: LauncherVersionRequest): LauncherVersionPaths {
+  const paths = resolveLauncherPaths(request);
+  const version = normalizeLauncherVersion(request.version);
+  const versionRoot = assertUnderRoot(paths.root, join(paths.versionsRoot, version));
+  return {
+    ...paths,
+    manifestPath: assertUnderRoot(paths.root, join(versionRoot, "manifest.json")),
+    payloadRoot: assertUnderRoot(paths.root, join(versionRoot, "payload")),
+    version,
+    versionRoot,
+  };
+}
+
+function normalizePointer(value: LauncherVersionPointer | null): LauncherVersionPointer | null {
+  if (value == null) return null;
+  const version = normalizeLauncherVersion(value.version);
+  if (!Number.isSafeInteger(value.generation) || value.generation < 0) {
+    throw new LauncherProtocolError(`launcher generation must be a non-negative safe integer: ${value.generation}`);
+  }
+  return { generation: value.generation, version };
+}
+
+function normalizeRequiredPointer(value: LauncherVersionPointer | null, label: string): LauncherVersionPointer {
+  const pointer = normalizePointer(value);
+  if (pointer == null) throw new LauncherProtocolError(`${label} is required`);
+  return pointer;
+}
+
+function normalizeOptionalIsoString(value: unknown, label: string): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new LauncherProtocolError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function normalizeIsoString(value: unknown, label: string): string {
+  const normalized = normalizeOptionalIsoString(value, label);
+  if (normalized == null) throw new LauncherProtocolError(`${label} is required`);
+  return normalized;
+}
+
+function normalizeLauncherCleanupState(value: unknown): LauncherCleanupState {
+  if (
+    value === "cleanup-deferred" ||
+    value === "cleanup-removed" ||
+    value === "deprecated" ||
+    value === "retained"
+  ) {
+    return value;
+  }
+  throw new LauncherProtocolError(`unsupported launcher cleanup state: ${String(value)}`);
+}
+
+function normalizeLauncherCleanupReason(value: unknown): LauncherCleanupReason {
+  if (
+    value === "cleanup-failed" ||
+    value === "current-bound-package" ||
+    value === "older-than-bound-package"
+  ) {
+    return value;
+  }
+  throw new LauncherProtocolError(`unsupported launcher cleanup reason: ${String(value)}`);
+}
+
+function normalizeCleanupError(value: unknown): LauncherCleanupEntry["error"] {
+  if (value == null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new LauncherProtocolError("launcher cleanup error must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.code !== "string" || record.code.length === 0) {
+    throw new LauncherProtocolError("launcher cleanup error code must be a non-empty string");
+  }
+  if (typeof record.message !== "string" || record.message.length === 0) {
+    throw new LauncherProtocolError("launcher cleanup error message must be a non-empty string");
+  }
+  return { code: record.code, message: record.message };
+}
+
+function normalizeCleanupEntry(value: unknown): LauncherCleanupEntry {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    throw new LauncherProtocolError("launcher cleanup entry must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const rawGeneration = record.generation;
+  if (typeof rawGeneration !== "number" || !Number.isSafeInteger(rawGeneration) || rawGeneration < 0) {
+    throw new LauncherProtocolError(`launcher cleanup generation must be a non-negative safe integer: ${String(rawGeneration)}`);
+  }
+  const generation = rawGeneration;
+  const version = normalizeLauncherVersion(record.version);
+  const state = normalizeLauncherCleanupState(record.state);
+  const reason = normalizeLauncherCleanupReason(record.reason);
+  const error = normalizeCleanupError(record.error);
+  const removedAt = normalizeOptionalIsoString(record.removedAt, "launcher cleanup removedAt");
+  return {
+    ...(error == null ? {} : { error }),
+    generation,
+    reason,
+    ...(removedAt == null ? {} : { removedAt }),
+    state,
+    updatedAt: normalizeIsoString(record.updatedAt, "launcher cleanup updatedAt"),
+    version,
+  };
+}
+
+export function validateLauncherRuntimeDescriptor(
+  runtime: LauncherRuntimeDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherRuntimeDescriptor {
+  if (runtime.schemaVersion !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher runtime schemaVersion: ${String(runtime.schemaVersion)}`);
+  }
+  const channel = normalizeLauncherChannel(runtime.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher runtime channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(runtime.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher runtime namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  return {
+    ...runtime,
+    active: normalizePointer(runtime.active),
+    channel,
+    lastSuccessful: normalizePointer(runtime.lastSuccessful),
+    namespace,
+  };
+}
+
+export function validateLauncherAttemptDescriptor(
+  attempt: LauncherAttemptDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherAttemptDescriptor {
+  if (attempt.schemaVersion !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher attempt schemaVersion: ${String(attempt.schemaVersion)}`);
+  }
+  const channel = normalizeLauncherChannel(attempt.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher attempt channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(attempt.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher attempt namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  const pointer = normalizeRequiredPointer(attempt, "launcher attempt pointer");
+  return {
+    channel,
+    generation: pointer.generation,
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    ...(attempt.startedAt == null ? {} : {
+      startedAt: normalizeIsoString(attempt.startedAt, "launcher attempt startedAt"),
+    }),
+    version: pointer.version,
+  };
+}
+
+function normalizeAbsoluteLauncherPath(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    throw new LauncherProtocolError(`${label} must be a non-empty absolute path`);
+  }
+  if (!isAbsolute(value)) throw new LauncherProtocolError(`${label} must be absolute: ${value}`);
+  return resolve(value);
+}
+
+export function validateLauncherDesktopHandoffDescriptor(
+  handoff: LauncherDesktopHandoffDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherDesktopHandoffDescriptor {
+  if (handoff.schemaVersion !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher desktop handoff schemaVersion: ${String(handoff.schemaVersion)}`);
+  }
+  const channel = normalizeLauncherChannel(handoff.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher desktop handoff channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(handoff.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher desktop handoff namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  if (
+    handoff.state !== "prepared" &&
+    handoff.state !== "armed" &&
+    handoff.state !== "confirmed"
+  ) {
+    throw new LauncherProtocolError(`unsupported launcher desktop handoff state: ${String(handoff.state)}`);
+  }
+  const target = handoff.target == null ? null : normalizePointer(handoff.target);
+  if ((handoff.state === "armed" || handoff.state === "confirmed") && target == null) {
+    throw new LauncherProtocolError(`${handoff.state} launcher desktop handoff requires a target pointer`);
+  }
+  if (handoff.state === "prepared" && target != null) {
+    throw new LauncherProtocolError("prepared launcher desktop handoff must not include a target pointer");
+  }
+  if (handoff.outer == null || typeof handoff.outer !== "object") {
+    throw new LauncherProtocolError("launcher desktop handoff outer identity is required");
+  }
+  return {
+    channel,
+    createdAt: normalizeIsoString(handoff.createdAt, "launcher desktop handoff createdAt"),
+    handoffId: normalizeLauncherHandoffId(handoff.handoffId),
+    namespace,
+    outer: {
+      executablePath: normalizeAbsoluteLauncherPath(
+        handoff.outer.executablePath,
+        "launcher desktop handoff outer executablePath",
+      ),
+      pid: normalizePositiveInteger(handoff.outer.pid, "launcher desktop handoff outer pid"),
+    },
+    payloadExecutablePath: normalizeAbsoluteLauncherPath(
+      handoff.payloadExecutablePath,
+      "launcher desktop handoff payloadExecutablePath",
+    ),
+    previous: normalizeRequiredPointer(handoff.previous, "launcher desktop handoff previous pointer"),
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    source: normalizeRequiredPointer(handoff.source, "launcher desktop handoff source pointer"),
+    state: handoff.state,
+    ...(target == null ? {} : { target }),
+    updatedAt: normalizeIsoString(handoff.updatedAt, "launcher desktop handoff updatedAt"),
+  };
+}
+
+export function validateLauncherCleanupDescriptor(
+  cleanup: LauncherCleanupDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherCleanupDescriptor {
+  if (cleanup.version !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher cleanup version: ${String(cleanup.version)}`);
+  }
+  const channel = normalizeLauncherChannel(cleanup.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher cleanup channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(cleanup.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher cleanup namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  if (!Array.isArray(cleanup.versions)) {
+    throw new LauncherProtocolError("launcher cleanup versions must be an array");
+  }
+  return {
+    channel,
+    ...(cleanup.currentVersion == null ? {} : { currentVersion: normalizeLauncherVersion(cleanup.currentVersion) }),
+    namespace,
+    updatedAt: normalizeIsoString(cleanup.updatedAt, "launcher cleanup updatedAt"),
+    version: LAUNCHER_SCHEMA_VERSION,
+    versions: cleanup.versions.map(normalizeCleanupEntry),
+  };
+}

--- a/packages/shell/tests/launch-context.test.ts
+++ b/packages/shell/tests/launch-context.test.ts
@@ -1,0 +1,143 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  beginPackagedLaunchContext,
+  claimPackagedLaunchContext,
+  markPackagedLaunchContextRelaunchable,
+  parsePackagedLaunchContext,
+  rearmPackagedLaunchContext,
+  recoverPackagedLaunchContext,
+  restorePackagedLaunchContext,
+} from "../src/launch-context/index.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(async (root) => await rm(root, { force: true, recursive: true })));
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "od-launch-context-"));
+  roots.push(root);
+  const namespaceBaseRoot = join(root, "runtime", "namespaces");
+  const path = join(root, "profile", "open-design-launch-context.json");
+  await mkdir(namespaceBaseRoot, { recursive: true });
+  return { namespaceBaseRoot, path, root };
+}
+
+describe("packaged launch context", () => {
+  it("claims, parks, reclaims, and restores one transaction", async () => {
+    const { namespaceBaseRoot, path } = await fixture();
+    const active = new Set([11, 22]);
+    const runtime = { isProcessAlive: (pid: number) => active.has(pid) };
+    const pending = await beginPackagedLaunchContext({
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      path,
+      runtime,
+      sessionId: "session-one",
+      target: { namespace: "release-beta", namespaceBaseRoot },
+    });
+    expect(pending.state).toBe("pending");
+
+    const claimed = await claimPackagedLaunchContext({
+      owner: { pid: 22, startedAt: "2026-08-14T00:00:01.000Z" },
+      path,
+      runtime,
+      sessionId: pending.sessionId,
+    });
+    expect(claimed).toMatchObject({ owner: { pid: 22 }, state: "active" });
+    expect(await markPackagedLaunchContextRelaunchable({ ownerPid: 22, path, runtime })).toBe(true);
+    active.add(33);
+    expect(await claimPackagedLaunchContext({
+      owner: { pid: 33, startedAt: "2026-08-14T00:00:02.000Z" },
+      path,
+      runtime,
+    })).toMatchObject({ owner: { pid: 33 }, state: "active" });
+    active.delete(22);
+    expect(await restorePackagedLaunchContext({ path, runtime })).toBe(true);
+    await expect(readFile(path, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("re-arms a parked transaction for an external cold launcher", async () => {
+    const { namespaceBaseRoot, path } = await fixture();
+    const runtime = { isProcessAlive: (pid: number) => pid === 11 };
+    const pending = await beginPackagedLaunchContext({
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      path,
+      runtime,
+      sessionId: "session-one",
+      target: { namespace: "release-beta", namespaceBaseRoot },
+    });
+    await claimPackagedLaunchContext({ path, runtime, sessionId: pending.sessionId });
+    await markPackagedLaunchContextRelaunchable({ path, runtime, sessionId: pending.sessionId });
+
+    const rearmed = await rearmPackagedLaunchContext({
+      owner: { pid: 22, startedAt: "2026-08-14T00:00:02.000Z" },
+      path,
+      runtime,
+      target: { namespace: "release-beta", namespaceBaseRoot },
+    });
+    expect(rearmed).toMatchObject({
+      owner: { pid: 22 },
+      sessionId: pending.sessionId,
+      state: "pending",
+    });
+    expect(await claimPackagedLaunchContext({
+      owner: { pid: 33, startedAt: "2026-08-14T00:00:03.000Z" },
+      path,
+      runtime,
+      sessionId: pending.sessionId,
+    })).toMatchObject({ owner: { pid: 33 }, state: "active" });
+  });
+
+  it("recovers a killed owner and removes legacy unleased state", async () => {
+    const { namespaceBaseRoot, path } = await fixture();
+    const runtime = { isProcessAlive: () => false };
+    await beginPackagedLaunchContext({
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      path,
+      runtime: { isProcessAlive: (pid) => pid === 11 },
+      target: { namespace: "beta", namespaceBaseRoot },
+    });
+    expect(await recoverPackagedLaunchContext(path, runtime)).toBe("recovered");
+    await expect(readFile(path, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+    await mkdir(join(path, ".."), { recursive: true });
+    await writeFile(path, JSON.stringify({ namespace: "old", namespaceBaseRoot, schemaVersion: 1 }));
+    expect(await recoverPackagedLaunchContext(path, runtime)).toBe("recovered");
+    await expect(readFile(path, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a dangling root, conflicting transaction, and malformed snapshot", async () => {
+    const { namespaceBaseRoot, path, root } = await fixture();
+    const runtime = { isProcessAlive: (pid: number) => pid === 11 };
+    await beginPackagedLaunchContext({
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      path,
+      runtime,
+      target: { namespace: "beta", namespaceBaseRoot },
+    });
+    await expect(beginPackagedLaunchContext({
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      path,
+      runtime,
+      target: { namespace: "beta", namespaceBaseRoot },
+    })).rejects.toThrow(/already active/);
+
+    expect(parsePackagedLaunchContext({
+      createdAt: "2026-08-14T00:00:00.000Z",
+      expiresAt: "2026-08-14T01:00:00.000Z",
+      owner: { pid: 11, startedAt: "2026-08-14T00:00:00.000Z" },
+      previous: { bodyBase64: "e30=", sha256: "0".repeat(64) },
+      schemaVersion: 2,
+      sessionId: "session-one",
+      state: "active",
+      target: { namespace: "beta", namespaceBaseRoot: root },
+      updatedAt: "2026-08-14T00:00:00.000Z",
+    })).toBeNull();
+  });
+});

--- a/packages/shell/tests/update.test.ts
+++ b/packages/shell/tests/update.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  LauncherProtocolError,
+  normalizeLauncherGeneration,
+  normalizeLauncherHandoffId,
+  resolveLauncherPaths,
+  resolveLauncherVersionPaths,
+  validateLauncherCleanupDescriptor,
+  validateLauncherDesktopHandoffDescriptor,
+  validateLauncherRuntimeDescriptor,
+  type LauncherCleanupDescriptor,
+  type LauncherDesktopHandoffDescriptor,
+  type LauncherRuntimeDescriptor,
+} from "../src/update/index.js";
+
+const root = process.platform === "win32" ? "C:\\od-data" : "/tmp/od-data";
+const shellRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function sourceFilesUnder(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const path = join(directory, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) return sourceFilesUnder(path);
+    return /\.(?:cts|mts|ts|tsx)$/u.test(path) ? [path] : [];
+  });
+}
+
+describe("Shell update persistence contract", () => {
+  it("stays independent from renderer host and product-owned implementations", () => {
+    const pkg = JSON.parse(readFileSync(join(shellRoot, "package.json"), "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(pkg.dependencies).not.toHaveProperty("@open-design/host");
+    expect(pkg.dependencies).not.toHaveProperty("@open-design/shell-electron");
+    expect(pkg.dependencies).not.toHaveProperty("@open-design/standalone");
+    expect(pkg.dependencies).not.toHaveProperty("@open-design/closure");
+
+    const offenders = sourceFilesUnder(join(shellRoot, "src")).filter((path) =>
+      /@open-design\/(?:closure|host|shell-electron|standalone)(?:\/|["'])/u.test(
+        readFileSync(path, "utf8"),
+      ),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("resolves channel, namespace, and version paths below the explicit root", () => {
+    const paths = resolveLauncherVersionPaths({
+      channel: "beta",
+      namespace: "release-beta",
+      root,
+      version: "0.19.1-beta.2",
+    });
+
+    expect(paths.namespaceRoot).toBe(join(root, "launcher", "channels", "beta", "namespaces", "release-beta"));
+    expect(paths.runtimePath).toBe(join(paths.namespaceRoot, "runtime.json"));
+    expect(paths.handoffPath).toBe(join(paths.namespaceRoot, "state", "desktop-handoff.json"));
+    expect(paths.versionRoot).toBe(join(paths.namespaceRoot, "versions", "0.19.1-beta.2"));
+    expect(paths.payloadRoot).toBe(join(paths.versionRoot, "payload"));
+  });
+
+  it("rejects unsafe roots, namespaces, versions, generations, and handoff ids", () => {
+    expect(() => resolveLauncherPaths({ channel: "beta", namespace: "../escape", root })).toThrow(LauncherProtocolError);
+    expect(() => resolveLauncherPaths({ channel: "Canary", namespace: "release-beta", root })).toThrow(LauncherProtocolError);
+    expect(() => resolveLauncherPaths({ channel: "beta", namespace: "release-beta", root: "relative" })).toThrow(LauncherProtocolError);
+    expect(() => resolveLauncherVersionPaths({ channel: "beta", namespace: "release-beta", root, version: "../0.19.1" })).toThrow(LauncherProtocolError);
+    expect(() => normalizeLauncherGeneration(-1)).toThrow(LauncherProtocolError);
+    expect(() => normalizeLauncherHandoffId("../handoff")).toThrow(LauncherProtocolError);
+  });
+
+  it("validates runtime identity without changing the serialized schema", () => {
+    const runtime: LauncherRuntimeDescriptor = {
+      active: { generation: 3, version: "0.19.1-beta.3" },
+      channel: "beta",
+      lastSuccessful: { generation: 2, version: "0.19.1-beta.2" },
+      namespace: "release-beta",
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    };
+
+    expect(validateLauncherRuntimeDescriptor(runtime, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toEqual(runtime);
+  });
+
+  it("validates desktop handoff and cleanup records", () => {
+    const handoff: LauncherDesktopHandoffDescriptor = {
+      channel: "beta",
+      createdAt: "2026-08-13T00:00:00.000Z",
+      handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+      namespace: "release-beta",
+      outer: { executablePath: join(root, "Open Design.exe"), pid: 1234 },
+      payloadExecutablePath: join(root, "payload", "Open Design.exe"),
+      previous: { generation: 1, version: "0.19.1-beta.1" },
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      source: { generation: 2, version: "0.19.1-beta.2" },
+      state: "confirmed",
+      target: { generation: 2, version: "0.19.1-beta.2" },
+      updatedAt: "2026-08-13T00:00:01.000Z",
+    };
+    expect(validateLauncherDesktopHandoffDescriptor(handoff, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toEqual(handoff);
+
+    const cleanup: LauncherCleanupDescriptor = {
+      channel: "beta",
+      namespace: "release-beta",
+      updatedAt: "2026-08-13T00:00:02.000Z",
+      version: LAUNCHER_SCHEMA_VERSION,
+      versions: [{
+        generation: 1,
+        reason: "older-than-bound-package",
+        state: "deprecated",
+        updatedAt: "2026-08-13T00:00:02.000Z",
+        version: "0.19.1-beta.1",
+      }],
+    };
+    expect(validateLauncherCleanupDescriptor(cleanup, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toEqual(cleanup);
+  });
+});

--- a/packages/shell/tsconfig.json
+++ b/packages/shell/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/shell/tsconfig.tests.json
+++ b/packages/shell/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,31 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/shell:
+    dependencies:
+      '@open-design/release':
+        specifier: workspace:*
+        version: link:../release
+      '@open-design/sidecar':
+        specifier: workspace:*
+        version: link:../sidecar
+    devDependencies:
+      '@types/node':
+        specifier: 24.12.2
+        version: 24.12.2
+      esbuild:
+        specifier: 0.28.0
+        version: 0.28.0
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/sidecar:
     dependencies:
       '@open-design/release':
@@ -864,6 +889,8 @@ importers:
       vitest:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  shells/electron: {}
 
   tools/dev:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - apps/*
+  - shells/*
   - tools/*
   - e2e
 

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -21,6 +21,7 @@ const buildTargets = [
   "packages/sidecar-proto",
   "packages/launcher-proto",
   "packages/sidecar",
+  "packages/shell",
   "packages/closure",
   "apps/standalone",
   "packages/diagnostics",

--- a/shells/electron/AGENTS.md
+++ b/shells/electron/AGENTS.md
@@ -1,0 +1,11 @@
+# shells/electron
+
+Follow the root `AGENTS.md` first.
+
+This workspace is the Electron-specific Shell boundary. Keep product lifecycle,
+Closure storage/update policy, and generic sidecar orchestration in their
+shell-neutral packages. Code added here may adapt those contracts to Electron;
+it must not create a second interpretation of them.
+
+Until an implementation PR lands, this directory is intentionally inert: do
+not add build, runtime, packaging, or release entrypoints to the preload branch.

--- a/shells/electron/README.md
+++ b/shells/electron/README.md
@@ -1,0 +1,8 @@
+# Electron Shell
+
+This workspace owns the Electron-specific adapter for the shell-neutral
+`@open-design/standalone` runtime.
+
+The preload layer intentionally registers only the workspace boundary. It has
+no build, runtime, packaging, or release entrypoint until the Electron adapter
+is reviewed and landed separately.

--- a/shells/electron/package.json
+++ b/shells/electron/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@open-design/shell-electron",
+  "version": "0.19.2",
+  "private": true,
+  "type": "module",
+  "description": "Electron Shell boundary for the Open Design standalone runtime.",
+  "engines": {
+    "node": "~24"
+  }
+}


### PR DESCRIPTION
## Outcome

Adds the shared `@open-design/shell` launch-context and update persistence contracts, then reserves `shells/electron` as the Electron-specific adapter workspace.

## Transparency boundary

- The shared Shell package is buildable and tested but has no current consumer.
- `shells/electron` contains only package ownership and boundary documentation.
- The Electron workspace has no scripts, exports, source, packaging, or release entrypoint.
- No existing application or workflow changes behavior.

## Validation

- `pnpm install --frozen-lockfile` including all repository postinstall builds
- Shared Shell contracts: 9 tests + typecheck
- Electron boundary is dependency-free and inert
