### PR TITLE
docs: sync zh-CN README with English (Claude Desktop, roadmap, license)

### DIFF
--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -115,6 +115,7 @@ OpenDesign 是这样一种产物：Anthropic 随 Claude Design 推出的 **Agent
 | 编码 Agent / 平台 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | 状态 &nbsp;&nbsp; | 快速接入 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
 |---|:---:|---|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ 支持 | `od mcp install claude` |
+| [Claude Desktop](https://claude.ai/download) | ✅ 支持¹ | `od mcp install claude-desktop` |
 | [Codex CLI](https://github.com/openai/codex) | ✅ 支持 | `od mcp install codex` |
 | [DeepSeek Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | ✅ 支持 | `od mcp install reasonix` |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) | ✅ 原生运行时 | `od agent setup deepseek-harness` |
@@ -134,6 +135,8 @@ OpenDesign 是这样一种产物：Anthropic 随 Claude Design 推出的 **Agent
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ 支持 | `od mcp install hermes` |
 
 使用 DeepSeek Harness 时，请先安装官方 `dsh` CLI，再在 OpenDesign 中选择它，或运行 `od agent setup deepseek-harness` 安装/修复 OD 连接组件。MCP 集成可用 `od mcp install <agent> --print` 干跑预览 · `--uninstall` 卸载 · 完整清单 `od mcp install --help`。
+
+¹ Claude Desktop 的自动 MCP 配置目前仅在 macOS 和 Windows 上支持。
 
 <p align="center">
   <img src="https://repo-assets.open-design.ai/resources/images/coding-agents.png" alt="OpenDesign 支持的 26 个编码 Agent CLI — DeepSeek Harness · Claude Code · Codex · OpenCode · Hermes · Antigravity · Vela · Grok Build · Kimi · Cursor Agent · Qwen · Qoder · GitHub Copilot · Pi · Kiro · Kilo · Mistral Vibe · DeepSeek · Reasonix · Aider · Amp · CodeBuddy · Mimo · AtomCode · Devin · Trae" width="100%" />
@@ -573,6 +576,11 @@ pnpm guard && pnpm --filter @open-design/plugin-runtime typecheck
 - [x] Sidecar 协议 + Electron 桌面 + IPC 自动化
 - [x] 工件 Lint API + 五维自评预输出门控
 - [x] **0.8.0**——插件市场基础设施（261 个官方插件、manifest 规范、逐 Agent 安装脚本）
+- [x] **0.9.0**——OpenDesign Cloud（应用内置的官方模型服务：零配置，一键登录）
+- [x] **0.10.0**——一体化设计工作区：一个窗口内完成完整创作闭环（参考 → 素材 → 交互编辑 → 动效 → 交付）
+- [x] **0.11.0**——_The Bazaar_：在开放中构建——人人都可以挑选和贡献的插件与设计系统社区市场
+- [x] **0.12.0**——_品牌设计系统_：把你已经拥有的品牌变成可复用、可移植的 `DESIGN.md` 系统
+- [x] **0.13.0**——_Stay in Flow_：原生会话恢复、更快的模型选择、直接导出截图支撑的 PPTX / PDF
 - [x] 打包 Electron 构建——macOS（Apple Silicon + Intel）+ Windows（x64）+ Linux AppImage（可选通道）
 - [ ] 评论模式精确编辑——部分已发布，可靠的定向补丁进行中
 - [ ] AI 输出的调参面板 UX——尚未实现
@@ -727,4 +735,4 @@ gh pr create --fill
 
 ## 许可证
 
-Apache-2.0。打包的 `design-templates/guizang-ppt/` 保留其原始 [LICENSE](../../design-templates/guizang-ppt/LICENSE)（MIT，[@op7418](https://github.com/op7418)）。打包的 `design-templates/html-ppt/` 保留其原始 [LICENSE](../../design-templates/html-ppt/LICENSE)（MIT，[@lewislulu](https://github.com/lewislulu)）。
+Apache-2.0。打包的 `design-templates/guizang-ppt/` 保留其原始 [LICENSE](../../design-templates/guizang-ppt/LICENSE)（MIT，[@op7418](https://github.com/op7418)）。打包的 `design-templates/html-ppt/` 保留其原始 [LICENSE](../../design-templates/html-ppt/LICENSE)（MIT，[@lewislulu](https://github.com/lewislulu)）。打包的 `skills/web-clone/` 保留其原始 [LICENSE](../../skills/web-clone/LICENSE)（MIT，[@Jane-xiaoer](https://github.com/Jane-xiaoer)）。


### PR DESCRIPTION
## Why

The zh-CN README (`docs/i18n/README.zh-CN.md`) has drifted from the English `README.md`:

- The platform compatibility table is missing the **Claude Desktop** row (`od mcp install claude-desktop`) and its footnote.
- The roadmap stops at 0.8.0; the 0.9.0 → 0.13.0 entries are missing.
- The license section omits the bundled `skills/web-clone/` (MIT, @Jane-xiaoer) attribution.

This makes the Chinese documentation incomplete for Chinese-speaking users.

## What users will see

Chinese readers of the zh-CN README now see:

- The Claude Desktop integration row with the matching install command (`od mcp install claude-desktop`) and the macOS/Windows-only footnote.
- The roadmap through 0.13.0.
- The correct license attribution for the bundled `skills/web-clone/`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag
- [ ] **API / contract** — new `/api/*` endpoint or changed shape
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, etc.
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — docs only (`docs/i18n/README.zh-CN.md`)

## Validation

- Reviewed each addition against the English `README.md` section-by-section.
- Confirmed `skills/web-clone/LICENSE` exists in the repository.
- Markdown structure and formatting match the surrounding lines; no other files changed.
