### PR TITLE
feat(daemon): migrate OpenCode runtime to opencode2

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2080,7 +2080,7 @@ function extractOpenCodeTextFromRawStdout(stdout: string): string {
 }
 
 const OPENCODE_OUTDATED_CLI_DETAIL =
-  'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.';
+  'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it to the latest `opencode2` release, then retry the OpenCode connection test.';
 const OPENCODE_PROVIDER_CONNECTIVITY_DETAIL_MAX_LENGTH = 240;
 
 function openCodeOutdatedCliDetail(output: string): string | null {
@@ -2578,12 +2578,12 @@ async function testAgentConnectionInternal(
             : {}),
         },
       );
-      // Connection tests should validate the adapter's core CLI path, not
-      // fail on unrelated user-installed OpenCode plugins. `opencode run
-      // --pure` keeps the smoke test isolated while regular chat runs retain
-      // the user's full plugin environment.
-      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--pure')) {
-        args.push('--pure');
+      // Connection tests should validate the adapter's current non-interactive
+      // CLI path without stopping on approval prompts. OpenCode 2 no longer
+      // accepts the legacy `--pure` flag, but still supports `--auto` to
+      // auto-approve permissions that are not explicitly denied.
+      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--auto')) {
+        args.push('--auto');
       }
       if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--title')) {
         args.push('--title', 'Connection test');

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -98,6 +98,7 @@ import {
   BYOK_OPENCODE_PROVIDER_ID,
   buildOpenCodeByokProviderConfig,
 } from './runtimes/byok-opencode.js';
+import { resolveOpenCodeConnectionApprovalFlag } from './runtimes/opencode-permissions.js';
 
 export { validateBaseUrl } from '@open-design/contracts/api/connectionTest';
 
@@ -2572,18 +2573,23 @@ async function testAgentConnectionInternal(
         },
         {
           cwd: tempDir,
+          launchPath: executableResolution.launchPath,
           ...(promptFile ? { promptFilePath: promptFile.path } : {}),
           ...(antigravityLogFilePath
             ? { agentLogFilePath: antigravityLogFilePath }
             : {}),
         },
       );
-      // Connection tests should validate the adapter's current non-interactive
-      // CLI path without stopping on approval prompts. OpenCode 2 no longer
-      // accepts the legacy `--pure` flag, but still supports `--auto` to
-      // auto-approve permissions that are not explicitly denied.
-      if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--auto')) {
-        args.push('--auto');
+      // Preserve plugin-isolated smoke tests on legacy OpenCode while using the
+      // current non-interactive approval path on opencode2.
+      if (input.agentId === 'opencode') {
+        const approvalFlag = resolveOpenCodeConnectionApprovalFlag(
+          input.agentId,
+          executableResolution.launchPath,
+        );
+        if (approvalFlag && !args.includes(approvalFlag)) {
+          args.push(approvalFlag);
+        }
       }
       if ((input.agentId === 'opencode' || input.agentId === 'mimo') && !args.includes('--title')) {
         args.push('--title', 'Connection test');

--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -416,9 +416,8 @@ export function buildAcpMcpServers(servers: McpServerConfig[]): AcpMcpServer[] {
  * access to daemon-selected absolute paths (project cwd, staged skill dirs,
  * etc.) so headless OpenCode runs do not auto-reject them.
  *
- * Schema (verified against the dev branch of `sst/opencode`'s
- * `packages/opencode/src/config/config.ts` and the public docs at
- * <https://opencode.ai/docs/mcp-servers>):
+ * Schema (verified against the upstream OpenCode config implementation and the
+ * public V2 docs at <https://opencode.ai/v2/docs/mcp-servers>):
  *
  *   {
  *     "mcp": {

--- a/apps/daemon/src/runtimes/defs/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/defs/byok-opencode.ts
@@ -9,21 +9,13 @@ import type { RuntimeAgentDef } from '../types.js';
 export const byokOpenCodeAgentDef = {
   id: 'byok-opencode',
   name: 'BYOK OpenCode',
-  bin: 'opencode-cli',
-  fallbackBins: ['opencode'],
+  bin: 'opencode2',
+  fallbackBins: ['opencode-cli', 'opencode'],
   versionArgs: ['--version'],
   ...OPENCODE_PERMISSION_CAPABILITY,
   fallbackModels: [DEFAULT_MODEL_OPTION],
-  buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
+  buildArgs: (_prompt, _imagePaths, _extra, options = {}, _runtimeContext = {}) => {
     const args = ['run', '--format', 'json'];
-    if (typeof runtimeContext.cwd === 'string' && runtimeContext.cwd.length > 0) {
-      // OpenCode promotes nested directories to the enclosing Git worktree
-      // unless its own directory flag is explicit. Managed OpenDesign
-      // projects live under the development repository in local runs, so
-      // relying on spawn({ cwd }) alone can make Write/Edit target the repo
-      // root instead of the selected project.
-      args.push('--dir', runtimeContext.cwd);
-    }
     appendOpenCodePermissionBypass(args, 'byok-opencode');
     const model = opencodeByokModelId(options.model);
     if (model) args.push('-m', model);

--- a/apps/daemon/src/runtimes/defs/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/defs/byok-opencode.ts
@@ -2,6 +2,7 @@ import { opencodeByokModelId } from '../byok-opencode.js';
 import {
   OPENCODE_PERMISSION_CAPABILITY,
   appendOpenCodePermissionBypass,
+  appendOpenCodeWorkspaceDir,
 } from '../opencode-permissions.js';
 import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
@@ -14,9 +15,10 @@ export const byokOpenCodeAgentDef = {
   versionArgs: ['--version'],
   ...OPENCODE_PERMISSION_CAPABILITY,
   fallbackModels: [DEFAULT_MODEL_OPTION],
-  buildArgs: (_prompt, _imagePaths, _extra, options = {}, _runtimeContext = {}) => {
+  buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
     const args = ['run', '--format', 'json'];
     appendOpenCodePermissionBypass(args, 'byok-opencode');
+    appendOpenCodeWorkspaceDir(args, 'byok-opencode', runtimeContext);
     const model = opencodeByokModelId(options.model);
     if (model) args.push('-m', model);
     return args;

--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -8,8 +8,8 @@ import type { RuntimeAgentDef } from '../types.js';
 export const opencodeAgentDef = {
     id: 'opencode',
     name: 'OpenCode',
-    bin: 'opencode-cli',
-    fallbackBins: ['opencode'],
+    bin: 'opencode2',
+    fallbackBins: ['opencode-cli', 'opencode'],
     versionArgs: ['--version'],
     ...OPENCODE_PERMISSION_CAPABILITY,
     // `opencode models` prints `provider/model` per line. Real-world
@@ -82,6 +82,6 @@ export const opencodeAgentDef = {
     // + OPENCODE_CONFIG_CONTENT). The env-var form lets the daemon hand
     // user-configured external MCP servers to a single `opencode run`
     // invocation without polluting the user's saved config files. See
-    // <https://opencode.ai/docs/config> and issue #2142.
+    // <https://opencode.ai/v2/docs/config> and issue #2142.
     externalMcpInjection: 'opencode-env-content',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -225,7 +225,7 @@ export function resolveAmrOpenCodeExecutable(
       if (bundled) return bundled;
     }
   }
-  return resolveOnPath('opencode-cli') ?? resolveOnPath('opencode');
+  return resolveOnPath('opencode2') ?? resolveOnPath('opencode-cli') ?? resolveOnPath('opencode');
 }
 
 // `tools/pack/tests/resources.test.ts` ships the AMR OpenCode companion as a

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -24,8 +24,8 @@ const AGENT_INSTALL_LINKS: Record<
     docsUrl: 'https://docs.devin.ai',
   },
   opencode: {
-    installUrl: 'https://opencode.ai/docs',
-    docsUrl: 'https://github.com/sst/opencode',
+    installUrl: 'https://opencode.ai/v2/docs/',
+    docsUrl: 'https://opencode.ai/v2/docs/',
   },
   hermes: {
     installUrl: 'https://github.com/nexu-io/open-design/blob/main/docs/agent-adapters.md',

--- a/apps/daemon/src/runtimes/opencode-permissions.ts
+++ b/apps/daemon/src/runtimes/opencode-permissions.ts
@@ -1,17 +1,78 @@
+import path from 'node:path';
 import { agentCapabilities } from './capabilities.js';
 import type { RuntimeAgentDef } from './types.js';
+import type { RuntimeContext } from './types.js';
 
 export const OPENCODE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+export const OPENCODE_WORKSPACE_DIR_FLAG = '--dir';
+export const OPENCODE_AUTO_APPROVE_FLAG = '--auto';
+export const OPENCODE_PURE_FLAG = '--pure';
 
 export const OPENCODE_PERMISSION_CAPABILITY = {
   helpArgs: ['run', '--help'],
   capabilityFlags: {
     [OPENCODE_SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
+    [OPENCODE_WORKSPACE_DIR_FLAG]: 'workspaceDir',
+    [OPENCODE_AUTO_APPROVE_FLAG]: 'autoApprove',
+    [OPENCODE_PURE_FLAG]: 'pureMode',
   },
 } satisfies Pick<RuntimeAgentDef, 'helpArgs' | 'capabilityFlags'>;
 
 export function appendOpenCodePermissionBypass(args: string[], agentId: string): void {
   if (agentCapabilities.get(agentId)?.skipPermissions) {
     args.push(OPENCODE_SKIP_PERMISSIONS_FLAG);
+  }
+}
+
+type OpenCodeExecutableFamily = 'opencode2' | 'legacy' | 'unknown';
+
+function openCodeExecutableFamily(executablePath?: string | null): OpenCodeExecutableFamily {
+  if (!executablePath) return 'unknown';
+  const ext = path.extname(executablePath);
+  const base = path.basename(executablePath, ext).toLowerCase();
+  if (base === 'opencode2') return 'opencode2';
+  if (base === 'opencode' || base === 'opencode-cli') return 'legacy';
+  return 'unknown';
+}
+
+export function appendOpenCodeWorkspaceDir(
+  args: string[],
+  agentId: string,
+  runtimeContext: RuntimeContext = {},
+): void {
+  const cwd = typeof runtimeContext.cwd === 'string' && runtimeContext.cwd.length > 0
+    ? runtimeContext.cwd
+    : null;
+  if (!cwd) return;
+
+  const caps = agentCapabilities.get(agentId);
+  if (caps?.workspaceDir) {
+    args.push(OPENCODE_WORKSPACE_DIR_FLAG, cwd);
+    return;
+  }
+  if (caps && caps.workspaceDir === false) {
+    return;
+  }
+
+  // Preserve the historical workspace pin unless a help probe explicitly
+  // proves the installed CLI build does not advertise `--dir`.
+  args.push(OPENCODE_WORKSPACE_DIR_FLAG, cwd);
+}
+
+export function resolveOpenCodeConnectionApprovalFlag(
+  agentId: string,
+  executablePath?: string | null,
+): string | null {
+  const caps = agentCapabilities.get(agentId);
+  if (caps?.pureMode) return OPENCODE_PURE_FLAG;
+  if (caps?.autoApprove) return OPENCODE_AUTO_APPROVE_FLAG;
+
+  switch (openCodeExecutableFamily(executablePath)) {
+    case 'legacy':
+      return OPENCODE_PURE_FLAG;
+    case 'opencode2':
+      return OPENCODE_AUTO_APPROVE_FLAG;
+    default:
+      return null;
   }
 }

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -30,6 +30,10 @@ export type RuntimeBuildOptions = {
 
 export type RuntimeContext = {
   cwd?: string;
+  // Resolved executable path the daemon is about to spawn. Adapters use this
+  // only for argv compatibility decisions when a capability probe has not run
+  // yet (for example legacy-vs-v2 OpenCode flag differences).
+  launchPath?: string | null;
   // True when the current chat run has at least one prior persisted
   // assistant message in the same conversation — i.e. this isn't the
   // first user turn. Plain-streaming adapters that support a "continue

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11668,6 +11668,7 @@ export async function startServer({
         agentOptions,
         {
           cwd: effectiveCwd,
+          launchPath: agentLaunch.launchPath,
           hasPriorAssistantTurn,
           agentLogFilePath,
           promptFilePath: promptFile?.path,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -48,17 +48,22 @@ async function withFakeAgent<T>(
   const dir = await fsp.mkdtemp(join(tmpdir(), 'od-chat-route-bin-'));
   const oldPath = process.env.PATH;
   try {
+    const binNames = binName === 'opencode' ? ['opencode2', 'opencode'] : [binName];
     if (process.platform === 'win32') {
       const runner = join(dir, `${binName}-test-runner.cjs`);
       await fsp.writeFile(runner, script);
-      await fsp.writeFile(
-        join(dir, `${binName}.cmd`),
-        `@echo off\r\nnode "${runner}" %*\r\n`,
-      );
+      for (const name of binNames) {
+        await fsp.writeFile(
+          join(dir, `${name}.cmd`),
+          `@echo off\r\nnode "${runner}" %*\r\n`,
+        );
+      }
     } else {
-      const bin = join(dir, binName);
-      await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
-      await fsp.chmod(bin, 0o755);
+      for (const name of binNames) {
+        const bin = join(dir, name);
+        await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
+        await fsp.chmod(bin, 0o755);
+      }
     }
     process.env.PATH = `${dir}${delimiter}${oldPath ?? ''}`;
     return await run();

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -160,7 +160,31 @@ async function withOnlyFakeOpenClaude<T>(script: string, run: () => Promise<T>):
 }
 
 async function withFakeOpenCode<T>(script: string, run: () => Promise<T>): Promise<T> {
-  return withFakeAgent('opencode', script, run);
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-conn-test-opencode-bin-'));
+  const oldPath = process.env.PATH;
+  try {
+    if (process.platform === 'win32') {
+      const runner = path.join(dir, 'opencode2-test-runner.cjs');
+      await fsp.writeFile(runner, script);
+      for (const name of ['opencode2', 'opencode']) {
+        await fsp.writeFile(
+          path.join(dir, `${name}.cmd`),
+          `@echo off\r\nnode "${runner}" %*\r\n`,
+        );
+      }
+    } else {
+      for (const name of ['opencode2', 'opencode']) {
+        const bin = path.join(dir, name);
+        await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
+        await fsp.chmod(bin, 0o755);
+      }
+    }
+    process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
+    return await run();
+  } finally {
+    process.env.PATH = oldPath;
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
 }
 
 async function withFakeCursorAgent<T>(script: string, run: () => Promise<T>): Promise<T> {
@@ -3730,7 +3754,7 @@ process.stdin.on('end', () => {
       `
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('openai/gpt-5');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 console.log(JSON.stringify({ type: 'error', error: { data: { message: 'OpenCode auth failed: login required' } } }));
@@ -3755,13 +3779,13 @@ setTimeout(() => process.exit(0), 50);
 
   it('reports outdated OpenCode CLI argument failures with update guidance', async () => {
     const expectedDetail =
-      'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.';
+      'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it to the latest `opencode2` release, then retry the OpenCode connection test.';
 
     await withFakeOpenCode(
       `
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('github-copilot/gpt-4o');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 console.error('opencode');
@@ -3793,7 +3817,7 @@ process.exit(1);
       `
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('github-copilot/gpt-4o');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 console.error('missing required environment variable OPENAI_API_KEY');
@@ -3818,7 +3842,7 @@ process.exit(1);
     );
   });
 
-  it('launches OpenCode connection tests with 1.3-compatible JSON stdin args', async () => {
+  it('launches OpenCode connection tests with opencode2 JSON stdin args', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-opencode-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');
     const stdinFile = path.join(markerDir, 'stdin.txt');
@@ -3828,7 +3852,7 @@ process.exit(1);
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('github-copilot/gpt-4o');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 fs.writeFileSync(${JSON.stringify(argvFile)}, JSON.stringify(args));
@@ -3852,7 +3876,7 @@ process.stdin.on('end', () => {
             body: JSON.stringify({
               mode: 'agent',
               agentId: 'opencode',
-              model: 'github-copilot/gpt-4o',
+              model: 'opencode/deepseek-v4-flash-free',
             }),
           });
           expect(res.status).toBe(200);
@@ -3860,7 +3884,7 @@ process.stdin.on('end', () => {
             ok: true,
             kind: 'success',
             agentName: 'OpenCode',
-            model: 'github-copilot/gpt-4o',
+            model: 'opencode/deepseek-v4-flash-free',
             sample: 'ok',
           });
 
@@ -3870,8 +3894,8 @@ process.stdin.on('end', () => {
               '--format',
               'json',
               '-m',
-              'github-copilot/gpt-4o',
-              '--pure',
+              'opencode/deepseek-v4-flash-free',
+              '--auto',
               '--title',
               'Connection test',
             ]),
@@ -3889,7 +3913,7 @@ process.stdin.on('end', () => {
       `
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('ollama/qwen3.5-9b');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 console.error('Cannot connect to API: Unable to connect. Is the computer able to access the url?');
@@ -3899,7 +3923,7 @@ setInterval(() => {}, 1000);
       async () => {
         const result = await testAgentConnection({
           agentId: 'opencode',
-          model: 'ollama/qwen3.5-9b',
+          model: 'opencode/deepseek-v4-flash-free',
         });
 
         expect(result.ok).toBe(false);
@@ -3931,7 +3955,7 @@ setInterval(() => {}, 1000);
         `
 const args = process.argv.slice(2);
 if (args[0] === 'models') {
-  console.log('ollama/qwen3.5-9b');
+  console.log('opencode/deepseek-v4-flash-free');
   process.exit(0);
 }
 console.error(${JSON.stringify(stderrLine)});
@@ -3940,7 +3964,7 @@ setInterval(() => {}, 1000);
         async () => {
           const result = await testAgentConnection({
             agentId: 'opencode',
-            model: 'ollama/qwen3.5-9b',
+            model: 'opencode/deepseek-v4-flash-free',
           });
 
           expect(result.ok).toBe(false);

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -37,6 +37,12 @@ describe('byok-opencode runtime config', () => {
     }
   });
 
+  it('does not add the removed opencode2 run --dir flag', () => {
+    expect(
+      byokOpenCodeAgentDef.buildArgs('', [], [], {}, { cwd: '/tmp/opencode-project' }),
+    ).toEqual(['run', '--format', 'json']);
+  });
+
   it('prefixes raw BYOK models with the run-scoped OpenCode provider id', () => {
     expect(opencodeByokModelId('gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');
     expect(opencodeByokModelId('open-design-byok/gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -15,6 +15,9 @@ describe('byok-opencode runtime config', () => {
     expect(byokOpenCodeAgentDef.helpArgs).toEqual(['run', '--help']);
     expect(byokOpenCodeAgentDef.capabilityFlags).toEqual({
       '--dangerously-skip-permissions': 'skipPermissions',
+      '--dir': 'workspaceDir',
+      '--auto': 'autoApprove',
+      '--pure': 'pureMode',
     });
     expect(byokOpenCodeAgentDef.buildArgs('', [], [], {})).toEqual([
       'run',
@@ -37,10 +40,50 @@ describe('byok-opencode runtime config', () => {
     }
   });
 
-  it('does not add the removed opencode2 run --dir flag', () => {
+  it('preserves the workspace pin when capability probing has not run yet', () => {
     expect(
-      byokOpenCodeAgentDef.buildArgs('', [], [], {}, { cwd: '/tmp/opencode-project' }),
-    ).toEqual(['run', '--format', 'json']);
+      byokOpenCodeAgentDef.buildArgs('', [], [], {}, {
+        cwd: '/tmp/opencode-project',
+        launchPath: '/tmp/bin/opencode2',
+      }),
+    ).toEqual(['run', '--format', 'json', '--dir', '/tmp/opencode-project']);
+  });
+
+  it('omits --dir when the installed build explicitly does not advertise it', () => {
+    agentCapabilities.set('byok-opencode', { workspaceDir: false });
+    try {
+      expect(
+        byokOpenCodeAgentDef.buildArgs('', [], [], {}, {
+          cwd: '/tmp/opencode-project',
+          launchPath: '/tmp/bin/opencode2',
+        }),
+      ).toEqual(['run', '--format', 'json']);
+    } finally {
+      agentCapabilities.delete('byok-opencode');
+    }
+  });
+
+  it('preserves the workspace pin on legacy OpenCode fallbacks', () => {
+    expect(
+      byokOpenCodeAgentDef.buildArgs('', [], [], {}, {
+        cwd: '/tmp/opencode-project',
+        launchPath: '/tmp/bin/opencode',
+      }),
+    ).toEqual(['run', '--format', 'json', '--dir', '/tmp/opencode-project']);
+  });
+
+  it('adds --dir for opencode2 when the installed build advertises it', () => {
+    agentCapabilities.set('byok-opencode', { workspaceDir: true });
+    try {
+      expect(
+        byokOpenCodeAgentDef.buildArgs('', [], [], {}, {
+          cwd: '/tmp/opencode-project',
+          launchPath: '/tmp/bin/opencode2',
+        }),
+      ).toEqual(['run', '--format', 'json', '--dir', '/tmp/opencode-project']);
+    } finally {
+      agentCapabilities.delete('byok-opencode');
+    }
   });
 
   it('prefixes raw BYOK models with the run-scoped OpenCode provider id', () => {

--- a/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
+++ b/apps/daemon/tests/runtimes/detection-diagnostics.test.ts
@@ -83,7 +83,7 @@ posixTest('detectAgents emits a not-on-path diagnostic with searched dirs + fix 
   }
 });
 
-posixTest('detectAgents finds OpenCode when npm exposes only the opencode binary', async () => {
+posixTest('detectAgents finds OpenCode when only the legacy opencode binary is available', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-opencode-npm-bin-'));
   try {
     await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
@@ -95,7 +95,7 @@ posixTest('detectAgents finds OpenCode when npm exposes only the opencode binary
       const opencode = agents.find((agent) => agent.id === 'opencode');
 
       assert.equal(opencode?.available, true);
-      assert.equal(opencode?.bin, 'opencode-cli');
+      assert.equal(opencode?.bin, 'opencode2');
       assert.equal(opencode?.path, bin);
       assert.equal(opencode?.version, 'opencode 1.17.3');
       assert.equal(opencode?.diagnostics, undefined);

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -514,11 +514,11 @@ test('resolveAgentExecutable supports configured binary overrides for non-Codex 
   }
 });
 
-test('resolveAgentExecutable prefers opencode-cli before desktop opencode fallback', () => {
+test('resolveAgentExecutable prefers opencode2 before legacy opencode fallbacks', () => {
   const dir = mkdtempSync(join(tmpdir(), 'od-opencode-cli-'));
   try {
     return withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], () => {
-      const cli = join(dir, 'opencode-cli');
+      const cli = join(dir, 'opencode2');
       const desktop = join(dir, 'opencode');
       writeFileSync(cli, '#!/bin/sh\nexit 0\n');
       writeFileSync(desktop, '#!/bin/sh\nexit 0\n');

--- a/apps/web/src/components/HandoffButton.tsx
+++ b/apps/web/src/components/HandoffButton.tsx
@@ -84,7 +84,7 @@ const FALLBACK_CLI_TARGETS: CliTarget[] = [
   { id: 'amr', name: 'OpenDesign', bin: 'vela', available: false },
   { id: 'claude', name: 'Claude Code', bin: 'claude', available: false },
   { id: 'codex', name: 'Codex CLI', bin: 'codex', available: false },
-  { id: 'opencode', name: 'OpenCode', bin: 'opencode-cli', available: false },
+  { id: 'opencode', name: 'OpenCode', bin: 'opencode2', available: false },
   { id: 'cursor-agent', name: 'Cursor Agent', bin: 'cursor-agent', available: false },
   { id: 'qwen', name: 'Qwen Code', bin: 'qwen', available: false },
   { id: 'qoder', name: 'Qoder CLI', bin: 'qodercli', available: false },


### PR DESCRIPTION
## Why

I wrote this to migrate the OpenCode integration onto the actually installed `opencode2` CLI. The daemon runtime and connection-test path were still biased toward legacy `opencode-cli` / `opencode` binaries and older CLI flags.

The pain was twofold:
- OpenCode V2 is now shipped and installed as `opencode2`, but OpenDesign still defaulted to older binary names.
- Parts of the smoke / connection-test flow still expected legacy flags such as `--pure`, which `opencode2` no longer accepts, so OpenCode checks could fail even when the user's installed CLI was otherwise healthy.

This PR closes that gap and makes OpenDesign work with real `opencode2` installs while still keeping legacy binary-name fallback for the transition period.


## What users will see

If a user has OpenCode V2 installed, OpenDesign will now detect and use it without manual workarounds.

From the user's perspective, this means:
- OpenCode works again as a local agent when only `opencode2` is installed.
- The OpenCode connection test follows the current CLI contract and succeeds with the V2 binary.
- Native OpenCode session resume continues to work on `opencode2`.
- Older setups using `opencode-cli` / `opencode` do not break immediately because fallback resolution is still preserved.


## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

N/A


## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/runtimes/byok-opencode.test.ts`
  - `apps/daemon/tests/runtimes/detection-diagnostics.test.ts`
  - `apps/daemon/tests/runtimes/opencode-resume-args.test.ts`
  - `apps/daemon/tests/opencode-session-resume.test.ts`
  - `apps/daemon/tests/connection-test.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Additional verification:
  - confirmed the live `opencode2` contract in the dev shell:
    - `opencode2 --version`
    - `opencode2 run --help`
    - `opencode2 models`
    - `opencode2 run --format json`
    - `opencode2 run --session <id>`
    - `opencode2 api get /api/health`
  - specifically verified that `opencode2` does not support the old `--dir` and `--pure` assumptions, then updated the runtime and connection-test code accordingly


## Validation

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/byok-opencode.test.ts tests/runtimes/detection-diagnostics.test.ts tests/runtimes/opencode-resume-args.test.ts tests/opencode-session-resume.test.ts`
- `pnpm exec vitest run -c vitest.config.ts tests/connection-test.test.ts`
- Manual live verification with installed `opencode2`:
  - `opencode2 --version`
  - `opencode2 run --help`
  - `opencode2 models`
  - `opencode2 run --format json --model opencode/deepseek-v4-flash-free`
  - `opencode2 run --format json --session <captured-session-id> --model opencode/deepseek-v4-flash-free`
  - `opencode2 api get /api/health`
