### PR TITLE
fix(release): derive DSH bootstrap version from installer bytes

### DIFF
--- a/.github/workflows/landing-page-production.yml
+++ b/.github/workflows/landing-page-production.yml
@@ -185,32 +185,46 @@ jobs:
 
       # The short open-design.ai/install-dsh.* entry points ship with the
       # landing page. Preserve the exact production bytes separately under an
-      # immutable R2 version before allowing Pages to deploy them. Re-running a
-      # production promotion is idempotent; changing an already-published v1
-      # fails closed and requires an explicit v2 instead.
+      # immutable R2 version before allowing Pages to deploy them. The version
+      # is derived from the installer bytes rather than pinned here: unchanged
+      # installers reuse the version already published, edited ones mint the
+      # next one, and every published version stays byte-for-byte immutable.
+      # `DSH_BOOTSTRAP_VERSION` remains an escape hatch that forces one specific
+      # version and still fails closed on a content mismatch.
       - name: Publish immutable DeepSeek Harness bootstrap installers to R2
+        id: dsh_bootstrap
         env:
           DSH_BOOTSTRAP_SOURCE_DIR: apps/landing-page/public
-          DSH_BOOTSTRAP_VERSION: v1
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_COMMIT: ${{ github.sha }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
           RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}
           RELEASE_STORAGE_BUCKET: ${{ secrets.CLOUDFLARE_R2_RELEASES_BUCKET }}
           RELEASE_STORAGE_ENDPOINT: ${{ secrets.CLOUDFLARE_R2_RELEASES_URL }}
           RELEASE_STORAGE_REGION: auto
           RELEASE_STORAGE_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_RELEASES_SK }}
+          RELEASE_WORKFLOW: ${{ github.workflow }}
         run: pnpm exec tools-release publish-dsh-bootstrap
 
       - name: Verify public DeepSeek Harness bootstrap downloads
         env:
+          DSH_BOOTSTRAP_VERSION: ${{ steps.dsh_bootstrap.outputs.version }}
           RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}
         run: |
           set -euo pipefail
+          if [ -z "$DSH_BOOTSTRAP_VERSION" ]; then
+            echo "::error::publish step did not report a bootstrap version"
+            exit 1
+          fi
           download_dir="$(mktemp -d)"
           trap 'rm -rf "$download_dir"' EXIT
           for name in install-dsh.sh install-dsh.ps1 install-dsh.cmd SHA256SUMS; do
             curl --fail --silent --show-error --location \
               --retry 5 --retry-delay 1 --retry-all-errors \
-              "$RELEASE_PUBLIC_ORIGIN/bootstrap/dsh/v1/$name" \
+              "$RELEASE_PUBLIC_ORIGIN/bootstrap/dsh/$DSH_BOOTSTRAP_VERSION/$name" \
               --output "$download_dir/$name"
           done
           (

--- a/docs/deepseek-harness-one-click-install.zh-CN.md
+++ b/docs/deepseek-harness-one-click-install.zh-CN.md
@@ -4,10 +4,10 @@
 
 正式发布不采用开发机手动上传。脚本合并到 `main` 后，由 `landing-page-production` 生产发布 workflow 自动完成两件事：
 
-1. 将脚本和 `SHA256SUMS` 以不可覆盖的 `v1` 版本保存到 `https://releases.open-design.ai/bootstrap/dsh/v1/`。
+1. 将脚本和 `SHA256SUMS` 以不可覆盖的版本保存到 `https://releases.open-design.ai/bootstrap/dsh/<version>/`。
 2. 将相同脚本发布为下方 `open-design.ai/install-dsh.*` 用户短链接。
 
-如果 R2 中已有同名 `v1` 但内容不同，workflow 会停止，必须提升为 `v2`，不能静默覆盖已经对外分发的安装器。
+版本号由脚本内容决定，不需要人工维护：脚本没变就复用已发布的那一版，脚本改了就自动开下一版（`v1` → `v2` → …）。每个已发布版本都保持逐字节不可覆盖，历史版本永久留存，`https://releases.open-design.ai/bootstrap/dsh/latest.json` 指向当前版本并附带各文件的 sha256 与发布来源。
 
 ## 对外宣发文案
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -2585,7 +2585,14 @@ process.stdin.on("end", () => {
     expect(productionWorkflow).toContain('wranglerVersion: "4.110.0"');
     expect(productionWorkflow).toContain("d1 migrations apply open-design-landing-attribution --remote");
     expect(productionWorkflow).toContain("Publish immutable DeepSeek Harness bootstrap installers to R2");
-    expect(productionWorkflow).toContain("DSH_BOOTSTRAP_VERSION: v1");
+    expect(productionWorkflow).toContain("id: dsh_bootstrap");
+    // The bootstrap version follows the installer bytes. Pinning it in the
+    // workflow is what turned a copy edit inside install-dsh.ps1 into a hard
+    // production deploy failure, so the promotion must read the version the
+    // publisher resolved instead of naming one.
+    expect(productionWorkflow).not.toMatch(/DSH_BOOTSTRAP_VERSION: v\d/);
+    expect(productionWorkflow).toContain("DSH_BOOTSTRAP_VERSION: ${{ steps.dsh_bootstrap.outputs.version }}");
+    expect(productionWorkflow).toContain('"$RELEASE_PUBLIC_ORIGIN/bootstrap/dsh/$DSH_BOOTSTRAP_VERSION/$name"');
     expect(productionWorkflow).toContain("DSH_BOOTSTRAP_SOURCE_DIR: apps/landing-page/public");
     expect(productionWorkflow).toContain("RELEASE_PUBLIC_ORIGIN: ${{ vars.CLOUDFLARE_R2_RELEASES_PUBLIC_ORIGIN }}");
     expect(productionWorkflow).toContain("RELEASE_STORAGE_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_RELEASES_AK }}");

--- a/tools/release/src/storage/publish-dsh-bootstrap.ts
+++ b/tools/release/src/storage/publish-dsh-bootstrap.ts
@@ -1,12 +1,17 @@
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { contentType, publicUrl, required, storageConfigFromEnv } from "./common.ts";
-import { getStorageObject, putStorageObjectWithStatus, type StorageConfig } from "./s3-upload.ts";
+import { contentType, githubInfo, optional, publicUrl, required, storageConfigFromEnv } from "./common.ts";
+import { getStorageObject, putStorageObject, putStorageObjectWithStatus, type StorageConfig } from "./s3-upload.ts";
 
 const BOOTSTRAP_FILES = ["install-dsh.cmd", "install-dsh.ps1", "install-dsh.sh"] as const;
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const POINTER_CACHE_CONTROL = "public, max-age=60";
+const POINTER_KEY = "bootstrap/dsh/latest.json";
+// Versions are minted one at a time by production promotions, so a run that has
+// to probe past this many of them is looping on a bug rather than catching up.
+const MAX_VERSION_PROBE = 100;
 
 type BootstrapObject = {
   body: Buffer;
@@ -15,6 +20,10 @@ type BootstrapObject = {
 
 function sha256(body: Buffer): string {
   return createHash("sha256").update(body).digest("hex");
+}
+
+function versionPrefix(version: string): string {
+  return `bootstrap/dsh/${version}`;
 }
 
 async function publishImmutableBootstrapObject(
@@ -46,15 +55,40 @@ async function publishImmutableBootstrapObject(
   console.log(`reused identical immutable bootstrap object ${objectKey}`);
 }
 
-const version = required("DSH_BOOTSTRAP_VERSION");
-if (!/^v[1-9]\d*$/.test(version)) {
-  throw new Error(`DSH_BOOTSTRAP_VERSION must look like v1 or v2; got ${version}`);
+/**
+ * The bootstrap version is a function of the installer bytes, not a constant a
+ * human is expected to bump. Probe published versions in ascending order and
+ * settle on the first one that either does not exist yet (mint it) or already
+ * holds exactly these bytes (reuse it). `SHA256SUMS` fingerprints all three
+ * installers, so a single GET per version decides the whole set.
+ *
+ * This keeps every published version permanently immutable while making an
+ * edited installer roll forward on its own instead of failing the deploy.
+ */
+async function resolveBootstrapVersion(storage: StorageConfig, checksums: Buffer): Promise<string> {
+  for (let candidate = 1; candidate <= MAX_VERSION_PROBE; candidate += 1) {
+    const version = `v${candidate}`;
+    const published = await getStorageObject({ ...storage, objectKey: `${versionPrefix(version)}/SHA256SUMS` });
+    if (published == null) {
+      console.log(`minting new immutable bootstrap version ${version}`);
+      return version;
+    }
+    if (published.bytes.equals(checksums)) {
+      console.log(`reusing published immutable bootstrap version ${version}`);
+      return version;
+    }
+  }
+  throw new Error(`no free DeepSeek Harness bootstrap version below v${MAX_VERSION_PROBE + 1}`);
+}
+
+const pinnedVersion = optional("DSH_BOOTSTRAP_VERSION");
+if (pinnedVersion.length > 0 && !/^v[1-9]\d*$/.test(pinnedVersion)) {
+  throw new Error(`DSH_BOOTSTRAP_VERSION must look like v1 or v2; got ${pinnedVersion}`);
 }
 
 const sourceDir = required("DSH_BOOTSTRAP_SOURCE_DIR");
 const publicOrigin = required("RELEASE_PUBLIC_ORIGIN");
 const storage = storageConfigFromEnv();
-const prefix = `bootstrap/dsh/${version}`;
 const installers = BOOTSTRAP_FILES.map((name) => ({
   body: readFileSync(join(sourceDir, name)),
   name,
@@ -64,6 +98,11 @@ const checksums = Buffer.from(
   "utf8",
 );
 const objects: BootstrapObject[] = [...installers, { body: checksums, name: "SHA256SUMS" }];
+
+// An explicit pin stays fail-closed: it is the escape hatch for forcing a
+// specific version, and it must never silently overwrite different bytes.
+const version = pinnedVersion.length > 0 ? pinnedVersion : await resolveBootstrapVersion(storage, checksums);
+const prefix = versionPrefix(version);
 
 for (const object of objects) {
   await publishImmutableBootstrapObject(storage, prefix, object);
@@ -76,4 +115,32 @@ for (const object of objects) {
     throw new Error(`published bootstrap object failed byte-for-byte verification: ${objectKey}`);
   }
   console.log(publicUrl(publicOrigin, prefix, object.name));
+}
+
+// Mutable pointer so consumers and the deploy workflow can find the current
+// version without hard-coding it.
+await putStorageObject({
+  ...storage,
+  body: Buffer.from(
+    `${JSON.stringify(
+      {
+        files: Object.fromEntries(installers.map(({ body, name }) => [name, sha256(body)])),
+        github: githubInfo(),
+        publishedAt: new Date().toISOString(),
+        version,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  ),
+  cacheControl: POINTER_CACHE_CONTROL,
+  contentType: contentType("latest.json"),
+  objectKey: POINTER_KEY,
+});
+console.log(publicUrl(publicOrigin, "bootstrap/dsh", "latest.json"));
+
+const githubOutput = optional("GITHUB_OUTPUT");
+if (githubOutput.length > 0) {
+  appendFileSync(githubOutput, `version=${version}\n`, "utf8");
 }

--- a/tools/serve/tests/dsh-bootstrap-publish.test.ts
+++ b/tools/serve/tests/dsh-bootstrap-publish.test.ts
@@ -45,10 +45,9 @@ describe("DeepSeek Harness bootstrap publisher", () => {
     };
     await Promise.all(Object.entries(files).map(([name, body]) => writeFile(join(sourceDir, name), body, "utf8")));
 
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       DSH_BOOTSTRAP_SOURCE_DIR: sourceDir,
-      DSH_BOOTSTRAP_VERSION: "v1",
       RELEASE_PUBLIC_ORIGIN: "https://releases.example.test",
       RELEASE_STORAGE_ACCESS_KEY_ID: "ak",
       RELEASE_STORAGE_BUCKET: server.info.bucket,
@@ -56,11 +55,14 @@ describe("DeepSeek Harness bootstrap publisher", () => {
       RELEASE_STORAGE_REGION: "auto",
       RELEASE_STORAGE_SECRET_ACCESS_KEY: "sk",
     };
+    delete env.DSH_BOOTSTRAP_VERSION;
+    delete env.GITHUB_OUTPUT;
 
     try {
       const output = await runPublisher(repoRoot, env);
       expect(output).toContain("https://releases.example.test/bootstrap/dsh/v1/install-dsh.sh");
       expect(server.listObjectKeys()).toEqual([
+        "bootstrap/dsh/latest.json",
         "bootstrap/dsh/v1/SHA256SUMS",
         "bootstrap/dsh/v1/install-dsh.cmd",
         "bootstrap/dsh/v1/install-dsh.ps1",
@@ -72,9 +74,66 @@ describe("DeepSeek Harness bootstrap publisher", () => {
       expect(server.getObject("bootstrap/dsh/v1/SHA256SUMS")?.toString("utf8")).toMatch(
         /^[a-f0-9]{64}  install-dsh\.cmd\n[a-f0-9]{64}  install-dsh\.ps1\n[a-f0-9]{64}  install-dsh\.sh\n$/,
       );
+      expect(JSON.parse(server.getObject("bootstrap/dsh/latest.json")?.toString("utf8") ?? "{}")).toMatchObject({
+        version: "v1",
+      });
 
+      // Re-promoting the same bytes is a no-op that stays on the same version.
       await expect(runPublisher(repoRoot, env)).resolves.toContain("reused identical immutable bootstrap object");
+      expect(server.listObjectKeys()).toContain("bootstrap/dsh/v1/SHA256SUMS");
+      expect(server.listObjectKeys()).not.toContain("bootstrap/dsh/v2/SHA256SUMS");
 
+      // Changed bytes open the next version automatically instead of failing the
+      // deploy; v1 keeps its original bytes as the immutable archive.
+      const changedShell = "#!/usr/bin/env sh\necho changed\n";
+      await writeFile(join(sourceDir, "install-dsh.sh"), changedShell, "utf8");
+      const rolled = await runPublisher(repoRoot, env);
+      expect(rolled).toContain("https://releases.example.test/bootstrap/dsh/v2/install-dsh.sh");
+      expect(server.getObject("bootstrap/dsh/v2/install-dsh.sh")?.toString("utf8")).toBe(changedShell);
+      expect(server.getObject("bootstrap/dsh/v1/install-dsh.sh")?.toString("utf8")).toBe(files["install-dsh.sh"]);
+      expect(JSON.parse(server.getObject("bootstrap/dsh/latest.json")?.toString("utf8") ?? "{}")).toMatchObject({
+        version: "v2",
+      });
+
+      // Rolling back to the earlier bytes reuses the version that already holds
+      // them rather than minting a third copy.
+      await writeFile(join(sourceDir, "install-dsh.sh"), files["install-dsh.sh"], "utf8");
+      const rolledBack = await runPublisher(repoRoot, env);
+      expect(rolledBack).toContain("https://releases.example.test/bootstrap/dsh/v1/install-dsh.sh");
+      expect(server.listObjectKeys()).not.toContain("bootstrap/dsh/v3/SHA256SUMS");
+    } finally {
+      await server.close();
+      await rm(sourceDir, { force: true, recursive: true });
+    }
+  });
+
+  it("still fails closed when an explicit version pin would overwrite different bytes", async () => {
+    const repoRoot = resolve(import.meta.dirname, "../../..");
+    const sourceDir = await mkdtemp(join(tmpdir(), "od-dsh-bootstrap-pin-"));
+    const server = await startReleaseStorageFixtureServer();
+    await Promise.all(
+      Object.entries({
+        "install-dsh.cmd": "@echo off\r\necho cmd\r\n",
+        "install-dsh.ps1": "Write-Host 'powershell'\n",
+        "install-dsh.sh": "#!/usr/bin/env sh\necho posix\n",
+      }).map(([name, body]) => writeFile(join(sourceDir, name), body, "utf8")),
+    );
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      DSH_BOOTSTRAP_SOURCE_DIR: sourceDir,
+      DSH_BOOTSTRAP_VERSION: "v1",
+      RELEASE_PUBLIC_ORIGIN: "https://releases.example.test",
+      RELEASE_STORAGE_ACCESS_KEY_ID: "ak",
+      RELEASE_STORAGE_BUCKET: server.info.bucket,
+      RELEASE_STORAGE_ENDPOINT: server.info.endpointUrl,
+      RELEASE_STORAGE_REGION: "auto",
+      RELEASE_STORAGE_SECRET_ACCESS_KEY: "sk",
+    };
+    delete env.GITHUB_OUTPUT;
+
+    try {
+      await runPublisher(repoRoot, env);
       await writeFile(join(sourceDir, "install-dsh.sh"), "#!/usr/bin/env sh\necho changed\n", "utf8");
       await expect(runPublisher(repoRoot, env)).rejects.toThrow(
         /immutable bootstrap object already exists with different content/,


### PR DESCRIPTION
## Why

The last production landing-page promotion ([run 32213116590](https://github.com/nexu-io/open-design/actions/runs/32213116590)) failed and never reached Cloudflare Pages, so open-design.ai is still serving the 08-14 build.

The failing step was `Publish immutable DeepSeek Harness bootstrap installers to R2`:

```
Error: immutable bootstrap object already exists with different content:
       bootstrap/dsh/v1/install-dsh.ps1
```

`landing-page-production.yml` pinned `DSH_BOOTSTRAP_VERSION: v1`, while the publisher refuses to overwrite an already-published immutable version whose bytes differ. #6983 renamed the brand to OpenDesign inside `install-dsh.ps1` and `install-dsh.sh` (5 copy lines total) without bumping that pin, so the very next production deploy failed closed — and because the step sits before the deploy, every later step was skipped, including the Pages publish and the D1 migration.

The fail-closed behavior is correct and worth keeping: these bytes get an immutable one-year cache header and act as the supply-chain archive for the `open-design.ai/install-dsh.*` entry points. The defect is that **the version is a function of the installer bytes but was maintained as a hand-written constant**. Anyone editing a line of installer copy has to remember to bump a version in a workflow they are not touching, and the failure surfaces only at production promotion time with an error that never names the fix.

## What users will see

Nothing changes about the one-click install commands themselves — they still point at `open-design.ai/install-dsh.*`.

Operationally, editing an installer no longer breaks the production deploy. The promotion resolves the bootstrap version on its own: unchanged installers reuse the published version, changed installers roll forward to the next one. `https://releases.open-design.ai/bootstrap/dsh/latest.json` is new and names the current version plus each file's sha256 and the publishing run.

On the next production run this failure clears itself: the publisher sees that `v1` holds different bytes, mints `v2` with the OpenDesign copy, and leaves `v1` intact as the historical archive. No brand rename gets reverted.

## Surface area

- [x] **None** — release tooling, workflow, tests, docs

## Bug fix verification

- Test path: `tools/serve/tests/dsh-bootstrap-publish.test.ts`
- Red on `main`, green on this branch: **yes**

The existing suite already ended with an assertion that changed bytes *must* throw. That assertion is inverted into the new expected behavior (auto-mint `v2`, `v1` keeps its original bytes, pointer follows), plus a rollback case proving previously-published bytes reuse their original version instead of minting a third copy. Run against the pre-fix publisher it fails on the missing `DSH_BOOTSTRAP_VERSION`; against this branch both tests pass.

A second test pins `DSH_BOOTSTRAP_VERSION` explicitly and asserts the old fail-closed error still fires, so the escape hatch keeps its guarantee.

## How it resolves the version

`SHA256SUMS` fingerprints all three installers, so one GET per version decides the whole set. The publisher probes `v1`, `v2`, … and settles on the first version that either does not exist (mint it) or already holds exactly these bytes (reuse it).

This needs no new R2 permissions — the storage layer only signs `GET`/`PUT` and has no `ListObjectsV2`, and the probe is GET-only. Every published version still goes up with `if-none-match: *` and the immutable cache header, so history stays permanent and unoverwritable; only the manual bump is gone. Concurrent promotions of different bytes still collide on the 412 path and fail loudly rather than clobbering.

## Adjacent issues

Not addressed here: the R2 archive has no consumer that actually diffs it against what Pages serves, so its supply-chain value is currently latent. Worth deciding separately whether to publish these checksums to users or drop the archive.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/tools-serve typecheck` / `@open-design/tools-release typecheck` — exit 0
- `tools/serve` → `vitest run tests/dsh-bootstrap-publish.test.ts` — 2 passed (red before the fix)
- `e2e` → `vitest run tests/packaged-smoke-workflow.test.ts` — 70 passed, 1 skipped

Not run: the real R2 publish path. It needs production credentials, so it is exercised through the storage fixture server rather than end-to-end.
