### PR TITLE
fix(dsh-runtime): emit a failed result frame when model selection derivation throws

### DIFF
--- a/apps/daemon/src/agent-protocol/dsh-profile/session.ts
+++ b/apps/daemon/src/agent-protocol/dsh-profile/session.ts
@@ -212,6 +212,19 @@ export function attachDshProfileSession({
           fail(frame.error?.message ?? 'DeepSeek Harness profile could not start a session.', frame.error?.code);
           return;
         }
+        // Pre-session cancellation: the runtime may emit `cancelled` before
+        // any session frame (e.g. the user cancels while model-selection
+        // derivation is still running). That is a legitimate completion path
+        // — but only when OpenDesign actually requested the cancel; an
+        // unsolicited pre-session `cancelled` is still a protocol error.
+        if (!sessionId && frame.status === 'cancelled') {
+          if (!aborted) {
+            fail('DeepSeek Harness profile cancelled a run before establishing a session.');
+            return;
+          }
+          finish('cancelled');
+          return;
+        }
         if (!requireSession()) return;
         if (frame.session_id !== sessionId) {
           fail('DeepSeek Harness profile terminal result changed the session id.', 'DSH_PROFILE_SESSION_MISMATCH');

--- a/apps/daemon/src/origin-validation.ts
+++ b/apps/daemon/src/origin-validation.ts
@@ -225,21 +225,16 @@ export function isLocalSameOrigin(
 
   const localHostAllowed = isAllowedBrowserHost(host, ports, bindHost, ipOnlyExtraOrigins);
   if (origin == null || origin === '') {
-    if (localHostAllowed) return true;
-    // Browsers (Firefox, Chrome) omit Origin on same-origin GET subresource
-    // requests per the Fetch spec, which made hostname entries in
-    // OD_ALLOWED_ORIGINS unreachable for legitimate same-origin GETs
-    // through a reverse proxy. Sec-Fetch-Site is set by the user agent and
-    // cannot be modified by JavaScript, so a value of "same-origin"
-    // attests that the request originated from the same origin as the
-    // target — a cross-site `<img>`/`<script>` exploit would carry
-    // "cross-site" instead. Only consult the broader allow-list once that
-    // signal is present.
-    const fetchSite = headerValue(req.headers?.['sec-fetch-site']);
-    if (fetchSite === 'same-origin') {
-      return isAllowedBrowserHost(host, ports, bindHost, extraAllowedOrigins);
-    }
-    return false;
+    // Only a loopback / private-LAN host (or an explicitly configured
+    // IP-literal origin) may omit the Origin header. Sec-Fetch-Site is
+    // intentionally NOT consulted here (issue #7041): browsers set it and
+    // JavaScript cannot modify it, but any non-browser HTTP client (curl,
+    // scripts) can forge it, so treating `Sec-Fetch-Site: same-origin` as
+    // an authorization signal would let a forged header reach the full
+    // OD_ALLOWED_ORIGINS allow-list on the non-loopback path. Reverse-proxy
+    // deployments whose public hostname is listed in OD_ALLOWED_ORIGINS
+    // must send an Origin header (or use bearer auth) instead.
+    return localHostAllowed;
   }
   // Reverse-proxy deployments (e.g. Nginx in front of the daemon) terminate
   // the browser connection at the proxy and open a fresh upstream

--- a/apps/daemon/tests/agent-protocol/dsh-profile.test.ts
+++ b/apps/daemon/tests/agent-protocol/dsh-profile.test.ts
@@ -469,6 +469,67 @@ describe('DeepSeek Harness profile session controller', () => {
     assert.equal(controller.getTerminalStatus(), 'cancelled');
   });
 
+  test('treats a pre-session cancelled result after abort as a user cancellation, not fatal', () => {
+    // Regression: when the user cancels before a session is established and
+    // the runtime's model-selection derivation then throws, the runtime
+    // emits a pre-session `cancelled` result. The daemon must accept that as
+    // a legitimate cancellation completion — previously the !sessionId guard
+    // only accepted `failed`, so `cancelled` fell through to requireSession()
+    // and marked the run fatal with DSH_PROFILE_PROTOCOL_ERROR.
+    const child = new FakeDshChild();
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const controller = attachDshProfileSession({
+      child: child as never,
+      requestId: 'run-pre-session-cancel',
+      prompt: 'start',
+      cwd: '/project',
+      send: (event, payload) => events.push({ event, payload: payload as Record<string, unknown> }),
+    });
+
+    child.emitFrame(readyFrame);
+    controller.abort();
+    child.emitFrame({
+      v: 1,
+      type: 'result',
+      request_id: 'run-pre-session-cancel',
+      status: 'cancelled',
+      session_id: 'od-pending-run',
+      resume_rejected: false,
+    });
+
+    assert.equal(controller.hasFatalError(), false);
+    assert.equal(controller.getTerminalStatus(), 'cancelled');
+    assert.equal(events.some(({ event }) => event === 'error'), false);
+  });
+
+  test('rejects an unsolicited pre-session cancelled result as a protocol error', () => {
+    // The mirror case: a pre-session `cancelled` result WITHOUT an abort is
+    // still a protocol error — the runtime must not cancel on its own.
+    const child = new FakeDshChild();
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const controller = attachDshProfileSession({
+      child: child as never,
+      requestId: 'run-unsolicited-cancel',
+      prompt: 'start',
+      cwd: '/project',
+      send: (event, payload) => events.push({ event, payload: payload as Record<string, unknown> }),
+    });
+
+    child.emitFrame(readyFrame);
+    child.emitFrame({
+      v: 1,
+      type: 'result',
+      request_id: 'run-unsolicited-cancel',
+      status: 'cancelled',
+      session_id: 'od-pending-run',
+      resume_rejected: false,
+    });
+
+    assert.equal(controller.hasFatalError(), true);
+    assert.equal(events.at(-1)?.event, 'error');
+    assert.match(String(events.at(-1)?.payload.message), /cancelled a run before establishing a session/);
+  });
+
   test('EOF without a terminal result is a fatal failure', () => {
     const child = new FakeDshChild();
     const events: Array<{ event: string; payload: Record<string, unknown> }> = [];

--- a/apps/daemon/tests/origin-validation.test.ts
+++ b/apps/daemon/tests/origin-validation.test.ts
@@ -701,15 +701,16 @@ describe('isLocalSameOrigin: OD_ALLOWED_ORIGINS bypass for reverse-proxy deploym
   });
 });
 
-// Firefox and Chrome omit the Origin header on same-origin GET requests per
-// the Fetch spec. When the daemon runs behind a remote-access proxy whose
-// public hostname is listed in OD_ALLOWED_ORIGINS, those legitimate
-// same-origin GETs (e.g. /api/app-config) get rejected by the no-Origin
-// host check because hostname entries in OD_ALLOWED_ORIGINS are only
-// honored via the IP-literal subset in that branch. Sec-Fetch-Site is set
-// by the browser and cannot be modified by JavaScript, so a value of
-// "same-origin" is a trustworthy substitute for the missing Origin header.
-describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin GETs', () => {
+// Issue #7041 — Sec-Fetch-Site must not act as an authorization signal.
+// Browsers set Sec-Fetch-Site and JavaScript cannot modify it, but any
+// non-browser HTTP client (curl, scripts) can forge it trivially. For
+// no-Origin requests, the only acceptable authorization is a loopback /
+// private-LAN host (or an explicitly configured IP-literal origin); a
+// client-supplied Sec-Fetch-Site header never widens that. Reverse-proxy
+// deployments whose public hostname is listed in OD_ALLOWED_ORIGINS must
+// send an Origin header (or use bearer auth) instead — see #2477 for the
+// earlier behavior this fix intentionally closes.
+describe('isLocalSameOrigin: Sec-Fetch-Site is not an authorization signal (issue #7041)', () => {
   const ALLOWED = 'https://nas.example.ts.net';
   const previousAllowedOrigins = process.env.OD_ALLOWED_ORIGINS;
   const env: NodeJS.ProcessEnv = {
@@ -726,14 +727,17 @@ describe('isLocalSameOrigin: Sec-Fetch-Site fallback for no-Origin same-origin G
     else process.env.OD_ALLOWED_ORIGINS = previousAllowedOrigins;
   });
 
-  it('accepts a no-Origin request whose Host matches OD_ALLOWED_ORIGINS when Sec-Fetch-Site is same-origin', () => {
+  it('rejects a no-Origin request even when Host matches OD_ALLOWED_ORIGINS and Sec-Fetch-Site is same-origin (forged header cannot authorize)', () => {
+    // Issue #7041 repro: a non-browser client can forge Sec-Fetch-Site, so
+    // it must never substitute for the Origin header / bearer auth on the
+    // non-loopback path.
     const req = {
       headers: {
         host: 'nas.example.ts.net',
         'sec-fetch-site': 'same-origin',
       },
     };
-    expect(isLocalSameOrigin(req, 7456, env)).toBe(true);
+    expect(isLocalSameOrigin(req, 7456, env)).toBe(false);
   });
 
   it('still rejects a no-Origin request whose Host matches the allow-list but Sec-Fetch-Site is cross-site', () => {

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -257,7 +257,18 @@ async function execute(
   output: Output,
   onHandle: (handle: AgentHandle | undefined) => void,
   signal: AbortSignal,
+  terminalWritten?: { value: boolean },
 ): Promise<void> {
+  // Tracks whether a terminal result frame was already emitted for this
+  // execute. `serve` shares this object so its defense-in-depth fallback can
+  // avoid emitting a second result frame (the DSH protocol requires exactly
+  // one terminal result; the daemon treats any frame after `finished` as
+  // fatal). Every result frame emitted below goes through emitResult().
+  const terminal = terminalWritten ?? { value: false };
+  const emitResult = (frame: Record<string, unknown>): void => {
+    terminal.value = true;
+    writeFrame(output, frame);
+  };
   // Model selection derivation (provider/id/resume-id → resolved selection)
   // runs before the try below, so a host-supplied value that the harness
   // rejects (e.g. an unknown reasoning_effort) would throw OUTSIDE the
@@ -276,7 +287,20 @@ async function execute(
       ? { ...baseSelection, reasoningEffort: ReasoningEffortId(request.reasoning_effort) }
       : baseSelection;
   } catch (error: unknown) {
-    writeFrame(output, {
+    // Cancellation stays authoritative: if the selection derivation throws
+    // while the abort signal is already set (e.g. the default-model service
+    // is unavailable during an immediate cancel), report `cancelled`, not
+    // `failed` — a user cancellation must never surface as a failed run.
+    if (signal.aborted) {
+      terminal.value = true;
+      writeCancelledResult(
+        output,
+        request.request_id,
+        String(SessionId(request.resume_session_id ?? `od-${randomUUID()}`)),
+      );
+      return;
+    }
+    emitResult({
       v: 1,
       type: 'result',
       request_id: request.request_id,
@@ -320,13 +344,14 @@ async function execute(
       onHandle(handle);
     } catch (error: unknown) {
       if (signal.aborted) {
+        terminal.value = true;
         writeCancelledResult(output, request.request_id, String(sessionId));
         return;
       }
       const facts = errorFacts(error, request.resume_session_id
         ? 'DSH_PROFILE_RESUME_REJECTED'
         : 'DSH_PROFILE_SESSION_CREATE_FAILED');
-      writeFrame(output, {
+      emitResult({
         v: 1,
         type: 'result',
         request_id: request.request_id,
@@ -347,6 +372,7 @@ async function execute(
     });
     await handle.agent.whenIdle();
     if (signal.aborted) {
+      terminal.value = true;
       writeCancelledResult(output, request.request_id, String(sessionId));
       return;
     }
@@ -359,6 +385,7 @@ async function execute(
     await handle.agent.whenIdle();
     await ctx.sessions.flush(handle.agent.session);
     if (signal.aborted) {
+      terminal.value = true;
       writeCancelledResult(output, request.request_id, String(sessionId));
       return;
     }
@@ -366,7 +393,7 @@ async function execute(
     const reason = turnEnd?.data.reason;
     const status = resultStatus(reason);
     const failed = resultError(reason);
-    writeFrame(output, {
+    emitResult({
       v: 1,
       type: 'result',
       request_id: request.request_id,
@@ -379,10 +406,11 @@ async function execute(
     });
   } catch (error: unknown) {
     if (signal.aborted) {
+      terminal.value = true;
       writeCancelledResult(output, request.request_id, String(sessionId));
       return;
     }
-    writeFrame(output, {
+    emitResult({
       v: 1,
       type: 'result',
       request_id: request.request_id,
@@ -392,9 +420,22 @@ async function execute(
       error: errorFacts(error, 'DSH_PROFILE_EXECUTION_FAILED'),
     });
   } finally {
-    disposeEvent();
+    // Cleanup must never reject `execute`: the terminal result frame has
+    // already been emitted at this point (or the error path above returned),
+    // so a throw here would reject the task promise and `serve`'s fallback
+    // would synthesize a SECOND result frame, violating the exactly-one
+    // contract and turning a completed run into a fatal protocol error.
+    try {
+      disposeEvent();
+    } catch {
+      // Cleanup errors are non-rejecting by design (see above).
+    }
     await handle?.dispose().catch(() => undefined);
-    onHandle(undefined);
+    try {
+      onHandle(undefined);
+    } catch {
+      // Same as disposeEvent: never reject after a terminal frame.
+    }
   }
 }
 
@@ -454,20 +495,33 @@ async function serve(
       requestId = command.request_id;
       const taskAbort = new AbortController();
       cancellation.activate(requestId, taskAbort);
+      // Shared with `execute`: once a terminal result frame has been written
+      // for this request, `serve` must NOT synthesize another one.
+      const terminalWritten: { value: boolean } = { value: false };
       task = execute(
         ctx,
         command,
         output,
         (nextHandle) => { handle = nextHandle; },
         taskAbort.signal,
+        terminalWritten,
       );
       // Defense in depth: `execute` reports every failure via a result frame
-      // and resolves, so a rejection here would mean a bug in that contract.
-      // Still convert it into an explicit failed frame instead of an
-      // unhandled rejection (which would make the process exit silently and
-      // leave the host waiting on a result that never arrives).
+      // and resolves, so a rejection here would mean a bug in that contract
+      // (e.g. an unguarded cleanup throw). Still convert it into an explicit
+      // failed frame instead of an unhandled rejection (which would make the
+      // process exit silently and leave the host waiting on a result that
+      // never arrives) — but only when no terminal frame was already emitted:
+      // a second result frame would violate the exactly-one-result protocol
+      // contract and be marked fatal by the daemon.
       void task
         .catch((error: unknown) => {
+          if (terminalWritten.value) {
+            process.stderr.write(
+              `open-design-runtime: execute rejected after its result frame was emitted (${error instanceof Error ? error.message : String(error)})\n`,
+            );
+            return;
+          }
           writeFrame(output, {
             v: 1,
             type: 'result',

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -258,13 +258,35 @@ async function execute(
   onHandle: (handle: AgentHandle | undefined) => void,
   signal: AbortSignal,
 ): Promise<void> {
-  const defaultSelection = ctx.agentDefaultModel.currentSelection();
-  const baseSelection = request.model
-    ? { provider: request.model.provider, model: request.model.id }
-    : defaultSelection;
-  const selection = request.reasoning_effort
-    ? { ...baseSelection, reasoningEffort: ReasoningEffortId(request.reasoning_effort) }
-    : baseSelection;
+  // Model selection derivation (provider/id/resume-id → resolved selection)
+  // runs before the try below, so a host-supplied value that the harness
+  // rejects (e.g. an unknown reasoning_effort) would throw OUTSIDE the
+  // handler's error path and reject the task promise with no result frame —
+  // `serve` would then exit the process silently and the host would wait on
+  // a response that never comes. Derive inside its own guard and emit an
+  // explicit failed frame so the protocol contract (every execute gets
+  // exactly one result) holds even for malformed selections.
+  let selection: ModelSelectionRef['current'];
+  try {
+    const defaultSelection = ctx.agentDefaultModel.currentSelection();
+    const baseSelection = request.model
+      ? { provider: request.model.provider, model: request.model.id }
+      : defaultSelection;
+    selection = request.reasoning_effort
+      ? { ...baseSelection, reasoningEffort: ReasoningEffortId(request.reasoning_effort) }
+      : baseSelection;
+  } catch (error: unknown) {
+    writeFrame(output, {
+      v: 1,
+      type: 'result',
+      request_id: request.request_id,
+      status: 'failed',
+      session_id: String(SessionId(request.resume_session_id ?? `od-${randomUUID()}`)),
+      resume_rejected: false,
+      error: errorFacts(error, 'DSH_PROFILE_INVALID_MODEL_SELECTION'),
+    });
+    return;
+  }
   const sessionId = SessionId(request.resume_session_id ?? `od-${randomUUID()}`);
   let handle: AgentHandle | undefined;
   let firstSeq = Number.POSITIVE_INFINITY;
@@ -439,7 +461,24 @@ async function serve(
         (nextHandle) => { handle = nextHandle; },
         taskAbort.signal,
       );
-      void task.finally(settle);
+      // Defense in depth: `execute` reports every failure via a result frame
+      // and resolves, so a rejection here would mean a bug in that contract.
+      // Still convert it into an explicit failed frame instead of an
+      // unhandled rejection (which would make the process exit silently and
+      // leave the host waiting on a result that never arrives).
+      void task
+        .catch((error: unknown) => {
+          writeFrame(output, {
+            v: 1,
+            type: 'result',
+            request_id: requestId ?? command.request_id,
+            status: 'failed',
+            session_id: `od-${randomUUID()}`,
+            resume_rejected: false,
+            error: errorFacts(error, 'DSH_PROFILE_EXECUTION_FAILED'),
+          });
+        })
+        .finally(settle);
     });
     lines.on('close', () => {
       if (!task) settle();

--- a/packages/dsh-runtime/src/index.ts
+++ b/packages/dsh-runtime/src/index.ts
@@ -427,14 +427,21 @@ async function execute(
     // contract and turning a completed run into a fatal protocol error.
     try {
       disposeEvent();
-    } catch {
-      // Cleanup errors are non-rejecting by design (see above).
+    } catch (error: unknown) {
+      // Cleanup errors are non-rejecting by design (see above), but keep
+      // them observable: a failed event disposer can leave the session-event
+      // listener installed, so silent swallowing would hide teardown bugs.
+      process.stderr.write(
+        `open-design-runtime: session event disposer failed (${error instanceof Error ? error.message : String(error)})\n`,
+      );
     }
     await handle?.dispose().catch(() => undefined);
     try {
       onHandle(undefined);
-    } catch {
-      // Same as disposeEvent: never reject after a terminal frame.
+    } catch (error: unknown) {
+      process.stderr.write(
+        `open-design-runtime: handle callback failed during cleanup (${error instanceof Error ? error.message : String(error)})\n`,
+      );
     }
   }
 }

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -334,4 +334,36 @@ describe('@open-design/dsh-runtime protocol', () => {
     assert.equal(frames.at(-1)?.status, 'cancelled');
     assert.equal(frames.at(-1)?.error, undefined);
   });
+
+  test('emits a failed result frame when model selection derivation throws (no silent exit)', async () => {
+    // Model selection (provider/id → resolved selection) is derived before
+    // the run itself. If that derivation throws — e.g. the default-model
+    // service is unavailable, or a host-supplied value is rejected — the
+    // execute must still settle the protocol contract: exactly one result
+    // frame, status failed. Before the fix the derivation sat outside the
+    // error path, so a throw rejected the task promise with no frame at all
+    // and the serve loop exited the process silently, leaving the host
+    // waiting on a result that never arrived.
+    const chunks: string[] = [];
+    const ctx = {
+      agentDefaultModel: {
+        currentSelection: () => {
+          throw new Error('default model unavailable');
+        },
+      },
+    };
+    await internals.execute(ctx as never, {
+      v: 1,
+      type: 'execute',
+      request_id: 'run-bad-selection',
+      cwd: '/project',
+      prompt: 'hi',
+      mcp_servers: [],
+    }, { write: (chunk: string) => chunks.push(chunk) }, () => {}, new AbortController().signal);
+
+    const frames = chunks.map((chunk) => JSON.parse(chunk) as { type: string; status?: string; error?: { code?: string } });
+    assert.equal(frames.filter((frame) => frame.type === 'result').length, 1);
+    assert.equal(frames.at(-1)?.status, 'failed');
+    assert.equal(frames.at(-1)?.error?.code, 'DSH_PROFILE_INVALID_MODEL_SELECTION');
+  });
 });

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -366,4 +366,113 @@ describe('@open-design/dsh-runtime protocol', () => {
     assert.equal(frames.at(-1)?.status, 'failed');
     assert.equal(frames.at(-1)?.error?.code, 'DSH_PROFILE_INVALID_MODEL_SELECTION');
   });
+
+  test('serve emits exactly one result frame when cleanup throws after a terminal frame', async () => {
+    // Regression: `execute`'s finally runs cleanup (disposeEvent / dispose /
+    // onHandle) AFTER the terminal result frame has been written. If a
+    // disposer throws, `execute` must not reject — otherwise `serve`'s
+    // defense-in-depth fallback would synthesize a SECOND result frame,
+    // violating the exactly-one-terminal-result protocol contract and being
+    // marked fatal by the daemon.
+    let disposeCalls = 0;
+    const handle = {
+      agent: {
+        session: { seq: 0 },
+        whenIdle: async () => {},
+        followup: async () => {},
+        cancel: () => {},
+      },
+      dispose: async () => { disposeCalls += 1; },
+    };
+    const ctx = {
+      agentDefaultModel: {
+        currentSelection: () => ({ provider: 'deepseek-official', model: 'deepseek-chat' }),
+      },
+      agents: {
+        create: async () => handle,
+      },
+      on: () => () => {
+        throw new Error('disposeEvent failed');
+      },
+      sessions: { flush: async () => {} },
+    };
+    const input = new PassThrough();
+    const chunks: string[] = [];
+    const exitCodes: number[] = [];
+    const serving = internals.serve(
+      ctx as never,
+      { write: (chunk: string) => chunks.push(chunk) },
+      (code) => exitCodes.push(code),
+      input,
+      (exit) => exit(0),
+    );
+
+    input.write(`${JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'run-cleanup-throw',
+      cwd: '/project',
+      prompt: 'hi',
+      mcp_servers: [],
+    })}\n`);
+    await serving;
+
+    assert.equal(disposeCalls, 1);
+    assert.deepEqual(exitCodes, [0]);
+    const frames = chunks.map((chunk) => JSON.parse(chunk) as { type: string; status?: string });
+    // The key protocol assertion: exactly ONE terminal result frame despite
+    // the cleanup throw — a second frame (from serve's fallback) would be
+    // fatal. (Status is 'failed' here only because this mock never delivers a
+    // turn/end event; the bug under test is the duplicate frame, not status.)
+    assert.equal(frames.filter((frame) => frame.type === 'result').length, 1);
+  });
+
+  test('reports cancelled, not failed, when selection derivation throws during an active cancel', async () => {
+    // Regression: the model-selection error branch must respect cancellation
+    // semantics. If currentSelection() throws while the abort signal is
+    // already set (e.g. the default-model service is unavailable during an
+    // immediate cancel), the execute must emit `cancelled` — a user
+    // cancellation reported as a failed run would be wrong on the wire.
+    const ctx = {
+      agentDefaultModel: {
+        currentSelection: () => {
+          throw new Error('default model unavailable during cancel');
+        },
+      },
+    };
+    const input = new PassThrough();
+    const chunks: string[] = [];
+    const exitCodes: number[] = [];
+    const serving = internals.serve(
+      ctx as never,
+      { write: (chunk: string) => chunks.push(chunk) },
+      (code) => exitCodes.push(code),
+      input,
+      (exit) => exit(0),
+    );
+
+    // Cancel lands before execute initializes its AbortController, exactly
+    // like the pre-existing handshake-cancel test — but here the selection
+    // derivation ALSO throws, so both conditions collide.
+    input.write(`${JSON.stringify({
+      v: 1,
+      type: 'cancel',
+      request_id: 'run-select-cancel',
+    })}\n`);
+    input.write(`${JSON.stringify({
+      v: 1,
+      type: 'execute',
+      request_id: 'run-select-cancel',
+      cwd: '/project',
+      prompt: 'hi',
+      mcp_servers: [],
+    })}\n`);
+    await serving;
+
+    assert.deepEqual(exitCodes, [0]);
+    const frames = chunks.map((chunk) => JSON.parse(chunk) as { type: string; status?: string; error?: { code?: string } });
+    assert.equal(frames.filter((frame) => frame.type === 'result').length, 1);
+    assert.equal(frames.at(-1)?.status, 'cancelled');
+    assert.equal(frames.at(-1)?.error, undefined);
+  });
 });

--- a/packages/dsh-runtime/tests/protocol.test.ts
+++ b/packages/dsh-runtime/tests/protocol.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { PassThrough } from 'node:stream';
-import { describe, test } from 'vitest';
+import { describe, test, vi } from 'vitest';
 import { identityFrame, modelsFrame, parseHostCommand } from '../src/protocol.js';
 import { internals } from '../src/index.js';
 
@@ -415,7 +415,17 @@ describe('@open-design/dsh-runtime protocol', () => {
       prompt: 'hi',
       mcp_servers: [],
     })}\n`);
-    await serving;
+    const stderrWrites: string[] = [];
+    const stderrSpy = vi.spyOn(process.stderr, 'write');
+    stderrSpy.mockImplementation((chunk) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    try {
+      await serving;
+    } finally {
+      stderrSpy.mockRestore();
+    }
 
     assert.equal(disposeCalls, 1);
     assert.deepEqual(exitCodes, [0]);
@@ -425,6 +435,9 @@ describe('@open-design/dsh-runtime protocol', () => {
     // fatal. (Status is 'failed' here only because this mock never delivers a
     // turn/end event; the bug under test is the duplicate frame, not status.)
     assert.equal(frames.filter((frame) => frame.type === 'result').length, 1);
+    // Cleanup failures stay non-rejecting but must remain observable: the
+    // failed event disposer is reported on stderr, never silently swallowed.
+    assert.equal(stderrWrites.some((line) => /disposer failed/.test(line)), true);
   });
 
   test('reports cancelled, not failed, when selection derivation throws during an active cancel', async () => {


### PR DESCRIPTION
Supersedes #7081 (consolidated per maintainer request — both fixes are reviewed together here; the daemon changes were already byte-identical on this branch).

## Why

**Part 1 — daemon origin validation (fixes #7041).** `Sec-Fetch-Site` is set by user agents and JavaScript cannot modify it, but **any non-browser HTTP client (curl, scripts) can forge it trivially**. The current code treats `Sec-Fetch-Site: same-origin` as sufficient authorization for a no-Origin request, widening the host check to the full `OD_ALLOWED_ORIGINS` allow-list on the non-loopback path — so a forged header reaches guarded endpoints (`/api/app-config`, MCP oauth/install routes, `/api/dir-exists`, …) that should require a real browser same-origin context or bearer auth.

**Part 2 — dsh-runtime silent exit.** Model selection derivation (`currentSelection()` / `ReasoningEffortId()` / `SessionId()`) runs **outside** `execute`'s error path. A throw there — e.g. the default-model service is unavailable, or a host-supplied value is rejected — rejects the task promise with **no result frame at all**; `serve` then exits the process silently (exit 0) and the host waits on a response that never comes. I reproduced the silent exit against a real `dsh --profile open-design --stdio` session before fixing: only the `ready` frame was emitted, then the process vanished.

## What users will see

**Part 1:** no UI change. Security behavior: a no-Origin request whose Host only matches a hostname entry in `OD_ALLOWED_ORIGINS` is now rejected even when it carries `Sec-Fetch-Site: same-origin`. Reverse-proxy deployments that rely on that combination must send an `Origin` header that matches the allow-list (or use bearer auth) — this is the fail-closed direction already confirmed by the maintainer in #7041.

**Part 2:** nothing in the app UI. Protocol robustness: an `execute` whose model selection cannot be derived now receives an explicit `failed` result frame (`DSH_PROFILE_INVALID_MODEL_SELECTION`) instead of a silently exiting stdio process, so Open Design (and any other host) always gets exactly one result per execute — the protocol contract in the plugin README.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — no wire-shape change: a new `error.code` value (`DSH_PROFILE_INVALID_MODEL_SELECTION`) may appear on already-failed result frames.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — Part 1: no-Origin requests to non-loopback hosts listed in `OD_ALLOWED_ORIGINS` are now rejected unless they carry a matching `Origin`.
- [ ] **None**

## Screenshots

N/A (security guard + protocol robustness, no UI surface).

## Bug fix verification

**Part 1:** `apps/daemon/tests/origin-validation.test.ts` → `isLocalSameOrigin: Sec-Fetch-Site is not an authorization signal (issue #7041)` → "rejects a no-Origin request even when Host matches OD_ALLOWED_ORIGINS and Sec-Fetch-Site is same-origin (forged header cannot authorize)". Red on `main` (the forged header passes — `expected true to be false`), green on this branch (full file 61/61).

**Part 2:** `packages/dsh-runtime/tests/protocol.test.ts` → "emits a failed result frame when model selection derivation throws (no silent exit)" (mocks `agentDefaultModel.currentSelection()` to throw and asserts the execute resolves with exactly one `failed` result frame). Red on `main`, green on this branch (all 13 tests). Also reproduced live on `main` behavior via `dsh --profile open-design --stdio` before the fix: ready frame only, then silent exit.

## Validation

Ran on this branch (node v22, pnpm 10):

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/origin-validation.test.ts` — **61/61 pass**.
- `pnpm --filter @open-design/daemon typecheck` — passes.
- `pnpm --filter @open-design/dsh-runtime test` — **13/13 pass**.
- `pnpm --filter @open-design/dsh-runtime typecheck` — passes.
