### PR TITLE
fix(web): align model limit recovery card

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -1314,6 +1314,11 @@ export function ChatPane({
         failedRunErrorEvent?.detail,
       )
     : null;
+  // A rolling model-window limit has no useful immediate retry path. Keep its
+  // localized recovery copy fully visible and present a single upgrade action
+  // instead of hiding the actionable message behind technical details.
+  const isModelWindowLimitCard =
+    failedRunErrorEvent?.failureDetail === 'model_window_limit';
   const hasInlineAmrAuthorizeFailure = Boolean(
     retryAssistant && onRetry && runFailureUi?.primaryAction === 'authorize',
   );
@@ -2768,14 +2773,16 @@ export function ChatPane({
                   icon="alert-triangle"
                   tone={runErrorTone}
                   title={
-                    runFailureUi
-                      ? t(runFailureUi.titleKey)
-                      : t('chat.runError.title.generic')
+                    isModelWindowLimitCard && displayError
+                      ? displayError
+                      : runFailureUi
+                        ? t(runFailureUi.titleKey)
+                        : t('chat.runError.title.generic')
                   }
-                  open={errorSourceOpen}
-                  onOpenChange={setErrorSourceOpen}
-                  detailsLabel={t('brand.viewDetails')}
-                  details={
+                  open={isModelWindowLimitCard ? false : errorSourceOpen}
+                  onOpenChange={isModelWindowLimitCard ? undefined : setErrorSourceOpen}
+                  detailsLabel={isModelWindowLimitCard ? undefined : t('brand.viewDetails')}
+                  details={isModelWindowLimitCard ? undefined : (
                     <div className="run-error__details">
                       <p className="run-error__description">{displayError}</p>
                       {errorDiagnosticText ? (
@@ -2796,7 +2803,7 @@ export function ChatPane({
                         </div>
                       ) : null}
                     </div>
-                  }
+                  )}
                   footerActions={showErrorActions ? (
                     <>
                       {showByokRecoveryCta ? (

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -516,7 +516,7 @@ export function resolveRunFailureUi(
     const parsed = readModelWindowResetAt(rawMessage);
     const retryAt = parsed && Number.isFinite(Date.parse(parsed)) ? parsed : null;
     return {
-      primaryAction: 'retry',
+      primaryAction: 'upgrade',
       titleKey: 'chat.runError.title.modelWindowLimit',
       messageKey: retryAt
         ? 'chat.runError.modelWindowLimitMessage'

--- a/apps/web/tests/components/ChatPane.resume-failed.test.tsx
+++ b/apps/web/tests/components/ChatPane.resume-failed.test.tsx
@@ -82,10 +82,11 @@ function renderChat(opts: {
   onRetry: (m: ChatMessage) => void;
   onSend?: (...args: unknown[]) => void;
   activeAgentId?: string;
+  messages?: ChatMessage[];
 }) {
   return render(
     <ChatPane
-      messages={[resumableFailedMessage()]}
+      messages={opts.messages ?? [resumableFailedMessage()]}
       streaming={false}
       error={null}
       projectId="project-1"
@@ -104,6 +105,29 @@ function renderChat(opts: {
       config={{ agentId: opts.activeAgentId ?? 'claude', agentCliEnv: {} } as unknown as AppConfig}
     />,
   );
+}
+
+function modelWindowLimitMessage(): ChatMessage {
+  return {
+    id: 'msg-model-window-limit',
+    role: 'assistant',
+    content: '',
+    createdAt: 1,
+    runId: 'run-model-window-limit',
+    runStatus: 'failed',
+    resumable: false,
+    agentId: 'amr',
+    events: [
+      {
+        kind: 'status',
+        label: 'error',
+        detail:
+          '[code=model_limit_exceeded] Model usage limit reached. Try again after 2026-08-26T04:00:00Z.',
+        code: 'RATE_LIMITED',
+        failureDetail: 'model_window_limit',
+      },
+    ],
+  };
 }
 
 describe('ChatPane resume-on-failure', () => {
@@ -184,5 +208,23 @@ describe('ChatPane resume-on-failure', () => {
     const retryButton = screen.getByRole('button', { name: 'promptTemplates.retry' });
     expect(retryButton).toBeTruthy();
     expect(retryButton.classList.contains('chat-error-action')).toBe(true);
+  });
+});
+
+describe('ChatPane model-window limit', () => {
+  it('shows the full recovery copy with only the upgrade action', () => {
+    const onRetry = vi.fn();
+    const { container } = renderChat({
+      onRetry,
+      activeAgentId: 'amr',
+      messages: [modelWindowLimitMessage()],
+    });
+
+    const card = container.querySelector('[data-user-action-card="run-recovery"]');
+    expect(card?.textContent).toContain('chat.runError.modelWindowLimitMessage');
+    expect(card?.textContent).toContain('Aug 26, 12:00 PM');
+    expect(screen.queryByRole('button', { name: 'brand.viewDetails' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'promptTemplates.retry' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.amrBalanceGate.plansCta' })).toBeTruthy();
   });
 });

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -400,7 +400,7 @@ describe('resolveRunFailureUi', () => {
       'You have reached the 5-hour usage limit for Kimi K2.6. Try again after 2026-08-12T06:34:47Z. This request was not charged to Wallet Credits.',
     );
     expect(ui).toMatchObject({
-      primaryAction: 'retry',
+      primaryAction: 'upgrade',
       titleKey: 'chat.runError.title.modelWindowLimit',
       messageKey: 'chat.runError.modelWindowLimitMessage',
       showSwitchCard: false,


### PR DESCRIPTION
## Why

While validating Coding Plan window exhaustion against the local Vela/AMR stack, the chat recovery card exposed technical details and offered an immediate retry even though the model window could not accept another request. This differed from the approved Go-plan recovery treatment and made the blocked state harder to understand.

This change aligns the existing model-window-limit path with the approved recovery UI without bringing in unrelated Go marketing surfaces.

## What users will see

When a model window is exhausted, OpenDesign now shows the complete localized recovery message directly in a flat error card. The card no longer exposes the expandable technical details or a Retry action, and instead offers a single plan-upgrade action.

Other run failure cards keep their existing title, details disclosure, and recovery actions.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Validated locally in the existing OpenDesign quota-exhaustion project against the `local` Vela profile. The CLI-created PR does not include an uploaded screenshot.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/ChatPane.resume-failed.test.tsx`
  - `apps/web/tests/runtime/amr-guidance.test.ts`
- Red on `main`: not rerun on `main`; the previous local UI reproduced the old expandable-details + Retry behavior before this change.
- Green on this branch: yes.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/ChatPane.resume-failed.test.tsx tests/runtime/amr-guidance.test.ts tests/components/HomeView.model-window-limit.test.tsx` — 45 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm typecheck` — passed
- Local Vela/AMR acceptance with `nettee.liu+029@gmail.com` on the `local` profile — model-window limit reproduced and rendered with the aligned recovery treatment
- `pnpm guard` — blocked by existing repository baseline issues unrelated to this PR: missing `apps/telemetry-worker/package.json` and residual `apps/landing-page/public/enhancers/{cobe.js,matter.min.js}` files
