### PR TITLE
fix(web): keep first Home run output live

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1879,6 +1879,8 @@ export function ProjectView({
         : projectRunWorkspaceContext
           ? 'workspace'
           : 'pending';
+  const projectResourceAuthorityRef = useRef(projectResourceAuthority);
+  projectResourceAuthorityRef.current = projectResourceAuthority;
   const projectRunWorkspaceContextRef = useRef(projectRunWorkspaceContext);
   projectRunWorkspaceContextRef.current = projectRunWorkspaceContext;
   // The AMR pre-run balance gate uses the project's resolved scope, or the one
@@ -7042,14 +7044,45 @@ export function ProjectView({
       let streamedText = '';
 
       const updateAssistant = (updater: (prev: ChatMessage) => ChatMessage) => {
-        setMessages((curr) =>
-          curr.map((m) => {
+        setMessages((curr) => {
+          let found = false;
+          const next = curr.map((m) => {
             if (m.id !== assistantId) return m;
+            found = true;
             const updated = updater(m);
             latestAssistantMsg = updated;
             return updated;
-          }),
-        );
+          });
+          if (found) return next;
+
+          // A workspace-authority refresh can reload the same conversation
+          // while POST /runs is retrying. That authoritative read may still
+          // be empty and replace the Home handoff's client-owned user and
+          // assistant placeholders. The stream remains attached, however, so
+          // dropping later deltas here leaves a successful daemon run blank
+          // until a tab switch or reload reads the persisted transcript.
+          //
+          // Restore only the two rows owned by the live controller for the
+          // project and conversation still on screen. A revoked authority is
+          // never allowed to resurrect them, and settled historical messages
+          // keep the existing clear-on-authority-change behavior.
+          if (
+            abortRef.current !== controller
+            || projectIdRef.current !== project.id
+            || activeConversationIdRef.current !== runConversationId
+            || projectResourceAuthorityRef.current === 'denied'
+          ) {
+            return curr;
+          }
+          const updated = updater(latestAssistantMsg);
+          latestAssistantMsg = updated;
+          const userAlreadyPresent = curr.some((message) => message.id === userMsg.id);
+          return [
+            ...curr,
+            ...(userAlreadyPresent ? [] : [userMsg]),
+            updated,
+          ];
+        });
       };
       let persistTimer: ReturnType<typeof setTimeout> | null = null;
       const persistAssistantSoon = () => {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3004,27 +3004,60 @@ export function ProjectView({
     const reloadingCurrentConversation =
       messagesConversationIdRef.current === activeConversationId
       && messagesAuthorityKeyRef.current === projectRunAuthorityKey;
+    const liveReloadMessageIds = new Set<string>();
+    if (
+      messagesConversationIdRef.current === activeConversationId
+      && streamingConversationIdRef.current === activeConversationId
+      && abortRef.current !== null
+      && cancelRef.current !== null
+      && projectResourceAuthorityRef.current !== 'denied'
+    ) {
+      const currentMessages = messagesRef.current;
+      let assistantIndex = -1;
+      for (let index = currentMessages.length - 1; index >= 0; index -= 1) {
+        const message = currentMessages[index];
+        if (message?.role === 'assistant' && isActiveRunStatus(message.runStatus)) {
+          liveReloadMessageIds.add(message.id);
+          assistantIndex = index;
+          break;
+        }
+      }
+      for (let index = assistantIndex - 1; index >= 0; index -= 1) {
+        const message = currentMessages[index];
+        if (message?.role !== 'user') continue;
+        liveReloadMessageIds.add(message.id);
+        break;
+      }
+    }
+    const preservingLiveConversation = liveReloadMessageIds.size > 0;
     // Reset the initialized flag so auto-send waits for this authoritative DB
     // read to settle before checking messages.length. A same-conversation
-    // authority refresh keeps the prior transcript visible, but invalidates
-    // its initialized state until the refresh succeeds.
+    // authority refresh keeps the prior transcript visible. An authority-key
+    // handoff keeps only the live turn, so its pending read cannot detach the
+    // stream or later replace those rows with an empty snapshot.
     setMessagesInitialized(false);
     let cancelled = false;
     const requestWorkspaceContext = projectRunWorkspaceContextRef.current;
-    setMessagesConversationId(null);
     setFailedMessagesConversationId(null);
-    setStreaming(false);
-    streamingConversationIdRef.current = null;
-    setStreamingConversationId(null);
+    if (!preservingLiveConversation) {
+      setMessagesConversationId(null);
+      setStreaming(false);
+      streamingConversationIdRef.current = null;
+      setStreamingConversationId(null);
+    }
     if (!reloadingCurrentConversation) {
-      setMessages([]);
+      setMessages((current) =>
+        preservingLiveConversation
+          ? current.filter((message) => liveReloadMessageIds.has(message.id))
+          : [],
+      );
       commitPreviewComments([]);
       setAttachedComments([]);
       setArtifact(null);
       savedArtifactRef.current = null;
     }
     const commentsGeneration = previewCommentsGenerationRef.current;
-    if (!reloadingCurrentConversation) {
+    if (!reloadingCurrentConversation && !preservingLiveConversation) {
       messagesConversationIdRef.current = null;
       messagesAuthorityKeyRef.current = null;
     }
@@ -3052,7 +3085,14 @@ export function ProjectView({
           requestWorkspaceContext,
         );
         if (cancelled) return;
-        setMessages(normalizeConversationMessageOrder(list));
+        setMessages((current) =>
+          preservingLiveConversation
+            ? mergeServerMessagesIntoConversation(
+                current.filter((message) => liveReloadMessageIds.has(message.id)),
+                list,
+              )
+            : normalizeConversationMessageOrder(list),
+        );
         setMessagesInitialized(true);
         setAttachedComments([]);
         setArtifact(null);
@@ -3066,16 +3106,22 @@ export function ProjectView({
         if (cancelled) return;
         const message = err instanceof Error ? err.message : 'Could not load messages for this conversation.';
         if (!reloadingCurrentConversation) {
-          setMessages([]);
+          setMessages((current) =>
+            preservingLiveConversation
+              ? current.filter((item) => liveReloadMessageIds.has(item.id))
+              : [],
+          );
           commitPreviewComments([]);
           setAttachedComments([]);
           setArtifact(null);
           savedArtifactRef.current = null;
         }
         setError(message);
-        messagesConversationIdRef.current = null;
-        messagesAuthorityKeyRef.current = null;
-        setMessagesConversationId(null);
+        if (!preservingLiveConversation) {
+          messagesConversationIdRef.current = null;
+          messagesAuthorityKeyRef.current = null;
+          setMessagesConversationId(null);
+        }
         setFailedMessagesConversationId(activeConversationId);
       }
     })();

--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -646,6 +646,126 @@ describe('a Home auto-send identifies its caller before the project scope resolv
     expect(mockedStreamViaDaemon).not.toHaveBeenCalled();
   });
 
+  it('keeps a cold Home run attached while workspace authority refreshes', async () => {
+    const activeStream = deferred<void>();
+    let runOptions: Parameters<typeof streamViaDaemon>[0] | undefined;
+    mockedStreamViaDaemon.mockImplementation((options) => {
+      runOptions = options;
+      return activeStream.promise;
+    });
+
+    const view = renderProjectView();
+
+    await waitFor(() => expect(runOptions).toBeDefined());
+    await waitFor(() => {
+      expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([
+        expect.objectContaining({ role: 'user', content: SEED_PROMPT }),
+        expect.objectContaining({ role: 'assistant', runStatus: 'running' }),
+      ]);
+    });
+
+    const authorityReload = deferred<ChatMessage[]>();
+    mockedListMessages.mockReturnValueOnce(authorityReload.promise);
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: {
+        kind: 'team',
+        projectId: PROJECT_ID,
+        workspaceId: TEAM_WORKSPACE,
+        visibility: 'team',
+        context: {
+          ...CALLER_CONTEXT,
+          role: 'admin',
+          permissions: buildWorkspacePermissions({
+            role: 'admin',
+            lifecycleState: 'active',
+          }),
+        } as WorkspaceCollabContext & { workspaceType: 'team' },
+      },
+    };
+    await act(async () => {
+      view.rerender(projectViewElement());
+    });
+
+    await waitFor(() => expect(mockedListMessages).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      authorityReload.resolve([]);
+      await authorityReload.promise;
+    });
+
+    const expectedOutput = 'The first packaged run is still live.';
+    await act(async () => {
+      runOptions?.onRunCreated?.('run-first-home');
+      runOptions?.onRunStatus?.('running');
+      runOptions?.handlers.onAgentEvent({ kind: 'text', text: expectedOutput });
+      runOptions?.handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'write-index',
+        name: 'Write',
+        input: { file_path: 'index.html', content: '<main>ready</main>' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([
+        expect.objectContaining({ role: 'user', content: SEED_PROMPT }),
+        expect.objectContaining({
+          role: 'assistant',
+          runId: 'run-first-home',
+          events: expect.arrayContaining([
+            expect.objectContaining({ kind: 'text', text: expectedOutput }),
+          ]),
+        }),
+      ]);
+    });
+
+    activeStream.resolve();
+  });
+
+  it('does not restore a cold Home run after project authority is revoked', async () => {
+    const activeStream = deferred<void>();
+    let runOptions: Parameters<typeof streamViaDaemon>[0] | undefined;
+    mockedStreamViaDaemon.mockImplementation((options) => {
+      runOptions = options;
+      return activeStream.promise;
+    });
+
+    const view = renderProjectView();
+    await waitFor(() => expect(runOptions).toBeDefined());
+
+    workspaceScopeMocks.ambientContext = null;
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: null,
+      failure: 'forbidden',
+    };
+    await act(async () => {
+      view.rerender(projectViewElement());
+    });
+
+    await waitFor(() => expect(mockedListMessages).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([]);
+    });
+
+    await act(async () => {
+      runOptions?.onRunCreated?.('run-revoked-home');
+      runOptions?.handlers.onAgentEvent({
+        kind: 'text',
+        text: 'This output belongs to the revoked authority.',
+      });
+      runOptions?.handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'revoked-write',
+        name: 'Write',
+        input: { file_path: 'index.html', content: '<main>private</main>' },
+      });
+    });
+
+    expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([]);
+    activeStream.resolve();
+  });
+
   it('reuses one Home handoff identity across ProjectView remounts', async () => {
     const firstView = renderProjectView();
     await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalledTimes(1));

--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -646,7 +646,7 @@ describe('a Home auto-send identifies its caller before the project scope resolv
     expect(mockedStreamViaDaemon).not.toHaveBeenCalled();
   });
 
-  it('keeps a cold Home run attached while workspace authority refreshes', async () => {
+  it('keeps a cold Home run attached when an empty authority refresh settles after stream events', async () => {
     const activeStream = deferred<void>();
     let runOptions: Parameters<typeof streamViaDaemon>[0] | undefined;
     mockedStreamViaDaemon.mockImplementation((options) => {
@@ -688,11 +688,6 @@ describe('a Home auto-send identifies its caller before the project scope resolv
     });
 
     await waitFor(() => expect(mockedListMessages).toHaveBeenCalledTimes(2));
-    await act(async () => {
-      authorityReload.resolve([]);
-      await authorityReload.promise;
-    });
-
     const expectedOutput = 'The first packaged run is still live.';
     await act(async () => {
       runOptions?.onRunCreated?.('run-first-home');
@@ -718,6 +713,92 @@ describe('a Home auto-send identifies its caller before the project scope resolv
         }),
       ]);
     });
+
+    await act(async () => {
+      authorityReload.resolve([]);
+      await authorityReload.promise;
+    });
+
+    expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([
+      expect.objectContaining({ role: 'user', content: SEED_PROMPT }),
+      expect.objectContaining({
+        role: 'assistant',
+        runId: 'run-first-home',
+        events: expect.arrayContaining([
+          expect.objectContaining({ kind: 'text', text: expectedOutput }),
+        ]),
+      }),
+    ]);
+
+    activeStream.resolve();
+  });
+
+  it('keeps a terminal cold Home run attached when the empty refresh outlives its controller', async () => {
+    const activeStream = deferred<void>();
+    let runOptions: Parameters<typeof streamViaDaemon>[0] | undefined;
+    mockedStreamViaDaemon.mockImplementation((options) => {
+      runOptions = options;
+      return activeStream.promise;
+    });
+
+    const view = renderProjectView();
+    await waitFor(() => expect(runOptions).toBeDefined());
+
+    const authorityReload = deferred<ChatMessage[]>();
+    mockedListMessages.mockReturnValueOnce(authorityReload.promise);
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: {
+        kind: 'team',
+        projectId: PROJECT_ID,
+        workspaceId: TEAM_WORKSPACE,
+        visibility: 'team',
+        context: {
+          ...CALLER_CONTEXT,
+          role: 'admin',
+          permissions: buildWorkspacePermissions({
+            role: 'admin',
+            lifecycleState: 'active',
+          }),
+        } as WorkspaceCollabContext & { workspaceType: 'team' },
+      },
+    };
+    await act(async () => {
+      view.rerender(projectViewElement());
+    });
+    await waitFor(() => expect(mockedListMessages).toHaveBeenCalledTimes(2));
+
+    const expectedOutput = 'The terminal first run stays visible.';
+    await act(async () => {
+      runOptions?.onRunCreated?.('run-terminal-home');
+      runOptions?.onRunStatus?.('running');
+      runOptions?.handlers.onAgentEvent({ kind: 'text', text: expectedOutput });
+      runOptions?.handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'write-terminal-index',
+        name: 'Write',
+        input: { file_path: 'index.html', content: '<main>complete</main>' },
+      });
+      runOptions?.onRunStatus?.('succeeded');
+    });
+
+    await act(async () => {
+      authorityReload.resolve([]);
+      await authorityReload.promise;
+      runOptions?.handlers.onDone('');
+    });
+
+    expect(chatPaneSpy.mock.calls.at(-1)?.[0].messages).toEqual([
+      expect.objectContaining({ role: 'user', content: SEED_PROMPT }),
+      expect.objectContaining({
+        role: 'assistant',
+        runId: 'run-terminal-home',
+        endedAt: expect.any(Number),
+        events: expect.arrayContaining([
+          expect.objectContaining({ kind: 'text', text: expectedOutput }),
+        ]),
+      }),
+    ]);
 
     activeStream.resolve();
   });

--- a/e2e/lib/vitest/packaged-home-first-run.ts
+++ b/e2e/lib/vitest/packaged-home-first-run.ts
@@ -1,0 +1,286 @@
+export const PACKAGED_HOME_FIRST_RUN_PROMPT =
+  'Create a delayed deterministic smoke artifact';
+
+export const PACKAGED_HOME_FIRST_RUN_OUTPUT =
+  'I recovered the delayed reasoning path and will persist the artifact now.';
+
+export type PackagedHomeFirstRunResult = {
+  assistantText: string;
+  conversationId: string;
+  createRunRequestCount: number;
+  createRunResponseStatuses: number[];
+  daemonAssistantText: string;
+  hrefAfter: string;
+  hrefBefore: string;
+  inputTextBeforeSubmit: string;
+  injectedAuthorityOutageCount: number;
+  navigationEntryCountAfter: number;
+  navigationEntryCountBefore: number;
+  performanceTimeOriginAfter: number;
+  performanceTimeOriginBefore: number;
+  projectId: string;
+  runEventRequestCount: number;
+  runEventResponseStatuses: number[];
+  runEventsContainExpectedOutput: boolean;
+  submitClicked: boolean;
+  workspaceTabClicksBeforeOutput: number;
+};
+
+/**
+ * Instruments the first packaged Home send without recovering the renderer.
+ * Output observation is polled through a separate expression, so this setup
+ * never reloads the page or clicks a workspace tab after submission.
+ */
+export function packagedHomeFirstRunExpression(): string {
+  return `
+    (async () => {
+      const prompt = ${JSON.stringify(PACKAGED_HOME_FIRST_RUN_PROMPT)};
+      const stateKey = '__odPackagedHomeFirstRun';
+      const state = {
+        hrefBefore: location.href,
+        inputTextBeforeSubmit: '',
+        injectedAuthorityOutageCount: 0,
+        navigationEntryCountBefore: performance.getEntriesByType('navigation').length,
+        performanceTimeOriginBefore: performance.timeOrigin,
+        createRunRequestCount: 0,
+        createRunResponseStatuses: [],
+        runEventRequestCount: 0,
+        runEventResponseStatuses: [],
+        submitClicked: false,
+        workspaceRequestHeaders: {},
+        workspaceTabClicksBeforeOutput: 0,
+      };
+      globalThis[stateKey] = state;
+
+      const originalFetch = globalThis.fetch.bind(globalThis);
+      state.originalFetch = originalFetch;
+      globalThis.fetch = async (...args) => {
+        const [input, init] = args;
+        const requestUrl = input instanceof Request ? input.url : String(input);
+        const requestMethod = (
+          init?.method ?? (input instanceof Request ? input.method : 'GET')
+        ).toUpperCase();
+        const pathname = new URL(requestUrl, location.href).pathname;
+        const isCreateRun = requestMethod === 'POST' && pathname === '/api/runs';
+        const isRunEvents =
+          requestMethod === 'GET'
+          && pathname.startsWith('/api/runs/')
+          && pathname.endsWith('/events')
+          && pathname.split('/').length === 5;
+        if (isCreateRun) {
+          const requestHeaders = new Headers(
+            input instanceof Request ? input.headers : init?.headers,
+          );
+          const workspaceId = requestHeaders.get('x-od-workspace-id');
+          const workspaceMemberId = requestHeaders.get('x-od-workspace-member-id');
+          state.workspaceRequestHeaders = {
+            ...(workspaceId ? { 'x-od-workspace-id': workspaceId } : {}),
+            ...(workspaceMemberId ? { 'x-od-workspace-member-id': workspaceMemberId } : {}),
+          };
+          state.createRunRequestCount += 1;
+          if (state.injectedAuthorityOutageCount === 0) {
+            state.injectedAuthorityOutageCount += 1;
+            state.createRunResponseStatuses.push(503);
+            return new Response(JSON.stringify({
+              error: {
+                code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+                message: 'workspace membership authority is temporarily unavailable',
+                retryable: true,
+              },
+            }), {
+              status: 503,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+        }
+        if (isRunEvents) state.runEventRequestCount += 1;
+        const response = await originalFetch(...args);
+        if (isCreateRun) state.createRunResponseStatuses.push(response.status);
+        if (isRunEvents) state.runEventResponseStatuses.push(response.status);
+        return response;
+      };
+
+      document.addEventListener('click', (event) => {
+        const target = event.target instanceof Element ? event.target : null;
+        if (target?.closest('[role="tab"], [data-testid="workspace-home-chrome"]')) {
+          state.workspaceTabClicksBeforeOutput += 1;
+        }
+      }, true);
+
+      const input = document.querySelector('[data-testid="home-hero-input"]');
+      const visible = input instanceof HTMLElement && input.getClientRects().length > 0;
+      if (!visible || !(input instanceof HTMLElement) || !input.isContentEditable) {
+        throw new Error('packaged first Home run found no visible Lexical composer');
+      }
+      const editor = input.__lexicalEditor;
+      if (!editor?.parseEditorState || !editor?.setEditorState) {
+        throw new Error('packaged first Home run could not resolve the Lexical editor');
+      }
+      input.focus();
+      editor.setEditorState(editor.parseEditorState(JSON.stringify({
+        root: {
+          children: [{
+            children: [{
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text: prompt,
+              type: 'text',
+              version: 1,
+            }],
+            direction: null,
+            format: '',
+            indent: 0,
+            type: 'paragraph',
+            version: 1,
+            textFormat: 0,
+            textStyle: '',
+          }],
+          direction: null,
+          format: '',
+          indent: 0,
+          type: 'root',
+          version: 1,
+        },
+      })));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      state.inputTextBeforeSubmit = input.textContent?.trim() ?? '';
+
+      return {
+        hrefBefore: state.hrefBefore,
+        inputTextBeforeSubmit: state.inputTextBeforeSubmit,
+        navigationEntryCountBefore: state.navigationEntryCountBefore,
+        performanceTimeOriginBefore: state.performanceTimeOriginBefore,
+        submitClicked: state.submitClicked,
+      };
+    })()
+  `;
+}
+
+export function packagedHomeFirstRunSubmitExpression(): string {
+  return `
+    (() => {
+      const state = globalThis.__odPackagedHomeFirstRun;
+      const submit = document.querySelector('[data-testid="home-hero-submit"]');
+      const visible = submit instanceof HTMLElement && submit.getClientRects().length > 0;
+      const ready = submit instanceof HTMLButtonElement && visible && !submit.disabled;
+      if (ready && state?.submitClicked !== true) {
+        submit.click();
+        state.submitClicked = true;
+      }
+      return { ready, submitClicked: state?.submitClicked === true };
+    })()
+  `;
+}
+
+export function packagedHomeFirstRunSnapshotExpression(): string {
+  return `
+    (async () => {
+      const expectedOutput = ${JSON.stringify(PACKAGED_HOME_FIRST_RUN_OUTPUT)};
+      const state = globalThis.__odPackagedHomeFirstRun;
+      const diagnosticFetch = typeof state?.originalFetch === 'function'
+        ? state.originalFetch
+        : globalThis.fetch.bind(globalThis);
+      const diagnosticRequestInit = { headers: state?.workspaceRequestHeaders ?? {} };
+      const [route, encodedProjectId, conversationsRoute, encodedConversationId] =
+        location.pathname.split('/').filter(Boolean);
+      const projectId = route === 'projects' && encodedProjectId
+        ? decodeURIComponent(encodedProjectId)
+        : '';
+      const conversationId = conversationsRoute === 'conversations' && encodedConversationId
+        ? decodeURIComponent(encodedConversationId)
+        : '';
+      const assistant = Array.from(document.querySelectorAll('[data-assistant-message-id]')).find(
+        (candidate) => candidate.textContent?.includes(expectedOutput),
+      );
+      const runsResponse = projectId
+        ? await diagnosticFetch(
+            '/api/runs?projectId=' + encodeURIComponent(projectId),
+            diagnosticRequestInit,
+          )
+        : null;
+      const runsBody = runsResponse?.ok ? await runsResponse.json() : { runs: [] };
+      const runs = Array.isArray(runsBody?.runs) ? runsBody.runs : [];
+      const terminalRun = runs.find((run) =>
+        ['succeeded', 'failed', 'canceled'].includes(String(run?.status)),
+      );
+      const eventsResponse = terminalRun?.id
+        ? await diagnosticFetch(
+            '/api/runs/' + encodeURIComponent(terminalRun.id) + '/events',
+            diagnosticRequestInit,
+          )
+        : null;
+      const eventsText = eventsResponse?.ok ? await eventsResponse.text() : '';
+      const messagesResponse = projectId && conversationId
+        ? await diagnosticFetch(
+            '/api/projects/' + encodeURIComponent(projectId)
+              + '/conversations/' + encodeURIComponent(conversationId) + '/messages',
+            diagnosticRequestInit,
+          )
+        : null;
+      const messagesBody = messagesResponse?.ok
+        ? await messagesResponse.json()
+        : { messages: [] };
+      const messages = Array.isArray(messagesBody?.messages) ? messagesBody.messages : [];
+      const daemonAssistantText = messages
+        .filter((message) => message?.role === 'assistant')
+        .map((message) => String(message?.content ?? ''))
+        .join(String.fromCharCode(10));
+
+      return {
+        assistantText: assistant?.textContent ?? '',
+        conversationId,
+        createRunRequestCount: state?.createRunRequestCount ?? -1,
+        createRunResponseStatuses: state?.createRunResponseStatuses ?? [],
+        daemonAssistantText,
+        hrefAfter: location.href,
+        hrefBefore: state?.hrefBefore ?? '',
+        inputTextBeforeSubmit: state?.inputTextBeforeSubmit ?? '',
+        injectedAuthorityOutageCount: state?.injectedAuthorityOutageCount ?? -1,
+        navigationEntryCountAfter: performance.getEntriesByType('navigation').length,
+        navigationEntryCountBefore: state?.navigationEntryCountBefore ?? -1,
+        performanceTimeOriginAfter: performance.timeOrigin,
+        performanceTimeOriginBefore: state?.performanceTimeOriginBefore ?? -1,
+        projectId,
+        runEventRequestCount: state?.runEventRequestCount ?? -1,
+        runEventResponseStatuses: state?.runEventResponseStatuses ?? [],
+        runEventsContainExpectedOutput: eventsText.includes(expectedOutput),
+        submitClicked: state?.submitClicked === true,
+        workspaceTabClicksBeforeOutput: state?.workspaceTabClicksBeforeOutput ?? -1,
+      };
+    })()
+  `;
+}
+
+export function assertPackagedHomeFirstRunResult(
+  value: unknown,
+): PackagedHomeFirstRunResult {
+  const candidate = value as Partial<PackagedHomeFirstRunResult> | null;
+  if (
+    candidate == null
+    || typeof candidate !== 'object'
+    || typeof candidate.assistantText !== 'string'
+    || typeof candidate.conversationId !== 'string'
+    || typeof candidate.createRunRequestCount !== 'number'
+    || !Array.isArray(candidate.createRunResponseStatuses)
+    || typeof candidate.daemonAssistantText !== 'string'
+    || typeof candidate.hrefAfter !== 'string'
+    || typeof candidate.hrefBefore !== 'string'
+    || typeof candidate.inputTextBeforeSubmit !== 'string'
+    || typeof candidate.injectedAuthorityOutageCount !== 'number'
+    || typeof candidate.navigationEntryCountAfter !== 'number'
+    || typeof candidate.navigationEntryCountBefore !== 'number'
+    || typeof candidate.performanceTimeOriginAfter !== 'number'
+    || typeof candidate.performanceTimeOriginBefore !== 'number'
+    || typeof candidate.projectId !== 'string'
+    || typeof candidate.runEventRequestCount !== 'number'
+    || !Array.isArray(candidate.runEventResponseStatuses)
+    || typeof candidate.runEventsContainExpectedOutput !== 'boolean'
+    || typeof candidate.submitClicked !== 'boolean'
+    || typeof candidate.workspaceTabClicksBeforeOutput !== 'number'
+  ) {
+    throw new Error(`unexpected packaged first Home run value: ${JSON.stringify(value)}`);
+  }
+  return candidate as PackagedHomeFirstRunResult;
+}

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -8,6 +8,16 @@ import { promisify } from 'node:util';
 
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
+import { createFakeAgentRuntimes } from '@/fake-agents';
+import {
+  assertPackagedHomeFirstRunResult,
+  PACKAGED_HOME_FIRST_RUN_OUTPUT,
+  PACKAGED_HOME_FIRST_RUN_PROMPT,
+  packagedHomeFirstRunExpression,
+  packagedHomeFirstRunSnapshotExpression,
+  packagedHomeFirstRunSubmitExpression,
+  type PackagedHomeFirstRunResult,
+} from '@/vitest/packaged-home-first-run';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
 import {
   assertPackagedPtySmokeResult,
@@ -352,6 +362,66 @@ const desktopMacDescribe = shouldRunDesktopMacSmoke ? describe : describe.skip;
 macDescribe('packaged mac runtime smoke', () => {
   let installedAppPath: string | null = null;
   let started = false;
+
+  test('[P0] @electron-smoke cold first Home run renders assistant output without refresh or workspace-tab switching', async () => {
+    const fakeAgentRoot = join(toolsPackDir, 'fixtures', `home-first-run-${namespace}`);
+    let firstRunInstalledAppPath: string | null = null;
+    let firstRunStarted = false;
+    try {
+      await resetPackagedRuntimeState();
+      const fakeAgents = await createFakeAgentRuntimes({
+        root: fakeAgentRoot,
+        runtimeIds: ['codex'],
+      });
+      const install = await runToolsPackJson<MacInstallResult>('install');
+      firstRunInstalledAppPath = install.installedAppPath;
+      await seedPackagedHomeFirstRunConfig(fakeAgents.codex.env);
+
+      const start = await runToolsPackJson<MacStartResult>('start');
+      firstRunStarted = true;
+      expect(start.source).toBe('installed');
+      await waitForHealthyDesktop();
+
+      const setup = await runToolsPackJson<MacInspectResult>('inspect', [
+        '--expr',
+        packagedHomeFirstRunExpression(),
+      ]);
+      if (setup.eval?.ok !== true) {
+        throw new Error(`packaged first Home run setup failed: ${formatUnknown(setup.eval)}`);
+      }
+      expect(setup.eval.value).toMatchObject({
+        inputTextBeforeSubmit: PACKAGED_HOME_FIRST_RUN_PROMPT,
+        submitClicked: false,
+      });
+
+      await waitForPackagedHomeFirstRunSubmit();
+      const firstRun = await waitForPackagedHomeFirstRunOutput();
+      expect(firstRun.submitClicked).toBe(true);
+      expect(firstRun.projectId).toEqual(expect.any(String));
+      expect(firstRun.hrefBefore).toMatch(/^(od:\/\/app\/|http:\/\/127\.0\.0\.1:\d+\/$)/);
+      expect(firstRun.hrefAfter).toContain(`/projects/${firstRun.projectId}`);
+      expect(firstRun.injectedAuthorityOutageCount).toBe(1);
+      expect(firstRun.createRunRequestCount).toBeGreaterThanOrEqual(2);
+      expect(firstRun.createRunResponseStatuses[0]).toBe(503);
+      expect(firstRun.createRunResponseStatuses.at(-1)).toBeGreaterThanOrEqual(200);
+      expect(firstRun.createRunResponseStatuses.at(-1)).toBeLessThan(300);
+      expect(firstRun.runEventRequestCount).toBeGreaterThan(0);
+      expect(firstRun.runEventResponseStatuses).toContain(200);
+      expect(firstRun.runEventsContainExpectedOutput).toBe(true);
+      expect(firstRun.daemonAssistantText).toContain(PACKAGED_HOME_FIRST_RUN_OUTPUT);
+      expect(firstRun.assistantText).toContain(PACKAGED_HOME_FIRST_RUN_OUTPUT);
+      expect(firstRun.workspaceTabClicksBeforeOutput).toBe(0);
+      expect(firstRun.navigationEntryCountAfter).toBe(firstRun.navigationEntryCountBefore);
+      expect(firstRun.performanceTimeOriginAfter).toBe(firstRun.performanceTimeOriginBefore);
+    } finally {
+      if (firstRunStarted || firstRunInstalledAppPath != null) {
+        await runToolsPackJson<MacUninstallResult>('uninstall').catch((error: unknown) => {
+          console.error('failed to uninstall packaged first-Home-run app during cleanup', error);
+        });
+      }
+      await rm(fakeAgentRoot, { force: true, recursive: true }).catch(() => undefined);
+    }
+  }, 180_000);
 
   test('installs, starts, inspects, stops, and uninstalls the built mac artifact', async () => {
     const report = await createPackagedSmokeReport('mac');
@@ -2140,6 +2210,62 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
+async function waitForPackagedHomeFirstRunOutput(): Promise<PackagedHomeFirstRunResult> {
+  const timeoutMs = 15_000;
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const inspect = await runToolsPackJson<MacInspectResult>('inspect', [
+      '--expr',
+      packagedHomeFirstRunSnapshotExpression(),
+    ]);
+    lastResult = inspect;
+    if (inspect.eval?.ok === true) {
+      const snapshot = assertPackagedHomeFirstRunResult(inspect.eval.value);
+      lastResult = snapshot;
+      if (
+        snapshot.assistantText.includes(PACKAGED_HOME_FIRST_RUN_OUTPUT)
+        && snapshot.daemonAssistantText.includes(PACKAGED_HOME_FIRST_RUN_OUTPUT)
+        && snapshot.runEventsContainExpectedOutput
+      ) {
+        return snapshot;
+      }
+    }
+    await delay(750);
+  }
+
+  throw new Error(
+    `packaged first Home run did not render assistant output without recovery: ${formatUnknown(lastResult)}`,
+  );
+}
+
+async function waitForPackagedHomeFirstRunSubmit(): Promise<void> {
+  const timeoutMs = 15_000;
+  const startedAt = Date.now();
+  let lastResult: unknown = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const inspect = await runToolsPackJson<MacInspectResult>('inspect', [
+      '--expr',
+      packagedHomeFirstRunSubmitExpression(),
+    ]);
+    lastResult = inspect;
+    if (
+      inspect.eval?.ok === true
+      && isRecord(inspect.eval.value)
+      && inspect.eval.value.submitClicked === true
+    ) {
+      return;
+    }
+    await delay(250);
+  }
+
+  throw new Error(
+    `packaged first Home run submit never became ready: ${formatUnknown(lastResult)}`,
+  );
+}
+
 async function waitForHealthyDesktopVersion(
   expectedVersion: string,
   previousPid: number | null | undefined,
@@ -2613,9 +2739,31 @@ async function fileSizeBytes(filePath: string): Promise<number> {
 }
 
 async function seedPackagedOnboardingComplete(): Promise<void> {
+  await seedPackagedAppConfig({ onboardingCompleted: true });
+}
+
+async function seedPackagedHomeFirstRunConfig(
+  codexEnv: Record<string, string>,
+): Promise<void> {
+  await seedPackagedAppConfig({
+    mode: 'daemon',
+    apiKey: '',
+    baseUrl: 'https://api.anthropic.com',
+    model: 'claude-sonnet-4-5',
+    agentId: 'codex',
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: true,
+    mediaProviders: {},
+    agentModels: { codex: { model: 'default', reasoning: 'default' } },
+    agentCliEnv: { codex: codexEnv },
+  });
+}
+
+async function seedPackagedAppConfig(config: Record<string, unknown>): Promise<void> {
   const configPath = join(runtimeNamespaceRoot, 'data', 'app-config.json');
   await mkdir(dirname(configPath), { recursive: true });
-  await writeFile(configPath, `${JSON.stringify({ onboardingCompleted: true }, null, 2)}\n`, 'utf8');
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 }
 
 async function resetPackagedMacRuntimeData(): Promise<void> {

--- a/e2e/ui/workspace-team-design-system-picker.test.ts
+++ b/e2e/ui/workspace-team-design-system-picker.test.ts
@@ -489,13 +489,16 @@ async function expectProjectSharedLogo(
       return 0;
     }
 
+    // A late workspace restoration can replace this panel after tabReady was
+    // observed. Bound the locator probe so the outer poll can select the tab
+    // again instead of waiting on the removed image until the full timeout.
     const image = await logo.evaluate((element: HTMLImageElement) => ({
       complete: element.complete,
       width: element.naturalWidth,
       height: element.naturalHeight,
       workspaceId: new URL(element.src).searchParams.get('workspaceId'),
       workspaceMemberId: new URL(element.src).searchParams.get('workspaceMemberId'),
-    })).catch(() => null);
+    }), { timeout: T.short }).catch(() => null);
     const matches = image?.complete === true
       && image.width === 320
       && image.height === 160


### PR DESCRIPTION
## Why

A packaged-app user reported that the first task submitted from Home could enter the run preview while the agent continued normally, yet render no transcript output until the renderer was refreshed or a workspace tab was switched away and back.

The attached diagnostics showed a transient `WORKSPACE_AUTHORITY_UNAVAILABLE` during that first-run handoff followed by a successful run with persisted output. The web-side root cause was a race between workspace-authority revalidation and the live run: an authoritative message reload could replace the client-owned Home user/assistant placeholders with an empty snapshot, after which stream deltas only mapped an ID that no longer existed and were silently dropped.

## What users will see

The first task launched from Home continues rendering its live assistant output even if workspace authority refreshes while run creation is retrying. Refreshing the page or switching workspace tabs is no longer required to reveal the persisted transcript.

The recovery is limited to the live controller for the project and conversation currently on screen. Revoked project authority still clears the transcript and cannot resurrect streamed output.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: there is no visual layout or entry-point change. This restores the existing run-preview transcript during a stateful authority race, which is captured by the red/green component regression and the packaged P0 probe.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx` (`keeps a cold Home run attached while workspace authority refreshes`).
- Did the test go red on `main` and green on this branch? **Yes.** Before the source fix the rendered `messages` array remained empty after the daemon emitted the expected text; after the fix the original Home user/assistant pair remains attached and receives the event.
- Permission boundary: the adjacent `does not restore a cold Home run after project authority is revoked` regression confirms forbidden authority cannot restore the live rows.
- Packaged boundary: `e2e/specs/mac.spec.ts` adds a P0 that cold-starts Home, injects one retryable 503, avoids reload/tab recovery, and independently checks run events, persisted daemon messages, and rendered DOM output.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=1 tests/components/ProjectView.run-workspace-identity.test.tsx --reporter=dot` — 38 passed
- `corepack pnpm --filter @open-design/e2e typecheck`
- Packaged renderer setup/submit/snapshot expressions parsed with `new Function`
- The new macOS packaged P0 was not executed against a newly built artifact in this worktree; it requires the prepared installed-app smoke environment.
