### PR TITLE
fix daemon: hide media models from chat picker

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -104,6 +104,8 @@ function isVelaChatModelId(modelId: string): boolean {
   // Remove this filter when AMR grows first-class image/video execution.
   const id = modelId.toLowerCase();
   if (id.startsWith('gpt-image-')) return false;
+  if (id.startsWith('nano-banana-')) return false;
+  if (id.startsWith('seedream-')) return false;
   if (id.startsWith('seedance-')) return false;
   if (id.startsWith('doubao-seedance-')) return false;
   if (id.startsWith('veo-')) return false;

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -202,6 +202,10 @@ describe('AMR runtime def', () => {
       'public_model_glm_5_1          vela',
       'public_model_claude_opus_4_6  vela',
       'public_model_gpt_image_2      vela',
+      'public_model_nano_banana_2    vela',
+      'public_model_nano_banana_2_lite vela',
+      'public_model_seedream_5_0     vela',
+      'public_model_seedream_5_0_pro vela',
       'vela/kimi-k2.6                vela',
       'public_model_seedance_2       vela',
       'public_model_deepseek_v3_2    vela',
@@ -216,6 +220,10 @@ describe('AMR runtime def', () => {
     ]);
     expect(models.every((model) => !model.label.includes('vela/'))).toBe(true);
     expect(models.map((model) => model.id)).not.toContain('gpt-image-2');
+    expect(models.map((model) => model.id)).not.toContain('nano-banana-2');
+    expect(models.map((model) => model.id)).not.toContain('nano-banana-2-lite');
+    expect(models.map((model) => model.id)).not.toContain('seedream-5-0');
+    expect(models.map((model) => model.id)).not.toContain('seedream-5-0-pro');
     expect(models.map((model) => model.id)).not.toContain('seedance-2');
   });
 
@@ -233,6 +241,10 @@ describe('AMR runtime def', () => {
           metadata: { cost: 'low', capability: 'standard' },
         },
         { id: 'gpt-image-2' },
+        { id: 'nano-banana-2' },
+        { id: 'nano-banana-2-lite' },
+        { id: 'seedream-5.0' },
+        { id: 'seedream-5.0-pro' },
         { id: 'deepseek-v4-flash' },
       ],
     }), 'remote');
@@ -250,6 +262,10 @@ describe('AMR runtime def', () => {
       { id: 'kimi-k2.7-code', label: 'kimi-k2.7-code', enabled: false },
     ]);
     expect(models.map((m) => m.id)).not.toContain('gpt-image-2');
+    expect(models.map((m) => m.id)).not.toContain('nano-banana-2');
+    expect(models.map((m) => m.id)).not.toContain('nano-banana-2-lite');
+    expect(models.map((m) => m.id)).not.toContain('seedream-5.0');
+    expect(models.map((m) => m.id)).not.toContain('seedream-5.0-pro');
     expect(models.map((m) => m.id)).not.toContain('public_model_kimi_k2_7_code');
     expect(() => parseVelaModelJson(JSON.stringify({ source: 'preset', data: [] }), 'remote'))
       .toThrow(/expected remote/);


### PR DESCRIPTION
## Why

OpenDesign's AMR runtime consumes Vela's general model catalog for the chat model picker. Vela now publishes image-generation models in that catalog, so `nano-banana-2`, `nano-banana-2-lite`, `seedream-5.0`, and `seedream-5.0-pro` appeared beside chat models even though the AMR runtime only drives chat completions on this surface.

This keeps media generation available through the Vela media CLI while preventing unsupported media models from being selected as chat models in OpenDesign.

## What users will see

The OpenDesign execution model dropdown no longer lists Vela image-generation models. Existing chat models remain unchanged, and `vela media gen` remains available because this filter only applies when OpenDesign parses Vela models for its chat runtime.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Validated against a locally built and installed arm64 DMG. The packaged model picker rendered 28 chat models and none of the five current Vela image models (`gpt-image-2`, both `nano-banana-2` variants, and both `seedream-5.0` variants).

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/amr-acp-integration.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** Before the source change, both the legacy text and canonical JSON parser tests failed because Nano Banana and Seedream entries remained in the parsed chat model list. Both pass after the filter change.
- Packaged verification: built and installed a local macOS arm64 DMG, opened the compact execution-model dropdown through desktop inspect, and asserted all five current Vela image model IDs were absent.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run -c vitest.config.ts tests/amr-acp-integration.test.ts` from `apps/daemon` — 40 passed
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- `pnpm tools-pack mac build --to dmg` plus isolated install/start/desktop inspect validation
