### PR TITLE
fix(daemon): treat Sec-Fetch-Site as a hint, not an authorization signal

### DIFF
--- a/apps/daemon/src/origin-validation.ts
+++ b/apps/daemon/src/origin-validation.ts
@@ -225,21 +225,16 @@ export function isLocalSameOrigin(
 
   const localHostAllowed = isAllowedBrowserHost(host, ports, bindHost, ipOnlyExtraOrigins);
   if (origin == null || origin === '') {
-    if (localHostAllowed) return true;
-    // Browsers (Firefox, Chrome) omit Origin on same-origin GET subresource
-    // requests per the Fetch spec, which made hostname entries in
-    // OD_ALLOWED_ORIGINS unreachable for legitimate same-origin GETs
-    // through a reverse proxy. Sec-Fetch-Site is set by the user agent and
-    // cannot be modified by JavaScript, so a value of "same-origin"
-    // attests that the request originated from the same origin as the
-    // target — a cross-site `<img>`/`<script>` exploit would carry
-    // "cross-site" instead. Only consult the broader allow-list once that
-    // signal is present.
-    const fetchSite = headerValue(req.headers?.['sec-fetch-site']);
-    if (fetchSite === 'same-origin') {
-      return isAllowedBrowserHost(host, ports, bindHost, extraAllowedOrigins);
-    }
-    return false;
+    // Only a loopback / private-LAN host (or an explicitly configured
+    // IP-literal origin) may omit the Origin header. Sec-Fetch-Site is
+    // intentionally NOT consulted here (issue #7041): browsers set it and
+    // JavaScript cannot modify it, but any non-browser HTTP client (curl,
+    // scripts) can forge it, so treating `Sec-Fetch-Site: same-origin` as
+    // an authorization signal would let a forged header reach the full
+    // OD_ALLOWED_ORIGINS allow-list on the non-loopback path. Reverse-proxy
+    // deployments whose public hostname is listed in OD_ALLOWED_ORIGINS
+    // must send an Origin header (or use bearer auth) instead.
+    return localHostAllowed;
   }
   // Reverse-proxy deployments (e.g. Nginx in front of the daemon) terminate
   // the browser connection at the proxy and open a fresh upstream

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -701,15 +701,16 @@ describe('isLocalSameOrigin: OD_ALLOWED_ORIGINS bypass for reverse-proxy deploym
   });
 });
 
-// Firefox and Chrome omit the Origin header on same-origin GET requests per
-// the Fetch spec. When the daemon runs behind a remote-access proxy whose
-// public hostname is listed in OD_ALLOWED_ORIGINS, those legitimate
-// same-origin GETs (e.g. /api/app-config) get rejected by the no-Origin
-// host check because hostname entries in OD_ALLOWED_ORIGINS are only
-// honored via the IP-literal subset in that branch. Sec-Fetch-Site is set
-// by the browser and cannot be modified by JavaScript, so a value of
-// "same-origin" is a trustworthy substitute for the missing Origin header.
-describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin GETs', () => {
+// Issue #7041 — Sec-Fetch-Site must not act as an authorization signal.
+// Browsers set Sec-Fetch-Site and JavaScript cannot modify it, but any
+// non-browser HTTP client (curl, scripts) can forge it trivially. For
+// no-Origin requests, the only acceptable authorization is a loopback /
+// private-LAN host (or an explicitly configured IP-literal origin); a
+// client-supplied Sec-Fetch-Site header never widens that. Reverse-proxy
+// deployments whose public hostname is listed in OD_ALLOWED_ORIGINS must
+// send an Origin header (or use bearer auth) instead — see #2477 for the
+// earlier behavior this fix intentionally closes.
+describe('isLocalSameOrigin: Sec-Fetch-Site is not an authorization signal (issue #7041)', () => {
   const ALLOWED = 'https://nas.example.ts.net';
   const previousAllowedOrigins = process.env.OD_ALLOWED_ORIGINS;
   const env: NodeJS.ProcessEnv = {
@@ -726,14 +727,17 @@ describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin G
     else process.env.OD_ALLOWED_ORIGINS = previousAllowedOrigins;
   });
 
-  it('accepts a no-Origin request whose Host matches OD_ALLOWED_ORIGINS when Sec-Fetch-Site is same-origin', () => {
+  it('rejects a no-Origin request even when Host matches OD_ALLOWED_ORIGINS and Sec-Fetch-Site is same-origin (forged header cannot authorize)', () => {
+    // Issue #7041 repro: a non-browser client can forge Sec-Fetch-Site, so
+    // it must never substitute for the Origin header / bearer auth on the
+    // non-loopback path.
     const req = {
       headers: {
         host: 'nas.example.ts.net',
         'sec-fetch-site': 'same-origin',
       },
     };
-    expect(isLocalSameOrigin(req, 7456, env)).toBe(true);
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
   });
 
   it('still rejects a no-Origin request whose Host matches the allow-list but Sec-Fetch-Site is cross-site', () => {


### PR DESCRIPTION
Fixes #7041

## Why

I hit this while auditing the daemon's local origin guard. The pain: `Sec-Fetch-Site` is set by user agents and JavaScript cannot modify it, but **any non-browser HTTP client (curl, scripts) can forge it trivially**. The current code treats `Sec-Fetch-Site: same-origin` as sufficient authorization for a no-Origin request, widening the host check to the full `OD_ALLOWED_ORIGINS` allow-list on the non-loopback path — so a forged header reaches guarded endpoints (`/api/app-config`, MCP oauth/install routes, `/api/dir-exists`, …) that should require a real browser same-origin context or bearer auth.

## What users will see

No UI change. Security behavior: a no-Origin request whose Host only matches a hostname entry in `OD_ALLOWED_ORIGINS` is now rejected even when it carries `Sec-Fetch-Site: same-origin`. Reverse-proxy deployments that rely on that combination must send an `Origin` header that matches the allow-list (or use bearer auth) — this is the fail-closed direction already confirmed by the maintainer in #7041.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — no-Origin requests to non-loopback hosts listed in `OD_ALLOWED_ORIGINS` are now rejected unless they carry a matching `Origin`; `Sec-Fetch-Site` no longer substitutes.
- [ ] **None**

## Screenshots

N/A (security guard change, no UI surface).

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/origin-validation.test.ts` → `isLocalSameOrigin: Sec-Fetch-Site is not an authorization signal (issue #7041)` → "rejects a no-Origin request even when Host matches OD_ALLOWED_ORIGINS and Sec-Fetch-Site is same-origin (forged header cannot authorize)".
- Did the test go red on `main` and green on this branch? **Yes.** On `main` the new assertion fails (`expected true to be false` — the forged header passes); on this branch the full file is green (61/61).
- `pnpm --filter @open-design/daemon typecheck` passes.


## Validation

Ran on this branch (node v22, pnpm 10):

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/origin-validation.test.ts` — **61/61 pass** (full file, including the new "Sec-Fetch-Site is not an authorization signal" case).
- `pnpm --filter @open-design/daemon typecheck` — passes (contracts + registry-protocol build, both tsc configs clean).
