### PR TITLE
feat(daemon): add Prime Agent RPC session resume

### DIFF
--- a/apps/daemon/src/agent-protocol/pi-rpc/session.ts
+++ b/apps/daemon/src/agent-protocol/pi-rpc/session.ts
@@ -239,7 +239,7 @@ export function attachPiRpcSession({
 
   const fail = (message: string, code?: string): void => {
     if (finished) return;
-    captureSessionPath();
+    if (onSessionPath) captureSessionPath();
     finished = true;
     fatal = true;
     send('error', { message, ...(code ? { code } : {}) });
@@ -349,9 +349,11 @@ export function attachPiRpcSession({
     // acting on the parsed objects.
     if (finished) return;
 
-    // Capture while the run is live so cancellation, failure, and application
-    // restart do not discard the native session handle.
-    captureSessionPath();
+    // Live capture is opt-in for runtimes whose caller supplied a
+    // child-specific directory. Shared-directory runtimes (ordinary Pi) must
+    // wait for terminal conservative resolution so a transient foreign write
+    // cannot become an irreversible candidate.
+    if (onSessionPath) captureSessionPath();
 
     // Extension UI requests: auto-resolve to keep pi unblocked.
     if (raw.type === 'extension_ui_request') {
@@ -429,7 +431,7 @@ export function attachPiRpcSession({
       // (SIGTERM fallback) is owned by the caller (runs.cancel()),
       // not by this method.
       if (finished || child.killed) return;
-      captureSessionPath();
+      if (onSessionPath) captureSessionPath();
       finished = true;
       sendCommand(stdin, 'abort');
     },

--- a/apps/daemon/src/agent-protocol/pi-rpc/session.ts
+++ b/apps/daemon/src/agent-protocol/pi-rpc/session.ts
@@ -31,6 +31,7 @@ export type PiRpcSessionOptions = {
   imagePaths?: string[];
   uploadRoot?: string;
   parentSession?: string;
+  sessionDir?: string;
 };
 /** Handle returned by `attachPiRpcSession` for querying run state and requesting abort. */
 export type PiRpcSession = {
@@ -100,9 +101,9 @@ export type PiSessionFileSnapshot = Map<string, { mtimeMs: number; size: number 
  *
  * @param cwd - Absolute path to the pi working directory; may be undefined.
  */
-export function readPiSessionFiles(cwd: string | undefined): Array<{ path: string; mtimeMs: number; size: number }> {
-  if (typeof cwd !== 'string' || cwd.length === 0) return [];
-  const sessionsDir = path.join(cwd, '.pi', 'sessions');
+export function readPiSessionFiles(cwd: string | undefined, sessionDir?: string): Array<{ path: string; mtimeMs: number; size: number }> {
+  if (!sessionDir && (typeof cwd !== 'string' || cwd.length === 0)) return [];
+  const sessionsDir = sessionDir ?? path.join(cwd as string, '.pi', 'sessions');
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
@@ -128,9 +129,9 @@ export function readPiSessionFiles(cwd: string | undefined): Array<{ path: strin
  *
  * @param cwd - Absolute path to the pi working directory; may be undefined.
  */
-export function snapshotPiSessionFiles(cwd: string | undefined): PiSessionFileSnapshot {
+export function snapshotPiSessionFiles(cwd: string | undefined, sessionDir?: string): PiSessionFileSnapshot {
   const snapshot: PiSessionFileSnapshot = new Map();
-  for (const file of readPiSessionFiles(cwd)) {
+  for (const file of readPiSessionFiles(cwd, sessionDir)) {
     snapshot.set(file.path, { mtimeMs: file.mtimeMs, size: file.size });
   }
   return snapshot;
@@ -148,8 +149,9 @@ export function snapshotPiSessionFiles(cwd: string | undefined): PiSessionFileSn
 export function resolveSessionPathChangedSince(
   cwd: string | undefined,
   before: PiSessionFileSnapshot,
+  sessionDir?: string,
 ): string | null {
-  const changed = readPiSessionFiles(cwd).filter((file) => {
+  const changed = readPiSessionFiles(cwd, sessionDir).filter((file) => {
     const previous = before.get(file.path);
     return !previous || file.mtimeMs > previous.mtimeMs || file.size !== previous.size;
   });
@@ -187,6 +189,7 @@ export function attachPiRpcSession({
   imagePaths,
   uploadRoot,
   parentSession,
+  sessionDir,
 }: PiRpcSessionOptions): PiRpcSession {
   const stdin = child.stdin;
   const stdout = child.stdout;
@@ -198,11 +201,20 @@ export function attachPiRpcSession({
   }
 
   const runStartedAt = Date.now();
-  const sessionFilesBeforePrompt = snapshotPiSessionFiles(cwd);
+  const sessionFilesBeforePrompt = snapshotPiSessionFiles(cwd, sessionDir);
   let finished = false;
   let fatal = false;
   const sentFirstToken = { value: false };
   let capturedSessionPath: string | null = null;
+
+  const captureSessionPath = (): void => {
+    if (capturedSessionPath) return;
+    capturedSessionPath = resolveSessionPathChangedSince(
+      cwd,
+      sessionFilesBeforePrompt,
+      sessionDir,
+    );
+  };
 
   let nextRpcId = 1;
   let stdinOpen = true;
@@ -222,6 +234,7 @@ export function attachPiRpcSession({
 
   const fail = (message: string, code?: string): void => {
     if (finished) return;
+    captureSessionPath();
     finished = true;
     fatal = true;
     send('error', { message, ...(code ? { code } : {}) });
@@ -331,6 +344,10 @@ export function attachPiRpcSession({
     // acting on the parsed objects.
     if (finished) return;
 
+    // Capture while the run is live so cancellation, failure, and application
+    // restart do not discard the native session handle.
+    captureSessionPath();
+
     // Extension UI requests: auto-resolve to keep pi unblocked.
     if (raw.type === 'extension_ui_request') {
       replyExtensionUi(stdin, raw);
@@ -365,7 +382,7 @@ export function attachPiRpcSession({
       // Capture only the session file changed by this run. If another pi
       // process wrote to the shared session directory concurrently, the
       // resolver returns null instead of risking cross-conversation resume.
-      capturedSessionPath = resolveSessionPathChangedSince(cwd, sessionFilesBeforePrompt);
+      captureSessionPath();
       // pi's RPC process stays alive after agent_end (designed for
       // multi-prompt sessions). The daemon's /api/chat is single-shot,
       // so close stdin and let the process exit naturally, or kill it
@@ -407,6 +424,7 @@ export function attachPiRpcSession({
       // (SIGTERM fallback) is owned by the caller (runs.cancel()),
       // not by this method.
       if (finished || child.killed) return;
+      captureSessionPath();
       finished = true;
       sendCommand(stdin, 'abort');
     },

--- a/apps/daemon/src/agent-protocol/pi-rpc/session.ts
+++ b/apps/daemon/src/agent-protocol/pi-rpc/session.ts
@@ -32,6 +32,7 @@ export type PiRpcSessionOptions = {
   uploadRoot?: string;
   parentSession?: string;
   sessionDir?: string;
+  onSessionPath?: (sessionPath: string) => void;
 };
 /** Handle returned by `attachPiRpcSession` for querying run state and requesting abort. */
 export type PiRpcSession = {
@@ -190,6 +191,7 @@ export function attachPiRpcSession({
   uploadRoot,
   parentSession,
   sessionDir,
+  onSessionPath,
 }: PiRpcSessionOptions): PiRpcSession {
   const stdin = child.stdin;
   const stdout = child.stdout;
@@ -209,11 +211,14 @@ export function attachPiRpcSession({
 
   const captureSessionPath = (): void => {
     if (capturedSessionPath) return;
-    capturedSessionPath = resolveSessionPathChangedSince(
+    const sessionPath = resolveSessionPathChangedSince(
       cwd,
       sessionFilesBeforePrompt,
       sessionDir,
     );
+    if (!sessionPath) return;
+    capturedSessionPath = sessionPath;
+    onSessionPath?.(sessionPath);
   };
 
   let nextRpcId = 1;

--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -224,6 +224,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['kilo', new Set(['KILO_BIN'])],
   ['opencode', new Set(['OPENCODE_BIN'])],
   ['pi', new Set(['PI_BIN'])],
+  ['prime-agent', new Set(['PRIME_AGENT_BIN'])],
   ['qoder', new Set(['QODER_BIN'])],
   ['qwen', new Set(['QWEN_BIN'])],
   ['trae-cli', new Set(['TRAE_CLI_BIN'])],

--- a/apps/daemon/src/runtimes/defs/prime-agent.ts
+++ b/apps/daemon/src/runtimes/defs/prime-agent.ts
@@ -1,0 +1,74 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef, RuntimeModelOption } from '../types.js';
+
+export function parsePrimeAgentModels(stdout: string): RuntimeModelOption[] {
+  const models: RuntimeModelOption[] = [DEFAULT_MODEL_OPTION];
+  const seen = new Set<string>();
+  for (const rawLine of String(stdout || '').split('\n')) {
+    const columns = rawLine.trim().split(/\s+/);
+    if (columns.length < 2 || columns[0]?.toLowerCase() === 'provider') continue;
+    const provider = columns[0];
+    const model = columns[1];
+    if (!provider || !model || /^[-─]+$/.test(provider)) continue;
+    const id = `${provider}/${model}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    models.push({ id, label: id });
+  }
+  return models;
+}
+
+export const primeAgentDef = {
+  id: 'prime-agent',
+  name: 'Prime Agent',
+  bin: 'prime-agent',
+  versionArgs: ['--version'],
+  listModels: {
+    args: ['model', 'list'],
+    parse: parsePrimeAgentModels,
+    timeoutMs: 15_000,
+  },
+  fallbackModels: [DEFAULT_MODEL_OPTION],
+  reasoningOptions: [
+    DEFAULT_MODEL_OPTION,
+    { id: 'off', label: 'Off' },
+    { id: 'minimal', label: 'Minimal' },
+    { id: 'low', label: 'Low' },
+    { id: 'medium', label: 'Medium' },
+    { id: 'high', label: 'High' },
+    { id: 'xhigh', label: 'Extra high' },
+    { id: 'max', label: 'Maximum' },
+  ],
+  buildArgs: (_prompt, _images, _dirs, options = {}, runtimeContext = {}) => {
+    const args = ['--mode', 'rpc'];
+    if (runtimeContext.cwd) args.push('--cwd', runtimeContext.cwd);
+    if (runtimeContext.resumeSessionId) args.push('--resume', runtimeContext.resumeSessionId);
+    if (options.model && options.model !== 'default') {
+      const slash = options.model.indexOf('/');
+      if (slash > 0 && slash < options.model.length - 1) {
+        args.push('--provider', options.model.slice(0, slash));
+        args.push('--model', options.model.slice(slash + 1));
+      } else {
+        args.push('--model', options.model);
+      }
+    }
+    if (options.reasoning && options.reasoning !== 'default') {
+      args.push('--thinking', options.reasoning);
+    }
+    return args;
+  },
+  // Prime's ACP server advertises loadSession=false. Its CLI can reopen the
+  // same JSONL session in RPC mode with `--resume`; using pi's
+  // `new_session(parentSession)` instead would fork another native session.
+  streamFormat: 'pi-rpc',
+  piRpcSessionDir: path.join(os.homedir(), '.prime', 'agent', 'sessions'),
+  piRpcResumeViaProcessArgs: true,
+  supportsImagePaths: true,
+  mcpDiscovery: 'mature-acp',
+  externalMcpInjection: 'acp-merge',
+  installUrl: 'https://github.com/PrimeIntellect-ai/prime-agent',
+  docsUrl: 'https://github.com/PrimeIntellect-ai/prime-agent',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/prime-agent.ts
+++ b/apps/daemon/src/runtimes/defs/prime-agent.ts
@@ -45,6 +45,9 @@ export const primeAgentDef = {
   buildArgs: (_prompt, _images, _dirs, options = {}, runtimeContext = {}) => {
     const args = ['--mode', 'rpc'];
     if (runtimeContext.cwd) args.push('--cwd', runtimeContext.cwd);
+    if (runtimeContext.piRpcSessionDir) {
+      args.push('--session-dir', runtimeContext.piRpcSessionDir);
+    }
     if (runtimeContext.resumeSessionId) args.push('--resume', runtimeContext.resumeSessionId);
     if (options.model && options.model !== 'default') {
       const slash = options.model.indexOf('/');

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -32,6 +32,7 @@ const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['opencode', 'OPENCODE_BIN'],
   ['byok-opencode', 'OPENCODE_BIN'],
   ['pi', 'PI_BIN'],
+  ['prime-agent', 'PRIME_AGENT_BIN'],
   ['qoder', 'QODER_BIN'],
   ['qwen', 'QWEN_BIN'],
   ['reasonix', 'REASONIX_BIN'],

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -23,6 +23,7 @@ import { aiderAgentDef } from './defs/aider.js';
 import { antigravityAgentDef } from './defs/antigravity.js';
 import { codebuddyAgentDef } from './defs/codebuddy.js';
 import { reasonixAgentDef } from './defs/reasonix.js';
+import { primeAgentDef } from './defs/prime-agent.js';
 import { mimoAgentDef } from './defs/mimo.js';
 import { atomcodeAgentDef } from './defs/atomcode.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
@@ -62,6 +63,7 @@ export const SHIPPED_AGENT_DEFS: RuntimeAgentDef[] = [
   aiderAgentDef,
   antigravityAgentDef,
   reasonixAgentDef,
+  primeAgentDef,
   codebuddyAgentDef,
   mimoAgentDef,
   atomcodeAgentDef,

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -254,6 +254,14 @@ export type RuntimeAgentDef = {
   // path and `agent-cli-session-resume.md`. Profile-stdio transports can also
   // capture the id from a validated protocol status frame.
   capturesSessionIdFromStream?: boolean;
+  // Override the native session directory inspected by the pi-compatible RPC
+  // adapter. Plain pi defaults to <cwd>/.pi/sessions; Prime Agent stores its
+  // compatible JSONL sessions under ~/.prime/agent/sessions instead.
+  piRpcSessionDir?: string;
+  // Some pi-compatible runtimes can resume the same native session file via
+  // a process argument. This avoids `new_session(parentSession)`, whose
+  // semantics intentionally fork a new JSONL session on every turn.
+  piRpcResumeViaProcessArgs?: boolean;
   // ACP-runtime analogue of capture-style resume: the agent talks `acp-json-rpc`
   // (today only AMR/vela) and supports resuming via `session/load`. The daemon
   // captures the durable upstream session handle from the ACP session
@@ -345,6 +353,7 @@ export type DetectedAgent = Omit<
   // def directly, the registry payload stays unchanged.
   | 'inactivityTimeoutMs'
   | 'firstOutputTimeoutMs'
+  | 'piRpcResumeViaProcessArgs'
   | 'authProbe'
 > & {
   models: RuntimeModelOption[];

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -66,6 +66,10 @@ export type RuntimeContext = {
   // persists), while capture-style transports report their own id.
   resumeSessionId?: string | null;
   newSessionId?: string;
+  // Daemon-owned directory for pi-compatible runtimes to create this
+  // child's native session. A per-run directory prevents shared-directory
+  // discovery from attributing another process's file to this run.
+  piRpcSessionDir?: string;
   // Per-run plugin isolation for agent subprocesses. External Plugin entry
   // points use this for Local Codex so the child cannot recursively load the
   // same Codex Plugin and route itself into another OpenDesign workflow.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14388,18 +14388,22 @@ export async function startServer({
         imagePaths: def.supportsImagePaths ? promptImagePaths : [],
         uploadRoot: odNextTaskInputSnapshot?.projectionDir ?? UPLOAD_DIR,
         sessionDir: runPiRpcSessionDir,
-        onSessionPath: (sessionPath) => {
-          persistCapturedAgentSession(db, {
-            conversationId: run.conversationId,
-            agentId: def.id,
-            sessionId: sessionPath,
-            stablePromptHash: currentStableHash,
-            stablePromptSections: currentStableSectionsJson,
-            model: safeModel ?? null,
-            cwd: effectiveCwd,
-            lastMessageId: run.assistantMessageId ?? null,
-          });
-        },
+        ...(def.piRpcResumeViaProcessArgs === true && runPiRpcSessionDir
+          ? {
+              onSessionPath: (sessionPath: string) => {
+                persistCapturedAgentSession(db, {
+                  conversationId: run.conversationId,
+                  agentId: def.id,
+                  sessionId: sessionPath,
+                  stablePromptHash: currentStableHash,
+                  stablePromptSections: currentStableSectionsJson,
+                  model: safeModel ?? null,
+                  cwd: effectiveCwd,
+                  lastMessageId: run.assistantMessageId ?? null,
+                });
+              },
+            }
+          : {}),
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
       const acpStageTimeoutMs = resolveAcpStageTimeoutMs(def.inactivityTimeoutMs);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14308,7 +14308,7 @@ export async function startServer({
         prompt: composed,
         cwd: effectiveCwd,
         model: safeModel,
-        parentSession: agentResumePromptPolicy.resumeSessionId
+        parentSession: !def.piRpcResumeViaProcessArgs && agentResumePromptPolicy.resumeSessionId
           ? agentResumePromptPolicy.resumeSessionId
           : undefined,
         send: (channel, payload) => {
@@ -14342,6 +14342,7 @@ export async function startServer({
         },
         imagePaths: def.supportsImagePaths ? promptImagePaths : [],
         uploadRoot: odNextTaskInputSnapshot?.projectionDir ?? UPLOAD_DIR,
+        sessionDir: def.piRpcSessionDir,
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
       const acpStageTimeoutMs = resolveAcpStageTimeoutMs(def.inactivityTimeoutMs);
@@ -15276,7 +15277,7 @@ export async function startServer({
       // another conversation in the same cwd cannot inherit this history.
       if (acpSession && typeof acpSession.getLastSessionPath === 'function') {
         const sessionPath = acpSession.getLastSessionPath();
-        if (status === 'succeeded' && def.streamFormat === 'pi-rpc') {
+        if (sessionPath && def.streamFormat === 'pi-rpc') {
           persistCapturedAgentSession(db, {
             conversationId: run.conversationId,
             agentId: def.id,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11186,7 +11186,7 @@ export async function startServer({
         // the probe failure and applies the identical fallback.
       }
     }
-    const resolvedAgentResumeCtx =
+    let resolvedAgentResumeCtx =
       agentSupportsSessionResume && run.conversationId
         ? resolveAgentResumeContext(db, {
             conversationId: run.conversationId,
@@ -11196,6 +11196,39 @@ export async function startServer({
             currentAssistantMessageId: run.assistantMessageId ?? null,
           })
         : { storedSessionId: null as string | null, resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, storedStableSections: null as StableSectionHashes | null, invalidationReason: null };
+    // Prime 0.8.0 silently creates a new session at a missing `--resume` path
+    // instead of reporting a resume failure. Reject a stale local file handle
+    // before prompt composition so this turn keeps the full DB transcript.
+    if (
+      def.piRpcResumeViaProcessArgs === true &&
+      run.conversationId &&
+      resolvedAgentResumeCtx.resumeSessionId
+    ) {
+      let resumeFileExists = false;
+      try {
+        resumeFileExists = fs.statSync(resolvedAgentResumeCtx.resumeSessionId).isFile();
+      } catch {
+        resumeFileExists = false;
+      }
+      if (!resumeFileExists) {
+        const staleSessionId = resolvedAgentResumeCtx.resumeSessionId;
+        clearAgentSession(db, run.conversationId, def.id);
+        resolvedAgentResumeCtx = resolveAgentResumeContext(db, {
+          conversationId: run.conversationId,
+          agentId: def.id,
+          currentModel: safeModel ?? null,
+          currentCwd: effectiveCwd,
+          currentAssistantMessageId: run.assistantMessageId ?? null,
+        });
+        design.runs.emit(run, 'diagnostic', {
+          type: 'agent_resume_auto_reseed',
+          agent_id: def.id,
+          reason: 'resume_failed',
+          previous_session_id: staleSessionId,
+          stale_session_cleared: true,
+        });
+      }
+    }
     // A same-run post-tool recovery resumes the exact session id captured from
     // the interrupted attempt. The ordinary cross-turn cursor guard cannot
     // admit it yet because the current assistant placeholder is still in
@@ -14343,6 +14376,18 @@ export async function startServer({
         imagePaths: def.supportsImagePaths ? promptImagePaths : [],
         uploadRoot: odNextTaskInputSnapshot?.projectionDir ?? UPLOAD_DIR,
         sessionDir: def.piRpcSessionDir,
+        onSessionPath: (sessionPath) => {
+          persistCapturedAgentSession(db, {
+            conversationId: run.conversationId,
+            agentId: def.id,
+            sessionId: sessionPath,
+            stablePromptHash: currentStableHash,
+            stablePromptSections: currentStableSectionsJson,
+            model: safeModel ?? null,
+            cwd: effectiveCwd,
+            lastMessageId: run.assistantMessageId ?? null,
+          });
+        },
       });
     } else if (def.streamFormat === 'acp-json-rpc') {
       const acpStageTimeoutMs = resolveAcpStageTimeoutMs(def.inactivityTimeoutMs);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12628,6 +12628,17 @@ export async function startServer({
       antigravityModelLockRelease = await acquireAntigravityModelLock();
     }
 
+    // Prime's default session directory is shared by every process. Give each
+    // fresh Open Design child its own durable directory before spawn so file
+    // discovery is attributable by construction. Resume turns keep using the
+    // directory containing their already-attributed native session file.
+    const runPiRpcSessionDir =
+      def.piRpcResumeViaProcessArgs === true && def.piRpcSessionDir
+        ? agentResumePromptPolicy.resumeSessionId
+          ? path.dirname(agentResumePromptPolicy.resumeSessionId)
+          : path.join(def.piRpcSessionDir, 'open-design', run.id)
+        : def.piRpcSessionDir;
+
     let args;
     const observeClaudeNativeChildBehavior =
       def.id === 'claude' && strategyTaskAtStart !== null;
@@ -12675,6 +12686,7 @@ export async function startServer({
           promptFilePath: promptFile?.path,
           resumeSessionId: agentResumePromptPolicy.resumeSessionId,
           newSessionId: agentResumeCtx.newSessionId,
+          piRpcSessionDir: runPiRpcSessionDir,
           disablePlugins:
             def.id === 'codex'
             && run.externalPluginAnalytics?.externalPluginId
@@ -14375,7 +14387,7 @@ export async function startServer({
         },
         imagePaths: def.supportsImagePaths ? promptImagePaths : [],
         uploadRoot: odNextTaskInputSnapshot?.projectionDir ?? UPLOAD_DIR,
-        sessionDir: def.piRpcSessionDir,
+        sessionDir: runPiRpcSessionDir,
         onSessionPath: (sessionPath) => {
           persistCapturedAgentSession(db, {
             conversationId: run.conversationId,

--- a/apps/daemon/tests/app-config.test.ts
+++ b/apps/daemon/tests/app-config.test.ts
@@ -452,6 +452,9 @@ describe('app-config', () => {
           'trae-cli': {
             TRAE_CLI_BIN: '  ~/bin/traecli-public  ',
           },
+          'prime-agent': {
+            PRIME_AGENT_BIN: '  ~/bin/prime-agent  ',
+          },
           __proto__: {
             CLAUDE_CONFIG_DIR: 'bad',
           },
@@ -471,6 +474,7 @@ describe('app-config', () => {
         },
         opencode: { OPENCODE_BIN: '~/bin/opencode' },
         'trae-cli': { TRAE_CLI_BIN: '~/bin/traecli-public' },
+        'prime-agent': { PRIME_AGENT_BIN: '~/bin/prime-agent' },
       });
       expect(agentCliEnvForAgent(cfg.agentCliEnv, 'byok-opencode')).toEqual({
         OPENCODE_BIN: '~/bin/opencode',

--- a/apps/daemon/tests/opencode-session-resume.test.ts
+++ b/apps/daemon/tests/opencode-session-resume.test.ts
@@ -40,7 +40,7 @@ type RunStatus = {
   resumable?: boolean;
 };
 
-type RunInvocation = { argv: string[]; stdin: string; cwd: string };
+type RunInvocation = { argv: string[]; stdin: string; cwd: string; sessionPath?: string };
 type RunEvent = { event: string; data: unknown };
 
 const SESSION = 'ses_e2e0000resume0000';
@@ -188,7 +188,7 @@ describe('opencode native session resume', () => {
   it('re-seeds Prime with the full transcript when its saved session file is missing', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-prime-resume-bin-'));
     const sessionDir = path.join(binDir, 'sessions');
-    const { bin, logPath, sessionPath } = await writeCapturingPrime(
+    const { bin, logPath } = await writeCapturingPrime(
       binDir,
       'prime-agent-capture',
       sessionDir,
@@ -215,7 +215,9 @@ describe('opencode native session resume', () => {
       'prime-agent',
     );
     expect(turn1, JSON.stringify(turn1)).toMatchObject({ status: 'succeeded' });
-    await rm(sessionPath, { force: true });
+    const [firstInvocation] = await readConversationRuns(logPath, conversationId);
+    expect(firstInvocation?.sessionPath).toContain(`${path.sep}open-design${path.sep}`);
+    await rm(firstInvocation?.sessionPath ?? '', { force: true });
 
     const turn2 = await sendRunAndWait(
       started.url,
@@ -248,16 +250,17 @@ async function writeCapturingPrime(
   dir: string,
   name: string,
   sessionDir: string,
-): Promise<{ bin: string; logPath: string; sessionPath: string }> {
+): Promise<{ bin: string; logPath: string }> {
   const bin = path.join(dir, name);
   const logPath = path.join(dir, `${name}-log.jsonl`);
-  const sessionPath = path.join(sessionDir, 'prime-session.jsonl');
   await writeFile(bin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const path = require('node:path');
 const argv = process.argv.slice(2);
 const logPath = ${JSON.stringify(logPath)};
-const sessionPath = ${JSON.stringify(sessionPath)};
+const sessionDirIndex = argv.indexOf('--session-dir');
+const runSessionDir = sessionDirIndex >= 0 ? argv[sessionDirIndex + 1] : ${JSON.stringify(sessionDir)};
+const sessionPath = path.join(runSessionDir, 'prime-session.jsonl');
 if (argv.includes('--version')) { console.log('0.8.0'); process.exit(0); }
 if (argv[0] === 'model' && argv[1] === 'list') { console.log('openai gpt-5'); process.exit(0); }
 let stdin = '';
@@ -270,7 +273,7 @@ process.stdin.on('data', (chunk) => {
     if (command.type !== 'prompt') continue;
     fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
     fs.writeFileSync(sessionPath, JSON.stringify({ type: 'session' }) + '\\n');
-    fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd() }) + '\\n');
+    fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd(), sessionPath }) + '\\n');
     console.log(JSON.stringify({ id: command.id, type: 'response', command: 'prompt', success: true }));
     console.log(JSON.stringify({ type: 'agent_start' }));
     console.log(JSON.stringify({ type: 'turn_start' }));
@@ -283,7 +286,7 @@ process.stdin.on('data', (chunk) => {
 process.stdin.on('end', () => process.exit(0));
 `, 'utf8');
   await chmod(bin, 0o755);
-  return { bin, logPath, sessionPath };
+  return { bin, logPath };
 }
 
 // Fake opencode CLI: stamps a FIXED session id on a create turn and echoes it

--- a/apps/daemon/tests/opencode-session-resume.test.ts
+++ b/apps/daemon/tests/opencode-session-resume.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
+import { primeAgentDef } from '../src/runtimes/defs/prime-agent.js';
+import type { RuntimeAgentDef } from '../src/runtimes/types.js';
 
 // End-to-end coverage for OpenCode native (capture-style) session resume.
 //
@@ -46,6 +48,8 @@ const FIRST_REPLY_SENTINEL = 'FIRST_TURN_REPLY_SENTINEL_0c7d2';
 
 describe('opencode native session resume', () => {
   const originalEnv = snapshotEnv();
+  const originalPrimeSessionDir = primeAgentDef.piRpcSessionDir;
+  const originalPrimePromptViaStdin = (primeAgentDef as RuntimeAgentDef).promptViaStdin;
   let started: StartedServer | null = null;
   let binDir: string | null = null;
 
@@ -58,6 +62,12 @@ describe('opencode native session resume', () => {
     if (binDir) await removeTempDir(binDir);
     binDir = null;
     restoreEnv(originalEnv);
+    primeAgentDef.piRpcSessionDir = originalPrimeSessionDir;
+    if (originalPrimePromptViaStdin === undefined) {
+      delete (primeAgentDef as RuntimeAgentDef).promptViaStdin;
+    } else {
+      (primeAgentDef as RuntimeAgentDef).promptViaStdin = originalPrimePromptViaStdin;
+    }
   });
 
   it('captures the session id on turn 1 and resumes it (without resending history) on turn 2', async () => {
@@ -174,7 +184,107 @@ describe('opencode native session resume', () => {
     expect(turn2.argv[0]).toBe('run');
     expect(turn2.argv).not.toContain('-s');
   });
+
+  it('re-seeds Prime with the full transcript when its saved session file is missing', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-prime-resume-bin-'));
+    const sessionDir = path.join(binDir, 'sessions');
+    const { bin, logPath, sessionPath } = await writeCapturingPrime(
+      binDir,
+      'prime-agent-capture',
+      sessionDir,
+    );
+    primeAgentDef.piRpcSessionDir = sessionDir;
+    // PR #7263 owns the generic pi-rpc stdin invariant. Keep this lifecycle
+    // test independent while that focused prerequisite is reviewed.
+    (primeAgentDef as RuntimeAgentDef).promptViaStdin = true;
+
+    clearTelemetryEnv();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'prime-agent',
+      agentCliEnv: { 'prime-agent': { PRIME_AGENT_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+    const turn1 = await sendRunAndWait(
+      started.url,
+      conversationId,
+      'first request',
+      'prime-agent',
+    );
+    expect(turn1, JSON.stringify(turn1)).toMatchObject({ status: 'succeeded' });
+    await rm(sessionPath, { force: true });
+
+    const turn2 = await sendRunAndWait(
+      started.url,
+      conversationId,
+      '## user\nfirst request\n\n## assistant\n'
+        + `${FIRST_REPLY_SENTINEL}\n\n## user\nsecond request`,
+      'prime-agent',
+      'second request',
+    );
+    expect(turn2.status).toBe('succeeded');
+
+    const events = await readRunEvents(turn2.eventsLogPath);
+    expect(hasDiagnostic(events, {
+      type: 'agent_resume_auto_reseed',
+      reason: 'resume_failed',
+      stale_session_cleared: true,
+    })).toBe(true);
+
+    const runs = await readConversationRuns(logPath, conversationId);
+    expect(runs).toHaveLength(2);
+    const [create, reseed] = runs as [RunInvocation, RunInvocation];
+    expect(create.argv).not.toContain('--resume');
+    expect(reseed.argv).not.toContain('--resume');
+    expect(reseed.stdin).toContain('first request');
+    expect(reseed.stdin).toContain('second request');
+  });
 });
+
+async function writeCapturingPrime(
+  dir: string,
+  name: string,
+  sessionDir: string,
+): Promise<{ bin: string; logPath: string; sessionPath: string }> {
+  const bin = path.join(dir, name);
+  const logPath = path.join(dir, `${name}-log.jsonl`);
+  const sessionPath = path.join(sessionDir, 'prime-session.jsonl');
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const argv = process.argv.slice(2);
+const logPath = ${JSON.stringify(logPath)};
+const sessionPath = ${JSON.stringify(sessionPath)};
+if (argv.includes('--version')) { console.log('0.8.0'); process.exit(0); }
+if (argv[0] === 'model' && argv[1] === 'list') { console.log('openai gpt-5'); process.exit(0); }
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  stdin += chunk;
+  for (const line of chunk.trim().split('\\n')) {
+    if (!line.trim()) continue;
+    const command = JSON.parse(line);
+    if (command.type !== 'prompt') continue;
+    fs.mkdirSync(path.dirname(sessionPath), { recursive: true });
+    fs.writeFileSync(sessionPath, JSON.stringify({ type: 'session' }) + '\\n');
+    fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd() }) + '\\n');
+    console.log(JSON.stringify({ id: command.id, type: 'response', command: 'prompt', success: true }));
+    console.log(JSON.stringify({ type: 'agent_start' }));
+    console.log(JSON.stringify({ type: 'turn_start' }));
+    console.log(JSON.stringify({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: ${JSON.stringify(FIRST_REPLY_SENTINEL)} } }));
+    console.log(JSON.stringify({ type: 'turn_end', message: { role: 'assistant', content: [{ type: 'text', text: ${JSON.stringify(FIRST_REPLY_SENTINEL)} }], usage: { input: 10, output: 2, totalTokens: 12 } } }));
+    console.log(JSON.stringify({ type: 'agent_end', messages: [] }));
+    setTimeout(() => process.exit(0), 50);
+  }
+});
+process.stdin.on('end', () => process.exit(0));
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return { bin, logPath, sessionPath };
+}
 
 // Fake opencode CLI: stamps a FIXED session id on a create turn and echoes it
 // on a resume turn. Logs `{argv, stdin}` per invocation.
@@ -342,6 +452,8 @@ async function sendRunAndWait(
   url: string,
   encoded: string,
   message: string,
+  agentId = 'opencode',
+  currentPrompt = message,
 ): Promise<RunStatus> {
   const [projectId, conversationId] = encoded.split('::');
   const assistantMessageId = `assistant_opencode_${randomUUID()}`;
@@ -358,9 +470,9 @@ async function sendRunAndWait(
       conversationId,
       assistantMessageId,
       clientRequestId: `client_opencode_${randomUUID()}`,
-      agentId: 'opencode',
+      agentId,
       message,
-      currentPrompt: message,
+      currentPrompt,
     }),
   });
   expect(runResponse.status).toBe(202);
@@ -370,16 +482,18 @@ async function sendRunAndWait(
 
 async function waitForRun(url: string, runId: string): Promise<RunStatus> {
   const startedAt = Date.now();
+  let lastRun: RunStatus | null = null;
   while (Date.now() - startedAt < 10_000) {
     const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
     expect(response.status).toBe(200);
     const run = (await response.json()) as RunStatus;
+    lastRun = run;
     if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
       return run;
     }
     await delay(100);
   }
-  throw new Error(`run ${runId} did not finish`);
+  throw new Error(`run ${runId} did not finish: ${JSON.stringify(lastRun)}`);
 }
 
 // Chat-turn `run` invocations for this conversation, in call order. OpenCode is
@@ -409,6 +523,25 @@ async function readChatTurnRuns(
         typeof rec.cwd === 'string' &&
         rec.cwd.includes(projectId),
     );
+}
+
+async function readConversationRuns(
+  logPath: string,
+  encoded: string,
+): Promise<RunInvocation[]> {
+  const projectId = encoded.split('::')[0] ?? encoded;
+  let raw = '';
+  try {
+    raw = await readFile(logPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as RunInvocation)
+    .filter((rec) => typeof rec.cwd === 'string' && rec.cwd.includes(projectId));
 }
 
 async function readRunEvents(eventsLogPath: string): Promise<RunEvent[]> {

--- a/apps/daemon/tests/pi-rpc.test.ts
+++ b/apps/daemon/tests/pi-rpc.test.ts
@@ -859,6 +859,29 @@ test('attachPiRpcSession sends prompt without images when imagePaths is empty', 
   assert.equal(parsed.images, undefined, 'prompt should not include images when none provided');
 });
 
+test('attachPiRpcSession retains a live session path when aborted', async () => {
+  const fs = await import('node:fs/promises');
+  const os = await import('node:os');
+  const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-rpc-abort-'));
+  const child = createMockChild();
+  try {
+    const session = attachPiRpcSession({
+      child: child as unknown as ChildProcess,
+      prompt: 'hello',
+      cwd: '/tmp',
+      model: null,
+      send: () => {},
+      sessionDir,
+    });
+    const sessionPath = path.join(sessionDir, 'session.jsonl');
+    await fs.writeFile(sessionPath, '{"type":"session"}\n');
+    session.abort();
+    assert.equal(session.getLastSessionPath(), sessionPath);
+  } finally {
+    await fs.rm(sessionDir, { recursive: true, force: true });
+  }
+});
+
 test('attachPiRpcSession skips unreadable image paths gracefully', () => {
   const events: TestSentEvent[] = [];
   const send = (channel: string, payload: JsonRecord) => events.push({ channel, ...payload });

--- a/apps/daemon/tests/pi-rpc.test.ts
+++ b/apps/daemon/tests/pi-rpc.test.ts
@@ -919,6 +919,40 @@ test('attachPiRpcSession never publishes a foreign shared-directory change befor
   }
 });
 
+test('attachPiRpcSession does not latch a foreign file live for ordinary Pi without a sessionDir override', async () => {
+  const fs = await import('node:fs/promises');
+  const os = await import('node:os');
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-rpc-ordinary-'));
+  const sharedDir = path.join(cwd, '.pi', 'sessions');
+  const child = createMockChild();
+  try {
+    await fs.mkdir(sharedDir, { recursive: true });
+    const session = attachPiRpcSession({
+      child: child as unknown as ChildProcess,
+      prompt: 'hello',
+      cwd,
+      model: null,
+      send: () => {},
+    });
+
+    const foreignPath = path.join(sharedDir, 'foreign.jsonl');
+    await fs.writeFile(foreignPath, '{"type":"foreign"}\n');
+    feedStdoutLines(child, [{ type: 'response', id: 1, success: true }]);
+    assert.equal(session.getLastSessionPath(), null, 'foreign first-frame change must not latch');
+
+    const ownPath = path.join(sharedDir, 'own.jsonl');
+    await fs.writeFile(ownPath, '{"type":"session"}\n');
+    feedStdoutLines(child, [{ type: 'agent_start' }, { type: 'agent_end' }]);
+    assert.equal(
+      session.getLastSessionPath(),
+      null,
+      'terminal resolution must reject the now-ambiguous shared-directory changes',
+    );
+  } finally {
+    await fs.rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test('attachPiRpcSession skips unreadable image paths gracefully', () => {
   const events: TestSentEvent[] = [];
   const send = (channel: string, payload: JsonRecord) => events.push({ channel, ...payload });

--- a/apps/daemon/tests/pi-rpc.test.ts
+++ b/apps/daemon/tests/pi-rpc.test.ts
@@ -885,6 +885,40 @@ test('attachPiRpcSession retains a live session path when aborted', async () => 
   }
 });
 
+test('attachPiRpcSession never publishes a foreign shared-directory change before its isolated child file', async () => {
+  const fs = await import('node:fs/promises');
+  const os = await import('node:os');
+  const sharedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-rpc-shared-'));
+  const childSessionDir = path.join(sharedDir, 'open-design', 'run-child');
+  const child = createMockChild();
+  const captured: string[] = [];
+  try {
+    await fs.mkdir(childSessionDir, { recursive: true });
+    attachPiRpcSession({
+      child: child as unknown as ChildProcess,
+      prompt: 'hello',
+      cwd: '/tmp',
+      model: null,
+      send: () => {},
+      sessionDir: childSessionDir,
+      onSessionPath: (sessionPath) => captured.push(sessionPath),
+    });
+
+    const foreignPath = path.join(sharedDir, 'foreign.jsonl');
+    await fs.writeFile(foreignPath, '{"type":"foreign"}\n');
+    feedStdoutLines(child, [{ type: 'response', id: 1, success: true }]);
+    assert.deepEqual(captured, [], 'a foreign file must never become a live candidate');
+
+    const ownPath = path.join(childSessionDir, 'own.jsonl');
+    await fs.writeFile(ownPath, '{"type":"session"}\n');
+    feedStdoutLines(child, [{ type: 'agent_start' }]);
+    assert.deepEqual(captured, [ownPath]);
+    assert.notEqual(captured[0], foreignPath);
+  } finally {
+    await fs.rm(sharedDir, { recursive: true, force: true });
+  }
+});
+
 test('attachPiRpcSession skips unreadable image paths gracefully', () => {
   const events: TestSentEvent[] = [];
   const send = (channel: string, payload: JsonRecord) => events.push({ channel, ...payload });

--- a/apps/daemon/tests/pi-rpc.test.ts
+++ b/apps/daemon/tests/pi-rpc.test.ts
@@ -864,6 +864,7 @@ test('attachPiRpcSession retains a live session path when aborted', async () => 
   const os = await import('node:os');
   const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-rpc-abort-'));
   const child = createMockChild();
+  const captured: string[] = [];
   try {
     const session = attachPiRpcSession({
       child: child as unknown as ChildProcess,
@@ -872,11 +873,13 @@ test('attachPiRpcSession retains a live session path when aborted', async () => 
       model: null,
       send: () => {},
       sessionDir,
+      onSessionPath: (sessionPath) => captured.push(sessionPath),
     });
     const sessionPath = path.join(sessionDir, 'session.jsonl');
     await fs.writeFile(sessionPath, '{"type":"session"}\n');
     session.abort();
     assert.equal(session.getLastSessionPath(), sessionPath);
+    assert.deepEqual(captured, [sessionPath]);
   } finally {
     await fs.rm(sessionDir, { recursive: true, force: true });
   }

--- a/apps/daemon/tests/runtimes/prime-agent.test.ts
+++ b/apps/daemon/tests/runtimes/prime-agent.test.ts
@@ -6,8 +6,9 @@ describe('Prime Agent runtime', () => {
     expect(primeAgentDef.buildArgs('', [], [], {
       model: 'openai/gpt-5',
       reasoning: 'high',
-    }, { cwd: '/tmp/design' })).toEqual([
+    }, { cwd: '/tmp/design', piRpcSessionDir: '/tmp/prime/run-1' })).toEqual([
       '--mode', 'rpc', '--cwd', '/tmp/design',
+      '--session-dir', '/tmp/prime/run-1',
       '--provider', 'openai', '--model', 'gpt-5',
       '--thinking', 'high',
     ]);
@@ -19,9 +20,11 @@ describe('Prime Agent runtime', () => {
     expect(primeAgentDef.piRpcResumeViaProcessArgs).toBe(true);
     expect(primeAgentDef.buildArgs('', [], [], {}, {
       cwd: '/tmp/design',
+      piRpcSessionDir: '/tmp/prime/run-1',
       resumeSessionId: '/tmp/prime-session.jsonl',
     })).toEqual([
       '--mode', 'rpc', '--cwd', '/tmp/design',
+      '--session-dir', '/tmp/prime/run-1',
       '--resume', '/tmp/prime-session.jsonl',
     ]);
   });

--- a/apps/daemon/tests/runtimes/prime-agent.test.ts
+++ b/apps/daemon/tests/runtimes/prime-agent.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parsePrimeAgentModels, primeAgentDef } from '../../src/runtimes/defs/prime-agent.js';
+
+describe('Prime Agent runtime', () => {
+  it('selects provider, model, thinking, and cwd through process arguments', () => {
+    expect(primeAgentDef.buildArgs('', [], [], {
+      model: 'openai/gpt-5',
+      reasoning: 'high',
+    }, { cwd: '/tmp/design' })).toEqual([
+      '--mode', 'rpc', '--cwd', '/tmp/design',
+      '--provider', 'openai', '--model', 'gpt-5',
+      '--thinking', 'high',
+    ]);
+  });
+
+  it('reopens the same native session file instead of forking it', () => {
+    expect(primeAgentDef.streamFormat).toBe('pi-rpc');
+    expect(primeAgentDef.piRpcSessionDir).toMatch(/\.prime\/agent\/sessions$/);
+    expect(primeAgentDef.piRpcResumeViaProcessArgs).toBe(true);
+    expect(primeAgentDef.buildArgs('', [], [], {}, {
+      cwd: '/tmp/design',
+      resumeSessionId: '/tmp/prime-session.jsonl',
+    })).toEqual([
+      '--mode', 'rpc', '--cwd', '/tmp/design',
+      '--resume', '/tmp/prime-session.jsonl',
+    ]);
+  });
+
+  it('parses provider-qualified model ids from the model table', () => {
+    const parsed = parsePrimeAgentModels(`Provider  Model  Context\nopenai gpt-5 400k\n`);
+    expect(parsed.map((entry) => entry.id)).toEqual(['default', 'openai/gpt-5']);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -570,6 +570,7 @@ const CANONICAL_AGENT_ORDER = [
   'aider',
   'antigravity',
   'reasonix',
+  'prime-agent',
 ] as const;
 
 const CANONICAL_AGENT_ORDER_INDEX = new Map<string, number>(

--- a/apps/web/src/components/HandoffButton.tsx
+++ b/apps/web/src/components/HandoffButton.tsx
@@ -78,6 +78,7 @@ const CLI_ORDER = [
   'trae-cli',
   'pi',
   'reasonix',
+  'prime-agent',
 ];
 
 const FALLBACK_CLI_TARGETS: CliTarget[] = [
@@ -102,6 +103,7 @@ const FALLBACK_CLI_TARGETS: CliTarget[] = [
   { id: 'trae-cli', name: 'Trae CLI', bin: 'traecli', available: false },
   { id: 'pi', name: 'Pi', bin: 'pi', available: false },
   { id: 'reasonix', name: 'DeepSeek Reasonix', bin: 'reasonix', available: false },
+  { id: 'prime-agent', name: 'Prime Agent', bin: 'prime-agent', available: false },
 ];
 
 interface Props {

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -868,6 +868,7 @@ const AGENT_SHORT_DESCRIPTIONS: Record<string, string> = {
   hermes: 'ACP agent CLI',
   'grok-build': 'xAI coding CLI',
   reasonix: 'DeepSeek native coding CLI',
+  'prime-agent': 'Prime Intellect coding agent',
 };
 
 function cleanAgentVersionLabel(

--- a/packages/contracts/src/analytics/events/ui-click.ts
+++ b/packages/contracts/src/analytics/events/ui-click.ts
@@ -1226,6 +1226,7 @@ export const TRACKING_HANDOFF_TARGET_IDS = [
   'amr', 'claude', 'codex', 'opencode', 'cursor-agent', 'gemini', 'qwen',
   'copilot', 'grok-build', 'deepseek', 'kimi', 'hermes', 'devin', 'kiro',
   'kilo', 'vibe', 'aider', 'trae-cli', 'pi', 'reasonix',
+  'prime-agent',
 ] as const;
 
 export type TrackingHandoffTargetId =


### PR DESCRIPTION
## Summary

- add Prime Agent as a first-class runtime over the existing pi-compatible RPC bridge
- discover Prime's native JSONL sessions under `~/.prime/agent/sessions`
- resume the same native file with `prime-agent --mode rpc --resume <path>` instead of forking via `new_session(parentSession)`
- persist a uniquely discovered session path immediately while the run is live and retain it across canceled/failed terminal runs
- launch each fresh Prime child with a durable run-specific `--session-dir`, eliminating cross-process file attribution in Prime's shared directory
- preflight saved Prime session files before prompt trimming; a missing file clears the stale handle and re-seeds a fresh session with the full client transcript
- expose Prime in agent ordering, Settings, handoff targets, and bounded analytics

## Problem

Follow-up to #7261. Prime Agent 0.8.0 exposed two continuity gaps in the generic pi-RPC path:

1. `attachPiRpcSession()` only resolved the changed session file at `agent_end`, while `server.ts` persisted it only during terminal handling. Cancel/Retry or an application restart could therefore leave no `(conversationId, agentId)` session mapping and open another top-level Prime session.
2. `new_session(parentSession)` preserves history by creating a forked continuation. Prime supports true same-file RPC resume through its process-level `--resume <session-file>` option, which avoids multiplying top-level sessions.

Prime 0.8.0 silently creates a new file when `--resume` points to a missing path instead of returning an error. The daemon therefore validates this local file handle before composing the prompt; stale handles enter the existing fresh-session/full-transcript path before history can be trimmed.

The capture resolver remains conservative: it stores a handle only when exactly one JSONL file changed, preventing cross-conversation attribution when concurrent processes write the shared directory.

Fresh Prime children no longer scan that shared directory at all: Open Design assigns `~/.prime/agent/sessions/open-design/<run-id>` before spawn and passes it to both Prime and the capture bridge. Resume turns use the directory containing their already-attributed session file. This makes live discovery child-specific by construction while keeping the session durable across daemon restarts.

The activity-card `input.code` rendering tweak discussed in #7261 is intentionally excluded from this PR.

## Surface area checklist

- [x] UI: Prime appears in Settings and handoff targets; existing web visual coverage exercises the dynamic agent row.
- [x] CLI / environment: `PRIME_AGENT_BIN` is accepted as the per-agent executable override, with app-config coverage.
- [x] API / contract: Prime is included in the bounded analytics agent target union; no endpoint shape changes.
- [x] Default behavior: installed Prime users gain same-session RPC continuity and stale-file recovery; other runtimes keep their existing behavior.
- [ ] None of the above.

## Bug-fix verification

- `apps/daemon/tests/opencode-session-resume.test.ts`: server-level red/green coverage deletes Prime's captured session file between two turns and proves turn two starts without `--resume`, emits `agent_resume_auto_reseed`, and receives both the prior and current user transcript.
- `apps/daemon/tests/pi-rpc.test.ts`: proves the uniquely discovered session path is published during the live run rather than only at terminal finalization.
- `apps/daemon/tests/pi-rpc.test.ts`: also covers the requested race ordering—an unrelated shared-directory file changes before the child's first frame, the child's own file changes afterward, and only the isolated child path is published.
- `apps/daemon/tests/pi-rpc.test.ts`: covers the same ordering without a session-directory override for ordinary Pi; live capture remains disabled and terminal resolution rejects the two-file ambiguity.
- `apps/daemon/tests/app-config.test.ts`: proves `PRIME_AGENT_BIN` survives allowlist normalization.

## Validation

- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- 141 focused tests across `tests/pi-rpc.test.ts`, `tests/runtimes/prime-agent.test.ts`, `tests/opencode-session-resume.test.ts`, and `tests/app-config.test.ts`
- `pnpm guard`
- `git diff --check`
- manually verified Prime Agent 0.8.0 accepts `--mode rpc --resume` using a temporary copy of a real session file
- manually verified Prime Agent 0.8.0 silently creates a missing `--resume` path, motivating the preflight check

## Related

- Follow-up to #7261
- Related transport prerequisite: #7263
