### PR TITLE
fix(download): ignore OS-managed root artifacts when claiming a base (#7266)

### DIFF
--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -13,7 +13,26 @@ import { join } from "node:path";
 
 import { LOCK_DIR, PARTIAL_DIR, STATE_DIR, STORE_KIND, STORE_SCHEMA_VERSION, STORE_SENTINEL } from "./constants.js";
 import { MANAGED_DOWNLOAD_ERROR_CODES, ManagedDownloadError } from "./errors.js";
-import { directoryIsEmpty, readJson, writeJson } from "./fs-io.js";
+import { readJson, writeJson } from "./fs-io.js";
+
+/**
+ * @internal Filesystem-browser artifacts the OS drops into any directory it
+ * renders, independent of anything this package does. Their mere presence
+ * must never be treated as "not empty": Finder writes .DS_Store the moment a
+ * managed base is viewed even once, and Explorer does the same with
+ * Thumbs.db/desktop.ini. Mirrors apps/desktop's isOsManagedRootArtifact —
+ * duplicated rather than shared since apps/desktop depends on this package,
+ * not the reverse.
+ */
+const OS_MANAGED_ROOT_ARTIFACTS = new Set([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"]);
+
+/**
+ * @internal Whether `name` is a benign, OS-managed root artifact that should
+ * never count as real content when deciding whether a directory is claimable.
+ */
+function isOsManagedRootArtifact(name: string): boolean {
+  return OS_MANAGED_ROOT_ARTIFACTS.has(name);
+}
 
 /**
  * @internal On-disk ownership marker written at the root of a managed base.
@@ -84,7 +103,9 @@ export async function ensureManagedBase(basePath: string): Promise<void> {
   const sentinelPath = join(basePath, STORE_SENTINEL);
   const sentinel = await readJson<unknown>(sentinelPath);
   if (sentinel == null) {
-    if (!(await directoryIsEmpty(basePath))) {
+    const entries = await readdir(basePath);
+    const content = entries.filter((name) => !isOsManagedRootArtifact(name));
+    if (content.length > 0) {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not empty and has no ownership marker: ${basePath}`);
     }
     await writeSentinel(basePath);

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -438,5 +438,47 @@ describe("managed download package", () => {
     } finally {
       await fixture.close();
     }
+  });
+
+  it.each([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"])(
+    "claims a fresh managed base that contains only the OS-managed artifact %s",
+    async (artifactName) => {
+      const root = tmpRoot("os-artifact-fresh-claim");
+      const basePath = join(root, "downloads");
+      mkdirSync(basePath, { recursive: true });
+      writeFileSync(join(basePath, artifactName), "binary-os-junk");
+
+      const pruned = await pruneManagedDownloads({ basePath });
+
+      expect(pruned.removed).toBe(0);
+      expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(true);
+      expect(existsSync(join(basePath, artifactName))).toBe(true);
+    },
+  );
+
+  it("still rejects a fresh managed base containing a genuine stray file alongside .DS_Store", async () => {
+    const root = tmpRoot("os-artifact-stray-file");
+    const basePath = join(root, "downloads");
+    mkdirSync(basePath, { recursive: true });
+    writeFileSync(join(basePath, ".DS_Store"), "binary-finder-junk");
+    writeFileSync(join(basePath, "stray-file.bin"), "junk");
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
+  });
+
+  it("does not extend the OS-artifact allowance to arbitrary directories such as a stray .git", async () => {
+    const root = tmpRoot("os-artifact-stray-dir");
+    const basePath = join(root, "downloads");
+    mkdirSync(basePath, { recursive: true });
+    writeFileSync(join(basePath, ".DS_Store"), "binary-finder-junk");
+    mkdirSync(join(basePath, ".git"));
+
+    await expect(pruneManagedDownloads({ basePath })).rejects.toMatchObject({
+      code: MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED,
+    });
+    expect(existsSync(join(basePath, ".open-design-download-root.json"))).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #7266

## Why

Found while adversarially reviewing #7259 / PR #7267 (the desktop updater's own `.DS_Store`-defeats-store-validation fix): `packages/download` has the identical unpatched defect in a completely separate code path, reachable from the same desktop updater.

## What users will see

Downloading or updating (anything routed through `managedDownload`/`downloadCopyAndClear`, including the desktop app's own update-payload download) no longer fails with a "not owned" error just because the download folder has ever been viewed in Finder (macOS) or Explorer (Windows) before its first use.

## Surface area

- [x] **None** — bug fix confined to internal ownership-claim validation in `packages/download/src/store.ts`; no new UI, CLI, API, extension point, i18n keys, or dependency, and no default-setting change.

## Bug fix verification

- Test path that reproduces the bug: `packages/download/tests/index.test.ts` — `it.each([".DS_Store", "Thumbs.db", "desktop.ini", ".localized"])("claims a fresh managed base that contains only the OS-managed artifact %s", ...)`, plus `"still rejects a fresh managed base containing a genuine stray file alongside .DS_Store"` and `"does not extend the OS-artifact allowance to arbitrary directories such as a stray .git"`.
- Did the test go red on `main` and green on this branch? **Yes** — reverting the `store.ts` filter (restoring the original `directoryIsEmpty(basePath)` call) reproduces the `ManagedDownloadError(STORE_NOT_OWNED)` rejection for a base containing only `.DS_Store`, matching the bug exactly.

## Validation

- `pnpm --filter @open-design/download exec vitest run` — 19/19 passing (13 pre-existing + 6 new across the parameterized artifact cases and the two negative tests). One pre-existing, unrelated test (`"falls back to a full download when Range is not honored"`, an HTTP fixture-server timing test) flaked once on a full-suite run but passed consistently in isolation and on a subsequent full-suite rerun — confirmed pre-existing flakiness, unrelated to this diff.
- `pnpm --filter @open-design/download typecheck` — clean, zero errors, both configs.
- Two independent adversarial code reviews (Claude Code, Codex on `gpt-5.6-terra`) each independently re-derived (not just trusted) that no sibling file in this package (`remove.ts`, `prune.ts`, `run.ts`, `manifest.ts`, `lock.ts`, `transfer.ts`, `target.ts`, `registry.ts`, `copy.ts`) has an equivalent unpatched "reject based on directory contents" pattern, that testing indirectly through the public `pruneManagedDownloads()` API exercises the real production call path (it calls `ensureManagedBase` exactly like `managedDownload`/`downloadCopyAndClear` do), and that the allowlist can't be used to smuggle anything past validation (nothing downstream reads or executes a root-level file by these exact names). Both approved; minor non-blocking suggestions (parameterizing the success test across all 4 artifact names, avoiding a variable-name shadow) were applied.

## Related

Sibling fix for the same defect class in `apps/desktop`: #7259 / PR #7267 (not a dependency of this PR — separate package, separate branch, can land independently).
