### PR TITLE
fix(i18n): preserve locale in Pricing handoff

### DIFF
--- a/apps/landing-page/app/_components/locale-switcher-script.astro
+++ b/apps/landing-page/app/_components/locale-switcher-script.astro
@@ -17,7 +17,7 @@ const script = `
   // strippable locale segment, or switching language on an alias page like
   // /zh-CN/blog/ would rebuild a nested, non-existent /<locale>/zh-CN/blog/.
   // Mirrors LEGACY_LOCALE_PREFIXES in app/i18n.ts.
-  const legacyAliases = new Set(['zh-cn', 'es-es', 'fa', 'hu', 'th']);
+  const legacyAliases = new Set(['zh-cn', 'zh-tw', 'es-es', 'fa', 'hu', 'th']);
   const isLocaleSegment = (segment) => {
     const value = (segment || '').toLowerCase();
     return value !== '' && (codes.has(value) || legacyAliases.has(value));
@@ -34,7 +34,7 @@ const script = `
       raw === 'zh-hant' ||
       raw.startsWith('zh-hant-')
     ) {
-      return 'zh-tw';
+      return codes.has('zh-tw') ? 'zh-tw' : 'zh';
     }
     if (raw === 'pt' || raw.startsWith('pt-br')) return 'pt-br';
     if (codes.has(raw)) return raw;
@@ -158,7 +158,16 @@ const script = `
     // design-system detail pages): keep the visitor on the URL they clicked.
     // hreflang + manual language switching stay intact.
     if (document.documentElement.getAttribute('data-locale-autoredirect') === 'off') return;
-    if (currentFromPath() !== DEFAULT_LOCALE) return;
+    const current = currentFromPath();
+    const searchParams = new URLSearchParams(window.location.search);
+    const requested = normalizeLocale(searchParams.get('od_locale'));
+    // A product that links here already knows the user's selected language.
+    // Honor that explicit handoff before this site's saved/browser fallback.
+    if (requested) {
+      if (requested !== current) selectLocale(requested, false);
+      return;
+    }
+    if (current !== DEFAULT_LOCALE) return;
     let saved = null;
     try {
       saved = normalizeLocale(window.localStorage.getItem(STORAGE_KEY) ?? '');

--- a/apps/landing-page/app/_components/locale-switcher-script.astro
+++ b/apps/landing-page/app/_components/locale-switcher-script.astro
@@ -59,11 +59,18 @@ const script = `
   const isCanonicalOnly = () =>
     document.documentElement.getAttribute('data-locale-canonical') === 'true';
 
+  const searchWithoutLocaleHandoff = () => {
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.delete('od_locale');
+    const search = searchParams.toString();
+    return search ? \`?\${search}\` : '';
+  };
+
   const targetFor = (locale) => {
     const basePath = basePathFromCurrent();
     const nextPath =
       isCanonicalOnly() || locale === DEFAULT_LOCALE ? basePath : \`/\${locale}\${basePath}\`;
-    return \`\${nextPath}\${window.location.search}\${window.location.hash}\`;
+    return \`\${nextPath}\${searchWithoutLocaleHandoff()}\${window.location.hash}\`;
   };
 
   const persistLocale = (locale) => {
@@ -162,9 +169,14 @@ const script = `
     const searchParams = new URLSearchParams(window.location.search);
     const requested = normalizeLocale(searchParams.get('od_locale'));
     // A product that links here already knows the user's selected language.
-    // Honor that explicit handoff before this site's saved/browser fallback.
+    // Honor that explicit handoff before this site's saved/browser fallback,
+    // then consume it so a later manual language choice remains authoritative.
     if (requested) {
       if (requested !== current) selectLocale(requested, false);
+      else {
+        const target = \`\${window.location.pathname}\${searchWithoutLocaleHandoff()}\${window.location.hash}\`;
+        window.history.replaceState(window.history.state, '', target);
+      }
       return;
     }
     if (current !== DEFAULT_LOCALE) return;

--- a/apps/landing-page/app/_components/sub-page-layout.astro
+++ b/apps/landing-page/app/_components/sub-page-layout.astro
@@ -134,6 +134,7 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <LocaleSwitcherScript />
     <meta name="theme-color" content="#efe7d2" />
     <title>{title}</title>
     <meta name="description" content={metaDescription} />
@@ -185,7 +186,6 @@ const ldArray = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
     </div>
 
     <HeaderEnhancer />
-    <LocaleSwitcherScript />
     <PreciseLazyload />
     {/* Hover-autoplay + idle hold/pan loop for any TemplateCard preview clips on
         the page. Self-initialising and a no-op when the page has no cards, so it

--- a/apps/landing-page/tests/locale-handoff.test.ts
+++ b/apps/landing-page/tests/locale-handoff.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
+import vm from 'node:vm';
 
 const LOCALE_SCRIPT_PATH = new URL(
   '../app/_components/locale-switcher-script.astro',
@@ -11,16 +12,114 @@ const SUB_PAGE_LAYOUT_PATH = new URL(
   import.meta.url,
 );
 
-describe('locale handoff', () => {
-  it('lets an explicit source locale override browser detection', async () => {
-    const source = await readFile(LOCALE_SCRIPT_PATH, 'utf8');
+async function localeScript(): Promise<string> {
+  const source = await readFile(LOCALE_SCRIPT_PATH, 'utf8');
+  const match = source.match(/const script = `([\s\S]*?)`;\n---/);
+  assert.ok(match?.[1]);
+  return match[1]
+    .replace('${JSON.stringify(DEFAULT_LOCALE)}', JSON.stringify('en'))
+    .replace(
+      '${JSON.stringify(localeRoutes)}',
+      JSON.stringify([
+        { code: 'en', htmlLang: 'en' },
+        { code: 'zh', htmlLang: 'zh-CN' },
+        { code: 'ja', htmlLang: 'ja' },
+      ]),
+    )
+    .replaceAll('\\`', '`')
+    .replaceAll('\\${', '${');
+}
 
-    assert.match(source, /searchParams\.get\('od_locale'\)/);
-    assert.match(source, /if \(requested[\s\S]*?requested !== current[\s\S]*?return;/);
-    assert.ok(
-      source.indexOf("searchParams.get('od_locale')") <
-        source.indexOf("window.localStorage.getItem(STORAGE_KEY)"),
-    );
+async function runLocaleScript(initialUrl: string) {
+  const location = new URL(initialUrl, 'https://open-design.ai');
+  const assigned: string[] = [];
+  const replaced: string[] = [];
+  let click: ((event: Record<string, unknown>) => void) | undefined;
+  const link = {
+    dataset: { localeCode: 'ja' },
+    addEventListener(type: string, listener: (event: Record<string, unknown>) => void) {
+      if (type === 'click') click = listener;
+    },
+    closest: () => null,
+  };
+  const window = {
+    location: {
+      get pathname() {
+        return location.pathname;
+      },
+      get search() {
+        return location.search;
+      },
+      get hash() {
+        return location.hash;
+      },
+      assign(target: string) {
+        assigned.push(target);
+      },
+    },
+    history: {
+      state: { fixture: true },
+      replaceState(_state: unknown, _title: string, target: string) {
+        replaced.push(target);
+        const next = new URL(target, location);
+        location.pathname = next.pathname;
+        location.search = next.search;
+        location.hash = next.hash;
+      },
+    },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => undefined,
+    },
+    matchMedia: () => ({ matches: false }),
+    clearTimeout,
+    setTimeout,
+  };
+  const document = {
+    documentElement: { getAttribute: () => null },
+    readyState: 'complete',
+    querySelectorAll: (selector: string) =>
+      selector === '[data-locale-link]' ? [link] : [],
+    addEventListener: () => undefined,
+  };
+
+  vm.runInNewContext(await localeScript(), {
+    document,
+    HTMLElement: class {},
+    navigator: { language: 'en', languages: ['en'] },
+    Node: class {},
+    URLSearchParams,
+    window,
+  });
+
+  return { assigned, click, replaced };
+}
+
+describe('locale handoff', () => {
+  it('applies an explicit source locale once and keeps other attribution', async () => {
+    const fixture = await runLocaleScript('/pricing/?od_locale=zh&utm_source=amr#plans');
+
+    assert.deepEqual(fixture.assigned, ['/zh/pricing/?utm_source=amr#plans']);
+  });
+
+  it('consumes a matching handoff before a manual language switch', async () => {
+    const fixture = await runLocaleScript('/zh/pricing/?od_locale=zh&utm_source=amr#plans');
+
+    assert.deepEqual(fixture.replaced, ['/zh/pricing/?utm_source=amr#plans']);
+    assert.ok(fixture.click);
+    fixture.click({
+      altKey: false,
+      button: 0,
+      ctrlKey: false,
+      defaultPrevented: false,
+      metaKey: false,
+      preventDefault: () => undefined,
+      shiftKey: false,
+    });
+    assert.deepEqual(fixture.assigned, ['/ja/pricing/?utm_source=amr#plans']);
+
+    const reload = await runLocaleScript(fixture.assigned[0]);
+    assert.deepEqual(reload.assigned, []);
   });
 
   it('runs locale adaptation in the head before localized body content paints', async () => {

--- a/apps/landing-page/tests/locale-handoff.test.ts
+++ b/apps/landing-page/tests/locale-handoff.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+const LOCALE_SCRIPT_PATH = new URL(
+  '../app/_components/locale-switcher-script.astro',
+  import.meta.url,
+);
+const SUB_PAGE_LAYOUT_PATH = new URL(
+  '../app/_components/sub-page-layout.astro',
+  import.meta.url,
+);
+
+describe('locale handoff', () => {
+  it('lets an explicit source locale override browser detection', async () => {
+    const source = await readFile(LOCALE_SCRIPT_PATH, 'utf8');
+
+    assert.match(source, /searchParams\.get\('od_locale'\)/);
+    assert.match(source, /if \(requested[\s\S]*?requested !== current[\s\S]*?return;/);
+    assert.ok(
+      source.indexOf("searchParams.get('od_locale')") <
+        source.indexOf("window.localStorage.getItem(STORAGE_KEY)"),
+    );
+  });
+
+  it('runs locale adaptation in the head before localized body content paints', async () => {
+    const layout = await readFile(SUB_PAGE_LAYOUT_PATH, 'utf8');
+    const headEnd = layout.indexOf('</head>');
+    const script = layout.indexOf('<LocaleSwitcherScript />');
+
+    assert.ok(script > 0);
+    assert.ok(script < headEnd);
+    assert.equal(layout.indexOf('<LocaleSwitcherScript />', script + 1), -1);
+  });
+});

--- a/apps/web/src/campaigns/go-plan.ts
+++ b/apps/web/src/campaigns/go-plan.ts
@@ -1,3 +1,4 @@
+import type { Locale } from '../i18n/types';
 import type { DeepSeekV4FlashCampaignAudience } from './deepseek-v4-flash';
 
 export const GO_PLAN_CAMPAIGN = {
@@ -9,6 +10,36 @@ export const GO_PLAN_CAMPAIGN = {
 } as const;
 
 export const GO_PLAN_PRICING_URL = 'https://open-design.ai/pricing/';
+
+const LANDING_LOCALE_BY_APP_LOCALE: Record<Locale, string> = {
+  en: 'en',
+  id: 'en',
+  de: 'de',
+  'zh-CN': 'zh',
+  'zh-TW': 'zh',
+  'pt-BR': 'pt-br',
+  'es-ES': 'es',
+  ru: 'ru',
+  fa: 'en',
+  ar: 'en',
+  ja: 'ja',
+  ko: 'ko',
+  pl: 'en',
+  hu: 'en',
+  fr: 'fr',
+  uk: 'en',
+  tr: 'tr',
+  th: 'en',
+  it: 'it',
+};
+
+export function goPlanPricingUrl(locale: Locale): string {
+  const landingLocale = LANDING_LOCALE_BY_APP_LOCALE[locale];
+  const path = landingLocale === 'en' ? '/pricing/' : `/${landingLocale}/pricing/`;
+  const url = new URL(path, GO_PLAN_PRICING_URL);
+  url.searchParams.set('od_locale', landingLocale);
+  return url.toString();
+}
 
 export function isGoPlanCampaignWindowOpen(now: number): boolean {
   const startAt = Date.parse(GO_PLAN_CAMPAIGN.window.startAt);

--- a/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
@@ -7,7 +7,7 @@ import {
   type DeepSeekV4FlashCampaignAudience,
 } from '../campaigns/deepseek-v4-flash';
 import { getGoPlanCampaignCopy } from '../campaigns/go-plan-content';
-import { GO_PLAN_CAMPAIGN, GO_PLAN_PRICING_URL } from '../campaigns/go-plan';
+import { GO_PLAN_CAMPAIGN, goPlanPricingUrl } from '../campaigns/go-plan';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackDeepSeekCampaignModalClick,
@@ -201,7 +201,7 @@ export function DeepSeekV4FlashCampaign({
       return;
     }
     window.open(
-      GO_PLAN_PRICING_URL,
+      goPlanPricingUrl(locale),
       '_blank',
       'noopener,noreferrer',
     );

--- a/apps/web/src/components/WorkbenchCampaignBadge.tsx
+++ b/apps/web/src/components/WorkbenchCampaignBadge.tsx
@@ -10,7 +10,7 @@ import {
 } from '../analytics/amr-attribution';
 import { getResolvedDeviceId } from '../analytics/client';
 import { useAnalytics } from '../analytics/provider';
-import { GO_PLAN_PRICING_URL } from '../campaigns/go-plan';
+import { goPlanPricingUrl } from '../campaigns/go-plan';
 import { getGoPlanCampaignCopy } from '../campaigns/go-plan-content';
 import { useI18n } from '../i18n';
 import { Icon } from './Icon';
@@ -47,8 +47,9 @@ export function WorkbenchCampaignBadge({
   }, [analytics.track, kind, page]);
 
   const openCampaignPricing = useCallback(() => {
+    const pricingUrl = goPlanPricingUrl(locale);
     if (kind === 'go') {
-      window.open(GO_PLAN_PRICING_URL, '_blank', 'noopener,noreferrer');
+      window.open(pricingUrl, '_blank', 'noopener,noreferrer');
       return;
     }
     if (page === 'home') {
@@ -76,11 +77,11 @@ export function WorkbenchCampaignBadge({
       installationId,
     });
     window.open(
-      attributedAmrUrl(GO_PLAN_PRICING_URL, attribution, deviceId),
+      attributedAmrUrl(pricingUrl, attribution, deviceId),
       '_blank',
       'noopener,noreferrer',
     );
-  }, [analytics.track, installationId, kind, metricsConsent, page]);
+  }, [analytics.track, installationId, kind, locale, metricsConsent, page]);
 
   return (
     <button

--- a/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
@@ -174,7 +174,7 @@ describe('unpaid Go path opens public Pricing', () => {
     expect(open).toHaveBeenCalledTimes(1);
     const url = new URL(String(open.mock.calls[0]?.[0]));
     expect(url.origin + url.pathname).toBe('https://open-design.ai/pricing/');
-    expect(url.search).toBe('');
+    expect(url.searchParams.get('od_locale')).toBe('en');
   });
 
   it('keeps the same target without metrics consent', () => {

--- a/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
@@ -120,11 +120,11 @@ describe('DeepSeek V4 Flash workbench campaign entry', () => {
 
   it('sends both Go and paid DeepSeek badges to public Pricing', () => {
     expect(entryShellSource).not.toContain('amrPlansUrlForWorkspace');
-    expect(workbenchCampaignBadgeSource).toContain('GO_PLAN_PRICING_URL');
+    expect(workbenchCampaignBadgeSource).toContain('goPlanPricingUrl(locale)');
     expect(workbenchCampaignBadgeSource).toContain("'deepseek_workbench_badge'");
     expect(workbenchCampaignBadgeSource).toContain("'noopener,noreferrer'");
-    // The public URL is locale-neutral; no language is pinned into a link
-    // shown to every locale.
+    // The destination comes from the active app locale rather than pinning one
+    // language into a link shown to every locale.
     expect(workbenchCampaignBadgeSource).not.toContain('open-design.ai/zh/pricing');
   });
 
@@ -214,7 +214,7 @@ describe('DeepSeek V4 Flash workbench campaign entry', () => {
   it('keeps existing DeepSeek analytics while the Go pass stays UI-only', () => {
     expect(workbenchCampaignBadgeSource).toContain('trackDeepSeekCampaignBadgeSurfaceView');
     expect(workbenchCampaignBadgeSource).toContain('trackDeepSeekCampaignBadgeClick');
-    expect(workbenchCampaignBadgeSource).toContain("window.open(GO_PLAN_PRICING_URL, '_blank', 'noopener,noreferrer')");
+    expect(workbenchCampaignBadgeSource).toContain("window.open(pricingUrl, '_blank', 'noopener,noreferrer')");
     expect(workbenchCampaignBadgeSource).toContain("page !== 'home'");
     expect(modelSwitcherSource).toContain('trackDeepSeekCampaignModelBenefitSurfaceView');
     expect(modelSwitcherSource).toContain('trackExecutionSettingsPopoverClick');

--- a/apps/web/tests/campaigns/deepseek-v4-flash.test.ts
+++ b/apps/web/tests/campaigns/deepseek-v4-flash.test.ts
@@ -153,7 +153,7 @@ describe('DeepSeek V4 Flash campaign', () => {
 
   it('reuses the modal shell for Go without showing the paid secondary action', () => {
     expect(campaignDialogSource).toContain('styles.goWelcomePrimary');
-    expect(campaignDialogSource).toContain('GO_PLAN_PRICING_URL');
+    expect(campaignDialogSource).toContain('goPlanPricingUrl');
     expect(campaignDialogSource).not.toContain("'go_plan_modal'");
     expect(campaignDialogSource.indexOf('styles.goWelcomePrimary')).toBeLessThan(
       campaignDialogSource.indexOf('styles.laterAction'),

--- a/apps/web/tests/campaigns/go-plan.test.ts
+++ b/apps/web/tests/campaigns/go-plan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   GO_PLAN_CAMPAIGN,
   GO_PLAN_PRICING_URL,
+  goPlanPricingUrl,
   goPlanCampaignNextBoundary,
   isGoPlanCampaignWindowOpen,
   resolveSubscriptionAudience,
@@ -23,6 +24,27 @@ describe('Go plan touchpoints', () => {
     expect(goPlanCampaignNextBoundary(start)).toBe(end);
     expect(goPlanCampaignNextBoundary(end)).toBeNull();
     expect(GO_PLAN_PRICING_URL).toBe('https://open-design.ai/pricing/');
+  });
+
+  it('hands Pricing the source locale without targeting retired Landing routes', () => {
+    expect(goPlanPricingUrl('en')).toBe(
+      'https://open-design.ai/pricing/?od_locale=en',
+    );
+    expect(goPlanPricingUrl('zh-CN')).toBe(
+      'https://open-design.ai/zh/pricing/?od_locale=zh',
+    );
+    expect(goPlanPricingUrl('zh-TW')).toBe(
+      'https://open-design.ai/zh/pricing/?od_locale=zh',
+    );
+    expect(goPlanPricingUrl('pt-BR')).toBe(
+      'https://open-design.ai/pt-br/pricing/?od_locale=pt-br',
+    );
+    expect(goPlanPricingUrl('es-ES')).toBe(
+      'https://open-design.ai/es/pricing/?od_locale=es',
+    );
+    expect(goPlanPricingUrl('id')).toBe(
+      'https://open-design.ai/pricing/?od_locale=en',
+    );
   });
 
   it('resolves paid and unpaid state independently of the campaign window', () => {


### PR DESCRIPTION
## Why

Opening Pricing from Open Design could lose the language already selected in the product. Landing would then render its default locale and only later apply saved/browser detection, which caused a visible language flash or required a refresh to reach the expected locale.

This PR fixes the cross-project handoff while preserving Landing's existing behavior for direct visitors.

## What users will see

Pricing links opened from Open Design now go directly to an active localized Pricing route and include the source locale explicitly. Landing honors that explicit locale before its saved/browser fallback and runs the decision in the document head, so localized content does not paint in the wrong language first.

Direct visits without `od_locale` continue to use the existing saved/browser locale detection.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual layout change. Browser verification covered English `/pricing/?od_locale=en` and Chinese `/zh/pricing/?od_locale=zh`; each rendered the matching localized title and headings without a follow-up locale rewrite.

## Bug fix verification

- Test paths: `apps/web/tests/campaigns/go-plan.test.ts`, `apps/landing-page/tests/locale-handoff.test.ts`
- Red on `main`, green on this branch: yes. The web spec initially failed because locale-aware Pricing URL generation did not exist; the Landing spec initially failed because `od_locale` was not recognized and locale adaptation ran after body content.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web exec vitest run tests/campaigns/go-plan.test.ts tests/campaigns/deepseek-v4-flash-ui-contract.test.ts`
- `pnpm --filter @open-design/landing-page exec tsx --test tests/locale-handoff.test.ts`
- `pnpm --filter @open-design/landing-page build`
- Browser verification of English and Chinese explicit locale handoffs against the local production build
