### PR TITLE
fix(daemon): anchor run phases on first model event

### DIFF
--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1021,6 +1021,12 @@ function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unkno
   addMeasured('runtime-init-to-first-token', marks.stdinWriteEndAt ?? marks.modelCallStartAt ?? marks.processSpawnedAt, marks.firstTokenAt);
   addMeasured('agent-call', marks.modelCallStartAt, ctx.run.endedAt);
   addMeasured('stream-output', marks.firstTokenAt, marks.finalizeStartAt ?? ctx.run.endedAt);
+  // `stream-output` starts at the first text token, so a tool-first run shows
+  // only its closing message here. `model-active` is the same window anchored
+  // on the first model event of any kind. Kept as a diagnostics entry rather
+  // than a second span: this map rides along in existing metadata, while a new
+  // span would add an observation row per run.
+  addMeasured('model-active', marks.firstModelEventAt ?? marks.firstTokenAt, marks.finalizeStartAt ?? ctx.run.endedAt);
   addMeasured('artifact-write', marks.firstArtifactWriteAt, marks.finalizeStartAt ?? ctx.run.endedAt);
   addMeasured('finalize', marks.finalizeStartAt, ctx.run.endedAt);
   return {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -31,6 +31,7 @@ import {
 import {
   canonicalizeToolAnalyticsName,
   type RunTelemetryTimestamps,
+  phaseAnchorFromMarks,
   type RunTimingAnalytics,
 } from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
@@ -998,19 +999,6 @@ function buildArtifactWriteDiagnostics(
   };
 }
 
-// Earliest of the supplied marks, ignoring absent and non-finite values. Mirrors
-// how `summarizeRunTimingAnalytics` picks its phase anchor: the model cannot
-// have started responding after it emitted its first token, so a later mark is
-// always a producer bug rather than a later start.
-function earliestFiniteTimestamp(
-  ...values: Array<number | undefined>
-): number | undefined {
-  const finite = values.filter(
-    (value): value is number => typeof value === 'number' && Number.isFinite(value),
-  );
-  return finite.length > 0 ? Math.min(...finite) : undefined;
-}
-
 function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unknown> {
   const marks = ctx.run.timingMarks ?? {};
   const measured: Record<string, unknown> = {};
@@ -1044,11 +1032,7 @@ function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unkno
   // exactly -- earliest of the two marks, through run end -- because the whole
   // point of this entry is to be compared against that number. Deliberately
   // unlike its neighbours above, which end at `finalizeStartAt`.
-  addMeasured(
-    'model-active',
-    earliestFiniteTimestamp(marks.firstModelEventAt, marks.firstTokenAt),
-    ctx.run.endedAt,
-  );
+  addMeasured('model-active', phaseAnchorFromMarks(marks), ctx.run.endedAt);
   addMeasured('artifact-write', marks.firstArtifactWriteAt, marks.finalizeStartAt ?? ctx.run.endedAt);
   addMeasured('finalize', marks.finalizeStartAt, ctx.run.endedAt);
   return {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -998,6 +998,19 @@ function buildArtifactWriteDiagnostics(
   };
 }
 
+// Earliest of the supplied marks, ignoring absent and non-finite values. Mirrors
+// how `summarizeRunTimingAnalytics` picks its phase anchor: the model cannot
+// have started responding after it emitted its first token, so a later mark is
+// always a producer bug rather than a later start.
+function earliestFiniteTimestamp(
+  ...values: Array<number | undefined>
+): number | undefined {
+  const finite = values.filter(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
+  return finite.length > 0 ? Math.min(...finite) : undefined;
+}
+
 function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unknown> {
   const marks = ctx.run.timingMarks ?? {};
   const measured: Record<string, unknown> = {};
@@ -1026,7 +1039,16 @@ function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unkno
   // on the first model event of any kind. Kept as a diagnostics entry rather
   // than a second span: this map rides along in existing metadata, while a new
   // span would add an observation row per run.
-  addMeasured('model-active', marks.firstModelEventAt ?? marks.firstTokenAt, marks.finalizeStartAt ?? ctx.run.endedAt);
+  //
+  // Boundaries mirror `model_active_duration_ms` in run-analytics-observability
+  // exactly -- earliest of the two marks, through run end -- because the whole
+  // point of this entry is to be compared against that number. Deliberately
+  // unlike its neighbours above, which end at `finalizeStartAt`.
+  addMeasured(
+    'model-active',
+    earliestFiniteTimestamp(marks.firstModelEventAt, marks.firstTokenAt),
+    ctx.run.endedAt,
+  );
   addMeasured('artifact-write', marks.firstArtifactWriteAt, marks.finalizeStartAt ?? ctx.run.endedAt);
   addMeasured('finalize', marks.finalizeStartAt, ctx.run.endedAt);
   return {

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -984,6 +984,16 @@ export function summarizeRunTimingAnalytics(args: {
   // by a retry is not merged with the corpse of the same id from a dead
   // attempt.
   const attemptStartAt = telemetry.attemptStartedAt ?? scanStartAt;
+  // Phase occupancy counts only tools THIS attempt opened. `run.events` survives
+  // a retry, so the list still carries the previous attempt's frames, and a
+  // stale entry can reach an interval three different ways: its id gets reused
+  // by a new call, it is still open at run end, or its result arrives late (a
+  // buffered flush racing the abort). Every append to `toolIntervals` goes
+  // through this gate. `tool_duration_ms` deliberately does not -- it keeps its
+  // whole-run paired-sum definition.
+  const openedInCurrentAttempt = (openedAt: number | undefined): boolean =>
+    openedAt !== undefined &&
+    (attemptStartAt === undefined || openedAt >= attemptStartAt);
   let toolCallCount = 0;
   let toolDurationMs = 0;
   const toolIntervals: Array<{ start: number; end: number }> = [];
@@ -1085,7 +1095,9 @@ export function summarizeRunTimingAnalytics(args: {
       const startedAt = openTools.get(data.toolUseId);
       if (startedAt !== undefined && ts >= startedAt) {
         toolDurationMs += ts - startedAt;
-        toolIntervals.push({ start: startedAt, end: ts });
+        if (openedInCurrentAttempt(openToolObservedAt.get(data.toolUseId))) {
+          toolIntervals.push({ start: startedAt, end: ts });
+        }
         lastToolActivityAt = ts;
         const name = openToolNames.get(data.toolUseId);
         if (
@@ -1144,9 +1156,7 @@ export function summarizeRunTimingAnalytics(args: {
   // `startedAt` can legitimately predate the anchor on a live tool, and the
   // clip below already handles that.
   for (const [toolUseId, startedAt] of openTools) {
-    const observedAt = openToolObservedAt.get(toolUseId);
-    if (observedAt === undefined) continue;
-    if (attemptStartAt !== undefined && observedAt < attemptStartAt) continue;
+    if (!openedInCurrentAttempt(openToolObservedAt.get(toolUseId))) continue;
     toolIntervals.push({ start: startedAt, end: runEndAt });
   }
   const firstModelEventType =

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -104,6 +104,10 @@ export interface RunTelemetryTimestamps {
   stdinWriteStartAt?: number;
   stdinWriteEndAt?: number;
   firstModelEventAt?: number;
+  // When the model began responding, as opposed to when we first saw evidence
+  // of it. Phase boundaries anchor here; `firstModelEventAt` keeps feeding the
+  // published `time_to_first_model_event_ms`.
+  firstModelResponseAt?: number;
   firstModelEventType?: TrackingFirstModelEventType;
   firstTokenAt?: number;
   firstVisibleOutputAt?: number;
@@ -172,7 +176,7 @@ export interface RunTimingAnalytics {
   // thinking, text, artifact) rather than to the first text token. On a
   // tool-first run `runtime_init_to_first_token_ms` swallows the entire tool
   // loop; this one stops the moment the model starts responding.
-  runtime_init_to_first_model_event_ms?: number;
+  runtime_init_to_first_model_response_ms?: number;
   spawn_to_first_token_ms?: number;
   time_to_first_artifact_ms?: number;
   // `spawn_to_first_token_ms` split into auditable subsegments. By construction
@@ -1009,6 +1013,12 @@ export function summarizeRunTimingAnalytics(args: {
   // separate from its start, which may be a producer-supplied `startedAt` from
   // a different clock and so cannot be compared against our own marks.
   const openToolObservedAt = new Map<string, number>();
+  // Tool ids whose opener was replaced by a same-id call from a later attempt.
+  const displacedToolUseIds = new Set<string>();
+  // Set when a `tool_result` arrives for such an id: the two candidate openers
+  // differ by seconds of occupancy and the log cannot say which one closed, so
+  // phase attribution for this run is not a measurement.
+  let toolLedgerAmbiguous = false;
   const openToolNames = new Map<string, string>();
   // Count unique tool_use ids so historical double-emits (or retries) do not
   // inflate tool_call_count.
@@ -1068,6 +1078,10 @@ export function summarizeRunTimingAnalytics(args: {
         attemptStartAt !== undefined &&
         priorObservedAt < attemptStartAt &&
         ts >= attemptStartAt;
+      // Remember that a previous attempt's opener was pushed aside. Its result
+      // may still be in flight, and once two calls have shared an id nothing in
+      // the event log says which of them a later `tool_result` closes.
+      if (reusesDeadAttemptId) displacedToolUseIds.add(data.id);
       if (!openTools.has(data.id) || reusesDeadAttemptId) {
         openTools.set(data.id, toolStartedAt);
         openToolObservedAt.set(data.id, ts);
@@ -1095,6 +1109,7 @@ export function summarizeRunTimingAnalytics(args: {
       const startedAt = openTools.get(data.toolUseId);
       if (startedAt !== undefined && ts >= startedAt) {
         toolDurationMs += ts - startedAt;
+        if (displacedToolUseIds.has(data.toolUseId)) toolLedgerAmbiguous = true;
         if (openedInCurrentAttempt(openToolObservedAt.get(data.toolUseId))) {
           toolIntervals.push({ start: startedAt, end: ts });
         }
@@ -1133,6 +1148,7 @@ export function summarizeRunTimingAnalytics(args: {
   // daemon-generated finalizer event, a producer clock offset), and this keeps
   // one from dragging every boundary to the end of the run.
   const phaseAnchorCandidates = [
+    telemetry.firstModelResponseAt,
     telemetry.firstModelEventAt,
     telemetry.firstTokenAt,
   ].filter((value): value is number => value !== undefined && Number.isFinite(value));
@@ -1196,7 +1212,7 @@ export function summarizeRunTimingAnalytics(args: {
   if (runtimeInitToFirstToken !== undefined) {
     result.runtime_init_to_first_token_ms = runtimeInitToFirstToken;
   }
-  setMeasuredDuration(result, 'runtime_init_to_first_model_event_ms', phaseDurations, 'runtime_init', runtimeInitStartAt, phaseAnchorAt);
+  setMeasuredDuration(result, 'runtime_init_to_first_model_response_ms', phaseDurations, 'runtime_init', runtimeInitStartAt, phaseAnchorAt);
   const spawnToFirstToken = durationBetween(telemetry.processSpawnedAt, telemetry.firstTokenAt);
   if (spawnToFirstToken !== undefined) result.spawn_to_first_token_ms = spawnToFirstToken;
   const timeToFirstArtifact = durationBetween(startAt, firstArtifactWriteAt);
@@ -1281,7 +1297,12 @@ export function summarizeRunTimingAnalytics(args: {
   // built from lifecycle marks are still sound, but we cannot know whether an
   // evicted tool would have outweighed them, so naming a winner would report
   // an artefact of what the buffer happened to keep.
-  if (bottleneckPhase !== undefined && eventStreamComplete) {
+  // The ledger phases are reconstructed from tool frames. Truncation removes
+  // frames; an id shared by two attempts makes the surviving ones
+  // unattributable. Either way the winner would describe the log rather than
+  // the run.
+  const phaseLedgerReliable = eventStreamComplete && !toolLedgerAmbiguous;
+  if (bottleneckPhase !== undefined && phaseLedgerReliable) {
     result.bottleneck_phase = bottleneckPhase;
   }
   result.phase_schema_version = RUN_PHASE_SCHEMA_VERSION;
@@ -1302,7 +1323,7 @@ export function summarizeRunTimingAnalytics(args: {
   // Truncation can only downgrade a `complete` claim; it never upgrades a
   // bundle whose boundaries were genuinely missing.
   result.phase_timing_status =
-    !eventStreamComplete && phaseTimingStatus === 'complete'
+    !phaseLedgerReliable && phaseTimingStatus === 'complete'
       ? 'partial'
       : phaseTimingStatus;
 

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -970,6 +970,11 @@ export function summarizeRunTimingAnalytics(args: {
 }): RunTimingAnalytics {
   const telemetry = args.telemetry ?? {};
   const runEndAt = args.runUpdatedAt;
+  const scanStartAt = telemetry.startChatRunStartedAt ?? telemetry.startRequestedAt;
+  // When the current attempt began. Needed inside the scan so a tool id reused
+  // by a retry is not merged with the corpse of the same id from a dead
+  // attempt.
+  const attemptStartAt = telemetry.attemptStartedAt ?? scanStartAt;
   let toolCallCount = 0;
   let toolDurationMs = 0;
   const toolIntervals: Array<{ start: number; end: number }> = [];
@@ -1032,7 +1037,19 @@ export function summarizeRunTimingAnalytics(args: {
           : undefined;
       const toolStartedAt = payloadStartedAt ?? ts;
       // First tool_use timestamp wins for duration pairing.
-      if (!openTools.has(data.id)) {
+      const priorObservedAt = openToolObservedAt.get(data.id);
+      // Sequential tool ids (`call_0`, `call_1`, ...) restart in a retry's
+      // fresh session, so a still-open entry from a killed attempt can collide
+      // with a genuinely new call. Keeping the old start would pair attempt
+      // one's opening with attempt two's close and report a tool that never
+      // ran. Replace, rather than merge, when the open entry predates this
+      // attempt and the new one does not.
+      const reusesDeadAttemptId =
+        priorObservedAt !== undefined &&
+        attemptStartAt !== undefined &&
+        priorObservedAt < attemptStartAt &&
+        ts >= attemptStartAt;
+      if (!openTools.has(data.id) || reusesDeadAttemptId) {
         openTools.set(data.id, toolStartedAt);
         openToolObservedAt.set(data.id, ts);
       } else if (payloadStartedAt !== undefined) {
@@ -1100,10 +1117,6 @@ export function summarizeRunTimingAnalytics(args: {
   ].filter((value): value is number => value !== undefined && Number.isFinite(value));
   const phaseAnchorAt =
     phaseAnchorCandidates.length > 0 ? Math.min(...phaseAnchorCandidates) : undefined;
-  // When the current attempt began. Distinct from `phaseAnchorAt`: the anchor
-  // is when the model started responding, this is when the attempt started
-  // running, and on a tool-first run the tools come between them.
-  const attemptStartAt = telemetry.attemptStartedAt ?? startAt;
   // A run can end while a tool is still outstanding (crash, cancel, timeout),
   // leaving a tool_use with no tool_result. That span still occupied the clock,
   // so close it at run end for phase purposes.

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -981,6 +981,10 @@ export function summarizeRunTimingAnalytics(args: {
   let artifactWriteSource: TrackingArtifactWriteSource | undefined;
   let liveArtifactSeen = false;
   const openTools = new Map<string, number>();
+  // When each still-open tool_use was OBSERVED, on the daemon's clock. Kept
+  // separate from its start, which may be a producer-supplied `startedAt` from
+  // a different clock and so cannot be compared against our own marks.
+  const openToolObservedAt = new Map<string, number>();
   const openToolNames = new Map<string, string>();
   // Count unique tool_use ids so historical double-emits (or retries) do not
   // inflate tool_call_count.
@@ -1030,6 +1034,7 @@ export function summarizeRunTimingAnalytics(args: {
       // First tool_use timestamp wins for duration pairing.
       if (!openTools.has(data.id)) {
         openTools.set(data.id, toolStartedAt);
+        openToolObservedAt.set(data.id, ts);
       } else if (payloadStartedAt !== undefined) {
         const prev = openTools.get(data.id);
         if (prev !== undefined && payloadStartedAt < prev) {
@@ -1064,18 +1069,12 @@ export function summarizeRunTimingAnalytics(args: {
           firstArtifactWriteToolEndedAt = ts;
         }
         openTools.delete(data.toolUseId);
+        openToolObservedAt.delete(data.toolUseId);
         openToolNames.delete(data.toolUseId);
       }
     }
   }
 
-  // A run can end while a tool is still outstanding (crash, cancel, timeout),
-  // leaving a tool_use with no tool_result. That span still occupied the clock,
-  // so close it at run end for phase purposes. `tool_duration_ms` keeps
-  // counting completed pairs only and is unaffected.
-  for (const startedAt of openTools.values()) {
-    toolIntervals.push({ start: startedAt, end: runEndAt });
-  }
   const startAt = telemetry.startChatRunStartedAt ?? telemetry.startRequestedAt;
   const totalDurationMs = Math.max(0, args.analyticsCapturedAt - args.runCreatedAt);
   const firstModelEventAt = telemetry.firstModelEventAt ?? firstToolUseAt ?? telemetry.firstTokenAt;
@@ -1101,6 +1100,25 @@ export function summarizeRunTimingAnalytics(args: {
   ].filter((value): value is number => value !== undefined && Number.isFinite(value));
   const phaseAnchorAt =
     phaseAnchorCandidates.length > 0 ? Math.min(...phaseAnchorCandidates) : undefined;
+  // A run can end while a tool is still outstanding (crash, cancel, timeout),
+  // leaving a tool_use with no tool_result. That span still occupied the clock,
+  // so close it at run end for phase purposes.
+  //
+  // Only for tools this attempt actually issued. `run.events` survives a retry
+  // while lifecycle telemetry does not, so an attempt whose child was killed
+  // mid-tool leaves an open span behind; closing that at run end would stretch
+  // it across the retry boundary and bill the new attempt for a tool it never
+  // called. The gate is the daemon-clock timestamp we OBSERVED the tool_use at,
+  // not its start -- a producer-supplied `startedAt` can legitimately predate
+  // the anchor on a tool that is genuinely running, and clipping already
+  // handles that.
+  if (phaseAnchorAt !== undefined) {
+    for (const [toolUseId, startedAt] of openTools) {
+      const observedAt = openToolObservedAt.get(toolUseId);
+      if (observedAt === undefined || observedAt < phaseAnchorAt) continue;
+      toolIntervals.push({ start: startedAt, end: runEndAt });
+    }
+  }
   const firstModelEventType =
     telemetry.firstModelEventType ??
     firstObservedModelEventType ??

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -1006,7 +1006,9 @@ export function summarizeRunTimingAnalytics(args: {
       rec.event === 'agent' &&
       data?.type === 'artifact'
     ) {
-      firstObservedModelEventType = firstObservedModelEventType ?? 'artifact';
+      // Not a first-model-event candidate, for the same reason the lifecycle
+      // tracer skips it: this event is the daemon persisting stdout at close
+      // time, not the model responding. It is still the artifact-write source.
       if (artifactWriteSource === undefined) artifactWriteSource = 'artifact_event';
     }
 
@@ -1067,6 +1069,13 @@ export function summarizeRunTimingAnalytics(args: {
     }
   }
 
+  // A run can end while a tool is still outstanding (crash, cancel, timeout),
+  // leaving a tool_use with no tool_result. That span still occupied the clock,
+  // so close it at run end for phase purposes. `tool_duration_ms` keeps
+  // counting completed pairs only and is unaffected.
+  for (const startedAt of openTools.values()) {
+    toolIntervals.push({ start: startedAt, end: runEndAt });
+  }
   const startAt = telemetry.startChatRunStartedAt ?? telemetry.startRequestedAt;
   const totalDurationMs = Math.max(0, args.analyticsCapturedAt - args.runCreatedAt);
   const firstModelEventAt = telemetry.firstModelEventAt ?? firstToolUseAt ?? telemetry.firstTokenAt;
@@ -1080,7 +1089,18 @@ export function summarizeRunTimingAnalytics(args: {
   // is scanned off event records stamped with the daemon's clock and is never
   // reset between retry attempts. Subtracting that from a tracer timestamp is
   // cross-clock arithmetic. Phase anchoring uses tracer-reported marks only.
-  const phaseAnchorAt = telemetry.firstModelEventAt ?? telemetry.firstTokenAt;
+  //
+  // Taken as the EARLIEST of the two rather than preferring the model-event
+  // mark: "the model started responding" cannot be later than the moment it
+  // emitted its first token. A late mark is always a bug at the producer (a
+  // daemon-generated finalizer event, a producer clock offset), and this keeps
+  // one from dragging every boundary to the end of the run.
+  const phaseAnchorCandidates = [
+    telemetry.firstModelEventAt,
+    telemetry.firstTokenAt,
+  ].filter((value): value is number => value !== undefined && Number.isFinite(value));
+  const phaseAnchorAt =
+    phaseAnchorCandidates.length > 0 ? Math.min(...phaseAnchorCandidates) : undefined;
   const firstModelEventType =
     telemetry.firstModelEventType ??
     firstObservedModelEventType ??
@@ -1208,7 +1228,11 @@ export function summarizeRunTimingAnalytics(args: {
     telemetry.processSpawnStartedAt,
     telemetry.processSpawnedAt,
     telemetry.modelCallStartAt,
-    telemetry.firstTokenAt,
+    // The boundary the phases are actually measured from. A tool-only turn
+    // never emits text, and requiring a token here would mark a fully
+    // instrumented run `partial` and drop it from dashboards that filter on
+    // complete timings. The first-token FIELDS are unchanged.
+    phaseAnchorAt,
     runEndAt,
   ]);
 

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -970,6 +970,15 @@ export function summarizeRunTimingAnalytics(args: {
 }): RunTimingAnalytics {
   const telemetry = args.telemetry ?? {};
   const runEndAt = args.runUpdatedAt;
+  // `run.events` is a bounded ring buffer, so a long run evicts its earliest
+  // records -- including the tool_use frames that phase occupancy is
+  // reconstructed from. Lifecycle marks live on the run itself and survive, so
+  // without this check a truncated run reports zero tool occupancy, hands the
+  // whole active window to `stream_output`, and still calls the bundle
+  // complete. Same signal the execution diagnostics in runtimes/runs.ts use.
+  const firstEventId = args.events[0]?.id;
+  const eventStreamComplete =
+    args.events.length === 0 || firstEventId === undefined || firstEventId === 1;
   const scanStartAt = telemetry.startChatRunStartedAt ?? telemetry.startRequestedAt;
   // When the current attempt began. Needed inside the scan so a tool id reused
   // by a retry is not merged with the corpse of the same id from a dead
@@ -1258,9 +1267,15 @@ export function summarizeRunTimingAnalytics(args: {
   else if (lastObservedAt !== undefined) result.last_observed_phase = 'unknown';
 
   const bottleneckPhase = largestMeasuredPhase(phaseDurations);
-  if (bottleneckPhase !== undefined) result.bottleneck_phase = bottleneckPhase;
+  // Withheld rather than guessed when the event log was truncated: the phases
+  // built from lifecycle marks are still sound, but we cannot know whether an
+  // evicted tool would have outweighed them, so naming a winner would report
+  // an artefact of what the buffer happened to keep.
+  if (bottleneckPhase !== undefined && eventStreamComplete) {
+    result.bottleneck_phase = bottleneckPhase;
+  }
   result.phase_schema_version = RUN_PHASE_SCHEMA_VERSION;
-  result.phase_timing_status = measuredStatus([
+  const phaseTimingStatus = measuredStatus([
     startAt,
     telemetry.promptBuildStartAt,
     telemetry.promptBuildEndAt,
@@ -1274,6 +1289,12 @@ export function summarizeRunTimingAnalytics(args: {
     phaseAnchorAt,
     runEndAt,
   ]);
+  // Truncation can only downgrade a `complete` claim; it never upgrades a
+  // bundle whose boundaries were genuinely missing.
+  result.phase_timing_status =
+    !eventStreamComplete && phaseTimingStatus === 'complete'
+      ? 'partial'
+      : phaseTimingStatus;
 
   if (spawnToFirstToken !== undefined) {
     const cliReady = durationBetween(

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -168,6 +168,11 @@ export interface RunTimingAnalytics {
   time_to_first_token_ms?: number;
   time_to_first_visible_output_ms?: number;
   runtime_init_to_first_token_ms?: number;
+  // Runtime init measured to the first model event of ANY kind (tool call,
+  // thinking, text, artifact) rather than to the first text token. On a
+  // tool-first run `runtime_init_to_first_token_ms` swallows the entire tool
+  // loop; this one stops the moment the model starts responding.
+  runtime_init_to_first_model_event_ms?: number;
   spawn_to_first_token_ms?: number;
   time_to_first_artifact_ms?: number;
   // `spawn_to_first_token_ms` split into auditable subsegments. By construction
@@ -179,6 +184,10 @@ export interface RunTimingAnalytics {
   model_first_token_ms?: number;
   spawn_to_first_token_remainder_ms?: number;
   generation_duration_ms?: number;
+  // The full window during which the model was working: first model event to
+  // run end. `generation_duration_ms` starts at the first text token instead,
+  // so for tool-first runs it reports only the closing message.
+  model_active_duration_ms?: number;
   tool_call_count: number;
   tool_duration_ms?: number;
   artifact_write_duration_ms?: number;
@@ -187,6 +196,9 @@ export interface RunTimingAnalytics {
   finalize_duration_ms?: number;
   total_duration_ms: number;
   bottleneck_phase?: TrackingRunLifecyclePhase;
+  // Which phase-boundary definition produced `bottleneck_phase`. Rows from
+  // different versions are not comparable; filter, do not average.
+  phase_schema_version?: number;
   last_observed_phase?: TrackingRunLifecyclePhase;
   phase_timing_status?: TrackingRunPhaseTimingStatus;
   attempt_index?: number;
@@ -272,6 +284,14 @@ function measuredStatus(values: Array<number | undefined>): TrackingRunPhaseTimi
   if (measured === 0) return 'missing';
   return measured === values.length ? 'complete' : 'partial';
 }
+
+// Bumped when phase BOUNDARY definitions change in a way that makes new rows
+// incomparable with old ones, so a dashboard can filter to one definition
+// instead of averaging two.
+//   v2: `runtime_init` and `stream_output` re-anchored from the first text
+//       token to the first model event, and `stream_output` made mutually
+//       exclusive with `tool_execution`.
+const RUN_PHASE_SCHEMA_VERSION = 2;
 
 function setMeasuredDuration(
   result: Partial<RunTimingAnalytics>,
@@ -1007,6 +1027,17 @@ export function summarizeRunTimingAnalytics(args: {
   const startAt = telemetry.startChatRunStartedAt ?? telemetry.startRequestedAt;
   const totalDurationMs = Math.max(0, args.analyticsCapturedAt - args.runCreatedAt);
   const firstModelEventAt = telemetry.firstModelEventAt ?? firstToolUseAt ?? telemetry.firstTokenAt;
+  // Phase boundaries anchor on when the model STARTED RESPONDING, in whatever
+  // form -- a tool call and a thinking delta both mean the model is working
+  // and the user can see something happen. `firstTokenAt` marks the first
+  // *text* only, so on a tool-first run it lands after the whole tool loop and
+  // bills that loop to startup.
+  //
+  // Deliberately NOT the composite above: its middle fallback `firstToolUseAt`
+  // is scanned off event records stamped with the daemon's clock and is never
+  // reset between retry attempts. Subtracting that from a tracer timestamp is
+  // cross-clock arithmetic. Phase anchoring uses tracer-reported marks only.
+  const phaseAnchorAt = telemetry.firstModelEventAt ?? telemetry.firstTokenAt;
   const firstModelEventType =
     telemetry.firstModelEventType ??
     firstObservedModelEventType ??
@@ -1035,12 +1066,38 @@ export function summarizeRunTimingAnalytics(args: {
   if (timeToFirstToken !== undefined) result.time_to_first_token_ms = timeToFirstToken;
   const timeToFirstVisibleOutput = durationBetween(startAt, firstVisibleOutputAt);
   if (timeToFirstVisibleOutput !== undefined) result.time_to_first_visible_output_ms = timeToFirstVisibleOutput;
-  setMeasuredDuration(result, 'runtime_init_to_first_token_ms', phaseDurations, 'runtime_init', telemetry.stdinWriteEndAt ?? telemetry.modelCallStartAt ?? telemetry.processSpawnedAt, telemetry.firstTokenAt);
+  const runtimeInitStartAt =
+    telemetry.stdinWriteEndAt ?? telemetry.modelCallStartAt ?? telemetry.processSpawnedAt;
+  // The published field keeps its first-token meaning so existing dashboards
+  // keep reading the same number; only the `runtime_init` PHASE moves to the
+  // model-event anchor, which is what bottleneck attribution consumes.
+  const runtimeInitToFirstToken = durationBetween(runtimeInitStartAt, telemetry.firstTokenAt);
+  if (runtimeInitToFirstToken !== undefined) {
+    result.runtime_init_to_first_token_ms = runtimeInitToFirstToken;
+  }
+  setMeasuredDuration(result, 'runtime_init_to_first_model_event_ms', phaseDurations, 'runtime_init', runtimeInitStartAt, phaseAnchorAt);
   const spawnToFirstToken = durationBetween(telemetry.processSpawnedAt, telemetry.firstTokenAt);
   if (spawnToFirstToken !== undefined) result.spawn_to_first_token_ms = spawnToFirstToken;
   const timeToFirstArtifact = durationBetween(startAt, firstArtifactWriteAt);
   if (timeToFirstArtifact !== undefined) result.time_to_first_artifact_ms = timeToFirstArtifact;
-  setMeasuredDuration(result, 'generation_duration_ms', phaseDurations, 'stream_output', telemetry.firstTokenAt, runEndAt);
+  // Same split as runtime_init: `generation_duration_ms` keeps its first-token
+  // meaning, `model_active_duration_ms` is the corrected window. The
+  // `stream_output` PHASE additionally subtracts tool time so it stays
+  // mutually exclusive with `tool_execution`; without that the tool loop is
+  // counted in both and `stream_output` wins the bottleneck by construction.
+  const generationDuration = durationBetween(telemetry.firstTokenAt, runEndAt);
+  if (generationDuration !== undefined) result.generation_duration_ms = generationDuration;
+  const modelActiveDuration = durationBetween(phaseAnchorAt, runEndAt);
+  if (modelActiveDuration !== undefined) {
+    result.model_active_duration_ms = modelActiveDuration;
+    phaseDurations.push({
+      phase: 'stream_output',
+      // Floored: tool spans can overlap (parallel calls) or carry a
+      // producer-supplied `startedAt` from another clock, either of which can
+      // push the sum past the model-active window.
+      duration: Math.max(0, modelActiveDuration - Math.round(toolDurationMs)),
+    });
+  }
   if (toolCallCount > 0) result.tool_duration_ms = Math.round(toolDurationMs);
   if (toolCallCount > 0) {
     phaseDurations.push({ phase: 'tool_execution', duration: Math.round(toolDurationMs) });
@@ -1097,6 +1154,7 @@ export function summarizeRunTimingAnalytics(args: {
 
   const bottleneckPhase = largestMeasuredPhase(phaseDurations);
   if (bottleneckPhase !== undefined) result.bottleneck_phase = bottleneckPhase;
+  result.phase_schema_version = RUN_PHASE_SCHEMA_VERSION;
   result.phase_timing_status = measuredStatus([
     startAt,
     telemetry.promptBuildStartAt,

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -1100,6 +1100,10 @@ export function summarizeRunTimingAnalytics(args: {
   ].filter((value): value is number => value !== undefined && Number.isFinite(value));
   const phaseAnchorAt =
     phaseAnchorCandidates.length > 0 ? Math.min(...phaseAnchorCandidates) : undefined;
+  // When the current attempt began. Distinct from `phaseAnchorAt`: the anchor
+  // is when the model started responding, this is when the attempt started
+  // running, and on a tool-first run the tools come between them.
+  const attemptStartAt = telemetry.attemptStartedAt ?? startAt;
   // A run can end while a tool is still outstanding (crash, cancel, timeout),
   // leaving a tool_use with no tool_result. That span still occupied the clock,
   // so close it at run end for phase purposes.
@@ -1108,16 +1112,20 @@ export function summarizeRunTimingAnalytics(args: {
   // while lifecycle telemetry does not, so an attempt whose child was killed
   // mid-tool leaves an open span behind; closing that at run end would stretch
   // it across the retry boundary and bill the new attempt for a tool it never
-  // called. The gate is the daemon-clock timestamp we OBSERVED the tool_use at,
-  // not its start -- a producer-supplied `startedAt` can legitimately predate
-  // the anchor on a tool that is genuinely running, and clipping already
-  // handles that.
-  if (phaseAnchorAt !== undefined) {
-    for (const [toolUseId, startedAt] of openTools) {
-      const observedAt = openToolObservedAt.get(toolUseId);
-      if (observedAt === undefined || observedAt < phaseAnchorAt) continue;
-      toolIntervals.push({ start: startedAt, end: runEndAt });
-    }
+  // called.
+  //
+  // Gated on the ATTEMPT boundary, not the phase anchor. The anchor falls back
+  // to the first token when no model-event mark exists, and on a tool-first run
+  // that lands after the tools -- gating on it would discard the very spans
+  // this measures. Compared against the daemon-clock timestamp we OBSERVED the
+  // tool_use at, which shares a clock with our own marks; a producer-supplied
+  // `startedAt` can legitimately predate the anchor on a live tool, and the
+  // clip below already handles that.
+  for (const [toolUseId, startedAt] of openTools) {
+    const observedAt = openToolObservedAt.get(toolUseId);
+    if (observedAt === undefined) continue;
+    if (attemptStartAt !== undefined && observedAt < attemptStartAt) continue;
+    toolIntervals.push({ start: startedAt, end: runEndAt });
   }
   const firstModelEventType =
     telemetry.firstModelEventType ??
@@ -1280,7 +1288,6 @@ export function summarizeRunTimingAnalytics(args: {
   }
 
   if (typeof telemetry.attemptIndex === 'number') result.attempt_index = telemetry.attemptIndex;
-  const attemptStartAt = telemetry.attemptStartedAt ?? startAt;
   setMeasuredDuration(result, 'attempt_duration_ms', [], 'unknown', attemptStartAt, runEndAt);
   setMeasuredDuration(result, 'attempt_time_to_first_token_ms', [], 'unknown', attemptStartAt, telemetry.firstTokenAt);
   if (result.last_observed_phase !== undefined) {

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -965,6 +965,36 @@ function eventTimestamp(
   return readNumber(rec.timestamp);
 }
 
+/**
+ * When the model started responding, for phase-boundary purposes.
+ *
+ * Exported because two sinks report this window -- PostHog via
+ * `model_active_duration_ms` and the Langfuse phase diagnostics -- and they are
+ * only comparable if they anchor identically. Re-listing the marks at each call
+ * site is what let them drift apart before.
+ *
+ * Earliest of the three rather than a preference order: `firstModelResponseAt`
+ * carries a producer-supplied start (ACP emits its canonical `tool_use` when the
+ * call is terminal, so arrival is the tool's END), `firstModelEventAt` is our
+ * own arrival mark, and `firstTokenAt` covers producers that report neither. A
+ * mark later than another is a producer artefact, never a later start.
+ */
+export function phaseAnchorFromMarks(marks: {
+  firstModelResponseAt?: number;
+  firstModelEventAt?: number;
+  firstTokenAt?: number;
+}): number | undefined {
+  const candidates = [
+    marks.firstModelResponseAt,
+    marks.firstModelEventAt,
+    marks.firstTokenAt,
+  ].filter(
+    (value): value is number =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 0,
+  );
+  return candidates.length > 0 ? Math.min(...candidates) : undefined;
+}
+
 export function summarizeRunTimingAnalytics(args: {
   runCreatedAt: number;
   runUpdatedAt: number;
@@ -1147,13 +1177,7 @@ export function summarizeRunTimingAnalytics(args: {
   // emitted its first token. A late mark is always a bug at the producer (a
   // daemon-generated finalizer event, a producer clock offset), and this keeps
   // one from dragging every boundary to the end of the run.
-  const phaseAnchorCandidates = [
-    telemetry.firstModelResponseAt,
-    telemetry.firstModelEventAt,
-    telemetry.firstTokenAt,
-  ].filter((value): value is number => value !== undefined && Number.isFinite(value));
-  const phaseAnchorAt =
-    phaseAnchorCandidates.length > 0 ? Math.min(...phaseAnchorCandidates) : undefined;
+  const phaseAnchorAt = phaseAnchorFromMarks(telemetry);
   // A run can end while a tool is still outstanding (crash, cancel, timeout),
   // leaving a tool_use with no tool_result. That span still occupied the clock,
   // so close it at run end for phase purposes.

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -285,6 +285,47 @@ function measuredStatus(values: Array<number | undefined>): TrackingRunPhaseTimi
   return measured === values.length ? 'complete' : 'partial';
 }
 
+// Wall-clock occupancy of tool work inside a window: the union of tool
+// intervals, clipped to [windowStart, windowEnd].
+//
+// This is deliberately NOT `tool_duration_ms`, which sums each paired
+// tool_use -> tool_result span. That sum is the right published answer to "how
+// much tool work happened", but it is not elapsed time and so cannot be a
+// phase:
+//   - two tools running in parallel sum to more than the clock they occupy;
+//   - `run.events` is never cleared between retry attempts, so a retried run
+//     carries the previous attempt's tool spans while the phase anchor comes
+//     from the current attempt's lifecycle marks;
+//   - ACP producers supply their own `startedAt`, which can predate the anchor
+//     when their clock differs from ours.
+// Each of those inflates the tool phase past the window it sits in, letting it
+// win `bottleneck_phase` with a duration longer than the run was even active.
+function toolOccupancyWithin(
+  intervals: Array<{ start: number; end: number }>,
+  windowStart: number | undefined,
+  windowEnd: number | undefined,
+): number {
+  if (windowStart === undefined || windowEnd === undefined) return 0;
+  if (windowEnd <= windowStart) return 0;
+  const clipped = intervals
+    .map((interval) => ({
+      start: Math.max(interval.start, windowStart),
+      end: Math.min(interval.end, windowEnd),
+    }))
+    .filter((interval) => interval.end > interval.start)
+    .sort((a, b) => a.start - b.start);
+  let total = 0;
+  let cursor = Number.NEGATIVE_INFINITY;
+  for (const interval of clipped) {
+    const start = Math.max(interval.start, cursor);
+    if (interval.end > start) {
+      total += interval.end - start;
+      cursor = interval.end;
+    }
+  }
+  return Math.round(total);
+}
+
 // Bumped when phase BOUNDARY definitions change in a way that makes new rows
 // incomparable with old ones, so a dashboard can filter to one definition
 // instead of averaging two.
@@ -931,6 +972,7 @@ export function summarizeRunTimingAnalytics(args: {
   const runEndAt = args.runUpdatedAt;
   let toolCallCount = 0;
   let toolDurationMs = 0;
+  const toolIntervals: Array<{ start: number; end: number }> = [];
   let firstToolUseAt: number | undefined;
   let firstObservedModelEventType: TrackingFirstModelEventType | undefined;
   let lastToolActivityAt: number | undefined;
@@ -1010,6 +1052,7 @@ export function summarizeRunTimingAnalytics(args: {
       const startedAt = openTools.get(data.toolUseId);
       if (startedAt !== undefined && ts >= startedAt) {
         toolDurationMs += ts - startedAt;
+        toolIntervals.push({ start: startedAt, end: ts });
         lastToolActivityAt = ts;
         const name = openToolNames.get(data.toolUseId);
         if (
@@ -1088,19 +1131,22 @@ export function summarizeRunTimingAnalytics(args: {
   const generationDuration = durationBetween(telemetry.firstTokenAt, runEndAt);
   if (generationDuration !== undefined) result.generation_duration_ms = generationDuration;
   const modelActiveDuration = durationBetween(phaseAnchorAt, runEndAt);
+  // Tool occupancy inside the model-active window. `stream_output` and
+  // `tool_execution` are then two halves of that window by construction, so
+  // they partition it exactly instead of double-counting the tool loop.
+  const toolOccupancyMs = toolOccupancyWithin(toolIntervals, phaseAnchorAt, runEndAt);
   if (modelActiveDuration !== undefined) {
     result.model_active_duration_ms = modelActiveDuration;
     phaseDurations.push({
       phase: 'stream_output',
-      // Floored: tool spans can overlap (parallel calls) or carry a
-      // producer-supplied `startedAt` from another clock, either of which can
-      // push the sum past the model-active window.
-      duration: Math.max(0, modelActiveDuration - Math.round(toolDurationMs)),
+      duration: Math.max(0, modelActiveDuration - toolOccupancyMs),
     });
   }
+  // Published field keeps summing paired spans; only the PHASE switches to
+  // occupancy, because only the phase has to add up to elapsed time.
   if (toolCallCount > 0) result.tool_duration_ms = Math.round(toolDurationMs);
   if (toolCallCount > 0) {
-    phaseDurations.push({ phase: 'tool_execution', duration: Math.round(toolDurationMs) });
+    phaseDurations.push({ phase: 'tool_execution', duration: toolOccupancyMs });
   }
   setMeasuredDuration(result, 'artifact_write_duration_ms', phaseDurations, 'artifact_write', firstArtifactWriteToolStartedAt, firstArtifactWriteToolEndedAt ?? firstArtifactWriteAt);
   setMeasuredDuration(result, 'finalize_duration_ms', phaseDurations, 'finalize', runEndAt, args.analyticsCapturedAt);

--- a/apps/daemon/src/run-lifecycle-tracer.ts
+++ b/apps/daemon/src/run-lifecycle-tracer.ts
@@ -57,11 +57,15 @@ export function runLifecycleMarkersForStreamEvent(
       ? (data as { type?: unknown }).type
       : undefined;
   if (event === 'agent') {
+    // `artifact` is deliberately absent. Agent `artifact` events are emitted
+    // from exactly one place -- the daemon's close-time persistence of
+    // plain-stream stdout -- and never by a runtime relaying model output.
+    // Marking one would stamp a daemon action taken at the END of the run as
+    // the moment the model started responding, which is both wrong on its own
+    // terms and would push every phase boundary to the end of the run. Re-add
+    // it only if a runtime starts emitting a model-authored artifact event.
     const firstModelEventType =
-      type === 'text_delta' ||
-      type === 'thinking_delta' ||
-      type === 'tool_use' ||
-      type === 'artifact'
+      type === 'text_delta' || type === 'thinking_delta' || type === 'tool_use'
         ? type
         : undefined;
     return {

--- a/apps/daemon/src/run-lifecycle-tracer.ts
+++ b/apps/daemon/src/run-lifecycle-tracer.ts
@@ -103,7 +103,10 @@ export function runLifecycleMarkersForStreamEvent(
 
 export function createRunLifecycleTracer(run: RunWithLifecycleTelemetry): {
   mark(mark: RunLifecycleMark, timestamp?: number): void;
-  markFirstModelEvent(type: TrackingFirstModelEventType, timestamp?: number): void;
+  markFirstModelEvent(
+    type: TrackingFirstModelEventType,
+    producerStartedAt?: number,
+  ): void;
   resetForAttempt(attemptIndex: number, timestamp?: number): void;
 } {
   const mark = (lifecycleMark: RunLifecycleMark, timestamp = Date.now()) => {
@@ -118,22 +121,45 @@ export function createRunLifecycleTracer(run: RunWithLifecycleTelemetry): {
 
   return {
     mark,
-    markFirstModelEvent(type: TrackingFirstModelEventType, timestamp = Date.now()) {
-      if (!Number.isFinite(timestamp)) return;
+    markFirstModelEvent(
+      type: TrackingFirstModelEventType,
+      producerStartedAt?: number,
+    ) {
+      const arrivedAt = Date.now();
       const current = run.analyticsTelemetry ?? {};
-      const existing = current.firstModelEventAt;
-      // Earliest wins, not first observed. ACP holds each toolCallId until it
-      // is terminal, so two parallel calls can complete in the opposite order
-      // they started: the call that began later can be the first one we hear
-      // about. First-write-wins would anchor on it and lose the real head
-      // start. Marks without a producer timestamp default to arrival, which is
-      // monotonic, so this only ever moves the anchor earlier.
-      if (existing !== undefined && timestamp >= existing) return;
-      run.analyticsTelemetry = {
-        ...current,
-        firstModelEventAt: timestamp,
-        firstModelEventType: type,
-      };
+      const next = { ...current };
+      let changed = false;
+
+      // `firstModelEventAt` is when we SAW the first model event. It is already
+      // published as `time_to_first_model_event_ms`, so it stays first-write-
+      // wins on arrival -- a producer-supplied start must not silently move it.
+      if (current.firstModelEventAt === undefined) {
+        next.firstModelEventAt = arrivedAt;
+        next.firstModelEventType = type;
+        changed = true;
+      }
+
+      // `firstModelResponseAt` is when the model actually began responding, and
+      // is what phase boundaries anchor on. Two reasons it differs from
+      // arrival: ACP holds each toolCallId until terminal status, so the
+      // canonical `tool_use` arrives when the tool ENDS while its payload
+      // carries the real start; and parallel calls can terminate in the
+      // opposite order they began, so earliest-wins rather than first-wins.
+      // Clamped to arrival so a producer clock running ahead cannot claim the
+      // model responded in the future.
+      const responseAt =
+        typeof producerStartedAt === 'number' && Number.isFinite(producerStartedAt)
+          ? Math.min(producerStartedAt, arrivedAt)
+          : arrivedAt;
+      if (
+        current.firstModelResponseAt === undefined ||
+        responseAt < current.firstModelResponseAt
+      ) {
+        next.firstModelResponseAt = responseAt;
+        changed = true;
+      }
+
+      if (changed) run.analyticsTelemetry = next;
     },
     resetForAttempt(attemptIndex: number, timestamp = Date.now()) {
       run.analyticsTelemetry = {

--- a/apps/daemon/src/run-lifecycle-tracer.ts
+++ b/apps/daemon/src/run-lifecycle-tracer.ts
@@ -119,8 +119,16 @@ export function createRunLifecycleTracer(run: RunWithLifecycleTelemetry): {
   return {
     mark,
     markFirstModelEvent(type: TrackingFirstModelEventType, timestamp = Date.now()) {
+      if (!Number.isFinite(timestamp)) return;
       const current = run.analyticsTelemetry ?? {};
-      if (current.firstModelEventAt !== undefined) return;
+      const existing = current.firstModelEventAt;
+      // Earliest wins, not first observed. ACP holds each toolCallId until it
+      // is terminal, so two parallel calls can complete in the opposite order
+      // they started: the call that began later can be the first one we hear
+      // about. First-write-wins would anchor on it and lose the real head
+      // start. Marks without a producer timestamp default to arrival, which is
+      // monotonic, so this only ever moves the anchor earlier.
+      if (existing !== undefined && timestamp >= existing) return;
       run.analyticsTelemetry = {
         ...current,
         firstModelEventAt: timestamp,

--- a/apps/daemon/src/run-lifecycle-tracer.ts
+++ b/apps/daemon/src/run-lifecycle-tracer.ts
@@ -44,6 +44,13 @@ export interface RunWithLifecycleTelemetry {
 
 export interface RunLifecycleStreamEventMarkers {
   firstModelEventType?: TrackingFirstModelEventType;
+  // When the producer says this event's work actually began, on the daemon's
+  // clock. Present when a payload carries `startedAt`, which ACP does: it
+  // accumulates tool_call frames and emits the canonical `tool_use` only once
+  // the call is terminal, so the arrival time of that event is the tool's END.
+  // Stamping the anchor from arrival would measure a tool-only ACP turn as
+  // runtime init, which is the case this whole boundary change exists for.
+  firstModelEventAt?: number;
   firstVisibleOutput: boolean;
   firstArtifactWrite: boolean;
 }
@@ -68,8 +75,19 @@ export function runLifecycleMarkersForStreamEvent(
       type === 'text_delta' || type === 'thinking_delta' || type === 'tool_use'
         ? type
         : undefined;
+    const startedAt =
+      data && typeof data === 'object' && 'startedAt' in data
+        ? (data as { startedAt?: unknown }).startedAt
+        : undefined;
+    const firstModelEventAt =
+      typeof startedAt === 'number' && Number.isFinite(startedAt)
+        ? startedAt
+        : undefined;
     return {
       ...(firstModelEventType ? { firstModelEventType } : {}),
+      ...(firstModelEventType && firstModelEventAt !== undefined
+        ? { firstModelEventAt }
+        : {}),
       firstVisibleOutput:
         type === 'text_delta' ||
         type === 'thinking_delta' ||

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1027,6 +1027,18 @@ export function createChatRunService({
     run.stdinOpen = false;
     run.eventsLogStream = null;
     run.eventsLogClosed = false;
+    // A resumed attempt is a fresh execution, so it must not inherit the prior
+    // attempt's lifecycle marks. Keeping them makes every phase boundary
+    // measure from before the recharge pause, putting the wait time inside the
+    // new attempt's model-active window. Only the logical run start survives,
+    // so queue time is still measured from when the user asked for the run.
+    run.analyticsTelemetry = {
+      ...(run.analyticsTelemetry?.startRequestedAt !== undefined
+        ? { startRequestedAt: run.analyticsTelemetry.startRequestedAt }
+        : {}),
+      attemptStartedAt: resumedAt,
+      attemptIndex: 0,
+    };
     run.manualResumeAttemptCount = (run.manualResumeAttemptCount ?? 0) + 1;
     run.rechargeWaitDurationMs =
       (run.rechargeWaitDurationMs ?? 0) + rechargeWaitDurationMs;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10688,7 +10688,13 @@ export async function startServer({
     const send = (event, data) => {
       const lifecycleMarkers = runLifecycleMarkersForStreamEvent(event, data);
       if (lifecycleMarkers.firstModelEventType) {
-        lifecycle.markFirstModelEvent(lifecycleMarkers.firstModelEventType);
+        // `firstModelEventAt` is present when the producer told us when the
+        // work began. ACP emits `tool_use` at terminal status, so without this
+        // the anchor lands at tool completion.
+        lifecycle.markFirstModelEvent(
+          lifecycleMarkers.firstModelEventType,
+          lifecycleMarkers.firstModelEventAt,
+        );
       }
       if (lifecycleMarkers.firstVisibleOutput) {
         lifecycle.mark('first_visible_output');

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10688,9 +10688,10 @@ export async function startServer({
     const send = (event, data) => {
       const lifecycleMarkers = runLifecycleMarkersForStreamEvent(event, data);
       if (lifecycleMarkers.firstModelEventType) {
-        // `firstModelEventAt` is present when the producer told us when the
-        // work began. ACP emits `tool_use` at terminal status, so without this
-        // the anchor lands at tool completion.
+        // Second argument is the PRODUCER's start, used only for the phase
+        // anchor. ACP emits `tool_use` at terminal status, so without it the
+        // anchor lands at tool completion. `time_to_first_model_event_ms`
+        // still measures to arrival and is unaffected.
         lifecycle.markFirstModelEvent(
           lifecycleMarkers.firstModelEventType,
           lifecycleMarkers.firstModelEventAt,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10853,7 +10853,13 @@ export async function startServer({
       run.turnCompletedCleanly = false;
       run.terminalTrigger = null;
       lifecycle.resetForAttempt(run.retryAttemptCount ?? 0);
+      // Spread, not replace: `resetForAttempt` has just stamped this attempt's
+      // `attemptStartedAt`/`attemptIndex`, and replacing the object wholesale
+      // dropped them, so nothing downstream could tell which attempt a run
+      // event belonged to. Only the `run.createdAt` fallback for the logical
+      // run start is added on top.
       run.analyticsTelemetry = {
+        ...run.analyticsTelemetry,
         startRequestedAt: run.analyticsTelemetry?.startRequestedAt ?? run.createdAt,
       };
     };

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1358,6 +1358,43 @@ describe('buildTracePayload', () => {
     expect(metadata.total_duration_ms).toBe(100);
   });
 
+  it('measures model-active on the same boundaries as the analytics metric', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        run: {
+          runId: 'run-model-active',
+          status: 'succeeded',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_010_000,
+          timingMarks: {
+            startChatRunStartedAt: 1_700_000_000_100,
+            processSpawnedAt: 1_700_000_000_300,
+            stdinWriteEndAt: 1_700_000_000_500,
+            // Text-first: the server stamps first-token before the send() path
+            // records the model-event mark, so the two are not equal and the
+            // earlier one is the true start of the response.
+            firstTokenAt: 1_700_000_001_000,
+            firstModelEventAt: 1_700_000_001_200,
+            finalizeStartAt: 1_700_000_009_000,
+          },
+        },
+      }),
+    );
+
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+    const measured =
+      generation.metadata.performance_diagnostics.semantic_phases.measured;
+
+    // `model_active_duration_ms` takes the earliest of the two marks and runs
+    // to run end. This entry exists to be compared against that number, so a
+    // different window here makes PostHog and Langfuse disagree on the same
+    // run.
+    expect(measured['model-active']).toMatchObject({
+      duration_ms: 9_000,
+      status: 'measured',
+    });
+  });
+
   it('adds duration spans for run timing marks', () => {
     const promptTelemetry = buildPromptStackTelemetry({
       composedPrompt:

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1358,6 +1358,42 @@ describe('buildTracePayload', () => {
     expect(metadata.total_duration_ms).toBe(100);
   });
 
+  it('uses the response anchor for model-active on an ACP tool-first run', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        run: {
+          runId: 'run-model-active-acp',
+          status: 'succeeded',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_030_000,
+          timingMarks: {
+            startChatRunStartedAt: 1_700_000_000_100,
+            stdinWriteEndAt: 1_700_000_000_500,
+            // ACP emits the canonical tool_use when the call is terminal, so
+            // the event arrived at 20s while the tool began at 4s. A tool-only
+            // turn never produces a text token at all.
+            firstModelResponseAt: 1_700_000_004_000,
+            firstModelEventAt: 1_700_000_020_000,
+            finalizeStartAt: 1_700_000_029_000,
+          },
+        },
+      }),
+    );
+
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+    const measured =
+      generation.metadata.performance_diagnostics.semantic_phases.measured;
+
+    // `model_active_duration_ms` anchors on the earliest of the three marks,
+    // which is the response at 4s. Ignoring it here reports 10s against the
+    // analytics value of 26s for the same run -- on the exact runtime shape
+    // this change targets.
+    expect(measured['model-active']).toMatchObject({
+      duration_ms: 26_000,
+      status: 'measured',
+    });
+  });
+
   it('measures model-active on the same boundaries as the analytics metric', () => {
     const batch = buildTracePayload(
       makeCtx({

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1148,7 +1148,7 @@ describe('summarizeRunTimingAnalytics', () => {
       time_to_first_token_ms: 1300,
       time_to_first_visible_output_ms: 1300,
       runtime_init_to_first_token_ms: 650,
-      runtime_init_to_first_model_event_ms: 150,
+      runtime_init_to_first_model_response_ms: 150,
       spawn_to_first_token_ms: 740,
       time_to_first_artifact_ms: 3050,
       // No subsegment markers were observed, so the whole spawn->first-token
@@ -1550,7 +1550,7 @@ describe('summarizeRunTimingAnalytics phase anchoring', () => {
     const result = summarizeRunTimingAnalytics(toolFirstRun);
 
     // stdin closed at 3.2s and the model responded at 4s.
-    expect(result.runtime_init_to_first_model_event_ms).toBe(800);
+    expect(result.runtime_init_to_first_model_response_ms).toBe(800);
   });
 
   it('counts the whole tool loop as model-active time', () => {
@@ -1614,7 +1614,7 @@ describe('summarizeRunTimingAnalytics phase anchoring', () => {
 
     // Text-first runs already had a truthful anchor, so the new fields must
     // land on exactly the old numbers -- no drift for Claude Code-shaped runs.
-    expect(result.runtime_init_to_first_model_event_ms).toBe(result.runtime_init_to_first_token_ms);
+    expect(result.runtime_init_to_first_model_response_ms).toBe(result.runtime_init_to_first_token_ms);
     expect(result.model_active_duration_ms).toBe(result.generation_duration_ms);
   });
 
@@ -1644,7 +1644,7 @@ describe('summarizeRunTimingAnalytics phase anchoring', () => {
     // are not reset per retry attempt. `time_to_first_model_event_ms` keeps
     // its existing scan-based fallback and is unaffected.
     expect(result.time_to_first_model_event_ms).toBe(2_000);
-    expect(result.runtime_init_to_first_model_event_ms).toBe(20_800);
+    expect(result.runtime_init_to_first_model_response_ms).toBe(20_800);
     expect(result.model_active_duration_ms).toBe(1_000);
   });
 });
@@ -1788,7 +1788,7 @@ describe('summarizeRunTimingAnalytics anchor and completeness edges', () => {
     // reports a 1s active window and a 16s runtime init for a run that was
     // streaming the whole time.
     expect(result.model_active_duration_ms).toBe(15_000);
-    expect(result.runtime_init_to_first_model_event_ms).toBe(2_000);
+    expect(result.runtime_init_to_first_model_response_ms).toBe(2_000);
     expect(result.bottleneck_phase).toBe('stream_output');
   });
 
@@ -2066,5 +2066,79 @@ describe('summarizeRunTimingAnalytics late tool results from a dead attempt', ()
     expect(result.bottleneck_phase).toBe('stream_output');
     // The published metric keeps its whole-run paired-sum definition.
     expect(result.tool_duration_ms).toBe(26_900);
+  });
+});
+
+describe('summarizeRunTimingAnalytics separates the response anchor from the event mark', () => {
+  it('anchors phases on the response while the published metric keeps arrival', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 30_000,
+      analyticsCapturedAt: 30_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        stdinWriteEndAt: 3_000,
+        // ACP: the canonical tool_use arrived at 20s, but the tool began at 4s.
+        firstModelEventAt: 20_000,
+        firstModelResponseAt: 4_000,
+        firstModelEventType: 'tool_use' as const,
+        attemptStartedAt: 2_000,
+        attemptIndex: 1,
+      },
+      events: [],
+    });
+
+    // Already published, and this PR promised not to move it.
+    expect(result.time_to_first_model_event_ms).toBe(18_000);
+    // New, and measured from when the model actually started working.
+    expect(result.runtime_init_to_first_model_response_ms).toBe(1_000);
+    expect(result.model_active_duration_ms).toBe(26_000);
+  });
+});
+
+describe('summarizeRunTimingAnalytics with an unattributable tool ledger', () => {
+  const ambiguousRun = {
+    runCreatedAt: 1_000,
+    runUpdatedAt: 30_000,
+    analyticsCapturedAt: 30_050,
+    telemetry: {
+      startRequestedAt: 1_100,
+      attemptStartedAt: 20_000,
+      attemptIndex: 2,
+      stdinWriteEndAt: 20_500,
+      firstModelEventAt: 21_000,
+      firstModelResponseAt: 21_000,
+      firstModelEventType: 'text_delta' as const,
+      firstTokenAt: 21_000,
+    },
+    events: [
+      // Attempt 1 opened `call_0` and was killed before it returned.
+      { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 'call_0', name: 'Bash' } },
+      // Attempt 2's fresh session restarts sequential ids and opens the same
+      // one for a different call.
+      { id: 2, event: 'agent', timestamp: 21_500, data: { type: 'tool_use', id: 'call_0', name: 'Read' } },
+      // A result arrives. Nothing in the event log says which of the two it
+      // belongs to, and the two readings differ by 8s of occupancy.
+      { id: 3, event: 'agent', timestamp: 22_000, data: { type: 'tool_result', toolUseId: 'call_0' } },
+    ],
+  };
+
+  it('withholds the bottleneck when a result cannot be attributed to an attempt', () => {
+    const result = summarizeRunTimingAnalytics(ambiguousRun);
+
+    expect(result.bottleneck_phase).toBeUndefined();
+  });
+
+  it('marks phase timing partial rather than complete', () => {
+    const result = summarizeRunTimingAnalytics(ambiguousRun);
+
+    expect(result.phase_timing_status).toBe('partial');
+  });
+
+  it('still reports mark-derived timings', () => {
+    const result = summarizeRunTimingAnalytics(ambiguousRun);
+
+    expect(result.model_active_duration_ms).toBe(9_000);
   });
 });

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1858,3 +1858,57 @@ describe('summarizeRunTimingAnalytics anchor and completeness edges', () => {
     expect(result.tool_duration_ms).toBe(0);
   });
 });
+
+describe('summarizeRunTimingAnalytics outstanding tools across a retry', () => {
+  it('does not carry a killed attempt\'s unfinished tool into the new attempt', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 25_000,
+      analyticsCapturedAt: 25_100,
+      telemetry: {
+        // Post-retry telemetry: attempt 2 only, and it never called a tool.
+        startRequestedAt: 1_100,
+        stdinWriteEndAt: 19_000,
+        firstModelEventAt: 20_000,
+        firstModelEventType: 'text_delta' as const,
+        firstTokenAt: 20_000,
+      },
+      events: [
+        // Attempt 1's child was killed mid-tool, so this tool_use never got a
+        // result and stays open. `run.events` survives the retry.
+        { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 'a1', name: 'Bash' } },
+      ],
+    });
+
+    // Closing that span at run end stretches it across the retry boundary, so
+    // clipping to the attempt-2 window hands 5s of "tool execution" to an
+    // attempt that made no tool call at all.
+    expect(result.model_active_duration_ms).toBe(5_000);
+    expect(result.bottleneck_phase).toBe('stream_output');
+    expect(result.tool_duration_ms).toBe(0);
+  });
+
+  it('still closes an outstanding tool whose producer start predates the anchor', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 15_000,
+      analyticsCapturedAt: 15_050,
+      telemetry: {
+        startRequestedAt: 1_050,
+        startChatRunStartedAt: 1_100,
+        stdinWriteEndAt: 3_500,
+        firstModelEventAt: 4_000,
+        firstModelEventType: 'tool_use' as const,
+      },
+      events: [
+        // Observed after the anchor, so this tool really is running in this
+        // attempt; only its producer-supplied start is skewed early.
+        { id: 1, event: 'agent', timestamp: 5_000, data: { type: 'tool_use', id: 't1', name: 'Bash', startedAt: 1_000 } },
+      ],
+    });
+
+    // The skewed start is clipped to the anchor, not discarded: 4s -> 15s.
+    expect(result.model_active_duration_ms).toBe(11_000);
+    expect(result.bottleneck_phase).toBe('tool_execution');
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1758,3 +1758,103 @@ describe('summarizeRunTimingAnalytics tool phase occupancy', () => {
     expect(result.tool_duration_ms).toBe(7_000);
   });
 });
+
+describe('summarizeRunTimingAnalytics anchor and completeness edges', () => {
+  it('does not let a late daemon-persisted artifact push the anchor past the first token', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 20_000,
+      analyticsCapturedAt: 20_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        processSpawnedAt: 2_500,
+        stdinWriteEndAt: 3_000,
+        // Plain-stream runs stamp first-token from the first buffered stdout
+        // chunk, then the daemon persists stdout artifacts at close time and
+        // emits an `artifact` agent event. That event is a daemon action, not
+        // a model response, and it arrives near the end of the run.
+        firstTokenAt: 5_000,
+        firstVisibleOutputAt: 5_000,
+        firstModelEventAt: 19_000,
+        firstModelEventType: 'artifact' as const,
+        attemptIndex: 1,
+        attemptStartedAt: 2_000,
+      },
+      events: [],
+    });
+
+    // The model had produced output by 5s. Anchoring on the 19s artifact
+    // reports a 1s active window and a 16s runtime init for a run that was
+    // streaming the whole time.
+    expect(result.model_active_duration_ms).toBe(15_000);
+    expect(result.runtime_init_to_first_model_event_ms).toBe(2_000);
+    expect(result.bottleneck_phase).toBe('stream_output');
+  });
+
+  it('reports complete phase timing for a fully instrumented run with no text token', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 12_000,
+      analyticsCapturedAt: 12_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        promptBuildStartAt: 2_100,
+        promptBuildEndAt: 2_200,
+        processSpawnStartedAt: 2_300,
+        processSpawnedAt: 2_400,
+        modelCallStartAt: 2_500,
+        stdinWriteEndAt: 2_600,
+        // A tool-only turn: the model worked and finished without ever
+        // emitting text.
+        firstModelEventAt: 3_000,
+        firstModelEventType: 'tool_use' as const,
+        attemptIndex: 1,
+        attemptStartedAt: 2_000,
+      },
+      events: [
+        { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 't1', name: 'Bash' } },
+        { id: 2, event: 'agent', timestamp: 8_000, data: { type: 'tool_result', toolUseId: 't1' } },
+      ],
+    });
+
+    // Every boundary the phases are actually measured from is present, so
+    // this run is fully measured. Requiring a text token here marks it
+    // partial and drops it from dashboards that filter on complete timings.
+    expect(result.time_to_first_token_ms).toBeUndefined();
+    expect(result.phase_timing_status).toBe('complete');
+  });
+
+  it('counts a tool still running at run end as tool occupancy', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 15_000,
+      analyticsCapturedAt: 15_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        processSpawnedAt: 3_000,
+        stdinWriteEndAt: 3_500,
+        firstModelEventAt: 4_000,
+        firstModelEventType: 'tool_use' as const,
+        attemptIndex: 1,
+        attemptStartedAt: 2_000,
+      },
+      events: [
+        // The run died while this tool was still outstanding, so there is no
+        // tool_result to pair with.
+        { id: 1, event: 'agent', timestamp: 5_000, data: { type: 'tool_use', id: 't1', name: 'Bash' } },
+      ],
+    });
+
+    // 10s of the 11s active window was spent inside that tool. Treating the
+    // unpaired span as zero occupancy hands the whole window to stream_output
+    // and contradicts last_observed_phase.
+    expect(result.model_active_duration_ms).toBe(11_000);
+    expect(result.bottleneck_phase).toBe('tool_execution');
+    expect(result.last_observed_phase).toBe('tool_execution');
+    // The published metric only ever sums completed pairs.
+    expect(result.tool_duration_ms).toBe(0);
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1868,6 +1868,8 @@ describe('summarizeRunTimingAnalytics outstanding tools across a retry', () => {
       telemetry: {
         // Post-retry telemetry: attempt 2 only, and it never called a tool.
         startRequestedAt: 1_100,
+        attemptStartedAt: 18_000,
+        attemptIndex: 2,
         stdinWriteEndAt: 19_000,
         firstModelEventAt: 20_000,
         firstModelEventType: 'text_delta' as const,
@@ -1909,6 +1911,38 @@ describe('summarizeRunTimingAnalytics outstanding tools across a retry', () => {
 
     // The skewed start is clipped to the anchor, not discarded: 4s -> 15s.
     expect(result.model_active_duration_ms).toBe(11_000);
+    expect(result.bottleneck_phase).toBe('tool_execution');
+  });
+});
+
+describe('summarizeRunTimingAnalytics outstanding tools without a model-event mark', () => {
+  it('keeps a current-attempt outstanding tool when the anchor fell back to the first token', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 30_000,
+      analyticsCapturedAt: 30_050,
+      telemetry: {
+        // Legacy or recovery telemetry: no `firstModelEventAt`, so the phase
+        // anchor falls back to the first token at 10s.
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        stdinWriteEndAt: 3_000,
+        firstTokenAt: 10_000,
+        attemptStartedAt: 2_000,
+        attemptIndex: 1,
+      },
+      events: [
+        // Issued by THIS attempt at 4s and never completed. It was observed
+        // before the first token, which is exactly the tool-first shape this
+        // change exists to measure.
+        { id: 1, event: 'agent', timestamp: 4_000, data: { type: 'tool_use', id: 't1', name: 'Bash' } },
+      ],
+    });
+
+    // The tool held the whole 10s-30s active window. Gating the close on the
+    // phase anchor rather than the attempt boundary discards it and hands the
+    // window to stream_output.
+    expect(result.model_active_duration_ms).toBe(20_000);
     expect(result.bottleneck_phase).toBe('tool_execution');
   });
 });

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1979,3 +1979,57 @@ describe('summarizeRunTimingAnalytics tool id reuse across a retry', () => {
     expect(result.model_active_duration_ms).toBe(4_500);
   });
 });
+
+describe('summarizeRunTimingAnalytics with a truncated event stream', () => {
+  const truncatedRun = {
+    runCreatedAt: 1_000,
+    runUpdatedAt: 60_000,
+    analyticsCapturedAt: 60_050,
+    telemetry: {
+      startRequestedAt: 1_100,
+      startChatRunStartedAt: 2_000,
+      promptBuildStartAt: 2_100,
+      promptBuildEndAt: 2_200,
+      processSpawnStartedAt: 2_300,
+      processSpawnedAt: 2_400,
+      modelCallStartAt: 2_500,
+      stdinWriteEndAt: 2_600,
+      firstModelEventAt: 3_000,
+      firstModelEventType: 'tool_use' as const,
+      firstTokenAt: 25_000,
+      attemptStartedAt: 2_000,
+      attemptIndex: 1,
+    },
+    // The run's event ring buffer evicted everything before id 2001, which is
+    // where the opening tool_use lived. Every lifecycle mark still survives,
+    // because those live on the run rather than in the event list.
+    events: [
+      { id: 2_001, event: 'agent', timestamp: 55_000, data: { type: 'text_delta', text: 'done' } },
+    ],
+  };
+
+  it('does not claim complete phase timing when tool intervals may be missing', () => {
+    const result = summarizeRunTimingAnalytics(truncatedRun);
+
+    expect(result.phase_timing_status).toBe('partial');
+  });
+
+  it('withholds the bottleneck rather than blaming the phase that survived', () => {
+    const result = summarizeRunTimingAnalytics(truncatedRun);
+
+    // With the tool events evicted, occupancy reconstructs as zero and the
+    // whole active window lands on stream_output. That is not a measurement,
+    // it is an artefact of what the buffer happened to keep.
+    expect(result.bottleneck_phase).toBeUndefined();
+  });
+
+  it('still reports timings that come from lifecycle marks', () => {
+    const result = summarizeRunTimingAnalytics(truncatedRun);
+
+    // These never depended on the event list, so truncation does not touch
+    // them.
+    expect(result.model_active_duration_ms).toBe(57_000);
+    expect(result.time_to_first_token_ms).toBe(23_000);
+    expect(result.total_duration_ms).toBe(59_050);
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1946,3 +1946,36 @@ describe('summarizeRunTimingAnalytics outstanding tools without a model-event ma
     expect(result.bottleneck_phase).toBe('tool_execution');
   });
 });
+
+describe('summarizeRunTimingAnalytics tool id reuse across a retry', () => {
+  it('does not pair a dead attempt\'s open tool with a same-id retry tool', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 25_000,
+      analyticsCapturedAt: 25_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        attemptStartedAt: 20_000,
+        attemptIndex: 2,
+        stdinWriteEndAt: 20_200,
+        firstModelEventAt: 20_500,
+        firstModelEventType: 'text_delta' as const,
+        firstTokenAt: 20_500,
+      },
+      events: [
+        // Attempt 1's child was killed mid-tool, leaving `call_0` open.
+        { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 'call_0', name: 'Bash' } },
+        // Sequential ids restart at `call_0` in the retry's fresh session, so
+        // the id collides with the corpse above.
+        { id: 2, event: 'agent', timestamp: 21_500, data: { type: 'tool_use', id: 'call_0', name: 'Read' } },
+        { id: 3, event: 'agent', timestamp: 22_000, data: { type: 'tool_result', toolUseId: 'call_0' } },
+      ],
+    });
+
+    // The retry tool ran 21.5s -> 22.0s. Keeping the stale start pairs
+    // attempt 1's 3s opening with attempt 2's 22s close and reports a 19s
+    // tool that never existed.
+    expect(result.tool_duration_ms).toBe(500);
+    expect(result.model_active_duration_ms).toBe(4_500);
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1648,3 +1648,113 @@ describe('summarizeRunTimingAnalytics phase anchoring', () => {
     expect(result.model_active_duration_ms).toBe(1_000);
   });
 });
+
+describe('summarizeRunTimingAnalytics tool phase occupancy', () => {
+  // Phase durations have to partition elapsed time. `tool_duration_ms` sums
+  // each paired tool_use -> tool_result span, which is the right definition
+  // for a published "how much tool work happened" metric but the wrong one for
+  // a phase: parallel calls, a retried run's earlier attempt, and a
+  // producer-supplied `startedAt` from another clock all push the sum past the
+  // wall clock it is supposed to occupy.
+
+  it('uses wall-clock occupancy, not summed tool work, for the tool phase', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 16_000,
+      analyticsCapturedAt: 16_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 8_000,
+        processSpawnedAt: 8_500,
+        stdinWriteEndAt: 9_000,
+        firstModelEventAt: 10_000,
+        firstModelEventType: 'tool_use' as const,
+        firstTokenAt: 15_800,
+        attemptIndex: 1,
+        attemptStartedAt: 8_000,
+      },
+      events: [
+        // Two overlapping tools: 4s and 5s of work, but only 5.5s of wall
+        // clock (10.0s -> 15.5s).
+        { id: 1, event: 'agent', timestamp: 10_000, data: { type: 'tool_use', id: 't1', name: 'Read' } },
+        { id: 2, event: 'agent', timestamp: 10_500, data: { type: 'tool_use', id: 't2', name: 'Bash' } },
+        { id: 3, event: 'agent', timestamp: 14_000, data: { type: 'tool_result', toolUseId: 't1' } },
+        { id: 4, event: 'agent', timestamp: 15_500, data: { type: 'tool_result', toolUseId: 't2' } },
+      ],
+    });
+
+    // The model was active for 6s total, so no phase inside that window can
+    // exceed 6s. Summing gives 9s, which would beat the genuine 7s queue wait
+    // and report the wrong bottleneck.
+    expect(result.model_active_duration_ms).toBe(6_000);
+    expect(result.bottleneck_phase).toBe('queued');
+    // The published metric keeps summing paired spans.
+    expect(result.tool_duration_ms).toBe(9_000);
+  });
+
+  it('ignores a previous attempt\'s tool work when the anchor is from this attempt', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 25_000,
+      analyticsCapturedAt: 25_100,
+      telemetry: {
+        // A retry clears lifecycle telemetry down to `startRequestedAt`, so
+        // every mark here belongs to attempt 2.
+        startRequestedAt: 1_100,
+        stdinWriteEndAt: 19_000,
+        firstModelEventAt: 20_000,
+        firstModelEventType: 'tool_use' as const,
+        firstTokenAt: 24_000,
+        attemptIndex: 2,
+        attemptStartedAt: 18_000,
+      },
+      events: [
+        // `run.events` is never cleared between attempts, so attempt 1's 10s
+        // tool is still in the list even though the anchor is at 20s.
+        { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 'a1', name: 'Bash' } },
+        { id: 2, event: 'agent', timestamp: 13_000, data: { type: 'tool_result', toolUseId: 'a1' } },
+        { id: 3, event: 'agent', timestamp: 21_000, data: { type: 'tool_use', id: 'a2', name: 'Read' } },
+        { id: 4, event: 'agent', timestamp: 22_000, data: { type: 'tool_result', toolUseId: 'a2' } },
+      ],
+    });
+
+    // Attempt 2 was active for 5s and spent 1s of it in a tool. Counting
+    // attempt 1's 10s tool here reports 11s of tool execution inside a 5s
+    // window and blames tooling for work that predates the anchor.
+    expect(result.model_active_duration_ms).toBe(5_000);
+    expect(result.bottleneck_phase).toBe('stream_output');
+    // Whole-run tool work is unchanged: the published metric is not
+    // attempt-scoped.
+    expect(result.tool_duration_ms).toBe(11_000);
+  });
+
+  it('clips a producer-supplied tool start that predates the anchor', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 10_000,
+      analyticsCapturedAt: 10_050,
+      telemetry: {
+        startRequestedAt: 1_050,
+        startChatRunStartedAt: 1_100,
+        stdinWriteEndAt: 1_200,
+        firstModelEventAt: 5_000,
+        firstModelEventType: 'tool_use' as const,
+        firstTokenAt: 9_000,
+        attemptIndex: 1,
+        attemptStartedAt: 1_100,
+      },
+      events: [
+        // ACP producers supply their own `startedAt`; here it is 4s earlier
+        // than the anchor, which cannot be time this run spent in a tool.
+        { id: 1, event: 'agent', timestamp: 6_000, data: { type: 'tool_use', id: 't1', name: 'Read', startedAt: 1_000 } },
+        { id: 2, event: 'agent', timestamp: 8_000, data: { type: 'tool_result', toolUseId: 't1' } },
+      ],
+    });
+
+    // Only 5.0s -> 8.0s falls inside the model-active window, so runtime init
+    // (3.8s) is the real bottleneck. The unclipped 7s span would outrank it.
+    expect(result.model_active_duration_ms).toBe(5_000);
+    expect(result.bottleneck_phase).toBe('runtime_init');
+    expect(result.tool_duration_ms).toBe(7_000);
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -2033,3 +2033,38 @@ describe('summarizeRunTimingAnalytics with a truncated event stream', () => {
     expect(result.total_duration_ms).toBe(59_050);
   });
 });
+
+describe('summarizeRunTimingAnalytics late tool results from a dead attempt', () => {
+  it('does not charge the current attempt for a tool opened before it started', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 30_000,
+      analyticsCapturedAt: 30_050,
+      telemetry: {
+        startRequestedAt: 1_100,
+        attemptStartedAt: 20_000,
+        attemptIndex: 2,
+        stdinWriteEndAt: 20_500,
+        firstModelEventAt: 21_000,
+        firstModelEventType: 'text_delta' as const,
+        firstTokenAt: 21_000,
+      },
+      events: [
+        // Opened by attempt 1.
+        { id: 1, event: 'agent', timestamp: 3_000, data: { type: 'tool_use', id: 'call_0', name: 'Bash' } },
+        // Its result lands long after attempt 2 is under way -- a buffered
+        // stdout flush racing the abort, which the ACP session code already
+        // documents as a real sequence. Attempt 2 issued no tool of its own.
+        { id: 2, event: 'agent', timestamp: 29_900, data: { type: 'tool_result', toolUseId: 'call_0' } },
+      ],
+    });
+
+    // Pairing this into an interval spans the retry boundary; clipping then
+    // reports 8.9s of tool execution inside a 9s window for an attempt that
+    // never called a tool.
+    expect(result.model_active_duration_ms).toBe(9_000);
+    expect(result.bottleneck_phase).toBe('stream_output');
+    // The published metric keeps its whole-run paired-sum definition.
+    expect(result.tool_duration_ms).toBe(26_900);
+  });
+});

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -1148,12 +1148,14 @@ describe('summarizeRunTimingAnalytics', () => {
       time_to_first_token_ms: 1300,
       time_to_first_visible_output_ms: 1300,
       runtime_init_to_first_token_ms: 650,
+      runtime_init_to_first_model_event_ms: 150,
       spawn_to_first_token_ms: 740,
       time_to_first_artifact_ms: 3050,
       // No subsegment markers were observed, so the whole spawn->first-token
       // span is unattributed and falls into the remainder.
       spawn_to_first_token_remainder_ms: 740,
       generation_duration_ms: 5500,
+      model_active_duration_ms: 6000,
       tool_call_count: 2,
       tool_duration_ms: 650,
       artifact_write_duration_ms: 250,
@@ -1162,6 +1164,7 @@ describe('summarizeRunTimingAnalytics', () => {
       finalize_duration_ms: 20,
       total_duration_ms: 7020,
       bottleneck_phase: 'stream_output',
+      phase_schema_version: 2,
       last_observed_phase: 'artifact_write',
       phase_timing_status: 'complete',
       attempt_index: 1,
@@ -1257,11 +1260,13 @@ describe('summarizeRunTimingAnalytics', () => {
     expect(result).toEqual({
       queue_duration_ms: 100,
       generation_duration_ms: 2440,
+      model_active_duration_ms: 2440,
       tool_call_count: 0,
       artifact_write_status: 'none',
       total_duration_ms: 2450,
       first_model_event_type: 'text_delta',
       bottleneck_phase: 'stream_output',
+      phase_schema_version: 2,
       last_observed_phase: 'stream_output',
       phase_timing_status: 'partial',
       attempt_duration_ms: 2400,
@@ -1500,5 +1505,146 @@ describe('summarizeToolAnalytics', () => {
     ]);
     expect(result.tool_names).toEqual(['Write', 'Bash', 'Fetch', 'Tool']);
     expect(result.tool_name_count).toBe(4);
+  });
+});
+
+describe('summarizeRunTimingAnalytics phase anchoring', () => {
+  // A tool-first run: the model starts working at 4s (a tool_use) but stays
+  // silent until 24s, then emits one short closing sentence before the run
+  // ends at 25s. This is the dominant shape for OpenCode/OpenAI runs.
+  //
+  // Phase boundaries must follow when the model STARTED RESPONDING, not when
+  // it first emitted text. Anchoring phases on `firstTokenAt` charges the
+  // whole 20s tool loop to `runtime_init` and leaves the generation phase
+  // holding only the closing sentence.
+  const toolFirstRun = {
+    runCreatedAt: 1_000,
+    runUpdatedAt: 25_000,
+    analyticsCapturedAt: 25_200,
+    telemetry: {
+      startRequestedAt: 1_100,
+      startChatRunStartedAt: 2_000,
+      processSpawnStartedAt: 2_500,
+      processSpawnedAt: 3_000,
+      modelCallStartAt: 3_100,
+      stdinWriteStartAt: 3_100,
+      stdinWriteEndAt: 3_200,
+      firstModelEventAt: 4_000,
+      firstModelEventType: 'tool_use' as const,
+      firstTokenAt: 24_000,
+      firstVisibleOutputAt: 24_000,
+      attemptIndex: 1,
+      attemptStartedAt: 2_000,
+    },
+    events: [
+      { id: 1, event: 'agent', timestamp: 4_000, data: { type: 'tool_use', id: 't1', name: 'Read' } },
+      { id: 2, event: 'agent', timestamp: 9_000, data: { type: 'tool_result', toolUseId: 't1' } },
+      { id: 3, event: 'agent', timestamp: 10_000, data: { type: 'tool_use', id: 't2', name: 'Bash' } },
+      { id: 4, event: 'agent', timestamp: 16_000, data: { type: 'tool_result', toolUseId: 't2' } },
+      { id: 5, event: 'agent', timestamp: 17_000, data: { type: 'tool_use', id: 't3', name: 'Write' } },
+      { id: 6, event: 'agent', timestamp: 22_000, data: { type: 'tool_result', toolUseId: 't3' } },
+    ],
+  };
+
+  it('measures runtime init up to the first model event, not the first token', () => {
+    const result = summarizeRunTimingAnalytics(toolFirstRun);
+
+    // stdin closed at 3.2s and the model responded at 4s.
+    expect(result.runtime_init_to_first_model_event_ms).toBe(800);
+  });
+
+  it('counts the whole tool loop as model-active time', () => {
+    const result = summarizeRunTimingAnalytics(toolFirstRun);
+
+    // The model responded at 4s and the run ended at 25s.
+    expect(result.model_active_duration_ms).toBe(21_000);
+  });
+
+  it('blames the tool loop rather than startup for a tool-first run', () => {
+    const result = summarizeRunTimingAnalytics(toolFirstRun);
+
+    // Tool execution is 16s of the 21s model-active window; the re-anchored
+    // runtime_init phase is 0.8s. Anchoring on firstTokenAt reports a 20.8s
+    // `runtime_init` phase and wins the bottleneck with pure startup.
+    expect(result.tool_duration_ms).toBe(16_000);
+    expect(result.bottleneck_phase).toBe('tool_execution');
+  });
+
+  it('stamps the phase schema version so old and new rows are separable', () => {
+    const result = summarizeRunTimingAnalytics(toolFirstRun);
+
+    expect(result.phase_schema_version).toBe(2);
+  });
+
+  it('leaves every first-token metric at its published meaning', () => {
+    const result = summarizeRunTimingAnalytics(toolFirstRun);
+
+    // These four are consumed by existing dashboards. Re-anchoring phases
+    // must not silently redefine them.
+    expect(result.time_to_first_token_ms).toBe(22_000);
+    expect(result.runtime_init_to_first_token_ms).toBe(20_800);
+    expect(result.spawn_to_first_token_ms).toBe(21_000);
+    expect(result.generation_duration_ms).toBe(1_000);
+  });
+
+  it('reports identical old and new values when the model leads with text', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 8_000,
+      analyticsCapturedAt: 8_020,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        processSpawnStartedAt: 2_500,
+        processSpawnedAt: 3_000,
+        stdinWriteStartAt: 3_100,
+        stdinWriteEndAt: 3_200,
+        firstModelEventAt: 4_000,
+        firstModelEventType: 'text_delta' as const,
+        firstTokenAt: 4_000,
+        firstVisibleOutputAt: 4_000,
+        attemptIndex: 1,
+        attemptStartedAt: 2_000,
+      },
+      events: [
+        { id: 1, event: 'agent', timestamp: 5_000, data: { type: 'tool_use', id: 't1', name: 'Read' } },
+        { id: 2, event: 'agent', timestamp: 5_500, data: { type: 'tool_result', toolUseId: 't1' } },
+      ],
+    });
+
+    // Text-first runs already had a truthful anchor, so the new fields must
+    // land on exactly the old numbers -- no drift for Claude Code-shaped runs.
+    expect(result.runtime_init_to_first_model_event_ms).toBe(result.runtime_init_to_first_token_ms);
+    expect(result.model_active_duration_ms).toBe(result.generation_duration_ms);
+  });
+
+  it('falls back to the first token when the client reported no model event', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 25_000,
+      analyticsCapturedAt: 25_100,
+      telemetry: {
+        startRequestedAt: 1_100,
+        startChatRunStartedAt: 2_000,
+        processSpawnedAt: 3_000,
+        stdinWriteEndAt: 3_200,
+        firstTokenAt: 24_000,
+        attemptIndex: 1,
+        attemptStartedAt: 2_000,
+      },
+      events: [
+        { id: 1, event: 'agent', timestamp: 4_000, data: { type: 'tool_use', id: 't1', name: 'Read' } },
+        { id: 2, event: 'agent', timestamp: 9_000, data: { type: 'tool_result', toolUseId: 't1' } },
+      ],
+    });
+
+    // Older clients send no `firstModelEventAt`. The phase anchor falls back
+    // to the first token rather than to the scanned `tool_use` timestamp:
+    // event records carry the daemon's clock, not the lifecycle tracer's, and
+    // are not reset per retry attempt. `time_to_first_model_event_ms` keeps
+    // its existing scan-based fallback and is unaffected.
+    expect(result.time_to_first_model_event_ms).toBe(2_000);
+    expect(result.runtime_init_to_first_model_event_ms).toBe(20_800);
+    expect(result.model_active_duration_ms).toBe(1_000);
   });
 });

--- a/apps/daemon/tests/run-lifecycle-tracer.test.ts
+++ b/apps/daemon/tests/run-lifecycle-tracer.test.ts
@@ -44,3 +44,37 @@ describe('createRunLifecycleTracer', () => {
     });
   });
 });
+
+describe('runLifecycleMarkersForStreamEvent artifact events', () => {
+  it('does not treat a persisted artifact as the first model event', () => {
+    const markers = runLifecycleMarkersForStreamEvent('agent', {
+      type: 'artifact',
+      source: 'plain-stream',
+      name: 'index.html',
+    });
+
+    // `artifact` agent events are emitted only by the daemon's close-time
+    // stdout persistence, never by a runtime relaying model output. Marking
+    // one as the first model event stamps a daemon action at the end of the
+    // run as the moment the model started responding.
+    expect(markers.firstModelEventType).toBeUndefined();
+    // It is still an artifact write, and still visible output.
+    expect(markers.firstArtifactWrite).toBe(true);
+    expect(markers.firstVisibleOutput).toBe(true);
+  });
+
+  it('still marks real model stream events', () => {
+    expect(
+      runLifecycleMarkersForStreamEvent('agent', { type: 'tool_use', id: 't1' })
+        .firstModelEventType,
+    ).toBe('tool_use');
+    expect(
+      runLifecycleMarkersForStreamEvent('agent', { type: 'text_delta', text: 'hi' })
+        .firstModelEventType,
+    ).toBe('text_delta');
+    expect(
+      runLifecycleMarkersForStreamEvent('agent', { type: 'thinking_delta', text: 'hm' })
+        .firstModelEventType,
+    ).toBe('thinking_delta');
+  });
+});

--- a/apps/daemon/tests/run-lifecycle-tracer.test.ts
+++ b/apps/daemon/tests/run-lifecycle-tracer.test.ts
@@ -118,3 +118,32 @@ describe('runLifecycleMarkersForStreamEvent producer-supplied start', () => {
     }
   });
 });
+
+describe('createRunLifecycleTracer first model event ordering', () => {
+  it('keeps the earliest producer start when terminal events arrive out of order', () => {
+    const run: { analyticsTelemetry?: Record<string, unknown> | null } = {};
+    const tracer = createRunLifecycleTracer(run as never);
+
+    // ACP holds each toolCallId until it reaches terminal status, so two
+    // parallel calls can complete in the opposite order they started. Call B
+    // (started 200) finishes first; call A (started 100) finishes after.
+    tracer.markFirstModelEvent('tool_use', 200);
+    tracer.markFirstModelEvent('tool_use', 100);
+
+    // First-write-wins would anchor at 200 and lose the 100ms head start,
+    // pushing every phase boundary later.
+    expect(run.analyticsTelemetry?.firstModelEventAt).toBe(100);
+    expect(run.analyticsTelemetry?.firstModelEventType).toBe('tool_use');
+  });
+
+  it('does not let a later event move the anchor forward', () => {
+    const run: { analyticsTelemetry?: Record<string, unknown> | null } = {};
+    const tracer = createRunLifecycleTracer(run as never);
+
+    tracer.markFirstModelEvent('tool_use', 100);
+    tracer.markFirstModelEvent('text_delta', 300);
+
+    expect(run.analyticsTelemetry?.firstModelEventAt).toBe(100);
+    expect(run.analyticsTelemetry?.firstModelEventType).toBe('tool_use');
+  });
+})

--- a/apps/daemon/tests/run-lifecycle-tracer.test.ts
+++ b/apps/daemon/tests/run-lifecycle-tracer.test.ts
@@ -78,3 +78,43 @@ describe('runLifecycleMarkersForStreamEvent artifact events', () => {
     ).toBe('thinking_delta');
   });
 });
+
+describe('runLifecycleMarkersForStreamEvent producer-supplied start', () => {
+  it('carries a tool_use startedAt so the anchor is not stamped at completion', () => {
+    // ACP accumulates tool_call frames and emits the canonical tool_use only
+    // once the call reaches a terminal status, with `startedAt` set to the
+    // first frame's arrival (daemon clock). Stamping the anchor when that
+    // delayed event arrives puts it at tool COMPLETION, so a tool-only ACP
+    // turn measures its whole tool loop as runtime init.
+    const markers = runLifecycleMarkersForStreamEvent('agent', {
+      type: 'tool_use',
+      id: 't1',
+      name: 'Bash',
+      startedAt: 1_700_000_000_000,
+    });
+
+    expect(markers.firstModelEventType).toBe('tool_use');
+    expect(markers.firstModelEventAt).toBe(1_700_000_000_000);
+  });
+
+  it('leaves the timestamp to the caller when the payload carries no start', () => {
+    const markers = runLifecycleMarkersForStreamEvent('agent', {
+      type: 'text_delta',
+      text: 'hi',
+    });
+
+    expect(markers.firstModelEventType).toBe('text_delta');
+    expect(markers.firstModelEventAt).toBeUndefined();
+  });
+
+  it('ignores a start that is not a finite number', () => {
+    for (const startedAt of [Number.NaN, Number.POSITIVE_INFINITY, '123', null]) {
+      const markers = runLifecycleMarkersForStreamEvent('agent', {
+        type: 'tool_use',
+        id: 't1',
+        startedAt,
+      });
+      expect(markers.firstModelEventAt).toBeUndefined();
+    }
+  });
+});

--- a/apps/daemon/tests/run-lifecycle-tracer.test.ts
+++ b/apps/daemon/tests/run-lifecycle-tracer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createRunLifecycleTracer,
   runLifecycleMarkersForStreamEvent,
@@ -27,21 +27,30 @@ describe('runLifecycleMarkersForStreamEvent', () => {
 
 describe('createRunLifecycleTracer', () => {
   it('only records first timestamps for repeated lifecycle marks', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T00:00:10.000Z'));
+    const arrivedAt = Date.now();
     const run = {};
     const lifecycle = createRunLifecycleTracer(run);
 
     lifecycle.mark('first_artifact_write', 1_000);
     lifecycle.mark('first_artifact_write', 2_000);
+    // Second argument is the producer's start, not the mark's timestamp.
     lifecycle.markFirstModelEvent('tool_use', 3_000);
     lifecycle.markFirstModelEvent('text_delta', 4_000);
 
     expect(run).toEqual({
       analyticsTelemetry: {
         firstArtifactWriteAt: 1_000,
-        firstModelEventAt: 3_000,
+        // Arrival, first-write-wins -- the repeat does not overwrite it.
+        firstModelEventAt: arrivedAt,
         firstModelEventType: 'tool_use',
+        // Earliest producer start wins, so the 4_000 repeat does not win here
+        // either.
+        firstModelResponseAt: 3_000,
       },
     });
+    vi.useRealTimers();
   });
 });
 
@@ -132,7 +141,7 @@ describe('createRunLifecycleTracer first model event ordering', () => {
 
     // First-write-wins would anchor at 200 and lose the 100ms head start,
     // pushing every phase boundary later.
-    expect(run.analyticsTelemetry?.firstModelEventAt).toBe(100);
+    expect(run.analyticsTelemetry?.firstModelResponseAt).toBe(100);
     expect(run.analyticsTelemetry?.firstModelEventType).toBe('tool_use');
   });
 
@@ -143,7 +152,34 @@ describe('createRunLifecycleTracer first model event ordering', () => {
     tracer.markFirstModelEvent('tool_use', 100);
     tracer.markFirstModelEvent('text_delta', 300);
 
-    expect(run.analyticsTelemetry?.firstModelEventAt).toBe(100);
+    expect(run.analyticsTelemetry?.firstModelResponseAt).toBe(100);
     expect(run.analyticsTelemetry?.firstModelEventType).toBe('tool_use');
   });
 })
+
+describe('createRunLifecycleTracer keeps the legacy model-event mark intact', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records arrival for firstModelEventAt and the producer start separately', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T00:00:20.000Z'));
+    const arrivedAt = Date.now();
+    const producerStartedAt = arrivedAt - 16_000;
+    const run: { analyticsTelemetry?: Record<string, unknown> | null } = {};
+    const tracer = createRunLifecycleTracer(run as never);
+
+    // ACP emits the canonical tool_use at terminal status, so this arrives at
+    // 20s carrying a first-frame time of 4s.
+    tracer.markFirstModelEvent('tool_use', producerStartedAt);
+
+    // `time_to_first_model_event_ms` is built from this field and is already
+    // published. It must keep meaning "when we saw the first model event",
+    // or every dashboard reading it silently shifts.
+    expect(run.analyticsTelemetry?.firstModelEventAt).toBe(arrivedAt);
+    expect(run.analyticsTelemetry?.firstModelEventType).toBe('tool_use');
+    // The phase anchor is a separate mark: when the model actually began.
+    expect(run.analyticsTelemetry?.firstModelResponseAt).toBe(producerStartedAt);
+  });
+});

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -381,6 +381,51 @@ describe('chat run service shutdown', () => {
     });
   });
 
+  it('clears the prior attempt\'s lifecycle marks when reopening for recharge', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T00:00:00.000Z'));
+    const runs = createRuns();
+    const run = runs.create({
+      projectId: 'project-1',
+      conversationId: 'conv-1',
+      clientRequestId: 'brief-recharge-marks',
+      requestFingerprint: 'same-logical-request',
+      agentId: 'amr',
+    });
+    const runStartedAt = Date.now();
+    (run as any).analyticsTelemetry = {
+      startRequestedAt: runStartedAt,
+      startChatRunStartedAt: runStartedAt + 10,
+      processSpawnedAt: runStartedAt + 100,
+      stdinWriteEndAt: runStartedAt + 150,
+      firstModelEventAt: runStartedAt + 400,
+      firstModelEventType: 'text_delta',
+      firstTokenAt: runStartedAt + 400,
+      attemptStartedAt: runStartedAt,
+      attemptIndex: 0,
+    };
+    (run as any).failureAction = 'recharge';
+    runs.finish(run, 'failed', 1, null);
+    vi.advanceTimersByTime(600_000);
+
+    runs.prepareRestart(run);
+
+    // The resumed attempt is a fresh execution. Keeping attempt 1's marks
+    // makes every phase boundary measure from before the recharge pause, so
+    // the wait time lands inside the new attempt's model-active window.
+    const telemetry = (run as any).analyticsTelemetry ?? {};
+    expect(telemetry.firstModelEventAt).toBeUndefined();
+    expect(telemetry.firstTokenAt).toBeUndefined();
+    expect(telemetry.stdinWriteEndAt).toBeUndefined();
+    expect(telemetry.processSpawnedAt).toBeUndefined();
+    // The logical run start survives -- queue time is still measured from
+    // when the user asked for this run, not from the resume.
+    expect(telemetry.startRequestedAt).toBe(runStartedAt);
+    // The attempt boundary moves to the resume, which is what scopes
+    // outstanding tool spans to the current attempt.
+    expect(telemetry.attemptStartedAt).toBe(runStartedAt + 600_000);
+  });
+
   it('reopens the same logical run for an explicit recharge recovery attempt', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'));

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -220,6 +220,11 @@ export interface RunTimingProps {
   time_to_first_visible_output_ms?: number;
   time_to_first_artifact_ms?: number;
   generation_duration_ms?: number;
+  // Model-active window: first model event of any kind (tool call, thinking,
+  // text, artifact) to run end. Prefer this over `generation_duration_ms` when
+  // comparing agents -- the latter starts at the first text token, so a
+  // tool-first run reports only its closing message.
+  model_active_duration_ms?: number;
   finalize_duration_ms?: number;
   collection_status?: TrackingRunPhaseTimingStatus;
 }
@@ -509,6 +514,10 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   time_to_first_token_ms?: number;
   time_to_first_visible_output_ms?: number;
   runtime_init_to_first_token_ms?: number;
+  // Runtime init measured to the first model event of any kind rather than to
+  // the first text token. On a tool-first run the first-token variant absorbs
+  // the whole tool loop and reads as slow startup.
+  runtime_init_to_first_model_event_ms?: number;
   spawn_to_first_token_ms?: number;
   time_to_first_artifact_ms?: number;
   // `spawn_to_first_token_ms` split into auditable subsegments so dashboards
@@ -520,6 +529,8 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   model_first_token_ms?: number;
   spawn_to_first_token_remainder_ms?: number;
   generation_duration_ms?: number;
+  // See `RunTimingProps.model_active_duration_ms`.
+  model_active_duration_ms?: number;
   tool_call_count?: number;
   tool_duration_ms?: number;
   artifact_write_duration_ms?: number;
@@ -533,6 +544,10 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   diagnostics?: RunDiagnosticsProps;
   langfuse_delivery?: RunLangfuseDeliveryProps;
   bottleneck_phase?: TrackingRunLifecyclePhase;
+  // Which phase-boundary definition produced `bottleneck_phase`. Absent on
+  // rows written before the definition was versioned. Rows from different
+  // versions are not comparable -- filter to one, do not average across.
+  phase_schema_version?: number;
   last_observed_phase?: TrackingRunLifecyclePhase;
   phase_timing_status?: TrackingRunPhaseTimingStatus;
   // E-lite root-cause discriminators. `last_observed_phase` tells us WHICH phase

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -517,7 +517,7 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   // Runtime init measured to the first model event of any kind rather than to
   // the first text token. On a tool-first run the first-token variant absorbs
   // the whole tool loop and reads as slow startup.
-  runtime_init_to_first_model_event_ms?: number;
+  runtime_init_to_first_model_response_ms?: number;
   spawn_to_first_token_ms?: number;
   time_to_first_artifact_ms?: number;
   // `spawn_to_first_token_ms` split into auditable subsegments so dashboards

--- a/packages/contracts/src/analytics/run-schema-v4.ts
+++ b/packages/contracts/src/analytics/run-schema-v4.ts
@@ -285,7 +285,7 @@ function diagnosticsFromLegacy(legacy: JsonRecord): RunDiagnosticsProps | undefi
     launch_preflight_duration_ms: numberValue(legacy.launch_preflight_duration_ms),
     stdin_write_duration_ms: numberValue(legacy.stdin_write_duration_ms),
     runtime_init_to_first_token_ms: numberValue(legacy.runtime_init_to_first_token_ms),
-    runtime_init_to_first_model_event_ms: numberValue(legacy.runtime_init_to_first_model_event_ms),
+    runtime_init_to_first_model_response_ms: numberValue(legacy.runtime_init_to_first_model_response_ms),
     spawn_to_first_token_ms: numberValue(legacy.spawn_to_first_token_ms),
     cli_ready_ms: numberValue(legacy.cli_ready_ms),
     session_init_ms: numberValue(legacy.session_init_ms),

--- a/packages/contracts/src/analytics/run-schema-v4.ts
+++ b/packages/contracts/src/analytics/run-schema-v4.ts
@@ -180,6 +180,7 @@ function timingFromLegacy(legacy: JsonRecord): RunTimingProps {
   const firstVisibleOutputDuration = numberValue(legacy.time_to_first_visible_output_ms);
   const firstArtifactDuration = numberValue(legacy.time_to_first_artifact_ms);
   const generationDuration = numberValue(legacy.generation_duration_ms);
+  const modelActiveDuration = numberValue(legacy.model_active_duration_ms);
   const finalizeDuration = numberValue(legacy.finalize_duration_ms);
   const firstModelEventType = stringValue(legacy.first_model_event_type);
   const collectionStatus = stringValue(legacy.phase_timing_status);
@@ -208,6 +209,9 @@ function timingFromLegacy(legacy: JsonRecord): RunTimingProps {
       : {}),
     ...(generationDuration !== undefined
       ? { generation_duration_ms: generationDuration }
+      : {}),
+    ...(modelActiveDuration !== undefined
+      ? { model_active_duration_ms: modelActiveDuration }
       : {}),
     ...(finalizeDuration !== undefined
       ? { finalize_duration_ms: finalizeDuration }
@@ -281,6 +285,7 @@ function diagnosticsFromLegacy(legacy: JsonRecord): RunDiagnosticsProps | undefi
     launch_preflight_duration_ms: numberValue(legacy.launch_preflight_duration_ms),
     stdin_write_duration_ms: numberValue(legacy.stdin_write_duration_ms),
     runtime_init_to_first_token_ms: numberValue(legacy.runtime_init_to_first_token_ms),
+    runtime_init_to_first_model_event_ms: numberValue(legacy.runtime_init_to_first_model_event_ms),
     spawn_to_first_token_ms: numberValue(legacy.spawn_to_first_token_ms),
     cli_ready_ms: numberValue(legacy.cli_ready_ms),
     session_init_ms: numberValue(legacy.session_init_ms),


### PR DESCRIPTION
## Why

I was drilling into generation speed across agents and could not get a straight
answer out of the run timing waterfall. Runs that were visibly working the
whole time came back reported as bottlenecked on `runtime_init` — startup.

The cause is that phase boundaries anchor on `firstTokenAt`, the first *text*
token. For a run that opens with a tool call and stays quiet until the end,
that timestamp lands after the entire tool loop. Everything before it is billed
to startup, and the generation phase is left holding only the closing sentence.
That is not a rare shape — tool-first is the dominant opening for the
OpenCode/OpenAI families.

The phase decomposition was also not a partition. On the fixture in the new
spec (a 24.2s run) the old boundaries produce:

    runtime_init 20.8s + stream_output 1.0s + tool_execution 16.0s = 37.8s

156% of the run, because the tool loop is counted inside `runtime_init` and
again in `tool_execution`. Any bottleneck attribution built on that is
arithmetic over overlapping intervals.

I hit this while trying to answer "which agent is slower and where does the
time go", so this is scratching my own itch, but the same numbers feed anyone
reading the run performance dashboards.

## What users will see

Nothing in the product UI — this is the analytics and observability path.

For anyone reading run performance dashboards: `bottleneck_phase` stops
blaming startup for time the model spent working, and two new metrics appear
that measure the model-active window truthfully. Every metric that exists
today keeps its current meaning and value.

## What changed

Phase boundaries now anchor on the first model event of any kind — a tool
call, a thinking delta, text, or an artifact all mean the model is responding
and the user can see something happen.

Published metrics are untouched. `time_to_first_token_ms`,
`spawn_to_first_token_ms`, `runtime_init_to_first_token_ms`, and
`generation_duration_ms` keep their exact current values; one of the new specs
asserts all four, so a future edit that redefines them fails loudly.

Additive:

- `runtime_init_to_first_model_event_ms` — runtime init to first model event.
- `model_active_duration_ms` — first model event to run end. This is the one
  to use when comparing agent speed.
- `phase_schema_version` (= 2) — stamps which boundary definition produced
  `bottleneck_phase`, so rows either side of this change can be filtered apart
  instead of averaged together.

Internal to the phase bundle:

- The `runtime_init` phase is measured to the model-event anchor.
- The `stream_output` phase subtracts tool time so it is mutually exclusive
  with `tool_execution`. The same fixture then decomposes to 23.6s of the
  24.2s run; the 0.6s remainder is `pre_spawn` and the model-call gap, which
  are deliberately fields rather than phases.

## Anchor choice

The anchor is `telemetry.firstModelEventAt ?? telemetry.firstTokenAt`, taken
from lifecycle tracer marks only.

It deliberately does not reuse the existing `firstModelEventAt` composite a few
lines above, whose middle fallback is `firstToolUseAt`. That value is scanned
off event records stamped with the daemon's clock and is never reset between
retry attempts, so subtracting it from a tracer timestamp is cross-clock
arithmetic. `time_to_first_model_event_ms` keeps that composite and is
untouched; only the phase anchor is restricted. There is a spec for this.

Corroboration that the anchor is right: the `od` execution-diagnostics surface
in `apps/daemon/src/runtimes/runs.ts` already computes
`firstModelEventAt -> run end` and labels it `agentExecutionDurationMs`, with
the same tracer-only restriction. That surface had it right; only the
analytics/phase surface was anchored on text.

Coverage: `markFirstModelEvent` fires from the universal SSE `send()` path, so
every structured-stream family populates it. The plain/BYOK/antigravity family
emits `stdout` chunks rather than `agent` events, and falls back to
`firstTokenAt`.

An earlier revision of this description claimed that fallback made plain-stream
runs behave exactly as before. Review showed that was wrong, and the correction
is worth stating rather than quietly editing away: the daemon persists
plain-stream stdout as an `artifact` agent event at close time, which went
through the same `send()` path and stamped `firstModelEventAt` near the end of
the run. The fallback was never reached, because the field was set — by the
daemon, not the model — and the anchor moved to run end. Fixed in 9801429985;
see the review thread on `run-analytics-observability.ts`.

## Review rounds

Two rounds of blocking review found five real defects in the first cut, all of
the same shape: a value that was correct as a published metric being reused as
a phase boundary, where it has to partition elapsed time.

1. The residual subtracted summed tool work from a wall-clock window.
2. Retried runs mixed a current-attempt anchor with all-attempt tool spans.
3. A daemon-persisted artifact could win the anchor and move every boundary to
   the end of the run.
4. `phase_timing_status` still required a text token after the boundaries had
   moved off it.
5. A tool still outstanding at run end counted as zero occupancy.

Each has a fixture that was red before its fix. The `Math.max(0, ...)` floor in
the first cut is worth calling out as a mistake to avoid repeating: it made the
symptom of (1) invisible while `tool_execution` kept the inflated value and
still won the bottleneck.

## Trace side

`langfuse-trace.ts` already emitted `runtime-init-to-first-model-event` and
`runtime-init-to-first-token` side by side; only the generation window was
still anchored on text. Added a `model-active` entry to the existing phase
diagnostics map.

Deliberately an entry in that map rather than a second span: the map rides
along inside metadata that is already being sent, while a new span is an extra
observation row per run. That cluster just came back from a ClickHouse
disk-full incident, so this is not the moment to add a row per run for a value
the analytics path already carries.

## Surface area

- [x] **API / contract** — additive fields in `packages/contracts`
      (`RunFinishedProps`, `RunTimingProps`, v4 mapping). No endpoint or SSE
      event changes.

No CLI subcommand: this is not a new user-facing capability, and the `od`
execution-diagnostics surface already exposes the model-active window as
`agentExecutionDurationMs`.

## Bug fix verification

- Test path: `apps/daemon/tests/run-analytics-observability.test.ts` →
  `summarizeRunTimingAnalytics phase anchoring`
- Red on base, green on this branch: **yes**. 6 failing before the source
  change, the load-bearing one being
  `AssertionError: expected 'runtime_init' to be 'tool_execution'` — a run
  whose model started working at 4s with a 16s tool loop, reported as
  bottlenecked on startup.
- Two pre-existing `toEqual` assertions were updated to carry the three new
  fields. That diff is purely additive — no existing value moved, which is the
  point.

## Validation

- `pnpm guard` (exit 0)
- `pnpm typecheck`; `pnpm --filter @open-design/daemon typecheck`;
  `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon build`
- `@open-design/contracts` suite: 39 files / 282 tests passed
- Daemon targeted suites: `run-analytics-observability`, `langfuse-trace`,
  `langfuse-bridge`, `langfuse-bridge-nonblocking`, `run-runtime-type-analytics`,
  `telemetry-message-finalization` — 212 passed, re-confirmed after rebasing
  onto current `main`
- Full daemon suite re-running against the rebased tree; I will post the result
  in a comment rather than leave it implied.
