### PR TITLE
fix(web): wrap follow-up composer placeholder instead of clipping

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -3099,6 +3099,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 scenarios={placeholderScenarios}
                 active={placeholderCarouselActive}
                 paused={composerFocused}
+                caretPlacement="typing-edge"
                 onScenarioChange={setPlaceholderScenario}
               />
             ) : null}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1672,6 +1672,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
             <PlaceholderCarousel
               active={carouselActive}
               paused={promptFocused}
+              caretPlacement="row-end"
               scenarios={carouselScenarios}
               onScenarioChange={setCarouselScenario}
             />

--- a/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
+++ b/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
@@ -44,12 +44,21 @@ interface Props {
   // keeps `active` true so Send still submits the current scenario from an
   // empty composer — this only silences the animation.
   paused?: boolean;
+  // Home hero keeps the caret outside its ellipsized text; the chat composer
+  // keeps it inline so it follows wrapped lines.
+  caretPlacement?: 'row-end' | 'typing-edge';
 }
 
 // Pointer-events-none overlay that types the rotating scenario placeholders
 // over the (empty) Lexical editor. It owns the per-character animation state so
 // the frequent re-renders stay confined here and never touch the editor.
-export function PlaceholderCarousel({ scenarios, active, paused = false, onScenarioChange }: Props) {
+export function PlaceholderCarousel({
+  scenarios,
+  active,
+  paused = false,
+  onScenarioChange,
+  caretPlacement = 'row-end',
+}: Props) {
   const reducedMotion = usePrefersReducedMotion();
   const visualStabilityMode = isVisualStabilityMode();
   const [state, setState] = useState(initialTypewriterState);
@@ -110,14 +119,22 @@ export function PlaceholderCarousel({ scenarios, active, paused = false, onScena
   const visible = reducedMotion || visualStabilityMode
     ? scenario.text
     : scenario.text.slice(0, state.charCount);
-  // Caret is nested in the text span so it follows the last character when the
-  // placeholder wraps (long follow-up scenarios in the chat composer).
+
+  const caret = <span className="home-hero__carousel-caret" />;
+
   return (
     <div className="home-hero__carousel" aria-hidden="true" data-testid="home-hero-carousel">
-      <span className="home-hero__carousel-text">
-        {visible}
-        <span className="home-hero__carousel-caret" />
-      </span>
+      {caretPlacement === 'typing-edge' ? (
+        <span className="home-hero__carousel-text">
+          {visible}
+          {caret}
+        </span>
+      ) : (
+        <>
+          <span className="home-hero__carousel-text">{visible}</span>
+          {caret}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
+++ b/apps/web/src/components/home-hero/PlaceholderCarousel.tsx
@@ -110,10 +110,14 @@ export function PlaceholderCarousel({ scenarios, active, paused = false, onScena
   const visible = reducedMotion || visualStabilityMode
     ? scenario.text
     : scenario.text.slice(0, state.charCount);
+  // Caret is nested in the text span so it follows the last character when the
+  // placeholder wraps (long follow-up scenarios in the chat composer).
   return (
     <div className="home-hero__carousel" aria-hidden="true" data-testid="home-hero-carousel">
-      <span className="home-hero__carousel-text">{visible}</span>
-      <span className="home-hero__carousel-caret" />
+      <span className="home-hero__carousel-text">
+        {visible}
+        <span className="home-hero__carousel-caret" />
+      </span>
     </div>
   );
 }

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1483,13 +1483,7 @@
   white-space: nowrap;
   max-width: calc(100% - 8px);
 }
-/* Follow-up scenarios can be full paragraphs (visualPolish is ~270 chars);
-   the placeholder wraps within the composer's width instead of clipping.
-   pre-wrap (not normal) keeps the typewriter's trailing spaces at wrap
-   edges so the caret doesn't jitter to the next line for one frame.
-   The wrap grows to fit up to four wrapped lines (13px * 1.6 * 4 + padding)
-   only while the carousel is mounted, so the composer chrome doesn't
-   bounce as the typewriter rotates and the toolbar row stays uncovered. */
+/* Reserve four wrapped lines while follow-up prompts are visible. */
 .composer-input-wrap:has(.home-hero__carousel) {
   min-height: 104px;
 }
@@ -1516,10 +1510,14 @@
   text-overflow: clip;
 }
 .composer-input-wrap .home-hero__carousel-caret {
+  display: inline-block;
   width: 1px;
   height: 1.25em;
+  margin: 0 0 0 1px;
+  vertical-align: text-bottom;
+  background: var(--accent);
   opacity: 0.85;
-  animation: home-hero-carousel-caret 900ms steps(1) infinite;
+  animation: home-hero-caret-blink 1.05s steps(1, end) infinite;
 }
 /* Single-paragraph + LineBreakNode model: collapse paragraph margins so a
    serialized "\n" reads as a single visual line break (no \n\n gap). */

--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1483,33 +1483,41 @@
   white-space: nowrap;
   max-width: calc(100% - 8px);
 }
+/* Follow-up scenarios can be full paragraphs (visualPolish is ~270 chars);
+   the placeholder wraps within the composer's width instead of clipping.
+   pre-wrap (not normal) keeps the typewriter's trailing spaces at wrap
+   edges so the caret doesn't jitter to the next line for one frame.
+   The wrap grows to fit up to four wrapped lines (13px * 1.6 * 4 + padding)
+   only while the carousel is mounted, so the composer chrome doesn't
+   bounce as the typewriter rotates and the toolbar row stays uncovered. */
+.composer-input-wrap:has(.home-hero__carousel) {
+  min-height: 104px;
+}
 .composer-input-wrap .home-hero__carousel {
   position: absolute;
   left: 9px;
   right: 9px;
   top: 8px;
   z-index: 2;
-  display: flex;
-  align-items: center;
-  gap: 1px;
   color: var(--text-faint);
   font-size: 13px;
   line-height: 1.6;
   pointer-events: none;
   user-select: none;
-  white-space: nowrap;
-  overflow: hidden;
 }
 .composer-input-wrap .home-hero__carousel-text {
-  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
 }
 .composer-input-wrap .home-hero__carousel-caret {
   width: 1px;
   height: 1.25em;
-  flex: 0 0 auto;
-  background: var(--accent);
   opacity: 0.85;
   animation: home-hero-carousel-caret 900ms steps(1) infinite;
 }

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -796,11 +796,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Caret is nested inline in the text span (see PlaceholderCarousel.tsx). */
 .home-hero__carousel-caret {
-  flex: none;
+  display: inline-block;
   width: 1.5px;
-  align-self: stretch;
-  margin: 3px 0 3px 2px;
+  height: 1.1em;
+  vertical-align: text-bottom;
+  margin-inline-start: 2px;
   background: var(--accent);
   border-radius: 1px;
   animation: home-hero-caret-blink 1.05s steps(1, end) infinite;

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -796,13 +796,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* Caret is nested inline in the text span (see PlaceholderCarousel.tsx). */
 .home-hero__carousel-caret {
-  display: inline-block;
+  flex: none;
   width: 1.5px;
-  height: 1.1em;
-  vertical-align: text-bottom;
-  margin-inline-start: 2px;
+  align-self: stretch;
+  margin: 3px 0 3px 2px;
   background: var(--accent);
   border-radius: 1px;
   animation: home-hero-caret-blink 1.05s steps(1, end) infinite;

--- a/apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx
+++ b/apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+//
+// The caret must be nested inside the text span, not a sibling, so it
+// follows the last character when the placeholder wraps in the chat
+// composer. Layout measurements live in the Playwright spec at
+// `e2e/ui/composer-carousel-placeholder-wrap.test.ts`; jsdom cannot lay
+// out, so this file locks the DOM shape only.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import { PlaceholderCarousel } from '../../../src/components/home-hero/PlaceholderCarousel';
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+const LONG_SCENARIO = {
+  id: 'visual-polish',
+  text: 'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues.',
+  chipId: 'design-toolbox',
+} as const;
+
+describe('PlaceholderCarousel caret is nested inline in the text span', () => {
+  it('renders caret as the last child of .home-hero__carousel-text (not a sibling)', () => {
+    const { container } = render(
+      <PlaceholderCarousel
+        scenarios={[LONG_SCENARIO]}
+        active
+        onScenarioChange={() => {}}
+      />,
+    );
+
+    const carousel = container.querySelector('[data-testid="home-hero-carousel"]');
+    expect(carousel, 'carousel root missing').not.toBeNull();
+
+    const textSpan = carousel!.querySelector('.home-hero__carousel-text');
+    expect(textSpan, 'text span missing').not.toBeNull();
+
+    const caret = textSpan!.querySelector('.home-hero__carousel-caret');
+    expect(caret, 'caret must be a descendant of the text span').not.toBeNull();
+    expect(caret!.parentElement).toBe(textSpan);
+    expect(textSpan!.lastElementChild).toBe(caret);
+
+    const siblingCaret = Array.from(carousel!.children).find(
+      (child) => child !== textSpan && child.classList.contains('home-hero__carousel-caret'),
+    );
+    expect(siblingCaret, 'caret must not appear as a sibling of the text span').toBeUndefined();
+
+    expect(carousel!.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx
+++ b/apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx
@@ -1,10 +1,8 @@
 // @vitest-environment jsdom
 //
-// The caret must be nested inside the text span, not a sibling, so it
-// follows the last character when the placeholder wraps in the chat
-// composer. Layout measurements live in the Playwright spec at
-// `e2e/ui/composer-carousel-placeholder-wrap.test.ts`; jsdom cannot lay
-// out, so this file locks the DOM shape only.
+// jsdom cannot lay out, so this file locks only the DOM shape each surface's
+// caret contract requires; the geometric visibility oracle lives in
+// e2e/ui/composer-carousel-placeholder-wrap.test.ts.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
@@ -16,38 +14,70 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const LONG_SCENARIO = {
+const SCENARIO = {
   id: 'visual-polish',
-  text: 'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues.',
+  text: 'Polish this design until it is ready to ship.',
   chipId: 'design-toolbox',
 } as const;
 
-describe('PlaceholderCarousel caret is nested inline in the text span', () => {
-  it('renders caret as the last child of .home-hero__carousel-text (not a sibling)', () => {
-    const { container } = render(
-      <PlaceholderCarousel
-        scenarios={[LONG_SCENARIO]}
-        active
-        onScenarioChange={() => {}}
-      />,
-    );
+function renderCarousel(caretPlacement?: 'row-end' | 'typing-edge') {
+  return render(
+    <PlaceholderCarousel
+      scenarios={[SCENARIO]}
+      active
+      {...(caretPlacement === undefined ? {} : { caretPlacement })}
+      onScenarioChange={() => {}}
+    />,
+  );
+}
+
+describe('PlaceholderCarousel caret placement', () => {
+  // The home hero ellipsizes inside .home-hero__carousel-text; a caret nested
+  // there is clipped away with the overflow, so row-end keeps it outside.
+  it("default renders the caret as a flex sibling after the clipped text span ('row-end')", () => {
+    const { container } = renderCarousel();
 
     const carousel = container.querySelector('[data-testid="home-hero-carousel"]');
-    expect(carousel, 'carousel root missing').not.toBeNull();
+    expect(carousel).not.toBeNull();
+    expect(carousel!.getAttribute('aria-hidden')).toBe('true');
 
     const textSpan = carousel!.querySelector('.home-hero__carousel-text');
-    expect(textSpan, 'text span missing').not.toBeNull();
+    expect(textSpan).not.toBeNull();
+    expect(textSpan!.querySelector('.home-hero__carousel-caret')).toBeNull();
 
+    const children = Array.from(carousel!.children);
+    expect(children).toHaveLength(2);
+    expect(children[0]).toBe(textSpan);
+    expect(children[1]!.classList.contains('home-hero__carousel-caret')).toBe(true);
+  });
+
+  it("explicit 'row-end' matches the default shape", () => {
+    const { container } = renderCarousel('row-end');
+    const carousel = container.querySelector('[data-testid="home-hero-carousel"]')!;
+    const textSpan = carousel.querySelector('.home-hero__carousel-text')!;
+    expect(textSpan.querySelector('.home-hero__carousel-caret')).toBeNull();
+    expect(carousel.children[1]!.classList.contains('home-hero__carousel-caret')).toBe(true);
+  });
+
+  // The follow-up composer wraps its placeholder across clamped lines, so the
+  // caret must be the last inline child of the text span to track the typing edge.
+  it("'typing-edge' nests the caret as the last child of the text span", () => {
+    const { container } = renderCarousel('typing-edge');
+
+    const carousel = container.querySelector('[data-testid="home-hero-carousel"]');
+    expect(carousel).not.toBeNull();
+    expect(carousel!.getAttribute('aria-hidden')).toBe('true');
+
+    const textSpan = carousel!.querySelector('.home-hero__carousel-text');
+    expect(textSpan).not.toBeNull();
     const caret = textSpan!.querySelector('.home-hero__carousel-caret');
-    expect(caret, 'caret must be a descendant of the text span').not.toBeNull();
+    expect(caret).not.toBeNull();
     expect(caret!.parentElement).toBe(textSpan);
     expect(textSpan!.lastElementChild).toBe(caret);
 
     const siblingCaret = Array.from(carousel!.children).find(
       (child) => child !== textSpan && child.classList.contains('home-hero__carousel-caret'),
     );
-    expect(siblingCaret, 'caret must not appear as a sibling of the text span').toBeUndefined();
-
-    expect(carousel!.getAttribute('aria-hidden')).toBe('true');
+    expect(siblingCaret).toBeUndefined();
   });
 });

--- a/e2e/ui/composer-carousel-placeholder-wrap.test.ts
+++ b/e2e/ui/composer-carousel-placeholder-wrap.test.ts
@@ -1,0 +1,297 @@
+// Composer follow-up placeholder — clip-free at supported widths.
+//
+// Once the user has completed at least one chat turn in a project, ChatPane
+// seeds the composer's PlaceholderCarousel with the design-toolbox next-step
+// prompts (`followUpComposerScenarios`). Several — visualPolish at ~270
+// chars — used to ellipsis-clip against the pre-fix composer CSS. This spec
+// drives a real fake-agent turn and measures the carousel at three widths.
+//
+// DOM shape (caret nested in the text span) is locked separately at the
+// Vitest layer: apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx.
+
+import { expect, test } from '@/playwright/suite';
+import { createFakeAgentRuntimes } from '@/playwright/fake-agents';
+import type { FakeAgentRuntime } from '@/playwright/fake-agents';
+import { T } from '@/timeouts';
+
+const STORAGE_KEY = 'open-design:config';
+
+// Verbatim `chat.designToolbox.prompt.visualPolish` from apps/web/src/i18n/locales/en.ts.
+const VISUAL_POLISH_TEXT =
+  'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues.';
+
+// Mid-prompt slice — robust against a rotate boundary and a harmless copy tweak.
+const VISUAL_POLISH_MATCH = 'Polish this design until it is ready to ship';
+
+const COMPOSER_WIDTHS_PX = [780, 640, 456] as const;
+
+let fakeRuntimes: Record<string, FakeAgentRuntime>;
+
+test.beforeAll(async () => {
+  fakeRuntimes = await createFakeAgentRuntimes(['codex']);
+});
+
+test.beforeEach(async ({ page }) => {
+  test.setTimeout(T.xlong);
+
+  // reduce-motion short-circuits the typewriter to full-text-per-rotation
+  // (~2s per scenario), so visualPolish appears in seconds instead of ~10s.
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+
+  const codexEnv = fakeRuntimes.codex!.env;
+  await page.request.put('/api/app-config', {
+    data: {
+      onboardingCompleted: true,
+      agentId: 'codex',
+      agentModels: { codex: { model: 'default', reasoning: 'default' } },
+      agentCliEnv: { codex: codexEnv },
+      skillId: null,
+      designSystemId: null,
+    },
+  });
+
+  await page.addInitScript(({ key, env }) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'codex',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: { codex: { model: 'default', reasoning: 'default' } },
+        agentCliEnv: { codex: env },
+      }),
+    );
+  }, { key: STORAGE_KEY, env: codexEnv });
+});
+
+test('[P1] follow-up composer placeholder wraps long design-toolbox prompts without clipping', async ({ page }) => {
+  const projectId = `carousel-wrap-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
+  const createResponse = await page.request.post('/api/projects', {
+    data: {
+      id: projectId,
+      name: 'Composer follow-up placeholder wrap',
+      skillId: null,
+      designSystemId: null,
+      pendingPrompt: null,
+      metadata: { kind: 'prototype' },
+    },
+  });
+  expect(createResponse.ok(), await createResponse.text()).toBeTruthy();
+  const { conversationId } = (await createResponse.json()) as { conversationId: string };
+
+  await page.goto(`/projects/${projectId}/conversations/${conversationId}`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve OpenDesign' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+
+  const composer = page.getByTestId('chat-composer');
+  await expect(composer).toBeVisible();
+  const composerInput = page.getByTestId('chat-composer-input');
+  await expect(composerInput).toBeVisible();
+  const sendButton = page.getByTestId('chat-send');
+
+  // Run one real turn so displayMessages > 0 flips composer scenarios from
+  // blank-project to follow-up (the code path that surfaces visualPolish).
+  await composerInput.click();
+  await composerInput.fill('Create a deterministic smoke artifact');
+  await expect(sendButton).toBeEnabled();
+  await sendButton.click();
+
+  await expect(page.getByTestId('file-workspace').getByText('real-daemon-smoke.html', { exact: true }))
+    .toBeVisible({ timeout: T.long });
+
+  // Blur composer — carousel pauses while the composer is focused.
+  await page.getByTestId('file-workspace').click({ position: { x: 10, y: 10 } });
+  await expect(composerInput).not.toBeFocused();
+
+  const carousel = page.getByTestId('home-hero-carousel');
+  await expect(carousel).toBeVisible({ timeout: T.medium });
+
+  await expect
+    .poll(async () => (await carousel.textContent()) ?? '', { timeout: T.medium })
+    .toContain(VISUAL_POLISH_MATCH);
+
+  const measurements: Array<{
+    viewportWidth: number;
+    carouselScrollWidth: number;
+    carouselClientWidth: number;
+    carouselHeight: number;
+    lineCount: number;
+    whiteSpace: string;
+    textOverflow: string;
+    caretGapDx: number | null;
+    caretGapDy: number | null;
+    caretVisible: boolean;
+    visibleTextSample: string;
+  }> = [];
+
+  for (const w of COMPOSER_WIDTHS_PX) {
+    await page.setViewportSize({ width: w, height: 720 });
+    await expect
+      .poll(async () => (await carousel.textContent()) ?? '', { timeout: T.medium })
+      .toContain(VISUAL_POLISH_MATCH);
+
+    const m = await carousel.evaluate((el) => {
+      const textSpan = el.querySelector('.home-hero__carousel-text') as HTMLElement | null;
+      const caret = el.querySelector('.home-hero__carousel-caret') as HTMLElement | null;
+      if (!textSpan || !caret) {
+        return { error: `structure missing text=${!!textSpan} caret=${!!caret}` } as const;
+      }
+      const rect = el.getBoundingClientRect();
+      const caretRect = caret.getBoundingClientRect();
+      const cs = window.getComputedStyle(textSpan);
+      const lineHeight = parseFloat(cs.lineHeight);
+
+      let textNode: Text | null = null;
+      for (let i = textSpan.childNodes.length - 1; i >= 0; i--) {
+        const child = textSpan.childNodes[i];
+        if (child && child.nodeType === Node.TEXT_NODE) {
+          textNode = child as Text;
+          break;
+        }
+      }
+      let caretGapDx: number | null = null;
+      let caretGapDy: number | null = null;
+      const visibleTextSample = (textNode?.data ?? '').slice(-64);
+      if (textNode && textNode.length > 0) {
+        const range = document.createRange();
+        range.setStart(textNode, textNode.length - 1);
+        range.setEnd(textNode, textNode.length);
+        const rects = range.getClientRects();
+        const lcr = rects[rects.length - 1];
+        if (lcr) {
+          caretGapDx = caretRect.left - lcr.right;
+          caretGapDy = caretRect.bottom - lcr.bottom;
+        }
+      }
+
+      return {
+        carouselScrollWidth: el.scrollWidth,
+        carouselClientWidth: el.clientWidth,
+        carouselHeight: Math.round(rect.height),
+        lineCount: Math.max(1, Math.round(rect.height / lineHeight)),
+        whiteSpace: cs.whiteSpace,
+        textOverflow: cs.textOverflow,
+        caretGapDx,
+        caretGapDy,
+        caretVisible: caretRect.width > 0 && caretRect.height > 0,
+        visibleTextSample,
+      };
+    });
+
+    if ('error' in m) throw new Error(m.error);
+    measurements.push({ viewportWidth: w, ...m });
+  }
+
+  const detail = JSON.stringify(measurements, null, 2);
+
+  for (const m of measurements) {
+    expect(m.carouselScrollWidth, `horizontal clip at ${m.viewportWidth}px: ${detail}`)
+      .toBeLessThanOrEqual(m.carouselClientWidth + 1);
+    expect(m.whiteSpace, `white-space regressed at ${m.viewportWidth}px: ${detail}`)
+      .toBe('pre-wrap');
+    expect(m.textOverflow, `text-overflow regressed at ${m.viewportWidth}px: ${detail}`)
+      .toBe('clip');
+    expect(m.caretVisible, `caret not visible at ${m.viewportWidth}px: ${detail}`).toBe(true);
+    expect(m.caretGapDx, `caret dx unreadable at ${m.viewportWidth}px: ${detail}`).not.toBeNull();
+    expect(m.caretGapDy, `caret dy unreadable at ${m.viewportWidth}px: ${detail}`).not.toBeNull();
+    expect(Math.abs(m.caretGapDx!), `caret horizontal drift at ${m.viewportWidth}px: ${detail}`)
+      .toBeLessThanOrEqual(6);
+    expect(Math.abs(m.caretGapDy!), `caret vertical drift at ${m.viewportWidth}px: ${detail}`)
+      .toBeLessThanOrEqual(4);
+  }
+
+  const wrapped = measurements.filter((m) => m.lineCount >= 2);
+  expect(wrapped.length, `expected wrapping at every width: ${detail}`)
+    .toBe(COMPOSER_WIDTHS_PX.length);
+  void VISUAL_POLISH_TEXT;
+});
+
+test('[P1] follow-up carousel caps growth at four lines under pathological placeholder lengths', async ({ page }) => {
+  // Guardrail against a future scenario copy landing at 500+ chars. The
+  // composer's min-height accommodates four wrapped lines; line-clamp
+  // prevents growth past that so a monster prompt cannot overtake the
+  // composer chrome. Measured under the app's real composer-scoped CSS
+  // without depending on a real chat turn (the cap holds independent of
+  // whether the carousel is home-hero or follow-up).
+  await page.goto('/');
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  const seed = 'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues. ';
+  const cases = [
+    { label: 'baseline (~270 chars)', text: seed.trim() },
+    { label: 'double (~540 chars)', text: (seed + seed).trim() },
+    { label: 'quadruple (~1080 chars)', text: (seed + seed + seed + seed).trim() },
+    { label: 'unbreakable-monster (600-char no-space run)', text: 'a'.repeat(600) },
+    { label: 'punctuation-only (200 chars)', text: '.-.-.-.-.'.repeat(20) },
+    { label: 'mixed CJK', text: '设计校对'.repeat(80) },
+  ];
+
+  const results = await page.evaluate((args) => {
+    const { widths, cases } = args as { widths: number[]; cases: Array<{ label: string; text: string }> };
+    const out: Array<{
+      width: number;
+      label: string;
+      carouselHeight: number;
+      wrapHeight: number;
+      carouselOverflowsWrap: boolean;
+      lineCount: number;
+    }> = [];
+    for (const w of widths) {
+      for (const c of cases) {
+        const wrap = document.createElement('div');
+        wrap.className = 'composer-input-wrap';
+        wrap.style.cssText = `position:fixed;top:-3000px;left:0;width:${w}px;padding:8px 9px;box-sizing:border-box;`;
+        const carousel = document.createElement('div');
+        carousel.className = 'home-hero__carousel';
+        const text = document.createElement('span');
+        text.className = 'home-hero__carousel-text';
+        text.appendChild(document.createTextNode(c.text));
+        const caret = document.createElement('span');
+        caret.className = 'home-hero__carousel-caret';
+        text.appendChild(caret);
+        carousel.appendChild(text);
+        wrap.appendChild(carousel);
+        document.body.appendChild(wrap);
+        const carouselRect = carousel.getBoundingClientRect();
+        const wrapRect = wrap.getBoundingClientRect();
+        const lineHeight = parseFloat(getComputedStyle(text).lineHeight);
+        out.push({
+          width: w,
+          label: c.label,
+          carouselHeight: Math.round(carouselRect.height),
+          wrapHeight: Math.round(wrapRect.height),
+          carouselOverflowsWrap: carouselRect.bottom > wrapRect.bottom + 0.5,
+          lineCount: Math.max(1, Math.round(carouselRect.height / lineHeight)),
+        });
+        wrap.remove();
+      }
+    }
+    return out;
+  }, { widths: [780, 456, 360], cases });
+
+  const detail = JSON.stringify(results, null, 2);
+
+  // Cap invariant: the carousel never exceeds four wrapped lines regardless
+  // of input length. If a scenario is intentionally shorter, that is fine
+  // (lineCount < 4); the cap only prevents unbounded growth.
+  for (const r of results) {
+    expect(r.lineCount, `line-clamp breach at ${r.width}px [${r.label}]: ${detail}`)
+      .toBeLessThanOrEqual(4);
+    // The carousel must stay within the composer wrap's own box so it
+    // never paints over the toolbar row below.
+    expect(r.carouselOverflowsWrap, `wrap overflow at ${r.width}px [${r.label}]: ${detail}`)
+      .toBe(false);
+  }
+});

--- a/e2e/ui/composer-carousel-placeholder-wrap.test.ts
+++ b/e2e/ui/composer-carousel-placeholder-wrap.test.ts
@@ -1,13 +1,17 @@
-// Composer follow-up placeholder — clip-free at supported widths.
+// Geometric visibility contract for the placeholder-carousel caret on both
+// surfaces that mount it:
 //
-// Once the user has completed at least one chat turn in a project, ChatPane
-// seeds the composer's PlaceholderCarousel with the design-toolbox next-step
-// prompts (`followUpComposerScenarios`). Several — visualPolish at ~270
-// chars — used to ellipsis-clip against the pre-fix composer CSS. This spec
-// drives a real fake-agent turn and measures the carousel at three widths.
+// - Home hero: single-line, ellipsized text, caret pinned row-end so the clip
+//   cannot take it out with the overflow.
+// - Follow-up composer: pre-wrapped text capped at four lines (-webkit-line-clamp)
+//   with the caret on the typing edge.
 //
-// DOM shape (caret nested in the text span) is locked separately at the
-// Vitest layer: apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx.
+// Oracle: chain-intersect the caret rect with the text span, carousel, and
+// viewport rects. Chromium reports nonzero geometry for descendants clipped by
+// overflow/-webkit-line-clamp, so `rect.width > 0` alone proves nothing.
+//
+// DOM-shape-only coverage lives in
+// apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx.
 
 import { expect, test } from '@/playwright/suite';
 import { createFakeAgentRuntimes } from '@/playwright/fake-agents';
@@ -16,14 +20,41 @@ import { T } from '@/timeouts';
 
 const STORAGE_KEY = 'open-design:config';
 
-// Verbatim `chat.designToolbox.prompt.visualPolish` from apps/web/src/i18n/locales/en.ts.
-const VISUAL_POLISH_TEXT =
-  'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues.';
-
-// Mid-prompt slice — robust against a rotate boundary and a harmless copy tweak.
+// Distinct prefixes of `chat.designToolbox.prompt.visualPolish` (206 chars) and
+// `.assetSearch` (287 chars) from apps/web/src/i18n/locales/en.ts.
 const VISUAL_POLISH_MATCH = 'Polish this design until it is ready to ship';
+const ASSET_SEARCH_MATCH = 'Find the best image/reference assets';
 
 const COMPOSER_WIDTHS_PX = [780, 640, 456] as const;
+
+interface RectLike {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+interface CarouselMetrics {
+  error?: string;
+  shown: string;
+  whiteSpace: string;
+  textOverflow: string;
+  lineCount: number;
+  scrollWidth: number;
+  clientWidth: number;
+  ellipsisEngaged: boolean;
+  carouselBottom: number;
+  toolbarTop: number | null;
+  docOverflowFree: boolean;
+  caretWidth: number;
+  caretHeight: number;
+  caretTop: number;
+  caretRight: number;
+  textBottom: number;
+  carouselRight: number;
+  visibleWidth: number;
+  visibleHeight: number;
+}
 
 let fakeRuntimes: Record<string, FakeAgentRuntime>;
 
@@ -34,8 +65,8 @@ test.beforeAll(async () => {
 test.beforeEach(async ({ page }) => {
   test.setTimeout(T.xlong);
 
-  // reduce-motion short-circuits the typewriter to full-text-per-rotation
-  // (~2s per scenario), so visualPolish appears in seconds instead of ~10s.
+  // reduce-motion swaps the typewriter to whole-scenario holds (~1.9s each), so
+  // a target prompt is measurable within seconds instead of a full type cycle.
   await page.emulateMedia({ reducedMotion: 'reduce' });
 
   const codexEnv = fakeRuntimes.codex!.env;
@@ -66,10 +97,25 @@ test.beforeEach(async ({ page }) => {
         agentCliEnv: { codex: env },
       }),
     );
+    // Keep the survey out of layout screenshots.
+    window.localStorage.setItem('open-design:experience-survey:v1:retired', '1');
   }, { key: STORAGE_KEY, env: codexEnv });
 });
 
-test('[P1] follow-up composer placeholder wraps long design-toolbox prompts without clipping', async ({ page }) => {
+async function dismissEntryChrome(page: import('@playwright/test').Page): Promise<void> {
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve OpenDesign' });
+  if (await privacyDialog.isVisible().catch(() => false)) {
+    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+}
+
+// Runs one real fake-agent turn so displayMessages flips the composer pool to
+// the follow-up scenarios (the surface whose placeholder wraps).
+async function openFollowUpCarousel(
+  page: import('@playwright/test').Page,
+): Promise<void> {
   const projectId = `carousel-wrap-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
   const createResponse = await page.request.post('/api/projects', {
     data: {
@@ -87,155 +133,227 @@ test('[P1] follow-up composer placeholder wraps long design-toolbox prompts with
   await page.goto(`/projects/${projectId}/conversations/${conversationId}`, {
     waitUntil: 'domcontentloaded',
   });
-  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+  await dismissEntryChrome(page);
 
-  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve OpenDesign' });
-  if (await privacyDialog.isVisible().catch(() => false)) {
-    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
-    await expect(privacyDialog).toHaveCount(0);
-  }
-
-  const composer = page.getByTestId('chat-composer');
-  await expect(composer).toBeVisible();
   const composerInput = page.getByTestId('chat-composer-input');
   await expect(composerInput).toBeVisible();
   const sendButton = page.getByTestId('chat-send');
 
-  // Run one real turn so displayMessages > 0 flips composer scenarios from
-  // blank-project to follow-up (the code path that surfaces visualPolish).
   await composerInput.click();
   await composerInput.fill('Create a deterministic smoke artifact');
-  await expect(sendButton).toBeEnabled();
+  // Agent availability arrives through the /api/agents SSE stream.
+  await expect(sendButton, 'codex availability must stream in before submit')
+    .toBeEnabled({ timeout: T.long });
   await sendButton.click();
 
   await expect(page.getByTestId('file-workspace').getByText('real-daemon-smoke.html', { exact: true }))
     .toBeVisible({ timeout: T.long });
 
-  // Blur composer — carousel pauses while the composer is focused.
+  // Blur the composer so the carousel mounts.
   await page.getByTestId('file-workspace').click({ position: { x: 10, y: 10 } });
   await expect(composerInput).not.toBeFocused();
 
-  const carousel = page.getByTestId('home-hero-carousel');
-  await expect(carousel).toBeVisible({ timeout: T.medium });
+  await expect(page.getByTestId('home-hero-carousel')).toBeVisible({ timeout: T.medium });
+}
 
-  await expect
-    .poll(async () => (await carousel.textContent()) ?? '', { timeout: T.medium })
-    .toContain(VISUAL_POLISH_MATCH);
+async function measureCarousel(page: import('@playwright/test').Page): Promise<CarouselMetrics> {
+  return page.evaluate(() => {
+    const carousel = document.querySelector<HTMLElement>('[data-testid="home-hero-carousel"]');
+    const textSpan = carousel?.querySelector<HTMLElement>('.home-hero__carousel-text');
+    const caret = carousel?.querySelector<HTMLElement>('.home-hero__carousel-caret');
+    if (!carousel || !textSpan || !caret) {
+      return {
+        error: `structure missing carousel=${!!carousel} text=${!!textSpan} caret=${!!caret}`,
+        shown: '', whiteSpace: '', textOverflow: '', lineCount: 0, scrollWidth: 0,
+        clientWidth: 0, ellipsisEngaged: false, carouselBottom: 0, toolbarTop: null,
+        docOverflowFree: false, caretWidth: 0, caretHeight: 0,
+        caretTop: 0, caretRight: 0, textBottom: 0, carouselRight: 0,
+        visibleWidth: 0, visibleHeight: 0,
+      };
+    }
+    const toolbar = carousel.closest('.composer-shell')?.querySelector('.composer-row');
+    const cRect = carousel.getBoundingClientRect();
+    const tRect = textSpan.getBoundingClientRect();
+    const kRect = caret.getBoundingClientRect();
+    const cs = window.getComputedStyle(textSpan);
+    const lineHeight = parseFloat(cs.lineHeight) || 1;
 
-  const measurements: Array<{
-    viewportWidth: number;
-    carouselScrollWidth: number;
-    carouselClientWidth: number;
-    carouselHeight: number;
-    lineCount: number;
-    whiteSpace: string;
-    textOverflow: string;
-    caretGapDx: number | null;
-    caretGapDy: number | null;
-    caretVisible: boolean;
-    visibleTextSample: string;
-  }> = [];
+    let box: RectLike = {
+      left: kRect.left, top: kRect.top, right: kRect.right, bottom: kRect.bottom,
+    };
+    // typing-edge carets live inside the text span (its clamp box clips them);
+    // row-end carets are siblings after it, so only the carousel clips them.
+    const clips: RectLike[] = caret.parentElement === textSpan
+      ? [tRect, cRect]
+      : [cRect];
+    clips.push({ left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight });
+    for (const clip of clips) {
+      box = {
+        left: Math.max(box.left, clip.left),
+        top: Math.max(box.top, clip.top),
+        right: Math.min(box.right, clip.right),
+        bottom: Math.min(box.bottom, clip.bottom),
+      };
+    }
 
+    return {
+      shown: textSpan.textContent ?? '',
+      whiteSpace: cs.whiteSpace,
+      textOverflow: cs.textOverflow,
+      lineCount: Math.max(1, Math.round(cRect.height / lineHeight)),
+      scrollWidth: carousel.scrollWidth,
+      clientWidth: carousel.clientWidth,
+      ellipsisEngaged: textSpan.scrollWidth > textSpan.clientWidth,
+      carouselBottom: cRect.bottom,
+      toolbarTop: toolbar ? toolbar.getBoundingClientRect().top : null,
+      docOverflowFree: document.documentElement.scrollWidth <= window.innerWidth + 1,
+      caretWidth: kRect.width,
+      caretHeight: kRect.height,
+      caretTop: kRect.top,
+      caretRight: kRect.right,
+      textBottom: tRect.bottom,
+      carouselRight: cRect.right,
+      visibleWidth: Math.max(0, box.right - box.left),
+      visibleHeight: Math.max(0, box.bottom - box.top),
+    };
+  });
+}
+
+// Samples until both the requested scenario is showing and its metrics are
+// readable; the reduced-motion carousel rotates every ~1.9s, so a single
+// instant snapshot can land between scenarios.
+async function measureWhenShowing(
+  page: import('@playwright/test').Page,
+  match: string,
+): Promise<CarouselMetrics> {
+  const deadline = Date.now() + T.long;
+  for (;;) {
+    await expect(page.getByTestId('home-hero-carousel')).toContainText(match, { timeout: T.long });
+    const m = await measureCarousel(page);
+    if (!m.error && m.shown.includes(match)) return m;
+    if (Date.now() > deadline) {
+      throw new Error(`no stable measurement for "${match}": ${JSON.stringify(m)}`);
+    }
+    await page.waitForTimeout(300);
+  }
+}
+
+function expectCaretTruth(m: CarouselMetrics, label: string): void {
+  const detail = JSON.stringify(m);
+  expect(m.visibleWidth, `caret has no visible horizontal intersection ${label}: ${detail}`)
+    .toBeGreaterThanOrEqual(m.caretWidth * 0.9);
+  expect(m.visibleHeight, `caret has no visible vertical intersection ${label}: ${detail}`)
+    .toBeGreaterThanOrEqual(m.caretHeight * 0.5);
+}
+
+test('[P1] follow-up composer wraps prompts and keeps the caret truthfully placed', async ({ page }, testInfo) => {
+  await openFollowUpCarousel(page);
+
+  const measurements: CarouselMetrics[] = [];
   for (const w of COMPOSER_WIDTHS_PX) {
     await page.setViewportSize({ width: w, height: 720 });
-    await expect
-      .poll(async () => (await carousel.textContent()) ?? '', { timeout: T.medium })
-      .toContain(VISUAL_POLISH_MATCH);
+    const m = await measureWhenShowing(page, VISUAL_POLISH_MATCH);
+    const detail = `[${w}px] ${JSON.stringify(m)}`;
 
-    const m = await carousel.evaluate((el) => {
-      const textSpan = el.querySelector('.home-hero__carousel-text') as HTMLElement | null;
-      const caret = el.querySelector('.home-hero__carousel-caret') as HTMLElement | null;
-      if (!textSpan || !caret) {
-        return { error: `structure missing text=${!!textSpan} caret=${!!caret}` } as const;
-      }
-      const rect = el.getBoundingClientRect();
-      const caretRect = caret.getBoundingClientRect();
-      const cs = window.getComputedStyle(textSpan);
-      const lineHeight = parseFloat(cs.lineHeight);
+    expect(m.whiteSpace, `white-space regressed ${detail}`).toBe('pre-wrap');
+    expect(m.textOverflow, `text-overflow regressed ${detail}`).toBe('clip');
+    expect(m.lineCount, `expected wrapping ${detail}`).toBeGreaterThanOrEqual(2);
+    expect(m.lineCount, `four-line cap breached ${detail}`).toBeLessThanOrEqual(4);
+    expect(m.scrollWidth, `horizontal spill ${detail}`).toBeLessThanOrEqual(m.clientWidth + 1);
+    expect(m.docOverflowFree, `document horizontal overflow ${detail}`).toBe(true);
+    expect(m.toolbarTop, `toolbar missing ${detail}`).not.toBeNull();
+    expect(m.carouselBottom, `carousel covers toolbar ${detail}`).toBeLessThanOrEqual(m.toolbarTop! + 0.5);
+    expectCaretTruth(m, detail);
 
-      let textNode: Text | null = null;
-      for (let i = textSpan.childNodes.length - 1; i >= 0; i--) {
-        const child = textSpan.childNodes[i];
-        if (child && child.nodeType === Node.TEXT_NODE) {
-          textNode = child as Text;
-          break;
-        }
-      }
-      let caretGapDx: number | null = null;
-      let caretGapDy: number | null = null;
-      const visibleTextSample = (textNode?.data ?? '').slice(-64);
-      if (textNode && textNode.length > 0) {
-        const range = document.createRange();
-        range.setStart(textNode, textNode.length - 1);
-        range.setEnd(textNode, textNode.length);
-        const rects = range.getClientRects();
-        const lcr = rects[rects.length - 1];
-        if (lcr) {
-          caretGapDx = caretRect.left - lcr.right;
-          caretGapDy = caretRect.bottom - lcr.bottom;
-        }
-      }
-
-      return {
-        carouselScrollWidth: el.scrollWidth,
-        carouselClientWidth: el.clientWidth,
-        carouselHeight: Math.round(rect.height),
-        lineCount: Math.max(1, Math.round(rect.height / lineHeight)),
-        whiteSpace: cs.whiteSpace,
-        textOverflow: cs.textOverflow,
-        caretGapDx,
-        caretGapDy,
-        caretVisible: caretRect.width > 0 && caretRect.height > 0,
-        visibleTextSample,
-      };
-    });
-
-    if ('error' in m) throw new Error(m.error);
-    measurements.push({ viewportWidth: w, ...m });
+    const shot = testInfo.outputPath(`composer-followup-w${w}.png`);
+    await page.screenshot({ path: shot });
+    await testInfo.attach(`composer-followup-w${w}`, { path: shot, contentType: 'image/png' });
+    measurements.push(m);
   }
 
-  const detail = JSON.stringify(measurements, null, 2);
+  // assetSearch exceeds four wrapped lines at 456px, so the inline caret is
+  // clipped by the line clamp.
+  await page.setViewportSize({ width: 456, height: 720 });
+  const clamped = await measureWhenShowing(page, ASSET_SEARCH_MATCH);
+  const clampedDetail = `[clamp] ${JSON.stringify(clamped)}`;
+  expect(clamped.lineCount, `cap breached beyond clamp ${clampedDetail}`).toBeLessThanOrEqual(4);
+  expect(clamped.caretTop, `caret box must sit below the clamp box ${clampedDetail}`)
+    .toBeGreaterThanOrEqual(clamped.textBottom - 1);
+  expect(clamped.visibleWidth * clamped.visibleHeight,
+    `clamped caret must have zero-area intersection ${clampedDetail}`).toBe(0);
+  expect(clamped.carouselBottom, `carousel covers toolbar ${clampedDetail}`)
+    .toBeLessThanOrEqual((clamped.toolbarTop ?? 0) + 0.5);
 
-  for (const m of measurements) {
-    expect(m.carouselScrollWidth, `horizontal clip at ${m.viewportWidth}px: ${detail}`)
-      .toBeLessThanOrEqual(m.carouselClientWidth + 1);
-    expect(m.whiteSpace, `white-space regressed at ${m.viewportWidth}px: ${detail}`)
-      .toBe('pre-wrap');
-    expect(m.textOverflow, `text-overflow regressed at ${m.viewportWidth}px: ${detail}`)
-      .toBe('clip');
-    expect(m.caretVisible, `caret not visible at ${m.viewportWidth}px: ${detail}`).toBe(true);
-    expect(m.caretGapDx, `caret dx unreadable at ${m.viewportWidth}px: ${detail}`).not.toBeNull();
-    expect(m.caretGapDy, `caret dy unreadable at ${m.viewportWidth}px: ${detail}`).not.toBeNull();
-    expect(Math.abs(m.caretGapDx!), `caret horizontal drift at ${m.viewportWidth}px: ${detail}`)
-      .toBeLessThanOrEqual(6);
-    expect(Math.abs(m.caretGapDy!), `caret vertical drift at ${m.viewportWidth}px: ${detail}`)
-      .toBeLessThanOrEqual(4);
-  }
-
-  const wrapped = measurements.filter((m) => m.lineCount >= 2);
-  expect(wrapped.length, `expected wrapping at every width: ${detail}`)
-    .toBe(COMPOSER_WIDTHS_PX.length);
-  void VISUAL_POLISH_TEXT;
+  const shot = testInfo.outputPath('composer-followup-beyond-clamp.png');
+  await page.screenshot({ path: shot });
+  await testInfo.attach('composer-followup-beyond-clamp', { path: shot, contentType: 'image/png' });
 });
 
-test('[P1] follow-up carousel caps growth at four lines under pathological placeholder lengths', async ({ page }) => {
-  // Guardrail against a future scenario copy landing at 500+ chars. The
-  // composer's min-height accommodates four wrapped lines; line-clamp
-  // prevents growth past that so a monster prompt cannot overtake the
-  // composer chrome. Measured under the app's real composer-scoped CSS
-  // without depending on a real chat turn (the cap holds independent of
-  // whether the carousel is home-hero or follow-up).
+test('[P1] home hero placeholder stays single-line with a visible row-end caret', async ({ page }, testInfo) => {
+  // German copy carries the longest home-hero scenario strings; a narrow card
+  // guarantees at least one rotating scenario trips the ellipsis clip.
+  await page.addInitScript(() => {
+    window.localStorage.setItem('open-design:locale', 'de');
+    window.localStorage.setItem('open-design:locale-source', 'manual');
+  });
+  await page.setViewportSize({ width: 360, height: 800 });
   await page.goto('/');
-  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+  await dismissEntryChrome(page);
 
-  const seed = 'Polish this design until it is ready to ship: check hierarchy, typography, spacing, responsive behavior, button states, empty/loading/error states, and accessibility; directly fix the most important issues. ';
+  // Avoid the editor and logo; click empty hero padding until the carousel mounts.
+  const carousel = page.getByTestId('home-hero-carousel');
+  const blurDeadline = Date.now() + T.long;
+  while (!(await carousel.isVisible().catch(() => false))) {
+    if (Date.now() > blurDeadline) break;
+    await page.mouse.click(180, 60);
+    await page.waitForTimeout(400);
+  }
+  await expect(carousel).toBeVisible({ timeout: T.medium });
+  // Require the mount to survive late focus/remount activity.
+  await page.waitForTimeout(2_000);
+  await expect(carousel).toBeVisible();
+
+  // Find a rotation that exercises ellipsis.
+  const deadline = Date.now() + T.xlong;
+  let m: CarouselMetrics | null = null;
+  for (;;) {
+    const probe = await measureCarousel(page);
+    if (!probe.error && probe.ellipsisEngaged) {
+      m = probe;
+      break;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`no overflowing home-hero rotation observed: ${JSON.stringify(probe)}`);
+    }
+    await page.waitForTimeout(250);
+  }
+
+  const detail = JSON.stringify(m);
+  expect(m.whiteSpace, detail).toBe('nowrap');
+  expect(m.lineCount, `home hero must stay single-line ${detail}`).toBe(1);
+  expect(m.scrollWidth, `hero carousel spills horizontally ${detail}`)
+    .toBeLessThanOrEqual(m.clientWidth + 1);
+  expect(m.docOverflowFree, `document horizontal overflow ${detail}`).toBe(true);
+  expect(m.caretRight, `row-end caret must stay pinned inside the carousel row ${detail}`)
+    .toBeLessThanOrEqual(m.carouselRight + 1);
+  expectCaretTruth(m, detail);
+
+  const shot = testInfo.outputPath('home-hero-ellipsis.png');
+  await page.screenshot({ path: shot });
+  await testInfo.attach('home-hero-ellipsis', { path: shot, contentType: 'image/png' });
+});
+
+test('[P2] four-line clamp caps pathological placeholders without covering the toolbar', async ({ page }) => {
+  await page.goto('/');
+  await dismissEntryChrome(page);
+
+  const seed = 'Polish this design until it is ready to ship.';
   const cases = [
-    { label: 'baseline (~270 chars)', text: seed.trim() },
-    { label: 'double (~540 chars)', text: (seed + seed).trim() },
-    { label: 'quadruple (~1080 chars)', text: (seed + seed + seed + seed).trim() },
-    { label: 'unbreakable-monster (600-char no-space run)', text: 'a'.repeat(600) },
-    { label: 'punctuation-only (200 chars)', text: '.-.-.-.-.'.repeat(20) },
-    { label: 'mixed CJK', text: '设计校对'.repeat(80) },
+    { label: 'double', text: `${seed} ${seed}`.trim() },
+    { label: 'quadruple', text: Array(4).fill(seed).join(' ') },
+    { label: 'unbreakable-600', text: 'a'.repeat(600) },
+    { label: 'punctuation-200', text: '.-.-.-.-.'.repeat(20) },
+    { label: 'cjk-320', text: '设计校对'.repeat(80) },
   ];
 
   const results = await page.evaluate((args) => {
@@ -243,8 +361,6 @@ test('[P1] follow-up carousel caps growth at four lines under pathological place
     const out: Array<{
       width: number;
       label: string;
-      carouselHeight: number;
-      wrapHeight: number;
       carouselOverflowsWrap: boolean;
       lineCount: number;
     }> = [];
@@ -264,14 +380,13 @@ test('[P1] follow-up carousel caps growth at four lines under pathological place
         carousel.appendChild(text);
         wrap.appendChild(carousel);
         document.body.appendChild(wrap);
+        const textEl = wrap.querySelector<HTMLElement>('.home-hero__carousel-text')!;
         const carouselRect = carousel.getBoundingClientRect();
         const wrapRect = wrap.getBoundingClientRect();
-        const lineHeight = parseFloat(getComputedStyle(text).lineHeight);
+        const lineHeight = parseFloat(getComputedStyle(textEl).lineHeight) || 1;
         out.push({
           width: w,
           label: c.label,
-          carouselHeight: Math.round(carouselRect.height),
-          wrapHeight: Math.round(wrapRect.height),
           carouselOverflowsWrap: carouselRect.bottom > wrapRect.bottom + 0.5,
           lineCount: Math.max(1, Math.round(carouselRect.height / lineHeight)),
         });
@@ -282,15 +397,9 @@ test('[P1] follow-up carousel caps growth at four lines under pathological place
   }, { widths: [780, 456, 360], cases });
 
   const detail = JSON.stringify(results, null, 2);
-
-  // Cap invariant: the carousel never exceeds four wrapped lines regardless
-  // of input length. If a scenario is intentionally shorter, that is fine
-  // (lineCount < 4); the cap only prevents unbounded growth.
   for (const r of results) {
     expect(r.lineCount, `line-clamp breach at ${r.width}px [${r.label}]: ${detail}`)
       .toBeLessThanOrEqual(4);
-    // The carousel must stay within the composer wrap's own box so it
-    // never paints over the toolbar row below.
     expect(r.carouselOverflowsWrap, `wrap overflow at ${r.width}px [${r.label}]: ${detail}`)
       .toBe(false);
   }


### PR DESCRIPTION
## Why

The composer's placeholder rotates through the design-toolbox next-step prompts after you've sent a message in a project. Several are full paragraphs (visualPolish is ~270 chars), and the current composer CSS clips them with an ellipsis at every realistic width:

| composer width | text hidden |
| --- | --- |
| 780px | 75 chars (28%) |
| 640px | 99 chars (37%) |
| 456px | 127 chars (47%) |

Half the suggestion sits behind `…`.

The wrap fix touches four spots because they interlock:

1. `apps/web/src/styles/chat.css` had `white-space: nowrap` + `text-overflow: ellipsis` on the composer's carousel, inherited from the home-hero context where scenarios are one-liners. Relaxed to `pre-wrap + break-word`. Using `pre-wrap` (not `normal`) preserves the typewriter's trailing spaces at wrap edges so the caret doesn't jitter to the next line for one frame when a space is typed there.
2. `chat.css` boosts the composer wrap's `min-height` to `104px` only while the carousel is mounted (`:has()` selector), so up to four wrapped lines fit inside the composer's own box and the toolbar row underneath stays uncovered. The previous height silently assumed a single-line placeholder because that was the only case the original CSS handled.
3. `chat.css` line-clamps the carousel text at four lines as a guardrail. Any future scenario copy above the current ~270-char ceiling still stays inside the wrap's 104px, so a monster prompt cannot overtake the composer chrome.
4. `PlaceholderCarousel` now exposes explicit caret placement. ChatComposer uses an inline `typing-edge` caret so it follows wrapped text; HomeHero keeps a sibling `row-end` caret beside its single-line ellipsis.

## What users will see

After the first message in a project, the composer's rotating placeholder wraps to fit the composer width instead of ellipsis-truncating. The caret sits right after the last typed character on the last wrapped line. Toolbar row underneath stays uncovered.

Home-hero composer is unchanged.

## Surface area

- [x] **UI**: composer placeholder rendering in `apps/web`
- [x] **Default behavior change**: placeholder wraps where it used to clip; composer wrap grows to 104px while the follow-up carousel is showing

## Screenshots

Top plate is `main`, bottom plate is this branch. Red marks the pre-fix, green marks the fix.

![composer-carousel-wrap · 700px](https://raw.githubusercontent.com/worflor/meowtimedesign/pr-assets/composer-carousel-wrap/composer-carousel-wrap-700.png)

![composer-carousel-wrap · 520px](https://raw.githubusercontent.com/worflor/meowtimedesign/pr-assets/composer-carousel-wrap/composer-carousel-wrap-520.png)

## Bug fix verification

- `apps/web/tests/components/home-hero/PlaceholderCarousel.caret-inline.test.tsx` locks the two surface contracts: HomeHero keeps a sibling row-end caret, while ChatComposer nests the typing-edge caret inside wrapped text.
- `e2e/ui/composer-carousel-placeholder-wrap.test.ts` drives the real follow-up path at 780/640/456px, verifies the HomeHero path remains single-line, and exercises the four-line clamp with long, unbreakable, punctuation, and CJK strings.
- The regression cases went red on `main` and green on this branch.

## Validation

- Focused Vitest suites: 9/9 passed
- Focused Playwright spec with `--repeat-each=3 --workers=1`: 9/9 passed
- `pnpm --filter @open-design/web typecheck`: clean
- `pnpm --filter @open-design/web build`: clean
- Current-main integration: `pnpm guard` and full `pnpm typecheck` clean