### PR TITLE
feat(ci): preload hash skip and notification primitives

### DIFF
--- a/.github/actions/hash-skip/action.yml
+++ b/.github/actions/hash-skip/action.yml
@@ -1,0 +1,44 @@
+name: Hash skip
+description: Skip a caller-defined unit when its declared input hash has already completed successfully
+
+inputs:
+  hash_skip:
+    description: Declaration key under .github/hash_skip
+    required: true
+  mode:
+    description: normal, verify, quarantine, or complete
+    required: false
+    default: normal
+
+outputs:
+  hash:
+    value: ${{ steps.resolve.outputs.hash }}
+  reason:
+    value: ${{ inputs.mode == 'complete' && 'complete' || inputs.mode == 'quarantine' && 'quarantine' || inputs.mode == 'verify' && 'verify' || steps.restore.outputs.cache-hit == 'true' && 'hit' || 'miss' }}
+  run:
+    value: ${{ inputs.mode != 'complete' && (inputs.mode != 'normal' || steps.restore.outputs.cache-hit != 'true') }}
+  skip:
+    value: ${{ inputs.mode == 'normal' && steps.restore.outputs.cache-hit == 'true' }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve declared hash
+      id: resolve
+      shell: bash
+      run: node --experimental-strip-types .github/scripts/hash_skip.ts "${{ inputs.hash_skip }}" --mode "${{ inputs.mode }}"
+    - name: Resolve successful execution cache
+      id: restore
+      if: ${{ inputs.mode != 'quarantine' && inputs.mode != 'complete' }}
+      uses: actions/cache/restore@v5.0.5
+      with:
+        enableCrossOsArchive: true
+        key: ${{ steps.resolve.outputs.cache_key }}
+        path: ${{ steps.resolve.outputs.marker }}
+    - name: Register successful execution cache
+      if: ${{ inputs.mode == 'complete' }}
+      uses: actions/cache/save@v5.0.5
+      with:
+        enableCrossOsArchive: true
+        key: ${{ steps.resolve.outputs.cache_key }}
+        path: ${{ steps.resolve.outputs.marker }}

--- a/.github/scripts/hash_skip.ts
+++ b/.github/scripts/hash_skip.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { ensure, fail } from "./lib/control.ts";
+import { git, gitPathSetDigest, type GitHashPath } from "./lib/git.ts";
+import { canonicalJson, digest, type Digest } from "./lib/json.ts";
+
+type Declaration = Readonly<{
+  extraDigests: readonly string[];
+  hashPaths: readonly GitHashPath[];
+  schemaVersion: number;
+}>;
+
+const KEY_PATTERN = /^[a-z][a-z0-9.-]*$/u;
+const EXTRA_PATTERN = /^[a-z][a-z0-9]*$/u;
+const CONTROL_PATHS = [
+  ".github/actions/hash-skip/action.yml",
+  ".github/scripts/hash_skip.ts",
+  ".github/scripts/lib/control.ts",
+  ".github/scripts/lib/git.ts",
+  ".github/scripts/lib/json.ts",
+] as const;
+
+function repoPath(value: unknown, label: string): string {
+  const text = ensure.text(value, label).replaceAll("\\", "/").replace(/^\.\//u, "").replace(/\/+$/u, "");
+  if (isAbsolute(text) || text === ".." || text.startsWith("../") || text.includes("/../")) {
+    fail(`${label} must be repository-relative`);
+  }
+  return text;
+}
+
+function strings(value: unknown, label: string): readonly string[] {
+  const entries = ensure.array(value, label).map((entry, index) => ensure.text(entry, `${label}[${index}]`)).sort();
+  ensure.that(new Set(entries).size === entries.length, `${label} must not contain duplicates`);
+  return Object.freeze(entries);
+}
+
+function hashPath(value: unknown, label: string): GitHashPath {
+  if (typeof value === "string") return Object.freeze({ path: repoPath(value, label) });
+  const input = ensure.record(value, label);
+  ensure.exactKeys(input, ["excludeDirectoryNames", "excludePaths", "normalizePackageVersion", "normalizeTextLineEndings", "path"], label);
+  for (const field of ["normalizePackageVersion", "normalizeTextLineEndings"] as const) {
+    ensure.that(input[field] == null || typeof input[field] === "boolean", `${label}.${field} must be boolean`);
+  }
+  return Object.freeze({
+    ...(input.excludeDirectoryNames == null ? {} : { excludeDirectoryNames: strings(input.excludeDirectoryNames, `${label}.excludeDirectoryNames`) }),
+    ...(input.excludePaths == null ? {} : { excludePaths: strings(input.excludePaths, `${label}.excludePaths`).map((entry) => repoPath(entry, `${label}.excludePaths`)) }),
+    ...(input.normalizePackageVersion === true ? { normalizePackageVersion: true } : {}),
+    ...(input.normalizeTextLineEndings === true ? { normalizeTextLineEndings: true } : {}),
+    path: repoPath(input.path, `${label}.path`),
+  });
+}
+
+function declaration(root: string, key: string, ref: string): Declaration {
+  ensure.that(KEY_PATTERN.test(key), `invalid hash_skip key: ${key}`);
+  const path = `.github/hash_skip/${key}.json`;
+  let value: unknown;
+  try { value = JSON.parse(git(["show", `${ref}:${path}`], root).toString("utf8")); } catch (error) {
+    fail(`invalid hash_skip declaration ${key}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  const input = ensure.record(value, `hash_skip ${key}`);
+  ensure.exactKeys(input, ["extraDigests", "hashPaths", "schemaVersion"], `hash_skip ${key}`);
+  const extraDigests = strings(input.extraDigests, `hash_skip ${key}.extraDigests`);
+  ensure.that(extraDigests.every((name) => EXTRA_PATTERN.test(name)), `hash_skip ${key}.extraDigests contains an invalid name`);
+  const hashPaths = ensure.array(input.hashPaths, `hash_skip ${key}.hashPaths`).map((entry, index) => hashPath(entry, `hash_skip ${key}.hashPaths[${index}]`));
+  ensure.that(hashPaths.length > 0, `hash_skip ${key}.hashPaths must not be empty`);
+  return Object.freeze({ extraDigests, hashPaths: Object.freeze(hashPaths), schemaVersion: ensure.integer(input.schemaVersion, `hash_skip ${key}.schemaVersion`) });
+}
+
+function extraDigests(definition: Declaration): Readonly<Record<string, Digest>> {
+  return Object.freeze(Object.fromEntries(definition.extraDigests.map((name) => {
+    const env = `HASH_SKIP_EXTRA_${name.replace(/([a-z0-9])([A-Z])/gu, "$1_$2").toUpperCase()}`;
+    return [name, ensure.digest(process.env[env], env)];
+  })));
+}
+
+function resolveKey(root: string, key: string, ref: string, mode = "normal"): Readonly<{ cacheKey: string; hash: Digest; marker: string }> {
+  ensure.that(["complete", "normal", "quarantine", "verify"].includes(mode), "hash_skip mode must be complete, normal, quarantine, or verify");
+  const commit = git(["rev-parse", "--verify", `${ref}^{commit}`], root).toString("utf8").trim();
+  const definition = declaration(root, key, commit);
+  const source = gitPathSetDigest(root, commit, definition.hashPaths, { domain: "open-design/hash-skip/source/v1", label: key });
+  const control = gitPathSetDigest(root, commit, CONTROL_PATHS.map((path) => ({ path })), { domain: "open-design/hash-skip/control/v1", label: "hash_skip control" });
+  const hash = digest(canonicalJson({ control, definition, domain: "open-design/hash-skip/v1", extras: extraDigests(definition), key, source }));
+  const token = hash.slice("sha256:".length);
+  const marker = `.tmp/hash_skip/${token}/success.json`;
+  const absoluteMarker = join(root, marker);
+  mkdirSync(dirname(absoluteMarker), { recursive: true });
+  writeFileSync(absoluteMarker, `${JSON.stringify({ hash, key, schemaVersion: 1 })}\n`);
+  return Object.freeze({ cacheKey: `hash-skip-v1-${key}-${token}`, hash, marker });
+}
+
+function emit(result: ReturnType<typeof resolveKey>): void {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output == null) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  else appendFileSync(output, `cache_key=${result.cacheKey}\nhash=${result.hash}\nmarker=${result.marker}\n`);
+}
+
+function init(root: string): void {
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "hash-skip@open-design.invalid"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "hash_skip self-check"], { cwd: root });
+}
+
+function selfCheck(): void {
+  const root = mkdtempSync(join(tmpdir(), "open-design-hash-skip-"));
+  try {
+    init(root);
+    for (const path of CONTROL_PATHS) { mkdirSync(dirname(join(root, path)), { recursive: true }); writeFileSync(join(root, path), `${path}\n`); }
+    mkdirSync(join(root, ".github", "hash_skip"), { recursive: true });
+    writeFileSync(join(root, ".github", "hash_skip", "probe.json"), JSON.stringify({ extraDigests: ["runtime"], hashPaths: ["source.txt"], schemaVersion: 1 }));
+    writeFileSync(join(root, "source.txt"), "one\n");
+    execFileSync("git", ["add", "."], { cwd: root }); execFileSync("git", ["commit", "-qm", "one"], { cwd: root });
+    process.env.HASH_SKIP_EXTRA_RUNTIME = digest("node24");
+    const first = resolveKey(root, "probe", "HEAD");
+    ensure.that(first.marker.startsWith(".tmp/hash_skip/") && !isAbsolute(first.marker), "cache marker must be repository-relative and cross-runner portable");
+    ensure.that(first.hash === resolveKey(root, "probe", "HEAD").hash, "same inputs produced different hashes");
+    const completed = resolveKey(root, "probe", "HEAD", "complete");
+    ensure.that(first.hash === completed.hash && first.cacheKey === completed.cacheKey && first.marker === completed.marker, "normal and complete modes produced asymmetric identities");
+    writeFileSync(join(root, "source.txt"), "two\n"); execFileSync("git", ["add", "."], { cwd: root }); execFileSync("git", ["commit", "-qm", "two"], { cwd: root });
+    const sourceChanged = resolveKey(root, "probe", "HEAD");
+    ensure.that(first.hash !== sourceChanged.hash, "source change did not invalidate hash");
+    process.env.HASH_SKIP_EXTRA_RUNTIME = digest("node25");
+    ensure.that(sourceChanged.hash !== resolveKey(root, "probe", "HEAD").hash, "extra digest change did not invalidate hash");
+    process.stdout.write("hash_skip self-check OK\n");
+  } finally { rmSync(root, { force: true, recursive: true }); }
+}
+
+const [key, ...args] = process.argv.slice(2);
+if (key == null || key === "--help") process.stdout.write("Usage: hash_skip.ts <key> [--root <path>] [--ref <git-ref>] | self-check\n");
+else if (key === "self-check") selfCheck();
+else {
+  ensure.that(args.length % 2 === 0, "hash_skip options must be pairs");
+  const options = Object.fromEntries(Array.from({ length: args.length / 2 }, (_, index) => [args[index * 2]!.replace(/^--/u, ""), args[index * 2 + 1]!]));
+  ensure.exactKeys(options, ["mode", "ref", "root"], "hash_skip options");
+  emit(resolveKey(resolve(options.root ?? process.cwd()), key, options.ref ?? "HEAD", options.mode ?? "normal"));
+}

--- a/.github/scripts/lib/control.ts
+++ b/.github/scripts/lib/control.ts
@@ -1,0 +1,108 @@
+import { DIGEST_PATTERN, type Digest } from "./json.ts";
+
+type Ensure = Readonly<{
+  array(value: unknown, label: string): unknown[];
+  digest(value: unknown, label: string): Digest;
+  exactKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void;
+  integer(value: unknown, label: string): number;
+  never(message: string): never;
+  record(value: unknown, label: string): Record<string, unknown>;
+  that(condition: unknown, message: string): asserts condition;
+  text(value: unknown, label: string): string;
+}>;
+
+export const ensure: Ensure = Object.freeze({
+  array(value, label) {
+    if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+    return value;
+  },
+  digest(value, label) {
+    if (typeof value !== "string" || !DIGEST_PATTERN.test(value)) throw new Error(`${label} must be a sha256 digest`);
+    return value as Digest;
+  },
+  exactKeys(value, allowed, label) {
+    const unknown = Object.keys(value).filter((key) => !allowed.includes(key));
+    if (unknown.length > 0) throw new Error(`${label} contains unknown fields: ${unknown.join(", ")}`);
+  },
+  integer(value, label) {
+    if (!Number.isSafeInteger(value) || Number(value) < 1) throw new Error(`${label} must be a positive integer`);
+    return Number(value);
+  },
+  never(message) {
+    throw new Error(message);
+  },
+  record(value, label) {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+    return value as Record<string, unknown>;
+  },
+  that(condition, message) {
+    if (!condition) throw new Error(message);
+  },
+  text(value, label) {
+    if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+    return value;
+  },
+});
+
+export const fail = ensure.never;
+
+export function switchBy<Key extends string, Result>(
+  key: Key,
+  branches: Readonly<Record<Key, () => Result>>,
+): Result {
+  const branch = branches[key];
+  ensure.that(branch != null, `unsupported switch value: ${key}`);
+  return branch();
+}
+
+export class Options {
+  readonly #values: ReadonlyMap<string, string>;
+
+  constructor(values: Readonly<Record<string, string>>) {
+    this.#values = new Map(Object.entries(values));
+  }
+
+  get(name: string): string {
+    return this.#values.get(name) ?? ensure.never(`--${name} is required`);
+  }
+
+  optional(name: string): string | undefined {
+    return this.#values.get(name);
+  }
+}
+
+type Command = Readonly<{
+  options: readonly string[];
+  run: (args: Options) => Promise<void> | void;
+}>;
+
+export function command(options: readonly string[], run: Command["run"]): Command {
+  const sorted = [...options].sort();
+  ensure.that(new Set(sorted).size === sorted.length, "command options must not contain duplicates");
+  return Object.freeze({ options: Object.freeze(sorted), run });
+}
+
+export function commands<const Table extends Readonly<Record<string, Command>>>(
+  table: Table,
+  usage: () => string,
+) {
+  return Object.freeze({
+    async run(argv: readonly string[]): Promise<void> {
+      const [name, ...args] = argv;
+      ensure.that(name != null && Object.hasOwn(table, name), `unknown command: ${name ?? ""}\n${usage()}`);
+      const selected = table[name as keyof Table]!;
+      ensure.that(args.length % 2 === 0, `${name} options must be --name value pairs`);
+      const values: Record<string, string> = {};
+      for (let index = 0; index < args.length; index += 2) {
+        const rawKey = args[index]!;
+        const key = rawKey.replace(/^--/u, "");
+        ensure.that(rawKey === `--${key}` && selected.options.includes(key), `${name} does not support ${rawKey}`);
+        ensure.that(values[key] == null, `${name} received duplicate option ${rawKey}`);
+        const value = args[index + 1];
+        ensure.that(value != null && !value.startsWith("--"), `${rawKey} requires a value`);
+        values[key] = value;
+      }
+      await selected.run(new Options(values));
+    },
+  });
+}

--- a/.github/scripts/lib/feishu/client.ts
+++ b/.github/scripts/lib/feishu/client.ts
@@ -1,0 +1,105 @@
+import { createHmac } from "node:crypto";
+
+export type ReleaseFeishuBot = {
+  signSecret: string;
+  webhook: string;
+};
+
+export function decodeReleaseFeishuBot(value: string): ReleaseFeishuBot | null {
+  if (value.trim().length === 0) return null;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(value) as unknown;
+  } catch {
+    throw new Error('release Feishu bot must use JSON tuple codec ["v1","webhook","sign-secret"]');
+  }
+  if (
+    !Array.isArray(decoded)
+    || decoded.length !== 3
+    || decoded[0] !== "v1"
+    || typeof decoded[1] !== "string"
+    || typeof decoded[2] !== "string"
+  ) throw new Error('release Feishu bot must use JSON tuple codec ["v1","webhook","sign-secret"]');
+  const parsed = new URL(decoded[1]);
+  const isFeishu = parsed.protocol === "https:"
+    && ["open.feishu.cn", "open.larksuite.com"].includes(parsed.hostname)
+    && /^\/open-apis\/bot\/v2\/hook\/[A-Za-z0-9_-]+$/u.test(parsed.pathname);
+  const isLoopbackFixture = parsed.protocol === "http:"
+    && ["127.0.0.1", "localhost"].includes(parsed.hostname);
+  if (!isFeishu && !isLoopbackFixture) {
+    throw new Error("release Feishu bot webhook must be a Feishu/Lark custom-bot v2 hook URL");
+  }
+  return { signSecret: decoded[2], webhook: parsed.toString() };
+}
+
+export type FeishuCard = Record<string, unknown>;
+
+export function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (value == null || value.length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+export function optionalEnv(name: string, fallback = ""): string {
+  const value = process.env[name];
+  return value == null || value.length === 0 ? fallback : value;
+}
+
+export function createFeishuSignedEnvelope(
+  card: FeishuCard,
+  signSecret: string,
+): Record<string, unknown> {
+  const envelope = { msg_type: "interactive", card };
+  if (signSecret.length === 0) return envelope;
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const stringToSign = `${timestamp}\n${signSecret}`;
+  const sign = createHmac("sha256", stringToSign).update("").digest("base64");
+  return { timestamp, sign, ...envelope };
+}
+
+function sleep(attempt: number): Promise<void> {
+  const ms = Math.min(1000 * 2 ** (attempt - 1), 15000);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function postFeishuWebhook(
+  webhook: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const attempts = 5;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    let response: Response;
+    try {
+      response = await fetch(webhook, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      console.warn(`[feishu] POST attempt ${attempt}/${attempts} threw: ${error instanceof Error ? error.message : String(error)}`);
+      if (attempt === attempts) throw error;
+      await sleep(attempt);
+      continue;
+    }
+    const text = await response.text();
+    let code: unknown = null;
+    try {
+      const parsed = JSON.parse(text) as { code?: unknown; StatusCode?: unknown };
+      code = parsed.code ?? parsed.StatusCode ?? null;
+    } catch {
+      // A non-JSON response has no bot-specific status code.
+    }
+    if (response.ok && (code === 0 || code === null)) {
+      console.log(`[feishu] delivered (HTTP ${response.status}, code ${code ?? "n/a"})`);
+      return;
+    }
+    console.warn(`[feishu] POST attempt ${attempt}/${attempts} HTTP ${response.status} code ${String(code)}: ${text.slice(0, 500)}`);
+    const retryable = response.status === 429 || response.status >= 500 || code === 9499;
+    if (!retryable || attempt === attempts) {
+      throw new Error(`Feishu webhook failed: HTTP ${response.status} code ${String(code)}`);
+    }
+    await sleep(attempt);
+  }
+}

--- a/.github/scripts/lib/feishu/release.ts
+++ b/.github/scripts/lib/feishu/release.ts
@@ -1,0 +1,461 @@
+import type { FeishuCard } from "./client.ts";
+import {
+  loadReleaseRunContext,
+  loadReleaseRunFailures,
+  loadReleaseChangelog,
+  type ReleaseRunContext,
+  type ReleaseRunFailure,
+} from "../http.ts";
+
+type JsonRecord = Record<string, unknown>;
+type FeishuElement = Record<string, unknown>;
+const EXACT_RELEASE_NAME_PATTERN = /^[a-z0-9]{1,12}$/;
+
+export function isNotificationReleaseChannel(value: unknown): value is string {
+  return typeof value === "string"
+    && (value === "stable" || value === "prerelease" || EXACT_RELEASE_NAME_PATTERN.test(value));
+}
+
+function releaseChannelDisplayLabel(channel: string): string {
+  if (channel === "stable") return "Stable";
+  if (channel === "prerelease") return "Prerelease";
+  if (!EXACT_RELEASE_NAME_PATTERN.test(channel)) throw new Error(`unsupported release notification channel: ${channel}`);
+  return channel[0]!.toUpperCase() + channel.slice(1);
+}
+
+export type ReleaseNotificationInput = {
+  activationCompletedAt: string;
+  actor: string;
+  branch: string;
+  channel: string;
+  commit: string;
+  eventName: string;
+  macArm64Smoke: string;
+  macArm64Url: string;
+  macX64Smoke: string;
+  macX64Url: string;
+  metadataUrl: string;
+  previousCommit: string;
+  releaseMode: string;
+  releaseResult: string;
+  releaseState: string;
+  repository: string;
+  runAttempt: string;
+  runNumber: string;
+  runUrl: string;
+  stream: string;
+  version: string;
+  winX64Smoke: string;
+  winX64Url: string;
+  triggeringActor: string;
+  workflowName: string;
+};
+
+type ColdStartDetail = {
+  bodyBytes: number;
+  budgetBytes: number;
+  launcherBytes: number;
+  nativeBytes: number;
+  requiredBytes: number;
+  target: string;
+  timing?: {
+    readinessBudgetMs: number;
+    readinessDurationMs: number;
+    totalDurationMs: number;
+  };
+};
+
+export type ReleaseNotificationDetails = {
+  changelog: string[];
+  coldStarts: ColdStartDetail[];
+  execution: ReleaseRunContext | null;
+  failures: ReleaseRunFailure[];
+  warnings: string[];
+};
+
+function record(value: unknown): JsonRecord | null {
+  return value != null && typeof value === "object" && !Array.isArray(value) ? value as JsonRecord : null;
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function escapeMarkdown(value: string): string {
+  return value.replace(/([\\`*_[\]])/gu, "\\$1");
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function notificationState(input: ReleaseNotificationInput): "candidate" | "failed" | "partial" | "published" | "promoted" | "validation" {
+  if (input.releaseResult !== "success") return "failed";
+  if (input.releaseState === "partial") return "partial";
+  if (input.releaseMode === "candidate") return "candidate";
+  if (["metadata", "prepublish", "validation", "false"].includes(input.releaseMode)) return "validation";
+  if (input.version.length === 0 || input.metadataUrl.length === 0) return "validation";
+  return input.releaseMode === "promote" ? "promoted" : "published";
+}
+
+function coldStartFromMetadata(metadata: JsonRecord): ColdStartDetail[] {
+  const closure = record(metadata.closure);
+  const required = record(closure?.required);
+  const targets = record(required?.targets);
+  const blobs = record(closure?.blobs);
+  const body = record(required?.body);
+  const launcher = record(required?.launcher);
+  if (targets == null || blobs == null || body == null || launcher == null) return [];
+  const component = (value: JsonRecord | null): { digest: string; bytes: number } | null => {
+    const digest = typeof value?.blob === "string" ? value.blob : "";
+    const artifact = record(blobs[digest]);
+    const bytes = positiveInteger(artifact?.size);
+    return digest.length > 0 && bytes != null ? { bytes, digest } : null;
+  };
+  const commonBody = component(body);
+  const commonLauncher = component(launcher);
+  if (commonBody == null || commonLauncher == null) return [];
+  return Object.entries(targets).flatMap(([target, targetValue]) => {
+    const native = component(record(record(targetValue)?.native));
+    if (native == null) return [];
+    const unique = new Map([
+      [commonBody.digest, commonBody.bytes],
+      [commonLauncher.digest, commonLauncher.bytes],
+      [native.digest, native.bytes],
+    ]);
+    return [{
+      bodyBytes: commonBody.bytes,
+      budgetBytes: 30_000_000,
+      launcherBytes: commonLauncher.bytes,
+      nativeBytes: native.bytes,
+      requiredBytes: [...unique.values()].reduce((total, bytes) => total + bytes, 0),
+      target,
+    }];
+  });
+}
+
+async function acceptanceTiming(metadataUrl: string, target: string, fetchImpl: typeof fetch) {
+  const acceptanceUrl = new URL(`acceptance/${target.replace("darwin-arm64", "mac_arm64").replace("darwin-x64", "mac_x64").replace("win32-x64", "win_x64")}.json`, metadataUrl);
+  const response = await fetchImpl(acceptanceUrl);
+  if (!response.ok) return undefined;
+  const credential = record(await response.json());
+  const timing = record(record(credential?.coldStart)?.timing);
+  const readinessBudgetMs = positiveInteger(timing?.readinessBudgetMs);
+  const readinessDurationMs = positiveInteger(timing?.readinessDurationMs);
+  const totalDurationMs = positiveInteger(timing?.totalDurationMs);
+  return readinessBudgetMs == null || readinessDurationMs == null || totalDurationMs == null
+    ? undefined
+    : { readinessBudgetMs, readinessDurationMs, totalDurationMs };
+}
+
+export async function loadReleaseNotificationDetails(
+  input: ReleaseNotificationInput,
+  fetchImpl: typeof fetch = fetch,
+  githubToken = "",
+): Promise<ReleaseNotificationDetails> {
+  const state = notificationState(input);
+  const smokeFailed = [input.macArm64Smoke, input.macX64Smoke, input.winX64Smoke].includes("failure");
+  let execution: ReleaseRunContext | null = null;
+  let changelog: string[] = [];
+  try {
+    [execution, changelog] = await Promise.all([
+      loadReleaseRunContext({
+        fetchImpl,
+        repository: input.repository,
+        runUrl: input.runUrl,
+        token: githubToken,
+      }),
+      loadReleaseChangelog({
+        commit: input.commit,
+        fetchImpl,
+        previousCommit: input.previousCommit,
+        repository: input.repository,
+        token: githubToken,
+      }),
+    ]);
+  } catch {
+    // Execution metadata is presentational. A GitHub API outage must not turn a
+    // successful release card into a warning or change the release outcome.
+  }
+  if (!["failed", "partial"].includes(state) && !smokeFailed) {
+    return { changelog, coldStarts: [], execution, failures: [], warnings: [] };
+  }
+  const warnings: string[] = [];
+  let coldStarts: ColdStartDetail[] = [];
+  let failures: ReleaseRunFailure[] = [];
+  if (input.metadataUrl.length > 0) {
+    try {
+      const response = await fetchImpl(input.metadataUrl);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const metadata = record(await response.json());
+      if (metadata == null) throw new Error("metadata is not an object");
+      coldStarts = coldStartFromMetadata(metadata);
+      if (input.channel !== "stable" && input.channel !== "prerelease") {
+        await Promise.all(coldStarts.map(async (entry) => {
+          const timing = await acceptanceTiming(input.metadataUrl, entry.target, fetchImpl);
+          if (timing != null) entry.timing = timing;
+        }));
+      }
+    } catch (error) {
+      warnings.push(`未能读取发布元数据：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (state === "failed") {
+    try {
+      failures = await loadReleaseRunFailures({
+        fetchImpl,
+        repository: input.repository,
+        runUrl: input.runUrl,
+        token: githubToken,
+      });
+    } catch (error) {
+      warnings.push(`未能读取失败步骤：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  return { changelog, coldStarts, execution, failures, warnings };
+}
+
+function bytes(value: number): string {
+  return `${(value / 1_000_000).toFixed(2)} MB`;
+}
+
+function seconds(value: number): string {
+  return `${(value / 1_000).toFixed(1)}s`;
+}
+
+function duration(value: number): string {
+  const totalSeconds = Math.max(0, Math.round(value / 1_000));
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  return [hours > 0 ? `${hours}h` : "", minutes > 0 ? `${minutes}m` : "", `${seconds}s`]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function actorMarkdown(actor: string): string {
+  const escaped = escapeMarkdown(actor);
+  return actor.length > 0
+    ? `[@${escaped}](https://github.com/${encodeURIComponent(actor)})`
+    : "未知";
+}
+
+function commitMarkdown(input: ReleaseNotificationInput): string {
+  const shortCommit = input.commit.slice(0, 7);
+  if (shortCommit.length === 0) return "";
+  return input.repository.length > 0
+    ? `[${shortCommit}](https://github.com/${input.repository}/commit/${input.commit})`
+    : shortCommit;
+}
+
+function executionTimingMarkdown(input: ReleaseNotificationInput, execution: ReleaseRunContext | null): string {
+  if (execution == null) return "";
+  const activationMs = Date.parse(input.activationCompletedAt);
+  const hasActivation = Number.isFinite(activationMs)
+    && activationMs >= execution.runStartedAtMs
+    && activationMs <= execution.observedAtMs;
+  const releaseMs = hasActivation ? activationMs - execution.runStartedAtMs : execution.durationMs;
+  const notificationMs = hasActivation ? execution.observedAtMs - activationMs : 0;
+  return [
+    `发布 ${duration(releaseMs)}`,
+    hasActivation ? `通知 ${duration(notificationMs)}` : "",
+    execution.queueDurationMs > 0 ? `排队 ${duration(execution.queueDurationMs)}` : "",
+  ].filter(Boolean).join(" · ");
+}
+
+function triggerLabel(eventName: string): string {
+  return {
+    push: "Push",
+    repository_dispatch: "外部调度",
+    schedule: "定时",
+    workflow_call: "复用工作流",
+    workflow_dispatch: "手动",
+    workflow_run: "上游工作流",
+  }[eventName] ?? (eventName.length > 0 ? eventName : "未知");
+}
+
+function releaseModeLabel(mode: string): string {
+  if (mode === "candidate") return "publish=false · 公开候选 / 无 latest 入口";
+  if (["false", "metadata", "prepublish", "validation"].includes(mode)) return "publish=false · 内部验证";
+  if (mode === "promote") return "publish=true · 晋升 latest";
+  return "publish=true · 不晋升";
+}
+
+function targetLabel(target: string): string {
+  return {
+    "darwin-arm64": "Apple 芯片",
+    "darwin-x64": "Intel",
+    "win32-x64": "Windows",
+  }[target] ?? target;
+}
+
+function coldStartMarkdown(details: ReleaseNotificationDetails): string {
+  return details.coldStarts.map((entry) => {
+    const timing = entry.timing == null
+      ? ""
+      : `\n启动 ${seconds(entry.timing.totalDurationMs - entry.timing.readinessDurationMs)}`
+        + ` · 就绪 ${seconds(entry.timing.readinessDurationMs)}/${seconds(entry.timing.readinessBudgetMs)}`
+        + ` · 总计 ${seconds(entry.timing.totalDurationMs)}`;
+    return `**${targetLabel(entry.target)}** · ${bytes(entry.requiredBytes)} / ${bytes(entry.budgetBytes)}`
+      + `\nbody ${bytes(entry.bodyBytes)} · launcher ${bytes(entry.launcherBytes)} · native ${bytes(entry.nativeBytes)}`
+      + timing;
+  }).join("\n\n");
+}
+
+function failureMarkdown(details: ReleaseNotificationDetails): string {
+  return details.failures.map((failure) => {
+    const label = truncate(
+      failure.step.length > 0 ? `${failure.job} · ${failure.step}` : failure.job,
+      100,
+    );
+    return failure.url.length > 0
+      ? `- [${escapeMarkdown(label)}](${failure.url})`
+      : `- ${escapeMarkdown(label)}`;
+  }).join("\n");
+}
+
+function changelogMarkdown(lines: string[], repository: string): string {
+  return lines.slice(0, 5).map((line) => {
+    const match = line.match(/^(.*) \(([0-9a-f]{7,40})\)$/u);
+    const subject = truncate(match?.[1]?.trim() || line, 90);
+    const commit = match?.[2] ?? "";
+    const suffix = commit.length === 0
+      ? ""
+      : repository.length > 0
+        ? ` · [${commit.slice(0, 7)}](https://github.com/${repository}/commit/${commit})`
+        : ` · ${commit.slice(0, 7)}`;
+    return `- ${escapeMarkdown(subject)}${suffix}`;
+  }).join("\n");
+}
+
+export function buildReleaseFeishuCard(
+  input: ReleaseNotificationInput,
+  details: ReleaseNotificationDetails,
+): FeishuCard {
+  const state = notificationState(input);
+  const channelLabel = releaseChannelDisplayLabel(input.channel);
+  const smokeFailures = [
+    ["macOS arm64", input.macArm64Smoke],
+    ["macOS x64", input.macX64Smoke],
+    ["Windows x64", input.winX64Smoke],
+  ].filter(([, result]) => result === "failure").map(([label]) => `${label} smoke 失败`);
+  const warning = state === "partial" || smokeFailures.length > 0 || details.warnings.length > 0;
+  const icon = state === "failed" ? "🚨" : state === "validation" ? "🧪" : state === "candidate" ? "📦" : warning ? "⚠️" : "🚀";
+  const stateLabel = {
+    candidate: warning ? "候选就绪（有告警）" : "候选就绪 · 公开下载 / 无 latest 入口",
+    failed: "发布失败",
+    partial: "部分完成",
+    promoted: warning ? "发布并晋升完成（有告警）" : "发布并晋升完成",
+    published: warning ? "不可变发布完成（有告警）" : "不可变发布完成 · 未晋升",
+    validation: "验证完成",
+  }[state];
+  const fields: FeishuElement[] = [];
+  const rerunActor = input.triggeringActor.length > 0 && input.triggeringActor !== input.actor
+    ? ` · 重跑 ${actorMarkdown(input.triggeringActor)}`
+    : "";
+  const source = [escapeMarkdown(input.branch), commitMarkdown(input)].filter(Boolean).join(" · ");
+  fields.push({
+    is_short: false,
+    text: {
+      tag: "lark_md",
+      content: `**触发** · ${actorMarkdown(input.actor)}${rerunActor} · ${escapeMarkdown(triggerLabel(input.eventName))}`
+        + (source.length > 0 ? ` · ${source}` : ""),
+    },
+  });
+  fields.push({
+    is_short: false,
+    text: { tag: "lark_md", content: `**模式** · ${releaseModeLabel(input.releaseMode)}` },
+  });
+  if (input.runNumber.length > 0) {
+    const attempt = Number.parseInt(input.runAttempt, 10);
+    const attemptLabel = Number.isSafeInteger(attempt) && attempt > 1 ? ` · 第 ${attempt} 次执行` : "";
+    const runLabel = `${input.workflowName || "Workflow"} #${input.runNumber}${attemptLabel}`;
+    fields.push({
+      is_short: false,
+      text: {
+        tag: "lark_md",
+        content: `**执行** · ${input.runUrl.length > 0
+          ? `[${escapeMarkdown(runLabel)}](${input.runUrl})`
+          : escapeMarkdown(runLabel)}`
+          + (details.execution?.pullRequest != null
+            ? ` · [PR #${details.execution.pullRequest.number}](${details.execution.pullRequest.url})`
+            : "")
+          + (details.execution != null
+            ? ` · ${executionTimingMarkdown(input, details.execution)}`
+            : ""),
+      },
+    });
+  }
+  const elements: FeishuElement[] = fields.length > 0
+    ? [{ tag: "div", fields }, { tag: "hr" }]
+    : [];
+  const notices = [...smokeFailures, ...details.warnings];
+  if (details.failures.length > 0) elements.push({
+    tag: "div",
+    text: { tag: "lark_md", content: `**失败位置**\n${failureMarkdown(details)}` },
+  });
+  if (notices.length > 0) elements.push({
+    tag: "div",
+    text: {
+      tag: "lark_md",
+      content: `**告警**\n${notices.map((line) => `- ${escapeMarkdown(line)}`).join("\n")}`,
+    },
+  });
+  if (details.coldStarts.length > 0) elements.push({ tag: "div", text: { tag: "lark_md", content: `**Closure 冷启动**\n${coldStartMarkdown(details)}` } });
+  if (details.changelog.length > 0) elements.push({
+    tag: "div",
+    text: {
+      tag: "lark_md",
+      content: `**变更**\n${changelogMarkdown(details.changelog, input.repository)}`,
+    },
+  });
+  const downloads = ([
+    ["Mac Arm", input.macArm64Url],
+    ["Mac x64", input.macX64Url],
+    ["Win x64", input.winX64Url],
+  ] satisfies Array<[string, string]>).filter(([, url]) => url.length > 0);
+  if (downloads.length > 0 && state !== "failed") elements.push({
+    tag: "action",
+    actions: downloads.map(([label, url], index) => ({
+      tag: "button",
+      text: { tag: "plain_text", content: state === "candidate" ? `候选 · ${label}` : label },
+      type: index === 0 ? "primary" : "default",
+      url,
+    })),
+  });
+  if (state === "candidate" && input.repository.length > 0) {
+    const workflow = input.channel === "stable"
+      ? "release-stable-promote.yml"
+      : "distribution-exact-accept.yml";
+    elements.push({
+      tag: "action",
+      actions: [{
+        tag: "button",
+        text: { tag: "plain_text", content: "发布 / 晋升候选" },
+        type: "primary",
+        url: `https://github.com/${input.repository}/actions/workflows/${workflow}`,
+      }],
+    });
+  }
+  const links = [
+    input.metadataUrl.length > 0 ? `[${state === "candidate" ? "候选清单" : "发布详情"}](${input.metadataUrl})` : "",
+    input.runUrl.length > 0 ? `[GitHub Actions](${input.runUrl})` : "",
+  ].filter(Boolean);
+  if (links.length > 0) elements.push({
+    tag: "note",
+    elements: [{ tag: "lark_md", content: links.join(" · ") }],
+  });
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template: state === "failed" ? "red" : warning ? "orange" : state === "published" || state === "promoted" ? "green" : "blue",
+      title: {
+        tag: "plain_text",
+        content: `${icon} ${channelLabel} ${input.version || "(未生成版本)"} ${stateLabel}`,
+      },
+    },
+    elements,
+  };
+}
+
+export const releaseNotificationInternals = { coldStartFromMetadata, notificationState };

--- a/.github/scripts/lib/git.ts
+++ b/.github/scripts/lib/git.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from "node:child_process";
+
+import { ensure, fail } from "./control.ts";
+import { canonicalJson, digest, type Digest, type Json } from "./json.ts";
+
+export type GitHashPath = Readonly<{
+  excludeDirectoryNames?: readonly string[];
+  excludePaths?: readonly string[];
+  normalizePackageVersion?: boolean;
+  normalizeTextLineEndings?: boolean;
+  path: string;
+}>;
+
+type GitEntry = Readonly<{ mode: string; object: string; path: string; type: string }>;
+
+export function git(args: readonly string[], cwd: string): Buffer {
+  try {
+    return execFileSync("git", args, { cwd, encoding: "buffer", maxBuffer: 256 * 1024 * 1024 });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    fail(`git ${args.join(" ")} failed: ${detail}`);
+  }
+}
+
+function listGitEntries(root: string, ref: string, source: GitHashPath): readonly GitEntry[] {
+  const raw = git(["ls-tree", "-rz", "--full-tree", ref, "--", source.path], root);
+  const entries = raw.toString("utf8").split("\0").filter(Boolean).map((line): GitEntry => {
+    const tab = line.indexOf("\t");
+    if (tab < 0) fail(`invalid git ls-tree entry: ${line}`);
+    const [mode, type, object] = line.slice(0, tab).split(" ");
+    if (mode == null || type == null || object == null) fail(`invalid git ls-tree metadata: ${line}`);
+    return { mode, object, path: line.slice(tab + 1), type };
+  });
+  const excludedDirectories = new Set(source.excludeDirectoryNames ?? []);
+  const exclusions = (source.excludePaths ?? []).map((path) => `${source.path}/${path}`);
+  return entries.filter((entry) => {
+    const relativePath = entry.path === source.path ? "" : entry.path.slice(source.path.length + 1);
+    if (relativePath.split("/").some((segment) => excludedDirectories.has(segment))) return false;
+    return !exclusions.some((excluded) => entry.path === excluded || entry.path.startsWith(`${excluded}/`));
+  });
+}
+
+function normalizedBlob(root: string, entry: GitEntry, source: GitHashPath): Readonly<{ digest: Digest; size: number }> {
+  let body = git(["cat-file", "blob", entry.object], root);
+  if (source.normalizePackageVersion === true && (entry.path === "package.json" || entry.path.endsWith("/package.json"))) {
+    try {
+      const packageJson = ensure.record(JSON.parse(body.toString("utf8")), `${entry.path} package metadata`);
+      delete packageJson.version;
+      body = Buffer.from(`${canonicalJson(packageJson)}\n`);
+    } catch {
+      // The owning validation reports malformed JSON; identity remains byte-exact.
+    }
+  }
+  if (source.normalizeTextLineEndings === true && !body.includes(0)) {
+    body = Buffer.from(body.toString("utf8").replace(/\r\n?/gu, "\n"));
+  }
+  return { digest: digest(body), size: body.byteLength };
+}
+
+export function gitPathSetDigest(
+  root: string,
+  ref: string,
+  sources: readonly GitHashPath[],
+  options: Readonly<{ domain: string; label: string }>,
+): Digest {
+  const seen = new Set<string>();
+  const entries: Json[] = [];
+  for (const source of sources) {
+    const matched = listGitEntries(root, ref, source);
+    if (matched.length === 0) fail(`${options.label} path does not exist at ${ref}: ${source.path}`);
+    for (const entry of matched) {
+      if (seen.has(entry.path)) fail(`${options.label} paths overlap at ${entry.path}`);
+      seen.add(entry.path);
+      if (entry.type === "blob") {
+        const normalized = normalizedBlob(root, entry, source);
+        entries.push({ kind: entry.mode === "120000" ? "symlink" : "file", mode: entry.mode, path: entry.path, ...normalized });
+      } else {
+        entries.push({ kind: entry.type, mode: entry.mode, object: entry.object, path: entry.path });
+      }
+    }
+  }
+  entries.sort((left, right) => String((left as Record<string, Json>).path).localeCompare(String((right as Record<string, Json>).path)));
+  return digest(canonicalJson({ domain: options.domain, entries }));
+}

--- a/.github/scripts/lib/http.ts
+++ b/.github/scripts/lib/http.ts
@@ -1,0 +1,180 @@
+// HTTP-backed GitHub enrichment for workflow notifications.
+type GitHubJobStep = {
+  conclusion?: unknown;
+  name?: unknown;
+};
+
+type GitHubJob = {
+  conclusion?: unknown;
+  html_url?: unknown;
+  name?: unknown;
+  steps?: unknown;
+};
+
+export type ReleaseRunFailure = {
+  job: string;
+  step: string;
+  url: string;
+};
+
+export type ReleaseRunContext = {
+  durationMs: number;
+  observedAtMs: number;
+  pullRequest: {
+    number: number;
+    url: string;
+  } | null;
+  queueDurationMs: number;
+  runStartedAtMs: number;
+};
+
+type GitHubCompareCommit = {
+  commit?: { message?: unknown };
+  parents?: unknown;
+  sha?: unknown;
+};
+
+const FAILED_CONCLUSIONS = new Set([
+  "action_required",
+  "failure",
+  "stale",
+  "startup_failure",
+  "timed_out",
+]);
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function runId(runUrl: string): string | null {
+  try {
+    const match = new URL(runUrl).pathname.match(/\/actions\/runs\/(\d+)(?:\/|$)/u);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "user-agent": "open-design-release-notifier",
+    "x-github-api-version": "2022-11-28",
+  };
+}
+
+export async function loadReleaseChangelog(input: {
+  commit: string;
+  fetchImpl?: typeof fetch;
+  previousCommit: string;
+  repository: string;
+  token: string;
+}): Promise<string[]> {
+  if (
+    input.repository.length === 0
+    || input.previousCommit.length === 0
+    || input.commit.length === 0
+    || input.token.length === 0
+  ) return [];
+  const response = await (input.fetchImpl ?? fetch)(
+    `https://api.github.com/repos/${input.repository}/compare/${encodeURIComponent(input.previousCommit)}...${encodeURIComponent(input.commit)}?per_page=25`,
+    { headers: githubHeaders(input.token) },
+  );
+  if (!response.ok) throw new Error(`GitHub compare HTTP ${response.status}`);
+  const payload = await response.json() as { commits?: unknown };
+  if (!Array.isArray(payload.commits)) throw new Error("GitHub compare response is invalid");
+  return (payload.commits as GitHubCompareCommit[])
+    .filter((entry) => !Array.isArray(entry.parents) || entry.parents.length <= 1)
+    .reverse()
+    .flatMap((entry) => {
+      const sha = text(entry.sha);
+      const subject = text(entry.commit?.message).split("\n", 1)[0]?.trim() ?? "";
+      return sha.length > 0 && subject.length > 0 ? [`${subject} (${sha})`] : [];
+    });
+}
+
+export async function loadReleaseRunContext(input: {
+  fetchImpl?: typeof fetch;
+  now?: number;
+  repository: string;
+  runUrl: string;
+  token: string;
+}): Promise<ReleaseRunContext | null> {
+  const id = runId(input.runUrl);
+  if (id == null || input.repository.length === 0 || input.token.length === 0) return null;
+  const response = await (input.fetchImpl ?? fetch)(
+    `https://api.github.com/repos/${input.repository}/actions/runs/${id}`,
+    { headers: githubHeaders(input.token) },
+  );
+  if (!response.ok) throw new Error(`GitHub Actions run HTTP ${response.status}`);
+  const payload = await response.json() as {
+    created_at?: unknown;
+    pull_requests?: unknown;
+    run_started_at?: unknown;
+  };
+  const createdAtMs = Date.parse(text(payload.created_at));
+  const startedAt = text(payload.run_started_at) || text(payload.created_at);
+  const startedAtMs = Date.parse(startedAt);
+  const now = input.now ?? Date.now();
+  const durationMs = Number.isFinite(startedAtMs) ? Math.max(0, now - startedAtMs) : 0;
+  const queueDurationMs = Number.isFinite(createdAtMs) && Number.isFinite(startedAtMs)
+    ? Math.max(0, startedAtMs - createdAtMs)
+    : 0;
+  const pullRequests = Array.isArray(payload.pull_requests)
+    ? payload.pull_requests.flatMap((entry) => {
+      if (entry == null || typeof entry !== "object") return [];
+      const number = (entry as { number?: unknown }).number;
+      return typeof number === "number" && Number.isSafeInteger(number) && number > 0 ? [number] : [];
+    })
+    : [];
+  const uniquePullRequests = [...new Set(pullRequests)];
+  const pullRequest = uniquePullRequests.length === 1
+    ? {
+        number: uniquePullRequests[0]!,
+        url: `https://github.com/${input.repository}/pull/${uniquePullRequests[0]}`,
+      }
+    : null;
+  return {
+    durationMs,
+    observedAtMs: now,
+    pullRequest,
+    queueDurationMs,
+    runStartedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : 0,
+  };
+}
+
+function failedStep(value: unknown): string {
+  if (!Array.isArray(value)) return "";
+  const steps = value as GitHubJobStep[];
+  return text(steps.find((step) => FAILED_CONCLUSIONS.has(text(step.conclusion)))?.name);
+}
+
+export async function loadReleaseRunFailures(input: {
+  fetchImpl?: typeof fetch;
+  repository: string;
+  runUrl: string;
+  token: string;
+}): Promise<ReleaseRunFailure[]> {
+  const id = runId(input.runUrl);
+  if (id == null || input.repository.length === 0 || input.token.length === 0) return [];
+  const response = await (input.fetchImpl ?? fetch)(
+    `https://api.github.com/repos/${input.repository}/actions/runs/${id}/jobs?filter=latest&per_page=100`,
+    {
+      headers: {
+        ...githubHeaders(input.token),
+      },
+    },
+  );
+  if (!response.ok) throw new Error(`GitHub Actions jobs HTTP ${response.status}`);
+  const payload = await response.json() as { jobs?: unknown };
+  if (!Array.isArray(payload.jobs)) throw new Error("GitHub Actions jobs response is invalid");
+  return (payload.jobs as GitHubJob[])
+    .filter((job) => FAILED_CONCLUSIONS.has(text(job.conclusion)))
+    .slice(0, 3)
+    .map((job) => ({
+      job: text(job.name) || "未命名 job",
+      step: failedStep(job.steps),
+      url: text(job.html_url) || input.runUrl,
+    }));
+}

--- a/.github/scripts/lib/json.ts
+++ b/.github/scripts/lib/json.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+export type Digest = `sha256:${string}`;
+
+export const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+export function canonicalize(value: unknown): Json {
+  if (value === null) return null;
+  if (typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("canonical JSON cannot contain non-finite numbers");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value == null || typeof value !== "object") throw new Error("canonical JSON value must be an object");
+  return Object.fromEntries(Object.entries(value)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => [key, canonicalize(entry)]));
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function digest(value: string | Uint8Array): Digest {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}

--- a/.github/scripts/release_notice.ts
+++ b/.github/scripts/release_notice.ts
@@ -1,0 +1,51 @@
+// Posts a generic notice to a Feishu (Lark) custom-bot webhook as an interactive
+// card: a colored header title plus a markdown body, with no download buttons.
+//
+// This is the lightweight sibling of feishu.ts (the build/download card). It is
+// for events that are NOT a package build — e.g. cut-patch-release announcing
+// that the Thursday patch cut was skipped because the week's minor has not
+// shipped stable yet. The signing + retry transport mirrors feishu.ts so both
+// notifiers behave identically against the same bot.
+//
+// Inputs (all via env):
+//   FEISHU_WEBHOOK        (required) custom-bot webhook URL
+//   FEISHU_SIGN_SECRET    (optional) signing secret when the bot enables 签名校验
+//   NOTICE_TITLE          (required) header title, e.g. "⏭️ 周四小版本已跳过"
+//   NOTICE_TEMPLATE       (optional) header color: blue | orange | red | grey | green … (default "orange")
+//   NOTICE_BODY           (required) card body, rendered as lark_md markdown
+//   RUN_URL               (optional) link back to the GitHub Actions run
+
+import {
+  createFeishuSignedEnvelope,
+  optionalEnv as optional,
+  postFeishuWebhook,
+  requiredEnv as required,
+  type FeishuCard,
+} from "./lib/feishu/client.ts";
+
+const webhook = required("FEISHU_WEBHOOK");
+const signSecret = optional("FEISHU_SIGN_SECRET");
+const title = required("NOTICE_TITLE");
+const template = optional("NOTICE_TEMPLATE", "orange");
+const body = required("NOTICE_BODY");
+const runUrl = optional("RUN_URL");
+
+function buildCard(): FeishuCard {
+  const elements: Record<string, unknown>[] = [{ tag: "div", text: { tag: "lark_md", content: body } }];
+  if (runUrl.length > 0) {
+    elements.push({
+      tag: "note",
+      elements: [{ tag: "lark_md", content: `[GitHub Actions run](${runUrl})` }],
+    });
+  }
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      template,
+      title: { tag: "plain_text", content: title },
+    },
+    elements,
+  };
+}
+
+await postFeishuWebhook(webhook, createFeishuSignedEnvelope(buildCard(), signSecret));

--- a/.github/scripts/release_notification.ts
+++ b/.github/scripts/release_notification.ts
@@ -1,0 +1,65 @@
+import { appendFileSync } from "node:fs";
+
+import { decodeReleaseFeishuBot } from "./lib/feishu/client.ts";
+import {
+  buildReleaseFeishuCard,
+  loadReleaseNotificationDetails,
+  type ReleaseNotificationInput,
+  isNotificationReleaseChannel,
+} from "./lib/feishu/release.ts";
+import {
+  createFeishuSignedEnvelope,
+  optionalEnv,
+  postFeishuWebhook,
+} from "./lib/feishu/client.ts";
+
+function summary(line: string): void {
+  const path = optionalEnv("GITHUB_STEP_SUMMARY");
+  if (path.length > 0) appendFileSync(path, `${line}\n`, "utf8");
+  console.log(line);
+}
+
+const bot = decodeReleaseFeishuBot(optionalEnv("RELEASE_FEISHU_BOT"));
+if (bot == null) {
+  summary("Feishu: not configured");
+} else {
+  const channel = optionalEnv("RELEASE_CHANNEL");
+  if (!isNotificationReleaseChannel(channel)) {
+    throw new Error(`unsupported release notification channel: ${channel}`);
+  }
+  const input: ReleaseNotificationInput = {
+    activationCompletedAt: optionalEnv("RELEASE_ACTIVATION_COMPLETED_AT"),
+    actor: optionalEnv("RELEASE_ACTOR"),
+    branch: optionalEnv("RELEASE_BRANCH"),
+    channel,
+    commit: optionalEnv("RELEASE_COMMIT"),
+    eventName: optionalEnv("RELEASE_EVENT_NAME"),
+    macArm64Smoke: optionalEnv("RELEASE_MAC_ARM64_SMOKE"),
+    macArm64Url: optionalEnv("RELEASE_MAC_ARM64_URL"),
+    macX64Smoke: optionalEnv("RELEASE_MAC_X64_SMOKE"),
+    macX64Url: optionalEnv("RELEASE_MAC_X64_URL"),
+    metadataUrl: optionalEnv("RELEASE_METADATA_URL"),
+    previousCommit: optionalEnv("RELEASE_PREVIOUS_COMMIT"),
+    releaseMode: optionalEnv("RELEASE_MODE", "publish"),
+    releaseResult: optionalEnv("RELEASE_RESULT", "success"),
+    releaseState: optionalEnv("RELEASE_STATE", "complete"),
+    repository: optionalEnv("RELEASE_REPOSITORY"),
+    runAttempt: optionalEnv("RELEASE_RUN_ATTEMPT"),
+    runNumber: optionalEnv("RELEASE_RUN_NUMBER"),
+    runUrl: optionalEnv("RELEASE_RUN_URL"),
+    stream: optionalEnv("RELEASE_NOTIFICATION_STREAM", "release"),
+    version: optionalEnv("RELEASE_VERSION"),
+    winX64Smoke: optionalEnv("RELEASE_WIN_X64_SMOKE"),
+    winX64Url: optionalEnv("RELEASE_WIN_X64_URL"),
+    triggeringActor: optionalEnv("RELEASE_TRIGGERING_ACTOR"),
+    workflowName: optionalEnv("RELEASE_WORKFLOW_NAME"),
+  };
+  const details = await loadReleaseNotificationDetails(
+    input,
+    fetch,
+    optionalEnv("RELEASE_GITHUB_TOKEN"),
+  );
+  const card = buildReleaseFeishuCard(input, details);
+  await postFeishuWebhook(bot.webhook, createFeishuSignedEnvelope(card, bot.signSecret));
+  summary(`Feishu: delivered ${channel} ${input.version || "validation"}`);
+}

--- a/e2e/tests/scripts/release-notification.test.ts
+++ b/e2e/tests/scripts/release-notification.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeReleaseFeishuBot } from "../../../.github/scripts/lib/feishu/client.js";
+import {
+  buildReleaseFeishuCard,
+  loadReleaseNotificationDetails,
+  releaseNotificationInternals,
+  type ReleaseNotificationInput,
+} from "../../../.github/scripts/lib/feishu/release.js";
+
+function input(overrides: Partial<ReleaseNotificationInput> = {}): ReleaseNotificationInput {
+  return {
+    activationCompletedAt: "2026-08-17T03:47:30Z",
+    actor: "alice",
+    branch: "feat/standalone-closure",
+    channel: "beta",
+    commit: "0123456789abcdef0123456789abcdef01234567",
+    eventName: "workflow_dispatch",
+    macArm64Smoke: "success",
+    macArm64Url: "https://releases.example/mac-arm64.dmg",
+    macX64Smoke: "success",
+    macX64Url: "https://releases.example/mac-x64.dmg",
+    metadataUrl: "https://releases.example/beta/versions/0.19.1-beta.4/metadata.json",
+    previousCommit: "abcdef0123456789abcdef0123456789abcdef01",
+    releaseMode: "publish",
+    releaseResult: "success",
+    releaseState: "complete",
+    repository: "nexu-io/open-design",
+    runAttempt: "1",
+    runNumber: "123",
+    runUrl: "https://github.com/nexu-io/open-design/actions/runs/1",
+    stream: "release",
+    version: "0.19.1-beta.4",
+    winX64Smoke: "success",
+    winX64Url: "https://releases.example/win.exe",
+    triggeringActor: "alice",
+    workflowName: "release-beta",
+    ...overrides,
+  };
+}
+
+const digest = (character: string) => `sha256:${character.repeat(64)}`;
+
+function metadata() {
+  const body = digest("a");
+  const launcher = digest("b");
+  const native = digest("c");
+  return {
+    closure: {
+      blobs: {
+        [body]: { digest: body, mediaType: "application/zip", size: 19_000_000, url: "https://example/body" },
+        [launcher]: { digest: launcher, mediaType: "application/zip", size: 40_000, url: "https://example/launcher" },
+        [native]: { digest: native, mediaType: "application/zip", size: 2_000_000, url: "https://example/native" },
+      },
+      required: {
+        body: { blob: body },
+        launcher: { blob: launcher },
+        targets: { "darwin-arm64": { native: { blob: native } } },
+      },
+    },
+  };
+}
+
+const emptyDetails = {
+  changelog: [],
+  coldStarts: [],
+  execution: null,
+  failures: [],
+  warnings: [],
+};
+
+describe("release Feishu notification", () => {
+  it("decodes one compact secret and rejects ambiguous bot declarations", () => {
+    expect(decodeReleaseFeishuBot('["v1","https://open.feishu.cn/open-apis/bot/v2/hook/abc_123",""]'))
+      .toEqual({ signSecret: "", webhook: "https://open.feishu.cn/open-apis/bot/v2/hook/abc_123" });
+    expect(decodeReleaseFeishuBot("")).toBeNull();
+    expect(() => decodeReleaseFeishuBot('["v2","https://open.feishu.cn/open-apis/bot/v2/hook/a",""]'))
+      .toThrow(/tuple codec/u);
+  });
+
+  it("derives the unique cold-start set and attaches public acceptance timing", async () => {
+    const fetchImpl = async (request: string | URL | Request) => {
+      const url = String(request);
+      if (url.endsWith("metadata.json")) return Response.json(metadata());
+      if (url.endsWith("acceptance/mac_arm64.json")) return Response.json({
+        coldStart: {
+          timing: { readinessBudgetMs: 90_000, readinessDurationMs: 2_000, totalDurationMs: 3_000 },
+        },
+      });
+      return new Response(null, { status: 404 });
+    };
+    const details = await loadReleaseNotificationDetails(
+      input({ releaseState: "partial" }),
+      fetchImpl as typeof fetch,
+    );
+    expect(details.coldStarts).toEqual([expect.objectContaining({
+      bodyBytes: 19_000_000,
+      launcherBytes: 40_000,
+      nativeBytes: 2_000_000,
+      requiredBytes: 21_040_000,
+      target: "darwin-arm64",
+      timing: { readinessBudgetMs: 90_000, readinessDurationMs: 2_000, totalDurationMs: 3_000 },
+    })]);
+  });
+
+  it("keeps successful cards compact and formats a bounded changelog", async () => {
+    const details = await loadReleaseNotificationDetails(input(), (async (request: string | URL | Request) => {
+      const url = String(request);
+      if (url.includes("/compare/")) return Response.json({
+        commits: [
+          { commit: { message: "chore: hidden oldest change" }, parents: [{}], sha: "0".repeat(40) },
+          { commit: { message: "feat: first change\n\nbody" }, parents: [{}], sha: "1".repeat(40) },
+          { commit: { message: "fix: second change" }, parents: [{}], sha: "2".repeat(40) },
+          { commit: { message: "refactor: third change" }, parents: [{}], sha: "3".repeat(40) },
+          { commit: { message: "test: fourth change" }, parents: [{}], sha: "4".repeat(40) },
+          { commit: { message: "docs: fifth change" }, parents: [{}], sha: "5".repeat(40) },
+          { commit: { message: "merge: hidden" }, parents: [{}, {}], sha: "6".repeat(40) },
+        ],
+      });
+      expect(url).toContain("/actions/runs/1");
+      return Response.json({
+        created_at: "2026-08-17T03:45:00Z",
+        pull_requests: [{ number: 6956 }],
+        run_started_at: "2026-08-17T03:45:00Z",
+      });
+    }) as typeof fetch, "github-token");
+    const card = buildReleaseFeishuCard(input({ releaseMode: "promote" }), details);
+      const serialized = JSON.stringify(card);
+      expect(card.header).toMatchObject({ template: "green" });
+      expect(details).toEqual({
+        changelog: [
+          `docs: fifth change (${"5".repeat(40)})`,
+          `test: fourth change (${"4".repeat(40)})`,
+          `refactor: third change (${"3".repeat(40)})`,
+          `fix: second change (${"2".repeat(40)})`,
+          `feat: first change (${"1".repeat(40)})`,
+          `chore: hidden oldest change (${"0".repeat(40)})`,
+        ],
+        coldStarts: [],
+        execution: expect.objectContaining({
+          durationMs: expect.any(Number),
+          observedAtMs: expect.any(Number),
+          pullRequest: {
+            number: 6956,
+            url: "https://github.com/nexu-io/open-design/pull/6956",
+          },
+          queueDurationMs: 0,
+          runStartedAtMs: expect.any(Number),
+        }),
+        failures: [],
+        warnings: [],
+      });
+      expect(serialized).toContain("feat/standalone-closure");
+      expect(serialized).toContain("[0123456](https://github.com/nexu-io/open-design/commit/");
+      expect(serialized).not.toContain("`0123456`");
+      expect(serialized).not.toContain("渠道");
+      expect(serialized).toContain("触发");
+      expect(serialized).toContain("[@alice](https://github.com/alice)");
+      expect(serialized).toContain("手动");
+      expect(serialized).toContain("publish=true · 晋升 latest");
+      expect(serialized).toContain("release-beta #123");
+      expect(serialized).toContain("[PR #6956](https://github.com/nexu-io/open-design/pull/6956)");
+      expect(serialized).toContain("发布");
+      expect(serialized).toContain("通知");
+      expect(serialized).not.toContain("Closure 冷启动");
+      expect(serialized).not.toContain("hidden oldest change");
+      expect(serialized).toContain("Mac Arm");
+      expect(serialized).toContain("Mac x64");
+      expect(serialized).toContain("Win x64");
+      expect(serialized).toContain("发布详情");
+      expect(serialized).toContain("GitHub Actions");
+  });
+
+  it("loads failed jobs and suppresses unaccepted downloads on failure", async () => {
+    const details = await loadReleaseNotificationDetails(
+      input({ metadataUrl: "", releaseResult: "failure" }),
+      (async (request: string | URL | Request) => {
+        expect(String(request)).toContain("/actions/runs/1/jobs");
+        return Response.json({
+          jobs: [{
+            conclusion: "failure",
+            html_url: "https://github.com/nexu-io/open-design/actions/runs/1/job/2",
+            name: "Distribute beta / Build beta mac_x64",
+            steps: [{ conclusion: "failure", name: "Accept public mac_x64 beta artifacts" }],
+          }],
+        });
+      }) as typeof fetch,
+      "github-token",
+    );
+    const card = buildReleaseFeishuCard(input({ metadataUrl: "", releaseResult: "failure" }), details);
+    const serialized = JSON.stringify(card);
+    expect(card.header).toMatchObject({ template: "red" });
+    expect(serialized).toContain("Accept public mac");
+    expect(serialized).toContain("beta artifacts");
+    expect(serialized).not.toContain("https://releases.example/mac-arm64.dmg");
+    expect(serialized).toContain("https://github.com/nexu-io/open-design/actions/runs/1/job/2");
+  });
+
+  it("renders complete, partial, failed, and validation terminal states from one capability", () => {
+    expect(releaseNotificationInternals.notificationState(input())).toBe("published");
+    expect(releaseNotificationInternals.notificationState(input({ releaseMode: "promote" }))).toBe("promoted");
+    expect(releaseNotificationInternals.notificationState(input({ releaseMode: "candidate" }))).toBe("candidate");
+    const candidate = JSON.stringify(buildReleaseFeishuCard(input({ releaseMode: "candidate" }), emptyDetails));
+    expect(candidate).toContain("distribution-exact-accept.yml");
+    expect(candidate).toContain("publish=false · 公开候选 / 无 latest 入口");
+    expect(releaseNotificationInternals.notificationState(input({ releaseState: "partial" }))).toBe("partial");
+    expect(releaseNotificationInternals.notificationState(input({ releaseResult: "failure" }))).toBe("failed");
+    expect(releaseNotificationInternals.notificationState(input({ releaseMode: "prepublish" }))).toBe("validation");
+    const card = buildReleaseFeishuCard(input({ winX64Smoke: "failure" }), {
+      changelog: [],
+      coldStarts: [],
+      execution: null,
+      failures: [],
+      warnings: [],
+    });
+    expect(card.header).toMatchObject({ template: "orange" });
+    expect(JSON.stringify(card)).toContain("Windows x64 smoke 失败");
+    expect(JSON.stringify(card)).toContain("https://releases.example/win.exe");
+    expect(buildReleaseFeishuCard(input({ releaseMode: "validation" }), emptyDetails).header)
+      .toMatchObject({ template: "blue" });
+  });
+
+  it("renders arbitrary validated exact names without workspace dependencies", () => {
+    expect(JSON.stringify(buildReleaseFeishuCard(input({ channel: "qa2", version: "0.19.1-qa2.1" }), emptyDetails)))
+      .toContain("Qa2 0.19.1-qa2.1");
+    expect(() => buildReleaseFeishuCard(input({ channel: "Preview-2" }), emptyDetails))
+      .toThrow("unsupported release notification channel");
+  });
+
+  it("distinguishes the original actor from a rerun operator", () => {
+    const card = buildReleaseFeishuCard(input({ runAttempt: "2", triggeringActor: "bob" }), emptyDetails);
+    const serialized = JSON.stringify(card);
+    expect(serialized).toContain("[@alice](https://github.com/alice)");
+    expect(serialized).toContain("重跑 [@bob](https://github.com/bob)");
+    expect(serialized).toContain("第 2 次执行");
+  });
+});


### PR DESCRIPTION
## Outcome

Adds two orthogonal CI primitives without changing any workflow:

- a self-contained `hash_skip` action/script whose only input boundary is `.github/hash_skip/<key>.json`
- shared control, git, canonical JSON, HTTP, and Feishu modules plus generic release notification entrypoints

## Transparency boundary

- No hash declaration is included.
- No job or action consumes `hash_skip`.
- No workflow calls the notification entrypoints.
- No tools-release compatibility layer or second cache dialect is introduced.

## Validation

- `node --experimental-strip-types .github/scripts/hash_skip.ts self-check`
- release notification: 7 tests
- `pnpm install --frozen-lockfile` including repository postinstall builds
