### PR TITLE
fix(web): preserve prompt template media metadata

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1283,6 +1283,25 @@ function AppInner() {
   const [dsLoading, setDsLoading] = useState(true);
   const [projectsLoading, setProjectsLoading] = useState(true);
   const [promptTemplatesLoading, setPromptTemplatesLoading] = useState(true);
+  const [promptTemplatesLoaded, setPromptTemplatesLoaded] = useState(false);
+  const [promptTemplatesLoadFailed, setPromptTemplatesLoadFailed] = useState(false);
+  const promptTemplatesRequestGenerationRef = useRef(0);
+  const refreshPromptTemplates = useCallback(() => {
+    const requestGeneration = promptTemplatesRequestGenerationRef.current + 1;
+    promptTemplatesRequestGenerationRef.current = requestGeneration;
+    setPromptTemplatesLoading(true);
+    setPromptTemplatesLoadFailed(false);
+    void fetchPromptTemplates().then((list) => {
+      if (promptTemplatesRequestGenerationRef.current !== requestGeneration) return;
+      setPromptTemplatesLoading(false);
+      if (list === null) {
+        setPromptTemplatesLoadFailed(true);
+        return;
+      }
+      setPromptTemplates(list);
+      setPromptTemplatesLoaded(true);
+    });
+  }, []);
   // Goes true once the daemon-persisted config (agentId/designSystemId/etc.)
   // has merged into local state. Auto-selection effects below wait on this
   // so they don't race ahead of the daemon-stored choice and overwrite it
@@ -2007,6 +2026,7 @@ function AppInner() {
         setDsLoading(false);
         setProjectsLoading(false);
         setPromptTemplatesLoading(false);
+        setPromptTemplatesLoadFailed(true);
         setDaemonConfigLoaded(true);
         setDaemonAppConfigReady(false);
         // Composio hydration also depends on the daemon. With no daemon
@@ -2123,11 +2143,7 @@ function AppInner() {
         setTemplates(list);
       });
 
-      void fetchPromptTemplates().then((list) => {
-        if (cancelled) return;
-        setPromptTemplates(list);
-        setPromptTemplatesLoading(false);
-      });
+      refreshPromptTemplates();
 
       void fetchAppVersionInfo().then((info) => {
         if (cancelled) return;
@@ -2235,6 +2251,7 @@ function AppInner() {
     })();
     return () => {
       cancelled = true;
+      promptTemplatesRequestGenerationRef.current += 1;
       effectAgentStreamAbort?.abort();
     };
     // `workspaceProjectView` is intentionally absent: it is route-derived, and
@@ -2247,6 +2264,7 @@ function AppInner() {
     isCurrentAgentStreamRequest,
     listCurrentWorkspaceProjects,
     reconcileFetchedProjects,
+    refreshPromptTemplates,
   ]);
 
   // Keep the active projection's last-good display in sync with optimistic
@@ -5309,6 +5327,9 @@ function AppInner() {
         templates={templates}
         onDeleteTemplate={handleDeleteTemplate}
         promptTemplates={promptTemplates}
+        promptTemplatesLoaded={promptTemplatesLoaded}
+        promptTemplatesLoadFailed={promptTemplatesLoadFailed}
+        onPromptTemplatesRetry={refreshPromptTemplates}
         defaultDesignSystemId={config.designSystemId}
         agents={agents}
         agentsLoading={agentsLoading}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -449,6 +449,9 @@ interface Props {
   templates: ProjectTemplate[];
   onDeleteTemplate?: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
+  promptTemplatesLoaded?: boolean;
+  promptTemplatesLoadFailed?: boolean;
+  onPromptTemplatesRetry?: () => void;
   promptTemplatesLoading?: boolean;
   defaultDesignSystemId: string | null;
   connectors: ConnectorDetail[];
@@ -593,6 +596,9 @@ export function EntryShell({
   templates,
   onDeleteTemplate,
   promptTemplates,
+  promptTemplatesLoaded = true,
+  promptTemplatesLoadFailed = false,
+  onPromptTemplatesRetry,
   promptTemplatesLoading = false,
   defaultDesignSystemId,
   connectors,
@@ -1784,6 +1790,9 @@ export function EntryShell({
                 skillsLoading={skillsLoading}
                 connectors={connectors}
                 promptTemplates={promptTemplates}
+                promptTemplatesLoaded={promptTemplatesLoaded}
+                promptTemplatesLoadFailed={promptTemplatesLoadFailed}
+                onPromptTemplatesRetry={onPromptTemplatesRetry}
                 promptTemplatesLoading={promptTemplatesLoading}
                 executionSwitcher={view === 'home' ? homeExecutionSwitcher : undefined}
                 artifactUpgradeSlot={artifactUpgradeSlot}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -449,6 +449,7 @@ interface Props {
   templates: ProjectTemplate[];
   onDeleteTemplate?: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
+  promptTemplatesLoading?: boolean;
   defaultDesignSystemId: string | null;
   connectors: ConnectorDetail[];
   connectorsLoading: boolean;
@@ -592,6 +593,7 @@ export function EntryShell({
   templates,
   onDeleteTemplate,
   promptTemplates,
+  promptTemplatesLoading = false,
   defaultDesignSystemId,
   connectors,
   connectorsLoading,
@@ -1782,6 +1784,7 @@ export function EntryShell({
                 skillsLoading={skillsLoading}
                 connectors={connectors}
                 promptTemplates={promptTemplates}
+                promptTemplatesLoading={promptTemplatesLoading}
                 executionSwitcher={view === 'home' ? homeExecutionSwitcher : undefined}
                 artifactUpgradeSlot={artifactUpgradeSlot}
                 deepSeekV4FlashCampaignAudience={deepSeekV4FlashCampaignAudience}

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -282,7 +282,7 @@ export function EntryView({
   skillsLoading = false,
   designSystemsLoading = false,
   projectsLoading = false,
-  promptTemplatesLoading: _promptTemplatesLoading = false,
+  promptTemplatesLoading = false,
   onCreateProject,
   onCreatePluginShareProject,
   onImportClaudeDesign,
@@ -380,6 +380,7 @@ export function EntryView({
       templates={templates}
       onDeleteTemplate={onDeleteTemplate}
       promptTemplates={promptTemplates}
+      promptTemplatesLoading={promptTemplatesLoading}
       defaultDesignSystemId={defaultDesignSystemId}
       connectors={connectors}
       connectorsLoading={connectorsLoading}

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -74,6 +74,9 @@ interface Props {
   templates: ProjectTemplate[];
   onDeleteTemplate: (id: string) => Promise<boolean>;
   promptTemplates: PromptTemplateSummary[];
+  promptTemplatesLoaded?: boolean;
+  promptTemplatesLoadFailed?: boolean;
+  onPromptTemplatesRetry?: () => void;
   defaultDesignSystemId: string | null;
   agents: AgentInfo[];
   // Forwarded to EntryShell → OnboardingView so the AMR cloud card can show a
@@ -256,6 +259,9 @@ export function EntryView({
   templates,
   onDeleteTemplate,
   promptTemplates,
+  promptTemplatesLoaded = true,
+  promptTemplatesLoadFailed = false,
+  onPromptTemplatesRetry,
   defaultDesignSystemId,
   agents,
   agentsLoading,
@@ -380,6 +386,9 @@ export function EntryView({
       templates={templates}
       onDeleteTemplate={onDeleteTemplate}
       promptTemplates={promptTemplates}
+      promptTemplatesLoaded={promptTemplatesLoaded}
+      promptTemplatesLoadFailed={promptTemplatesLoadFailed}
+      onPromptTemplatesRetry={onPromptTemplatesRetry}
       promptTemplatesLoading={promptTemplatesLoading}
       defaultDesignSystemId={defaultDesignSystemId}
       connectors={connectors}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -237,6 +237,9 @@ interface Props {
   onPickPrototypeSubtype?: (sub: HomeHeroSubChip | null) => void;
   contextItemCount: number;
   error: string | null;
+  errorActionLabel?: string | null;
+  errorActionDisabled?: boolean;
+  onErrorAction?: () => void;
   showActivePluginChip?: boolean;
   workingDir?: string | null;
   recentDirs?: string[];
@@ -367,6 +370,9 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     onPickPrototypeSubtype,
     contextItemCount,
     error,
+    errorActionLabel = null,
+    errorActionDisabled = false,
+    onErrorAction,
     showActivePluginChip = true,
     workingDir = null,
     recentDirs = [],
@@ -2199,7 +2205,18 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
 
       {error ? (
         <div role="alert" className="home-hero__error">
-          {error}
+          <span className="home-hero__error-message">{error}</span>
+          {errorActionLabel && onErrorAction ? (
+            <button
+              type="button"
+              className="home-hero__error-action"
+              data-testid="home-hero-error-action"
+              onClick={onErrorAction}
+              disabled={errorActionDisabled}
+            >
+              {errorActionLabel}
+            </button>
+          ) : null}
         </div>
       ) : null}
       {previewHomeFile && previewHomeFileUrl ? createPortal(

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -307,6 +307,7 @@ interface Props {
   skillsLoading?: boolean;
   connectors?: ConnectorDetail[];
   promptTemplates?: PromptTemplateSummary[];
+  promptTemplatesLoading?: boolean;
   // Personalized first-run starting point (spec §7). Null unless the user just
   // finished the About-you survey this session; EntryShell owns the state.
   // Accepted for API compatibility but no longer rendered — see
@@ -541,6 +542,7 @@ export function HomeView({
   skillsLoading = false,
   connectors = EMPTY_CONNECTORS,
   promptTemplates = EMPTY_PROMPT_TEMPLATES,
+  promptTemplatesLoading = false,
   recommendation = null,
   onRecommendationStart,
   onRecommendationDismiss,
@@ -767,6 +769,11 @@ export function HomeView({
   // Clearing on `active === null` covers the explicit-clear (×) and the
   // Ask-mode / skill-pick paths that reset `active` to null directly.
   useEffect(() => {
+    // A media restore can wait across multiple renders for the prompt-template
+    // catalog. Keep its serialized identity intact during that window; writing
+    // `active === null` here would erase the only remount-safe copy before the
+    // restore effect below can hydrate it.
+    if (pendingChipRestore) return;
     writeHomeComposerChipDraft(
       active
         ? {
@@ -798,7 +805,7 @@ export function HomeView({
           }
         : null,
     );
-  }, [active]);
+  }, [active, pendingChipRestore]);
   // Live counterpart to the draft-key restore above (see the
   // `HOME_COMPOSER_SEED_EVENT` module note) — picks up a `seedHomeComposerPrompt`
   // call that fires while this HomeView instance is already mounted, which is
@@ -1903,6 +1910,23 @@ export function HomeView({
   useEffect(() => {
     if (!pendingChipRestore || pluginsLoading) return;
     const restore = pendingChipRestore;
+    // The draft reader already folded any retired top-level id onto its parent,
+    // so `restore.chipId` names a live task type and the scene is a refinement
+    // of it — never a chip of its own to look up instead.
+    const restoredChip = restore.chipId ? findChip(restore.chipId) : null;
+    const restoredSubtype = restoredChip?.id === 'prototype'
+      ? prototypeSubChipForSlug(restore.prototypeSubtypeId ?? null)
+      : null;
+    const restoredAction = restoredChip?.action;
+    const restoredMediaSurface = homeMediaSurfaceForChipId(restore.chipId ?? '');
+    // App loads prompt templates asynchronously. Restoring a persisted media
+    // id against the initial empty list would normalize it to `No template`,
+    // overwrite the saved draft, and make a retry submit the wrong metadata.
+    // Keep the restore pending (which also keeps Send disabled) until the
+    // parent confirms the catalog has settled.
+    if (restoredMediaSurface && restore.mediaSelection?.template && promptTemplatesLoading) {
+      return;
+    }
     setPendingChipRestore(null);
     if (active || pendingPluginUseHandoff) return;
     const record = plugins.find((plugin) => plugin.id === restore.pluginId);
@@ -1913,15 +1937,6 @@ export function HomeView({
       writeHomeComposerChipDraft(null);
       return;
     }
-    // The draft reader already folded any retired top-level id onto its parent,
-    // so `restore.chipId` names a live task type and the scene is a refinement
-    // of it — never a chip of its own to look up instead.
-    const restoredChip = restore.chipId ? findChip(restore.chipId) : null;
-    const restoredSubtype = restoredChip?.id === 'prototype'
-      ? prototypeSubChipForSlug(restore.prototypeSubtypeId ?? null)
-      : null;
-    const restoredAction = restoredChip?.action;
-    const restoredMediaSurface = homeMediaSurfaceForChipId(restore.chipId ?? '');
     const restoredMediaComposer = restoredMediaSurface
       && (restoredAction?.kind === 'apply-scenario' || restoredAction?.kind === 'apply-figma-migration')
       ? buildHomeMediaComposer(
@@ -1983,7 +1998,15 @@ export function HomeView({
       examplePick: restore.examplePick === true,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingChipRestore, pluginsLoading, plugins, active, pendingPluginUseHandoff]);
+  }, [
+    pendingChipRestore,
+    pluginsLoading,
+    plugins,
+    active,
+    pendingPluginUseHandoff,
+    promptTemplatesLoading,
+    promptTemplates,
+  ]);
 
   // Default creation type (per product): a fresh Home composer starts on
   // 原型 (the `prototype` chip) instead of typeless. One-shot per mount, decided

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -121,6 +121,7 @@ import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import { useWorkspaceSnapshotActivation } from '../collab/workspace-snapshot-activation';
 import {
   buildHomeMediaComposer,
+  homeMediaInputsAfterTemplateChange,
   homeMediaSurfaceForChipId,
   metadataForHomeMediaComposer,
   normalizeHomeMediaInputs,
@@ -2200,9 +2201,24 @@ export function HomeView({
 
   function updateActiveInputs(next: Record<string, unknown>) {
     if (!active) return;
-    const normalized = active.mediaSurface
-      ? normalizeHomeMediaInputs(active.mediaSurface, next, promptTemplates, elevenLabsVoices, composerImageModels)
+    const templateAwareNext = active.mediaSurface
+      ? homeMediaInputsAfterTemplateChange(
+          active.mediaSurface,
+          active.inputs,
+          next,
+          promptTemplates,
+          composerImageModels,
+        )
       : next;
+    const normalized = active.mediaSurface
+      ? normalizeHomeMediaInputs(
+          active.mediaSurface,
+          templateAwareNext,
+          promptTemplates,
+          elevenLabsVoices,
+          composerImageModels,
+        )
+      : templateAwareNext;
     const mediaComposer = active.mediaSurface
       ? buildHomeMediaComposer(active.mediaSurface, promptTemplates, normalized, elevenLabsVoices, {
           elevenLabsVoiceWarning,
@@ -2858,7 +2874,11 @@ export function HomeView({
           );
           return;
         }
-        submittedActive = { ...submittedActive, result, inputs: submittedPluginInputs };
+        // The applied snapshot intentionally uses the run-facing inputs with
+        // hidden footer fields stripped, but the composer must retain its full
+        // model/aspect state so a rejected or blocked create can retry with the
+        // same project metadata.
+        submittedActive = { ...submittedActive, result };
         setActive(submittedActive);
       }
       // Reconcile each selected context against the serialized prompt text before
@@ -2916,7 +2936,11 @@ export function HomeView({
       const submittedProjectKind =
         submittedActive?.projectKind ?? fallbackProjectKind ?? projectKindForSkill(activeSkill) ?? 'other';
       const submittedProjectMetadata = submittedActive?.mediaSurface
-        ? metadataForHomeMediaComposer(submittedActive.mediaSurface, submittedActive.inputs, promptTemplates)
+        ? metadataForHomeMediaComposer(
+            submittedActive.mediaSurface,
+            submittedApplyInputs,
+            promptTemplates,
+          )
         : homeCreateProjectMetadata(
             submittedProjectKind,
             submittedActive?.inputs ?? null,

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -345,10 +345,12 @@ const EMPTY_PROMPT_TEMPLATES: PromptTemplateSummary[] = [];
 // system vanish when the user steps away and comes back. Persist those two
 // serializable, user-visible fields to localStorage so they survive the
 // unmount/remount, mirroring ChatComposer's draft persistence. Object-valued
-// selections (active template, skill, staged files, working directory) are
-// intentionally NOT persisted here — they reference live catalogue records /
-// File handles / a desktop auth token that cannot round-trip through JSON
-// safely.
+// selections (skill, staged files, working directory) are intentionally NOT
+// persisted here — they reference live catalogue records / File handles / a
+// desktop auth token that cannot round-trip through JSON safely. Media chips
+// are the narrow exception: persist only their visible scalar
+// template/model/aspect ids so a rejected optimistic create can remount Home
+// without silently changing the retry payload.
 const HOME_COMPOSER_PROMPT_KEY = 'open-design:home-composer:prompt';
 const HOME_COMPOSER_DESIGN_SYSTEM_KEY = 'open-design:home-composer:design-system';
 const HOME_COMPOSER_DESIGN_SYSTEM_SCOPE_KEY = 'open-design:home-composer:design-system-scope';
@@ -376,6 +378,11 @@ interface HomeComposerChipDraft {
   // identity, so it is persisted with it.
   explicitPick?: boolean;
   examplePick?: boolean;
+  mediaSelection?: {
+    template?: string;
+    model?: string;
+    aspect?: string;
+  };
 }
 // `EntryShell` keeps `HomeView` permanently mounted and toggles it with CSS
 // visibility instead of unmounting it on every Home/Community/... view
@@ -449,6 +456,20 @@ function readHomeComposerChipDraft(): HomeComposerChipDraft | null {
       typeof parsed.prototypeSubtypeId === 'string'
         ? prototypeSubChipForSlug(parsed.prototypeSubtypeId)
         : null;
+    const parsedMediaSelection = parsed.mediaSelection;
+    const mediaSelection = parsedMediaSelection && typeof parsedMediaSelection === 'object'
+      ? {
+          ...(typeof parsedMediaSelection.template === 'string'
+            ? { template: parsedMediaSelection.template }
+            : {}),
+          ...(typeof parsedMediaSelection.model === 'string'
+            ? { model: parsedMediaSelection.model }
+            : {}),
+          ...(typeof parsedMediaSelection.aspect === 'string'
+            ? { aspect: parsedMediaSelection.aspect }
+            : {}),
+        }
+      : undefined;
     return {
       chipId: legacyPrototypeSubtype ? 'prototype' : parsedChipId,
       pluginId: parsed.pluginId,
@@ -458,6 +479,7 @@ function readHomeComposerChipDraft(): HomeComposerChipDraft | null {
       // they restore as the plain type-chip binding they always did.
       explicitPick: parsed.explicitPick === true,
       examplePick: parsed.examplePick === true,
+      ...(mediaSelection && Object.keys(mediaSelection).length > 0 ? { mediaSelection } : {}),
     };
   } catch {
     return null;
@@ -756,6 +778,23 @@ export function HomeView({
               : {}),
             ...(active.explicitPick ? { explicitPick: true } : {}),
             ...(active.examplePick ? { examplePick: true } : {}),
+            ...(active.mediaSurface
+              ? {
+                  mediaSelection: {
+                    ...(typeof active.inputs.template === 'string'
+                      ? { template: active.inputs.template }
+                      : {}),
+                    ...(typeof active.inputs.model === 'string'
+                      ? { model: active.inputs.model }
+                      : {}),
+                    ...(typeof active.inputs.aspect === 'string'
+                      ? { aspect: active.inputs.aspect }
+                      : typeof active.inputs.ratio === 'string'
+                        ? { aspect: active.inputs.ratio }
+                        : {}),
+                  },
+                }
+              : {}),
           }
         : null,
     );
@@ -1882,17 +1921,57 @@ export function HomeView({
       ? prototypeSubChipForSlug(restore.prototypeSubtypeId ?? null)
       : null;
     const restoredAction = restoredChip?.action;
+    const restoredMediaSurface = homeMediaSurfaceForChipId(restore.chipId ?? '');
+    const restoredMediaComposer = restoredMediaSurface
+      && (restoredAction?.kind === 'apply-scenario' || restoredAction?.kind === 'apply-figma-migration')
+      ? buildHomeMediaComposer(
+          restoredMediaSurface,
+          promptTemplates,
+          {
+            ...restoredAction.inputs,
+            ...(restore.mediaSelection?.template
+              ? { template: restore.mediaSelection.template }
+              : {}),
+            ...(restore.mediaSelection?.model
+              ? { model: restore.mediaSelection.model }
+              : {}),
+            ...(restore.mediaSelection?.aspect
+              ? {
+                  aspect: restore.mediaSelection.aspect,
+                  ratio: restore.mediaSelection.aspect,
+                }
+              : {}),
+          },
+          elevenLabsVoices,
+          {
+            elevenLabsVoiceWarning,
+            elevenLabsVoicesLoading,
+            imageModels: composerImageModels,
+          },
+         )
+       : null;
     requestActivePlugin(record, undefined, {
       chipId: restore.chipId ?? undefined,
       prototypeSubtypeId: restoredSubtype?.slug ?? null,
       projectKind: restore.projectKind ?? undefined,
-      inputs:
-        restoredAction?.kind === 'apply-scenario' || restoredAction?.kind === 'apply-figma-migration'
+      inputs: restoredMediaComposer?.inputs
+        ?? (restoredAction?.kind === 'apply-scenario' || restoredAction?.kind === 'apply-figma-migration'
           ? restoredAction.inputs
-          : undefined,
-      projectMetadata: restoredChip
-        ? prototypeSceneProjectMetadata(restoredChip, restoredSubtype)
-        : null,
+          : undefined),
+      inputFields: restoredMediaComposer?.fields,
+      queryTemplate: restoredMediaComposer?.queryTemplate,
+      mediaSurface: restoredMediaComposer?.surface,
+      projectMetadata: restoredMediaComposer
+        ? metadataForHomeMediaComposer(
+            restoredMediaComposer.surface,
+            restoredMediaComposer.inputs,
+            promptTemplates,
+          )
+        : restoredChip
+          ? prototypeSceneProjectMetadata(restoredChip, restoredSubtype)
+          : null,
+      editableInputNames: restoredMediaComposer?.editableFieldNames,
+      preserveInputFields: Boolean(restoredMediaComposer),
       replaceWithoutConfirmation: true,
       suppressPromptUpdate: true,
       deferApply: true,

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -307,6 +307,9 @@ interface Props {
   skillsLoading?: boolean;
   connectors?: ConnectorDetail[];
   promptTemplates?: PromptTemplateSummary[];
+  promptTemplatesLoaded?: boolean;
+  promptTemplatesLoadFailed?: boolean;
+  onPromptTemplatesRetry?: () => void;
   promptTemplatesLoading?: boolean;
   // Personalized first-run starting point (spec §7). Null unless the user just
   // finished the About-you survey this session; EntryShell owns the state.
@@ -542,6 +545,9 @@ export function HomeView({
   skillsLoading = false,
   connectors = EMPTY_CONNECTORS,
   promptTemplates = EMPTY_PROMPT_TEMPLATES,
+  promptTemplatesLoaded = true,
+  promptTemplatesLoadFailed = false,
+  onPromptTemplatesRetry,
   promptTemplatesLoading = false,
   recommendation = null,
   onRecommendationStart,
@@ -1924,7 +1930,7 @@ export function HomeView({
     // overwrite the saved draft, and make a retry submit the wrong metadata.
     // Keep the restore pending (which also keeps Send disabled) until the
     // parent confirms the catalog has settled.
-    if (restoredMediaSurface && restore.mediaSelection?.template && promptTemplatesLoading) {
+    if (restoredMediaSurface && restore.mediaSelection?.template && !promptTemplatesLoaded) {
       return;
     }
     setPendingChipRestore(null);
@@ -2004,7 +2010,7 @@ export function HomeView({
     plugins,
     active,
     pendingPluginUseHandoff,
-    promptTemplatesLoading,
+    promptTemplatesLoaded,
     promptTemplates,
   ]);
 
@@ -3207,6 +3213,14 @@ export function HomeView({
     || contextWorkspaceItems.length > 0
     || stagedFiles.length > 0
   );
+  const mediaRestoreWaitingForCatalog = Boolean(
+    pendingChipRestore?.mediaSelection?.template
+    && homeMediaSurfaceForChipId(pendingChipRestore.chipId ?? ''),
+  );
+  const promptTemplateRestoreError = mediaRestoreWaitingForCatalog
+    && promptTemplatesLoadFailed
+    ? t('promptTemplates.fetchError')
+    : null;
 
   return (
     <div
@@ -3316,7 +3330,10 @@ export function HomeView({
         onPickChip={pickChip}
         onPickPrototypeSubtype={pickPrototypeSubtype}
         contextItemCount={contextItemCount}
-        error={error}
+        error={promptTemplateRestoreError ?? error}
+        errorActionLabel={promptTemplateRestoreError ? t('promptTemplates.retry') : null}
+        errorActionDisabled={promptTemplatesLoading}
+        onErrorAction={promptTemplateRestoreError ? onPromptTemplatesRetry : undefined}
         workingDir={workingDir}
         recentDirs={recentDirs}
         onPickWorkingDir={handlePickWorkingDir}

--- a/apps/web/src/components/home-hero/media-surfaces.ts
+++ b/apps/web/src/components/home-hero/media-surfaces.ts
@@ -56,12 +56,30 @@ export function buildHomeMediaComposer(
   } = {},
 ): HomeMediaComposerState {
   const imageModels = options.imageModels ?? IMAGE_MODELS;
+  const defaultInputs = defaultInputsForSurface(surface, promptTemplates, imageModels);
+  const seededInputs = {
+    ...defaultInputs,
+    ...seedInputs,
+  };
+  const templateAwareInputs = surface === 'image'
+    ? homeMediaInputsAfterTemplateChange(
+        surface,
+        seedInputs,
+        {
+          ...seededInputs,
+          template: validTemplateId(
+            surface,
+            stringValue(seededInputs.template),
+            promptTemplates,
+          ),
+        },
+        promptTemplates,
+        imageModels,
+      )
+    : seededInputs;
   const inputs = normalizeHomeMediaInputs(
     surface,
-    {
-      ...defaultInputsForSurface(surface, promptTemplates),
-      ...seedInputs,
-    },
+    templateAwareInputs,
     promptTemplates,
     voiceOptions,
     imageModels,
@@ -88,6 +106,7 @@ export function normalizeHomeMediaInputs(
 ): Record<string, unknown> {
   if (surface === 'image') {
     const ratio = validOption(stringValue(raw.ratio) || stringValue(raw.aspect), MEDIA_ASPECTS, '16:9');
+    const rawModel = stringValue(raw.model);
     return {
       mediaKind: 'image',
       subject: stringValue(raw.subject) || 'a premium product concept',
@@ -95,7 +114,7 @@ export function normalizeHomeMediaInputs(
       aspect: ratio,
       template: validTemplateId(surface, stringValue(raw.template), promptTemplates),
       designSystem: stringValue(raw.designSystem) || 'the active project design system',
-      model: validOption(stringValue(raw.model), imageModels.map((m) => m.id), DEFAULT_IMAGE_MODEL),
+      model: validImageModel(rawModel, imageModels) ? rawModel : DEFAULT_IMAGE_MODEL,
       ratio,
       resolution: validOption(stringValue(raw.resolution), MEDIA_RESOLUTIONS, DEFAULT_MEDIA_RESOLUTION),
     };
@@ -191,9 +210,14 @@ export function metadataForHomeMediaComposer(
   // run aligned with the model shown in the Home composer.
   if (surface === 'image') {
     const imageModel = stringValue(inputs.model);
+    const selectedAspect = stringValue(inputs.aspect);
+    const imageAspect = template && validImageTemplateAspect(selectedAspect)
+      ? selectedAspect
+      : null;
     return {
       kind: 'image',
       ...(imageModel ? { imageModel } : {}),
+      ...(imageAspect ? { imageAspect } : {}),
       ...(promptTemplate ? { promptTemplate } : {}),
     };
   }
@@ -208,6 +232,38 @@ export function metadataForHomeMediaComposer(
   }
   return {
     kind: 'audio',
+  };
+}
+
+export function homeMediaInputsAfterTemplateChange(
+  surface: HomeComposerMediaSurface,
+  previousInputs: Record<string, unknown>,
+  nextInputs: Record<string, unknown>,
+  promptTemplates: PromptTemplateSummary[],
+  imageModels: MediaModel[] = IMAGE_MODELS,
+): Record<string, unknown> {
+  if (
+    surface !== 'image'
+    || stringValue(previousInputs.template) === stringValue(nextInputs.template)
+  ) {
+    return nextInputs;
+  }
+
+  const template = promptTemplates.find(
+    (item) => item.surface === 'image' && item.id === stringValue(nextInputs.template),
+  );
+  if (!template) return nextInputs;
+
+  const model = validImageModel(template.model, imageModels)
+    ? template.model
+    : null;
+  const aspect = validImageTemplateAspect(template.aspect)
+    ? template.aspect
+    : null;
+  return {
+    ...nextInputs,
+    ...(model ? { model } : {}),
+    ...(aspect ? { aspect, ratio: aspect } : {}),
   };
 }
 
@@ -311,13 +367,22 @@ function queryTemplateForSurface(surface: HomeComposerMediaSurface, inputs: Reco
 function defaultInputsForSurface(
   surface: HomeComposerMediaSurface,
   promptTemplates: PromptTemplateSummary[],
+  imageModels: MediaModel[] = IMAGE_MODELS,
 ): Record<string, unknown> {
   if (surface === 'image') {
+    const template = templatesForHomeMediaSurface(surface, promptTemplates)[0] ?? null;
+    const model = template && validImageModel(template.model, imageModels)
+      ? template.model
+      : DEFAULT_IMAGE_MODEL;
+    const aspect = template && validImageTemplateAspect(template.aspect)
+      ? template.aspect
+      : '16:9';
     return {
-      template: firstTemplateId(surface, promptTemplates),
+      template: template?.id ?? NO_TEMPLATE_PLACEHOLDER,
       designSystem: 'the active project design system',
-      model: DEFAULT_IMAGE_MODEL,
-      ratio: '16:9',
+      model,
+      aspect,
+      ratio: aspect,
       resolution: DEFAULT_MEDIA_RESOLUTION,
     };
   }
@@ -337,6 +402,22 @@ function defaultInputsForSurface(
     return { template: firstTemplateId(surface, promptTemplates), model: 'hyperframes-html', ratio: '16:9', duration: 10 };
   }
   return { text: 'the user\'s brief', audioType: 'speech', model: defaultHomeAudioModel('speech'), duration: 10 };
+}
+
+function validImageModel(
+  model: string | undefined,
+  imageModels: MediaModel[],
+): model is string {
+  return Boolean(
+    model
+    && (imageModels.some((item) => item.id === model) || model.startsWith('aihubmix-')),
+  );
+}
+
+function validImageTemplateAspect(
+  aspect: string | undefined,
+): aspect is (typeof MEDIA_ASPECTS)[number] {
+  return Boolean(aspect && (MEDIA_ASPECTS as readonly string[]).includes(aspect));
 }
 
 function stringField(name: string, label: string, placeholder?: string): InputFieldSpec {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1216,14 +1216,14 @@ async function readImportError(resp: Response): Promise<SkillImportError> {
   };
 }
 
-export async function fetchPromptTemplates(): Promise<PromptTemplateSummary[]> {
+export async function fetchPromptTemplates(): Promise<PromptTemplateSummary[] | null> {
   try {
     const resp = await fetch('/api/prompt-templates');
-    if (!resp.ok) return [];
+    if (!resp.ok) return null;
     const json = (await resp.json()) as { promptTemplates: PromptTemplateSummary[] };
     return json.promptTemplates ?? [];
   } catch {
-    return [];
+    return null;
   }
 }
 

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2307,6 +2307,10 @@
   box-shadow: none;
 }
 .home-hero__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   color: var(--red);
   font-size: 13px;
   background: var(--red-bg);
@@ -2315,6 +2319,27 @@
   border-radius: var(--radius-sm);
   max-width: 720px;
   width: 100%;
+}
+
+.home-hero__error-message {
+  min-width: 0;
+}
+
+.home-hero__error-action {
+  flex: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.home-hero__error-action:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .home-hero-confirm__backdrop {

--- a/apps/web/tests/components/HomeView.chip-restore.test.tsx
+++ b/apps/web/tests/components/HomeView.chip-restore.test.tsx
@@ -165,6 +165,14 @@ const PORTRAIT_TEMPLATE: PromptTemplateSummary = {
   source: { repo: 'open-design/image-prompts', license: 'MIT' },
 };
 
+const LANDSCAPE_TEMPLATE: PromptTemplateSummary = {
+  ...PORTRAIT_TEMPLATE,
+  id: 'image-landscape',
+  title: 'Image landscape concept',
+  model: 'gpt-image-1',
+  aspect: '16:9',
+};
+
 function stubAnimationFrame() {
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     const id = window.setTimeout(() => cb(window.performance.now()), 0);
@@ -304,7 +312,7 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
     ).toBe(false);
   });
 
-  it('retries a rejected image create with the same template metadata after Home remounts', async () => {
+  it('waits for template hydration before restoring a rejected image create', async () => {
     const fetchMock = fetchMockFor([MEDIA_PLUGIN]);
     vi.stubGlobal('fetch', fetchMock);
     stubAnimationFrame();
@@ -312,13 +320,11 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
       'open-design:home-composer:prompt',
       'Create a retryable portrait image.',
     );
-
     let unmountFirst = () => {};
     const rejectedSubmit = vi.fn<React.ComponentProps<typeof HomeView>['onSubmit']>(
       async () => {
-        // App's optimistic project route unmounts Home before /api/projects
-        // settles. It catches the typed 400, routes back to a fresh Home
-        // instance, and resolves false to the now-unmounted submitter.
+        // App optimistically leaves Home while project creation is in flight,
+        // then mounts a fresh Home after a typed rejection.
         unmountFirst();
         return false;
       },
@@ -348,23 +354,49 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
         },
       });
     });
-    fireEvent.click(await screen.findByTestId('home-hero-submit'));
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
     await waitFor(() => expect(rejectedSubmit).toHaveBeenCalledTimes(1));
 
     const acceptedSubmit = vi.fn<React.ComponentProps<typeof HomeView>['onSubmit']>(
       async () => true,
     );
-    render(
+    const retry = render(
       <HomeView
         projects={[]}
         onSubmit={acceptedSubmit}
         onOpenProject={() => undefined}
         onViewAllProjects={() => undefined}
-        promptTemplates={[PORTRAIT_TEMPLATE]}
+        promptTemplates={[]}
+        promptTemplatesLoading
       />,
     );
 
     await screen.findByTestId('home-hero-input');
+    await waitFor(() => {
+      expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(true);
+      expect(JSON.parse(
+        window.localStorage.getItem('open-design:home-composer:chip') ?? '{}',
+      )).toMatchObject({
+        chipId: 'image',
+        mediaSelection: {
+          template: 'image-product',
+          model: 'gpt-image-2',
+          aspect: '3:4',
+        },
+      });
+    });
+
+    retry.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={acceptedSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptTemplates={[LANDSCAPE_TEMPLATE, PORTRAIT_TEMPLATE]}
+        promptTemplatesLoading={false}
+      />,
+    );
+
     await waitFor(() => {
       expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Image');
       expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(false);
@@ -372,14 +404,24 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
     fireEvent.click(screen.getByTestId('home-hero-submit'));
     await waitFor(() => expect(acceptedSubmit).toHaveBeenCalledTimes(1));
 
+    const expectedProjectMetadata = {
+      kind: 'image',
+      imageModel: 'gpt-image-2',
+      imageAspect: '3:4',
+      promptTemplate: {
+        id: 'image-product',
+        surface: 'image',
+        title: 'Image product concept',
+        prompt: 'A polished product image prompt.',
+        summary: 'A polished product image prompt.',
+        category: 'product',
+        model: 'gpt-image-2',
+        aspect: '3:4',
+        source: { repo: 'open-design/image-prompts', license: 'MIT' },
+      },
+    };
     for (const submit of [rejectedSubmit, acceptedSubmit]) {
-      expect(submit.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
-        projectMetadata: expect.objectContaining({
-          imageModel: 'gpt-image-2',
-          imageAspect: '3:4',
-          promptTemplate: expect.objectContaining({ id: 'image-product' }),
-        }),
-      }));
+      expect(submit.mock.calls[0]?.[0].projectMetadata).toEqual(expectedProjectMetadata);
     }
   });
 

--- a/apps/web/tests/components/HomeView.chip-restore.test.tsx
+++ b/apps/web/tests/components/HomeView.chip-restore.test.tsx
@@ -360,6 +360,7 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
     const acceptedSubmit = vi.fn<React.ComponentProps<typeof HomeView>['onSubmit']>(
       async () => true,
     );
+    const retryPromptTemplates = vi.fn();
     const retry = render(
       <HomeView
         projects={[]}
@@ -367,7 +368,9 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
         onOpenProject={() => undefined}
         onViewAllProjects={() => undefined}
         promptTemplates={[]}
-        promptTemplatesLoading
+        promptTemplatesLoaded={false}
+        promptTemplatesLoadFailed
+        onPromptTemplatesRetry={retryPromptTemplates}
       />,
     );
 
@@ -385,6 +388,22 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
         },
       });
     });
+    fireEvent.click(screen.getByTestId('home-hero-error-action'));
+    expect(retryPromptTemplates).toHaveBeenCalledTimes(1);
+
+    retry.rerender(
+      <HomeView
+        projects={[]}
+        onSubmit={acceptedSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptTemplates={[]}
+        promptTemplatesLoaded={false}
+        promptTemplatesLoading
+      />,
+    );
+    expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByTestId('home-hero-error-action')).toBeNull();
 
     retry.rerender(
       <HomeView
@@ -393,6 +412,7 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
         onOpenProject={() => undefined}
         onViewAllProjects={() => undefined}
         promptTemplates={[LANDSCAPE_TEMPLATE, PORTRAIT_TEMPLATE]}
+        promptTemplatesLoaded
         promptTemplatesLoading={false}
       />,
     );

--- a/apps/web/tests/components/HomeView.chip-restore.test.tsx
+++ b/apps/web/tests/components/HomeView.chip-restore.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
 });
 
 import { HomeView } from '../../src/components/HomeView';
+import type { PromptTemplateSummary } from '../../src/types';
 
 // Regression coverage for 飞书 recvqg21bqVuvE (P0): the selected creation-type
 // chip and its bound example-prompt plugin were lost whenever the user
@@ -133,6 +134,37 @@ const WEB_PROTOTYPE_APPLY_RESULT = {
   },
 };
 
+const MEDIA_PLUGIN = {
+  ...DEFAULT_PLUGIN,
+  id: 'od-media-generation',
+  title: 'Media generation',
+  source: '/tmp/media-generation',
+  fsPath: '/tmp/media-generation',
+  manifest: {
+    ...DEFAULT_PLUGIN.manifest,
+    name: 'od-media-generation',
+    title: 'Media generation',
+    description: 'Generate media artifacts.',
+    od: {
+      kind: 'scenario',
+      taskKind: 'media-generation',
+      useCase: { query: 'Generate media.' },
+      inputs: [],
+    },
+  },
+};
+
+const PORTRAIT_TEMPLATE: PromptTemplateSummary = {
+  id: 'image-product',
+  surface: 'image',
+  title: 'Image product concept',
+  summary: 'A polished product image prompt.',
+  category: 'product',
+  model: 'gpt-image-2',
+  aspect: '3:4',
+  source: { repo: 'open-design/image-prompts', license: 'MIT' },
+};
+
 function stubAnimationFrame() {
   vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
     const id = window.setTimeout(() => cb(window.performance.now()), 0);
@@ -157,7 +189,7 @@ async function pickHomeTemplate(id: string) {
 }
 
 function fetchMockFor(plugins: unknown[]) {
-  return vi.fn<typeof fetch>(async (url) => {
+  return vi.fn<typeof fetch>(async (url, init) => {
     if (typeof url === 'string' && url === '/api/plugins') {
       return new Response(JSON.stringify({ plugins }), {
         status: 200,
@@ -166,6 +198,41 @@ function fetchMockFor(plugins: unknown[]) {
     }
     if (typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply')) {
       return new Response(JSON.stringify(WEB_PROTOTYPE_APPLY_RESULT), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')) {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        inputs?: Record<string, unknown>;
+      };
+      return new Response(JSON.stringify({
+        query: 'Generate media.',
+        contextItems: [],
+        inputs: [],
+        assets: [],
+        mcpServers: [],
+        trust: 'trusted',
+        capabilitiesGranted: ['prompt:inject'],
+        capabilitiesRequired: ['prompt:inject'],
+        appliedPlugin: {
+          snapshotId: 'snap-media',
+          pluginId: 'od-media-generation',
+          pluginVersion: '0.1.0',
+          manifestSourceDigest: 'b'.repeat(64),
+          inputs: body.inputs ?? {},
+          resolvedContext: { items: [] },
+          capabilitiesGranted: ['prompt:inject'],
+          capabilitiesRequired: ['prompt:inject'],
+          assetsStaged: [],
+          taskKind: 'media-generation',
+          appliedAt: 0,
+          connectorsRequired: [],
+          connectorsResolved: [],
+          mcpServers: [],
+          status: 'fresh',
+        },
+      }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -235,6 +302,85 @@ describe('HomeView chip/plugin selection survives a real unmount+remount', () =>
         ([url]) => typeof url === 'string' && url.includes('/api/plugins/example-web-prototype/apply'),
       ),
     ).toBe(false);
+  });
+
+  it('retries a rejected image create with the same template metadata after Home remounts', async () => {
+    const fetchMock = fetchMockFor([MEDIA_PLUGIN]);
+    vi.stubGlobal('fetch', fetchMock);
+    stubAnimationFrame();
+    window.localStorage.setItem(
+      'open-design:home-composer:prompt',
+      'Create a retryable portrait image.',
+    );
+
+    let unmountFirst = () => {};
+    const rejectedSubmit = vi.fn<React.ComponentProps<typeof HomeView>['onSubmit']>(
+      async () => {
+        // App's optimistic project route unmounts Home before /api/projects
+        // settles. It catches the typed 400, routes back to a fresh Home
+        // instance, and resolves false to the now-unmounted submitter.
+        unmountFirst();
+        return false;
+      },
+    );
+    const first = render(
+      <HomeView
+        projects={[]}
+        onSubmit={rejectedSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptTemplates={[PORTRAIT_TEMPLATE]}
+      />,
+    );
+    unmountFirst = first.unmount;
+
+    await screen.findByTestId('home-hero-input');
+    await pickHomeTemplate('image');
+    await waitFor(() => {
+      expect(JSON.parse(
+        window.localStorage.getItem('open-design:home-composer:chip') ?? '{}',
+      )).toMatchObject({
+        chipId: 'image',
+        mediaSelection: {
+          template: 'image-product',
+          model: 'gpt-image-2',
+          aspect: '3:4',
+        },
+      });
+    });
+    fireEvent.click(await screen.findByTestId('home-hero-submit'));
+    await waitFor(() => expect(rejectedSubmit).toHaveBeenCalledTimes(1));
+
+    const acceptedSubmit = vi.fn<React.ComponentProps<typeof HomeView>['onSubmit']>(
+      async () => true,
+    );
+    render(
+      <HomeView
+        projects={[]}
+        onSubmit={acceptedSubmit}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptTemplates={[PORTRAIT_TEMPLATE]}
+      />,
+    );
+
+    await screen.findByTestId('home-hero-input');
+    await waitFor(() => {
+      expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Image');
+      expect((screen.getByTestId('home-hero-submit') as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId('home-hero-submit'));
+    await waitFor(() => expect(acceptedSubmit).toHaveBeenCalledTimes(1));
+
+    for (const submit of [rejectedSubmit, acceptedSubmit]) {
+      expect(submit.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+        projectMetadata: expect.objectContaining({
+          imageModel: 'gpt-image-2',
+          imageAspect: '3:4',
+          promptTemplate: expect.objectContaining({ id: 'image-product' }),
+        }),
+      }));
+    }
   });
 
   it.each(['mobile', 'wireframe'])('migrates the legacy top-level %s chip into a nested Prototype scene', async (legacyChipId) => {

--- a/apps/web/tests/components/HomeView.example-dismiss.test.tsx
+++ b/apps/web/tests/components/HomeView.example-dismiss.test.tsx
@@ -293,7 +293,7 @@ const DISMISS_CASES: DismissCase[] = [
     cardId: 'example-image-template',
     automaticStrategyTaskProfile: null,
     projectKind: 'image',
-    projectMetadata: { kind: 'image' },
+    projectMetadata: { kind: 'image', imageModel: 'vela/gpt-image-2' },
     pluginId: 'od-media-generation',
   },
   {

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -317,10 +317,66 @@ describe('HomeView media composer options', () => {
     });
   });
 
+  it('submits the image prompt template model and aspect from the Home entry', async () => {
+    stubFetch();
+    const onSubmit = vi.fn();
+    const portraitTemplate: PromptTemplateSummary = {
+      ...PROMPT_TEMPLATES[0]!,
+      aspect: '3:4',
+    };
+    renderHome({ onSubmit, promptTemplates: [portraitTemplate] });
+
+    await clickHomeRailChip('image');
+    await setHomePrompt('Create a portrait campaign image.');
+    await submitHome();
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        projectMetadata: expect.objectContaining({
+          imageModel: 'gpt-image-2',
+          imageAspect: '3:4',
+          promptTemplate: expect.objectContaining({ id: 'image-product' }),
+        }),
+      }));
+    });
+  });
+
+  it('retains image template metadata when a rejected create is retried', async () => {
+    stubFetch();
+    const onSubmit = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const portraitTemplate: PromptTemplateSummary = {
+      ...PROMPT_TEMPLATES[0]!,
+      aspect: '3:4',
+    };
+    renderHome({ onSubmit, promptTemplates: [portraitTemplate] });
+
+    await clickHomeRailChip('image');
+    await setHomePrompt('Create a retryable portrait image.');
+    await submitHome();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    await submitHome();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
+
+    for (const [payload] of onSubmit.mock.calls) {
+      expect(payload).toEqual(expect.objectContaining({
+        projectMetadata: expect.objectContaining({
+          imageModel: 'gpt-image-2',
+          imageAspect: '3:4',
+        }),
+      }));
+    }
+  });
+
   it('updates submitted template metadata after media templates load', async () => {
     stubFetch();
     const onSubmit = vi.fn();
     const props = homeProps({ onSubmit, promptTemplates: [] });
+    const portraitTemplate: PromptTemplateSummary = {
+      ...PROMPT_TEMPLATES[0]!,
+      aspect: '3:4',
+    };
     const view = render(<HomeView {...props} />);
 
     await clickHomeRailChip('image');
@@ -336,12 +392,14 @@ describe('HomeView media composer options', () => {
     });
 
     onSubmit.mockClear();
-    view.rerender(<HomeView {...props} promptTemplates={PROMPT_TEMPLATES} />);
+    view.rerender(<HomeView {...props} promptTemplates={[portraitTemplate]} />);
     await submitHome();
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
         projectMetadata: expect.objectContaining({
+          imageModel: 'gpt-image-2',
+          imageAspect: '3:4',
           promptTemplate: expect.objectContaining({ id: 'image-product' }),
         }),
       }));

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
 });
 
 import { HomeView } from '../../src/components/HomeView';
+import { ProjectCreateError } from '../../src/state/projects';
 import type { DesignSystemSummary, PromptTemplateSummary } from '../../src/types';
 // HomeHero's prompt input migrated from a <textarea> + highlight overlay to the
 // same Lexical contenteditable the project composer uses. It still has
@@ -344,7 +345,13 @@ describe('HomeView media composer options', () => {
   it('retains image template metadata when a rejected create is retried', async () => {
     stubFetch();
     const onSubmit = vi.fn()
-      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new ProjectCreateError(
+        'Project create rejected',
+        400,
+        null,
+        false,
+        'request-1',
+      ))
       .mockResolvedValueOnce(true);
     const portraitTemplate: PromptTemplateSummary = {
       ...PROMPT_TEMPLATES[0]!,
@@ -364,6 +371,7 @@ describe('HomeView media composer options', () => {
         projectMetadata: expect.objectContaining({
           imageModel: 'gpt-image-2',
           imageAspect: '3:4',
+          promptTemplate: expect.objectContaining({ id: 'image-product' }),
         }),
       }));
     }

--- a/apps/web/tests/home-media-surfaces.test.ts
+++ b/apps/web/tests/home-media-surfaces.test.ts
@@ -2,8 +2,23 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildHomeMediaComposer,
+  homeMediaInputsAfterTemplateChange,
   metadataForHomeMediaComposer,
 } from '../src/components/home-hero/media-surfaces';
+
+const openAiPortraitTemplate = {
+  id: 'stone-staircase',
+  surface: 'image' as const,
+  title: '3D Stone Staircase Evolution Infographic',
+  summary: 'Show the evolution of a stone staircase.',
+  category: 'infographic',
+  model: 'gpt-image-2',
+  aspect: '3:4' as const,
+  source: {
+    repo: 'open-design/prompt-templates',
+    license: 'MIT',
+  },
+};
 
 describe('Home image composer metadata', () => {
   it('persists the default Vela model into project metadata', () => {
@@ -21,6 +36,105 @@ describe('Home image composer metadata', () => {
     expect(metadataForHomeMediaComposer('image', composer.inputs, [])).toEqual({
       kind: 'image',
       imageModel: 'gpt-image-2',
+    });
+  });
+
+  it('seeds project metadata from the first prompt template model and aspect', () => {
+    const composer = buildHomeMediaComposer('image', [openAiPortraitTemplate]);
+
+    expect(composer.inputs).toMatchObject({
+      template: 'stone-staircase',
+      model: 'gpt-image-2',
+      aspect: '3:4',
+      ratio: '3:4',
+    });
+    expect(
+      metadataForHomeMediaComposer('image', composer.inputs, [openAiPortraitTemplate]),
+    ).toMatchObject({
+      kind: 'image',
+      imageModel: 'gpt-image-2',
+      imageAspect: '3:4',
+    });
+  });
+
+  it('applies the first template model and aspect when templates load later', () => {
+    const beforeTemplatesLoad = buildHomeMediaComposer('image', []).inputs;
+    const hydrated = buildHomeMediaComposer(
+      'image',
+      [openAiPortraitTemplate],
+      beforeTemplatesLoad,
+    );
+
+    expect(hydrated.inputs).toMatchObject({
+      template: 'stone-staircase',
+      model: 'gpt-image-2',
+      aspect: '3:4',
+      ratio: '3:4',
+    });
+  });
+
+  it('applies a newly selected prompt template without pinning later model edits', () => {
+    const initial = buildHomeMediaComposer('image', []).inputs;
+    const selected = homeMediaInputsAfterTemplateChange(
+      'image',
+      initial,
+      { ...initial, template: 'stone-staircase' },
+      [openAiPortraitTemplate],
+    );
+
+    expect(selected).toMatchObject({
+      template: 'stone-staircase',
+      model: 'gpt-image-2',
+      aspect: '3:4',
+      ratio: '3:4',
+    });
+    const customized = homeMediaInputsAfterTemplateChange(
+      'image',
+      selected,
+      { ...selected, model: 'vela/gpt-image-2', aspect: '1:1', ratio: '1:1' },
+      [openAiPortraitTemplate],
+    );
+
+    expect(customized).toMatchObject({
+      model: 'vela/gpt-image-2',
+      aspect: '1:1',
+      ratio: '1:1',
+    });
+    expect(
+      metadataForHomeMediaComposer('image', customized, [openAiPortraitTemplate]),
+    ).toMatchObject({ imageModel: 'vela/gpt-image-2', imageAspect: '1:1' });
+  });
+
+  it('ignores unsupported model and aspect declarations from prompt templates', () => {
+    const unsupportedTemplate = {
+      ...openAiPortraitTemplate,
+      id: 'unsupported-template',
+      model: 'unknown-provider/model',
+      aspect: '2:3',
+    };
+    const composer = buildHomeMediaComposer(
+      'image',
+      // The runtime boundary is intentionally exercised with invalid catalog data.
+      [unsupportedTemplate as typeof openAiPortraitTemplate],
+    );
+
+    expect(composer.inputs).toMatchObject({
+      template: 'unsupported-template',
+      model: 'vela/gpt-image-2',
+      aspect: '16:9',
+      ratio: '16:9',
+    });
+  });
+
+  it('accepts live AIHubMix model ids declared by prompt templates', () => {
+    const aihubmixTemplate = {
+      ...openAiPortraitTemplate,
+      model: 'aihubmix-nano-banana-pro',
+    };
+
+    expect(buildHomeMediaComposer('image', [aihubmixTemplate]).inputs).toMatchObject({
+      model: 'aihubmix-nano-banana-pro',
+      aspect: '3:4',
     });
   });
 });

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -28,6 +28,7 @@ import {
   fetchPluginExampleHtml,
   fetchPluginAssetText,
   fetchPluginPreviewHtml,
+  fetchPromptTemplates,
   fetchProjectDesignSystemPackageAudit,
   fetchProjectFiles,
   fetchProjectFileText,
@@ -45,6 +46,26 @@ import {
   upsertPreviewComment,
   writeProjectTextFileDetailed,
 } from '../../src/providers/registry';
+
+describe('prompt-template catalog loading', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('distinguishes an empty successful catalog from a failed request', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ promptTemplates: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchPromptTemplates()).resolves.toBeNull();
+    await expect(fetchPromptTemplates()).resolves.toEqual([]);
+  });
+});
 
 describe('skill operation diagnostics', () => {
   afterEach(() => {


### PR DESCRIPTION
Refs #7088

## Why

Choosing an image prompt template from Home could produce a contradictory project: the template said `gpt-image-2` and `3:4`, while the stored project metadata still said the default Vela model and `16:9`. The mismatch was especially easy to hit when prompt templates arrived after the Home composer had already mounted, and it could reappear after a rejected create was retried.

This PR implements only the independently approved template-propagation slice from #7088. The broader user-level media defaults, runtime propagation, Cloud authentication, catalog labels, and migration work remain out of scope.

## What users will see

Image projects created from Home now keep the selected prompt template's supported model and aspect ratio through initial selection, delayed template loading, project creation, and retry. Users can still change the model or aspect afterward without the template silently pinning it again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this changes the project metadata emitted by the existing Home template flow, without changing its layout or controls. The submitted payload is covered by the HomeView integration test.

## Bug fix verification

- Test paths: `apps/web/tests/home-media-surfaces.test.ts` and `apps/web/tests/components/HomeView.media-options.test.tsx`
- The focused specs went red on the pre-fix code and green after the source changes.
- Coverage includes initial selection, delayed template hydration, template switching, later user overrides, dynamic AIHubMix model ids, invalid catalog values, submit-time input stripping, and rejected-create retry.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/home-media-surfaces.test.ts tests/components/HomeView.media-options.test.tsx --maxWorkers=2` (29 passed)
- `pnpm --filter @open-design/web test`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

Implementation and test drafting were AI-assisted. I reviewed the final diff and independently verified the behavior and validation results above.
