### PR TITLE
ci: refine plan orchestration and Windows payload routing

### DIFF
--- a/.github/config/scopes.json
+++ b/.github/config/scopes.json
@@ -5,6 +5,7 @@
     "web_tests_required",
     "tools_dev_tests_required",
     "tools_pack_tests_required",
+    "windows_tools_pack_payload_tests_required",
     "ui_critical_validation_required",
     "ui_p0_validation_required",
     "visual_validation_required",
@@ -42,6 +43,29 @@
       "prefixes": [
         "apps/desktop/src/", "apps/desktop/tests/", "apps/packaged/src/", "apps/packaged/tests/",
         "tools/pack/src/", "tools/pack/tests/", "tools/pack/resources/"
+      ]
+    },
+    "windows-launcher-payload": {
+      "prefixes": [
+        "tools/pack/src/win/", "tools/pack/resources/win/",
+        "packages/launcher-proto/src/", "packages/sidecar-proto/src/"
+      ],
+      "exact": [
+        "tools/pack/src/cache.ts",
+        "tools/pack/src/config.ts",
+        "tools/pack/src/launcher-layout.ts",
+        "tools/pack/src/launcher-runtime-snapshot.ts",
+        "tools/pack/src/lock.ts",
+        "tools/pack/src/resources.ts",
+        "tools/pack/src/update-cache-lifecycle-snapshot.ts",
+        "tools/pack/src/versions.ts",
+        "tools/pack/src/win-prebundle.ts",
+        "tools/pack/tests/launcher-payload-windows.test.ts",
+        "packages/platform/src/command.ts",
+        "packages/platform/src/index.ts",
+        "packages/release/src/index.ts",
+        "packages/sidecar/src/index.ts",
+        "packages/sidecar/src/paths.ts"
       ]
     },
     "daemon-core": {
@@ -119,6 +143,12 @@
       "confidence": "certain"
     },
     {
+      "id": "certain-windows-launcher-payload",
+      "match": { "include": ["match://windows-launcher-payload"] },
+      "effects": ["windows_tools_pack_payload_tests_required"],
+      "confidence": "certain"
+    },
+    {
       "id": "tools-pack-sources",
       "match": {
         "prefixes": ["tools/pack/", "apps/packaged/", "apps/desktop/", "packages/release/", "packages/components/", "packages/host/", "packages/platform/", "packages/sidecar/", "packages/sidecar-proto/"],
@@ -132,7 +162,7 @@
         "exact": ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", ".github/workflows/ci.yml", "e2e/package.json"],
         "regexes": ["^apps/[^/]+/package\\.json$", "^packages/[^/]+/package\\.json$", "^tools/[^/]+/package\\.json$"]
       },
-      "effects": ["daemon_tests_required", "web_tests_required", "tools_dev_tests_required", "tools_pack_tests_required"],
+      "effects": ["daemon_tests_required", "web_tests_required", "tools_dev_tests_required", "tools_pack_tests_required", "windows_tools_pack_payload_tests_required"],
       "confidence": "medium"
     },
     {

--- a/.github/scripts/scopes.py
+++ b/.github/scripts/scopes.py
@@ -189,7 +189,7 @@ def enabled_workloads(outputs, ci_mode, full_lanes):
         "preflight": True,
         "workspace_unit_tests": broad,
         "daemon_unit_tests": outputs["daemon_tests_required"],
-        "windows_tools_pack_payload_tests": full_lanes or outputs["tools_pack_tests_required"],
+        "windows_tools_pack_payload_tests": full_lanes or outputs["windows_tools_pack_payload_tests_required"],
         "web_workspace_tests": full_lanes or outputs["web_tests_required"],
         "e2e_vitest": full_lanes or outputs["web_tests_required"] or outputs["ui_p0_validation_required"],
         "playwright_critical": outputs["ui_critical_validation_required"] and not ui_p0,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
           runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).windows_tools) }}
 
       - name: Windows launcher payload archive tests
-        run: pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts
+        run: pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload-windows.test.ts
 
   web_workspace_tests:
     name: Web workspace tests (${{ matrix.shard }}/2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,68 +661,25 @@ jobs:
         if: ${{ steps.visual.outcome != 'success' }}
         run: exit 1
 
-  validate:
-    name: Validate workspace
-    needs:
-      - plan
-      - runners
-      - static_gate
-      - preflight
-      - workspace_unit_tests
-      - daemon_unit_tests
-      - windows_tools_pack_payload_tests
-      - web_workspace_tests
-      - e2e_vitest
-      - playwright_critical
-      - ui_p0
-      - playwright_visual
-    if: ${{ always() }}
+  # This policy is a sibling of the validation workloads, not their prerequisite.
+  # Labeled merge groups still receive the same workload coverage before the
+  # required Validate workspace check rejects the converged result.
+  merge_policy:
+    name: Merge policy
+    needs: [plan, runners]
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
     timeout-minutes: 5
 
     steps:
-      # The merge-blocking label gate below produces a `handoff/comment` artifact when it ejects a
+      # The merge-blocking label gate produces a `handoff/comment` artifact when it ejects a
       # queued PR, and that production goes through `.github/scripts/handoff.py` (the only
-      # sanctioned source of handoff names and layout). Only the merge_group context can eject,
-      # so pull_request runs skip the checkout entirely.
+      # sanctioned source of handoff names and layout).
       - name: Checkout handoff helper
-        if: ${{ github.event_name == 'merge_group' }}
         uses: actions/checkout@v6.0.2
         with:
           sparse-checkout: .github
           sparse-checkout-cone-mode: true
-
-      - name: Check workspace validation jobs
-        env:
-          NEEDS_JSON: ${{ toJSON(needs) }}
-        run: |
-          set -euo pipefail
-          echo "$NEEDS_JSON" | jq .
-          failures="$(echo "$NEEDS_JSON" | jq -r '
-            to_entries[]
-            | select(.value.result != "success" and .value.result != "skipped")
-            | "\(.key)=\(.value.result)"')"
-          if [ -n "$failures" ]; then
-            echo "Workspace validation failed:"
-            echo "$failures"
-            exit 1
-          fi
-
-          required_misses="$(echo "$NEEDS_JSON" | jq -r '
-            . as $needs |
-            (($needs.plan.outputs.run // "{}") | fromjson) as $run |
-            (
-              ["plan"]
-              + [$run | to_entries[] | select(.value) | .key]
-            )[]
-            | select(($needs[.].result // "missing") != "success")
-            | "\(.)=\($needs[.].result // "missing")"
-          ')"
-          if [ -n "$required_misses" ]; then
-            echo "Required validation jobs did not succeed:"
-            echo "$required_misses"
-            exit 1
-          fi
 
       - name: Block merge while a merge-blocking label is present
         id: merge_blocking_label_gate
@@ -894,6 +851,59 @@ jobs:
         with:
           name: ${{ steps.merge_blocking_label_gate.outputs.comment_name }}
           path: ${{ steps.merge_blocking_label_gate.outputs.comment_path }}
+
+  validate:
+    name: Validate workspace
+    needs:
+      - plan
+      - runners
+      - merge_policy
+      - static_gate
+      - preflight
+      - workspace_unit_tests
+      - daemon_unit_tests
+      - windows_tools_pack_payload_tests
+      - web_workspace_tests
+      - e2e_vitest
+      - playwright_critical
+      - ui_p0
+      - playwright_visual
+    if: ${{ always() }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Check workspace validation jobs
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS_JSON" | jq .
+          failures="$(echo "$NEEDS_JSON" | jq -r '
+            to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | "\(.key)=\(.value.result)"')"
+          if [ -n "$failures" ]; then
+            echo "Workspace validation failed:"
+            echo "$failures"
+            exit 1
+          fi
+
+          required_misses="$(echo "$NEEDS_JSON" | jq -r '
+            . as $needs |
+            (($needs.plan.outputs.run // "{}") | fromjson) as $run |
+            (
+              ["plan"]
+              + [$run | to_entries[] | select(.value) | .key]
+            )[]
+            | select(($needs[.].result // "missing") != "success")
+            | "\(.)=\($needs[.].result // "missing")"
+          ')"
+          if [ -n "$required_misses" ]; then
+            echo "Required validation jobs did not succeed:"
+            echo "$required_misses"
+            exit 1
+          fi
 
       - name: Download pending hash map
         uses: actions/download-artifact@v8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file is the single source of truth for agents entering this repository. Rea
 - Contribution and environment: `CONTRIBUTING.md`, `docs/i18n/CONTRIBUTING.zh-CN.md`.
 - Architecture and protocols: `docs/architecture.md`, `docs/skills-protocol.md`, `docs/agent-adapters.md`, `docs/modes.md`.
 - Historical product baseline: `docs/spec.md`, `docs/roadmap.md` (both explicitly archived; do not treat their dated decisions as current behavior).
-- References and current plans: `docs/references.md`, `docs/code-review-guidelines.md`, `specs/current/maintainability-roadmap.md`, `specs/current/ci.md` (CI scope confidence methodology — required before changing confidence or guard fields in `scripts/scopes.ts`).
+- References and current plans: `docs/references.md`, `docs/code-review-guidelines.md`, `specs/current/maintainability-roadmap.md`, `specs/current/ci.md` (CI scope confidence methodology — required before changing planner confidence, routing, or omission policy in `.github/config/scopes.json` and `.github/scripts/scopes.py`).
 - Directory-level agent guidance: `.github/AGENTS.md`, `apps/AGENTS.md`, `packages/AGENTS.md`, `tools/AGENTS.md`, `e2e/AGENTS.md`.
 - Packaged auto-update architecture and high-confidence local harness: read `tools/pack/AGENTS.md` section "Packaged auto-update architecture and harness" before touching packaged updater code, release-channel identity, installer behavior, or updater UI.
 - Packaged build cache contract: `tools/pack/CACHE.md` (determinant rules, materialization-time parameters, confidence grading — required before changing any build-cache node key).
@@ -150,6 +150,58 @@ CI-related GitHub automation uses a two-layer architecture:
 - Atomic capability workflows own reusable trusted operations. `comment.atom.yml` publishes pure text PR comments, `autofix.atom.yml` applies same-repository patches, and `report.atom.yml` materializes advanced comments that need trusted dependencies, secrets, or report generation before upsert.
 
 Do not add a new business-named follow-on workflow such as `foo.comment.atom.yml` or `bar.autofix.atom.yml` without first trying to express the flow as a `ci.yml` producer plus the existing `comment`, `autofix`, or `report` capability. Keep artifact naming, storage layout, and parser behavior centralized in `.github/scripts/handoff.py`; do not let individual workflows invent parallel handoff conventions.
+
+## CI test-set orchestration
+
+CI selection follows one direction: changed paths → source units → test sets →
+execution workloads. The `plan` job runs before and governs every downstream
+job, including repository guards, so only the planner may authorize omission.
+A downstream job may reject an unknown or malformed selection, but its success
+must never be treated as evidence that an earlier omission was safe.
+
+Keep the model split into three responsibilities:
+
+- **Source units** name stable ownership or behavior boundaries in production,
+  test, fixture, and control-plane paths. Compose repeated selectors under a
+  named unit instead of copying the same prefixes into unrelated rules.
+- **Test sets** name independently useful semantic validation groups. Their
+  membership and execution contract belong to one authoritative declaration;
+  do not duplicate a matrix or file list between planner configuration,
+  workflow YAML, and a framework-local registry.
+- **Routes** map source units to the test sets required to validate them. Routes
+  express impact, not runner mechanics; runner image, setup, sharding, and job
+  packing remain execution concerns derived after selection.
+
+Split a source unit or test set only when the boundary is stable, changes the
+work that can actually be omitted, and has enough runtime cost or diagnostic
+value to justify another scheduling identity. Directory size, file count, or
+the ability to write a narrower glob is not sufficient. Prefer a small number
+of composable semantic units over per-file mappings, exception lists, or
+negative-rule forests. Existing duplicated or implicit declarations are
+migration surfaces, not patterns to extend.
+
+Every orchestration change must preserve these fallbacks:
+
+- unknown, mixed, unresolved, invalid, or below-threshold input selects the
+  conservative full plan;
+- editing a test, fixture, or suite manifest selects the test set that consumes
+  it; shared harness, contract, setup, or lockfile changes fan out to every
+  affected set;
+- a selected test-set identifier that the executor cannot run fails visibly
+  instead of being ignored;
+- direct planner tests cover representative in-bound, out-of-bound, mixed, and
+  fallback inputs without reimplementing the evaluator in another language.
+
+Scope routing and hash invalidation remain orthogonal. Scope answers which test
+sets are necessary for a change; hash answers whether the selected workload's
+declared inputs equal a previous invocation. Do not use hash equality to weaken
+source-to-test coverage, or copy route policy into `.github/config/hash.json`.
+
+Before adding routes, inventory the complete current chain from changed path to
+match, effect, workload, job command, and concrete test cases. Remove or name
+implicit joins before making them finer. Changes under `.github/` must also
+follow `.github/AGENTS.md` and the current confidence methodology in
+`specs/current/ci.md`.
 
 ## Release channel model
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,57 +151,66 @@ CI-related GitHub automation uses a two-layer architecture:
 
 Do not add a new business-named follow-on workflow such as `foo.comment.atom.yml` or `bar.autofix.atom.yml` without first trying to express the flow as a `ci.yml` producer plus the existing `comment`, `autofix`, or `report` capability. Keep artifact naming, storage layout, and parser behavior centralized in `.github/scripts/handoff.py`; do not let individual workflows invent parallel handoff conventions.
 
-## CI test-set orchestration
+## CI test-set orchestration guidance
 
-CI selection follows one direction: changed paths → source units → test sets →
-execution workloads. The `plan` job runs before and governs every downstream
-job, including repository guards, so only the planner may authorize omission.
-A downstream job may reject an unknown or malformed selection, but its success
-must never be treated as evidence that an earlier omission was safe.
+Use the following as a recommended convergence model, not a repository-wide
+conformance gate. Existing workflows and coarse test lanes may remain while
+their boundaries are understood. Do not block an unrelated change or require it
+to repay adjacent orchestration debt solely because it touches an existing
+lane. Apply these recommendations incrementally when the local scope and
+measured scheduling benefit justify the migration.
 
-Keep the model split into three responsibilities:
+Prefer one selection direction: changed paths → source units → test sets →
+execution workloads. Because the `plan` job runs before and governs downstream
+jobs, new omission policy should live in the planner rather than rely on a
+downstream guard to justify it after scheduling has already occurred.
+
+When a CI area is being reorganized, prefer three named responsibilities:
 
 - **Source units** name stable ownership or behavior boundaries in production,
-  test, fixture, and control-plane paths. Compose repeated selectors under a
-  named unit instead of copying the same prefixes into unrelated rules.
+  test, fixture, and control-plane paths. Prefer composing repeated selectors
+  under a named unit instead of copying prefixes into unrelated rules.
 - **Test sets** name independently useful semantic validation groups. Their
-  membership and execution contract belong to one authoritative declaration;
-  do not duplicate a matrix or file list between planner configuration,
-  workflow YAML, and a framework-local registry.
+  membership and execution contract should converge on one authoritative
+  declaration instead of accumulating more matrix or file-list copies across
+  planner configuration, workflow YAML, and framework-local registries.
 - **Routes** map source units to the test sets required to validate them. Routes
-  express impact, not runner mechanics; runner image, setup, sharding, and job
-  packing remain execution concerns derived after selection.
+  should express impact rather than runner mechanics; runner image, setup,
+  sharding, and job packing can remain execution concerns derived after
+  selection.
 
-Split a source unit or test set only when the boundary is stable, changes the
-work that can actually be omitted, and has enough runtime cost or diagnostic
-value to justify another scheduling identity. Directory size, file count, or
-the ability to write a narrower glob is not sufficient. Prefer a small number
-of composable semantic units over per-file mappings, exception lists, or
-negative-rule forests. Existing duplicated or implicit declarations are
-migration surfaces, not patterns to extend.
+Good split candidates have a stable boundary, change work that can actually be
+omitted, and carry enough runtime cost or diagnostic value to justify another
+scheduling identity. Directory size, file count, or the ability to write a
+narrower glob is weak evidence on its own. Prefer a small number of composable
+semantic units over per-file mappings, exception lists, or negative-rule
+forests. Treat existing duplicated or implicit declarations as migration
+surfaces without requiring every nearby change to remove them.
 
-Every orchestration change must preserve these fallbacks:
+Before promoting a new route from observation to active omission, retain
+conservative behavior such as:
 
 - unknown, mixed, unresolved, invalid, or below-threshold input selects the
   conservative full plan;
 - editing a test, fixture, or suite manifest selects the test set that consumes
   it; shared harness, contract, setup, or lockfile changes fan out to every
   affected set;
-- a selected test-set identifier that the executor cannot run fails visibly
-  instead of being ignored;
+- making a selected test-set identifier that the executor cannot run fail
+  visibly instead of being ignored;
 - direct planner tests cover representative in-bound, out-of-bound, mixed, and
   fallback inputs without reimplementing the evaluator in another language.
 
-Scope routing and hash invalidation remain orthogonal. Scope answers which test
-sets are necessary for a change; hash answers whether the selected workload's
-declared inputs equal a previous invocation. Do not use hash equality to weaken
-source-to-test coverage, or copy route policy into `.github/config/hash.json`.
+Keep scope routing and hash invalidation conceptually orthogonal: scope answers
+which test sets are necessary for a change, while hash answers whether the
+selected workload's declared inputs equal a previous invocation. New designs
+should not use hash equality to weaken source-to-test coverage or copy route
+policy into `.github/config/hash.json`.
 
-Before adding routes, inventory the complete current chain from changed path to
-match, effect, workload, job command, and concrete test cases. Remove or name
-implicit joins before making them finer. Changes under `.github/` must also
-follow `.github/AGENTS.md` and the current confidence methodology in
-`specs/current/ci.md`.
+For work whose purpose is CI orchestration, start by inventorying the current
+chain from changed path to match, effect, workload, job command, and concrete
+test cases. Prefer naming or removing implicit joins before making them finer.
+Changes under `.github/` must also follow `.github/AGENTS.md` and the current
+confidence methodology in `specs/current/ci.md`.
 
 ## Release channel model
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -403,7 +403,7 @@ describe("packaged smoke workflow", () => {
     expect(workflow).not.toContain("OD_PACKAGED_E2E_");
   });
 
-  it("[P2] runs Windows launcher payload archive validation when tools-pack is touched", async () => {
+  it("[P2] runs the independent Windows launcher payload test set", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
     const job = sectionBetween(workflow, "  windows_tools_pack_payload_tests:", "  web_workspace_tests:");
     const validate = sectionBetween(workflow, "  validate:", "          if [ -n \"$failures\" ]; then");
@@ -411,7 +411,7 @@ describe("packaged smoke workflow", () => {
     expect(job).toContain("fromJSON(needs.runners.outputs.runs_on).windows_tools");
     expect(job).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).windows_tools)");
     expect(job).toContain("fromJSON(needs.plan.outputs.run).windows_tools_pack_payload_tests");
-    expect(job).toContain("pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload.test.ts");
+    expect(job).toContain("pnpm --filter @open-design/tools-pack exec vitest run tests/launcher-payload-windows.test.ts");
     expect(validate).toContain("windows_tools_pack_payload_tests");
   });
 
@@ -1202,10 +1202,28 @@ process.stdin.on("end", () => {
       run_playwright_visual: false,
       run_ui_p0: false,
       run_web_workspace_tests: false,
-      run_windows_tools_pack_payload_tests: true,
+      run_windows_tools_pack_payload_tests: false,
       tools_dev_tests_required: true,
       tools_pack_tests_required: true,
+      windows_tools_pack_payload_tests_required: false,
       workspace_validation_required: true,
+    });
+
+    await expect(runScopesPrint("merge_group", mergeGroup, ["tools/pack/src/mac/app.ts"])).resolves.toMatchObject({
+      run_windows_tools_pack_payload_tests: false,
+      tools_pack_tests_required: true,
+      windows_tools_pack_payload_tests_required: false,
+    });
+
+    await expect(runScopesPrint("merge_group", mergeGroup, ["tools/pack/src/win/custom-installer.ts"])).resolves.toMatchObject({
+      run_windows_tools_pack_payload_tests: true,
+      tools_pack_tests_required: true,
+      windows_tools_pack_payload_tests_required: true,
+    });
+
+    await expect(runScopesPrint("merge_group", mergeGroup, ["packages/launcher-proto/src/index.ts"])).resolves.toMatchObject({
+      run_windows_tools_pack_payload_tests: true,
+      windows_tools_pack_payload_tests_required: true,
     });
 
     await expect(runScopesPrint("merge_group", mergeGroup, ["apps/desktop/package.json"])).resolves.toMatchObject({

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -194,7 +194,7 @@ function extractValidateGateJqPrograms(workflow: string): { failures: string; re
   const needsCheck = sectionBetween(
     validate,
     "      - name: Check workspace validation jobs",
-    "      - name: Block merge while a merge-blocking label is present",
+    "      - name: Download pending hash map",
   );
   const programs = [...needsCheck.matchAll(/jq -r '([\s\S]*?)'/g)].map((match) => match[1] ?? "");
   expect(programs).toHaveLength(2);
@@ -533,13 +533,40 @@ describe("packaged smoke workflow", () => {
       readFile(commentWorkflowPath, "utf8"),
     ]);
 
-    // Producer: the merge_group gate emits a handoff/comment artifact for the labeled PR when
-    // it blocks, and uploads it on the failure path (the gate exits 1 exactly when it produces).
-    expect(ciWorkflow).toContain("<!-- merge-queue-needs-validation -->");
-    expect(ciWorkflow).toContain("emit_ejection_notice");
-    expect(ciWorkflow).toContain(
+    const mergePolicy = sectionBetween(ciWorkflow, "  merge_policy:", "  validate:");
+    const validate = sectionBetween(ciWorkflow, "  validate:", "  runtime_summary:");
+
+    // Producer: merge policy is a merge-group-only sibling of every workload. It emits a
+    // handoff/comment artifact for a labeled PR and uploads it on the failure path.
+    expect(mergePolicy).toContain("needs: [plan, runners]");
+    expect(mergePolicy).toContain("if: ${{ github.event_name == 'merge_group' }}");
+    expect(mergePolicy).toContain("fromJSON(needs.runners.outputs.runs_on).control");
+    expect(mergePolicy).toContain("<!-- merge-queue-needs-validation -->");
+    expect(mergePolicy).toContain("emit_ejection_notice");
+    expect(mergePolicy).toContain(
       "if: ${{ failure() && steps.merge_blocking_label_gate.outputs.comment_created == 'true' }}",
     );
+
+    // Policy converges only at the required workspace gate. It never becomes a prerequisite
+    // that could suppress workload coverage for a labeled merge group.
+    expect(validate).toContain("      - merge_policy");
+    expect(validate).toContain("if: ${{ always() }}");
+    expect(validate).not.toContain("Block merge while a merge-blocking label is present");
+    const workloadSections = [
+      ["  static_gate:", "  preflight:"],
+      ["  preflight:", "  workspace_unit_tests:"],
+      ["  workspace_unit_tests:", "  daemon_unit_tests:"],
+      ["  daemon_unit_tests:", "  windows_tools_pack_payload_tests:"],
+      ["  windows_tools_pack_payload_tests:", "  web_workspace_tests:"],
+      ["  web_workspace_tests:", "  e2e_vitest:"],
+      ["  e2e_vitest:", "  playwright_critical:"],
+      ["  playwright_critical:", "  ui_p0:"],
+      ["  ui_p0:", "  playwright_visual:"],
+      ["  playwright_visual:", "  merge_policy:"],
+    ] as const;
+    for (const [start, end] of workloadSections) {
+      expect(sectionBetween(ciWorkflow, start, end)).toContain("needs: [plan, runners]");
+    }
 
     // Consumer: a merge_group run's head_sha is the queue's synthetic merge commit, so the atom
     // binds merge_group artifacts to their producing run by run_id and skips the base-freshness
@@ -1270,8 +1297,23 @@ process.stdin.on("end", () => {
     await expect(
       validateGatePasses(workflow, {
         plan: { result: "success", outputs: { run: JSON.stringify(baseRun) } },
+        merge_policy: { result: "skipped" },
       }),
     ).resolves.toBe(true);
+
+    await expect(
+      validateGatePasses(workflow, {
+        plan: { result: "success", outputs: { run: JSON.stringify(baseRun) } },
+        merge_policy: { result: "success" },
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      validateGatePasses(workflow, {
+        plan: { result: "success", outputs: { run: JSON.stringify(baseRun) } },
+        merge_policy: { result: "failure" },
+      }),
+    ).resolves.toBe(false);
 
     const needsWithFailedWeb = {
       plan: { result: "success", outputs: { run: JSON.stringify({ ...baseRun, web_workspace_tests: true }) } },
@@ -1292,9 +1334,7 @@ process.stdin.on("end", () => {
     expect(validate.indexOf("Save successful hash map")).toBeGreaterThan(
       validate.indexOf("Check workspace validation jobs"),
     );
-    expect(validate.indexOf("Save successful hash map")).toBeGreaterThan(
-      validate.indexOf("Block merge while a merge-blocking label is present"),
-    );
+    expect(validate).not.toContain("Block merge while a merge-blocking label is present");
 
     const run = {
       static_gate: false,
@@ -1335,7 +1375,7 @@ process.stdin.on("end", () => {
     const e2eVitest = sectionBetween(workflow, "  e2e_vitest:", "  playwright_critical:");
     const preflight = sectionBetween(workflow, "  preflight:", "  workspace_unit_tests:");
     const uiP0 = sectionBetween(workflow, "  ui_p0:", "  playwright_visual:");
-    const visual = sectionBetween(workflow, "  playwright_visual:", "  validate:");
+    const visual = sectionBetween(workflow, "  playwright_visual:", "  merge_policy:");
 
     expect(runners).toContain("|| 'nexu-runners-small'");
     expect(runners).toContain("&& 'ubuntu-24.04'");

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -60,7 +60,19 @@ describe("workflow scope planner", () => {
     });
     expect(plan("pr", ["apps/desktop/src/main.ts"])).toMatchObject({
       scopes: { tools_dev_tests_required: true, tools_pack_tests_required: true },
+      enabled: { windows_tools_pack_payload_tests: false, ui_p0: false, playwright_critical: false },
+    });
+    expect(plan("pr", ["tools/pack/src/win/payload.ts"])).toMatchObject({
+      scopes: { tools_pack_tests_required: true, windows_tools_pack_payload_tests_required: true },
       enabled: { windows_tools_pack_payload_tests: true, ui_p0: false, playwright_critical: false },
+    });
+    expect(plan("pr", ["packages/launcher-proto/src/index.ts"])).toMatchObject({
+      scopes: { windows_tools_pack_payload_tests_required: true },
+      enabled: { windows_tools_pack_payload_tests: true },
+    });
+    expect(plan("pr", ["pnpm-lock.yaml"])).toMatchObject({
+      scopes: { windows_tools_pack_payload_tests_required: true },
+      enabled: { windows_tools_pack_payload_tests: true },
     });
     expect(plan("pr", ["docs/spec.md"])).toMatchObject({
       scopes: { workspace_validation_required: false },
@@ -98,12 +110,24 @@ describe("workflow scope planner", () => {
       trace: { escalations: [] },
     });
     expect(plan("merge-queue", ["apps/desktop/src/main.ts"])).toMatchObject({
+      enabled: { windows_tools_pack_payload_tests: false, workspace_unit_tests: true, e2e_vitest: false },
+      trace: { escalations: [] },
+    });
+    expect(plan("merge-queue", ["tools/pack/src/win/custom-installer.ts"])).toMatchObject({
       enabled: { windows_tools_pack_payload_tests: true, workspace_unit_tests: true, e2e_vitest: false },
       trace: { escalations: [] },
     });
     const medium = plan("merge-queue", ["apps/web/src/App.tsx"]);
     expect(medium.trace.escalations).toHaveLength(1);
     expect(Object.values(medium.scopes).filter((value) => typeof value === "boolean")).not.toContain(false);
+
+    const unknown = plan("merge-queue", ["some-new-root/file.ts"]);
+    expect(unknown).toMatchObject({ enabled: { windows_tools_pack_payload_tests: true } });
+    expect(unknown.trace.escalations).toHaveLength(1);
+  });
+
+  test("keeps the Windows payload workload in forced-full plans", () => {
+    expect(plan("full")).toMatchObject({ enabled: { windows_tools_pack_payload_tests: true } });
   });
 
   test("preserves the four-domain runtime-definition shadow candidate", () => {

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -135,9 +135,20 @@ Rule `certain-packaged-leaf-sources` covers only:
 It claims `tools_dev_tests_required`, `tools_pack_tests_required`, and
 `workspace_validation_required`. A pure matching merge group therefore keeps
 preflight/typecheck, workspace unit tests, desktop/packaged/tools-pack tests,
-the focused packaged launcher update-loop fallback, and Windows launcher
-payload tests. It skips web workspace tests, broad E2E Vitest, UI P0, critical
-Playwright, and visual Playwright.
+and the focused packaged launcher update-loop fallback. It skips web workspace
+tests, broad E2E Vitest, UI P0, critical Playwright, and visual Playwright.
+
+Windows launcher-payload validation is an independent test set. Rule
+`certain-windows-launcher-payload` maps the Windows pack source unit to
+`windows_tools_pack_payload_tests_required`, which alone arms the existing
+Windows workload outside forced-full plans. The source unit includes the
+Windows tools-pack implementation and resources, its explicit shared-module
+closure, the Windows-only test file, launcher-proto and sidecar-proto sources,
+and the narrow platform/release/sidecar exports consumed by that closure.
+Desktop, packaged-runtime, mac-only, and unrelated tools-pack changes retain
+their Linux package coverage without starting a Windows runner. Package
+manifests and workspace/lock configuration remain conservative broad inputs;
+unknown or below-threshold queue inputs still select the full plan.
 
 Package manifests, build configs, bins, vendor content, and files outside the
 listed core remain medium. A mixed queue group containing any medium file
@@ -146,10 +157,17 @@ effects and escalation behavior; they do not claim to prove every consumer.
 
 Current evidence:
 
-- The latest 400 first-parent merges contain 19 pure packaged-leaf groups.
-- All 19 have successful narrow PR validation paired with successful full
-  merge-queue validation; the active narrow plan additionally runs desktop,
-  packaged, and focused update-loop coverage absent from the historical plan.
+- The latest 400 first-parent merges contain 23 pure packaged-leaf groups.
+- Direct replay through `scopes.py plan --context merge-queue` retains the
+  Windows payload workload for 5 of those groups and omits it for 18. The
+  retained groups touch the Windows implementation closure; the omitted groups
+  are desktop, packaged-runtime, mac-only, or unrelated tools-pack changes.
+- Nineteen earlier pure-leaf groups have successful narrow PR validation paired
+  with successful full merge-queue validation. The narrow plan retains desktop,
+  packaged, tools-pack, and focused update-loop coverage.
+- Recent pure-leaf PR runs spend about 3.4–4.7 elapsed minutes in the Windows
+  payload job; it is longer than the Linux workspace-unit job and can determine
+  the validation critical path when the change has no Windows payload impact.
 - A current full merge-group run measures about 11.8 elapsed minutes and 68
   runner-minutes. A representative pure-leaf narrow PR run measures about 4.2
   elapsed minutes and 8.1 runner-minutes.

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -1,130 +1,257 @@
-# CI scope confidence methodology
+# CI orchestration evolution
 
-This is the current authority for CI scope confidence rules in
-`.github/config/scopes.json`, their planner invariants, and their evidence recipes.
-Workflow topology and the capability/handoff architecture stay owned by
-`.github/AGENTS.md`; do not restate them here.
+This document is the current authority for how this repository evolves CI
+scope policy, how `.github/config/scopes.json` and
+`.github/scripts/scopes.py` make workload decisions, and how those decisions
+are evaluated. Workflow ownership and local editing instructions remain in
+`.github/AGENTS.md`; this document describes the design contract rather than
+restating workflow implementation line by line.
 
-This document records current state only. State active rules, boundaries,
-invariants, evidence, and unresolved questions directly; do not add dated or
-numbered rollout stages, before/after narratives, or a history of how the
-current design was reached. Git history, pull requests, and task records own
-that change history.
+The document has four kinds of content:
 
-## The model in three paragraphs
+- **Method** describes how to choose and evaluate an orchestration change.
+- **Paradigm** gives reusable models for reasoning about CI responsibilities.
+- **Current contract** records behavior that the implementation must preserve.
+- **Reference** shows how the method and paradigms are applied today.
 
-Every changed file is classified by the additive rule table in
-`.github/config/scopes.json`: effects union across matched rules, confidence is the
-minimum across matched rules. Each evaluation context brings a trust threshold:
-PR and manual-hot runs believe `medium`, the merge queue believes only
-`certain`, manual-full runs believe nothing. Renames contribute both the
-current and previous filename so moving a file cannot discard the source
-path's validation effects. A file below threshold — or
-matching no rule — escalates fail-closed to the full radius.
+Methods and paradigms are intended to guide incremental convergence. They do
+not require unrelated work to repay existing CI declaration debt. Current
+contracts use normative language because changing them changes runtime safety.
+References are replaceable examples, not precedent that every future slice
+must copy. Git history, pull requests, and task records own change history; this
+document records the design that is useful now.
 
-The scope policy floor never moves: `preflight` is enabled in every scope plan.
-Its current `"*"` hash declaration makes workspace setup, `pnpm guard`, and
-i18n structure checks execute for every new tracked tree, while an identical
-cached invocation may skip the whole job. Broad
-app declaration builds, workspace typecheck, and `run_workspace_unit_tests`
-may skip only for a merge-queue plan whose certain-tier evaluation claims zero
-validation effects. PR, manual-hot, forced-full, and escalated queue plans keep
-all broad workspace validation.
+## Iteration method
 
-`.github/scripts/scopes.py` is the install-independent, Linux workflow-control entrypoint.
-Its rule and matrix data lives in `.github/config/scopes.json`; it never imports
-workspace code. `.github/scripts/runners.py` and `.github/scripts/hash.py` share
-the same stdlib-only cold-start boundary.
+CI optimization starts from a scheduling problem, not from a desire to make the
+rule table look complete. A useful iteration follows this sequence:
+
+1. **Find a confused declaration point.** Look for one scope effect that arms
+   unrelated tests, one test file that mixes independently schedulable
+   responsibilities, a job that interprets paths after planning, or a workload
+   whose cost and validation meaning do not align.
+2. **Choose a measured vertical slice.** Prefer a boundary with stable semantic
+   ownership, an independently executable test set, meaningful change
+   frequency or omitted cost, limited cross-boundary fanout, and a simple
+   conservative fallback. Critical-path time, runner-minutes, queue/startup
+   cost, and maintenance clarity are useful but distinct benefits.
+3. **Decompose only as far as execution needs.** Name the source unit and test
+   set needed for this slice. Split source or tests only when the resulting set
+   can be scheduled and validated independently. Avoid per-file taxonomies and
+   repository-wide cleanup campaigns.
+4. **Add the narrowest useful route.** Map the source unit to a validation
+   effect, the effect to one test set, and the test set to an execution
+   workload. Preserve broad handling for manifests, lockfiles, mixed changes,
+   and uncertain dependency edges.
+5. **Challenge the omission.** Exercise representative in-bound, out-of-bound,
+   mixed, unknown, renamed, and forced-full inputs through the real planner.
+   Replay recent changes to estimate tonnage and compare the retained coverage
+   with the cost being omitted.
+6. **Promote and observe.** Activate omission only when its fallback and direct
+   planner contracts are explicit. Keep the route small enough to demote or
+   revise when dependency shape, test ownership, or measured value changes.
+
+This is a recommended discovery and decomposition method. Once a route actively
+omits pre-main validation, the safety requirements in the current contract are
+not optional.
+
+## Orchestration paradigms
+
+### Source units, test sets, and workloads
+
+The preferred directional model is:
+
+```text
+changed paths -> source units -> validation effects -> test sets -> workloads
+                                                               -> convergence
+```
+
+A **source unit** is a named, composable ownership or dependency boundary. A
+**validation effect** states what responsibility became relevant; it should not
+merely repeat the name of a directory. A **test set** is one authoritative,
+independently executable collection of checks. A **workload** supplies the
+runner, environment, matrix, and command that execute that set.
+
+These layers may remain coarse where finer scheduling has no measured value.
+When a high-cost or platform-specific workload validates only part of a broad
+package, an independent effect and test set are preferred over treating every
+package change as platform relevant.
+
+### One-way planning authority
+
+The plan is the only component allowed to authorize omission. Executors consume
+the plan and fail hard when an enabled workload cannot run; they do not infer
+changed-path policy. Aggregation checks the results that the plan required; it
+does not reconstruct scope rules. Repository guards can validate ordinary
+policy and detect declaration drift, but a downstream guard cannot prove an
+omission already made by the planner that scheduled it.
+
+Unknown, unresolved, mixed, or below-threshold inputs move toward broader
+coverage. They never gain trust from the absence of a matching rule. This
+directionality is the central fail-closed property of active omission.
+
+### Relevance and freshness are orthogonal
+
+Scope answers whether a workload is relevant to the changed-file context. Hash
+state answers whether that workload's declared Git inputs differ from the last
+successful invocation on the branch. The execution predicate is:
+
+```text
+scope_enabled && !hash_equal
+```
+
+Neither mechanism may infer the other's semantics. Fine-grained commands inside
+a workload remain a separate business-layer concern.
+
+### Fan-out, convergence, and policy
+
+Planning should complete before workloads fan out. Independent policy checks
+should run alongside workloads when they do not authorize coverage. A single
+plan-derived convergence point should decide whether every required result is
+acceptable and publish success-dependent state. Telemetry follows convergence
+and observes the result; it does not alter it.
+
+This separation keeps policy failure visible without shortening the validation
+coverage of a blocked change, and lets later source-to-test routes remain local
+planner changes rather than workflow rewrites.
+
+### Evidence is operational, not semantic proof
+
+Planner replay, paired narrow/full runs, and job timing can justify an
+operational omission. They cannot prove that every semantic dependency is
+complete. Evidence should answer:
+
+- How often does the candidate route apply?
+- Which workload time and runner-minutes would it omit?
+- What retained test sets cover the affected responsibility?
+- Which inputs deliberately fall back to the full plan?
+- Can the decision be observed and reversed cheaply?
+
+## Current runtime contract
+
+### Planner ownership and evaluation
+
+Every changed file is evaluated by the additive rule table in
+`.github/config/scopes.json`: effects union across matching rules, and
+confidence is the minimum across those rules. Renames contribute both current
+and previous paths so moving a file cannot discard the source path's validation
+effects.
+
+Each context has a trust threshold:
+
+- PR and manual-hot plans trust `medium` and `certain` rules.
+- Merge-queue plans trust only `certain` rules.
+- Forced-full plans omit no workload based on scope confidence.
+
+A file below the active threshold, a file matching no rule, or an unresolved or
+empty queue change set selects the full radius. Invalid configuration or
+arguments fail before workload dispatch.
+
+`.github/scripts/scopes.py` is the install-independent Linux control-plane
+entrypoint. Rule and matrix data lives in `.github/config/scopes.json`; the
+planner never imports workspace code. `.github/scripts/runners.py` and
+`.github/scripts/hash.py` share the same stdlib-only cold-start boundary. The
+planner validates configuration and routing before emitting a workload
+decision.
+
 `scripts/guard.ts` is a downstream repository-policy entrypoint. It runs only
-after the plan exists and therefore does not authorize scope classification or
-workload omission. The planner validates its own configuration and routing
-contract before emitting any workload decision; repository guards remain
-useful checks, but they are not part of the planner's trust chain.
+after a plan exists and therefore has no scope-classification or omission
+authority.
 
-## Orthogonal hash composition
+### Policy floor and broad validation
 
-The scope planner answers whether a workload is relevant to the changed-file
-context. The hash register answers whether that workload's declared Git input
-combination differs from the previous invocation on the branch. CI runs a
-workload only when `scope_enabled && !hash_equal`; fine-grained commands inside
-the workload remain a separate business-layer concern.
+`preflight` is enabled in every scope plan. Its current `"*"` hash declaration
+makes workspace setup, `pnpm guard`, and i18n structure checks execute for every
+new tracked tree, while an identical cached invocation may skip the whole job.
 
-Declarations live in `.github/config/hash.json`. A declaration may contain Git
-paths/globs, `suite://<name>` reusable path groups, `key://<workflow>/<identity>`
-dependencies, or `"*"` for the entire tracked tree. Cycles, dangling references,
-unsafe paths, empty matches, schema drift, and scope/hash identity drift fail at
-the Linux plan entrypoint before workload dispatch. The initial contract uses
-`"*"` for every identity; narrow closures require high-confidence evidence and
-may be introduced independently later.
+Broad app declaration builds, workspace typecheck, and
+`run_workspace_unit_tests` may skip only for a merge-queue plan whose
+certain-tier evaluation claims zero validation effects. PR, manual-hot,
+forced-full, and escalated queue plans retain broad workspace validation.
 
-Actions cache stores only the previous identity-to-hash map. `hash.py` reads it,
-computes and compares every current identity, then atomically replaces the local
-state before workloads run. The plan transfers that pending map to `validate`,
-which publishes it to Actions cache only after the gate succeeds. The map carries
-no job-success, retry, or reliability meaning; success controls publication, not
-payload. Restore, transfer, and save failures are non-fatal and therefore start
-cold; invalid configuration is fatal. Only
-`if: ${{ fromJSON(needs.plan.outputs.run).<identity> }}` in `ci.yml` turns the
-static comparison into a skip.
+### Confidence tiers
 
-The error cost is asymmetric by tier. A wrong `medium` rule under-arms a PR
-run and gets caught by the merge queue's stricter threshold — cost: one queue
-bounce. A wrong `certain` rule lets an invalid change reach `main` with no
-automatic detection behind it. That asymmetry is why the two tiers have
-different iteration rules below.
+The error cost is asymmetric. A wrong `medium` rule can under-arm a PR and be
+backstopped by the merge queue's stricter threshold, at the cost of a queue
+bounce. A wrong `certain` rule can let an invalid change reach `main` without
+automatic detection behind it.
 
-## Medium-tier requirements
+A `medium` rule refinement requires a rule-table diff, direct planner goldens,
+and a tonnage estimate from the replay recipe. Candidates should come from
+measured value rather than speculative attempts to make the rule table look
+complete.
 
-Adding or refining a `medium` rule needs: the rule-table diff, updated goldens
-in `e2e/tests/scripts/scopes.test.ts`, and a tonnage estimate from the replay
-recipe. The queue backstops mistakes. Do not add speculative rules for
-surfaces nobody touches; candidates come from measurement, not from reading
-the rule table for imperfections (measured imperfection lists and
-frequency-weighted tonnage lists barely intersect).
+An active `certain` omission requires:
 
-## Certain-tier requirements
-
-`certain` is an operational planner policy, not a proof that semantic
-dependencies are complete. A downstream job, including `pnpm guard`, cannot
-authorize an omission already made by the plan that scheduled it.
-
-Requirements:
-
-1. **A conservative rule-table boundary.** Keep promoted matches explicit and
-   narrow. Unknown, mixed, empty-unresolved, invalid, or below-threshold inputs
-   must select the full plan.
-2. **Planner-owned validation.** `python3 .github/scripts/scopes.py validate`
-   must reject schema drift, unknown effects, invalid regexes, match cycles,
-   malformed or duplicate matrices, and invalid UI P0 shadow references before
-   any workload decision is emitted.
-3. **Direct planner behavior tests.** Goldens invoke `scopes.py plan` itself for
-   representative in-bound, out-of-bound, mixed, and fallback inputs. Do not
-   reimplement the evaluator in another language and compare two copies.
+1. **A conservative rule-table boundary.** Promoted matches stay explicit and
+   narrow. Unknown or mixed changes, empty, unresolved, or invalid change
+   resolution, and below-threshold inputs select the full plan.
+2. **Planner-owned validation.** `scopes.py validate` rejects schema drift,
+   unknown effects, invalid regexes, match cycles, malformed or duplicate
+   matrices, and invalid UI P0 shadow references before dispatch.
+3. **Direct planner behavior tests.** Goldens invoke `scopes.py plan` for
+   representative positive, negative, mixed, and fallback inputs. They do not
+   reimplement the evaluator in another language.
 4. **Measured operational evidence.** Replay and paired-run evidence quantify
-   how often a rule applies and whether the retained plan has passed in
-   practice. This evidence can justify an operational decision, but it must not
-   be described as a complete dependency proof.
+   applicability, retained coverage, and observed cost. It is not described as
+   a complete dependency proof.
 
-Independent semantic-closure guards may be evaluated later. They must sit
+Independent semantic-closure checks may be evaluated later. They must remain
 outside the planner's scheduling authority before their evidence can strengthen
-a `certain` claim.
+a `certain` decision.
 
-## Certain-exempt boundary
+### Hash composition and publication
 
-Rule `certain-exempt-surface`: prefixes `docs/`, `apps/landing-page/`,
-`.vscode/`, `.idea/`, `.github/ISSUE_TEMPLATE/` plus exacts `LICENSE`,
+Hash declarations live in `.github/config/hash.json`. A declaration may contain
+Git paths/globs, `suite://<name>` reusable path groups,
+`key://<workflow>/<identity>` dependencies, or `"*"` for the tracked tree.
+Cycles, dangling references, unsafe paths, empty matches, schema drift, and
+scope/hash identity drift fail at the plan entrypoint. The current contract
+uses `"*"` for every identity; narrower closures require separate evidence and
+may be introduced independently.
+
+Actions cache stores only the previous identity-to-hash map. `hash.py` computes
+and compares the current map, and the plan transfers the pending map to
+`validate`. Only successful convergence publishes it. The map carries no job
+success, retry, or reliability meaning. Restore, transfer, and save failures
+start cold without failing CI; invalid configuration remains fatal.
+
+### Job graph and convergence
+
+The current control flow is:
+
+```text
+runners -> plan -> workloads ---------> validate -> runtime summary
+                -> merge policy ------/
+```
+
+`merge_policy` is merge-group-only and runs in parallel with workloads. It does
+not cancel or suppress validation for a blocked group. `Validate workspace` is
+the sole required convergence check: it consumes the plan-derived required-job
+set, enforces merge policy at convergence, and is the only successful publisher
+of pending hash state. Runner allocation failure and external cancellation are
+operational failures rather than alternate coverage policy.
+
+## Current references
+
+These sections describe active or observed applications of the method. They are
+kept here to make the paradigms concrete and may be revised or removed with the
+corresponding planner behavior.
+
+### Certain-exempt surface
+
+Rule `certain-exempt-surface` covers prefixes `docs/`,
+`apps/landing-page/`, `.vscode/`, `.idea/`, and
+`.github/ISSUE_TEMPLATE/`, plus exact paths `LICENSE` and
 `.github/CODEOWNERS`. The planner owns this classification directly; no
 downstream guard is treated as proof that these files are unconsumed.
 
-Current evidence and exceptions:
+A replay of 398 first-parent merges ending at `b99a9fdc3` produced 46 certain,
+zero-effect plans (11.6%). Root markdown such as `README.md` remains medium
+because bare filename literals are widespread as fixture data and cannot be
+distinguished locally from repository-root reads.
 
-- A replay of 398 first-parent merges ending at `b99a9fdc3` produces 46
-  certain, zero-effect plans (11.6%).
-- Root markdown such as `README.md` remains medium because bare filename
-  literals are widespread as project-fixture data and are not locally
-  distinguishable from repository-root reads.
-
-## Certain packaged-leaf boundary
+### Packaged leaf and Windows payload
 
 Rule `certain-packaged-leaf-sources` covers only:
 
@@ -133,48 +260,41 @@ Rule `certain-packaged-leaf-sources` covers only:
 - `tools/pack/{src,tests,resources}/`
 
 It claims `tools_dev_tests_required`, `tools_pack_tests_required`, and
-`workspace_validation_required`. A pure matching merge group therefore keeps
+`workspace_validation_required`. A pure matching merge group keeps
 preflight/typecheck, workspace unit tests, desktop/packaged/tools-pack tests,
 and the focused packaged launcher update-loop fallback. It skips web workspace
 tests, broad E2E Vitest, UI P0, critical Playwright, and visual Playwright.
 
-Windows launcher-payload validation is an independent test set. Rule
+Windows launcher-payload validation is a separate test set. Rule
 `certain-windows-launcher-payload` maps the Windows pack source unit to
-`windows_tools_pack_payload_tests_required`, which alone arms the existing
-Windows workload outside forced-full plans. The source unit includes the
-Windows tools-pack implementation and resources, its explicit shared-module
-closure, the Windows-only test file, launcher-proto and sidecar-proto sources,
-and the narrow platform/release/sidecar exports consumed by that closure.
-Desktop, packaged-runtime, mac-only, and unrelated tools-pack changes retain
-their Linux package coverage without starting a Windows runner. Package
-manifests and workspace/lock configuration remain conservative broad inputs;
-unknown or below-threshold queue inputs still select the full plan.
+`windows_tools_pack_payload_tests_required`, which alone arms its Windows
+workload outside forced-full plans. The source unit includes the Windows
+tools-pack implementation and resources, its explicit shared-module closure,
+the Windows-only test file, launcher-proto and sidecar-proto sources, and the
+narrow platform/release/sidecar exports consumed by that closure.
 
-Package manifests, build configs, bins, vendor content, and files outside the
-listed core remain medium. A mixed queue group containing any medium file
-still escalates to the full plan. Direct `scopes.py plan` tests pin the retained
-effects and escalation behavior; they do not claim to prove every consumer.
+Desktop, packaged-runtime, mac-only, and unrelated tools-pack changes retain
+Linux package coverage without starting a Windows runner. Package manifests,
+workspace/lock configuration, build configuration, bins, vendor content,
+unknown inputs, and below-threshold queue inputs retain conservative broad or
+full behavior.
 
 Current evidence:
 
 - The latest 400 first-parent merges contain 23 pure packaged-leaf groups.
-- Direct replay through `scopes.py plan --context merge-queue` retains the
-  Windows payload workload for 5 of those groups and omits it for 18. The
-  retained groups touch the Windows implementation closure; the omitted groups
-  are desktop, packaged-runtime, mac-only, or unrelated tools-pack changes.
+- Direct merge-queue replay retains the Windows workload for 5 groups and omits
+  it for 18 desktop, packaged-runtime, mac-only, or unrelated tools-pack groups.
 - Nineteen earlier pure-leaf groups have successful narrow PR validation paired
-  with successful full merge-queue validation. The narrow plan retains desktop,
-  packaged, tools-pack, and focused update-loop coverage.
+  with successful full merge-queue validation.
 - Recent pure-leaf PR runs spend about 3.4–4.7 elapsed minutes in the Windows
-  payload job; it is longer than the Linux workspace-unit job and can determine
-  the validation critical path when the change has no Windows payload impact.
+  payload job, which can determine the validation critical path.
 - A current full merge-group run measures about 11.8 elapsed minutes and 68
   runner-minutes. A representative pure-leaf narrow PR run measures about 4.2
   elapsed minutes and 8.1 runner-minutes.
 - Expected savings are about 7.5 elapsed minutes and 60 runner-minutes per
   qualifying single-PR group, before queue batching discounts.
 
-## Certain daemon-core boundary
+### Certain daemon core
 
 Rule `certain-daemon-core` covers `apps/daemon/src/` and
 `apps/daemon/tests/`, excluding `apps/daemon/src/sidecar/` and the
@@ -183,83 +303,72 @@ configuration, bins, the packaged sidecar compatibility bridge, and runtime
 definition source/companion tests stay medium-tier.
 
 A pure matching merge group keeps preflight and workspace typecheck, workspace
-unit coverage, broad E2E Vitest, and the complete four-domain UI P0 matrix. It
-skips web workspace tests, visual Playwright, Windows launcher-payload tests,
-and tools-dev/tools-pack unit coverage. The retained plan therefore continues
-to exercise daemon buildability, user-level API/runtime behavior, and every
-merge-gated UI P0 capability without treating web-owned rendering tests or
-packaging-format tests as daemon consumers.
-
-Direct `scopes.py plan` tests pin representative daemon-core routing and
-out-of-bound escalation. General cross-app and visual-harness guards remain
-repository checks, but they do not authorize the planner's daemon-core
-omissions.
+unit coverage, broad E2E Vitest, and the complete UI P0 matrix. It skips web
+workspace tests, visual Playwright, Windows launcher-payload tests, and
+tools-dev/tools-pack unit coverage. Direct planner tests pin representative
+routing and out-of-bound escalation. The retained plan continues to exercise
+daemon buildability, user-level API/runtime behavior, and every merge-gated UI
+P0 capability without treating web rendering or packaging-format tests as
+daemon consumers.
 
 The authoritative cross-app critique coverage walker lives in
-`e2e/tests/critique-coverage.test.ts`, which remains armed by the daemon-core
-plan. The latest 400 first-parent merges contain 78 pure daemon-core groups.
-Fifteen recent groups have successful narrow PR validation paired with
-successful full merge-group validation. A representative full queue run spends
-about 20 runner-minutes in the web, visual, and Windows jobs omitted by the
-planner; UI P0 remains the critical path.
+`e2e/tests/critique-coverage.test.ts`, which remains armed by this plan. The
+latest 400 first-parent merges contain 78 pure daemon-core groups. Fifteen
+recent groups have successful narrow PR validation paired with successful full
+merge-group validation. A representative full queue run spends about 20
+runner-minutes in the web, visual, and Windows jobs omitted by the planner; UI
+P0 remains the critical path.
 
-## Daemon UI P0 capability shadow
+### Daemon UI P0 capability shadow
 
-The UI P0 capability shadow is evidence-only. The applied `ui_p0_matrix`
-remains the full four-domain matrix in PR and merge-queue plans; no job reads
+The `daemon-runtime-definition` capability is evidence-only. The applied
+`ui_p0` matrix remains all six current shards in PR and merge-queue plans:
+`entry-settings`, `project-workspace`, `project-workspace-editor`,
+`project-collab`, `project-runtime`, and `workspace-restoration`. No job reads
 the shadow candidate as an execution input.
 
-The `daemon-runtime-definition` capability matches changes confined to:
+The capability matches changes confined to:
 
 - `apps/daemon/src/runtimes/defs/`;
 - `capabilities.ts`, `local-profiles.ts`, `metadata.ts`, and `registry.ts`
   directly under `apps/daemon/src/runtimes/`;
-- the explicit companion-test list in
-  the `daemon-runtime-definition` exact list (`.github/config/scopes.json`).
+- the explicit companion-test list in `.github/config/scopes.json`.
 
-Its candidate keeps `entry-settings`, `project-workspace`, and
-`project-runtime`, and omits only `workspace-restoration`. The project
-workspace remains included because its P0 coverage contains the local-agent
-and model selector. Any empty, unresolved, mixed, unknown, or out-of-surface
-change falls back to the full four-domain matrix and records the reason in
-`trace.uiP0Shadow`.
+Its four-shard candidate keeps `entry-settings`, `project-workspace`,
+`project-collab`, and `project-runtime`; it would omit
+`project-workspace-editor` and `workspace-restoration`. Any empty, unresolved,
+mixed, unknown, or out-of-surface change records a full-fallback shadow. Direct
+planner tests pin both the applied six-shard matrix and the four-shard
+candidate. `project-workspace` remains because its P0 coverage contains the
+local-agent and model selector.
 
-Direct `scopes.py plan` tests pin the applied full matrix, candidate group set,
-representative in-bound resolution, and full fallback. The shadow must
-accumulate successful paired runs before it can become an execution input.
+The latest-400 replay contains three matching groups. Historical timing placed
+the omitted shadow worker at about 8.5–9.2 runner-minutes per matching group,
+but the shadow produces no execution savings until it independently satisfies
+the active-omission requirements.
 
-The latest-400 first-parent replay contains three matching groups. The
-candidate would avoid one UI P0 worker per matching group, currently about
-8.5–9.2 runner-minutes, but the shadow produces no execution savings until its
-paired evidence satisfies the promotion requirements.
-
-## Zero-effect merge-queue policy floor
+### Zero-effect merge-queue policy floor
 
 A merge-queue plan that trusts every changed file at `certain` and receives no
 scope effects keeps preflight setup, `pnpm guard`, and the i18n structure check,
 but skips preflight's app prebuild/typecheck steps and the workspace-unit job.
-The predicate is queue-only: PR/manual-hot run broad validation even when the
-medium-tier plan has no effects, and forced-full or escalated queue plans run
-everything.
+PR/manual-hot, forced-full, and escalated queue plans retain broad validation.
 
-`pnpm guard` still runs as ordinary policy-floor work when preflight is
-enabled, but its result does not authorize the zero-effect plan. The planner's
-classification and fail-open behavior are the operative contract.
+`pnpm guard` runs as ordinary policy-floor work; it does not authorize the
+zero-effect plan. The 398-merge replay ending at `b99a9fdc3` contains 46
+qualifying plans (11.6%). A sample of 12 successful merge-group runs measures
+broad prebuild/typecheck at about 1.95 runner-minutes and workspace unit at
+about 1.6 runner-minutes, avoiding roughly 3.6 runner-minutes and 2.1
+critical-path minutes per qualifying run, or about 166 runner-minutes across
+that replay window.
 
-The 398-merge replay ending at `b99a9fdc3` contains 46 qualifying queue plans
-(11.6%). A sample of 12 successful merge-group runs measures broad prebuild
-and typecheck at about 1.95 runner-min and workspace unit at about 1.6
-runner-min. The policy floor therefore avoids roughly 3.6 runner-min and 2.1
-critical-path minutes per qualifying run (~166 runner-min across the replay
-window).
+## Evidence and evaluation
 
-## Evidence recipes
+Shell may fetch file lists and extract logs, but every scope judgment goes
+through `.github/scripts/scopes.py plan`. Do not reimplement rule semantics in
+an evidence pipeline.
 
-Design rule: shell only fetches file lists and extracts logs; every scope
-judgment goes through `.github/scripts/scopes.py plan`. Never reimplement rule
-semantics in a pipeline.
-
-Replay recent merges through the evaluator (candidate tonnage):
+Replay recent merges through the evaluator:
 
 ```bash
 git log --first-parent -400 --pretty=%H origin/main | while read -r sha; do
@@ -271,44 +380,38 @@ git log --first-parent -400 --pretty=%H origin/main | while read -r sha; do
 done | sort | uniq -c
 ```
 
-Classify one change set offline (PR-side view, prints `{ plan, trace }`):
+Classify one change set offline:
 
 ```bash
 python3 .github/scripts/scopes.py plan --context pr \
   --files apps/web/src/App.tsx docs/architecture.md
 ```
 
-Pull the shadow column from a real queue run (the certain-rule evidence stream
-for structural/behavioral proposals; prefer job logs — do not rely on
-artifacts):
+Read the decision trace from a real queue run; prefer logs over artifacts:
 
 ```bash
 gh run view <run-id> --log | sed -n '/scope decision trace:/,/^}/p'
 ```
 
-Each recipe's sanity check: the replay loop must print only `PURE`/`ESCALATED`
-counts; `plan` must print JSON with a `trace.threshold` matching the context.
-
-## Evidence tooling policy
-
-Keep these commands as recipes. Check in a script only when a certain-rule
-evaluation needs evidence beyond the CI log retention window, or repeated
-manual execution has produced copy errors. Evidence must justify additional
-infrastructure.
+The replay must emit only `PURE`/`ESCALATED` counts, and an individual `plan`
+call must emit JSON whose `trace.threshold` matches the context. Keep these as
+recipes. Check in evidence tooling only when the required window exceeds CI log
+retention or repeated manual execution has become error-prone.
 
 ## Open questions
 
-- A demotion policy for `certain` rules when planner evidence becomes stale.
-- What independent evidence source could strengthen semantic closure without
-  being scheduled by the plan it is meant to assess.
-- Whether medium-tier zero-effect PR plans should use the policy floor; this
-  needs its own evidence and containment review.
-- Queue batching discount: the 11.6% figure assumes single-PR queue groups; a
-  mixed group loses the benefit file-by-file. Check real `merge_group` traces
-  once a few have accumulated.
-- Adjacent medium-tier gaps (each is its own small PR): `e2e/tests/**` arms no
-  e2e Vitest lane (and atom-workflow edits therefore skip the topology tests
-  on PR runs — the queue is currently their only pre-main execution);
-  `mocks/**` is fallback-classified into Playwright lanes instead of the
-  daemon tests that consume it; the dispatch-hot branch never re-derives
-  workspace validation (pinned asymmetry in the goldens).
+- How should a `certain` rule be demoted when planner evidence or its source
+  closure becomes stale?
+- What independent evidence source could detect source-closure drift without
+  being scheduled by the plan it assesses?
+- Should planner traces expose source unit, test set, and fallback reason as
+  separate first-class fields?
+- Should replay output directly summarize workload deltas and measured cost,
+  rather than requiring per-slice shell analysis?
+- Should medium-tier zero-effect PR plans use the policy floor? This needs a
+  separate evidence and containment review.
+- How much does real merge-queue batching discount single-PR replay savings?
+- Adjacent medium-tier gaps remain separate candidate slices:
+  `e2e/tests/**` does not arm E2E Vitest on PRs; `mocks/**` reaches Playwright
+  through fallback rather than the daemon tests that consume it; manual-hot
+  dispatch does not re-derive workspace validation.

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -37,8 +37,10 @@ rule table look complete. A useful iteration follows this sequence:
    cost, and maintenance clarity are useful but distinct benefits.
 3. **Decompose only as far as execution needs.** Name the source unit and test
    set needed for this slice. Split source or tests only when the resulting set
-   can be scheduled and validated independently. Avoid per-file taxonomies and
-   repository-wide cleanup campaigns.
+   can be scheduled and validated independently. If the route needs a long list
+   of scattered files, first ask whether the source tree is hiding the real
+   responsibility boundary. Avoid per-file taxonomies and repository-wide
+   cleanup campaigns.
 4. **Add the narrowest useful route.** Map the source unit to a validation
    effect, the effect to one test set, and the test set to an execution
    workload. Preserve broad handling for manifests, lockfiles, mixed changes,
@@ -76,6 +78,32 @@ These layers may remain coarse where finer scheduling has no measured value.
 When a high-cost or platform-specific workload validates only part of a broad
 package, an independent effect and test set are preferred over treating every
 package change as platform relevant.
+
+### Mapping shape is architecture feedback
+
+Plan is deliberately a weak architecture constraint. It does not prescribe
+source layout, reject existing mixed directories, or require unrelated changes
+to repay historical debt. It does make the cost of an unclear boundary visible
+when an optimization tries to name that boundary.
+
+A stable responsibility usually produces a short composition of directory
+prefixes and a few genuine entrypoints. A growing exact-file list, repeated
+negative exclusions, or a hand-maintained transitive closure is a signal that
+the source or test hierarchy does not express the responsibility being
+scheduled. The mapping is then diagnosing architecture debt; adding more
+planner precision does not resolve it.
+
+An iteration encountering that signal has three honest choices:
+
+1. Refactor the local source or test hierarchy until the responsibility has a
+   stable boundary.
+2. Accept a broader route and its execution cost.
+3. Defer active omission while retaining full fallback.
+
+Do not create a fourth choice by using a fragile enumeration to manufacture
+`certain` confidence. This feedback remains local to the slice under active CI
+optimization, so it can guide gradual improvement without turning plan into a
+repository-wide architecture gate.
 
 ### One-way planning authority
 
@@ -185,7 +213,10 @@ An active `certain` omission requires:
 
 1. **A conservative rule-table boundary.** Promoted matches stay explicit and
    narrow. Unknown or mixed changes, empty, unresolved, or invalid change
-   resolution, and below-threshold inputs select the full plan.
+   resolution, and below-threshold inputs select the full plan. An enumerated
+   dependency closure may be promoted only when unmapped sibling changes fall
+   back to broader coverage; a broad `certain` parent must not silently absorb
+   future dependencies outside the enumeration.
 2. **Planner-owned validation.** `scopes.py validate` rejects schema drift,
    unknown effects, invalid regexes, match cycles, malformed or duplicate
    matrices, and invalid UI P0 shadow references before dispatch.
@@ -272,6 +303,13 @@ workload outside forced-full plans. The source unit includes the Windows
 tools-pack implementation and resources, its explicit shared-module closure,
 the Windows-only test file, launcher-proto and sidecar-proto sources, and the
 narrow platform/release/sidecar exports consumed by that closure.
+
+That exact shared-module closure is also a diagnostic signal: the flat
+`tools/pack/src/` root does not yet expose stable core, launcher, and
+platform-specific source units. The enumeration records the current dependency
+shape, but it is not a durable pattern to copy or a substitute for decomposing
+that source hierarchy. Until the source boundary or its conservative fallback
+is strengthened, this route remains an active migration surface.
 
 Desktop, packaged-runtime, mac-only, and unrelated tools-pack changes retain
 Linux package coverage without starting a Windows runner. Package manifests,

--- a/tools/pack/tests/launcher-payload-windows.test.ts
+++ b/tools/pack/tests/launcher-payload-windows.test.ts
@@ -1,0 +1,341 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { LAUNCHER_SCHEMA_VERSION } from "@open-design/launcher-proto";
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { ToolPackCache } from "../src/cache.js";
+import { winResources } from "../src/resources.js";
+import {
+  buildWinLauncherPayloadArchive,
+  buildWinLauncherPayloadManifest,
+  validateWinLauncherPayloadArchive,
+} from "../src/win/payload.js";
+import type { WinBuiltAppManifest, WinPaths } from "../src/win/types.js";
+
+const execFileAsync = promisify(execFile);
+
+function makeWinConfig(root: string, namespace: string, appVersion: string): ToolPackConfig {
+  return {
+    appVersion,
+    containerized: false,
+    electronBuilderCliPath: "/x/electron-builder/cli.js",
+    electronDistPath: "/x/electron/dist",
+    electronVersion: "41.3.0",
+    macCompression: "normal",
+    namespace,
+    platform: "win",
+    portable: false,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    requireVelaCli: false,
+    roots: {
+      cacheRoot: join(root, ".tmp", "tools-pack", "cache"),
+      output: {
+        appBuilderRoot: join(root, ".tmp", "tools-pack", "out", "win", "namespaces", namespace, "builder"),
+        namespaceRoot: join(root, ".tmp", "tools-pack", "out", "win", "namespaces", namespace),
+        platformRoot: join(root, ".tmp", "tools-pack", "out", "win"),
+        root: join(root, ".tmp", "tools-pack", "out"),
+      },
+      runtime: {
+        namespaceBaseRoot: join(root, ".tmp", "tools-pack", "runtime", "win", "namespaces"),
+        namespaceRoot: join(root, ".tmp", "tools-pack", "runtime", "win", "namespaces", namespace),
+      },
+      toolPackRoot: join(root, ".tmp", "tools-pack"),
+    },
+    signed: false,
+    silent: true,
+    to: "nsis",
+    webOutputMode: "standalone",
+    workspaceRoot: root,
+  };
+}
+
+async function expectPathExists(path: string): Promise<void> {
+  await expect(access(path)).resolves.toBeUndefined();
+}
+
+function createWinPaths(root: string, namespace: string): WinPaths {
+  const namespaceRoot = join(root, ".tmp", "tools-pack", "out", "win", "namespaces", namespace);
+  return {
+    appBuilderConfigPath: join(namespaceRoot, "builder-config.json"),
+    appBuilderOutputRoot: join(namespaceRoot, "builder"),
+    assembledAppRoot: join(namespaceRoot, "assembled", "app"),
+    assembledMainEntryPath: join(namespaceRoot, "assembled", "app", "main.cjs"),
+    assembledPackageJsonPath: join(namespaceRoot, "assembled", "app", "package.json"),
+    assembledPrebundledRoot: join(namespaceRoot, "assembled", "app", "prebundled"),
+    blockmapPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-setup.exe.blockmap"),
+    builtManifestPath: join(namespaceRoot, "built-app.json"),
+    daemonCliPrebundleEntrypointPath: join(namespaceRoot, "prebundle-entrypoints", "daemon-cli.js"),
+    daemonCliPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "daemon", "daemon-cli.mjs"),
+    daemonPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "daemon.meta.json"),
+    daemonPrebundleRoot: join(namespaceRoot, "assembled", "app", "prebundled", "daemon"),
+    daemonSidecarPrebundleEntrypointPath: join(namespaceRoot, "prebundle-entrypoints", "daemon-sidecar.js"),
+    daemonSidecarPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "daemon", "daemon-sidecar.mjs"),
+    exePath: join(namespaceRoot, "builder", "Open Design-release-beta-win.exe"),
+    installDir: join(namespaceRoot, "runtime", "install", "Open Design Beta"),
+    installedExePath: join(namespaceRoot, "runtime", "install", "Open Design Beta", "Open Design.exe"),
+    installerBasePayloadPath: join(namespaceRoot, "installer", "payload-base.7z"),
+    installerOverlayPayloadPath: join(namespaceRoot, "installer", "payload-overlay.7z"),
+    installerScriptPath: join(namespaceRoot, "installer", "installer.nsi"),
+    launcherPayloadPath: join(namespaceRoot, "payload", "Open Design-release-beta-win-payload.7z"),
+    publicDesktopShortcutPath: join(namespaceRoot, "desktop", "public.lnk"),
+    latestYmlPath: join(namespaceRoot, "builder", "latest.yml"),
+    installMarkerPath: join(namespaceRoot, "logs", "install.marker.json"),
+    installTimingPath: join(namespaceRoot, "logs", "install.timing.json"),
+    nsisLogPath: join(namespaceRoot, "logs", "nsis.log"),
+    nsisIncludePath: join(namespaceRoot, "nsis", "installer.nsh"),
+    packagedConfigPath: join(namespaceRoot, "open-design-config.json"),
+    packagedMainPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "packaged-main.meta.json"),
+    packagedMainPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "packaged-main.mjs"),
+    resourceRoot: join(namespaceRoot, "resources", "open-design"),
+    setupPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-setup.exe"),
+    setupZipPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-portable.zip"),
+    startMenuShortcutPath: join(namespaceRoot, "start-menu.lnk"),
+    tarballsRoot: join(namespaceRoot, "tarballs"),
+    userDesktopShortcutPath: join(namespaceRoot, "desktop", "user.lnk"),
+    uninstallMarkerPath: join(namespaceRoot, "logs", "uninstall.marker.json"),
+    uninstallTimingPath: join(namespaceRoot, "logs", "uninstall.timing.json"),
+    uninstallerPath: join(namespaceRoot, "runtime", "install", "Open Design Beta", "Uninstall.exe"),
+    webStandaloneHookAuditPath: join(namespaceRoot, "web-standalone-after-pack-audit.json"),
+    webStandaloneHookConfigPath: join(namespaceRoot, "web-standalone-after-pack-config.json"),
+    webSidecarPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "web-sidecar.meta.json"),
+    webSidecarPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "web-sidecar.mjs"),
+    winIconPath: join(namespaceRoot, "resources", "win", "icon.ico"),
+    unpackedExePath: join(namespaceRoot, "builder", "win-unpacked", "Open Design.exe"),
+    unpackedRoot: join(namespaceRoot, "builder", "win-unpacked"),
+  };
+}
+
+async function writeFakeWinUnpackedApp(root: string, namespace: string, version: string): Promise<{
+  builtApp: WinBuiltAppManifest;
+  paths: WinPaths;
+}> {
+  const paths = createWinPaths(root, namespace);
+  await mkdir(join(paths.unpackedRoot, "resources"), { recursive: true });
+  await writeFile(join(paths.unpackedRoot, "Open Design.exe"), "fake executable\n", "utf8");
+  await writeFile(
+    join(paths.unpackedRoot, "resources", "open-design-config.json"),
+    `${JSON.stringify({
+      appVersion: version,
+      daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
+      namespace,
+      nodeCommandRelative: "open-design/bin/node",
+      webOutputMode: "standalone",
+      webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  await mkdir(join(paths.unpackedRoot, "resources", "app"), { recursive: true });
+  await writeFile(
+    join(paths.unpackedRoot, "resources", "app", "package.json"),
+    `${JSON.stringify({ name: "open-design-packaged-app", version })}\n`,
+    "utf8",
+  );
+  await mkdir(join(paths.packagedConfigPath, ".."), { recursive: true });
+  await writeFile(
+    paths.packagedConfigPath,
+    `${JSON.stringify({
+      appVersion: version,
+      daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
+      namespace,
+      nodeCommandRelative: "open-design/bin/node",
+      webOutputMode: "standalone",
+      webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
+    }, null, 2)}\n`,
+    "utf8",
+  );
+  return {
+    builtApp: {
+      appBuilderOutputRoot: paths.appBuilderOutputRoot,
+      cacheEntryPath: null,
+      configPath: paths.packagedConfigPath,
+      executablePath: join(paths.unpackedRoot, "Open Design.exe"),
+      source: "namespace",
+      unpackedRoot: paths.unpackedRoot,
+      version: 1,
+      webStandaloneHookAuditPath: null,
+    },
+    paths,
+  };
+}
+
+describe("tools-pack Windows launcher payload archives", () => {
+  it("builds a channel- and namespace-scoped payload manifest", () => {
+    expect(buildWinLauncherPayloadManifest({
+      channel: "beta",
+      namespace: "release-beta-win",
+      version: "0.9.0-beta.2",
+    })).toEqual({
+      channel: "beta",
+      entry: {
+        cwd: "payload",
+        executable: "payload/Open Design.exe",
+      },
+      namespace: "release-beta-win",
+      payloadRoot: "payload",
+      platform: "win32",
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      version: "0.9.0-beta.2",
+    });
+  });
+
+  it.skipIf(process.platform !== "win32")("creates a Windows payload 7z with bootstrap-readable contents", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-"));
+    try {
+      const namespace = "release-beta-win";
+      const version = "0.9.0-beta.2";
+      const config = makeWinConfig(root, namespace, version);
+      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
+      await buildWinLauncherPayloadArchive(config, paths, builtApp);
+
+      const extractRoot = join(root, "extracted");
+      await mkdir(extractRoot, { recursive: true });
+      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
+
+      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as {
+        entry: { executable: string };
+        namespace: string;
+        platform: string;
+        version: string;
+      };
+      expect(manifest.namespace).toBe(namespace);
+      expect(manifest.platform).toBe("win32");
+      expect(manifest.entry.executable).toBe("payload/Open Design.exe");
+      expect(manifest.version).toBe(version);
+      await expectPathExists(join(extractRoot, "payload", "Open Design.exe"));
+      await expectPathExists(join(extractRoot, "payload", "resources", "open-design-config.json"));
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")("validates Windows launcher payload archives", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-validate-"));
+    try {
+      const namespace = "release-beta-win";
+      const version = "0.9.0-beta.2";
+      const config = makeWinConfig(root, namespace, version);
+      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
+      await buildWinLauncherPayloadArchive(config, paths, builtApp);
+
+      await expect(validateWinLauncherPayloadArchive({
+        expectedVersion: version,
+        namespace,
+        payloadPath: paths.launcherPayloadPath,
+        workspaceRoot: root,
+      })).resolves.toMatchObject({
+        manifest: {
+          namespace,
+          version,
+        },
+        valid: true,
+      });
+      await expect(validateWinLauncherPayloadArchive({
+        expectedVersion: "0.9.0-beta.3",
+        namespace,
+        payloadPath: paths.launcherPayloadPath,
+        workspaceRoot: root,
+      })).rejects.toThrow("launcher payload manifest version expected");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")("reuses the Windows payload archive when base and overlay metadata are unchanged", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-cache-"));
+    try {
+      const namespace = "release-beta-win";
+      const initialVersion = "0.9.0-beta.0";
+      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, initialVersion);
+      const cache = new ToolPackCache(join(root, "cache"));
+
+      for (const version of ["0.9.0-beta.1", "0.9.0-beta.2", "0.9.0-beta.2"]) {
+        const config = makeWinConfig(root, namespace, version);
+        await writeFile(
+          paths.packagedConfigPath,
+          `${JSON.stringify({
+            appVersion: version,
+            daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
+            namespace,
+            nodeCommandRelative: "open-design/bin/node",
+            webOutputMode: "standalone",
+            webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
+          }, null, 2)}\n`,
+          "utf8",
+        );
+        await buildWinLauncherPayloadArchive(config, paths, builtApp, cache);
+      }
+
+      const payloadCacheEntries = cache.report().entries.filter((entry) => entry.nodeId === "win.launcher-payload-base");
+      expect(payloadCacheEntries.map((entry) => entry.status)).toEqual(["miss", "hit", "hit"]);
+      const archiveCacheEntries = cache.report().entries.filter((entry) => entry.nodeId === "win.launcher-payload");
+      expect(archiveCacheEntries.map((entry) => entry.status)).toEqual(["miss", "miss", "hit"]);
+      expect(archiveCacheEntries.at(-1)?.materialized).toEqual([
+        expect.objectContaining({ from: "payload.7z", to: paths.launcherPayloadPath }),
+      ]);
+
+      const extractRoot = join(root, "extracted");
+      await mkdir(extractRoot, { recursive: true });
+      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
+
+      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as { version: string };
+      const config = JSON.parse(
+        await readFile(join(extractRoot, "payload", "resources", "open-design-config.json"), "utf8"),
+      ) as { appVersion: string };
+      const packageJson = JSON.parse(
+        await readFile(join(extractRoot, "payload", "resources", "app", "package.json"), "utf8"),
+      ) as { version: string };
+      expect(manifest.version).toBe("0.9.0-beta.2");
+      expect(config.appVersion).toBe("0.9.0-beta.2");
+      expect(packageJson.version).toBe("0.9.0-beta.2");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")("can seed the Windows launcher payload from the NSIS base archive", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-nsis-seed-"));
+    try {
+      const namespace = "release-beta-win";
+      const version = "0.9.0-beta.3";
+      const config = makeWinConfig(root, namespace, version);
+      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
+      const cache = new ToolPackCache(join(root, "cache"));
+
+      await mkdir(join(paths.installerBasePayloadPath, ".."), { recursive: true });
+      await execFileAsync(winResources.sevenZipExe, [
+        "a",
+        "-t7z",
+        paths.installerBasePayloadPath,
+        "resources",
+      ], { cwd: paths.unpackedRoot, windowsHide: true });
+
+      await buildWinLauncherPayloadArchive(config, paths, builtApp, cache, { seedFromInstallerPayload: true });
+
+      expect(cache.report().entries.some((entry) => entry.nodeId === "win.launcher-payload-base")).toBe(false);
+      expect(cache.report().entries.some((entry) => entry.nodeId === "win.launcher-payload")).toBe(true);
+
+      const extractRoot = join(root, "extracted");
+      await mkdir(extractRoot, { recursive: true });
+      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
+
+      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as { version: string };
+      const configJson = JSON.parse(
+        await readFile(join(extractRoot, "payload", "resources", "open-design-config.json"), "utf8"),
+      ) as { appVersion: string };
+      expect(manifest.version).toBe(version);
+      expect(configJson.appVersion).toBe(version);
+      await expectPathExists(join(extractRoot, "payload", "Open Design.exe"));
+      await expectPathExists(join(extractRoot, "payload", "resources"));
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/tests/launcher-payload.test.ts
+++ b/tools/pack/tests/launcher-payload.test.ts
@@ -7,25 +7,17 @@ import { promisify } from "node:util";
 import { LAUNCHER_SCHEMA_VERSION } from "@open-design/launcher-proto";
 import { describe, expect, it } from "vitest";
 
-import type { ToolPackConfig, ToolPackPlatform } from "../src/config.js";
-import { ToolPackCache } from "../src/cache.js";
+import type { ToolPackConfig } from "../src/config.js";
 import { resolveMacInstallIdentity } from "../src/mac/identity.js";
 import {
   buildMacLauncherPayloadManifest,
   createMacLauncherPayloadArchive,
 } from "../src/mac/payload.js";
 import { resolveMacPaths } from "../src/mac/paths.js";
-import { winResources } from "../src/resources.js";
-import {
-  buildWinLauncherPayloadArchive,
-  buildWinLauncherPayloadManifest,
-  validateWinLauncherPayloadArchive,
-} from "../src/win/payload.js";
-import type { WinBuiltAppManifest, WinPaths } from "../src/win/types.js";
 
 const execFileAsync = promisify(execFile);
 
-function makeConfig(root: string, platform: ToolPackPlatform, namespace: string, appVersion: string): ToolPackConfig {
+function makeMacConfig(root: string, namespace: string, appVersion: string): ToolPackConfig {
   return {
     appVersion,
     containerized: false,
@@ -34,7 +26,7 @@ function makeConfig(root: string, platform: ToolPackPlatform, namespace: string,
     electronVersion: "41.3.0",
     macCompression: "normal",
     namespace,
-    platform,
+    platform: "mac",
     portable: false,
     removeData: false,
     removeLogs: false,
@@ -44,20 +36,20 @@ function makeConfig(root: string, platform: ToolPackPlatform, namespace: string,
     roots: {
       cacheRoot: join(root, ".tmp", "tools-pack", "cache"),
       output: {
-        appBuilderRoot: join(root, ".tmp", "tools-pack", "out", platform, "namespaces", namespace, "builder"),
-        namespaceRoot: join(root, ".tmp", "tools-pack", "out", platform, "namespaces", namespace),
-        platformRoot: join(root, ".tmp", "tools-pack", "out", platform),
+        appBuilderRoot: join(root, ".tmp", "tools-pack", "out", "mac", "namespaces", namespace, "builder"),
+        namespaceRoot: join(root, ".tmp", "tools-pack", "out", "mac", "namespaces", namespace),
+        platformRoot: join(root, ".tmp", "tools-pack", "out", "mac"),
         root: join(root, ".tmp", "tools-pack", "out"),
       },
       runtime: {
-        namespaceBaseRoot: join(root, ".tmp", "tools-pack", "runtime", platform, "namespaces"),
-        namespaceRoot: join(root, ".tmp", "tools-pack", "runtime", platform, "namespaces", namespace),
+        namespaceBaseRoot: join(root, ".tmp", "tools-pack", "runtime", "mac", "namespaces"),
+        namespaceRoot: join(root, ".tmp", "tools-pack", "runtime", "mac", "namespaces", namespace),
       },
       toolPackRoot: join(root, ".tmp", "tools-pack"),
     },
     signed: false,
     silent: true,
-    to: platform === "win" ? "nsis" : "app",
+    to: "app",
     webOutputMode: "standalone",
     workspaceRoot: root,
   };
@@ -97,120 +89,15 @@ async function writeFakeMacApp(config: ToolPackConfig): Promise<ReturnType<typeo
   return paths;
 }
 
-function createWinPaths(root: string, namespace: string): WinPaths {
-  const namespaceRoot = join(root, ".tmp", "tools-pack", "out", "win", "namespaces", namespace);
-  return {
-    appBuilderConfigPath: join(namespaceRoot, "builder-config.json"),
-    appBuilderOutputRoot: join(namespaceRoot, "builder"),
-    assembledAppRoot: join(namespaceRoot, "assembled", "app"),
-    assembledMainEntryPath: join(namespaceRoot, "assembled", "app", "main.cjs"),
-    assembledPackageJsonPath: join(namespaceRoot, "assembled", "app", "package.json"),
-    assembledPrebundledRoot: join(namespaceRoot, "assembled", "app", "prebundled"),
-    blockmapPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-setup.exe.blockmap"),
-    builtManifestPath: join(namespaceRoot, "built-app.json"),
-    daemonCliPrebundleEntrypointPath: join(namespaceRoot, "prebundle-entrypoints", "daemon-cli.js"),
-    daemonCliPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "daemon", "daemon-cli.mjs"),
-    daemonPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "daemon.meta.json"),
-    daemonPrebundleRoot: join(namespaceRoot, "assembled", "app", "prebundled", "daemon"),
-    daemonSidecarPrebundleEntrypointPath: join(namespaceRoot, "prebundle-entrypoints", "daemon-sidecar.js"),
-    daemonSidecarPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "daemon", "daemon-sidecar.mjs"),
-    exePath: join(namespaceRoot, "builder", "Open Design-release-beta-win.exe"),
-    installDir: join(namespaceRoot, "runtime", "install", "Open Design Beta"),
-    installedExePath: join(namespaceRoot, "runtime", "install", "Open Design Beta", "Open Design.exe"),
-    installerBasePayloadPath: join(namespaceRoot, "installer", "payload-base.7z"),
-    installerOverlayPayloadPath: join(namespaceRoot, "installer", "payload-overlay.7z"),
-    installerScriptPath: join(namespaceRoot, "installer", "installer.nsi"),
-    launcherPayloadPath: join(namespaceRoot, "payload", "Open Design-release-beta-win-payload.7z"),
-    publicDesktopShortcutPath: join(namespaceRoot, "desktop", "public.lnk"),
-    latestYmlPath: join(namespaceRoot, "builder", "latest.yml"),
-    installMarkerPath: join(namespaceRoot, "logs", "install.marker.json"),
-    installTimingPath: join(namespaceRoot, "logs", "install.timing.json"),
-    nsisLogPath: join(namespaceRoot, "logs", "nsis.log"),
-    nsisIncludePath: join(namespaceRoot, "nsis", "installer.nsh"),
-    packagedConfigPath: join(namespaceRoot, "open-design-config.json"),
-    packagedMainPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "packaged-main.meta.json"),
-    packagedMainPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "packaged-main.mjs"),
-    resourceRoot: join(namespaceRoot, "resources", "open-design"),
-    setupPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-setup.exe"),
-    setupZipPath: join(namespaceRoot, "builder", "Open Design-release-beta-win-portable.zip"),
-    startMenuShortcutPath: join(namespaceRoot, "start-menu.lnk"),
-    tarballsRoot: join(namespaceRoot, "tarballs"),
-    userDesktopShortcutPath: join(namespaceRoot, "desktop", "user.lnk"),
-    uninstallMarkerPath: join(namespaceRoot, "logs", "uninstall.marker.json"),
-    uninstallTimingPath: join(namespaceRoot, "logs", "uninstall.timing.json"),
-    uninstallerPath: join(namespaceRoot, "runtime", "install", "Open Design Beta", "Uninstall.exe"),
-    webStandaloneHookAuditPath: join(namespaceRoot, "web-standalone-after-pack-audit.json"),
-    webStandaloneHookConfigPath: join(namespaceRoot, "web-standalone-after-pack-config.json"),
-    webSidecarPrebundleMetaPath: join(namespaceRoot, "prebundle-meta", "web-sidecar.meta.json"),
-    webSidecarPrebundlePath: join(namespaceRoot, "assembled", "app", "prebundled", "web-sidecar.mjs"),
-    winIconPath: join(namespaceRoot, "resources", "win", "icon.ico"),
-    unpackedExePath: join(namespaceRoot, "builder", "win-unpacked", "Open Design.exe"),
-    unpackedRoot: join(namespaceRoot, "builder", "win-unpacked"),
-  };
-}
-
-async function writeFakeWinUnpackedApp(root: string, namespace: string, version: string): Promise<{
-  builtApp: WinBuiltAppManifest;
-  paths: WinPaths;
-}> {
-  const paths = createWinPaths(root, namespace);
-  await mkdir(join(paths.unpackedRoot, "resources"), { recursive: true });
-  await writeFile(join(paths.unpackedRoot, "Open Design.exe"), "fake executable\n", "utf8");
-  await writeFile(
-    join(paths.unpackedRoot, "resources", "open-design-config.json"),
-    `${JSON.stringify({
-      appVersion: version,
-      daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
-      namespace,
-      nodeCommandRelative: "open-design/bin/node",
-      webOutputMode: "standalone",
-      webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
-    }, null, 2)}\n`,
-    "utf8",
-  );
-  await mkdir(join(paths.unpackedRoot, "resources", "app"), { recursive: true });
-  await writeFile(
-    join(paths.unpackedRoot, "resources", "app", "package.json"),
-    `${JSON.stringify({ name: "open-design-packaged-app", version })}\n`,
-    "utf8",
-  );
-  await mkdir(join(paths.packagedConfigPath, ".."), { recursive: true });
-  await writeFile(
-    paths.packagedConfigPath,
-    `${JSON.stringify({
-      appVersion: version,
-      daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
-      namespace,
-      nodeCommandRelative: "open-design/bin/node",
-      webOutputMode: "standalone",
-      webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
-    }, null, 2)}\n`,
-    "utf8",
-  );
-  return {
-    builtApp: {
-      appBuilderOutputRoot: paths.appBuilderOutputRoot,
-      cacheEntryPath: null,
-      configPath: paths.packagedConfigPath,
-      executablePath: join(paths.unpackedRoot, "Open Design.exe"),
-      source: "namespace",
-      unpackedRoot: paths.unpackedRoot,
-      version: 1,
-      webStandaloneHookAuditPath: null,
-    },
-    paths,
-  };
-}
-
-describe("tools-pack launcher payload archives", () => {
-  it("builds channel and namespace scoped payload manifests for both desktop platforms", () => {
-    const macIdentity = resolveMacInstallIdentity({ appVersion: "0.9.0-beta.2", namespace: "release-beta" });
+describe("tools-pack mac launcher payload archives", () => {
+  it("builds a channel- and namespace-scoped payload manifest", () => {
+    const identity = resolveMacInstallIdentity({ appVersion: "0.9.0-beta.2", namespace: "release-beta" });
 
     expect(buildMacLauncherPayloadManifest({
       channel: "beta",
-      executableName: macIdentity.executableName,
+      executableName: identity.executableName,
       namespace: "release-beta",
-      publicAppBundleName: macIdentity.publicAppBundleName,
+      publicAppBundleName: identity.publicAppBundleName,
       version: "0.9.0-beta.2",
     })).toEqual({
       appBundleName: "Open Design Beta.app",
@@ -225,29 +112,12 @@ describe("tools-pack launcher payload archives", () => {
       schemaVersion: LAUNCHER_SCHEMA_VERSION,
       version: "0.9.0-beta.2",
     });
-
-    expect(buildWinLauncherPayloadManifest({
-      channel: "beta",
-      namespace: "release-beta-win",
-      version: "0.9.0-beta.2",
-    })).toEqual({
-      channel: "beta",
-      entry: {
-        cwd: "payload",
-        executable: "payload/Open Design.exe",
-      },
-      namespace: "release-beta-win",
-      payloadRoot: "payload",
-      platform: "win32",
-      schemaVersion: LAUNCHER_SCHEMA_VERSION,
-      version: "0.9.0-beta.2",
-    });
   });
 
-  it.skipIf(process.platform !== "darwin")("creates a mac payload zip with bootstrap-readable contents", async () => {
+  it.skipIf(process.platform !== "darwin")("creates a payload zip with bootstrap-readable contents", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-tools-pack-mac-payload-"));
     try {
-      const config = makeConfig(root, "mac", "release-beta", "0.9.0-beta.2");
+      const config = makeMacConfig(root, "release-beta", "0.9.0-beta.2");
       const paths = await writeFakeMacApp(config);
       const archivePath = await createMacLauncherPayloadArchive(config, paths);
       const extractRoot = join(root, "extracted");
@@ -271,159 +141,6 @@ describe("tools-pack launcher payload archives", () => {
         "Resources",
         "open-design-config.json",
       ));
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
-  });
-
-  it.skipIf(process.platform !== "win32")("creates a Windows payload 7z with bootstrap-readable contents", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-"));
-    try {
-      const namespace = "release-beta-win";
-      const version = "0.9.0-beta.2";
-      const config = makeConfig(root, "win", namespace, version);
-      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
-      await buildWinLauncherPayloadArchive(config, paths, builtApp);
-
-      const extractRoot = join(root, "extracted");
-      await mkdir(extractRoot, { recursive: true });
-      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
-
-      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as {
-        entry: { executable: string };
-        namespace: string;
-        platform: string;
-        version: string;
-      };
-      expect(manifest.namespace).toBe(namespace);
-      expect(manifest.platform).toBe("win32");
-      expect(manifest.entry.executable).toBe("payload/Open Design.exe");
-      expect(manifest.version).toBe(version);
-      await expectPathExists(join(extractRoot, "payload", "Open Design.exe"));
-      await expectPathExists(join(extractRoot, "payload", "resources", "open-design-config.json"));
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
-  });
-
-  it.skipIf(process.platform !== "win32")("validates Windows launcher payload archives", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-validate-"));
-    try {
-      const namespace = "release-beta-win";
-      const version = "0.9.0-beta.2";
-      const config = makeConfig(root, "win", namespace, version);
-      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
-      await buildWinLauncherPayloadArchive(config, paths, builtApp);
-
-      await expect(validateWinLauncherPayloadArchive({
-        expectedVersion: version,
-        namespace,
-        payloadPath: paths.launcherPayloadPath,
-        workspaceRoot: root,
-      })).resolves.toMatchObject({
-        manifest: {
-          namespace,
-          version,
-        },
-        valid: true,
-      });
-      await expect(validateWinLauncherPayloadArchive({
-        expectedVersion: "0.9.0-beta.3",
-        namespace,
-        payloadPath: paths.launcherPayloadPath,
-        workspaceRoot: root,
-      })).rejects.toThrow("launcher payload manifest version expected");
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
-  });
-
-  it.skipIf(process.platform !== "win32")("reuses the Windows payload archive when base and overlay metadata are unchanged", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-cache-"));
-    try {
-      const namespace = "release-beta-win";
-      const initialVersion = "0.9.0-beta.0";
-      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, initialVersion);
-      const cache = new ToolPackCache(join(root, "cache"));
-
-      for (const version of ["0.9.0-beta.1", "0.9.0-beta.2", "0.9.0-beta.2"]) {
-        const config = makeConfig(root, "win", namespace, version);
-        await writeFile(
-          paths.packagedConfigPath,
-          `${JSON.stringify({
-            appVersion: version,
-            daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
-            namespace,
-            nodeCommandRelative: "open-design/bin/node",
-            webOutputMode: "standalone",
-            webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
-          }, null, 2)}\n`,
-          "utf8",
-        );
-        await buildWinLauncherPayloadArchive(config, paths, builtApp, cache);
-      }
-
-      const payloadCacheEntries = cache.report().entries.filter((entry) => entry.nodeId === "win.launcher-payload-base");
-      expect(payloadCacheEntries.map((entry) => entry.status)).toEqual(["miss", "hit", "hit"]);
-      const archiveCacheEntries = cache.report().entries.filter((entry) => entry.nodeId === "win.launcher-payload");
-      expect(archiveCacheEntries.map((entry) => entry.status)).toEqual(["miss", "miss", "hit"]);
-      expect(archiveCacheEntries.at(-1)?.materialized).toEqual([
-        expect.objectContaining({ from: "payload.7z", to: paths.launcherPayloadPath }),
-      ]);
-
-      const extractRoot = join(root, "extracted");
-      await mkdir(extractRoot, { recursive: true });
-      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
-
-      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as { version: string };
-      const config = JSON.parse(
-        await readFile(join(extractRoot, "payload", "resources", "open-design-config.json"), "utf8"),
-      ) as { appVersion: string };
-      const packageJson = JSON.parse(
-        await readFile(join(extractRoot, "payload", "resources", "app", "package.json"), "utf8"),
-      ) as { version: string };
-      expect(manifest.version).toBe("0.9.0-beta.2");
-      expect(config.appVersion).toBe("0.9.0-beta.2");
-      expect(packageJson.version).toBe("0.9.0-beta.2");
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
-  });
-
-  it.skipIf(process.platform !== "win32")("can seed the Windows launcher payload from the NSIS base archive", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-payload-nsis-seed-"));
-    try {
-      const namespace = "release-beta-win";
-      const version = "0.9.0-beta.3";
-      const config = makeConfig(root, "win", namespace, version);
-      const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
-      const cache = new ToolPackCache(join(root, "cache"));
-
-      await mkdir(join(paths.installerBasePayloadPath, ".."), { recursive: true });
-      await execFileAsync(winResources.sevenZipExe, [
-        "a",
-        "-t7z",
-        paths.installerBasePayloadPath,
-        "resources",
-      ], { cwd: paths.unpackedRoot, windowsHide: true });
-
-      await buildWinLauncherPayloadArchive(config, paths, builtApp, cache, { seedFromInstallerPayload: true });
-
-      expect(cache.report().entries.some((entry) => entry.nodeId === "win.launcher-payload-base")).toBe(false);
-      expect(cache.report().entries.some((entry) => entry.nodeId === "win.launcher-payload")).toBe(true);
-
-      const extractRoot = join(root, "extracted");
-      await mkdir(extractRoot, { recursive: true });
-      await execFileAsync(winResources.sevenZipExe, ["x", paths.launcherPayloadPath, `-o${extractRoot}`, "-y"]);
-
-      const manifest = JSON.parse(await readFile(join(extractRoot, "manifest.json"), "utf8")) as { version: string };
-      const configJson = JSON.parse(
-        await readFile(join(extractRoot, "payload", "resources", "open-design-config.json"), "utf8"),
-      ) as { appVersion: string };
-      expect(manifest.version).toBe(version);
-      expect(configJson.appVersion).toBe(version);
-      await expectPathExists(join(extractRoot, "payload", "Open Design.exe"));
-      await expectPathExists(join(extractRoot, "payload", "resources"));
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary

- document the recommended `changed paths -> source units -> test sets -> workloads` iteration model without turning existing CI debt into a repository-wide hard constraint
- establish mapping complexity as architecture feedback: a fragile exact-file closure must not substitute for a stable source boundary
- separate merge-group policy from planning so workloads still fan out unchanged and `Validate workspace` remains the sole required convergence point
- split the Windows launcher payload tests into an independent test set and route them through a dedicated planner effect
- reorganize `specs/current/ci.md` into iteration method, reusable paradigms, current runtime contract, current references, evidence, and open questions

## Safety and coverage

- planner outputs and workload coverage are preserved by the job-DAG refactor
- blocked merge groups still execute their planned validation before policy is enforced at convergence
- unknown, mixed, unresolved, below-threshold, and forced-full plans retain conservative full coverage
- manifests and workspace/lock configuration continue to arm Windows payload validation
- desktop, packaged-runtime, mac-only, and unrelated tools-pack changes retain Linux package coverage without unnecessarily starting a Windows runner
- the current Windows shared-module enumeration is explicitly documented as a migration surface: it exposes that the flat `tools/pack/src/` hierarchy does not yet provide a durable prefix boundary

## Evidence

- replayed the latest 400 first-parent merges through `scopes.py plan --context merge-queue`
- among 23 pure packaged-leaf groups, the independent Windows route retains 5 and omits 18
- recent pure-leaf Windows payload jobs take about 3.4-4.7 elapsed minutes and can determine the validation critical path

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack test`
- focused planner tests: 8 passed
- CI topology tests: 71 passed, 1 skipped
- `python3 .github/scripts/scopes.py validate`
- `python3 .github/scripts/hash.py validate`
- `python3 .github/scripts/handoff.py self-check`
- `actionlint -color`
- `git diff --check`