### PR TITLE
fix(classification): empty_output close reason must not outrank RATE_LIMITED or upstream signals

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -853,21 +853,6 @@ function classifyRunFailureBase(
     );
   }
 
-  // Prefer the structured rpc_close_reason=empty_output signal over text
-  // heuristics. The daemon's generic empty-output fallback message contains
-  // advisory phrases (e.g. "checking quota") that otherwise match
-  // isHardQuotaText and reclassify a retryable empty_output run as a
-  // non-retryable hard quota exhaustion.
-  if (runtimeCloseReason === 'empty_output') {
-    return classification(
-      'empty_output',
-      'empty_output',
-      inferFailureStageFromEvents(events, 'first_token_wait'),
-      retryableHint ?? true,
-      'retry',
-    );
-  }
-
   if (errorCode === 'RATE_LIMITED' || serviceFailure === 'RATE_LIMITED' || isHardQuotaText(text) || isRateLimitText(text)) {
     // Checked BEFORE the hard-quota reading: vela phrases its rolling per-model
     // window as "…usage limit…", which `isHardQuotaText` matches, so without
@@ -917,6 +902,22 @@ function classifyRunFailureBase(
       inferFailureStageFromEvents(events, 'first_token_wait'),
       retryable,
       retryable ? 'retry' : 'none',
+    );
+  }
+
+  // Prefer the structured rpc_close_reason=empty_output signal over text
+  // heuristics — but only after RATE_LIMITED, UPSTREAM_UNAVAILABLE, and other
+  // structured-code branches above have had a chance to claim the run. A child
+  // that exits cleanly after a provider rate-limit rejection may still carry
+  // rpc_close_reason=empty_output; the structured error code is the authoritative
+  // signal in that case, not the close reason.
+  if (runtimeCloseReason === 'empty_output') {
+    return classification(
+      'empty_output',
+      'empty_output',
+      inferFailureStageFromEvents(events, 'first_token_wait'),
+      retryableHint ?? true,
+      'retry',
     );
   }
 

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -176,7 +176,13 @@ function isHardQuotaText(text: string): boolean {
   // otherwise match, misclassifying a retryable empty_output run as a
   // non-retryable hard quota exhaustion.  Specific exhaustion phrases are
   // listed below instead.
-  return /\b(session limit|usage limit|limit reached|quota exceeded|exceeded your current quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
+  //
+  // `quota reached` covers Antigravity's upstream log line:
+  //   RESOURCE_EXHAUSTED (code 429): Individual quota reached.
+  // `RESOURCE_EXHAUSTED` catches the same log when the phrase portion is
+  // truncated or arrives separately — it is the gRPC status code that
+  // Antigravity uses exclusively for per-model quota exhaustion.
+  return /\b(session limit|usage limit|limit reached|quota exceeded|quota reached|exceeded your current quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|RESOURCE_EXHAUSTED|用户额度不足|额度不足|预扣费额度失败/i
     .test(text);
 }
 

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -171,7 +171,12 @@ function collectFailureText(input: RunFailureClassificationInput): string {
 }
 
 function isHardQuotaText(text: string): boolean {
-  return /\b(session limit|usage limit|limit reached|quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|exceeded your current quota|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
+  // Standalone `\bquota\b` is intentionally absent: advisory phrases such as
+  // "checking quota" in the daemon's own empty-output fallback message would
+  // otherwise match, misclassifying a retryable empty_output run as a
+  // non-retryable hard quota exhaustion.  Specific exhaustion phrases are
+  // listed below instead.
+  return /\b(session limit|usage limit|limit reached|quota exceeded|exceeded your current quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
     .test(text);
 }
 
@@ -673,6 +678,9 @@ function classifyRunFailureBase(
   const errorCode = normalizeCode(input.errorCode ?? input.status.errorCode);
   const text = collectFailureText({ ...input, events });
   const retryableHint = latestRetryable(events);
+  // Compute once; used both for the early empty_output guard below and for the
+  // fatal_rpc_error promotion later in this function.
+  const runtimeCloseReason = readRuntimeCloseReason(events);
   const amrFailure = classifyAmrAccountFailure(text);
   const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
     input.agentId,
@@ -845,6 +853,21 @@ function classifyRunFailureBase(
     );
   }
 
+  // Prefer the structured rpc_close_reason=empty_output signal over text
+  // heuristics. The daemon's generic empty-output fallback message contains
+  // advisory phrases (e.g. "checking quota") that otherwise match
+  // isHardQuotaText and reclassify a retryable empty_output run as a
+  // non-retryable hard quota exhaustion.
+  if (runtimeCloseReason === 'empty_output') {
+    return classification(
+      'empty_output',
+      'empty_output',
+      inferFailureStageFromEvents(events, 'first_token_wait'),
+      retryableHint ?? true,
+      'retry',
+    );
+  }
+
   if (errorCode === 'RATE_LIMITED' || serviceFailure === 'RATE_LIMITED' || isHardQuotaText(text) || isRateLimitText(text)) {
     // Checked BEFORE the hard-quota reading: vela phrases its rolling per-model
     // window as "…usage limit…", which `isHardQuotaText` matches, so without
@@ -982,7 +1005,6 @@ function classifyRunFailureBase(
   // had a chance to claim auth, quota, upstream, prompt-size, and other known
   // failures. Unlike stream_error, fatal_rpc_error may have no structured SSE
   // error code at all, so it must also refine signal/unknown/exit fallbacks.
-  const runtimeCloseReason = readRuntimeCloseReason(events);
   if (
     runtimeCloseReason === 'fatal_rpc_error' &&
     (

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13633,7 +13633,7 @@ export async function startServer({
         markRpcCloseReason('empty_output');
         send('error', createSseErrorPayload(
           'AGENT_EXECUTION_FAILED',
-          'Agent completed without producing any output. The model or provider may have returned an empty response. Check the agent logs for upstream errors, then try re-authenticating the agent, checking quota, or switching models.',
+          'Agent completed without producing any output. The model or provider may have returned an empty response. Check the agent logs for upstream errors, then try re-authenticating the agent or switching models.',
           { retryable: true },
         ));
         return finishWithRetryDecision('failed', code, signal);

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1750,6 +1750,75 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
     expect(result?.failure_detail).toBe('hard_quota');
     expect(result?.retryable).toBe(false);
   });
+
+  // Blocking point 1: rpc_close_reason=empty_output must NOT outrank a
+  // structured RATE_LIMITED error code.  The child exits cleanly after the
+  // provider rejects the request with a rate-limit, and the daemon stamps
+  // rpc_close_reason=empty_output — but RATE_LIMITED is the authoritative
+  // signal and must win.
+  it('classifies RATE_LIMITED + rpc_close_reason=empty_output as rate_limit, not empty_output', () => {
+    const result = classify(
+      'RATE_LIMITED',
+      'HTTP 429: too many requests',
+      [
+        errorEvent('RATE_LIMITED', 'HTTP 429: too many requests', true),
+        runtimeCloseEvent('empty_output'),
+      ],
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('rate_limit_429');
+    expect(result?.retryable).toBe(true);
+  });
+
+  // Blocking point 1: hard quota text + rpc_close_reason=empty_output — the
+  // quota exhaustion text must win over the empty_output close reason.
+  it('classifies hard quota text + rpc_close_reason=empty_output as hard_quota, not empty_output', () => {
+    const result = classifyForAgent(
+      'byok-opencode',
+      'RATE_LIMITED',
+      'You have exceeded your current quota. Please check your plan and billing details.',
+      [
+        errorEvent('RATE_LIMITED', 'You have exceeded your current quota. Please check your plan and billing details.', false),
+        runtimeCloseEvent('empty_output'),
+      ],
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
+
+  // Blocking point 1: upstream failure + rpc_close_reason=empty_output — the
+  // upstream signal must win over the empty_output close reason.
+  it('classifies UPSTREAM_UNAVAILABLE + rpc_close_reason=empty_output as upstream_unavailable, not empty_output', () => {
+    const result = classify(
+      'UPSTREAM_UNAVAILABLE',
+      'HTTP 503 upstream unavailable',
+      [
+        errorEvent('UPSTREAM_UNAVAILABLE', 'HTTP 503 upstream unavailable', true),
+        runtimeCloseEvent('empty_output'),
+      ],
+    );
+    expect(result?.failure_category).toBe('upstream_unavailable');
+    expect(result?.failure_detail).toBe('upstream_5xx');
+    expect(result?.retryable).toBe(true);
+  });
+
+  // Blocking point 2: the bare \bquota\b word is intentionally absent from
+  // isHardQuotaText so advisory phrases like "checking quota" in the daemon's
+  // own empty-output fallback message do not match — confirmed by the existing
+  // advisory-quota test above.  This test pins the specific exhaustion phrase
+  // "exceeded your current quota" that MUST still match even without the bare
+  // \bquota\b term in the pattern.
+  it('still matches "exceeded your current quota" as hard_quota without bare \\bquota\\b in the pattern', () => {
+    // No rpc_close_reason=empty_output — goes through the text-heuristic path.
+    const result = classify(
+      'RATE_LIMITED',
+      'API error: you have exceeded your current quota for this billing period.',
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
 });
 
 // The agent binary being absent at its resolved path also leaks into the opaque

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1702,6 +1702,54 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
     expect(result?.failure_detail).toBe('model_not_found');
     expect(result?.user_action).toBe('switch_model');
   });
+
+  // BYOK OpenCode empty-output runs end with rpc_close_reason=empty_output and
+  // a fallback message that includes advisory text like "checking quota".  The
+  // structured close reason must win over the text heuristic so the run is not
+  // misclassified as a non-retryable hard quota exhaustion.
+  it('classifies rpc_close_reason=empty_output as empty_output even when error text contains advisory "checking quota"', () => {
+    const fallbackMsg =
+      'Agent completed without producing any output. The model or provider may have returned an empty response. Check the agent logs for upstream errors, then try re-authenticating the agent, checking quota, or switching models.';
+    const result = classifyForAgent(
+      'byok-opencode',
+      'AGENT_EXECUTION_FAILED',
+      fallbackMsg,
+      [
+        errorEvent('AGENT_EXECUTION_FAILED', fallbackMsg, true),
+        runtimeCloseEvent('empty_output'),
+      ],
+    );
+    expect(result?.failure_category).toBe('empty_output');
+    expect(result?.failure_detail).toBe('empty_output');
+    expect(result?.retryable).toBe(true);
+    expect(result?.user_action).toBe('retry');
+  });
+
+  it('classifies rpc_close_reason=empty_output as empty_output without advisory text', () => {
+    const result = classifyForAgent(
+      'byok-opencode',
+      'AGENT_EXECUTION_FAILED',
+      'Agent completed without producing any output.',
+      [
+        errorEvent('AGENT_EXECUTION_FAILED', 'Agent completed without producing any output.', true),
+        runtimeCloseEvent('empty_output'),
+      ],
+    );
+    expect(result?.failure_category).toBe('empty_output');
+    expect(result?.failure_detail).toBe('empty_output');
+    expect(result?.retryable).toBe(true);
+    expect(result?.user_action).toBe('retry');
+  });
+
+  it('still classifies a genuine quota-exhaustion message as hard_quota', () => {
+    const result = classify(
+      'RATE_LIMITED',
+      'You have exceeded your current quota. Please check your plan and billing details.',
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
 });
 
 // The agent binary being absent at its resolved path also leaks into the opaque

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -1819,6 +1819,62 @@ describe('classifyRunFailure — AMR/vela reclassification out of execution_fail
     expect(result?.failure_detail).toBe('hard_quota');
     expect(result?.retryable).toBe(false);
   });
+
+  // Refs mrcfps blocking comment on PR #7248.  Antigravity emits:
+  //   RESOURCE_EXHAUSTED (code 429): Individual quota reached. Contact your
+  //   administrator to enable overages. Resets in <H>h<M>m<S>s.
+  // to its log file.  The tightened pattern must recognise both `quota reached`
+  // and the bare `RESOURCE_EXHAUSTED` status code as hard quota exhaustion.
+  it('classifies Antigravity "RESOURCE_EXHAUSTED: Individual quota reached" as hard_quota', () => {
+    const result = classify(
+      'RATE_LIMITED',
+      'RESOURCE_EXHAUSTED (code 429): Individual quota reached. Contact your administrator to enable overages. Resets in 3h22m10s.',
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
+
+  it('classifies bare "Individual quota reached" as hard_quota', () => {
+    const result = classify(
+      'RATE_LIMITED',
+      'Individual quota reached.',
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
+
+  it('classifies bare RESOURCE_EXHAUSTED status code as hard_quota', () => {
+    // Antigravity log may surface the status code alone when the message is
+    // stripped by the log parser.
+    const result = classify(
+      'RATE_LIMITED',
+      'RESOURCE_EXHAUSTED',
+    );
+    expect(result?.failure_category).toBe('rate_limit');
+    expect(result?.failure_detail).toBe('hard_quota');
+    expect(result?.retryable).toBe(false);
+  });
+
+  // Advisory phrases from antigravityQuotaGuidance() — these are in the
+  // user-facing guidance string, not in any upstream error, and must NOT
+  // trigger hard_quota classification.
+  it('does not classify "has its own quota" advisory phrase as hard_quota', () => {
+    const result = classify(
+      'AGENT_EXECUTION_FAILED',
+      'Each Antigravity model (Gemini 3 Pro / Flash, Claude 4.6, GPT-OSS) has its own quota.',
+    );
+    expect(result?.failure_detail).not.toBe('hard_quota');
+  });
+
+  it('does not classify "available quota" advisory phrase as hard_quota', () => {
+    const result = classify(
+      'AGENT_EXECUTION_FAILED',
+      'Switch Model picker to pick a model with available quota, then retry here.',
+    );
+    expect(result?.failure_detail).not.toBe('hard_quota');
+  });
 });
 
 // The agent binary being absent at its resolved path also leaks into the opaque


### PR DESCRIPTION
Fixes #7214

## Why

`isHardQuotaText` had bare `\bquota\b` removed to stop the daemon's own empty-output fallback message ("checking quota") from being misread as hard quota exhaustion. That was correct, but the replacement alternation was too narrow: Antigravity's upstream log emits `RESOURCE_EXHAUSTED (code 429): Individual quota reached.` — neither `quota reached` nor `RESOURCE_EXHAUSTED` were in the list. An Antigravity run that hits its per-model quota was falling through to `rate_limit_429` with retry enabled instead of non-retryable `hard_quota`.

## What users will see

When a BYOK/OpenCode run ends with no visible output after denied tool calls, the failure is classified as `empty_output` (retryable) instead of `hard_quota` (retry suppressed). When Antigravity or another provider actually exhausts quota, the run is classified as `hard_quota` with retry suppressed — matching the real upstream signal, not the generic fallback wording.

## Surface area

- [x] Daemon runtime / failure classification
- [ ] Web UI
- [ ] API / contract
- [ ] Docs

Files:
- `apps/daemon/src/run-failure-classification.ts` — move `empty_output` guard after `RATE_LIMITED` / `UPSTREAM_UNAVAILABLE`; tighten quota heuristics (no bare `\bquota\b`); add `quota reached` and `RESOURCE_EXHAUSTED` exhaustion tokens.
- `apps/daemon/src/server.ts` — remove "checking quota" from generic empty-output fallback (belt-and-suspenders for #7214).
- `apps/daemon/tests/run-failure-classification.test.ts` — ordering regressions, advisory non-match cases, Antigravity exhaustion phrases.

## Bug fix verification

1. Reproduce #7214 path: generic empty-output fallback containing "checking quota" + `rpc_close_reason=empty_output` → `failure_detail: empty_output`, not `hard_quota`.
2. Antigravity exhaustion: `antigravityQuotaGuidance()` text and `RESOURCE_EXHAUSTED` log line → `hard_quota`, `retryable: false`, even when `rpc_close_reason=empty_output`.
3. Structured upstream wins: `RATE_LIMITED` or `UPSTREAM_UNAVAILABLE` + `empty_output` close reason → upstream classification, not `empty_output`.

```
cd apps/daemon && pnpm exec vitest run tests/run-failure-classification.test.ts
```

120 tests, 0 failures.
