### PR TITLE
fix(web): allow unlimited plan models at zero balance

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -134,7 +134,11 @@ import type { OnboardingEntry } from '../onboarding/onboarding-entry';
 import type { PluginUseAction } from './plugins-home/useActions';
 import { Icon } from './Icon';
 import { Button } from '@open-design/components';
-import { defaultAgentModelId, effectiveAgentModelChoice } from './agentModelSelection';
+import {
+  defaultAgentModelId,
+  effectiveAgentModelChoice,
+  effectiveAgentModelId,
+} from './agentModelSelection';
 import { AgentIcon } from './AgentIcon';
 import { CommunityView } from './CommunityView';
 import { TeamSlotPlaceholder } from './TeamSlotPlaceholder';
@@ -1348,6 +1352,10 @@ export function EntryShell({
     let amrGatePrecheckWitness: AmrBalanceGateScope | undefined;
     let amrGatePrecheckPassed = false;
     if (config.mode === 'daemon' && config.agentId === 'amr') {
+      const amrModelId = effectiveAgentModelId(
+        agents.find((agent) => agent.id === 'amr'),
+        config.agentModels?.amr,
+      );
       // PRODUCT INVARIANT: Send never starts Workspace identity discovery.
       // Billing consumes the shell's current in-memory snapshot; if it has not
       // arrived yet, the existing account-scoped gate is used. The daemon's
@@ -1364,7 +1372,7 @@ export function EntryShell({
         const gateWorkspaceIdentity = workspaceIdentityCacheKey(gateWorkspaceContext);
         const gateScope = amrBalanceGateScopeForWorkspaceContext(gateWorkspaceContext);
         let gate = await retryUnavailableAmrBalanceGate(
-          () => checkAmrBalanceGate(gateScope),
+          () => checkAmrBalanceGate(gateScope, amrModelId),
         );
         // Hard blocks hold THIS submit open: the dialog resolves 'retry' when
         // its blocking condition clears (sign-in completed, recharge landed)
@@ -1383,7 +1391,7 @@ export function EntryShell({
           setAmrBalanceGateBlock(null);
           if (decision === 'dismiss') return 'blocked' as const;
           gate = await retryUnavailableAmrBalanceGate(
-            () => checkAmrBalanceGate(gateScope),
+            () => checkAmrBalanceGate(gateScope, amrModelId),
           );
         }
         if (gate.kind === 'unavailable') return false;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -333,7 +333,7 @@ import { buildContinueInCliToast } from '../lib/build-continue-in-cli-toast';
 import { buildClipboardPrompt } from '../lib/build-clipboard-prompt';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { effectiveMaxTokens } from '../state/maxTokens';
-import { effectiveAgentModelChoice } from './agentModelSelection';
+import { effectiveAgentModelChoice, effectiveAgentModelId } from './agentModelSelection';
 import { mediaExecutionPolicyForProjectMetadata } from '../media/execution-policy';
 import { mediaModelProviderId } from '../media/models';
 import { byokProviderRequiresApiKey } from '../utils/byokProvider';
@@ -6709,6 +6709,10 @@ export function ProjectView({
               persistedWorkspaceId.length > 0
               || projectWorkspaceScopeState.scope?.kind === 'unbound'
             );
+          const amrModelId = effectiveAgentModelId(
+            agentsById.get('amr'),
+            config.agentModels?.amr,
+          );
           const gate =
             deferAmrPreflightToDaemon
               ? { kind: 'allow' as const }
@@ -6721,6 +6725,7 @@ export function ProjectView({
                           projectRunPreflightContext.workspaceMemberId,
                       }
                     : undefined,
+                  amrModelId,
                 );
           // A blocked send parks in the conversation queue with its FULL
           // payload (prompt, attachments, comment context) — the composer

--- a/apps/web/src/components/agentModelSelection.ts
+++ b/apps/web/src/components/agentModelSelection.ts
@@ -48,6 +48,16 @@ export function effectiveAgentModelChoice(
   return normalizeAgentModelChoice(agent, choice) ?? choice;
 }
 
+export function effectiveAgentModelId(
+  agent: AgentModelSource,
+  choice: AgentModelChoice | undefined,
+): string | null {
+  const configuredModel = effectiveAgentModelChoice(agent, choice)?.model?.trim();
+  return configuredModel && configuredModel !== 'default'
+    ? configuredModel
+    : defaultAgentModelId(agent);
+}
+
 /**
  * Whether `modelId` may be OFFERED to the user as a selectable model.
  *

--- a/apps/web/src/runtime/amr-balance-gate.ts
+++ b/apps/web/src/runtime/amr-balance-gate.ts
@@ -262,7 +262,7 @@ async function checkWorkspaceBalanceGate(
   }
   const balance = amrWalletBalanceUsd(workspaceSnapshot);
   if (balance == null) return { kind: 'unavailable' };
-  if (balance <= AMR_HARD_BLOCK_BALANCE_USD && scope.workspaceType === 'personal') {
+  if (balance <= AMR_LOW_BALANCE_WARN_USD && scope.workspaceType === 'personal') {
     const plan = await resolveAmrPlan(workspaceSnapshot!);
     if (isUnlimitedAmrModelForPlan(plan, modelId)) return { kind: 'allow' };
   }
@@ -298,6 +298,8 @@ export async function checkAmrBalanceGate(
         return { kind: 'allow' };
       }
       // cached is non-null here: a definitive balance implies a snapshot.
+      const plan = await resolveAmrPlan(cached!);
+      if (isUnlimitedAmrModelForPlan(plan, modelId)) return { kind: 'allow' };
       return { kind: 'soft', snapshot: cached! };
     }
     // Hard-block candidate (signed out or empty): confirm against the live
@@ -317,7 +319,7 @@ export async function checkAmrBalanceGate(
     if (fresh.stale || fresh.error != null) return { kind: 'allow' };
     const freshBalance = amrWalletBalanceUsd(fresh);
     if (freshBalance == null) return { kind: 'allow' };
-    if (freshBalance <= AMR_HARD_BLOCK_BALANCE_USD) {
+    if (freshBalance <= AMR_LOW_BALANCE_WARN_USD) {
       const plan = await resolveAmrPlan(fresh);
       if (isUnlimitedAmrModelForPlan(plan, modelId)) return { kind: 'allow' };
     }

--- a/apps/web/src/runtime/amr-balance-gate.ts
+++ b/apps/web/src/runtime/amr-balance-gate.ts
@@ -18,6 +18,8 @@ import type {
   WorkspaceBillingResponse,
 } from '@open-design/contracts';
 import { fetchAmrWalletSnapshot } from '../providers/daemon';
+import { resolveAmrPlan } from './amr-low-balance-plan';
+import { isUnlimitedAmrModelForPlan } from './amr-unlimited-models';
 
 /**
  * Hard-block line (USD): at or below this the wallet cannot fund any part of
@@ -229,6 +231,7 @@ async function fetchWorkspaceWalletSnapshot(
 
 async function checkWorkspaceBalanceGate(
   scope: AmrBalanceGateScope,
+  modelId?: string | null,
 ): Promise<AmrBalanceGateResult> {
   // The URL carries the selected workspace identity. The daemon authorizes
   // that exact directory membership and returns a v2 identity-stamped wallet.
@@ -259,6 +262,10 @@ async function checkWorkspaceBalanceGate(
   }
   const balance = amrWalletBalanceUsd(workspaceSnapshot);
   if (balance == null) return { kind: 'unavailable' };
+  if (balance <= AMR_HARD_BLOCK_BALANCE_USD && scope.workspaceType === 'personal') {
+    const plan = await resolveAmrPlan(workspaceSnapshot!);
+    if (isUnlimitedAmrModelForPlan(plan, modelId)) return { kind: 'allow' };
+  }
   if (balance <= AMR_HARD_BLOCK_BALANCE_USD) {
     return {
       kind: 'hard',
@@ -274,10 +281,11 @@ async function checkWorkspaceBalanceGate(
 
 export async function checkAmrBalanceGate(
   scope?: AmrBalanceGateScope,
+  modelId?: string | null,
 ): Promise<AmrBalanceGateResult> {
   try {
     if (scope) {
-      return await checkWorkspaceBalanceGate(scope);
+      return await checkWorkspaceBalanceGate(scope, modelId);
     }
     const cached = await fetchAmrWalletSnapshot().catch(() => null);
     const cachedBalance = amrWalletBalanceUsd(cached);
@@ -309,6 +317,10 @@ export async function checkAmrBalanceGate(
     if (fresh.stale || fresh.error != null) return { kind: 'allow' };
     const freshBalance = amrWalletBalanceUsd(fresh);
     if (freshBalance == null) return { kind: 'allow' };
+    if (freshBalance <= AMR_HARD_BLOCK_BALANCE_USD) {
+      const plan = await resolveAmrPlan(fresh);
+      if (isUnlimitedAmrModelForPlan(plan, modelId)) return { kind: 'allow' };
+    }
     if (freshBalance <= AMR_HARD_BLOCK_BALANCE_USD) {
       return { kind: 'hard', reason: 'insufficient', snapshot: fresh };
     }

--- a/apps/web/src/runtime/amr-unlimited-models.ts
+++ b/apps/web/src/runtime/amr-unlimited-models.ts
@@ -1,0 +1,46 @@
+const GO_UNLIMITED_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+  'glm-5.2',
+] as const;
+
+const PLUS_UNLIMITED_MODELS = [
+  ...GO_UNLIMITED_MODELS,
+  'kimi-k2.7-code',
+] as const;
+
+const PRO_UNLIMITED_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+  'glm-5.2',
+  'kimi-k2.7-code',
+  'minimax-m2.7',
+  'mimo-v2.5-pro',
+] as const;
+
+const MAX_UNLIMITED_MODELS = [
+  ...PRO_UNLIMITED_MODELS,
+  'kimi-k2.6',
+  'glm-5.1',
+] as const;
+
+// This table only decides whether the client-side zero-balance preflight may
+// stand down. Vela remains authoritative for plan access and usage limits.
+const UNLIMITED_MODELS_BY_PLAN: Readonly<Record<string, ReadonlySet<string>>> = {
+  go: new Set(GO_UNLIMITED_MODELS),
+  plus: new Set(PLUS_UNLIMITED_MODELS),
+  pro: new Set(PRO_UNLIMITED_MODELS),
+  max: new Set(MAX_UNLIMITED_MODELS),
+};
+
+function normalize(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+export function isUnlimitedAmrModelForPlan(
+  plan: string | null | undefined,
+  modelId: string | null | undefined,
+): boolean {
+  const models = UNLIMITED_MODELS_BY_PLAN[normalize(plan)];
+  return models?.has(normalize(modelId)) ?? false;
+}

--- a/apps/web/src/runtime/amr-unlimited-models.ts
+++ b/apps/web/src/runtime/amr-unlimited-models.ts
@@ -14,17 +14,17 @@ const PRO_UNLIMITED_MODELS = [
   'deepseek-v4-pro',
   'glm-5.2',
   'kimi-k2.7-code',
-  'minimax-m2.7',
   'mimo-v2.5-pro',
 ] as const;
 
 const MAX_UNLIMITED_MODELS = [
   ...PRO_UNLIMITED_MODELS,
+  'minimax-m2.7',
   'kimi-k2.6',
   'glm-5.1',
 ] as const;
 
-// This table only decides whether the client-side zero-balance preflight may
+// This table only decides whether the client-side balance preflight may
 // stand down. Vela remains authoritative for plan access and usage limits.
 const UNLIMITED_MODELS_BY_PLAN: Readonly<Record<string, ReadonlySet<string>>> = {
   go: new Set(GO_UNLIMITED_MODELS),

--- a/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
+++ b/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
@@ -310,7 +310,9 @@ describe('EntryShell AMR workspace precheck race', () => {
     setHomeHeroPrompt('Create a poster after I sign in.');
     fireEvent.click(await screen.findByTestId('home-hero-submit'));
 
-    await waitFor(() => expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined));
+    await waitFor(() => {
+      expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined, 'glm-5');
+    });
     const dialog = await screen.findByTestId('amr-balance-dialog');
     expect(dialog.getAttribute('data-reason')).toBe('signed_out');
     expect(onCreateProject).not.toHaveBeenCalled();
@@ -393,7 +395,9 @@ describe('EntryShell AMR workspace precheck race', () => {
     setHomeHeroPrompt('Create through the old daemon compatibility lane.');
     fireEvent.click(await screen.findByTestId('home-hero-submit'));
 
-    await waitFor(() => expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined));
+    await waitFor(() => {
+      expect(mockedCheckAmrBalanceGate).toHaveBeenCalledWith(undefined, 'glm-5');
+    });
     await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
   });
 
@@ -890,7 +894,7 @@ describe('EntryShell AMR workspace precheck race', () => {
         workspaceType: 'team',
         workspaceId: 'workspace-a',
         workspaceMemberId: 'member-a',
-      });
+      }, 'glm-5');
     });
 
     currentContext = workspaceB;
@@ -905,7 +909,7 @@ describe('EntryShell AMR workspace precheck race', () => {
         workspaceType: 'team',
         workspaceId: 'workspace-b',
         workspaceMemberId: 'member-b',
-      });
+      }, 'glm-5');
     });
     await waitFor(() => expect(onCreateProject).toHaveBeenCalledTimes(1));
     expect(onCreateProject).toHaveBeenCalledWith(

--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -412,7 +412,16 @@ function projectViewElement(overrides: Partial<ComponentProps<typeof ProjectView
       project={project()}
       routeFileName={null}
       config={config}
-      agents={[{ id: 'amr', name: 'amr', available: true }] as unknown as AgentInfo[]}
+      agents={[{
+        id: 'amr',
+        name: 'amr',
+        available: true,
+        models: [{
+          id: 'deepseek-v4-flash',
+          label: 'DeepSeek V4 Flash',
+          default: true,
+        }],
+      }] as unknown as AgentInfo[]}
       skills={[] as SkillSummary[]}
       designTemplates={[] as SkillSummary[]}
       designSystems={[] as DesignSystemSummary[]}
@@ -502,7 +511,7 @@ describe('a Home auto-send identifies its caller before the project scope resolv
       workspaceType: 'team',
       workspaceId: TEAM_WORKSPACE,
       workspaceMemberId: TEAM_MEMBER,
-    });
+    }, 'deepseek-v4-flash');
     const options = mockedStreamViaDaemon.mock.calls[0]?.[0];
     expect(
       options?.workspaceContext,
@@ -997,7 +1006,7 @@ describe('a Home auto-send identifies its caller before the project scope resolv
       workspaceType: 'team',
       workspaceId: TEAM_WORKSPACE,
       workspaceMemberId: TEAM_MEMBER,
-    });
+    }, 'deepseek-v4-flash');
     expect(mockedStreamViaDaemon.mock.calls[0]?.[0].workspaceContext).toEqual(
       CALLER_CONTEXT,
     );
@@ -1018,7 +1027,16 @@ describe('a Home auto-send identifies its caller before the project scope resolv
 
     const stableOverrides: Partial<ComponentProps<typeof ProjectView>> = {
       project: project(),
-      agents: [{ id: 'amr', name: 'amr', available: true }] as unknown as AgentInfo[],
+      agents: [{
+        id: 'amr',
+        name: 'amr',
+        available: true,
+        models: [{
+          id: 'deepseek-v4-flash',
+          label: 'DeepSeek V4 Flash',
+          default: true,
+        }],
+      }] as unknown as AgentInfo[],
       skills: [] as SkillSummary[],
       designTemplates: [] as SkillSummary[],
       designSystems: [] as DesignSystemSummary[],
@@ -1080,7 +1098,7 @@ describe('a Home auto-send identifies its caller before the project scope resolv
         workspaceType: 'personal',
         workspaceId: PERSONAL_CONTEXT.workspaceId,
         workspaceMemberId: PERSONAL_CONTEXT.workspaceMemberId,
-      });
+      }, 'deepseek-v4-flash');
     });
     await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalled());
   });
@@ -1109,7 +1127,7 @@ describe('a Home auto-send identifies its caller before the project scope resolv
         workspaceType: 'personal',
         workspaceId: PERSONAL_CONTEXT.workspaceId,
         workspaceMemberId: PERSONAL_CONTEXT.workspaceMemberId,
-      });
+      }, 'deepseek-v4-flash');
     });
     await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalled());
     expect(mockedStreamViaDaemon.mock.calls[0]?.[0].workspaceContext).toEqual(
@@ -1205,7 +1223,16 @@ describe('a Home auto-send observes a project billing scope that settles after m
     // only dependency allowed to change in this regression.
     const stableOverrides: Partial<ComponentProps<typeof ProjectView>> = {
       project: project(),
-      agents: [{ id: 'amr', name: 'amr', available: true }] as unknown as AgentInfo[],
+      agents: [{
+        id: 'amr',
+        name: 'amr',
+        available: true,
+        models: [{
+          id: 'deepseek-v4-flash',
+          label: 'DeepSeek V4 Flash',
+          default: true,
+        }],
+      }] as unknown as AgentInfo[],
       skills: [] as SkillSummary[],
       designTemplates: [] as SkillSummary[],
       designSystems: [] as DesignSystemSummary[],
@@ -1249,7 +1276,7 @@ describe('a Home auto-send observes a project billing scope that settles after m
         workspaceType: 'team',
         workspaceId: TEAM_WORKSPACE,
         workspaceMemberId: TEAM_MEMBER,
-      });
+      }, 'deepseek-v4-flash');
     });
     await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalled());
   });

--- a/apps/web/tests/components/agentModelSelection.test.ts
+++ b/apps/web/tests/components/agentModelSelection.test.ts
@@ -3,6 +3,7 @@ import {
   agentModelIsSelectable,
   defaultAgentModelId,
   effectiveAgentModelChoice,
+  effectiveAgentModelId,
   normalizeAgentModelChoice,
 } from '../../src/components/agentModelSelection';
 import type { AgentInfo } from '../../src/types';
@@ -61,6 +62,7 @@ describe('agent model selection', () => {
 
     expect(normalizeAgentModelChoice(amrAgent, choice)).toBeNull();
     expect(effectiveAgentModelChoice(amrAgent, choice)).toEqual(choice);
+    expect(effectiveAgentModelId(amrAgent, choice)).toBe('glm-5');
   });
 
   it('does not select a disabled model as the AMR default when every catalog row is locked', () => {

--- a/apps/web/tests/runtime/amr-balance-gate.test.ts
+++ b/apps/web/tests/runtime/amr-balance-gate.test.ts
@@ -186,6 +186,35 @@ describe('checkAmrBalanceGate', () => {
     await expect(checkAmrBalanceGate()).resolves.toEqual({ kind: 'allow' });
   });
 
+  it.each([
+    ['plus', 'kimi-k2.7-code'],
+    ['pro', 'glm-5.2'],
+    ['max', 'minimax-m2.7'],
+  ])('does not soft-warn a %s unlimited model at low balance', async (plan, modelId) => {
+    const low = snapshot({
+      balanceUsd: '1.20',
+      user: { id: 'u1', email: 'user@example.com', plan },
+    });
+    mockedFetch.mockResolvedValueOnce(low);
+
+    await expect(checkAmrBalanceGate(undefined, modelId)).resolves.toEqual({
+      kind: 'allow',
+    });
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still soft-warns when a low-balance Pro account selects MiniMax M2.7', async () => {
+    const low = snapshot({
+      balanceUsd: '1.20',
+      user: { id: 'u1', email: 'user@example.com', plan: 'pro' },
+    });
+    mockedFetch.mockResolvedValueOnce(low);
+
+    await expect(
+      checkAmrBalanceGate(undefined, 'minimax-m2.7'),
+    ).resolves.toEqual({ kind: 'soft', snapshot: low });
+  });
+
   it('skips the soft warning once the user opted out — but never the hard block', async () => {
     expect(isAmrLowBalanceWarnOptedOut()).toBe(false);
     setAmrLowBalanceWarnOptedOut();
@@ -452,6 +481,32 @@ describe('checkAmrBalanceGate', () => {
         workspaceId: 'ws-personal-go',
         workspaceMemberId: 'wm-personal-go',
       }, 'deepseek-v4-pro'),
+    ).resolves.toEqual({ kind: 'allow' });
+  });
+
+  it('does not soft-warn an unlimited model in a low-balance personal workspace', async () => {
+    mockedFetch.mockResolvedValue(snapshot({
+      balanceUsd: '1.50',
+      user: { id: 'u1', email: 'user@example.com', plan: 'pro' },
+    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify(authoritativeWorkspaceBillingResponse(
+          'ws-personal-pro',
+          'wm-personal-pro',
+          '1.50',
+        )),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )),
+    );
+
+    await expect(
+      checkAmrBalanceGate({
+        workspaceType: 'personal',
+        workspaceId: 'ws-personal-pro',
+        workspaceMemberId: 'wm-personal-pro',
+      }, 'glm-5.2'),
     ).resolves.toEqual({ kind: 'allow' });
   });
 

--- a/apps/web/tests/runtime/amr-balance-gate.test.ts
+++ b/apps/web/tests/runtime/amr-balance-gate.test.ts
@@ -14,13 +14,18 @@ import {
   retryUnavailableAmrBalanceGate,
   setAmrLowBalanceWarnOptedOut,
 } from '../../src/runtime/amr-balance-gate';
-import { fetchAmrWalletSnapshot } from '../../src/providers/daemon';
+import {
+  fetchAmrWalletSnapshot,
+  fetchVelaLoginStatus,
+} from '../../src/providers/daemon';
 
 vi.mock('../../src/providers/daemon', () => ({
   fetchAmrWalletSnapshot: vi.fn(),
+  fetchVelaLoginStatus: vi.fn(),
 }));
 
 const mockedFetch = vi.mocked(fetchAmrWalletSnapshot);
+const mockedFetchStatus = vi.mocked(fetchVelaLoginStatus);
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -83,10 +88,12 @@ function authoritativeWorkspaceBillingResponse(
 
 beforeEach(() => {
   window.localStorage.clear();
+  mockedFetchStatus.mockRejectedValue(new Error('status unavailable'));
 });
 
 afterEach(() => {
   mockedFetch.mockReset();
+  mockedFetchStatus.mockReset();
   vi.unstubAllGlobals();
 });
 
@@ -206,6 +213,62 @@ describe('checkAmrBalanceGate', () => {
       snapshot: fresh,
     });
     expect(mockedFetch).toHaveBeenNthCalledWith(2, { refresh: true });
+  });
+
+  it.each([
+    ['go', 'glm-5.2'],
+    ['plus', 'kimi-k2.7-code'],
+    ['pro', 'glm-5.2'],
+    ['max', 'glm-5.1'],
+  ])('allows a %s unlimited model with a fresh zero-dollar wallet', async (plan, modelId) => {
+    const planAccount = snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan },
+    });
+    mockedFetch
+      .mockResolvedValueOnce({ ...planAccount, source: 'daemon_cache' })
+      .mockResolvedValueOnce(planAccount);
+
+    await expect(
+      checkAmrBalanceGate(undefined, modelId),
+    ).resolves.toEqual({ kind: 'allow' });
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, { refresh: true });
+  });
+
+  it('uses the live billing account when the fresh wallet omits the Go plan', async () => {
+    const emptyWallet = snapshot({ balanceUsd: '0' });
+    mockedFetch
+      .mockResolvedValueOnce({ ...emptyWallet, source: 'daemon_cache' })
+      .mockResolvedValueOnce(emptyWallet);
+    mockedFetchStatus.mockResolvedValue({
+      loggedIn: true,
+      profile: 'prod',
+      user: null,
+      account: { plan: 'go', balanceUsd: '0' },
+      configPath: '/tmp/vela.json',
+    });
+
+    await expect(
+      checkAmrBalanceGate(undefined, 'glm-5.2'),
+    ).resolves.toEqual({ kind: 'allow' });
+  });
+
+  it('keeps the zero-dollar block for a model outside the current plan allowance', async () => {
+    const plusAccount = snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan: 'plus' },
+    });
+    mockedFetch
+      .mockResolvedValueOnce({ ...plusAccount, source: 'daemon_cache' })
+      .mockResolvedValueOnce(plusAccount);
+
+    await expect(
+      checkAmrBalanceGate(undefined, 'glm-5.1'),
+    ).resolves.toEqual({
+      kind: 'hard',
+      reason: 'insufficient',
+      snapshot: plusAccount,
+    });
   });
 
   it('hard-blocks a signed-out account after refresh confirmation', async () => {
@@ -364,6 +427,61 @@ describe('checkAmrBalanceGate', () => {
       workspaceId: 'ws-personal-a',
       workspaceMemberId: 'wm-personal-a',
     })).resolves.toEqual({ kind: 'allow' });
+  });
+
+  it('allows a personal Go workspace with a zero-dollar wallet', async () => {
+    mockedFetch.mockResolvedValue(snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan: 'go' },
+    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify(authoritativeWorkspaceBillingResponse(
+          'ws-personal-go',
+          'wm-personal-go',
+          '0',
+        )),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )),
+    );
+
+    await expect(
+      checkAmrBalanceGate({
+        workspaceType: 'personal',
+        workspaceId: 'ws-personal-go',
+        workspaceMemberId: 'wm-personal-go',
+      }, 'deepseek-v4-pro'),
+    ).resolves.toEqual({ kind: 'allow' });
+  });
+
+  it('does not use a personal Go plan to bypass a team workspace zero balance', async () => {
+    const goAccount = snapshot({
+      balanceUsd: '0',
+      user: { id: 'u1', email: 'user@example.com', plan: 'go' },
+    });
+    mockedFetch.mockResolvedValue(goAccount);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify(authoritativeWorkspaceBillingResponse(
+          'ws-team-go-member',
+          'wm-team-go-member',
+          '0',
+        )),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )),
+    );
+
+    await expect(checkAmrBalanceGate({
+      workspaceType: 'team',
+      workspaceId: 'ws-team-go-member',
+      workspaceMemberId: 'wm-team-go-member',
+    }, 'deepseek-v4-flash')).resolves.toEqual({
+      kind: 'hard',
+      reason: 'insufficient',
+      snapshot: expect.objectContaining({ balanceUsd: '0' }),
+    });
   });
 
   it('does not authorize a positive balance from a daemon that cannot prove an authoritative read', async () => {

--- a/apps/web/tests/runtime/amr-unlimited-models.test.ts
+++ b/apps/web/tests/runtime/amr-unlimited-models.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isUnlimitedAmrModelForPlan } from '../../src/runtime/amr-unlimited-models';
+
+describe('AMR unlimited model entitlements', () => {
+  it.each([
+    ['go', 'glm-5.2', true],
+    ['go', 'kimi-k2.7-code', false],
+    ['plus', 'kimi-k2.7-code', true],
+    ['plus', 'minimax-m2.7', false],
+    ['pro', 'glm-5.2', true],
+    ['pro', 'mimo-v2.5-pro', true],
+    ['pro', 'kimi-k2.6', false],
+    ['max', 'glm-5.1', true],
+  ])('maps %s / %s to unlimited=%s', (plan, modelId, unlimited) => {
+    expect(isUnlimitedAmrModelForPlan(plan, modelId)).toBe(unlimited);
+  });
+});

--- a/apps/web/tests/runtime/amr-unlimited-models.test.ts
+++ b/apps/web/tests/runtime/amr-unlimited-models.test.ts
@@ -9,7 +9,9 @@ describe('AMR unlimited model entitlements', () => {
     ['plus', 'minimax-m2.7', false],
     ['pro', 'glm-5.2', true],
     ['pro', 'mimo-v2.5-pro', true],
+    ['pro', 'minimax-m2.7', false],
     ['pro', 'kimi-k2.6', false],
+    ['max', 'minimax-m2.7', true],
     ['max', 'glm-5.1', true],
   ])('maps %s / %s to unlimited=%s', (plan, modelId, unlimited) => {
     expect(isUnlimitedAmrModelForPlan(plan, modelId)).toBe(unlimited);


### PR DESCRIPTION
## Why

Users on the new Go, Plus, Pro, and Max plans can have a low or zero dollar wallet while still being entitled to unlimited models. The desktop pre-run gate treated wallet balance as an unconditional hard block or low-balance warning, so it opened a subscription or warning dialog even though pool usage does not deduct wallet funds.

## What users will see

On Home and project chat, a Personal workspace no longer opens either balance dialog when the selected AMR model is unlimited for the current plan, including balances from $0 through the $2 warning threshold. Models outside the plan allowance remain blocked or warned. Team workspaces continue to use their own balance and do not inherit a member personal plan.

Pro has five unlimited models and includes GLM-5.2; MiniMax M2.7 is Max-only.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — balance preflight now respects unlimited-model entitlements
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this bug fix suppresses incorrect existing dialogs and adds no new visual surface.

## Bug fix verification

- Test paths: `apps/web/tests/runtime/amr-balance-gate.test.ts`, `apps/web/tests/runtime/amr-unlimited-models.test.ts`, `apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx`, and `apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx`
- Red on `main`, green on this branch: yes
- Coverage includes all four plans, Pro + GLM-5.2, Pro excluding MiniMax M2.7, low and zero balances, models outside the allowance, Personal Workspace, Team Workspace, and live-plan fallback.

## Validation

- Focused Web tests: 114 passed
- Full Web shard 1/2: 317 files passed, 3,432 tests passed, 4 skipped
- Full Web shard 2/2: 316 files passed, 3,270 tests passed, 1 expected fail, 7 skipped
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`