### PR TITLE
fix(daemon): constrain web clone browser broker

### DIFF
--- a/apps/daemon/src/browser-cdp.ts
+++ b/apps/daemon/src/browser-cdp.ts
@@ -1,0 +1,261 @@
+import { WebSocket } from 'undici';
+
+import {
+  assertBrowserNetworkUrl,
+  type BrowserNetworkPolicy,
+} from './browser-network-policy.js';
+
+const COMMAND_TIMEOUT_MS = 30_000;
+const EVENT_BACKLOG_LIMIT = 4_000;
+const PAGE_CONTENT_METHODS = new Set([
+  'Page.captureScreenshot',
+  'Page.getLayoutMetrics',
+  'Runtime.evaluate',
+]);
+
+export const WEB_CLONE_CDP_METHODS = new Set([
+  'Emulation.setDeviceMetricsOverride',
+  'Input.dispatchMouseEvent',
+  'Network.enable',
+  'Network.getCookies',
+  'Network.getResponseBody',
+  'Page.captureScreenshot',
+  'Page.enable',
+  'Page.getLayoutMetrics',
+  'Page.navigate',
+  'Runtime.enable',
+  'Runtime.evaluate',
+]);
+
+export interface BrowserCdpEvent {
+  method: string;
+  params: Record<string, unknown>;
+  sequence: number;
+}
+
+type PendingCommand = {
+  reject: (error: Error) => void;
+  resolve: (result: Record<string, unknown>) => void;
+  timer: NodeJS.Timeout;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class BrowserCdpPage {
+  readonly id: string;
+
+  #closed = false;
+  #events: BrowserCdpEvent[] = [];
+  #nextCommandId = 1;
+  #nextEventSequence = 1;
+  #networkPolicy: BrowserNetworkPolicy;
+  #networkChecks = new Map<string, Promise<void>>();
+  #pending = new Map<number, PendingCommand>();
+  #ready: Promise<void>;
+  #socket: WebSocket;
+  #waiters = new Set<() => void>();
+  #currentUrl = 'about:blank';
+
+  private constructor(id: string, websocketUrl: string, networkPolicy: BrowserNetworkPolicy) {
+    this.id = id;
+    this.#networkPolicy = networkPolicy;
+    this.#socket = new WebSocket(websocketUrl);
+    this.#ready = new Promise<void>((resolve, reject) => {
+      this.#socket.addEventListener('open', () => resolve(), { once: true });
+      this.#socket.addEventListener('error', () => reject(new Error('browser CDP connection failed')), { once: true });
+    });
+    this.#socket.addEventListener('message', (event) => this.#handleMessage(String(event.data)));
+    this.#socket.addEventListener('close', () => this.#handleClose());
+  }
+
+  static async connect(
+    id: string,
+    websocketUrl: string,
+    networkPolicy: BrowserNetworkPolicy = {},
+  ): Promise<BrowserCdpPage> {
+    const page = new BrowserCdpPage(id, websocketUrl, networkPolicy);
+    try {
+      await page.#ready;
+      // Fetch interception is daemon-owned and never exposed through the client
+      // allowlist. Page scripts therefore cannot disable the private-network
+      // boundary even when Runtime.evaluate is used for DOM reconnaissance.
+      await page.#sendRaw('Fetch.enable', { patterns: [{ urlPattern: '*' }] });
+      return page;
+    } catch (error) {
+      await page.close();
+      throw error;
+    }
+  }
+
+  async command(method: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    if (!WEB_CLONE_CDP_METHODS.has(method)) {
+      throw new Error(`CDP method is not allowed for Website Clone: ${method}`);
+    }
+    let navigationUrl: string | null = null;
+    if (method === 'Page.navigate') {
+      const url = typeof params.url === 'string' ? params.url : '';
+      await this.#assertNetworkUrl(url);
+      navigationUrl = url;
+    }
+    if (PAGE_CONTENT_METHODS.has(method)) {
+      await this.#assertReadablePage();
+    }
+    if (method === 'Network.getCookies') {
+      const urls = Array.isArray(params.urls) ? params.urls : [];
+      await Promise.all(urls.map((url) => this.#assertNetworkUrl(typeof url === 'string' ? url : '')));
+    }
+    const result = await this.#sendRaw(method, params);
+    if (navigationUrl && typeof result.errorText !== 'string') this.#currentUrl = navigationUrl;
+    return result;
+  }
+
+  async eventsAfter(after: number, timeoutMs: number): Promise<BrowserCdpEvent[]> {
+    const available = () => this.#events.filter((event) => event.sequence > after);
+    const initial = available();
+    if (initial.length > 0 || this.#closed || timeoutMs <= 0) return initial;
+
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        clearTimeout(timer);
+        this.#waiters.delete(finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, timeoutMs);
+      timer.unref?.();
+      this.#waiters.add(finish);
+    });
+    return available();
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#socket.close();
+    this.#handleClose();
+  }
+
+  async #sendRaw(method: string, params: Record<string, unknown>): Promise<Record<string, unknown>> {
+    await this.#ready;
+    if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
+      throw new Error('browser CDP connection is closed');
+    }
+    const id = this.#nextCommandId++;
+    const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(new Error(`${method} timed out after ${COMMAND_TIMEOUT_MS}ms`));
+      }, COMMAND_TIMEOUT_MS);
+      timer.unref?.();
+      this.#pending.set(id, { reject, resolve, timer });
+    });
+    this.#socket.send(JSON.stringify({ id, method, params }));
+    return response;
+  }
+
+  #handleMessage(raw: string): void {
+    let message: {
+      error?: { message?: string };
+      id?: number;
+      method?: string;
+      params?: Record<string, unknown>;
+      result?: Record<string, unknown>;
+    };
+    try {
+      message = JSON.parse(raw) as typeof message;
+    } catch {
+      return;
+    }
+
+    if (typeof message.id === 'number') {
+      const pending = this.#pending.get(message.id);
+      if (!pending) return;
+      this.#pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) pending.reject(new Error(message.error.message ?? JSON.stringify(message.error)));
+      else pending.resolve(message.result ?? {});
+      return;
+    }
+
+    if (!message.method) return;
+    const params = message.params ?? {};
+    if (message.method === 'Fetch.requestPaused') {
+      void this.#handleRequestPaused(params).catch(() => undefined);
+      return;
+    }
+    if (message.method === 'Page.frameNavigated') {
+      const frame = params.frame as { parentId?: unknown; url?: unknown } | undefined;
+      if (frame && !frame.parentId && typeof frame.url === 'string') this.#currentUrl = frame.url;
+    }
+    this.#events.push({ method: message.method, params, sequence: this.#nextEventSequence++ });
+    if (this.#events.length > EVENT_BACKLOG_LIMIT) this.#events.splice(0, this.#events.length - EVENT_BACKLOG_LIMIT);
+    this.#wakeWaiters();
+  }
+
+  async #handleRequestPaused(params: Record<string, unknown>): Promise<void> {
+    const requestId = typeof params.requestId === 'string' ? params.requestId : '';
+    const request = params.request as { url?: unknown } | undefined;
+    const url = typeof request?.url === 'string' ? request.url : '';
+    if (!requestId) return;
+    try {
+      await this.#assertNetworkUrl(url);
+      await this.#sendRaw('Fetch.continueRequest', { requestId });
+    } catch (error) {
+      await this.#sendRaw('Fetch.failRequest', { errorReason: 'BlockedByClient', requestId }).catch(() => undefined);
+      this.#events.push({
+        method: 'OpenDesign.browserRequestBlocked',
+        params: { error: errorMessage(error), url },
+        sequence: this.#nextEventSequence++,
+      });
+      this.#wakeWaiters();
+    }
+  }
+
+  async #assertNetworkUrl(url: string): Promise<void> {
+    let key = url;
+    try {
+      const parsed = new URL(url);
+      key = `${parsed.protocol}//${parsed.host}`;
+    } catch {
+      // The validator below owns the user-facing invalid-URL error.
+    }
+    const existing = this.#networkChecks.get(key);
+    if (existing) return existing;
+    const check = assertBrowserNetworkUrl(url, this.#networkPolicy);
+    this.#networkChecks.set(key, check);
+    try {
+      await check;
+    } finally {
+      this.#networkChecks.delete(key);
+    }
+  }
+
+  async #assertReadablePage(): Promise<void> {
+    let protocol = '';
+    try {
+      protocol = new URL(this.#currentUrl).protocol;
+    } catch {
+      // The network validator below returns the canonical invalid-URL error.
+    }
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      throw new Error(`page content is unavailable for privileged URL scheme: ${protocol || 'invalid'}`);
+    }
+    await this.#assertNetworkUrl(this.#currentUrl);
+  }
+
+  #handleClose(): void {
+    if (this.#closed && this.#pending.size === 0) return;
+    this.#closed = true;
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('browser CDP connection closed'));
+    }
+    this.#pending.clear();
+    this.#wakeWaiters();
+  }
+
+  #wakeWaiters(): void {
+    for (const wake of [...this.#waiters]) wake();
+  }
+}

--- a/apps/daemon/src/browser-network-policy.ts
+++ b/apps/daemon/src/browser-network-policy.ts
@@ -1,0 +1,66 @@
+import { promises as dns } from 'node:dns';
+
+import { assertSafePublicUrl, isPrivateAddress } from './plugins/plugin-asset-cache.js';
+
+export type BrowserDnsLookup = typeof dns.lookup;
+
+export interface BrowserNetworkPolicy {
+  allowPrivateNetwork?: boolean;
+  lookup?: BrowserDnsLookup;
+}
+
+export interface BrowserNetworkTarget {
+  address: string;
+  family: number;
+  url: URL;
+}
+
+function isBrowserLocalUrl(rawUrl: string): boolean {
+  if (rawUrl === 'about:blank') return true;
+  return rawUrl.startsWith('data:') || rawUrl.startsWith('blob:');
+}
+
+/**
+ * Website Clone drives a daemon-owned browser, so every network destination
+ * must be checked at the privileged boundary. Literal private addresses and
+ * hostnames resolving to loopback, RFC1918, link-local, metadata, CGNAT, or
+ * multicast space are refused before Chromium can issue the request.
+ */
+export async function assertBrowserNetworkUrl(
+  rawUrl: string,
+  policy: BrowserNetworkPolicy = {},
+): Promise<void> {
+  if (isBrowserLocalUrl(rawUrl)) return;
+
+  await resolveBrowserNetworkTarget(rawUrl, policy);
+}
+
+export async function resolveBrowserNetworkTarget(
+  rawUrl: string,
+  policy: BrowserNetworkPolicy = {},
+): Promise<BrowserNetworkTarget> {
+  let parsed: URL;
+
+  if (policy.allowPrivateNetwork) {
+    parsed = new URL(rawUrl);
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+      throw new Error('browser destination must be an HTTP(S) URL without credentials');
+    }
+  } else {
+    parsed = assertSafePublicUrl(rawUrl);
+  }
+
+  const lookup = policy.lookup ?? dns.lookup;
+  const addresses = await lookup(parsed.hostname, { all: true, family: 0 });
+  if (addresses.length === 0) {
+    throw new Error('browser destination did not resolve');
+  }
+  for (const { address } of addresses) {
+    if (!policy.allowPrivateNetwork && isPrivateAddress(address)) {
+      throw new Error(`browser destination resolves to a private address: ${address}`);
+    }
+  }
+  const selected = addresses[0];
+  if (!selected) throw new Error('browser destination did not resolve');
+  return { address: selected.address, family: selected.family, url: parsed };
+}

--- a/apps/daemon/src/browser-network-proxy.ts
+++ b/apps/daemon/src/browser-network-proxy.ts
@@ -1,0 +1,196 @@
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import net from 'node:net';
+import type { Duplex } from 'node:stream';
+
+import {
+  resolveBrowserNetworkTarget,
+  type BrowserNetworkPolicy,
+} from './browser-network-policy.js';
+
+export interface BrowserNetworkProxy {
+  close: () => Promise<void>;
+  port: number;
+}
+
+function proxyErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function requestUrl(request: IncomingMessage, fallbackProtocol = 'http:'): URL {
+  const raw = request.url ?? '';
+  if (/^https?:\/\//i.test(raw)) return new URL(raw);
+  if (/^wss?:\/\//i.test(raw)) {
+    const parsed = new URL(raw);
+    parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+    return parsed;
+  }
+  const host = request.headers.host;
+  if (!host) throw new Error('proxy request is missing Host');
+  return new URL(`${fallbackProtocol}//${host}${raw.startsWith('/') ? raw : `/${raw}`}`);
+}
+
+function upstreamHeaders(request: IncomingMessage, host: string): http.OutgoingHttpHeaders {
+  const headers: http.OutgoingHttpHeaders = { ...request.headers, host };
+  delete headers['proxy-authorization'];
+  delete headers['proxy-connection'];
+  return headers;
+}
+
+function writeProxyFailure(socket: Duplex, status: number, message: string): void {
+  if (socket.destroyed) return;
+  const body = `${message}\n`;
+  socket.end(
+    `HTTP/1.1 ${status} ${status === 403 ? 'Forbidden' : 'Bad Gateway'}\r\n`
+    + 'Content-Type: text/plain; charset=utf-8\r\n'
+    + `Content-Length: ${Buffer.byteLength(body)}\r\n`
+    + 'Connection: close\r\n\r\n'
+    + body,
+  );
+}
+
+/**
+ * Chrome is forced through this loopback proxy with its implicit localhost
+ * bypass removed. The proxy resolves and connects to the exact vetted address,
+ * closing the DNS-rebinding gap between URL validation and Chromium's socket.
+ */
+export async function createBrowserNetworkProxy(
+  policy: BrowserNetworkPolicy = {},
+): Promise<BrowserNetworkProxy> {
+  const tunnels = new Set<Duplex>();
+  const server = http.createServer((request, response) => {
+    void proxyHttpRequest(request, response, policy);
+  });
+
+  server.on('connect', (request, client, head) => {
+    void proxyConnect(request, client, head, policy, tunnels);
+  });
+  server.on('upgrade', (request, client, head) => {
+    void proxyUpgrade(request, client, head, policy, tunnels);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('browser network proxy did not bind a TCP port');
+  }
+
+  return {
+    port: address.port,
+    close: async () => {
+      for (const socket of tunnels) socket.destroy();
+      tunnels.clear();
+      if (!server.listening) return;
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function proxyHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  policy: BrowserNetworkPolicy,
+): Promise<void> {
+  try {
+    const target = await resolveBrowserNetworkTarget(requestUrl(request).href, policy);
+    const upstream = http.request({
+      family: target.family,
+      headers: upstreamHeaders(request, target.url.host),
+      host: target.address,
+      method: request.method,
+      path: `${target.url.pathname}${target.url.search}`,
+      port: target.url.port ? Number(target.url.port) : 80,
+    }, (upstreamResponse) => {
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(response);
+    });
+    upstream.once('error', (error) => {
+      if (!response.headersSent) response.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' });
+      response.end(`browser proxy upstream failed: ${proxyErrorMessage(error)}\n`);
+    });
+    request.pipe(upstream);
+  } catch (error) {
+    response.writeHead(403, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end(`browser proxy blocked request: ${proxyErrorMessage(error)}\n`);
+  }
+}
+
+async function proxyConnect(
+  request: IncomingMessage,
+  client: Duplex,
+  head: Buffer,
+  policy: BrowserNetworkPolicy,
+  tunnels: Set<Duplex>,
+): Promise<void> {
+  try {
+    const authority = request.url ?? '';
+    const target = await resolveBrowserNetworkTarget(`https://${authority}`, policy);
+    const upstream = net.connect({
+      family: target.family,
+      host: target.address,
+      port: target.url.port ? Number(target.url.port) : 443,
+    });
+    trackTunnel(client, upstream, tunnels);
+    upstream.once('connect', () => {
+      client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head.length > 0) upstream.write(head);
+      client.pipe(upstream);
+      upstream.pipe(client);
+    });
+    upstream.once('error', (error) => writeProxyFailure(client, 502, proxyErrorMessage(error)));
+  } catch (error) {
+    writeProxyFailure(client, 403, `browser proxy blocked tunnel: ${proxyErrorMessage(error)}`);
+  }
+}
+
+async function proxyUpgrade(
+  request: IncomingMessage,
+  client: Duplex,
+  head: Buffer,
+  policy: BrowserNetworkPolicy,
+  tunnels: Set<Duplex>,
+): Promise<void> {
+  try {
+    const target = await resolveBrowserNetworkTarget(requestUrl(request).href, policy);
+    const upstream = net.connect({
+      family: target.family,
+      host: target.address,
+      port: target.url.port ? Number(target.url.port) : 80,
+    });
+    trackTunnel(client, upstream, tunnels);
+    upstream.once('connect', () => {
+      const headers = upstreamHeaders(request, target.url.host);
+      const serialized = Object.entries(headers)
+        .filter(([, value]) => value != null)
+        .map(([name, value]) => `${name}: ${Array.isArray(value) ? value.join(', ') : String(value)}`)
+        .join('\r\n');
+      upstream.write(
+        `${request.method ?? 'GET'} ${target.url.pathname}${target.url.search} HTTP/${request.httpVersion}\r\n`
+        + `${serialized}\r\n\r\n`,
+      );
+      if (head.length > 0) upstream.write(head);
+      client.pipe(upstream);
+      upstream.pipe(client);
+    });
+    upstream.once('error', (error) => writeProxyFailure(client, 502, proxyErrorMessage(error)));
+  } catch (error) {
+    writeProxyFailure(client, 403, `browser proxy blocked upgrade: ${proxyErrorMessage(error)}`);
+  }
+}
+
+function trackTunnel(client: Duplex, upstream: Duplex, tunnels: Set<Duplex>): void {
+  tunnels.add(client);
+  tunnels.add(upstream);
+  const forget = () => {
+    tunnels.delete(client);
+    tunnels.delete(upstream);
+  };
+  client.once('close', forget);
+  upstream.once('close', forget);
+}

--- a/apps/daemon/src/browser-network-proxy.ts
+++ b/apps/daemon/src/browser-network-proxy.ts
@@ -128,6 +128,7 @@ async function proxyConnect(
   policy: BrowserNetworkPolicy,
   tunnels: Set<Duplex>,
 ): Promise<void> {
+  const stopPendingClientError = guardPendingClient(client);
   try {
     const authority = request.url ?? '';
     const target = await resolveBrowserNetworkTarget(`https://${authority}`, policy);
@@ -136,14 +137,20 @@ async function proxyConnect(
       host: target.address,
       port: target.url.port ? Number(target.url.port) : 443,
     });
-    trackTunnel(client, upstream, tunnels);
+    let connected = false;
+    trackBrowserNetworkTunnel(client, upstream, tunnels, (error) => {
+      if (connected) return false;
+      writeProxyFailure(client, 502, proxyErrorMessage(error));
+      return true;
+    });
+    stopPendingClientError();
     upstream.once('connect', () => {
+      connected = true;
       client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
       if (head.length > 0) upstream.write(head);
       client.pipe(upstream);
       upstream.pipe(client);
     });
-    upstream.once('error', (error) => writeProxyFailure(client, 502, proxyErrorMessage(error)));
   } catch (error) {
     writeProxyFailure(client, 403, `browser proxy blocked tunnel: ${proxyErrorMessage(error)}`);
   }
@@ -156,6 +163,7 @@ async function proxyUpgrade(
   policy: BrowserNetworkPolicy,
   tunnels: Set<Duplex>,
 ): Promise<void> {
+  const stopPendingClientError = guardPendingClient(client);
   try {
     const target = await resolveBrowserNetworkTarget(requestUrl(request).href, policy);
     const upstream = net.connect({
@@ -163,8 +171,15 @@ async function proxyUpgrade(
       host: target.address,
       port: target.url.port ? Number(target.url.port) : 80,
     });
-    trackTunnel(client, upstream, tunnels);
+    let connected = false;
+    trackBrowserNetworkTunnel(client, upstream, tunnels, (error) => {
+      if (connected) return false;
+      writeProxyFailure(client, 502, proxyErrorMessage(error));
+      return true;
+    });
+    stopPendingClientError();
     upstream.once('connect', () => {
+      connected = true;
       const headers = upstreamHeaders(request, target.url.host);
       const serialized = Object.entries(headers)
         .filter(([, value]) => value != null)
@@ -178,19 +193,67 @@ async function proxyUpgrade(
       client.pipe(upstream);
       upstream.pipe(client);
     });
-    upstream.once('error', (error) => writeProxyFailure(client, 502, proxyErrorMessage(error)));
   } catch (error) {
     writeProxyFailure(client, 403, `browser proxy blocked upgrade: ${proxyErrorMessage(error)}`);
   }
 }
 
-function trackTunnel(client: Duplex, upstream: Duplex, tunnels: Set<Duplex>): void {
+function guardPendingClient(client: Duplex): () => void {
+  const onError = () => client.destroy();
+  const stop = () => client.off('error', onError);
+  client.on('error', onError);
+  client.once('close', stop);
+  return stop;
+}
+
+/**
+ * A CONNECT/upgrade tunnel is one lifecycle even though Node exposes two
+ * sockets. `pipe()` deliberately does not forward source errors, so both
+ * endpoints need their own guard and either endpoint closing must tear down
+ * its peer. Otherwise a normal Chrome TLS shutdown can surface EPIPE as an
+ * uncaught daemon exception or leave a half-open upstream behind.
+ */
+export function trackBrowserNetworkTunnel(
+  client: Duplex,
+  upstream: Duplex,
+  tunnels: Set<Duplex>,
+  handleUpstreamConnectError?: (error: Error) => boolean,
+): void {
   tunnels.add(client);
   tunnels.add(upstream);
-  const forget = () => {
+
+  let clientClosed = false;
+  let upstreamClosed = false;
+  const destroyBoth = () => {
+    if (!client.destroyed) client.destroy();
+    if (!upstream.destroyed) upstream.destroy();
+  };
+  const forgetWhenClosed = () => {
+    if (!clientClosed || !upstreamClosed) return;
     tunnels.delete(client);
     tunnels.delete(upstream);
+    client.off('error', onClientError);
+    upstream.off('error', onUpstreamError);
   };
-  client.once('close', forget);
-  upstream.once('close', forget);
+  const onClientError = () => destroyBoth();
+  const onUpstreamError = (error: Error) => {
+    const responseOwnsClient = handleUpstreamConnectError?.(error) ?? false;
+    if (!upstream.destroyed) upstream.destroy();
+    if (!responseOwnsClient && !client.destroyed) client.destroy();
+  };
+  const onClientClose = () => {
+    clientClosed = true;
+    if (!upstream.destroyed) upstream.destroy();
+    forgetWhenClosed();
+  };
+  const onUpstreamClose = () => {
+    upstreamClosed = true;
+    if (!client.destroyed) client.destroy();
+    forgetWhenClosed();
+  };
+
+  client.on('error', onClientError);
+  upstream.on('error', onUpstreamError);
+  client.once('close', onClientClose);
+  upstream.once('close', onUpstreamClose);
 }

--- a/apps/daemon/src/browser-network-proxy.ts
+++ b/apps/daemon/src/browser-network-proxy.ts
@@ -1,5 +1,5 @@
-import http, { type IncomingMessage, type ServerResponse } from 'node:http';
-import net from 'node:net';
+import http, { type ClientRequest, type IncomingMessage, type ServerResponse } from 'node:http';
+import net, { type Socket } from 'node:net';
 import type { Duplex } from 'node:stream';
 
 import {
@@ -57,8 +57,18 @@ export async function createBrowserNetworkProxy(
   policy: BrowserNetworkPolicy = {},
 ): Promise<BrowserNetworkProxy> {
   const tunnels = new Set<Duplex>();
+  const httpRequests = new Set<ClientRequest>();
+  const httpSockets = new Set<Socket>();
+  let closing = false;
   const server = http.createServer((request, response) => {
-    void proxyHttpRequest(request, response, policy);
+    void proxyHttpRequest(
+      request,
+      response,
+      policy,
+      httpRequests,
+      httpSockets,
+      () => closing,
+    );
   });
 
   server.on('connect', (request, client, head) => {
@@ -84,6 +94,11 @@ export async function createBrowserNetworkProxy(
   return {
     port: address.port,
     close: async () => {
+      closing = true;
+      for (const request of httpRequests) request.destroy();
+      for (const socket of httpSockets) socket.destroy();
+      httpRequests.clear();
+      httpSockets.clear();
       for (const socket of tunnels) socket.destroy();
       tunnels.clear();
       if (!server.listening) return;
@@ -96,10 +111,18 @@ async function proxyHttpRequest(
   request: IncomingMessage,
   response: ServerResponse,
   policy: BrowserNetworkPolicy,
+  httpRequests: Set<ClientRequest>,
+  httpSockets: Set<Socket>,
+  isClosing: () => boolean,
 ): Promise<void> {
   try {
     const target = await resolveBrowserNetworkTarget(requestUrl(request).href, policy);
+    if (isClosing() || response.destroyed) {
+      response.destroy();
+      return;
+    }
     const upstream = http.request({
+      agent: false,
       family: target.family,
       headers: upstreamHeaders(request, target.url.host),
       host: target.address,
@@ -107,9 +130,34 @@ async function proxyHttpRequest(
       path: `${target.url.pathname}${target.url.search}`,
       port: target.url.port ? Number(target.url.port) : 80,
     }, (upstreamResponse) => {
+      if (response.destroyed) {
+        upstreamResponse.destroy();
+        return;
+      }
       response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
       upstreamResponse.pipe(response);
+      upstreamResponse.once('error', (error) => {
+        if (!response.destroyed) response.destroy(error);
+      });
     });
+    httpRequests.add(upstream);
+    const destroyUpstream = () => upstream.destroy();
+    const forgetUpstream = () => {
+      httpRequests.delete(upstream);
+      request.off('aborted', destroyUpstream);
+      request.off('error', destroyUpstream);
+      response.off('close', destroyUpstream);
+      response.off('error', destroyUpstream);
+    };
+    upstream.once('socket', (socket) => {
+      httpSockets.add(socket);
+      socket.once('close', () => httpSockets.delete(socket));
+    });
+    upstream.once('close', forgetUpstream);
+    request.once('aborted', destroyUpstream);
+    request.once('error', destroyUpstream);
+    response.once('close', destroyUpstream);
+    response.once('error', destroyUpstream);
     upstream.once('error', (error) => {
       if (!response.headersSent) response.writeHead(502, { 'content-type': 'text/plain; charset=utf-8' });
       response.end(`browser proxy upstream failed: ${proxyErrorMessage(error)}\n`);

--- a/apps/daemon/src/browser-sessions.ts
+++ b/apps/daemon/src/browser-sessions.ts
@@ -4,17 +4,30 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { BrowserCdpPage } from './browser-cdp.js';
+import type { BrowserNetworkPolicy } from './browser-network-policy.js';
+import { createBrowserNetworkProxy, type BrowserNetworkProxy } from './browser-network-proxy.js';
+
 const STARTUP_TIMEOUT_MS = 15_000;
 const SHUTDOWN_GRACE_MS = 2_000;
+const FORCED_SHUTDOWN_WAIT_MS = 2_000;
 
 export interface BrowserSessionView {
   id: string;
-  websocketUrl: string;
+}
+
+export interface BrowserPageView {
+  id: string;
+  url: string;
 }
 
 interface BrowserSession extends BrowserSessionView {
+  browserHttpBase: string;
   child: ChildProcess;
+  networkProxy: BrowserNetworkProxy;
+  pages: Map<string, BrowserCdpPage>;
   profileDir: string;
+  projectId: string;
   closing: boolean;
 }
 
@@ -80,27 +93,74 @@ function waitForExit(child: ChildProcess, timeoutMs: number): Promise<void> {
   ]);
 }
 
-export function createBrowserSessionService() {
+type RemoveDirectory = (path: string, options: { force: true; recursive: true }) => Promise<void>;
+
+export async function removeBrowserProfile(
+  profileDir: string,
+  remove: RemoveDirectory = fs.promises.rm,
+  delay: (timeoutMs: number) => Promise<void> = (timeoutMs) => new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+): Promise<void> {
+  for (let attempt = 0; attempt < 7; attempt += 1) {
+    try {
+      await remove(profileDir, { force: true, recursive: true });
+      return;
+    } catch (error) {
+      if (attempt === 6) throw error;
+      // Antivirus and Chromium child processes can briefly retain handles on
+      // Windows after the parent exits. Retry with a small bounded backoff.
+      await delay(100 * (attempt + 1));
+    }
+  }
+}
+
+export async function terminateBrowserProcess(
+  child: ChildProcess,
+  profileDir: string,
+  removeProfile: (profileDir: string) => Promise<void> = removeBrowserProfile,
+  wait = { forcedMs: FORCED_SHUTDOWN_WAIT_MS, gracefulMs: SHUTDOWN_GRACE_MS },
+): Promise<void> {
+  if (child.exitCode == null && child.signalCode == null) {
+    child.kill('SIGTERM');
+    await waitForExit(child, wait.gracefulMs);
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill('SIGKILL');
+      // Windows keeps the profile locked until the process has actually
+      // exited. Never race recursive deletion against a still-live browser.
+      await waitForExit(child, wait.forcedMs);
+    }
+  }
+  await removeProfile(profileDir);
+}
+
+export interface BrowserSessionServiceOptions extends BrowserNetworkPolicy {
+  removeProfile?: (profileDir: string) => Promise<void>;
+}
+
+export function createBrowserSessionService(options: BrowserSessionServiceOptions = {}) {
   const sessions = new Map<string, BrowserSession>();
 
-  const close = async (id: string): Promise<boolean> => {
+  const sessionForProject = (projectId: string, id: string): BrowserSession | null => {
     const session = sessions.get(id);
+    return session?.projectId === projectId ? session : null;
+  };
+
+  const close = async (projectId: string, id: string): Promise<boolean> => {
+    const session = sessionForProject(projectId, id);
     if (!session) return false;
     sessions.delete(id);
     if (session.closing) return true;
     session.closing = true;
-    if (session.child.exitCode == null && session.child.signalCode == null) {
-      session.child.kill('SIGTERM');
-      await waitForExit(session.child, SHUTDOWN_GRACE_MS);
-      if (session.child.exitCode == null && session.child.signalCode == null) {
-        session.child.kill('SIGKILL');
-      }
+    await Promise.allSettled([...session.pages.values()].map((page) => page.close()));
+    session.pages.clear();
+    try {
+      await terminateBrowserProcess(session.child, session.profileDir, options.removeProfile);
+    } finally {
+      await session.networkProxy.close();
     }
-    fs.rmSync(session.profileDir, { recursive: true, force: true });
     return true;
   };
 
-  const create = async (): Promise<BrowserSessionView> => {
+  const create = async (projectId: string): Promise<BrowserSessionView> => {
     const executablePath = findBrowserExecutable();
     if (!executablePath) {
       throw new Error(
@@ -110,17 +170,23 @@ export function createBrowserSessionService() {
     }
     const id = randomUUID();
     const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-browser-session-'));
+    const networkProxy = await createBrowserNetworkProxy(options);
     const child = spawn(executablePath, [
       '--headless=new',
+      '--remote-debugging-address=127.0.0.1',
       '--remote-debugging-port=0',
-      '--remote-allow-origins=*',
+      `--proxy-server=http://127.0.0.1:${networkProxy.port}`,
+      '--proxy-bypass-list=<-loopback>',
       `--user-data-dir=${profileDir}`,
       '--no-first-run',
       '--no-default-browser-check',
       '--disable-background-networking',
       '--disable-component-update',
       '--disable-default-apps',
+      '--disable-extensions',
+      '--disable-quic',
       '--disable-sync',
+      '--force-webrtc-ip-handling-policy=disable_non_proxied_udp',
       '--metrics-recording-only',
       'about:blank',
     ], { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -151,28 +217,100 @@ export function createBrowserSessionService() {
       child.stderr?.on('data', inspect);
       child.once('error', onError);
       child.once('exit', onExit);
-    }).catch((error) => {
-      child.kill('SIGKILL');
-      fs.rmSync(profileDir, { recursive: true, force: true });
+    }).catch(async (error) => {
+      try {
+        await terminateBrowserProcess(child, profileDir, options.removeProfile);
+      } finally {
+        await networkProxy.close();
+      }
       throw error;
     });
 
-    const session: BrowserSession = { id, websocketUrl, child, profileDir, closing: false };
+    const socket = new URL(websocketUrl);
+    const session: BrowserSession = {
+      browserHttpBase: `http://${socket.host}`,
+      child,
+      closing: false,
+      id,
+      networkProxy,
+      pages: new Map(),
+      profileDir,
+      projectId,
+    };
     sessions.set(id, session);
     child.once('exit', () => {
       if (!session.closing) {
         sessions.delete(id);
-        fs.rmSync(profileDir, { recursive: true, force: true });
+        void Promise.all([...session.pages.values()].map((page) => page.close()))
+          .then(() => Promise.all([
+            (options.removeProfile ?? removeBrowserProfile)(profileDir),
+            networkProxy.close(),
+          ]))
+          .catch((error) => console.warn('[od] failed to clean browser session profile:', error));
       }
     });
-    return { id, websocketUrl };
+    return { id };
+  };
+
+  const createPage = async (projectId: string, sessionId: string): Promise<BrowserPageView | null> => {
+    const session = sessionForProject(projectId, sessionId);
+    if (!session || session.closing) return null;
+    const response = await fetch(`${session.browserHttpBase}/json/new?${encodeURIComponent('about:blank')}`, {
+      method: 'PUT',
+    });
+    if (!response.ok) throw new Error(`Chrome target creation failed: HTTP ${response.status}`);
+    const target = await response.json() as { id?: unknown; url?: unknown; webSocketDebuggerUrl?: unknown };
+    if (typeof target.id !== 'string' || typeof target.webSocketDebuggerUrl !== 'string') {
+      throw new Error('Chrome returned an invalid target');
+    }
+    let page: BrowserCdpPage;
+    try {
+      page = await BrowserCdpPage.connect(target.id, target.webSocketDebuggerUrl, options);
+    } catch (error) {
+      await fetch(`${session.browserHttpBase}/json/close/${encodeURIComponent(target.id)}`).catch(() => undefined);
+      throw error;
+    }
+    session.pages.set(target.id, page);
+    return { id: target.id, url: typeof target.url === 'string' ? target.url : 'about:blank' };
+  };
+
+  const command = async (
+    projectId: string,
+    sessionId: string,
+    pageId: string,
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<Record<string, unknown> | null> => {
+    const page = sessionForProject(projectId, sessionId)?.pages.get(pageId);
+    return page ? page.command(method, params) : null;
+  };
+
+  const events = async (
+    projectId: string,
+    sessionId: string,
+    pageId: string,
+    after: number,
+    timeoutMs: number,
+  ) => {
+    const page = sessionForProject(projectId, sessionId)?.pages.get(pageId);
+    return page ? page.eventsAfter(after, timeoutMs) : null;
+  };
+
+  const closePage = async (projectId: string, sessionId: string, pageId: string): Promise<boolean> => {
+    const session = sessionForProject(projectId, sessionId);
+    const page = session?.pages.get(pageId);
+    if (!session || !page) return false;
+    session.pages.delete(pageId);
+    await page.close();
+    await fetch(`${session.browserHttpBase}/json/close/${encodeURIComponent(pageId)}`).catch(() => undefined);
+    return true;
   };
 
   const shutdownActive = async (): Promise<void> => {
-    await Promise.all([...sessions.keys()].map((id) => close(id)));
+    await Promise.all([...sessions.values()].map((session) => close(session.projectId, session.id)));
   };
 
-  return { create, close, shutdownActive };
+  return { close, closePage, command, create, createPage, events, shutdownActive };
 }
 
 export type BrowserSessionService = ReturnType<typeof createBrowserSessionService>;

--- a/apps/daemon/src/routes/browser-sessions.ts
+++ b/apps/daemon/src/routes/browser-sessions.ts
@@ -19,7 +19,7 @@ export function registerBrowserSessionRoutes(app: Express, ctx: RegisterBrowserS
     }
     if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
     try {
-      res.json({ browserSession: await browserSessions.create() });
+      res.json({ browserSession: await browserSessions.create(req.params.id) });
     } catch (error) {
       sendApiError(
         res,
@@ -35,6 +35,74 @@ export function registerBrowserSessionRoutes(app: Express, ctx: RegisterBrowserS
       return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
     }
     if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
-    res.json({ closed: await browserSessions.close(req.params.sessionId) });
+    res.json({ closed: await browserSessions.close(req.params.id, req.params.sessionId) });
+  });
+
+  app.post('/api/projects/:id/browser-sessions/:sessionId/pages', async (req, res) => {
+    if (!getProject(db, req.params.id)) {
+      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+    }
+    if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
+    try {
+      const page = await browserSessions.createPage(req.params.id, req.params.sessionId);
+      if (!page) return sendApiError(res, 404, 'BROWSER_SESSION_NOT_FOUND', 'browser session not found');
+      res.json({ page });
+    } catch (error) {
+      sendApiError(res, 503, 'BROWSER_PAGE_START_FAILED', error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  app.post('/api/projects/:id/browser-sessions/:sessionId/pages/:pageId/commands', async (req, res) => {
+    if (!getProject(db, req.params.id)) {
+      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+    }
+    if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
+    const method = typeof req.body?.method === 'string' ? req.body.method : '';
+    const params = req.body?.params && typeof req.body.params === 'object' && !Array.isArray(req.body.params)
+      ? req.body.params as Record<string, unknown>
+      : {};
+    try {
+      const result = await browserSessions.command(
+        req.params.id,
+        req.params.sessionId,
+        req.params.pageId,
+        method,
+        params,
+      );
+      if (!result) return sendApiError(res, 404, 'BROWSER_PAGE_NOT_FOUND', 'browser page not found');
+      res.json({ result });
+    } catch (error) {
+      sendApiError(res, 400, 'BROWSER_COMMAND_REJECTED', error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  app.get('/api/projects/:id/browser-sessions/:sessionId/pages/:pageId/events', async (req, res) => {
+    if (!getProject(db, req.params.id)) {
+      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+    }
+    if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
+    const after = Math.max(0, Number.parseInt(String(req.query.after ?? '0'), 10) || 0);
+    const timeoutMs = Math.min(25_000, Math.max(0, Number.parseInt(String(req.query.timeout ?? '20000'), 10) || 0));
+    const events = await browserSessions.events(
+      req.params.id,
+      req.params.sessionId,
+      req.params.pageId,
+      after,
+      timeoutMs,
+    );
+    if (!events) return sendApiError(res, 404, 'BROWSER_PAGE_NOT_FOUND', 'browser page not found');
+    res.json({ events });
+  });
+
+  app.delete('/api/projects/:id/browser-sessions/:sessionId/pages/:pageId', async (req, res) => {
+    if (!getProject(db, req.params.id)) {
+      return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
+    }
+    if (!await authorizeProjectRequest(req, res, req.params.id, { mode: 'read' })) return;
+    res.json({ closed: await browserSessions.closePage(
+      req.params.id,
+      req.params.sessionId,
+      req.params.pageId,
+    ) });
   });
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7123,7 +7123,12 @@ export async function startServer({
   // Interactive Terminal sessions (node-pty). In-memory, process-local, and
   // killed on daemon shutdown — see shutdownDaemonRuns below.
   const terminalService = createTerminalService();
-  const browserSessionService = createBrowserSessionService();
+  const browserSessionService = createBrowserSessionService({
+    // Hermetic E2E fixtures bind loopback. This is daemon-startup authority,
+    // not an agent-controlled request field, and stays off in normal product
+    // runs so prompt-injected code cannot opt itself into private networking.
+    allowPrivateNetwork: process.env.OD_BROWSER_ALLOW_PRIVATE_NETWORK_FOR_TESTS === '1',
+  });
 
   // Tracks runs whose finalized assistant message has already been forwarded
   // to Langfuse so repeated message updates only emit one final trace per run.

--- a/apps/daemon/tests/browser-session-security.test.ts
+++ b/apps/daemon/tests/browser-session-security.test.ts
@@ -1,0 +1,149 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { createServer, request } from 'node:http';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { WEB_CLONE_CDP_METHODS } from '../src/browser-cdp.js';
+import { createBrowserNetworkProxy } from '../src/browser-network-proxy.js';
+import { assertBrowserNetworkUrl, type BrowserDnsLookup } from '../src/browser-network-policy.js';
+import { removeBrowserProfile, terminateBrowserProcess } from '../src/browser-sessions.js';
+
+// Website Clone is a primary UI + od CLI generation path. Its agent runs in a
+// sandbox, while the daemon-owned Chrome process has host privileges. These
+// tests pin the broker as a strict privilege boundary: no raw/general CDP and
+// no file, loopback, private-network, or metadata navigation can cross it.
+describe('Website Clone browser broker security boundary', () => {
+  it.each([
+    'file:///etc/passwd',
+    'http://127.0.0.1:3000/admin',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::1]:7456/api/app-config',
+  ])('rejects a privileged destination: %s', async (url) => {
+    await expect(assertBrowserNetworkUrl(url)).rejects.toThrow();
+  });
+
+  it('rejects a public-looking hostname when DNS resolves it into private space', async () => {
+    const lookup = vi.fn().mockResolvedValue([{ address: '10.20.30.40', family: 4 }]) as unknown as BrowserDnsLookup;
+
+    await expect(assertBrowserNetworkUrl('https://attacker.example/private', { lookup }))
+      .rejects.toThrow(/private address/);
+  });
+
+  it('allows public HTTP(S) destinations after DNS validation', async () => {
+    const lookup = vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]) as unknown as BrowserDnsLookup;
+
+    await expect(assertBrowserNetworkUrl('https://example.com/', { lookup })).resolves.toBeUndefined();
+  });
+
+  it('forces the actual Chromium HTTP connection through the private-address guard', async () => {
+    let targetHits = 0;
+    const target = createServer((_request, response) => {
+      targetHits += 1;
+      response.end('secret');
+    });
+    await new Promise<void>((resolve) => target.listen(0, '127.0.0.1', resolve));
+    const address = target.address();
+    if (!address || typeof address === 'string') throw new Error('target did not bind');
+    const proxy = await createBrowserNetworkProxy();
+    try {
+      const response = await requestThroughProxy(proxy.port, `http://127.0.0.1:${address.port}/secret`);
+      expect(response.status).toBe(403);
+      expect(response.body).toContain('blocked request');
+      expect(targetHits).toBe(0);
+    } finally {
+      await proxy.close();
+      await new Promise<void>((resolve) => target.close(() => resolve()));
+    }
+  });
+
+  it('exposes only the CDP methods required by the staged recon adapter', () => {
+    expect(WEB_CLONE_CDP_METHODS).toEqual(new Set([
+      'Emulation.setDeviceMetricsOverride',
+      'Input.dispatchMouseEvent',
+      'Network.enable',
+      'Network.getCookies',
+      'Network.getResponseBody',
+      'Page.captureScreenshot',
+      'Page.enable',
+      'Page.getLayoutMetrics',
+      'Page.navigate',
+      'Runtime.enable',
+      'Runtime.evaluate',
+    ]));
+    expect(WEB_CLONE_CDP_METHODS.has('Browser.getVersion')).toBe(false);
+    expect(WEB_CLONE_CDP_METHODS.has('Fetch.disable')).toBe(false);
+    expect(WEB_CLONE_CDP_METHODS.has('Target.createTarget')).toBe(false);
+  });
+});
+
+async function requestThroughProxy(proxyPort: number, url: string): Promise<{ body: string; status: number }> {
+  return new Promise((resolve, reject) => {
+    const outbound = request({
+      headers: { host: new URL(url).host },
+      host: '127.0.0.1',
+      method: 'GET',
+      path: url,
+      port: proxyPort,
+    }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => { body += chunk; });
+      response.once('end', () => resolve({ body, status: response.statusCode ?? 0 }));
+    });
+    outbound.once('error', reject);
+    outbound.end();
+  });
+}
+
+describe('Website Clone browser process cleanup', () => {
+  it('waits for a SIGTERM-resistant browser to exit after SIGKILL before deleting its profile', async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+      signalCode: NodeJS.Signals | null;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    const signals: Array<NodeJS.Signals | number | undefined> = [];
+    child.kill = (signal) => {
+      signals.push(signal);
+      if (signal === 'SIGKILL') {
+        setTimeout(() => {
+          child.exitCode = 137;
+          child.signalCode = 'SIGKILL';
+          child.emit('exit', 137, 'SIGKILL');
+        }, 5);
+      }
+      return true;
+    };
+    const removeProfile = vi.fn(async () => {
+      expect(child.exitCode).toBe(137);
+    });
+
+    await terminateBrowserProcess(
+      child as unknown as ChildProcess,
+      'locked-profile',
+      removeProfile,
+      { forcedMs: 50, gracefulMs: 1 },
+    );
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(removeProfile).toHaveBeenCalledWith('locked-profile');
+  });
+
+  it('retries transient Windows-style profile deletion failures with bounded backoff', async () => {
+    const locked = Object.assign(new Error('file is locked'), { code: 'EPERM' });
+    const remove = vi.fn()
+      .mockRejectedValueOnce(locked)
+      .mockRejectedValueOnce(locked)
+      .mockResolvedValueOnce(undefined);
+    const delay = vi.fn().mockResolvedValue(undefined);
+
+    await removeBrowserProfile('profile', remove, delay);
+
+    expect(remove).toHaveBeenCalledTimes(3);
+    expect(delay).toHaveBeenNthCalledWith(1, 100);
+    expect(delay).toHaveBeenNthCalledWith(2, 200);
+  });
+});

--- a/apps/daemon/tests/browser-session-security.test.ts
+++ b/apps/daemon/tests/browser-session-security.test.ts
@@ -115,6 +115,71 @@ describe('Website Clone browser broker security boundary', () => {
     }
   });
 
+  it('tears down an ordinary HTTP upstream when the browser client disconnects', async () => {
+    const targetSockets = new Set<Socket>();
+    const target = createServer((_request, response) => {
+      response.writeHead(200);
+      response.write('partial response');
+    });
+    target.on('connection', (socket) => {
+      targetSockets.add(socket);
+      socket.on('error', () => undefined);
+      socket.once('close', () => targetSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => target.listen(0, '127.0.0.1', resolve));
+    const targetAddress = target.address();
+    if (!targetAddress || typeof targetAddress === 'string') throw new Error('target did not bind');
+    const proxy = await createBrowserNetworkProxy({ allowPrivateNetwork: true });
+    const client = openHttpStreamThroughProxy(proxy.port, targetAddress.port);
+
+    try {
+      await client.responseStarted;
+      expect(targetSockets.size).toBe(1);
+      client.request.destroy();
+      await waitFor(() => targetSockets.size === 0);
+    } finally {
+      client.request.destroy();
+      await proxy.close();
+      for (const socket of targetSockets) socket.destroy();
+      await new Promise<void>((resolve) => target.close(() => resolve()));
+    }
+  });
+
+  it('does not retain ordinary HTTP upstreams across repeated proxy lifecycles', async () => {
+    const targetSockets = new Set<Socket>();
+    const target = createServer((_request, response) => {
+      response.writeHead(200);
+      response.write('partial response');
+    });
+    target.on('connection', (socket) => {
+      targetSockets.add(socket);
+      socket.on('error', () => undefined);
+      socket.once('close', () => targetSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => target.listen(0, '127.0.0.1', resolve));
+    const targetAddress = target.address();
+    if (!targetAddress || typeof targetAddress === 'string') throw new Error('target did not bind');
+
+    try {
+      for (let iteration = 0; iteration < 3; iteration += 1) {
+        const proxy = await createBrowserNetworkProxy({ allowPrivateNetwork: true });
+        const client = openHttpStreamThroughProxy(proxy.port, targetAddress.port);
+        try {
+          await client.responseStarted;
+          expect(targetSockets.size).toBe(1);
+          await proxy.close();
+          await waitFor(() => targetSockets.size === 0);
+        } finally {
+          client.request.destroy();
+          await proxy.close();
+        }
+      }
+    } finally {
+      for (const socket of targetSockets) socket.destroy();
+      await new Promise<void>((resolve) => target.close(() => resolve()));
+    }
+  });
+
   it('exposes only the CDP methods required by the staged recon adapter', () => {
     expect(WEB_CLONE_CDP_METHODS).toEqual(new Set([
       'Emulation.setDeviceMetricsOverride',
@@ -177,6 +242,29 @@ async function connectTunnel(proxyPort: number, targetPort: number): Promise<Soc
       socket.write(`CONNECT 127.0.0.1:${targetPort} HTTP/1.1\r\nHost: 127.0.0.1:${targetPort}\r\n\r\n`);
     });
   });
+}
+
+function openHttpStreamThroughProxy(proxyPort: number, targetPort: number): {
+  request: ReturnType<typeof request>;
+  responseStarted: Promise<void>;
+} {
+  let responseStartedResolve: (() => void) | undefined;
+  let responseStartedReject: ((error: Error) => void) | undefined;
+  const responseStarted = new Promise<void>((resolve, reject) => {
+    responseStartedResolve = resolve;
+    responseStartedReject = reject;
+  });
+  const outbound = request({
+    headers: { host: `127.0.0.1:${targetPort}` },
+    host: '127.0.0.1',
+    path: `http://127.0.0.1:${targetPort}/stream`,
+    port: proxyPort,
+  }, (response) => {
+    response.once('data', () => responseStartedResolve?.());
+  });
+  outbound.on('error', (error) => responseStartedReject?.(error));
+  outbound.end();
+  return { request: outbound, responseStarted };
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {

--- a/apps/daemon/tests/browser-session-security.test.ts
+++ b/apps/daemon/tests/browser-session-security.test.ts
@@ -1,11 +1,16 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { createServer, request } from 'node:http';
+import { createConnection, createServer as createTcpServer, type Socket } from 'node:net';
+import { PassThrough, type Duplex } from 'node:stream';
 
 import { describe, expect, it, vi } from 'vitest';
 
 import { WEB_CLONE_CDP_METHODS } from '../src/browser-cdp.js';
-import { createBrowserNetworkProxy } from '../src/browser-network-proxy.js';
+import {
+  createBrowserNetworkProxy,
+  trackBrowserNetworkTunnel,
+} from '../src/browser-network-proxy.js';
 import { assertBrowserNetworkUrl, type BrowserDnsLookup } from '../src/browser-network-policy.js';
 import { removeBrowserProfile, terminateBrowserProcess } from '../src/browser-sessions.js';
 
@@ -57,6 +62,59 @@ describe('Website Clone browser broker security boundary', () => {
     }
   });
 
+  it.each(['client', 'upstream'] as const)(
+    'contains a normal HTTPS tunnel EPIPE from the %s endpoint and tears down its peer',
+    async (source) => {
+      const client = new PassThrough();
+      const upstream = new PassThrough();
+      const tunnels = new Set<Duplex>();
+      const clientClosed = new Promise<void>((resolve) => client.once('close', () => resolve()));
+      const upstreamClosed = new Promise<void>((resolve) => upstream.once('close', () => resolve()));
+
+      trackBrowserNetworkTunnel(client, upstream, tunnels);
+      const socketError = Object.assign(new Error('normal HTTPS tunnel teardown'), { code: 'EPIPE' });
+      expect(() => (source === 'client' ? client : upstream).emit('error', socketError)).not.toThrow();
+
+      await Promise.all([clientClosed, upstreamClosed]);
+      expect(client.destroyed).toBe(true);
+      expect(upstream.destroyed).toBe(true);
+      expect(tunnels.size).toBe(0);
+    },
+  );
+
+  it('closes an HTTPS CONNECT peer and keeps the proxy available for the next browser tunnel', async () => {
+    const targetSockets = new Set<Socket>();
+    const target = createTcpServer((socket) => {
+      targetSockets.add(socket);
+      socket.on('error', () => undefined);
+      socket.once('close', () => targetSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => target.listen(0, '127.0.0.1', resolve));
+    const targetAddress = target.address();
+    if (!targetAddress || typeof targetAddress === 'string') throw new Error('target did not bind');
+    const proxy = await createBrowserNetworkProxy({ allowPrivateNetwork: true });
+
+    try {
+      const first = await connectTunnel(proxy.port, targetAddress.port);
+      first.on('error', () => undefined);
+      await waitFor(() => targetSockets.size === 1);
+      first.destroy();
+      await waitFor(() => targetSockets.size === 0);
+
+      // A daemon-fatal uncaughtException would prevent this follow-up tunnel,
+      // which represents the next browser session using the same broker.
+      const second = await connectTunnel(proxy.port, targetAddress.port);
+      second.on('error', () => undefined);
+      expect(second.destroyed).toBe(false);
+      second.destroy();
+      await waitFor(() => targetSockets.size === 0);
+    } finally {
+      await proxy.close();
+      for (const socket of targetSockets) socket.destroy();
+      await new Promise<void>((resolve) => target.close(() => resolve()));
+    }
+  });
+
   it('exposes only the CDP methods required by the staged recon adapter', () => {
     expect(WEB_CLONE_CDP_METHODS).toEqual(new Set([
       'Emulation.setDeviceMetricsOverride',
@@ -94,6 +152,39 @@ async function requestThroughProxy(proxyPort: number, url: string): Promise<{ bo
     outbound.once('error', reject);
     outbound.end();
   });
+}
+
+async function connectTunnel(proxyPort: number, targetPort: number): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host: '127.0.0.1', port: proxyPort });
+    let response = '';
+    const onError = (error: Error) => reject(error);
+    const onData = (chunk: Buffer) => {
+      response += chunk.toString('latin1');
+      if (!response.includes('\r\n\r\n')) return;
+      socket.off('data', onData);
+      socket.off('error', onError);
+      if (!response.startsWith('HTTP/1.1 200')) {
+        reject(new Error(`CONNECT failed: ${response}`));
+        socket.destroy();
+        return;
+      }
+      resolve(socket);
+    };
+    socket.once('error', onError);
+    socket.on('data', onData);
+    socket.once('connect', () => {
+      socket.write(`CONNECT 127.0.0.1:${targetPort} HTTP/1.1\r\nHost: 127.0.0.1:${targetPort}\r\n\r\n`);
+    });
+  });
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now();
+  while (!condition()) {
+    if (Date.now() - startedAt >= timeoutMs) throw new Error('condition timed out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 describe('Website Clone browser process cleanup', () => {

--- a/apps/daemon/tests/server-bootstrap-regression.test.ts
+++ b/apps/daemon/tests/server-bootstrap-regression.test.ts
@@ -233,6 +233,10 @@ describe('server route inventory', () => {
     const browserSessionRouteKeys = [
       'POST /api/projects/:id/browser-sessions',
       'DELETE /api/projects/:id/browser-sessions/:sessionId',
+      'POST /api/projects/:id/browser-sessions/:sessionId/pages',
+      'POST /api/projects/:id/browser-sessions/:sessionId/pages/:pageId/commands',
+      'GET /api/projects/:id/browser-sessions/:sessionId/pages/:pageId/events',
+      'DELETE /api/projects/:id/browser-sessions/:sessionId/pages/:pageId',
     ];
 
     expect(routeKeys).toEqual(expect.arrayContaining([

--- a/e2e/specs/web-clone/main.spec.ts
+++ b/e2e/specs/web-clone/main.spec.ts
@@ -25,7 +25,11 @@ type SkillResponse = {
 };
 
 type BrowserSessionResponse = {
-  browserSession: { id: string; websocketUrl: string };
+  browserSession: { id: string; websocketUrl?: never };
+};
+
+type BrowserPageResponse = {
+  page: { id: string; url: string };
 };
 
 type CreatedProjectResponse = ProjectResponse & {
@@ -85,9 +89,7 @@ describe('Website Clone main path', () => {
         { body: {} },
       );
       expect(created.browserSession.id).toEqual(expect.any(String));
-      expect(created.browserSession.websocketUrl).toBe(
-        'ws://127.0.0.1:65534/devtools/browser/web-clone-e2e',
-      );
+      expect(created.browserSession).not.toHaveProperty('websocketUrl');
 
       const closed = await requestJson<{ closed: boolean }>(
         webUrl,
@@ -212,8 +214,75 @@ describe('Website Clone main path', () => {
         env: {
           CODEX_BIN: fakeCodex,
           OD_BROWSER_EXECUTABLE_PATH: browserExecutable,
+          // The hermetic fixture is deliberately loopback-only. Production
+          // daemon runs omit this test-only authority and reject private hosts.
+          OD_BROWSER_ALLOW_PRIVATE_NETWORK_FOR_TESTS: '1',
         },
       });
+    } finally {
+      await closeServer(fixture.server);
+    }
+  }, 300_000);
+
+  test('[P0] broker rejects raw CDP and private-network navigation before Chromium can reach it', async () => {
+    const suite = await createSmokeSuite('web-clone-browser-boundary');
+    const fixture = await startFixtureSite();
+    const browserExecutable = await resolveBrowserExecutable();
+
+    try {
+      await suite.with.toolsDev(async ({ webUrl }) => {
+        const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+          body: {
+            designSystemId: null,
+            id: randomUUID(),
+            metadata: { intent: 'web-clone', kind: 'prototype' },
+            name: 'Website Clone broker boundary smoke',
+            pendingPrompt: `复刻 ${fixture.url}`,
+            skillId: 'web-clone',
+          },
+        });
+        const base = `/api/projects/${encodeURIComponent(project.project.id)}/browser-sessions`;
+        const created = await requestJson<BrowserSessionResponse>(webUrl, base, { body: {} });
+        expect(created.browserSession).not.toHaveProperty('websocketUrl');
+        const sessionBase = `${base}/${encodeURIComponent(created.browserSession.id)}`;
+        const createdPage = await requestJson<BrowserPageResponse>(webUrl, `${sessionBase}/pages`, { body: {} });
+        const commandUrl = `${webUrl}${sessionBase}/pages/${encodeURIComponent(createdPage.page.id)}/commands`;
+
+        const blankPageRead = await fetch(commandUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ method: 'Runtime.evaluate', params: { expression: 'document.body.innerText' } }),
+        });
+        expect(blankPageRead.status).toBe(400);
+        expect(await blankPageRead.text()).toContain('privileged URL scheme');
+
+        const fileNavigation = await fetch(commandUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ method: 'Page.navigate', params: { url: 'file:///etc/passwd' } }),
+        });
+        expect(fileNavigation.status).toBe(400);
+        expect(await fileNavigation.text()).toContain('unsupported url scheme');
+
+        const privateNavigation = await fetch(commandUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ method: 'Page.navigate', params: { url: fixture.url } }),
+        });
+        expect(privateNavigation.status).toBe(400);
+        expect(await privateNavigation.text()).toContain('BROWSER_COMMAND_REJECTED');
+        expect(fixture.requests.count).toBe(0);
+
+        const generalCdp = await fetch(commandUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ method: 'Browser.getVersion', params: {} }),
+        });
+        expect(generalCdp.status).toBe(400);
+        expect(await generalCdp.text()).toContain('CDP method is not allowed');
+
+        await requestJson(webUrl, sessionBase, { method: 'DELETE' });
+      }, { env: { OD_BROWSER_EXECUTABLE_PATH: browserExecutable } });
     } finally {
       await closeServer(fixture.server);
     }
@@ -271,12 +340,14 @@ async function resolveBrowserExecutable(): Promise<string> {
   );
 }
 
-async function startFixtureSite(): Promise<{ server: Server; url: string }> {
+async function startFixtureSite(): Promise<{ requests: { count: number }; server: Server; url: string }> {
+  const requests = { count: 0 };
   const server = createServer((request, response) => {
     if (request.url === '/favicon.ico') {
       response.writeHead(204).end();
       return;
     }
+    requests.count += 1;
     response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
     response.end(`<!doctype html>
 <html lang="en">
@@ -311,7 +382,7 @@ async function startFixtureSite(): Promise<{ server: Server; url: string }> {
   if (address == null || typeof address === 'string') {
     throw new Error('Website Clone fixture did not bind to a TCP port');
   }
-  return { server, url: `http://127.0.0.1:${address.port}/` };
+  return { requests, server, url: `http://127.0.0.1:${address.port}/` };
 }
 
 async function closeServer(server: Server): Promise<void> {

--- a/e2e/specs/web-clone/main.spec.ts
+++ b/e2e/specs/web-clone/main.spec.ts
@@ -98,8 +98,24 @@ describe('Website Clone main path', () => {
       );
       expect(closed.closed).toBe(true);
 
+      // Paired with the CONNECT teardown regression in the daemon suite, pin
+      // that the daemon-wide broker can serve the next Website Clone session.
+      const recreated = await requestJson<BrowserSessionResponse>(
+        webUrl,
+        `/api/projects/${encodeURIComponent(project.project.id)}/browser-sessions`,
+        { body: {} },
+      );
+      expect(recreated.browserSession.id).not.toBe(created.browserSession.id);
+      const reclosed = await requestJson<{ closed: boolean }>(
+        webUrl,
+        `/api/projects/${encodeURIComponent(project.project.id)}/browser-sessions/${encodeURIComponent(recreated.browserSession.id)}`,
+        { method: 'DELETE' },
+      );
+      expect(reclosed.closed).toBe(true);
+
       await suite.report.json('summary.json', {
         browserBroker: created.browserSession,
+        browserBrokerRecreated: recreated.browserSession,
         electronRequired: false,
         playwrightInstalledInProject: false,
         projectId: project.project.id,

--- a/skills/web-clone/scripts/lib/system-browser.mjs
+++ b/skills/web-clone/scripts/lib/system-browser.mjs
@@ -16,6 +16,28 @@ function withTimeout(promise, timeoutMs, label) {
   ]).finally(() => clearTimeout(timer));
 }
 
+async function waitForChildExit(child, timeoutMs) {
+  if (child.exitCode != null || child.signalCode != null) return;
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, timeoutMs)),
+  ]);
+}
+
+async function removeDirectoryWithRetries(directory) {
+  let lastError;
+  for (let attempt = 0; attempt < 7; attempt += 1) {
+    try {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 6) await new Promise((resolve) => setTimeout(resolve, 100 * (attempt + 1)));
+    }
+  }
+  throw lastError;
+}
+
 class CdpConnection {
   constructor(url) {
     this.url = url;
@@ -85,6 +107,77 @@ class CdpConnection {
   }
 }
 
+class DaemonCdpConnection {
+  constructor(endpoint) {
+    this.endpoint = endpoint;
+    this.listeners = new Map();
+    this.closed = false;
+    this.after = 0;
+    this.pollController = new AbortController();
+    this.ready = Promise.resolve();
+    this.#poll().catch(() => {});
+  }
+
+  async send(method, params = {}, timeoutMs = COMMAND_TIMEOUT_MS) {
+    if (this.closed) throw new Error("CDP connection closed");
+    const response = await withTimeout(fetch(`${this.endpoint}/commands`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ method, params }),
+    }), timeoutMs, method);
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(`daemon CDP command failed: HTTP ${response.status}${detail ? ` ${detail}` : ""}`);
+    }
+    const payload = await response.json();
+    return payload.result || {};
+  }
+
+  on(method, listener) {
+    const listeners = this.listeners.get(method) || new Set();
+    listeners.add(listener);
+    this.listeners.set(method, listeners);
+    return () => listeners.delete(listener);
+  }
+
+  close() {
+    this.closed = true;
+    this.pollController.abort();
+  }
+
+  async #poll() {
+    while (!this.closed) {
+      let response;
+      try {
+        response = await fetch(
+          `${this.endpoint}/events?after=${this.after}&timeout=20000`,
+          { signal: this.pollController.signal },
+        );
+      } catch (error) {
+        if (this.closed || error?.name === "AbortError") return;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        continue;
+      }
+      if (!response.ok) {
+        if (response.status === 404) return;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        continue;
+      }
+      const payload = await response.json();
+      for (const event of payload.events || []) {
+        this.after = Math.max(this.after, Number(event.sequence) || 0);
+        for (const listener of this.listeners.get(event.method) || []) {
+          try {
+            listener(event.params || {});
+          } catch {
+            // A consumer event handler must not break the broker poll.
+          }
+        }
+      }
+    }
+  }
+}
+
 function normalizeResourceType(value = "other") {
   const lower = String(value).toLowerCase();
   return lower === "xhr" || lower === "fetch" ? lower : lower;
@@ -135,7 +228,7 @@ class CdpPage {
   constructor(browser, target, options) {
     this.browser = browser;
     this.target = target;
-    this.connection = new CdpConnection(target.webSocketDebuggerUrl);
+    this.connection = target.connection || new CdpConnection(target.webSocketDebuggerUrl);
     this.listeners = new Map();
     this.requests = new Map();
     this.finishedRequests = new Map();
@@ -424,7 +517,7 @@ class CdpPage {
 
   async close() {
     this.connection.close();
-    await fetch(`${this.browser.httpBase}/json/close/${this.target.id}`).catch(() => undefined);
+    await this.browser.closePage(this.target.id);
   }
 }
 
@@ -469,16 +562,32 @@ class CdpContext {
 }
 
 class SystemBrowser {
-  constructor(child, profileDir, browserSocketUrl, closeRemote = null) {
+  constructor(child, profileDir, browserSocketUrl, closeRemote = null, remoteEndpoint = null) {
     this.child = child;
     this.profileDir = profileDir;
     this.closeRemote = closeRemote;
-    const socket = new URL(browserSocketUrl);
-    this.httpBase = `http://${socket.host}`;
+    this.remoteEndpoint = remoteEndpoint;
+    if (browserSocketUrl) {
+      const socket = new URL(browserSocketUrl);
+      this.httpBase = `http://${socket.host}`;
+    } else {
+      this.httpBase = null;
+    }
     this.closed = false;
   }
 
   async createPage(options = {}) {
+    if (this.remoteEndpoint) {
+      const response = await fetch(`${this.remoteEndpoint}/pages`, { method: "POST" });
+      if (!response.ok) throw new Error(`daemon target creation failed: HTTP ${response.status}`);
+      const payload = await response.json();
+      const target = payload.page;
+      if (!target?.id) throw new Error("daemon returned an invalid browser page");
+      target.connection = new DaemonCdpConnection(
+        `${this.remoteEndpoint}/pages/${encodeURIComponent(target.id)}`,
+      );
+      return CdpPage.create(this, target, options);
+    }
     const response = await fetch(`${this.httpBase}/json/new?${encodeURIComponent("about:blank")}`, { method: "PUT" });
     if (!response.ok) throw new Error(`Chrome target creation failed: HTTP ${response.status}`);
     const target = await response.json();
@@ -493,6 +602,14 @@ class SystemBrowser {
     return Promise.resolve(new CdpContext(this, options));
   }
 
+  async closePage(pageId) {
+    if (this.remoteEndpoint) {
+      await fetch(`${this.remoteEndpoint}/pages/${encodeURIComponent(pageId)}`, { method: "DELETE" }).catch(() => undefined);
+      return;
+    }
+    await fetch(`${this.httpBase}/json/close/${encodeURIComponent(pageId)}`).catch(() => undefined);
+  }
+
   async close() {
     if (this.closed) return;
     this.closed = true;
@@ -501,12 +618,12 @@ class SystemBrowser {
       return;
     }
     this.child.kill("SIGTERM");
-    await Promise.race([
-      new Promise((resolve) => this.child.once("exit", resolve)),
-      new Promise((resolve) => setTimeout(resolve, 2_000)),
-    ]);
-    if (this.child.exitCode == null) this.child.kill("SIGKILL");
-    fs.rmSync(this.profileDir, { recursive: true, force: true });
+    await waitForChildExit(this.child, 2_000);
+    if (this.child.exitCode == null && this.child.signalCode == null) {
+      this.child.kill("SIGKILL");
+      await waitForChildExit(this.child, 2_000);
+    }
+    await removeDirectoryWithRetries(this.profileDir);
   }
 }
 
@@ -520,10 +637,11 @@ async function connectOverDaemon({ daemonUrl, projectId }) {
   }
   const payload = await response.json();
   const session = payload.browserSession;
-  if (!session?.id || !session?.websocketUrl) throw new Error("daemon returned an invalid browser session");
-  return new SystemBrowser(null, null, session.websocketUrl, async () => {
+  if (!session?.id) throw new Error("daemon returned an invalid browser session");
+  const remoteEndpoint = `${endpoint}/${encodeURIComponent(session.id)}`;
+  return new SystemBrowser(null, null, null, async () => {
     await fetch(`${endpoint}/${encodeURIComponent(session.id)}`, { method: "DELETE" }).catch(() => undefined);
-  });
+  }, remoteEndpoint);
 }
 
 async function launchSystemBrowser({ executablePath }) {
@@ -531,8 +649,8 @@ async function launchSystemBrowser({ executablePath }) {
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-web-clone-browser-"));
   const child = spawn(executablePath, [
     "--headless=new",
+    "--remote-debugging-address=127.0.0.1",
     "--remote-debugging-port=0",
-    "--remote-allow-origins=*",
     `--user-data-dir=${profileDir}`,
     "--no-first-run",
     "--no-default-browser-check",
@@ -555,9 +673,10 @@ async function launchSystemBrowser({ executablePath }) {
     child.stderr.on("data", inspect);
     child.once("error", reject);
     child.once("exit", (code) => reject(new Error(`System browser exited before CDP was ready (code ${code})`)));
-  }), 15_000, "system browser startup").catch((error) => {
+  }), 15_000, "system browser startup").catch(async (error) => {
     child.kill("SIGKILL");
-    fs.rmSync(profileDir, { recursive: true, force: true });
+    await waitForChildExit(child, 2_000);
+    await removeDirectoryWithRetries(profileDir);
     throw error;
   });
 


### PR DESCRIPTION
## Why

This is the main-branch follow-up to the blocking security and lifecycle review on backport PR #7048 (original change: #7000). While validating the web-clone path, we confirmed that returning Chrome's raw CDP WebSocket to a sandboxed agent crossed the daemon privilege boundary: a caller could issue unrestricted CDP commands and navigate to file, loopback, or private-network targets. We also confirmed that cleanup sent `SIGKILL` and immediately removed the profile, which can race Windows process teardown and leave locked files behind.

The web-clone main path still needs to work from the real `od` CLI when the Electron client is not running, without installing Playwright into each project or shipping another browser in the desktop bundle. This change keeps that behavior while constraining what the agent can ask the daemon-owned browser to do.

## What users will see

Website clone continues to launch an available system Chrome-family browser through the daemon, including from `od` CLI with no desktop window running. It does not install Playwright, package Chromium, or add client bundle bytes.

Attempts to clone `file://`, loopback, link-local, metadata, or private-network targets now fail at the daemon boundary. Browser-session cleanup also waits for termination and retries profile removal, making the path reliable on Windows-style file locking.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The only new environment switch, `OD_BROWSER_ALLOW_PRIVATE_NETWORK_FOR_TESTS`, is daemon-startup-only and exists solely so the hermetic E2E fixture can opt in; an agent request cannot enable it.

## Screenshots

Not applicable: no UI surface changes.

## Bug fix verification

- Red specs: `e2e/specs/web-clone/main.spec.ts` and `apps/daemon/tests/browser-session-security.test.ts`.
- Yes. On `main`, the lifecycle spec failed because the create-session response exposed `ws://127.0.0.1:65534/devtools/browser/web-clone-e2e`; on this branch it exposes only an opaque session ID. The new security spec also exercises the CDP allowlist, exact-IP proxy enforcement, private/file target rejection, SIGKILL waiting, and Windows-style `EPERM` cleanup retry.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon test` — 679 files passed, 2 skipped; 8,676 tests passed, 6 skipped
- `pnpm --filter @open-design/daemon exec vitest run tests/browser-session-security.test.ts --reporter=dot` — 10 passed
- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts specs/web-clone/main.spec.ts --reporter=dot` — 3 passed; real `od` CLI, daemon browser, staged `recon-site.mjs`, 1440/768/390 captures, zero console/page errors
- `pnpm --filter @open-design/tools-pack test` — 279 passed, 8 skipped
- `node --check skills/web-clone/scripts/lib/system-browser.mjs`
- `git diff --check origin/main...HEAD`

No runtime dependency or packaged browser was added.
