### PR TITLE
fix(web): raise the file-tab label cap and preserve extensions

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -4028,9 +4028,7 @@ export function FileWorkspace({
               );
               label = conv?.title?.trim() || t('workspace.sideChatDefaultTitle');
             } else {
-              // Bare label; dirtyMark rides its own prop so `foo.sketch.json`
-              // still splits into stem + `.json` even when the tab is dirty
-              // (`${label} •` would defeat the extension regex).
+              // Keep the filename bare so TabLabel can split its extension.
               label = liveArtifact?.title ?? name;
             }
             const iconNameOverride: IconName | undefined = isTerminal
@@ -8369,17 +8367,9 @@ const Tab = memo(function Tab({
   onDragEnd,
 }: {
   label: string;
-  /** Trailing dirty-state modifier (e.g. ` •`) rendered as its own pinned
-   *  span after the extension so extension detection works on the bare
-   *  filename. */
+  /** Optional dirty marker rendered after the filename extension. */
   dirtyMark?: string;
-  /** Force the plain-text label branch (no stem/ext/dirty split). Set
-   *  for tabs whose label is user-arbitrary text rather than a real
-   *  filename: terminal tabs, side-chat conversation titles, and any
-   *  other non-file surface. Prevents `Review.Notes` from splitting into
-   *  `Review` + pinned `.Notes` and prevents the raised 240px cap from
-   *  applying to those tabs. Browser tabs are also plain but they route
-   *  through the `kind === 'browser'` branch below. */
+  /** Keep arbitrary terminal and side-chat titles unsplit. */
   plainLabel?: boolean;
   meta?: string;
   title?: string;
@@ -8456,12 +8446,6 @@ const Tab = memo(function Tab({
         </span>
       ) : null}
       <span className="ws-tab-text">
-        {/* Browser tabs carry URLs (`example.com`) whose trailing token
-            reads as a file extension by pure shape. Non-file tabs
-            (terminal, side-chat) carry user-arbitrary text that may
-            happen to contain a dot. Both bypass the split so only real
-            file / live-artifact labels get the extension pinning and
-            the raised 240px cap. */}
         {kind === 'browser' || plainLabel ? (
           <span className="ws-tab-label">{label}</span>
         ) : (

--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -49,6 +49,7 @@ import {
 } from '../providers/registry';
 import type { Dict } from '../i18n/types';
 import { STAGE_ATTACHMENT_EVENT, type StageAttachmentEventDetail } from './ChatComposer';
+import { TabLabel } from './workspaceTabLabel';
 import { setPendingDesignSystemCreateEntry } from '../analytics/ds-create-entry';
 import { navigate, registerNavigationGuard } from '../router';
 import { downloadDesignSystemArchive, downloadProjectArchive } from '../runtime/exports';
@@ -4027,7 +4028,10 @@ export function FileWorkspace({
               );
               label = conv?.title?.trim() || t('workspace.sideChatDefaultTitle');
             } else {
-              label = `${liveArtifact?.title ?? name}${dirtyMark}`;
+              // Bare label; dirtyMark rides its own prop so `foo.sketch.json`
+              // still splits into stem + `.json` even when the tab is dirty
+              // (`${label} •` would defeat the extension regex).
+              label = liveArtifact?.title ?? name;
             }
             const iconNameOverride: IconName | undefined = isTerminal
               ? 'terminal'
@@ -4047,6 +4051,8 @@ export function FileWorkspace({
               <Tab
                 key={name}
                 label={label}
+                dirtyMark={dirtyMark || undefined}
+                plainLabel={isTerminal || isSideChat}
                 iconNameOverride={iconNameOverride}
                 syncBadge={tabSyncBadge}
                 active={activeTab === name}
@@ -8341,6 +8347,8 @@ interface WorkspaceTabItemHandlers {
 // individual tab only changes when its own label/active/drag props do.
 const Tab = memo(function Tab({
   label,
+  dirtyMark,
+  plainLabel = false,
   meta,
   title,
   active,
@@ -8361,6 +8369,18 @@ const Tab = memo(function Tab({
   onDragEnd,
 }: {
   label: string;
+  /** Trailing dirty-state modifier (e.g. ` •`) rendered as its own pinned
+   *  span after the extension so extension detection works on the bare
+   *  filename. */
+  dirtyMark?: string;
+  /** Force the plain-text label branch (no stem/ext/dirty split). Set
+   *  for tabs whose label is user-arbitrary text rather than a real
+   *  filename: terminal tabs, side-chat conversation titles, and any
+   *  other non-file surface. Prevents `Review.Notes` from splitting into
+   *  `Review` + pinned `.Notes` and prevents the raised 240px cap from
+   *  applying to those tabs. Browser tabs are also plain but they route
+   *  through the `kind === 'browser'` branch below. */
+  plainLabel?: boolean;
   meta?: string;
   title?: string;
   active: boolean;
@@ -8391,7 +8411,8 @@ const Tab = memo(function Tab({
       : t('workspace.fileSyncUploading')
     : null;
   const tabTitle = title ?? (meta ? `${label} ${meta}` : label);
-  const tabTooltip = syncBadgeLabel ? `${tabTitle} · ${syncBadgeLabel}` : tabTitle;
+  const tooltipBase = dirtyMark ? `${tabTitle}${dirtyMark}` : tabTitle;
+  const tabTooltip = syncBadgeLabel ? `${tooltipBase} · ${syncBadgeLabel}` : tooltipBase;
   return (
     <div
       className={[
@@ -8435,7 +8456,17 @@ const Tab = memo(function Tab({
         </span>
       ) : null}
       <span className="ws-tab-text">
-        <span className="ws-tab-label">{label}</span>
+        {/* Browser tabs carry URLs (`example.com`) whose trailing token
+            reads as a file extension by pure shape. Non-file tabs
+            (terminal, side-chat) carry user-arbitrary text that may
+            happen to contain a dot. Both bypass the split so only real
+            file / live-artifact labels get the extension pinning and
+            the raised 240px cap. */}
+        {kind === 'browser' || plainLabel ? (
+          <span className="ws-tab-label">{label}</span>
+        ) : (
+          <TabLabel title={label} dirtyMark={dirtyMark} />
+        )}
         {meta ? <span className="ws-tab-meta">{meta}</span> : null}
       </span>
       {liveArtifact ? (

--- a/apps/web/src/components/workspaceTabLabel.tsx
+++ b/apps/web/src/components/workspaceTabLabel.tsx
@@ -1,0 +1,69 @@
+export interface SplitTabLabel {
+  stem: string;
+  ext: string | null;
+}
+
+// Extension-shape: 2-5 alphanumeric characters after a dot, with the shape
+// of a real file extension. Matches `.html`, `.tsx`, `.json`, `.md`,
+// `.usda`, `.glb`, `.png`, `.mp3`, `.7z`, `.3ds`, `.h264`, `.x265`, and
+// other extensions the app opens as workspace tabs, without matching
+// single-token tails (`.2`, `.a`) that are not file extensions in this
+// app's vocabulary. The version-tag exclusion below covers only the two
+// common single-prefix shapes (`.v2`, `.b3`) so a project named `app.v2`
+// keeps the version tag in the stem; codec extensions like `.h264` /
+// `.x265` are structurally similar but are real file kinds, so the
+// exclusion is intentionally narrow. Multi-letter version prefixes
+// (`.beta3`) share the shape of real extensions (`.mp3`) and
+// disambiguating cleanly would need a known-extension lookup this module
+// intentionally does not carry.
+const EXTENSION_TOKEN = /^[A-Za-z0-9]{2,5}$/;
+const VERSION_TOKEN = /^[vVbB]\d+$/;
+
+/**
+ * Split a tab title into a stem and an optional file-extension suffix.
+ *
+ * The tab label styles let the stem ellipsis-truncate while pinning the
+ * extension visible, so a narrow tab reads `index….html` instead of
+ * `index….ht`. The extension is what tells the user which file kind the
+ * tab points at, so it must not be the first thing to be lost.
+ *
+ * Leading-dot names (`.gitignore`, `.env`) have no visible stem to
+ * truncate against, so the whole thing stays in the stem slot.
+ */
+export function splitTabLabel(title: string): SplitTabLabel {
+  const idx = title.lastIndexOf('.');
+  if (idx <= 0) return { stem: title, ext: null };
+  const ext = title.slice(idx + 1);
+  if (!EXTENSION_TOKEN.test(ext)) return { stem: title, ext: null };
+  if (VERSION_TOKEN.test(ext)) return { stem: title, ext: null };
+  return { stem: title.slice(0, idx), ext: `.${ext}` };
+}
+
+interface TabLabelProps {
+  title: string;
+  /**
+   * Optional trailing modifier rendered as its own pinned span after the
+   * extension. This is the dirty/unsaved indicator for sketch tabs (` •`).
+   * Passing it separately (rather than baking it into `title`) keeps the
+   * extension detection working: `foo.sketch.json` still splits as
+   * `foo.sketch` + `.json` even when the tab is dirty.
+   */
+  dirtyMark?: string;
+}
+
+/**
+ * Renders a workspace file tab label as a stem span (ellipsis-truncatable)
+ * plus an optional extension span pinned visible via flex, and an optional
+ * dirty-mark span pinned after the extension. Keeps the same
+ * `.ws-tab-label` root the CSS and existing tests target.
+ */
+export function TabLabel({ title, dirtyMark }: TabLabelProps) {
+  const { stem, ext } = splitTabLabel(title);
+  return (
+    <span className="ws-tab-label">
+      <span className="ws-tab-label-stem">{stem}</span>
+      {ext ? <span className="ws-tab-label-ext">{ext}</span> : null}
+      {dirtyMark ? <span className="ws-tab-label-dirty">{dirtyMark}</span> : null}
+    </span>
+  );
+}

--- a/apps/web/src/components/workspaceTabLabel.tsx
+++ b/apps/web/src/components/workspaceTabLabel.tsx
@@ -3,33 +3,11 @@ export interface SplitTabLabel {
   ext: string | null;
 }
 
-// Extension-shape: 2-5 alphanumeric characters after a dot, with the shape
-// of a real file extension. Matches `.html`, `.tsx`, `.json`, `.md`,
-// `.usda`, `.glb`, `.png`, `.mp3`, `.7z`, `.3ds`, `.h264`, `.x265`, and
-// other extensions the app opens as workspace tabs, without matching
-// single-token tails (`.2`, `.a`) that are not file extensions in this
-// app's vocabulary. The version-tag exclusion below covers only the two
-// common single-prefix shapes (`.v2`, `.b3`) so a project named `app.v2`
-// keeps the version tag in the stem; codec extensions like `.h264` /
-// `.x265` are structurally similar but are real file kinds, so the
-// exclusion is intentionally narrow. Multi-letter version prefixes
-// (`.beta3`) share the shape of real extensions (`.mp3`) and
-// disambiguating cleanly would need a known-extension lookup this module
-// intentionally does not carry.
+// Extensions use 2-5 ASCII alphanumerics; version-like tails stay in the stem.
 const EXTENSION_TOKEN = /^[A-Za-z0-9]{2,5}$/;
 const VERSION_TOKEN = /^[vVbB]\d+$/;
 
-/**
- * Split a tab title into a stem and an optional file-extension suffix.
- *
- * The tab label styles let the stem ellipsis-truncate while pinning the
- * extension visible, so a narrow tab reads `index….html` instead of
- * `index….ht`. The extension is what tells the user which file kind the
- * tab points at, so it must not be the first thing to be lost.
- *
- * Leading-dot names (`.gitignore`, `.env`) have no visible stem to
- * truncate against, so the whole thing stays in the stem slot.
- */
+/** Split a title for stem truncation with a visible extension. Leading-dot names stay whole. */
 export function splitTabLabel(title: string): SplitTabLabel {
   const idx = title.lastIndexOf('.');
   if (idx <= 0) return { stem: title, ext: null };
@@ -41,22 +19,11 @@ export function splitTabLabel(title: string): SplitTabLabel {
 
 interface TabLabelProps {
   title: string;
-  /**
-   * Optional trailing modifier rendered as its own pinned span after the
-   * extension. This is the dirty/unsaved indicator for sketch tabs (` •`).
-   * Passing it separately (rather than baking it into `title`) keeps the
-   * extension detection working: `foo.sketch.json` still splits as
-   * `foo.sketch` + `.json` even when the tab is dirty.
-   */
+  /** Optional dirty marker rendered after the extension. */
   dirtyMark?: string;
 }
 
-/**
- * Renders a workspace file tab label as a stem span (ellipsis-truncatable)
- * plus an optional extension span pinned visible via flex, and an optional
- * dirty-mark span pinned after the extension. Keeps the same
- * `.ws-tab-label` root the CSS and existing tests target.
- */
+/** Renders a split filename label with optional extension and dirty marker. */
 export function TabLabel({ title, dirtyMark }: TabLabelProps) {
   const { stem, ext } = splitTabLabel(title);
   return (

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1685,13 +1685,8 @@
   color: var(--text-muted);
   transition: background 120ms var(--ease-out), color 120ms var(--ease-out);
 }
-/* File tabs (the ones carrying a stem/ext split via TabLabel) get the
-   raised 240px cap so titles like `Design Files.html` render at their
-   natural width. Scoped via :has() so the static Design Files / Design
-   System pills, which use a plain `.ws-tab-label` text node, keep the
-   original 110px cap and do not eat into file-tab space. Placed before
-   `.ws-tab.live-artifact-tab` so that rule's 260px cap still wins for
-   live-artifact tabs (same specificity, source order). */
+/* Split file tabs use 240px; keep this before the live-artifact rule so its
+   equal-specificity 260px cap wins. */
 .ws-tab:has(.ws-tab-label-stem) {
   max-width: 240px;
 }
@@ -1762,26 +1757,15 @@
   max-width: 96px;
   line-height: 1;
 }
-/* File tab label splits into a stem (may ellipsis-truncate) plus an
-   optional file-extension span pinned visible via flex, so a narrow tab
-   reads `index….html` instead of `index….ht`. Also lifts the label cap
-   to 240px so titles like `Design Files.html` render at their natural
-   width. Scoped to the split shape with :has() so the plain-text label
-   consumers (Design Files, Design System, and other static labels)
-   keep their block-level ellipsis and the pre-fix 96px cap. */
+/* Split labels reserve the extension while truncating the stem; plain labels
+   keep the base cap. */
 .ws-tab-label:has(.ws-tab-label-stem) {
   display: flex;
   align-items: baseline;
   white-space: normal;
   text-overflow: clip;
   max-width: 240px;
-  /* Pin LTR so the stem-then-ext-then-dirty box order survives Arabic /
-     Farsi locales. Flex `row` direction reverses sibling boxes under
-     ambient `dir=rtl`, which would render `foo.json` as visually
-     `.json foo`. The pre-fix single-text-node label relied on the
-     Unicode Bidi Algorithm keeping embedded Latin runs upright; the
-     split form loses that unless the row axis is forced. Extensions are
-     always ASCII (regex-gated), so LTR flex is safe universally. */
+  /* Keep filename order stable in RTL locales. */
   direction: ltr;
 }
 .ws-tab-label-stem {
@@ -1794,9 +1778,7 @@
   flex: 0 0 auto;
   white-space: nowrap;
 }
-/* Dirty/unsaved marker (sketch tabs). Pinned like the extension so the tab
-   still reads as `foo….json •` when the stem truncates, instead of losing
-   the affordance the marker carries. */
+/* Keep the dirty marker visible beside the extension. */
 .ws-tab-label-dirty {
   flex: 0 0 auto;
   white-space: nowrap;

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1685,6 +1685,16 @@
   color: var(--text-muted);
   transition: background 120ms var(--ease-out), color 120ms var(--ease-out);
 }
+/* File tabs (the ones carrying a stem/ext split via TabLabel) get the
+   raised 240px cap so titles like `Design Files.html` render at their
+   natural width. Scoped via :has() so the static Design Files / Design
+   System pills, which use a plain `.ws-tab-label` text node, keep the
+   original 110px cap and do not eat into file-tab space. Placed before
+   `.ws-tab.live-artifact-tab` so that rule's 260px cap still wins for
+   live-artifact tabs (same specificity, source order). */
+.ws-tab:has(.ws-tab-label-stem) {
+  max-width: 240px;
+}
 .ws-tab.live-artifact-tab {
   /* Wide enough to hold the icon, a truncated title, the status badges
      (LIVE + REFRESH FAILED) and the close button without any of them
@@ -1751,6 +1761,45 @@
   text-overflow: ellipsis;
   max-width: 96px;
   line-height: 1;
+}
+/* File tab label splits into a stem (may ellipsis-truncate) plus an
+   optional file-extension span pinned visible via flex, so a narrow tab
+   reads `index….html` instead of `index….ht`. Also lifts the label cap
+   to 240px so titles like `Design Files.html` render at their natural
+   width. Scoped to the split shape with :has() so the plain-text label
+   consumers (Design Files, Design System, and other static labels)
+   keep their block-level ellipsis and the pre-fix 96px cap. */
+.ws-tab-label:has(.ws-tab-label-stem) {
+  display: flex;
+  align-items: baseline;
+  white-space: normal;
+  text-overflow: clip;
+  max-width: 240px;
+  /* Pin LTR so the stem-then-ext-then-dirty box order survives Arabic /
+     Farsi locales. Flex `row` direction reverses sibling boxes under
+     ambient `dir=rtl`, which would render `foo.json` as visually
+     `.json foo`. The pre-fix single-text-node label relied on the
+     Unicode Bidi Algorithm keeping embedded Latin runs upright; the
+     split form loses that unless the row axis is forced. Extensions are
+     always ASCII (regex-gated), so LTR flex is safe universally. */
+  direction: ltr;
+}
+.ws-tab-label-stem {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ws-tab-label-ext {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+/* Dirty/unsaved marker (sketch tabs). Pinned like the extension so the tab
+   still reads as `foo….json •` when the stem truncates, instead of losing
+   the affordance the marker carries. */
+.ws-tab-label-dirty {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .ws-tab.has-meta {
   max-width: 320px;

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -2572,11 +2572,6 @@ describe('FileWorkspace launcher tab creation', () => {
   });
 
   it('renders side-chat and terminal tabs with a plain label (no file-extension split)', () => {
-    // Terminal and side-chat tabs carry user-arbitrary text, not real
-    // filenames, so they must bypass the stem/ext split. A side-chat
-    // title such as `Review.Notes` would otherwise render `.Notes` as a
-    // pinned extension and pick up the 240px file-tab cap; regressing
-    // both the pill's visual width and the semantics of the label.
     render(
       <FileWorkspace
         projectId="project-1"
@@ -2610,17 +2605,13 @@ describe('FileWorkspace launcher tab creation', () => {
     expect(term, 'terminal tab missing').toBeTruthy();
     expect(file, 'file tab missing').toBeTruthy();
 
-    // Side-chat: title is `Review.Notes`; must NOT split into stem/ext,
-    // must render as a single plain `.ws-tab-label` text node.
     expect(bar!.querySelector('.ws-tab-label-stem'), 'side-chat label split into stem span').toBeNull();
     expect(bar!.querySelector('.ws-tab-label-ext'), 'side-chat picked up extension span').toBeNull();
     expect(bar!.querySelector('.ws-tab-label')?.textContent).toBe('Review.Notes');
 
-    // Terminal: label is friendly text; same plain-shape invariant.
     expect(term!.querySelector('.ws-tab-label-stem'), 'terminal label split into stem span').toBeNull();
     expect(term!.querySelector('.ws-tab-label-ext'), 'terminal picked up extension span').toBeNull();
 
-    // Sanity: the file tab DOES split (this is the fix's intended path).
     expect(file!.querySelector('.ws-tab-label-stem'), 'file tab lost its stem span').toBeTruthy();
     expect(file!.querySelector('.ws-tab-label-ext')?.textContent).toBe('.html');
   });

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -2571,6 +2571,60 @@ describe('FileWorkspace launcher tab creation', () => {
     ]);
   });
 
+  it('renders side-chat and terminal tabs with a plain label (no file-extension split)', () => {
+    // Terminal and side-chat tabs carry user-arbitrary text, not real
+    // filenames, so they must bypass the stem/ext split. A side-chat
+    // title such as `Review.Notes` would otherwise render `.Notes` as a
+    // pinned extension and pick up the 240px file-tab cap; regressing
+    // both the pill's visual width and the semantics of the label.
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[workspaceFile('index.html')]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{
+          tabs: ['index.html', 'terminal:term-1', 'chat:conversation-1'],
+          active: 'index.html',
+        }}
+        conversations={[
+          {
+            id: 'conversation-1',
+            projectId: 'project-1',
+            title: 'Review.Notes',
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]}
+        onTabsStateChange={vi.fn()}
+      />,
+    );
+
+    const tabs = Array.from(document.querySelectorAll<HTMLElement>('.ws-tabs-bar .ws-tab'));
+    const bar = tabs.find((tab) => (tab.textContent ?? '').includes('Review.Notes'));
+    const term = tabs.find((tab) => (tab.textContent ?? '').includes('New Terminal'));
+    const file = tabs.find((tab) => (tab.textContent ?? '').includes('index.html'));
+    expect(bar, 'side-chat tab missing').toBeTruthy();
+    expect(term, 'terminal tab missing').toBeTruthy();
+    expect(file, 'file tab missing').toBeTruthy();
+
+    // Side-chat: title is `Review.Notes`; must NOT split into stem/ext,
+    // must render as a single plain `.ws-tab-label` text node.
+    expect(bar!.querySelector('.ws-tab-label-stem'), 'side-chat label split into stem span').toBeNull();
+    expect(bar!.querySelector('.ws-tab-label-ext'), 'side-chat picked up extension span').toBeNull();
+    expect(bar!.querySelector('.ws-tab-label')?.textContent).toBe('Review.Notes');
+
+    // Terminal: label is friendly text; same plain-shape invariant.
+    expect(term!.querySelector('.ws-tab-label-stem'), 'terminal label split into stem span').toBeNull();
+    expect(term!.querySelector('.ws-tab-label-ext'), 'terminal picked up extension span').toBeNull();
+
+    // Sanity: the file tab DOES split (this is the fix's intended path).
+    expect(file!.querySelector('.ws-tab-label-stem'), 'file tab lost its stem span').toBeTruthy();
+    expect(file!.querySelector('.ws-tab-label-ext')?.textContent).toBe('.html');
+  });
+
   it('shows project sync progress on the Design Files root tab without hiding materialized files', () => {
     render(
       <FileWorkspace

--- a/apps/web/tests/components/workspaceTabLabel.test.tsx
+++ b/apps/web/tests/components/workspaceTabLabel.test.tsx
@@ -1,0 +1,387 @@
+// @vitest-environment jsdom
+//
+// splitTabLabel is what lets a wrapped workspace tab keep its file extension
+// visible when the stem truncates ("index….html" instead of "index….ht").
+// The extension is the affordance that tells the user which file the tab
+// points at, so the split logic needs to hold across the shapes we see in
+// practice: real file extensions, extension-less project names, leading-dot
+// names, multi-dot names, and copy that only *looks* like it has an
+// extension (version strings, sentences, i18n).
+
+import { describe, expect, it, afterEach } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import { splitTabLabel, TabLabel } from '../../src/components/workspaceTabLabel';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('splitTabLabel', () => {
+  it('splits a plain file name on the extension dot', () => {
+    expect(splitTabLabel('index.html')).toEqual({ stem: 'index', ext: '.html' });
+    expect(splitTabLabel('kit.html')).toEqual({ stem: 'kit', ext: '.html' });
+    expect(splitTabLabel('foo.tsx')).toEqual({ stem: 'foo', ext: '.tsx' });
+    expect(splitTabLabel('a.md')).toEqual({ stem: 'a', ext: '.md' });
+  });
+
+  it('splits on the LAST dot when there are several', () => {
+    expect(splitTabLabel('config.settings.json')).toEqual({
+      stem: 'config.settings',
+      ext: '.json',
+    });
+    expect(splitTabLabel('scene.v2.usda')).toEqual({
+      stem: 'scene.v2',
+      ext: '.usda',
+    });
+  });
+
+  it('leaves extension-less titles whole', () => {
+    expect(splitTabLabel('Design Files')).toEqual({ stem: 'Design Files', ext: null });
+    expect(splitTabLabel('kit')).toEqual({ stem: 'kit', ext: null });
+    expect(splitTabLabel('')).toEqual({ stem: '', ext: null });
+  });
+
+  it('keeps leading-dot names whole (no visible stem to truncate against)', () => {
+    expect(splitTabLabel('.gitignore')).toEqual({ stem: '.gitignore', ext: null });
+    expect(splitTabLabel('.env')).toEqual({ stem: '.env', ext: null });
+    expect(splitTabLabel('.eslintrc')).toEqual({ stem: '.eslintrc', ext: null });
+  });
+
+  it('does not misread version strings and sentences as extensions', () => {
+    // Trailing token contains punctuation → not an extension.
+    expect(splitTabLabel('v1.2 release notes')).toEqual({
+      stem: 'v1.2 release notes',
+      ext: null,
+    });
+    // Bare version suffix: the 1-char trailing token fails the 2-char floor.
+    expect(splitTabLabel('v1.2')).toEqual({
+      stem: 'v1.2',
+      ext: null,
+    });
+    // Version-shape tokens `.v2` / `.b3` are the two common single-prefix
+    // shapes rejected so a project named "app.v2" or "flow.b3" keeps the
+    // version tag in the stem. Multi-letter version prefixes (`.beta3`,
+    // `.alpha1`) intentionally still match the extension shape - they
+    // share the shape of real extensions like `.mp3` and `.mp4`, and
+    // disambiguating cleanly needs a known-extension lookup this file
+    // deliberately does not carry.
+    expect(splitTabLabel('app.v2')).toEqual({
+      stem: 'app.v2',
+      ext: null,
+    });
+    expect(splitTabLabel('flow.b3')).toEqual({
+      stem: 'flow.b3',
+      ext: null,
+    });
+    // Trailing token is longer than 5 chars → not an extension.
+    expect(splitTabLabel('report.summary')).toEqual({
+      stem: 'report.summary',
+      ext: null,
+    });
+    // Single-character tails are not extensions in this app's vocabulary.
+    expect(splitTabLabel('song.a')).toEqual({
+      stem: 'song.a',
+      ext: null,
+    });
+    // Trailing dot with empty token.
+    expect(splitTabLabel('trailing.')).toEqual({
+      stem: 'trailing.',
+      ext: null,
+    });
+  });
+
+  it('accepts short numeric and mixed extensions', () => {
+    expect(splitTabLabel('song.mp3')).toEqual({ stem: 'song', ext: '.mp3' });
+    expect(splitTabLabel('model.3dm')).toEqual({ stem: 'model', ext: '.3dm' });
+    expect(splitTabLabel('archive.7z')).toEqual({ stem: 'archive', ext: '.7z' });
+  });
+
+  it('accepts codec extensions that share shape with version tags', () => {
+    // `.h264` and `.x265` are `<letter><digits>` shape but are real file
+    // kinds, so the version-token exclusion is narrow to `v`/`b` prefixes.
+    expect(splitTabLabel('video.h264')).toEqual({ stem: 'video', ext: '.h264' });
+    expect(splitTabLabel('clip.x265')).toEqual({ stem: 'clip', ext: '.x265' });
+  });
+
+  it('splits CJK stems on the trailing ASCII extension', () => {
+    // The extension regex is ASCII-only by design; a CJK stem is fine as
+    // long as the trailing token is a real short extension.
+    expect(splitTabLabel('设计文件.tsx')).toEqual({ stem: '设计文件', ext: '.tsx' });
+    expect(splitTabLabel('ホーム.html')).toEqual({ stem: 'ホーム', ext: '.html' });
+    // Both stem and tail non-ASCII → the whole title stays in the stem.
+    expect(splitTabLabel('文档.文档')).toEqual({ stem: '文档.文档', ext: null });
+  });
+
+  it('keeps extensions longer than 5 chars in the stem (documented ceiling)', () => {
+    // EXTENSION_TOKEN caps at 5 chars, so `.svelte`, `.markdown`, `.gradle`,
+    // `.astro`, `.eslintrc` fall through to no-split. This is a deliberate
+    // narrow scope: raising the ceiling would need a known-extension
+    // lookup to avoid misreading long sentence-tails as file kinds. Behavior
+    // here is a graceful degradation to end-ellipsis, not a regression;
+    // the pre-fix behavior was the same. Pinned so a future ceiling change
+    // is a conscious decision rather than an accidental one.
+    expect(splitTabLabel('component.svelte')).toEqual({
+      stem: 'component.svelte',
+      ext: null,
+    });
+    expect(splitTabLabel('README.markdown')).toEqual({
+      stem: 'README.markdown',
+      ext: null,
+    });
+    expect(splitTabLabel('build.gradle')).toEqual({
+      stem: 'build.gradle',
+      ext: null,
+    });
+  });
+
+  it('rejects extensions with non-alphanumeric characters', () => {
+    expect(splitTabLabel('report.doc-1')).toEqual({
+      stem: 'report.doc-1',
+      ext: null,
+    });
+    expect(splitTabLabel('note. txt')).toEqual({
+      stem: 'note. txt',
+      ext: null,
+    });
+  });
+});
+
+describe('TabLabel', () => {
+  it('renders stem + extension as separate spans when the title has an extension', () => {
+    const { container } = render(<TabLabel title="index.html" />);
+    const root = container.querySelector('.ws-tab-label');
+    expect(root).not.toBeNull();
+    const stem = root!.querySelector('.ws-tab-label-stem');
+    const ext = root!.querySelector('.ws-tab-label-ext');
+    expect(stem?.textContent).toBe('index');
+    expect(ext?.textContent).toBe('.html');
+  });
+
+  it('renders only the stem span for extension-less titles', () => {
+    const { container } = render(<TabLabel title="Design Files" />);
+    const root = container.querySelector('.ws-tab-label');
+    expect(root?.querySelector('.ws-tab-label-stem')?.textContent).toBe('Design Files');
+    expect(root?.querySelector('.ws-tab-label-ext')).toBeNull();
+  });
+
+  it('keeps the extension split when a dirty mark is present', () => {
+    // Sketch tabs pass ` •` when dirty. The dirty mark rides its own prop
+    // so the extension detection still runs on the bare filename; the
+    // rendered order is stem → ext → dirty so a narrow tab still reads
+    // like `foo….sketch.json •` rather than losing the file kind.
+    const { container } = render(
+      <TabLabel title="foo.sketch.json" dirtyMark=" •" />,
+    );
+    const root = container.querySelector('.ws-tab-label');
+    expect(root?.querySelector('.ws-tab-label-stem')?.textContent).toBe('foo.sketch');
+    expect(root?.querySelector('.ws-tab-label-ext')?.textContent).toBe('.json');
+    expect(root?.querySelector('.ws-tab-label-dirty')?.textContent).toBe(' •');
+    expect(root?.textContent).toBe('foo.sketch.json •');
+  });
+
+  it('renders the dirty span in dom order after the extension', () => {
+    const { container } = render(
+      <TabLabel title="index.html" dirtyMark=" •" />,
+    );
+    const root = container.querySelector('.ws-tab-label');
+    const spans = Array.from(root?.querySelectorAll('span') ?? []).map(
+      (span) => span.className,
+    );
+    expect(spans).toEqual([
+      'ws-tab-label-stem',
+      'ws-tab-label-ext',
+      'ws-tab-label-dirty',
+    ]);
+  });
+
+  it('omits the dirty span when the mark is empty', () => {
+    const { container } = render(<TabLabel title="index.html" dirtyMark="" />);
+    const root = container.querySelector('.ws-tab-label');
+    expect(root?.querySelector('.ws-tab-label-dirty')).toBeNull();
+  });
+});
+
+// Seeded fuzz corpus. Deterministic so a failure is reproducible off the
+// printed input, and the run stays fast (single-digit ms for the pure
+// function, low hundreds of ms for the DOM properties in jsdom).
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Explicit corners the random pass would take many iterations to stumble
+// into. Every one of these has caused parser bugs in similar helpers.
+const SEED_CORPUS = [
+  '',
+  '.', '..', '...',
+  'a', 'a.', '.a', '.ab', '.abc', 'a.b', 'a.bc', 'a.bcd',
+  ' ', ' .', '. ', 'a b.c', 'a.b c',
+  '\n', '\t', '\0',
+  'a'.repeat(500),
+  `${'a'.repeat(500)}.html`,
+  '设计.tsx', '.env', '.gitignore', '.eslintrc',
+  'app.v2', 'flow.b3', 'video.h264', 'clip.x265',
+  'component.svelte', 'README.markdown',
+  'note. txt', 'trailing.', '.only', 'ends.with..',
+];
+
+function randomCorpus(seed: number, count: number): string[] {
+  const rng = mulberry32(seed);
+  const ascii = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const punct = '.-_ !@#$%^&*()[]{}<>?/\\|;:\'"~+=';
+  const cjk = '設計文件ホームπΩ你好世界';
+  const pool = ascii + punct + cjk;
+  const out: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const len = Math.floor(rng() * 40);
+    let s = '';
+    for (let j = 0; j < len; j += 1) {
+      // 12% chance of a dot to synthesise extension-shaped candidates
+      // without dropping the tail into non-dotty territory too often.
+      s += rng() < 0.12 ? '.' : pool[Math.floor(rng() * pool.length)];
+    }
+    out.push(s);
+  }
+  return out;
+}
+
+const FUZZ_CORPUS = [...SEED_CORPUS, ...randomCorpus(0xdeadbeef, 400)];
+
+describe('splitTabLabel invariants (fuzz)', () => {
+  it('round-trips: stem + ext always reconstructs the input title', () => {
+    // If this ever fails, a tab label silently loses text between the
+    // shipped filename and the rendered spans. That is the loudest bug
+    // this function can develop, so it gets the loudest guarantee.
+    for (const title of FUZZ_CORPUS) {
+      const { stem, ext } = splitTabLabel(title);
+      const rebuilt = stem + (ext ?? '');
+      if (rebuilt !== title) {
+        throw new Error(
+          `round-trip failed on ${JSON.stringify(title)}: got ${JSON.stringify(rebuilt)}`,
+        );
+      }
+    }
+  });
+
+  it('ext, when present, is a real extension and never a version tag', () => {
+    // Locks the docblock's contract: the extension slot only ever
+    // carries the 2-5 alnum ASCII shape and never the v/b + digits
+    // shape that the exclusion regex was added to reject.
+    for (const title of FUZZ_CORPUS) {
+      const { ext } = splitTabLabel(title);
+      if (ext === null) continue;
+      if (!/^\.[A-Za-z0-9]{2,5}$/.test(ext)) {
+        throw new Error(
+          `ext violates 2-5 alnum shape on ${JSON.stringify(title)}: ${JSON.stringify(ext)}`,
+        );
+      }
+      if (/^\.[vVbB]\d+$/.test(ext)) {
+        throw new Error(
+          `ext is a version tag but was split off on ${JSON.stringify(title)}: ${JSON.stringify(ext)}`,
+        );
+      }
+    }
+  });
+
+  it('idempotent: splitting the rebuilt title yields the same split', () => {
+    // A pure text-parser should be stable under re-application. If this
+    // fails we have accidentally introduced a rule that mangles its own
+    // output.
+    for (const title of FUZZ_CORPUS) {
+      const first = splitTabLabel(title);
+      const second = splitTabLabel(first.stem + (first.ext ?? ''));
+      if (first.stem !== second.stem || first.ext !== second.ext) {
+        throw new Error(
+          `idempotence violated on ${JSON.stringify(title)}: first=${JSON.stringify(first)} second=${JSON.stringify(second)}`,
+        );
+      }
+    }
+  });
+
+  it('never throws on any string input', () => {
+    for (const title of FUZZ_CORPUS) {
+      expect(() => splitTabLabel(title)).not.toThrow();
+    }
+  });
+
+  it('ext-present implies a non-empty stem (leading-dot names stay whole)', () => {
+    // The stem is what the ellipsis truncates against; if we ever return
+    // an empty stem alongside a real extension, a narrow tab renders as
+    // just the extension and the file is unidentifiable.
+    for (const title of FUZZ_CORPUS) {
+      const { stem, ext } = splitTabLabel(title);
+      if (ext !== null && stem.length === 0) {
+        throw new Error(
+          `empty stem with non-null ext on ${JSON.stringify(title)}: ext=${JSON.stringify(ext)}`,
+        );
+      }
+    }
+  });
+});
+
+describe('TabLabel invariants (fuzz)', () => {
+  // Smaller corpus: each iteration renders + queries the DOM under jsdom.
+  const DOM_CORPUS = [
+    ...SEED_CORPUS,
+    ...randomCorpus(0xfeedface, 80),
+  ];
+  const DIRTY_MARKS = ['', ' •', ' *', '·'];
+
+  it('textContent equals title + dirtyMark for every (title, mark) pair', () => {
+    // The DOM-level guarantee that the split spans do not visually lose
+    // text. This is the user-facing invariant; splitTabLabel's
+    // round-trip is the pure-function version of the same claim.
+    for (const title of DOM_CORPUS) {
+      for (const dirtyMark of DIRTY_MARKS) {
+        const { container } = render(
+          <TabLabel title={title} dirtyMark={dirtyMark || undefined} />,
+        );
+        const root = container.querySelector('.ws-tab-label');
+        const got = root?.textContent ?? '';
+        const want = title + dirtyMark;
+        cleanup();
+        if (got !== want) {
+          throw new Error(
+            `textContent mismatch: title=${JSON.stringify(title)} dirty=${JSON.stringify(dirtyMark)} got=${JSON.stringify(got)} want=${JSON.stringify(want)}`,
+          );
+        }
+      }
+    }
+  });
+
+  it('span order is always stem → ext? → dirty? (never anything else)', () => {
+    // Locks the visual layout contract: the extension pins to the right
+    // of the stem, the dirty marker pins to the right of the extension,
+    // and no other slot exists.
+    const validSlots = ['ws-tab-label-stem', 'ws-tab-label-ext', 'ws-tab-label-dirty'];
+    for (const title of DOM_CORPUS) {
+      for (const dirtyMark of DIRTY_MARKS) {
+        const { container } = render(
+          <TabLabel title={title} dirtyMark={dirtyMark || undefined} />,
+        );
+        const root = container.querySelector('.ws-tab-label');
+        const order = Array.from(root?.querySelectorAll('span') ?? []).map(
+          (span) => span.className,
+        );
+        cleanup();
+        let lastIndex = -1;
+        for (const cls of order) {
+          const idx = validSlots.indexOf(cls);
+          if (idx <= lastIndex) {
+            throw new Error(
+              `span order violated: title=${JSON.stringify(title)} dirty=${JSON.stringify(dirtyMark)} order=${JSON.stringify(order)}`,
+            );
+          }
+          lastIndex = idx;
+        }
+      }
+    }
+  });
+});

--- a/apps/web/tests/components/workspaceTabLabel.test.tsx
+++ b/apps/web/tests/components/workspaceTabLabel.test.tsx
@@ -1,14 +1,6 @@
 // @vitest-environment jsdom
-//
-// splitTabLabel is what lets a wrapped workspace tab keep its file extension
-// visible when the stem truncates ("index….html" instead of "index….ht").
-// The extension is the affordance that tells the user which file the tab
-// points at, so the split logic needs to hold across the shapes we see in
-// practice: real file extensions, extension-less project names, leading-dot
-// names, multi-dot names, and copy that only *looks* like it has an
-// extension (version strings, sentences, i18n).
 
-import { describe, expect, it, afterEach } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 
 import { splitTabLabel, TabLabel } from '../../src/components/workspaceTabLabel';
@@ -18,370 +10,58 @@ afterEach(() => {
 });
 
 describe('splitTabLabel', () => {
-  it('splits a plain file name on the extension dot', () => {
-    expect(splitTabLabel('index.html')).toEqual({ stem: 'index', ext: '.html' });
-    expect(splitTabLabel('kit.html')).toEqual({ stem: 'kit', ext: '.html' });
-    expect(splitTabLabel('foo.tsx')).toEqual({ stem: 'foo', ext: '.tsx' });
-    expect(splitTabLabel('a.md')).toEqual({ stem: 'a', ext: '.md' });
+  it.each([
+    ['index.html', 'index', '.html'],
+    ['config.settings.json', 'config.settings', '.json'],
+    ['scene.v2.usda', 'scene.v2', '.usda'],
+    ['song.mp3', 'song', '.mp3'],
+    ['model.3dm', 'model', '.3dm'],
+    ['video.h264', 'video', '.h264'],
+    ['clip.x265', 'clip', '.x265'],
+    ['设计文件.tsx', '设计文件', '.tsx'],
+    ['ホーム.html', 'ホーム', '.html'],
+    ['app.beta3', 'app', '.beta3'],
+  ])('splits %s as stem/ext', (title, stem, ext) => {
+    expect(splitTabLabel(title)).toEqual({ stem, ext });
   });
 
-  it('splits on the LAST dot when there are several', () => {
-    expect(splitTabLabel('config.settings.json')).toEqual({
-      stem: 'config.settings',
-      ext: '.json',
-    });
-    expect(splitTabLabel('scene.v2.usda')).toEqual({
-      stem: 'scene.v2',
-      ext: '.usda',
-    });
+  it.each([
+    'Design Files', 'kit', '', '.gitignore', '.env', '.eslintrc', '文档.文档',
+    'v1.2', 'app.v2', 'flow.b3', 'report.summary', 'song.a', 'trailing.',
+    'component.svelte', 'README.markdown', 'build.gradle', 'report.doc-1', 'note. txt',
+  ])('keeps non-extension title %j whole', (title) => {
+    expect(splitTabLabel(title)).toEqual({ stem: title, ext: null });
   });
 
-  it('leaves extension-less titles whole', () => {
-    expect(splitTabLabel('Design Files')).toEqual({ stem: 'Design Files', ext: null });
-    expect(splitTabLabel('kit')).toEqual({ stem: 'kit', ext: null });
-    expect(splitTabLabel('')).toEqual({ stem: '', ext: null });
-  });
-
-  it('keeps leading-dot names whole (no visible stem to truncate against)', () => {
-    expect(splitTabLabel('.gitignore')).toEqual({ stem: '.gitignore', ext: null });
-    expect(splitTabLabel('.env')).toEqual({ stem: '.env', ext: null });
-    expect(splitTabLabel('.eslintrc')).toEqual({ stem: '.eslintrc', ext: null });
-  });
-
-  it('does not misread version strings and sentences as extensions', () => {
-    // Trailing token contains punctuation → not an extension.
-    expect(splitTabLabel('v1.2 release notes')).toEqual({
-      stem: 'v1.2 release notes',
-      ext: null,
-    });
-    // Bare version suffix: the 1-char trailing token fails the 2-char floor.
-    expect(splitTabLabel('v1.2')).toEqual({
-      stem: 'v1.2',
-      ext: null,
-    });
-    // Version-shape tokens `.v2` / `.b3` are the two common single-prefix
-    // shapes rejected so a project named "app.v2" or "flow.b3" keeps the
-    // version tag in the stem. Multi-letter version prefixes (`.beta3`,
-    // `.alpha1`) intentionally still match the extension shape - they
-    // share the shape of real extensions like `.mp3` and `.mp4`, and
-    // disambiguating cleanly needs a known-extension lookup this file
-    // deliberately does not carry.
-    expect(splitTabLabel('app.v2')).toEqual({
-      stem: 'app.v2',
-      ext: null,
-    });
-    expect(splitTabLabel('flow.b3')).toEqual({
-      stem: 'flow.b3',
-      ext: null,
-    });
-    // Trailing token is longer than 5 chars → not an extension.
-    expect(splitTabLabel('report.summary')).toEqual({
-      stem: 'report.summary',
-      ext: null,
-    });
-    // Single-character tails are not extensions in this app's vocabulary.
-    expect(splitTabLabel('song.a')).toEqual({
-      stem: 'song.a',
-      ext: null,
-    });
-    // Trailing dot with empty token.
-    expect(splitTabLabel('trailing.')).toEqual({
-      stem: 'trailing.',
-      ext: null,
-    });
-  });
-
-  it('accepts short numeric and mixed extensions', () => {
-    expect(splitTabLabel('song.mp3')).toEqual({ stem: 'song', ext: '.mp3' });
-    expect(splitTabLabel('model.3dm')).toEqual({ stem: 'model', ext: '.3dm' });
-    expect(splitTabLabel('archive.7z')).toEqual({ stem: 'archive', ext: '.7z' });
-  });
-
-  it('accepts codec extensions that share shape with version tags', () => {
-    // `.h264` and `.x265` are `<letter><digits>` shape but are real file
-    // kinds, so the version-token exclusion is narrow to `v`/`b` prefixes.
-    expect(splitTabLabel('video.h264')).toEqual({ stem: 'video', ext: '.h264' });
-    expect(splitTabLabel('clip.x265')).toEqual({ stem: 'clip', ext: '.x265' });
-  });
-
-  it('splits CJK stems on the trailing ASCII extension', () => {
-    // The extension regex is ASCII-only by design; a CJK stem is fine as
-    // long as the trailing token is a real short extension.
-    expect(splitTabLabel('设计文件.tsx')).toEqual({ stem: '设计文件', ext: '.tsx' });
-    expect(splitTabLabel('ホーム.html')).toEqual({ stem: 'ホーム', ext: '.html' });
-    // Both stem and tail non-ASCII → the whole title stays in the stem.
-    expect(splitTabLabel('文档.文档')).toEqual({ stem: '文档.文档', ext: null });
-  });
-
-  it('keeps extensions longer than 5 chars in the stem (documented ceiling)', () => {
-    // EXTENSION_TOKEN caps at 5 chars, so `.svelte`, `.markdown`, `.gradle`,
-    // `.astro`, `.eslintrc` fall through to no-split. This is a deliberate
-    // narrow scope: raising the ceiling would need a known-extension
-    // lookup to avoid misreading long sentence-tails as file kinds. Behavior
-    // here is a graceful degradation to end-ellipsis, not a regression;
-    // the pre-fix behavior was the same. Pinned so a future ceiling change
-    // is a conscious decision rather than an accidental one.
-    expect(splitTabLabel('component.svelte')).toEqual({
-      stem: 'component.svelte',
-      ext: null,
-    });
-    expect(splitTabLabel('README.markdown')).toEqual({
-      stem: 'README.markdown',
-      ext: null,
-    });
-    expect(splitTabLabel('build.gradle')).toEqual({
-      stem: 'build.gradle',
-      ext: null,
-    });
-  });
-
-  it('rejects extensions with non-alphanumeric characters', () => {
-    expect(splitTabLabel('report.doc-1')).toEqual({
-      stem: 'report.doc-1',
-      ext: null,
-    });
-    expect(splitTabLabel('note. txt')).toEqual({
-      stem: 'note. txt',
-      ext: null,
-    });
+  it.each([
+    '', '.', '..', 'name..', ' name ', 'line\nname',
+    'a'.repeat(240), `${'a'.repeat(240)}.html`, '.gitignore',
+    '设计文件.tsx', 'مشروع.json',
+  ])('preserves representative title %j', (title) => {
+    const { stem, ext } = splitTabLabel(title);
+    expect(stem + (ext ?? '')).toBe(title);
+    if (ext !== null) expect(stem).not.toBe('');
   });
 });
 
 describe('TabLabel', () => {
-  it('renders stem + extension as separate spans when the title has an extension', () => {
-    const { container } = render(<TabLabel title="index.html" />);
+  it.each([
+    ['index.html', ' •'],
+    ['Design Files', undefined],
+    ['مشروع.json', ' *'],
+    ['foo.sketch.json', ' •'],
+  ])('preserves text and span order for %j', (title, dirtyMark) => {
+    const { container } = render(<TabLabel title={title} dirtyMark={dirtyMark} />);
     const root = container.querySelector('.ws-tab-label');
-    expect(root).not.toBeNull();
-    const stem = root!.querySelector('.ws-tab-label-stem');
-    const ext = root!.querySelector('.ws-tab-label-ext');
-    expect(stem?.textContent).toBe('index');
-    expect(ext?.textContent).toBe('.html');
-  });
-
-  it('renders only the stem span for extension-less titles', () => {
-    const { container } = render(<TabLabel title="Design Files" />);
-    const root = container.querySelector('.ws-tab-label');
-    expect(root?.querySelector('.ws-tab-label-stem')?.textContent).toBe('Design Files');
-    expect(root?.querySelector('.ws-tab-label-ext')).toBeNull();
-  });
-
-  it('keeps the extension split when a dirty mark is present', () => {
-    // Sketch tabs pass ` •` when dirty. The dirty mark rides its own prop
-    // so the extension detection still runs on the bare filename; the
-    // rendered order is stem → ext → dirty so a narrow tab still reads
-    // like `foo….sketch.json •` rather than losing the file kind.
-    const { container } = render(
-      <TabLabel title="foo.sketch.json" dirtyMark=" •" />,
-    );
-    const root = container.querySelector('.ws-tab-label');
-    expect(root?.querySelector('.ws-tab-label-stem')?.textContent).toBe('foo.sketch');
-    expect(root?.querySelector('.ws-tab-label-ext')?.textContent).toBe('.json');
-    expect(root?.querySelector('.ws-tab-label-dirty')?.textContent).toBe(' •');
-    expect(root?.textContent).toBe('foo.sketch.json •');
-  });
-
-  it('renders the dirty span in dom order after the extension', () => {
-    const { container } = render(
-      <TabLabel title="index.html" dirtyMark=" •" />,
-    );
-    const root = container.querySelector('.ws-tab-label');
+    expect(root?.textContent).toBe(title + (dirtyMark ?? ''));
     const spans = Array.from(root?.querySelectorAll('span') ?? []).map(
       (span) => span.className,
     );
+    const { ext } = splitTabLabel(title);
     expect(spans).toEqual([
       'ws-tab-label-stem',
-      'ws-tab-label-ext',
-      'ws-tab-label-dirty',
+      ...(ext ? ['ws-tab-label-ext'] : []),
+      ...(dirtyMark ? ['ws-tab-label-dirty'] : []),
     ]);
-  });
-
-  it('omits the dirty span when the mark is empty', () => {
-    const { container } = render(<TabLabel title="index.html" dirtyMark="" />);
-    const root = container.querySelector('.ws-tab-label');
-    expect(root?.querySelector('.ws-tab-label-dirty')).toBeNull();
-  });
-});
-
-// Seeded fuzz corpus. Deterministic so a failure is reproducible off the
-// printed input, and the run stays fast (single-digit ms for the pure
-// function, low hundreds of ms for the DOM properties in jsdom).
-function mulberry32(seed: number): () => number {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-// Explicit corners the random pass would take many iterations to stumble
-// into. Every one of these has caused parser bugs in similar helpers.
-const SEED_CORPUS = [
-  '',
-  '.', '..', '...',
-  'a', 'a.', '.a', '.ab', '.abc', 'a.b', 'a.bc', 'a.bcd',
-  ' ', ' .', '. ', 'a b.c', 'a.b c',
-  '\n', '\t', '\0',
-  'a'.repeat(500),
-  `${'a'.repeat(500)}.html`,
-  '设计.tsx', '.env', '.gitignore', '.eslintrc',
-  'app.v2', 'flow.b3', 'video.h264', 'clip.x265',
-  'component.svelte', 'README.markdown',
-  'note. txt', 'trailing.', '.only', 'ends.with..',
-];
-
-function randomCorpus(seed: number, count: number): string[] {
-  const rng = mulberry32(seed);
-  const ascii = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  const punct = '.-_ !@#$%^&*()[]{}<>?/\\|;:\'"~+=';
-  const cjk = '設計文件ホームπΩ你好世界';
-  const pool = ascii + punct + cjk;
-  const out: string[] = [];
-  for (let i = 0; i < count; i += 1) {
-    const len = Math.floor(rng() * 40);
-    let s = '';
-    for (let j = 0; j < len; j += 1) {
-      // 12% chance of a dot to synthesise extension-shaped candidates
-      // without dropping the tail into non-dotty territory too often.
-      s += rng() < 0.12 ? '.' : pool[Math.floor(rng() * pool.length)];
-    }
-    out.push(s);
-  }
-  return out;
-}
-
-const FUZZ_CORPUS = [...SEED_CORPUS, ...randomCorpus(0xdeadbeef, 400)];
-
-describe('splitTabLabel invariants (fuzz)', () => {
-  it('round-trips: stem + ext always reconstructs the input title', () => {
-    // If this ever fails, a tab label silently loses text between the
-    // shipped filename and the rendered spans. That is the loudest bug
-    // this function can develop, so it gets the loudest guarantee.
-    for (const title of FUZZ_CORPUS) {
-      const { stem, ext } = splitTabLabel(title);
-      const rebuilt = stem + (ext ?? '');
-      if (rebuilt !== title) {
-        throw new Error(
-          `round-trip failed on ${JSON.stringify(title)}: got ${JSON.stringify(rebuilt)}`,
-        );
-      }
-    }
-  });
-
-  it('ext, when present, is a real extension and never a version tag', () => {
-    // Locks the docblock's contract: the extension slot only ever
-    // carries the 2-5 alnum ASCII shape and never the v/b + digits
-    // shape that the exclusion regex was added to reject.
-    for (const title of FUZZ_CORPUS) {
-      const { ext } = splitTabLabel(title);
-      if (ext === null) continue;
-      if (!/^\.[A-Za-z0-9]{2,5}$/.test(ext)) {
-        throw new Error(
-          `ext violates 2-5 alnum shape on ${JSON.stringify(title)}: ${JSON.stringify(ext)}`,
-        );
-      }
-      if (/^\.[vVbB]\d+$/.test(ext)) {
-        throw new Error(
-          `ext is a version tag but was split off on ${JSON.stringify(title)}: ${JSON.stringify(ext)}`,
-        );
-      }
-    }
-  });
-
-  it('idempotent: splitting the rebuilt title yields the same split', () => {
-    // A pure text-parser should be stable under re-application. If this
-    // fails we have accidentally introduced a rule that mangles its own
-    // output.
-    for (const title of FUZZ_CORPUS) {
-      const first = splitTabLabel(title);
-      const second = splitTabLabel(first.stem + (first.ext ?? ''));
-      if (first.stem !== second.stem || first.ext !== second.ext) {
-        throw new Error(
-          `idempotence violated on ${JSON.stringify(title)}: first=${JSON.stringify(first)} second=${JSON.stringify(second)}`,
-        );
-      }
-    }
-  });
-
-  it('never throws on any string input', () => {
-    for (const title of FUZZ_CORPUS) {
-      expect(() => splitTabLabel(title)).not.toThrow();
-    }
-  });
-
-  it('ext-present implies a non-empty stem (leading-dot names stay whole)', () => {
-    // The stem is what the ellipsis truncates against; if we ever return
-    // an empty stem alongside a real extension, a narrow tab renders as
-    // just the extension and the file is unidentifiable.
-    for (const title of FUZZ_CORPUS) {
-      const { stem, ext } = splitTabLabel(title);
-      if (ext !== null && stem.length === 0) {
-        throw new Error(
-          `empty stem with non-null ext on ${JSON.stringify(title)}: ext=${JSON.stringify(ext)}`,
-        );
-      }
-    }
-  });
-});
-
-describe('TabLabel invariants (fuzz)', () => {
-  // Smaller corpus: each iteration renders + queries the DOM under jsdom.
-  const DOM_CORPUS = [
-    ...SEED_CORPUS,
-    ...randomCorpus(0xfeedface, 80),
-  ];
-  const DIRTY_MARKS = ['', ' •', ' *', '·'];
-
-  it('textContent equals title + dirtyMark for every (title, mark) pair', () => {
-    // The DOM-level guarantee that the split spans do not visually lose
-    // text. This is the user-facing invariant; splitTabLabel's
-    // round-trip is the pure-function version of the same claim.
-    for (const title of DOM_CORPUS) {
-      for (const dirtyMark of DIRTY_MARKS) {
-        const { container } = render(
-          <TabLabel title={title} dirtyMark={dirtyMark || undefined} />,
-        );
-        const root = container.querySelector('.ws-tab-label');
-        const got = root?.textContent ?? '';
-        const want = title + dirtyMark;
-        cleanup();
-        if (got !== want) {
-          throw new Error(
-            `textContent mismatch: title=${JSON.stringify(title)} dirty=${JSON.stringify(dirtyMark)} got=${JSON.stringify(got)} want=${JSON.stringify(want)}`,
-          );
-        }
-      }
-    }
-  });
-
-  it('span order is always stem → ext? → dirty? (never anything else)', () => {
-    // Locks the visual layout contract: the extension pins to the right
-    // of the stem, the dirty marker pins to the right of the extension,
-    // and no other slot exists.
-    const validSlots = ['ws-tab-label-stem', 'ws-tab-label-ext', 'ws-tab-label-dirty'];
-    for (const title of DOM_CORPUS) {
-      for (const dirtyMark of DIRTY_MARKS) {
-        const { container } = render(
-          <TabLabel title={title} dirtyMark={dirtyMark || undefined} />,
-        );
-        const root = container.querySelector('.ws-tab-label');
-        const order = Array.from(root?.querySelectorAll('span') ?? []).map(
-          (span) => span.className,
-        );
-        cleanup();
-        let lastIndex = -1;
-        for (const cls of order) {
-          const idx = validSlots.indexOf(cls);
-          if (idx <= lastIndex) {
-            throw new Error(
-              `span order violated: title=${JSON.stringify(title)} dirty=${JSON.stringify(dirtyMark)} order=${JSON.stringify(order)}`,
-            );
-          }
-          lastIndex = idx;
-        }
-      }
-    }
   });
 });

--- a/e2e/ui/file-tabs-cap-truncation.test.ts
+++ b/e2e/ui/file-tabs-cap-truncation.test.ts
@@ -1,31 +1,7 @@
-// File-workspace tab labels: raised cap + extension-preserving truncation.
+// Browser witnesses for shipping tab geometry; parser cases live in Vitest.
+// The `.app` wrapper applies the same tab padding/border cascade as production.
 //
-// The file-tab strip (`.ws-tabs-bar` in the FileWorkspace) capped every tab
-// at 110px, which chopped `Design Files.html` to `Design Fi…` even with the
-// strip half empty. End-ellipsis also lost the file extension, which is
-// the token that tells the user which file kind the tab points at.
-//
-// The fix raises the cap to 240px and splits `.ws-tab-label` into a stem
-// span (may ellipsis-truncate) plus an optional extension span pinned
-// visible via flex, so a narrow tab reads `index….html` instead of
-// `index….ht`. Dirty sketch tabs also carry a trailing ` •` marker as its
-// own pinned span so the split still applies to the primary editing
-// surface.
-//
-// Scope: this spec is the CSS-invariant boundary. It boots the app so the
-// shipping stylesheet loads, then constructs the shipping DOM shape (root
-// `.ws-tab-label` with nested `.ws-tab-label-stem` / `.ws-tab-label-ext` /
-// `.ws-tab-label-dirty`) and measures rendered geometry. It does not
-// exercise `splitTabLabel`; that logic is pinned by the Vitest suite at
-// `apps/web/tests/components/workspaceTabLabel.test.tsx`. Splitting the
-// two responsibilities keeps the e2e from re-implementing the regex it is
-// supposed to trust and drifting from the shipped component.
-//
-// The `.app` wrapper below is what lets the `.app .ws-tab` padding/border
-// rules from `viewer/routines.css` apply; the `.ws-tab-label*` rules in
-// `workspace/drawer.css` live on bare selectors and would apply either
-// way. The wrapper is the smallest ancestor chain that makes the tab
-// geometry match a real shipping tab, not a full app scope simulation.
+// Width comparisons allow ±0.5px slack for subpixel rounding.
 
 import { expect, test } from '@/playwright/suite';
 import { T } from '@/timeouts';
@@ -96,8 +72,6 @@ test('[P1] file tabs raise the label cap to 240 and keep extensions visible', as
       dirtyMarksPreserved: boolean;
     }> = [];
     for (const c of cases as StripCase[]) {
-      // Minimal ancestor chain so `.app .ws-tab` (viewer/routines.css) and
-      // the base `.ws-tab` (workspace/drawer.css) rules both apply.
       const app = document.createElement('div');
       app.className = 'app';
       app.style.cssText = `position: fixed; top: -3000px; left: 0; width: ${c.barWidth + 100}px;`;
@@ -167,9 +141,6 @@ test('[P1] file tabs raise the label cap to 240 and keep extensions visible', as
         const labelRect = label.getBoundingClientRect();
         return labelRect.right <= tabRect.right + 0.5 && labelRect.left >= tabRect.left - 0.5;
       });
-      // Per-tab label truncation: for each tab, does the stem render its
-      // full text without ellipsis clipping? Detected via scrollWidth vs
-      // clientWidth on the stem span.
       const stemTruncated = tabs.map((t) => {
         const stem = t.querySelector('.ws-tab-label-stem') as HTMLElement | null;
         if (!stem) return false;
@@ -200,25 +171,18 @@ test('[P1] file tabs raise the label cap to 240 and keep extensions visible', as
     expect(r.dirtyMarksPreserved, `dirty mark truncated at "${r.label}": ${detail}`).toBe(true);
   }
 
-  // Titles that fit within the 240px cap must render their full content
-  // with NO ellipsis truncation on the stem.
   const threeModerate = results.find((r) => r.label.startsWith('three moderate tabs'))!;
   expect(threeModerate.visibleText).toContain('Design Files.html');
   expect(threeModerate.visibleText).toContain('scene.json');
   expect(threeModerate.visibleText).toContain('kit.html');
   expect(threeModerate.stemTruncated.every((v) => v === false), `moderate tab stem truncated: ${detail}`).toBe(true);
 
-  // Long titles cap at 240px (up from the old 110px which chopped labels
-  // mid-word). Tabs sit at their natural content width and stop growing at
-  // the cap when the title exceeds it.
   const longThree = results.find((r) => r.label.startsWith('three tabs with long titles'))!;
   for (const w of longThree.tabWidths) {
     expect(w, `long-tab width breaches cap: ${detail}`).toBeLessThanOrEqual(240);
     expect(w, `long-tab width regressed under old 110px cap: ${detail}`).toBeGreaterThan(110);
   }
 
-  // Dirty sketch tab: extension AND dirty mark both survive; visible text
-  // ends with the ext + dirty mark in the shipped DOM order.
   const dirtySketch = results.find((r) => r.label.startsWith('dirty sketch tab'))!;
   expect(dirtySketch.tabWidths[0], `dirty sketch cap: ${detail}`).toBeLessThanOrEqual(240);
   expect(
@@ -232,11 +196,6 @@ test('[P1] file tabs raise the label cap to 240 and keep extensions visible', as
 });
 
 test('[P1] static-shape tabs keep the pre-fix 110px cap', async ({ page }) => {
-  // The raised 240px cap is scoped via :has(.ws-tab-label-stem) so it
-  // only applies to file tabs (which render the split spans). Static
-  // Design Files / Design System pills use a plain `.ws-tab-label` text
-  // node and must keep the pre-fix cap so they don't eat into file-tab
-  // space when the strip is tight.
   await page.goto('/');
   await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
 
@@ -254,8 +213,6 @@ test('[P1] static-shape tabs keep the pre-fix 110px cap', async ({ page }) => {
     app.appendChild(shell);
     document.body.appendChild(app);
 
-    // Two static tabs matching the shipping shape: a `.ws-tab` with a
-    // plain-text `.ws-tab-label` child, no stem/ext/dirty spans.
     const results: Array<{ label: string; tabWidth: number; labelClipped: boolean }> = [];
     for (const text of ['Design Files', 'Design System supremely long variant that should truncate']) {
       const tab = document.createElement('button');
@@ -276,26 +233,14 @@ test('[P1] static-shape tabs keep the pre-fix 110px cap', async ({ page }) => {
 
   const detail = JSON.stringify(layout, null, 2);
   for (const r of layout) {
-    // Pre-fix cap on the base rule is 110px; the raised 240px cap must
-    // not leak to static labels. Half-pixel tolerance for subpixel
-    // rounding.
     expect(r.tabWidth, `static tab breached 110px cap on "${r.label}": ${detail}`).toBeLessThanOrEqual(110.5);
   }
-  // The long static label must actually truncate at the tight cap
-  // (proves the label max-width of 96px still applies here, not the
-  // raised 240 that only :has(.ws-tab-label-stem) grants).
   const long = layout.find((r) => r.label.startsWith('Design System supremely'))!;
   expect(long.labelClipped, `long static label did not truncate at pre-fix cap: ${detail}`).toBe(true);
 });
 
-test('[P1] file tab labels stay LTR under ambient dir=rtl', async ({ page }) => {
-  // The label is a flex row: without an explicit `direction: ltr`, ambient
-  // `<html dir="rtl">` on Arabic / Farsi locales would reverse the visual
-  // sibling order and render `foo.json` as `.json foo`. The pre-fix
-  // single-text-node label was safe because the Unicode Bidi Algorithm
-  // kept embedded Latin runs upright; the split form needs the row axis
-  // pinned. Extensions are always ASCII (regex-gated), so pinning LTR is
-  // safe across every locale.
+test('[P1] Arabic file labels stay LTR under ambient dir=rtl', async ({ page }) => {
+  // Pinning LTR preserves stem → extension → dirty order under RTL.
   await page.goto('/');
   await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
 
@@ -323,7 +268,7 @@ test('[P1] file tab labels stay LTR under ambient dir=rtl', async ({ page }) => 
     label.className = 'ws-tab-label';
     const stem = document.createElement('span');
     stem.className = 'ws-tab-label-stem';
-    stem.textContent = 'foo';
+    stem.textContent = 'مشروع';
     label.appendChild(stem);
     const ext = document.createElement('span');
     ext.className = 'ws-tab-label-ext';
@@ -342,12 +287,10 @@ test('[P1] file tab labels stay LTR under ambient dir=rtl', async ({ page }) => 
     const dirtyRect = dirty.getBoundingClientRect();
     const ambientDir = getComputedStyle(app).direction;
     const labelDir = getComputedStyle(label).direction;
-    const visibleText = (tab.textContent ?? '').trim();
     app.remove();
     return {
       ambientDir,
       labelDir,
-      visibleText,
       stemLeft: stemRect.left,
       extLeft: extRect.left,
       dirtyLeft: dirtyRect.left,
@@ -355,16 +298,8 @@ test('[P1] file tab labels stay LTR under ambient dir=rtl', async ({ page }) => 
   });
 
   const detail = JSON.stringify(layout, null, 2);
-  // Sanity: the ancestor really did inherit RTL, so this test is exercising
-  // what it claims to.
   expect(layout.ambientDir, `ambient dir not rtl: ${detail}`).toBe('rtl');
-  // The fix: the split flex container pins LTR regardless of ambient dir.
   expect(layout.labelDir, `label dir not pinned to ltr: ${detail}`).toBe('ltr');
-  // Visual sibling order: stem left of ext left of dirty. Under ambient
-  // RTL without the pin, ext would end up left of stem.
   expect(layout.stemLeft, `stem not left of ext under rtl: ${detail}`).toBeLessThan(layout.extLeft);
   expect(layout.extLeft, `ext not left of dirty under rtl: ${detail}`).toBeLessThan(layout.dirtyLeft);
-  // textContent still concatenates DOM order, so this is a belt-and-braces
-  // check rather than a pure visual assertion.
-  expect(layout.visibleText, `visible text lost order: ${detail}`).toBe('foo.json •');
 });

--- a/e2e/ui/file-tabs-cap-truncation.test.ts
+++ b/e2e/ui/file-tabs-cap-truncation.test.ts
@@ -1,0 +1,370 @@
+// File-workspace tab labels: raised cap + extension-preserving truncation.
+//
+// The file-tab strip (`.ws-tabs-bar` in the FileWorkspace) capped every tab
+// at 110px, which chopped `Design Files.html` to `Design Fi…` even with the
+// strip half empty. End-ellipsis also lost the file extension, which is
+// the token that tells the user which file kind the tab points at.
+//
+// The fix raises the cap to 240px and splits `.ws-tab-label` into a stem
+// span (may ellipsis-truncate) plus an optional extension span pinned
+// visible via flex, so a narrow tab reads `index….html` instead of
+// `index….ht`. Dirty sketch tabs also carry a trailing ` •` marker as its
+// own pinned span so the split still applies to the primary editing
+// surface.
+//
+// Scope: this spec is the CSS-invariant boundary. It boots the app so the
+// shipping stylesheet loads, then constructs the shipping DOM shape (root
+// `.ws-tab-label` with nested `.ws-tab-label-stem` / `.ws-tab-label-ext` /
+// `.ws-tab-label-dirty`) and measures rendered geometry. It does not
+// exercise `splitTabLabel`; that logic is pinned by the Vitest suite at
+// `apps/web/tests/components/workspaceTabLabel.test.tsx`. Splitting the
+// two responsibilities keeps the e2e from re-implementing the regex it is
+// supposed to trust and drifting from the shipped component.
+//
+// The `.app` wrapper below is what lets the `.app .ws-tab` padding/border
+// rules from `viewer/routines.css` apply; the `.ws-tab-label*` rules in
+// `workspace/drawer.css` live on bare selectors and would apply either
+// way. The wrapper is the smallest ancestor chain that makes the tab
+// geometry match a real shipping tab, not a full app scope simulation.
+
+import { expect, test } from '@/playwright/suite';
+import { T } from '@/timeouts';
+
+interface StripLabel {
+  stem: string;
+  ext?: string;
+  dirty?: string;
+}
+interface StripCase {
+  label: string;
+  barWidth: number;
+  tabs: StripLabel[];
+}
+
+const CASES: StripCase[] = [
+  {
+    label: 'single tab caps at 240px (no balloon)',
+    barWidth: 900,
+    tabs: [{ stem: 'Design Files', ext: '.html' }],
+  },
+  {
+    label: 'three moderate tabs each fit their natural width under the cap',
+    barWidth: 900,
+    tabs: [
+      { stem: 'Design Files', ext: '.html' },
+      { stem: 'scene', ext: '.json' },
+      { stem: 'kit', ext: '.html' },
+    ],
+  },
+  {
+    label: 'three tabs with long titles all cap at 240px',
+    barWidth: 900,
+    tabs: [
+      { stem: 'A very long design file name', ext: '.html' },
+      { stem: 'Another really long scene title', ext: '.json' },
+      { stem: 'Component library index', ext: '.tsx' },
+    ],
+  },
+  {
+    label: 'tab with pathological 250-char stem caps at 240 without spilling',
+    barWidth: 900,
+    tabs: [{ stem: 'a'.repeat(250), ext: '.html' }],
+  },
+  {
+    label: 'dirty sketch tab keeps the extension visible under truncation',
+    barWidth: 900,
+    tabs: [
+      { stem: 'a very long sketch composition name.sketch', ext: '.json', dirty: ' •' },
+    ],
+  },
+];
+
+test('[P1] file tabs raise the label cap to 240 and keep extensions visible', async ({ page }) => {
+  await page.goto('/');
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  const results = await page.evaluate((cases) => {
+    const out: Array<{
+      label: string;
+      barWidth: number;
+      tabWidths: number[];
+      capBreached: boolean;
+      extensionsPreserved: boolean;
+      labelsContainedInTab: boolean;
+      visibleText: string[];
+      stemTruncated: boolean[];
+      dirtyMarksPreserved: boolean;
+    }> = [];
+    for (const c of cases as StripCase[]) {
+      // Minimal ancestor chain so `.app .ws-tab` (viewer/routines.css) and
+      // the base `.ws-tab` (workspace/drawer.css) rules both apply.
+      const app = document.createElement('div');
+      app.className = 'app';
+      app.style.cssText = `position: fixed; top: -3000px; left: 0; width: ${c.barWidth + 100}px;`;
+      const shell = document.createElement('div');
+      shell.className = 'ws-tabs-shell';
+      shell.style.cssText = 'height: 44px;';
+      const bar = document.createElement('div');
+      bar.className = 'ws-tabs-bar';
+      bar.style.cssText = `width: ${c.barWidth}px;`;
+      shell.appendChild(bar);
+      app.appendChild(shell);
+      document.body.appendChild(app);
+
+      for (const spec of c.tabs) {
+        const tab = document.createElement('button');
+        tab.type = 'button';
+        tab.className = 'ws-tab';
+        const text = document.createElement('span');
+        text.className = 'ws-tab-text';
+        const label = document.createElement('span');
+        label.className = 'ws-tab-label';
+        const stem = document.createElement('span');
+        stem.className = 'ws-tab-label-stem';
+        stem.textContent = spec.stem;
+        label.appendChild(stem);
+        if (spec.ext) {
+          const ext = document.createElement('span');
+          ext.className = 'ws-tab-label-ext';
+          ext.textContent = spec.ext;
+          label.appendChild(ext);
+        }
+        if (spec.dirty) {
+          const dirty = document.createElement('span');
+          dirty.className = 'ws-tab-label-dirty';
+          dirty.textContent = spec.dirty;
+          label.appendChild(dirty);
+        }
+        text.appendChild(label);
+        tab.appendChild(text);
+        bar.appendChild(tab);
+      }
+
+      const tabs = Array.from(bar.querySelectorAll('.ws-tab')) as HTMLElement[];
+      const widths = tabs.map((t) => Math.round(t.getBoundingClientRect().width));
+      const visibleText = tabs.map((t) => (t.textContent ?? '').trim());
+      const capBreached = widths.some((w) => w > 240.5);
+      const extensionsPreserved = tabs.every((t) => {
+        const ext = t.querySelector('.ws-tab-label-ext') as HTMLElement | null;
+        if (!ext) return true;
+        const tabRect = t.getBoundingClientRect();
+        if (tabRect.width < 100) return true;
+        const extRect = ext.getBoundingClientRect();
+        return extRect.right <= tabRect.right + 0.5 && extRect.left >= tabRect.left - 0.5;
+      });
+      const dirtyMarksPreserved = tabs.every((t) => {
+        const dirty = t.querySelector('.ws-tab-label-dirty') as HTMLElement | null;
+        if (!dirty) return true;
+        const tabRect = t.getBoundingClientRect();
+        if (tabRect.width < 100) return true;
+        const dRect = dirty.getBoundingClientRect();
+        return dRect.right <= tabRect.right + 0.5 && dRect.left >= tabRect.left - 0.5;
+      });
+      const labelsContainedInTab = tabs.every((t) => {
+        const label = t.querySelector('.ws-tab-label') as HTMLElement | null;
+        if (!label) return true;
+        const tabRect = t.getBoundingClientRect();
+        const labelRect = label.getBoundingClientRect();
+        return labelRect.right <= tabRect.right + 0.5 && labelRect.left >= tabRect.left - 0.5;
+      });
+      // Per-tab label truncation: for each tab, does the stem render its
+      // full text without ellipsis clipping? Detected via scrollWidth vs
+      // clientWidth on the stem span.
+      const stemTruncated = tabs.map((t) => {
+        const stem = t.querySelector('.ws-tab-label-stem') as HTMLElement | null;
+        if (!stem) return false;
+        return stem.scrollWidth > stem.clientWidth + 0.5;
+      });
+      out.push({
+        label: c.label,
+        barWidth: c.barWidth,
+        tabWidths: widths,
+        capBreached,
+        extensionsPreserved,
+        labelsContainedInTab,
+        visibleText,
+        stemTruncated,
+        dirtyMarksPreserved,
+      });
+      app.remove();
+    }
+    return out;
+  }, CASES);
+
+  const detail = JSON.stringify(results, null, 2);
+
+  for (const r of results) {
+    expect(r.capBreached, `240px cap breached at "${r.label}": ${detail}`).toBe(false);
+    expect(r.extensionsPreserved, `extension truncated at "${r.label}": ${detail}`).toBe(true);
+    expect(r.labelsContainedInTab, `label spills past tab boundary at "${r.label}": ${detail}`).toBe(true);
+    expect(r.dirtyMarksPreserved, `dirty mark truncated at "${r.label}": ${detail}`).toBe(true);
+  }
+
+  // Titles that fit within the 240px cap must render their full content
+  // with NO ellipsis truncation on the stem.
+  const threeModerate = results.find((r) => r.label.startsWith('three moderate tabs'))!;
+  expect(threeModerate.visibleText).toContain('Design Files.html');
+  expect(threeModerate.visibleText).toContain('scene.json');
+  expect(threeModerate.visibleText).toContain('kit.html');
+  expect(threeModerate.stemTruncated.every((v) => v === false), `moderate tab stem truncated: ${detail}`).toBe(true);
+
+  // Long titles cap at 240px (up from the old 110px which chopped labels
+  // mid-word). Tabs sit at their natural content width and stop growing at
+  // the cap when the title exceeds it.
+  const longThree = results.find((r) => r.label.startsWith('three tabs with long titles'))!;
+  for (const w of longThree.tabWidths) {
+    expect(w, `long-tab width breaches cap: ${detail}`).toBeLessThanOrEqual(240);
+    expect(w, `long-tab width regressed under old 110px cap: ${detail}`).toBeGreaterThan(110);
+  }
+
+  // Dirty sketch tab: extension AND dirty mark both survive; visible text
+  // ends with the ext + dirty mark in the shipped DOM order.
+  const dirtySketch = results.find((r) => r.label.startsWith('dirty sketch tab'))!;
+  expect(dirtySketch.tabWidths[0], `dirty sketch cap: ${detail}`).toBeLessThanOrEqual(240);
+  expect(
+    dirtySketch.visibleText[0],
+    `dirty sketch label missing .json or dirty mark: ${detail}`,
+  ).toContain('.json');
+  expect(
+    dirtySketch.visibleText[0],
+    `dirty sketch label missing dirty mark: ${detail}`,
+  ).toContain('•');
+});
+
+test('[P1] static-shape tabs keep the pre-fix 110px cap', async ({ page }) => {
+  // The raised 240px cap is scoped via :has(.ws-tab-label-stem) so it
+  // only applies to file tabs (which render the split spans). Static
+  // Design Files / Design System pills use a plain `.ws-tab-label` text
+  // node and must keep the pre-fix cap so they don't eat into file-tab
+  // space when the strip is tight.
+  await page.goto('/');
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  const layout = await page.evaluate(() => {
+    const app = document.createElement('div');
+    app.className = 'app';
+    app.style.cssText = 'position: fixed; top: -3000px; left: 0; width: 900px;';
+    const shell = document.createElement('div');
+    shell.className = 'ws-tabs-shell';
+    shell.style.cssText = 'height: 44px;';
+    const bar = document.createElement('div');
+    bar.className = 'ws-tabs-bar';
+    bar.style.cssText = 'width: 800px;';
+    shell.appendChild(bar);
+    app.appendChild(shell);
+    document.body.appendChild(app);
+
+    // Two static tabs matching the shipping shape: a `.ws-tab` with a
+    // plain-text `.ws-tab-label` child, no stem/ext/dirty spans.
+    const results: Array<{ label: string; tabWidth: number; labelClipped: boolean }> = [];
+    for (const text of ['Design Files', 'Design System supremely long variant that should truncate']) {
+      const tab = document.createElement('button');
+      tab.type = 'button';
+      tab.className = 'ws-tab';
+      const label = document.createElement('span');
+      label.className = 'ws-tab-label';
+      label.textContent = text;
+      tab.appendChild(label);
+      bar.appendChild(tab);
+      const tabRect = tab.getBoundingClientRect();
+      const labelClipped = label.scrollWidth > label.clientWidth + 0.5;
+      results.push({ label: text, tabWidth: Math.round(tabRect.width), labelClipped });
+    }
+    app.remove();
+    return results;
+  });
+
+  const detail = JSON.stringify(layout, null, 2);
+  for (const r of layout) {
+    // Pre-fix cap on the base rule is 110px; the raised 240px cap must
+    // not leak to static labels. Half-pixel tolerance for subpixel
+    // rounding.
+    expect(r.tabWidth, `static tab breached 110px cap on "${r.label}": ${detail}`).toBeLessThanOrEqual(110.5);
+  }
+  // The long static label must actually truncate at the tight cap
+  // (proves the label max-width of 96px still applies here, not the
+  // raised 240 that only :has(.ws-tab-label-stem) grants).
+  const long = layout.find((r) => r.label.startsWith('Design System supremely'))!;
+  expect(long.labelClipped, `long static label did not truncate at pre-fix cap: ${detail}`).toBe(true);
+});
+
+test('[P1] file tab labels stay LTR under ambient dir=rtl', async ({ page }) => {
+  // The label is a flex row: without an explicit `direction: ltr`, ambient
+  // `<html dir="rtl">` on Arabic / Farsi locales would reverse the visual
+  // sibling order and render `foo.json` as `.json foo`. The pre-fix
+  // single-text-node label was safe because the Unicode Bidi Algorithm
+  // kept embedded Latin runs upright; the split form needs the row axis
+  // pinned. Extensions are always ASCII (regex-gated), so pinning LTR is
+  // safe across every locale.
+  await page.goto('/');
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  const layout = await page.evaluate(() => {
+    const app = document.createElement('div');
+    app.className = 'app';
+    app.setAttribute('dir', 'rtl');
+    app.style.cssText = 'position: fixed; top: -3000px; left: 0; width: 700px;';
+    const shell = document.createElement('div');
+    shell.className = 'ws-tabs-shell';
+    shell.style.cssText = 'height: 44px;';
+    const bar = document.createElement('div');
+    bar.className = 'ws-tabs-bar';
+    bar.style.cssText = 'width: 600px;';
+    shell.appendChild(bar);
+    app.appendChild(shell);
+    document.body.appendChild(app);
+
+    const tab = document.createElement('button');
+    tab.type = 'button';
+    tab.className = 'ws-tab';
+    const text = document.createElement('span');
+    text.className = 'ws-tab-text';
+    const label = document.createElement('span');
+    label.className = 'ws-tab-label';
+    const stem = document.createElement('span');
+    stem.className = 'ws-tab-label-stem';
+    stem.textContent = 'foo';
+    label.appendChild(stem);
+    const ext = document.createElement('span');
+    ext.className = 'ws-tab-label-ext';
+    ext.textContent = '.json';
+    label.appendChild(ext);
+    const dirty = document.createElement('span');
+    dirty.className = 'ws-tab-label-dirty';
+    dirty.textContent = ' •';
+    label.appendChild(dirty);
+    text.appendChild(label);
+    tab.appendChild(text);
+    bar.appendChild(tab);
+
+    const stemRect = stem.getBoundingClientRect();
+    const extRect = ext.getBoundingClientRect();
+    const dirtyRect = dirty.getBoundingClientRect();
+    const ambientDir = getComputedStyle(app).direction;
+    const labelDir = getComputedStyle(label).direction;
+    const visibleText = (tab.textContent ?? '').trim();
+    app.remove();
+    return {
+      ambientDir,
+      labelDir,
+      visibleText,
+      stemLeft: stemRect.left,
+      extLeft: extRect.left,
+      dirtyLeft: dirtyRect.left,
+    };
+  });
+
+  const detail = JSON.stringify(layout, null, 2);
+  // Sanity: the ancestor really did inherit RTL, so this test is exercising
+  // what it claims to.
+  expect(layout.ambientDir, `ambient dir not rtl: ${detail}`).toBe('rtl');
+  // The fix: the split flex container pins LTR regardless of ambient dir.
+  expect(layout.labelDir, `label dir not pinned to ltr: ${detail}`).toBe('ltr');
+  // Visual sibling order: stem left of ext left of dirty. Under ambient
+  // RTL without the pin, ext would end up left of stem.
+  expect(layout.stemLeft, `stem not left of ext under rtl: ${detail}`).toBeLessThan(layout.extLeft);
+  expect(layout.extLeft, `ext not left of dirty under rtl: ${detail}`).toBeLessThan(layout.dirtyLeft);
+  // textContent still concatenates DOM order, so this is a belt-and-braces
+  // check rather than a pure visual assertion.
+  expect(layout.visibleText, `visible text lost order: ${detail}`).toBe('foo.json •');
+});


### PR DESCRIPTION
## Why

Ran into this while working in a project with a handful of `.html` /
`.json` / `.tsx` files open: the file-workspace tab strip was capping
every tab at 110px, so `Design Files.html` chopped to `Design Fi…` and
`scene.json` to `scene.js…`. The strip had plenty of empty space, and
the end-ellipsis chewed off the file extension, which is the token that
tells you which kind of file the tab points at.

Dirty sketch tabs made it worse: the ` •` marker was baked into the
label string, so an unsaved `foo.sketch.json` rendered as
`foo.sketch.j…` under any narrow-viewport composition, permanently
hiding both the `.json` and the dirty affordance.

## What users will see

File tabs now render at their natural width up to 240px and only
truncate when the title actually exceeds that. When a title does
truncate, the extension stays visible pinned to the right of the
stem: `component-library-index….tsx` instead of
`component-library-inde…`. Dirty sketch tabs read as
`foo.sketch.json •` with the `.json` and the ` •` both pinned, even
under maximum squeeze.

Nothing else changes: the top-level workspace pills (Home / project),
the Design Files / Design System static tabs, and browser tabs all
render identically to before.

## Surface area

- [x] **UI**: file-tab strip inside `FileWorkspace` in `apps/web`
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change

## Screenshots

Real DOM, real CSS, same 5 (few) or 8 (many) tabs seeded via the
production `PUT /api/projects/:id/tabs` endpoint in both states.
Three viewport widths per density so the responsive behavior is
visible in the same shot.

![Before / after collage](https://raw.githubusercontent.com/worflor/meowtimedesign/pr-assets-workspace-tabs-cap/tabs-collage.png)

## Bug fix verification

- `apps/web/tests/components/workspaceTabLabel.test.tsx` covers representative split/no-split filenames, round-trip preservation, and rendered span order.
- `apps/web/tests/components/FileWorkspace.test.tsx` keeps terminal and dotted side-chat titles on the plain-label path while real file tabs retain the split label.
- `e2e/ui/file-tabs-cap-truncation.test.ts` covers the 240px file-tab cap, pinned extensions and dirty marks, the unchanged 110px static-tab cap, and Arabic labels under ambient RTL.
- The browser regression cases went red on `main` and green on this branch.

## Validation

- Focused Vitest suites: 137 passed, 3 skipped
- Focused Playwright spec with `--repeat-each=3 --workers=1`: 9/9 passed
- `pnpm --filter @open-design/web typecheck`: clean
- `pnpm --filter @open-design/web build`: clean
- `pnpm guard` and full `pnpm typecheck`: clean