### PR TITLE
fix(web,daemon): preview snapshot bridge captured every real page as blank (empty-render)

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -1172,6 +1172,13 @@ const URL_PREVIEW_SNAPSHOT_BRIDGE = `<script data-od-url-snapshot-bridge>
       copyComputedStyle(originals[i], clones[i]);
       syncElementState(originals[i], clones[i]);
     }
+  }
+  // Must run AFTER pruneHiddenSnapshotNodes: prune pairs originalRoot/cloneRoot
+  // querySelectorAll('*') lists by index, so removing clone nodes (scripts,
+  // links) before it shifts every later clone under the wrong original and the
+  // misdirected removals can delete the visible content (or the body itself),
+  // yielding a uniform "empty-render" frame.
+  function stripSnapshotResources(cloneRoot){
     var scripts = cloneRoot.querySelectorAll('script');
     for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
     var links = cloneRoot.querySelectorAll('link[rel~="stylesheet"], link[rel~="preload"], link[rel~="preconnect"]');
@@ -1182,6 +1189,29 @@ const URL_PREVIEW_SNAPSHOT_BRIDGE = `<script data-od-url-snapshot-bridge>
         .replace(/@import[^;]+;/gi, '')
         .replace(/@font-face\\s*\\{[^}]*\\}/gi, '');
     }
+    // HTML tolerates attribute names XML rejects (@click, :href, {shorthand}).
+    // One such attribute anywhere makes the whole foreignObject SVG unparseable,
+    // so drop any attribute whose name is not a valid XML Name.
+    var XML_NAME = /^[A-Za-z_][A-Za-z0-9_.-]*(?::[A-Za-z_][A-Za-z0-9_.-]*)?$/;
+    var all = cloneRoot.querySelectorAll('*');
+    for (var e = 0; e < all.length; e++) {
+      var attrs = all[e].attributes;
+      for (var a = attrs.length - 1; a >= 0; a--) {
+        if (!XML_NAME.test(attrs[a].name)) all[e].removeAttribute(attrs[a].name);
+      }
+    }
+  }
+  // innerHTML uses the HTML serializer, which emits void elements (<br>, <img>)
+  // without self-closing slashes — invalid XML, so the foreignObject SVG image
+  // fails to parse (img.onerror → 'snapshot image failed'). XMLSerializer emits
+  // well-formed XHTML instead.
+  function serializeSnapshotXhtml(node){
+    try {
+      var serializer = new XMLSerializer();
+      var out = '';
+      for (var i = 0; i < node.childNodes.length; i++) out += serializer.serializeToString(node.childNodes[i]);
+      return out;
+    } catch (_) { return node.innerHTML || ''; }
   }
   function pruneHiddenSnapshotNodes(originalRoot, cloneRoot){
     var originals = originalRoot.querySelectorAll('*');
@@ -1253,11 +1283,12 @@ const URL_PREVIEW_SNAPSHOT_BRIDGE = `<script data-od-url-snapshot-bridge>
     clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     inlineSnapshotStyles(document.documentElement, clone);
     pruneHiddenSnapshotNodes(document.documentElement, clone);
+    stripSnapshotResources(clone);
     var scroll = scrollOffset();
     var cloneBody = clone.querySelector('body');
     var rootStyle = clone.getAttribute('style') || '';
     var bodyStyle = cloneBody ? cloneBody.getAttribute('style') || '' : '';
-    var bodyContent = cloneBody ? cloneBody.innerHTML : clone.innerHTML;
+    var bodyContent = serializeSnapshotXhtml(cloneBody || clone);
     var wrapperStyle = rootStyle + bodyStyle +
       'margin:0;position:relative;left:' + (-scroll.x) + 'px;top:' + (-scroll.y) + 'px;' +
       'width:' + docW + 'px;height:' + docH + 'px;overflow:visible;';

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -661,6 +661,13 @@ function injectSnapshotBridge(doc: string): string {
       copyComputedStyle(originals[i], clones[i]);
       syncElementState(originals[i], clones[i]);
     }
+  }
+  // Must run AFTER pruneHiddenSnapshotNodes: prune pairs originalRoot/cloneRoot
+  // querySelectorAll('*') lists by index, so removing clone nodes (scripts,
+  // links) before it shifts every later clone under the wrong original and the
+  // misdirected removals can delete the visible content (or the body itself),
+  // yielding a uniform "empty-render" frame.
+  function stripSnapshotResources(cloneRoot){
     var scripts = cloneRoot.querySelectorAll('script');
     for (var s = scripts.length - 1; s >= 0; s--) scripts[s].remove();
     var links = cloneRoot.querySelectorAll('link[rel~="stylesheet"], link[rel~="preload"], link[rel~="preconnect"]');
@@ -671,6 +678,29 @@ function injectSnapshotBridge(doc: string): string {
         .replace(/@import[^;]+;/gi, '')
         .replace(/@font-face\\s*\\{[^}]*\\}/gi, '');
     }
+    // HTML tolerates attribute names XML rejects (@click, :href, {shorthand}).
+    // One such attribute anywhere makes the whole foreignObject SVG unparseable,
+    // so drop any attribute whose name is not a valid XML Name.
+    var XML_NAME = /^[A-Za-z_][A-Za-z0-9_.-]*(?::[A-Za-z_][A-Za-z0-9_.-]*)?$/;
+    var all = cloneRoot.querySelectorAll('*');
+    for (var e = 0; e < all.length; e++) {
+      var attrs = all[e].attributes;
+      for (var a = attrs.length - 1; a >= 0; a--) {
+        if (!XML_NAME.test(attrs[a].name)) all[e].removeAttribute(attrs[a].name);
+      }
+    }
+  }
+  // innerHTML uses the HTML serializer, which emits void elements (<br>, <img>)
+  // without self-closing slashes — invalid XML, so the foreignObject SVG image
+  // fails to parse (img.onerror → 'snapshot image failed'). XMLSerializer emits
+  // well-formed XHTML instead.
+  function serializeSnapshotXhtml(node){
+    try {
+      var serializer = new XMLSerializer();
+      var out = '';
+      for (var i = 0; i < node.childNodes.length; i++) out += serializer.serializeToString(node.childNodes[i]);
+      return out;
+    } catch (_) { return node.innerHTML || ''; }
   }
   function pruneHiddenSnapshotNodes(originalRoot, cloneRoot){
     var originals = originalRoot.querySelectorAll('*');
@@ -759,11 +789,12 @@ function injectSnapshotBridge(doc: string): string {
       clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
       inlineSnapshotStyles(document.documentElement, clone);
       pruneHiddenSnapshotNodes(document.documentElement, clone);
+      stripSnapshotResources(clone);
       var scroll = full ? { x: 0, y: 0 } : scrollOffset();
       var cloneBody = clone.querySelector('body');
       var rootStyle = clone.getAttribute('style') || '';
       var bodyStyle = cloneBody ? cloneBody.getAttribute('style') || '' : '';
-      var bodyContent = cloneBody ? cloneBody.innerHTML : clone.innerHTML;
+      var bodyContent = serializeSnapshotXhtml(cloneBody || clone);
       var wrapperStyle = rootStyle + bodyStyle +
         'margin:0;position:relative;left:' + (-scroll.x) + 'px;top:' + (-scroll.y) + 'px;' +
         'width:' + docW + 'px;height:' + docH + 'px;overflow:visible;';

--- a/apps/web/tests/runtime/srcdoc.test.ts
+++ b/apps/web/tests/runtime/srcdoc.test.ts
@@ -263,6 +263,44 @@ describe('buildSrcdoc', () => {
     expect(srcdoc).toContain('pruneHiddenSnapshotNodes(document.documentElement, clone)');
   });
 
+  it('strips snapshot resources only AFTER pruning so the original/clone lists stay index-aligned', () => {
+    // Regression (#5444): prune pairs original/clone querySelectorAll('*')
+    // lists by index. Removing clone scripts/links first shifted every later
+    // clone under the wrong original and the misdirected removals deleted
+    // visible content (often the <body> itself), so any page containing a
+    // script or stylesheet link rasterized as a uniform frame → the capture
+    // failed with 'empty-render' ("Preview is still loading" toast) on every
+    // pure-web (no desktop compositor) deployment.
+    const srcdoc = buildSrcdoc('<main style="color:red">Hero</main>');
+
+    expect(srcdoc).toContain('function stripSnapshotResources');
+    const pruneCall = srcdoc.indexOf('pruneHiddenSnapshotNodes(document.documentElement, clone)');
+    const stripCall = srcdoc.indexOf('stripSnapshotResources(clone)');
+    expect(pruneCall).toBeGreaterThan(-1);
+    expect(stripCall).toBeGreaterThan(pruneCall);
+    // And inlineSnapshotStyles no longer removes nodes itself.
+    const inlineBody = srcdoc.slice(
+      srcdoc.indexOf('function inlineSnapshotStyles'),
+      srcdoc.indexOf('function stripSnapshotResources'),
+    );
+    expect(inlineBody).not.toContain('.remove()');
+  });
+
+  it('serializes snapshot content as XHTML so void elements do not break the SVG parse', () => {
+    // Regression (#5444): innerHTML emits void elements (<br>, <img>) without
+    // self-closing slashes — invalid XML inside foreignObject, so the SVG
+    // image fired onerror ('snapshot image failed') for any page containing
+    // one. XMLSerializer emits well-formed XHTML; XML-invalid attribute
+    // names (@click, :href) are dropped for the same reason.
+    const srcdoc = buildSrcdoc('<main style="color:red">Hero<br><img alt="x"></main>');
+
+    expect(srcdoc).toContain('function serializeSnapshotXhtml');
+    expect(srcdoc).toContain('new XMLSerializer()');
+    expect(srcdoc).toContain('serializeSnapshotXhtml(cloneBody || clone)');
+    expect(srcdoc).not.toContain('cloneBody ? cloneBody.innerHTML : clone.innerHTML');
+    expect(srcdoc).toContain('XML_NAME');
+  });
+
   it('injects a deck-stage fallback before the deck bridge for broken runtime decks', () => {
     const srcdoc = buildSrcdoc(brokenDeckStageHtml, { deck: true });
 


### PR DESCRIPTION
Fixes #5444

## Why

I run Open Design in a browser-only deployment (web app + daemon, no desktop shell) and hit exactly what #5444 reports: every click on the preview's screenshot capture immediately fails with **"Preview is still loading. Try again in a moment."**, and Mark-mode annotations lose their screenshot — on every real page, while the preview itself renders fine.

Desktop never sees this because `captureHostIframeSnapshot` (the Electron compositor path) short-circuits the capture; pure-web deployments always fall through to the SVG `<foreignObject>` snapshot bridge, which turns out to have two stacked bugs. The maintainer's diagnosis in #5444 (the network dump showing an SVG with an **empty** `<foreignObject><div>` shell) is precisely bug 1's signature.

## What happens (root cause)

**Bug 1 — the prune step deletes the page content.** `inlineSnapshotStyles` strips `<script>`/`<link>` nodes from the clone, and *then* `pruneHiddenSnapshotNodes` runs — but prune pairs the original and clone `querySelectorAll('*')` lists **by index**. The earlier removals shift every later clone under the wrong original, so the hidden-node verdicts land on the wrong nodes and the removals delete visible content. Instrumented on a real page: original list 782 elements vs clone 776 after stripping → the misaligned prune removed the clone's **`<body>` itself**, so the serialized SVG was a 1.6 KB empty wrapper and the canvas came back uniform → `empty-render`. Any page with at least one script or stylesheet link (i.e. every real artifact) is affected; a trivial static page with neither stays aligned, which is why this survived so long.

**Bug 2 — innerHTML is not valid XML.** With bug 1 fixed, the next failure surfaces: `bodyContent` is serialized with `innerHTML`, whose HTML serialization emits void elements (`<br>`, `<img>`) without self-closing slashes. That is invalid XML inside `<foreignObject>`, so the SVG `<img>` fires `onerror` → `'snapshot image failed'` for any page containing a single void element.

## The fix

Same change in both copies of the bridge (`apps/web/src/runtime/srcdoc.ts` and the daemon-injected `URL_PREVIEW_SNAPSHOT_BRIDGE` in `apps/daemon/src/routes/project/index.ts`):

1. Moved the script/link/style stripping out of `inlineSnapshotStyles` into a new `stripSnapshotResources`, called **after** `pruneHiddenSnapshotNodes` — nothing may remove clone nodes while the original/clone lists still need to pair by index.
2. Serialize the body content with `XMLSerializer` (`serializeSnapshotXhtml`) instead of `innerHTML`, and drop attribute names that are not valid XML Names (`@click`, `:href`, `{shorthand}` — HTML tolerates them, the SVG XML parser does not).

## What users will see

In browser deployments (Docker/K8s, or `pnpm tools-dev run web` opened in a browser), the preview toolbar's screenshot capture and Mark-mode annotation screenshots now produce a real image instead of "Preview is still loading. Try again in a moment." / "Could not capture the preview." Desktop behavior is unchanged (compositor path still wins).

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — bug fix inside the existing capture path, no new surface

## Screenshots

No UI change (the fix makes the existing button work).

## Bug fix verification

- Test path: `apps/web/tests/runtime/srcdoc.test.ts` — two new specs: *"strips snapshot resources only AFTER pruning so the original/clone lists stay index-aligned"* and *"serializes snapshot content as XHTML so void elements do not break the SVG parse"*.
- Red on `main`, green on this branch? **Yes** — on `main` the two specs fail (2 failed | 39 passed), on this branch all 41 pass.
- Runtime verification beyond the specs: in a browser-mode run I drove the real bridge with Playwright — before the fix, a minimal page with only `<h1>` + `<div>` captured fine while the same page plus one `<script src>`/`<link>` returned `empty-render`, and one `<br>` returned `snapshot image failed`; after the fix a real ~10,000 px-tall artifact page returns a correct PNG and the screenshot flows end-to-end (capture → upload → staged chat attachment).

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` / `pnpm --filter @open-design/daemon typecheck` — pass
- `apps/web`: `vitest run tests/runtime/srcdoc.test.ts` — 41 passed (includes the 2 new regression specs)
- `apps/daemon`: `vitest run tests/project-preview-containment.test.ts tests/project-file-range.test.ts` (the suites covering the URL-preview serving path) — 54 passed
