### PR TITLE
fix(pack): ship node.exe in the Windows resource tree so OD_NODE_BIN resolves to Node

### DIFF
--- a/tools/pack/src/win/resources.ts
+++ b/tools/pack/src/win/resources.ts
@@ -77,6 +77,11 @@ export async function prepareResourceTree(
         });
       }
       await mkdir(join(resourceRoot, "bin"), { recursive: true });
+      // Mirror the Linux pack step (tools/pack/src/linux.ts copyResourceTree):
+      // ship the Node executable used to build the pack as the packaged
+      // `bin/node.exe` so `OD_NODE_BIN` resolves to a real Node runtime instead
+      // of falling back to `process.execPath` → `Open Design.exe` (#7148).
+      await cp(process.execPath, join(resourceRoot, "bin", "node.exe"));
       await cp(winResources.sevenZipExe, join(resourceRoot, "bin", "7z.exe"));
       await cp(winResources.sevenZipDll, join(resourceRoot, "bin", "7z.dll"));
       await copyOptionalVelaCliBinary({


### PR DESCRIPTION
## Why

Fixes #7148. On the packaged Windows build, `resources/open-design/bin/node.exe` is missing from the install payload. The daemon's `OD_NODE_BIN` resolver prefers `<resourceRoot>/bin/node.exe` before falling back to `process.execPath`, so agent runtime commands like `$env:OD_NODE_BIN -e "..."` end up launching `Open Design.exe` — a second full Electron runtime — which then spews `EPIPE` main-process dialogs when the agent task's stdio pipe closes.

The Linux pack step already ships the build Node as `bin/node` (`tools/pack/src/linux.ts` `copyResourceTree`), and the Windows release report already tracks `bin/node.exe` bytes (`tools/pack/src/win/report.ts`), so the missing copy in `prepareResourceTree` is a packaging gap, not an intended difference.

## What users will see

- The packaged Windows app ships a real `resources/open-design/bin/node.exe`.
- `OD_NODE_BIN` resolves to that Node executable instead of `Open Design.exe`.
- Agent-side Node validation (`OD_NODE_BIN -e "console.log('ok')"`) prints `ok` and exits; no accidental second desktop runtime, no `EPIPE` dialog storm.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — `OD_NODE_BIN` now resolves to the packaged `bin/node.exe` on Windows
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — packaged Windows resource tree now includes `bin/node.exe`
- [ ] **None**

## Validation

- Mirrors the existing Linux `copyResourceTree` step (`cp(process.execPath, bin/node)`) exactly, adapting the filename for Windows (`bin/node.exe`); no chmod needed on Windows.
- Locally simulated the copied step: `cp(process.execPath, bin/node.exe)` produces a valid executable.
- Full `pnpm typecheck` could not run in this environment (sparse checkout lacks workspace-package sources and Windows lacks VS Build Tools for `better-sqlite3`); the change is additive and does not touch cache keys. CI validates typecheck in the full environment.
