### PR TITLE
fix(web): correct Home Hero deck preview positioning

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2718,12 +2718,11 @@
    width-fit scale letterboxes top/bottom with the card bg and never clips. */
 .home-hero__plugin-preset[data-od-mode="deck"] .plugins-home__html-iframe {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  inset: auto;
+  inset: 0 auto auto 0;
   width: 1280px;
   height: 720px;
-  transform: translate(-50%, -50%) scale(var(--deck-preview-scale));
+  transform: scale(var(--deck-preview-scale));
+  transform-origin: top left;
 }
 
 /* Baked deck posters/clips use the gallery's 1.31:1 capture frame, with the

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -150,6 +150,9 @@ const HOME_PLUGINS = [
       od: {
         kind: 'scenario',
         taskKind: 'new-generation',
+        mode: 'deck',
+        surface: 'web',
+        preview: { type: 'html', entry: './example.html' },
         useCase: {
           query:
             'Create a {{deckType}} for {{audience}} about {{topic}} with {{slideCount}}. Speaker notes: {{speakerNotes}}. Use {{designSystem}}.',
@@ -1873,6 +1876,53 @@ test('[P1] home hero deck example preset updates the composer input', async ({ p
   await expect(input).toHaveText(
     'Create a pitch deck for decision makers about quarterly review with 10-15 pages. Speaker notes: include speaker notes. Use the active project design system.',
   );
+});
+
+test('[P1] home hero deck preview iframe stays anchored inside its preview frame', async ({ page }) => {
+  await page.route('**/api/plugins/example-simple-deck/preview*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><html><body style="margin:0"><main style="width:1280px;height:720px">Deck preview</main></body></html>',
+    });
+  });
+
+  await gotoEntryHome(page);
+  await pickHomeTemplate(page, 'deck');
+  await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
+
+  const card = page.locator(
+    '[data-testid="home-hero-plugin-preset"][data-plugin-id="example-simple-deck"]',
+  );
+  await expect(card).toBeVisible();
+
+  const iframe = card.locator('.plugins-home__html-iframe');
+  await expect(iframe).toBeVisible();
+
+  const metrics = await iframe.evaluate((element) => {
+    const frame = element.closest('.plugins-home__html-frame');
+    if (!(frame instanceof HTMLElement)) {
+      throw new Error('Deck preview frame not found');
+    }
+
+    const iframeRect = element.getBoundingClientRect();
+    const frameRect = frame.getBoundingClientRect();
+    const style = getComputedStyle(element);
+
+    return {
+      left: style.left,
+      top: style.top,
+      transformOrigin: style.transformOrigin,
+      deltaX: iframeRect.left - frameRect.left,
+      deltaY: iframeRect.top - frameRect.top,
+    };
+  });
+
+  expect(metrics.left).toBe('0px');
+  expect(metrics.top).toBe('0px');
+  expect(metrics.transformOrigin).toMatch(/^0px 0px/);
+  expect(Math.abs(metrics.deltaX)).toBeLessThanOrEqual(1);
+  expect(Math.abs(metrics.deltaY)).toBeLessThanOrEqual(1);
 });
 
 test('[P1] home hero prompt example cards fill the composer for fallback modes', async ({ page }) => {


### PR DESCRIPTION
- **fix(web): correct Home Hero deck preview positioning**
- **test(web): cover Home Hero deck preview positioning**

## Why

I hit this issue while running OpenDesign in a self-hosted environment and noticed that Slide Deck example presets on the Home screen appeared blank, even though the underlying plugin preview pages loaded correctly when opened directly.

The Deck previews use a fixed 1280×720 iframe that is scaled down to fit the Home Hero preset card. The existing CSS centered that unscaled iframe using:

```css
top: 50%;
left: 50%;
transform: translate(-50%, -50%) scale(var(--deck-preview-scale));
```

Because the translation is calculated from the iframe's unscaled 1280×720 dimensions, the iframe was positioned hundreds of pixels outside the clipped preview area.

During reproduction, the iframe itself was loaded correctly and had the expected 1280×720 logical size and scale factor, but its computed position was negative. In the regression test against `main`, the horizontal position resolved to:

```text
Expected: "0px"
Received: "-540.672px"
```

The fix anchors the iframe at the top-left of the preview frame and scales it from that origin instead:

```css
inset: 0 auto auto 0;
transform: scale(var(--deck-preview-scale));
transform-origin: top left;
```

This keeps the fixed-size Deck iframe inside the clipped preview card while preserving the existing proportional scaling behavior.

## What users will see

Slide Deck example presets on the Home screen now display their visual preview instead of appearing blank.

The change only affects Deck preview positioning in the Home Hero preset rail.

Other preview types and plugin behavior are unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### Before

Slide Deck preset cards appear blank even though their corresponding plugin preview pages load successfully.

### After

Slide Deck preset cards render the scaled 16:9 first-slide preview correctly inside the Home Hero preset card.

## Bug fix verification

- **Test path that reproduces the bug:**  
  `e2e/ui/home-hero-rail.test.ts`

- **Regression test:**  
  `[P1] home hero deck preview iframe stays anchored inside its preview frame`

- **Did the test go red on `main` and green on this branch?**  
  **Yes.**

### RED on `main`

The regression test was run with the original Home Hero Deck CSS from `origin/main`.

It failed as expected:

```text
Error: expect(received).toBe(expected) // Object.is equality

Expected: "0px"
Received: "-540.672px"
```

This demonstrates that the fixed 1280×720 iframe is positioned outside the preview frame when the original center-based positioning is used.

The observed failure matches the browser reproduction of the issue, where Deck previews were loaded and scaled correctly but displaced outside their clipped card.

### GREEN on this branch

The same regression test passes with the corrected positioning:

```text
1 passed
```

The iframe is now anchored at the preview frame's top-left and scaled from that origin.

The test verifies the user-visible layout invariant rather than checking for a specific CSS declaration:

- computed `left` is `0px`
- computed `top` is `0px`
- transform origin is top-left
- iframe/frame X offset is within 1 px
- iframe/frame Y offset is within 1 px

This should allow future implementations to change the CSS mechanism while still protecting the actual preview positioning behavior.

## Validation

### Focused regression test

Regression test:

```text
e2e/ui/home-hero-rail.test.ts
[P1] home hero deck preview iframe stays anchored inside its preview frame
```

Environment:

```text
Playwright 1.60.0
Chromium
mcr.microsoft.com/playwright:v1.60.0-noble
```

GREEN run on the fix branch:

```text
1 passed
```

RED run using the original `origin/main` CSS:

```text
Expected: "0px"
Received: "-540.672px"
```

Final GREEN run after restoring the fix:

```text
1 passed
```

### Repository validation

- `pnpm guard` — passed
- `pnpm typecheck` — passed
