### PR TITLE
daemon: wire OD_PROJECT_STORAGE=s3 as a write-through project mirror (#7043)

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -75,6 +75,24 @@ export function projectDir(projectsRoot, projectId) {
   return path.join(projectsRoot, projectId);
 }
 
+// ---------------------------------------------------------------------------
+// S3 mirror wiring (#7043). The local tree stays the authoritative working
+// copy (agent runtimes spawn with the project dir as cwd); when
+// OD_PROJECT_STORAGE=s3 the mirror pushes mutations to the blob store.
+// Module-level state is set once at daemon startup by server.ts.
+// ---------------------------------------------------------------------------
+let projectStorageMirror: import('./storage/project-storage-mirror.js').ProjectStorageMirror | null = null;
+
+export function setProjectStorageMirror(
+  mirror: import('./storage/project-storage-mirror.js').ProjectStorageMirror | null,
+): void {
+  projectStorageMirror = mirror;
+}
+
+export function getProjectStorageMirror() {
+  return projectStorageMirror;
+}
+
 export class SandboxImportedProjectError extends Error {
   code = 'SANDBOX_IMPORTED_PROJECT_UNAVAILABLE';
 
@@ -142,6 +160,9 @@ export async function ensureProject(projectsRoot, projectId, metadata?) {
   // Git-linked folders already exist; skip mkdir to avoid side-effects.
   if (!usesExternalProjectRoot(metadata)) {
     await mkdir(dir, { recursive: true });
+    // #7043 — a fresh daemon with an empty local tree restores the managed
+    // project from the blob store before the first agent run materializes it.
+    await projectStorageMirror?.restoreIfEmpty(projectId, dir).catch(() => {});
   }
   return dir;
 }
@@ -253,6 +274,18 @@ export async function deleteProjectFolder(projectsRoot, projectId, name, metadat
     const err = new Error('target is not a folder');
     err.code = 'ENOTDIR';
     throw err;
+  }
+  if (projectStorageMirror) {
+    // #7043 — capture the folder's relative paths before the local delete so
+    // the mirror can remove exactly those keys (best-effort).
+    const prefix = safeName + '/';
+    const all = await listFiles(projectsRoot, projectId, { metadata });
+    const folderPaths = all
+      .filter((f) => f.path === safeName || f.path.startsWith(prefix))
+      .map((f) => f.path);
+    for (const p of folderPaths) {
+      await projectStorageMirror.deleteFile(projectId, p).catch(() => {});
+    }
   }
   await rm(target, { recursive: true, force: true });
 }
@@ -916,6 +949,14 @@ export async function writeProjectFile(
     const manifestFileName = artifactManifestNameFor(safeName);
     const manifestTarget = await resolveSafeReal(dir, manifestFileName);
     await writeFile(manifestTarget, JSON.stringify(validatedManifest, null, 2));
+    if (projectStorageMirror) {
+      // #7043 — write-through, best-effort (a store outage must never break
+      // local work; the next uploadProject retries the whole tree).
+      await projectStorageMirror.uploadFile(projectId, safeName).catch(() => {});
+      await projectStorageMirror.uploadFile(projectId, manifestFileName).catch(() => {});
+    }
+  } else if (projectStorageMirror) {
+    await projectStorageMirror.uploadFile(projectId, safeName).catch(() => {});
   }
   const st = await stat(target);
   const persistedManifest = await readManifestForPath(dir, safeName);
@@ -1021,7 +1062,10 @@ export async function deleteProjectFile(projectsRoot, projectId, name, metadata?
   assertVisibleForImportedProject(name, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
+  const rel = toProjectPath(path.relative(await realpath(dir).catch(() => dir), file));
   await unlink(file);
+  // #7043 — best-effort write-through delete.
+  await projectStorageMirror?.deleteFile(projectId, rel).catch(() => {});
 }
 
 export async function renameProjectFile(projectsRoot, projectId, fromName, toName, metadata?) {
@@ -1087,6 +1131,11 @@ export async function renameProjectFile(projectsRoot, projectId, fromName, toNam
   await renameFilePath(source, targetPath, { noOverwrite: true });
   await commitArtifactManifestRename(manifestRename, newName);
   await updateArtifactManifestRefsForRename(dir, oldName, newName);
+  if (projectStorageMirror) {
+    // #7043 — rename = delete old key + upload the renamed file.
+    await projectStorageMirror.deleteFile(projectId, oldName).catch(() => {});
+    await projectStorageMirror.uploadFile(projectId, newName).catch(() => {});
+  }
 
   const st = await stat(targetPath);
   const manifest = await readManifestForPath(dir, newName);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -85,8 +85,10 @@ let projectStorageMirror: import('./storage/project-storage-mirror.js').ProjectS
 
 export function setProjectStorageMirror(
   mirror: import('./storage/project-storage-mirror.js').ProjectStorageMirror | null,
-): void {
+): import('./storage/project-storage-mirror.js').ProjectStorageMirror | null {
+  const previous = projectStorageMirror;
   projectStorageMirror = mirror;
+  return previous;
 }
 
 export function getProjectStorageMirror() {
@@ -1132,14 +1134,11 @@ export async function renameProjectFile(projectsRoot, projectId, fromName, toNam
   await commitArtifactManifestRename(manifestRename, newName);
   await updateArtifactManifestRefsForRename(dir, oldName, newName);
   if (projectStorageMirror) {
-    // #7043 — rename mirrors the artifact sidecar too: delete the old file
-    // and old manifest keys, then upload the renamed file and its manifest.
-    const oldManifestName = oldName + '.artifact.json';
-    const newManifestName = newName + '.artifact.json';
-    await projectStorageMirror.deleteFile(projectId, oldName).catch(() => {});
-    await projectStorageMirror.deleteFile(projectId, oldManifestName).catch(() => {});
-    await projectStorageMirror.uploadFile(projectId, newName).catch(() => {});
-    await projectStorageMirror.uploadFile(projectId, newManifestName).catch(() => {});
+    // #7043 — a rename touches the file, its manifest sidecar, AND the
+    // manifests of other artifacts that reference the old name, so run the
+    // authoritative full-tree sync: it uploads every local file and deletes
+    // remote objects (old name + old manifest) that no longer exist locally.
+    await projectStorageMirror.uploadProject(projectId).catch(() => {});
   }
 
   const st = await stat(targetPath);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -1132,9 +1132,14 @@ export async function renameProjectFile(projectsRoot, projectId, fromName, toNam
   await commitArtifactManifestRename(manifestRename, newName);
   await updateArtifactManifestRefsForRename(dir, oldName, newName);
   if (projectStorageMirror) {
-    // #7043 — rename = delete old key + upload the renamed file.
+    // #7043 — rename mirrors the artifact sidecar too: delete the old file
+    // and old manifest keys, then upload the renamed file and its manifest.
+    const oldManifestName = oldName + '.artifact.json';
+    const newManifestName = newName + '.artifact.json';
     await projectStorageMirror.deleteFile(projectId, oldName).catch(() => {});
+    await projectStorageMirror.deleteFile(projectId, oldManifestName).catch(() => {});
     await projectStorageMirror.uploadFile(projectId, newName).catch(() => {});
+    await projectStorageMirror.uploadFile(projectId, newManifestName).catch(() => {});
   }
 
   const st = await stat(targetPath);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -277,19 +277,15 @@ export async function deleteProjectFolder(projectsRoot, projectId, name, metadat
     err.code = 'ENOTDIR';
     throw err;
   }
-  if (projectStorageMirror) {
-    // #7043 — capture the folder's relative paths before the local delete so
-    // the mirror can remove exactly those keys (best-effort).
-    const prefix = safeName + '/';
-    const all = await listFiles(projectsRoot, projectId, { metadata });
-    const folderPaths = all
-      .filter((f) => f.path === safeName || f.path.startsWith(prefix))
-      .map((f) => f.path);
-    for (const p of folderPaths) {
-      await projectStorageMirror.deleteFile(projectId, p).catch(() => {});
-    }
-  }
   await rm(target, { recursive: true, force: true });
+  if (projectStorageMirror && !usesExternalProjectRoot(metadata)) {
+    // #7043 — delete the local folder FIRST, then run the authoritative
+    // full-tree sync. Reconciliation removes every remote key that no longer
+    // exists locally — including hidden files and artifact sidecars that a
+    // targeted prefix walk would miss — and the per-project serialization
+    // keeps a concurrent terminal sync from resurrecting the deletion.
+    await projectStorageMirror.uploadProject(projectId).catch(() => {});
+  }
 }
 
 // Best-effort entry-file detector — looks for index.html at the root,

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -60,7 +60,7 @@ import {
 import { connectorService } from '../../connectors/service.js';
 import type { RouteDeps } from '../../server-context.js';
 import { listSkills } from '../../skills.js';
-import { isSafeId } from '../../projects.js';
+import { getProjectStorageMirror, isSafeId } from '../../projects.js';
 import {
   ensureTeamProjectCommentConversations,
   SYNC_KEEPS_UPDATED_AT,
@@ -4621,6 +4621,8 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       await cancelRunsOwnedBy(design.runs, { projectId: req.params.id });
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
+      // #7043 — mirror the project delete to the S3 store (best-effort).
+      await getProjectStorageMirror()?.deleteProject(req.params.id).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */
       const body = { ok: true };
       res.json(body);

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -11,6 +11,7 @@ import {
 import { createRunLifecycleTracer } from '../run-lifecycle-tracer.js';
 import { projectWorkspaceProvenance } from '../workspace-contract.js';
 import { OPEN_DESIGN_PLUGIN_ID } from '../mcp-observability.js';
+import { getProjectStorageMirror } from '../projects.js';
 import {
   scanRunEventsForUsageAnalytics,
   summarizeRunTimingAnalytics,
@@ -1197,6 +1198,16 @@ export function createChatRunService({
       const finalize = run.onFinalize;
       run.onFinalize = null;
       try { finalize(); } catch { /* best-effort */ }
+    }
+    // #7043 — agent processes write project files directly (outside the HTTP
+    // write path), so the terminal choke point re-syncs the whole managed
+    // project tree to the S3 mirror when one is active. Best-effort and
+    // fire-and-forget: the local tree stays the source of truth.
+    if (typeof run.projectId === 'string' && run.projectId) {
+      const mirror = getProjectStorageMirror();
+      if (mirror) {
+        void mirror.uploadProject(run.projectId).catch(() => {});
+      }
     }
     emit(run, 'end', {
       code,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -543,6 +543,8 @@ import {
 import {
   resolveExternalMcpServersForRun,
 } from './run-tool-bundle.js';
+import { setProjectStorageMirror } from './projects.js';
+import { resolveProjectStorageMirror } from './storage/project-storage-mirror.js';
 import {
   beginAuth,
   exchangeCodeForToken,
@@ -2572,6 +2574,9 @@ export async function startServer({
   host = normalizeDaemonBindHost(host);
   let resolvedPort = port;
   let daemonShuttingDown = false;
+  // #7043 — when OD_PROJECT_STORAGE=s3, activate the write-through/restore
+  // mirror between the local project working copy and the blob store.
+  setProjectStorageMirror(resolveProjectStorageMirror(process.env, PROJECTS_DIR));
   const extraAllowedOrigins = configuredAllowedOrigins();
   const workspaceAuthorityCacheMode = resolveWorkspaceAuthorityCacheMode(
     process.env.OD_WORKSPACE_AUTHORITY_CACHE_MODE,

--- a/apps/daemon/src/storage/project-storage-mirror.ts
+++ b/apps/daemon/src/storage/project-storage-mirror.ts
@@ -14,9 +14,15 @@ import { resolveProjectStorage, type ProjectStorage } from './project-storage.js
  * and re-syncs the whole tree when a run terminates (agent processes write
  * files directly, bypassing the HTTP write path).
  *
- * All operations are best-effort: a blob-store outage must never break local
- * project work, so callers swallow upload failures (the local tree remains the
- * source of truth and the next sync retries the whole tree).
+ * Consistency rules:
+ *  - All mirror mutations for a project are SERIALIZED through a per-project
+ *    promise chain, so a terminal full-tree sync can never overwrite a newer
+ *    write or resurrect an object that a later delete removed.
+ *  - Full-tree syncs are AUTHORITATIVE: remote objects with no local
+ *    counterpart are deleted, so stale objects can never be restored locally.
+ *  - All operations are best-effort: a blob-store outage must never break
+ *    local project work (the local tree remains the source of truth and the
+ *    next sync retries the whole tree).
  */
 export interface ProjectStorageMirror {
   readonly enabled: true;
@@ -55,46 +61,74 @@ export function createProjectStorageMirror(
   adapter: ProjectStorage,
   projectsRoot: string,
 ): ProjectStorageMirror {
+  // Per-project mutation chains. Each operation awaits the previous one so
+  // uploads, deletes, and full-tree syncs apply in submission order. Links
+  // never reject: the chain must survive a failing op so later ops still run.
+  const chains = new Map<string, Promise<void>>();
+  const enqueue = (projectId: string, op: () => Promise<void>): Promise<void> => {
+    const prev = chains.get(projectId) ?? Promise.resolve();
+    const next = prev.then(op).catch(() => {});
+    chains.set(projectId, next);
+    return next;
+  };
+
   return {
     enabled: true,
     adapter,
-    async uploadFile(projectId, relpath) {
-      const body = await fsp.readFile(path.join(projectsRoot, projectId, relpath));
-      await adapter.writeFile(projectId, relpath, body);
+    uploadFile(projectId, relpath) {
+      return enqueue(projectId, async () => {
+        const body = await fsp.readFile(path.join(projectsRoot, projectId, relpath));
+        await adapter.writeFile(projectId, relpath, body);
+      });
     },
-    async uploadProject(projectId) {
-      const root = path.join(projectsRoot, projectId);
-      const files = await walkFiles(root);
-      for (const file of files) {
-        const rel = path.relative(root, file).split(path.sep).join('/');
-        const body = await fsp.readFile(file);
-        await adapter.writeFile(projectId, rel, body);
-      }
+    uploadProject(projectId) {
+      return enqueue(projectId, async () => {
+        const root = path.join(projectsRoot, projectId);
+        const files = await walkFiles(root);
+        const localRel = new Set(files.map((file) => path.relative(root, file).split(path.sep).join('/')));
+        // Authoritative reconciliation: remote objects without a local
+        // counterpart are deleted so stale objects can never be restored.
+        const remote = await adapter.listFiles(projectId);
+        for (const entry of remote) {
+          if (!localRel.has(entry.path)) {
+            await adapter.deleteFile(projectId, entry.path);
+          }
+        }
+        for (const file of files) {
+          const rel = path.relative(root, file).split(path.sep).join('/');
+          const body = await fsp.readFile(file);
+          await adapter.writeFile(projectId, rel, body);
+        }
+      });
     },
-    async deleteFile(projectId, relpath) {
-      await adapter.deleteFile(projectId, relpath);
+    deleteFile(projectId, relpath) {
+      return enqueue(projectId, () => adapter.deleteFile(projectId, relpath));
     },
-    async deleteProject(projectId) {
-      const entries = await adapter.listFiles(projectId);
-      for (const entry of entries) {
-        await adapter.deleteFile(projectId, entry.path);
-      }
+    deleteProject(projectId) {
+      return enqueue(projectId, async () => {
+        const entries = await adapter.listFiles(projectId);
+        for (const entry of entries) {
+          await adapter.deleteFile(projectId, entry.path);
+        }
+      });
     },
-    async restoreIfEmpty(projectId, localDir) {
-      let entries;
-      try {
-        entries = await fsp.readdir(localDir);
-      } catch {
-        return;
-      }
-      if (entries.length > 0) return;
-      const remote = await adapter.listFiles(projectId);
-      for (const entry of remote) {
-        const body = await adapter.readFile(projectId, entry.path);
-        const target = path.join(localDir, entry.path);
-        await fsp.mkdir(path.dirname(target), { recursive: true });
-        await fsp.writeFile(target, body);
-      }
+    restoreIfEmpty(projectId, localDir) {
+      return enqueue(projectId, async () => {
+        let entries;
+        try {
+          entries = await fsp.readdir(localDir);
+        } catch {
+          return;
+        }
+        if (entries.length > 0) return;
+        const remote = await adapter.listFiles(projectId);
+        for (const entry of remote) {
+          const body = await adapter.readFile(projectId, entry.path);
+          const target = path.join(localDir, entry.path);
+          await fsp.mkdir(path.dirname(target), { recursive: true });
+          await fsp.writeFile(target, body);
+        }
+      });
     },
   };
 }

--- a/apps/daemon/src/storage/project-storage-mirror.ts
+++ b/apps/daemon/src/storage/project-storage-mirror.ts
@@ -1,0 +1,111 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+
+import { resolveProjectStorage, type ProjectStorage } from './project-storage.js';
+
+/**
+ * #7043 — best-effort mirror between the daemon's local project working copy
+ * and an S3-compatible blob store (AWS S3, MinIO, ...).
+ *
+ * The daemon's agent runtimes spawn with the project directory as their cwd on
+ * local disk, so the local tree stays the authoritative working copy. When
+ * OD_PROJECT_STORAGE=s3, this mirror pushes every project-file mutation to the
+ * blob store (write-through), restores a fresh/empty local tree from the store,
+ * and re-syncs the whole tree when a run terminates (agent processes write
+ * files directly, bypassing the HTTP write path).
+ *
+ * All operations are best-effort: a blob-store outage must never break local
+ * project work, so callers swallow upload failures (the local tree remains the
+ * source of truth and the next sync retries the whole tree).
+ */
+export interface ProjectStorageMirror {
+  readonly enabled: true;
+  adapter: ProjectStorage;
+  uploadFile(projectId: string, relpath: string): Promise<void>;
+  uploadProject(projectId: string): Promise<void>;
+  deleteFile(projectId: string, relpath: string): Promise<void>;
+  deleteProject(projectId: string): Promise<void>;
+  restoreIfEmpty(projectId: string, localDir: string): Promise<void>;
+}
+
+async function walkFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const queue: string[] = [dir];
+  while (queue.length > 0) {
+    const current = queue.pop() as string;
+    let entries;
+    try {
+      entries = await fsp.readdir(current, { withFileTypes: true });
+    } catch {
+      continue; // missing dir mid-walk: treat as empty
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        queue.push(full);
+      } else if (entry.isFile()) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+export function createProjectStorageMirror(
+  adapter: ProjectStorage,
+  projectsRoot: string,
+): ProjectStorageMirror {
+  return {
+    enabled: true,
+    adapter,
+    async uploadFile(projectId, relpath) {
+      const body = await fsp.readFile(path.join(projectsRoot, projectId, relpath));
+      await adapter.writeFile(projectId, relpath, body);
+    },
+    async uploadProject(projectId) {
+      const root = path.join(projectsRoot, projectId);
+      const files = await walkFiles(root);
+      for (const file of files) {
+        const rel = path.relative(root, file).split(path.sep).join('/');
+        const body = await fsp.readFile(file);
+        await adapter.writeFile(projectId, rel, body);
+      }
+    },
+    async deleteFile(projectId, relpath) {
+      await adapter.deleteFile(projectId, relpath);
+    },
+    async deleteProject(projectId) {
+      const entries = await adapter.listFiles(projectId);
+      for (const entry of entries) {
+        await adapter.deleteFile(projectId, entry.path);
+      }
+    },
+    async restoreIfEmpty(projectId, localDir) {
+      let entries;
+      try {
+        entries = await fsp.readdir(localDir);
+      } catch {
+        return;
+      }
+      if (entries.length > 0) return;
+      const remote = await adapter.listFiles(projectId);
+      for (const entry of remote) {
+        const body = await adapter.readFile(projectId, entry.path);
+        const target = path.join(localDir, entry.path);
+        await fsp.mkdir(path.dirname(target), { recursive: true });
+        await fsp.writeFile(target, body);
+      }
+    },
+  };
+}
+
+export function resolveProjectStorageMirror(
+  env: NodeJS.ProcessEnv,
+  projectsRoot: string,
+): ProjectStorageMirror | null {
+  const kind = (env.OD_PROJECT_STORAGE ?? 'local').trim().toLowerCase();
+  if (kind !== 's3') return null;
+  const adapter = resolveProjectStorage({ projectsRoot, env });
+  return createProjectStorageMirror(adapter, projectsRoot);
+}
+

--- a/apps/daemon/src/storage/project-storage-mirror.ts
+++ b/apps/daemon/src/storage/project-storage-mirror.ts
@@ -123,8 +123,14 @@ export function createProjectStorageMirror(
         if (entries.length > 0) return;
         const remote = await adapter.listFiles(projectId);
         for (const entry of remote) {
-          const body = await adapter.readFile(projectId, entry.path);
-          const target = path.join(localDir, entry.path);
+          // Confine restores to the project tree: a hostile or corrupt store
+          // must never be able to materialize a path outside localDir.
+          const rel = String(entry.path || '').replace(/\\/g, '/');
+          if (!rel || rel.startsWith('/') || rel.split('/').some((seg) => seg === '..' || seg === '.')) {
+            continue;
+          }
+          const body = await adapter.readFile(projectId, rel);
+          const target = path.join(localDir, rel);
           await fsp.mkdir(path.dirname(target), { recursive: true });
           await fsp.writeFile(target, body);
         }

--- a/apps/daemon/tests/project-storage-mirror.test.ts
+++ b/apps/daemon/tests/project-storage-mirror.test.ts
@@ -1,0 +1,223 @@
+import http from 'node:http';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeProjectFile } from '../src/projects.js';
+import { startServer } from '../src/server.js';
+import {
+  createProjectStorageMirror,
+  type ProjectStorageMirror,
+} from '../src/storage/project-storage-mirror.js';
+import { StorageError, type ProjectStorage } from '../src/storage/project-storage.js';
+
+class FakeStorage implements ProjectStorage {
+  map = new Map<string, Buffer>();
+  calls: string[] = [];
+  async readFile(projectId: string, relpath: string): Promise<Buffer> {
+    const key = projectId + '/' + relpath;
+    const body = this.map.get(key);
+    if (!body) throw new StorageError('NOT_FOUND', key);
+    return body;
+  }
+  async writeFile(projectId: string, relpath: string, body: Buffer) {
+    this.map.set(projectId + '/' + relpath, Buffer.from(body));
+    this.calls.push('put:' + projectId + '/' + relpath);
+    return { path: relpath, size: body.length, mtimeMs: Date.now() };
+  }
+  async listFiles(projectId: string) {
+    const prefix = projectId + '/';
+    return [...this.map.keys()]
+      .filter((k) => k.startsWith(prefix))
+      .map((k) => ({ path: k.slice(prefix.length), size: 0, mtimeMs: 0 }));
+  }
+  async deleteFile(projectId: string, relpath: string): Promise<void> {
+    this.map.delete(projectId + '/' + relpath);
+    this.calls.push('del:' + projectId + '/' + relpath);
+  }
+  async statFile() { return null; }
+}
+
+describe('project storage mirror (#7043)', () => {
+  describe('unit: mirror operations against an adapter', () => {
+    let dir: string;
+    let fake: FakeStorage;
+    let mirror: ProjectStorageMirror;
+
+    beforeEach(() => {
+      dir = mkdtempSync(path.join(tmpdir(), 'od-mirror-'));
+      fake = new FakeStorage();
+      mirror = createProjectStorageMirror(fake, dir);
+    });
+
+    afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+    it('uploadFile pushes one file', async () => {
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), '<h1>hi</h1>');
+      await mirror.uploadFile('p1', 'index.html');
+      expect(fake.calls).toEqual(['put:p1/index.html']);
+      expect(fake.map.get('p1/index.html')?.toString()).toContain('<h1>hi</h1>');
+    });
+
+    it('uploadProject walks the whole tree', async () => {
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(path.join(projectDir, 'assets'), { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), 'a');
+      await writeFile(path.join(projectDir, 'assets/logo.svg'), 'b');
+      await mirror.uploadProject('p1');
+      expect(fake.calls).toEqual(['put:p1/index.html', 'put:p1/assets/logo.svg']);
+    });
+
+    it('deleteProject removes every stored key', async () => {
+      fake.map.set('p1/index.html', Buffer.from('a'));
+      fake.map.set('p1/assets/logo.svg', Buffer.from('b'));
+      await mirror.deleteProject('p1');
+      expect(fake.map.size).toBe(0);
+      expect(fake.calls).toEqual(['del:p1/index.html', 'del:p1/assets/logo.svg']);
+    });
+
+    it('restoreIfEmpty materializes a fresh local tree', async () => {
+      fake.map.set('p1/index.html', Buffer.from('<h1>restored</h1>'));
+      fake.map.set('p1/assets/logo.svg', Buffer.from('svg'));
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await mirror.restoreIfEmpty('p1', projectDir);
+      expect((await readFile(path.join(projectDir, 'index.html'))).toString()).toContain('restored');
+      expect((await readFile(path.join(projectDir, 'assets/logo.svg'))).toString()).toBe('svg');
+    });
+
+    it('restoreIfEmpty leaves a non-empty tree alone', async () => {
+      fake.map.set('p1/index.html', Buffer.from('remote'));
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), 'local');
+      await mirror.restoreIfEmpty('p1', projectDir);
+      expect((await readFile(path.join(projectDir, 'index.html'))).toString()).toBe('local');
+    });
+  });
+
+  describe('integration: daemon write-through + delete against a mock S3', () => {
+    let server: http.Server;
+    let baseUrl: string;
+    let mockS3: http.Server;
+    let mockPort = 0;
+    const records: Array<{ method: string; path: string; body?: string }> = [];
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeAll(async () => {
+      // In-memory S3: PUT/GET/DELETE/HEAD on /<bucket>/<key...>;
+      // GET /<bucket>?list-type=2&prefix=... returns ListObjectsV2 XML.
+      mockS3 = http.createServer((req, res) => {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        const parts = url.pathname.split('/').filter(Boolean);
+        const bucket = parts[0] ?? 'od-test-bucket';
+        if (url.searchParams.get('list-type') === '2') {
+          const prefix = url.searchParams.get('prefix') ?? '';
+          const keys = records
+            .filter((r) => r.method === 'PUT' && r.path.startsWith('/' + bucket + '/' + prefix))
+            .map((r) => r.path.slice(('/' + bucket + '/').length));
+          const xml = '<?xml version="1.0"?><ListBucketResult><IsTruncated>false</IsTruncated>'
+            + keys.map((k) => '<Contents><Key>' + k + '</Key><Size>1</Size><LastModified>2026-01-01T00:00:00Z</LastModified></Contents>').join('')
+            + '</ListBucketResult>';
+          res.writeHead(200, { 'content-type': 'application/xml' });
+          res.end(xml);
+          return;
+        }
+        const existing = records.find((r) => r.method === 'PUT' && r.path === url.pathname);
+        if (req.method === 'PUT') {
+          const chunks: Buffer[] = [];
+          req.on('data', (c) => chunks.push(c));
+          req.on('end', () => {
+            records.push({ method: 'PUT', path: url.pathname, body: Buffer.concat(chunks).toString() });
+            res.writeHead(200);
+            res.end();
+          });
+          return;
+        }
+        if (req.method === 'DELETE') {
+          records.push({ method: 'DELETE', path: url.pathname });
+          res.writeHead(204);
+          res.end();
+          return;
+        }
+        if (req.method === 'GET') {
+          if (!existing) { res.writeHead(404); res.end(); return; }
+          res.writeHead(200);
+          res.end(existing.body ?? '');
+          return;
+        }
+        if (req.method === 'HEAD') {
+          res.writeHead(existing ? 200 : 404);
+          res.end();
+          return;
+        }
+        res.writeHead(405);
+        res.end();
+      });
+      await new Promise<void>((resolve) => mockS3.listen(0, '127.0.0.1', resolve));
+      const addr = mockS3.address();
+      mockPort = typeof addr === 'object' && addr ? addr.port : 0;
+
+      const envKeys = ['OD_PROJECT_STORAGE', 'OD_S3_ENDPOINT', 'OD_S3_BUCKET', 'OD_S3_REGION', 'OD_S3_ACCESS_KEY_ID', 'OD_S3_SECRET_ACCESS_KEY'];
+      for (const k of envKeys) { savedEnv[k] = process.env[k]; }
+      process.env.OD_PROJECT_STORAGE = 's3';
+      process.env.OD_S3_ENDPOINT = 'http://127.0.0.1:' + mockPort;
+      process.env.OD_S3_BUCKET = 'od-test-bucket';
+      process.env.OD_S3_REGION = 'us-east-1';
+      process.env.OD_S3_ACCESS_KEY_ID = 'test-key';
+      process.env.OD_S3_SECRET_ACCESS_KEY = 'test-secret';
+
+      const started = (await startServer({ port: 0, returnServer: true })) as {
+        url: string;
+        server: http.Server;
+      };
+      baseUrl = started.url;
+      server = started.server;
+    });
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => mockS3.close(() => resolve()));
+      for (const k of Object.keys(savedEnv)) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      }
+    });
+
+    it('write-through: file write lands in the bucket', async () => {
+      const id = 's3-int-' + Date.now();
+      const create = await fetch(baseUrl + '/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, name: 'S3 Integration' }),
+      });
+      expect(create.status).toBe(200);
+
+      const projectsRoot = path.join(process.env.OD_DATA_DIR as string, 'projects');
+      const result = await writeProjectFile(projectsRoot, id, 'index.html', Buffer.from('<h1>s3</h1>'));
+      expect(result.name).toBe('index.html');
+      const put = records.find((r) => r.method === 'PUT' && r.path === '/od-test-bucket/' + id + '/index.html');
+      expect(put).toBeTruthy();
+      expect(put?.body).toContain('<h1>s3</h1>');
+    });
+
+    it('project delete mirrors to the bucket', async () => {
+      const id = 's3-del-' + Date.now();
+      await fetch(baseUrl + '/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, name: 'S3 Delete' }),
+      });
+      const projectsRoot = path.join(process.env.OD_DATA_DIR as string, 'projects');
+      await writeProjectFile(projectsRoot, id, 'index.html', Buffer.from('<h1>bye</h1>'));
+      const del = await fetch(baseUrl + '/api/projects/' + id, { method: 'DELETE' });
+      expect(del.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 300));
+      expect(records.some((r) => r.method === 'DELETE' && r.path === '/od-test-bucket/' + id + '/index.html')).toBe(true);
+    });
+  });
+});

--- a/apps/daemon/tests/project-storage-mirror.test.ts
+++ b/apps/daemon/tests/project-storage-mirror.test.ts
@@ -168,6 +168,30 @@ describe('project storage mirror (#7043)', () => {
       expect((await readFile(path.join(projectDir, 'ok.html'))).toString()).toBe('ok');
       expect(await import('node:fs').then((fs) => fs.existsSync(path.join(dir, 'escape.html')))).toBe(false);
     });
+    it('folder delete reconciles hidden files and sidecars authoritatively', async () => {
+      // Remote state: the folder's visible file, a hidden file, and a sidecar.
+      fake.map.set('p1/sub/page.html', Buffer.from('page'));
+      fake.map.set('p1/sub/.hidden.html', Buffer.from('hidden'));
+      fake.map.set('p1/sub/page.html.artifact.json', Buffer.from('sidecar'));
+      fake.map.set('p1/keep.html', Buffer.from('keep'));
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(path.join(projectDir, 'sub'), { recursive: true });
+      await writeFile(path.join(projectDir, 'sub', 'page.html'), 'page');
+      await writeFile(path.join(projectDir, 'keep.html'), 'keep');
+      const { deleteProjectFolder, setProjectStorageMirror } = await import('../src/projects.js');
+      const prev = setProjectStorageMirror(mirror);
+      try {
+        await deleteProjectFolder(dir, 'p1', 'sub');
+      } finally {
+        setProjectStorageMirror(prev);
+      }
+      // The authoritative sync removes all remote keys the local tree no
+      // longer has — visible, hidden, and sidecar — and re-uploads keep.html.
+      expect(fake.map.has('p1/sub/page.html')).toBe(false);
+      expect(fake.map.has('p1/sub/.hidden.html')).toBe(false);
+      expect(fake.map.has('p1/sub/page.html.artifact.json')).toBe(false);
+      expect(fake.map.get('p1/keep.html')?.toString()).toBe('keep');
+    });
   });
 
   describe('integration: daemon write-through + delete against a mock S3', () => {

--- a/apps/daemon/tests/project-storage-mirror.test.ts
+++ b/apps/daemon/tests/project-storage-mirror.test.ts
@@ -16,6 +16,10 @@ import { StorageError, type ProjectStorage } from '../src/storage/project-storag
 class FakeStorage implements ProjectStorage {
   map = new Map<string, Buffer>();
   calls: string[] = [];
+  delayMs = 0;
+  private async maybeDelay() {
+    if (this.delayMs > 0) await new Promise((r) => setTimeout(r, this.delayMs));
+  }
   async readFile(projectId: string, relpath: string): Promise<Buffer> {
     const key = projectId + '/' + relpath;
     const body = this.map.get(key);
@@ -23,6 +27,7 @@ class FakeStorage implements ProjectStorage {
     return body;
   }
   async writeFile(projectId: string, relpath: string, body: Buffer) {
+    await this.maybeDelay();
     this.map.set(projectId + '/' + relpath, Buffer.from(body));
     this.calls.push('put:' + projectId + '/' + relpath);
     return { path: relpath, size: body.length, mtimeMs: Date.now() };
@@ -34,6 +39,7 @@ class FakeStorage implements ProjectStorage {
       .map((k) => ({ path: k.slice(prefix.length), size: 0, mtimeMs: 0 }));
   }
   async deleteFile(projectId: string, relpath: string): Promise<void> {
+    await this.maybeDelay();
     this.map.delete(projectId + '/' + relpath);
     this.calls.push('del:' + projectId + '/' + relpath);
   }
@@ -97,6 +103,55 @@ describe('project storage mirror (#7043)', () => {
       await writeFile(path.join(projectDir, 'index.html'), 'local');
       await mirror.restoreIfEmpty('p1', projectDir);
       expect((await readFile(path.join(projectDir, 'index.html'))).toString()).toBe('local');
+    });
+    it('uploadProject reconciles stale remote objects authoritatively', async () => {
+      fake.map.set('p1/index.html', Buffer.from('remote'));
+      fake.map.set('p1/stale.html', Buffer.from('stale'));
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), 'local');
+      await mirror.uploadProject('p1');
+      expect(fake.map.has('p1/stale.html')).toBe(false);
+      expect(fake.calls).toEqual([
+        'del:p1/stale.html',
+        'put:p1/index.html',
+      ]);
+    });
+
+    it('serializes mirror mutations per project', async () => {
+      fake.delayMs = 25;
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'a.html'), 'a');
+      // Fire the sync without awaiting, then immediately queue a delete.
+      const sync = mirror.uploadProject('p1');
+      const del = mirror.deleteFile('p1', 'a.html');
+      await Promise.all([sync, del]);
+      // The delete must land after the sync's write, in submission order.
+      const putIdx = fake.calls.indexOf('put:p1/a.html');
+      const delIdx = fake.calls.indexOf('del:p1/a.html');
+      expect(putIdx).toBeGreaterThanOrEqual(0);
+      expect(delIdx).toBeGreaterThan(putIdx);
+    });
+
+    it('rename mirrors the artifact manifest sidecar too', async () => {
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await writeFile(path.join(projectDir, 'index.html'), '<h1>old</h1>');
+      await writeFile(path.join(projectDir, 'index.html.artifact.json'), '{"kind":"html"}');
+      const { renameProjectFile, setProjectStorageMirror } = await import('../src/projects.js');
+      const prev = setProjectStorageMirror(mirror);
+      try {
+        await renameProjectFile(dir, 'p1', 'index.html', 'home.html');
+      } finally {
+        setProjectStorageMirror(prev);
+      }
+      expect(fake.calls).toEqual([
+        'del:p1/index.html',
+        'del:p1/index.html.artifact.json',
+        'put:p1/home.html',
+        'put:p1/home.html.artifact.json',
+      ]);
     });
   });
 

--- a/apps/daemon/tests/project-storage-mirror.test.ts
+++ b/apps/daemon/tests/project-storage-mirror.test.ts
@@ -146,12 +146,24 @@ describe('project storage mirror (#7043)', () => {
       } finally {
         setProjectStorageMirror(prev);
       }
+      // The rename runs the authoritative full-tree sync: the old file and
+      // old manifest are reconciled away and every local file is re-uploaded.
       expect(fake.calls).toEqual([
         'del:p1/index.html',
         'del:p1/index.html.artifact.json',
         'put:p1/home.html',
         'put:p1/home.html.artifact.json',
       ]);
+    });
+
+    it('restoreIfEmpty refuses to materialize unsafe remote paths', async () => {
+      fake.map.set('p1/../escape.html', Buffer.from('evil'));
+      fake.map.set('p1/ok.html', Buffer.from('ok'));
+      const projectDir = path.join(dir, 'p1');
+      await mkdir(projectDir, { recursive: true });
+      await mirror.restoreIfEmpty('p1', projectDir);
+      expect((await readFile(path.join(projectDir, 'ok.html'))).toString()).toBe('ok');
+      expect(await import('node:fs').then((fs) => fs.existsSync(path.join(dir, 'escape.html')))).toBe(false);
     });
   });
 

--- a/apps/daemon/tests/project-storage-mirror.test.ts
+++ b/apps/daemon/tests/project-storage-mirror.test.ts
@@ -139,6 +139,11 @@ describe('project storage mirror (#7043)', () => {
       await mkdir(projectDir, { recursive: true });
       await writeFile(path.join(projectDir, 'index.html'), '<h1>old</h1>');
       await writeFile(path.join(projectDir, 'index.html.artifact.json'), '{"kind":"html"}');
+      // Seed the old remote state: the rename's authoritative full-tree sync
+      // must reconcile away the old file and old manifest, then re-upload
+      // the renamed file and its manifest.
+      fake.map.set('p1/index.html', Buffer.from('old-remote'));
+      fake.map.set('p1/index.html.artifact.json', Buffer.from('old-manifest-remote'));
       const { renameProjectFile, setProjectStorageMirror } = await import('../src/projects.js');
       const prev = setProjectStorageMirror(mirror);
       try {
@@ -146,8 +151,6 @@ describe('project storage mirror (#7043)', () => {
       } finally {
         setProjectStorageMirror(prev);
       }
-      // The rename runs the authoritative full-tree sync: the old file and
-      // old manifest are reconciled away and every local file is re-uploaded.
       expect(fake.calls).toEqual([
         'del:p1/index.html',
         'del:p1/index.html.artifact.json',


### PR DESCRIPTION
## Why

The daemon ships a complete S3-compatible project-storage adapter
(`apps/daemon/src/storage/project-storage.ts`, SigV4, MinIO-compatible) and the
`OD_PROJECT_STORAGE=s3` + `OD_S3_*` env knobs, but nothing wires the adapter into
the project routes. This PR activates the flag as a **best-effort write-through
mirror**: the local tree stays the authoritative working copy (agent runtimes
spawn with the project dir as their cwd and write files directly), while every
project-file mutation is pushed to the blob store, a fresh/empty local tree is
restored from the store, and the whole tree re-syncs when a run terminates.
Tracked in #7043.

## What users will see

With `OD_PROJECT_STORAGE=s3` + `OD_S3_ENDPOINT/BUCKET/REGION/ACCESS_KEY_ID/SECRET_ACCESS_KEY`
set, managed project files are persisted to the S3-compatible store:

- project file writes, deletes, folder deletes, renames, and project deletes are
  mirrored to the store;
- a daemon started with an empty local tree pulls the project back from the
  store before the first run;
- when an agent run finishes, the project tree is re-synced (agents write files
  outside the HTTP path).

Without the flag (the default), behavior is unchanged — all mirror calls are
no-ops behind a null check. Mirror operations are best-effort: a store outage
never breaks local project work, and the next sync retries the whole tree.

## Changes

- `apps/daemon/src/storage/project-storage-mirror.ts` (new): mirror operations
  (uploadFile / uploadProject / deleteFile / deleteProject / restoreIfEmpty)
  over the existing `ProjectStorage` adapter. All mutations for a project are
  serialized through a per-project promise chain; full-tree syncs are
  authoritative (remote objects without a local counterpart are deleted).
- `apps/daemon/src/projects.ts`: module-level mirror hooks in ensureProject
  (restore), writeProjectFile (write-through), deleteProjectFile,
  deleteProjectFolder, renameProjectFile.
- `apps/daemon/src/routes/project/index.ts`: mirror project delete.
- `apps/daemon/src/runtimes/runs.ts`: re-sync at the run terminal choke point.
- `apps/daemon/src/server.ts`: resolve and activate the mirror from env at
  startup.
- `apps/daemon/tests/project-storage-mirror.test.ts` (new): unit tests against
  a fake adapter plus an integration test that boots the daemon against an
  in-process mock S3 (HTTP) and asserts write-through and delete propagation.

## Testing

- `pnpm --filter @open-design/daemon exec vitest run tests/project-storage-mirror.test.ts` (7 specs)
- Full daemon suite: 8461 passed; the only failures are pre-existing in this
  environment and reproduced identically on main (codex tilde-EPERM, node-pty
  PTY spawn, claude auth-diagnostics family — all environment-dependent).
- `pnpm guard` and `pnpm typecheck` pass.

## Bug fix verification

- Red on main: `OD_PROJECT_STORAGE=s3` had no effect — `resolveProjectStorage()`
  has zero callers outside the storage module, so project files stayed local
  regardless of the flag (a project write produced no S3 traffic against a
  mock S3 endpoint; verified while reproducing #7043).
- Green on this branch: the same flag now activates the mirror — the daemon
  boots with the env, and the integration spec asserts the project write and
  delete produce the expected PUT/DELETE traffic on the S3 endpoint.

## Validation note

MinIO validation pass (self-hosted MinIO, real bucket):
- Built the branch image and booted the daemon with the S3 env against an
  empty bucket.
- MCP create_project + write_file (index.html, 25 B) -> object appeared in the
  bucket with the exact content (write-through verified).
- MCP delete_project -> bucket listing back to empty (delete propagation
  verified).
- restore-on-empty is covered by the unit specs (fake adapter) on the same
  code path.

## Surface area

- [x] API / contracts (daemon project persistence path)
- [x] Env vars (OD_PROJECT_STORAGE, OD_S3_* — existing knobs, now active)
- [ ] Web UI (no new UI; existing project flows unchanged)
- [ ] CLI (no new command; od mcp / project commands exercise the same path)
- [ ] Skills / design systems / design templates / craft
- [ ] i18n
- [ ] New dependencies

Fixes #7043
