### PR TITLE
fix(web): make plugin detail page scrollable

### DIFF
--- a/apps/web/src/styles/home/plugin-marketplace-demo.css
+++ b/apps/web/src/styles/home/plugin-marketplace-demo.css
@@ -888,7 +888,14 @@
 }
 
 .plugin-suite-detail {
-  padding-top: 18px;
+  height: 100%;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  padding: 18px 0 72px;
 }
 
 .plugin-suite-detail__topbar {

--- a/apps/web/tests/styles/plugin-detail-scroll.test.ts
+++ b/apps/web/tests/styles/plugin-detail-scroll.test.ts
@@ -1,0 +1,23 @@
+import postcss, { type Declaration, type Rule } from 'postcss';
+import { describe, expect, it } from 'vitest';
+import { readExpandedIndexCss } from '../helpers/read-expanded-css';
+
+describe('plugin detail page scrolling', () => {
+  it('owns vertical overflow inside the fixed-height workspace shell', () => {
+    const root = postcss.parse(readExpandedIndexCss(), { from: 'src/index.css' });
+    const rule = root.nodes.find(
+      (node): node is Rule => node.type === 'rule' && node.selector === '.plugin-suite-detail',
+    );
+    const declarations = new Map(
+      rule?.nodes
+        .filter((node): node is Declaration => node.type === 'decl')
+        .map((declaration) => [declaration.prop, declaration.value]),
+    );
+
+    expect(declarations.get('height')).toBe('100%');
+    expect(declarations.get('min-height')).toBe('0');
+    expect(declarations.get('overflow-x')).toBe('hidden');
+    expect(declarations.get('overflow-y')).toBe('auto');
+    expect(declarations.get('scrollbar-gutter')).toBe('stable');
+  });
+});


### PR DESCRIPTION
## Why

I hit this while checking an official plugin's full-page details from the Plugins catalog. The fixed-height workspace shell clips overflow, while `PluginDetailView` did not own a scroll container, so content below the viewport—including developer details and the final action—could not be reached.

This fixes that user-facing navigation dead end and keeps the scroll behavior encoded as a narrow style contract.

## What users will see

Official plugin detail pages now scroll vertically inside the workspace. Users can reach every section and the final "Use plugin" action, while horizontal overflow remains clipped and the scrollbar gutter stays stable.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Chrome E2E capture recorded after scrolling the official `Build test` plugin detail page to the bottom; the measured evidence is included in Validation below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/plugin-detail-scroll.test.ts`
- Did the test go red on `main` and green on this branch? **yes**
- The red spec proves the full-page detail surface lacked a fixed-height vertical scroll container; it passes after the style contract is added.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/styles/plugin-detail-scroll.test.ts tests/components/PluginDetailView.curated-layout.test.tsx tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx --maxWorkers=2` (14 tests)
- Chrome + Open Browser Use E2E: Home → Plugins → Build test → scroll to bottom; measured `clientHeight=809`, `scrollHeight=978`, `scrollTop=168.5`, `overflow-y=auto`, stable scrollbar gutter, final action visible, and no console errors.
