### PR TITLE
fix(web): make slash picker navigable

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -185,6 +185,7 @@ interface SlashCommand {
   descKey: keyof Dict;
   // Optional argument hint shown after the description.
   argHint?: string;
+  searchTerms?: readonly string[];
   // Icon glyph from the project Icon set.
   icon: 'sparkles' | 'eye' | 'sliders';
 }
@@ -1011,6 +1012,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           descKey: 'pet.slashMcp',
           icon: 'sparkles',
           argHint: s.label || s.transport,
+          searchTerms: [s.id, s.label ?? '', s.transport],
         });
       }
       if (researchAvailable) {
@@ -1030,8 +1032,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       if (!slash) return [] as SlashCommand[];
       const q = slash.q.toLowerCase();
       if (!q) return slashCommands;
-      return slashCommands.filter((c) => c.label.toLowerCase().includes(q));
-    }, [slash, slashCommands]);
+      return slashCommands.filter((command) => [
+        command.label,
+        command.id,
+        command.argHint ?? '',
+        t(command.descKey),
+        ...(command.searchTerms ?? []),
+      ].some((value) => value.toLowerCase().includes(q)));
+    }, [slash, slashCommands, t]);
 
     function pickSlash(cmd: SlashCommand) {
       if (!slash) return;
@@ -2447,22 +2455,29 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     function handlePopoverKey(
       key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
     ): boolean {
-      if (slash && filteredSlash.length > 0) {
-        if (key === 'ArrowDown') {
-          setSlashIndex((i) => (i + 1) % filteredSlash.length);
+      if (slash) {
+        if (filteredSlash.length > 0) {
+          if (key === 'ArrowDown') {
+            setSlashIndex((i) => (i + 1) % filteredSlash.length);
+            return true;
+          }
+          if (key === 'ArrowUp') {
+            setSlashIndex(
+              (i) => (i - 1 + filteredSlash.length) % filteredSlash.length,
+            );
+            return true;
+          }
+          if (key === 'Tab' || key === 'Enter') {
+            const safe = Math.min(slashIndex, filteredSlash.length - 1);
+            pickSlash(filteredSlash[safe]!);
+            return true;
+          }
+        }
+        if (key === 'Enter') {
+          void submit();
           return true;
         }
-        if (key === 'ArrowUp') {
-          setSlashIndex(
-            (i) => (i - 1 + filteredSlash.length) % filteredSlash.length,
-          );
-          return true;
-        }
-        if (key === 'Tab' || key === 'Enter') {
-          const safe = Math.min(slashIndex, filteredSlash.length - 1);
-          pickSlash(filteredSlash[safe]!);
-          return true;
-        }
+        if (key === 'ArrowDown' || key === 'ArrowUp' || key === 'Tab') return true;
         if (key === 'Escape') {
           setSlash(null);
           return true;
@@ -3087,11 +3102,18 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               onTrigger={handleEditorTrigger}
               onEnterSend={() => void submit()}
               onPasteFiles={handlePasteFiles}
-              popoverOpen={Boolean(mention) || Boolean(slash && filteredSlash.length > 0)}
+              popoverOpen={Boolean(mention) || Boolean(slash)}
               onPopoverKey={handlePopoverKey}
               comboboxAria={{
-                expanded: Boolean(mention),
-                activeId: mention ? `mention-opt-${mentionIndex}` : null,
+                expanded: Boolean(mention) || Boolean(slash),
+                controlsId: slash ? 'slash-listbox' : 'mention-listbox',
+                activeId: slash
+                  ? filteredSlash.length > 0
+                    ? `slash-opt-${Math.min(slashIndex, filteredSlash.length - 1)}`
+                    : null
+                  : mention
+                    ? `mention-opt-${mentionIndex}`
+                    : null,
               }}
             />
             {placeholderScenarios.length > 0 ? (
@@ -3133,11 +3155,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           </CaretFloatingLayer>
           <CaretFloatingLayer
             caret={caretRect}
-            open={Boolean(slash && filteredSlash.length > 0)}
+            open={Boolean(slash)}
             boundaryRef={composerRootRef}
           >
             <SlashPopover
               commands={filteredSlash}
+              query={slash?.q ?? ''}
               activeIndex={Math.min(slashIndex, filteredSlash.length - 1)}
               onPick={pickSlash}
               onHover={(i) => setSlashIndex(i)}
@@ -5607,62 +5630,83 @@ function ImportItem({
 
 function SlashPopover({
   commands,
+  query,
   activeIndex,
   onPick,
   onHover,
   t,
 }: {
   commands: SlashCommand[];
+  query: string;
   activeIndex: number;
   onPick: (cmd: SlashCommand) => void;
   onHover: (index: number) => void;
   t: TranslateFn;
 }) {
+  const resultsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (activeIndex < 0) return;
+    resultsRef.current
+      ?.querySelector(`#slash-opt-${activeIndex}`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, commands]);
+
   return (
     <div
       className="slash-popover"
       data-testid="slash-popover"
-      role="listbox"
-      aria-label={t('pet.slashPopoverAria')}
     >
       <div className="slash-popover-head">
         <span>{t('pet.slashPopoverTitle')}</span>
         <span className="slash-popover-hint">{t('pet.slashPopoverHint')}</span>
       </div>
-      {commands.map((cmd, idx) => {
-        const active = idx === activeIndex;
-        return (
-          <button
-            key={cmd.id}
-            id={`slash-opt-${idx}`}
-            type="button"
-            role="option"
-            aria-selected={active}
-            className={`slash-item${active ? ' active' : ''}`}
-            onMouseDown={(e) => {
-              // Prevent the textarea from losing focus before the click
-              // handler fires — otherwise selectionStart resets and the
-              // pick replacement targets the wrong substring.
-              e.preventDefault();
-            }}
-            onMouseEnter={() => onHover(idx)}
-            onClick={() => onPick(cmd)}
-          >
-            <span className="slash-item-icon" aria-hidden>
-              <Icon name={cmd.icon} size={13} />
-            </span>
-            <span className="slash-item-body">
-              <span className="slash-item-row">
-                <code className="slash-item-label">{cmd.label}</code>
-                {cmd.argHint ? (
-                  <span className="slash-item-arg">{cmd.argHint}</span>
-                ) : null}
+      <div
+        ref={resultsRef}
+        id="slash-listbox"
+        className="slash-popover-results"
+        role="listbox"
+        aria-label={t('pet.slashPopoverAria')}
+      >
+        {commands.length === 0 ? (
+          <div className="mention-empty">
+            {t('chat.mentionNoResults', { query })}
+          </div>
+        ) : commands.map((cmd, idx) => {
+          const active = idx === activeIndex;
+          return (
+            <button
+              key={cmd.id}
+              id={`slash-opt-${idx}`}
+              type="button"
+              role="option"
+              aria-selected={active}
+              className={`slash-item${active ? ' active' : ''}`}
+              onMouseDown={(e) => {
+                // Prevent the textarea from losing focus before the click
+                // handler fires — otherwise selectionStart resets and the
+                // pick replacement targets the wrong substring.
+                e.preventDefault();
+              }}
+              onMouseEnter={() => onHover(idx)}
+              onClick={() => onPick(cmd)}
+            >
+              <span className="slash-item-icon" aria-hidden>
+                <Icon name={cmd.icon} size={13} />
               </span>
-              <span className="slash-item-desc">{t(cmd.descKey)}</span>
-            </span>
-          </button>
-        );
-      })}
+              <span className="slash-item-body">
+                <span className="slash-item-row">
+                  <code className="slash-item-label">{cmd.label}</code>
+                  {cmd.argHint ? (
+                    <span className="slash-item-arg">{cmd.argHint}</span>
+                  ) : null}
+                </span>
+                <span className="slash-item-desc">{t(cmd.descKey)}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -165,7 +165,7 @@ export interface LexicalComposerInputProps {
   ): boolean;
   // Optional combobox a11y. When set, the ContentEditable announces the active
   // mention row (id lives in the portaled listbox) without moving DOM focus.
-  comboboxAria?: { activeId: string | null; expanded: boolean };
+  comboboxAria?: { activeId: string | null; controlsId?: string; expanded: boolean };
   // Read-only mode (team-shared project viewer). Makes the Lexical editor
   // non-editable so the caret/typing is blocked, applies a muted read-only
   // visual state, and hard-stops Enter from firing a send (belt-and-suspenders
@@ -819,7 +819,7 @@ export const LexicalComposerInput = forwardRef<
               title={title ?? placeholder}
               role="combobox"
               aria-expanded={comboboxAria?.expanded ? 'true' : 'false'}
-              aria-controls="mention-listbox"
+              aria-controls={comboboxAria?.controlsId ?? 'mention-listbox'}
               {...(comboboxAria?.activeId
                 ? { 'aria-activedescendant': comboboxAria.activeId }
                 : {})}

--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -370,6 +370,7 @@
   /* removed: position, bottom, left, right, margin-bottom, fixed max-height, z-index */
 }
 .slash-popover-head {
+  flex: 0 0 auto;
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -389,6 +390,12 @@
   text-transform: none;
   letter-spacing: 0;
   color: var(--text-muted);
+}
+.slash-popover-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scroll-padding-block: 5px;
 }
 .slash-item {
   display: flex;

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import {
+  KEY_ARROW_DOWN_COMMAND,
+  KEY_ARROW_UP_COMMAND,
+  KEY_TAB_COMMAND,
+} from 'lexical';
 import { createRef, useState, type ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -17,8 +22,18 @@ vi.mock('../../src/analytics/events', async (importOriginal) => {
 import { ChatComposer, type ChatComposerHandle } from '../../src/components/ChatComposer';
 import { I18nProvider } from '../../src/i18n';
 import type { Locale } from '../../src/i18n/types';
-import type { AppliedPluginSnapshot, ProjectMetadata } from '@open-design/contracts';
-import { composerText, pressEnter, typeAndSettle, typeInComposer } from '../helpers/lexical-composer';
+import type {
+  AppliedPluginSnapshot,
+  McpServerConfig,
+  ProjectMetadata,
+} from '@open-design/contracts';
+import {
+  composerText,
+  getComposerEditor,
+  pressEnter,
+  typeAndSettle,
+  typeInComposer,
+} from '../helpers/lexical-composer';
 
 const COMMUNITY_PLUGIN = {
   id: 'community-deck',
@@ -127,7 +142,7 @@ const APPLY_RESULT = {
 let fetchMock: ReturnType<typeof vi.fn>;
 let plugins = [COMMUNITY_PLUGIN, USER_PLUGIN];
 let skills = [SKILL];
-let servers = [MCP_SERVER];
+let servers: McpServerConfig[] = [MCP_SERVER];
 let openFolderPaths: string[];
 let deferNextProjectPatch = false;
 let rejectNextProjectPatch = false;
@@ -142,6 +157,7 @@ let referenceProjects: Array<{
   metadata: { kind: 'prototype' };
 }>;
 let referenceProjectDetails: Record<string, { project: (typeof referenceProjects)[number]; resolvedDir: string | null }>;
+const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 function composerElement(
   overrides: Partial<ComponentProps<typeof ChatComposer>> = {},
@@ -197,6 +213,7 @@ function projectPatchBodies(): Array<{ metadata?: { linkedDirs?: string[] } }> {
 // every editor-text assertion (it walks the tree and emits real `\n`s).
 
 beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
   trackChatPanelClickMock.mockClear();
   plugins = [COMMUNITY_PLUGIN, USER_PLUGIN];
   skills = [SKILL];
@@ -313,6 +330,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  if (originalScrollIntoView) {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  } else {
+    delete (Element.prototype as { scrollIntoView?: Element['scrollIntoView'] }).scrollIntoView;
+  }
   vi.unstubAllGlobals();
   cleanup();
 });
@@ -428,6 +450,118 @@ describe('ChatComposer context pickers', () => {
     expect(settingsRow?.textContent).not.toContain('Toggle, adopt, or jump to pet settings.');
     expect(mcpRow?.textContent).toContain('Open MCP server settings or insert a server tool hint.');
     expect(mcpRow?.textContent).not.toContain('Toggle, adopt, or jump to pet settings.');
+  });
+
+  it('filters slash commands by command and MCP metadata in the active locale', async () => {
+    servers = [{
+      id: 'palette-bridge',
+      label: 'Presentation Bridge',
+      transport: 'http',
+      enabled: true,
+      url: 'https://mcp.example.test',
+    }];
+    renderComposer({}, { locale: 'zh-CN' });
+    await flushMounts();
+
+    const matchingQueries = [
+      ['http', '/mcp palette-bridge'],
+      ['presentation', '/mcp palette-bridge'],
+      ['palette-bridge', '/mcp palette-bridge'],
+      ['server-id', '/mcp'],
+      ['插入', '/mcp'],
+      ['mcp', '/mcp'],
+    ] as const;
+
+    for (const [query, commandLabel] of matchingQueries) {
+      await typeAndSettle(`/${query}`);
+      const listbox = await screen.findByRole('listbox', { name: '斜杠命令' });
+      expect(within(listbox).getByText(commandLabel)).toBeTruthy();
+    }
+  });
+
+  it('keeps zero-result slash state open and exposes the active slash option to the combobox', async () => {
+    renderComposer({}, { locale: 'zh-CN' });
+    await flushMounts();
+
+    await typeAndSettle('/');
+
+    const input = screen.getByTestId('chat-composer-input');
+    const listbox = await screen.findByRole('listbox', { name: '斜杠命令' });
+    expect(listbox.id).toBe('slash-listbox');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+    expect(input.getAttribute('aria-controls')).toBe('slash-listbox');
+    expect(input.getAttribute('aria-activedescendant')).toBe(
+      within(listbox).getByRole('option', { selected: true }).id,
+    );
+
+    await typeAndSettle('/missing');
+
+    expect(await screen.findByText('没有找到“missing”的结果。')).toBeTruthy();
+    expect(screen.getByRole('listbox', { name: '斜杠命令' }).id).toBe('slash-listbox');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+    expect(input.getAttribute('aria-controls')).toBe('slash-listbox');
+    expect(input.hasAttribute('aria-activedescendant')).toBe(false);
+  });
+
+  it('scrolls the keyboard-selected slash option into view with nearest alignment', async () => {
+    servers = Array.from({ length: 8 }, (_, index) => ({
+      id: `server-${index + 1}`,
+      label: `Server ${index + 1}`,
+      transport: 'stdio' as const,
+      enabled: true,
+      command: `server-${index + 1}`,
+    }));
+    renderComposer();
+    await flushMounts();
+    await typeAndSettle('/');
+
+    const listbox = await screen.findByRole('listbox', { name: 'Slash commands' });
+    const initialOption = within(listbox).getByRole('option', { selected: true });
+    const scrollIntoView = vi.mocked(Element.prototype.scrollIntoView);
+    scrollIntoView.mockClear();
+
+    act(() => {
+      getComposerEditor().dispatchCommand(
+        KEY_ARROW_DOWN_COMMAND,
+        new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+      );
+    });
+
+    const nextOption = within(listbox).getByRole('option', { selected: true });
+    expect(nextOption.id).not.toBe(initialOption.id);
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: 'nearest' });
+
+    act(() => {
+      getComposerEditor().dispatchCommand(
+        KEY_ARROW_UP_COMMAND,
+        new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+      );
+    });
+
+    expect(within(listbox).getByRole('option', { selected: true }).id).toBe(initialOption.id);
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: 'nearest' });
+  });
+
+  it('submits an unmatched slash literal with Enter but never with Tab', async () => {
+    const onSend = vi.fn();
+    renderComposer({ onSend });
+    await flushMounts();
+    await typeAndSettle('/unmatched-literal');
+
+    act(() => {
+      getComposerEditor().dispatchCommand(
+        KEY_TAB_COMMAND,
+        new KeyboardEvent('keydown', { key: 'Tab' }),
+      );
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composerText()).toBe('/unmatched-literal');
+
+    pressEnter();
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend.mock.calls[0]?.[0]).toBe('/unmatched-literal');
   });
 
   it('lists Design Files first in All and picks the first file with Enter', async () => {

--- a/apps/web/tests/styles/slash-popover.test.ts
+++ b/apps/web/tests/styles/slash-popover.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const libraryCss = readFileSync(
+  new URL('../../src/styles/viewer/library.css', import.meta.url),
+  'utf8',
+);
+
+function cssBlock(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = libraryCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('slash popover styles', () => {
+  it('bounds the shell while the inner results region owns vertical scrolling', () => {
+    const popover = cssBlock('.slash-popover');
+    const results = cssBlock('.slash-popover-results');
+
+    expect(ruleValue(popover, 'max-height')).toBe('var(--cfl-max-h, 320px)');
+    expect(ruleValue(popover, 'overflow')).toBe('hidden');
+    expect(ruleValue(results, 'flex')).toBe('1 1 auto');
+    expect(ruleValue(results, 'min-height')).toBe('0');
+    expect(ruleValue(results, 'overflow-y')).toBe('auto');
+  });
+});


### PR DESCRIPTION
Fixes #5822

## Why

With enough enabled MCP servers, the slash-command picker can exceed its bounded popover height while the command rows have no scroll owner. Lower commands are clipped, keyboard selection can move outside the visible region, and filtering only searches the visible command label. An unmatched query also removes the picker entirely, while the editor continues to expose mention-listbox ARIA state instead of the active slash listbox.

The misleading MCP description from the original report was already corrected by #6597. This PR preserves that newer `pet.slashMcp` copy and focuses on the remaining navigation, filtering, empty-state, and accessibility behavior in the current ChatComposer UI.

## What users will see

- The complete slash-command catalog remains reachable inside a bounded scroll region.
- Arrow Up/Down keeps the active command visible, while Enter/Tab still selects a matching command.
- MCP commands can be found by command label, server ID, display label, transport, argument hint, or translated description.
- An unmatched query keeps the picker open with an explicit localized no-results message.
- Tab keeps unmatched literal slash text focused and unsent; Enter still sends it normally.
- Assistive technology receives the active slash listbox and option relationship while the picker is open.

## Surface area

- [x] **UI** — fixes the existing slash-command popover and adds its empty state
- [ ] **Keyboard shortcut** — no shortcut is added or changed; existing picker navigation is made reliable
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — reuses existing localized empty-state and MCP strings
- [ ] **New top-level dependency**
- [x] **Default behavior change** — existing slash-command discovery, filtering, scrolling, and accessibility improve without opt-in
- [ ] **None**

## Screenshots

Current-head interaction recording: [MP4 evidence](https://gist.githubusercontent.com/roian6/995581fe392b505c72e8983da7c4cc4f/raw/9e689660451ab3010e469655f4f60c7587e10408/open-design-5822-interaction.mp4)

The recording uses 30 synthetic enabled MCP servers and shows deep Arrow-key scrolling, transport filtering, the zero-results state, Tab preserving `/missing` without submission, and Enter submitting it once. The run API is intercepted by the local evidence harness, so no agent/provider request is made.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
  - `apps/web/tests/styles/slash-popover.test.ts`
- Before the source change:
  - focused component regressions: `3 failed, 1 passed`
  - style regression: failed because `.slash-popover-results` did not exist
- After the source change:
  - focused component regressions: `4 passed`
  - style regression: `1 passed`
  - complete context-picker + style files: `37 passed`
- Coverage includes metadata and translated-description filtering, zero-results feedback, literal unmatched-slash submission, bounded inner scrolling, active-option visibility, and combobox/listbox ARIA relationships.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/ChatComposer.context-pickers.test.tsx tests/styles/slash-popover.test.ts --maxWorkers=2` — 37 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
- current-head Chromium QA at 375, 768, and 1280 px — passed
  - bounded 460 px shell; inner results `overflow-y: auto`
  - 30 synthetic MCP matches; deep navigation reached `scrollTop=492` with the selected row visible
  - slash listbox/active-descendant ARIA correct
  - zero-results picker remained open
  - Tab preserved `/missing` focused and unsent; Enter produced exactly one intercepted local run request
  - no page errors
- full web suite — all 633 test files and 6,689 tests passed (`1 expected fail`, `11 skipped`), but Vitest exited 1 after two unrelated order-sensitive unhandled rejections from `EntryShell.onboarding.test.tsx`; that untouched file passed independently on both clean `main` and this candidate (`38 passed` each)

AI assistance was used to prepare the implementation and tests. I reviewed the diff and reran the listed verification and current-head browser evidence locally.
