### PR TITLE
fix(mcp): implement empty resources/templates/list

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -15,6 +15,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -955,6 +956,16 @@ export function createLocalMcpBriefStore() {
 /** Handler body for MCP `resources/list`. Exported so tests can call it
  * directly without a real server. Mirrors the inline logic in
  * `runMcpStdio` to keep the test harness cheap. */
+export async function _listMcpResourceTemplates(): Promise<{
+  resourceTemplates: Array<Record<string, unknown>>;
+}> {
+  // OD currently exposes only concrete resources (od://...), not URI
+  // templates. Returning an empty page keeps clients that always call
+  // resources/templates/list after advertising capabilities.resources
+  // from failing with Method not found (#7014).
+  return { resourceTemplates: [] };
+}
+
 export async function _listMcpResources(
   daemonTarget: ReturnType<typeof createMcpDaemonTarget>,
 ): Promise<{ resources: Array<{ uri: string; name: string; description: string; mimeType: string }> }> {
@@ -1911,6 +1922,13 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
 
   server.setRequestHandler(ListResourcesRequestSchema, withMcpActivity(async () => {
     return await _listMcpResources(daemonTarget);
+  }));
+
+  // Advertise resources => clients may call resources/templates/list.
+  // Open Design has concrete resources only (no URI templates yet), so
+  // return an empty page instead of JSON-RPC -32601 Method not found.
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, withMcpActivity(async () => {
+    return await _listMcpResourceTemplates();
   }));
 
   server.setRequestHandler(ReadResourceRequestSchema, withMcpActivity(async (req) => {

--- a/apps/daemon/tests/mcp-resource-templates.test.ts
+++ b/apps/daemon/tests/mcp-resource-templates.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ListResourceTemplatesRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+import { _listMcpResourceTemplates } from '../src/mcp.js';
+
+/**
+ * #7014 — when capabilities.resources is advertised, clients call
+ * resources/templates/list. The handler must exist and may return an
+ * empty page when OD has no URI templates.
+ */
+describe('MCP resources/templates/list (#7014)', () => {
+  it('ListResourceTemplatesRequestSchema targets resources/templates/list', () => {
+    const parsed = ListResourceTemplatesRequestSchema.parse({
+      method: 'resources/templates/list',
+      params: {},
+    });
+    expect(parsed.method).toBe('resources/templates/list');
+  });
+
+  it('returns an empty resourceTemplates page', async () => {
+    await expect(_listMcpResourceTemplates()).resolves.toEqual({
+      resourceTemplates: [],
+    });
+  });
+});


### PR DESCRIPTION
## Why

`capabilities.resources` was already advertised, but `resources/templates/list` was unimplemented and returned JSON-RPC `-32601` (Method not found). Open Design only has concrete `od://` resources, not URI templates, so registering the handler with an empty `resourceTemplates` page is the correct fix.

Fixes #7014

## What users will see

MCP clients that call `resources/templates/list` now get a valid empty response instead of a method-not-found error.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- `apps/daemon/src/mcp/server.ts`: registers the `ListResourceTemplatesRequestSchema` handler
- `apps/daemon/tests/mcp-resource-templates.test.ts`: regression test for the previously missing method

## Validation

- `npx vitest run tests/mcp-resource-templates.test.ts` in `apps/daemon` — 2 tests pass
- `npx vitest run tests/mcp-*.test.ts` in `apps/daemon` — focused MCP suite passes
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/daemon lint` — clean