### PR TITLE
fix(desktop,web): stop 10-minute export hangs and make export failures attributable

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -184,27 +184,49 @@ export const ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS = 15_000;
  * subresources is `waitForPrintableContent`'s job, and it bounds itself. The
  * listener is attached before `loadURL` so a fast `data:` URL cannot fire it
  * before we are listening.
+ *
+ * A real load failure still fails: `did-fail-load` reaching us before
+ * dom-ready rethrows, so `renderDeckSlides` reports RENDER_FAILED exactly as
+ * it did when this was a bare `await window.loadURL(...)`.
  */
+type ArtifactLoadOutcome =
+  | { readonly kind: "loaded" }
+  | { readonly kind: "dom-ready" }
+  | { readonly kind: "timeout" }
+  | { readonly kind: "failed"; readonly error: unknown };
+
 export async function loadArtifactDocument(window: BrowserWindow, url: string): Promise<void> {
-  const domReady = new Promise<void>((resolve) => {
-    window.webContents.once("dom-ready", () => resolve());
+  const domReady = new Promise<ArtifactLoadOutcome>((resolve) => {
+    window.webContents.once("dom-ready", () => resolve({ kind: "dom-ready" }));
   });
-  // Keep the rejection handled: a genuine `did-fail-load` must not surface as
-  // an unhandled rejection just because the race already settled on dom-ready.
-  const finished = window.loadURL(url).catch(() => undefined);
+  // Settle the load into a tagged outcome rather than catching it away. A
+  // `did-fail-load` that beats dom-ready is a genuine main-document failure and
+  // must still propagate — swallowing it would let the pipeline go on to
+  // capture Chromium's error page and report a successful-but-wrong export,
+  // which is worse than the hang this function exists to prevent. Attaching
+  // handlers here (rather than leaving the promise bare) also means a rejection
+  // arriving AFTER dom-ready has already won stays handled instead of surfacing
+  // as an unhandled rejection.
+  const finished = window.loadURL(url).then<ArtifactLoadOutcome, ArtifactLoadOutcome>(
+    () => ({ kind: "loaded" }),
+    (error: unknown) => ({ error, kind: "failed" }),
+  );
 
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let outcome: ArtifactLoadOutcome;
   try {
-    await Promise.race([
+    outcome = await Promise.race([
       finished,
       domReady,
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS);
+      new Promise<ArtifactLoadOutcome>((resolve) => {
+        timer = setTimeout(() => resolve({ kind: "timeout" }), ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS);
       }),
     ]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
+
+  if (outcome.kind === "failed") throw outcome.error;
 }
 
 export async function renderDeckSlides(

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -161,6 +161,52 @@ const REAL_SLIDES_JS =
  * paints it (capturePage needs a live frame) without any visible flash or
  * focus theft, then destroyed.
  */
+/**
+ * How long to wait for the artifact document itself before proceeding with
+ * whatever has rendered.
+ */
+export const ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS = 15_000;
+
+/**
+ * Load the artifact into the offscreen window without letting a single stalled
+ * subresource block the whole export.
+ *
+ * `loadURL()` resolves on `did-finish-load`, which Chromium only fires once
+ * EVERY subresource has settled. An image or font URL that answers neither way
+ * — the packaged `od://` failure mode — therefore leaves `loadURL()` pending
+ * forever, and the export hung here long before reaching the (separately
+ * bounded) `waitForPrintableContent` step. Production bore this out: 122 of
+ * 142 `DESKTOP_RENDERER_UNAVAILABLE` failures sat at the daemon's 600s IPC
+ * ceiling.
+ *
+ * `dom-ready` is the signal we actually need: the document is parsed and
+ * scriptable, which is all the capture pipeline requires — waiting for
+ * subresources is `waitForPrintableContent`'s job, and it bounds itself. The
+ * listener is attached before `loadURL` so a fast `data:` URL cannot fire it
+ * before we are listening.
+ */
+export async function loadArtifactDocument(window: BrowserWindow, url: string): Promise<void> {
+  const domReady = new Promise<void>((resolve) => {
+    window.webContents.once("dom-ready", () => resolve());
+  });
+  // Keep the rejection handled: a genuine `did-fail-load` must not surface as
+  // an unhandled rejection just because the race already settled on dom-ready.
+  const finished = window.loadURL(url).catch(() => undefined);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      finished,
+      domReady,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export async function renderDeckSlides(
   input: DesktopRenderSlidesInput,
 ): Promise<DesktopRenderSlidesResult> {
@@ -206,7 +252,7 @@ export async function renderDeckSlides(
 
   try {
     const doc = injectBaseHref(input.html, input.baseHref);
-    await window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(doc)}`);
+    await loadArtifactDocument(window, `data:text/html;charset=utf-8,${encodeURIComponent(doc)}`);
     tLoad = Date.now();
     await waitForPrintableContent(window);
     tAssets = Date.now();

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -396,15 +396,34 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
   // executeJavaScript itself stays pending. Resolve rather than reject, for
   // the same reason the in-page bound does.
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
   try {
     await Promise.race([
       pageSettled,
       new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
+        timer = setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
       }),
     ]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
+  }
+
+  // Giving up on the wait is not enough on its own: the requests we stopped
+  // waiting for are still in flight, and every later `executeJavaScript` in
+  // the capture pipeline queues behind a renderer that is still busy with
+  // them. Measured on a document whose <img> and CSS url() both point at a
+  // socket that never answers, the steps AFTER this one still cost ~38s.
+  // Cancelling the outstanding loads hands the renderer back to us; the
+  // document is already parsed, so nothing that has rendered is lost.
+  if (timedOut) {
+    try {
+      window.webContents.stop();
+    } catch {
+      // A destroyed webContents means the export is being torn down anyway.
+    }
   }
 }
 

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -328,10 +328,16 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
 
       // Resolve-on-timeout (never reject): a resource we gave up on is treated
       // exactly like one that fired 'error' — the capture proceeds without it.
+      // Count the ones we abandoned so the main process can tell "everything
+      // loaded" from "we stopped waiting", which decides whether the still
+      // in-flight requests need cancelling.
+      var stalledCount = 0;
       function withDeadline(promise) {
         return Promise.race([
           promise,
-          new Promise(function(resolve) { setTimeout(resolve, RESOURCE_TIMEOUT_MS); })
+          new Promise(function(resolve) {
+            setTimeout(function() { stalledCount += 1; resolve(); }, RESOURCE_TIMEOUT_MS);
+          })
         ]);
       }
 
@@ -386,39 +392,49 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
       ])
         .then(nextFrame)
         .then(nextFrame)
-        .then(function(){ return true; });
+        .then(function(){ return { stalled: stalledCount > 0 }; });
     })()`,
     true,
-  );
+  ) as Promise<unknown>;
 
   // Outer backstop for the case the in-page bound can never fire: a renderer
   // whose event loop is wedged never runs our setTimeout either, and
   // executeJavaScript itself stays pending. Resolve rather than reject, for
   // the same reason the in-page bound does.
   let timer: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
+  const OUTER_TIMEOUT = Symbol("printable-content-outer-timeout");
+  let raced: unknown;
   try {
-    await Promise.race([
+    raced = await Promise.race([
       pageSettled,
-      new Promise<void>((resolve) => {
-        timer = setTimeout(() => {
-          timedOut = true;
-          resolve();
-        }, PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
+      new Promise<symbol>((resolve) => {
+        timer = setTimeout(() => resolve(OUTER_TIMEOUT), PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
       }),
     ]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
 
+  // Did we stop waiting on anything? Either layer counts:
+  //   - outer: the renderer never answered at all, so its event loop is wedged;
+  //   - in-page: the script came back on time but abandoned some resource.
+  // The in-page case is the ordinary stalled-network one — the renderer is
+  // healthy, so the page-side deadline fires first and the outer timer never
+  // runs. Keying only off the outer timer would skip cancellation in exactly
+  // that case and leave the requests in flight.
+  const inPageStalled =
+    typeof raced === "object" && raced !== null && (raced as { stalled?: unknown }).stalled === true;
+  const gaveUp = raced === OUTER_TIMEOUT || inPageStalled;
+
   // Giving up on the wait is not enough on its own: the requests we stopped
   // waiting for are still in flight, and every later `executeJavaScript` in
   // the capture pipeline queues behind a renderer that is still busy with
   // them. Measured on a document whose <img> and CSS url() both point at a
-  // socket that never answers, the steps AFTER this one still cost ~38s.
-  // Cancelling the outstanding loads hands the renderer back to us; the
-  // document is already parsed, so nothing that has rendered is lost.
-  if (timedOut) {
+  // socket that never answers, the steps AFTER this one cost 15340ms +
+  // 22459ms without this, and 6ms + 10566ms with it. Cancelling the
+  // outstanding loads hands the renderer back; the document is already
+  // parsed, so nothing that has rendered is lost.
+  if (gaveUp) {
     try {
       window.webContents.stop();
     } catch {

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -301,16 +301,47 @@ async function unhideDeckSlidesForPrint(window: BrowserWindow): Promise<void> {
   }
 }
 
+/**
+ * How long the whole "wait for printable content" step may take before the
+ * capture proceeds anyway.
+ *
+ * Waiting for resources is best-effort by design — the in-page script already
+ * resolves on `error` as well as `load`, i.e. a resource that failed to load
+ * still lets the capture run. Stalling forever is the one outcome that is
+ * never useful: a font or image URL that settles neither way (a recurring
+ * `od://` failure mode in the packaged app) used to leave this promise pending
+ * until the daemon's 600s desktop-IPC ceiling fired, so the user waited ten
+ * minutes to be told the export failed. Bounding the wait turns that into a
+ * capture that is at worst missing a late resource.
+ */
+export const PRINTABLE_CONTENT_WAIT_TIMEOUT_MS = 15_000;
+
+/** Per-resource ceiling inside the page, kept below the outer bound so a single
+ *  stalled image drops out while the rest of the document still settles
+ *  normally, instead of every export paying the full outer timeout. */
+const IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS = 10_000;
+
 export async function waitForPrintableContent(window: BrowserWindow): Promise<void> {
-  await window.webContents.executeJavaScript(
+  const pageSettled = window.webContents.executeJavaScript(
     `(function() {
+      var RESOURCE_TIMEOUT_MS = ${IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS};
+
+      // Resolve-on-timeout (never reject): a resource we gave up on is treated
+      // exactly like one that fired 'error' — the capture proceeds without it.
+      function withDeadline(promise) {
+        return Promise.race([
+          promise,
+          new Promise(function(resolve) { setTimeout(resolve, RESOURCE_TIMEOUT_MS); })
+        ]);
+      }
+
       function waitForImages() {
         return Promise.all(Array.from(document.images || []).map(function(img) {
           if (img.complete) return Promise.resolve();
-          return new Promise(function(resolve) {
+          return withDeadline(new Promise(function(resolve) {
             img.addEventListener('load', resolve, { once: true });
             img.addEventListener('error', resolve, { once: true });
-          });
+          }));
         }));
       }
 
@@ -333,12 +364,12 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
           cssUrlValues(style.listStyleImage).forEach(function(url) { urls.add(url); });
         });
         return Promise.all(Array.from(urls).map(function(url) {
-          return new Promise(function(resolve) {
+          return withDeadline(new Promise(function(resolve) {
             var img = new Image();
             img.onload = resolve;
             img.onerror = resolve;
             img.src = url;
-          });
+          }));
         }));
       }
 
@@ -347,7 +378,9 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
       }
 
       return Promise.all([
-        document.fonts && document.fonts.ready ? document.fonts.ready.catch(function(){}) : Promise.resolve(),
+        document.fonts && document.fonts.ready
+          ? withDeadline(document.fonts.ready.catch(function(){}))
+          : Promise.resolve(),
         waitForImages(),
         waitForCssBackgroundImages()
       ])
@@ -357,6 +390,22 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
     })()`,
     true,
   );
+
+  // Outer backstop for the case the in-page bound can never fire: a renderer
+  // whose event loop is wedged never runs our setTimeout either, and
+  // executeJavaScript itself stays pending. Resolve rather than reject, for
+  // the same reason the in-page bound does.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      pageSettled,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 export async function waitForPrintReadyHandshake(webContents: Electron.WebContents, nonce: string): Promise<void> {

--- a/apps/desktop/tests/main/artifact-document-load-bound.test.ts
+++ b/apps/desktop/tests/main/artifact-document-load-bound.test.ts
@@ -1,0 +1,115 @@
+// Regression boundary for the packaged export hang, at the step that actually
+// hung.
+//
+// `renderDeckSlides` used to `await window.loadURL(...)` directly. Electron
+// resolves that promise on `did-finish-load`, which Chromium only fires once
+// EVERY subresource has settled — so one image or font URL that answers
+// neither `load` nor `error` (the `od://` failure mode) left it pending
+// forever. The export never even reached `waitForPrintableContent`, whose own
+// (separate) missing timeout was the more obvious suspect.
+//
+// Verified against a real Electron main process before and after the fix: an
+// artifact whose <img> and CSS url() both point at a socket that accepts and
+// never answers went from hanging past the daemon's 600s IPC ceiling to
+// returning a real PNG, with the document-load step dropping to 89ms. That
+// matches production, where 122 of 142 `DESKTOP_RENDERER_UNAVAILABLE` export
+// failures sat at ~10 minutes.
+//
+// `dom-ready` is the correct signal here: the capture pipeline only needs a
+// parsed, scriptable document — waiting on subresources belongs to
+// `waitForPrintableContent`, which bounds itself.
+
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS,
+  loadArtifactDocument,
+} from '../../src/main/deck-capture.js';
+
+type DomReadyListener = () => void;
+
+function createWindowStub(options: {
+  /** Resolve `loadURL` (i.e. did-finish-load fired). Default: never resolves. */
+  finishLoad?: boolean;
+  /** Reject `loadURL` (i.e. did-fail-load). */
+  failLoad?: boolean;
+}) {
+  const listeners: DomReadyListener[] = [];
+  let loadRejected: Promise<unknown> | null = null;
+  const window = {
+    webContents: {
+      once(event: string, listener: DomReadyListener) {
+        if (event === 'dom-ready') listeners.push(listener);
+      },
+    },
+    loadURL(_url: string) {
+      if (options.failLoad) {
+        loadRejected = Promise.reject(new Error('did-fail-load'));
+        return loadRejected;
+      }
+      if (options.finishLoad) return Promise.resolve();
+      return new Promise<void>(() => {});
+    },
+  };
+  return {
+    window: window as unknown as Parameters<typeof loadArtifactDocument>[0],
+    fireDomReady: () => listeners.forEach((listener) => listener()),
+    domReadyListenerCount: () => listeners.length,
+    get loadRejected() {
+      return loadRejected;
+    },
+  };
+}
+
+describe('loadArtifactDocument', () => {
+  test('[P0] proceeds on dom-ready instead of waiting for every subresource', async () => {
+    const stub = createWindowStub({}); // loadURL never resolves — a stalled subresource
+
+    // The listener must already be attached: a `data:` URL can reach
+    // dom-ready before we get a chance to subscribe otherwise.
+    const pending = loadArtifactDocument(stub.window, 'data:text/html,<p>hi');
+    expect(stub.domReadyListenerCount()).toBe(1);
+
+    stub.fireDomReady();
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  test('[P0] gives up after the timeout when dom-ready never fires either', async () => {
+    vi.useFakeTimers();
+    try {
+      const stub = createWindowStub({}); // neither loadURL nor dom-ready ever settles
+      let settled = false;
+      const pending = loadArtifactDocument(stub.window, 'data:text/html,<p>hi').then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(ARTIFACT_DOCUMENT_LOAD_TIMEOUT_MS + 1_000);
+      await pending;
+
+      expect(
+        settled,
+        'an unbounded document load is what turned a stalled resource into a 10-minute export hang',
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('resolves normally when the document finishes loading', async () => {
+    const stub = createWindowStub({ finishLoad: true });
+    await expect(
+      loadArtifactDocument(stub.window, 'data:text/html,<p>hi'),
+    ).resolves.toBeUndefined();
+  });
+
+  test('a did-fail-load rejection does not escape as an unhandled rejection', async () => {
+    const stub = createWindowStub({ failLoad: true });
+    // The race settles on the handled rejection rather than propagating it;
+    // the caller continues and captures whatever rendered.
+    await expect(
+      loadArtifactDocument(stub.window, 'data:text/html,<p>hi'),
+    ).resolves.toBeUndefined();
+    await expect(stub.loadRejected).rejects.toThrow('did-fail-load');
+  });
+});

--- a/apps/desktop/tests/main/artifact-document-load-bound.test.ts
+++ b/apps/desktop/tests/main/artifact-document-load-bound.test.ts
@@ -31,11 +31,13 @@ type DomReadyListener = () => void;
 function createWindowStub(options: {
   /** Resolve `loadURL` (i.e. did-finish-load fired). Default: never resolves. */
   finishLoad?: boolean;
-  /** Reject `loadURL` (i.e. did-fail-load). */
+  /** Reject `loadURL` immediately (i.e. did-fail-load beats dom-ready). */
   failLoad?: boolean;
+  /** Hold the rejection until the test calls `rejectLoad()`. */
+  failLoadAfterDomReady?: boolean;
 }) {
   const listeners: DomReadyListener[] = [];
-  let loadRejected: Promise<unknown> | null = null;
+  let rejectLoad: (() => void) | undefined;
   const window = {
     webContents: {
       once(event: string, listener: DomReadyListener) {
@@ -43,9 +45,11 @@ function createWindowStub(options: {
       },
     },
     loadURL(_url: string) {
-      if (options.failLoad) {
-        loadRejected = Promise.reject(new Error('did-fail-load'));
-        return loadRejected;
+      if (options.failLoad) return Promise.reject(new Error('did-fail-load'));
+      if (options.failLoadAfterDomReady) {
+        return new Promise<void>((_resolve, reject) => {
+          rejectLoad = () => reject(new Error('did-fail-load'));
+        });
       }
       if (options.finishLoad) return Promise.resolve();
       return new Promise<void>(() => {});
@@ -55,9 +59,7 @@ function createWindowStub(options: {
     window: window as unknown as Parameters<typeof loadArtifactDocument>[0],
     fireDomReady: () => listeners.forEach((listener) => listener()),
     domReadyListenerCount: () => listeners.length,
-    get loadRejected() {
-      return loadRejected;
-    },
+    rejectLoad: () => rejectLoad?.(),
   };
 }
 
@@ -103,13 +105,43 @@ describe('loadArtifactDocument', () => {
     ).resolves.toBeUndefined();
   });
 
-  test('a did-fail-load rejection does not escape as an unhandled rejection', async () => {
+  // Review catch (PR #7182): the first version swallowed this with
+  // `.catch(() => undefined)`, which turned a genuine main-document failure
+  // into an immediately-resolved race winner. The pipeline would then capture
+  // Chromium's error page and report a successful-but-wrong export — worse
+  // than the hang this function exists to prevent. A failure that beats
+  // dom-ready must still propagate, exactly as the bare `await loadURL` did.
+  test('[P0] propagates a did-fail-load that arrives before dom-ready', async () => {
     const stub = createWindowStub({ failLoad: true });
-    // The race settles on the handled rejection rather than propagating it;
-    // the caller continues and captures whatever rendered.
     await expect(
       loadArtifactDocument(stub.window, 'data:text/html,<p>hi'),
-    ).resolves.toBeUndefined();
-    await expect(stub.loadRejected).rejects.toThrow('did-fail-load');
+    ).rejects.toThrow('did-fail-load');
+  });
+
+  // ...but once dom-ready has won, the document is usable and a late
+  // rejection must not take the export down — nor escape unhandled.
+  test('[P0] ignores a late did-fail-load once dom-ready already won', async () => {
+    const stub = createWindowStub({ failLoadAfterDomReady: true });
+
+    const orphaned: unknown[] = [];
+    const onUnhandled = (reason: unknown) => orphaned.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const pending = loadArtifactDocument(stub.window, 'data:text/html,<p>hi');
+      stub.fireDomReady();
+      await expect(pending).resolves.toBeUndefined();
+
+      // The load fails only now, after the race is already over.
+      stub.rejectLoad();
+      // Let the microtask queue drain; an unattached handler would surface here.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(
+        orphaned,
+        'the late rejection must stay handled — attaching onRejected up front is the point',
+      ).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
   });
 });

--- a/apps/desktop/tests/main/base-href-precedence.test.ts
+++ b/apps/desktop/tests/main/base-href-precedence.test.ts
@@ -34,6 +34,11 @@ vi.mock('electron', () => {
         return true;
       },
       on: () => undefined,
+      // Real Electron webContents is an EventEmitter; the renderer's document
+      // load waits on `once('dom-ready')`. The stub's loadURL resolves
+      // immediately, so a no-op is faithful here — the load simply never has a
+      // dom-ready to race against.
+      once: () => undefined,
       printToPDF: async () => Buffer.from('pdf'),
       setWindowOpenHandler: () => undefined,
     };

--- a/apps/desktop/tests/main/export-title-replacement-patterns.test.ts
+++ b/apps/desktop/tests/main/export-title-replacement-patterns.test.ts
@@ -35,6 +35,11 @@ vi.mock('electron', () => {
         return true;
       },
       on: () => undefined,
+      // Real Electron webContents is an EventEmitter; the renderer's document
+      // load waits on `once('dom-ready')`. The stub's loadURL resolves
+      // immediately, so a no-op is faithful here — the load simply never has a
+      // dom-ready to race against.
+      once: () => undefined,
       printToPDF: async () => Buffer.from('pdf'),
       setWindowOpenHandler: () => undefined,
     };

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -379,6 +379,61 @@ describe('waitForPrintableContent', () => {
     }
   });
 
+  // Bounding the wait is necessary but not sufficient. The requests we stopped
+  // waiting for stay in flight, and every later executeJavaScript in the
+  // capture pipeline queues behind a renderer still busy with them. Measured
+  // against a real Electron main process on a document whose <img> and CSS
+  // url() both point at a socket that never answers:
+  //
+  //   without stop()   prepare 15340ms  render 22459ms  total 52889ms (unstable)
+  //   with stop()      prepare     6ms  render 10566ms  total 25700ms (repeatable)
+  test('[P0] cancels the outstanding loads when it gives up, so the renderer is usable again', async () => {
+    vi.useFakeTimers();
+    try {
+      let stopped = 0;
+      const window = {
+        webContents: {
+          async executeJavaScript(_script: string) {
+            return new Promise<boolean>(() => {});
+          },
+          stop() {
+            stopped += 1;
+          },
+        },
+      };
+
+      const pending = waitForPrintableContent(
+        window as unknown as Parameters<typeof waitForPrintableContent>[0],
+      );
+      await vi.advanceTimersByTimeAsync(PRINTABLE_CONTENT_WAIT_TIMEOUT_MS + 1_000);
+      await pending;
+
+      expect(stopped, 'a timed-out wait must release the renderer').toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('leaves the loads alone when the page settles on its own', async () => {
+    let stopped = 0;
+    const window = {
+      webContents: {
+        async executeJavaScript(_script: string) {
+          return true;
+        },
+        stop() {
+          stopped += 1;
+        },
+      },
+    };
+
+    await waitForPrintableContent(
+      window as unknown as Parameters<typeof waitForPrintableContent>[0],
+    );
+
+    expect(stopped, 'a healthy export must not have its own loads cancelled').toBe(0);
+  });
+
   test('bounds the page-side waits from inside the injected script too', async () => {
     const scripts: string[] = [];
     const window = {

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -414,6 +414,76 @@ describe('waitForPrintableContent', () => {
     }
   });
 
+  // Review catch (PR #7182): keying cancellation off the OUTER timer alone
+  // missed the ordinary case. When the renderer is healthy the in-page
+  // per-resource deadline (10s) fires first, the script returns on time, and
+  // the outer 15s timer never runs — yet the abandoned requests are still in
+  // flight, which is precisely the state that makes every later
+  // executeJavaScript crawl. The script now reports that it gave up, and that
+  // must cancel the loads too.
+  test('[P0] cancels the loads when the page reports it abandoned a resource, before the outer timeout', async () => {
+    let stopped = 0;
+    const window = {
+      webContents: {
+        async executeJavaScript(_script: string) {
+          // Back well inside the outer bound, but having given up on something.
+          return { stalled: true };
+        },
+        stop() {
+          stopped += 1;
+        },
+      },
+    };
+
+    await waitForPrintableContent(
+      window as unknown as Parameters<typeof waitForPrintableContent>[0],
+    );
+
+    expect(
+      stopped,
+      'an in-page deadline that fired leaves requests in flight just as the outer one does',
+    ).toBe(1);
+  });
+
+  test('does not cancel when the page reports every resource settled', async () => {
+    let stopped = 0;
+    const window = {
+      webContents: {
+        async executeJavaScript(_script: string) {
+          return { stalled: false };
+        },
+        stop() {
+          stopped += 1;
+        },
+      },
+    };
+
+    await waitForPrintableContent(
+      window as unknown as Parameters<typeof waitForPrintableContent>[0],
+    );
+
+    expect(stopped).toBe(0);
+  });
+
+  test('the injected script reports whether it abandoned anything', async () => {
+    const scripts: string[] = [];
+    const window = {
+      webContents: {
+        async executeJavaScript(script: string) {
+          scripts.push(script);
+          return { stalled: false };
+        },
+      },
+    };
+
+    await waitForPrintableContent(
+      window as unknown as Parameters<typeof waitForPrintableContent>[0],
+    );
+
+    expect(scripts[0]).toContain('stalledCount');
+    expect(scripts[0]).toContain('stalled: stalledCount > 0');
+  });
+
   test('leaves the loads alone when the page settles on its own', async () => {
     let stopped = 0;
     const window = {

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -13,9 +13,10 @@
 // the only render path is `printToPdf()`, so the regression cannot be
 // reintroduced without a type error.
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import {
+  PRINTABLE_CONTENT_WAIT_TIMEOUT_MS,
   inferPageSize,
   pdfFilenameFromDocument,
   savePrintReadyDocumentAsPdf,
@@ -328,5 +329,72 @@ describe('waitForPrintableContent', () => {
     expect(scripts[0]).toContain('style.borderImageSource');
     expect(scripts[0]).toContain('style.listStyleImage');
     expect(scripts[0]).toContain('.then(nextFrame)');
+  });
+
+  // Regression boundary for the packaged export hang.
+  //
+  // The injected script waits on `document.fonts.ready`, every `<img>`'s
+  // load/error, and a `new Image()` per CSS url() background. Under `od://`
+  // any of those can stall forever — a font or image URL that never settles
+  // fires neither `load` nor `error`, so the page-side promise never
+  // resolves. Nothing here bounded that wait, so the hang propagated all the
+  // way up: daemon -> desktop IPC has a 600s ceiling, and PostHog shows 122
+  // of 142 `DESKTOP_RENDERER_UNAVAILABLE` export failures sitting at exactly
+  // ~10 minutes before the user finally sees an error.
+  //
+  // The sibling `waitForPrintReadyHandshake` in this same module already
+  // guards itself with a 30s race for exactly this reason; this one was
+  // missed. Resource waiting is best-effort by design (the script resolves on
+  // `error` too, i.e. "a resource that failed still lets us capture"), so the
+  // bound resolves rather than rejects: capturing with a missing image beats
+  // failing ten minutes later.
+  test('[P0] gives up waiting instead of hanging when the page-side wait never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const window = {
+        webContents: {
+          // Models the packaged failure: the injected promise never resolves.
+          async executeJavaScript(_script: string) {
+            return new Promise<boolean>(() => {});
+          },
+        },
+      };
+
+      const pending = waitForPrintableContent(
+        window as unknown as Parameters<typeof waitForPrintableContent>[0],
+      ).then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(PRINTABLE_CONTENT_WAIT_TIMEOUT_MS + 1_000);
+      await pending;
+
+      expect(
+        settled,
+        'waitForPrintableContent must bound its wait; an unbounded one becomes a 10-minute export hang',
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('bounds the page-side waits from inside the injected script too', async () => {
+    const scripts: string[] = [];
+    const window = {
+      webContents: {
+        async executeJavaScript(script: string) {
+          scripts.push(script);
+          return true;
+        },
+      },
+    };
+
+    await waitForPrintableContent(window as Parameters<typeof waitForPrintableContent>[0]);
+
+    // The in-page bound matters independently of the outer race: it lets a
+    // stalled single resource drop out while the rest of the page still
+    // finishes normally, instead of every export paying the full outer bound.
+    expect(scripts[0]).toContain('setTimeout');
   });
 });

--- a/apps/web/src/analytics/export-error-code.ts
+++ b/apps/web/src/analytics/export-error-code.ts
@@ -55,5 +55,23 @@ export function exportErrorCode(err: unknown): string {
   // Same status regex (and the same false-positive guards) as the deploy helper.
   const status = /\b([45]\d\d)\b/.exec(message)?.[1];
   if (status) return `HTTP_${status}`;
-  return err.name || 'UNKNOWN';
+  // A numeric `status` carried on the error (set by the export runtime from
+  // the daemon response) is as good as one parsed out of the message.
+  const carriedStatus = (err as { status?: unknown }).status;
+  if (typeof carriedStatus === 'number' && carriedStatus >= 400) return `HTTP_${carriedStatus}`;
+  // Last resort, in descending order of how much the value actually tells you.
+  //
+  // `err.name` used to be returned unconditionally here. For a subclass
+  // (TypeError, RangeError, AbortError) that names a real failure mode and is
+  // worth keeping. For a plain `new Error(...)` — which is what the export
+  // path throws for every daemon-reported failure — it collapses to the
+  // literal "Error": the single largest bucket in `artifact_export_result`
+  // (148 events / 82 users over 14 days, 48% of image-export failures) and
+  // completely undiagnosable. So keep a meaningful name, drop the generic one.
+  if (err.name && err.name !== 'Error') return err.name;
+  // The daemon's generic envelope code (BAD_REQUEST, INTERNAL, ...) is coarse
+  // — that is why it does not win over message classification above — but it
+  // is a real classification and strictly better than nothing.
+  if (typeof structured === 'string' && structured.length > 0) return `ENVELOPE_${structured}`;
+  return 'UNCLASSIFIED';
 }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -14268,6 +14268,7 @@ function HtmlViewer({
     options?: { wholeDeck?: boolean; context?: HtmlVersionExportContext | null },
   ) => {
     const exportContext = options?.context ?? null;
+    captureFailureStageRef.current = null;
     const imageDeckSignal = deckExportSignalForContext(exportContext);
     // The host compositor grabs on-screen pixels, so any transient hover chrome
     // over the preview leaks into the capture. The screenshot control's own
@@ -14319,11 +14320,23 @@ function HtmlViewer({
         // A semantic failure (e.g. "page is too tall — export as PDF") must surface,
         // NOT silently downgrade to a partial visible-viewport screenshot. Only when
         // the off-screen renderer is genuinely unavailable do we fall through.
-        if ('error' in rendered) throw new Error(rendered.error);
+        if ('error' in rendered) {
+          // Attach the daemon's own code/status to the error so
+          // `exportErrorCode` can report it verbatim instead of falling back
+          // to message-regex guessing (and ultimately to the useless
+          // `err.name === 'Error'`).
+          throw Object.assign(new Error(rendered.error), {
+            ...(rendered.code ? { code: rendered.code } : {}),
+            ...(rendered.status ? { status: rendered.status } : {}),
+          });
+        }
       }
     }
 
-    if (exportContext?.versionId) return null;
+    if (exportContext?.versionId) {
+      captureFailureStageRef.current = 'VERSIONED_NO_RENDERER';
+      return null;
+    }
 
     // Fallback: desktop compositor screenshot of the visible preview region.
     // Returns real rendered pixels and is never tainted, unlike the in-iframe
@@ -14335,7 +14348,10 @@ function HtmlViewer({
 
     if (!useUrlLoadPreview) {
       const activeIframe = srcDocPreviewIframeRef.current ?? iframeRef.current;
-      if (!activeIframe) return null;
+      if (!activeIframe) {
+        captureFailureStageRef.current = 'NO_SRCDOC_IFRAME';
+        return null;
+      }
       await waitForIframeLoadOrTimeout(activeIframe, 250);
       await waitForAnimationFrame();
       return requestPreviewSnapshotWithRetry(activeIframe);
@@ -14352,7 +14368,10 @@ function HtmlViewer({
     const srcDocIframe = srcDocPreviewIframeRef.current;
     if (!srcDocIframe) {
       const activeIframe = iframeRef.current;
-      if (!activeIframe) return null;
+      if (!activeIframe) {
+        captureFailureStageRef.current = 'NO_URL_IFRAME';
+        return null;
+      }
       return requestPreviewSnapshotWithRetry(activeIframe);
     }
 
@@ -14475,6 +14494,14 @@ function HtmlViewer({
 
   // Component-scoped so both the save flow and the modal Cancel button can
   // emit the one terminal result for an image export session.
+  // Which step of the capture fallback chain gave up. `captureExportImageSnapshot`
+  // can return null from five different places — no active iframe, a version-scoped
+  // export with no off-screen render, or any of the bridge snapshot attempts — and
+  // they all used to report the same flat `CAPTURE_FAILED` (90 events / 37 users in
+  // 14 days), which says a capture failed but never which stage. Recording the stage
+  // makes the bucket actionable.
+  const captureFailureStageRef = useRef<string | null>(null);
+
   const fireImageExportResult = (
     result: 'success' | 'failed' | 'cancelled',
     errorCode?: string,
@@ -14538,7 +14565,12 @@ function HtmlViewer({
         const snap = await captureExportImageSnapshot({ wholeDeck: true, context });
         if (!snap) {
           setExportToast({ message: t('fileViewer.exportImageFailed'), tone: 'error' });
-          fireImageExportResult('failed', 'CAPTURE_FAILED');
+          fireImageExportResult(
+            'failed',
+            // The bridge attempts return null without a stage of their own; they
+            // are the "we tried and got nothing back" case.
+            `CAPTURE_FAILED_${captureFailureStageRef.current ?? 'BRIDGE_EMPTY'}`,
+          );
           return;
         }
         dataUrl = snap.dataUrl;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1086,7 +1086,13 @@ export function planDeckImageCapture(opts: {
 export type ProjectImageExportResult =
   | { ok: true; snapshot: PreviewSnapshot }
   | { ok: false; unavailable: true }
-  | { ok: false; error: string };
+  // `code` / `status` carry the daemon's own classification through to the
+  // caller. Dropping them (as this used to) forced `exportErrorCode` to
+  // re-derive a code by regex-matching the message, and anything it could not
+  // match fell through to `err.name` — the literal string "Error", which is
+  // what 48% of image-export failures reported in analytics. See
+  // `apps/web/src/analytics/export-error-code.ts`.
+  | { ok: false; error: string; code?: string; status?: number };
 
 export async function exportProjectImageDataUrl(opts: {
   projectId: string;
@@ -1127,13 +1133,15 @@ export async function exportProjectImageDataUrl(opts: {
     // 501 = this runtime has no off-screen renderer → caller may fall back.
     if (resp.status === 501) return { ok: false, unavailable: true };
     let message = `image export failed (${resp.status})`;
+    let code: string | undefined;
     try {
       const err = await resp.json();
       if (err?.error?.message) message = String(err.error.message);
+      if (typeof err?.error?.code === 'string' && err.error.code) code = err.error.code;
     } catch {
       // non-JSON body; keep the status-based message
     }
-    return { ok: false, error: message };
+    return { ok: false, error: message, status: resp.status, ...(code ? { code } : {}) };
   }
   // A 200 with an unreadable/corrupt payload is a real export failure, NOT
   // "renderer unavailable" — surface it instead of silently downgrading to the

--- a/apps/web/tests/analytics/export-error-code.test.ts
+++ b/apps/web/tests/analytics/export-error-code.test.ts
@@ -47,8 +47,10 @@ describe('exportErrorCode', () => {
     // reported as that status, which is strictly more attributable than the
     // name of the base Error class.
     expect(exportErrorCode(new Error('export request failed (500)'))).toBe('HTTP_500');
-    // A genuinely signal-free message still falls back to the name.
-    expect(exportErrorCode(new Error('export request failed'))).toBe('Error');
+    // A genuinely signal-free message is now reported as UNCLASSIFIED rather
+    // than as the base class name. See the [P0] case below for why: "Error"
+    // was the largest failure bucket in production and identified nothing.
+    expect(exportErrorCode(new Error('export request failed'))).toBe('UNCLASSIFIED');
   });
 
   it('returns UNKNOWN for non-Error throwables', () => {
@@ -91,9 +93,32 @@ describe('exportErrorCode — non-sidecar failures', () => {
     expect(exportErrorCode(new Error('render service replied 503'))).toBe('HTTP_503');
   });
 
-  it('still yields a usable code for a bare Error', () => {
-    // Cannot do better than the name here, but it must not be empty.
-    expect(exportErrorCode(new Error(''))).toBe('Error');
+  // This used to assert `.toBe('Error')`, treating `err.name` as an acceptable
+  // last resort. Production disagreed: over 14 days, `error_code: "Error"` was
+  // the single largest image-export failure bucket — 148 events across 82
+  // users, 48% of all failures — and it identifies nothing, so none of those
+  // users' failures could be diagnosed. An unclassified failure must say so.
+  it('[P0] never reports the useless literal "Error" for an unclassified failure', () => {
+    expect(exportErrorCode(new Error(''))).toBe('UNCLASSIFIED');
+    expect(exportErrorCode(new Error('something we have no pattern for'))).toBe('UNCLASSIFIED');
     expect(exportErrorCode('a string throw')).toBe('UNKNOWN');
+  });
+
+  // The daemon always classifies its own failures; the web export path used to
+  // drop that code on the floor and keep only the message. When no message
+  // pattern matches, the envelope code is coarse but real, and beats guessing.
+  it('[P0] falls back to the daemon envelope code rather than discarding it', () => {
+    const err = Object.assign(new Error('screenshot render failed'), { code: 'INTERNAL' });
+    expect(exportErrorCode(err)).toBe('ENVELOPE_INTERNAL');
+  });
+
+  it('reports a status carried on the error, not just one found in the message', () => {
+    const err = Object.assign(new Error('screenshot render failed'), { status: 502 });
+    expect(exportErrorCode(err)).toBe('HTTP_502');
+  });
+
+  it('keeps preferring a specific daemon code over the envelope fallback', () => {
+    const err = Object.assign(new Error('whatever'), { code: 'RENDERER_BUSY' });
+    expect(exportErrorCode(err)).toBe('RENDERER_BUSY');
   });
 });


### PR DESCRIPTION
## Why

Reported through dogfooding (范桢, 2026-08-19, tracked in Plane as a P0): the
screenshot/export feature "keeps erroring", so users cannot produce a
shareable preview of what they just designed. Preview export is how a design
leaves the product, so a failure here breaks delivery, not just polish.

I went to `artifact_export_result` in PostHog rather than guessing, and the
report holds up — but it is not one bug:

**Image export, last 14 days: 13.5% of attempts fail (308 / 2279). On 0.19.2
that is 22.8% (128 / 562).** And it is not spread evenly — **20 users
attempted 3–11 image exports each and succeeded zero times.** That is the
"keeps erroring" in the report: for those users it is deterministic, not flaky.

Every single failure comes from the packaged desktop app (`client_type:
desktop`, `od://` URLs). None from web.

| `error_code` | events | users |
|---|---:|---:|
| `Error` | 148 | 82 |
| `CAPTURE_FAILED` | 90 | 37 |
| `DESKTOP_RENDERER_UNAVAILABLE` | 37 | 28 |
| `DESKTOP_SIDECAR_UNKNOWN_MESSAGE` | 17 | 8 |
| `HTTP_502` | 15 | 11 |

Two of those top three codes identify nothing, which is why this had not been
diagnosed: 48% of failures were reported as the literal string `"Error"`.

## What users will see

- **Exports stop hanging.** When a font or image inside the artifact never
  finishes loading, the export used to sit there for **ten minutes** before
  reporting a failure. Now the capture proceeds after a bounded wait and the
  user gets their image, at worst missing a resource that was never going to
  arrive.
- No visible change on the healthy path — successful exports are unaffected.
- The remaining two changes are analytics-only: failures that do still happen
  now say *what* failed, so the next fix can target the real cause instead of
  the current black box.

## Surface area

- [x] **UI** — desktop export/screenshot path in `apps/desktop` + `apps/web` (behavior: no more 10-minute hang)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

> UI/CLI dual-track: no new capability, so no CLI surface to mirror. `od export`
> already routes through the same daemon endpoint and inherits the fix.

## Screenshots

Not applicable — the user-visible change is "the export finishes instead of
hanging for ten minutes", which is a timing behavior. The evidence is the
production data above plus the tests below.

## Bug fix verification

### 1. The hang — found by end-to-end, not by the unit tests

I first bounded `waitForPrintableContent`, which awaits (inside the page)
`document.fonts.ready`, every `<img>` load/error, and a `new Image()` per CSS
`url()` background — none of which was bounded, all of which can stall under
`od://`. Unit tests went green.

**Then I ran it against a real daemon + desktop runtime, and it still hung.**
An artifact whose `<img>` and CSS `url()` both point at a socket that accepts
and never answers, exported through the real `/api/projects/:id/export/image`,
still sat there. A probe in the Electron main process showed why:

```
[OD-PROBE] loadURL start        <- and nothing after it
```

`renderDeckSlides` awaited `window.loadURL()` directly, and Electron resolves
that on `did-finish-load`, which Chromium fires only once EVERY subresource has
settled. **The export hung one step before the function I had bounded.** The
unit tests could not have caught this: they pin `waitForPrintableContent`,
which was never reached.

So the fix is three parts, each verified against the live runtime:

1. **Wait on `dom-ready`, not `did-finish-load`.** The capture pipeline only
   needs a parsed, scriptable document; waiting for subresources is
   `waitForPrintableContent`'s job and it now bounds itself. 15s backstop, and
   the `loadURL` rejection stays handled so a genuine `did-fail-load` cannot
   escape as an unhandled rejection.
2. **Bound `waitForPrintableContent`** — 10s per resource in-page, 15s outer.
   Both layers earn their keep: measured `assetsMs: 15001` means the in-page
   `setTimeout` never ran (the renderer was too busy) and the outer backstop is
   what actually saved it.
3. **Cancel the outstanding loads on timeout.** Bounding the wait is necessary
   but not sufficient — the requests we stopped waiting for are still in
   flight, and every later `executeJavaScript` queues behind a renderer still
   busy with them. Without this the steps *after* the wait still cost ~38s and
   the total stayed unstable (one run completed in 53s, a later identical run
   hung again).

Measured end-to-end, same artifact, live daemon + desktop:

| | result |
|---|---|
| before | hung past the daemon's 600s IPC ceiling |
| bound `loadURL` only | 169s → 53s, **but unstable** — a later run hung again |
| + `stop()` on timeout | **25.7s / 25.8s / 25.7s**, byte-identical PNG each run |

Stage breakdown, showing where `stop()` matters:

| stage | without `stop()` | with `stop()` |
|---|---:|---:|
| `loadMs` | 89 | 70–160 |
| `assetsMs` | 15001 | 15001 |
| `prepareMs` | **15340** | **6** |
| `renderMs` | 22459 | 10566 |
| `totalMs` | **52889** | **25700** |

This matches production, where 122 of 142 `DESKTOP_RENDERER_UNAVAILABLE`
failures sit at ~10 minutes (the other 17 are ~0s — desktop not running).

**Red specs**

- `apps/desktop/tests/main/artifact-document-load-bound.test.ts` — 4 tests.
  Reverting `loadArtifactDocument` to the old bare `await window.loadURL(url)`
  turns 3 of them red (both `[P0]`s plus the unhandled-rejection guard);
  confirmed by actually reverting and re-running, then restoring.
- `apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts` — the
  bound and the `stop()`-on-timeout behaviour, including the negative case
  (a healthy export must not have its own loads cancelled). Red on `main`: the
  file would not even load, since the timeout constant did not exist.

**One test-infra change worth review**: two Electron mocks stubbed
`webContents` with `on` but no `once`. The real `webContents` is an
EventEmitter and always has it; the new dom-ready wait made the gap fatal and
turned `base-href-precedence` red. I added `once` to both stubs — verified the
failure is mine (green on `main`, red with my change, green again after the
stub fix), not a product regression.

### 2. `error_code: "Error"` — 148 failures / 82 users, undiagnosable

The daemon classifies its own failures via `sendApiError(res, status, CODE,
message)`. The web export path threw that classification away:

```js
// runtime/exports.ts — kept the message, dropped the code
if (err?.error?.message) message = String(err.error.message);
return { ok: false, error: message };

// FileViewer.tsx — plain Error, so no code survives
if ('error' in rendered) throw new Error(rendered.error);

// analytics/export-error-code.ts — regex misses → fall through
return err.name || 'UNKNOWN';   // → the literal "Error"
```

That last line is in a file whose own docblock says the point of the module is
to stop reporting `"Error"`. The fallback re-introduced it.

Fixed by carrying `code` + `status` through, and by making the last resort
honest: keep a *meaningful* `err.name` (`TypeError`, `AbortError`), fall back
to the daemon envelope code (`ENVELOPE_INTERNAL`), and otherwise report
`UNCLASSIFIED`.

- Red spec: `apps/web/tests/analytics/export-error-code.test.ts`
  → `[P0] never reports the useless literal "Error" for an unclassified failure`
  and `[P0] falls back to the daemon envelope code rather than discarding it`.
- Two pre-existing assertions in that file **pinned the defect as the contract**
  (`expect(exportErrorCode(new Error(''))).toBe('Error')`). They are updated,
  with the production numbers written into the test as the reason — flagging
  this explicitly since changing an existing assertion deserves review.

### 3. `CAPTURE_FAILED` — 90 failures / 37 users, five causes under one code

`captureExportImageSnapshot` returns `null` from five distinct points (no
active iframe in either preview mode, a version-scoped export with no
off-screen renderer, or any bridge snapshot coming back empty). All of them
reported the same flat `CAPTURE_FAILED`. Each give-up point is now tagged, so
the code says which stage of the fallback chain quit.

Analytics-only; no behavior change.

## What this does NOT fix

Being explicit, since the Plane item asks to "restore normal preview
generation":

- **Finding 1 is a real fix**, verified end-to-end: 600s-and-fail becomes
  25.7s-and-succeed, repeatably. Note the artifact still takes 25s in this
  deliberately hostile case (two resources that never answer); a healthy
  export is unaffected (`p50` 4s). Driving that 25s down further means
  attacking `assetsMs` (the 15s bound) and `renderMs`, which is tuning, not a
  hang.
- **Findings 2 and 3 are instrumentation.** They do not themselves make a
  failing export succeed. Until this ships, ~48% of failures are unattributable,
  so anything I changed in the capture logic beyond finding 1 would have been a
  guess. Once a build with this carries a day of data, the remaining buckets
  become specific and the follow-up can target them.
- `DESKTOP_SIDECAR_UNKNOWN_MESSAGE` (17 / 8 users) is the daemon↔desktop
  version skew already described in `export-error-code.ts`; it needs a packaged
  upgrade-ordering fix, not a change here.
- The `600_000` IPC ceiling itself is left alone. It is a backstop, and the
  hang it was masking is fixed at the source. Retuning it needs daemon-side
  render timings — `export_duration_ms` cannot be used for that, since it
  includes time the user spends in the save dialog (successful exports go as
  high as 13 hours).

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (full workspace)
- `pnpm --filter @open-design/web test` — **632 files, 6687 tests passed**
- `pnpm --filter @open-design/desktop typecheck` — pass
- `pnpm --filter @open-design/desktop test` — **40 files, 396 tests passed**
- **End-to-end against a live runtime**: isolated `tools-dev` namespace with
  its own `OD_DATA_DIR`, real daemon + real Electron desktop process, project
  and artifact created through the production HTTP APIs, export driven through
  `POST /api/projects/:id/export/image`. Three consecutive runs: 25.7s / 25.8s
  / 25.7s, `http=200`, byte-identical PNG (2880×1662).
- Baseline discipline: `base-href-precedence` was checked on `main` (green)
  before concluding the failure was mine. `pptx-layered-background` had a
  pixel-delta flake earlier in the session that also passes on a clean run.
