### PR TITLE
fix(web): separate updater from account capsule

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -238,12 +238,9 @@ interface Props {
    * The update-ready host (`UpdaterPopup`), which renders nothing until the
    * updater reports a downloaded, unopened installer.
    *
-   * It rides the floating account module's row IMMEDIATELY AFTER the avatar
-   * chip (`.entry-nav-rail__account-updater`), per product: 升级提醒按钮跟在
-   * 头像后边，不再单独占一行。 Earlier homes — the rail footer (#5517) and a
-   * strip above the identity row — both detached the reminder from the
-   * avatar. The footer stays as the fallback home for the signed-out shell,
-   * which has no account row at all.
+   * It is an independent control immediately after the floating credits/avatar
+   * capsule (`.entry-nav-rail__account-updater`). The footer stays as the
+   * fallback home for the signed-out shell, which has no account capsule.
    */
   updaterSlot?: ReactNode;
   /** Optional notice shown above the footer controls. */
@@ -786,7 +783,8 @@ export function EntryTopRightCluster({
               The capsule owns the pill material; the segments inside are
               chrome-free click targets. */}
           {context ? (
-            <div className="entry-top-right-account-pill">
+            <>
+              <div className="entry-top-right-account-pill">
           {(billing || balanceLabel) && showCreditsBalance ? (
             <button
               type="button"
@@ -836,19 +834,6 @@ export function EntryTopRightCluster({
                   ) : null}
                 </span>
               </button>
-              {/* Update-ready rocket, riding the same row immediately AFTER the
-                  avatar chip. It is mounted unconditionally so the row's shape
-                  is stable, and it holds no element children until the updater
-                  actually has something to show; `:empty { display: none }` is
-                  what keeps an idle slot from reserving width (plus the row's
-                  6px gap) next to the avatar.
-
-                  The rocket must never be a DESCENDANT of the trigger above:
-                  a button inside the account button would be invalid markup and
-                  would make every rocket click toggle the account menu too. */}
-              <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
-                {updaterSlot}
-              </div>
               {accountOpen ? (
                 <>
                   {/* No backdrop here (unlike the team menu): hover-open relies
@@ -1018,8 +1003,16 @@ export function EntryTopRightCluster({
                   }}
                 />
               ) : null}
-            </div>
-            </div>
+              </div>
+              </div>
+              {/* Update-ready rocket: an independent control immediately after
+                  the credits/avatar capsule. The slot stays mounted so
+                  `:empty { display: none }` can remove it from cluster layout
+                  until an installer has downloaded. */}
+              <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
+                {updaterSlot}
+              </div>
+            </>
           ) : null}
         </div>,
         document.body,

--- a/apps/web/src/components/UpdaterPopup.module.css
+++ b/apps/web/src/components/UpdaterPopup.module.css
@@ -1,6 +1,7 @@
-/* Update-ready indicator: a round brand-green rocket button pinned to the
-   bottom-left rail footer. Visual carried over from the accepted #6156 design;
-   the state behind it is the real updater's `shouldShowControl`.
+/* Update-ready indicator: a round brand-green rocket button shown as its own
+   top-right cluster control for signed-in users, with the rail footer retained
+   as the signed-out fallback. The state behind it is the real updater's
+   `shouldShowControl`.
 
    There is deliberately no progress ring here: the indicator only exists once
    the installer has finished downloading, so any percentage it drew would be
@@ -9,8 +10,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* Same 32px circle as the account avatar chip it rides next to — the two
-     must read as one row of equal-height controls. */
+  /* Compact standalone circle aligned with the neighbouring account capsule. */
   width: 32px;
   height: 32px;
   padding: 0;

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -5705,10 +5705,9 @@
   margin: auto 0 0;
   padding-top: var(--spacing-10);
 }
-/* Update-ready slot: rides the floating account row immediately AFTER the
-   avatar chip (per product: 升级提醒按钮跟在头像后边). Earlier homes — the
-   rail footer (#5517) and a strip on its own line above the identity row —
-   both detached the reminder from the avatar.
+/* Update-ready slot: an independent top-right cluster item immediately AFTER
+   the credits/avatar capsule. The rail footer remains the signed-out fallback
+   because that shell has no account capsule.
 
    This stays a global selector next to the rest of the account block rather
    than a CSS Module: its only child is `.entry-updater-menu`, itself a global
@@ -5716,10 +5715,9 @@
    it.
 
    `:empty` is load-bearing, not tidiness. The slot is mounted unconditionally
-   so the row's shape is stable, and the updater host renders nothing until an
-   installer is downloaded and unopened — so without this rule an idle account
-   row would reserve the slot's width plus the container's 6px `gap` next to
-   the avatar, shifting the whole cluster for a control that is not there.
+   so the cluster's shape is stable, and the updater host renders nothing until
+   an installer is downloaded and unopened — so without this rule an idle
+   cluster would reserve its gap for a control that is not there.
    `display: none` (not `width: 0`) is what drops it out of flex layout so the
    `gap` collapses with it. */
 .entry-nav-rail__account-updater {
@@ -6048,11 +6046,8 @@
   top: auto;
   bottom: calc(100% + 4px);
 }
-/* Floating account module (top-right cluster): compact pill trigger that
-   matches the campaign badge's height/material, and a downward,
-   right-aligned menu instead of the rail-bottom upward one. Lays out as a
-   ROW so the update rocket sits inline after the avatar chip instead of
-   stacking above it (the base class is a column for the rail-era layout). */
+/* Floating account module inside the credits/avatar capsule: compact trigger
+   with a downward, right-aligned menu instead of the rail-bottom upward one. */
 .entry-nav-rail__account--floating {
   order: 0;
   margin: 0;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -409,11 +409,6 @@
   left: auto;
 }
 
-[dir='rtl'] .entry-top-right-cluster > .entry-nav-rail__account-updater .entry-updater-menu .updater-popup {
-  right: auto;
-  left: 0;
-}
-
 .updater-popup__body {
   min-width: 0;
 }

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -398,18 +398,18 @@
   left: 0;
 }
 
-/* Floating account row (top-right cluster): the rocket rides right after the
-   avatar chip, hugging the viewport's right edge, so the side-flyout base
-   rule would push the panel off-screen (and `bottom: 0` would grow it past
-   the top). Open DOWNWARD instead, right-aligned to the host. */
-.entry-nav-rail__account--floating .entry-updater-menu .updater-popup {
+/* Standalone updater slot (top-right cluster): the rocket rides right after
+   the account capsule, hugging the viewport's right edge, so the side-flyout
+   base rule would push the panel off-screen (and `bottom: 0` would grow it
+   past the top). Open DOWNWARD instead, right-aligned to the host. */
+.entry-top-right-cluster > .entry-nav-rail__account-updater .entry-updater-menu .updater-popup {
   top: calc(100% + 10px);
   bottom: auto;
   right: 0;
   left: auto;
 }
 
-[dir='rtl'] .entry-nav-rail__account--floating .entry-updater-menu .updater-popup {
+[dir='rtl'] .entry-top-right-cluster > .entry-nav-rail__account-updater .entry-updater-menu .updater-popup {
   right: auto;
   left: 0;
 }

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -4,14 +4,14 @@
 //
 // #5517 removed the entry topbar and parked the updater host in the rail
 // footer — bottom-left, detached from the identity it belongs to. A follow-up
-// moved it to a strip above the account row; product then placed it INLINE:
-// 升级提醒按钮跟在头像后边，不再单独占一行 — the rocket rides the floating
-// account row immediately AFTER the avatar chip.
+// moved it to a strip above the account row; product then placed it inline
+// inside the account capsule. OPEND-2154 separates it again: the rocket stays
+// immediately AFTER the credits/avatar capsule, but paints as its own control.
 //
 // These specs pin the DOM relationship rather than any pixel value: the rocket
-// lives in a slot that is the account trigger's immediately-following sibling,
-// inside the same account container. The row layout and the slot's
-// zero-width-when-empty behaviour are CSS facts (see
+// lives in a slot that is the account capsule's immediately-following sibling,
+// outside the capsule. The cluster layout and the slot's zero-width-when-empty
+// behaviour are CSS facts (see
 // `.entry-nav-rail__account-updater` in styles/home/entry-layout.css) and are
 // verified in a real browser, not here — jsdom applies no stylesheets.
 //
@@ -144,7 +144,7 @@ async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null
   return view;
 }
 
-describe('updater rocket placement after the account avatar', () => {
+describe('standalone updater rocket placement after the account capsule', () => {
   it('shows the shared Go campaign badge on an unpaid project detail route', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-20T10:00:00.000Z'));
@@ -165,7 +165,7 @@ describe('updater rocket placement after the account avatar', () => {
     );
   });
 
-  it('keeps the project-detail updater slot in the shared account row', () => {
+  it('keeps the project-detail updater slot outside the shared account capsule', () => {
     render(
       <I18nProvider initial="zh-CN">
         <WorkspaceTopRightAccountCluster
@@ -175,13 +175,14 @@ describe('updater rocket placement after the account avatar', () => {
       </I18nProvider>,
     );
 
-    const trigger = screen.getByTestId('entry-nav-account');
     const slot = screen.getByTestId('entry-nav-account-updater');
+    const pill = document.querySelector('.entry-top-right-account-pill');
     expect(screen.getByTestId('project-updater-slot-content')).toBeTruthy();
-    expect(trigger.nextElementSibling).toBe(slot);
+    expect(pill?.contains(slot)).toBe(false);
+    expect(pill?.nextElementSibling).toBe(slot);
   });
 
-  it('renders the rocket inline immediately after the avatar chip', async () => {
+  it('renders the rocket independently immediately after the account capsule', async () => {
     await renderWithDownloadedUpdate();
 
     const rocket = screen.getByTestId('entry-nav-updater');
@@ -192,11 +193,15 @@ describe('updater rocket placement after the account avatar', () => {
     expect(slot, 'rocket must live in the updater slot').not.toBeNull();
     expect(slot?.contains(trigger)).toBe(false);
 
-    // AFTER the avatar chip: same account container, and the slot is the
-    // trigger's immediately-following sibling — nothing may slip between them.
+    // AFTER the capsule: same top-right cluster, but outside the account
+    // container so the capsule material never wraps the update control.
     const account = trigger.closest('.entry-nav-rail__account');
-    expect(account?.contains(slot as Node)).toBe(true);
-    expect(trigger.nextElementSibling).toBe(slot);
+    const pill = trigger.closest('.entry-top-right-account-pill');
+    const cluster = trigger.closest('.entry-top-right-cluster');
+    expect(account?.contains(slot as Node)).toBe(false);
+    expect(pill?.contains(slot as Node)).toBe(false);
+    expect(cluster?.contains(slot as Node)).toBe(true);
+    expect(pill?.nextElementSibling).toBe(slot);
     expect(
       trigger.compareDocumentPosition(rocket) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -224,7 +229,7 @@ describe('updater rocket placement after the account avatar', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('leaves an empty slot after the avatar while no update is in flight', async () => {
+  it('leaves an empty standalone slot after the capsule while no update is in flight', async () => {
     restoreHost = installMockOpenDesignHost({
       host: { updater: { status: vi.fn(async () => idleStatus()) } },
     });

--- a/e2e/ui/updater-popup-stacking.test.ts
+++ b/e2e/ui/updater-popup-stacking.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@/playwright/suite';
 import { applyStandardMocks } from '@/playwright/mock-factory';
+import { mockAmrPersonalWorkspace } from '@/playwright/amr';
 import { ensureRailOpen } from '@/playwright/rail';
 import { T } from '@/timeouts';
 
@@ -75,6 +76,45 @@ test.beforeEach(async ({ page }) => {
       },
     };
   });
+});
+
+test('[P1] signed-in update prompt opens below the standalone rocket within the viewport', async ({
+  page,
+}) => {
+  await mockAmrPersonalWorkspace(page);
+  await page.setViewportSize({ width: 700, height: 600 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+  await expect(page.getByTestId('entry-nav-account')).toBeVisible();
+
+  const updaterButton = page.getByTestId('entry-nav-updater');
+  await updaterButton.click();
+  const popup = page.getByTestId('updater-popup');
+  await expect(popup).toBeVisible();
+
+  const geometry = await page.evaluate(() => {
+    const rocket = document.querySelector('[data-testid="entry-nav-updater"]');
+    const prompt = document.querySelector('[data-testid="updater-popup"]');
+    if (rocket == null || prompt == null) return null;
+    const rocketRect = rocket.getBoundingClientRect();
+    const promptRect = prompt.getBoundingClientRect();
+    return {
+      rocketBottom: rocketRect.bottom,
+      promptTop: promptRect.top,
+      promptLeft: promptRect.left,
+      promptRight: promptRect.right,
+      viewportWidth: window.innerWidth,
+    };
+  });
+
+  expect(geometry, 'standalone updater rocket and prompt must both be measurable').not.toBeNull();
+  expect(geometry!.promptTop, 'prompt must open below the standalone rocket').toBeGreaterThan(
+    geometry!.rocketBottom,
+  );
+  expect(geometry!.promptLeft, 'prompt must stay inside the viewport left edge').toBeGreaterThanOrEqual(0);
+  expect(geometry!.promptRight, 'prompt must stay inside the viewport right edge').toBeLessThanOrEqual(
+    geometry!.viewportWidth,
+  );
 });
 
 test('[P1] update ready prompt paints above the composer and its agent picker', async ({ page }) => {

--- a/e2e/ui/updater-popup-stacking.test.ts
+++ b/e2e/ui/updater-popup-stacking.test.ts
@@ -78,44 +78,52 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('[P1] signed-in update prompt opens below the standalone rocket within the viewport', async ({
-  page,
-}) => {
-  await mockAmrPersonalWorkspace(page);
-  await page.setViewportSize({ width: 700, height: 600 });
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
-  await expect(page.getByTestId('entry-nav-account')).toBeVisible();
+for (const direction of ['ltr', 'rtl'] as const) {
+  test(`[P1] signed-in ${direction.toUpperCase()} update prompt opens below the standalone rocket within the viewport`, async ({
+    page,
+  }) => {
+    await mockAmrPersonalWorkspace(page);
+    await page.setViewportSize({ width: 700, height: 600 });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+    await expect(page.getByTestId('entry-nav-account')).toBeVisible();
+    await page.locator('html').evaluate((element, dir) => element.setAttribute('dir', dir), direction);
 
-  const updaterButton = page.getByTestId('entry-nav-updater');
-  await updaterButton.click();
-  const popup = page.getByTestId('updater-popup');
-  await expect(popup).toBeVisible();
+    const updaterButton = page.getByTestId('entry-nav-updater');
+    await updaterButton.click();
+    const popup = page.getByTestId('updater-popup');
+    await expect(popup).toBeVisible();
 
-  const geometry = await page.evaluate(() => {
-    const rocket = document.querySelector('[data-testid="entry-nav-updater"]');
-    const prompt = document.querySelector('[data-testid="updater-popup"]');
-    if (rocket == null || prompt == null) return null;
-    const rocketRect = rocket.getBoundingClientRect();
-    const promptRect = prompt.getBoundingClientRect();
-    return {
-      rocketBottom: rocketRect.bottom,
-      promptTop: promptRect.top,
-      promptLeft: promptRect.left,
-      promptRight: promptRect.right,
-      viewportWidth: window.innerWidth,
-    };
+    const geometry = await page.evaluate(() => {
+      const rocket = document.querySelector('[data-testid="entry-nav-updater"]');
+      const prompt = document.querySelector('[data-testid="updater-popup"]');
+      if (rocket == null || prompt == null) return null;
+      const rocketRect = rocket.getBoundingClientRect();
+      const promptRect = prompt.getBoundingClientRect();
+      return {
+        rocketBottom: rocketRect.bottom,
+        rocketRight: rocketRect.right,
+        promptTop: promptRect.top,
+        promptLeft: promptRect.left,
+        promptRight: promptRect.right,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+    expect(geometry, 'standalone updater rocket and prompt must both be measurable').not.toBeNull();
+    expect(geometry!.promptTop, 'prompt must open below the standalone rocket').toBeGreaterThan(
+      geometry!.rocketBottom,
+    );
+    expect(
+      Math.abs(geometry!.promptRight - geometry!.rocketRight),
+      'prompt must stay right-aligned to the physically right-pinned rocket',
+    ).toBeLessThanOrEqual(1);
+    expect(geometry!.promptLeft, 'prompt must stay inside the viewport left edge').toBeGreaterThanOrEqual(0);
+    expect(geometry!.promptRight, 'prompt must stay inside the viewport right edge').toBeLessThanOrEqual(
+      geometry!.viewportWidth,
+    );
   });
-
-  expect(geometry, 'standalone updater rocket and prompt must both be measurable').not.toBeNull();
-  expect(geometry!.promptTop, 'prompt must open below the standalone rocket').toBeGreaterThan(
-    geometry!.rocketBottom,
-  );
-  expect(geometry!.promptLeft, 'prompt must stay inside the viewport left edge').toBeGreaterThanOrEqual(0);
-  expect(geometry!.promptRight, 'prompt must stay inside the viewport right edge').toBeLessThanOrEqual(
-    geometry!.viewportWidth,
-  );
-});
+}
 
 test('[P1] update ready prompt paints above the composer and its agent picker', async ({ page }) => {
   test.fail(


### PR DESCRIPTION
## Why

OPEND-2154 reports that the ready-update control in the top-right chrome should not share the credits/avatar capsule. The current DOM placed the updater slot inside that capsule, so its standalone green button was still wrapped by the account material and layout.

Plane: https://plane.powerformer.net/open-design/browse/OPEND-2154

## What users will see

When an update has downloaded, the green update button now appears as an independent control immediately to the right of the credits/avatar capsule. The account capsule, account menu, update action, signed-out footer fallback, and no-update zero-space behavior remain unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached per request. The entry point was verified locally in the tools-dev environment at a 1280x720 viewport with a downloaded-update state.

## Bug fix verification

- Test path: `apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx`
- Red on `main`: yes — 2 placement assertions failed because the updater slot was inside the account capsule.
- Green on this branch: yes — all 6 placement tests pass.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/EntryNavRail.updater-after-avatar.test.tsx tests/components/UpdaterPopup.rocket-indicator.test.tsx tests/components/UpdaterPopup.test.tsx` — 26 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- Visual verification in `pnpm tools-dev run web`: updater slot is outside and immediately after the account capsule, with a 10px cluster gap
