### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-mt2rgq9e/SKILL.md
+++ b/plugins/community/source-project-context-mt2rgq9e/SKILL.md
@@ -1,0 +1,61 @@
+# Source Project Context
+
+This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 423b4bd1-640e-4dcd-9cb1-e11aa0c9186d
+- Source project name: Web Prototype
+- New design-system project id: aeadc299-6651-467a-b576-7c242466acdf
+- New design-system id: user:web-prototype-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/parasana/Downloads/Antigravity/portifolio"
+  ]
+}
+```
+
+## Copied files
+
+- portfolio-os.html
+- sketch-2026-08-21T07-55-24.sketch.json
+- tsconfig.json
+- README.md
+- quality.md
+- skills-lock.json
+- package.json
+- postcss.config.mjs
+- package-lock.json
+- AGENTS.md
+- next.config.ts
+- k8s-deployment.yaml
+- next-env.d.ts
+- eslint.config.mjs
+- Dockerfile
+- docker-compose.yml
+- components.json
+- CLAUDE.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable OpenDesign design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by OpenDesign from candidate 7961d4b0-0f9c-4641-9a72-52f59fc57f17.

--- a/plugins/community/source-project-context-mt2rgq9e/open-design.json
+++ b/plugins/community/source-project-context-mt2rgq9e/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-mt2rgq9e",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-mt2rgq9e/references/provenance.json
+++ b/plugins/community/source-project-context-mt2rgq9e/references/provenance.json
@@ -1,0 +1,33 @@
+{
+  "candidateId": "7961d4b0-0f9c-4641-9a72-52f59fc57f17",
+  "projectId": "aeadc299-6651-467a-b576-7c242466acdf",
+  "runId": "f1e2c551-9885-4924-9a79-21a46d2065f5",
+  "conversationId": "9885d553-50a0-40cf-864b-134b244fced2",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, README.md, SKILL.md after a successful run.",
+    "detectedAt": 1787305339764
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 1774,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 5171,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 2864,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-mt2rgq9e/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-mt2rgq9e/references/source-1-source-context.md
@@ -1,0 +1,57 @@
+# Source Project Context
+
+This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 423b4bd1-640e-4dcd-9cb1-e11aa0c9186d
+- Source project name: Web Prototype
+- New design-system project id: aeadc299-6651-467a-b576-7c242466acdf
+- New design-system id: user:web-prototype-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/parasana/Downloads/Antigravity/portifolio"
+  ]
+}
+```
+
+## Copied files
+
+- portfolio-os.html
+- sketch-2026-08-21T07-55-24.sketch.json
+- tsconfig.json
+- README.md
+- quality.md
+- skills-lock.json
+- package.json
+- postcss.config.mjs
+- package-lock.json
+- AGENTS.md
+- next.config.ts
+- k8s-deployment.yaml
+- next-env.d.ts
+- eslint.config.mjs
+- Dockerfile
+- docker-compose.yml
+- components.json
+- CLAUDE.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable OpenDesign design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.

--- a/plugins/community/source-project-context-mt2rgq9e/references/source-2-README.md
+++ b/plugins/community/source-project-context-mt2rgq9e/references/source-2-README.md
@@ -1,0 +1,139 @@
+# Project As Complete OpenDesign Design System
+
+> A reusable, production-ready design system for technical portfolios and high-impact engineering showcases.
+
+---
+
+## Overview
+
+This design system is derived from the **Portfolio OS** project, a personal technical showcase engineered for Big Tech visibility and freelance impact. It is not a generic portfolio template; it is a **digital twin** of engineering capabilities, designed to demonstrate production-grade precision, security, and futuristic aesthetics.
+
+---
+
+## Design System Package
+
+### Core Files
+
+| File | Purpose |
+|------|---------|
+| `DESIGN.md` | Complete design system specification with tokens, components, and rules |
+| `SKILL.md` | Skill definition for reuse in OpenDesign projects |
+| `colors_and_type.css` | CSS variables for colors, typography, spacing, and motion |
+| `context/provenance.md` | Evidence and source references for design decisions |
+
+### Preview Cards
+
+| Card | Purpose |
+|------|---------|
+| `preview/colors.html` | Visual review of the color palette and semantic roles |
+| `preview/typography.html` | Typography scale, typefaces, and rendering examples |
+| `preview/spacing.html` | Spacing scale, layout density, and container examples |
+| `preview/radius_shadows.html` | Border radius, shadows, and depth effects |
+| `preview/components.html` | Interactive component gallery (buttons, cards, forms, navigation) |
+| `preview/brand_assets.html` | Logo, wordmark, and brand identity examples |
+| `preview/applied_ui.html` | Applied interface surfaces (hero, about, projects, contact) |
+
+### Applied Interface Kit
+
+| Path | Purpose |
+|------|---------|
+| `ui_kits/app/` | Production-ready interface kit with index and component files |
+| `ui_kits/app/index.html` | Entry point for the applied UI kit |
+| `ui_kits/app/components/` | Reusable component examples |
+
+### Assets
+
+| Path | Purpose |
+|------|---------|
+| `assets/fonts/` | Font files (Space Grotesk, Inter, JetBrains Mono) |
+| `assets/icons/` | SVG icons and logos |
+| `assets/images/` | Background images, mesh textures, and brand imagery |
+
+---
+
+## Usage
+
+### For Designers
+
+1. **Review the design system:**
+   - Start with `DESIGN.md` for tokens, components, and rules.
+   - Use preview cards to inspect colors, typography, spacing, and components.
+   - Reference `colors_and_type.css` for CSS variables.
+
+2. **Apply the system:**
+   - Use OKLch tokens for all colors.
+   - Use Space Grotesk for display, Inter for body, JetBrains Mono for mono.
+   - Follow component patterns for buttons, cards, forms, and navigation.
+
+3. **Preserve authenticity:**
+   - Do not deviate from the locked visual language.
+   - Use realistic technical imagery and code examples.
+
+### For Developers
+
+1. **Integrate tokens:**
+   ```css
+   :root {
+     --bg: oklch(0 0 0);
+     --surface: oklch(0.14 0.004 250);
+     --fg: oklch(0.97 0.005 80);
+     --muted: oklch(0.65 0.01 250);
+     --border: oklch(0.26 0.006 250);
+     --accent: oklch(0.82 0.16 80);
+   }
+   ```
+
+2. **Use components:**
+   - Buttons: `.btn-primary`, `.btn-secondary`
+   - Cards: `.card`
+   - Navigation: `.topnav`
+   - Forms: Plain inputs with `--surface` background
+
+3. **Respect constraints:**
+   - Only one primary button per viewport.
+   - Use `--accent` sparingly (no more than twice per screen).
+   - Ensure all interactive elements have clear focus rings.
+
+---
+
+## Provenance
+
+### Source Evidence
+
+- **portfolio-os.html:** Primary source for tokens, components, layout, and interaction patterns.
+- **README.md:** Provides context for purpose, tech stack, and future roadmap.
+- **quality.md:** Confirms TypeScript, linting, accessibility, and performance standards.
+- **components.json:** Confirms Tailwind CSS 4, OKLCH color space, and shadcn/ui usage.
+- **package.json:** Confirms bleeding-edge stack (Next.js 16, React 19, Framer Motion, Tailwind CSS 4).
+
+### Preserved Assets
+
+- **Fonts:** Space Grotesk, Inter, JetBrains Mono (loaded from Google Fonts).
+- **Icons:** SVG icons used in feature marks and buttons.
+- **Imagery:** Mesh background, vignette overlay, and status dot animations.
+
+---
+
+## Next Steps
+
+1. **Inspect previews:** Start with `preview/colors.html` and `preview/components.html`.
+2. **Apply to projects:** Use the system for new technical portfolios or engineering showcases.
+3. **Contribute:** Extend the system with new components or refinements based on real-world usage.
+
+---
+
+## Summary
+
+This design system is a **production-ready, high-impact** system for technical portfolios. It balances geometric typography, vibrant amber accents, and dynamic motion to convey precision engineering and futuristic ambition. Every decision is rooted in the source project's evidence, ensuring consistency and authenticity.
+
+**Key takeaways:**
+- Use OKLch tokens for all colors.
+- Use Space Grotesk for display, Inter for body, JetBrains Mono for mono.
+- Use `--accent` sparingly—no more than twice per screen.
+- Motion should enhance clarity, not distract.
+- Avoid generic templates; prioritize realism and technical authenticity.
+
+---
+
+**Design system id:** user:web-prototype-design-system  
+**Project id:** aeadc299-6651-467a-b576-7c242466acdf

--- a/plugins/community/source-project-context-mt2rgq9e/references/source-3-SKILL.md
+++ b/plugins/community/source-project-context-mt2rgq9e/references/source-3-SKILL.md
@@ -1,0 +1,76 @@
+# Project As Complete OpenDesign Design System Skill
+
+> A specialized skill for creating technical portfolios and high-impact engineering showcases.
+
+---
+
+## Instructions
+
+This skill governs the creation and refinement of projects using the **Project As Complete OpenDesign Design System**. It enforces the system's visual language, component patterns, and technical standards.
+
+### 1. Bind Design System Tokens
+
+Every project created with this skill must bind the following OKLch tokens to its `:root` block:
+
+```css
+:root {
+  --bg: oklch(0 0 0);
+  --surface: oklch(0.14 0.004 250);
+  --fg: oklch(0.97 0.005 80);
+  --muted: oklch(0.65 0.01 250);
+  --border: oklch(0.26 0.006 250);
+  --accent: oklch(0.82 0.16 80);
+  --accent-soft: oklch(0.82 0.16 80 / 0.14);
+  --fg-soft: oklch(0.97 0.005 80 / 0.06);
+
+  --font-display: 'Space Grotesk', sans-serif;
+  --font-body: 'Inter', -apple-system, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+```
+
+### 2. Follow Component Patterns
+
+| Component | Rule |
+|-----------|------|
+| **Buttons** | Only one primary button (`.btn-primary`) per viewport. |
+| **Cards** | Use `.card` with hover feedback (border color shift to `--accent`). |
+| **Navigation**| Fixed top navigation bar (`.topnav`) with backdrop blur. |
+| **Forms** | Use `--surface` background for inputs/textareas. |
+
+### 3. Enforce Visual Constraints
+
+- **Accent color:** Use `--accent` sparingly—no more than twice per screen.
+- **Typography:** Space Grotesk for headings, Inter for body, JetBrains Mono for mono.
+- **Motion:** Subtle, fast for interactions; slow, ambient for background effects.
+- **Contrast:** Ensure all text and icons have sufficient contrast in all states.
+- **Accessibility:** Use semantic HTML and provide clear focus rings.
+
+### 4. Technical Standards
+
+- **Color space:** Use OKLch for all color values.
+- **Framework:** Next.js 16 (App Router) + React 19 + Tailwind CSS 4.
+- **Realism:** Use realistic technical imagery and code examples.
+- **Security:** Follow security best practices for data handling and bot protection.
+
+---
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/plan` | Generate a task plan for creating or refining a project. |
+| `/build`| Build project artifacts based on the design system. |
+| `/verify`| Verify project artifacts against design system rules. |
+| `/ship` | Finalize and ship project artifacts. |
+
+---
+
+## Summary
+
+This skill is designed to help you create technical portfolios and high-impact engineering showcases that demonstrate production-grade precision and futuristic aesthetics. By following the design system's tokens, component patterns, and visual constraints, you can ensure consistency and authenticity across all projects.
+
+---
+
+**Design system id:** user:web-prototype-design-system  
+**Project id:** aeadc299-6651-467a-b576-7c242466acdf


### PR DESCRIPTION
Add Source Project Context (source-project-context-mt2rgq9e) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing OpenDesign project. Treat the copied project files as the primary source evidence for the generated design system.