### PR TITLE
fix(runtimes): pass Antigravity prompt via -p argument

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -203,7 +203,7 @@ export const antigravityAgentDef = {
   // composed in server.ts gives a second line of defense for weak
   // plain-stream models like Gemini 3.5 Flash.
   buildArgs: (
-    _prompt,
+    prompt,
     _imagePaths,
     _extra = [],
     options = {},
@@ -215,18 +215,12 @@ export const antigravityAgentDef = {
         runtimeContext.antigravitySettingsPath,
       );
     }
-    // We invoke agy via `-p -` (print mode + stdin sentinel), NOT
-    // `chat -`. Verified against `agy --help` on v1.0.3 — the
-    // `Available subcommands` list is `changelog / help / install /
-    // plugin / update`, and `chat` is NOT among them. `-p` is the
-    // documented print-mode flag (`Short alias for --print`) and
-    // `agy -p -` reads the prompt from stdin. The looper reviewer
-    // bot's environment runs a different agy build that may have
-    // renamed the entry point; until upstream confirms a stable
-    // headless subcommand (see google-antigravity/antigravity-cli#119)
-    // and the change actually ships in the auto-update channel that
-    // packaged OD users get, `-p -` is the contract that actually
-    // produces a print-mode reply on the installed CLI.
+    // Print mode via `-p <prompt>`. Older OD used `agy -p -` and wrote the
+    // prompt on stdin, but current agy (reproduced on 1.1.13) treats `-`
+    // as the literal prompt string and ignores stdin — the model only
+    // ever sees a single dash (#7161). Passing the real prompt as the
+    // `-p` argument matches the verified working CLI form
+    // (`agy -p "say hello"`).
     const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
     // it can post-exit grep for the actual upstream failure shape
@@ -235,19 +229,15 @@ export const antigravityAgentDef = {
     // never echoes those errors on stdout. See server.ts empty-output
     // guard for the consumer.
     //
-    // Flag order is load-bearing on agy v1.0.3: `agy -p --log-file
-    // /tmp/x -` runs successfully but leaves /tmp/x empty, while `agy
-    // --log-file /tmp/x -p -` captures the diagnostic log, including
-    // `Propagating selected model override to backend: label="<model>"`
-    // and auth/quota failures.
+    // Flag order is load-bearing on agy: put `--log-file` before `-p`
+    // so diagnostics (model override / auth / quota) land in the log.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    args.push('-p');
-    args.push('-');
+    args.push('-p', prompt);
     return args;
   },
-  promptViaStdin: true,
+  promptViaStdin: false,
   streamFormat: 'plain',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -528,24 +528,26 @@ test('qwen args check promptViaStdin, base args, model args and exclude `-` sent
 // `agy` exposes `-p` (print mode, alias for `--print`) plus `-` as
 // the stdin sentinel — confirmed against `agy --help` on v1.0.3, where
 // `Available subcommands` is `changelog / help / install / plugin /
-// update` (no `chat`). Earlier review iterations pinned `['chat', '-']`
-// based on a different agy build the looper reviewer environment uses;
-// the installed CLI does not recognise it, exits 0 with no stdout, and
-// the daemon would render the resulting empty reply as a "successful"
-// agent response — exactly the failure mode the auth/quota guard at
-// server.ts ~12090 is meant to catch but for the wrong reason.
-test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
+// update` (no `chat`). Current agy treats `agy -p -` as a literal
+// prompt of "-" (stdin is ignored) — see #7161. OD therefore passes
+// the real prompt as the `-p` argument.
+test('antigravity passes prompt via -p argument (print mode)', () => {
   assert.equal(antigravity.bin, 'agy');
   assert.equal(antigravity.streamFormat, 'plain');
-  assert.equal(antigravity.promptViaStdin, true);
+  assert.equal(antigravity.promptViaStdin, false);
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
-  assert.deepEqual(args, ['-p', '-']);
+  assert.deepEqual(args, ['-p', 'write hello world']);
 
   const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
     agentLogFilePath: '/tmp/od-agy-test.log',
   });
-  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+  assert.deepEqual(argsWithLog, [
+    '--log-file',
+    '/tmp/od-agy-test.log',
+    '-p',
+    'write hello world',
+  ]);
 
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
@@ -560,7 +562,12 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
       antigravitySettingsPath: join(settingsDir, 'settings.json'),
     });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+    assert.deepEqual(withModel, [
+      '--log-file',
+      '/tmp/od-agy-test.log',
+      '-p',
+      'hi',
+    ]);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }
@@ -576,13 +583,13 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   const followUp = antigravity.buildArgs('next message', [], [], {}, {
     hasPriorAssistantTurn: true,
   });
-  assert.deepEqual(followUp, ['-p', '-']);
+  assert.deepEqual(followUp, ['-p', 'next message']);
   assert.equal(followUp.includes('-c'), false);
 
   const firstTurn = antigravity.buildArgs('first', [], [], {}, {
     hasPriorAssistantTurn: false,
   });
-  assert.deepEqual(firstTurn, ['-p', '-']);
+  assert.deepEqual(firstTurn, ['-p', 'first']);
   assert.equal(antigravity.resumesSessionViaCli, undefined);
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);


### PR DESCRIPTION
## Summary
- Current `agy` treats `agy -p -` as a literal prompt of `-` and ignores stdin, so every Antigravity turn only sees a dash.
- Pass the real prompt as the `-p` argument and stop using the stdin sentinel.

Fixes #7161

## Test plan
- [x] `npx vitest run tests/runtimes/agent-args.test.ts -t 'antigravity passes prompt'` in `apps/daemon`