### PR TITLE
fix(daemon): show DSH usage attribution in execution diagnostics

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -203,6 +203,8 @@ function summarizeAssistantMessageEvents(events) {
   let upstreamErrorCount = 0;
   let provider;
   let model;
+  let usageProvider;
+  let usageModel;
   let fallbackOrdinal = 0;
   const countErrorClass = (value) => {
     if (value === 'rate_limited') rateLimitedCount += 1;
@@ -212,6 +214,15 @@ function summarizeAssistantMessageEvents(events) {
   for (const record of events) {
     if (record?.event !== 'agent' || !record.data || typeof record.data !== 'object') continue;
     const data = record.data;
+    if (data.type === 'usage') {
+      if (typeof data.provider === 'string' && data.provider.trim()) {
+        usageProvider = data.provider.trim();
+      }
+      if (typeof data.model === 'string' && data.model.trim()) {
+        usageModel = data.model.trim();
+      }
+      continue;
+    }
     if (data.type !== 'diagnostic') continue;
     if (data.name === 'model_retry') {
       retryCount += 1;
@@ -282,8 +293,8 @@ function summarizeAssistantMessageEvents(events) {
     rateLimitedCount,
     timeoutCount,
     upstreamErrorCount,
-    provider,
-    model,
+    provider: provider ?? usageProvider,
+    model: model ?? usageModel,
   };
 }
 

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -155,6 +155,64 @@ describe('chat run service shutdown', () => {
     vi.useRealTimers();
   });
 
+  it('uses runtime usage attribution when the adapter has no message lifecycle', () => {
+    const runs = createRuns();
+    const run = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      agentId: 'deepseek-harness',
+    }) as any;
+    run.model = 'default';
+    runs.emit(run, 'agent', {
+      type: 'usage',
+      provider: 'deepseek-official',
+      model: 'deepseek-v4-flash',
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+    runs.finish(run, 'succeeded', 0, null);
+
+    const diagnostics = runs.statusBody(run).executionDiagnostics;
+    expect(diagnostics?.environment).toMatchObject({
+      requestedModel: { state: 'available', value: 'default' },
+      provider: { state: 'available', value: 'deepseek-official' },
+      resolvedModel: { state: 'available', value: 'deepseek-v4-flash' },
+    });
+    expect(diagnostics?.assistantMessages.count).toMatchObject({
+      state: 'not_collected',
+      missingReason: 'assistant_message_lifecycle_not_exposed_by_runtime',
+    });
+  });
+
+  it('keeps lifecycle attribution ahead of the usage fallback', () => {
+    const runs = createRuns();
+    const run = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      agentId: 'amr',
+    }) as any;
+    runs.emit(run, 'agent', {
+      type: 'usage',
+      provider: 'usage-provider',
+      model: 'usage-model',
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+    runs.emit(run, 'agent', {
+      type: 'diagnostic',
+      name: 'assistant_message_lifecycle',
+      phase: 'end',
+      status: 'completed',
+      assistantMessageIndex: 1,
+      provider: 'lifecycle-provider',
+      model: 'lifecycle-model',
+    });
+    runs.finish(run, 'succeeded', 0, null);
+
+    expect(runs.statusBody(run).executionDiagnostics?.environment).toMatchObject({
+      provider: { state: 'available', value: 'lifecycle-provider' },
+      resolvedModel: { state: 'available', value: 'lifecycle-model' },
+    });
+  });
+
   it('keeps model-step percentiles unavailable until the documented sample minimum', () => {
     const runs = createRuns();
     const run = runs.create({ projectId: 'project-1', conversationId: 'conv-1', agentId: 'amr' }) as any;


### PR DESCRIPTION
## Why

A QA incident report showed that DeepSeek Harness usage frames already carried provider and model metadata, but the daemon execution diagnostics still reported both fields as not collected. The diagnostics summarizer only consulted assistant-message lifecycle diagnostics, which this runtime does not emit.

This focused fix preserves the runtime attribution already available on successful DSH runs without changing the DSH protocol, analytics pipeline, model selection, or message lifecycle accounting.

## What users will see

Execution diagnostics for DeepSeek Harness runs now show the runtime-reported provider and resolved model instead of not collected. Assistant-message counts and durations remain explicitly unavailable when the runtime does not expose lifecycle events.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — execution diagnostics now use runtime usage attribution as a fallback
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes daemon-owned diagnostic values and introduces no UI surface.

## Bug fix verification

- Test path that reproduces the bug: apps/daemon/tests/runtimes/runs.test.ts
- Did the test go red on main and green on this branch? Yes. The red spec reproduced provider and resolvedModel as not_collected before the source change, then passed after the fallback was added.
- The companion precedence test confirms existing lifecycle attribution still wins over usage metadata.

## Validation

- pnpm --filter @open-design/daemon exec vitest run tests/runtimes/runs.test.ts — 47 passed
- pnpm --filter @open-design/daemon exec vitest run tests/agent-protocol/dsh-profile.test.ts tests/run-analytics-observability.test.ts tests/runtimes/runs.test.ts — 117 passed
- pnpm --filter @open-design/daemon typecheck
- pnpm guard
- pnpm typecheck
- git diff --check
- Real local E2E: isolated daemon data root → official dsh 0.1.0-rc.6 open-design profile → deepseek-official/deepseek-v4-flash → successful response → GET /api/runs/:id reported provider=deepseek-official and resolvedModel=deepseek-v4-flash while assistant-message lifecycle metrics remained not_collected. The isolated daemon was stopped after verification.