### PR TITLE
fix(web): restore interactive srcdoc previews

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -4033,7 +4033,7 @@ function FileVersionManagerModal({
             <iframe
               ref={versionPreviewIframeRef}
               title={selectedVersion ? `${file.name} v${selectedVersion.version}` : file.name}
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
               srcDoc={srcDoc}
               onLoad={() => setLoadedSrcDoc(srcDoc)}
             />
@@ -7211,7 +7211,7 @@ function ReactComponentViewer({
             <iframe
               data-testid="react-component-preview-frame"
               title={file.name}
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
               srcDoc={srcDoc}
               style={{ width: '100%', height: '100%', border: 0 }}
             />
@@ -16857,7 +16857,7 @@ function HtmlViewer({
                         aria-hidden={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? undefined : true}
                         tabIndex={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? 0 : -1}
                         title={file.name}
-                        sandbox="allow-scripts allow-downloads"
+                        sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
                         src={srcDocTransportUrl ?? 'about:blank'}
                         srcDoc={srcDocTransportUrl ? undefined : srcDocTransportContent}
                         onLoad={() => {
@@ -17251,7 +17251,7 @@ function HtmlViewer({
           {effectiveDeck || !useUrlLoadPreview ? (
             <iframe
               title="present"
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
               data-od-render-mode="srcdoc"
               srcDoc={effectiveDeck ? presentationSrcDoc : srcDoc}
             />

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -4605,7 +4605,7 @@ describe('FileViewer SVG artifacts', () => {
     });
   });
 
-  it('allows downloads in React component preview iframes', async () => {
+  it('allows interactive controls and downloads in React component preview iframes', async () => {
     const file = baseFile({
       name: 'Card.jsx',
       path: 'Card.jsx',
@@ -4631,7 +4631,9 @@ describe('FileViewer SVG artifacts', () => {
     render(<FileViewer projectId="project-1" projectKind="prototype" file={file} />);
 
     const frame = await screen.findByTestId('react-component-preview-frame');
-    expect(frame.getAttribute('sandbox')).toBe('allow-scripts allow-downloads');
+    expect(frame.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-forms allow-popups allow-modals allow-downloads',
+    );
   });
 
   it('disables React component sharing controls for viewer-only shared projects', async () => {
@@ -4734,7 +4736,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(onOpenFileReplacing).toHaveBeenCalledWith('backups.html', 'icons.jsx');
   });
 
-  it('keeps decks on the srcDoc path so the deck postMessage bridge can run', () => {
+  it('keeps decks on the srcDoc path with interactive sandbox permissions', () => {
     const file = baseFile({
       name: 'deck.html',
       path: 'deck.html',
@@ -4762,7 +4764,17 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('data-od-render-mode="srcdoc" data-od-active="true"');
     expect(markup).toContain('data-od-render-mode="url-load" data-od-active="false"');
     expect(markup).not.toContain('data-od-lazy-srcdoc-transport');
-    expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
+    const parsedMarkup = new DOMParser().parseFromString(markup, 'text/html');
+    const srcDocFrame = parsedMarkup.querySelector<HTMLIFrameElement>(
+      'iframe[data-od-render-mode="srcdoc"]',
+    );
+    const urlLoadFrame = parsedMarkup.querySelector<HTMLIFrameElement>(
+      'iframe[data-od-render-mode="url-load"]',
+    );
+    expect(srcDocFrame?.getAttribute('sandbox')).toBe(
+      'allow-scripts allow-forms allow-popups allow-modals allow-downloads',
+    );
+    expect(urlLoadFrame?.getAttribute('sandbox')).toBe('allow-scripts allow-downloads');
   });
 
   it('falls back to srcDoc when the HTML body looks deck-shaped even without an isDeck hint', () => {


### PR DESCRIPTION
Fixes #6563

## Why

Interactive HTML previews rendered through the `srcDoc` sandbox could not submit forms, open modals, or open popups. I hit this while validating the HTML preview behavior requested by #6563. The fix restores the browser capabilities needed by interactive previews while keeping the iframe sandbox and the URL-load preview path unchanged.

This is a fresh implementation from the current `main` branch. Maintainer @lefarcen explicitly reopened #6563 for community contribution after Draft PR #6566 had no author activity; #6566 remains open as a draft for its original author but is not used as this branch's base.

## What users will see

HTML previews rendered through the `srcDoc` path can use interactive controls again: forms submit, modal dialogs work, popups open, and downloads continue to work. URL-loaded previews retain their existing sandbox permissions.

## Surface area

- [ ] **UI** — no new page, dialog, panel, menu item, or setting
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — restores interaction in existing `srcDoc` HTML previews
- [ ] **None**

## Screenshots

Not applicable; this is a sandbox capability change with no layout change.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.test.tsx`
- The focused regression spec went red before the source change on main because the srcDoc iframe exposed only `allow-scripts allow-downloads`; it is green on this branch.
- The regression asserts the interactive srcDoc sandbox tokens and explicitly preserves the URL-load sandbox contract.
- Browser smoke in Chromium passed for form submission, modal dialogs, popups, and downloads.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx tests/components/file-viewer-render-mode.test.ts tests/components/PreviewModal.test.tsx --maxWorkers=2 --reporter=dot` — 363 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
- `pnpm --filter @open-design/web test` — attempted; the repository-wide suite has unrelated baseline failures in the current Node 26 environment (localStorage/test isolation, component timing, and worker timeouts). The changed FileViewer-related matrix above passes.
- No `allow-same-origin` was added; the URL-load preview path was not changed.