### PR TITLE
fix(pricing): align P1 acceptance details

### DIFF
--- a/apps/landing-page/app/_components/pricing-individual-plans.astro
+++ b/apps/landing-page/app/_components/pricing-individual-plans.astro
@@ -88,25 +88,43 @@ const unlimitedByTier: Record<TierId, Set<string>> = {
   max: new Set(popularModels.map((model) => model.name)),
 };
 
+const popularOrderByTier: Record<TierId, string[]> = {
+  go: [
+    'DeepSeek V4 Flash',
+    'DeepSeek V4 Pro',
+    'GLM-5.2',
+    'Kimi K2.7 Code',
+    'MiniMax M2.7',
+    'Kimi K2.6',
+    'MiMo V2.5 Pro',
+    'GLM-5.1',
+  ],
+  plus: ['DeepSeek V4 Flash', 'DeepSeek V4 Pro', 'GLM-5.2', 'Kimi K2.7 Code'],
+  pro: [
+    'DeepSeek V4 Flash',
+    'DeepSeek V4 Pro',
+    'GLM-5.2',
+    'Kimi K2.7 Code',
+    'MiniMax M2.7',
+  ],
+  max: [
+    'DeepSeek V4 Flash',
+    'DeepSeek V4 Pro',
+    'GLM-5.2',
+    'Kimi K2.7 Code',
+    'MiniMax M2.7',
+    'Kimi K2.6',
+    'MiMo V2.5 Pro',
+    'GLM-5.1',
+  ],
+};
+
 const popularOrderForTier = (tier: TierId) => {
-  const unlimited = unlimitedByTier[tier];
-  if (tier === 'go' || tier === 'plus') {
-    const lead = ['DeepSeek V4 Flash', 'DeepSeek V4 Pro'];
-    return [
-      ...lead.map((name) => popularModels.find((model) => model.name === name)!),
-      ...popularModels.filter((model) => !lead.includes(model.name)),
-    ];
-  }
-  if (tier === 'pro') {
-    const lead = ['DeepSeek V4 Flash', 'MiMo V2.5 Pro', 'Kimi K2.7 Code'];
-    return [
-      ...lead.map((name) => popularModels.find((model) => model.name === name)!),
-      ...popularModels.filter((model) => !lead.includes(model.name)),
-    ];
-  }
-  return [...popularModels].sort(
-    (a, b) => Number(unlimited.has(b.name)) - Number(unlimited.has(a.name)),
-  );
+  const lead = popularOrderByTier[tier];
+  return [
+    ...lead.map((name) => popularModels.find((model) => model.name === name)!),
+    ...popularModels.filter((model) => !lead.includes(model.name)),
+  ];
 };
 
 const renderCatalogLabel = (label: string) => fillTemplate(label, {
@@ -160,9 +178,7 @@ const tierBenefits: Record<TierId, string[]> = {
 };
 
 const compactSavings = (amountUsd: number, interval: 'monthly' | 'yearly') => {
-  const amount = locale === 'en'
-    ? formatUsd(amountUsd).replace('$', '')
-    : formatUsd(amountUsd);
+  const amount = formatUsd(amountUsd);
   return locale === 'en' && interval === 'monthly' ? `${amount}/mo` : amount;
 };
 const compactBillingTotal = (amountUsd: number) =>
@@ -263,9 +279,9 @@ const comparisonPopular = [
   'DeepSeek V4 Pro',
   'GLM-5.2',
   'Kimi K2.7 Code',
-  'MiMo V2.5 Pro',
   'MiniMax M2.7',
   'Kimi K2.6',
+  'MiMo V2.5 Pro',
   'GLM-5.1',
 ].map((name) => popularModels.find((model) => model.name === name)!);
 
@@ -386,7 +402,13 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
               <small>{view.yearly.billed}</small>
             </div>
 
-            <a class="pricing-card-cta" href={cloudSubscribeUrl(tier, 'yearly')} data-pricing-cta data-tier={tier}>
+            <a
+              class="pricing-card-cta"
+              href={cloudSubscribeUrl(tier, 'yearly')}
+              data-pricing-cta
+              data-tier={tier}
+              data-plan-name={tier.charAt(0).toUpperCase() + tier.slice(1)}
+            >
               <span>{tierCopy[tier].ctaLabel}</span>
             </a>
 
@@ -656,7 +678,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
     line-height: 1;
     letter-spacing: 0.055em;
     text-align: center;
-    background: var(--pricing-accent);
+    background: #d8ffb5;
     border-radius: 12px 12px 0 0;
   }
 
@@ -834,7 +856,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
     line-height: 1;
     text-decoration: none;
     background: #11120f;
-    border: 1px solid #11120f;
+    border: 0;
     border-radius: 8px;
     transition: transform 0.2s, background-color 0.18s;
     overflow: hidden;
@@ -851,7 +873,6 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
   .plan-max .pricing-card-cta {
     color: #10140d;
     background: var(--pricing-accent);
-    border-color: var(--pricing-accent);
   }
 
   .plan-pro .pricing-card-cta:hover,
@@ -865,7 +886,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
   .pricing-card .pricing-card-cta[aria-disabled='true']:focus-visible {
     color: #595d54;
     background: #d8dad4;
-    border-color: #c5c8c0;
+    border: 0;
     cursor: not-allowed;
     transform: none;
   }
@@ -1566,18 +1587,21 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
   .model-name-cell > .model-logo { margin-right: 9px; }
 
   .model-access-status {
-    display: inline-flex;
+    display: inline-grid;
+    grid-template-columns: 23px max-content;
     align-items: center;
-    justify-content: center;
+    justify-content: start;
+    gap: 8px;
+    width: 104px;
+    margin: 0 auto;
     color: #1f7e16;
     font-size: 12px;
     font-weight: 650;
     white-space: nowrap;
   }
 
-  .model-access-status.unlimited { gap: 8px; }
   .model-access-status.more-ample {
-    width: 23px;
+    width: 104px;
     height: 23px;
   }
   .model-access-status.resolution { font-weight: 500; }
@@ -1612,7 +1636,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
 
   .model-access-status.ample,
   .model-access-status.included {
-    width: 23px;
+    width: 104px;
     height: 23px;
     overflow: hidden;
     font-size: 0;
@@ -1620,6 +1644,8 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
 
   .model-access-status.ample::after,
   .model-access-status.included::after {
+    grid-column: 1;
+    justify-self: center;
     width: 5px;
     height: 9px;
     content: '';
@@ -1630,7 +1656,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
 
   .model-access-status.unavailable {
     position: relative;
-    width: 23px;
+    width: 104px;
     height: 23px;
     overflow: hidden;
     color: #a5aaa1;
@@ -1640,7 +1666,7 @@ const otherModels = 'Gemini-3.1-Pro, Grok-4.5, GPT-5.4, GPT-5.6-Terra, Qwen3.7-M
   .model-access-status.unavailable::after {
     position: absolute;
     top: 50%;
-    left: 50%;
+    left: 11.5px;
     width: 9px;
     height: 1.5px;
     content: '';

--- a/apps/landing-page/app/_lib/pricing-content.ts
+++ b/apps/landing-page/app/_lib/pricing-content.ts
@@ -16,21 +16,31 @@
  */
 import type { LandingLocaleCode } from '../i18n';
 
-const CURRENT_PLAN_LABELS: Partial<Record<LandingLocaleCode, string>> = {
-  en: 'Current plan',
-  zh: '当前套餐',
-  'zh-tw': '目前方案',
-  ja: '現在のプラン',
-  ko: '현재 요금제',
-  de: 'Aktueller Tarif',
-  fr: 'Offre actuelle',
-  ru: 'Текущий тариф',
-  es: 'Plan actual',
-  'pt-br': 'Plano atual',
+export interface PricingPlanActionLabels {
+  current: string;
+  downgrade: string;
+  upgrade: string;
+}
+
+const PLAN_ACTION_LABELS: Partial<Record<LandingLocaleCode, PricingPlanActionLabels>> = {
+  en: { current: 'Current plan', downgrade: 'Downgrade to {plan}', upgrade: 'Upgrade to {plan}' },
+  zh: { current: '当前套餐', downgrade: '降级至 {plan}', upgrade: '升级至 {plan}' },
+  'zh-tw': { current: '目前方案', downgrade: '降級至 {plan}', upgrade: '升級至 {plan}' },
+  ja: { current: '現在のプラン', downgrade: '{plan} にダウングレード', upgrade: '{plan} にアップグレード' },
+  ko: { current: '현재 요금제', downgrade: '{plan}(으)로 다운그레이드', upgrade: '{plan}(으)로 업그레이드' },
+  de: { current: 'Aktueller Tarif', downgrade: 'Auf {plan} downgraden', upgrade: 'Auf {plan} upgraden' },
+  fr: { current: 'Offre actuelle', downgrade: 'Rétrograder vers {plan}', upgrade: 'Passer à {plan}' },
+  ru: { current: 'Текущий тариф', downgrade: 'Понизить до {plan}', upgrade: 'Повысить до {plan}' },
+  es: { current: 'Plan actual', downgrade: 'Bajar a {plan}', upgrade: 'Subir a {plan}' },
+  'pt-br': { current: 'Plano atual', downgrade: 'Fazer downgrade para {plan}', upgrade: 'Fazer upgrade para {plan}' },
 };
 
 export function getCurrentPlanLabel(locale: LandingLocaleCode): string {
-  return CURRENT_PLAN_LABELS[locale] ?? CURRENT_PLAN_LABELS.en!;
+  return getPricingPlanActionLabels(locale).current;
+}
+
+export function getPricingPlanActionLabels(locale: LandingLocaleCode): PricingPlanActionLabels {
+  return PLAN_ACTION_LABELS[locale] ?? PLAN_ACTION_LABELS.en!;
 }
 
 export type PlanTierId = 'plus' | 'pro' | 'max';

--- a/apps/landing-page/app/_lib/pricing-current-plan.ts
+++ b/apps/landing-page/app/_lib/pricing-current-plan.ts
@@ -31,6 +31,20 @@ export function isPersonalPlanAtOrBelow(
   );
 }
 
+export function personalPlanRelation(
+  candidateTier: string,
+  currentTier: PersonalPlanTier,
+): 'lower' | 'current' | 'higher' | null {
+  const candidateIndex = PERSONAL_PLAN_ORDER.indexOf(
+    candidateTier as PersonalPlanTier,
+  );
+  if (candidateIndex < 0) return null;
+  const currentIndex = PERSONAL_PLAN_ORDER.indexOf(currentTier);
+  if (candidateIndex < currentIndex) return 'lower';
+  if (candidateIndex === currentIndex) return 'current';
+  return 'higher';
+}
+
 function personalPlanTier(value: unknown): PersonalPlanTier | null {
   if (typeof value !== 'string') return null;
   const normalized = value.trim().toLowerCase().replace(/_(monthly|yearly)$/, '');

--- a/apps/landing-page/app/pages/pricing/index.astro
+++ b/apps/landing-page/app/pages/pricing/index.astro
@@ -21,7 +21,7 @@ import {
   type TeamPlanTierConfig,
 } from '../../_lib/pricing';
 import {
-  getCurrentPlanLabel,
+  getPricingPlanActionLabels,
   getPricingContent,
   fillTemplate,
 } from '../../_lib/pricing-content';
@@ -40,7 +40,7 @@ const locale = localeFromPath(Astro.url.pathname);
 const isZh = locale === 'zh' || locale === 'zh-tw';
 const href = (path: string) => localizedHref(path, locale);
 const content = getPricingContent(locale);
-const currentPlanLabel = getCurrentPlanLabel(locale);
+const planActionLabels = getPricingPlanActionLabels(locale);
 const teamContent = getTeamPricingContent(locale);
 const L = content.labels;
 const env = import.meta.env as Record<string, string | undefined>;
@@ -184,13 +184,24 @@ const jsonLd = [
     data-audience="creator"
     data-interval="yearly"
     data-billing-api-origin={apiOrigin}
-    data-current-plan-label={currentPlanLabel}
+    data-current-plan-label={planActionLabels.current}
+    data-downgrade-plan-label={planActionLabels.downgrade}
+    data-upgrade-plan-label={planActionLabels.upgrade}
     data-campaign-start-at={DEEPSEEK_V4_PRO_CAMPAIGN.startAt}
     data-campaign-end-at={DEEPSEEK_V4_PRO_CAMPAIGN.endAtExclusive}
   >
     <header class="pr-hero">
       <h1 class="pr-hero-heading">{isZh ? '零配置，只为结果付费' : locale === 'en' ? 'Zero setup. Pay only for results.' : L.heroTitle}</h1>
       <div class="pr-controls-row">
+        <div class="pr-toggle" role="tablist" aria-label={teamContent.billingIntervalLabel}>
+          <button type="button" class="pr-toggle-btn" role="tab" data-interval-btn="monthly" aria-selected="false">
+            {L.monthly}
+          </button>
+          <button type="button" class="pr-toggle-btn is-active" role="tab" data-interval-btn="yearly" aria-selected="true">
+            <span>{L.yearly}</span>
+            <span class="pr-toggle-save">{L.yearlySave}</span>
+          </button>
+        </div>
         <div class="pr-audience-toggle" role="tablist" aria-label={teamContent.audienceTabsLabel}>
           <button
             id="pr-audience-creator"
@@ -204,6 +215,7 @@ const jsonLd = [
           >
             {isZh ? '个人' : locale === 'en' ? 'Individual' : teamContent.creatorTab}
           </button>
+          <span class="pr-audience-separator" aria-hidden="true">/</span>
           <button
             id="pr-audience-team"
             type="button"
@@ -216,16 +228,6 @@ const jsonLd = [
           >
             {isZh ? '团队' : locale === 'en' ? 'Team' : teamContent.teamTab}
           </button>
-        </div>
-        <div class="pr-toggle" role="tablist" aria-label={teamContent.billingIntervalLabel}>
-          <button type="button" class="pr-toggle-btn" role="tab" data-interval-btn="monthly" aria-selected="false">
-            {L.monthly}
-          </button>
-          <span class="pr-toggle-separator" aria-hidden="true">/</span>
-          <button type="button" class="pr-toggle-btn is-active" role="tab" data-interval-btn="yearly" aria-selected="true">
-            {L.yearly}
-          </button>
-          <span class="pr-toggle-save">{L.yearlySave}</span>
         </div>
       </div>
     </header>
@@ -1011,28 +1013,40 @@ const jsonLd = [
   </script>
   <script>
     import {
-      isPersonalPlanAtOrBelow,
       loadCurrentPersonalPlanTier,
+      personalPlanRelation,
     } from '../../_lib/pricing-current-plan';
 
     const pricingRoot = document.querySelector('[data-pricing-root]');
     if (pricingRoot) {
       const apiOrigin = pricingRoot.getAttribute('data-billing-api-origin') || '';
       const currentPlanLabel = pricingRoot.getAttribute('data-current-plan-label') || '';
+      const downgradePlanLabel = pricingRoot.getAttribute('data-downgrade-plan-label') || '';
+      const upgradePlanLabel = pricingRoot.getAttribute('data-upgrade-plan-label') || '';
+      const fillPlanLabel = (template: string, plan: string) =>
+        template.replace('{plan}', plan);
       void loadCurrentPersonalPlanTier(apiOrigin).then((currentTier) => {
-        if (!currentTier || !currentPlanLabel) return;
+        if (!currentTier || !currentPlanLabel || !downgradePlanLabel || !upgradePlanLabel) return;
         for (const cta of pricingRoot.querySelectorAll('[data-pricing-cta]')) {
           const tier = cta.getAttribute('data-tier') || '';
-          if (!isPersonalPlanAtOrBelow(tier, currentTier)) continue;
+          const relation = personalPlanRelation(tier, currentTier);
+          if (!relation) continue;
+          const label = cta.querySelector(':scope > span');
+          const plan = cta.getAttribute('data-plan-name') || tier;
+          if (relation === 'higher') {
+            if (label) label.textContent = fillPlanLabel(upgradePlanLabel, plan);
+            continue;
+          }
           cta.setAttribute('data-subscription-disabled', '');
           cta.setAttribute('aria-disabled', 'true');
           cta.setAttribute('tabindex', '-1');
           cta.removeAttribute('href');
+          if (label) {
+            label.textContent = relation === 'current'
+              ? currentPlanLabel
+              : fillPlanLabel(downgradePlanLabel, plan);
+          }
         }
-        const label = pricingRoot.querySelector(
-          `[data-pricing-cta][data-tier="${currentTier}"] > span`,
-        );
-        if (label) label.textContent = currentPlanLabel;
       });
     }
   </script>
@@ -1102,48 +1116,54 @@ const jsonLd = [
     margin-top: 65px;
   }
   .pr-toggle {
-    grid-column: 3;
-    justify-self: end;
+    grid-column: 2;
+    justify-self: center;
     display: inline-flex;
     align-items: center;
-    gap: 0;
-    min-height: 42px;
-    margin-right: 24px;
+    gap: 4px;
+    min-height: 48px;
+    padding: 4px;
+    background: #e8e9e3;
+    border-radius: 999px;
   }
   .pr-toggle[hidden] { display: none !important; }
   .pr-audience-toggle {
-    grid-column: 2;
+    grid-column: 3;
     position: relative;
     display: flex;
-    justify-content: center;
+    justify-self: end;
+    justify-content: flex-end;
     align-items: center;
-    gap: 10px;
-    width: 420px;
+    gap: 8px;
+    margin-right: 24px;
   }
   .pr-toggle-btn {
     display: inline-flex;
     align-items: center;
-    min-height: 36px;
+    gap: 10px;
+    min-height: 40px;
     border: 0;
     background: transparent;
+    border-radius: 999px;
     cursor: pointer;
     font-family: Albert Sans, Arial, sans-serif;
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 600;
     line-height: 1;
     color: #858980;
-    padding: 0 2px;
-    transition: color 200ms cubic-bezier(0.23, 1, 0.32, 1);
+    padding: 0 18px;
+    transition: color 200ms cubic-bezier(0.23, 1, 0.32, 1), background-color 200ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 200ms cubic-bezier(0.23, 1, 0.32, 1);
   }
-  .pr-toggle-btn.is-active { color: #151712; }
-  .pr-toggle-separator { margin: 0 9px; color: #c0c3bb; font-size: 14px; }
+  .pr-toggle-btn.is-active {
+    color: #151712;
+    background: #fff;
+    box-shadow: 0 1px 4px rgb(31 36 27 / 12%);
+  }
   .pr-audience-btn {
     position: relative;
-    min-width: 60px;
-    min-height: 38px;
-    padding: 0 16px;
+    min-height: 36px;
+    padding: 0 2px;
     border: 0;
-    border-radius: 9px;
     background: transparent;
     color: #74786f;
     font-family: Albert Sans, Arial, sans-serif;
@@ -1152,14 +1172,13 @@ const jsonLd = [
     line-height: 1;
     white-space: nowrap;
     cursor: pointer;
-    transition: color 200ms cubic-bezier(0.23, 1, 0.32, 1), background-color 200ms cubic-bezier(0.23, 1, 0.32, 1);
+    transition: color 200ms cubic-bezier(0.23, 1, 0.32, 1);
   }
   .pr-audience-btn.is-active {
     color: #11120f;
-    background: #e8e9e3;
   }
+  .pr-audience-separator { color: #c0c3bb; font-size: 14px; }
   .pr-toggle-save {
-    margin-left: 7px;
     padding: 0;
     color: #2f8b25;
     background: transparent;
@@ -1172,8 +1191,7 @@ const jsonLd = [
     .pr-controls-row { grid-template-columns: 1fr; gap: 14px; }
     .pr-audience-toggle,
     .pr-toggle { grid-column: 1; justify-self: center; }
-    .pr-audience-toggle { width: 100%; }
-    .pr-toggle { margin-right: 0; }
+    .pr-audience-toggle { margin-right: 0; }
   }
 
   /* ---- Interval-conditional visibility ---- */
@@ -1314,7 +1332,7 @@ const jsonLd = [
     margin: 40px auto 0;
     max-width: 640px;
     text-align: center;
-    font-size: 0.82rem;
+    font-size: 10.5px;
     line-height: 1.6;
     color: var(--ink-soft, #666);
   }

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -21,11 +21,13 @@ import {
 import {
   PREMIUM_MODELS,
   getCurrentPlanLabel,
+  getPricingPlanActionLabels,
   getPricingContent,
 } from "../app/_lib/pricing-content.ts";
 import {
   isPersonalPlanAtOrBelow,
   loadCurrentPersonalPlanTier,
+  personalPlanRelation,
 } from "../app/_lib/pricing-current-plan.ts";
 import { LANDING_LOCALES } from "../app/i18n.ts";
 import { DEEPSEEK_V4_PRO_CAMPAIGN } from "../app/_lib/deepseek-v4-pro-campaign.ts";
@@ -207,6 +209,7 @@ describe("pricing contract", () => {
       individualPlans,
       /const compactSavings = \(amountUsd: number, interval: 'monthly' \| 'yearly'\)/,
     );
+    assert.match(individualPlans, /const amount = formatUsd\(amountUsd\);/);
     assert.match(
       individualPlans,
       /locale === 'en' && interval === 'monthly' \? `\$\{amount\}\/mo` : amount/,
@@ -215,6 +218,11 @@ describe("pricing contract", () => {
       individualPlans,
       /const compactBillingTotal = \(amountUsd: number\) =>\s*locale === 'en'/,
     );
+    const compactSavingsBlock = individualPlans.match(
+      /const compactSavings = \(amountUsd: number, interval: 'monthly' \| 'yearly'\) => \{([\s\S]*?)\n\};/,
+    )?.[1];
+    assert.ok(compactSavingsBlock);
+    assert.doesNotMatch(compactSavingsBlock, /replace\('\$', ''\)/);
   });
 
   it("keeps recommendation ribbons legible, animated, and motion-safe", async () => {
@@ -223,6 +231,10 @@ describe("pricing contract", () => {
     assert.match(
       individualPlans,
       /\.new-plan-ribbon\s*\{[^}]*font-size:\s*11px;/s,
+    );
+    assert.match(
+      individualPlans,
+      /\.new-plan-ribbon\s*\{[^}]*background:\s*#d8ffb5;/s,
     );
     assert.match(
       individualPlans,
@@ -307,7 +319,7 @@ describe("pricing contract", () => {
     assert.doesNotMatch(page, /\{false && \(/);
     assert.doesNotMatch(page, /<section class="pr-grid"/);
     assert.match(individualPlans, /tier:\s*'go' as const/);
-    assert.match(individualPlans, /data-pricing-cta data-tier=\{tier\}/);
+    assert.match(individualPlans, /data-pricing-cta\s+data-tier=\{tier\}/);
     assert.deepEqual(GO_PLAN, {
       tier: "go",
       monthly: { priceUsd: 10, introPriceUsd: 5 },
@@ -407,28 +419,48 @@ describe("pricing contract", () => {
     assert.equal(proUnlimitedModels.includes("MiniMax M2.7"), false);
   });
 
-  it("groups the Pro unlimited models together and keeps ample access check-only", async () => {
+  it("uses the reviewed popular-model order and keeps ample access check-only", async () => {
     const individualPlans = await readFile(PRICING_INDIVIDUAL_PATH, "utf8");
     const comparisonBlock = individualPlans.match(
       /const comparisonPopular = \[([\s\S]*?)\]\.map/,
     )?.[1];
 
     assert.ok(comparisonBlock);
+    const reviewedOrder = [
+      "DeepSeek V4 Flash",
+      "DeepSeek V4 Pro",
+      "GLM-5.2",
+      "Kimi K2.7 Code",
+      "MiniMax M2.7",
+      "Kimi K2.6",
+      "MiMo V2.5 Pro",
+      "GLM-5.1",
+    ];
     assert.deepEqual(
-      Array.from(comparisonBlock.matchAll(/'([^']+)'/g), (match) => match[1]).slice(0, 6),
-      [
-        "DeepSeek V4 Flash",
-        "DeepSeek V4 Pro",
-        "GLM-5.2",
-        "Kimi K2.7 Code",
-        "MiMo V2.5 Pro",
-        "MiniMax M2.7",
-      ],
+      Array.from(comparisonBlock.matchAll(/'([^']+)'/g), (match) => match[1]),
+      reviewedOrder,
     );
+    assert.match(individualPlans, /go:\s*\[[\s\S]*?'GLM-5\.1',\s*\],\s*plus:/);
+    assert.match(individualPlans, /plus:\s*\['DeepSeek V4 Flash', 'DeepSeek V4 Pro', 'GLM-5\.2', 'Kimi K2\.7 Code'\]/);
+    assert.match(individualPlans, /pro:\s*\[[\s\S]*?'MiniMax M2\.7',\s*\],\s*max:/);
     assert.match(
       individualPlans,
       /status\.kind === 'more-ample'\s*\?\s*\(\s*<td><span class=\{`model-access-status \$\{status\.kind\}`\} aria-label=\{status\.text\}><i class="status-icon check"><\/i><\/span><\/td>/s,
     );
+    assert.match(
+      individualPlans,
+      /\.model-access-status\s*\{[^}]*grid-template-columns:\s*23px max-content;[^}]*width:\s*104px;[^}]*margin:\s*0 auto;/s,
+    );
+  });
+
+  it("matches the legal footnote size to the model allowance note", async () => {
+    const [page, individualPlans] = await Promise.all([
+      readFile(PRICING_PAGE_PATH, "utf8"),
+      readFile(PRICING_INDIVIDUAL_PATH, "utf8"),
+    ]);
+
+    assert.match(individualPlans, /\.individual-usage-note p\s*\{[^}]*font-size:\s*10\.5px;/s);
+    assert.match(page, /\.pr-foot\s*\{[^}]*font-size:\s*10\.5px;/s);
   });
 
   it("renders paid flagship headings as one localized phrase", async () => {
@@ -715,6 +747,11 @@ describe("pricing contract", () => {
     );
     assert.equal(getCurrentPlanLabel("en"), "Current plan");
     assert.equal(getCurrentPlanLabel("zh"), "当前套餐");
+    assert.deepEqual(getPricingPlanActionLabels("en"), {
+      current: "Current plan",
+      downgrade: "Downgrade to {plan}",
+      upgrade: "Upgrade to {plan}",
+    });
   });
 
   it("disables the current personal plan and every downgrade target", () => {
@@ -726,6 +763,10 @@ describe("pricing contract", () => {
     );
     assert.equal(isPersonalPlanAtOrBelow("team", "pro"), false);
     assert.equal(isPersonalPlanAtOrBelow("max", "pro"), false);
+    assert.equal(personalPlanRelation("go", "pro"), "lower");
+    assert.equal(personalPlanRelation("pro", "pro"), "current");
+    assert.equal(personalPlanRelation("max", "pro"), "higher");
+    assert.equal(personalPlanRelation("team", "pro"), null);
   });
 
   it("keeps CTA copy unchanged when subscription identity is unavailable or non-personal", async () => {
@@ -759,10 +800,14 @@ describe("pricing contract", () => {
     ]);
 
     assert.match(page, /data-billing-api-origin=\{apiOrigin\}/);
-    assert.match(page, /data-current-plan-label=\{currentPlanLabel\}/);
+    assert.match(page, /data-current-plan-label=\{planActionLabels\.current\}/);
+    assert.match(page, /data-downgrade-plan-label=\{planActionLabels\.downgrade\}/);
+    assert.match(page, /data-upgrade-plan-label=\{planActionLabels\.upgrade\}/);
     assert.match(page, /loadCurrentPersonalPlanTier\(apiOrigin\)/);
-    assert.match(page, /\[data-pricing-cta\]\[data-tier="\$\{currentTier\}"\] > span/);
-    assert.match(page, /isPersonalPlanAtOrBelow\(tier, currentTier\)/);
+    assert.match(page, /personalPlanRelation\(tier, currentTier\)/);
+    assert.match(page, /relation === 'current'/);
+    assert.match(page, /fillPlanLabel\(downgradePlanLabel, plan\)/);
+    assert.match(page, /fillPlanLabel\(upgradePlanLabel, plan\)/);
     assert.match(page, /cta\.setAttribute\('aria-disabled', 'true'\)/);
     assert.match(page, /cta\.setAttribute\('tabindex', '-1'\)/);
     assert.match(page, /cta\.removeAttribute\('href'\)/);
@@ -771,7 +816,8 @@ describe("pricing contract", () => {
       individualPlans,
       /\.pricing-card-cta\[aria-disabled='true'\][\s\S]*?cursor:\s*not-allowed;/,
     );
-    assert.match(individualPlans, /data-pricing-cta data-tier=\{tier\}/);
+    assert.match(individualPlans, /data-pricing-cta\s+data-tier=\{tier\}/);
+    assert.match(individualPlans, /\.pricing-card-cta\s*\{[^}]*border:\s*0;/s);
   });
 
   it("preserves only an explicit inbound workspace without inferring local state", async () => {
@@ -953,24 +999,22 @@ describe("pricing contract", () => {
     // generic global section padding must be cancelled on the component root.
     assert.match(individualPlans, /\.demo-individual-pricing\s*\{[^}]*padding:\s*0 !important;/s);
 
-    // Creator/Team and billing interval share one compact row above the
-    // Individual cards. The billing group is right-aligned and disappears
-    // entirely when the Team tab is active, matching the approved demo.
+    // Billing is the centered segmented control. Individual/Team stays as the
+    // plain right-aligned slash control and billing hides for Team.
     assert.match(page, /class="pr-audience-toggle"[^>]*role="tablist"/);
     assert.match(page, /\.pr-controls-row\s*\{[^}]*grid-template-columns:\s*1fr auto 1fr;/s);
-    assert.match(page, /\.pr-toggle\s*\{[^}]*grid-column:\s*3;[^}]*justify-self:\s*end;/s);
+    assert.match(page, /\.pr-toggle\s*\{[^}]*grid-column:\s*2;[^}]*justify-self:\s*center;[^}]*background:\s*#e8e9e3;[^}]*border-radius:\s*999px;/s);
     assert.match(
       page,
-      /\.pr-toggle-btn\s*\{[^}]*min-height:\s*36px;[^}]*font-size:\s*13px;[^}]*font-weight:\s*600;[^}]*line-height:\s*1;/s,
+      /\.pr-toggle-btn\s*\{[^}]*min-height:\s*40px;[^}]*border-radius:\s*999px;[^}]*font-size:\s*14px;[^}]*font-weight:\s*600;/s,
     );
     assert.match(
       page,
-      /\.pr-audience-btn\s*\{[^}]*border-radius:\s*9px;[^}]*font-size:\s*14px;[^}]*font-weight:\s*600;/s,
+      /\.pr-audience-toggle\s*\{[^}]*grid-column:\s*3;[^}]*justify-self:\s*end;[^}]*margin-right:\s*24px;/s,
     );
-    assert.match(
-      page,
-      /\.pr-audience-btn\.is-active\s*\{[^}]*background:\s*#e8e9e3;/s,
-    );
+    assert.match(page, /<span class="pr-audience-separator" aria-hidden="true">\/<\/span>/);
+    assert.match(page, /<span class="pr-toggle-save">\{L\.yearlySave\}<\/span>/);
+    assert.doesNotMatch(page, /class="pr-toggle-separator"/);
     assert.match(
       page,
       /const billingToggle = root\.querySelector\('\.pr-toggle'\);[\s\S]*?billingToggle\.hidden = audience === 'team';/,


### PR DESCRIPTION
## Why

Follow-up to merged #7167 after the current [Feishu acceptance review](https://powerformer.feishu.cn/wiki/SdbywL1TViN4sCkDH4ecgLOyntf). The first six P1 items had concrete content and layout mismatches on the public Pricing page: missing currency symbols in savings, inconsistent model ordering and status alignment, mismatched note typography, ambiguous signed-in plan actions, and misplaced controls.

This branch is based on the latest `main`. It preserves the subscription safety boundary from #7191 (current and lower tiers stay non-navigable) and the entitlement/Team fixes from #7196.

## What users will see

- Savings amounts keep the `$` currency symbol.
- Popular models follow the accepted ordering, with aligned status/check columns.
- The legal footnote matches the model allowance note size.
- Monthly/Yearly is centered; Individual/Team is the right-aligned slash control.
- Signed-in users see Current, Downgrade, or Upgrade copy appropriate to each Personal tier; current and lower tiers remain disabled.
- Pricing recommendation ribbons use the homepage label green (`#d8ffb5`), and plan CTAs no longer show an outline.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API / contracts
- [ ] Agent runtime
- [ ] Desktop / packaged app
- [ ] CI / release tooling
- [ ] Documentation
- [x] i18n keys or localized copy
- [ ] Extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`)
- [ ] CLI flags
- [ ] Environment variables
- [ ] Root dependencies
- [x] Default behavior

## Screenshots

Verified locally with Playwright at 1440×1000 and 390×844 using a mocked Plus subscriber. Both viewports had no horizontal overflow; the desktop and mobile captures confirm the centered billing control, right-aligned audience control, accepted ribbon green, and all four CTA states. The acceptance reference is linked above.

## Bug-fix verification

- Red on `main`: not recorded as a standalone red-spec run. The acceptance differences were reproduced visually against `main` before implementation.
- Green on this branch: `apps/landing-page/tests/pricing-contract.test.ts` now covers the six accepted contracts plus the ribbon color.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/landing-page typecheck` (0 errors, 0 warnings)
- `pnpm --filter @open-design/landing-page test` (182 passed)
- `pnpm --filter @open-design/landing-page build` (6709 pages)
- `git diff --check`
- Playwright desktop/mobile check with mocked Plus subscription: no horizontal overflow; Go/Plus disabled, Pro/Max active; CTA borders 0; ribbon `rgb(216, 255, 181)`

## Risk and rollback

The behavior change is limited to the public Pricing page. Reverting this commit restores the previous ordering, controls, CTA copy, and styling. Checkout URLs and the existing current/lower-tier navigation guard are unchanged.
