### PR TITLE
fix(web): stop badging team plans as unlimited

### DIFF
--- a/apps/web/src/runtime/amr-unlimited-models.ts
+++ b/apps/web/src/runtime/amr-unlimited-models.ts
@@ -9,8 +9,8 @@
  *    inherit the personal answer (#7187);
  *  • the model switcher's badge asks what to mark on screen, via
  *    {@link isUnlimitedModelForPlanTier}, which reads the tier out of a
- *    team-namespaced id too, because a Team Pro subscriber's Kimi K2.7 Code is
- *    just as unlimited as a personal Pro's.
+ *    personal ladder only — see {@link planUnlimitedTier} for why a Team plan
+ *    is not the same question.
  *
  * Keeping both on one table is the point: the sets are a product promise, and
  * a second copy would drift. The Pricing page's own `unlimitedByTier`
@@ -75,14 +75,22 @@ const TIER_ORDER: readonly PlanUnlimitedTier[] = ['max', 'pro', 'plus', 'go'];
 
 /**
  * The unlimited-models tier a raw vela plan id belongs to, or null when the id
- * names no tier that carries an unlimited set (`free`, `team_basic`, or the
- * empty string billing reports before it has answered).
+ * names no tier that carries an unlimited set — `free`, the empty string
+ * billing reports before it has answered, and every TEAM plan.
  *
- * Team plans are namespaced ids on their own ladder (`team_plus`,
- * `team_max_yearly`), so the tier is read off the id's SEGMENTS rather than by
- * comparing the whole string. Substring matching is deliberately not used: it
- * is what made an earlier plan-badge rule answer `plus` for "Team Plus" before
- * the team branch could run.
+ * Team is excluded on evidence, not on tidiness. "Team plans are paid too" is
+ * the wrong test; the question is whether the plan funds usage without
+ * touching the wallet, and vela's schema answers no: in-plan usage is recorded
+ * through the `coding_plan` billing mode, constrained to
+ * `membership_tier_snapshot = ANY (ARRAY['go','plus','pro','max'])`, so a Team
+ * workspace never produces a zero-charge call. `team_basic` is seats-only on
+ * top of that (`monthly_credits_per_seat = 0` in the seeded catalog). The
+ * balance preflight above already refuses to stand down for Team, and a badge
+ * promising what the preflight then blocks is worse than no badge.
+ *
+ * The tier is read off the id's SEGMENTS rather than by substring: substring
+ * matching is what made an earlier plan-badge rule answer `plus` for
+ * "Team Plus", which is exactly the confusion this function must not repeat.
  */
 export function planUnlimitedTier(
   rawTier: string | null | undefined,
@@ -90,6 +98,7 @@ export function planUnlimitedTier(
   const normalized = normalize(rawTier);
   if (!normalized) return null;
   const segments = new Set(normalized.split(/[_\-\s]+/).filter(Boolean));
+  if (segments.has('team')) return null;
   return TIER_ORDER.find((tier) => segments.has(tier)) ?? null;
 }
 

--- a/apps/web/tests/components/EntryNavRail.credits-zero-balance.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.credits-zero-balance.test.tsx
@@ -83,8 +83,8 @@ function creditsPill(): HTMLElement | null {
 }
 
 describe('top-right credits pill', () => {
-  it.each(['go', 'plus', 'pro', 'max', 'team_plus', 'team_max_yearly'])(
-    'hides the zero balance on the subscribed plan %s',
+  it.each(['go', 'plus', 'pro', 'max'])(
+    'hides the zero balance on the subscribed personal plan %s',
     (tier) => {
       renderRail({
         context: context({ planId: tier } as Partial<WorkspaceCollabContext>),
@@ -109,6 +109,22 @@ describe('top-right credits pill', () => {
     renderRail({ balanceUsd: '-1.25' });
     expect(creditsPill()?.textContent).toContain('-$1.25');
   });
+
+  it.each(['team_basic', 'team_plus', 'team_max_yearly'])(
+    'keeps the zero balance on the team plan %s, which really is out of credits',
+    (tier) => {
+      // A Team workspace has no unlimited set to fall back on: vela records
+      // in-plan usage through the `coding_plan` billing mode, which its schema
+      // constrains to personal tiers, so a Team zero is an empty wallet and
+      // hiding it would hide the reason members get blocked.
+      renderRail({
+        context: context({ planId: tier } as Partial<WorkspaceCollabContext>),
+        billing: billing({ membershipTier: tier }),
+        balanceUsd: '0',
+      });
+      expect(creditsPill()?.textContent).toContain('$0.00');
+    },
+  );
 
   it('keeps the zero balance for a free plan, where it explains the gate', () => {
     renderRail({

--- a/apps/web/tests/components/InlineModelSwitcher.unlimited-badge.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.unlimited-badge.test.tsx
@@ -190,10 +190,25 @@ describe('unlimited badge follows the subscription tier', () => {
 
   it('badges every popular model on Max', () => {
     mockNow(AFTER_CAMPAIGN);
-    setPlan('team_max_yearly');
+    setPlan('max');
     renderSwitcher();
     expect(badgedModelIds()).toHaveLength(8);
   });
+
+  it.each(['team_plus', 'team_pro', 'team_max_yearly'])(
+    'badges nothing on the team plan %s',
+    (tier) => {
+      // Team workspaces spend their own balance and never get an in-plan
+      // zero-charge call (vela constrains the `coding_plan` billing mode to
+      // personal tiers), which is also why #7187's balance preflight refuses
+      // to stand down for them. A badge here would promise what the preflight
+      // then blocks.
+      mockNow(AFTER_CAMPAIGN);
+      setPlan(tier);
+      renderSwitcher();
+      expect(badgedModelIds()).toEqual([]);
+    },
+  );
 
   it('badges nothing for a free plan once the campaign window has closed', () => {
     mockNow(AFTER_CAMPAIGN);

--- a/apps/web/tests/runtime/amr-unlimited-models.plan-tier.test.ts
+++ b/apps/web/tests/runtime/amr-unlimited-models.plan-tier.test.ts
@@ -26,15 +26,23 @@ describe('planUnlimitedTier', () => {
     expect(planUnlimitedTier(raw)).toBe(expected);
   });
 
-  it.each([
-    ['team_plus', 'plus'],
-    ['team-pro', 'pro'],
-    ['team_max_yearly', 'max'],
-  ] as const)('reads the tier segment out of the team id %s', (raw, expected) => {
-    expect(planUnlimitedTier(raw)).toBe(expected);
-  });
+  it.each(['team_plus', 'team-pro', 'team_max_yearly', 'team_basic', 'team'])(
+    'refuses to read a personal tier out of the team id %s',
+    (raw) => {
+      // Being paid is not the question — whether the plan funds usage without
+      // touching the wallet is, and for Team it does not. vela records in-plan
+      // usage through the `coding_plan` billing mode, which its schema
+      // constrains to personal tiers
+      // (`membership_tier_snapshot = ANY (ARRAY['go','plus','pro','max'])`),
+      // so no Team workspace ever gets a zero-charge call. #7187's balance
+      // preflight already refuses to stand down for them; the badge must not
+      // promise what the preflight then blocks.
+      expect(planUnlimitedTier(raw)).toBeNull();
+      expect(isUnlimitedModelForPlanTier('deepseek-v4-flash', raw)).toBe(false);
+    },
+  );
 
-  it.each([null, undefined, '', '   ', 'free', 'team_basic'])(
+  it.each([null, undefined, '', '   ', 'free'])(
     'answers null for %s, which carries no unlimited set',
     (raw) => {
       expect(planUnlimitedTier(raw)).toBeNull();
@@ -82,9 +90,9 @@ describe('per-tier unlimited sets, as the badge sees them', () => {
     }
   });
 
-  it('gives a team-namespaced id the same set as its personal tier', () => {
-    expect(unlimitedOn('team_pro')).toEqual(unlimitedOn('pro'));
-    expect(unlimitedOn('team_max_yearly')).toEqual(unlimitedOn('max'));
+  it('marks nothing on a team-namespaced id', () => {
+    expect(unlimitedOn('team_pro')).toEqual([]);
+    expect(unlimitedOn('team_max_yearly')).toEqual([]);
   });
 });
 
@@ -104,7 +112,7 @@ describe('isUnlimitedModelForPlanTier', () => {
   it('badges Kimi K2.7 Code on Plus and above but not on Go', () => {
     expect(isUnlimitedModelForPlanTier('kimi-k2.7-code', 'go')).toBe(false);
     expect(isUnlimitedModelForPlanTier('kimi-k2.7-code', 'plus')).toBe(true);
-    expect(isUnlimitedModelForPlanTier('kimi-k2.7-code', 'team_pro')).toBe(true);
+    expect(isUnlimitedModelForPlanTier('kimi-k2.7-code', 'team_pro')).toBe(false);
   });
 
   it('fails closed while the plan is unknown or free', () => {


### PR DESCRIPTION
Fixes a defect I introduced in #7190.

## Why

#7190 had `planUnlimitedTier` read a personal tier out of a team-namespaced plan id, so a **Team** workspace got both of that PR's behaviours: 「无限使用」 badges on five models, and its zero balance hidden from the top-right credits pill. My reasoning was "Team plans are paid subscriptions too" — which is the wrong test.

The question is whether the plan funds usage **without touching the wallet**, and for Team the answer is no:

- In-plan usage is recorded through the `coding_plan` billing mode, and vela's schema constrains that mode to personal tiers — `membership_tier_snapshot = ANY (ARRAY['go','plus','pro','max'])` (`db/migrations/20260820031952_go_plan.sql`). A Team workspace can never produce a zero-charge usage row.
- `team_basic` is seats-only on top of that: `monthly_credits_per_seat = 0` in the seeded team catalog.

So a Team workspace at zero really is out of credits. Worse, #7187's balance preflight already refuses to stand down for Team workspaces — meaning the badge promised exactly what the preflight then blocked, and the pill hid the number that explains the block.

## What users will see

- **Team workspaces**: no 「无限使用」 badge on any model, and the credits pill shows their real balance again, `$0.00` included.
- **Personal go / plus / pro / max**: unchanged — still badged, still hiding a zero.
- The DeepSeek V4 campaign path is untouched: inside the window both campaign models keep their badge for everyone, Team included, because that entitlement does not come from the plan.

The console half of the same defect is fixed in powerformer/vela#1699.

## Bug fix verification

- Red spec first: `apps/web/tests/runtime/amr-unlimited-models.plan-tier.test.ts` (team ids must resolve to no tier) went **5 failed / 19 passed** before the source change, green after.
- Two existing specs were asserting the wrong behaviour and are corrected in the same commit, each with the evidence in a comment: `EntryNavRail.credits-zero-balance.test.tsx` (team tiers keep their zero) and `InlineModelSwitcher.unlimited-badge.test.tsx` (team tiers badge nothing).

## Validation

- `pnpm typecheck` — 0
- `pnpm guard` — 0
- 95 cases green across the five affected specs, including #7187's own `amr-unlimited-models.test.ts` and `amr-balance-gate.test.ts` (unchanged behaviour there).
