### PR TITLE
fix(pricing): return checkout to source Cloud Console

### DIFF
--- a/apps/landing-page/app/_components/pricing-individual-plans.astro
+++ b/apps/landing-page/app/_components/pricing-individual-plans.astro
@@ -2,7 +2,6 @@
 import {
   GO_PLAN,
   PRICING_SNAPSHOT,
-  cloudSubscribeUrl,
   formatUsd,
   type PlanTierConfig,
 } from '../_lib/pricing';
@@ -386,7 +385,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
               <small>{view.yearly.billed}</small>
             </div>
 
-            <a class="pricing-card-cta" href={cloudSubscribeUrl(tier, 'yearly')} data-pricing-cta data-tier={tier}>
+            <a class="pricing-card-cta" data-pricing-cta data-tier={tier}>
               <span>{tierCopy[tier].ctaLabel}</span>
             </a>
 

--- a/apps/landing-page/app/_lib/pricing-content.ts
+++ b/apps/landing-page/app/_lib/pricing-content.ts
@@ -107,6 +107,8 @@ export interface PricingLabels {
   footnote: string;
   /** Linked text inside the footnote, pointing at the cloud console. */
   consoleLabel: string;
+  /** Visible failure when an explicit Cloud Console handoff is invalid. */
+  checkoutDestinationUnavailable: string;
 }
 
 /** Copy owned by the live Personal comparison component. */
@@ -705,6 +707,7 @@ const EN: PricingContent = {
     heroTitle: 'Pay only for AI tasks that deliver results',
     footnote: 'Prices shown in USD. Checkout, billing, and auto top-up are handled in the {console}. Adjust or cancel your plan anytime.',
     consoleLabel: 'OpenDesign Cloud console',
+    checkoutDestinationUnavailable: 'Checkout destination unavailable. Return to your Cloud Console and open Pricing again.',
     monthly: 'Monthly',
     yearly: 'Yearly',
     yearlySave: 'Save up to 51%',
@@ -790,6 +793,7 @@ const ZH_CN: PricingContent = {
     heroTitle: '只为实际完成的 AI 任务付费',
     footnote: '价格以美元计。结账、账单与自动充值均在 {console} 完成。可随时调整或取消套餐。',
     consoleLabel: 'OpenDesign Cloud 控制台',
+    checkoutDestinationUnavailable: '结账环境不可用。请返回 Cloud 控制台后重新打开价格页。',
     monthly: '月付',
     yearly: '年付',
     yearlySave: '省最多 51%',
@@ -871,6 +875,7 @@ const ZH_TW: PricingContent = {
     heroTitle: '只為實際完成的 AI 任務付費',
     footnote: '價格以美元計。結帳、帳單與自動加值皆於 {console} 完成。可隨時調整或取消方案。',
     consoleLabel: 'OpenDesign Cloud 主控台',
+    checkoutDestinationUnavailable: '結帳環境無法使用。請返回 Cloud 主控台後重新開啟價格頁。',
     monthly: '月付',
     yearly: '年付',
     yearlySave: '最多省 51%',
@@ -952,6 +957,7 @@ const ES: PricingContent = {
     heroTitle: 'Paga solo por tareas de IA completadas',
     footnote: 'Precios en USD. El pago, la facturación y la recarga automática se gestionan en la {console}. Cambia o cancela tu plan cuando quieras.',
     consoleLabel: 'consola de OpenDesign Cloud',
+    checkoutDestinationUnavailable: 'El destino de pago no está disponible. Vuelve a la consola Cloud y abre Precios de nuevo.',
     monthly: 'Mensual',
     yearly: 'Anual',
     yearlySave: 'Ahorra hasta 51%',
@@ -1033,6 +1039,7 @@ const PT_BR: PricingContent = {
     heroTitle: 'Pague apenas por tarefas de IA concluídas',
     footnote: 'Preços em USD. Pagamento, faturamento e recarga automática são feitos no {console}. Ajuste ou cancele seu plano quando quiser.',
     consoleLabel: 'console do OpenDesign Cloud',
+    checkoutDestinationUnavailable: 'O destino de pagamento não está disponível. Volte ao console Cloud e abra Preços novamente.',
     monthly: 'Mensal',
     yearly: 'Anual',
     yearlySave: 'Economize até 51%',
@@ -1114,6 +1121,7 @@ const RU: PricingContent = {
     heroTitle: 'Платите только за выполненные задачи ИИ',
     footnote: 'Цены указаны в USD. Оплата, выставление счетов и автопополнение выполняются в {console}. Изменение или отмена тарифа в любое время.',
     consoleLabel: 'консоли OpenDesign Cloud',
+    checkoutDestinationUnavailable: 'Среда оплаты недоступна. Вернитесь в консоль Cloud и снова откройте страницу тарифов.',
     monthly: 'Месяц',
     yearly: 'Год',
     yearlySave: 'Экономия до 51%',
@@ -1195,6 +1203,7 @@ const FR: PricingContent = {
     heroTitle: 'Payez uniquement pour les tâches IA terminées',
     footnote: 'Prix indiqués en USD. Le paiement, la facturation et la recharge automatique se gèrent dans la {console}. Ajustez ou résiliez votre forfait à tout moment.',
     consoleLabel: 'console OpenDesign Cloud',
+    checkoutDestinationUnavailable: 'La destination de paiement est indisponible. Revenez à la console Cloud et rouvrez la page Tarifs.',
     monthly: 'Mensuel',
     yearly: 'Annuel',
     yearlySave: 'Économisez jusqu’à 51%',
@@ -1276,6 +1285,7 @@ const KO: PricingContent = {
     heroTitle: '완료된 AI 작업에만 비용을 지불하세요',
     footnote: '가격은 USD 기준입니다. 결제, 청구, 자동 충전은 {console}에서 처리됩니다. 플랜 변경 또는 취소는 언제든 가능합니다.',
     consoleLabel: 'OpenDesign Cloud 콘솔',
+    checkoutDestinationUnavailable: '결제 환경을 사용할 수 없습니다. Cloud 콘솔로 돌아가 요금 페이지를 다시 여세요.',
     monthly: '월간',
     yearly: '연간',
     yearlySave: '최대 51% 절약',
@@ -1357,6 +1367,7 @@ const DE: PricingContent = {
     heroTitle: 'Zahle nur für abgeschlossene KI-Aufgaben',
     footnote: 'Preise in USD. Checkout, Abrechnung und automatisches Aufladen erfolgen in der {console}. Plan jederzeit anpassen oder kündigen.',
     consoleLabel: 'OpenDesign Cloud Konsole',
+    checkoutDestinationUnavailable: 'Das Zahlungsziel ist nicht verfügbar. Kehre zur Cloud-Konsole zurück und öffne die Preisseite erneut.',
     monthly: 'Monatlich',
     yearly: 'Jährlich',
     yearlySave: 'Bis zu 51% sparen',
@@ -1438,6 +1449,7 @@ const JA: PricingContent = {
     heroTitle: '完了した AI タスクにだけ支払う',
     footnote: '価格は米ドル表示です。決済・請求・自動チャージは {console} で行います。プランの変更・解約はいつでも可能です。',
     consoleLabel: 'OpenDesign Cloud コンソール',
+    checkoutDestinationUnavailable: '決済先を利用できません。Cloud コンソールに戻り、料金ページを開き直してください。',
     monthly: '月額',
     yearly: '年額',
     yearlySave: '最大 51% オフ',

--- a/apps/landing-page/app/_lib/pricing.ts
+++ b/apps/landing-page/app/_lib/pricing.ts
@@ -79,8 +79,63 @@ export interface PricingContract {
   teamTiers: TeamPlanTierConfig[];
 }
 
+/** Query parameter carrying the Cloud Console deployment that opened Pricing. */
+export const CLOUD_CONSOLE_BASE_PARAM = 'cloud_console_base';
+
+/** Production Cloud Console used for direct public Pricing visits. */
+export const DEFAULT_CLOUD_CONSOLE_BASE_URL = 'https://open-design.ai/cloud/';
+
+/** Hosted Cloud Console deployments allowed to receive a Pricing handoff. */
+export const HOSTED_CLOUD_CONSOLE_BASE_URLS = [
+  DEFAULT_CLOUD_CONSOLE_BASE_URL,
+  'https://vela.powerformer.net/',
+  'https://amr-feature.powerformer.net/',
+] as const;
+
+function isLoopbackCloudConsole(url: URL): boolean {
+  return (
+    url.protocol === 'http:' &&
+    (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+    url.port.length > 0 &&
+    url.pathname === '/'
+  );
+}
+
+/**
+ * Resolve an explicit environment handoff without exposing an open redirect.
+ * A missing value is a normal direct public visit and uses production; a
+ * present but invalid value fails visibly at the Pricing CTA seam.
+ */
+export function resolveCloudConsoleBase(rawValue: string | null): string {
+  if (rawValue === null) return DEFAULT_CLOUD_CONSOLE_BASE_URL;
+  const value = rawValue.trim();
+  if (!value) throw new RangeError('Invalid Cloud Console base: value is empty');
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new RangeError('Invalid Cloud Console base: expected an absolute URL');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new RangeError('Invalid Cloud Console base: credentials and URL state are not allowed');
+  }
+
+  const normalized = url.toString();
+  if (
+    !(HOSTED_CLOUD_CONSOLE_BASE_URLS as readonly string[]).includes(normalized) &&
+    !isLoopbackCloudConsole(url)
+  ) {
+    throw new RangeError('Invalid Cloud Console base: destination is not allowlisted');
+  }
+  return normalized;
+}
+
 /** Production dashboard that owns authenticated checkout. */
-export const CLOUD_BASE_URL = 'https://open-design.ai/cloud/dashboard';
+export const CLOUD_BASE_URL = new URL(
+  'dashboard',
+  DEFAULT_CLOUD_CONSOLE_BASE_URL,
+).toString();
 
 /** Public pricing contract served by the landing page. */
 export const PLANS_JSON_URL = '/pricing/plans.json';

--- a/apps/landing-page/app/_lib/pricing.ts
+++ b/apps/landing-page/app/_lib/pricing.ts
@@ -85,12 +85,22 @@ export const CLOUD_CONSOLE_BASE_PARAM = 'cloud_console_base';
 /** Production Cloud Console used for direct public Pricing visits. */
 export const DEFAULT_CLOUD_CONSOLE_BASE_URL = 'https://open-design.ai/cloud/';
 
-/** Hosted Cloud Console deployments allowed to receive a Pricing handoff. */
-export const HOSTED_CLOUD_CONSOLE_BASE_URLS = [
-  DEFAULT_CLOUD_CONSOLE_BASE_URL,
-  'https://vela.powerformer.net/',
-  'https://amr-feature.powerformer.net/',
+/** Hosted domains (including their subdomains) allowed to receive a Pricing handoff. */
+export const HOSTED_CLOUD_CONSOLE_DOMAINS = [
+  'open-design.ai',
+  'powerformer.net',
 ] as const;
+
+function isHostedCloudConsole(url: URL): boolean {
+  return (
+    url.protocol === 'https:' &&
+    url.port.length === 0 &&
+    url.pathname.endsWith('/') &&
+    HOSTED_CLOUD_CONSOLE_DOMAINS.some(
+      (domain) => url.hostname === domain || url.hostname.endsWith(`.${domain}`),
+    )
+  );
+}
 
 function isLoopbackCloudConsole(url: URL): boolean {
   return (
@@ -122,10 +132,7 @@ export function resolveCloudConsoleBase(rawValue: string | null): string {
   }
 
   const normalized = url.toString();
-  if (
-    !(HOSTED_CLOUD_CONSOLE_BASE_URLS as readonly string[]).includes(normalized) &&
-    !isLoopbackCloudConsole(url)
-  ) {
+  if (!isHostedCloudConsole(url) && !isLoopbackCloudConsole(url)) {
     throw new RangeError('Invalid Cloud Console base: destination is not allowlisted');
   }
   return normalized;

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -11,9 +11,12 @@
 import Layout from '../../_components/sub-page-layout.astro';
 import PricingIndividualPlans from '../../_components/pricing-individual-plans.astro';
 import {
-  PRICING_SNAPSHOT,
+  CLOUD_CONSOLE_BASE_PARAM,
   CLOUD_CONSOLE_URL,
+  DEFAULT_CLOUD_CONSOLE_BASE_URL,
   GO_PLAN,
+  HOSTED_CLOUD_CONSOLE_BASE_URLS,
+  PRICING_SNAPSHOT,
   cloudSubscribeUrl,
   formatUsd,
   teamIntroTotalUsd,
@@ -183,6 +186,7 @@ const jsonLd = [
     data-pricing-root
     data-audience="creator"
     data-interval="yearly"
+    data-cloud-console-environment="production"
     data-billing-api-origin={apiOrigin}
     data-current-plan-label={currentPlanLabel}
     data-campaign-start-at={DEEPSEEK_V4_PRO_CAMPAIGN.startAt}
@@ -229,6 +233,9 @@ const jsonLd = [
         </div>
       </div>
     </header>
+    <p class="pr-handoff-error" data-cloud-console-handoff-error role="alert" hidden>
+      {L.checkoutDestinationUnavailable}
+    </p>
 
     <div
       id="pr-creator-panel"
@@ -400,7 +407,6 @@ const jsonLd = [
 
           <a
             class="btn btn-primary pr-team-checkout"
-            href={CLOUD_CONSOLE_URL}
             data-pricing-cta
             data-tier="team"
             data-team-checkout-total
@@ -465,7 +471,7 @@ const jsonLd = [
     </div>
   </div>
 
-  <script is:inline define:vars={{ labels: L, billingPlanUrl: CLOUD_CONSOLE_URL, teamTiers, teamCopy: teamContent }}>
+  <script is:inline define:vars={{ labels: L, defaultCloudConsoleBase: DEFAULT_CLOUD_CONSOLE_BASE_URL, hostedCloudConsoleBases: HOSTED_CLOUD_CONSOLE_BASE_URLS, cloudConsoleBaseParam: CLOUD_CONSOLE_BASE_PARAM, teamTiers, teamCopy: teamContent }}>
     (() => {
       const root = document.querySelector('[data-pricing-root]');
       if (!root) return;
@@ -528,7 +534,53 @@ const jsonLd = [
       // keeps the generic billing entry until a concrete Team tier is selected.
       const inboundParams = new URLSearchParams(window.location.search);
       const inboundWorkspaceId = inboundParams.get('workspaceId')?.trim();
+      const requestedCloudConsoleBase = inboundParams.get(cloudConsoleBaseParam);
+      const handoffError = root.querySelector('[data-cloud-console-handoff-error]');
+      let cloudConsoleBase = defaultCloudConsoleBase;
+      let cloudConsoleEnvironment = 'production';
+      let cloudConsoleHandoffValid = true;
+      try {
+        if (requestedCloudConsoleBase !== null) {
+          const candidate = new URL(requestedCloudConsoleBase.trim());
+          const normalized = candidate.toString();
+          const hosted = hostedCloudConsoleBases.includes(normalized);
+          const loopback =
+            candidate.protocol === 'http:' &&
+            (candidate.hostname === 'localhost' || candidate.hostname === '127.0.0.1') &&
+            candidate.port.length > 0 &&
+            candidate.pathname === '/';
+          if (
+            candidate.username ||
+            candidate.password ||
+            candidate.search ||
+            candidate.hash ||
+            (!hosted && !loopback)
+          ) {
+            throw new Error('cloud_console_base_not_allowed');
+          }
+          cloudConsoleBase = normalized;
+          cloudConsoleEnvironment =
+            normalized === defaultCloudConsoleBase ? 'production' : 'non-production';
+        }
+      } catch (error) {
+        cloudConsoleHandoffValid = false;
+        cloudConsoleEnvironment = 'invalid';
+        if (handoffError) handoffError.hidden = false;
+        console.error('Invalid Cloud Console Pricing handoff.', error);
+      }
+      root.setAttribute('data-cloud-console-environment', cloudConsoleEnvironment);
+      const cloudConsoleDashboardUrl = cloudConsoleHandoffValid
+        ? new URL('dashboard', cloudConsoleBase).toString()
+        : null;
+      const billingPlanUrl = cloudConsoleDashboardUrl
+        ? (() => {
+            const target = new URL(cloudConsoleDashboardUrl);
+            target.searchParams.set('billing', 'plan');
+            return target.toString();
+          })()
+        : null;
       const scopedBillingPlanUrl = () => {
+        if (!billingPlanUrl) throw new Error('Cloud Console Pricing handoff is unavailable.');
         const target = new URL(billingPlanUrl);
         if (inboundWorkspaceId) target.searchParams.set('workspaceId', inboundWorkspaceId);
         // od_campaign_id is intentionally NOT forwarded from the inbound URL:
@@ -569,13 +621,20 @@ const jsonLd = [
       const syncCtas = () => {
         const interval = root.getAttribute('data-interval') === 'monthly' ? 'monthly' : 'yearly';
         for (const cta of root.querySelectorAll('[data-pricing-cta]')) {
+          if (!cloudConsoleHandoffValid) {
+            cta.setAttribute('data-subscription-disabled', '');
+            cta.setAttribute('aria-disabled', 'true');
+            cta.setAttribute('tabindex', '-1');
+            cta.removeAttribute('href');
+            continue;
+          }
           if (cta.hasAttribute('data-subscription-disabled')) {
             cta.removeAttribute('href');
             continue;
           }
           const tier = cta.getAttribute('data-tier') || '';
           if (tier === 'free') {
-            cta.setAttribute('href', new URL('/cloud/dashboard', billingPlanUrl).toString());
+            cta.setAttribute('href', cloudConsoleDashboardUrl);
             continue;
           }
           if (tier === 'team') {
@@ -1016,7 +1075,7 @@ const jsonLd = [
     } from '../../_lib/pricing-current-plan';
 
     const pricingRoot = document.querySelector('[data-pricing-root]');
-    if (pricingRoot) {
+    if (pricingRoot?.getAttribute('data-cloud-console-environment') === 'production') {
       const apiOrigin = pricingRoot.getAttribute('data-billing-api-origin') || '';
       const currentPlanLabel = pricingRoot.getAttribute('data-current-plan-label') || '';
       void loadCurrentPersonalPlanTier(apiOrigin).then((currentTier) => {
@@ -1040,6 +1099,19 @@ const jsonLd = [
 
 <style>
   .pr-page [data-pricing-campaign-surface][hidden] { display: none !important; }
+  .pr-handoff-error {
+    margin: -20px auto 24px;
+    max-width: 720px;
+    border: 1px solid #c64b40;
+    border-radius: 10px;
+    background: #fff1ee;
+    padding: 12px 16px;
+    color: #8d271f;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.5;
+    text-align: center;
+  }
   .pr-campaign-disclaimer {
     width: 100%;
     max-width: none;

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -53,9 +53,10 @@ const apiOrigin =
   'https://amr-api.open-design.ai';
 
 // Footer line with the cloud-console link injected into the localized
-// template. Brand/URL only — safe to render as HTML.
+// template. Brand/marker only — safe to render as HTML; the validated URL is
+// attached in the handoff script below.
 const footnoteHtml = fillTemplate(L.footnote, {
-  console: `<a class="inline-link" href="${CLOUD_CONSOLE_URL}">${L.consoleLabel}</a>`,
+  console: `<a class="inline-link" data-cloud-console-link>${L.consoleLabel}</a>`,
 });
 
 const faqs = getFaqs(locale);
@@ -572,6 +573,15 @@ const jsonLd = [
       const cloudConsoleDashboardUrl = cloudConsoleHandoffValid
         ? new URL('dashboard', cloudConsoleBase).toString()
         : null;
+      for (const consoleLink of root.querySelectorAll('[data-cloud-console-link]')) {
+        if (cloudConsoleDashboardUrl) {
+          consoleLink.setAttribute('href', cloudConsoleDashboardUrl);
+        } else {
+          consoleLink.setAttribute('aria-disabled', 'true');
+          consoleLink.setAttribute('tabindex', '-1');
+          consoleLink.removeAttribute('href');
+        }
+      }
       const billingPlanUrl = cloudConsoleDashboardUrl
         ? (() => {
             const target = new URL(cloudConsoleDashboardUrl);

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -15,7 +15,7 @@ import {
   CLOUD_CONSOLE_URL,
   DEFAULT_CLOUD_CONSOLE_BASE_URL,
   GO_PLAN,
-  HOSTED_CLOUD_CONSOLE_BASE_URLS,
+  HOSTED_CLOUD_CONSOLE_DOMAINS,
   PRICING_SNAPSHOT,
   cloudSubscribeUrl,
   formatUsd,
@@ -472,7 +472,7 @@ const jsonLd = [
     </div>
   </div>
 
-  <script is:inline define:vars={{ labels: L, defaultCloudConsoleBase: DEFAULT_CLOUD_CONSOLE_BASE_URL, hostedCloudConsoleBases: HOSTED_CLOUD_CONSOLE_BASE_URLS, cloudConsoleBaseParam: CLOUD_CONSOLE_BASE_PARAM, teamTiers, teamCopy: teamContent }}>
+  <script is:inline define:vars={{ labels: L, defaultCloudConsoleBase: DEFAULT_CLOUD_CONSOLE_BASE_URL, hostedCloudConsoleDomains: HOSTED_CLOUD_CONSOLE_DOMAINS, cloudConsoleBaseParam: CLOUD_CONSOLE_BASE_PARAM, teamTiers, teamCopy: teamContent }}>
     (() => {
       const root = document.querySelector('[data-pricing-root]');
       if (!root) return;
@@ -544,7 +544,14 @@ const jsonLd = [
         if (requestedCloudConsoleBase !== null) {
           const candidate = new URL(requestedCloudConsoleBase.trim());
           const normalized = candidate.toString();
-          const hosted = hostedCloudConsoleBases.includes(normalized);
+          const hosted =
+            candidate.protocol === 'https:' &&
+            candidate.port.length === 0 &&
+            candidate.pathname.endsWith('/') &&
+            hostedCloudConsoleDomains.some(
+              (domain) =>
+                candidate.hostname === domain || candidate.hostname.endsWith(`.${domain}`),
+            );
           const loopback =
             candidate.protocol === 'http:' &&
             (candidate.hostname === 'localhost' || candidate.hostname === '127.0.0.1') &&

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -706,13 +706,22 @@ describe("pricing contract", () => {
       "https://amr-feature.powerformer.net/",
     );
     assert.equal(
+      resolveCloudConsoleBase("https://preview-42.open-design.ai/cloud/"),
+      "https://preview-42.open-design.ai/cloud/",
+    );
+    assert.equal(
+      resolveCloudConsoleBase("https://powerformer.net/vela/"),
+      "https://powerformer.net/vela/",
+    );
+    assert.equal(
       resolveCloudConsoleBase("http://127.0.0.1:5179/"),
       "http://127.0.0.1:5179/",
     );
 
     for (const invalid of [
       "https://evil.example/",
-      "https://open-design.ai/",
+      "https://open-design.ai.evil.example/",
+      "https://evilpowerformer.net/",
       "https://user:password@vela.powerformer.net/",
       "http://vela.powerformer.net/",
       "http://localhost:5173/dashboard",
@@ -726,6 +735,11 @@ describe("pricing contract", () => {
       readFile(PRICING_INDIVIDUAL_PATH, "utf8"),
     ]);
     assert.match(page, /inboundParams\.get\(cloudConsoleBaseParam\)/);
+    assert.match(page, /hostedCloudConsoleDomains\.some/);
+    assert.match(
+      page,
+      /candidate\.hostname\.endsWith\(`\.\$\{domain\}`\)/,
+    );
     assert.match(page, /data-cloud-console-handoff-error/);
     assert.match(page, /data-cloud-console-environment/);
     assert.match(page, /data-cloud-console-link/);

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 
 import {
+  CLOUD_CONSOLE_BASE_PARAM,
+  DEFAULT_CLOUD_CONSOLE_BASE_URL,
   CLOUD_CONSOLE_URL,
   GO_PLAN,
   PLANS_JSON_URL,
@@ -10,6 +12,7 @@ import {
   cloudSubscribeUrl,
   cloudTeamSubscribeUrl,
   formatUsd,
+  resolveCloudConsoleBase,
   scopedBillingPlanUrl,
   teamIntroTotalUsd,
   type PricingContract,
@@ -686,6 +689,58 @@ describe("pricing contract", () => {
       "https://open-design.ai/cloud/dashboard?billing=plan&workspaceId=workspace-a",
     );
     assert.equal(scopedBillingPlanUrl("  "), CLOUD_CONSOLE_URL);
+  });
+
+  it("returns Pricing selections to an allowlisted Cloud Console environment", async () => {
+    assert.equal(CLOUD_CONSOLE_BASE_PARAM, "cloud_console_base");
+    assert.equal(
+      resolveCloudConsoleBase(null),
+      DEFAULT_CLOUD_CONSOLE_BASE_URL,
+    );
+    assert.equal(
+      resolveCloudConsoleBase("https://vela.powerformer.net/"),
+      "https://vela.powerformer.net/",
+    );
+    assert.equal(
+      resolveCloudConsoleBase("https://amr-feature.powerformer.net/"),
+      "https://amr-feature.powerformer.net/",
+    );
+    assert.equal(
+      resolveCloudConsoleBase("http://127.0.0.1:5179/"),
+      "http://127.0.0.1:5179/",
+    );
+
+    for (const invalid of [
+      "https://evil.example/",
+      "https://open-design.ai/",
+      "https://user:password@vela.powerformer.net/",
+      "http://vela.powerformer.net/",
+      "http://localhost:5173/dashboard",
+      "javascript:alert(1)",
+    ]) {
+      assert.throws(() => resolveCloudConsoleBase(invalid), /Cloud Console base/);
+    }
+
+    const [page, individualPlans] = await Promise.all([
+      readFile(PRICING_PAGE_PATH, "utf8"),
+      readFile(PRICING_INDIVIDUAL_PATH, "utf8"),
+    ]);
+    assert.match(page, /inboundParams\.get\(cloudConsoleBaseParam\)/);
+    assert.match(page, /data-cloud-console-handoff-error/);
+    assert.match(page, /data-cloud-console-environment/);
+    assert.match(page, /cta\.setAttribute\('aria-disabled', 'true'\)/);
+    assert.match(
+      page,
+      /data-cloud-console-environment'\) === 'production'/,
+    );
+    assert.doesNotMatch(
+      individualPlans,
+      /href=\{cloudSubscribeUrl\([^)]*\)\}[^>]*data-pricing-cta/,
+    );
+    assert.doesNotMatch(
+      page,
+      /href=\{CLOUD_CONSOLE_URL\}[^>]*data-pricing-cta/,
+    );
   });
 
   it("recognizes only the signed-in account's current personal plan for CTA copy", async () => {

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -728,6 +728,11 @@ describe("pricing contract", () => {
     assert.match(page, /inboundParams\.get\(cloudConsoleBaseParam\)/);
     assert.match(page, /data-cloud-console-handoff-error/);
     assert.match(page, /data-cloud-console-environment/);
+    assert.match(page, /data-cloud-console-link/);
+    assert.match(
+      page,
+      /consoleLink\.setAttribute\('href', cloudConsoleDashboardUrl\)/,
+    );
     assert.match(page, /cta\.setAttribute\('aria-disabled', 'true'\)/);
     assert.match(
       page,


### PR DESCRIPTION
## Why

Pricing is hosted by the public Landing project, while authenticated checkout is owned by Vela. The page previously hard-coded the production Cloud Console, so a user arriving from test, feature-test, or local Vela could be sent into production after choosing a plan.

This keeps the existing project boundary while making the handoff environment-aware and closed to arbitrary redirect targets.

## What users will see

- Direct visits to public Pricing continue to use the production Cloud Console.
- Visits carrying an allowlisted `cloud_console_base` return Free, paid, and Team selections to that same test, feature-test, or loopback Vela environment.
- Hosted destinations allow HTTPS on `open-design.ai`, `powerformer.net`, and their subdomains; lookalike suffixes, credentials, query/hash state, and non-standard ports remain blocked.
- The generic Cloud Console link on Pricing follows the same validated destination.
- An explicit invalid destination shows a localized error and disables checkout CTAs instead of silently falling back to production.
- Non-production visits do not query the production current-subscription endpoint.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual change for valid handoffs. Invalid explicit destinations now render a localized inline error and make all subscription CTAs inert.

## Bug fix verification

- Test path: `apps/landing-page/tests/pricing-contract.test.ts`
- The new contract test failed before the implementation (missing resolver and unsafe static production CTA hrefs), then passed after the source change.

## Validation

- `node --import tsx --test tests/pricing-contract.test.ts` — 50 passed after merging latest `main`
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- `pnpm --filter @open-design/landing-page build:static` — all tests passed; 6,709 pages built; localized route and example-copy verification passed
- Local browser QA — production default, test, feature-test, loopback, invalid destination, Team CTA, and unauthenticated Vela redirect intent verified

## Coordination and rollout

Deploy this Landing change before the companion Vela change. That order is backward compatible: old Vela links omit the new parameter and continue to use production, while new Vela links become environment-aware as soon as the companion deploys.

Companion Vela PR: https://github.com/powerformer/vela/pull/1706
