### PR TITLE
fix(web): restore About update row spacing and stop the project frame flashing twice

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5103,13 +5103,21 @@ function AppInner() {
           : undefined,
     });
     if (pendingCreation && activeProject) {
+      // Same `div.app` element as the ProjectView branch below, deliberately.
+      // React reconciles one element across the pending -> real hand-off, so
+      // the `.app` entrance animation plays once for the whole transition
+      // instead of restarting when ProjectView takes over (the pending surface
+      // lives ~150ms, shorter than the 180ms animation, so a second mount read
+      // as the project frame flashing twice).
       appMain = (
-        <ProjectCreationPendingView
-          project={activeProject}
-          prompt={pendingCreation.prompt}
-          agentId={config.agentId}
-          onBack={handleBack}
-        />
+        <div className="app">
+          <ProjectCreationPendingView
+            project={activeProject}
+            prompt={pendingCreation.prompt}
+            agentId={config.agentId}
+            onBack={handleBack}
+          />
+        </div>
       );
     } else if (
       routeSurfaceState === 'loading-projects'
@@ -5176,6 +5184,7 @@ function AppInner() {
       );
     } else if (activeProject) {
       appMain = (
+        <div className="app">
         <ProjectView
           key={projectViewAuthorizationLifetimeKey(
             activeProject.id,
@@ -5252,6 +5261,7 @@ function AppInner() {
           onDuplicateProject={handleDuplicateProject}
           onRunActivityChange={handleProjectRunActivityChange}
         />
+        </div>
       );
     }
   } else {

--- a/apps/web/src/components/ProjectCreationPendingView.tsx
+++ b/apps/web/src/components/ProjectCreationPendingView.tsx
@@ -29,9 +29,12 @@ export function ProjectCreationPendingView({
   const agentName = agentDisplayName(agentId) ?? t('assistant.role');
   const iconId = agentIconId(agentId);
 
+  // The `.app` shell belongs to App.tsx, which wraps this view and ProjectView
+  // in the same element so React reconciles one `div.app` across the hand-off
+  // instead of mounting a second one and replaying its entrance animation.
   return (
-    <div className="app" data-testid="project-creation-pending-view">
-      <div className={`split ${styles.split}`}>
+    <>
+      <div className={`split ${styles.split}`} data-testid="project-creation-pending-view">
         <div className="split-chat-slot">
           <div className={`pane ${styles.chatPane}`}>
             <div className="chat-project-header">
@@ -108,6 +111,6 @@ export function ProjectCreationPendingView({
           </div>
         </section>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -11028,9 +11028,14 @@ export function ProjectView({
     </>
   );
 
+  // The `.app` shell belongs to the caller, not to this component. App.tsx
+  // renders the same `div.app` around both this view and
+  // ProjectCreationPendingView so React reconciles one element across the
+  // hand-off. Owning the shell here would make each view mount its own
+  // element and replay the `.app` entrance animation, which reads as the
+  // project frame flashing twice on the way in from Home.
   return (
     <CollabProvider value={collabValue}>
-    <div className="app">
       <CritiqueTheaterMount
         projectId={project.id}
         enabled={critiqueTheaterEnabled}
@@ -11559,7 +11564,6 @@ export function ProjectView({
           />
         ) : null}
       </AnimatePresence>
-    </div>
     </CollabProvider>
   );
 }

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -291,6 +291,19 @@
 .settings-about-version-row {
   justify-content: space-between;
 }
+/* The update action and "View release notes" are adjacent JSX siblings, so no
+   whitespace text node separates them — without an explicit row the two
+   inline-flex buttons render with their borders touching at 0px. The
+   container owns their spacing; `flex-shrink: 0` keeps the buttons off the
+   version copy when a long status string competes for the row. */
+.settings-about-update-actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
 .settings-about-list dt {
   font-size: 12px;
   color: var(--text-muted);

--- a/e2e/ui/settings-about-update-actions-gap.test.ts
+++ b/e2e/ui/settings-about-update-actions-gap.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@/playwright/suite';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+import { openSettingsDialog, settingsSurface } from '../lib/playwright/amr.js';
+import type { Page } from '@playwright/test';
+
+// Regression boundary for the Settings > About update row.
+//
+// `.settings-about-update-actions` holds two sibling buttons — the primary
+// update action and "View release notes". JSX emits no whitespace text node
+// between adjacent elements, so the row's spacing has to come from the
+// container. #6142 (workspace-team + the #5517 redesign) dropped the whole
+// `.settings-about-update-actions` / `.settings-about-update-button` /
+// `.settings-about-release-link` rule group while keeping the class names in
+// SettingsDialog.tsx, which left the container at `display: block` with no
+// gap. The two inline-flex buttons then rendered with their borders touching
+// at exactly 0px — the spacing QA reported against 0.20.0-prerelease.13.
+//
+// The row must read as two separate controls, so we assert both the declared
+// gap (the 8px the settings surface uses everywhere else) and the distance the
+// buttons actually end up at. The measured value is checked against a looser
+// floor than 8 because sub-pixel button widths round the edge-to-edge distance
+// down slightly (7.84px was observed at 8px gap); the point of the measurement
+// is that the borders are not touching, which the declared gap alone would not
+// prove if a later rule re-flowed the row.
+const DECLARED_BUTTON_GAP = '8px';
+const MIN_MEASURED_GAP_PX = 6;
+
+/**
+ * Stub the packaged-desktop host bridge with a fully downloaded update, and
+ * report the app as packaged. Both are required for the About row to render
+ * its primary action next to the release-notes link: `deriveAboutUpdateControl`
+ * returns a null primary action for a development build or a non-desktop
+ * environment, which would leave the row with a single button and hide the
+ * spacing defect entirely.
+ */
+async function stubPackagedDesktopWithReadyUpdate(page: Page) {
+  await page.route('**/api/version', async (route) => {
+    await route.fulfill({
+      json: {
+        version: {
+          version: '0.20.0-prerelease.13',
+          channel: 'prerelease',
+          packaged: true,
+          platform: 'darwin',
+          arch: 'arm64',
+        },
+      },
+    });
+  });
+
+  await page.addInitScript(() => {
+    const downloadedStatus = {
+      arch: 'arm64',
+      availableVersion: '0.20.1-prerelease.3',
+      capabilities: {
+        canApplyInPlace: true,
+        canDownload: true,
+        canOpenInstaller: true,
+        requiresManualInstall: false,
+      },
+      channel: 'prerelease',
+      currentVersion: '0.20.0-prerelease.13',
+      downloadPath: '/tmp/open-design-update.zip',
+      enabled: true,
+      mode: 'package-launcher',
+      platform: 'darwin',
+      state: 'downloaded',
+      supported: true,
+      updateKind: 'payload',
+    };
+    (window as unknown as { __od__?: unknown }).__od__ = {
+      version: 2,
+      client: { type: 'desktop', platform: 'darwin', osLocale: 'en-US' },
+      browser: { clearData: async () => ({ ok: true }) },
+      capture: { page: async () => ({ ok: false, reason: 'not mocked' }) },
+      pdf: { print: async () => ({ ok: true }) },
+      pet: { setVisible: () => {} },
+      project: {
+        pickAndImport: async () => ({ ok: false, canceled: true }),
+        pickAndReplaceWorkingDir: async () => ({ ok: false, canceled: true }),
+      },
+      shell: {
+        openExternal: async () => ({ ok: true }),
+        openPath: async () => ({ ok: true }),
+      },
+      updater: {
+        status: async () => downloadedStatus,
+        check: async () => downloadedStatus,
+        'clear-cache': async () => downloadedStatus,
+        download: async () => downloadedStatus,
+        install: async () => downloadedStatus,
+        quit: async () => ({ ok: true }),
+        setMenuLabels: async () => ({ ok: true }),
+        subscribe: () => () => {},
+        subscribeOpenDialog: () => () => {},
+      },
+    };
+  });
+}
+
+test('[P2] Settings > About keeps the update action and release-notes link visually separated', async ({ page }) => {
+  await applyStandardMocks(page);
+  await stubPackagedDesktopWithReadyUpdate(page);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await openSettingsDialog(page);
+
+  await settingsSurface(page)
+    .locator('.settings-nav-item', { has: page.locator('strong', { hasText: /^(About|关于)$/i }) })
+    .first()
+    .click();
+
+  const actions = page.locator('.settings-about-update-actions');
+  await expect(actions).toBeVisible();
+  // Guard the fixture itself: a single-button row cannot show the defect, so a
+  // regression in the stub must fail loudly instead of passing vacuously.
+  await expect(actions.locator('> button')).toHaveCount(2);
+
+  const layout = await actions.evaluate((el) => {
+    const style = getComputedStyle(el);
+    const [first, second] = [...el.children] as HTMLElement[];
+    if (!first || !second) throw new Error('expected two update action controls');
+    return {
+      display: style.display,
+      columnGap: style.columnGap,
+      gapPx: second.getBoundingClientRect().left - first.getBoundingClientRect().right,
+    };
+  });
+
+  expect(
+    layout.display,
+    'the update actions row must lay its two buttons out as a flex row so the container owns their spacing',
+  ).toBe('flex');
+  expect(
+    layout.columnGap,
+    'the update actions row must declare the settings surface control gap',
+  ).toBe(DECLARED_BUTTON_GAP);
+  expect(
+    layout.gapPx,
+    `update action and release-notes link sit ${layout.gapPx}px apart; their borders collide below ${MIN_MEASURED_GAP_PX}px`,
+  ).toBeGreaterThanOrEqual(MIN_MEASURED_GAP_PX);
+});


### PR DESCRIPTION
## Why

Two visual defects reported against `0.20.0-prerelease.13`, both traced back to
the same class of problem — a component keeps emitting a class name after the
rule behind it was dropped, or two components each claim ownership of the same
shell element.

- **QA** reported that the two buttons in Settings → About sit at the wrong
  distance from each other. Measured in a real browser, the distance is exactly
  **0px** — their borders collide.
- **A maintainer** reported that submitting from Home pauses on a loading state
  and then "flashes twice" on the way into the project view.

Neither is a cosmetic nitpick: the About row makes the primary update action
look like it is fused to the secondary link, and the Home → project flash is on
the single most-travelled path in the product.

## What users will see

- **Settings → About**: when an update is ready, the update action and "View
  release notes" are separated by the same 8px the rest of the settings surface
  uses, instead of sharing a border.
- **Home → project**: submitting a prompt from Home fades the project frame in
  once, continuously. Previously the frame faded in, snapped back to invisible,
  and faded in a second time.

No behavior, wording, or default changes — both are pure rendering fixes.

## Surface area

- [x] **UI** — Settings → About update row, and the Home → project transition in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

> On the UI/CLI dual-track rule: this PR adds no capability, so there is no CLI
> surface to mirror. Both changes fix how existing surfaces render.

## Screenshots

Settings → About, update ready, after the fix — the two buttons are separated:

<!-- Screenshot captured locally during verification; drag it in here.
     Path: scratchpad/shots/about-AFTER-fix.png -->

For the before state, compare against the 0.20.0-prerelease.13 report: the two
buttons render as one fused control with a doubled border down the middle.

The Home → project flash is a timing defect rather than a still frame, so it is
evidenced by the per-frame measurements below rather than a screenshot.

## Bug fix verification

**Settings → About button gap**

- Regression test: `e2e/ui/settings-about-update-actions-gap.test.ts`
- It stubs the packaged-desktop host bridge with a downloaded update so both
  buttons actually render (a development build renders only one, which cannot
  show the defect — the test asserts the two-button count so a stub regression
  fails loudly instead of passing vacuously), then asserts the container is a
  flex row, declares an 8px gap, and that the buttons land at least 6px apart.
- **This spec was not executed locally.** Playwright browsers are deliberately
  not installed on this machine (a previous install filled the disk), so it runs
  in CI only. The red evidence below was taken from a real Chrome instead.

**Home → project double fade**

- No automated spec. The defect is a ~150ms animation-restart during a route
  transition; asserting it needs per-frame `getAnimations()` sampling against a
  live daemon, which neither the jsdom suite nor a Playwright assertion models
  usefully. Verified by instrumented recording in a real browser instead —
  measurements below.

### Red → green, measured in a real Chrome against a local daemon/web runtime

Both were recorded through the real UI (typed prompt, clicked submit), against
an isolated `tools-dev` runtime with its own `OD_DATA_DIR`, using CDP to sample
computed styles and running animations per frame.

About row, `.settings-about-update-actions`:

| | `display` | `column-gap` | measured edge-to-edge |
|---|---|---|---|
| before | `block` | `normal` | **0px** |
| after | `flex` | `8px` | **8px** |

Home → project, sampling the `.app` element identity, its opacity and its
running `od-fade-in` every animation frame from the click onward.

Before — two distinct elements, the entrance restarts from zero:

```
t=260ms   .app #1   pending    opacity 0       od-fade-in@0
t=408ms   .app #2   ProjectView  opacity 0     od-fade-in@0     <- new element, animation restarts
```

After — one element, one continuous entrance:

```
distinctAppElements: 1

t=0ms     click
t=314ms   .app #1   pending=true    opacity 0       od-fade-in@0
t=443ms   .app #1   pending=false   opacity 0.991   od-fade-in@117   <- same element, animation continues
t=3222ms  .app #1   pending=false   opacity 1       od-fade-in@180   <- animation completes once
```

`distinctAppElements: 1` is the load-bearing number: across the whole Home →
project transition only one `.app` element is ever created, so `od-fade-in`
advances monotonically 0 → 117 → 180 and opacity never falls back to zero.

## Root causes

**About row.** `SettingsDialog.tsx` still emits
`.settings-about-update-actions`, `.settings-about-update-button` and
`.settings-about-release-link`, but #6142 (workspace-team + the #5517 redesign)
deleted that entire rule group while keeping the neighbouring
`.settings-about-download-link`. The container fell back to `display: block`,
and because JSX emits no whitespace text node between adjacent elements, the two
`inline-flex` buttons ended up with literally zero space between them. Fixed by
restoring the flex row and its gap.

**Home → project.** `ProjectCreationPendingView` and `ProjectView` each rendered
their own `<div className="app">`, and `.app` carries a 180ms `od-fade-in`
entrance. React therefore mounted a second element at the hand-off and the
entrance restarted from zero. The pending surface only lives ~150ms — shorter
than the animation it starts — so it never finished its first fade before the
second began. Fixed by moving the `.app` shell up to `App.tsx` and rendering it
around both branches, so React reconciles one element across the hand-off.

## Adjacent issues (not fixed here)

Both are out of this PR's scope and want their own change:

1. **`--primary` has no styling.** The same #6142 deletion removed
   `.settings-about-update-button--primary`. The modifier is still applied in
   `SettingsDialog.tsx`, so the primary update action renders with the identical
   background, border colour and radius as the secondary link — users cannot
   tell which is the main action. Restoring emphasis is a visual decision
   (the old rule used a gradient that predates the #5517 button baseline), so it
   needs a design call rather than a guess here.

2. **Home still stalls ~260ms before leaving.** `handleCreateProject` is written
   to hand off immediately — client-owned id, `flushSync`, optimistic route —
   but `POST /api/plugins/<template>/apply-local` runs *before* that and took
   **209ms of the 260ms** against a local daemon; a real user's environment will
   be slower. This is the "pause on loading" half of the report. Moving template
   application after the route change depends on whether the template must be
   materialised before the project frame appears, which is a product call.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/e2e typecheck` — pass
- `pnpm --filter @open-design/web test` — **632 test files, 6684 tests passed**
  (1 expected fail, 11 skipped) — full suite, run after the `.app` ownership
  move since that touches `ProjectView`'s render root
- Real-browser verification of both fixes against a local `tools-dev` runtime,
  per the measurements above
