### PR TITLE
fix(pack): declare HyperFrames native dependencies by platform

### DIFF
--- a/tools/pack/resources/web-standalone-after-pack.cjs
+++ b/tools/pack/resources/web-standalone-after-pack.cjs
@@ -835,13 +835,22 @@ function resolveHyperframesRuntimePackageNames(platformName) {
   if (arch !== "arm64" && arch !== "x64") {
     throw new Error(`[tools-pack hyperframes] unsupported ${platformName} architecture: ${arch}`);
   }
-  const platform = platformName === "darwin" ? "darwin" : "win32";
-  return [
-    "sharp",
-    "@img/colour",
-    `@img/sharp-${platform}-${arch}`,
-    `@img/sharp-libvips-${platform}-${arch}`,
-  ];
+  if (platformName === "win32") {
+    return [
+      "sharp",
+      "@img/colour",
+      `@img/sharp-win32-${arch}`,
+    ];
+  }
+  if (platformName === "darwin") {
+    return [
+      "sharp",
+      "@img/colour",
+      `@img/sharp-darwin-${arch}`,
+      `@img/sharp-libvips-darwin-${arch}`,
+    ];
+  }
+  throw new Error(`[tools-pack hyperframes] unsupported platform: ${platformName}`);
 }
 
 function packagePath(nodeModulesRoot, packageName) {
@@ -948,7 +957,9 @@ async function auditNoBrokenSymlinks(root, label) {
 }
 
 async function runWebStandaloneAfterPack(context) {
-  if (context?.electronPlatformName != null && context.electronPlatformName !== "darwin" && context.electronPlatformName !== "win32") return;
+  if (context?.electronPlatformName !== "darwin" && context?.electronPlatformName !== "win32") {
+    throw new Error(`[tools-pack web-standalone] unsupported platform: ${context?.electronPlatformName ?? "unknown"}`);
+  }
 
   const config = await readHookConfig();
   const appPath = resolveAppPath(context);

--- a/tools/pack/tests/web-standalone-after-pack.test.ts
+++ b/tools/pack/tests/web-standalone-after-pack.test.ts
@@ -49,8 +49,10 @@ async function writeHyperframesRuntimeFixture(options: {
   const arch = options.platformName === "win32" ? "x64" : process.arch;
   const platform = options.platformName === "darwin" ? "darwin" : "win32";
   const nativePackage = `@img/sharp-${platform}-${arch}`;
-  const libvipsPackage = `@img/sharp-libvips-${platform}-${arch}`;
-  const packages = ["@img/colour", nativePackage, libvipsPackage];
+  const libvipsPackage = options.platformName === "darwin"
+    ? `@img/sharp-libvips-${platform}-${arch}`
+    : null;
+  const packages = ["@img/colour", nativePackage, ...(libvipsPackage == null ? [] : [libvipsPackage])];
   const sourceNodeModulesRoot = join(options.runtimeSourceRoot, "node_modules");
 
   for (const packageName of packages) {
@@ -68,8 +70,12 @@ async function writeHyperframesRuntimeFixture(options: {
       [
         'import colour from "@img/colour";',
         `import native from ${JSON.stringify(nativePackage)};`,
-        `import libvips from ${JSON.stringify(libvipsPackage)};`,
-        "export default { colour, native, libvips };",
+        ...(libvipsPackage == null
+          ? ["export default { colour, native };"]
+          : [
+              `import libvips from ${JSON.stringify(libvipsPackage)};`,
+              "export default { colour, native, libvips };",
+            ]),
         "",
       ].join("\n"),
     );
@@ -289,7 +295,6 @@ describe("web standalone afterPack hook", () => {
         "sharp",
         "@img/colour",
         "@img/sharp-win32-x64",
-        "@img/sharp-libvips-win32-x64",
       ]);
       expect(report.hyperframesRuntimeCopies.every((entry) => entry.bytes > 0)).toBe(true);
       expect(report.hyperframesCliSmoke.stdout).toBe("hyperframes 0.8.1");
@@ -304,11 +309,19 @@ describe("web standalone afterPack hook", () => {
     }
   });
 
-  it("fails packaging when HyperFrames' target libvips payload is absent", async () => {
+  it("fails packaging when HyperFrames' target native sharp payload is absent", async () => {
     await expect(runFixture({
       includeWebNext: true,
-      omitHyperframesRuntimePackage: "@img/sharp-libvips-win32-x64",
-    })).rejects.toThrow(/required source missing.*sharp-libvips-win32-x64/);
+      omitHyperframesRuntimePackage: "@img/sharp-win32-x64",
+    })).rejects.toThrow(/required source missing.*sharp-win32-x64/);
+  });
+
+  it("rejects unsupported packaging platforms", async () => {
+    await expect(runWebStandaloneAfterPack({
+      appOutDir: "/tmp/open-design-linux",
+      electronPlatformName: "linux",
+      packager: { appInfo: { productFilename: "Open Design" } },
+    })).rejects.toThrow(/unsupported platform: linux/);
   });
 
   it("deduplicates win32 copied standalone Next while retaining the app-local Next package", async () => {


### PR DESCRIPTION
## Why

The prerelease workflow for `release/v0.20.0` repeatedly fails on Windows after HyperFrames packaging was introduced. The after-pack hook requires a synthetic `@img/sharp-libvips-win32-x64` package that sharp 0.35.3 does not publish, so both cached and clean retries fail before the packaged-runtime smoke can run.

This blocks producing a complete prerelease and cannot be recovered by rerunning the existing workflow.

## What users will see

Windows prerelease packaging can complete with HyperFrames' real native sharp dependency closure. macOS packaging remains unchanged, and unsupported platforms fail explicitly instead of being treated as Windows.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal packaging fix and regression tests only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test path that reproduces the bug: `tools/pack/tests/web-standalone-after-pack.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Red evidence: with the corrected Windows fixture, current `main` failed five cases on the nonexistent `@img/sharp-libvips-win32-x64`; the unsupported-Linux case resolved instead of rejecting.
- Green evidence: the focused file passes 9/9, including executing the final packaged HyperFrames CLI with `--version`.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/web-standalone-after-pack.test.ts`
- `pnpm --filter @open-design/tools-pack test` — 284 passed, 8 skipped
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

## Release follow-up

After this lands on `main`, backport it to `release/v0.20.0` and trigger a fresh prerelease run. Rerunning the currently failing commit is not sufficient.