### PR TITLE
fix(web): validate onboarding runtime on Continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ apps/desktop/vendor/dom-to-pptx/dom-to-pptx.bundle.js
 
 .cursor/
 .agents/
+.pi/
 .opencode/
 .claude/*
 # Exception: od-contribute skill ships with the repo so the OD app can mount it

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -34,7 +34,6 @@ import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackHomeNavClick,
-  trackHomeToolbarClick,
   trackOnboardingClick,
   trackOnboardingCompleteResult,
   trackOnboardingRuntimeScanResult,
@@ -180,13 +179,7 @@ import {
   recordOptimisticProjectOwnership,
   type OptimisticProjectOwnershipWitnesses,
 } from '../collab/optimistic-project-ownership';
-import {
-  getModelCapabilityTag,
-  getModelCostTier,
-  MODEL_CAPABILITY_TAG_LABEL_KEYS,
-  MODEL_COST_TIER_LABEL_KEYS,
-  type ModelCapabilityTag,
-} from './modelCapabilityTags';
+import type { ModelCapabilityTag } from './modelCapabilityTags';
 import { LanguageMenu } from './LanguageMenu';
 import { IntegrationsView, type IntegrationTab } from './IntegrationsView';
 import { InlineModelSwitcher } from './InlineModelSwitcher';
@@ -196,7 +189,6 @@ import { ExtensionsMarketplace } from './PluginsView';
 import type { CreateInput, CreateTab, ImportClaudeDesignOutcome } from './NewProjectPanel';
 import type { PluginLoopSubmit } from './PluginLoopHome';
 import {
-  createProject,
   duplicatePluginAsProject,
   patchProject,
   ProjectCreateError,
@@ -243,7 +235,6 @@ import {
   RAIL_OPEN_STORAGE_KEY,
   readStoredRailOpen,
 } from './entryRailBridge';
-import { enterpriseUrl } from './enterpriseUrl';
 import { resolveByokModelPreference } from './byok/validation';
 import onboardingSourceStyles from './OnboardingModelSource.module.css';
 
@@ -286,13 +277,6 @@ type OnboardingAgentTestState =
 // `specs/current/plugin-driven-flow-plan.md`.
 const ONBOARDING_BYOK_AUTO_FETCH_DELAY_MS = 300;
 const ONBOARDING_BYOK_AUTO_TEST_DELAY_MS = 500;
-
-const ONBOARDING_AMR_MODEL_OPTIONS: NonNullable<AgentInfo['models']> = [
-  { id: 'claude-opus-4.8', label: 'Claude Opus 4.8' },
-  { id: 'deepseek-v4-flash', label: 'DeepSeek V4 Flash' },
-  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
-  { id: 'glm-5.1', label: 'GLM 5.1' },
-];
 
 type EntryCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   metadata?: CreateInput['metadata'];
@@ -587,7 +571,6 @@ export function EntryShell({
   onSkillsChanged,
   onRefreshAgents,
   onCreateProject,
-  onCreatePluginShareProject,
   onImportClaudeDesign,
   onImportFolder,
   onImportFolderResponse,
@@ -3788,105 +3771,6 @@ function OnboardingCliSetupPanel({
   );
 }
 
-function OnboardingAmrModelSelect({
-  models,
-  modelsSource,
-  selectedModel,
-  onSelectModel,
-}: {
-  models: NonNullable<AgentInfo['models']>;
-  modelsSource: AgentInfo['modelsSource'];
-  selectedModel: string;
-  onSelectModel: (model: string) => void;
-}) {
-  const t = useT();
-  const modelSource = modelsSource ?? 'fallback';
-  const displayModels = models.map((model) => {
-    const capability = onboardingModelCapabilityLabel(t, model);
-    const cost = onboardingModelCostLabel(t, model);
-    return {
-      value: model.id,
-      label: formatOnboardingAmrModelLabel(model),
-      tag: capability?.label,
-      tagKind: capability?.kind,
-      meta: cost?.label,
-    };
-  });
-  const modelSourceLabel = t('settings.onboardingAmrModelSourceLabel');
-  return (
-    <div
-      className="onboarding-view__model-picker"
-      onClick={(event) => event.stopPropagation()}
-    >
-      <OnboardingDropdown
-        label={`${t('settings.modelPicker')} · ${modelSourceLabel}`}
-        placeholder={t('settings.modelSourceFallback')}
-        value={selectedModel}
-        options={displayModels}
-        onChange={onSelectModel}
-        searchable
-        searchPlaceholder={t('newproj.modelSearch')}
-        sourceTone={modelSource}
-      />
-    </div>
-  );
-}
-
-function formatOnboardingAmrModelLabel(
-  model: NonNullable<AgentInfo['models']>[number],
-): string {
-  const label = model.label?.trim();
-  if (label && label !== model.id && !/^[a-z0-9._-]+$/.test(label)) {
-    return label;
-  }
-  return model.id
-    .split('-')
-    .filter(Boolean)
-    .map(formatModelToken)
-    .join(' ');
-}
-
-function formatModelToken(token: string): string {
-  const lower = token.toLowerCase();
-  const known: Record<string, string> = {
-    claude: 'Claude',
-    opus: 'Opus',
-    sonnet: 'Sonnet',
-    haiku: 'Haiku',
-    deepseek: 'DeepSeek',
-    gemini: 'Gemini',
-    glm: 'GLM',
-    gpt: 'GPT',
-    oss: 'OSS',
-    kimi: 'Kimi',
-    minimax: 'MiniMax',
-    mimo: 'MiMo',
-    qwen3: 'Qwen3',
-    seed: 'Seed',
-  };
-  if (known[lower]) return known[lower];
-  if (/^v\d/i.test(token)) return token.toUpperCase();
-  if (/^\d+b$/i.test(token) || /^a\d+b$/i.test(token)) return token.toUpperCase();
-  if (/^\d+(\.\d+)*$/.test(token)) return token;
-  return token.charAt(0).toUpperCase() + token.slice(1);
-}
-
-function onboardingModelCapabilityLabel(
-  t: ReturnType<typeof useT>,
-  model: Pick<NonNullable<AgentInfo['models']>[number], 'id' | 'metadata'>,
-): { label: string; kind: ModelCapabilityTag } | undefined {
-  const tag = getModelCapabilityTag(model);
-  return tag ? { label: t(MODEL_CAPABILITY_TAG_LABEL_KEYS[tag]), kind: tag } : undefined;
-}
-
-function onboardingModelCostLabel(
-  t: ReturnType<typeof useT>,
-  model: Pick<NonNullable<AgentInfo['models']>[number], 'id' | 'metadata'>,
-): { label: string } | undefined {
-  const tier = getModelCostTier(model);
-  return tier ? { label: t(MODEL_COST_TIER_LABEL_KEYS[tier]) } : undefined;
-}
-
 function OnboardingByokSetupPanel({
   apiProtocol,
   apiKey,
@@ -4545,212 +4429,6 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
             ) : null}
           </div>
         </div>
-      ) : null}
-    </div>
-  );
-}
-
-// Placeholder for the AMR cloud card shown while AMR availability is still
-// being probed (the cold-start detection stream / one-shot re-probe). It
-// mirrors the real card's footprint exactly — same featured/amr grid, same
-// 246px min-height — so resolving to the real card causes no layout jump.
-// The AMR brand (icon + name) is known up-front and rendered solid; only the
-// version meta, benefit list, and model picker — the parts that depend on the
-// probe result — shimmer. Non-interactive and announced via role="status".
-function OnboardingAmrCloudSkeleton() {
-  const t = useT();
-  return (
-    <div className="onboarding-view__amr-cloud-card">
-      <div
-        className="onboarding-view__card onboarding-view__card--featured onboarding-view__card--amr onboarding-view__card--benefit-aside onboarding-view__card--skeleton"
-        role="status"
-        aria-busy="true"
-        aria-label={t('common.loading')}
-      >
-        <span className="onboarding-view__identity">
-          <span className="onboarding-view__icon onboarding-view__icon--asset">
-            <AgentIcon id="amr" size={52} className="onboarding-view__agent-logo" />
-          </span>
-          <span className="onboarding-view__card-copy">
-            <span className="onboarding-view__card-top">
-              <strong>{t('settings.amrCloud')}</strong>
-            </span>
-            <span className="onboarding-view__skeleton-line onboarding-view__skeleton-line--meta" />
-          </span>
-        </span>
-        <span className="onboarding-view__benefit-aside" aria-hidden="true">
-          <span className="onboarding-view__benefit-stack onboarding-view__benefit-stack--skeleton">
-            <span className="onboarding-view__skeleton-line onboarding-view__skeleton-line--benefit" />
-            <span className="onboarding-view__skeleton-line onboarding-view__skeleton-line--benefit" />
-            <span className="onboarding-view__skeleton-line onboarding-view__skeleton-line--benefit" />
-            <span className="onboarding-view__skeleton-line onboarding-view__skeleton-line--benefit" />
-          </span>
-        </span>
-        <span className="onboarding-view__card-model" aria-hidden="true">
-          <span className="onboarding-view__skeleton-model">
-            <span className="onboarding-view__skeleton-model-label" />
-            <span className="onboarding-view__skeleton-model-bar" />
-          </span>
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function OnboardingChoiceCard({
-  icon,
-  agentIconId,
-  title,
-  body,
-  benefits,
-  upcomingLabel,
-  upcomingBenefits,
-  benefitPlacement = 'copy',
-  metaLabel,
-  modelSlot,
-  actionLabel,
-  selected,
-  badge,
-  statusSlot,
-  featured,
-  variant,
-  onClick,
-}: {
-  icon: 'orbit' | 'hammer' | 'sliders' | 'github' | 'upload' | 'sparkles';
-  agentIconId?: string;
-  title: string;
-  body: string;
-  benefits?: string[];
-  upcomingLabel?: string;
-  upcomingBenefits?: string[];
-  benefitPlacement?: 'copy' | 'aside';
-  metaLabel?: string;
-  modelSlot?: ReactNode;
-  actionLabel?: string;
-  selected: boolean;
-  badge?: string;
-  statusSlot?: ReactNode;
-  featured?: boolean;
-  variant?: 'amr';
-  onClick: () => void;
-}) {
-  function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
-    if (event.target !== event.currentTarget) return;
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    event.preventDefault();
-    onClick();
-  }
-
-  const hasBenefits =
-    (benefits && benefits.length > 0) ||
-    (upcomingBenefits && upcomingBenefits.length > 0);
-  const benefitStack = hasBenefits ? (
-    <span className="onboarding-view__benefit-stack">
-      {benefits && benefits.length > 0 ? (
-        <span className="onboarding-view__benefits">
-          {benefits.map((item, index) => (
-            <span
-              key={item}
-              className={`onboarding-view__benefit${
-                index >= 2 ? ' onboarding-view__benefit--hero' : ''
-              }`}
-            >
-              {item}
-            </span>
-          ))}
-        </span>
-      ) : null}
-      {upcomingBenefits && upcomingBenefits.length > 0 ? (
-        <span className="onboarding-view__upcoming-benefits">
-          {upcomingLabel ? (
-            <span className="onboarding-view__upcoming-label">{upcomingLabel}</span>
-          ) : null}
-          {upcomingBenefits.map((item) => (
-            <span key={item} className="onboarding-view__benefit onboarding-view__benefit--upcoming">
-              {item}
-            </span>
-          ))}
-        </span>
-      ) : null}
-    </span>
-  ) : null;
-  const modelUnderLogo = variant === 'amr' && modelSlot;
-  const iconNode = (
-    <span
-      className={
-        'onboarding-view__icon' +
-        (agentIconId ? ' onboarding-view__icon--asset' : '')
-      }
-    >
-      {agentIconId ? (
-        <AgentIcon
-          id={agentIconId}
-          size={featured ? 52 : 40}
-          className="onboarding-view__agent-logo"
-        />
-      ) : (
-        <Icon name={icon} size={18} />
-      )}
-    </span>
-  );
-  const copyNode = (
-    <span className="onboarding-view__card-copy">
-      <span className="onboarding-view__card-top">
-        <strong>{title}</strong>
-        {badge ? <span className="onboarding-view__badge">{badge}</span> : null}
-      </span>
-      {metaLabel ? <span className="onboarding-view__card-meta">{metaLabel}</span> : null}
-      {modelUnderLogo ? null : modelSlot}
-      {benefitPlacement === 'copy' && benefitStack ? (
-        benefitStack
-      ) : !modelSlot ? (
-        <small>{body}</small>
-      ) : null}
-    </span>
-  );
-
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      className={`onboarding-view__card${selected ? ' is-selected' : ''}${
-        featured ? ' onboarding-view__card--featured' : ''
-      }${variant ? ` onboarding-view__card--${variant}` : ''}${
-        benefitPlacement === 'aside' ? ' onboarding-view__card--benefit-aside' : ''
-      }`}
-      onClick={onClick}
-      onKeyDown={handleKeyDown}
-      aria-pressed={selected}
-    >
-      {variant === 'amr' ? (
-        <span className="onboarding-view__identity">
-          {iconNode}
-          {copyNode}
-        </span>
-      ) : (
-        <>
-          {iconNode}
-          {copyNode}
-        </>
-      )}
-      {modelUnderLogo ? (
-        <span className="onboarding-view__card-model">
-          {modelSlot}
-        </span>
-      ) : null}
-      {benefitPlacement === 'aside' && benefitStack ? (
-        <span className="onboarding-view__benefit-aside">{benefitStack}</span>
-      ) : null}
-      {statusSlot ? (
-        <span className="onboarding-view__card-status">
-          {statusSlot}
-        </span>
-      ) : null}
-      {actionLabel ? <span className="onboarding-view__card-action">{actionLabel}</span> : null}
-      {selected ? (
-        <span className="onboarding-view__check">
-          <Icon name="check" size={14} />
-        </span>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2250,13 +2250,14 @@ function OnboardingView({
       : { status: 'idle' as const };
   const canTestAgent = Boolean(selectedAgent) && daemonLive;
   const runtimeSetupStep = step === 2;
-  const byokConnectionVerified =
-    visibleProviderTestState.status === 'done' && visibleProviderTestState.result.ok;
-  const localConnectionVerified =
-    visibleAgentTestState.status === 'done' && visibleAgentTestState.result.ok;
+  const localRuntimeConfigured = selectedAgent?.available === true;
+  const byokRuntimeConfigured = canTestProvider;
   const connectStepRuntimeReady =
-    (runtime === 'local' && selectedAgent !== null && localConnectionVerified) ||
-    (runtime === 'byok' && byokConnectionVerified);
+    (runtime === 'local' && localRuntimeConfigured) ||
+    (runtime === 'byok' && byokRuntimeConfigured);
+  const connectStepTestRunning =
+    (runtime === 'local' && visibleAgentTestState.status === 'running') ||
+    (runtime === 'byok' && visibleProviderTestState.status === 'running');
   const connectStepBlocked = runtimeSetupStep && !connectStepRuntimeReady;
   const connectGateReason: 'no_runtime' | 'local_agent_unavailable' | 'byok_unverified' | null =
     !runtimeSetupStep
@@ -2725,8 +2726,13 @@ function OnboardingView({
     setStep(2);
   }
   async function handlePrimaryAction() {
-    if (connectStepBlocked) return;
+    if (connectStepBlocked || connectStepTestRunning) return;
     if (runtime === 'local' && selectedAgent) {
+      const testResult =
+        visibleAgentTestState.status === 'done' && visibleAgentTestState.result.ok
+          ? visibleAgentTestState.result
+          : await testAgentInline();
+      if (!testResult?.ok) return;
       await onConfigPersist({
         ...config,
         mode: 'daemon',
@@ -2737,6 +2743,11 @@ function OnboardingView({
       return;
     }
     if (runtime === 'byok') {
+      const testResult =
+        visibleProviderTestState.status === 'done' && visibleProviderTestState.result.ok
+          ? visibleProviderTestState.result
+          : await testProviderInline();
+      if (!testResult?.ok) return;
       await onConfigPersist({ ...config, mode: 'api' });
       emitOnboardingClick('continue', 'continue', { runtime_type: 'byok' });
       completeStreamlinedOnboarding('byok');
@@ -3076,8 +3087,8 @@ function OnboardingView({
     }
   }
 
-  async function testProviderInline() {
-    if (!canTestProvider || providerTestState.status === 'running') return;
+  async function testProviderInline(): Promise<ConnectionTestResponse | null> {
+    if (!canTestProvider || providerTestState.status === 'running') return null;
     const inputKey = providerTestInputKey;
     providerAutoTestKeyRef.current = inputKey;
     setProviderTestState({ status: 'running', inputKey });
@@ -3093,23 +3104,22 @@ function OnboardingView({
             : undefined,
       });
       setProviderTestState({ status: 'done', inputKey, result });
+      return result;
     } catch (error) {
-      setProviderTestState({
-        status: 'done',
-        inputKey,
-        result: {
-          ok: false,
-          kind: 'unknown',
-          latencyMs: 0,
-          model: config.model,
-          detail: error instanceof Error ? error.message : 'Test request failed',
-        },
-      });
+      const result: ConnectionTestResponse = {
+        ok: false,
+        kind: 'unknown',
+        latencyMs: 0,
+        model: config.model,
+        detail: error instanceof Error ? error.message : 'Test request failed',
+      };
+      setProviderTestState({ status: 'done', inputKey, result });
+      return result;
     }
   }
 
-  async function testAgentInline() {
-    if (!selectedAgent || !canTestAgent || agentTestState.status === 'running') return;
+  async function testAgentInline(): Promise<ConnectionTestResponse | null> {
+    if (!selectedAgent || !canTestAgent || agentTestState.status === 'running') return null;
     const inputKey = agentTestInputKey;
     const agent = selectedAgent;
     const model = selectedAgentTestModel;
@@ -3123,19 +3133,18 @@ function OnboardingView({
         agentCliEnv: config.agentCliEnv ?? {},
       });
       setAgentTestState({ status: 'done', inputKey, result });
+      return result;
     } catch (error) {
-      setAgentTestState({
-        status: 'done',
-        inputKey,
-        result: {
-          ok: false,
-          kind: 'unknown',
-          latencyMs: 0,
-          model: model || 'default',
-          agentName: agent.name,
-          detail: error instanceof Error ? error.message : 'Test request failed',
-        },
-      });
+      const result: ConnectionTestResponse = {
+        ok: false,
+        kind: 'unknown',
+        latencyMs: 0,
+        model: model || 'default',
+        agentName: agent.name,
+        detail: error instanceof Error ? error.message : 'Test request failed',
+      };
+      setAgentTestState({ status: 'done', inputKey, result });
+      return result;
     }
   }
 
@@ -3620,7 +3629,7 @@ function OnboardingView({
               type="button"
               className={`onboarding-view__primary${connectGateTooltip ? ' od-tooltip' : ''}`}
               onClick={handlePrimaryAction}
-              disabled={amrLoginPending || amrLoginCancelPending}
+              disabled={amrLoginPending || amrLoginCancelPending || connectStepTestRunning}
               aria-disabled={connectStepBlocked || undefined}
               data-tooltip={connectGateTooltip ?? undefined}
               data-tooltip-placement="top"

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2242,6 +2242,22 @@ function OnboardingView({
     (runtime === 'local' && visibleAgentTestState.status === 'running') ||
     (runtime === 'byok' && visibleProviderTestState.status === 'running');
   const connectStepBlocked = runtimeSetupStep && !connectStepRuntimeReady;
+  // What the user is looking at RIGHT NOW. `handlePrimaryAction` awaits a
+  // validation round trip before it persists anything, and its closure is
+  // frozen at click time — so the continuation cannot ask this question of its
+  // own variables. See `continueAttemptStillCurrent`.
+  const onboardingIntentRef = useRef({
+    step,
+    runtime,
+    agentTestInputKey,
+    providerTestInputKey,
+  });
+  onboardingIntentRef.current = {
+    step,
+    runtime,
+    agentTestInputKey,
+    providerTestInputKey,
+  };
   const connectGateReason: 'no_runtime' | 'local_agent_unavailable' | 'byok_unverified' | null =
     !runtimeSetupStep
       ? null
@@ -2708,14 +2724,42 @@ function OnboardingView({
     setRuntime('byok');
     setStep(2);
   }
+  /**
+   * Whether the Continue attempt that started against `startedInputKey` still
+   * describes what the user is looking at.
+   *
+   * A validation round trip can outlive the intent that started it: Back stays
+   * enabled while the test is in flight, and the inputs being validated stay
+   * editable. Persisting a late result regardless would write a configuration
+   * the user already walked away from and finish onboarding under them — so
+   * the attempt must still be on the runtime setup step, on the same runtime,
+   * and against the same inputs it validated.
+   *
+   * `inputKey` already guards what gets DISPLAYED (`visibleAgentTestState` /
+   * `visibleProviderTestState` fall back to idle once it drifts); this applies
+   * the same rule to what gets PERSISTED.
+   */
+  function continueAttemptStillCurrent(
+    startedRuntime: 'local' | 'byok',
+    startedInputKey: string,
+  ): boolean {
+    const now = onboardingIntentRef.current;
+    if (now.step !== 2 || now.runtime !== startedRuntime) return false;
+    return startedRuntime === 'local'
+      ? now.agentTestInputKey === startedInputKey
+      : now.providerTestInputKey === startedInputKey;
+  }
+
   async function handlePrimaryAction() {
     if (connectStepBlocked || connectStepTestRunning) return;
     if (runtime === 'local' && selectedAgent) {
+      const startedInputKey = agentTestInputKey;
       const testResult =
         visibleAgentTestState.status === 'done' && visibleAgentTestState.result.ok
           ? visibleAgentTestState.result
           : await testAgentInline();
       if (!testResult?.ok) return;
+      if (!continueAttemptStillCurrent('local', startedInputKey)) return;
       await onConfigPersist({
         ...config,
         mode: 'daemon',
@@ -2726,11 +2770,13 @@ function OnboardingView({
       return;
     }
     if (runtime === 'byok') {
+      const startedInputKey = providerTestInputKey;
       const testResult =
         visibleProviderTestState.status === 'done' && visibleProviderTestState.result.ok
           ? visibleProviderTestState.result
           : await testProviderInline();
       if (!testResult?.ok) return;
+      if (!continueAttemptStillCurrent('byok', startedInputKey)) return;
       await onConfigPersist({ ...config, mode: 'api' });
       emitOnboardingClick('continue', 'continue', { runtime_type: 'byok' });
       completeStreamlinedOnboarding('byok');

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -873,8 +873,9 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
     expect(props.onAgentChange).not.toHaveBeenCalled();
   });
 
-  it('requires a successful Local Agent test before persisting and completing setup', async () => {
-    globalThis.fetch = vi.fn(async (input, init) => {
+  it('tests Local Agent on Continue, stays on failure, and retries on the next click', async () => {
+    let testCalls = 0;
+    const fetchMock = vi.fn(async (input, init) => {
       const url = String(input);
       if (url.endsWith('/api/integrations/vela/status')) {
         return jsonResponse({
@@ -885,17 +886,28 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
         });
       }
       if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
-        return jsonResponse({
-          ok: true,
-          kind: 'success',
-          latencyMs: 12,
-          model: 'sonnet',
-          sample: 'pong',
-          agentName: 'Claude Code',
-        });
+        testCalls += 1;
+        return testCalls === 1
+          ? jsonResponse({
+              ok: false,
+              kind: 'agent_spawn_failed',
+              latencyMs: 12,
+              model: 'sonnet',
+              agentName: 'Claude Code',
+              detail: 'process exited before responding',
+            })
+          : jsonResponse({
+              ok: true,
+              kind: 'success',
+              latencyMs: 12,
+              model: 'sonnet',
+              sample: 'pong',
+              agentName: 'Claude Code',
+            });
       }
       throw new Error(`unexpected fetch: ${url}`);
-    }) as typeof fetch;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
     const props = renderOnboarding({
       config: baseConfig({
         agentId: 'claude-code',
@@ -903,46 +915,27 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
       }),
     });
 
-    fireEvent.click(
-      await screen.findByRole('button', { name: /Continue \(signed in\)/i }),
-    );
-    fireEvent.click(await screen.findByRole('radio', { name: /Local Agent/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
-
-    expect(await screen.findByRole('heading', { name: 'Local Agent' })).toBeTruthy();
+    await openLocalRuntimeSetup();
     const continueButton = screen.getByRole('button', { name: /^Continue$/i });
-    expect(continueButton.getAttribute('aria-disabled')).toBe('true');
-    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }));
-    expect(await screen.findByText(/Claude Code replied in 12 ms/i)).toBeTruthy();
     expect(continueButton.getAttribute('aria-disabled')).toBeNull();
-    fireEvent.click(continueButton);
 
+    fireEvent.click(continueButton);
+    expect(await screen.findByText(/Could not start Claude Code/i)).toBeTruthy();
+    expect(props.onCompleteOnboarding).not.toHaveBeenCalled();
+
+    fireEvent.click(continueButton);
     await waitFor(() => {
+      expect(testCalls).toBe(2);
       expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
     });
     expect(props.onConfigPersist).toHaveBeenCalledWith(
       expect.objectContaining({ mode: 'daemon', agentId: 'claude-code' }),
     );
-    expect(
-      findTrackedEvent<Record<string, unknown>>(
-        'ui_click',
-        (payload) => payload.element === 'local_coding_agent',
-      ),
-    ).toMatchObject({
-      area: 'model_source',
-      step_name: 'model_source',
-      runtime_type: 'local_cli',
-    });
     expect(latestTrackedEvent('onboarding_complete_result')).toMatchObject({
       result: 'completed',
       exit_step_name: 'runtime_setup',
       runtime_type: 'local_cli',
     });
-    expect(
-      trackedEvents('page_view').filter(([, payload]) =>
-        (payload as Record<string, unknown>).area === 'runtime_setup',
-      ),
-    ).toHaveLength(1);
   });
 
   it('does not auto-select OpenDesign AMR when the AMR runtime is unavailable', async () => {
@@ -1575,6 +1568,72 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
       expect(props.onApiModelChange).toHaveBeenCalledWith('claude-sonnet-4-5');
     });
     expect(props.onApiModelChange).not.toHaveBeenCalledWith('upstream-first');
+  });
+
+  it('tests BYOK on Continue, stays on rate limit, and retries on the next click', async () => {
+    let testCalls = 0;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({
+          loggedIn: true,
+          profile: 'prod',
+          configPath: '/x',
+          user: { id: 'u', email: 'user@example.com' },
+        });
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [{ id: 'gpt-test', label: 'GPT Test' }],
+        });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        testCalls += 1;
+        return testCalls === 1
+          ? jsonResponse({
+              ok: false,
+              kind: 'rate_limited',
+              latencyMs: 12,
+              model: 'gpt-test',
+              status: 429,
+            })
+          : jsonResponse({
+              ok: true,
+              kind: 'success',
+              latencyMs: 12,
+              model: 'gpt-test',
+              sample: 'Connected',
+            });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding({
+      config: baseConfig({
+        mode: 'api',
+        apiProtocol: 'openai',
+        apiKey: 'test-api-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-test',
+        apiProviderBaseUrl: 'https://api.openai.com/v1',
+      }),
+    });
+
+    await openByokRuntimeSetup();
+    const continueButton = screen.getByRole('button', { name: /^Continue$/i });
+    expect(continueButton.getAttribute('aria-disabled')).toBeNull();
+
+    fireEvent.click(continueButton);
+    expect(await screen.findByText(/rate-limited the test/i)).toBeTruthy();
+    expect(props.onCompleteOnboarding).not.toHaveBeenCalled();
+
+    fireEvent.click(continueButton);
+    await waitFor(() => {
+      expect(testCalls).toBe(2);
+      expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('persists the BYOK config before finishing onboarding', async () => {

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -938,6 +938,65 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
     });
   });
 
+  it('drops a Local Agent validation that lands after the user goes Back', async () => {
+    // Continue awaits a network round trip before it persists. Back stays
+    // enabled through that wait, so a late success must not resurrect the
+    // configuration the user just walked away from.
+    let releaseTest: ((value: Response) => void) | undefined;
+    let testCalls = 0;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({
+          loggedIn: true,
+          profile: 'prod',
+          configPath: '/x',
+          user: { id: 'u', email: 'user@example.com' },
+        });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        testCalls += 1;
+        return new Promise<Response>((resolve) => {
+          releaseTest = resolve;
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding({
+      config: baseConfig({
+        agentId: 'claude-code',
+        agentModels: { 'claude-code': { model: 'sonnet' } },
+      }),
+    });
+
+    await openLocalRuntimeSetup();
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+    await waitFor(() => {
+      expect(testCalls).toBe(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Back$/i }));
+    expect(await screen.findByRole('radio', { name: /Local Agent/i })).toBeTruthy();
+
+    await act(async () => {
+      releaseTest?.(
+        jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'sonnet',
+          sample: 'pong',
+          agentName: 'Claude Code',
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(props.onConfigPersist).not.toHaveBeenCalled();
+    expect(props.onCompleteOnboarding).not.toHaveBeenCalled();
+    expect(screen.getByRole('radio', { name: /Local Agent/i })).toBeTruthy();
+  });
+
   it('does not auto-select OpenDesign AMR when the AMR runtime is unavailable', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),
@@ -1634,6 +1693,75 @@ describe('EntryShell onboarding OpenDesign AMR runtime', () => {
       expect(testCalls).toBe(2);
       expect(props.onCompleteOnboarding).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('drops a BYOK validation that lands after its inputs changed', async () => {
+    // The inputs stay editable while the test is in flight. A success for the
+    // key the user has already replaced must not complete onboarding.
+    let releaseTest: ((value: Response) => void) | undefined;
+    let testCalls = 0;
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({
+          loggedIn: true,
+          profile: 'prod',
+          configPath: '/x',
+          user: { id: 'u', email: 'user@example.com' },
+        });
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [{ id: 'gpt-test', label: 'GPT Test' }],
+        });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        testCalls += 1;
+        return new Promise<Response>((resolve) => {
+          releaseTest = resolve;
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding({
+      config: baseConfig({
+        mode: 'api',
+        apiProtocol: 'openai',
+        apiKey: 'test-api-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-test',
+        apiProviderBaseUrl: 'https://api.openai.com/v1',
+      }),
+    });
+
+    await openByokRuntimeSetup();
+    fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+    await waitFor(() => {
+      expect(testCalls).toBe(1);
+    });
+
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'rotated-api-key' },
+    });
+
+    await act(async () => {
+      releaseTest?.(
+        jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 12,
+          model: 'gpt-test',
+          sample: 'Connected',
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(props.onCompleteOnboarding).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Bring Your Own Key' })).toBeTruthy();
   });
 
   it('persists the BYOK config before finishing onboarding', async () => {

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -135,7 +135,7 @@ test('[P0] @critical onboarding Local CLI card lets the user pick an agent model
   await selectOnboardingOption(localPanel, 'Model', 'GLM 5');
 
   await expect(expectOnboardingTrigger(localPanel, 'Model')).toContainText('GLM 5');
-  await expect(page.getByRole('button', { name: /^Continue$/i })).toHaveAttribute(
+  await expect(page.getByRole('button', { name: /^Continue$/i })).not.toHaveAttribute(
     'aria-disabled',
     'true',
   );
@@ -634,7 +634,7 @@ test('[P0] @critical onboarding BYOK path can fetch models, test the provider, a
   });
 });
 
-test('[P0] onboarding BYOK path cannot continue before a successful connection test', async ({ page }) => {
+test('[P0] onboarding BYOK Continue tests the configuration and retries after failure', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
     initialLoggedIn: true,
@@ -679,24 +679,23 @@ test('[P0] onboarding BYOK path cannot continue before a successful connection t
 
   const continueButton = page.getByRole('button', { name: /^Continue$/i });
   await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
-  await expect(page.getByRole('heading', { name: /Bring your own key|自己的模型 Key/i })).toBeVisible();
 
   await fillInlineField(page, 'API key', 'bad-api-key');
   await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
   await page.getByRole('button', { name: /Fetch models/i }).click();
   await expect(page.getByText(/Fetched 1 model/)).toBeVisible();
   await selectOnboardingOption(byokPanel, 'Model', 'Claude Sonnet 4.5');
-  await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
 
-  await page.getByRole('button', { name: /^Test$/i }).click();
+  await continueButton.click();
   await expect(page.getByText(/Invalid API key|Connection failed|failed/i)).toBeVisible();
-  await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(page.getByRole('heading', { name: /Bring your own key|自己的模型 Key/i })).toBeVisible();
+  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
 
   connectionOk = true;
   await fillInlineField(page, 'API key', 'good-api-key');
-  await page.getByRole('button', { name: /^Test$/i }).click();
-  await expectConnectionSuccess(page);
-  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
+  await continueButton.click();
+  await expectOnboardingFinished(page);
 });
 
 test('[P0] onboarding BYOK path supports Anthropic model selection and API key visibility before completing', async ({ page }) => {
@@ -803,7 +802,8 @@ test('[P0] onboarding BYOK successful test is invalidated when connection settin
 
   await fillInlineField(page, 'API key', 'changed-api-key');
 
-  await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
+  await expect(page.getByText(/Connected\. Replied/i)).toHaveCount(0);
   await expect(page.getByRole('heading', { name: /Bring your own key|自己的模型 Key/i })).toBeVisible();
   await expect(page.getByText(/Optional details for better defaults/i)).toHaveCount(0);
 });
@@ -859,7 +859,8 @@ test('[P0] onboarding BYOK successful test is invalidated when Base URL or model
   await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
 
   await fillInlineField(page, 'Base URL', 'https://api.changed.example');
-  await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
+  await expect(page.getByText(/Connected\. Replied/i)).toHaveCount(0);
 
   await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
   await page.getByRole('button', { name: /^Test$/i }).click();
@@ -867,7 +868,8 @@ test('[P0] onboarding BYOK successful test is invalidated when Base URL or model
   await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
 
   await selectOnboardingOption(byokPanel, 'Model', 'Claude Opus 4.8');
-  await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(continueButton).not.toHaveAttribute('aria-disabled', 'true');
+  await expect(page.getByText(/Connected\. Replied/i)).toHaveCount(0);
   await expect(page.getByRole('heading', { name: /Bring your own key|自己的模型 Key/i })).toBeVisible();
   await expect(page.getByText(/Optional details for better defaults/i)).toHaveCount(0);
 });


### PR DESCRIPTION
## Why

Plane tasks [OPEND-2127](https://plane.powerformer.net/open-design/browse/OPEND-2127) and [OPEND-2130](https://plane.powerformer.net/open-design/browse/OPEND-2130) reported the same activation blocker: users could select a detected Local CLI or fill a BYOK configuration but the onboarding Continue action remained unavailable or appeared unresponsive.

I reproduced both reports while preparing the assigned reliability fixes. The existing gate required a separate successful connection test before Continue became actionable, which hid the required action and left users stuck. Simply bypassing validation would defer invalid credentials, authentication, or CLI startup failures until the first real run, so this change keeps validation mandatory while moving it into the Continue action itself.

## What users will see

- Continue becomes actionable as soon as the selected Local CLI is detected as available, or the BYOK key, base URL, and model are complete.
- Clicking Continue automatically runs the existing connection test.
- While the test runs, Continue is temporarily disabled to prevent duplicate requests.
- A failed or rate-limited test keeps users on the setup page and shows the existing actionable error. Clicking Continue again retries.
- Configuration is persisted and onboarding completes only after a successful test.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

This is a behavior-only change on the existing Local Agent and Bring Your Own Key onboarding screens; there is no layout or copy change. The before state is captured in the OPEND-2127 and OPEND-2130 report screenshots. The packaged arm64 DMG was also installed and inspected locally; the validation capture is `/tmp/open-design-continue-gate-local-cli.png`.

## Bug fix verification

- Test path that reproduces the bugs: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
- Red on `main`: yes — Local Agent completed without invoking the test under the first relaxed implementation, while BYOK remained gated before Continue could initiate/retry validation.
- Green on this branch: yes — both tests now prove the first failed test stays on the setup page and the second Continue click retries and completes only after success.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/EntryShell.onboarding.test.tsx --reporter=dot` — 39 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm tools-pack mac build --namespace continue-gate --to dmg --json`
- `hdiutil verify .tmp/tools-pack/out/mac/namespaces/continue-gate/dmg/Open\ Design-continue-gate.dmg`
- `pnpm tools-pack mac install --namespace continue-gate --json`
- `pnpm tools-pack mac start --namespace continue-gate --json`
- `pnpm tools-pack mac inspect --namespace continue-gate --status-poll-count 10 --status-poll-interval-ms 1000 --json`
- DMG SHA-256: `34facf2d2e0f3cba5a63e62c227ea3de8c24b5547e01d84225bde04e4bd70865`
