### PR TITLE
fix(brands): keep extracted DESIGN.md parseable, serve package assets, clean names

### DIFF
--- a/apps/daemon/src/brands/prefetch.ts
+++ b/apps/daemon/src/brands/prefetch.ts
@@ -637,6 +637,39 @@ export function extractInlineHeaderSvg(html: string): string | null {
     : svg.replace("<svg", '<svg xmlns="http://www.w3.org/2000/svg"');
 }
 
+/** Longest brand token in a hostname: "www.stripe.com" -> "stripe". */
+function hostBrandToken(rawUrl: string): string {
+  try {
+    const host = new URL(rawUrl).hostname.replace(/^www\./i, "");
+    return (host.split(".")[0] ?? "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Best-effort brand name out of a page title. Titles are usually
+ * "<Brand> <sep> <tagline>", so keep the leading segment when it reads like a
+ * name (short, and matching the hostname when the host gives us a hint).
+ * Anything ambiguous returns the title unchanged — a wrong split is worse than
+ * a long name.
+ */
+export function brandNameFromTitle(rawTitle: string, sourceUrl: string): string {
+  const title = (rawTitle ?? "").trim();
+  if (!title) return "";
+  const parts = title.split(/\s+[|\u2013\u2014\u00b7\u2022:-]\s+/).map((p) => p.trim()).filter(Boolean);
+  if (parts.length < 2) return title;
+  const lead = parts[0] ?? title;
+  const token = hostBrandToken(sourceUrl);
+  // The hostname agrees with the leading segment: that segment IS the brand.
+  if (token && lead.toLowerCase().replace(/[^a-z0-9]/g, "").includes(token)) return lead;
+  // No hostname signal: only trust a short lead followed by a longer tail,
+  // which is the shape of "Brand | some longer promise".
+  const tail = parts.slice(1).join(" ");
+  if (lead.length <= 24 && tail.length > lead.length) return lead;
+  return title;
+}
+
 function extractNavLinks(html: string, baseUrl: string): Array<{ label: string; url: string }> {
   const out: Array<{ label: string; url: string }> = [];
   const scope = /<nav[\s\S]{0,12000}?<\/nav>/i.exec(html)?.[0] ?? html.slice(0, 30000);
@@ -952,7 +985,15 @@ async function harvestFromHtml(
   const description = blocked
     ? ""
     : metaContent(html, "description") || metaContent(html, "og:description");
-  const siteName = blocked ? "" : metaContent(html, "og:site_name") || metaContent(html, "og:title");
+  // `og:site_name` is the real brand name; `og:title`/<title> are marketing
+  // lines ("Stripe | Financial Infrastructure to Grow Your Revenue"). Falling
+  // straight through to the title made THAT the brand/design-system name, so
+  // trim the tagline off the leading segment when we have to use one.
+  const siteName = blocked
+    ? ""
+    : metaContent(html, "og:site_name")
+      || metaContent(html, "application-name")
+      || brandNameFromTitle(metaContent(html, "og:title") || title, baseUrl);
   const headings = blocked
     ? []
     : [

--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -1033,6 +1033,17 @@ const DESIGN_SYSTEM_STATIC_SYSTEM_FILES = new Set([
   'system/artifacts/form.html',
 ]);
 
+/**
+ * Package-owned brand artifacts. A brand-extracted package (`od brand extract`)
+ * stores its kit next to DESIGN.md — `brand.json` plus the harvested `logos/`
+ * and `imagery/` files — and that package is the DURABLE copy: the scaffold
+ * project the extraction ran in is disposable and users delete it. Serving them
+ * lets a design-system view render its own logo/imagery without depending on
+ * that project still existing (the "No logo yet" panel on an extracted brand).
+ */
+const DESIGN_SYSTEM_BRAND_KIT_FILE = 'brand.json';
+const DESIGN_SYSTEM_BRAND_ASSET_DIRS = ['logos', 'imagery'];
+
 async function isAllowedDesignSystemStaticFile(
   brandRoot: string,
   manifest: DesignSystemProjectManifest | null,
@@ -1040,6 +1051,7 @@ async function isAllowedDesignSystemStaticFile(
 ): Promise<boolean> {
   if (!isSafeManifestPath(relativePath)) return false;
   if (DESIGN_SYSTEM_STATIC_SYSTEM_FILES.has(relativePath)) return true;
+  if (relativePath === DESIGN_SYSTEM_BRAND_KIT_FILE) return true;
 
   const allowed = new Set<string>();
   const add = (filePath: string | undefined): void => {
@@ -1059,6 +1071,12 @@ async function isAllowedDesignSystemStaticFile(
 
   if (manifest?.assetsDir === 'assets') {
     await addFilesUnderDeclaredDir(brandRoot, 'assets', allowed);
+  }
+
+  for (const dir of DESIGN_SYSTEM_BRAND_ASSET_DIRS) {
+    if (relativePath.startsWith(`${dir}/`)) {
+      await addFilesUnderDeclaredDir(brandRoot, dir, allowed);
+    }
   }
 
   return allowed.has(relativePath);
@@ -3444,12 +3462,53 @@ function firstHeading(raw: string): string | null {
   return /^#\s+(.+?)\s*$/m.exec(raw)?.[1]?.trim() ?? null;
 }
 
+/** Leading `---\n…\n---` block, when the document opens with YAML frontmatter. */
+const LEADING_FRONTMATTER = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/;
+
+/**
+ * Insert `heading` at the top of `body` — but never above leading frontmatter.
+ * YAML frontmatter only parses at byte 0, so a heading pushed above it turns the
+ * whole block into prose.
+ */
+function insertHeadingBelowFrontmatter(body: string, heading: string): string {
+  const frontmatter = LEADING_FRONTMATTER.exec(body)?.[0];
+  if (!frontmatter) return `${heading}\n\n${body}`;
+  const rest = body.slice(frontmatter.length).replace(/^(?:\r?\n)+/, '');
+  return `${frontmatter}\n${heading}\n\n${rest}`;
+}
+
+/**
+ * Repair a document whose frontmatter was pushed below a heading. Packages
+ * written before the guard above exist in the wild with `# Title` on line 1 and
+ * the `---` block under it — inert YAML that renders as identity prose. Only
+ * that exact shape is touched; anything else is returned untouched.
+ */
+function hoistLeadingFrontmatter(body: string): string {
+  const displaced = /^(#[ \t]+[^\n]*\r?\n(?:\r?\n)*)(---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$))/.exec(body);
+  if (!displaced) return body;
+  const heading = displaced[1] ?? '';
+  const frontmatter = displaced[2] ?? '';
+  if (!heading || !frontmatter) return body;
+  const rest = body.slice(displaced[0].length).replace(/^(?:\r?\n)+/, '');
+  return `${frontmatter}\n${heading.trimEnd()}\n\n${rest}`;
+}
+
 function withDesignSystemHeader(
-  body: string,
+  rawBody: string,
   input: { title: string; category: string; surface: DesignSystemSurface },
 ): string {
-  let next = body.replace(/^#\s+.*$/m, `# ${input.title}`);
-  if (next === body && !/^#\s+/.test(next)) next = `# ${input.title}\n\n${next}`;
+  const body = hoistLeadingFrontmatter(rawBody);
+  // An existing H1 IS the title line, so rewrite it in place. Decide that with a
+  // multiline test, not by comparing the string before/after the replace: when
+  // the new title already equals the current H1 the replace is a no-op, and the
+  // old `next === body` check misread that as "this body has no heading" and
+  // added a second one. That second H1 landed above the frontmatter (the `^#`
+  // guard was not multiline, so it only ever looked at byte 0), which stopped
+  // the frontmatter from parsing at all — the raw `--- name: … ---` block users
+  // saw rendered as identity prose after publishing an extracted brand.
+  let next = /^#[ \t]+/m.test(body)
+    ? body.replace(/^#[ \t]+.*$/m, `# ${input.title}`)
+    : insertHeadingBelowFrontmatter(body, `# ${input.title}`);
   next = upsertBlockquoteMeta(next, 'Category', input.category);
   next = upsertBlockquoteMeta(next, 'Surface', input.surface);
   return next.endsWith('\n') ? next : `${next}\n`;
@@ -3459,7 +3518,9 @@ function upsertBlockquoteMeta(body: string, key: string, value: string): string 
   const re = new RegExp(`^>\\s*${key}:\\s*.*$`, 'im');
   if (re.test(body)) return body.replace(re, `> ${key}: ${value}`);
   const h1 = /^#\s+.*$/m.exec(body);
-  if (!h1) return `> ${key}: ${value}\n\n${body}`;
+  // Same frontmatter rule as insertHeadingBelowFrontmatter: never prepend above
+  // a leading `---` block, or the frontmatter stops parsing.
+  if (!h1) return insertHeadingBelowFrontmatter(body, `> ${key}: ${value}`);
   const insertAt = h1.index + h1[0].length;
   return `${body.slice(0, insertAt)}\n> ${key}: ${value}${body.slice(insertAt)}`;
 }

--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -3489,6 +3489,11 @@ function hoistLeadingFrontmatter(body: string): string {
   const heading = displaced[1] ?? '';
   const frontmatter = displaced[2] ?? '';
   if (!heading || !frontmatter) return body;
+  // `# Title` + two horizontal rules is also ordinary Markdown, so the shape
+  // alone proves nothing. Only move a block the frontmatter parser reads as a
+  // non-empty mapping; a section fenced by `---` rules parses to {} and is left
+  // exactly where the author put it.
+  if (Object.keys(parseFrontmatter(frontmatter).data).length === 0) return body;
   const rest = body.slice(displaced[0].length).replace(/^(?:\r?\n)+/, '');
   return `${frontmatter}\n${heading.trimEnd()}\n\n${rest}`;
 }

--- a/apps/daemon/src/design-systems/index.ts
+++ b/apps/daemon/src/design-systems/index.ts
@@ -3478,6 +3478,42 @@ function insertHeadingBelowFrontmatter(body: string, heading: string): string {
 }
 
 /**
+ * Split off leading frontmatter so heading lookups only ever scan the document
+ * body. `# ` is a comment inside YAML, so a plain `/^#\s+/m` search can land on
+ * a frontmatter comment line instead of the real H1 — rewriting a comment while
+ * the title stays stale, or worse, splicing `> Category:` into the YAML.
+ */
+function splitLeadingFrontmatter(body: string): { frontmatter: string; rest: string } {
+  const frontmatter = LEADING_FRONTMATTER.exec(body)?.[0] ?? '';
+  return { frontmatter, rest: body.slice(frontmatter.length) };
+}
+
+/** First H1 in the document body, ignoring any leading frontmatter block. */
+function firstHeadingBelowFrontmatter(body: string): { index: number; length: number } | null {
+  const { frontmatter, rest } = splitLeadingFrontmatter(body);
+  const match = /^#[ \t]+.*$/m.exec(rest);
+  return match ? { index: frontmatter.length + match.index, length: match[0].length } : null;
+}
+
+/**
+ * Whether a `---` block is design-system frontmatter, as opposed to a Markdown
+ * section fenced by horizontal rules.
+ *
+ * Neither the surrounding shape nor "parses as a non-empty mapping" proves
+ * anything: ordinary prose becomes a valid YAML mapping the moment it contains
+ * a colon, so `---` / `Introduction: hello` / `---` would qualify on both
+ * counts while being authored content. Every package the repair below targets
+ * was written by `brandToDesignMd`, whose frontmatter always carries `name`
+ * plus `category`/`surface`. Require that signature; anything else stays put,
+ * even at the cost of leaving an exotic hand-written block unrepaired.
+ */
+function isDesignSystemFrontmatter(block: string): boolean {
+  const { data } = parseFrontmatter(block);
+  if (!stringField(data, 'name')) return false;
+  return stringField(data, 'category').length > 0 || frontmatterSurface(data) !== undefined;
+}
+
+/**
  * Repair a document whose frontmatter was pushed below a heading. Packages
  * written before the guard above exist in the wild with `# Title` on line 1 and
  * the `---` block under it — inert YAML that renders as identity prose. Only
@@ -3489,11 +3525,7 @@ function hoistLeadingFrontmatter(body: string): string {
   const heading = displaced[1] ?? '';
   const frontmatter = displaced[2] ?? '';
   if (!heading || !frontmatter) return body;
-  // `# Title` + two horizontal rules is also ordinary Markdown, so the shape
-  // alone proves nothing. Only move a block the frontmatter parser reads as a
-  // non-empty mapping; a section fenced by `---` rules parses to {} and is left
-  // exactly where the author put it.
-  if (Object.keys(parseFrontmatter(frontmatter).data).length === 0) return body;
+  if (!isDesignSystemFrontmatter(frontmatter)) return body;
   const rest = body.slice(displaced[0].length).replace(/^(?:\r?\n)+/, '');
   return `${frontmatter}\n${heading.trimEnd()}\n\n${rest}`;
 }
@@ -3511,8 +3543,9 @@ function withDesignSystemHeader(
   // guard was not multiline, so it only ever looked at byte 0), which stopped
   // the frontmatter from parsing at all — the raw `--- name: … ---` block users
   // saw rendered as identity prose after publishing an extracted brand.
-  let next = /^#[ \t]+/m.test(body)
-    ? body.replace(/^#[ \t]+.*$/m, `# ${input.title}`)
+  const h1 = firstHeadingBelowFrontmatter(body);
+  let next = h1
+    ? `${body.slice(0, h1.index)}# ${input.title}${body.slice(h1.index + h1.length)}`
     : insertHeadingBelowFrontmatter(body, `# ${input.title}`);
   next = upsertBlockquoteMeta(next, 'Category', input.category);
   next = upsertBlockquoteMeta(next, 'Surface', input.surface);
@@ -3522,11 +3555,11 @@ function withDesignSystemHeader(
 function upsertBlockquoteMeta(body: string, key: string, value: string): string {
   const re = new RegExp(`^>\\s*${key}:\\s*.*$`, 'im');
   if (re.test(body)) return body.replace(re, `> ${key}: ${value}`);
-  const h1 = /^#\s+.*$/m.exec(body);
+  const h1 = firstHeadingBelowFrontmatter(body);
   // Same frontmatter rule as insertHeadingBelowFrontmatter: never prepend above
   // a leading `---` block, or the frontmatter stops parsing.
   if (!h1) return insertHeadingBelowFrontmatter(body, `> ${key}: ${value}`);
-  const insertAt = h1.index + h1[0].length;
+  const insertAt = h1.index + h1.length;
   return `${body.slice(0, insertAt)}\n> ${key}: ${value}${body.slice(insertAt)}`;
 }
 

--- a/apps/daemon/tests/brand-design-system-regressions.test.ts
+++ b/apps/daemon/tests/brand-design-system-regressions.test.ts
@@ -111,7 +111,6 @@ describe('design-system header rewrite keeps frontmatter parseable', () => {
     expect(body.startsWith('---\n')).toBe(true);
     expect(body.indexOf('# Acme')).toBeGreaterThan(body.indexOf('\n---\n'));
   });
-});
 
   it('leaves ordinary horizontal rules under a heading exactly where the author put them', async () => {
     // `# Title` followed by two `---` rules is also plain Markdown. Only a block
@@ -147,6 +146,78 @@ describe('design-system header rewrite keeps frontmatter parseable', () => {
     expect(after.indexOf('# Acme')).toBeLessThan(after.indexOf('---'));
     expect(after).toContain('---\nIntroduction\n---');
   });
+
+  it('leaves a colon-bearing fenced section in place (prose is valid YAML too)', async () => {
+    // `Introduction: hello` parses as the mapping { Introduction: 'hello' }, so
+    // "non-empty mapping" is not a strong enough predicate either. Only a block
+    // carrying real design-system metadata may be hoisted.
+    const root = tmpRoot();
+    const authored = [
+      '# Acme',
+      '',
+      '---',
+      'Introduction: hello',
+      '---',
+      '',
+      'Details',
+      '',
+    ].join('\n');
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: authored,
+      artifactMode: 'agent-managed',
+    });
+    const dirId = created.id.replace(/^user:/, '');
+    const designPath = path.join(root, dirId, 'DESIGN.md');
+    const before = fs.readFileSync(designPath, 'utf8');
+
+    await updateUserDesignSystem(root, created.id, { status: 'published' });
+
+    const after = fs.readFileSync(designPath, 'utf8');
+    expect(after.replace(/^> (?:Category|Surface): .*$\n?/gm, '')).toBe(before);
+    expect(after.indexOf('# Acme')).toBeLessThan(after.indexOf('---'));
+    expect(after).toContain('---\nIntroduction: hello\n---');
+  });
+
+  it('renames the real H1, not a `#` comment line inside the frontmatter', async () => {
+    // `# …` is a YAML comment, so a naive first-`#` search lands inside the
+    // frontmatter: the comment gets rewritten, the title never changes, and the
+    // `> Category:` line is spliced into the YAML block.
+    const root = tmpRoot();
+    const withComment = [
+      '---',
+      '# harvested 2026-01-01',
+      'name: "Acme"',
+      'category: Brands',
+      'surface: web',
+      '---',
+      '',
+      '# Acme',
+      '',
+      'Body copy.',
+      '',
+    ].join('\n');
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: withComment,
+      artifactMode: 'agent-managed',
+    });
+
+    await updateUserDesignSystem(root, created.id, { title: 'Acme Renamed' });
+
+    const dirId = created.id.replace(/^user:/, '');
+    const body = fs.readFileSync(path.join(root, dirId, 'DESIGN.md'), 'utf8');
+    expect(body).toContain('# harvested 2026-01-01');
+    expect(body).toContain('# Acme Renamed');
+    // Metadata belongs under the H1, never inside the YAML block.
+    expect(body.indexOf('> Category:')).toBeGreaterThan(body.indexOf('# Acme Renamed'));
+    expect(body.match(/^#[ \t]+/gm)?.length).toBe(2); // the comment + one H1
+  });
+});
 
 describe('brand package serves its own kit assets', () => {
   it('allows brand.json and harvested logo/imagery files through static reads', async () => {

--- a/apps/daemon/tests/brand-design-system-regressions.test.ts
+++ b/apps/daemon/tests/brand-design-system-regressions.test.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { brandNameFromTitle } from '../src/brands/prefetch.js';
+import {
+  createUserDesignSystem,
+  readDesignSystemStaticFile,
+  updateUserDesignSystem,
+} from '../src/design-systems/index.js';
+
+function tmpRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'od-ds-regression-'));
+}
+
+/** A brand-extracted DESIGN.md: YAML frontmatter first, then the title H1. */
+function brandDesignMd(title: string): string {
+  return [
+    '---',
+    `name: "${title}"`,
+    'category: Brands',
+    'surface: web',
+    'colors:',
+    '  background: "#ffffff"',
+    '---',
+    '',
+    `# ${title}`,
+    '',
+    '> Category: Brands',
+    '',
+    '*A tagline.*',
+    '',
+    '## Color Palette',
+    '',
+    '| Role | Name | Hex | Usage |',
+    '| --- | --- | --- | --- |',
+    '',
+  ].join('\n');
+}
+
+describe('design-system header rewrite keeps frontmatter parseable', () => {
+  it('does not add a second H1 above the frontmatter when the title is unchanged', async () => {
+    // Publishing an extracted brand (PATCH /api/design-systems/:id) re-applies
+    // the header with the SAME title. That used to prepend a duplicate H1 above
+    // the `---` block, which stopped the frontmatter from parsing at all and
+    // rendered the raw YAML as identity prose.
+    const root = tmpRoot();
+    const title = 'Stripe | Financial Infrastructure to Grow Your Revenue';
+    const created = await createUserDesignSystem(root, {
+      title,
+      category: 'Brands',
+      surface: 'web',
+      body: brandDesignMd(title),
+      artifactMode: 'agent-managed',
+    });
+
+    await updateUserDesignSystem(root, created.id, { status: 'published' });
+
+    const dirId = created.id.replace(/^user:/, '');
+    const body = fs.readFileSync(path.join(root, dirId, 'DESIGN.md'), 'utf8');
+    expect(body.startsWith('---\n')).toBe(true);
+    expect(body.match(/^#[ \t]+/gm)?.length).toBe(1);
+  });
+
+  it('repairs a package whose frontmatter was already pushed below the heading', async () => {
+    // Packages corrupted before the guard existed heal on the next write.
+    const root = tmpRoot();
+    const corrupted = [
+      '# Acme',
+      '',
+      '---',
+      'name: "Acme"',
+      'category: Brands',
+      '---',
+      '',
+      'Body copy.',
+      '',
+    ].join('\n');
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: corrupted,
+      artifactMode: 'agent-managed',
+    });
+
+    await updateUserDesignSystem(root, created.id, { status: 'published' });
+
+    const dirId = created.id.replace(/^user:/, '');
+    const body = fs.readFileSync(path.join(root, dirId, 'DESIGN.md'), 'utf8');
+    expect(body.startsWith('---\n')).toBe(true);
+    expect(body.match(/^#[ \t]+/gm)?.length).toBe(1);
+  });
+
+  it('inserts a missing H1 below the frontmatter, never above it', async () => {
+    const root = tmpRoot();
+    const headless = ['---', 'name: "Acme"', 'category: Brands', '---', '', 'Body copy.', ''].join('\n');
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: headless,
+      artifactMode: 'agent-managed',
+    });
+
+    await updateUserDesignSystem(root, created.id, { title: 'Acme' });
+
+    const dirId = created.id.replace(/^user:/, '');
+    const body = fs.readFileSync(path.join(root, dirId, 'DESIGN.md'), 'utf8');
+    expect(body.startsWith('---\n')).toBe(true);
+    expect(body.indexOf('# Acme')).toBeGreaterThan(body.indexOf('\n---\n'));
+  });
+});
+
+describe('brand package serves its own kit assets', () => {
+  it('allows brand.json and harvested logo/imagery files through static reads', async () => {
+    // The scaffold project an extraction runs in is disposable; the package copy
+    // is what keeps a design system's logo rendering after that project is gone.
+    const root = tmpRoot();
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: brandDesignMd('Acme'),
+      artifactMode: 'agent-managed',
+    });
+    const dirId = created.id.replace(/^user:/, '');
+    fs.writeFileSync(
+      path.join(root, dirId, 'brand.json'),
+      JSON.stringify({ name: 'Acme', logo: { primary: 'logos/mark.svg', alternates: [] } }),
+    );
+    fs.mkdirSync(path.join(root, dirId, 'logos'), { recursive: true });
+    fs.writeFileSync(path.join(root, dirId, 'logos', 'mark.svg'), '<svg/>');
+
+    const brand = await readDesignSystemStaticFile(root, created.id, 'brand.json', {
+      idPrefix: 'user:',
+    });
+    expect(brand?.bytes.toString('utf8')).toContain('logos/mark.svg');
+
+    const logo = await readDesignSystemStaticFile(root, created.id, 'logos/mark.svg', {
+      idPrefix: 'user:',
+    });
+    expect(logo?.bytes.toString('utf8')).toBe('<svg/>');
+
+    // Traversal and unrelated files stay blocked.
+    expect(
+      await readDesignSystemStaticFile(root, created.id, '../secret.txt', { idPrefix: 'user:' }),
+    ).toBeNull();
+  });
+});
+
+describe('brand name from a marketing page title', () => {
+  it('keeps the brand and drops the tagline when the hostname agrees', () => {
+    expect(
+      brandNameFromTitle('Stripe | Financial Infrastructure to Grow Your Revenue', 'https://stripe.com/'),
+    ).toBe('Stripe');
+    expect(brandNameFromTitle('Linear – Plan and build products', 'https://linear.app')).toBe('Linear');
+  });
+
+  it('leaves titles alone when splitting would be a guess', () => {
+    // No separator at all.
+    expect(brandNameFromTitle('Acme Corporation', 'https://acme.com')).toBe('Acme Corporation');
+    // Lead segment is long and the tail is short: not the "Brand | promise" shape.
+    const wordy = 'Everything you need to know about widgets | Blog';
+    expect(brandNameFromTitle(wordy, 'https://example.org')).toBe(wordy);
+  });
+
+  it('returns an empty string for an empty title', () => {
+    expect(brandNameFromTitle('', 'https://acme.com')).toBe('');
+  });
+});

--- a/apps/daemon/tests/brand-design-system-regressions.test.ts
+++ b/apps/daemon/tests/brand-design-system-regressions.test.ts
@@ -113,6 +113,41 @@ describe('design-system header rewrite keeps frontmatter parseable', () => {
   });
 });
 
+  it('leaves ordinary horizontal rules under a heading exactly where the author put them', async () => {
+    // `# Title` followed by two `---` rules is also plain Markdown. Only a block
+    // that parses as real frontmatter may be hoisted; a fenced section must
+    // survive a metadata write byte-for-byte.
+    const root = tmpRoot();
+    const authored = [
+      '# Acme',
+      '',
+      '---',
+      'Introduction',
+      '---',
+      '',
+      'Details',
+      '',
+    ].join('\n');
+    const created = await createUserDesignSystem(root, {
+      title: 'Acme',
+      category: 'Brands',
+      surface: 'web',
+      body: authored,
+      artifactMode: 'agent-managed',
+    });
+    const dirId = created.id.replace(/^user:/, '');
+    const designPath = path.join(root, dirId, 'DESIGN.md');
+    const before = fs.readFileSync(designPath, 'utf8');
+
+    await updateUserDesignSystem(root, created.id, { status: 'published' });
+
+    const after = fs.readFileSync(designPath, 'utf8');
+    // The only permitted difference is the header metadata this write adds.
+    expect(after.replace(/^> (?:Category|Surface): .*$\n?/gm, '')).toBe(before);
+    expect(after.indexOf('# Acme')).toBeLessThan(after.indexOf('---'));
+    expect(after).toContain('---\nIntroduction\n---');
+  });
+
 describe('brand package serves its own kit assets', () => {
   it('allows brand.json and harvested logo/imagery files through static reads', async () => {
     // The scaffold project an extraction runs in is disposable; the package copy

--- a/apps/web/src/components/DesignSystemsTab.tsx
+++ b/apps/web/src/components/DesignSystemsTab.tsx
@@ -1585,6 +1585,7 @@ function DesignSystemDetail({
   }
   const { kit } = useDesignKit({
     designSystemId: system.id,
+    category: system.category,
     title: system.title,
     projectId,
     body: detail?.body,

--- a/apps/web/src/runtime/design-kit.ts
+++ b/apps/web/src/runtime/design-kit.ts
@@ -609,6 +609,9 @@ export function parsedToKit(parsed: ParsedDesignMd, opts: ParsedKitOptions): Des
 
 export interface DesignKitSource {
   designSystemId: string;
+  /** Catalog category. `Brands` marks a package produced by brand extraction —
+   *  the only kind that ships its own `brand.json` kit alongside DESIGN.md. */
+  category?: string | null;
   title: string;
   projectId?: string;
   /** DESIGN.md content, when the caller already has it (registry body). */
@@ -709,6 +712,7 @@ function mergeLegacyBrandLogo(
 export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; loading: boolean } {
   const {
     designSystemId,
+    category,
     title,
     projectId,
     body,
@@ -743,10 +747,13 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
     // A brand-extracted design system keeps its own copy of the kit
     // (`brand.json` + `logos/` + `imagery/`) inside the package. That copy is
     // the durable one: the scaffold project the extraction ran in is disposable
-    // and may be deleted, at which point the project fetch below returns
-    // nothing. Read the package as a fallback so the logo/imagery keep
-    // rendering instead of collapsing to "No logo yet".
-    const packageAssetUrl = designSystemId
+    // and may be deleted, at which point the project read below returns nothing.
+    // Read the package then, so the logo/imagery keep rendering instead of
+    // collapsing to an empty logo module. Only packages that actually ship a
+    // `brand.json` are asked for one — every other design system keeps its
+    // original single-hop, DESIGN.md-only resolution.
+    const isBrandPackage = (category ?? '').trim().toLowerCase() === 'brands';
+    const packageAssetUrl = designSystemId && isBrandPackage
       ? (rel: string): string => designSystemStaticUrl(designSystemId, rel, workspaceContext)
       : null;
     const fetchPackageBrand = async (): Promise<string | null> => {
@@ -758,10 +765,15 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
         return null;
       }
     };
-    const kitFromPackageBrand = (raw: string | null): DesignKit | null => {
+    /**
+     * Package brand.json is the ASSET source, never the source of truth for
+     * text: DESIGN.md is what edits and renames write to, so it overlays the
+     * package kit exactly the way it overlays the project-backed one.
+     */
+    const kitFromPackageBrand = (raw: string | null, designMd: string): DesignKit | null => {
       const parsed = tryParseBrand(raw);
       if (!parsed || !packageAssetUrl) return null;
-      return brandToKit(parsed, {
+      const packageKit = brandToKit(parsed, {
         designSystemId,
         editable,
         host,
@@ -770,16 +782,34 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
         assetUrl: packageAssetUrl,
         ...(projectId ? { projectId } : {}),
       });
+      return mergeBrandKitWithDesignMd(packageKit, designMd, {
+        designSystemId,
+        projectId,
+        editable,
+        title,
+        host,
+        swatches,
+        packageInfo,
+        showcaseHtml,
+        workspaceContext,
+      });
     };
 
     if (!projectId) {
-      setLoading(true);
-      void (async () => {
-        const packageKit = kitFromPackageBrand(await fetchPackageBrand());
-        if (cancelled) return;
-        setKit(packageKit ?? fromDesignMd(body));
+      // Paint from DESIGN.md immediately — the package read below only ever
+      // adds assets, so it must not delay or replace the first render.
+      setKit(fromDesignMd(body));
+      if (!packageAssetUrl) {
         setLoading(false);
+        return () => {
+          cancelled = true;
+        };
+      }
+      void (async () => {
+        const merged = kitFromPackageBrand(await fetchPackageBrand(), body ?? '');
+        if (!cancelled && merged) setKit(merged);
       })();
+      setLoading(false);
       return () => {
         cancelled = true;
       };
@@ -829,25 +859,14 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
       } else {
         // No usable brand.json in the project (deleted, or never had one) — try
         // the package's own copy before falling back to DESIGN.md prose.
-        const packageKit = kitFromPackageBrand(await fetchPackageBrand());
+        const packageKit = kitFromPackageBrand(await fetchPackageBrand(), rawDesignMd ?? '');
         if (cancelled) return;
         setKit(packageKit
-          ? mergeBrandKitWithDesignMd(packageKit, rawDesignMd ?? '', {
-              designSystemId,
-              projectId,
-              editable,
-              title,
-              host,
-              swatches,
-              packageInfo,
-              showcaseHtml,
-              workspaceContext,
-            })
-          : mergeLegacyBrandLogo(
-              fromDesignMd(rawDesignMd ?? ''),
-              tryParseLegacyBrandLogo(rawBrand),
-              { projectId, reloadKey, workspaceContext },
-            ));
+          ?? mergeLegacyBrandLogo(
+            fromDesignMd(rawDesignMd ?? ''),
+            tryParseLegacyBrandLogo(rawBrand),
+            { projectId, reloadKey, workspaceContext },
+          ));
       }
       setLoading(false);
     })();
@@ -857,6 +876,7 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
     };
   }, [
     designSystemId,
+    category,
     title,
     projectId,
     body,

--- a/apps/web/src/runtime/design-kit.ts
+++ b/apps/web/src/runtime/design-kit.ts
@@ -367,7 +367,14 @@ interface BrandKitOptions {
 export function brandToKit(brand: Brand, opts: BrandKitOptions): DesignKit {
   const { projectId } = opts;
   const ready = opts.ready !== false;
-  const showSystem = ready && Boolean(projectId);
+  // `assetUrl` means the caller resolves assets somewhere other than the
+  // project raw route — today, the design-system package, which serves only
+  // `brand.json`, `logos/`, and `imagery/`. The system/ artifacts (kit iframe,
+  // the `system/artifacts/*.html` tiles) live in the scaffold project alone, so
+  // a redirected kit must not advertise them: the package route rejects those
+  // paths outright, and the project we fell back FROM no longer has them.
+  const assetsFromPackage = Boolean(opts.assetUrl);
+  const showSystem = ready && Boolean(projectId) && !assetsFromPackage;
   const asset = (rel: string): string | null => {
     if (opts.assetUrl) return opts.assetUrl(rel);
     return projectId

--- a/apps/web/src/runtime/design-kit.ts
+++ b/apps/web/src/runtime/design-kit.ts
@@ -353,6 +353,13 @@ interface BrandKitOptions {
   /** The system/ artifacts only exist once a brand is finalized; gate the kit
    *  iframe + asset tiles so an in-flight brand does not point at 404s. */
   ready?: boolean;
+  /**
+   * Resolve a brand-relative asset path (`logos/mark.svg`) to a URL. Defaults to
+   * the scaffold project's raw-file route; the design-system package passes its
+   * own static route so an extracted brand keeps its logo/imagery after that
+   * disposable project is gone.
+   */
+  assetUrl?: (relativePath: string) => string | null;
 }
 
 /** Build a kit from a finalized Brand (brand.json). Assets resolve against the
@@ -361,10 +368,12 @@ export function brandToKit(brand: Brand, opts: BrandKitOptions): DesignKit {
   const { projectId } = opts;
   const ready = opts.ready !== false;
   const showSystem = ready && Boolean(projectId);
-  const asset = (rel: string): string | null =>
-    projectId
+  const asset = (rel: string): string | null => {
+    if (opts.assetUrl) return opts.assetUrl(rel);
+    return projectId
       ? withCacheBust(projectRawUrl(projectId, rel, opts.workspaceContext), opts.reloadKey)
       : null;
+  };
   const host = opts.host || hostnameOf(brand.sourceUrl || '');
   const imagery: KitImagery | undefined = brand.imagery
     ? {
@@ -731,9 +740,46 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
         workspaceContext,
       });
 
+    // A brand-extracted design system keeps its own copy of the kit
+    // (`brand.json` + `logos/` + `imagery/`) inside the package. That copy is
+    // the durable one: the scaffold project the extraction ran in is disposable
+    // and may be deleted, at which point the project fetch below returns
+    // nothing. Read the package as a fallback so the logo/imagery keep
+    // rendering instead of collapsing to "No logo yet".
+    const packageAssetUrl = designSystemId
+      ? (rel: string): string => designSystemStaticUrl(designSystemId, rel, workspaceContext)
+      : null;
+    const fetchPackageBrand = async (): Promise<string | null> => {
+      if (!packageAssetUrl) return null;
+      try {
+        const res = await fetch(packageAssetUrl('brand.json'), { cache: 'no-store' });
+        return res.ok ? await res.text() : null;
+      } catch {
+        return null;
+      }
+    };
+    const kitFromPackageBrand = (raw: string | null): DesignKit | null => {
+      const parsed = tryParseBrand(raw);
+      if (!parsed || !packageAssetUrl) return null;
+      return brandToKit(parsed, {
+        designSystemId,
+        editable,
+        host,
+        showcaseHtml,
+        workspaceContext,
+        assetUrl: packageAssetUrl,
+        ...(projectId ? { projectId } : {}),
+      });
+    };
+
     if (!projectId) {
-      setKit(fromDesignMd(body));
-      setLoading(false);
+      setLoading(true);
+      void (async () => {
+        const packageKit = kitFromPackageBrand(await fetchPackageBrand());
+        if (cancelled) return;
+        setKit(packageKit ?? fromDesignMd(body));
+        setLoading(false);
+      })();
       return () => {
         cancelled = true;
       };
@@ -781,11 +827,27 @@ export function useDesignKit(source: DesignKitSource): { kit: DesignKit | null; 
           workspaceContext,
         }));
       } else {
-        setKit(mergeLegacyBrandLogo(
-          fromDesignMd(rawDesignMd ?? ''),
-          tryParseLegacyBrandLogo(rawBrand),
-          { projectId, reloadKey, workspaceContext },
-        ));
+        // No usable brand.json in the project (deleted, or never had one) — try
+        // the package's own copy before falling back to DESIGN.md prose.
+        const packageKit = kitFromPackageBrand(await fetchPackageBrand());
+        if (cancelled) return;
+        setKit(packageKit
+          ? mergeBrandKitWithDesignMd(packageKit, rawDesignMd ?? '', {
+              designSystemId,
+              projectId,
+              editable,
+              title,
+              host,
+              swatches,
+              packageInfo,
+              showcaseHtml,
+              workspaceContext,
+            })
+          : mergeLegacyBrandLogo(
+              fromDesignMd(rawDesignMd ?? ''),
+              tryParseLegacyBrandLogo(rawBrand),
+              { projectId, reloadKey, workspaceContext },
+            ));
       }
       setLoading(false);
     })();

--- a/apps/web/tests/runtime/design-kit-package-fallback.test.ts
+++ b/apps/web/tests/runtime/design-kit-package-fallback.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useDesignKit } from '../../src/runtime/design-kit';
+
+describe('useDesignKit package fallback', () => {
+  const PACKAGE_BRAND = JSON.stringify({
+    name: 'Stale Package Name',
+    logo: { primary: 'logos/mark.svg', alternates: [] },
+    colors: [{ role: 'accent', name: 'Old Accent', hex: '#000000', usage: '' }],
+  });
+  const DESIGN_MD = [
+    '# Renamed System',
+    '',
+    '## Color Palette',
+    '',
+    '| Role | Name | Hex | Usage |',
+    '| --- | --- | --- | --- |',
+    '| accent | New Accent | #ff0000 | buttons |',
+    '',
+  ].join('\n');
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('adds package assets to the DESIGN.md kit without a project, and never overwrites its text', async () => {
+    const fetchMock = vi.fn(async () => new Response(PACKAGE_BRAND, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Stable source object: `packageInfo` is an effect dependency, so a fresh
+    // object per render would re-run the resolver forever.
+    const source = {
+      designSystemId: 'user:acme',
+      category: 'Brands',
+      title: 'Renamed System',
+      body: DESIGN_MD,
+      editable: false,
+      packageInfo: { availableFiles: ['DESIGN.md', 'brand.json'] },
+    };
+    const hook = renderHook(() => useDesignKit(source));
+
+    // First paint comes straight from DESIGN.md — the package read only adds.
+    expect(hook.result.current.kit?.name).toBe('Renamed System');
+
+    await waitFor(() =>
+      expect(hook.result.current.kit?.logoSrc).toContain(encodeURIComponent('logos/mark.svg')),
+    );
+    expect(hook.result.current.kit?.name).toBe('Renamed System');
+    expect(hook.result.current.kit?.colors.map((c) => c.hex)).toContain('#ff0000');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for nothing when the system is not a brand package', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const source = {
+      designSystemId: 'tom-modern',
+      category: 'Starter',
+      title: 'Tom Modern',
+      body: '# Tom Modern',
+      editable: false,
+      packageInfo: { availableFiles: ['DESIGN.md', 'tokens.css'] },
+    };
+    const hook = renderHook(() => useDesignKit(source));
+
+    await waitFor(() => expect(hook.result.current.kit?.name).toBe('Tom Modern'));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/runtime/design-kit.test.ts
+++ b/apps/web/tests/runtime/design-kit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseDesignMd } from '../../src/runtime/design-md-parse';
-import { parsedToKit } from '../../src/runtime/design-kit';
+import { brandToKit, mergeBrandKitWithDesignMd, parsedToKit } from '../../src/runtime/design-kit';
 
 describe('parsedToKit package static assets', () => {
   it('falls back to declared components and omits missing artifacts when packaged system files are absent', () => {
@@ -72,5 +72,54 @@ describe('parsedToKit package static assets', () => {
         url: '/api/design-systems/bento/static?path=system%2Fartifacts%2Flanding.html',
       },
     ]);
+  });
+});
+
+describe('package brand kit overlays DESIGN.md', () => {
+  const BRAND_JSON = JSON.stringify({
+    name: 'Stale Package Name',
+    tagline: 'stale tagline',
+    logo: { primary: 'logos/mark.svg', alternates: [] },
+    colors: [{ role: 'accent', name: 'Old Accent', hex: '#000000', usage: '' }],
+  });
+
+  const DESIGN_MD = [
+    '# Renamed System',
+    '',
+    '## Color Palette',
+    '',
+    '| Role | Name | Hex | Usage |',
+    '| --- | --- | --- | --- |',
+    '| accent | New Accent | #ff0000 | buttons |',
+    '',
+  ].join('\n');
+
+  it('keeps DESIGN.md name and colors while taking the logo from brand.json', () => {
+    // brand.json is the durable ASSET source for an extracted brand; DESIGN.md
+    // is what renames and edits write to, so it must win on text.
+    const packageKit = brandToKit(JSON.parse(BRAND_JSON) as Parameters<typeof brandToKit>[0], {
+      designSystemId: 'user:acme',
+      editable: false,
+      assetUrl: (rel) => `/api/design-systems/user%3Aacme/static?path=${rel}`,
+    });
+    expect(packageKit.logoSrc).toBe('/api/design-systems/user%3Aacme/static?path=logos/mark.svg');
+
+    const merged = mergeBrandKitWithDesignMd(packageKit, DESIGN_MD, {
+      designSystemId: 'user:acme',
+      editable: false,
+    });
+
+    expect(merged.name).toBe('Renamed System');
+    expect(merged.colors.map((c) => c.hex)).toContain('#ff0000');
+    expect(merged.logoSrc).toBe('/api/design-systems/user%3Aacme/static?path=logos/mark.svg');
+  });
+
+  it('resolves brand assets through the design-system package, not a project route', () => {
+    const kit = brandToKit(JSON.parse(BRAND_JSON) as Parameters<typeof brandToKit>[0], {
+      designSystemId: 'user:acme',
+      editable: false,
+      assetUrl: (rel) => `/pkg/${rel}`,
+    });
+    expect(kit.logoSrc).toBe('/pkg/logos/mark.svg');
   });
 });

--- a/apps/web/tests/runtime/design-kit.test.ts
+++ b/apps/web/tests/runtime/design-kit.test.ts
@@ -122,4 +122,19 @@ describe('package brand kit overlays DESIGN.md', () => {
     });
     expect(kit.logoSrc).toBe('/pkg/logos/mark.svg');
   });
+
+  it('does not advertise project-only system artifacts on a package-backed kit', () => {
+    // The package route serves brand.json/logos/imagery only, and the project we
+    // fell back FROM has no finalized system/ output — so the kit iframe and the
+    // `system/artifacts/*.html` tiles would both 404 if they were exposed here.
+    const kit = brandToKit(JSON.parse(BRAND_JSON) as Parameters<typeof brandToKit>[0], {
+      designSystemId: 'user:acme',
+      projectId: 'p1',
+      editable: true,
+      assetUrl: (rel) => `/pkg/${rel}`,
+    });
+    expect(kit.system).toBeUndefined();
+    expect(kit.assets).toBeUndefined();
+    expect(kit.logoSrc).toBe('/pkg/logos/mark.svg');
+  });
 });


### PR DESCRIPTION
## Why

I hit all three of these in one sitting while extracting a brand from a live site (`od brand extract`) and then trying to use the resulting design system, so this is a scratch-my-own-itch PR rather than a speculative one.

The first defect is the painful one: **publishing an extracted brand silently corrupts its own `DESIGN.md`**. The file stops being a valid frontmatter document, so the YAML block renders to the user as raw identity prose and every consumer that parses frontmatter (catalog title/category/surface precedence, colour swatches) loses its input. Nothing warns; the package just quietly degrades on a routine metadata write.

The other two are the same story at a smaller scale — an extracted brand that harvested six logo files still shows an empty logo module, and every brand ends up named after a marketing page title instead of the company.

## What users will see

- Publishing (or renaming) an extracted brand no longer scrambles its `DESIGN.md`; packages already written the broken way repair themselves on the next write, so the identity block goes back to reading like identity instead of `--- name: "..." category: Brands ... ---`.
- A brand design system shows its logo and imagery even when the scaffold project the extraction ran in has been deleted.
- Extracted brands are named `Stripe`, not `Stripe | Financial Infrastructure to Grow Your Revenue`. Page titles that don't clearly split into "brand + tagline" are left exactly as they are.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — brand-extracted design systems get a cleaner name, and their package `brand.json` / `logos/` / `imagery/` are now readable through the design-system static route (previously refused). No setting to opt into; nothing existing breaks.

## Screenshots

Not a UI change — the visible difference is inside generated package content (above).

## Bug fix verification

- Test path: `apps/daemon/tests/brand-design-system-regressions.test.ts` (7 specs: header rewrite keeps frontmatter parseable, missing H1 is inserted below frontmatter, already-corrupted packages heal, package brand assets are served while traversal stays blocked, and three name-derivation cases).
- Red on `main`, green on this branch: **yes** — with the two daemon source files stashed on this branch (i.e. clean `upstream/main` behaviour) all 7 specs fail; restoring them turns all 7 green.

Root cause of (1), for reviewers:

```js
let next = body.replace(/^#\s+.*$/m, `# ${input.title}`);
if (next === body && !/^#\s+/.test(next)) next = `# ${input.title}\n\n${next}`;
```

`replace` is a no-op when the title already equals the current H1, so `next === body` is true; and `/^#\s+/` has no `m` flag, so it only tests byte 0, which is `-` for a frontmatter document. Both conditions pass and a second H1 gets prepended above `---`.

## Validation

- `pnpm guard`
- `pnpm typecheck` (`@open-design/daemon`, `@open-design/web`)
- `pnpm --filter @open-design/daemon test` for the brand + design-system suites: 48 files / 431 tests green
- `pnpm --filter @open-design/web test` for the design-kit suites: 4 files / 17 tests green

## Adjacent issues (not fixed here)

While tracing (2) I noticed the scaffold project id recorded in a design system's `metadata.json` can outlive the project itself; the fallback added here makes that harmless for assets, but the dangling reference is worth its own look. Left alone to keep this PR to the three defects above.
