### PR TITLE
fix(pricing): disable current and lower plan actions

### DIFF
--- a/apps/landing-page/app/_components/pricing-individual-plans.astro
+++ b/apps/landing-page/app/_components/pricing-individual-plans.astro
@@ -856,6 +856,16 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
     background: #8cf76c;
   }
 
+  .pricing-card .pricing-card-cta[aria-disabled='true'],
+  .pricing-card .pricing-card-cta[aria-disabled='true']:hover,
+  .pricing-card .pricing-card-cta[aria-disabled='true']:focus-visible {
+    color: #595d54;
+    background: #d8dad4;
+    border-color: #c5c8c0;
+    cursor: not-allowed;
+    transform: none;
+  }
+
   .plan-feature-details {
     margin-top: 14px;
     padding-top: 0;

--- a/apps/landing-page/app/_lib/pricing-content.ts
+++ b/apps/landing-page/app/_lib/pricing-content.ts
@@ -16,6 +16,23 @@
  */
 import type { LandingLocaleCode } from '../i18n';
 
+const CURRENT_PLAN_LABELS: Partial<Record<LandingLocaleCode, string>> = {
+  en: 'Current plan',
+  zh: '当前套餐',
+  'zh-tw': '目前方案',
+  ja: '現在のプラン',
+  ko: '현재 요금제',
+  de: 'Aktueller Tarif',
+  fr: 'Offre actuelle',
+  ru: 'Текущий тариф',
+  es: 'Plan actual',
+  'pt-br': 'Plano atual',
+};
+
+export function getCurrentPlanLabel(locale: LandingLocaleCode): string {
+  return CURRENT_PLAN_LABELS[locale] ?? CURRENT_PLAN_LABELS.en!;
+}
+
 export type PlanTierId = 'plus' | 'pro' | 'max';
 
 export interface PlanCopy {

--- a/apps/landing-page/app/_lib/pricing-current-plan.ts
+++ b/apps/landing-page/app/_lib/pricing-current-plan.ts
@@ -1,0 +1,73 @@
+export type PersonalPlanTier = 'go' | 'plus' | 'pro' | 'max';
+
+type PricingFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+const PERSONAL_PLAN_TIERS = new Set<PersonalPlanTier>([
+  'go',
+  'plus',
+  'pro',
+  'max',
+]);
+const PERSONAL_PLAN_ORDER: readonly PersonalPlanTier[] = [
+  'go',
+  'plus',
+  'pro',
+  'max',
+];
+
+export function isPersonalPlanAtOrBelow(
+  candidateTier: string,
+  currentTier: PersonalPlanTier,
+): boolean {
+  const candidateIndex = PERSONAL_PLAN_ORDER.indexOf(
+    candidateTier as PersonalPlanTier,
+  );
+  return (
+    candidateIndex >= 0 &&
+    candidateIndex <= PERSONAL_PLAN_ORDER.indexOf(currentTier)
+  );
+}
+
+function personalPlanTier(value: unknown): PersonalPlanTier | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase().replace(/_(monthly|yearly)$/, '');
+  return PERSONAL_PLAN_TIERS.has(normalized as PersonalPlanTier)
+    ? (normalized as PersonalPlanTier)
+    : null;
+}
+
+/**
+ * Resolve only the signed-in account's personal subscription tier. Landing
+ * remains a static comparison surface: failures, signed-out visitors, and
+ * workspace/team plans leave every CTA exactly as rendered at build time.
+ */
+export async function loadCurrentPersonalPlanTier(
+  apiOrigin: string,
+  fetcher: PricingFetch = fetch,
+): Promise<PersonalPlanTier | null> {
+  const origin = apiOrigin.trim().replace(/\/+$/, '');
+  if (!origin) return null;
+
+  try {
+    const sessionResponse = await fetcher(`${origin}/api/auth/get-session`, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (!sessionResponse.ok) return null;
+    const session = await sessionResponse.json();
+    if (!session?.user) return null;
+
+    const billingResponse = await fetcher(`${origin}/api/v1/billing/summary`, {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    });
+    if (!billingResponse.ok) return null;
+    const summary = await billingResponse.json();
+    return personalPlanTier(summary?.membershipTier);
+  } catch {
+    return null;
+  }
+}

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -21,6 +21,7 @@ import {
   type TeamPlanTierConfig,
 } from '../../_lib/pricing';
 import {
+  getCurrentPlanLabel,
   getPricingContent,
   fillTemplate,
 } from '../../_lib/pricing-content';
@@ -39,8 +40,14 @@ const locale = localeFromPath(Astro.url.pathname);
 const isZh = locale === 'zh' || locale === 'zh-tw';
 const href = (path: string) => localizedHref(path, locale);
 const content = getPricingContent(locale);
+const currentPlanLabel = getCurrentPlanLabel(locale);
 const teamContent = getTeamPricingContent(locale);
 const L = content.labels;
+const env = import.meta.env as Record<string, string | undefined>;
+const apiOrigin =
+  env.PUBLIC_CLOUD_API_BASE ??
+  env.PUBLIC_AMR_API_BASE ??
+  'https://amr-api.open-design.ai';
 
 // Footer line with the cloud-console link injected into the localized
 // template. Brand/URL only — safe to render as HTML.
@@ -176,6 +183,8 @@ const jsonLd = [
     data-pricing-root
     data-audience="creator"
     data-interval="yearly"
+    data-billing-api-origin={apiOrigin}
+    data-current-plan-label={currentPlanLabel}
     data-campaign-start-at={DEEPSEEK_V4_PRO_CAMPAIGN.startAt}
     data-campaign-end-at={DEEPSEEK_V4_PRO_CAMPAIGN.endAtExclusive}
   >
@@ -560,6 +569,10 @@ const jsonLd = [
       const syncCtas = () => {
         const interval = root.getAttribute('data-interval') === 'monthly' ? 'monthly' : 'yearly';
         for (const cta of root.querySelectorAll('[data-pricing-cta]')) {
+          if (cta.hasAttribute('data-subscription-disabled')) {
+            cta.removeAttribute('href');
+            continue;
+          }
           const tier = cta.getAttribute('data-tier') || '';
           if (tier === 'free') {
             cta.setAttribute('href', new URL('/cloud/dashboard', billingPlanUrl).toString());
@@ -880,6 +893,10 @@ const jsonLd = [
       root.addEventListener('click', (event) => {
         const cta = event.target && event.target.closest && event.target.closest('[data-pricing-cta]');
         if (!cta) return;
+        if (cta.hasAttribute('data-subscription-disabled')) {
+          event.preventDefault();
+          return;
+        }
         try {
           const audience = root.getAttribute('data-audience') || 'creator';
           // Outside the activity window the CTA still records od_entry_*
@@ -991,6 +1008,33 @@ const jsonLd = [
         });
       }
     })();
+  </script>
+  <script>
+    import {
+      isPersonalPlanAtOrBelow,
+      loadCurrentPersonalPlanTier,
+    } from '../../_lib/pricing-current-plan';
+
+    const pricingRoot = document.querySelector('[data-pricing-root]');
+    if (pricingRoot) {
+      const apiOrigin = pricingRoot.getAttribute('data-billing-api-origin') || '';
+      const currentPlanLabel = pricingRoot.getAttribute('data-current-plan-label') || '';
+      void loadCurrentPersonalPlanTier(apiOrigin).then((currentTier) => {
+        if (!currentTier || !currentPlanLabel) return;
+        for (const cta of pricingRoot.querySelectorAll('[data-pricing-cta]')) {
+          const tier = cta.getAttribute('data-tier') || '';
+          if (!isPersonalPlanAtOrBelow(tier, currentTier)) continue;
+          cta.setAttribute('data-subscription-disabled', '');
+          cta.setAttribute('aria-disabled', 'true');
+          cta.setAttribute('tabindex', '-1');
+          cta.removeAttribute('href');
+        }
+        const label = pricingRoot.querySelector(
+          `[data-pricing-cta][data-tier="${currentTier}"] > span`,
+        );
+        if (label) label.textContent = currentPlanLabel;
+      });
+    }
   </script>
 </Layout>
 

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -20,8 +20,13 @@ import {
 } from "../app/_lib/pricing-team-content.ts";
 import {
   PREMIUM_MODELS,
+  getCurrentPlanLabel,
   getPricingContent,
 } from "../app/_lib/pricing-content.ts";
+import {
+  isPersonalPlanAtOrBelow,
+  loadCurrentPersonalPlanTier,
+} from "../app/_lib/pricing-current-plan.ts";
 import { LANDING_LOCALES } from "../app/i18n.ts";
 import { DEEPSEEK_V4_PRO_CAMPAIGN } from "../app/_lib/deepseek-v4-pro-campaign.ts";
 
@@ -658,6 +663,92 @@ describe("pricing contract", () => {
       "https://open-design.ai/cloud/dashboard?billing=plan&workspaceId=workspace-a",
     );
     assert.equal(scopedBillingPlanUrl("  "), CLOUD_CONSOLE_URL);
+  });
+
+  it("recognizes only the signed-in account's current personal plan for CTA copy", async () => {
+    const requests: string[] = [];
+    const requestOptions: Array<RequestInit | undefined> = [];
+    const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      requests.push(url);
+      requestOptions.push(init);
+      if (url.endsWith("/api/auth/get-session")) {
+        return Response.json({ user: { id: "user-1" } });
+      }
+      return Response.json({ membershipTier: "Pro" });
+    };
+
+    assert.equal(
+      await loadCurrentPersonalPlanTier("https://amr-api.open-design.ai/", fetcher),
+      "pro",
+    );
+    assert.deepEqual(requests, [
+      "https://amr-api.open-design.ai/api/auth/get-session",
+      "https://amr-api.open-design.ai/api/v1/billing/summary",
+    ]);
+    assert.deepEqual(
+      requestOptions.map((options) => options?.credentials),
+      ["include", "include"],
+    );
+    assert.equal(getCurrentPlanLabel("en"), "Current plan");
+    assert.equal(getCurrentPlanLabel("zh"), "当前套餐");
+  });
+
+  it("disables the current personal plan and every downgrade target", () => {
+    assert.deepEqual(
+      ["go", "plus", "pro", "max"].filter((tier) =>
+        isPersonalPlanAtOrBelow(tier, "pro"),
+      ),
+      ["go", "plus", "pro"],
+    );
+    assert.equal(isPersonalPlanAtOrBelow("team", "pro"), false);
+    assert.equal(isPersonalPlanAtOrBelow("max", "pro"), false);
+  });
+
+  it("keeps CTA copy unchanged when subscription identity is unavailable or non-personal", async () => {
+    const signedOut = async () => Response.json(null);
+    const teamPlan = async (input: string | URL | Request) =>
+      Response.json(
+        String(input).endsWith("/api/auth/get-session")
+          ? { user: { id: "user-1" } }
+          : { membershipTier: "team_pro" },
+      );
+    const failed = async () => new Response(null, { status: 503 });
+
+    assert.equal(
+      await loadCurrentPersonalPlanTier("https://amr-api.open-design.ai", signedOut),
+      null,
+    );
+    assert.equal(
+      await loadCurrentPersonalPlanTier("https://amr-api.open-design.ai", teamPlan),
+      null,
+    );
+    assert.equal(
+      await loadCurrentPersonalPlanTier("https://amr-api.open-design.ai", failed),
+      null,
+    );
+  });
+
+  it("labels the current CTA and disables current or lower personal tiers", async () => {
+    const [page, individualPlans] = await Promise.all([
+      readFile(PRICING_PAGE_PATH, "utf8"),
+      readFile(PRICING_INDIVIDUAL_PATH, "utf8"),
+    ]);
+
+    assert.match(page, /data-billing-api-origin=\{apiOrigin\}/);
+    assert.match(page, /data-current-plan-label=\{currentPlanLabel\}/);
+    assert.match(page, /loadCurrentPersonalPlanTier\(apiOrigin\)/);
+    assert.match(page, /\[data-pricing-cta\]\[data-tier="\$\{currentTier\}"\] > span/);
+    assert.match(page, /isPersonalPlanAtOrBelow\(tier, currentTier\)/);
+    assert.match(page, /cta\.setAttribute\('aria-disabled', 'true'\)/);
+    assert.match(page, /cta\.setAttribute\('tabindex', '-1'\)/);
+    assert.match(page, /cta\.removeAttribute\('href'\)/);
+    assert.match(page, /cta\.hasAttribute\('data-subscription-disabled'\)/);
+    assert.match(
+      individualPlans,
+      /\.pricing-card-cta\[aria-disabled='true'\][\s\S]*?cursor:\s*not-allowed;/,
+    );
+    assert.match(individualPlans, /data-pricing-cta data-tier=\{tier\}/);
   });
 
   it("preserves only an explicit inbound workspace without inferring local state", async () => {


### PR DESCRIPTION
## Why

Signed-in subscribers currently see the same active subscribe actions as visitors on the public Pricing page. That allows duplicate checkout attempts for the current plan and presents lower tiers as immediate downgrade actions even though this static Landing surface does not own a safe downgrade flow.

This keeps Landing independent from the product runtime while using the existing authenticated AMR session and billing-summary endpoints as a progressive enhancement.

## What users will see

For signed-in users with a personal Go, Plus, Pro, or Max subscription:

- the current plan CTA is relabeled with the localized `Current plan` copy;
- the current plan and every lower personal tier are gray and cannot be clicked;
- higher personal tiers remain available for upgrade;
- Team pricing is unchanged.

Signed-out visitors, Team subscribers, and failed or blocked API requests keep the original static Pricing page behavior.

## Surface area

- [x] **UI** — Landing Pricing CTA state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — localized current-plan CTA copy
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — authenticated Pricing visitors receive subscription-aware CTA state
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Local browser verification used a mocked Pro subscription. Go, Plus, and Pro rendered with the same gray disabled treatment; Pro read `当前套餐`; Max remained green and linked to checkout. The state also persisted after switching from yearly to monthly billing.

The authenticated state depends on a local billing mock, so no unauthenticated preview screenshot is attached to this Draft PR.

## Bug fix verification

- Test path: `apps/landing-page/tests/pricing-contract.test.ts`
- Red on the branch before implementation: yes, the new current-plan and downgrade-state contract failed before the helper and DOM behavior existed.
- Green after implementation: yes.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/landing-page test` (180 tests passed)
- `pnpm --filter @open-design/landing-page typecheck` (0 errors, 0 warnings)
- `git diff --check`
- Local browser verification with a mocked Pro subscription, including yearly-to-monthly switching
- Disabled CTA contrast: 4.78:1
