### PR TITLE
feat(landing): hero and header polish — capsule header back, smaller CTAs, green chips, no avatar

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -27,20 +27,6 @@ const FEISHU_GROUP_QR = '/community/feishu-group-qr.png';
 const FEISHU_MARK = '/launch-week/feishu-mark.png';
 const X_PROFILE = 'https://x.com/OpenDesignHQ';
 
-// OpenDesign Cloud endpoints for the header account module.
-// Production defaults; overridable at build time via PUBLIC_* env so a
-// preview/staging build can point at a non-prod cloud. These are surfaced to
-// the runtime via `data-*` on `.nav-account` because the auth logic lives in
-// `header-enhancer.astro`'s `<script is:inline>` (NOT processed by Vite, so it
-// cannot read `import.meta.env` itself).
-const env = (import.meta.env ?? {}) as Record<string, string | undefined>;
-const CLOUD_API_BASE =
-  env.PUBLIC_CLOUD_API_BASE ?? env.PUBLIC_AMR_API_BASE ?? 'https://amr-api.open-design.ai';
-const CLOUD_CONSOLE_URL =
-  env.PUBLIC_CLOUD_CONSOLE_URL ??
-  env.PUBLIC_AMR_CONSOLE_URL ??
-  'https://open-design.ai/cloud/dashboard?source=open_design';
-
 // Solution → Use cases / Roles. Hrefs mirror upstream main's header 1:1 and
 // pair positionally with the localized `useCaseItems` / `roleItems` tuples.
 const USE_CASE_HREFS = [
@@ -571,12 +557,12 @@ export function Header({
                     decoding='async'
                   />
                 ) : null}
-                <span className='nav-community-perk'>
+                <span className='nav-community-card-title'>
+                  {usesFeishuCommunity ? communityQrHint : communityLabel}
+                </span>
+                <span className='nav-community-card-sub'>
                   <span className='nav-community-perk-dot' aria-hidden='true' />
                   {communityPerk}
-                </span>
-                <span className='nav-community-qr-hint'>
-                  {usesFeishuCommunity ? communityQrHint : communityLabel}
                 </span>
               </div>
             </div>
@@ -637,58 +623,6 @@ export function Header({
           >
             {headerCopy.download}
           </a>
-          {/*
-            OpenDesign Cloud account entry. Signed-out visitors only see the
-            download CTA above; the avatar menu stays `hidden` until the
-            enhancer confirms a live cloud session via
-            `GET {api}/api/auth/get-session`. Config flows through `data-*`
-            because the enhancer script cannot read `import.meta.env`.
-          */}
-          <div
-            className='nav-account'
-            data-amr-account
-            data-amr-api={CLOUD_API_BASE}
-            data-amr-console={CLOUD_CONSOLE_URL}
-          >
-            <details className='nav-account-menu' data-amr-menu hidden>
-              <summary
-                className='nav-account-trigger'
-                aria-label={headerCopy.accountAria}
-                title={headerCopy.accountAria}
-              >
-                <img className='nav-avatar' alt='' data-amr-avatar />
-                <span
-                  className='nav-avatar-fallback'
-                  data-amr-avatar-fallback
-                  aria-hidden='true'
-                />
-              </summary>
-              <div className='nav-account-dropdown' role='menu'>
-                <div className='nav-account-id'>
-                  <span className='nav-account-name' data-amr-name />
-                  <span className='nav-account-email' data-amr-email />
-                </div>
-                <a
-                  className='nav-account-item'
-                  role='menuitem'
-                  href={CLOUD_CONSOLE_URL}
-                  target='_blank'
-                  rel='noreferrer noopener'
-                  data-amr-console-link
-                >
-                  {headerCopy.menuConsole}
-                </a>
-                <button
-                  type='button'
-                  className='nav-account-item nav-account-signout'
-                  role='menuitem'
-                  data-amr-signout
-                >
-                  {headerCopy.menuSignOut}
-                </button>
-              </div>
-            </details>
-          </div>
         </div>
       </div>
       {/*

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -2057,7 +2057,7 @@ a.nav-mega-col-head.is-active {
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
 }
-.hero-tags + .hero-actions { margin-top: 32px; }
+.hero-tags + .hero-actions { margin-top: 44px; }
 /* Hero CTA pair: one notch smaller than the default .hm-dl treatment. */
 .hero-actions .hm-dl-hero {
   padding: 11px 24px 11px 11px;

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -617,7 +617,7 @@ body::before {
      edge stays pinned while the right pulls in — reads as a left-to-right
      collapse. */
   margin-inline: auto;
-  padding: 14px 0;
+  padding: 22px 0;
   background: transparent;
   border-bottom: 1px solid transparent;
   transition:
@@ -648,33 +648,34 @@ body::before {
  * vertical padding for the condensed feel.
  */
 .site-chrome.is-condensed .nav {
-  /* Full-bleed, flush to the top, transparent ground: a soft backdrop blur
-     keeps the links legible over content, with a hairline bottom rule
-     instead of a floating capsule. */
-  margin: 0 auto;
-  width: 100%;
-  padding: 10px 0;
-  border-radius: 0;
-  border: 0;
-  border-bottom: 1px solid rgba(21, 20, 15, 0.08);
-  background: hsl(0 0% 100% / 0.55);
-  -webkit-backdrop-filter: blur(14px) saturate(1.3);
-  backdrop-filter: blur(14px) saturate(1.3);
-  box-shadow: none;
+  /* Detaches from the edges into a centered floating capsule: a gap from
+     the top, side margins, and fully rounded ends. 1280px (not 1080px) so
+     the longest translated nav rows (ja/ru/uk) still hold a single line —
+     the row must never wrap into a second line over the hero. */
+  margin: 14px auto 0;
+  width: min(1280px, calc(100% - 32px));
+  padding: 9px 0;
+  border-radius: 999px;
+  border: 1px solid rgba(21, 20, 15, 0.08);
+  background: hsl(0 0% 100% / 0.42);
+  -webkit-backdrop-filter: blur(12px) saturate(1.4);
+  backdrop-filter: blur(12px) saturate(1.4);
+  backdrop-filter: url(#nav-liquid-glass) blur(7px) saturate(1.4);
+  box-shadow:
+    inset 0 0 2px 1px rgba(255, 255, 255, 0.55),
+    inset 0 0 10px 4px rgba(255, 255, 255, 0.22),
+    0 6px 24px rgba(17, 17, 26, 0.06),
+    0 12px 40px rgba(17, 17, 26, 0.05);
 }
 /* The inner gutter eases in lockstep with the capsule width. */
 .nav > .container {
-  /* Edge-to-edge bar: brand flush left, actions flush right, with a fixed
-     side gutter instead of the centred 1280px content column. */
-  max-width: none;
-  padding: 0 32px;
   transition: padding 420ms cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 /* Tighten the inner container padding inside the capsule (the full 64px
    container gutter would over-inset the brand / links / actions). */
 .site-chrome.is-condensed .nav > .container {
   max-width: none;
-  padding: 0 32px;
+  padding: 0 28px;
 }
 .nav-inner {
   display: flex;
@@ -1940,15 +1941,15 @@ a.nav-mega-col-head.is-active {
 .hero-community-cta {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  height: 64px;
-  padding: 0 26px;
+  gap: 9px;
+  height: 52px;
+  padding: 0 20px;
   border: 1px solid rgba(26, 26, 26, 0.18);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.86);
   color: var(--ink);
   font-family: var(--sans);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 650;
   text-decoration: none;
   white-space: nowrap;
@@ -1972,14 +1973,14 @@ a.nav-mega-col-head.is-active {
   stroke-linejoin: round;
 }
 .hero-community-icon path:last-child { fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; }
-.hero-community-icon-feishu { width: 24px; height: auto; flex-basis: 24px; }
+.hero-community-icon-feishu { width: 22px; height: auto; flex-basis: 22px; }
 .hero-community-perk {
   margin-left: 2px;
-  padding: 3px 9px;
+  padding: 3px 8px;
   border-radius: 999px;
   background: var(--coral);
   color: #0d2601;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 800;
   line-height: 1.2;
   letter-spacing: 0.01em;
@@ -2058,7 +2059,7 @@ a.nav-mega-col-head.is-active {
 .hero-community-qr-img { display: block; width: 168px; height: 168px; border-radius: 8px; }
 @media (max-width: 640px) {
   .hero-actions { flex-wrap: wrap; }
-  .hero-community-cta { height: 52px; padding: 0 20px; font-size: 14px; }
+  .hero-community-cta { height: 46px; padding: 0 16px; font-size: 14px; }
 }
 .hero-download-attention {
   position: relative;
@@ -7128,16 +7129,6 @@ footer .container {
 }
 .hm-dl:hover .hm-di { transform: translateY(2px); }
 .hm-dl:active { transform: translateY(-1px) scale(0.99); }
-.hm-dl::after {
-  content: '';
-  position: absolute;
-  right: 10px;
-  top: 10px;
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: #ff3b30;
-}
 .hm-dl .hm-sheen { display: none; }
 .hm-dl-hero { animation: hm-dl-breathe 2.8s ease-in-out infinite; }
 .hm-dl-hero:hover { animation-play-state: paused; }

--- a/apps/landing-page/app/globals.css
+++ b/apps/landing-page/app/globals.css
@@ -1226,7 +1226,25 @@ a.nav-mega-col-head.is-active {
 .nav-social-link:hover,
 .nav-social-item:focus-within .nav-social-link { color: var(--ink); transform: translateY(-1px); }
 .nav-social-link:focus-visible { outline: 2px solid var(--ink); outline-offset: 3px; border-radius: 6px; }
-.nav-social-icon-feishu { display: block; width: 22px; height: auto; }
+/* Brand marks sit monochrome at rest and light up in brand colour on
+   hover / focus (Feishu via filter on the PNG, Discord via currentColor). */
+.nav-social-icon-feishu {
+  display: block;
+  width: 22px;
+  height: auto;
+  filter: grayscale(1) brightness(0.55) contrast(1.1);
+  opacity: 0.85;
+  transition: filter 160ms ease, opacity 160ms ease;
+}
+.nav-social-link:hover .nav-social-icon-feishu,
+.nav-social-item:focus-within .nav-social-icon-feishu {
+  filter: none;
+  opacity: 1;
+}
+.nav-social-link[data-community-platform='discord']:hover,
+.nav-social-item:focus-within .nav-social-link[data-community-platform='discord'] {
+  color: #5865f2;
+}
 /* Language switcher as a plain icon in the same cluster. */
 .nav-social .nav-locale-switch { display: inline-flex; align-items: center; }
 .nav-social .nav-locale-trigger {
@@ -1262,16 +1280,23 @@ a.nav-mega-col-head.is-active {
   60% { box-shadow: 0 0 0 2px #fff, 0 0 0 6px transparent; }
 }
 @media (prefers-reduced-motion: reduce) { .nav-social-badge { animation: none; } }
-.nav-community-perk {
+/* Hover card copy: a bold title line ("Join Discord" / scan-to-join) and a
+   quiet one-line perk underneath with a single accent dot. */
+.nav-community-card-title {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+.nav-community-card-sub {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--coral) 22%, #fff);
-  color: var(--ink);
+  color: var(--ink-mute, #8c8c8c);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 500;
   white-space: nowrap;
 }
 .nav-community-perk-dot {
@@ -1279,6 +1304,7 @@ a.nav-mega-col-head.is-active {
   height: 6px;
   border-radius: 50%;
   background: var(--coral);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--coral) 22%, transparent);
 }
 /* Feishu group QR — hover / focus card under the icon. */
 .nav-community-qr-card {
@@ -1288,9 +1314,11 @@ a.nav-mega-col-head.is-active {
   left: 50%;
   display: grid;
   justify-items: center;
-  gap: 8px;
-  width: 200px;
-  padding: 14px 14px 12px;
+  gap: 4px;
+  width: max-content;
+  min-width: 168px;
+  max-width: 260px;
+  padding: 12px 16px 11px;
   border: 1px solid rgba(26, 26, 26, 0.11);
   border-radius: 14px;
   background: #fff;
@@ -1315,7 +1343,7 @@ a.nav-mega-col-head.is-active {
   transform: translate(-50%, 0);
   pointer-events: auto;
 }
-.nav-community-qr-img { display: block; width: 168px; height: 168px; border-radius: 8px; }
+.nav-community-qr-img { display: block; width: 168px; height: 168px; margin-bottom: 6px; border-radius: 8px; }
 .nav-cta {
   display: inline-flex;
   align-items: center;
@@ -1585,7 +1613,7 @@ a.nav-mega-col-head.is-active {
   z-index: 1;
 }
 .hero-copy {
-  padding: calc(12vw - 12px) 0 4vh;
+  padding: max(48px, calc(12vw - 52px)) 0 4vh;
   display: flex;
   flex-direction: column;
   /* Centered hero — every first-screen module (eyebrow, manifesto, actions,
@@ -1765,14 +1793,32 @@ a.nav-mega-col-head.is-active {
   flex-direction: column;
   align-items: center;
   gap: 14px;
+  /* Shifted down 30px (top margin) to sit lower under the lead line. */
   margin: 30px auto 8px;
+  /* Frame hugs the text: shrink-wrap to the widest line (brand vs tagline) plus
+     padding, instead of spanning the full hero column. Stays centred. */
   width: fit-content;
   max-width: 100%;
   line-height: 1;
+  /* Blueprint-style selection frame around the brand title (reference comp):
+     a thin accent border with a small filled square sitting on each corner. */
   position: relative;
-  padding: 0;
-  border: 0;
+  /* Fluid frame padding so the blueprint border hugs the title at every
+     width instead of pushing the oversized line off-screen on mobile. */
+  padding: clamp(16px, 3.2vw, 28px) clamp(18px, 5vw, 48px);
+  border: 1px solid var(--coral);
 }
+/* Small filled squares centred on each corner of the title frame. */
+.hero-title-corner {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  background: var(--coral);
+}
+.hero-title-corner.tl { top: 0; left: 0; transform: translate(-50%, -50%); }
+.hero-title-corner.tr { top: 0; right: 0; transform: translate(50%, -50%); }
+.hero-title-corner.bl { bottom: 0; left: 0; transform: translate(-50%, 50%); }
+.hero-title-corner.br { bottom: 0; right: 0; transform: translate(50%, 50%); }
 .hero-title-brand {
   /* Editorial slab/serif treatment for the brand line only — system serif
      stack (no webfont load) so it costs zero extra requests. The CJK tagline
@@ -1941,9 +1987,9 @@ a.nav-mega-col-head.is-active {
 .hero-community-cta {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
-  height: 52px;
-  padding: 0 20px;
+  gap: 8px;
+  height: 48px;
+  padding: 0 18px;
   border: 1px solid rgba(26, 26, 26, 0.18);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.86);
@@ -1973,7 +2019,7 @@ a.nav-mega-col-head.is-active {
   stroke-linejoin: round;
 }
 .hero-community-icon path:last-child { fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; }
-.hero-community-icon-feishu { width: 22px; height: auto; flex-basis: 22px; }
+.hero-community-icon-feishu { width: 20px; height: auto; flex-basis: 20px; }
 .hero-community-perk {
   margin-left: 2px;
   padding: 3px 8px;
@@ -1998,12 +2044,11 @@ a.nav-mega-col-head.is-active {
 .hero-tag {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
   padding: 6px 13px;
-  border: 1px solid rgba(26, 26, 26, 0.14);
+  border: 1px solid transparent;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--ink-soft);
+  background: color-mix(in srgb, var(--coral) 26%, #fff);
+  color: var(--ink);
   font-family: var(--sans);
   font-size: 13px;
   font-weight: 600;
@@ -2012,14 +2057,14 @@ a.nav-mega-col-head.is-active {
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
 }
-.hero-tag::before {
-  content: '';
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--coral);
+.hero-tags + .hero-actions { margin-top: 32px; }
+/* Hero CTA pair: one notch smaller than the default .hm-dl treatment. */
+.hero-actions .hm-dl-hero {
+  padding: 11px 24px 11px 11px;
+  font-size: 15px;
+  gap: 11px;
 }
-.hero-tags + .hero-actions { margin-top: 22px; }
+.hero-actions .hm-dl-hero .hm-di { width: 30px; height: 30px; font-size: 15px; }
 
 .hero-community-icon-discord path { fill: currentColor; stroke: none; }
 .hero-community-qr-card {
@@ -2059,7 +2104,7 @@ a.nav-mega-col-head.is-active {
 .hero-community-qr-img { display: block; width: 168px; height: 168px; border-radius: 8px; }
 @media (max-width: 640px) {
   .hero-actions { flex-wrap: wrap; }
-  .hero-community-cta { height: 46px; padding: 0 16px; font-size: 14px; }
+  .hero-community-cta { height: 42px; padding: 0 14px; font-size: 13px; }
 }
 .hero-download-attention {
   position: relative;

--- a/apps/landing-page/app/page.tsx
+++ b/apps/landing-page/app/page.tsx
@@ -555,6 +555,10 @@ export default function Page({
                   kept in the SEO layer only (title / description / JSON-LD);
                   the first screen leads straight with the brand + positioning. */}
               <h1 className='hero-title' data-reveal>
+                <span className='hero-title-corner tl' aria-hidden='true' />
+                <span className='hero-title-corner tr' aria-hidden='true' />
+                <span className='hero-title-corner bl' aria-hidden='true' />
+                <span className='hero-title-corner br' aria-hidden='true' />
                 {/* Two-layer message: the brand-positioning headline, then the
                     design-system + scenario claim. The agent value promise
                     lives in the ABOUT statement below. */}

--- a/apps/landing-page/tests/header-community-entry.test.ts
+++ b/apps/landing-page/tests/header-community-entry.test.ts
@@ -46,10 +46,10 @@ test('Discord / Feishu no longer duplicate inside the Community dropdown', () =>
   assert.doesNotMatch(en, /<span class="dropdown-name">Feishu<\/span>/);
 });
 
-test('condensed header is a full-bleed flush-top bar, not a floating capsule', () => {
+test('condensed header keeps the floating capsule treatment', () => {
   assert.match(
     stylesSource,
-    /\.site-chrome\.is-condensed \.nav\s*\{[^}]*margin:\s*0 auto;[^}]*width:\s*100%;[^}]*border-radius:\s*0;/s,
+    /\.site-chrome\.is-condensed \.nav\s*\{[^}]*margin:\s*14px auto 0;[^}]*border-radius:\s*999px;/s,
   );
 });
 

--- a/apps/landing-page/tests/header-download-cta.test.ts
+++ b/apps/landing-page/tests/header-download-cta.test.ts
@@ -110,8 +110,8 @@ describe('landing header account and download entry', () => {
     assert.match(enhancer, /navPlatform\.match\(entry\.name\)/);
     assert.match(enhancer, /navNeedsLiveRefresh = navPlatform && !downloadPrompt/);
     assert.doesNotMatch(header, /data-amr-signin|className='nav-signin'/);
-    assert.match(header, /data-amr-menu hidden/);
-    assert.match(header, /data-amr-console-link/);
+    // The signed-in avatar module is gone from the marketing header entirely.
+    assert.doesNotMatch(header, /data-amr-account|nav-account/);
   });
 
   it('silently reveals the avatar for an existing session without wiring login', async () => {


### PR DESCRIPTION
## Why

Follow-up polish on the homepage first screen and header that landed in #7178, from a design pass over the merged result: the header capsule read better than the full-bleed bar once the icon cluster was in place, the hero CTAs were oversized relative to the new single-line headline, the trait chips' dots competed with the headline highlight, and the community hover card's green pill looked out of place. The signed-in avatar module in the marketing header is also removed — it duplicated the product's own account surface and had no marketing purpose.

## What users will see

**Header (all pages)**
- The condensed header is the centred floating Liquid Glass capsule again (as before #7178), keeping the icon-only action cluster from #7178.
- Feishu / Discord marks are monochrome at rest and turn brand-coloured on hover / focus.
- The community hover card is a bold title ("Join Discord" / scan-to-join) with a quiet one-line perk ("Weekly credit drops inside") underneath — no pill.
- The signed-in account avatar no longer appears in the marketing header.

**Homepage first screen**
- The blueprint selection frame is back around the headline block.
- Trait chips lose the dot and take a light coral fill.
- Download + community CTAs are one notch smaller (52px / 48px), with more air between the chips and the CTA row; the whole block sits slightly higher.
- The red attention dot on the download CTAs is removed.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Marketing site only (`apps/landing-page`). The header enhancer keeps its session probe but finds no `[data-amr-account]` element and no-ops.

## Screenshots

Staging preview: `https://pr-7186.open-design-landing-staging.pages.dev/` (en) and `/zh/` once the PR preview deploys — check the header at top / scrolled, the community icon hover (monochrome → colour, new card), the hero frame + chips + CTA sizes.

## Bug fix verification

- Not a bug fix.

## Validation

- `apps/landing-page`: `astro check` → 0 errors.
- `apps/landing-page`: `node --import tsx --test tests/*.test.ts` → 176 pass / 0 fail (`header-download-cta.test.ts` now asserts the header carries no account module; `header-community-entry.test.ts` asserts the capsule treatment and the 48px community CTA).
- Manually verified in a local `astro dev` build with Playwright screenshots (1600px, zh + en): capsule header at top and condensed, icon rest/hover states, hover card, hero frame, chips, CTA sizes.
