### PR TITLE
fix(daemon): bound sequential imported-folder listing rescans

### DIFF
--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -38,6 +38,18 @@ const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.file-versions', '.live-artifacts']);
 const DESIGN_HANDOFF_FILENAME = 'DESIGN-HANDOFF.md';
 const DESIGN_MANIFEST_FILENAME = 'DESIGN-MANIFEST.json';
+// Imported folders can contain hundreds of thousands of files. Browsers often
+// request the full inventory more than once while mounting/reconciling a
+// project, so retain a completed snapshot briefly instead of repeating a full
+// recursive walk after the previous request has already finished. Incremental
+// polling (`since`) deliberately bypasses this cache.
+const IMPORTED_PROJECT_FILE_LIST_CACHE_MS = 5_000;
+const MAX_IMPORTED_PROJECT_FILE_LISTS = 32;
+const importedProjectFileLists = new Map<string, { expiresAt: number; files: any[] }>();
+const importedProjectFileListWalks = new Map<
+  string,
+  { active: number; generation: number }
+>();
 export const RUN_ARTIFACT_RECONCILE_MTIME_GRACE_MS = 1000;
 export const projectFileRenameTestHooks = {
   beforeCommit: null as null | ((paths: { source: string; target: string }) => Promise<void> | void),
@@ -137,18 +149,69 @@ export async function ensureProject(projectsRoot, projectId, metadata?) {
 export async function listFiles(projectsRoot, projectId, opts = {}) {
   const metadata = opts?.metadata;
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
+  const since = Number(opts.since);
+  const canUseCompletedListCache = usesExternalProjectRoot(metadata)
+    && !(Number.isFinite(since) && since > 0);
+  const cacheKey = path.resolve(dir);
+  if (canUseCompletedListCache) {
+    const cached = importedProjectFileLists.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) return cached.files.slice();
+    importedProjectFileLists.delete(cacheKey);
+  }
+  let walkState: { active: number; generation: number } | undefined;
+  let walkGeneration = 0;
+  if (canUseCompletedListCache) {
+    walkState = importedProjectFileListWalks.get(cacheKey) ?? { active: 0, generation: 0 };
+    walkState.active += 1;
+    walkGeneration = walkState.generation;
+    importedProjectFileListWalks.set(cacheKey, walkState);
+  }
   const out = [];
   // Skip generated dependency/build trees for all project roots. Standard OD
   // projects can contain framework installs too; surfacing package HTML like
   // node_modules/tslib/*.html as artifacts produces blank previews.
-  await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
-  // Newest first — matches the visual order users expect after generating.
-  out.sort((a, b) => b.mtime - a.mtime);
-  const since = Number(opts.since);
+  try {
+    await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
+    // Newest first — matches the visual order users expect after generating.
+    out.sort((a, b) => b.mtime - a.mtime);
+    if (walkState && walkState.generation === walkGeneration) {
+      cacheImportedProjectFileList(cacheKey, out);
+    }
+  } finally {
+    if (walkState) {
+      walkState.active -= 1;
+      if (walkState.active === 0 && importedProjectFileListWalks.get(cacheKey) === walkState) {
+        importedProjectFileListWalks.delete(cacheKey);
+      }
+    }
+  }
   if (Number.isFinite(since) && since > 0) {
     return out.filter((f) => Number(f.mtime) > since);
   }
   return out;
+}
+
+export function invalidateImportedProjectFileList(dir) {
+  const cacheKey = path.resolve(dir);
+  importedProjectFileLists.delete(cacheKey);
+  const walkState = importedProjectFileListWalks.get(cacheKey);
+  if (walkState) walkState.generation += 1;
+}
+
+function cacheImportedProjectFileList(cacheKey, files) {
+  const now = Date.now();
+  for (const [key, cached] of importedProjectFileLists) {
+    if (cached.expiresAt <= now) importedProjectFileLists.delete(key);
+  }
+  while (importedProjectFileLists.size >= MAX_IMPORTED_PROJECT_FILE_LISTS) {
+    const oldestKey = importedProjectFileLists.keys().next().value;
+    if (!oldestKey) break;
+    importedProjectFileLists.delete(oldestKey);
+  }
+  importedProjectFileLists.set(cacheKey, {
+    expiresAt: now + IMPORTED_PROJECT_FILE_LIST_CACHE_MS,
+    files,
+  });
 }
 
 export async function listProjectFolders(projectsRoot, projectId, opts = {}) {
@@ -198,6 +261,7 @@ export async function createProjectFolder(projectsRoot, projectId, name, metadat
     err.code = 'ENOTDIR';
     throw err;
   }
+  invalidateImportedProjectFileList(dir);
   return {
     name: safeName,
     path: safeName,
@@ -243,6 +307,7 @@ export async function deleteProjectFolder(projectsRoot, projectId, name, metadat
     throw err;
   }
   await rm(target, { recursive: true, force: true });
+  invalidateImportedProjectFileList(dir);
 }
 
 // Best-effort entry-file detector — looks for index.html at the root,
@@ -877,6 +942,7 @@ export async function writeProjectFile(
     artifactManifest: persistedManifest,
   };
   if (stubGuardWarning) result.stubGuardWarning = stubGuardWarning;
+  invalidateImportedProjectFileList(dir);
   return result;
 }
 
@@ -940,6 +1006,7 @@ export async function reconcileHtmlArtifactManifest(projectsRoot, projectId, nam
   );
   if (!validated.ok || !validated.value) return null;
   await writeFile(manifestTarget, JSON.stringify(validated.value, null, 2));
+  invalidateImportedProjectFileList(dir);
   return validated.value;
 }
 
@@ -969,6 +1036,7 @@ export async function deleteProjectFile(projectsRoot, projectId, name, metadata?
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
   await unlink(file);
+  invalidateImportedProjectFileList(dir);
 }
 
 export async function renameProjectFile(projectsRoot, projectId, fromName, toName, metadata?) {
@@ -1034,6 +1102,7 @@ export async function renameProjectFile(projectsRoot, projectId, fromName, toNam
   await renameFilePath(source, targetPath, { noOverwrite: true });
   await commitArtifactManifestRename(manifestRename, newName);
   await updateArtifactManifestRefsForRename(dir, oldName, newName);
+  invalidateImportedProjectFileList(dir);
 
   const st = await stat(targetPath);
   const manifest = await readManifestForPath(dir, newName);

--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -46,7 +46,11 @@ import {
 } from '../library.js';
 import { reconcileLibrary, type ReconcileLibraryResult } from '../library-sync.js';
 import { fetchExternalBrandAsset } from '../brands/safe-fetch.js';
-import { ensureProjectSubdir } from '../projects.js';
+import {
+  ensureProjectSubdir,
+  invalidateImportedProjectFileList,
+  resolveProjectDir,
+} from '../projects.js';
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
@@ -240,6 +244,7 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
         }
       }
     }
+    invalidateImportedProjectFileList(resolveProjectDir(PROJECTS_DIR, projectId, project.metadata));
     return elementRelPath ? { relPath, elementRelPath } : { relPath };
   }
 

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -52,7 +52,11 @@ import {
 import { connectorService } from '../../connectors/service.js';
 import type { RouteDeps } from '../../server-context.js';
 import { listSkills } from '../../skills.js';
-import { isSafeId } from '../../projects.js';
+import {
+  invalidateImportedProjectFileList,
+  isSafeId,
+  resolveProjectDir,
+} from '../../projects.js';
 import {
   ensureTeamProjectCommentConversations,
   SYNC_KEEPS_UPDATED_AT,
@@ -6673,6 +6677,11 @@ export function registerProjectUploadRoutes(app: Express, ctx: RegisterProjectUp
           } catch {
             // skip files that vanished mid-flight
           }
+        }
+        if (project) {
+          invalidateImportedProjectFileList(
+            resolveProjectDir(PROJECTS_DIR, project.id, project.metadata),
+          );
         }
         /** @type {import('@open-design/contracts').UploadProjectFilesResponse} */
         const body = { files: out };

--- a/apps/daemon/tests/projects-list-files-import-cache.test.ts
+++ b/apps/daemon/tests/projects-list-files-import-cache.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const counters = vi.hoisted(() => ({
+  readdirCalls: 0,
+  afterReaddir: null as null | ((filePath: string) => Promise<void>),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('node:fs/promises');
+  return {
+    ...actual,
+    default: actual,
+    readdir: async (filePath: any, ...rest: any[]) => {
+      counters.readdirCalls += 1;
+      const entries = await (actual.readdir as any)(filePath, ...rest);
+      await counters.afterReaddir?.(String(filePath));
+      return entries;
+    },
+  };
+});
+
+const {
+  invalidateImportedProjectFileList,
+  listFiles,
+  writeProjectFile,
+} = await import('../src/projects.js');
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('listFiles imported-folder sequential cache', () => {
+  beforeEach(() => {
+    counters.readdirCalls = 0;
+    counters.afterReaddir = null;
+  });
+
+  it('reuses a completed imported-folder walk for an immediate sequential request', async () => {
+    const projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-import-list-cache-'));
+    tempRoots.push(projectsRoot);
+    const importedRoot = path.join(projectsRoot, 'imported');
+    await mkdir(path.join(importedRoot, 'nested'), { recursive: true });
+    await writeFile(path.join(importedRoot, 'index.html'), '<!doctype html>');
+    await writeFile(path.join(importedRoot, 'nested', 'app.js'), 'export {};');
+
+    const metadata = { baseDir: importedRoot };
+    const first = await listFiles(projectsRoot, 'imported-project', { metadata });
+    const second = await listFiles(projectsRoot, 'imported-project', { metadata });
+
+    expect(first.map((file: any) => file.path).sort()).toEqual(['index.html', 'nested/app.js']);
+    expect(second).toEqual(first);
+    expect(counters.readdirCalls).toBe(2);
+  });
+
+  it('does not serve the completed-list cache to incremental polling', async () => {
+    const projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-import-list-cache-'));
+    tempRoots.push(projectsRoot);
+    const importedRoot = path.join(projectsRoot, 'imported');
+    await mkdir(importedRoot, { recursive: true });
+    await writeFile(path.join(importedRoot, 'index.html'), '<!doctype html>');
+
+    const metadata = { baseDir: importedRoot };
+    await listFiles(projectsRoot, 'imported-project', { metadata });
+    const since = Date.now();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await writeFile(path.join(importedRoot, 'changed.js'), 'export {};');
+
+    const changed = await listFiles(projectsRoot, 'imported-project', { metadata, since });
+
+    expect(changed.map((file: any) => file.path)).toEqual(['changed.js']);
+    expect(counters.readdirCalls).toBe(2);
+  });
+
+  it('invalidates an imported-folder snapshot after a daemon-managed write', async () => {
+    const projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-import-list-cache-'));
+    tempRoots.push(projectsRoot);
+    const importedRoot = path.join(projectsRoot, 'imported');
+    await mkdir(importedRoot, { recursive: true });
+    await writeFile(path.join(importedRoot, 'index.html'), '<!doctype html>');
+
+    const metadata = { baseDir: importedRoot };
+    await listFiles(projectsRoot, 'imported-project', { metadata });
+    await writeProjectFile(projectsRoot, 'imported-project', 'written.js', 'export {};', {}, metadata);
+
+    const files = await listFiles(projectsRoot, 'imported-project', { metadata });
+
+    expect(files.map((file: any) => file.path)).toContain('written.js');
+    expect(counters.readdirCalls).toBe(2);
+  });
+
+  it('invalidates the snapshot for direct upload and copy-style writes', async () => {
+    const projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-import-list-cache-'));
+    tempRoots.push(projectsRoot);
+    const importedRoot = path.join(projectsRoot, 'imported');
+    await mkdir(importedRoot, { recursive: true });
+    await writeFile(path.join(importedRoot, 'index.html'), '<!doctype html>');
+    const metadata = { baseDir: importedRoot };
+    await listFiles(projectsRoot, 'imported-project', { metadata });
+
+    await writeFile(path.join(importedRoot, 'uploaded.png'), 'bytes');
+    invalidateImportedProjectFileList(importedRoot);
+    const files = await listFiles(projectsRoot, 'imported-project', { metadata });
+
+    expect(files.map((file: any) => file.path)).toContain('uploaded.png');
+    expect(counters.readdirCalls).toBe(2);
+  });
+
+  it('does not cache a walk that overlaps a direct mutation', async () => {
+    const projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-import-list-cache-'));
+    tempRoots.push(projectsRoot);
+    const importedRoot = path.join(projectsRoot, 'imported');
+    await mkdir(importedRoot, { recursive: true });
+    await writeFile(path.join(importedRoot, 'index.html'), '<!doctype html>');
+    const metadata = { baseDir: importedRoot };
+    let releaseWalk!: () => void;
+    const walkReleased = new Promise<void>((resolve) => { releaseWalk = resolve; });
+    let markWalkStarted!: () => void;
+    const walkStarted = new Promise<void>((resolve) => { markWalkStarted = resolve; });
+    let blocked = false;
+    counters.afterReaddir = async (filePath) => {
+      if (filePath === importedRoot && !blocked) {
+        blocked = true;
+        markWalkStarted();
+        await walkReleased;
+      }
+    };
+
+    const overlappingList = listFiles(projectsRoot, 'imported-project', { metadata });
+    await walkStarted;
+    await writeFile(path.join(importedRoot, 'uploaded-during-walk.png'), 'bytes');
+    invalidateImportedProjectFileList(importedRoot);
+    releaseWalk();
+    await overlappingList;
+    counters.afterReaddir = null;
+
+    const fresh = await listFiles(projectsRoot, 'imported-project', { metadata });
+    expect(fresh.map((file: any) => file.path)).toContain('uploaded-during-walk.png');
+    expect(counters.readdirCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7209.

Adds a bounded completed-result cache for full file lists of imported folders. This addresses sequential rescans that happen after a previous `listFiles()` Promise has settled; it complements, rather than replaces, the concurrent single-flight work in #4188.

The cache is limited to imported-folder full listings, expires after five seconds, and is capped at 32 roots. Incremental `since` queries bypass it.

## Correctness and freshness

- daemon-managed file/folder mutations invalidate the affected root;
- direct multipart upload and Library asset-copy paths use the same invalidation primitive;
- each active walk captures a per-root mutation generation;
- a walk that overlaps any daemon-owned mutation cannot install its pre-mutation result;
- expired snapshots are removed and retained snapshots remain bounded.

## Surface area

Daemon-only. No contract, schema, browser UI, migration, dependency, or public API shape change.

## Bug fix verification

Before the fix, two immediate sequential full listings walked the same imported tree twice (`readdir` count 4 instead of 2). The added race tests also failed before the shared invalidator/generation guard existed.

After the fix:

- sequential full listings reuse the completed snapshot;
- incremental polls always walk fresh;
- managed writes and direct upload/copy-style writes invalidate the snapshot;
- a mutation interleaved with an active walk prevents that walk from repopulating stale data.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/projects-list-files-import-cache.test.ts` — 5 passed
- affected daemon matrix covering file listing, range, upload, Library, and rename — 87 passed total; one parallel startup timeout was classified by rerunning `project-file-rename.test.ts` alone (11/11 passed)
- `pnpm --filter @open-design/daemon run typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed

## Relationship to #4188

#4188 removes per-file missing-sidecar fan-out and coalesces overlapping scans. This PR handles the separate gap after a scan has completed, where a later sequential request otherwise performs another O(N) walk. It does not supersede #4188 and can be rebased if that PR lands first.