### PR TITLE
fix(byok): add opt-in image input support

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -79,6 +79,15 @@ export function buildOpenCodeByokProviderConfig(
         models: {
           [rawModel]: {
             name: rawModel,
+            ...(provider.supportsImageInput === true
+              ? {
+                  attachment: true,
+                  modalities: {
+                    input: ['text', 'image'],
+                    output: ['text'],
+                  },
+                }
+              : {}),
             limit: {
               context: DEFAULT_CONTEXT_TOKEN_LIMIT,
               output: DEFAULT_OUTPUT_TOKEN_LIMIT,

--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -10,6 +10,13 @@ import {
 
 export const MAX_CHAT_IMAGE_BYTES = 1024 * 1024;
 export const UPLOAD_DIR = path.join(os.tmpdir(), 'od-uploads');
+const CHAT_IMAGE_ATTACHMENT_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+]);
 type InputValue =
   | string
   | number
@@ -598,6 +605,82 @@ export function resolveSafeProjectAttachments(
   }
 
   return out;
+}
+
+export function resolveAbsoluteProjectImageAttachments(
+  cwd: string | null | undefined,
+  attachments: readonly string[] | null | undefined,
+  opts: {
+    pathImpl?: typeof path;
+    statSync?: (path: string) => Pick<fs.Stats, 'isFile' | 'size'>;
+    maxBytes?: number;
+  } = {},
+) {
+  if (!cwd || !Array.isArray(attachments)) return [];
+  const pathImpl = opts.pathImpl ?? path;
+  const statSync = opts.statSync ?? ((target: string) => fs.statSync(target));
+  const maxBytes = Number.isFinite(opts.maxBytes)
+    ? Math.max(0, Number(opts.maxBytes))
+    : MAX_CHAT_IMAGE_BYTES;
+  const root = pathImpl.resolve(cwd);
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const attachment of attachments) {
+    if (typeof attachment !== 'string' || attachment.length === 0) continue;
+    try {
+      const absolutePath = pathImpl.resolve(root, attachment);
+      const relativePath = pathImpl.relative(root, absolutePath);
+      const withinRoot =
+        relativePath.length > 0
+        && !relativePath.startsWith('..')
+        && !pathImpl.isAbsolute(relativePath);
+      const extension = pathImpl.extname(absolutePath).toLowerCase();
+      if (
+        !withinRoot
+        || !CHAT_IMAGE_ATTACHMENT_EXTENSIONS.has(extension)
+        || seen.has(absolutePath)
+      ) {
+        continue;
+      }
+      const stats = statSync(absolutePath);
+      if (!stats.isFile() || stats.size > maxBytes) continue;
+      seen.add(absolutePath);
+      out.push(absolutePath);
+    } catch {
+      // Keep the attachment metadata fallback when image preparation fails.
+    }
+  }
+
+  return out;
+}
+
+export function resolveByokOpenCodeImagePaths(
+  input: {
+    enabled: boolean;
+    cwd?: string | null;
+    attachments?: readonly string[] | null;
+    promptImagePaths?: readonly string[] | null;
+  },
+  opts: Parameters<typeof resolveAbsoluteProjectImageAttachments>[2] = {},
+) {
+  if (!input.enabled) return [];
+  const projectImages = resolveAbsoluteProjectImageAttachments(
+    input.cwd,
+    input.attachments,
+    opts,
+  );
+  const directImages = Array.isArray(input.promptImagePaths)
+    ? input.promptImagePaths.filter(
+        (imagePath): imagePath is string =>
+          typeof imagePath === 'string'
+          && path.isAbsolute(imagePath)
+          && CHAT_IMAGE_ATTACHMENT_EXTENSIONS.has(
+            path.extname(imagePath).toLowerCase(),
+          ),
+      )
+    : [];
+  return Array.from(new Set([...directImages, ...projectImages]));
 }
 
 export function formatProjectAttachmentHint(attachments: readonly string[] | null | undefined) {

--- a/apps/daemon/src/runtimes/defs/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/defs/byok-opencode.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { opencodeByokModelId } from '../byok-opencode.js';
 import {
   OPENCODE_PERMISSION_CAPABILITY,
@@ -14,7 +15,7 @@ export const byokOpenCodeAgentDef = {
   versionArgs: ['--version'],
   ...OPENCODE_PERMISSION_CAPABILITY,
   fallbackModels: [DEFAULT_MODEL_OPTION],
-  buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
+  buildArgs: (_prompt, imagePaths, _extra, options = {}, runtimeContext = {}) => {
     const args = ['run', '--format', 'json'];
     if (typeof runtimeContext.cwd === 'string' && runtimeContext.cwd.length > 0) {
       // OpenCode promotes nested directories to the enclosing Git worktree
@@ -27,6 +28,11 @@ export const byokOpenCodeAgentDef = {
     appendOpenCodePermissionBypass(args, 'byok-opencode');
     const model = opencodeByokModelId(options.model);
     if (model) args.push('-m', model);
+    for (const imagePath of imagePaths) {
+      if (typeof imagePath === 'string' && path.isAbsolute(imagePath)) {
+        args.push('-f', imagePath);
+      }
+    }
     return args;
   },
   promptViaStdin: true,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -92,6 +92,7 @@ import {
   formatProjectAttachmentHint,
   normalizeCommentAttachments,
   renderCommentAttachmentHint,
+  resolveByokOpenCodeImagePaths,
   resolveChatExtraAllowedDirs,
   describeStablePromptCache,
   designSystemIdFromPluginSnapshot,
@@ -148,6 +149,8 @@ export {
   formatProjectAttachmentHint,
   normalizeCommentAttachments,
   renderCommentAttachmentHint,
+  resolveAbsoluteProjectImageAttachments,
+  resolveByokOpenCodeImagePaths,
   resolveChatExtraAllowedDirs,
   describeStablePromptCache,
   designSystemIdFromPluginSnapshot,
@@ -9872,6 +9875,15 @@ export async function startServer({
       ? resolveSafeProjectAttachments(cwd, attachments)
       : [];
     run.projectAttachmentPaths = safeAttachments;
+    const byokImageInputEnabled =
+      def.id === 'byok-opencode'
+      && byokProvider?.supportsImageInput === true;
+    const byokImagePaths = resolveByokOpenCodeImagePaths({
+      enabled: byokImageInputEnabled,
+      cwd,
+      attachments: safeAttachments,
+      promptImagePaths: safeImages,
+    });
 
     // Local code agents don't accept a separate "system" channel the way the
     // Messages API does — we fold the skill + design-system prompt into the
@@ -11663,7 +11675,7 @@ export async function startServer({
     try {
       args = def.buildArgs(
         composed,
-        safeImages,
+        def.id === 'byok-opencode' ? byokImagePaths : safeImages,
         extraAllowedDirs,
         agentOptions,
         {

--- a/apps/daemon/tests/chat-attachments.test.ts
+++ b/apps/daemon/tests/chat-attachments.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   formatDesignFilesWorkspaceHint,
   formatProjectAttachmentHint,
+  resolveAbsoluteProjectImageAttachments,
+  resolveByokOpenCodeImagePaths,
   resolveSafeProjectAttachments,
 } from '../src/server.js';
 
@@ -43,6 +45,82 @@ describe('resolveSafeProjectAttachments', () => {
         'When the user says "first attachment", "second file", or similar, map those references to the numbered list above.',
       ].join('\n'),
     );
+  });
+});
+
+describe('resolveAbsoluteProjectImageAttachments', () => {
+  it('keeps only unique, existing, in-project image files within the size limit', () => {
+    const root = '/project';
+    const stats = new Map([
+      ['/project/first.png', { isFile: () => true, size: 128 }],
+      ['/project/second.webp', { isFile: () => true, size: 256 }],
+      ['/project/folder.gif', { isFile: () => false, size: 0 }],
+      ['/project/large.jpg', { isFile: () => true, size: 1025 }],
+      ['/project/notes.txt', { isFile: () => true, size: 10 }],
+    ]);
+
+    expect(resolveAbsoluteProjectImageAttachments(root, [
+      'first.png',
+      './first.png',
+      'second.webp',
+      '../escape.png',
+      'missing.jpeg',
+      'folder.gif',
+      'large.jpg',
+      'notes.txt',
+    ], {
+      maxBytes: 1024,
+      statSync: (target: string) => {
+        const result = stats.get(target);
+        if (!result) throw new Error('missing');
+        return result as never;
+      },
+    })).toEqual(['/project/first.png', '/project/second.webp']);
+  });
+
+  it('accepts PNG, JPEG, GIF, and WebP extensions case-insensitively', () => {
+    expect(resolveAbsoluteProjectImageAttachments('/project', [
+      'a.PNG', 'b.jpg', 'c.JPEG', 'd.Gif', 'e.WEBP',
+    ], {
+      statSync: () => ({ isFile: () => true, size: 1 }) as never,
+    })).toEqual([
+      '/project/a.PNG',
+      '/project/b.jpg',
+      '/project/c.JPEG',
+      '/project/d.Gif',
+      '/project/e.WEBP',
+    ]);
+  });
+});
+
+describe('resolveByokOpenCodeImagePaths', () => {
+  it('merges direct uploads and project images for enabled BYOK runs', () => {
+    expect(resolveByokOpenCodeImagePaths({
+      enabled: true,
+      cwd: '/project',
+      attachments: ['saved.png', 'saved.png'],
+      promptImagePaths: [
+        '/tmp/od-uploads/direct.png',
+        '/tmp/od-uploads/direct.png',
+        '/tmp/od-uploads/not-an-image.txt',
+      ],
+    }, {
+      statSync: () => ({ isFile: () => true, size: 1 }),
+    })).toEqual([
+      '/tmp/od-uploads/direct.png',
+      '/project/saved.png',
+    ]);
+  });
+
+  it('keeps legacy and disabled BYOK runs text-only', () => {
+    expect(resolveByokOpenCodeImagePaths({
+      enabled: false,
+      cwd: '/project',
+      attachments: ['saved.png'],
+      promptImagePaths: ['/tmp/od-uploads/direct.png'],
+    }, {
+      statSync: () => ({ isFile: () => true, size: 1 }),
+    })).toEqual([]);
   });
 });
 

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -43,6 +43,72 @@ describe('byok-opencode runtime config', () => {
     expect(opencodeByokModelId('default')).toBeNull();
   });
 
+  it('passes only absolute image paths to OpenCode as repeated file arguments', () => {
+    expect(byokOpenCodeAgentDef.buildArgs(
+      '',
+      ['/project/first.png', 'relative.png', '/project/second.webp'],
+      [],
+      {},
+    )).toEqual([
+      'run',
+      '--format',
+      'json',
+      '-f',
+      '/project/first.png',
+      '-f',
+      '/project/second.webp',
+    ]);
+  });
+
+  it('adds image capability metadata only for explicitly enabled models', () => {
+    const enabled = buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'openai',
+        apiKey: 'sk-test',
+        baseUrl: 'https://example.com/openai/v1',
+        supportsImageInput: true,
+      },
+      'vision-model',
+    );
+    const disabled = buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'openai',
+        apiKey: 'sk-test',
+        baseUrl: 'https://example.com/openai/v1',
+        supportsImageInput: false,
+      },
+      'text-model',
+    );
+    const legacy = buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'openai',
+        apiKey: 'sk-test',
+        baseUrl: 'https://example.com/openai/v1',
+      },
+      'legacy-model',
+    );
+
+    expect(enabled?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          models: {
+            'vision-model': {
+              attachment: true,
+              modalities: { input: ['text', 'image'], output: ['text'] },
+            },
+          },
+        },
+      },
+    });
+    for (const result of [disabled, legacy]) {
+      expect(result).not.toBeNull();
+      const models = (result!.config.provider as Record<string, { models: Record<string, unknown> }>)[BYOK_OPENCODE_PROVIDER_ID]!.models;
+      const model = Object.values(models)[0] as Record<string, unknown>;
+      expect(model).not.toHaveProperty('attachment');
+      expect(model).not.toHaveProperty('modalities');
+    }
+  });
+
   it('builds OpenAI-compatible provider config without embedding the secret in JSON', () => {
     const out = buildOpenCodeByokProviderConfig(
       {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -400,6 +400,7 @@ export function resetExecutionConfigAfterSignOut(config: AppConfig): AppConfig {
     apiProtocol: DEFAULT_CONFIG.apiProtocol,
     apiKey: DEFAULT_CONFIG.apiKey,
     apiVersion: DEFAULT_CONFIG.apiVersion,
+    supportsImageInput: DEFAULT_CONFIG.supportsImageInput,
     baseUrl: DEFAULT_CONFIG.baseUrl,
     model: DEFAULT_CONFIG.model,
     byokImageModel: DEFAULT_CONFIG.byokImageModel,

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2534,10 +2534,24 @@ function OnboardingView({
       model: config.model,
       apiVersion: config.apiVersion ?? '',
       apiProviderBaseUrl: config.apiProviderBaseUrl ?? null,
+      supportsImageInput: config.supportsImageInput === true,
     };
     const nextProtocolConfig: ApiProtocolConfig = {
       ...currentConfig,
       ...patch,
+      ...(
+        patch.supportsImageInput === undefined
+        && (
+          (patch.baseUrl !== undefined && patch.baseUrl !== currentConfig.baseUrl)
+          || (patch.model !== undefined && patch.model !== currentConfig.model)
+          || (
+            patch.apiProviderBaseUrl !== undefined
+            && patch.apiProviderBaseUrl !== currentConfig.apiProviderBaseUrl
+          )
+        )
+          ? { supportsImageInput: false }
+          : {}
+      ),
     };
     const nextConfig: AppConfig = {
       ...config,
@@ -2548,6 +2562,7 @@ function OnboardingView({
       model: nextProtocolConfig.model,
       apiVersion: protocol === 'azure' ? (nextProtocolConfig.apiVersion ?? '') : '',
       apiProviderBaseUrl: nextProtocolConfig.apiProviderBaseUrl ?? null,
+      supportsImageInput: nextProtocolConfig.supportsImageInput === true,
       apiProtocolConfigs: {
         ...(config.apiProtocolConfigs ?? {}),
         [protocol]: nextProtocolConfig,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1613,6 +1613,7 @@ function byokOpenCodeProviderFromConfig(
     apiKey: config.apiKey.trim(),
     baseUrl: config.baseUrl.trim(),
     model,
+    supportsImageInput: config.supportsImageInput === true,
     ...(config.apiProtocol === 'azure' && config.apiVersion?.trim()
       ? { apiVersion: config.apiVersion.trim() }
       : {}),

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -946,6 +946,7 @@ function defaultApiProtocolConfig(protocol: ApiProtocol): ApiProtocolConfig {
     model: defaultKnownProviderModel(provider),
     apiVersion: '',
     apiProviderBaseUrl: provider ? provider.baseUrl : null,
+    supportsImageInput: false,
   };
 }
 
@@ -998,6 +999,7 @@ function nextApiProtocolConfig(
       apiKey: '',
       apiVersion: protocol === 'azure' ? currentConfig.apiVersion : '',
       apiProviderBaseUrl: null,
+      supportsImageInput: false,
     };
   }
 
@@ -1013,6 +1015,7 @@ function currentApiProtocolConfig(config: AppConfig): ApiProtocolConfig {
     model: config.model,
     apiVersion: config.apiVersion ?? '',
     apiProviderBaseUrl: config.apiProviderBaseUrl ?? null,
+    supportsImageInput: config.supportsImageInput === true,
     byokImageModel: config.byokImageModel ?? '',
     byokVideoModel: config.byokVideoModel ?? '',
     byokSpeechModel: config.byokSpeechModel ?? '',
@@ -1097,6 +1100,7 @@ export function resolveSettingsAutosavePayload(
     apiProtocol: active.apiProtocol,
     apiVersion: active.apiVersion,
     apiProviderBaseUrl: active.apiProviderBaseUrl,
+    supportsImageInput: active.supportsImageInput,
     apiProtocolConfigs: active.apiProtocolConfigs,
     baseUrl: active.baseUrl,
     model: active.model,
@@ -1150,6 +1154,7 @@ function applyApiProtocolConfig(
     baseUrl: resolveFixedOriginBaseUrl(protocol, apiConfig.baseUrl),
     model: apiConfig.model,
     apiProviderBaseUrl: apiConfig.apiProviderBaseUrl ?? null,
+    supportsImageInput: apiConfig.supportsImageInput === true,
     apiVersion: protocol === 'azure' ? (apiConfig.apiVersion ?? '') : '',
     // byokImageModel applies to the protocols that inject the daemon-side
     // generate_image tool (SenseAudio, AIHubMix) — flipping to another BYOK
@@ -1205,9 +1210,20 @@ export function updateCurrentApiProtocolConfig(
     !patch.apiKey.trim() &&
     Boolean(currentApiProtocolConfig(config).apiKey.trim());
   const defaultModel = defaultApiProtocolConfig(protocol).model;
+  const currentApiConfig = currentApiProtocolConfig(config);
+  const providerIdentityChanged =
+    (patch.baseUrl !== undefined && patch.baseUrl !== currentApiConfig.baseUrl)
+    || (patch.model !== undefined && patch.model !== currentApiConfig.model)
+    || (
+      patch.apiProviderBaseUrl !== undefined
+      && patch.apiProviderBaseUrl !== currentApiConfig.apiProviderBaseUrl
+    );
   const nextApiConfig: ApiProtocolConfig = {
-    ...currentApiProtocolConfig(config),
+    ...currentApiConfig,
     ...patch,
+    ...(providerIdentityChanged && patch.supportsImageInput === undefined
+      ? { supportsImageInput: false }
+      : {}),
     ...(clearedApiKey && defaultModel && patch.model === undefined
       ? { model: defaultModel }
       : {}),
@@ -1454,6 +1470,7 @@ export function sanitizeSettingsSavePayload(
     byokProviderConfigDrafts: initial.byokProviderConfigDrafts,
     byokPendingProviderKey: initial.byokPendingProviderKey,
     apiProviderBaseUrl: initial.apiProviderBaseUrl,
+    supportsImageInput: initial.supportsImageInput,
     baseUrl: initial.baseUrl,
     model: initial.model,
     agentId: initial.agentId,
@@ -5659,6 +5676,30 @@ export function SettingsDialog({
                   updateApiConfig({ model: nextValue });
                 }}
               />
+              {apiProtocol !== 'bedrock' ? (
+                <button
+                  type="button"
+                  className={`toggle-row${cfg.supportsImageInput === true ? ' on' : ''}`}
+                  role="switch"
+                  aria-checked={cfg.supportsImageInput === true}
+                  data-testid="settings-byok-supports-image-input"
+                  onClick={() =>
+                    updateApiConfig({
+                      supportsImageInput: cfg.supportsImageInput !== true,
+                    })
+                  }
+                >
+                  <span className="toggle-row-text">
+                    <span className="toggle-row-label">
+                      {t('settings.byokSupportsImageInput')}
+                    </span>
+                    <span className="toggle-row-hint">
+                      {t('settings.byokSupportsImageInputHint')}
+                    </span>
+                  </span>
+                  <span className="toggle-row-switch" aria-hidden="true" />
+                </button>
+              ) : null}
               <details className="agent-cli-env settings-memory-advanced">
                 <summary className="agent-cli-env-summary">
                   <span className="agent-cli-env-summary-title">

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ar: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const de: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const en: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const esES: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const fa: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const fr: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Invitation d'équipe",
   'invite.loading': "Chargement de l'invitation…",
   'invite.landing.title': "Rejoindre l'équipe",

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const hu: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const id: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const it: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ja: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ko: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const pl: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ptBR: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const ru: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const th: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const tr: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1,6 +1,8 @@
 import type { Dict } from '../types';
 
 export const uk: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "Team invitation",
   'invite.loading': "Loading invitation…",
   'invite.landing.title': "Join the team",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1,6 +1,8 @@
 import type { Dict } from "../types";
 
 export const zhCN: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "团队邀请",
   'invite.loading': "正在加载邀请…",
   'invite.landing.title': "加入团队",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1,6 +1,8 @@
 import type { Dict } from "../types";
 
 export const zhTW: Dict = {
+  'settings.byokSupportsImageInput': 'This model or deployment supports image input.',
+  'settings.byokSupportsImageInputHint': 'Enable only when the provider confirms image support. Text-only models will reject image payloads.',
   'invite.header.eyebrow': "團隊邀請",
   'invite.loading': "正在載入邀請…",
   'invite.landing.title': "加入團隊",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -386,6 +386,8 @@ export interface Dict {
   'settings.cloudCalloutButton': string;
   'settings.modeApiMeta': string;
   'settings.byokNoFileToolsNotice': string;
+  'settings.byokSupportsImageInput': string;
+  'settings.byokSupportsImageInputHint': string;
   'settings.byokDraftNotice': string;
   'settings.codeAgent': string;
   'settings.codeAgentHint': string;

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -84,6 +84,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   // saved baseUrl/model before applying the current migration version.
   apiProtocol: 'anthropic',
   apiVersion: '',
+  supportsImageInput: false,
   apiProtocolConfigs: {},
   configMigrationVersion: CONFIG_MIGRATION_VERSION,
   apiProviderBaseUrl: 'https://api.anthropic.com',

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -251,6 +251,8 @@ export interface ApiProtocolConfig {
   model: string;
   apiVersion?: string;
   apiProviderBaseUrl?: string | null;
+  /** Explicit per-provider/model opt-in for image input. */
+  supportsImageInput?: boolean;
   /** SenseAudio BYOK only — default image model the daemon-side
    *  `generate_image` tool uses when the LLM doesn't pass one. Carries
    *  one of the SenseAudio image model ids (`senseaudio-image-2.0-260319`,
@@ -390,6 +392,8 @@ export interface AppConfig {
   model: string;
   apiProtocol?: ApiProtocol;
   apiVersion?: string;
+  /** Active BYOK provider/model image-input capability projection. */
+  supportsImageInput?: boolean;
   /** SenseAudio BYOK only — default image model for the daemon-side
    *  generate_image tool. Mirrors apiProtocolConfigs.senseaudio.byokImageModel
    *  so the active protocol's value lives at the top level (consistent

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -2941,6 +2941,7 @@ describe('ProjectView conversation run isolation', () => {
       apiKey: 'byok-test-key',
       baseUrl: 'https://api.openai.com/v1',
       model: 'api-model',
+      supportsImageInput: true,
     });
 
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
@@ -2956,6 +2957,7 @@ describe('ProjectView conversation run isolation', () => {
         apiKey: 'byok-test-key',
         baseUrl: 'https://api.openai.com/v1',
         model: 'api-model',
+        supportsImageInput: true,
       }),
       model: 'api-model',
     }));

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -840,6 +840,28 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(screen.queryByTestId('settings-byok-no-file-tools-notice')).toBeNull();
   });
 
+  it('shows an off-by-default image-input capability switch and persists the opt-in', async () => {
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-openai-test',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+    const toggle = screen.getByTestId('settings-byok-supports-image-input');
+
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+    expect(toggle.textContent).toContain('This model or deployment supports image input.');
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({ supportsImageInput: true }),
+      {},
+    );
+  });
+
   it('only persists Max tokens overrides within the supported BYOK range', async () => {
     const { onPersist } = renderSettingsDialog({ apiKey: 'sk-ant-test' });
 

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -394,6 +394,7 @@ describe('SettingsDialog API protocol switching', () => {
       baseUrl: 'https://openai-proxy.example.com',
       model: 'openai-model',
       apiProviderBaseUrl: null,
+      supportsImageInput: true,
     });
     const google = switchApiProtocolConfig(openaiEdited, 'google');
     const googleEdited = updateCurrentApiProtocolConfig(google, {
@@ -412,13 +413,30 @@ describe('SettingsDialog API protocol switching', () => {
       baseUrl: 'https://openai-proxy.example.com',
       model: 'openai-model',
       apiProviderBaseUrl: null,
+      supportsImageInput: true,
     });
     expect(restoredOpenai.apiProtocolConfigs?.google).toMatchObject({
       apiKey: 'google-key',
       baseUrl: 'https://google-proxy.example.com',
       model: 'google-model',
       apiProviderBaseUrl: null,
+      supportsImageInput: false,
     });
+  });
+
+  it('keeps image support off for legacy settings and stores it per provider draft', () => {
+    const legacyOpenAi = switchApiProtocolConfig(baseConfig, 'openai');
+    expect(legacyOpenAi.supportsImageInput).toBe(false);
+
+    const enabled = updateCurrentApiProtocolConfig(legacyOpenAi, {
+      supportsImageInput: true,
+    });
+    const google = switchApiProtocolConfig(enabled, 'google');
+    const restored = switchApiProtocolConfig(google, 'openai');
+
+    expect(google.supportsImageInput).toBe(false);
+    expect(restored.supportsImageInput).toBe(true);
+    expect(restored.apiProtocolConfigs?.openai?.supportsImageInput).toBe(true);
   });
 
   it('loads the new protocol default on first visit', () => {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -66,6 +66,8 @@ export interface ByokChatProviderConfig {
    * because some presets (e.g. Ollama) infer the model from baseUrl/protocol.
    */
   model?: string;
+  /** Opt-in capability for deployments that accept image inputs. */
+  supportsImageInput?: boolean;
 }
 
 export interface ByokMediaDefaults {


### PR DESCRIPTION
Fixes #6482

References #3600.

## Why

I hit this in the native macOS Open Design app with an OpenAI-compatible BYOK model that accepts images. Open Design registered the model as text-only and did not pass uploaded image paths to the bundled OpenCode runtime. The file could appear to be read, but the model did not receive the image pixels.

This follows the useful attachment-handoff direction from #6495, but keeps image support explicit. Provider names and model names are not reliable capability signals, and not every BYOK endpoint accepts image payloads.

## What users will see

Settings -> Models & providers -> API providers has a new off-by-default setting: "This model or deployment supports image input."

When enabled for the active provider and model, Open Design registers image input support with OpenCode and forwards safe project images through repeated `-f` arguments. Existing and legacy configurations remain text-only. If image preparation fails, the prompt keeps the existing attachment metadata fallback.

Accepted image files are existing in-project PNG, JPEG, GIF, or WebP files within the existing 1 MB limit. The resolver rejects missing files, directories, path escapes, duplicates, unsupported formats, and oversized files.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Verified in a production local macOS desktop build. The setting renders below the model field, is off by default, toggles correctly, and has no visible overflow. A GitHub-hosted screenshot will be added before this draft is marked ready for review.

## Bug fix verification

- Test paths: `apps/daemon/tests/chat-attachments.test.ts`, `apps/daemon/tests/runtimes/byok-opencode.test.ts`, `apps/web/tests/components/SettingsDialog.execution.test.tsx`, `apps/web/tests/components/SettingsDialog.test.ts`, and `apps/web/tests/components/ProjectView.run-isolation.test.tsx`.
- Red on `main`, green on this branch: no. The initial red run was blocked by incomplete workspace dependencies. Source inspection confirmed the missing model capability and file handoff. During implementation, the first settings regression run exposed provider-switch capability leakage; the final implementation fixes it and all listed regression tests are green.
- Real endpoint verification: the reporter confirmed in the installed macOS app that the model answered from image pixels, that a second-turn read exposed the image, and that text prompts still worked. No credentials or private endpoint details are included here.

## Validation

- Node.js 24.19.0 and pnpm 10.33.2.
- Daemon focused tests: 29 passed.
- Settings dialog tests: 75 passed.
- Targeted Settings UI test: 1 passed.
- Targeted ProjectView run-contract test: 1 passed.
- Contracts, daemon, and web typechecks passed.
- `pnpm guard` passed.
- `pnpm i18n:check` passed.
- `git diff --check` passed.
- Production web build passed.
- Production local macOS desktop package launched and the new control was inspected.
