### PR TITLE
Amc

### DIFF
--- a/apps/web/app/[[...slug]]/client-app.tsx
+++ b/apps/web/app/[[...slug]]/client-app.tsx
@@ -2,9 +2,14 @@
 
 import dynamic from 'next/dynamic';
 
+import { applyAmcEmbedFromLocation } from '../../src/amc-embed';
 import { installErrorHandlers } from '../../src/analytics/error-tracking';
 import { MatrixLoader } from '../../src/components/MatrixLoader';
 import { installWebObservability } from '../../src/observability/install';
+
+if (typeof window !== 'undefined') {
+  applyAmcEmbedFromLocation(window);
+}
 
 // Install browser exception handlers at module-load time, before any other
 // client code can throw. The hooks buffer events until AnalyticsProvider

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,8 @@ import {
 import { deriveUploadCohort } from './analytics/upload-tracking';
 import { setPendingDesignSystemCreateEntry } from './analytics/ds-create-entry';
 import { detectClientType } from './analytics/identity';
+import { isAmcEmbedActive } from './amc-embed';
+import { pickDefaultDaemonAgent } from './utils/pickDefaultDaemonAgent';
 import {
   stashOnboardingEntryForProject,
   type OnboardingEntry,
@@ -2301,11 +2303,19 @@ function AppInner() {
   // persists it to the daemon, which then races and clobbers the user's AMR
   // selection on the next launch. Gate on onboardingCompleted so this only
   // backfills an empty slot for returning users.
+  //
+  // AMC Design embed is the other exception: the studio is deep-linked into a
+  // project conversation with the top bar hidden, so the user cannot finish
+  // onboarding or pick a CLI. Auto-fill an authenticated local agent or the
+  // first available one so Send does not fail with "Pick a local agent first".
   useEffect(() => {
     if (!daemonConfigLoaded || agentsLoading) return;
-    if (config.onboardingCompleted !== true) return;
+    const amcEmbed = typeof window !== 'undefined' && isAmcEmbedActive(window);
+    if (config.onboardingCompleted !== true && !amcEmbed) return;
     if (config.agentId) return;
-    const firstAvailable = agents.find((a) => a.available);
+    const firstAvailable = amcEmbed
+      ? pickDefaultDaemonAgent(agents)
+      : agents.find((a) => a.available);
     if (!firstAvailable) return;
     setConfig((prev) => {
       if (prev.agentId) return prev;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5375,7 +5375,9 @@ function AppInner() {
         className={`workspace-shell workspace-shell--${clientType}`}
         data-client-type={clientType}
         data-host-platform={hostPlatform}
+        data-amc-embed={typeof document !== 'undefined' && document.documentElement.dataset.amcEmbed === '1' ? '1' : undefined}
       >
+        {typeof document !== 'undefined' && document.documentElement.dataset.amcEmbed === '1' ? null : (
         <WorkspaceTabsBar
           route={route}
           // The ambient list may still be loading (or belong to a different
@@ -5395,12 +5397,13 @@ function AppInner() {
           onboardingCompleted={config.onboardingCompleted === true}
           identityScopeKey={workspaceTabsIdentityScopeKey}
         />
+        )}
         {/* Avatar + credits keep their home-view spot (the fixed top-right
             corner over the tabs chrome) while a project tab is open, even
             though EntryShell — the cluster's usual owner — is unmounted here.
             Home and the other entry views mount theirs through EntryNavRail;
             the routes are mutually exclusive, so exactly one is on screen. */}
-        {route.kind === 'project' ? (
+        {typeof document !== 'undefined' && document.documentElement.dataset.amcEmbed === '1' ? null : route.kind === 'project' ? (
           <WorkspaceTopRightAccountCluster
             onOpenSettings={openSettings}
             onSignedOut={handleActiveCloudSignOut}
@@ -5440,7 +5443,7 @@ function AppInner() {
           {appMain}
         </div>
       </div>
-      {clientType === 'desktop' ? null : (
+      {typeof document !== 'undefined' && document.documentElement.dataset.amcEmbed === '1' ? null : clientType === 'desktop' ? null : (
         <PetOverlay
           pet={config.pet?.enabled ? config.pet : undefined}
           taskCenter={petTaskCenter}

--- a/apps/web/src/amc-embed.ts
+++ b/apps/web/src/amc-embed.ts
@@ -11,6 +11,13 @@ export function isAmcEmbedSearch(search = ""): boolean {
   return params.get("amcEmbed") === "1" || params.get("embed") === "1";
 }
 
+export function isAmcEmbedActive(win: Window = window): boolean {
+  return (
+    win.document.documentElement.dataset.amcEmbed === "1" ||
+    isAmcEmbedSearch(win.location.search)
+  );
+}
+
 export function applyAmcEmbedFromLocation(win: Window = window): boolean {
   if (!isAmcEmbedSearch(win.location.search)) return false;
   win.document.documentElement.dataset.amcEmbed = "1";

--- a/apps/web/src/amc-embed.ts
+++ b/apps/web/src/amc-embed.ts
@@ -1,0 +1,32 @@
+/**
+ * AMC Design embed — when Open Design is hosted inside Agent Mission Control
+ * (`?amcEmbed=1` or `?embed=1`), strip product chrome so Studio fills the frame.
+ */
+
+export const AMC_EMBED_MESSAGE_READY = "amc-design-ready";
+export const AMC_EMBED_MESSAGE_COMPLETE = "amc-design-complete";
+
+export function isAmcEmbedSearch(search = ""): boolean {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  return params.get("amcEmbed") === "1" || params.get("embed") === "1";
+}
+
+export function applyAmcEmbedFromLocation(win: Window = window): boolean {
+  if (!isAmcEmbedSearch(win.location.search)) return false;
+  win.document.documentElement.dataset.amcEmbed = "1";
+  try {
+    win.parent?.postMessage({ type: AMC_EMBED_MESSAGE_READY }, "*");
+  } catch {
+    // Cross-origin postMessage is always allowed with target "*".
+  }
+  return true;
+}
+
+export function notifyAmcDesignComplete(detail: Record<string, unknown> = {}, win: Window = window): void {
+  if (win.document.documentElement.dataset.amcEmbed !== "1") return;
+  try {
+    win.parent?.postMessage({ type: AMC_EMBED_MESSAGE_COMPLETE, ...detail }, "*");
+  } catch {
+    /* ignore */
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10,6 +10,7 @@
 @import './styles/social-share.css';
 @import './styles/workspace/terminal.css';
 @import './styles/shell.css';
+@import './styles/amc-embed.css';
 @import './styles/chat.css';
 @import './styles/workspace/mention-home.css';
 @import './styles/workspace/artifacts.css';

--- a/apps/web/src/styles/amc-embed.css
+++ b/apps/web/src/styles/amc-embed.css
@@ -1,0 +1,20 @@
+/* AMC Design iframe — hide Open Design product chrome, keep Studio. */
+html[data-amc-embed] .workspace-tabs-chrome,
+html[data-amc-embed] .workspace-account-cluster,
+html[data-amc-embed] .pet-overlay,
+html[data-amc-embed] .entry-nav-rail,
+html[data-amc-embed] .ws-tabs-shell,
+html[data-amc-embed] .MemoryToast,
+html[data-amc-embed] .update-dialog {
+  display: none !important;
+}
+
+html[data-amc-embed] .workspace-shell {
+  grid-template-rows: 0 minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+}
+
+html[data-amc-embed] body {
+  overflow: hidden;
+}

--- a/apps/web/src/utils/pickDefaultDaemonAgent.ts
+++ b/apps/web/src/utils/pickDefaultDaemonAgent.ts
@@ -1,0 +1,18 @@
+export type PickableDaemonAgent = {
+  id: string;
+  available?: boolean;
+  authStatus?: "ok" | "missing" | "unknown";
+};
+
+/**
+ * Choose a daemon CLI to run when the user has not picked one yet.
+ * Prefer an installed agent that is already authenticated so Send does not
+ * bounce on "pick a local agent" / missing login.
+ */
+export function pickDefaultDaemonAgent<T extends PickableDaemonAgent>(
+  agents: T[],
+): T | undefined {
+  const available = agents.filter((agent) => agent.available);
+  if (available.length === 0) return undefined;
+  return available.find((agent) => agent.authStatus === "ok") ?? available[0];
+}

--- a/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
+++ b/apps/web/tests/components/App.onboarding-agent-autoselect.test.tsx
@@ -182,6 +182,7 @@ describe('App first-run agent auto-select', () => {
 
   afterEach(() => {
     cleanup();
+    delete document.documentElement.dataset.amcEmbed;
     vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
@@ -246,6 +247,18 @@ describe('App first-run agent auto-select', () => {
 
     // Returning user with an empty agent slot: the fallback should still fill
     // it with the first available agent.
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-id').textContent).toBe('claude');
+    });
+  });
+
+  it('auto-picks an agent in AMC embed even when onboarding is incomplete', async () => {
+    document.documentElement.dataset.amcEmbed = '1';
+    mockedLoadConfig.mockReturnValue(firstRunConfig());
+    mockedFetchDaemonConfig.mockResolvedValue({});
+
+    render(<App />);
+
     await waitFor(() => {
       expect(screen.getByTestId('agent-id').textContent).toBe('claude');
     });

--- a/apps/web/tests/utils/pickDefaultDaemonAgent.test.ts
+++ b/apps/web/tests/utils/pickDefaultDaemonAgent.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { pickDefaultDaemonAgent } from "../../src/utils/pickDefaultDaemonAgent";
+
+describe("pickDefaultDaemonAgent", () => {
+  it("returns undefined when no agent is available", () => {
+    expect(
+      pickDefaultDaemonAgent([
+        { id: "amr", available: false },
+        { id: "claude", available: false, authStatus: "missing" },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("prefers an authenticated available agent over an unauthenticated one", () => {
+    const picked = pickDefaultDaemonAgent([
+      { id: "claude", available: true, authStatus: "missing" },
+      { id: "codex", available: true, authStatus: "ok" },
+      { id: "cursor-agent", available: true, authStatus: "ok" },
+    ]);
+    expect(picked?.id).toBe("codex");
+  });
+
+  it("falls back to the first available agent when none report auth ok", () => {
+    const picked = pickDefaultDaemonAgent([
+      { id: "amr", available: false },
+      { id: "claude", available: true, authStatus: "missing" },
+      { id: "opencode", available: true },
+    ]);
+    expect(picked?.id).toBe("claude");
+  });
+});

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 120,
+    "restartPolicyType": "ON_FAILURE"
+  }
+}


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
