### PR TITLE
fix(runtimes): accept DeepSeek Harness 0.1.0-rc.7

### DIFF
--- a/apps/daemon/src/runtimes/defs/deepseek-harness.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek-harness.ts
@@ -53,7 +53,7 @@ export const deepseekHarnessAgentDef = {
   bin: 'dsh',
   versionArgs: ['--version'],
   versionPolicy: {
-    supportedVersions: ['0.1.0-rc.6'],
+    supportedVersions: ['0.1.0-rc.6', '0.1.0-rc.7'],
     requireVersion: true,
     parse: parseDeepSeekHarnessVersion,
   },

--- a/apps/daemon/tests/runtimes/version-policy.test.ts
+++ b/apps/daemon/tests/runtimes/version-policy.test.ts
@@ -8,7 +8,10 @@ import {
   buildVersionDiagnostic,
 } from '../../src/runtimes/diagnostics.js';
 import type { RuntimeAgentDef } from '../../src/runtimes/types.js';
-import { parseDeepSeekHarnessVersion } from '../../src/runtimes/defs/deepseek-harness.js';
+import {
+  deepseekHarnessAgentDef,
+  parseDeepSeekHarnessVersion,
+} from '../../src/runtimes/defs/deepseek-harness.js';
 
 const versionedDef: RuntimeAgentDef = {
   id: 'deepseek-harness',
@@ -65,6 +68,10 @@ function writeProfileBin(dir: string, compatible: boolean): string {
 }
 
 describe('runtime version policy', () => {
+  it('accepts the published DeepSeek Harness rc.7 release', () => {
+    expect(deepseekHarnessAgentDef.versionPolicy?.supportedVersions).toContain('0.1.0-rc.7');
+  });
+
   it.each([
     ['0.1.0-rc.6', true, undefined],
     ['0.1.0-rc.7', true, 'untested-version'],


### PR DESCRIPTION
Fixes #7193

## Why

I hit the native DeepSeek Harness runtime compatibility gate while using the published `dsh` `0.1.0-rc.7` release with the OpenDesign profile. The runtime integration (`--probe`, `--models`, profile setup, and profile stdio) works, but the explicit version policy still accepts only rc.6 and marks rc.7 unavailable before the compatible runtime can be used.

## What users will see

OpenDesign now recognizes DeepSeek Harness `0.1.0-rc.7` as a supported runtime release. The policy remains an explicit allowlist: unvalidated versions are still rejected.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — recognizes an explicitly validated, newly published DSH release by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — runtime version-policy change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/version-policy.test.ts`
- Did the test go red on `main` and green on this branch? yes
- The red failure asserted that `deepseekHarnessAgentDef.versionPolicy.supportedVersions` did not contain `0.1.0-rc.7`. The production definition now explicitly allows rc.6 and rc.7 only.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/version-policy.test.ts` (red before the source change; green after)
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm --filter @open-design/daemon test` (in progress at PR creation time)
