### PR TITLE
fix(nix): made vela available in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,12 +162,7 @@
           pnpm_10
         ];
         shellHook = ''
-          if [ -d "$PWD/tools/pack/node_modules/.bin" ]; then
-            export PATH="$PWD/tools/pack/node_modules/.bin:$PATH"
-          fi
-          if [ -d "$PWD/node_modules/.bin" ]; then
-            export PATH="$PWD/node_modules/.bin:$PATH"
-          fi
+          export PATH="$PWD/tools/pack/node_modules/.bin:$PWD/node_modules/.bin:$PATH"
 
           echo "🎨 OpenDesign dev shell loaded!"
           echo ""

--- a/flake.nix
+++ b/flake.nix
@@ -162,15 +162,27 @@
           pnpm_10
         ];
         shellHook = ''
+          if [ -d "$PWD/tools/pack/node_modules/.bin" ]; then
+            export PATH="$PWD/tools/pack/node_modules/.bin:$PATH"
+          fi
+          if [ -d "$PWD/node_modules/.bin" ]; then
+            export PATH="$PWD/node_modules/.bin:$PATH"
+          fi
+
           echo "🎨 OpenDesign dev shell loaded!"
           echo ""
           echo "Language runtimes:"
           echo "  - 🐢 Node.js: $(node --version 2>/dev/null || echo 'not found')"
           echo "  - 📦 pnpm:    $(pnpm --version 2>/dev/null || echo 'not found')"
+          echo "  - ☁️ vela:    $(vela --version 2>/dev/null || echo 'not found')"
           echo ""
           echo "Quick start:"
           echo "  - 🚀 pnpm install"
           echo "  - 🚀 pnpm tools-dev    # local lifecycle entry point"
+          if [ ! -x "$PWD/tools/pack/node_modules/.bin/vela" ]; then
+            echo ""
+            echo "Vela note: run 'pnpm install' in this repo to expose the pinned @powerformer/vela-cli binary in tools/pack/node_modules/.bin."
+          fi
           echo ""
         '';
       };


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->

## Why

Currently vela is not available in devshell and this is causing the error


## What users will see

Just more logs when starting devshell


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only


## Screenshots


## Bug fix verification

This is not processed by tests and I don’t think it’s necessary

-


## Validation

```
nix develop
pnpm i
```
After which you will see:
```

🎨 OpenDesign dev shell loaded!

Language runtimes:
  - 🐢 Node.js: v24.14.1
  - 📦 pnpm:    10.33.2
  - ☁️ vela:    not found

Quick start:
  - 🚀 pnpm install
  - 🚀 pnpm tools-dev    # local lifecycle entry point

Vela note: run 'pnpm install' in this repo to expose the pinned @powerformer/vela-cli binary in tools/pack/node_modules/.bin.
```

After running `pnpm i` just re-enter devshell
```
🎨 OpenDesign dev shell loaded!

Language runtimes:
  - 🐢 Node.js: v24.14.1
  - 📦 pnpm:    10.33.2
  - ☁️ vela:    0.0.33

Quick start:
  - 🚀 pnpm install
  - 🚀 pnpm tools-dev    # local lifecycle entry point
```
-
