### PR TITLE
fix(pack): use gzip AppImage compression so V8 snapshots extract

### DIFF
--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -354,7 +354,7 @@ export function matchesAppImageProcess(
 
 // --- Step 1: LinuxPaths type and resolveLinuxPaths ---
 
-type LinuxPaths = {
+export type LinuxPaths = {
   appBuilderConfigPath: string;
   appBuilderOutputRoot: string;
   appImageAppRunPath: string;
@@ -382,7 +382,7 @@ function iconFileName(namespace: string): string {
   return `open-design-${sanitizeNamespace(namespace)}.png`;
 }
 
-function resolveLinuxPaths(config: ToolPackConfig): LinuxPaths {
+export function resolveLinuxPaths(config: ToolPackConfig): LinuxPaths {
   const namespaceRoot = config.roots.output.namespaceRoot;
   const appBuilderOutputRoot = config.roots.output.appBuilderRoot;
   const home = homedir();
@@ -618,7 +618,7 @@ async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
 
 // --- Step 5: writeLinuxBuilderConfig helper ---
 
-async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
+export async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
   const target = config.to === "dir" ? ["dir"] : ["AppImage"];
   const namespaceToken = sanitizeNamespace(config.namespace);
   const packagedVersion = await readPackagedVersion(config);
@@ -629,7 +629,14 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
     artifactName: `${PRODUCT_NAME}-${namespaceToken}.\${ext}`,
     asar: false,
     buildDependenciesFromSource: false,
-    compression: "maximum",
+    // "normal" (gzip), not "maximum" (xz). With an xz payload the AppImage
+    // type-2 runtime behind `--appimage-extract-and-run` extracts most entries
+    // but silently omits the V8 snapshot files, so Electron dies with
+    // `Error loading V8 startup snapshot file` before main() runs (verified
+    // against runtime effcebc: 40272 files extracted, snapshot_blob.bin and
+    // v8_context_snapshot.bin absent). gzip extracts every entry. See
+    // startPackedLinuxApp for why we use --appimage-extract-and-run over FUSE.
+    compression: "normal",
     directories: {
       app: paths.assembledAppRoot,
       output: paths.appBuilderOutputRoot,

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -37,11 +37,13 @@ import {
   renderLinuxAppImageAppRun,
   renderLinuxPackagedMainEntry,
   resolveLinuxLifecycleMode,
+  resolveLinuxPaths,
   resolveProductionInstallCommand,
   shouldRejectLinuxHeadlessInspectOptions,
   stopPackedLinuxApp,
   sanitizeNamespace,
   stopPackedLinuxHeadless,
+  writeLinuxBuilderConfig,
 } from "@/linux.js";
 
 async function pathExists(path: string): Promise<boolean> {
@@ -1006,5 +1008,48 @@ describe("matchesAppImageProcess", () => {
       installPath,
     );
     expect(ok).toBe(false);
+  });
+});
+
+describe("writeLinuxBuilderConfig compression", () => {
+  // Regression guard for the AppImage xz-extraction bug: the AppImage type-2
+  // runtime behind `--appimage-extract-and-run` silently omits the V8 snapshot
+  // files from an xz payload, so Electron dies before main() runs. The Linux
+  // builder config must therefore NOT select `compression: "maximum"` (which
+  // app-builder-lib maps to an xz squashfs). See the comment at the
+  // `compression` field in writeLinuxBuilderConfig for the full rationale.
+  it("does not select xz (maximum) compression for the AppImage payload", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-linux-"));
+    try {
+      const config: ToolPackConfig = {
+        ...makeConfig(),
+        // appVersion short-circuits readPackagedVersion so the test does not
+        // depend on apps/packaged/package.json on disk.
+        appVersion: "0.16.1",
+        containerized: false,
+        to: "appimage",
+        workspaceRoot: root,
+        roots: {
+          ...makeConfig().roots,
+          output: {
+            appBuilderRoot: join(root, ".tmp", "tools-pack", "out", "linux", "namespaces", "default", "builder"),
+            namespaceRoot: join(root, ".tmp", "tools-pack", "out", "linux", "namespaces", "default"),
+            platformRoot: join(root, ".tmp", "tools-pack", "out", "linux"),
+            root: join(root, ".tmp", "tools-pack", "out"),
+          },
+        },
+      };
+      const paths = resolveLinuxPaths(config);
+
+      await writeLinuxBuilderConfig(config, paths);
+      const builderConfig = JSON.parse(await readFile(paths.appBuilderConfigPath, "utf8")) as {
+        compression?: string;
+      };
+
+      expect(builderConfig.compression).not.toBe("maximum");
+      expect(builderConfig.compression).toBe("normal");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
Fixes #6145

Replaces #6146, which was auto-closed by the queue bot after the branch fell behind `main` and conflicted; this is the same change rebased onto current `main` (`57de74360`). The only textual conflict was the test import alias (`../src/linux.js` → `@/linux.js`); the fix itself merged cleanly. (GitHub disallows reopening a PR whose branch was force-pushed, hence the new PR.)

## Why

The packaged Linux AppImage crashes before any app code runs. `tools-pack linux start` times out at 60s with `desktop-root.json not written`, and the Electron binary dies with `Error loading V8 startup snapshot file` (exit 133). I hit this myself trying to run the packaged Linux app; it's on the critical path for the open Linux-distribution requests (#4368, #5531, #3759), since an AppImage that crashes before boot can't ship.

**Root cause:** `compression: "maximum"` in the Linux electron-builder config maps to an **xz** SquashFS. The AppImage type-2 runtime behind `--appimage-extract-and-run` extracts most entries from an xz payload but **silently omits the V8 snapshot files**, so Electron can't initialize V8 and dies before `main()`. This is the downstream consequence of #5835's fix (move off FUSE to `--appimage-extract-and-run`).

Full evidence and reproduction are in #6145.

## What users will see

The packaged Linux AppImage launches. Previously it failed silently, no window, no user-visible error (the crash happened before logging initialized). After this change `tools-pack linux start` returns within a few seconds with a running desktop window instead of timing out.

A working AppImage built from this fix is published for anyone who wants to run it now: https://github.com/paoloantinori/open-design/releases/tag/v0.16.1-linux-appimage-fix

## Surface area

- [x] **Default behavior change** — packaged Linux AppImage compression changes xz → gzip. Artifact grows ~15% (~415MB → ~494MB), because the AppImage runtime cannot correctly extract the V8 snapshots from an xz payload. This is the whole point of the change.
- [x] **None** for everything else — no UI, no CLI flag, no API, no contracts, no new dependencies.

## Bug fix verification

- Test path: `tools/pack/tests/linux.test.ts` → `writeLinuxBuilderConfig compression > does not select xz (maximum) compression for the AppImage payload`.
- Red on `main`, green on this branch: **yes.** With `compression: "maximum"` the test fails on the `not.toBe("maximum")` assertion; with the fix it passes. Confirmed by flipping the value and re-running.
- End-to-end: built the AppImage from this fix, `linux install`, `linux start` (originally-failing command) returned a pid and wrote `desktop-root.json`; desktop log shows a clean boot through `od://app/onboarding`; `linux stop` cleaned up.

## Validation

On the rebased branch:

- `pnpm --filter @open-design/tools-pack test` — 286 passed, 8 skipped, 1 failed; the single failure (`resources.test.ts` → Vela npm resolver) fails identically on plain `main` (285 passed there), so it is pre-existing and unrelated to this change.
- `pnpm guard` + `pnpm typecheck` — passed pre-rebase; the rebase only touched the test import alias and the already-merged config line.

The new test follows the spirit of `docs/testing/test-efficiency.zh-CN.md`: it awaits the async config writer's Promise as its completion signal (no `setTimeout`/sleep/polling), uses an isolated `mkdtemp` dir cleaned in `finally` (no shared mutable runtime or serialization), and runs in ~12ms.

`"maximum"` had no Linux-specific rationale: copied from a `mac.ts` shape that mac itself made configurable in #424, and Linux has no blockmap/differential-update path that benefits from xz. zstd is rejected outright by the runtime (`supports only xz, zlib`), so gzip is the only viable compressor.
