### PR TITLE
fix(web): flatten message center list

### DIFF
--- a/apps/web/src/components/MessageCenter.module.css
+++ b/apps/web/src/components/MessageCenter.module.css
@@ -101,7 +101,6 @@
 }
 
 .close.close:focus-visible,
-.filter:focus-visible,
 .markAll:focus-visible,
 .syncStatus button:focus-visible,
 .itemSummary:focus-visible,
@@ -116,24 +115,11 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 12px 14px;
+  justify-content: flex-end;
+  padding: 9px 14px;
   border-bottom: 1px solid var(--border-soft);
 }
 
-.filters {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill, 999px);
-  background: var(--bg-subtle);
-}
-
-.filter,
 .markAll {
   border: 0;
   background: transparent;
@@ -143,37 +129,8 @@
   line-height: 1;
 }
 
-.filter {
-  min-height: 26px;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 0 9px;
-  border-radius: var(--radius-pill, 999px);
-}
-
-.filter:hover,
 .markAll:hover:not(:disabled) {
   color: var(--text-strong);
-}
-
-.filterActive {
-  background: var(--bg-elevated, var(--bg-panel));
-  color: var(--text-strong);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-.filterBadge {
-  min-width: 15px;
-  height: 15px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: var(--red);
-  color: var(--accent-contrast, #fff);
-  font-size: 9px;
-  font-weight: 700;
-  line-height: 15px;
-  text-align: center;
 }
 
 .markAll {
@@ -483,23 +440,6 @@
     border-left: 0;
     border-bottom: 0;
     border-radius: var(--radius) var(--radius) 0 0;
-  }
-
-  .controls {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .filters {
-    width: 100%;
-  }
-
-  .filter {
-    flex: 1;
-  }
-
-  .markAll {
-    align-self: flex-end;
   }
 
   .footer {

--- a/apps/web/src/components/MessageCenter.module.css
+++ b/apps/web/src/components/MessageCenter.module.css
@@ -50,13 +50,23 @@
 }
 
 .header {
+  position: relative;
   flex: 0 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 14px;
   padding: 18px 18px 14px;
-  border-bottom: 1px solid var(--border-soft);
+}
+
+.header::after {
+  content: '';
+  position: absolute;
+  right: 12px;
+  bottom: 0;
+  left: 12px;
+  height: 1px;
+  background: var(--border-soft);
 }
 
 .headerCopy {
@@ -101,7 +111,6 @@
 }
 
 .close.close:focus-visible,
-.markAll:focus-visible,
 .syncStatus button:focus-visible,
 .itemSummary:focus-visible,
 .itemActions button:focus-visible,
@@ -111,44 +120,12 @@
   outline-offset: 2px;
 }
 
-.controls {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 9px 14px;
-  border-bottom: 1px solid var(--border-soft);
-}
-
-.markAll {
-  border: 0;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
-}
-
-.markAll:hover:not(:disabled) {
-  color: var(--text-strong);
-}
-
-.markAll {
-  flex: 0 0 auto;
-  padding: 6px 4px;
-  border-radius: var(--radius-pill, 999px);
-}
-
-.markAll:disabled {
-  cursor: default;
-  opacity: 0.45;
-}
-
 .list {
   flex: 1 1 auto;
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   overscroll-behavior: contain;
   display: flex;
   flex-direction: column;
@@ -221,7 +198,20 @@
 }
 
 .itemUnread {
-  box-shadow: inset 2px 0 0 var(--accent);
+  position: relative;
+}
+
+.itemUnread::before {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  top: 38px;
+  left: 3px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--red, #ef4444);
+  pointer-events: none;
 }
 
 .itemExpanded {
@@ -242,6 +232,7 @@
   gap: 6px;
   padding: 12px 13px 10px;
   border: 0;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: inherit;
   text-align: left;
@@ -302,10 +293,7 @@
 
 .itemExpanded .bodyPreview {
   overflow: visible;
-  padding-top: 2px;
   color: var(--text);
-  font-size: 13px;
-  line-height: 1.58;
   overflow-wrap: anywhere;
   text-overflow: clip;
   white-space: normal;

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@open-design/components';
-import { useCallback, useEffect, useId, useMemo, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useI18n, type Locale } from '../i18n';
@@ -11,18 +11,11 @@ import {
   pullMessageCenter,
   readAnonymousMessages,
   readAnonymousReadIds,
-  type MessageCenterFilter,
   type MessageCenterMessage,
   writeAnonymousState,
 } from '../message-center-client';
 import { Icon } from './Icon';
 import styles from './MessageCenter.module.css';
-
-const FILTERS: Array<{ id: MessageCenterFilter; label: 'messageCenter.filterAll' | 'messageCenter.filterUnread' | 'messageCenter.filterRead' }> = [
-  { id: 'all', label: 'messageCenter.filterAll' },
-  { id: 'unread', label: 'messageCenter.filterUnread' },
-  { id: 'read', label: 'messageCenter.filterRead' },
-];
 
 function unreadBadgeLabel(count: number): string {
   return count > 9 ? '9+' : String(count);
@@ -74,7 +67,6 @@ export function MessageCenter({
     },
     [onOpenChange],
   );
-  const [filter, setFilter] = useState<MessageCenterFilter>('all');
   const [messages, setMessages] = useState<MessageCenterMessage[]>([]);
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
   const [loggedIn, setLoggedIn] = useState(false);
@@ -174,10 +166,6 @@ export function MessageCenter({
   useEffect(() => {
     onUnreadCountChange?.(unreadCount);
   }, [unreadCount, onUnreadCountChange]);
-  const visibleMessages = useMemo(
-    () => messages.filter((message) => filter === 'all' || (filter === 'read' ? Boolean(message.readAt) : !message.readAt)),
-    [filter, messages],
-  );
 
   /** The control keyboard focus must land on after the panel closes. Opening
    *  focuses the portaled dialog, so closing always unmounts the focused node —
@@ -241,7 +229,6 @@ export function MessageCenter({
   };
 
   const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');
-  const emptyTitle = filter === 'unread' ? t('messageCenter.emptyUnreadTitle') : filter === 'read' ? t('messageCenter.emptyReadTitle') : t('messageCenter.emptyAllTitle');
 
   return <div className={styles.root}>
     {hideTrigger ? null : <button ref={triggerRef} type="button" className={`settings-icon-btn od-tooltip ${styles.trigger}`} onClick={() => setOpen(!open)} title={t('messageCenter.openAria')} data-tooltip={t('messageCenter.openAria')} data-tooltip-placement="bottom" aria-label={openLabel} aria-haspopup="dialog" aria-expanded={open} data-testid="message-center-trigger">
@@ -249,7 +236,7 @@ export function MessageCenter({
     </button>}
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
       <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><Button size="icon" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={18} strokeWidth={2}/></Button></header>
-      <div className={styles.controls}><div className={styles.filters} role="group" aria-label={t('messageCenter.title')}>{FILTERS.map((item) => <button key={item.id} type="button" className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`} aria-pressed={filter === item.id} onClick={() => setFilter(item.id)}>{t(item.label)}{item.id === 'unread' && unreadCount > 0 ? <span className={styles.filterBadge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}</button>)}</div><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncState('error'))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
+      <div className={styles.controls}><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncState('error'))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
       <div className={styles.list} aria-live="polite">
         {syncState === 'error' && messages.length > 0 ? (
           <div className={styles.syncStatus} role="status">
@@ -274,7 +261,7 @@ export function MessageCenter({
               </button>
             </div>
           </div>
-        ) : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} locale={locale} message={message} onRead={markRead} onError={() => setSyncState('error')}/>)}
+        ) : messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : messages.map((message) => <MessageItem key={message.id} locale={locale} message={message} onRead={markRead} onError={() => setSyncState('error')}/>)}
       </div>
       <footer className={styles.footer}><p>{t('messageCenter.desktopSettingsHint')}</p>{onOpenNotificationSettings ? <Button variant="ghost" onClick={() => { closePanel(); onOpenNotificationSettings(); }}>{t('messageCenter.desktopSettings')}</Button> : null}</footer>
     </aside></div>, document.body) : null}

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -7,7 +7,6 @@ import {
   clearAnonymousState,
   isAmrLoggedIn,
   markAccountMessageRead,
-  markAllAccountMessagesRead,
   pullMessageCenter,
   readAnonymousMessages,
   readAnonymousReadIds,
@@ -214,20 +213,6 @@ export function MessageCenter({
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
   };
 
-  const markAllRead = async () => {
-    const account = await resolveLoggedInForWrite();
-    if (account) await markAllAccountMessagesRead();
-    const readAt = new Date().toISOString();
-    const nextIds = new Set(messagesRef.current.map((message) => message.id));
-    const nextMessages = messagesRef.current.map((message) => ({ ...message, readAt: message.readAt ?? readAt }));
-    if (account) {
-      pendingReadIdsRef.current = new Set(nextIds);
-      clearAnonymousState(window.localStorage);
-    }
-    invalidateSyncResponses();
-    commitState(nextMessages, nextIds, { persistAnonymous: !account });
-  };
-
   const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');
 
   return <div className={styles.root}>
@@ -236,7 +221,6 @@ export function MessageCenter({
     </button>}
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
       <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><Button size="icon" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={18} strokeWidth={2}/></Button></header>
-      <div className={styles.controls}><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncState('error'))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
       <div className={styles.list} aria-live="polite">
         {syncState === 'error' && messages.length > 0 ? (
           <div className={styles.syncStatus} role="status">

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -99,11 +99,6 @@ export async function markAccountMessageRead(messageId: string): Promise<void> {
   if (!response.ok) throw new Error(`Mark message read failed: ${response.status}`);
 }
 
-export async function markAllAccountMessagesRead(): Promise<void> {
-  const response = await fetch(`${ACCOUNT_PROXY}/read-all`, { method: 'POST' });
-  if (!response.ok) throw new Error(`Mark all messages read failed: ${response.status}`);
-}
-
 function apiLocale(locale: string): string {
   const mapping: Record<string, string> = { en: 'en-US', 'es-ES': 'es', 'pt-BR': 'pt' };
   return mapping[locale] ?? locale;

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -120,18 +120,14 @@ describe('MessageCenter', () => {
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) => String(url).includes('/release/read') && init?.method === 'POST')).toBe(true));
   });
 
-  it('shows read and unread messages in one flat list and marks all read', async () => {
+  it('shows read and unread messages in one flat list without filter or bulk actions', async () => {
     renderMessageCenter();
     const dialog = await openCenter();
 
     expect(within(dialog).queryByRole('button', { name: 'All' })).toBeNull();
     expect(within(dialog).queryByRole('button', { name: 'Unread' })).toBeNull();
     expect(within(dialog).queryByRole('button', { name: 'Read' })).toBeNull();
-    expect(within(dialog).getByText('OpenDesign 0.14 is available')).toBeTruthy();
-    expect(within(dialog).getByText('Credits added')).toBeTruthy();
-
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Mark all read' }));
-    await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
+    expect(within(dialog).queryByRole('button', { name: 'Mark all read' })).toBeNull();
     expect(within(dialog).getByText('OpenDesign 0.14 is available')).toBeTruthy();
     expect(within(dialog).getByText('Credits added')).toBeTruthy();
   });
@@ -396,7 +392,7 @@ describe('MessageCenter', () => {
       expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('release'),
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
+    fireEvent.click(screen.getByRole('button', { name: /Security notice/ }));
     await waitFor(() =>
       expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('security'),
     );

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -120,14 +120,20 @@ describe('MessageCenter', () => {
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) => String(url).includes('/release/read') && init?.method === 'POST')).toBe(true));
   });
 
-  it('filters messages and marks all read', async () => {
+  it('shows read and unread messages in one flat list and marks all read', async () => {
     renderMessageCenter();
-    await openCenter();
-    fireEvent.click(screen.getByRole('button', { name: 'Unread' }));
-    expect(screen.getByText('OpenDesign 0.14 is available')).toBeTruthy();
-    expect(screen.queryByText('Credits added')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
-    await waitFor(() => expect(screen.getByText('All caught up')).toBeTruthy());
+    const dialog = await openCenter();
+
+    expect(within(dialog).queryByRole('button', { name: 'All' })).toBeNull();
+    expect(within(dialog).queryByRole('button', { name: 'Unread' })).toBeNull();
+    expect(within(dialog).queryByRole('button', { name: 'Read' })).toBeNull();
+    expect(within(dialog).getByText('OpenDesign 0.14 is available')).toBeTruthy();
+    expect(within(dialog).getByText('Credits added')).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Mark all read' }));
+    await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
+    expect(within(dialog).getByText('OpenDesign 0.14 is available')).toBeTruthy();
+    expect(within(dialog).getByText('Credits added')).toBeTruthy();
   });
 
   it('expands the whole message row and opens its CTA', async () => {


### PR DESCRIPTION
## Why

Plane dogfooding item [OPEND-2175](https://plane.powerformer.net/open-design/browse/OPEND-2175) asks for the message center to remove its All, Unread, and Read tabs and present notifications in one list. The current three-way filter adds a navigation choice to a small feed and can hide already-read context when users revisit an announcement.

Follow-up dogfooding also found that the bulk "Mark all read" row added unnecessary empty chrome, the header divider touched the panel edges, unread styling was too heavy, and expanding a message could visibly shift the layout.

## What users will see

The message center now shows read and unread messages together in one flat list without filter tabs or a bulk "Mark all read" action. Unread messages use a compact red dot, the header divider is inset from both edges, hover backgrounds keep rounded corners, and expanding a message preserves its typography and horizontal layout.

Per-message read behavior remains available: opening an unread message marks that message as read.

## Surface area

- [x] **UI** - message-center panel in `apps/web`
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency** - added to the root `package.json`
- [x] **Default behavior change** - the message center no longer filters its feed through tabs or exposes a bulk read action
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The message-center panel was verified through a local `tools-dev` browser run with the live multi-message feed, including read/unread, hover, and expanded states.

## Bug fix verification

- Test path: `apps/web/tests/components/MessageCenter.test.tsx`
- The regression coverage asserts that filter and bulk-action controls are absent, read and unread messages stay visible in one list, and anonymous per-message read state remains persisted.
- The focused suite passes with 21 tests.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/MessageCenter.test.tsx --maxWorkers=1` (21 passed)
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check`
- Local `tools-dev` browser verification of the message-center panel