### PR TITLE
fix(daemon): pipe stdin for pi RPC runtimes

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -52,6 +52,7 @@ import {
   probeAgentAuthStatus,
 } from './runtimes/auth.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
+import { resolveAgentStdinMode } from './runtimes/launch.js';
 import {
   buildLegacyMaxTokensParam,
   buildMaxCompletionTokensParam,
@@ -2611,10 +2612,7 @@ async function testAgentConnectionInternal(
         diagnostics: buildDiagnostics(),
       };
     }
-    const stdinMode =
-      def.promptViaStdin || def.streamFormat === 'acp-json-rpc' || def.streamFormat === 'dsh-profile-jsonl'
-        ? 'pipe'
-        : 'ignore';
+    const stdinMode = resolveAgentStdinMode(def);
     const baseEnv = spawnEnvForAgent(
       input.agentId,
       {

--- a/apps/daemon/src/runtimes/launch.ts
+++ b/apps/daemon/src/runtimes/launch.ts
@@ -5,6 +5,24 @@ import type { RuntimeAgentDef } from './types.js';
 
 export type AgentLaunchKind = 'selected' | 'codex-native';
 
+export type AgentStdinMode = 'pipe' | 'ignore';
+
+/**
+ * Resolves whether an agent subprocess needs a writable stdin channel.
+ * Interactive stream protocols exchange commands over stdin even when the
+ * runtime does not use the simpler promptViaStdin transport.
+ */
+export function resolveAgentStdinMode(
+  def: Partial<Pick<RuntimeAgentDef, 'promptViaStdin' | 'streamFormat'>>,
+): AgentStdinMode {
+  return def.promptViaStdin ||
+    def.streamFormat === 'acp-json-rpc' ||
+    def.streamFormat === 'pi-rpc' ||
+    def.streamFormat === 'dsh-profile-jsonl'
+    ? 'pipe'
+    : 'ignore';
+}
+
 export type AgentLaunchResolution = ReturnType<typeof inspectAgentExecutableResolution> & {
   launchPath: string | null;
   launchKind: AgentLaunchKind;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -142,6 +142,7 @@ import {
   resolveChatRunShutdownGraceMs,
 } from './runtimes/chat-run-lifecycle.js';
 import { assertOdNextSemanticRequestFactProducerCoverage } from './runtimes/od-next-exact-input.js';
+import { resolveAgentStdinMode } from './runtimes/launch.js';
 import {
   normalizeRunContextSelection,
   renderRunContextPrompt,
@@ -13214,12 +13215,7 @@ export async function startServer({
     try {
       // Prompt delivery via stdin is now the universal default. This bypasses
       // both the cmd.exe 8KB limit and the CreateProcess 32KB limit.
-      const stdinMode =
-        def.promptViaStdin ||
-        def.streamFormat === 'acp-json-rpc' ||
-        def.streamFormat === 'dsh-profile-jsonl'
-          ? 'pipe'
-          : 'ignore';
+      const stdinMode = resolveAgentStdinMode(def);
       const env = applyAgentLaunchEnv({
         ...agentSpawnEnv,
         ...(mmdRouteLaunchEnv || {}),

--- a/apps/daemon/tests/runtimes/launch.test.ts
+++ b/apps/daemon/tests/runtimes/launch.test.ts
@@ -1,6 +1,7 @@
 import { delimiter, join } from 'node:path';
 import { realpathSync, symlinkSync } from 'node:fs';
 import { test } from 'vitest';
+import { resolveAgentStdinMode } from '../../src/runtimes/launch.js';
 import {
   applyAgentLaunchEnv,
   assert,
@@ -18,6 +19,21 @@ import {
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
 const winTest = process.platform === 'win32' ? test : test.skip;
+
+test('resolveAgentStdinMode pipes every interactive stream protocol', () => {
+  for (const streamFormat of ['acp-json-rpc', 'pi-rpc', 'dsh-profile-jsonl'] as const) {
+    assert.equal(
+      resolveAgentStdinMode({ streamFormat }),
+      'pipe',
+      `${streamFormat} requires a writable command channel`,
+    );
+  }
+});
+
+test('resolveAgentStdinMode preserves explicit prompt stdin and ignores plain output-only runs', () => {
+  assert.equal(resolveAgentStdinMode({ promptViaStdin: true }), 'pipe');
+  assert.equal(resolveAgentStdinMode({ streamFormat: 'plain' }), 'ignore');
+});
 
 test('applyAgentLaunchEnv prepends nodeBinDir and wrapper dir, deduping PATH', () => {
   const launch = {


### PR DESCRIPTION
Related to #7261.

## Why

While testing Prime Agent through a local `pi-rpc` runtime definition, every run failed before prompt delivery with:

```
AGENT_EXECUTION_FAILED: pi RPC child process is missing stdin
```

`attachPiRpcSession()` uses stdin for `new_session`, `prompt`, extension UI responses, and abort commands. The two process-spawn paths opened stdin for `promptViaStdin`, ACP, and DSH profiles, but did not recognize `pi-rpc` itself as an interactive protocol. A pi-compatible runtime that relies on its stream-format contract rather than also declaring `promptViaStdin` therefore received `child.stdin === null`.

## What users will see

Pi-compatible RPC runtimes can initialize and receive their prompt instead of failing immediately with a missing-stdin execution error. This is the transport prerequisite for the separately scoped Prime Agent runtime work in #7261.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — interactive `pi-rpc` subprocesses now receive a writable stdin pipe
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is daemon process transport.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/launch.test.ts`
- The regression assertion covers all interactive protocols and specifically requires `pi-rpc` to resolve to `pipe`; omitting the new `pi-rpc` invariant makes it fail.
- The same named resolver is used by both chat runs and Settings connection tests, preventing the two spawn paths from drifting again.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/launch.test.ts tests/pi-rpc.test.ts` — 61 passed, 1 platform skip.
- `pnpm --filter @open-design/daemon typecheck` — passed.
- `git diff --check` — passed.

## Adjacent issues

- The Prime Agent runtime definition, native session-directory selection, and activity-card rendering remain separate from this transport fix, per the maintainer guidance in #7261.
