### PR TITLE
fix(media): surface concrete image-generation failure reasons

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1786,14 +1786,14 @@ async function runMediaGenerate(rawArgs) {
       },
       body: JSON.stringify(body),
     });
-  } catch (err) {
-    surfaceFetchError(err, daemonUrl);
-    process.exit(3);
+  } catch {
+    exitWithMediaError({
+      code: 'MEDIA_DISPATCHER_UNREACHABLE',
+      message: 'local media dispatcher could not be reached',
+    }, 3);
   }
   if (!resp.ok) {
-    const text = await resp.text();
-    console.error(`daemon ${resp.status}: ${text}`);
-    process.exit(4);
+    await exitWithMediaHttpFailure(resp);
   }
   const accepted = await resp.json();
   const { taskId } = accepted;
@@ -1808,6 +1808,40 @@ async function runMediaGenerate(rawArgs) {
       ? { authorization: `Bearer ${token}` }
       : workspaceHeaders,
   });
+}
+
+function exitWithMediaError(error, exitCode) {
+  const safeError = {
+    code: error.code,
+    message: error.message,
+    ...(typeof error.retryable === 'boolean' ? { retryable: error.retryable } : {}),
+  };
+  process.stderr.write(JSON.stringify({ error: safeError }) + '\n');
+  process.exit(exitCode);
+}
+
+async function exitWithMediaHttpFailure(resp) {
+  let parsed = null;
+  try {
+    parsed = await resp.json();
+  } catch {
+    // Non-JSON daemon responses are operational diagnostics, not public copy.
+  }
+  const error = parsed?.error;
+  if (
+    error
+    && typeof error === 'object'
+    && typeof error.code === 'string'
+    && error.code.trim()
+    && typeof error.message === 'string'
+    && error.message.trim()
+  ) {
+    exitWithMediaError(error, 4);
+  }
+  exitWithMediaError({
+    code: 'MEDIA_DISPATCH_FAILED',
+    message: 'media dispatcher failed before generation started',
+  }, 4);
 }
 
 async function runMediaWait(rawArgs) {

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1787,7 +1787,7 @@ async function runMediaGenerate(rawArgs) {
       body: JSON.stringify(body),
     });
   } catch {
-    exitWithMediaError({
+    await exitWithMediaError({
       code: 'MEDIA_DISPATCHER_UNREACHABLE',
       message: 'local media dispatcher could not be reached',
     }, 3);
@@ -1810,14 +1810,14 @@ async function runMediaGenerate(rawArgs) {
   });
 }
 
-function exitWithMediaError(error, exitCode) {
+async function exitWithMediaError(error, exitCode) {
   const safeError = {
     code: error.code,
     message: error.message,
     ...(typeof error.retryable === 'boolean' ? { retryable: error.retryable } : {}),
   };
   process.stderr.write(JSON.stringify({ error: safeError }) + '\n');
-  process.exit(exitCode);
+  await flushStreamsAndExit(exitCode);
 }
 
 async function exitWithMediaHttpFailure(resp) {
@@ -1836,9 +1836,9 @@ async function exitWithMediaHttpFailure(resp) {
     && typeof error.message === 'string'
     && error.message.trim()
   ) {
-    exitWithMediaError(error, 4);
+    await exitWithMediaError(error, 4);
   }
-  exitWithMediaError({
+  await exitWithMediaError({
     code: 'MEDIA_DISPATCH_FAILED',
     message: 'media dispatcher failed before generation started',
   }, 4);

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -119,9 +119,10 @@ OD's behalf.
 
 External MCP media tools, when explicitly configured for this run, are outside
 this OD-owned media policy. If no such external tool is available and the user
-asks for media, describe the intended creative brief, prompt, surface, model
-preference, references, and output filename in chat, then stop. Do not claim a
-file was generated and do not emit an \`<artifact>\` block for media.
+asks for an image, use the fixed \`MEDIA_EXECUTION_DISABLED\` sentence from the
+user-reply contract below and stop. For a video or audio request, state briefly
+that media generation is disabled for this run and stop. Do not claim a file was
+generated and do not emit an \`<artifact>\` block for media.
 ${scope}
 
 ${MEDIA_USER_REPLY_CONTRACT}`;

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -54,20 +54,45 @@ localized sentence and nothing else:
   \`safety_rejection\`: say the localized equivalent of "The image was not
   generated because a content safety policy refused the request". For
   Simplified Chinese, reply exactly \`图片未生成：内容安全策略拒绝了该请求\`.
-- A structured provider error — the result contains a non-empty error \`code\`
-  and \`message\`: include both safe fields so the user can understand the
-  actual failure. For Simplified Chinese, reply exactly
-  \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned values.
-- Any other failure, including a placeholder/stub outcome: say the localized
-  equivalent of "The image generation service is temporarily unavailable". For
-  Simplified Chinese, reply exactly \`图片生成服务暂时不可用\`.
+- A known local failure: ignore diagnostic wording and use the fixed safe copy
+  for its code:
+  - \`MEDIA_EXECUTION_DISABLED\`: "Image was not generated: Media generation was
+    disabled for this run (error code: MEDIA_EXECUTION_DISABLED)." Simplified
+    Chinese: \`图片未生成：本次任务未启用图片生成（错误代码：MEDIA_EXECUTION_DISABLED）\`.
+  - \`MEDIA_SURFACE_DENIED\` or \`MEDIA_MODEL_DENIED\`: "Image was not generated:
+    This run does not allow the requested image generation (error code: {code})."
+    Simplified Chinese: \`图片未生成：本次任务不允许所请求的图片生成（错误代码：{code}）\`.
+  - \`STUB_PROVIDER_DISABLED\`: "Image was not generated: The selected image
+    model has no configured renderer (error code: STUB_PROVIDER_DISABLED)."
+    Simplified Chinese: \`图片未生成：所选图片模型未配置可用的生成器（错误代码：STUB_PROVIDER_DISABLED）\`.
+  - \`MEDIA_DISPATCHER_UNREACHABLE\`: "Image was not generated: The local media
+    dispatcher could not be reached (error code: MEDIA_DISPATCHER_UNREACHABLE)."
+    Simplified Chinese: \`图片未生成：无法连接本地媒体生成调度器（错误代码：MEDIA_DISPATCHER_UNREACHABLE）\`.
+  - \`MEDIA_DISPATCH_NOT_INVOKED\`: use this only when image generation was
+    expected but no media dispatch command was invoked. Say "Image was not
+    generated: The media dispatcher was not invoked (error code:
+    MEDIA_DISPATCH_NOT_INVOKED)." Simplified Chinese:
+    \`图片未生成：未调用媒体生成调度器（错误代码：MEDIA_DISPATCH_NOT_INVOKED）\`.
+  - \`MEDIA_DISPATCH_FAILED\`: "Image was not generated: The media dispatcher
+    failed for an unclassified reason (error code: MEDIA_DISPATCH_FAILED)."
+    Simplified Chinese: \`图片未生成：媒体生成调度失败，原因未分类（错误代码：MEDIA_DISPATCH_FAILED）\`.
+- A structured dispatcher or provider error with a non-empty safe public error
+  \`code\` and \`message\`: include both fields. For Simplified Chinese, reply
+  exactly \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned
+  values. Never use an unsanitized response body, stderr, or diagnostic field.
+- Any other failure: use \`MEDIA_DISPATCH_FAILED\` and its fixed copy above.
+  Do not infer an outage from HTTP status, a placeholder/stub, missing output,
+  or model-generated fallback text.
 
-A provider verdict is not automatically an outage. Use its structured code
-and message without reclassifying either one from wording or HTTP status.
+A provider verdict is not automatically an outage. Use its structured safe
+public code and message without reclassifying either one from wording or HTTP
+status. Claim service unavailability only when a structured availability code
+explicitly establishes it.
 
 Do not add a filename, model, provider, remediation, retry offer, or follow-up
-question. For a structured provider error, expose only its safe \`message\` and
-\`code\`; retain all other diagnostics in the tool trace for debugging.`;
+question. Expose only the fixed local-category copy or a structured safe public
+\`message\` and \`code\`; retain all other diagnostics in the tool trace for
+debugging.`;
 
 export function renderMediaGenerationContract(
   mediaExecution?: MediaExecutionPolicy | undefined,
@@ -94,7 +119,9 @@ this OD-owned media policy. If no such external tool is available and the user
 asks for media, describe the intended creative brief, prompt, surface, model
 preference, references, and output filename in chat, then stop. Do not claim a
 file was generated and do not emit an \`<artifact>\` block for media.
-${scope}`;
+${scope}
+
+${MEDIA_USER_REPLY_CONTRACT}`;
   }
   return renderEnabledMediaGenerationContract(mediaExecution, byokMediaDefaults);
 }
@@ -519,8 +546,8 @@ stub/error signal as described below.
 
 The dispatcher tags every outcome explicitly. Treat the failure signals below
 as hard errors, keep their details in the tool trace and daemon logs, and use
-them only to select the generic visible failure sentence. Never narrate a stub
-as if it were the final result.
+them only to select the safe visible failure category in the user-reply contract.
+Never narrate a stub as if it were the final result.
 
 1. **HTTP status.** When stubs are disabled (the default release-build
    posture), the dispatcher returns \`503 provider not configured\` for
@@ -551,8 +578,10 @@ as if it were the final result.
    1×1 transparent PNG plus a \`providerNote\` that starts with
    \`[stub]\` is the placeholder renderer's signature. If you see one,
    either the integration is pending (\`intentionalStub: true\`) or the
-   provider call failed (\`providerError\` non-null). Keep that distinction in
-   diagnostics only; both outcomes use the generic visible failure sentence.
+   provider call failed (\`providerError\` non-null). An intentional stub uses
+   the fixed \`STUB_PROVIDER_DISABLED\` renderer-not-configured copy. A provider
+   failure uses its structured safe public error when present; otherwise use
+   \`MEDIA_DISPATCH_FAILED\`.
 
 Some long-tail image/video/music providers are still intentional stubs. Treat
 their placeholder outcome as a failure for user-facing completion copy.

--- a/apps/daemon/src/prompts/media-contract.ts
+++ b/apps/daemon/src/prompts/media-contract.ts
@@ -57,28 +57,31 @@ localized sentence and nothing else:
 - A known local failure: ignore diagnostic wording and use the fixed safe copy
   for its code:
   - \`MEDIA_EXECUTION_DISABLED\`: "Image was not generated: Media generation was
-    disabled for this run (error code: MEDIA_EXECUTION_DISABLED)." Simplified
-    Chinese: \`图片未生成：本次任务未启用图片生成（错误代码：MEDIA_EXECUTION_DISABLED）\`.
+    disabled for this run (error code: \`MEDIA_EXECUTION_DISABLED\`)." Simplified
+    Chinese: 图片未生成：本次任务未启用图片生成（错误代码：\`MEDIA_EXECUTION_DISABLED\`）.
   - \`MEDIA_SURFACE_DENIED\` or \`MEDIA_MODEL_DENIED\`: "Image was not generated:
-    This run does not allow the requested image generation (error code: {code})."
-    Simplified Chinese: \`图片未生成：本次任务不允许所请求的图片生成（错误代码：{code}）\`.
+    This run does not allow the requested image generation (error code: \`{code}\`)."
+    Simplified Chinese: 图片未生成：本次任务不允许所请求的图片生成（错误代码：\`{code}\`）.
   - \`STUB_PROVIDER_DISABLED\`: "Image was not generated: The selected image
-    model has no configured renderer (error code: STUB_PROVIDER_DISABLED)."
-    Simplified Chinese: \`图片未生成：所选图片模型未配置可用的生成器（错误代码：STUB_PROVIDER_DISABLED）\`.
+    model has no configured renderer (error code: \`STUB_PROVIDER_DISABLED\`)."
+    Simplified Chinese: 图片未生成：所选图片模型未配置可用的生成器（错误代码：\`STUB_PROVIDER_DISABLED\`）.
   - \`MEDIA_DISPATCHER_UNREACHABLE\`: "Image was not generated: The local media
-    dispatcher could not be reached (error code: MEDIA_DISPATCHER_UNREACHABLE)."
-    Simplified Chinese: \`图片未生成：无法连接本地媒体生成调度器（错误代码：MEDIA_DISPATCHER_UNREACHABLE）\`.
+    dispatcher could not be reached (error code: \`MEDIA_DISPATCHER_UNREACHABLE\`)."
+    Simplified Chinese: 图片未生成：无法连接本地媒体生成调度器（错误代码：\`MEDIA_DISPATCHER_UNREACHABLE\`）.
   - \`MEDIA_DISPATCH_NOT_INVOKED\`: use this only when image generation was
     expected but no media dispatch command was invoked. Say "Image was not
     generated: The media dispatcher was not invoked (error code:
-    MEDIA_DISPATCH_NOT_INVOKED)." Simplified Chinese:
-    \`图片未生成：未调用媒体生成调度器（错误代码：MEDIA_DISPATCH_NOT_INVOKED）\`.
+    \`MEDIA_DISPATCH_NOT_INVOKED\`)." Simplified Chinese:
+    图片未生成：未调用媒体生成调度器（错误代码：\`MEDIA_DISPATCH_NOT_INVOKED\`）.
   - \`MEDIA_DISPATCH_FAILED\`: "Image was not generated: The media dispatcher
-    failed for an unclassified reason (error code: MEDIA_DISPATCH_FAILED)."
-    Simplified Chinese: \`图片未生成：媒体生成调度失败，原因未分类（错误代码：MEDIA_DISPATCH_FAILED）\`.
+    failed for an unclassified reason (error code: \`MEDIA_DISPATCH_FAILED\`)."
+    Simplified Chinese: 图片未生成：媒体生成调度失败，原因未分类（错误代码：\`MEDIA_DISPATCH_FAILED\`）.
+Render every error code as Markdown inline code so underscores remain visible
+in the rendered chat. Do not emit a bare underscore-delimited code.
+
 - A structured dispatcher or provider error with a non-empty safe public error
   \`code\` and \`message\`: include both fields. For Simplified Chinese, reply
-  exactly \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned
+  exactly 图片未生成：{message}（错误代码：\`{code}\`）, substituting the returned
   values. Never use an unsanitized response body, stderr, or diagnostic field.
 - Any other failure: use \`MEDIA_DISPATCH_FAILED\` and its fixed copy above.
   Do not infer an outage from HTTP status, a placeholder/stub, missing output,

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -283,8 +283,14 @@ describe('CLI startup boundaries', () => {
       const failed = error as { code?: number; stderr?: string };
       const stderr = failed.stderr ?? '';
       expect(failed.code).toBe(3);
-      expect(stderr).toContain('failed to reach daemon');
+      expect(JSON.parse(stderr)).toEqual({
+        error: {
+          code: 'MEDIA_DISPATCHER_UNREACHABLE',
+          message: 'local media dispatcher could not be reached',
+        },
+      });
       expect(stderr).not.toContain('OD_DATA_DIR');
+      expect(stderr).not.toContain('127.0.0.1');
     } finally {
       await chmod(dataDir, 0o700).catch(() => undefined);
       await rm(root, { recursive: true, force: true });

--- a/apps/daemon/tests/media-generate-structured-error.test.ts
+++ b/apps/daemon/tests/media-generate-structured-error.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const daemonRoot = fileURLToPath(new URL("..", import.meta.url));
 const cliEntry = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+const LARGE_ERROR_MESSAGE = "x".repeat(2 * 1024 * 1024);
 
 let server: http.Server | undefined;
 let baseUrl = "";
@@ -39,7 +40,7 @@ afterEach(async () => {
   server = undefined;
 });
 
-async function runCli(): Promise<{
+async function runCli(options: { delayStderrReadMs?: number } = {}): Promise<{
   code: number;
   stdout: string;
   stderr: string;
@@ -73,7 +74,13 @@ async function runCli(): Promise<{
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => (stdout += chunk));
-    child.stderr.on("data", (chunk) => (stderr += chunk));
+    if ((options.delayStderrReadMs ?? 0) > 0) child.stderr.pause();
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    if ((options.delayStderrReadMs ?? 0) > 0) {
+      setTimeout(() => child.stderr.resume(), options.delayStderrReadMs);
+    }
     child.on("error", reject);
     child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
   });
@@ -94,6 +101,27 @@ describe("od media generate structured daemon failures", () => {
     });
     expect(result.stderr).not.toContain("internalPath");
     expect(result.stderr).not.toContain("run-secret");
+  });
+
+  it("flushes a large structured error envelope before exiting", async () => {
+    responseBody = JSON.stringify({
+      error: {
+        code: "provider_error",
+        message: LARGE_ERROR_MESSAGE,
+        retryable: true,
+      },
+    });
+
+    const result = await runCli({ delayStderrReadMs: 100 });
+
+    expect(result.code).toBe(4);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: {
+        code: "provider_error",
+        message: LARGE_ERROR_MESSAGE,
+        retryable: true,
+      },
+    });
   });
 
   it("classifies an unstructured daemon failure without echoing its body", async () => {

--- a/apps/daemon/tests/media-generate-structured-error.test.ts
+++ b/apps/daemon/tests/media-generate-structured-error.test.ts
@@ -1,0 +1,132 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const daemonRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliEntry = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+let server: http.Server | undefined;
+let baseUrl = "";
+let responseStatus = 403;
+let responseBody = "";
+
+beforeEach(async () => {
+  responseStatus = 403;
+  responseBody = JSON.stringify({
+    error: {
+      code: "MEDIA_EXECUTION_DISABLED",
+      message: "media generation is disabled for this run",
+      retryable: false,
+      details: {
+        internalPath: "/private/runtime/media-config.json",
+        runId: "run-secret",
+      },
+    },
+  });
+  server = http.createServer((_req, res) => {
+    res.writeHead(responseStatus, { "content-type": "application/json" });
+    res.end(responseBody);
+  });
+  await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterEach(async () => {
+  if (server)
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+  server = undefined;
+});
+
+async function runCli(): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        cliEntry,
+        "media",
+        "generate",
+        "--surface",
+        "image",
+        "--model",
+        "test-model",
+        "--prompt",
+        "Draw a test image",
+        "--daemon-url",
+        baseUrl,
+      ],
+      {
+        cwd: daemonRoot,
+        env: { ...process.env, OD_PROJECT_ID: "project-1", OD_TOOL_TOKEN: "" },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
+describe("od media generate structured daemon failures", () => {
+  it("preserves the safe daemon error envelope without leaking diagnostics", async () => {
+    const result = await runCli();
+
+    expect(result.code).toBe(4);
+    expect(result.stdout).toBe("");
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: {
+        code: "MEDIA_EXECUTION_DISABLED",
+        message: "media generation is disabled for this run",
+        retryable: false,
+      },
+    });
+    expect(result.stderr).not.toContain("internalPath");
+    expect(result.stderr).not.toContain("run-secret");
+  });
+
+  it("classifies an unstructured daemon failure without echoing its body", async () => {
+    responseStatus = 500;
+    responseBody = "fatal: token=secret-value at /private/dispatcher.ts";
+
+    const result = await runCli();
+
+    expect(result.code).toBe(4);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: {
+        code: "MEDIA_DISPATCH_FAILED",
+        message: "media dispatcher failed before generation started",
+      },
+    });
+    expect(result.stderr).not.toContain("secret-value");
+    expect(result.stderr).not.toContain("/private/dispatcher.ts");
+  });
+
+  it("classifies daemon reachability without echoing the URL or network error", async () => {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+
+    const result = await runCli();
+
+    expect(result.code).toBe(3);
+    expect(JSON.parse(result.stderr)).toEqual({
+      error: {
+        code: "MEDIA_DISPATCHER_UNREACHABLE",
+        message: "local media dispatcher could not be reached",
+      },
+    });
+    expect(result.stderr).not.toContain(baseUrl);
+    expect(result.stderr).not.toContain("ECONNREFUSED");
+  });
+});

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -14,7 +14,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 62372,
+    "totalChars": 62531,
   },
   "ask-mode-full-context": {
     "sections": [
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 47887,
+    "totalChars": 48046,
   },
   "critique-enabled": {
     "sections": [
@@ -69,7 +69,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 60760,
+    "totalChars": 60919,
   },
   "deck-kind-no-skill": {
     "sections": [
@@ -84,7 +84,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87260,
+    "totalChars": 87419,
   },
   "deck-kind-with-skill-seed": {
     "sections": [
@@ -99,7 +99,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 59961,
+    "totalChars": 60120,
   },
   "design-ds-fixture-fallback": {
     "sections": [
@@ -120,7 +120,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 83342,
+    "totalChars": 83501,
   },
   "design-full-stack": {
     "sections": [
@@ -150,7 +150,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 70096,
+    "totalChars": 70255,
   },
   "design-minimal": {
     "sections": [
@@ -165,7 +165,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87216,
+    "totalChars": 87375,
   },
   "design-no-ds-multitarget": {
     "sections": [
@@ -180,7 +180,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 65527,
+    "totalChars": 65686,
   },
   "example-prompt": {
     "sections": [
@@ -195,7 +195,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 63774,
+    "totalChars": 63933,
   },
   "freeform-other": {
     "sections": [
@@ -211,7 +211,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 90912,
+    "totalChars": 91071,
   },
   "freeform-other-no-deck-signal": {
     "sections": [
@@ -225,7 +225,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 62697,
+    "totalChars": 62856,
   },
   "media-image": {
     "sections": [
@@ -237,7 +237,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 47885,
+    "totalChars": 48044,
   },
   "memory-hooks-off": {
     "sections": [
@@ -254,7 +254,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 89444,
+    "totalChars": 89603,
   },
   "plan-mode": {
     "sections": [
@@ -269,7 +269,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 66721,
+    "totalChars": 66880,
   },
   "plugin-stages": {
     "sections": [
@@ -286,7 +286,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87312,
+    "totalChars": 87471,
   },
   "skip-discovery-brief": {
     "sections": [
@@ -301,7 +301,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 63285,
+    "totalChars": 63444,
   },
   "slim-design-full-stack": {
     "sections": [
@@ -328,7 +328,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "role-marker-guard",
     ],
-    "totalChars": 42959,
+    "totalChars": 43118,
   },
   "slim-freeform-no-deck-signal": {
     "sections": [
@@ -338,7 +338,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "role-marker-guard",
     ],
-    "totalChars": 33683,
+    "totalChars": 33842,
   },
 }
 `;

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -14,7 +14,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 60675,
+    "totalChars": 62372,
   },
   "ask-mode-full-context": {
     "sections": [
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 46059,
+    "totalChars": 47887,
   },
   "critique-enabled": {
     "sections": [
@@ -69,7 +69,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 59063,
+    "totalChars": 60760,
   },
   "deck-kind-no-skill": {
     "sections": [
@@ -84,7 +84,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 85563,
+    "totalChars": 87260,
   },
   "deck-kind-with-skill-seed": {
     "sections": [
@@ -99,7 +99,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 58264,
+    "totalChars": 59961,
   },
   "design-ds-fixture-fallback": {
     "sections": [
@@ -120,7 +120,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 81645,
+    "totalChars": 83342,
   },
   "design-full-stack": {
     "sections": [
@@ -150,7 +150,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 68399,
+    "totalChars": 70096,
   },
   "design-minimal": {
     "sections": [
@@ -165,7 +165,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 85519,
+    "totalChars": 87216,
   },
   "design-no-ds-multitarget": {
     "sections": [
@@ -180,7 +180,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 63830,
+    "totalChars": 65527,
   },
   "example-prompt": {
     "sections": [
@@ -195,7 +195,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 62077,
+    "totalChars": 63774,
   },
   "freeform-other": {
     "sections": [
@@ -211,7 +211,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 89215,
+    "totalChars": 90912,
   },
   "freeform-other-no-deck-signal": {
     "sections": [
@@ -225,7 +225,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 61000,
+    "totalChars": 62697,
   },
   "media-image": {
     "sections": [
@@ -237,7 +237,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 46057,
+    "totalChars": 47885,
   },
   "memory-hooks-off": {
     "sections": [
@@ -254,7 +254,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 87747,
+    "totalChars": 89444,
   },
   "plan-mode": {
     "sections": [
@@ -269,7 +269,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 65024,
+    "totalChars": 66721,
   },
   "plugin-stages": {
     "sections": [
@@ -286,7 +286,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 85615,
+    "totalChars": 87312,
   },
   "skip-discovery-brief": {
     "sections": [
@@ -301,7 +301,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 61588,
+    "totalChars": 63285,
   },
   "slim-design-full-stack": {
     "sections": [
@@ -328,7 +328,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "role-marker-guard",
     ],
-    "totalChars": 41262,
+    "totalChars": 42959,
   },
   "slim-freeform-no-deck-signal": {
     "sections": [
@@ -338,7 +338,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "media-dispatch-hint",
       "role-marker-guard",
     ],
-    "totalChars": 31986,
+    "totalChars": 33683,
   },
 }
 `;

--- a/apps/daemon/tests/prompts/media-contract-mirror.test.ts
+++ b/apps/daemon/tests/prompts/media-contract-mirror.test.ts
@@ -42,12 +42,28 @@ describe('MEDIA_USER_REPLY_CONTRACT mirrors', () => {
     expect(daemonBody).toBe(contractsBody);
   });
 
-  it('carries all three outcomes in the copy the daemon actually renders', () => {
+  it('carries safe English and Simplified Chinese failure categories', () => {
+    const normalized = daemonBody.replace(/\s+/g, ' ');
     expect(daemonBody).toContain('图片已生成');
     expect(daemonBody).toContain('图片未生成：内容安全策略拒绝了该请求');
-    expect(daemonBody).toContain('图片生成服务暂时不可用');
+    expect(daemonBody).toContain('MEDIA_EXECUTION_DISABLED');
+    expect(daemonBody).toContain('本次任务未启用图片生成');
+    expect(daemonBody).toContain('STUB_PROVIDER_DISABLED');
+    expect(daemonBody).toContain('所选图片模型未配置可用的生成器');
+    expect(daemonBody).toContain('MEDIA_DISPATCHER_UNREACHABLE');
+    expect(daemonBody).toContain('无法连接本地媒体生成调度器');
+    expect(daemonBody).toContain('MEDIA_DISPATCH_NOT_INVOKED');
+    expect(daemonBody).toContain('未调用媒体生成调度器');
+    expect(daemonBody).toContain('MEDIA_DISPATCH_FAILED');
+    expect(daemonBody).toContain('媒体生成调度失败，原因未分类');
+    expect(normalized).toContain('Media generation was disabled for this run');
+    expect(normalized).toContain('The selected image model has no configured renderer');
+    expect(normalized).toContain('The local media dispatcher could not be reached');
+    expect(normalized).toContain('The media dispatcher was not invoked');
+    expect(normalized).toContain('The media dispatcher failed for an unclassified reason');
     expect(daemonBody).toContain('safety_rejection');
-		expect(daemonBody).toContain('错误代码：{code}');
-		expect(daemonBody).toContain('structured provider error');
+    expect(daemonBody).toContain('错误代码：{code}');
+    expect(normalized).toContain('structured dispatcher or provider error');
+    expect(daemonBody).not.toContain('图片生成服务暂时不可用');
   });
 });

--- a/apps/daemon/tests/prompts/media-contract-mirror.test.ts
+++ b/apps/daemon/tests/prompts/media-contract-mirror.test.ts
@@ -62,7 +62,8 @@ describe('MEDIA_USER_REPLY_CONTRACT mirrors', () => {
     expect(normalized).toContain('The media dispatcher was not invoked');
     expect(normalized).toContain('The media dispatcher failed for an unclassified reason');
     expect(daemonBody).toContain('safety_rejection');
-    expect(daemonBody).toContain('错误代码：{code}');
+    expect(daemonBody).toContain('错误代码：\\`MEDIA_EXECUTION_DISABLED\\`');
+    expect(daemonBody).toContain('错误代码：\\`{code}\\`');
     expect(normalized).toContain('structured dispatcher or provider error');
     expect(daemonBody).not.toContain('图片生成服务暂时不可用');
   });

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -559,6 +559,7 @@ describe('composeSystemPrompt', () => {
       expect(prompt).toContain('OpenDesign-owned media execution is **disabled for this run**');
       expect(prompt).toContain('MEDIA_EXECUTION_DISABLED');
       expect(prompt).toContain('本次任务未启用图片生成');
+      expect(prompt).not.toContain('describe the intended creative brief');
       expect(prompt).not.toContain('## Media generation contract');
       expect(prompt).not.toContain('External MCP servers — already authenticated');
     });

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -451,7 +451,7 @@ describe('composeSystemPrompt', () => {
           locale: 'zh-CN',
           metadata: metadata as any,
         });
-        expect(prompt).toContain('错误代码：{code}');
+        expect(prompt).toContain('错误代码：`{code}`');
         expect(prompt).toContain(
           'public code and message without reclassifying either one from wording or HTTP',
         );

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -410,14 +410,15 @@ describe('composeSystemPrompt', () => {
       expect(claudePrompt).toContain('`--model flux-pro-ultra`');
     });
 
-    it('keeps image completion copy generic while retaining internal diagnostics', () => {
+    it('keeps image completion copy concrete while retaining internal diagnostics', () => {
       const imagePrompt = composeSystemPrompt({
         agentId: 'amr',
         locale: 'zh-CN',
         metadata: { kind: 'image', imageModel: 'vela/gpt-image-2' } as any,
       });
       expect(imagePrompt).toContain('reply exactly `图片已生成`');
-      expect(imagePrompt).toContain('reply exactly `图片生成服务暂时不可用`');
+      expect(imagePrompt).toContain('MEDIA_DISPATCH_FAILED');
+      expect(imagePrompt).toContain('图片未生成：媒体生成调度失败，原因未分类');
       expect(imagePrompt).toContain('tool output and daemon logs');
       expect(imagePrompt).not.toContain('the filename, the model used');
       expect(imagePrompt).not.toContain('surface them verbatim to the user');
@@ -429,7 +430,8 @@ describe('composeSystemPrompt', () => {
         metadata: { kind: 'prototype' } as any,
       });
       expect(prototypePrompt).toContain('reply exactly `图片已生成`');
-      expect(prototypePrompt).toContain('reply exactly `图片生成服务暂时不可用`');
+      expect(prototypePrompt).toContain('MEDIA_DISPATCH_FAILED');
+      expect(prototypePrompt).toContain('图片未生成：媒体生成调度失败，原因未分类');
       expect(prototypePrompt).toContain('IMAGE_MODEL="vela/gpt-image-2"');
       expect(prototypePrompt).not.toContain(
         'For the best fal image model use `--model flux-pro-ultra`',
@@ -451,7 +453,7 @@ describe('composeSystemPrompt', () => {
         });
         expect(prompt).toContain('错误代码：{code}');
         expect(prompt).toContain(
-          'without reclassifying either one from wording or HTTP status',
+          'public code and message without reclassifying either one from wording or HTTP',
         );
       }
     });
@@ -555,6 +557,8 @@ describe('composeSystemPrompt', () => {
         mediaExecution: { mode: 'disabled' },
       });
       expect(prompt).toContain('OpenDesign-owned media execution is **disabled for this run**');
+      expect(prompt).toContain('MEDIA_EXECUTION_DISABLED');
+      expect(prompt).toContain('本次任务未启用图片生成');
       expect(prompt).not.toContain('## Media generation contract');
       expect(prompt).not.toContain('External MCP servers — already authenticated');
     });

--- a/packages/contracts/src/prompts/media-contract.ts
+++ b/packages/contracts/src/prompts/media-contract.ts
@@ -17,20 +17,45 @@ localized sentence and nothing else:
   \`safety_rejection\`: say the localized equivalent of "The image was not
   generated because a content safety policy refused the request". For
   Simplified Chinese, reply exactly \`图片未生成：内容安全策略拒绝了该请求\`.
-- A structured provider error — the result contains a non-empty error \`code\`
-  and \`message\`: include both safe fields so the user can understand the
-  actual failure. For Simplified Chinese, reply exactly
-  \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned values.
-- Any other failure, including a placeholder/stub outcome: say the localized
-  equivalent of "The image generation service is temporarily unavailable". For
-  Simplified Chinese, reply exactly \`图片生成服务暂时不可用\`.
+- A known local failure: ignore diagnostic wording and use the fixed safe copy
+  for its code:
+  - \`MEDIA_EXECUTION_DISABLED\`: "Image was not generated: Media generation was
+    disabled for this run (error code: MEDIA_EXECUTION_DISABLED)." Simplified
+    Chinese: \`图片未生成：本次任务未启用图片生成（错误代码：MEDIA_EXECUTION_DISABLED）\`.
+  - \`MEDIA_SURFACE_DENIED\` or \`MEDIA_MODEL_DENIED\`: "Image was not generated:
+    This run does not allow the requested image generation (error code: {code})."
+    Simplified Chinese: \`图片未生成：本次任务不允许所请求的图片生成（错误代码：{code}）\`.
+  - \`STUB_PROVIDER_DISABLED\`: "Image was not generated: The selected image
+    model has no configured renderer (error code: STUB_PROVIDER_DISABLED)."
+    Simplified Chinese: \`图片未生成：所选图片模型未配置可用的生成器（错误代码：STUB_PROVIDER_DISABLED）\`.
+  - \`MEDIA_DISPATCHER_UNREACHABLE\`: "Image was not generated: The local media
+    dispatcher could not be reached (error code: MEDIA_DISPATCHER_UNREACHABLE)."
+    Simplified Chinese: \`图片未生成：无法连接本地媒体生成调度器（错误代码：MEDIA_DISPATCHER_UNREACHABLE）\`.
+  - \`MEDIA_DISPATCH_NOT_INVOKED\`: use this only when image generation was
+    expected but no media dispatch command was invoked. Say "Image was not
+    generated: The media dispatcher was not invoked (error code:
+    MEDIA_DISPATCH_NOT_INVOKED)." Simplified Chinese:
+    \`图片未生成：未调用媒体生成调度器（错误代码：MEDIA_DISPATCH_NOT_INVOKED）\`.
+  - \`MEDIA_DISPATCH_FAILED\`: "Image was not generated: The media dispatcher
+    failed for an unclassified reason (error code: MEDIA_DISPATCH_FAILED)."
+    Simplified Chinese: \`图片未生成：媒体生成调度失败，原因未分类（错误代码：MEDIA_DISPATCH_FAILED）\`.
+- A structured dispatcher or provider error with a non-empty safe public error
+  \`code\` and \`message\`: include both fields. For Simplified Chinese, reply
+  exactly \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned
+  values. Never use an unsanitized response body, stderr, or diagnostic field.
+- Any other failure: use \`MEDIA_DISPATCH_FAILED\` and its fixed copy above.
+  Do not infer an outage from HTTP status, a placeholder/stub, missing output,
+  or model-generated fallback text.
 
-A provider verdict is not automatically an outage. Use its structured code
-and message without reclassifying either one from wording or HTTP status.
+A provider verdict is not automatically an outage. Use its structured safe
+public code and message without reclassifying either one from wording or HTTP
+status. Claim service unavailability only when a structured availability code
+explicitly establishes it.
 
 Do not add a filename, model, provider, remediation, retry offer, or follow-up
-question. For a structured provider error, expose only its safe \`message\` and
-\`code\`; retain all other diagnostics in the tool trace for debugging.`;
+question. Expose only the fixed local-category copy or a structured safe public
+\`message\` and \`code\`; retain all other diagnostics in the tool trace for
+debugging.`;
 
 export const MEDIA_GENERATION_CONTRACT = `
 ---

--- a/packages/contracts/src/prompts/media-contract.ts
+++ b/packages/contracts/src/prompts/media-contract.ts
@@ -20,28 +20,31 @@ localized sentence and nothing else:
 - A known local failure: ignore diagnostic wording and use the fixed safe copy
   for its code:
   - \`MEDIA_EXECUTION_DISABLED\`: "Image was not generated: Media generation was
-    disabled for this run (error code: MEDIA_EXECUTION_DISABLED)." Simplified
-    Chinese: \`图片未生成：本次任务未启用图片生成（错误代码：MEDIA_EXECUTION_DISABLED）\`.
+    disabled for this run (error code: \`MEDIA_EXECUTION_DISABLED\`)." Simplified
+    Chinese: 图片未生成：本次任务未启用图片生成（错误代码：\`MEDIA_EXECUTION_DISABLED\`）.
   - \`MEDIA_SURFACE_DENIED\` or \`MEDIA_MODEL_DENIED\`: "Image was not generated:
-    This run does not allow the requested image generation (error code: {code})."
-    Simplified Chinese: \`图片未生成：本次任务不允许所请求的图片生成（错误代码：{code}）\`.
+    This run does not allow the requested image generation (error code: \`{code}\`)."
+    Simplified Chinese: 图片未生成：本次任务不允许所请求的图片生成（错误代码：\`{code}\`）.
   - \`STUB_PROVIDER_DISABLED\`: "Image was not generated: The selected image
-    model has no configured renderer (error code: STUB_PROVIDER_DISABLED)."
-    Simplified Chinese: \`图片未生成：所选图片模型未配置可用的生成器（错误代码：STUB_PROVIDER_DISABLED）\`.
+    model has no configured renderer (error code: \`STUB_PROVIDER_DISABLED\`)."
+    Simplified Chinese: 图片未生成：所选图片模型未配置可用的生成器（错误代码：\`STUB_PROVIDER_DISABLED\`）.
   - \`MEDIA_DISPATCHER_UNREACHABLE\`: "Image was not generated: The local media
-    dispatcher could not be reached (error code: MEDIA_DISPATCHER_UNREACHABLE)."
-    Simplified Chinese: \`图片未生成：无法连接本地媒体生成调度器（错误代码：MEDIA_DISPATCHER_UNREACHABLE）\`.
+    dispatcher could not be reached (error code: \`MEDIA_DISPATCHER_UNREACHABLE\`)."
+    Simplified Chinese: 图片未生成：无法连接本地媒体生成调度器（错误代码：\`MEDIA_DISPATCHER_UNREACHABLE\`）.
   - \`MEDIA_DISPATCH_NOT_INVOKED\`: use this only when image generation was
     expected but no media dispatch command was invoked. Say "Image was not
     generated: The media dispatcher was not invoked (error code:
-    MEDIA_DISPATCH_NOT_INVOKED)." Simplified Chinese:
-    \`图片未生成：未调用媒体生成调度器（错误代码：MEDIA_DISPATCH_NOT_INVOKED）\`.
+    \`MEDIA_DISPATCH_NOT_INVOKED\`)." Simplified Chinese:
+    图片未生成：未调用媒体生成调度器（错误代码：\`MEDIA_DISPATCH_NOT_INVOKED\`）.
   - \`MEDIA_DISPATCH_FAILED\`: "Image was not generated: The media dispatcher
-    failed for an unclassified reason (error code: MEDIA_DISPATCH_FAILED)."
-    Simplified Chinese: \`图片未生成：媒体生成调度失败，原因未分类（错误代码：MEDIA_DISPATCH_FAILED）\`.
+    failed for an unclassified reason (error code: \`MEDIA_DISPATCH_FAILED\`)."
+    Simplified Chinese: 图片未生成：媒体生成调度失败，原因未分类（错误代码：\`MEDIA_DISPATCH_FAILED\`）.
+Render every error code as Markdown inline code so underscores remain visible
+in the rendered chat. Do not emit a bare underscore-delimited code.
+
 - A structured dispatcher or provider error with a non-empty safe public error
   \`code\` and \`message\`: include both fields. For Simplified Chinese, reply
-  exactly \`图片未生成：{message}（错误代码：{code}）\`, substituting the returned
+  exactly 图片未生成：{message}（错误代码：\`{code}\`）, substituting the returned
   values. Never use an unsanitized response body, stderr, or diagnostic field.
 - Any other failure: use \`MEDIA_DISPATCH_FAILED\` and its fixed copy above.
   Do not infer an outage from HTTP status, a placeholder/stub, missing output,

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -71,7 +71,10 @@ describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — prompt routing parity', 
     });
 
     expect(prompt).toContain('reply exactly `图片已生成`');
-    expect(prompt).toContain('reply exactly `图片生成服务暂时不可用`');
+    expect(prompt).toContain('图片未生成：内容安全策略拒绝了该请求');
+    expect(prompt).toContain('图片未生成：媒体生成调度失败，原因未分类');
+    expect(prompt).toContain('错误代码：`MEDIA_DISPATCH_FAILED`');
+    expect(prompt).not.toContain('图片生成服务暂时不可用');
     expect(prompt).toContain('tool output and daemon logs');
     expect(prompt).not.toContain('surface the actual stderr / exit status');
   });


### PR DESCRIPTION
Fixes #7116

## Why

A Vela test image run displayed “图片生成服务暂时不可用” even though Link and the image provider were healthy during the observed window. The same generic fallback was used for policy denial, missing renderers, local dispatcher failures, and genuinely unclassified outcomes, which gave users a false outage diagnosis and made agent-side recovery harder.

This PR preserves structured daemon failures through the public media CLI and gives the media reply contract a safe, explicit vocabulary without exposing raw operational diagnostics.

## What users will see

Failed image requests now return one concise localized reason instead of defaulting to a service-outage claim. The reply distinguishes disabled/denied media execution, an unconfigured renderer, a dispatcher that was not invoked or could not be reached, structured provider failures, content-safety rejection, and an unclassified dispatcher failure. Known local categories use fixed safe English and Simplified Chinese copy plus a stable error code.

`od media generate` also emits an immediately parseable JSON error envelope for non-2xx daemon responses. Unknown daemon bodies and network errors are classified without echoing raw stderr, URLs, internal paths, IDs, or diagnostic fields.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: no web or desktop UI component changed. The packaged Electron renderer was smoke-tested through `tools-pack mac inspect` and a local screenshot capture.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/media-generate-structured-error.test.ts`
- The public `od media generate` test went red on `main` because stderr began with `daemon 403:` and was not parseable JSON; it is green on this branch.
- Prompt coverage: `apps/daemon/tests/prompts/media-contract-mirror.test.ts`, `apps/daemon/tests/prompts/system.test.ts`, and `apps/daemon/tests/prompts/system-prompt-matrix.test.ts` pin the mirrored English/Chinese categories and disabled-run behavior.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/media-generate-structured-error.test.ts tests/media-wait-safety-output.test.ts tests/prompts/media-contract-mirror.test.ts tests/prompts/system.test.ts tests/prompts/system-prompt-matrix.test.ts tests/system-prompt-template.test.ts tests/cli-startup.test.ts` — 104 passed
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- `pnpm tools-pack mac build --namespace issue-7116 --to dmg --json`
- `pnpm tools-pack mac install/start/inspect/logs/stop --namespace issue-7116 --json`
- DMG packaged CLI probe passed for policy denial, unclassified immediate failure, structured provider failure, renderer-not-configured, content-safety rejection, provider task failure, and dispatcher-unreachable.
- Packaged prompt probe confirmed all required English/Simplified Chinese category markers and confirmed the old `图片生成服务暂时不可用` fallback is absent.
- The first full daemon-suite attempt exposed a missing local HyperFrames dependency and timed out; after `pnpm install --frozen-lockfile`, the isolated affected runtime file passed 11/11 and the 104-test impacted suite above passed.
