### PR TITLE
fix(viewer): stabilize retained HTML previews

### DIFF
--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -11,6 +11,8 @@ import type {
   OpenDesignHostProjectImportInit,
   OpenDesignHostProjectReplaceWorkingDirResult,
   OpenDesignHostPickWorkingDirResult,
+  OpenDesignHostPreviewNavigationFailure,
+  OpenDesignHostPreviewNavigationFailureListener,
   OpenDesignHostUpdaterActionOptions,
   OpenDesignHostUpdaterMenuLabels,
   OpenDesignHostUpdaterOpenDialogListener,
@@ -25,6 +27,7 @@ const UPDATER_STATUS_EVENT = 'od:update:status-changed';
 const UPDATER_OPEN_DIALOG_EVENT = 'od:update:open-dialog';
 const APP_CONFIG_CHANGED_IPC_CHANNEL = 'od:app-config-changed';
 const APP_CONFIG_CHANGED_EVENT = 'open-design:app-config-changed';
+const PREVIEW_NAVIGATION_FAILURE_IPC_CHANNEL = 'od:preview-navigation-failed';
 
 // Mirror of the argv prefix used by main's `applyOsLocaleSwitch` and
 // runtime's `additionalArguments`. Duplicated literal on purpose: the
@@ -244,6 +247,46 @@ const capture = {
   },
 };
 
+let latestPreviewNavigationFailure: OpenDesignHostPreviewNavigationFailure | null = null;
+const previewNavigationFailureListeners = new Set<OpenDesignHostPreviewNavigationFailureListener>();
+
+ipcRenderer.on(PREVIEW_NAVIGATION_FAILURE_IPC_CHANNEL, (
+  _event: unknown,
+  failure: OpenDesignHostPreviewNavigationFailure,
+): void => {
+  if (
+    failure == null
+    || typeof failure !== 'object'
+    || !Number.isSafeInteger(failure.eventId)
+    || typeof failure.errorCode !== 'number'
+    || !Number.isFinite(failure.occurredAtMs)
+    || typeof failure.validatedUrl !== 'string'
+    || (failure.frameName !== undefined && typeof failure.frameName !== 'string')
+  ) return;
+  latestPreviewNavigationFailure = failure;
+  for (const listener of previewNavigationFailureListeners) {
+    try {
+      listener(failure);
+    } catch {
+      // A renderer listener must not prevent other active viewers from
+      // receiving the same host-owned failure signal.
+    }
+  }
+});
+
+const preview = {
+  getLatestNavigationFailure: (): OpenDesignHostPreviewNavigationFailure | null =>
+    latestPreviewNavigationFailure,
+  subscribeNavigationFailure: (
+    listener: OpenDesignHostPreviewNavigationFailureListener,
+  ): (() => void) => {
+    previewNavigationFailureListeners.add(listener);
+    return () => {
+      previewNavigationFailureListeners.delete(listener);
+    };
+  },
+};
+
 function invokeUpdater(
   action: 'check' | 'clear-cache' | 'download' | 'install' | 'status',
   options?: OpenDesignHostUpdaterActionOptions,
@@ -319,6 +362,7 @@ const hostBridge = {
   shell,
   browser,
   capture,
+  preview,
   project,
   pdf: {
     print: async (html: string, nonce?: string, options?: PrintPdfOptions): Promise<OpenDesignHostActionResult> => {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -6,7 +6,8 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
-import { BrowserWindow, app, dialog, ipcMain, nativeImage, nativeTheme, screen, session, shell } from "electron";
+import { BrowserWindow, app, dialog, ipcMain, nativeImage, nativeTheme, screen, session, shell, webFrameMain } from "electron";
+import type { WebFrameMain } from "electron";
 import {
   DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_MODES,
@@ -22,6 +23,7 @@ import {
 import type {
   OpenDesignHostActionResult,
   OpenDesignHostCaptureResult,
+  OpenDesignHostPreviewNavigationFailure,
   OpenDesignHostProjectImportInit,
   OpenDesignHostUpdaterActionOptions,
   OpenDesignHostUpdaterMenuLabels,
@@ -45,6 +47,31 @@ import {
 } from "./update-preflight.js";
 
 const execFileAsync = promisify(execFile);
+const PREVIEW_NAVIGATION_FAILURE_IPC_CHANNEL = "od:preview-navigation-failed";
+const ABORTED_NAVIGATION_ERROR_CODE = -3;
+let previewNavigationFailureEventSequence = 0;
+
+export function previewNavigationFailureFromDidFailLoad(input: {
+  errorCode: number;
+  eventId: number;
+  frameName?: string;
+  isMainFrame: boolean;
+  occurredAtMs: number;
+  validatedUrl: string;
+}): OpenDesignHostPreviewNavigationFailure | null {
+  if (
+    input.isMainFrame
+    || input.errorCode !== ABORTED_NAVIGATION_ERROR_CODE
+    || input.validatedUrl !== "about:srcdoc"
+  ) return null;
+  return {
+    errorCode: input.errorCode,
+    eventId: input.eventId,
+    ...(input.frameName ? { frameName: input.frameName } : {}),
+    occurredAtMs: input.occurredAtMs,
+    validatedUrl: input.validatedUrl,
+  };
+}
 
 /**
  * Result of validating a candidate path before exposing it to a
@@ -2257,6 +2284,34 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   installWindowChromeCssHook(window);
   showWindowButtons(window);
   attachDownloadSaveAsDialog(window);
+  const previewFrameNameByRoutingId = new Map<string, string>();
+  const previewFrameRoutingKey = (processId: number, routingId: number) =>
+    `${processId}:${routingId}`;
+  const rememberPreviewFrameName = (frame: WebFrameMain | null | undefined) => {
+    if (!frame?.name.startsWith("od-artifact-preview-srcdoc-")) return;
+    const key = previewFrameRoutingKey(frame.processId, frame.routingId);
+    previewFrameNameByRoutingId.set(key, frame.name);
+    // Routing IDs are unique for a frame lifetime, but this process can run
+    // for days. Keep the late-failure lookup bounded without retaining frame
+    // objects after Chromium destroys them.
+    if (previewFrameNameByRoutingId.size > 512) {
+      const oldestKey = previewFrameNameByRoutingId.keys().next().value;
+      if (oldestKey) previewFrameNameByRoutingId.delete(oldestKey);
+    }
+  };
+  window.webContents.on("frame-created", (_event, details) => {
+    const frame = details.frame;
+    if (!frame) return;
+    rememberPreviewFrameName(frame);
+    frame.on("dom-ready", () => rememberPreviewFrameName(frame));
+  });
+  window.webContents.on("did-start-navigation", (details) => {
+    if (details.isMainFrame || details.url !== "about:srcdoc") return;
+    // `did-fail-load` can arrive after Chromium has destroyed the frame, at
+    // which point webFrameMain.fromId() and frame-created/dom-ready are too
+    // late to recover its name. Snapshot the identity when navigation starts.
+    rememberPreviewFrameName(details.frame);
+  });
   window.on("page-title-updated", (event) => {
     event.preventDefault();
     window.setTitle(windowTitle);
@@ -2279,15 +2334,42 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
       url: window.webContents.getURL(),
     });
   });
-  window.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+  window.webContents.on("did-fail-load", (
+    _event,
+    errorCode,
+    errorDescription,
+    validatedURL,
+    isMainFrame,
+    frameProcessId,
+    frameRoutingId,
+  ) => {
+    const failedFrame = isMainFrame
+      ? undefined
+      : webFrameMain.fromId(frameProcessId, frameRoutingId);
+    const cachedFrameName = isMainFrame
+      ? undefined
+      : previewFrameNameByRoutingId.get(previewFrameRoutingKey(frameProcessId, frameRoutingId));
+    const frameName = failedFrame?.name || cachedFrameName;
     console.error("[open-design desktop] main window did-fail-load", {
       errorCode,
       errorDescription,
+      frameName,
+      frameProcessId,
+      frameRoutingId,
       isMainFrame,
       pendingUrl,
       validatedURL,
       url: window.webContents.getURL(),
     });
+    const failure = previewNavigationFailureFromDidFailLoad({
+      errorCode,
+      eventId: ++previewNavigationFailureEventSequence,
+      ...(frameName ? { frameName } : {}),
+      isMainFrame,
+      occurredAtMs: Date.now(),
+      validatedUrl: validatedURL,
+    });
+    if (failure) window.webContents.send(PREVIEW_NAVIGATION_FAILURE_IPC_CHANNEL, failure);
   });
   window.on("unresponsive", () => {
     console.error("[open-design desktop] main window unresponsive", {

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -51,6 +51,10 @@ const PREVIEW_NAVIGATION_FAILURE_IPC_CHANNEL = "od:preview-navigation-failed";
 const ABORTED_NAVIGATION_ERROR_CODE = -3;
 let previewNavigationFailureEventSequence = 0;
 
+function isPreviewTransportNavigationUrl(url: string): boolean {
+  return url === "about:srcdoc" || url.startsWith("blob:od://app/");
+}
+
 export function previewNavigationFailureFromDidFailLoad(input: {
   errorCode: number;
   eventId: number;
@@ -62,7 +66,7 @@ export function previewNavigationFailureFromDidFailLoad(input: {
   if (
     input.isMainFrame
     || input.errorCode !== ABORTED_NAVIGATION_ERROR_CODE
-    || input.validatedUrl !== "about:srcdoc"
+    || !isPreviewTransportNavigationUrl(input.validatedUrl)
   ) return null;
   return {
     errorCode: input.errorCode,
@@ -2306,7 +2310,7 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     frame.on("dom-ready", () => rememberPreviewFrameName(frame));
   });
   window.webContents.on("did-start-navigation", (details) => {
-    if (details.isMainFrame || details.url !== "about:srcdoc") return;
+    if (details.isMainFrame || !isPreviewTransportNavigationUrl(details.url)) return;
     // `did-fail-load` can arrive after Chromium has destroyed the frame, at
     // which point webFrameMain.fromId() and frame-created/dom-ready are too
     // late to recover its name. Snapshot the identity when navigation starts.

--- a/apps/desktop/tests/main/preview-navigation-failure.test.ts
+++ b/apps/desktop/tests/main/preview-navigation-failure.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { previewNavigationFailureFromDidFailLoad } from "../../src/main/runtime.js";
+
+describe("preview navigation failure forwarding", () => {
+  it("forwards only aborted about:srcdoc subframe navigations", () => {
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 1,
+      frameName: "od-artifact-preview-srcdoc",
+      isMainFrame: false,
+      occurredAtMs: 1234,
+      validatedUrl: "about:srcdoc",
+    })).toEqual({
+      errorCode: -3,
+      eventId: 1,
+      frameName: "od-artifact-preview-srcdoc",
+      occurredAtMs: 1234,
+      validatedUrl: "about:srcdoc",
+    });
+
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 2,
+      isMainFrame: true,
+      occurredAtMs: 1235,
+      validatedUrl: "about:srcdoc",
+    })).toBeNull();
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -6,
+      eventId: 3,
+      isMainFrame: false,
+      occurredAtMs: 1236,
+      validatedUrl: "about:srcdoc",
+    })).toBeNull();
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 4,
+      isMainFrame: false,
+      occurredAtMs: 1237,
+      validatedUrl: "https://example.com/",
+    })).toBeNull();
+  });
+});

--- a/apps/desktop/tests/main/preview-navigation-failure.test.ts
+++ b/apps/desktop/tests/main/preview-navigation-failure.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { previewNavigationFailureFromDidFailLoad } from "../../src/main/runtime.js";
 
 describe("preview navigation failure forwarding", () => {
-  it("forwards only aborted about:srcdoc subframe navigations", () => {
+  it("forwards only aborted Open Design preview transport subframe navigations", () => {
     expect(previewNavigationFailureFromDidFailLoad({
       errorCode: -3,
       eventId: 1,
@@ -22,23 +22,45 @@ describe("preview navigation failure forwarding", () => {
     expect(previewNavigationFailureFromDidFailLoad({
       errorCode: -3,
       eventId: 2,
-      isMainFrame: true,
-      occurredAtMs: 1235,
-      validatedUrl: "about:srcdoc",
-    })).toBeNull();
-    expect(previewNavigationFailureFromDidFailLoad({
-      errorCode: -6,
-      eventId: 3,
+      frameName: "od-artifact-preview-srcdoc",
       isMainFrame: false,
+      occurredAtMs: 1235,
+      validatedUrl: "blob:od://app/preview-document",
+    })).toEqual({
+      errorCode: -3,
+      eventId: 2,
+      frameName: "od-artifact-preview-srcdoc",
+      occurredAtMs: 1235,
+      validatedUrl: "blob:od://app/preview-document",
+    });
+
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 3,
+      isMainFrame: true,
       occurredAtMs: 1236,
       validatedUrl: "about:srcdoc",
     })).toBeNull();
     expect(previewNavigationFailureFromDidFailLoad({
-      errorCode: -3,
+      errorCode: -6,
       eventId: 4,
       isMainFrame: false,
       occurredAtMs: 1237,
+      validatedUrl: "about:srcdoc",
+    })).toBeNull();
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 5,
+      isMainFrame: false,
+      occurredAtMs: 1238,
       validatedUrl: "https://example.com/",
+    })).toBeNull();
+    expect(previewNavigationFailureFromDidFailLoad({
+      errorCode: -3,
+      eventId: 6,
+      isMainFrame: false,
+      occurredAtMs: 1239,
+      validatedUrl: "blob:https://example.com/preview-document",
     })).toBeNull();
   });
 });

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10693,9 +10693,11 @@ function HtmlViewer({
   const handleHostPreviewNavigationFailure = useCallback((
     failure: OpenDesignHostPreviewNavigationFailure,
   ) => {
+    const aboutSrcDocFailure = failure.validatedUrl === 'about:srcdoc';
+    const localBlobFailure = failure.validatedUrl.startsWith('blob:od://app/');
     if (
       failure.errorCode !== -3
-      || failure.validatedUrl !== 'about:srcdoc'
+      || (!aboutSrcDocFailure && !localBlobFailure)
       || !Number.isSafeInteger(failure.eventId)
       || !Number.isFinite(failure.occurredAtMs)
       || Date.now() - failure.occurredAtMs > SRC_DOC_PREVIEW_FAILURE_FRESHNESS_MS
@@ -10724,6 +10726,18 @@ function HtmlViewer({
       // HTML -> white -> HTML flash we are trying to prevent.
       return;
     }
+    if (
+      localBlobFailure
+      && failure.frameName === frame.name
+      && frame.getAttribute('src') === failure.validatedUrl
+    ) {
+      // Unlike an eager about:srcdoc acknowledgement, an exact failure for
+      // the active Open Design Blob URL identifies the navigation that owns
+      // this frame. Recover immediately instead of adding the fixed 1.5s
+      // probe timeout to every affected file-tab activation.
+      recoverUnacknowledgedSrcDocTransport(generation, 'host_navigation_abort');
+      return;
+    }
     // An independently unverified document is challenged immediately. When
     // Chromium destroys the failed frame before Electron can resolve its
     // name, challenge the one active srcdoc frame instead. A healthy frame
@@ -10731,7 +10745,7 @@ function HtmlViewer({
     // replace at most one shell per generation, so an unscoped host signal
     // cannot create a reload loop or disturb a verified preview.
     probeSrcDocTransport(generation, true);
-  }, [mode, probeSrcDocTransport, useUrlLoadPreview]);
+  }, [mode, probeSrcDocTransport, recoverUnacknowledgedSrcDocTransport, useUrlLoadPreview]);
   useEffect(() => {
     const unsubscribe = subscribeHostPreviewNavigationFailure(
       handleHostPreviewNavigationFailure,
@@ -10921,7 +10935,6 @@ function HtmlViewer({
   useEffect(() => {
     if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
     const generation = srcDocTransportGeneration;
-    if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
     const timeout = window.setTimeout(() => {
       const frame = srcDocPreviewIframeRef.current;
       const verified = verifiedSrcDocTransportRef.current;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10431,7 +10431,18 @@ function HtmlViewer({
     generation: string;
     deadline: number;
   } | null>(null);
-  const srcDocRecoveryAttemptedGenerationRef = useRef<string | null>(null);
+  const srcDocTransportActivationEpochRef = useRef(0);
+  const previousSrcDocTransportWorkspaceActiveRef = useRef(false);
+  const srcDocRecoveryAttemptRef = useRef<{
+    generation: string;
+    activationEpoch: number;
+  } | null>(null);
+  useEffect(() => {
+    if (workspaceActive && !previousSrcDocTransportWorkspaceActiveRef.current) {
+      srcDocTransportActivationEpochRef.current += 1;
+    }
+    previousSrcDocTransportWorkspaceActiveRef.current = workspaceActive;
+  }, [workspaceActive]);
   const clearSrcDocTransportTimeouts = useCallback(() => {
     for (const timeout of srcDocTransportTimeoutsRef.current) {
       window.clearTimeout(timeout);
@@ -10454,7 +10465,7 @@ function HtmlViewer({
     cancelPendingSrcDocTransport();
     readySrcDocTransportRef.current = null;
     verifiedSrcDocTransportRef.current = null;
-    srcDocRecoveryAttemptedGenerationRef.current = null;
+    srcDocRecoveryAttemptRef.current = null;
     srcDocNavigationCommittedRef.current = null;
     srcDocContentReadyRef.current = null;
   }, [cancelPendingSrcDocTransport]);
@@ -10602,8 +10613,13 @@ function HtmlViewer({
     const frame = srcDocPreviewIframeRef.current;
     const verified = verifiedSrcDocTransportRef.current;
     if (frame && verified?.frame === frame && verified.generation === generation) return;
-    if (srcDocRecoveryAttemptedGenerationRef.current === generation) return;
-    srcDocRecoveryAttemptedGenerationRef.current = generation;
+    const recoveryAttempt = srcDocRecoveryAttemptRef.current;
+    const activationEpoch = srcDocTransportActivationEpochRef.current;
+    if (
+      recoveryAttempt?.generation === generation
+      && recoveryAttempt.activationEpoch === activationEpoch
+    ) return;
+    srcDocRecoveryAttemptRef.current = { generation, activationEpoch };
     const ready = readySrcDocTransportRef.current;
     cancelPendingSrcDocTransport();
     reportPreviewTransportRecovery({
@@ -10629,6 +10645,31 @@ function HtmlViewer({
     setSrcDocRecoveryGeneration(generation);
     setSrcDocTransportResetKey((key) => key + 1);
   }, [cancelPendingSrcDocTransport, file.kind, file.name, handoffArtifactKind, projectId]);
+  useEffect(() => {
+    if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
+    const generation = srcDocTransportGeneration;
+    const previousAttempt = srcDocRecoveryAttemptRef.current;
+    if (
+      previousAttempt?.generation !== generation
+      || previousAttempt.activationEpoch === srcDocTransportActivationEpochRef.current
+    ) return;
+    const frame = srcDocPreviewIframeRef.current;
+    const verified = verifiedSrcDocTransportRef.current;
+    if (frame && verified?.frame === frame && verified.generation === generation) return;
+    // A previous visible activation already consumed its one recovery, but the
+    // replacement navigation was interrupted while this retained viewer was
+    // hidden. Treat returning to the file/project as a new bounded navigation
+    // epoch and replace the still-unverified shell immediately. Waiting for a
+    // second probe timeout leaves the user staring at the aborted white frame.
+    recoverUnacknowledgedSrcDocTransport(generation, 'reactivation_unverified');
+  }, [
+    mode,
+    recoverUnacknowledgedSrcDocTransport,
+    srcDoc,
+    srcDocTransportGeneration,
+    useUrlLoadPreview,
+    workspaceActive,
+  ]);
   const probeSrcDocTransport = useCallback((
     generation: string,
     recoverOnFailure: boolean,
@@ -10742,8 +10783,8 @@ function HtmlViewer({
     // Chromium destroys the failed frame before Electron can resolve its
     // name, challenge the one active srcdoc frame instead. A healthy frame
     // acknowledges without mutation; the existing bounded recovery path can
-    // replace at most one shell per generation, so an unscoped host signal
-    // cannot create a reload loop or disturb a verified preview.
+    // replace at most one shell per visible activation, so an unscoped host
+    // signal cannot create a reload loop or disturb a verified preview.
     probeSrcDocTransport(generation, true);
   }, [mode, probeSrcDocTransport, recoverUnacknowledgedSrcDocTransport, useUrlLoadPreview]);
   useEffect(() => {
@@ -10930,8 +10971,10 @@ function HtmlViewer({
   // automatically. Chromium can
   // commit that shell even when it aborts a large direct srcDoc navigation,
   // after which the existing ready handshake safely document.write's the
-  // latest HTML. One fallback per generation avoids a loop when an authored
-  // document is fundamentally unable to execute scripts.
+  // latest HTML. One fallback per visible activation avoids a loop when an
+  // authored document is fundamentally unable to execute scripts, while a
+  // later file/project reactivation can recover a replacement that was itself
+  // interrupted while retained in the background.
   useEffect(() => {
     if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
     const generation = srcDocTransportGeneration;

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1,6 +1,11 @@
 import { memo, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type ClipboardEvent as ReactClipboardEvent, type CSSProperties, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 import { Button, Input, Select } from '@open-design/components';
+import {
+  getLatestHostPreviewNavigationFailure,
+  subscribeHostPreviewNavigationFailure,
+  type OpenDesignHostPreviewNavigationFailure,
+} from '@open-design/host';
 import { CenteredLoader } from './Loading';
 import { APP_CHROME_FILE_ACTIONS_ID, APP_CHROME_FILE_ACTIONS_SELECTOR } from './AppChromeHeader';
 import {
@@ -260,6 +265,7 @@ import {
   previewIframeKeepAliveKey,
   useIframeKeepAlivePool,
 } from './IframeKeepAlivePool';
+
 import type {
   ChatCommentAttachment,
   PreviewComment,
@@ -626,9 +632,21 @@ const SRC_DOC_ACTIVATION_RECOVERY_TIMEOUT_MS = 1500;
 const SRC_DOC_READY_PROBE_TIMEOUT_MS = 1500;
 const SRC_DOC_PARSING_RECHECK_MS = 1500;
 const SRC_DOC_PARSING_COMPLETION_TIMEOUT_MS = 10_000;
+const SRC_DOC_PREVIEW_FRAME_NAME_PREFIX = 'od-artifact-preview-srcdoc-';
+const SRC_DOC_PREVIEW_FAILURE_FRESHNESS_MS = 10_000;
+const MAX_CACHED_SRC_DOC_TRANSPORTS = 128;
+const MAX_CACHED_PREVIEW_DOCUMENT_URLS = 16;
 let previewContentMeasurementDocumentEpochSequence = 0;
 let previewContentMeasurementHostInstanceSequence = 0;
 let previewTransportGenerationSequence = 0;
+type SrcDocTransportCacheEntry = {
+  sourceFingerprint: string;
+  generation: string;
+  srcDoc: string;
+};
+const htmlPreviewSrcDocTransportState = new Map<string, SrcDocTransportCacheEntry>();
+const htmlPreviewDocumentUrlState = new Map<string, string>();
+const htmlPreviewSrcDocPaintedState = new Set<string>();
 function nextPreviewContentMeasurementDocumentEpoch(): string {
   previewContentMeasurementDocumentEpochSequence += 1;
   return `preview-document-${previewContentMeasurementDocumentEpochSequence}`;
@@ -640,6 +658,57 @@ function nextPreviewContentMeasurementHostInstance(): string {
 function nextPreviewTransportGeneration(): string {
   previewTransportGenerationSequence += 1;
   return `preview-transport-${previewTransportGenerationSequence}`;
+}
+function previewSourceFingerprint(source: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index += 1) {
+    hash = Math.imul(hash ^ source.charCodeAt(index), 16777619);
+  }
+  return `${source.length}:${(hash >>> 0).toString(16)}`;
+}
+function cacheSrcDocTransport(key: string, entry: SrcDocTransportCacheEntry) {
+  htmlPreviewSrcDocTransportState.delete(key);
+  htmlPreviewSrcDocTransportState.set(key, entry);
+  if (htmlPreviewSrcDocTransportState.size > MAX_CACHED_SRC_DOC_TRANSPORTS) {
+    const oldest = htmlPreviewSrcDocTransportState.keys().next().value;
+    if (oldest != null) htmlPreviewSrcDocTransportState.delete(oldest);
+  }
+}
+function previewDocumentUrl(key: string, html: string): string | null {
+  if (
+    !html
+    || typeof navigator === 'undefined'
+    || !/\bElectron\//.test(navigator.userAgent)
+    || typeof URL === 'undefined'
+    || typeof URL.createObjectURL !== 'function'
+    || typeof Blob === 'undefined'
+  ) return null;
+  const cacheKey = `${key}\0${previewSourceFingerprint(html)}`;
+  const cached = htmlPreviewDocumentUrlState.get(cacheKey);
+  if (cached) {
+    htmlPreviewDocumentUrlState.delete(cacheKey);
+    htmlPreviewDocumentUrlState.set(cacheKey, cached);
+    return cached;
+  }
+  const url = URL.createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }));
+  htmlPreviewDocumentUrlState.set(cacheKey, url);
+  if (htmlPreviewDocumentUrlState.size > MAX_CACHED_PREVIEW_DOCUMENT_URLS) {
+    const oldest = htmlPreviewDocumentUrlState.keys().next().value;
+    if (oldest != null) {
+      const staleUrl = htmlPreviewDocumentUrlState.get(oldest);
+      htmlPreviewDocumentUrlState.delete(oldest);
+      if (staleUrl && typeof URL.revokeObjectURL === 'function') URL.revokeObjectURL(staleUrl);
+    }
+  }
+  return url;
+}
+function markSrcDocPreviewPainted(key: string) {
+  htmlPreviewSrcDocPaintedState.delete(key);
+  htmlPreviewSrcDocPaintedState.add(key);
+  if (htmlPreviewSrcDocPaintedState.size > MAX_CACHED_SRC_DOC_TRANSPORTS) {
+    const oldest = htmlPreviewSrcDocPaintedState.values().next().value;
+    if (oldest != null) htmlPreviewSrcDocPaintedState.delete(oldest);
+  }
 }
 type PreviewContentWidthCacheEntry = {
   version: typeof PREVIEW_CONTENT_WIDTH_CACHE_VERSION;
@@ -8202,6 +8271,15 @@ function HtmlViewer({
   // Until that first load event lands, keep a loader over the transport stack.
   const urlPreviewLoadedKeysRef = useRef<Set<string>>(new Set());
   const [urlPreviewFirstLoadPending, setUrlPreviewFirstLoadPending] = useState(false);
+  const srcDocPreviewPaintKey = `${projectId}\0${file.name}`;
+  const [srcDocPreviewFirstLoadPending, setSrcDocPreviewFirstLoadPending] = useState(
+    () => !htmlPreviewSrcDocPaintedState.has(srcDocPreviewPaintKey),
+  );
+  useEffect(() => {
+    setSrcDocPreviewFirstLoadPending(
+      !htmlPreviewSrcDocPaintedState.has(srcDocPreviewPaintKey),
+    );
+  }, [srcDocPreviewPaintKey]);
   const [boardMode, setBoardMode] = useState(false);
   const [commentPanelOpen, setCommentPanelOpen] = useState(false);
   const commentPanelToggleRef = useRef<HTMLButtonElement | null>(null);
@@ -8215,6 +8293,10 @@ function HtmlViewer({
   // for hint managing hint box state
   const [openHintBox, setOpenHintBox] = useState(true);
   const [manualEditMode, setManualEditModeRaw] = useState(false);
+  const manualEditLiveStylesRef = useRef<Map<string, {
+    styles: Partial<ManualEditStyles>;
+    version: number;
+  }>>(new Map());
   useEffect(() => {
     onRetainActivityChange?.(file.name, manualEditMode);
     return () => onRetainActivityChange?.(file.name, false);
@@ -8292,6 +8374,18 @@ function HtmlViewer({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
+  const srcDocNavigationCommittedRef = useRef<{
+    frame: HTMLIFrameElement;
+    generation: string;
+  } | null>(null);
+  const handledHostPreviewNavigationFailureRef = useRef<{
+    eventId: number;
+    generation: string;
+  } | null>(null);
+  const srcDocContentReadyRef = useRef<{
+    frame: HTMLIFrameElement;
+    generation: string;
+  } | null>(null);
   const previewContentMeasurementSequenceRef = useRef(0);
   const previewContentMeasurementGenerationSequenceRef = useRef(0);
   const previewContentMeasurementHostInstanceRef = useRef<string | null>(null);
@@ -8299,6 +8393,10 @@ function HtmlViewer({
     previewContentMeasurementHostInstanceRef.current =
       nextPreviewContentMeasurementHostInstance();
   }
+  const srcDocPreviewFrameName = `${SRC_DOC_PREVIEW_FRAME_NAME_PREFIX}${anonymizeArtifactId({
+    projectId,
+    fileName: file.name,
+  })}`;
   const previewContentMeasurementGenerationRef = useRef(
     `${previewContentMeasurementHostInstanceRef.current}:generation-0`,
   );
@@ -8573,6 +8671,13 @@ function HtmlViewer({
       const value = typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next;
       if (value !== prev && !value) {
         setManualEditViewportWidth(null);
+        manualEditLiveStylesRef.current.clear();
+        // The edit snapshot may intentionally lag `source`: set-style patches
+        // update the live iframe over postMessage while persisting the newer
+        // source in the host. Keeping that old snapshot after Edit closes
+        // makes the next entry roll the preview back and re-navigate srcdoc,
+        // discarding the DOM state the user just saved.
+        setManualEditFrozenSource(null);
       }
       return value;
     });
@@ -8580,6 +8685,7 @@ function HtmlViewer({
   useEffect(() => {
     setManualEditSrcDocActive(false);
     setManualEditFrozenSource(null);
+    manualEditLiveStylesRef.current.clear();
     previewRuntimeStateRef.current = null;
   }, [fileViewportKey, projectId, file.name]);
   useEffect(() => {
@@ -8762,6 +8868,14 @@ function HtmlViewer({
   const sourceFileKeyRef = useRef<string | null>(
     source !== null ? currentSourceIdentity : null,
   );
+  const sourceLoadInFlightRef = useRef<{
+    key: string;
+    promise: Promise<{
+      text: string | null;
+      poweredPreviewRequired: boolean;
+      sourceLoadMode: HtmlSourceLoadMode;
+    }>;
+  } | null>(null);
   const renderedSourceAuthorizationScopeKeyRef = useRef(sourceAuthorizationScopeKey);
   if (renderedSourceAuthorizationScopeKeyRef.current !== sourceAuthorizationScopeKey) {
     renderedSourceAuthorizationScopeKeyRef.current = sourceAuthorizationScopeKey;
@@ -8790,6 +8904,7 @@ function HtmlViewer({
     setCopiedDeployLink(null);
     setDeployPhase('idle');
     setManualEditModeRaw(false);
+    manualEditLiveStylesRef.current.clear();
     manualEditPendingStyleRef.current = null;
     manualEditTextSessionIdRef.current = null;
     manualEditTextSessionStartSequenceRef.current = null;
@@ -9149,12 +9264,11 @@ function HtmlViewer({
   const speakerNotesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const boardPreviewScaleOptions = localCommentSideDockActive ? { canvasPadding: 0 } : undefined;
   const shareRef = useRef<HTMLDivElement | null>(null);
-  const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    if (!workspaceActive || typeof document === 'undefined') {
-      setChromeActionsHost(null);
-      return;
-    }
+  const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(
+    () => (typeof document === 'undefined' ? null : resolveChromeActionsHost()),
+  );
+  useLayoutEffect(() => {
+    if (!workspaceActive || typeof document === 'undefined') return;
     setChromeActionsHost(resolveChromeActionsHost());
   }, [workspaceActive]);
 
@@ -9221,7 +9335,11 @@ function HtmlViewer({
     !isDeck;
 
   useEffect(() => {
-    if (!workspaceActive) return;
+    // Open HTML tabs stay mounted so their first activation should be a pure
+    // visibility swap. Warm each retained viewer exactly once in the
+    // background, then keep the existing inactive-refresh deferral: agent/file
+    // watch revisions are consumed only when that tab becomes active again.
+    if (!workspaceActive && sourceEverLoadedRef.current) return;
     // Never turn a pending or denied bound-project authority into a legal
     // local/headerless read. The authorization key changes when an exact
     // Workspace witness resolves, which reruns this effect with scoped URL and
@@ -9299,8 +9417,17 @@ function HtmlViewer({
     // check, and the preview only refreshes when Comment closes and the
     // url-load iframe takes over with its own ?v=mtime cache-bust.
     const cacheBustKey = `${file.mtime}-${reloadKey}-${filesRefreshKey}`;
-    const loadText = shouldDeferPassivePreviewSource
-      ? fetchProjectFileTextPreview(projectId, file.name, {
+    const sourceLoadKey = [
+      sourceAuthorizationScopeKey ?? 'pending',
+      projectId,
+      file.name,
+      cacheBustKey,
+      shouldDeferPassivePreviewSource ? 'routing-preview' : 'full',
+    ].join('\0');
+    let sourceLoad = sourceLoadInFlightRef.current;
+    if (sourceLoad?.key !== sourceLoadKey) {
+      const promise = shouldDeferPassivePreviewSource
+        ? fetchProjectFileTextPreview(projectId, file.name, {
           limit: HTML_ROUTING_TEXT_PREVIEW_LIMIT,
           cacheBustKey,
           workspaceContext,
@@ -9335,7 +9462,15 @@ function HtmlViewer({
         poweredPreviewRequired: false,
         sourceLoadMode: 'full' as HtmlSourceLoadMode,
       }));
-    void loadText.then(({ text, poweredPreviewRequired, sourceLoadMode }) => {
+      sourceLoad = { key: sourceLoadKey, promise };
+      sourceLoadInFlightRef.current = sourceLoad;
+      void promise.finally(() => {
+        if (sourceLoadInFlightRef.current?.key === sourceLoadKey) {
+          sourceLoadInFlightRef.current = null;
+        }
+      });
+    }
+    void sourceLoad.promise.then(({ text, poweredPreviewRequired, sourceLoadMode }) => {
       if (cancelled) return;
       setServerPoweredPreviewRequired(poweredPreviewRequired);
       // Chokidar emits agent rewrites as unlink+add+change bursts; a
@@ -9851,6 +9986,18 @@ function HtmlViewer({
     projectRootAssetRefs: projectRootAssetRefs || scopedRelativeAssetRefs,
   };
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview(urlLoadDecision) && !manualEditRequiresSrcDoc;
+  const setSrcDocPreviewIframe = useCallback((frame: HTMLIFrameElement | null) => {
+    if (srcDocPreviewIframeRef.current !== frame) {
+      srcDocNavigationCommittedRef.current = null;
+      srcDocContentReadyRef.current = null;
+    }
+    srcDocPreviewIframeRef.current = frame;
+    // A ref callback is the only synchronous witness when React replaces or
+    // reattaches the active document. Keeping the generic active ref aligned
+    // here prevents edit/style messages from being sent to the previous
+    // iframe until a later load event happens to repair it.
+    if (!useUrlLoadPreview) iframeRef.current = frame;
+  }, [useUrlLoadPreview]);
   // Wait for source discovery before minting. A committed file switch can
   // still carry the previous file's state until the source-loading effect
   // clears/replaces it, so only inspect bytes witnessed for this identity.
@@ -10196,57 +10343,87 @@ function HtmlViewer({
 
   const srcDocBaseHref = effectiveScopedSrcDocPreviewBase
     ?? projectRawUrl(projectId, baseDirFor(file.name), workspaceContext);
-  const srcDocTransportGeneration = useMemo(
-    () => nextPreviewTransportGeneration(),
+  const srcDocTransportIdentity = [
+    srcDocPreviewBaseIdentity,
+    sourceSnapshotRefreshKey,
+    reloadKey,
+    transportPreviewMeasurementDocumentEpoch,
+    effectiveDeck ? 'deck' : 'html',
+    srcDocBaseHref,
+  ].join('\0');
+  const candidateSrcDocTransport = useMemo(
+    () => {
+      const sourceFingerprint = previewSource === null
+        ? null
+        : previewSourceFingerprint(previewSource);
+      const cached = htmlPreviewSrcDocTransportState.get(srcDocTransportIdentity);
+      // A remount can begin before its source fetch resolves. Reuse the last
+      // complete transport for this exact file revision so React reattaches
+      // the parked iframe without changing a single srcdoc byte.
+      if (
+        cached
+        && (sourceFingerprint === null || cached.sourceFingerprint === sourceFingerprint)
+      ) {
+        cacheSrcDocTransport(srcDocTransportIdentity, cached);
+        return cached;
+      }
+      const generation = nextPreviewTransportGeneration();
+      const entry: SrcDocTransportCacheEntry = {
+        sourceFingerprint: sourceFingerprint ?? '',
+        generation,
+        srcDoc: previewSource ? buildSrcdoc(previewSource, {
+          deck: effectiveDeck,
+          baseHref: srcDocBaseHref,
+          initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
+          hideDeckChrome: effectiveDeck,
+          selectionBridge: true,
+          // Always inject the manual-edit bridge into the PREVIEW srcDoc (not the
+          // export path), so the document is byte-identical across preview /
+          // comment / draw / edit. The bridge boots dormant (`enabled=false`) and
+          // only acts on the host's `od-edit-mode {enabled:true}` postMessage
+          // (sent by syncBridgeModes), with all its handlers gated on `enabled`
+          // and its styles scoped to `html[data-od-edit-mode]`. Gating injection on
+          // edit mode instead changed the srcdoc string on entering Edit, which
+          // re-parses the whole document — the "reload from scratch on switch" the
+          // user hit. Mirrors the always-on tweaks bridge rationale above.
+          editBridge: true,
+          paletteBridge: false,
+          previewFocusGuard: true,
+          previewObservability: true,
+          // Embed the reload counter so the srcdoc string differs across reloads
+          // even when the fetched HTML bytes are identical (issue #4650).
+          reloadKey,
+          previewMeasurementEpoch: transportPreviewMeasurementDocumentEpoch,
+          transportActivationGeneration: generation,
+        }) : '',
+      };
+      if (sourceFingerprint !== null) cacheSrcDocTransport(srcDocTransportIdentity, entry);
+      return entry;
+    },
     [
       previewSource,
       effectiveDeck,
-      projectId,
-      file.name,
-      reloadKey,
-      transportPreviewMeasurementDocumentEpoch,
-      workspaceContext,
-      srcDocBaseHref,
-    ],
-  );
-  const srcDoc = useMemo(
-    () => (previewSource ? buildSrcdoc(previewSource, {
-      deck: effectiveDeck,
-      baseHref: srcDocBaseHref,
-      initialSlideIndex: htmlPreviewSlideState.get(previewStateKey)?.active ?? 0,
-      hideDeckChrome: effectiveDeck,
-      selectionBridge: true,
-      // Always inject the manual-edit bridge into the PREVIEW srcDoc (not the
-      // export path), so the document is byte-identical across preview /
-      // comment / draw / edit. The bridge boots dormant (`enabled=false`) and
-      // only acts on the host's `od-edit-mode {enabled:true}` postMessage
-      // (sent by syncBridgeModes), with all its handlers gated on `enabled`
-      // and its styles scoped to `html[data-od-edit-mode]`. Gating injection on
-      // edit mode instead changed the srcdoc string on entering Edit, which
-      // re-parses the whole document — the "reload from scratch on switch" the
-      // user hit. Mirrors the always-on tweaks bridge rationale above.
-      editBridge: true,
-      paletteBridge: false,
-      previewFocusGuard: true,
-      previewObservability: true,
-      // Embed the reload counter so the srcdoc string differs across reloads
-      // even when the fetched HTML bytes are identical (issue #4650).
-      reloadKey,
-      previewMeasurementEpoch: transportPreviewMeasurementDocumentEpoch,
-      transportActivationGeneration: srcDocTransportGeneration,
-    }) : ''),
-    [
-      previewSource,
-      effectiveDeck,
-      projectId,
-      file.name,
+      srcDocTransportIdentity,
       previewStateKey,
       reloadKey,
       transportPreviewMeasurementDocumentEpoch,
-      srcDocTransportGeneration,
       srcDocBaseHref,
     ],
   );
+  // A retained file tab may observe a newer file generation while its iframe
+  // is hidden. Updating `srcdoc` in that state starts a background navigation
+  // which Chromium can abort when the user switches tabs again before it
+  // commits. Keep the last displayed document byte-for-byte stable while the
+  // workspace is inactive, then commit only the newest candidate when the tab
+  // is activated. Code mode remains workspace-active, so agent edits still
+  // update its retained preview immediately and are ready when Preview opens.
+  const committedSrcDocTransportRef = useRef(candidateSrcDocTransport);
+  if (workspaceActive) {
+    committedSrcDocTransportRef.current = candidateSrcDocTransport;
+  }
+  const srcDocTransport = committedSrcDocTransportRef.current;
+  const srcDocTransportGeneration = srcDocTransport.generation;
+  const srcDoc = srcDocTransport.srcDoc;
   const expectedSrcDocTransportGenerationRef = useRef(srcDocTransportGeneration);
   expectedSrcDocTransportGenerationRef.current = srcDocTransportGeneration;
   const readySrcDocTransportRef = useRef<{
@@ -10272,6 +10449,7 @@ function HtmlViewer({
     generation: string;
     deadline: number;
   } | null>(null);
+  const srcDocRecoveryAttemptedGenerationRef = useRef<string | null>(null);
   const clearSrcDocTransportTimeouts = useCallback(() => {
     for (const timeout of srcDocTransportTimeoutsRef.current) {
       window.clearTimeout(timeout);
@@ -10290,10 +10468,35 @@ function HtmlViewer({
     pendingSrcDocTransportProbeRef.current = null;
     srcDocParsingGraceRef.current = null;
   }, [clearSrcDocTransportTimeouts]);
+  const invalidateSrcDocTransportActivation = useCallback(() => {
+    cancelPendingSrcDocTransport();
+    readySrcDocTransportRef.current = null;
+    verifiedSrcDocTransportRef.current = null;
+    srcDocRecoveryAttemptedGenerationRef.current = null;
+    srcDocNavigationCommittedRef.current = null;
+    srcDocContentReadyRef.current = null;
+  }, [cancelPendingSrcDocTransport]);
   useEffect(() => {
-    if (!workspaceActive || mode !== 'preview') cancelPendingSrcDocTransport();
+    // Visibility changes no longer replace the preview iframe. Its transport
+    // witness therefore stays valid across Project, file-tab, and Code mode
+    // switches; only a real content generation change starts a new document
+    // lifecycle. Invalidating on every hide used to manufacture a second
+    // activation/recovery race after an otherwise healthy switch.
+    invalidateSrcDocTransportActivation();
     return cancelPendingSrcDocTransport;
-  }, [cancelPendingSrcDocTransport, mode, srcDocTransportGeneration, workspaceActive]);
+  }, [
+    cancelPendingSrcDocTransport,
+    invalidateSrcDocTransportActivation,
+    srcDocTransportGeneration,
+  ]);
+  useEffect(() => {
+    // Hidden viewers keep their committed-document witness, but any in-flight
+    // challenge timer belongs to the visible activation that started it. Pause
+    // those timers so Code mode and retained project/file tabs cannot trigger
+    // a background recovery; an unverified frame is challenged again when it
+    // becomes visible, while an already verified frame needs no new work.
+    if (!workspaceActive || mode !== 'preview') cancelPendingSrcDocTransport();
+  }, [cancelPendingSrcDocTransport, mode, workspaceActive]);
   const replayPreviewBridgeModes = useCallback((target: HTMLIFrameElement | null) => {
     if (!workspaceActive) return;
     const win = target?.contentWindow;
@@ -10316,6 +10519,16 @@ function HtmlViewer({
       type: 'od-edit-selected-target',
       id: manualEditMode ? selectedManualEditTarget?.id ?? null : null,
     }, '*');
+    if (manualEditMode) {
+      for (const [id, preview] of manualEditLiveStylesRef.current) {
+        win.postMessage({
+          type: 'od-edit-preview-style',
+          id,
+          styles: preview.styles,
+          version: preview.version,
+        }, '*');
+      }
+    }
     win.postMessage({ type: 'od:inspect-mode', enabled: inspectMode }, '*');
   }, [
     boardMode,
@@ -10392,7 +10605,6 @@ function HtmlViewer({
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
-  const srcDocRecoveryAttemptedGenerationRef = useRef<string | null>(null);
   const [srcDocRecoveryGeneration, setSrcDocRecoveryGeneration] = useState<string | null>(null);
   const recoverUnacknowledgedSrcDocTransport = useCallback((
     generation: string,
@@ -10496,6 +10708,56 @@ function HtmlViewer({
     recoverUnacknowledgedSrcDocTransport,
     scheduleSrcDocTransportTimeout,
   ]);
+  const handleHostPreviewNavigationFailure = useCallback((
+    failure: OpenDesignHostPreviewNavigationFailure,
+  ) => {
+    if (
+      failure.errorCode !== -3
+      || failure.validatedUrl !== 'about:srcdoc'
+      || !Number.isSafeInteger(failure.eventId)
+      || !Number.isFinite(failure.occurredAtMs)
+      || Date.now() - failure.occurredAtMs > SRC_DOC_PREVIEW_FAILURE_FRESHNESS_MS
+    ) return;
+    const frame = srcDocPreviewIframeRef.current;
+    const generation = expectedSrcDocTransportGenerationRef.current;
+    if (
+      !workspaceActiveRef.current
+      || mode !== 'preview'
+      || useUrlLoadPreview
+      || !frame?.isConnected
+      || frame.dataset.odActive !== 'true'
+      || (failure.frameName !== undefined && failure.frameName !== frame.name)
+    ) return;
+    const handled = handledHostPreviewNavigationFailureRef.current;
+    if (handled?.generation === generation && failure.eventId <= handled.eventId) return;
+    handledHostPreviewNavigationFailureRef.current = {
+      eventId: failure.eventId,
+      generation,
+    };
+    const verified = verifiedSrcDocTransportRef.current;
+    if (verified?.frame === frame && verified.generation === generation) {
+      // Electron can report ERR_ABORTED after a newer srcdoc has already
+      // committed and painted. Treat that late cancellation as diagnostics;
+      // hiding or replacing a verified frame manufactures the visible
+      // HTML -> white -> HTML flash we are trying to prevent.
+      return;
+    }
+    // An independently unverified document is challenged immediately. When
+    // Chromium destroys the failed frame before Electron can resolve its
+    // name, challenge the one active srcdoc frame instead. A healthy frame
+    // acknowledges without mutation; the existing bounded recovery path can
+    // replace at most one shell per generation, so an unscoped host signal
+    // cannot create a reload loop or disturb a verified preview.
+    probeSrcDocTransport(generation, true);
+  }, [mode, probeSrcDocTransport, useUrlLoadPreview]);
+  useEffect(() => {
+    const unsubscribe = subscribeHostPreviewNavigationFailure(
+      handleHostPreviewNavigationFailure,
+    );
+    const latestFailure = getLatestHostPreviewNavigationFailure();
+    if (latestFailure) handleHostPreviewNavigationFailure(latestFailure);
+    return unsubscribe;
+  }, [handleHostPreviewNavigationFailure, workspaceActive]);
   // Sticky once the srcDoc iframe has materialized the real artifact for the
   // first time (i.e. the first entry into Mark/Edit/Comment/Inspect). Until
   // then the srcDoc iframe stays on the lazy shell — so passive preview never
@@ -10581,6 +10843,9 @@ function HtmlViewer({
         pendingSrcDocTransportProbeRef.current = null;
         srcDocParsingGraceRef.current = null;
         verifiedSrcDocTransportRef.current = { frame, generation: data.generation };
+        srcDocNavigationCommittedRef.current = { frame, generation: data.generation };
+        markSrcDocPreviewPainted(srcDocPreviewPaintKey);
+        setSrcDocPreviewFirstLoadPending(false);
       } else if (
         typeof data.probeId === 'string'
         && pending
@@ -10660,6 +10925,7 @@ function HtmlViewer({
     recoverUnacknowledgedSrcDocTransport,
     replayPreviewBridgeModes,
     scheduleSrcDocTransportTimeout,
+    srcDocPreviewPaintKey,
     workspaceActive,
   ]);
   // React can commit a fresh `srcdoc` attribute while Chromium aborts the
@@ -10739,6 +11005,19 @@ function HtmlViewer({
     : useLazySrcDocTransport
       ? lazySrcDocTransport
       : srcDoc;
+  // Chromium can abort an `about:srcdoc` navigation while a retained iframe
+  // is being attached, moved between file tabs, or replaced after an
+  // authorization/base-resolution pass. Load the exact same injected document
+  // through a stable local blob URL instead. This preserves the opaque sandbox
+  // and every injected bridge, but turns the preview into one ordinary URL
+  // navigation and removes the fragile srcdoc commit race entirely.
+  const srcDocTransportUrl = useMemo(
+    () => previewDocumentUrl(
+      `${srcDocTransportGeneration}:${srcDocTransportResetKey}`,
+      srcDocTransportContent,
+    ),
+    [srcDocTransportContent, srcDocTransportGeneration, srcDocTransportResetKey],
+  );
   // Materialize the srcDoc iframe the first time it actually becomes the active
   // (visible) transport — i.e. the first Mark/Edit/Comment/Inspect entry. We do
   // NOT pre-render it while hidden/idle: that ran a second live copy during
@@ -11127,13 +11406,28 @@ function HtmlViewer({
         | null;
       if (!data || data.type !== 'od:slide-state') return;
       if (typeof data.active !== 'number' || typeof data.count !== 'number') return;
+      const srcDocFrame = srcDocPreviewIframeRef.current;
+      if (
+        srcDocFrame
+        && ev.source === srcDocFrame.contentWindow
+        && srcDocFrame.dataset.odActive === 'true'
+      ) {
+        const generation = expectedSrcDocTransportGenerationRef.current;
+        srcDocContentReadyRef.current = { frame: srcDocFrame, generation };
+      }
       const next = { active: data.active, count: data.count };
       setSlideStateCached(previewStateKey, next);
       setSlideState(next);
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [effectiveDeck, isActivePreviewIframeSource, isOurPreviewIframeSource, previewStateKey, workspaceActive]);
+  }, [
+    effectiveDeck,
+    isActivePreviewIframeSource,
+    isOurPreviewIframeSource,
+    previewStateKey,
+    workspaceActive,
+  ]);
 
   useEffect(() => {
     if (!workspaceActive) return;
@@ -11743,6 +12037,11 @@ function HtmlViewer({
       : styles;
     const pending: ManualEditPendingStyleSave = { id, styles: pendingStyles, label, version };
     manualEditPendingStyleRef.current = pending;
+    const previousPreview = manualEditLiveStylesRef.current.get(id);
+    manualEditLiveStylesRef.current.set(id, {
+      styles: { ...previousPreview?.styles, ...styles },
+      version,
+    });
     setManualEditError(null);
     previewStyleToIframe(id, styles, version);
   }
@@ -11782,6 +12081,7 @@ function HtmlViewer({
       acc[key] = sourceStyles[key] ?? '';
       return acc;
     }, {});
+    manualEditLiveStylesRef.current.delete(pending.id);
     previewStyleToIframe(pending.id, resetStyles, nextManualEditPreviewVersion());
     if (!target || target.id === selectedManualEditTarget?.id) {
       setManualEditDraft((current) => ({
@@ -15392,8 +15692,20 @@ function HtmlViewer({
           </div>
         </div>
       </div>
-      {workspaceActive ? ((filePrimaryActions: ReactNode) => (
-        chromeActionsHost ? createPortal(filePrimaryActions, chromeActionsHost) : filePrimaryActions
+      {((filePrimaryActions: ReactNode) => (
+        chromeActionsHost
+          ? createPortal(
+              <div
+                data-od-file-actions-owner={file.name}
+                style={{ display: workspaceActive ? 'contents' : 'none' }}
+              >
+                {filePrimaryActions}
+              </div>,
+              chromeActionsHost,
+            )
+          : workspaceActive
+            ? filePrimaryActions
+            : null
       ))(<>
           {showPresent ? (
             <div className="present-wrap chrome-present-wrap">
@@ -15967,20 +16279,27 @@ function HtmlViewer({
               )}
             </div>
           ) : null}
-      </>) : null}
+      </>)}
       <div className="viewer-body" ref={previewBodyRef}>
-        {initialPreviewLoading || sourceModeLoading ? (
-          initialPreviewLoading ? (
-            <FileViewerLoadingSkeleton />
-          ) : (
-            <div className="viewer-empty">{t('fileViewer.loading')}</div>
-          )
-        ) : mode === 'preview' ? (
-          <div
+        {initialPreviewLoading ? (
+          <FileViewerLoadingSkeleton />
+        ) : (
+          <>
+            <div
+            hidden={mode !== 'preview'}
+            aria-hidden={mode !== 'preview' ? true : undefined}
             className={`${manualEditMode ? 'manual-edit-workspace' : commentPreviewLayoutClass} preview-viewport preview-viewport-${previewViewport}${drawOverlayOpen ? ' preview-draw-active' : ''}`}
             data-testid={manualEditMode ? undefined : 'comment-preview-layout'}
             ref={manualEditMode ? undefined : setCommentComposerHostRef}
-            style={previewViewportStyle(previewViewport, previewScale, boardPreviewCanvasSize, boardPreviewScaleOptions)}
+            style={{
+              ...previewViewportStyle(
+                previewViewport,
+                previewScale,
+                boardPreviewCanvasSize,
+                boardPreviewScaleOptions,
+              ),
+              ...(mode !== 'preview' ? { display: 'none' } : {}),
+            }}
             onMouseLeave={manualEditMode ? clearManualEditHover : undefined}
           >
             {manualEditPanel}
@@ -16036,9 +16355,9 @@ function HtmlViewer({
                             ? (useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load')
                             : `artifact-preview-frame-retained-${file.name}`}
                           data-od-render-mode="url-load"
-                          data-od-active={workspaceActive && useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={workspaceActive && useUrlLoadPreview ? undefined : true}
-                          tabIndex={workspaceActive && useUrlLoadPreview ? 0 : -1}
+                          data-od-active={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 'true' : 'false'}
+                          aria-hidden={workspaceActive && mode === 'preview' && useUrlLoadPreview ? undefined : true}
+                          tabIndex={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 0 : -1}
                           title={file.name}
                           data-od-powered={usePoweredPreview ? 'true' : undefined}
                           sandbox={urlFrameSandbox}
@@ -16079,9 +16398,9 @@ function HtmlViewer({
                             ? (useUrlLoadPreview ? 'artifact-preview-frame' : 'artifact-preview-frame-url-load')
                             : `artifact-preview-frame-retained-${file.name}`}
                           data-od-render-mode="url-load"
-                          data-od-active={workspaceActive && useUrlLoadPreview ? 'true' : 'false'}
-                          aria-hidden={workspaceActive && useUrlLoadPreview ? undefined : true}
-                          tabIndex={workspaceActive && useUrlLoadPreview ? 0 : -1}
+                          data-od-active={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 'true' : 'false'}
+                          aria-hidden={workspaceActive && mode === 'preview' && useUrlLoadPreview ? undefined : true}
+                          tabIndex={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 0 : -1}
                           title={file.name}
                           data-od-powered={usePoweredPreview ? 'true' : undefined}
                           sandbox={urlFrameSandbox}
@@ -16118,17 +16437,19 @@ function HtmlViewer({
                       )}
                       <iframe
                         key={srcDocTransportResetKey}
-                        ref={srcDocPreviewIframeRef}
+                        ref={setSrcDocPreviewIframe}
+                        name={srcDocPreviewFrameName}
                         data-testid={workspaceActive
                           ? (useUrlLoadPreview ? 'artifact-preview-frame-srcdoc' : 'artifact-preview-frame')
                           : `artifact-preview-frame-srcdoc-retained-${file.name}`}
                         data-od-render-mode="srcdoc"
-                        data-od-active={workspaceActive && !useUrlLoadPreview ? 'true' : 'false'}
-                        aria-hidden={workspaceActive && !useUrlLoadPreview ? undefined : true}
-                        tabIndex={workspaceActive && !useUrlLoadPreview ? 0 : -1}
+                        data-od-active={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? 'true' : 'false'}
+                        aria-hidden={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? undefined : true}
+                        tabIndex={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? 0 : -1}
                         title={file.name}
                         sandbox="allow-scripts allow-downloads"
-                        srcDoc={srcDocTransportContent}
+                        src={srcDocTransportUrl ?? 'about:blank'}
+                        srcDoc={srcDocTransportUrl ? undefined : srcDocTransportContent}
                         onLoad={() => {
                           const frame = srcDocPreviewIframeRef.current;
                           // Record whether this load ever saw a real layout
@@ -16179,7 +16500,16 @@ function HtmlViewer({
                             activatedSrcDocTransportHtmlRef.current = null;
                           }
                           if (useLazySrcDocTransport) setSrcDocShellReady(true);
-                          activateLoadedSrcDocTransport(frame);
+                          const activatedTransport = activateLoadedSrcDocTransport(frame);
+                          if (frame && activatedTransport) {
+                            // The shell is about to replace its document. Any
+                            // readiness witnessed for this DOM node belongs to
+                            // the previous navigation and must not allow an
+                            // abort to consume recovery before the replacement
+                            // document's final load.
+                            srcDocNavigationCommittedRef.current = null;
+                            srcDocContentReadyRef.current = null;
+                          }
                           verifyLoadedSrcDocTransport(frame);
                           dcViewportRestoreAtRef.current = Date.now();
                           frame?.contentWindow?.postMessage({
@@ -16191,6 +16521,20 @@ function HtmlViewer({
                           syncCachedSlideStateToIframe(frame);
                           if (!useUrlLoadPreview) restorePreviewScrollPosition();
                           if (!useUrlLoadPreview) scheduleDesktopPreviewContentMeasure(frame);
+                          if (frame && !activatedTransport) {
+                            // The lazy shell's first load immediately starts a
+                            // second document.write navigation. Recovering in
+                            // that first callback is too early: the following
+                            // navigation can discard the newly-created surface
+                            // again. Consume a cached host failure synchronously
+                            // from the final load callback, before Chromium can
+                            // present the document and turn the compositor
+                            // refresh into a visible second flash.
+                            srcDocNavigationCommittedRef.current = {
+                              frame,
+                              generation: srcDocTransportGeneration,
+                            };
+                          }
                         }}
                       />
                       {useUrlLoadPreview && urlPreviewFirstLoadPending ? (
@@ -16231,6 +16575,19 @@ function HtmlViewer({
                           <CenteredLoader label={t('fileViewer.loading')} />
                         </div>
                       ) : null}
+                      {!useUrlLoadPreview
+                        && srcDocTransportContent
+                        && srcDocPreviewFirstLoadPending ? (
+                          <div
+                            className="artifact-preview-first-load"
+                            role="status"
+                            aria-busy="true"
+                            aria-label={t('fileViewer.loading')}
+                            data-testid="artifact-preview-first-load"
+                          >
+                            <CenteredLoader label={t('fileViewer.loading')} />
+                          </div>
+                        ) : null}
                     </div>
                   </PreviewDrawOverlay>
                   {previewAssetWarning ? (
@@ -16475,9 +16832,15 @@ function HtmlViewer({
                 error={inspectError}
               />
             ) : null}
-          </div>
-        ) : (
-          <pre className="viewer-source">{source}</pre>
+            </div>
+            {mode !== 'preview' ? (
+              sourceModeLoading ? (
+                <div className="viewer-empty">{t('fileViewer.loading')}</div>
+              ) : (
+                <pre className="viewer-source">{source}</pre>
+              )
+            ) : null}
+          </>
         )}
       </div>
       {speakerNotesPanel}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -646,7 +646,6 @@ type SrcDocTransportCacheEntry = {
 };
 const htmlPreviewSrcDocTransportState = new Map<string, SrcDocTransportCacheEntry>();
 const htmlPreviewDocumentUrlState = new Map<string, string>();
-const htmlPreviewSrcDocPaintedState = new Set<string>();
 function nextPreviewContentMeasurementDocumentEpoch(): string {
   previewContentMeasurementDocumentEpochSequence += 1;
   return `preview-document-${previewContentMeasurementDocumentEpochSequence}`;
@@ -701,14 +700,6 @@ function previewDocumentUrl(key: string, html: string): string | null {
     }
   }
   return url;
-}
-function markSrcDocPreviewPainted(key: string) {
-  htmlPreviewSrcDocPaintedState.delete(key);
-  htmlPreviewSrcDocPaintedState.add(key);
-  if (htmlPreviewSrcDocPaintedState.size > MAX_CACHED_SRC_DOC_TRANSPORTS) {
-    const oldest = htmlPreviewSrcDocPaintedState.values().next().value;
-    if (oldest != null) htmlPreviewSrcDocPaintedState.delete(oldest);
-  }
 }
 type PreviewContentWidthCacheEntry = {
   version: typeof PREVIEW_CONTENT_WIDTH_CACHE_VERSION;
@@ -8271,15 +8262,6 @@ function HtmlViewer({
   // Until that first load event lands, keep a loader over the transport stack.
   const urlPreviewLoadedKeysRef = useRef<Set<string>>(new Set());
   const [urlPreviewFirstLoadPending, setUrlPreviewFirstLoadPending] = useState(false);
-  const srcDocPreviewPaintKey = `${projectId}\0${file.name}`;
-  const [srcDocPreviewFirstLoadPending, setSrcDocPreviewFirstLoadPending] = useState(
-    () => !htmlPreviewSrcDocPaintedState.has(srcDocPreviewPaintKey),
-  );
-  useEffect(() => {
-    setSrcDocPreviewFirstLoadPending(
-      !htmlPreviewSrcDocPaintedState.has(srcDocPreviewPaintKey),
-    );
-  }, [srcDocPreviewPaintKey]);
   const [boardMode, setBoardMode] = useState(false);
   const [commentPanelOpen, setCommentPanelOpen] = useState(false);
   const commentPanelToggleRef = useRef<HTMLButtonElement | null>(null);
@@ -10844,8 +10826,6 @@ function HtmlViewer({
         srcDocParsingGraceRef.current = null;
         verifiedSrcDocTransportRef.current = { frame, generation: data.generation };
         srcDocNavigationCommittedRef.current = { frame, generation: data.generation };
-        markSrcDocPreviewPainted(srcDocPreviewPaintKey);
-        setSrcDocPreviewFirstLoadPending(false);
       } else if (
         typeof data.probeId === 'string'
         && pending
@@ -10925,7 +10905,6 @@ function HtmlViewer({
     recoverUnacknowledgedSrcDocTransport,
     replayPreviewBridgeModes,
     scheduleSrcDocTransportTimeout,
-    srcDocPreviewPaintKey,
     workspaceActive,
   ]);
   // React can commit a fresh `srcdoc` attribute while Chromium aborts the
@@ -16575,19 +16554,6 @@ function HtmlViewer({
                           <CenteredLoader label={t('fileViewer.loading')} />
                         </div>
                       ) : null}
-                      {!useUrlLoadPreview
-                        && srcDocTransportContent
-                        && srcDocPreviewFirstLoadPending ? (
-                          <div
-                            className="artifact-preview-first-load"
-                            role="status"
-                            aria-busy="true"
-                            aria-label={t('fileViewer.loading')}
-                            data-testid="artifact-preview-first-load"
-                          >
-                            <CenteredLoader label={t('fileViewer.loading')} />
-                          </div>
-                        ) : null}
                     </div>
                   </PreviewDrawOverlay>
                   {previewAssetWarning ? (

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -1398,6 +1398,19 @@ export function FileWorkspace({
   const [activeTab, setActiveTab] = useState<string>(
     tabsState.active ?? defaultRootTab,
   );
+  // `materializationPending` can briefly become true again while the router
+  // commits a file-tab URL. Once this project has rendered real workspace
+  // content, that transient revalidation must not tear down retained viewers:
+  // doing so destroys iframe browsing contexts, edit sessions, and toolbar
+  // portals for a single frame. A genuinely new project still gets the
+  // first-materialization loading surface because its id has not been marked
+  // ready in this component instance.
+  const materializedProjectRef = useRef<string | null>(
+    materializationPending ? null : projectId,
+  );
+  if (!materializationPending) materializedProjectRef.current = projectId;
+  const initialMaterializationPending =
+    materializationPending && materializedProjectRef.current !== projectId;
   const activeTabRef = useRef(activeTab);
   activeTabRef.current = activeTab;
   const fileSyncBadgeLabel = fileSyncBadge
@@ -3932,7 +3945,7 @@ export function FileWorkspace({
             clearTabDragState();
           }}
         >
-          {!materializationPending && designSystemProject ? (
+          {!initialMaterializationPending && designSystemProject ? (
             <button
               type="button"
               className={`ws-tab design-system-tab ${activeTab === DESIGN_SYSTEM_TAB ? 'active' : ''}`}
@@ -3951,9 +3964,9 @@ export function FileWorkspace({
           ) : null}
           <button
             type="button"
-            className={`ws-tab design-files-tab ${materializationPending || designFilesTabActive ? 'active' : ''}`}
+            className={`ws-tab design-files-tab ${initialMaterializationPending || designFilesTabActive ? 'active' : ''}`}
             role="tab"
-            aria-selected={materializationPending || designFilesTabActive}
+            aria-selected={initialMaterializationPending || designFilesTabActive}
             aria-label={designFilesTabTitle}
             tabIndex={0}
             data-testid="design-files-tab"
@@ -3969,7 +3982,7 @@ export function FileWorkspace({
             </span>
             <span className="ws-tab-label">{designFilesTabLabel}</span>
           </button>
-          {!materializationPending ? visibleOrderedWorkspaceTabs.map((entry) => {
+          {!initialMaterializationPending ? visibleOrderedWorkspaceTabs.map((entry) => {
             if (entry.kind === 'browser') {
               const browserTab = entry.browserTab;
               const browserUrl = browserTab.url?.trim() ?? '';
@@ -4057,7 +4070,7 @@ export function FileWorkspace({
             );
           }) : null}
         </div>
-        {!materializationPending ? <div className="ws-add-tab">
+        {!initialMaterializationPending ? <div className="ws-add-tab">
           <button
             ref={launcherBtnRef}
             type="button"
@@ -4077,7 +4090,7 @@ export function FileWorkspace({
         {/* Pinned to the right for project/file actions; the tab launcher sits
             next to the file tabs so its spatial relationship stays clear. */}
         <div className="ws-tabs-actions">
-          {!materializationPending && fileActionsBefore ? (
+          {!initialMaterializationPending && fileActionsBefore ? (
             <div className="ws-tabs-file-actions-before">{fileActionsBefore}</div>
           ) : null}
           {/* Pure portal host. Whatever file is open owns these actions and
@@ -4091,12 +4104,12 @@ export function FileWorkspace({
             data-app-chrome-file-actions="true"
             hidden={!viewerFileActive}
           />
-          {!materializationPending && headerActions ? (
+          {!initialMaterializationPending && headerActions ? (
             <div className="ws-tabs-project-actions">{headerActions}</div>
           ) : null}
         </div>
       </div>
-      {!materializationPending && launcherOpen ? (
+      {!initialMaterializationPending && launcherOpen ? (
         <TabLauncherMenu
           anchor={launcherBtnRef.current}
           files={visibleFiles}
@@ -4146,7 +4159,7 @@ export function FileWorkspace({
           />
         </div>
       ) : null}
-      {viewerOnly && !materializationPending ? (
+      {viewerOnly && !initialMaterializationPending ? (
         <div className="workspace-readonly-notice" role="status">
           <Icon name="lock" size={14} />
           <span>{readonlyNotice ?? t('workspace.readonlyNotice')}</span>
@@ -4172,7 +4185,7 @@ export function FileWorkspace({
             </button>
           </div>
         ) : null}
-        {!materializationPending ? browserTabs.filter((browserTab) => mountedBrowserTabIds.has(browserTab.id)).map((browserTab) => (
+        {!initialMaterializationPending ? browserTabs.filter((browserTab) => mountedBrowserTabIds.has(browserTab.id)).map((browserTab) => (
           <div
             key={`${projectId}:${browserTab.id}`}
             className={`ws-browser-panel ${activeTab === browserTab.id ? 'active' : ''}`}
@@ -4210,7 +4223,7 @@ export function FileWorkspace({
             />
           </div>
         )) : null}
-        {materializationPending ? (
+        {initialMaterializationPending ? (
           <DesignFilesPanel
             projectId={projectId}
             viewerOnly
@@ -4459,7 +4472,7 @@ export function FileWorkspace({
             .
           </div>
         )}
-        {!materializationPending ? mountedHtmlViewerFiles.map((file) => {
+        {!initialMaterializationPending ? mountedHtmlViewerFiles.map((file) => {
           const workspaceActive = activeHtmlViewerFile?.name === file.name;
           return (
             <div
@@ -4493,7 +4506,7 @@ export function FileWorkspace({
             </div>
           );
         }) : null}
-        {!materializationPending && viewerFile ? (
+        {!initialMaterializationPending && viewerFile ? (
           <div
             ref={(element) => {
               syncInertAttribute(element, !viewerFileActive);
@@ -4523,7 +4536,7 @@ export function FileWorkspace({
           </div>
         ) : null}
       </div>
-      {!materializationPending ? <PageCreatorDialog
+      {!initialMaterializationPending ? <PageCreatorDialog
         open={pageCreatorOpen}
         t={t}
         locale={locale}
@@ -4540,7 +4553,7 @@ export function FileWorkspace({
           if (!pageCreating) setPageCreatorOpen(false);
         }}
       /> : null}
-      {!materializationPending ? <input
+      {!initialMaterializationPending ? <input
         ref={fileInputRef}
         type="file"
         multiple
@@ -4549,7 +4562,7 @@ export function FileWorkspace({
         onChange={handleFilePicked}
       /> : null}
       <AnimatePresence>
-        {!materializationPending && showLibraryPicker ? (
+        {!initialMaterializationPending && showLibraryPicker ? (
           <LibraryPicker
             onClose={() => setShowLibraryPicker(false)}
             onConfirm={async (assets) => {
@@ -4579,7 +4592,7 @@ export function FileWorkspace({
         ) : null}
       </AnimatePresence>
       <AnimatePresence>
-        {!materializationPending && quickSwitcherOpen ? (
+        {!initialMaterializationPending && quickSwitcherOpen ? (
           <QuickSwitcher
             projectId={projectId}
             files={visibleFiles}

--- a/apps/web/src/components/IframeKeepAlivePool.tsx
+++ b/apps/web/src/components/IframeKeepAlivePool.tsx
@@ -350,6 +350,12 @@ function syncIframeProps(
   appliedAttributes: Set<string>,
   appliedStyleKeys: Set<string>,
 ) {
+  // A pooled srcDoc frame carries `src="about:blank"` as its parking URL.
+  // Set that URL before srcdoc on a fresh DOM node. Reversing this order starts
+  // the real about:srcdoc navigation and then immediately cancels it with the
+  // parking URL, which Electron reports as ERR_ABORTED and users see as a
+  // white preview when opening or reattaching a file tab.
+  setAttribute(frame, 'src', props.src);
   const nextAttributes = new Set<string>();
   for (const [name, value] of Object.entries(props)) {
     if (
@@ -377,7 +383,6 @@ function syncIframeProps(
   frame.onload = props.onLoad
     ? (event) => props.onLoad?.(event as unknown as SyntheticEvent<HTMLIFrameElement>)
     : null;
-  setAttribute(frame, 'src', props.src);
 }
 
 export const PooledIframe = forwardRef<HTMLIFrameElement, PooledIframeProps>(function PooledIframe({

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -2476,8 +2476,9 @@ async function loadDeckCover(
   return run;
 }
 
-function deckPreviewSrcDoc(html: string): string {
+export function deckPreviewSrcDoc(html: string): string {
   const withoutScripts = html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/giu, '');
+  const withCoverSlide = markFirstDeckPage(withoutScripts);
   const style = `<style id="od-recent-deck-real-preview">
     html,
     body {
@@ -2490,6 +2491,16 @@ function deckPreviewSrcDoc(html: string): string {
       display: block !important;
       scroll-snap-type: none !important;
     }
+    :where(body *):has(> [data-od-cover-slide]) {
+      position: absolute !important;
+      inset: 0 !important;
+      width: ${DECK_PREVIEW_WIDTH}px !important;
+      height: ${DECK_PREVIEW_HEIGHT}px !important;
+      margin: 0 !important;
+      overflow: hidden !important;
+      transform: none !important;
+      transform-origin: 0 0 !important;
+    }
     .slide,
     section[data-slide],
     section[data-screen-label] {
@@ -2500,9 +2511,24 @@ function deckPreviewSrcDoc(html: string): string {
       flex: none !important;
       scroll-snap-align: none !important;
     }
-    .slide:not(:first-of-type),
-    section[data-slide]:not(:first-of-type),
-    section[data-screen-label]:not(:first-of-type),
+    [data-od-cover-slide] {
+      opacity: 1 !important;
+      visibility: visible !important;
+      transform: none !important;
+    }
+    [data-od-cover-slide] > *,
+    [data-od-cover-slide] [data-anim],
+    [data-od-cover-slide] .reveal {
+      animation: none !important;
+      transition: none !important;
+      opacity: 1 !important;
+      visibility: visible !important;
+      transform: none !important;
+      clip-path: none !important;
+    }
+    .slide:not([data-od-cover-slide]),
+    section[data-slide]:not([data-od-cover-slide]),
+    section[data-screen-label]:not([data-od-cover-slide]),
     .deck-counter,
     .deck-controls,
     .deck-hint,
@@ -2521,6 +2547,7 @@ function deckPreviewSrcDoc(html: string): string {
     #deck-next,
     #deck-cur,
     #deck-total,
+    #hint,
     [data-deck-controls],
     [data-page-controls],
     [data-pagination],
@@ -2536,7 +2563,45 @@ function deckPreviewSrcDoc(html: string): string {
       pointer-events: none !important;
     }
   </style>`;
-  return injectBefore(withoutScripts, '</head>', style);
+  return injectBefore(withCoverSlide, '</head>', style);
+}
+
+function markFirstDeckPage(html: string): string {
+  const tags = [...html.matchAll(/<[a-z][\w:-]*\b[^>]*>/giu)];
+  const classSlide = tags.find((match) => {
+    const className = match[0].match(/\bclass\s*=\s*(["'])(.*?)\1/iu)?.[2];
+    return className?.split(/\s+/u).includes('slide') === true;
+  });
+  const page = classSlide
+    ?? tags.find((match) => /\sdata-slide(?:\s|=|>)/iu.test(match[0]))
+    ?? tags.find((match) => /\sdata-screen-label(?:\s|=|>)/iu.test(match[0]));
+  if (!page || page.index === undefined) return html;
+  const tag = page[0];
+  const classAttribute = tag.match(/\bclass\s*=\s*(["'])(.*?)\1/iu);
+  const activeClasses = ['active', 'is-active'];
+  let activated = tag;
+  if (classAttribute) {
+    const quote = classAttribute[1];
+    const classes = classAttribute[2]?.split(/\s+/u).filter(Boolean) ?? [];
+    for (const activeClass of activeClasses) {
+      if (!classes.includes(activeClass)) classes.push(activeClass);
+    }
+    activated = activated.replace(
+      classAttribute[0],
+      `class=${quote}${classes.join(' ')}${quote}`,
+    );
+  } else {
+    activated = activated.replace(/\s*\/?\s*>$/u, (ending) => (
+      ` class="${activeClasses.join(' ')}"${ending}`
+    ));
+  }
+  activated = activated
+    .replace(/\saria-hidden\s*=\s*(["'])true\1/iu, ' aria-hidden="false"')
+    .replace(/\shidden(?:\s*=\s*(["'])?hidden\1?)?(?=\s|\/?\s*>)/iu, '');
+  const marked = activated.endsWith('/>')
+    ? `${activated.slice(0, -2)} data-od-cover-slide />`
+    : `${activated.slice(0, -1)} data-od-cover-slide>`;
+  return `${html.slice(0, page.index)}${marked}${html.slice(page.index + tag.length)}`;
 }
 
 function injectBefore(source: string, marker: string, addition: string): string {

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -41,7 +41,8 @@ export interface PreviewIframeReportOptions {
 export type PreviewTransportRecoverySignal =
   | 'body_incomplete'
   | 'host_navigation_abort'
-  | 'probe_timeout';
+  | 'probe_timeout'
+  | 'reactivation_unverified';
 
 export interface PreviewTransportDocumentState {
   readyState?: string;
@@ -207,13 +208,23 @@ export function reportPreviewIframeMessage(
 export function reportPreviewTransportRecovery(
   options: PreviewTransportRecoveryOptions,
 ): void {
-  const transportStage = options.signal === 'body_incomplete'
-    ? 'head_bridge_alive_body_tail_missing'
-    : options.signal === 'host_navigation_abort'
-      ? 'active_blob_navigation_aborted'
-      : options.activationAcknowledged
+  let transportStage: string;
+  switch (options.signal) {
+    case 'body_incomplete':
+      transportStage = 'head_bridge_alive_body_tail_missing';
+      break;
+    case 'host_navigation_abort':
+      transportStage = 'active_blob_navigation_aborted';
+      break;
+    case 'reactivation_unverified':
+      transportStage = 'retained_frame_unverified_on_reactivation';
+      break;
+    case 'probe_timeout':
+      transportStage = options.activationAcknowledged
         ? 'head_bridge_lost_after_eager_ack'
         : 'no_head_bridge_ack';
+      break;
+  }
   reportSafetyEvent('client_preview_white_screen', {
     surface: options.surface,
     render_mode: options.renderMode,

--- a/apps/web/src/observability/iframe-error.ts
+++ b/apps/web/src/observability/iframe-error.ts
@@ -40,6 +40,7 @@ export interface PreviewIframeReportOptions {
 
 export type PreviewTransportRecoverySignal =
   | 'body_incomplete'
+  | 'host_navigation_abort'
   | 'probe_timeout';
 
 export interface PreviewTransportDocumentState {
@@ -208,9 +209,11 @@ export function reportPreviewTransportRecovery(
 ): void {
   const transportStage = options.signal === 'body_incomplete'
     ? 'head_bridge_alive_body_tail_missing'
-    : options.activationAcknowledged
-      ? 'head_bridge_lost_after_eager_ack'
-      : 'no_head_bridge_ack';
+    : options.signal === 'host_navigation_abort'
+      ? 'active_blob_navigation_aborted'
+      : options.activationAcknowledged
+        ? 'head_bridge_lost_after_eager_ack'
+        : 'no_head_bridge_ack';
   reportSafetyEvent('client_preview_white_screen', {
     surface: options.surface,
     render_mode: options.renderMode,

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3625,21 +3625,6 @@ function injectDeckBridge(
     }
     return null;
   }
-  function finishDirectJumpMotion(target){
-    var list = slides();
-    var slide = list[target];
-    if (!slide || typeof slide.getAnimations !== 'function') return;
-    try {
-      // A thumbnail is an explicit seek, not a request to replay every
-      // authored entrance transition. Finish only animations that belong to
-      // the selected slide after its own router has activated it. Arrow-key
-      // and in-canvas navigation still keep the artifact's native motion.
-      var animations = slide.getAnimations({ subtree: true });
-      for (var i=0; i<animations.length; i++) {
-        try { animations[i].finish(); } catch (_) {}
-      }
-    } catch (_) {}
-  }
   function goViaArtifactIndex(target, navigationSequence, onDone){
     var list = slides();
     var invoke = artifactIndexInvoker(target, list.length);
@@ -3652,11 +3637,7 @@ function injectDeckBridge(
       invoke();
       waitForDeckMove(beforeIndex, beforeTrack, function(moved){
         if (navigationSequence !== odNavigationSequence) return;
-        if (moved || activeIndex(slides()) === target) {
-          finishDirectJumpMotion(target);
-          onDone(true);
-          return;
-        }
+        if (moved || activeIndex(slides()) === target) { onDone(true); return; }
         // Some authored decks lock navigation during their entrance/slide
         // transition. Keep the current page visible and retry the SAME target;
         // never translate one thumbnail click into visible intermediate pages.

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3598,6 +3598,23 @@ function injectDeckBridge(
       });
     });
   }
+  function stepToIndexViaKeys(target, navigationSequence, onDone){
+    var guard = slides().length + 4;
+    function isCurrent(){ return navigationSequence === odNavigationSequence; }
+    function step(){
+      if (!isCurrent()) return;
+      var current = activeIndex(slides());
+      if (current === target) { onDone(true); return; }
+      if (guard <= 0) { onDone(false); return; }
+      guard -= 1;
+      goViaArtifactKeys(target > current ? 'ArrowRight' : 'ArrowLeft', function(moved){
+        if (!isCurrent()) return;
+        if (!moved) { onDone(false); return; }
+        step();
+      }, isCurrent);
+    }
+    step();
+  }
   function artifactIndexInvoker(target, count){
     var selectors = ['.nav-dot', '[data-slide-index]', '[data-page-index]'];
     for (var s=0; s<selectors.length; s++) {
@@ -3701,10 +3718,14 @@ function injectDeckBridge(
     goViaArtifactIndex(target, navigationSequence, function(moved){
       if (navigationSequence !== odNavigationSequence) return;
       if (moved) { report(); return; }
-      var now = slides();
-      if (canSetActive(now) && setActive(target)) return;
-      if (transformGo(target)) return;
-      setTimeout(report, 320);
+      stepToIndexViaKeys(target, navigationSequence, function(stepped){
+        if (navigationSequence !== odNavigationSequence) return;
+        if (stepped) { report(); return; }
+        var now = slides();
+        if (canSetActive(now) && setActive(target)) return;
+        if (transformGo(target)) return;
+        setTimeout(report, 320);
+      });
     });
   }
   function isInteractiveClickTarget(target){

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3619,7 +3619,28 @@ function injectDeckBridge(
           var hashPrefix = currentHashMatch
             ? currentHashMatch[1]
             : ${JSON.stringify(inlineHashIndexPrefix)};
-          window.location.hash = hashPrefix + (target + 1);
+          var nextHash = hashPrefix + (target + 1);
+          if (window.location.hash === nextHash) return;
+          var oldUrl = String(window.location.href || '');
+          try {
+            // A fragment assignment on a Blob-backed Electron preview can be
+            // promoted to a slow navigation and briefly clear the compositor.
+            // Match artifact-owned routers: update the same-document route
+            // synchronously, then deliver the event they already listen for.
+            window.history.replaceState(null, '', nextHash);
+            var hashChangeEvent;
+            try {
+              hashChangeEvent = new HashChangeEvent('hashchange', {
+                oldURL: oldUrl,
+                newURL: String(window.location.href || ''),
+              });
+            } catch (_) {
+              hashChangeEvent = new Event('hashchange');
+            }
+            window.dispatchEvent(hashChangeEvent);
+          } catch (_) {
+            window.location.hash = nextHash;
+          }
         } catch (_) {}
       };
     }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -3625,6 +3625,21 @@ function injectDeckBridge(
     }
     return null;
   }
+  function finishDirectJumpMotion(target){
+    var list = slides();
+    var slide = list[target];
+    if (!slide || typeof slide.getAnimations !== 'function') return;
+    try {
+      // A thumbnail is an explicit seek, not a request to replay every
+      // authored entrance transition. Finish only animations that belong to
+      // the selected slide after its own router has activated it. Arrow-key
+      // and in-canvas navigation still keep the artifact's native motion.
+      var animations = slide.getAnimations({ subtree: true });
+      for (var i=0; i<animations.length; i++) {
+        try { animations[i].finish(); } catch (_) {}
+      }
+    } catch (_) {}
+  }
   function goViaArtifactIndex(target, navigationSequence, onDone){
     var list = slides();
     var invoke = artifactIndexInvoker(target, list.length);
@@ -3637,7 +3652,11 @@ function injectDeckBridge(
       invoke();
       waitForDeckMove(beforeIndex, beforeTrack, function(moved){
         if (navigationSequence !== odNavigationSequence) return;
-        if (moved || activeIndex(slides()) === target) { onDone(true); return; }
+        if (moved || activeIndex(slides()) === target) {
+          finishDirectJumpMotion(target);
+          onDone(true);
+          return;
+        }
         // Some authored decks lock navigation during their entrance/slide
         // transition. Keep the current page visible and retry the SAME target;
         // never translate one thumbnail click into visible intermediate pages.

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2870,6 +2870,9 @@ function injectDeckBridge(
   const hasInlineSlideMessageListener =
     /addEventListener\s*\(\s*['"]message['"]/i.test(doc) && /\bod:slide\b/.test(doc);
   const hasInlineKeydownListener = !!options.artifactHasKeydownNavigation;
+  const hasInlineHashNavigation =
+    /(?:hashchange|onhashchange)/i.test(doc) && /location\.hash/i.test(doc);
+  const inlineHashIndexPrefix = /['"`]#\/['"`]/.test(doc) ? '#/' : '#';
   const isFrameworkDeck = /\bid\s*=\s*["']deck-stage["']/i.test(doc);
   const clickNavigation = !!options.clickNavigation && !isFrameworkDeck;
   // Framework decks (`id="deck-stage"`) get the inverse fix. Their skeleton
@@ -3514,7 +3517,9 @@ function injectDeckBridge(
   // deferred artifact handler still runs afterwards, advancing a second time
   // and desyncing the artifact's internal index from the visible slide.
   var KEY_PROBE_WINDOW_MS = 48;
+  var DIRECT_INDEX_UNLOCK_TIMEOUT_MS = 1500;
   var preferredKeyTarget = null;
+  var odNavigationSequence = 0;
   // Seeded from a source scan (inline artifact scripts run before this
   // bridge); the addEventListener patches below catch later registrations.
   // Decks with no keyboard handling at all skip the probe entirely, so their
@@ -3564,7 +3569,8 @@ function injectDeckBridge(
       target.dispatchEvent(new KeyboardEvent('keyup', init));
     } catch (_) {}
   }
-  function goViaArtifactKeys(key, onDone){
+  function goViaArtifactKeys(key, onDone, isCurrent){
+    if (isCurrent && !isCurrent()) { onDone(false); return; }
     if (!key || !artifactHasKeydownNavigation()) { onDone(false); return; }
     var beforeIndex = activeIndex(slides());
     var beforeTrack = trackTransformSnapshot();
@@ -3572,6 +3578,7 @@ function injectDeckBridge(
     // window first on every keypress would tax document-listening decks one
     // probe window per navigation.
     if (preferredKeyTarget) {
+      if (isCurrent && !isCurrent()) { onDone(false); return; }
       dispatchKeysTo(preferredKeyTarget, key);
       waitForDeckMove(beforeIndex, beforeTrack, onDone);
       return;
@@ -3583,6 +3590,7 @@ function injectDeckBridge(
     dispatchKeysTo(window, key);
     waitForDeckMove(beforeIndex, beforeTrack, function(moved){
       if (moved) { preferredKeyTarget = window; onDone(true); return; }
+      if (isCurrent && !isCurrent()) { onDone(false); return; }
       dispatchKeysTo(document, key);
       waitForDeckMove(beforeIndex, beforeTrack, function(movedViaDocument){
         if (movedViaDocument) preferredKeyTarget = document;
@@ -3590,21 +3598,57 @@ function injectDeckBridge(
       });
     });
   }
-  function stepToIndexViaKeys(target, onDone){
-    var guard = slides().length + 4;
-    function step(){
-      var current = activeIndex(slides());
-      if (current === target) { onDone(true); return; }
-      if (guard <= 0) { onDone(false); return; }
-      guard -= 1;
-      goViaArtifactKeys(target > current ? 'ArrowRight' : 'ArrowLeft', function(moved){
-        if (!moved) { onDone(false); return; }
-        step();
+  function artifactIndexInvoker(target, count){
+    var selectors = ['.nav-dot', '[data-slide-index]', '[data-page-index]'];
+    for (var s=0; s<selectors.length; s++) {
+      var controls = document.querySelectorAll(selectors[s]);
+      if (controls.length < count || !controls[target]) continue;
+      return function(){
+        try { controls[target].click(); } catch (_) {}
+      };
+    }
+    if (${JSON.stringify(hasInlineHashNavigation)}) {
+      return function(){
+        try {
+          // Preserve the artifact's own numeric hash route. Decks commonly
+          // use either #3 or #/3; changing the route shape makes their
+          // hashchange handler ignore the request, after which the bridge
+          // waits the full navigation-lock timeout and desynchronizes the
+          // artifact's private index with a DOM-only fallback.
+          var currentHashMatch = String(window.location.hash || '').match(/^(#.*?)(\d+)$/);
+          var hashPrefix = currentHashMatch
+            ? currentHashMatch[1]
+            : ${JSON.stringify(inlineHashIndexPrefix)};
+          window.location.hash = hashPrefix + (target + 1);
+        } catch (_) {}
+      };
+    }
+    return null;
+  }
+  function goViaArtifactIndex(target, navigationSequence, onDone){
+    var list = slides();
+    var invoke = artifactIndexInvoker(target, list.length);
+    if (!invoke) { onDone(false); return; }
+    var deadline = Date.now() + DIRECT_INDEX_UNLOCK_TIMEOUT_MS;
+    function attempt(){
+      if (navigationSequence !== odNavigationSequence) return;
+      var beforeIndex = activeIndex(slides());
+      var beforeTrack = trackTransformSnapshot();
+      invoke();
+      waitForDeckMove(beforeIndex, beforeTrack, function(moved){
+        if (navigationSequence !== odNavigationSequence) return;
+        if (moved || activeIndex(slides()) === target) { onDone(true); return; }
+        // Some authored decks lock navigation during their entrance/slide
+        // transition. Keep the current page visible and retry the SAME target;
+        // never translate one thumbnail click into visible intermediate pages.
+        if (Date.now() < deadline) { setTimeout(attempt, 80); return; }
+        onDone(false);
       });
     }
-    step();
+    attempt();
   }
   function go(action){
+    var navigationSequence = ++odNavigationSequence;
     var list = slides();
     if (!list.length) return;
     if (navigateViaDeckStage(list, action)) return;
@@ -3613,6 +3657,7 @@ function injectDeckBridge(
       return;
     }
     goViaArtifactKeys(keyForAction(action), function(moved){
+      if (navigationSequence !== odNavigationSequence) return;
       if (moved) { report(); return; }
       // Recompute the target at fallback time: rapid host requests can have
       // several probes in flight, and each fallback must step from the deck's
@@ -3622,26 +3667,22 @@ function injectDeckBridge(
       if (canSetActive(now) && setActive(target)) return;
       if (transformGo(target)) return;
       setTimeout(report, 280);
-    });
+    }, function(){ return navigationSequence === odNavigationSequence; });
   }
   function gotoIndex(i){
+    var navigationSequence = ++odNavigationSequence;
     var list = slides();
     if (!list.length) return;
     var target = Math.max(0, Math.min(list.length - 1, i));
     if (navigateViaDeckStage(list, 'go', target)) return;
     if (isScrollDeck(list)) { scrollGo(target); return; }
     if (activeIndex(list) === target) { report(); return; }
-    stepToIndexViaKeys(target, function(stepped){
-      if (stepped) { report(); return; }
+    goViaArtifactIndex(target, navigationSequence, function(moved){
+      if (navigationSequence !== odNavigationSequence) return;
+      if (moved) { report(); return; }
       var now = slides();
       if (canSetActive(now) && setActive(target)) return;
       if (transformGo(target)) return;
-      var current = activeIndex(slides());
-      var diff = target - current;
-      if (!diff) { report(); return; }
-      var key = diff > 0 ? 'ArrowRight' : 'ArrowLeft';
-      var n = Math.abs(diff);
-      for (var k = 0; k < n; k++) dispatchKey(key);
       setTimeout(report, 320);
     });
   }
@@ -3794,6 +3835,12 @@ function injectDeckBridge(
   addOdSlideMessageListener(function(ev){
     var data = ev && ev.data;
     if (!data || data.type !== 'od:slide') return;
+    // Every newer host intent cancels an older multi-step jump, including a
+    // request for the slide that is CURRENTLY visible. The older jump may not
+    // have dispatched its first accepted key yet (the artifact can register on
+    // document after the window probe), so returning early without cancelling
+    // lets that stale request move the deck after the user's newer click.
+    odNavigationSequence += 1;
     var before = odSlideMessageBeforeIndex;
     odSlideMessageBeforeIndex = -1;
     function applyBridgeFallback() {

--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -139,7 +139,7 @@
 .recent-projects__row--grid .recent-projects__card-thumb {
   flex: 0 0 auto;
   width: 100%;
-  min-height: 108px;
+  min-height: 0;
   margin-top: 0;
 }
 .recent-projects__row--grid .recent-projects__card-meta {

--- a/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
@@ -265,7 +265,9 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
     );
 
     expect(srcDocFrame().getAttribute('srcDoc')).toContain('REVISIT-CACHED-V1');
-    expect(screen.queryByRole('status', { name: /loading/i })).not.toBeInTheDocument();
+    // This source-cache regression deliberately does not forge the iframe's
+    // exact paint-probe acknowledgement. The first-load cover and its
+    // paint-verified remount behavior are exercised in FileViewer.test.tsx.
     expect(
       remountFetch.mock.calls.some(([input]) => String(input).startsWith(RAW_URL_PREFIX)),
     ).toBe(false);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7870,7 +7870,7 @@ describe('FileViewer tweaks toolbar', () => {
     }
   });
 
-  it('does not repeat a srcDoc recovery for the same content generation after reactivation', () => {
+  it('revalidates a recovered generation after reactivation without repeating recovery', () => {
     vi.useFakeTimers();
     try {
       const renderViewer = (workspaceActive: boolean) => (
@@ -7905,7 +7905,13 @@ describe('FileViewer tweaks toolbar', () => {
         ([message]) => (
           (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe'
         ),
-      )).toHaveLength(0);
+      )).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(recoveredFrame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
@@ -8035,6 +8041,53 @@ describe('FileViewer tweaks toolbar', () => {
         vi.advanceTimersByTime(1_500);
       });
       expect(screen.getByTestId('artifact-preview-frame')).not.toBe(frame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreHost();
+      vi.useRealTimers();
+    }
+  });
+
+  it('immediately recovers an exact active Open Design blob navigation abort', () => {
+    vi.useFakeTimers();
+    let navigationFailureListener: OpenDesignHostPreviewNavigationFailureListener | null = null;
+    const restoreHost = installMockOpenDesignHost({
+      host: {
+        preview: {
+          subscribeNavigationFailure: (listener) => {
+            navigationFailureListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'blob-deck.html', path: 'blob-deck.html' })}
+          liveHtml={'<!doctype html><html><body><main>Deck</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />,
+      );
+      const failedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const failedUrl = 'blob:od://app/failed-preview-document';
+      failedFrame.setAttribute('src', failedUrl);
+
+      act(() => {
+        navigationFailureListener?.({
+          errorCode: -3,
+          eventId: 1,
+          frameName: failedFrame.name,
+          occurredAtMs: Date.now(),
+          validatedUrl: failedUrl,
+        });
+      });
+
+      const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(recoveredFrame).not.toBe(failedFrame);
+      expect(recoveredFrame.srcdoc).toContain('data-od-lazy-srcdoc-transport');
       expect(safetyEventMock).toHaveBeenCalledTimes(1);
     } finally {
       restoreHost();

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7870,7 +7870,7 @@ describe('FileViewer tweaks toolbar', () => {
     }
   });
 
-  it('revalidates a recovered generation after reactivation without repeating recovery', () => {
+  it('allows one fresh recovery when an unverified generation is reactivated', () => {
     vi.useFakeTimers();
     try {
       const renderViewer = (workspaceActive: boolean) => (
@@ -7896,7 +7896,10 @@ describe('FileViewer tweaks toolbar', () => {
 
       rerender(renderViewer(false));
       rerender(renderViewer(true));
-      const postMessage = vi.spyOn(recoveredFrame.contentWindow!, 'postMessage');
+      const reactivatedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(reactivatedFrame).not.toBe(recoveredFrame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(2);
+      const postMessage = vi.spyOn(reactivatedFrame.contentWindow!, 'postMessage');
       act(() => {
         vi.advanceTimersByTime(1_500);
       });
@@ -7910,8 +7913,8 @@ describe('FileViewer tweaks toolbar', () => {
       act(() => {
         vi.advanceTimersByTime(1_500);
       });
-      expect(screen.getByTestId('artifact-preview-frame')).toBe(recoveredFrame);
-      expect(safetyEventMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(reactivatedFrame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1804,7 +1804,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(reactivatedFrame.name).toBe(frameName);
   });
 
-  it('shows localized loading only until a srcDoc file paints for the first time', () => {
+  it('does not cover non-empty srcDoc content while paint verification is pending', () => {
     const viewer = (
       <I18nProvider initial="zh-CN">
         <FileViewer
@@ -1822,10 +1822,7 @@ describe('FileViewer SVG artifacts', () => {
       </I18nProvider>
     );
     const { unmount } = render(viewer);
-    expect(screen.getByTestId('artifact-preview-first-load')).toHaveAttribute(
-      'aria-label',
-      '加载中…',
-    );
+    expect(screen.queryByTestId('artifact-preview-first-load')).not.toBeInTheDocument();
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
     const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
     fireEvent.load(frame);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -6,6 +6,10 @@ import { useLayoutEffect, useRef, useState, type ReactElement } from 'react';
 import { act, cleanup, createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { installMockOpenDesignHost } from '@open-design/host/testing';
+import type {
+  OpenDesignHostPreviewNavigationFailure,
+  OpenDesignHostPreviewNavigationFailureListener,
+} from '@open-design/host';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ANNOTATION_EVENT } from '../../src/components/PreviewDrawOverlay';
 
@@ -808,6 +812,66 @@ describe('FileViewer preview scale', () => {
     expect(rawReads[0]?.url).not.toContain('workspaceId=');
     expect(rawReads[0]?.url).not.toContain('workspaceMemberId=');
     expect(rawReads[0]?.init?.headers).toBeUndefined();
+  });
+
+  it('warms a newly retained inactive HTML viewer before its first activation', async () => {
+    const file = baseFile({
+      name: 'inactive-first-open.html',
+      path: 'inactive-first-open.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Inactive first open',
+        entry: 'inactive-first-open.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const rawReads: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/raw/inactive-first-open.html')) {
+        rawReads.push(url);
+        return new Response('<html><body>Already warm</body></html>', { status: 200 });
+      }
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    }));
+    const props = {
+      projectId: 'project-1',
+      projectKind: 'prototype' as const,
+      file,
+    };
+    const { rerender } = render(
+      <CollabProvider value={{
+        ...projectWorkspaceCollabValue(null),
+        projectResourceAuthority: 'local',
+      }}>
+        <FileViewer {...props} workspaceActive={false} />
+      </CollabProvider>,
+    );
+
+    const retainedFrame = await waitFor(() => {
+      expect(rawReads).toHaveLength(1);
+      const frame = document.querySelector<HTMLIFrameElement>(
+        'iframe[data-testid="artifact-preview-frame-retained-inactive-first-open.html"], iframe[data-testid="artifact-preview-frame-srcdoc-retained-inactive-first-open.html"]',
+      );
+      expect(frame).not.toBeNull();
+      return frame!;
+    });
+
+    rerender(
+      <CollabProvider value={{
+        ...projectWorkspaceCollabValue(null),
+        projectResourceAuthority: 'local',
+      }}>
+        <FileViewer {...props} workspaceActive />
+      </CollabProvider>,
+    );
+
+    expect(document.querySelector('iframe[data-testid="artifact-preview-frame"]')).toBe(retainedFrame);
+    expect(rawReads).toHaveLength(1);
   });
 
   it('never downgrades denied project resources to local reads', async () => {
@@ -1677,6 +1741,170 @@ describe('FileViewer SVG artifacts', () => {
     expect(parkedFrames).not.toContain(firstFrame);
   });
 
+  it('parks a newly pooled iframe before starting its srcDoc navigation', () => {
+    const originalSetAttribute = HTMLIFrameElement.prototype.setAttribute;
+    const navigationAttributes: string[] = [];
+    const setAttribute = vi.spyOn(HTMLIFrameElement.prototype, 'setAttribute')
+      .mockImplementation(function setIframeAttribute(
+        this: HTMLIFrameElement,
+        name: string,
+        value: string,
+      ) {
+        if (name === 'src' || name === 'srcdoc') navigationAttributes.push(name);
+        return originalSetAttribute.call(this, name, value);
+      });
+    try {
+      render(
+        <IframeKeepAliveProvider>
+          <PooledIframe
+            cacheKey={previewIframeKeepAliveKey('project-1', 'deck.html')}
+            src="about:blank"
+            srcDoc="<!doctype html><html><body>Deck</body></html>"
+            title="deck.html"
+          />
+        </IframeKeepAliveProvider>,
+      );
+
+      expect(navigationAttributes).toEqual(['src', 'srcdoc']);
+    } finally {
+      setAttribute.mockRestore();
+    }
+  });
+
+  it('recreates a srcDoc preview iframe instead of parking its browsing context across project views', () => {
+    const viewer = (
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={baseFile({
+          name: 'deck.html',
+          path: 'deck.html',
+          mime: 'text/html',
+          kind: 'html',
+        })}
+        liveHtml={'<!doctype html><html><body><main>Deck</main><script>location.reload()</script></body></html>'}
+        workspaceActive
+      />
+    );
+    const { container, rerender } = render(
+      <IframeKeepAliveProvider>{viewer}</IframeKeepAliveProvider>,
+    );
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const srcDoc = frame.srcdoc;
+    const frameName = frame.name;
+
+    rerender(<IframeKeepAliveProvider>{null}</IframeKeepAliveProvider>);
+    expect(container.querySelector('.iframe-keep-alive-pool')?.contains(frame)).toBe(false);
+    expect(frame.isConnected).toBe(false);
+
+    rerender(<IframeKeepAliveProvider>{viewer}</IframeKeepAliveProvider>);
+    const reactivatedFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    expect(reactivatedFrame).not.toBe(frame);
+    expect(reactivatedFrame.srcdoc).toBe(srcDoc);
+    expect(reactivatedFrame.name).toBe(frameName);
+  });
+
+  it('shows localized loading only until a srcDoc file paints for the first time', () => {
+    const viewer = (
+      <I18nProvider initial="zh-CN">
+        <FileViewer
+          projectId="first-paint-project"
+          projectKind="prototype"
+          file={baseFile({
+            name: 'first-paint-deck.html',
+            path: 'first-paint-deck.html',
+            mime: 'text/html',
+            kind: 'html',
+          })}
+          liveHtml={'<!doctype html><html><body><main>First paint</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />
+      </I18nProvider>
+    );
+    const { unmount } = render(viewer);
+    expect(screen.getByTestId('artifact-preview-first-load')).toHaveAttribute(
+      'aria-label',
+      '加载中…',
+    );
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    fireEvent.load(frame);
+    const probe = postMessage.mock.calls.find(
+      ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+    )?.[0] as { generation?: string; probeId?: string } | undefined;
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        source: frame.contentWindow,
+        data: {
+          type: 'od:srcdoc-transport-activated',
+          generation: probe?.generation,
+          probeId: probe?.probeId,
+          bodyComplete: true,
+        },
+      }));
+    });
+    expect(screen.queryByTestId('artifact-preview-first-load')).not.toBeInTheDocument();
+
+    unmount();
+    render(viewer);
+    expect(screen.queryByTestId('artifact-preview-first-load')).not.toBeInTheDocument();
+  });
+
+  it('loads an inline preview through a blob URL when the browser supports it', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = vi.fn(() => 'blob:od://app/preview-document');
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const userAgent = vi.spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue('OpenDesign/0.20 Electron/41.3.0');
+    try {
+      render(
+        <FileViewer
+          projectId="blob-preview-project"
+          projectKind="prototype"
+          file={baseFile({
+            name: 'blob-preview.html',
+            path: 'blob-preview.html',
+            mime: 'text/html',
+            kind: 'html',
+          })}
+          liveHtml={'<!doctype html><html><body><main>Blob preview</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />,
+      );
+
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(frame.getAttribute('src')).toBe('blob:od://app/preview-document');
+      expect(frame.hasAttribute('srcdoc')).toBe(false);
+    } finally {
+      userAgent.mockRestore();
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, 'createObjectURL', {
+          configurable: true,
+          value: originalCreateObjectURL,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'createObjectURL');
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, 'revokeObjectURL', {
+          configurable: true,
+          value: originalRevokeObjectURL,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'revokeObjectURL');
+      }
+    }
+  });
+
   it('enforces the iframe pool limit when new active frames attach over parked entries', () => {
     function Frame({ name }: { name: string }) {
       return (
@@ -2182,6 +2410,43 @@ describe('FileViewer SVG artifacts', () => {
     rerender(<FileViewer {...props} workspaceActive filesRefreshKey={9} />);
     await new Promise((resolve) => window.setTimeout(resolve, 240));
     expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps file action nodes mounted while a retained viewer becomes inactive', async () => {
+    const chromeActionsHost = document.createElement('div');
+    chromeActionsHost.id = 'app-chrome-file-actions';
+    chromeActionsHost.dataset.appChromeFileActions = 'true';
+    document.body.appendChild(chromeActionsHost);
+    const file = baseFile({
+      name: 'toolbar-owner.html',
+      path: 'toolbar-owner.html',
+      mime: 'text/html',
+      kind: 'html',
+    });
+    const props = {
+      projectId: 'project-1',
+      projectKind: 'prototype' as const,
+      file,
+      liveHtml: '<html><body>toolbar owner</body></html>',
+    };
+
+    try {
+      const { rerender } = render(<FileViewer {...props} workspaceActive />);
+      const owner = await waitFor(() => {
+        const node = chromeActionsHost.querySelector<HTMLElement>(
+          '[data-od-file-actions-owner="toolbar-owner.html"]',
+        );
+        expect(node).not.toBeNull();
+        return node!;
+      });
+
+      rerender(<FileViewer {...props} workspaceActive={false} />);
+
+      expect(chromeActionsHost.contains(owner)).toBe(true);
+      expect(owner.style.display).toBe('none');
+    } finally {
+      chromeActionsHost.remove();
+    }
   });
 
   it('defers simultaneous mtime and file-watch updates while retained, then applies only the latest version once', async () => {
@@ -7553,7 +7818,346 @@ describe('FileViewer tweaks toolbar', () => {
     }
   });
 
-  it('cancels srcDoc verification in Code mode and restarts it on Preview', () => {
+  it('preserves a verified srcDoc witness across retained viewer reactivation', () => {
+    vi.useFakeTimers();
+    try {
+      const renderViewer = (workspaceActive: boolean) => (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'sandbox.html', path: 'sandbox.html' })}
+          liveHtml={'<!doctype html><html><body><script>location.reload()</script></body></html>'}
+          workspaceActive={workspaceActive}
+        />
+      );
+      const { rerender } = render(renderViewer(true));
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+      fireEvent.load(frame);
+      const probes = () => postMessage.mock.calls
+        .map(([message]) => message as { type?: unknown; generation?: string; probeId?: string })
+        .filter((message) => message.type === 'od:srcdoc-transport-ready-probe');
+      const initialProbe = probes()[0]!;
+      expect(initialProbe.probeId).toBeTruthy();
+
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: frame.contentWindow,
+          data: {
+            type: 'od:srcdoc-transport-activated',
+            generation: initialProbe.generation,
+            probeId: initialProbe.probeId,
+            bodyComplete: true,
+          },
+        }));
+      });
+
+      safetyEventMock.mockClear();
+      rerender(renderViewer(false));
+      rerender(renderViewer(true));
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(probes()).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(safetyEventMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not repeat a srcDoc recovery for the same content generation after reactivation', () => {
+    vi.useFakeTimers();
+    try {
+      const renderViewer = (workspaceActive: boolean) => (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'sandbox.html', path: 'sandbox.html' })}
+          liveHtml={'<!doctype html><html><body><script>location.reload()</script></body></html>'}
+          workspaceActive={workspaceActive}
+        />
+      );
+      const { rerender } = render(renderViewer(true));
+      const initialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      fireEvent.load(initialFrame);
+
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+
+      const recoveredFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(recoveredFrame).not.toBe(initialFrame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
+
+      rerender(renderViewer(false));
+      rerender(renderViewer(true));
+      const postMessage = vi.spyOn(recoveredFrame.contentWindow!, 'postMessage');
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+
+      expect(postMessage.mock.calls.filter(
+        ([message]) => (
+          (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe'
+        ),
+      )).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a verified srcDoc frame visible when Electron reports a late ERR_ABORTED', () => {
+    vi.useFakeTimers();
+    let latestNavigationFailure: OpenDesignHostPreviewNavigationFailure | null = null;
+    let navigationFailureListener: OpenDesignHostPreviewNavigationFailureListener | null = null;
+    const emitNavigationFailure = (failure: OpenDesignHostPreviewNavigationFailure) => {
+      latestNavigationFailure = failure;
+      navigationFailureListener?.(failure);
+    };
+    const restoreHost = installMockOpenDesignHost({
+      host: {
+        preview: {
+          getLatestNavigationFailure: () => latestNavigationFailure,
+          subscribeNavigationFailure: (listener) => {
+            navigationFailureListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    try {
+      const renderViewer = (workspaceActive: boolean) => (
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'deck.html', path: 'deck.html' })}
+          liveHtml={'<!doctype html><html><body><main>Deck</main><script>location.reload()</script></body></html>'}
+          workspaceActive={workspaceActive}
+        />
+      );
+      const { rerender } = render(renderViewer(true));
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.name).toMatch(/^od-artifact-preview-srcdoc-[a-f0-9]+$/);
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+      fireEvent.load(frame);
+      const probe = postMessage.mock.calls.find(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )?.[0] as { generation?: string; probeId?: string } | undefined;
+      expect(probe?.generation).toBeTruthy();
+      expect(probe?.probeId).toBeTruthy();
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: frame.contentWindow,
+          data: {
+            type: 'od:srcdoc-transport-activated',
+            generation: probe!.generation,
+            probeId: probe!.probeId,
+            bodyComplete: true,
+          },
+        }));
+      });
+      const probesBeforeFailure = postMessage.mock.calls.filter(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      ).length;
+
+      act(() => {
+        emitNavigationFailure({
+          errorCode: -3,
+          eventId: 1,
+          frameName: frame.name,
+          occurredAtMs: Date.now(),
+          validatedUrl: 'about:srcdoc',
+        });
+        vi.runAllTimers();
+      });
+
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(frame.style.display).toBe('');
+      expect(postMessage.mock.calls.filter(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )).toHaveLength(probesBeforeFailure);
+      expect(safetyEventMock).not.toHaveBeenCalled();
+
+      rerender(renderViewer(false));
+      rerender(renderViewer(true));
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(frame.style.display).toBe('');
+    } finally {
+      restoreHost();
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses an exact active ERR_ABORTED to probe an unverified generation once', () => {
+    vi.useFakeTimers();
+    let navigationFailureListener: OpenDesignHostPreviewNavigationFailureListener | null = null;
+    const restoreHost = installMockOpenDesignHost({
+      host: {
+        preview: {
+          subscribeNavigationFailure: (listener) => {
+            navigationFailureListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'deck.html', path: 'deck.html' })}
+          liveHtml={'<!doctype html><html><body><main>Deck</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />,
+      );
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+      act(() => {
+        navigationFailureListener?.({
+          errorCode: -3,
+          eventId: 1,
+          frameName: frame.name,
+          occurredAtMs: Date.now(),
+          validatedUrl: 'about:srcdoc',
+        });
+      });
+      expect(postMessage.mock.calls.filter(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+      expect(screen.getByTestId('artifact-preview-frame')).not.toBe(frame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreHost();
+      vi.useRealTimers();
+    }
+  });
+
+  it('probes the active unverified frame when Electron loses the aborted frame name', () => {
+    vi.useFakeTimers();
+    let navigationFailureListener: OpenDesignHostPreviewNavigationFailureListener | null = null;
+    const restoreHost = installMockOpenDesignHost({
+      host: {
+        preview: {
+          subscribeNavigationFailure: (listener) => {
+            navigationFailureListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'deck.html', path: 'deck.html' })}
+          liveHtml={'<!doctype html><html><body><main>Deck</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />,
+      );
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+
+      act(() => {
+        navigationFailureListener?.({
+          errorCode: -3,
+          eventId: 1,
+          occurredAtMs: Date.now(),
+          validatedUrl: 'about:srcdoc',
+        });
+      });
+
+      expect(postMessage.mock.calls.filter(
+        ([message]) => (message as { type?: unknown }).type === 'od:srcdoc-transport-ready-probe',
+      )).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1_500);
+      });
+      expect(screen.getByTestId('artifact-preview-frame')).not.toBe(frame);
+      expect(safetyEventMock).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreHost();
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps live edit styles on the replacement frame and replays them when its bridge becomes ready', async () => {
+    vi.useFakeTimers();
+    let navigationFailureListener: OpenDesignHostPreviewNavigationFailureListener | null = null;
+    const restoreHost = installMockOpenDesignHost({
+      host: {
+        preview: {
+          subscribeNavigationFailure: (listener) => {
+            navigationFailureListener = listener;
+            return () => undefined;
+          },
+        },
+      },
+    });
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={htmlPreviewFile({ name: 'deck.html', path: 'deck.html' })}
+          liveHtml={'<!doctype html><html><body><main data-od-id="hero">Deck</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />,
+      );
+      const initialFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      act(() => {
+        navigationFailureListener?.({
+          errorCode: -3,
+          eventId: 1,
+          occurredAtMs: Date.now(),
+          validatedUrl: 'about:srcdoc',
+        });
+        vi.advanceTimersByTime(1_500);
+      });
+      const replacementFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(replacementFrame).not.toBe(initialFrame);
+      const replacementPostMessage = vi.spyOn(replacementFrame.contentWindow!, 'postMessage');
+
+      fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', {
+          source: replacementFrame.contentWindow,
+          data: { type: 'od-edit-background' },
+        }));
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Pick Background' }));
+      fireEvent.click(screen.getByRole('button', { name: '#3b82f6' }));
+      const expectedStyleMessage = expect.objectContaining({
+        type: 'od-edit-preview-style',
+        id: '__body__',
+        styles: { backgroundColor: '#3b82f6' },
+      });
+      expect(replacementPostMessage).toHaveBeenCalledWith(expectedStyleMessage, '*');
+
+      replacementPostMessage.mockClear();
+      fireEvent.load(replacementFrame);
+      expect(replacementPostMessage).toHaveBeenCalledWith(expectedStyleMessage, '*');
+    } finally {
+      restoreHost();
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the srcDoc iframe mounted across Code and Preview switches', () => {
     vi.useFakeTimers();
     try {
       render(
@@ -7575,6 +8179,9 @@ describe('FileViewer tweaks toolbar', () => {
 
       safetyEventMock.mockClear();
       fireEvent.click(screen.getByRole('tab', { name: 'Code' }));
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(frame.closest<HTMLElement>('[hidden]')).toHaveStyle({ display: 'none' });
+      expect(screen.getByText(/location\.reload/)).toBeVisible();
       act(() => {
         vi.advanceTimersByTime(1_500);
       });
@@ -7582,6 +8189,8 @@ describe('FileViewer tweaks toolbar', () => {
 
       fireEvent.click(screen.getByRole('tab', { name: 'Preview' }));
       const previewFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(previewFrame).toBe(frame);
+      expect(previewFrame.closest<HTMLElement>('[hidden]')).toBeNull();
       const previewPostMessage = vi.spyOn(previewFrame.contentWindow!, 'postMessage');
       const previewProbes = () => previewPostMessage.mock.calls
         .map(([message]) => message as { type?: unknown; generation?: string; probeId?: string })
@@ -7610,6 +8219,83 @@ describe('FileViewer tweaks toolbar', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('updates the retained srcDoc iframe when an agent edits the file in Code mode', () => {
+    const fileV1 = htmlPreviewFile({
+      name: 'agent-edit.html',
+      path: 'agent-edit.html',
+      mtime: 1_000,
+    });
+    const renderViewer = (mtime: number, liveHtml: string) => (
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={{ ...fileV1, mtime }}
+        liveHtml={liveHtml}
+        workspaceActive
+      />
+    );
+    const { rerender } = render(renderViewer(
+      1_000,
+      '<!doctype html><html><body><main>Agent V1</main><script>location.reload()</script></body></html>',
+    ));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Code' }));
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+    expect(frame.dataset.odActive).toBe('false');
+
+    rerender(renderViewer(
+      2_000,
+      '<!doctype html><html><body><main>Agent V2</main><script>location.reload()</script></body></html>',
+    ));
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+    expect(frame.srcdoc).toContain('Agent V2');
+    expect(frame.srcdoc).not.toContain('Agent V1');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Preview' }));
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+    expect(frame.dataset.odActive).toBe('true');
+    expect(frame.srcdoc).toContain('Agent V2');
+  });
+
+  it('defers hidden file-tab srcDoc updates and commits only the latest generation on activation', () => {
+    const fileV1 = htmlPreviewFile({
+      name: 'retained-agent-edit.html',
+      path: 'retained-agent-edit.html',
+      mtime: 1_000,
+    });
+    const renderViewer = (
+      workspaceActive: boolean,
+      mtime: number,
+      version: string,
+    ) => (
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={{ ...fileV1, mtime }}
+        liveHtml={`<!doctype html><html><body><main>${version}</main><script>location.reload()</script></body></html>`}
+        workspaceActive={workspaceActive}
+      />
+    );
+    const { rerender } = render(renderViewer(true, 1_000, 'Retained V1'));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const initialSrcDoc = frame.srcdoc;
+    expect(initialSrcDoc).toContain('Retained V1');
+
+    rerender(renderViewer(false, 2_000, 'Retained V2'));
+    expect(screen.getByTestId('artifact-preview-frame-srcdoc-retained-retained-agent-edit.html')).toBe(frame);
+    expect(frame.srcdoc).toBe(initialSrcDoc);
+
+    rerender(renderViewer(false, 3_000, 'Retained V3'));
+    expect(frame.srcdoc).toBe(initialSrcDoc);
+
+    rerender(renderViewer(true, 3_000, 'Retained V3'));
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+    expect(frame.srcdoc).toContain('Retained V3');
+    expect(frame.srcdoc).not.toContain('Retained V2');
+    expect(frame.srcdoc).not.toBe(initialSrcDoc);
   });
 
   it('preserves an authored base without minting a project-scoped preview capability', async () => {
@@ -8027,6 +8713,53 @@ describe('FileViewer tweaks toolbar', () => {
     });
     const srcDocAfter = (container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement).srcdoc;
     expect(srcDocAfter).toBe(materializedSrcDoc);
+  });
+
+  it('does not restore a stale edit snapshot when Edit is entered again', async () => {
+    const renderViewer = (liveHtml: string) => (
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={liveHtml}
+      />
+    );
+    const firstSource = '<html><body><main data-od-id="hero">Before edit</main></body></html>';
+    const savedSource = '<html><body><main data-od-id="hero" style="color: red">Saved edit</main></body></html>';
+    const { container, rerender } = render(renderViewer(firstSource));
+
+    clickAgentTool('draw-overlay-toggle');
+    await waitFor(() => {
+      const frame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
+      expect(frame.srcdoc).toContain('Before edit');
+    });
+    clickAgentTool('draw-overlay-toggle');
+    clickAgentTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      const frame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-active')).toBe('true');
+      expect(frame.srcdoc).toContain('Before edit');
+    });
+
+    // A saved style updates host source while the active edit document stays
+    // frozen and receives its visual patch over postMessage.
+    rerender(renderViewer(savedSource));
+    expect((container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement).srcdoc)
+      .toContain('Before edit');
+
+    clickAgentTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      const frame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
+      expect(frame.srcdoc).toContain('Saved edit');
+    });
+    const savedSrcDoc = (container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement).srcdoc;
+
+    clickAgentTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      const frame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-active')).toBe('true');
+      expect(frame.srcdoc).toBe(savedSrcDoc);
+    });
   });
 
   // The freeze / deferred-flush logic covers every interactive preview mode

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -2421,7 +2421,9 @@ describe('FileWorkspace launcher tab creation', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /alpha\.html/i }));
     await waitFor(() => expect(screen.getByTestId('artifact-preview-frame').getAttribute('title')).toBe('alpha.html'));
-    expect(mockedFetchProjectFileText).toHaveBeenCalledTimes(5);
+    // The evicted frame remounts from its exact-version source snapshot. It
+    // must not add a fifth raw read before the file revision changes.
+    expect(mockedFetchProjectFileText).toHaveBeenCalledTimes(4);
     await waitFor(() => {
       expect(screen.getAllByTestId('retained-file-viewer').map((viewer) => viewer.getAttribute('data-file-name')))
         .toEqual(['alpha.html', 'gamma.html', 'delta.html']);
@@ -4322,6 +4324,36 @@ describe('FileWorkspace empty-project generation contract', () => {
 
     expect(screen.getByTestId('design-files-syncing')).toBeTruthy();
     expect(screen.queryByTestId('design-files-empty')).toBeNull();
+  });
+
+  it('keeps an already-materialized viewer and header actions mounted during route revalidation', () => {
+    const file = workspaceFile('artifact.html');
+    const tabsState = { tabs: [file.name], active: file.name };
+    const onTabsStateChange = vi.fn();
+    const renderWorkspace = (materializationPending: boolean) => (
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[file]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={tabsState}
+        onTabsStateChange={onTabsStateChange}
+        materializationPending={materializationPending}
+        fileActionsBefore={<button type="button">Reveal artifact</button>}
+        headerActions={<button type="button">Project action</button>}
+      />
+    );
+    const { rerender } = render(renderWorkspace(false));
+    const retainedViewer = screen.getByTestId('retained-file-viewer');
+
+    rerender(renderWorkspace(true));
+
+    expect(screen.getByTestId('retained-file-viewer')).toBe(retainedViewer);
+    expect(screen.queryByTestId('design-files-syncing')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Reveal artifact' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Project action' })).toBeTruthy();
   });
 
   function assistantMessage(runStatus: 'running' | 'failed'): ChatMessage {

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { StrictMode } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { RecentProjectsStrip } from '../../src/components/RecentProjectsStrip';
+import {
+  deckPreviewSrcDoc,
+  RecentProjectsStrip,
+} from '../../src/components/RecentProjectsStrip';
 import {
   fetchProjectFiles,
   fetchProjectFileText,
@@ -212,6 +217,46 @@ class MockWorkspaceEventSource {
 }
 
 describe('RecentProjectsStrip', () => {
+  it('turns a script-activated deck into a deterministic visible first-page cover', () => {
+    const cover = deckPreviewSrcDoc(`<!doctype html>
+      <html><head><style>
+        #stage { position: fixed; top: 50%; left: 50%; width: 1920px; height: 1080px }
+        .slide { display: none; opacity: 0; visibility: hidden }
+        .slide.active,
+        .slide.is-active { display: flex; opacity: 1; visibility: visible }
+        [data-anim] { opacity: 0; transform: translateY(24px) }
+      </style></head><body>
+        <div id="stage">
+          <section class="slide orange"><h1 data-anim="fade-up">Launch</h1></section>
+          <section class="slide dark"><h1>Details</h1></section>
+        </div>
+        <script>document.querySelector('.slide').classList.add('is-active')</script>
+      </body></html>`);
+
+    expect(cover).not.toContain('<script>');
+    expect(cover).toMatch(
+      /<section class="slide orange active is-active" data-od-cover-slide(?:="")?>/,
+    );
+    expect(cover).toContain('[data-od-cover-slide] > *');
+    expect(cover).toContain(':where(body *):has(> [data-od-cover-slide])');
+    expect(cover).toContain('transform-origin: 0 0 !important');
+    expect(cover).toContain('[data-od-cover-slide] [data-anim]');
+    expect(cover).toContain('opacity: 1 !important');
+    expect(cover).toContain('.slide:not([data-od-cover-slide])');
+  });
+
+  it('lets a 16:9 project cover determine its grid-card height without a taller minimum', () => {
+    const css = readFileSync(
+      join(process.cwd(), 'src/styles/home/recent-projects.css'),
+      'utf8',
+    );
+    const gridThumb = css.match(
+      /\.recent-projects__row--grid \.recent-projects__card-thumb\s*\{([^}]*)\}/u,
+    )?.[1];
+    expect(gridThumb).toContain('min-height: 0');
+    expect(gridThumb).not.toContain('min-height: 108px');
+  });
+
   it('scans a shared project cover once after the same card materializes', async () => {
     stubCoverProbe();
     vi.mocked(fetchProjectFiles).mockResolvedValue([{

--- a/apps/web/tests/observability/iframe-error.test.ts
+++ b/apps/web/tests/observability/iframe-error.test.ts
@@ -161,6 +161,24 @@ describe('preview iframe observability', () => {
     },
   );
 
+  it('classifies a retained unverified frame recovered on reactivation', () => {
+    reportPreviewTransportRecovery({
+      surface: 'artifact_preview',
+      renderMode: 'srcdoc',
+      signal: 'reactivation_unverified',
+      activationAcknowledged: false,
+    });
+
+    expect(reportSafetyEvent).toHaveBeenCalledWith(
+      'client_preview_white_screen',
+      expect.objectContaining({
+        transport_signal: 'reactivation_unverified',
+        transport_stage: 'retained_frame_unverified_on_reactivation',
+        recovery_attempted: true,
+      }),
+    );
+  });
+
   it('deduplicates repeated failures from one preview', () => {
     const seen = new Set<string>();
     const message = {

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -48,6 +48,10 @@ interface CustomDeckOptions {
    * registry hook can observe the registration.
    */
   registerBeforeBridge?: boolean;
+  /** Ignore navigation keys while an authored slide transition is running. */
+  navigationLockMs?: number;
+  /** Expose one artifact-owned direct-index control per slide. */
+  directIndexControls?: boolean;
 }
 
 function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
@@ -105,14 +109,43 @@ function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
   const track = win.document.getElementById('deck-track') as HTMLElement;
   const pagerCur = win.document.getElementById('pager-cur') as HTMLElement;
   let active = 0;
+  let navigationLocked = false;
+  const visited: number[] = [];
   function apply(index: number) {
     active = Math.max(0, Math.min(slides.length - 1, index));
+    visited.push(active);
+    slides.forEach((slide, slideIndex) => {
+      slide.classList.toggle('is-active', slideIndex === active);
+    });
     track.style.transform = `translateX(-${active * 100}vw)`;
     pagerCur.textContent = String(active + 1);
+  }
+  function lockNavigation() {
+    if (!options.navigationLockMs) return;
+    navigationLocked = true;
+    win.setTimeout(() => {
+      navigationLocked = false;
+    }, options.navigationLockMs);
+  }
+  if (options.directIndexControls) {
+    const nav = win.document.createElement('div');
+    nav.className = 'deck-dots';
+    slides.forEach((_slide, index) => {
+      const dot = win.document.createElement('button');
+      dot.className = 'nav-dot';
+      dot.addEventListener('click', () => {
+        if (navigationLocked) return;
+        apply(index);
+        lockNavigation();
+      });
+      nav.appendChild(dot);
+    });
+    win.document.body.appendChild(nav);
   }
   const onKeydown = (event: KeyboardEvent) => {
     const key = event.key;
     if (key !== 'ArrowRight' && key !== 'ArrowLeft' && key !== 'Home' && key !== 'End') return;
+    if (navigationLocked) return;
     // Recompute from the live index inside the step, the way generated decks
     // do: when the update is deferred, every extra key event the bridge leaks
     // in becomes a visible extra advance.
@@ -124,6 +157,7 @@ function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
     };
     if (options.deferUpdate) win.setTimeout(step, 0);
     else step();
+    lockNavigation();
   };
   const registerArtifactHandler = () => {
     const listenTarget = options.listenOn === 'window' ? win : win.document;
@@ -143,7 +177,68 @@ function setupCustomCounterDeck(options: CustomDeckOptions = {}) {
     registerArtifactHandler();
   }
 
-  return { win, parentPostMessage, track, pagerCur };
+  return { win, parentPostMessage, track, pagerCur, visited };
+}
+
+function setupSlashHashDeck() {
+  const bodyHtml = `
+    <section class="slide active">One</section>
+    <section class="slide">Two</section>
+    <section class="slide">Three</section>
+    <span id="pager-cur">1</span>
+  `;
+  const artifactScript = `
+    window.addEventListener('hashchange', function () {
+      var match = location.hash.match(/^#\\/(\\d+)$/);
+      if (match) window.__artifactGo(Number(match[1]) - 1);
+    });
+    function artifactRoute(index) {
+      var target = '#/' + (index + 1);
+      location.hash = target;
+    }
+  `;
+  const srcdoc = buildSrcdoc(
+    `<!doctype html><html><body>${bodyHtml}<script>${artifactScript}</script></body></html>`,
+    { deck: true },
+  );
+  const bridgeScript = extractDeckBridgeScript(srcdoc);
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`, {
+    runScripts: 'outside-only',
+    pretendToBeVisual: true,
+    url: 'https://preview.test/',
+  });
+  const win = dom.window;
+  const parentPostMessage = vi.fn();
+  Object.defineProperty(win, 'parent', {
+    configurable: true,
+    value: { postMessage: parentPostMessage },
+  });
+  const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
+  const pagerCur = win.document.getElementById('pager-cur') as HTMLElement;
+  let current = 0;
+  const go = (index: number) => {
+    current = Math.max(0, Math.min(slides.length - 1, index));
+    slides.forEach((slide, slideIndex) => {
+      slide.classList.toggle('active', slideIndex === current);
+    });
+    pagerCur.textContent = String(current + 1);
+  };
+  Object.defineProperty(win, '__artifactGo', {
+    configurable: true,
+    value: go,
+  });
+  win.addEventListener('hashchange', () => {
+    const match = win.location.hash.match(/^#\/(\d+)$/);
+    if (match) go(Number(match[1]) - 1);
+  });
+  new win.Function(bridgeScript).call(win);
+
+  return {
+    current: () => current,
+    pagerCur,
+    parentPostMessage,
+    win,
+  };
 }
 
 function slideStatesOf(parentPostMessage: ReturnType<typeof vi.fn>) {
@@ -235,6 +330,61 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     expect(track.style.transform).toBe('translateX(-100vw)');
     expect(pagerCur.textContent).toBe('2');
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 1, count: 3 });
+  });
+
+  it('jumps directly to a selected thumbnail without exposing intermediate slides', async () => {
+    const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
+      navigationLockMs: 120,
+      directIndexControls: true,
+    });
+    visited.length = 0;
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 100));
+    expect(track.style.transform).toBe('translateX(-200vw)');
+    expect(pagerCur.textContent).toBe('3');
+    expect(win.document.querySelectorAll('.slide')[2]?.classList.contains('is-active')).toBe(true);
+    expect(visited).toEqual([2]);
+    expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+  });
+
+  it('preserves slash-hash routes for immediate artifact-owned thumbnail jumps', async () => {
+    const { current, pagerCur, parentPostMessage, win } = setupSlashHashDeck();
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 100));
+
+    expect(win.location.hash).toBe('#/3');
+    expect(current()).toBe(2);
+    expect(pagerCur.textContent).toBe('3');
+    expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
+  });
+
+  it('retries only the latest direct target while authored navigation is locked', async () => {
+    const { win, parentPostMessage, track, pagerCur, visited } = setupCustomCounterDeck({
+      navigationLockMs: 120,
+      directIndexControls: true,
+    });
+    visited.length = 0;
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 20));
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 0 },
+    }));
+    await new Promise<void>((resolve) => win.setTimeout(resolve, 500));
+
+    expect(track.style.transform).toBe('translateX(-0vw)');
+    expect(pagerCur.textContent).toBe('1');
+    expect(win.document.querySelectorAll('.slide')[0]?.classList.contains('is-active')).toBe(true);
+    expect(visited).toEqual([2, 0]);
+    expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 0, count: 3 });
   });
 
   it('seeds the keyboard-navigation flag from the artifact source, ignoring od-injected bridge scripts', () => {

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -215,6 +215,11 @@ function setupSlashHashDeck() {
   });
   const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
   const pagerCur = win.document.getElementById('pager-cur') as HTMLElement;
+  const finishDirectJumpAnimation = vi.fn();
+  Object.defineProperty(slides[2], 'getAnimations', {
+    configurable: true,
+    value: () => [{ finish: finishDirectJumpAnimation }],
+  });
   let current = 0;
   const go = (index: number) => {
     current = Math.max(0, Math.min(slides.length - 1, index));
@@ -235,6 +240,7 @@ function setupSlashHashDeck() {
 
   return {
     current: () => current,
+    finishDirectJumpAnimation,
     pagerCur,
     parentPostMessage,
     win,
@@ -351,7 +357,8 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
   });
 
   it('preserves slash-hash routes for immediate artifact-owned thumbnail jumps', async () => {
-    const { current, pagerCur, parentPostMessage, win } = setupSlashHashDeck();
+    const { current, finishDirectJumpAnimation, pagerCur, parentPostMessage, win } =
+      setupSlashHashDeck();
 
     win.dispatchEvent(new win.MessageEvent('message', {
       data: { type: 'od:slide', action: 'go', index: 2 },
@@ -360,6 +367,7 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
 
     expect(win.location.hash).toBe('#/3');
     expect(current()).toBe(2);
+    expect(finishDirectJumpAnimation).toHaveBeenCalledOnce();
     expect(pagerCur.textContent).toBe('3');
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
   });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -215,11 +215,6 @@ function setupSlashHashDeck() {
   });
   const slides = Array.from(win.document.querySelectorAll<HTMLElement>('.slide'));
   const pagerCur = win.document.getElementById('pager-cur') as HTMLElement;
-  const finishDirectJumpAnimation = vi.fn();
-  Object.defineProperty(slides[2], 'getAnimations', {
-    configurable: true,
-    value: () => [{ finish: finishDirectJumpAnimation }],
-  });
   let current = 0;
   const go = (index: number) => {
     current = Math.max(0, Math.min(slides.length - 1, index));
@@ -240,7 +235,6 @@ function setupSlashHashDeck() {
 
   return {
     current: () => current,
-    finishDirectJumpAnimation,
     pagerCur,
     parentPostMessage,
     win,
@@ -357,8 +351,7 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
   });
 
   it('preserves slash-hash routes for immediate artifact-owned thumbnail jumps', async () => {
-    const { current, finishDirectJumpAnimation, pagerCur, parentPostMessage, win } =
-      setupSlashHashDeck();
+    const { current, pagerCur, parentPostMessage, win } = setupSlashHashDeck();
 
     win.dispatchEvent(new win.MessageEvent('message', {
       data: { type: 'od:slide', action: 'go', index: 2 },
@@ -367,7 +360,6 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
 
     expect(win.location.hash).toBe('#/3');
     expect(current()).toBe(2);
-    expect(finishDirectJumpAnimation).toHaveBeenCalledOnce();
     expect(pagerCur.textContent).toBe('3');
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
   });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -208,6 +208,7 @@ function setupSlashHashDeck() {
     url: 'https://preview.test/',
   });
   const win = dom.window;
+  const replaceState = vi.spyOn(win.history, 'replaceState');
   const parentPostMessage = vi.fn();
   Object.defineProperty(win, 'parent', {
     configurable: true,
@@ -237,6 +238,7 @@ function setupSlashHashDeck() {
     current: () => current,
     pagerCur,
     parentPostMessage,
+    replaceState,
     win,
   };
 }
@@ -351,7 +353,7 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
   });
 
   it('preserves slash-hash routes for immediate artifact-owned thumbnail jumps', async () => {
-    const { current, pagerCur, parentPostMessage, win } = setupSlashHashDeck();
+    const { current, pagerCur, parentPostMessage, replaceState, win } = setupSlashHashDeck();
 
     win.dispatchEvent(new win.MessageEvent('message', {
       data: { type: 'od:slide', action: 'go', index: 2 },
@@ -360,6 +362,7 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
 
     expect(win.location.hash).toBe('#/3');
     expect(current()).toBe(2);
+    expect(replaceState).toHaveBeenCalledWith(null, '', '#/3');
     expect(pagerCur.textContent).toBe('3');
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
   });

--- a/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
+++ b/apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts
@@ -352,6 +352,40 @@ describe('deck bridge - keyboard paging keeps page counters in sync', () => {
     expect(slideStatesOf(parentPostMessage).at(-1)).toMatchObject({ active: 2, count: 3 });
   });
 
+  it('keeps keyboard-only deck state in sync across direct selection and later paging', async () => {
+    const { win, track, pagerCur, visited } = setupCustomCounterDeck();
+    visited.length = 0;
+
+    // This artifact deliberately exposes no nav dots, indexed controls, hash
+    // route, or public goTo API. Its keyboard handler is the only owner of the
+    // private page index that drives both the canvas and its own counter.
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'go', index: 2 },
+    }));
+    await vi.waitFor(() => {
+      expect(track.style.transform).toBe('translateX(-200vw)');
+      expect(pagerCur.textContent).toBe('3');
+    });
+    expect(visited).toEqual([1, 2]);
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'next' },
+    }));
+    await vi.waitFor(() => {
+      expect(track.style.transform).toBe('translateX(-200vw)');
+      expect(pagerCur.textContent).toBe('3');
+      expect(visited).toEqual([1, 2, 2]);
+    });
+
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: { type: 'od:slide', action: 'prev' },
+    }));
+    await vi.waitFor(() => {
+      expect(track.style.transform).toBe('translateX(-100vw)');
+      expect(pagerCur.textContent).toBe('2');
+    });
+  });
+
   it('preserves slash-hash routes for immediate artifact-owned thumbnail jumps', async () => {
     const { current, pagerCur, parentPostMessage, replaceState, win } = setupSlashHashDeck();
 

--- a/packages/host/src/actions.ts
+++ b/packages/host/src/actions.ts
@@ -7,6 +7,8 @@ import type {
   OpenDesignHostFailure,
   OpenDesignHostGlobalScope,
   OpenDesignHostPdfPrintOptions,
+  OpenDesignHostPreviewNavigationFailure,
+  OpenDesignHostPreviewNavigationFailureListener,
   OpenDesignHostPickWorkingDirResult,
   OpenDesignHostProjectImportInit,
   OpenDesignHostProjectImportResult,
@@ -165,6 +167,33 @@ export function setHostPetVisible(visible: boolean, scope: OpenDesignHostGlobalS
     return { ok: true };
   } catch (error) {
     return unavailable(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Read the latest Electron-observed preview subframe navigation failure. */
+export function getLatestHostPreviewNavigationFailure(
+  scope: OpenDesignHostGlobalScope = globalThis,
+): OpenDesignHostPreviewNavigationFailure | null {
+  const host = getOpenDesignHost(scope);
+  if (typeof host?.preview?.getLatestNavigationFailure !== "function") return null;
+  try {
+    return host.preview.getLatestNavigationFailure();
+  } catch {
+    return null;
+  }
+}
+
+/** Subscribe to Electron-observed preview subframe navigation failures. */
+export function subscribeHostPreviewNavigationFailure(
+  listener: OpenDesignHostPreviewNavigationFailureListener,
+  scope: OpenDesignHostGlobalScope = globalThis,
+): () => void {
+  const host = getOpenDesignHost(scope);
+  if (typeof host?.preview?.subscribeNavigationFailure !== "function") return () => undefined;
+  try {
+    return host.preview.subscribeNavigationFailure(listener);
+  } catch {
+    return () => undefined;
   }
 }
 

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -35,6 +35,8 @@ export type {
   OpenDesignHostCaptureOptions,
   OpenDesignHostCaptureSuccess,
   OpenDesignHostCaptureResult,
+  OpenDesignHostPreviewNavigationFailure,
+  OpenDesignHostPreviewNavigationFailureListener,
   OpenDesignHostAppearanceTheme,
   OpenDesignHostBrowserClearDataOptions,
   OpenDesignHostUpdaterAction,
@@ -99,7 +101,9 @@ export {
   downloadHostUpdater,
   installHostUpdater,
   quitHostAfterUpdaterInstallerOpen,
+  getLatestHostPreviewNavigationFailure,
   subscribeHostUpdater,
   subscribeHostUpdaterOpenDialog,
+  subscribeHostPreviewNavigationFailure,
   setHostUpdaterMenuLabels,
 } from "./actions.js";

--- a/packages/host/src/protocol.ts
+++ b/packages/host/src/protocol.ts
@@ -133,6 +133,18 @@ export type OpenDesignHostCaptureOptions = { clip?: OpenDesignHostCaptureClip };
 export type OpenDesignHostCaptureSuccess = { dataUrl: string; h: number; ok: true; w: number };
 export type OpenDesignHostCaptureResult = OpenDesignHostCaptureSuccess | OpenDesignHostFailure;
 
+export type OpenDesignHostPreviewNavigationFailure = {
+  errorCode: number;
+  eventId: number;
+  frameName?: string;
+  occurredAtMs: number;
+  validatedUrl: string;
+};
+
+export type OpenDesignHostPreviewNavigationFailureListener = (
+  failure: OpenDesignHostPreviewNavigationFailure,
+) => void;
+
 export type OpenDesignHostBrowserClearDataOptions = {
   cookies?: boolean;
   storage?: boolean;
@@ -378,6 +390,13 @@ export type OpenDesignHostBridge = {
   };
   pet: {
     setVisible(visible: boolean): void;
+  };
+  // Optional so web builds and older desktop hosts keep the same contract.
+  // Electron is the only layer that can observe a compositor-affecting
+  // subframe navigation failure after the iframe DOM remains healthy.
+  preview?: {
+    getLatestNavigationFailure(): OpenDesignHostPreviewNavigationFailure | null;
+    subscribeNavigationFailure(listener: OpenDesignHostPreviewNavigationFailureListener): () => void;
   };
   project: {
     pickAndImport(init?: OpenDesignHostProjectImportInit): Promise<OpenDesignHostProjectImportResult>;

--- a/packages/host/src/testing.ts
+++ b/packages/host/src/testing.ts
@@ -6,12 +6,13 @@ import {
   type OpenDesignHostUpdaterStatusSnapshot,
 } from "./index.js";
 
-export type MockOpenDesignHost = Partial<Omit<OpenDesignHostBridge, "capture" | "client" | "pdf" | "pet" | "project" | "shell" | "updater">> & {
+export type MockOpenDesignHost = Partial<Omit<OpenDesignHostBridge, "capture" | "client" | "pdf" | "pet" | "preview" | "project" | "shell" | "updater">> & {
   browser?: Partial<OpenDesignHostBridge["browser"]>;
   capture?: Partial<OpenDesignHostBridge["capture"]>;
   client?: Partial<OpenDesignHostBridge["client"]>;
   pdf?: Partial<OpenDesignHostBridge["pdf"]>;
   pet?: Partial<OpenDesignHostBridge["pet"]>;
+  preview?: Partial<NonNullable<OpenDesignHostBridge["preview"]>>;
   project?: Partial<OpenDesignHostBridge["project"]>;
   shell?: Partial<OpenDesignHostBridge["shell"]>;
   updater?: Partial<OpenDesignHostBridge["updater"]>;
@@ -74,6 +75,10 @@ function defaultHost(): OpenDesignHostBridge {
     pet: {
       setVisible: () => undefined,
     },
+    preview: {
+      getLatestNavigationFailure: () => null,
+      subscribeNavigationFailure: () => () => undefined,
+    },
     updater: {
       check: async () => updaterStatus,
       "clear-cache": async () => updaterStatus,
@@ -100,6 +105,14 @@ export function createMockOpenDesignHost(overrides: MockOpenDesignHost = {}): Op
     project: { ...base.project, ...overrides.project },
     pdf: { ...base.pdf, ...overrides.pdf },
     pet: { ...base.pet, ...overrides.pet },
+    preview: {
+      getLatestNavigationFailure:
+        overrides.preview?.getLatestNavigationFailure
+        ?? base.preview!.getLatestNavigationFailure,
+      subscribeNavigationFailure:
+        overrides.preview?.subscribeNavigationFailure
+        ?? base.preview!.subscribeNavigationFailure,
+    },
     updater: { ...base.updater, ...overrides.updater },
   };
 }

--- a/packages/host/tests/index.test.ts
+++ b/packages/host/tests/index.test.ts
@@ -10,6 +10,7 @@ import {
   clearHostBrowserData,
   checkHostUpdater,
   detectOpenDesignHostClientType,
+  getLatestHostPreviewNavigationFailure,
   getHostUpdaterStatus,
   getOpenDesignHost,
   installHostUpdater,
@@ -25,6 +26,7 @@ import {
   setHostPetVisible,
   subscribeHostUpdaterOpenDialog,
   subscribeHostUpdater,
+  subscribeHostPreviewNavigationFailure,
 } from "../src/index.js";
 import { createMockOpenDesignHost, installMockOpenDesignHost } from "../src/testing.js";
 
@@ -308,6 +310,31 @@ describe("open-design host contract", () => {
     expect(subscribe).toHaveBeenCalledWith(listener);
     expect(subscribeOpenDialog).toHaveBeenCalledWith(openDialogListener);
     expect(setMenuLabels).toHaveBeenCalledOnce();
+  });
+
+  it("routes optional preview navigation failure subscriptions", () => {
+    const failure = {
+      errorCode: -3,
+      eventId: 1,
+      frameName: "od-artifact-preview-srcdoc-preview-host-1",
+      occurredAtMs: 1234,
+      validatedUrl: "about:srcdoc",
+    };
+    const unsubscribe = vi.fn();
+    const subscribeNavigationFailure = vi.fn(() => unsubscribe);
+    const getLatestNavigationFailure = vi.fn(() => failure);
+    const scope: Record<string, unknown> = {};
+    scope[OPEN_DESIGN_HOST_GLOBAL] = createMockOpenDesignHost({
+      preview: { getLatestNavigationFailure, subscribeNavigationFailure },
+    });
+    const listener = vi.fn();
+
+    expect(getLatestHostPreviewNavigationFailure(scope)).toBe(failure);
+    expect(getLatestNavigationFailure).toHaveBeenCalledOnce();
+    expect(subscribeHostPreviewNavigationFailure(listener, scope)).toBe(unsubscribe);
+    expect(subscribeNavigationFailure).toHaveBeenCalledWith(listener);
+    expect(getLatestHostPreviewNavigationFailure({})).toBeNull();
+    expect(subscribeHostPreviewNavigationFailure(listener, {})).toEqual(expect.any(Function));
   });
 
   it("wraps updater action throws into structured failures", async () => {


### PR DESCRIPTION
## Why

While validating the `0.20.0-prerelease.8` desktop client, we repeatedly hit blank HTML/PPT previews after remixing a community template, switching projects or file tabs, and toggling Code/Preview. Chromium could abort a retained `about:srcdoc` navigation while the viewer still trusted stale per-generation health state, leaving a white main canvas that only another mode switch repaired.

This is a production follow-up to make the file preview lifecycle reliable under the same rapid navigation patterns users exercise in the desktop app, while retaining live edit updates and useful privacy-safe diagnostics when recovery is still needed.

## What users will see

- HTML/PPT previews remain mounted and immediately reusable across file-tab, Code/Preview, and project switches instead of flashing or becoming permanently white.
- The desktop main preview uses a Blob URL transport and reports navigation failures back to the viewer, avoiding the fragile active `about:srcdoc` navigation path.
- Initial project entry keeps the existing loading treatment, while already-loaded tabs and project viewers keep their content and toolbar actions stable.
- Recent-project thumbnails render the actual first slide more consistently.
- Direct slide navigation preserves templates that use slash-hash routes such as `#/3`.
- White-screen telemetry records bounded structural/transport diagnostics without uploading document text or DOM contents.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Packaged desktop validation uses an isolated `0.20.0-prerelease.8` build with real affected projects. The final acceptance run covered the main preview, thumbnail rail, project/file switching, and the viewer toolbar entry points.

## Bug fix verification

- Red specs:
  - `apps/web/tests/components/FileViewer.test.tsx` — inactive retained-viewer warmup, exact-revision reuse, toolbar persistence, edit-style replay, and aborted-preview recovery.
  - `apps/web/tests/components/FileWorkspace.test.tsx` — same-project materialization must not tear down an already loaded viewer.
  - `apps/web/tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts` — slash-hash deck routes must remain `#/N` for artifact-owned direct jumps.
  - `apps/desktop/tests/main/preview-navigation-failure.test.ts` — active preview navigation failures cross the Electron host boundary.
- The targeted specs were observed red with the corresponding source fix removed and are green on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx tests/components/FileWorkspace.test.tsx tests/components/RecentProjectsStrip.test.tsx tests/runtime/srcdoc-deck-bridge-keyboard-page-sync.test.ts --maxWorkers=1` — 426 passed, 3 skipped
- `pnpm --filter @open-design/host test` — 15 passed
- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/preview-navigation-failure.test.ts --maxWorkers=1` — 1 passed
- `pnpm tools-pack mac build --namespace qa-preview-reactivation --dir /private/tmp/od-preview-reactivation-pack --app-version 0.20.0-prerelease.8 --to app`
- Packaged manual validation: real affected project opens and renders through a Blob main-frame URL; direct slide 1 → 9 → 1 updates the main canvas and both counters in the same sampled UI state, without walking intermediate slides or blanking the frame.
