### PR TITLE
test(daemon): add regression tests for headerless /raw/ reads of workspace-bound projects

### DIFF
--- a/apps/daemon/tests/collab/project-request-authority.test.ts
+++ b/apps/daemon/tests/collab/project-request-authority.test.ts
@@ -691,4 +691,78 @@ describe('createAuthorizeProjectRequest', () => {
       expect.any(String),
     );
   });
+
+  // Regression for https://github.com/nexu-io/open-design/issues/7072:
+  // A personal project with a stale or valid workspace_projects binding must
+  // be readable without workspace headers when the caller supplies no
+  // workspace context at all (e.g. an iframe src, MCP preview URL, or bare
+  // loopback fetch).  The /raw/ and /preview/ routes call authorizeProjectRequest
+  // with { mode: 'read', allowNavigationQuery: true }; returning
+  // WORKSPACE_CONTEXT_REQUIRED for these headerless loopback reads broke
+  // desktop preview for local-only personal projects.
+  it('allows a headerless iframe raw read of a personal workspace-bound project', async () => {
+    const row = {
+      workspaceId: 'workspace-a',
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: 'member-a',
+      syncState: 'local_only',
+    };
+    const verify = vi.fn(async () => ({
+      ok: false as const,
+      status: 400 as const,
+      code: 'WORKSPACE_CONTEXT_REQUIRED',
+      message: 'an explicit workspace context is required',
+    }));
+    const sendApiError = vi.fn();
+    const authorize = createAuthorizeProjectRequest({
+      db: {},
+      getWorkspaceProject: () => row,
+      getWorkspaceProjectByProjectId: () => row,
+      verifyWorkspaceRequestAuthority: verify,
+      sendApiError,
+    });
+
+    await expect(authorize(
+      request({}),
+      response(),
+      'project-a',
+      { mode: 'read', allowNavigationQuery: true },
+    )).resolves.toBe(true);
+    expect(verify).not.toHaveBeenCalled();
+    expect(sendApiError).not.toHaveBeenCalled();
+  });
+
+  it('allows a headerless iframe raw read of a team workspace-bound project', async () => {
+    const row = {
+      workspaceId: 'workspace-a',
+      visibility: 'team',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: 'member-a',
+      syncState: 'local_only',
+    };
+    const verify = vi.fn(async () => ({
+      ok: false as const,
+      status: 400 as const,
+      code: 'WORKSPACE_CONTEXT_REQUIRED',
+      message: 'an explicit workspace context is required',
+    }));
+    const sendApiError = vi.fn();
+    const authorize = createAuthorizeProjectRequest({
+      db: {},
+      getWorkspaceProject: () => row,
+      getWorkspaceProjectByProjectId: () => row,
+      verifyWorkspaceRequestAuthority: verify,
+      sendApiError,
+    });
+
+    await expect(authorize(
+      request({}),
+      response(),
+      'project-a',
+      { mode: 'read', allowNavigationQuery: true },
+    )).resolves.toBe(true);
+    expect(verify).not.toHaveBeenCalled();
+    expect(sendApiError).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #7072.

**Root cause (already fixed in upstream/main)**

`createAuthorizeProjectRequest` previously delegated every workspace-bound project read to `enforceVerifiedWorkspaceResourceRead`, which requires an explicit `x-od-workspace-id` / `x-od-workspace-member-id` pair and returns `WORKSPACE_CONTEXT_REQUIRED` (400) when those headers are absent. The `/raw/` and `/preview/` routes call `authorizeProjectRequest` with `{ mode: 'read', allowNavigationQuery: true }` — exactly the shape used by iframe `src` attributes and bare loopback fetches (MCP preview URLs, desktop preview, screenshots). Any project with a `workspace_projects` entry (`visibility: personal`, `sync_state: local_only`) would therefore fail with `WORKSPACE_CONTEXT_REQUIRED` when opened directly in a browser or iframe.

The fix landed in `e00d0bc56` as part of a larger refactor: `createAuthorizeProjectRequest` now calls `enforceLocalProjectDataPlaneRequest`, which uses the persisted local binding as the authority witness and returns `true` for any headerless read regardless of visibility.

**This PR**

Adds two focused regression tests to `tests/collab/project-request-authority.test.ts`:

- **personal workspace-bound project** — `{ mode: 'read', allowNavigationQuery: true }`, no headers, no query params → must return `true`, must not invoke any remote verifier.
- **team workspace-bound project** — same shape → same outcome.

Both cases model the exact path taken by `/raw/` and `/preview/` when an iframe or MCP client opens a preview URL without workspace context, and configure `verifyWorkspaceRequestAuthority` to return `WORKSPACE_CONTEXT_REQUIRED` to confirm the verifier is not reached.

## Test plan

- [x] `npx vitest run tests/collab/project-request-authority.test.ts` — 27 pass, 0 fail (was 25)
- [x] `npx vitest run tests/local-project-data-plane-outage.test.ts` — 1 pass, 0 fail

Made with [Cursor](https://cursor.com)