### PR TITLE
fix(daemon): admit one design-system enrichment run per conversation

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -386,6 +386,44 @@ interface RunCreateMeta extends JsonRecord {
   workspaceScope?: RunWorkspaceScope | null;
 }
 
+/**
+ * Invariant: a conversation runs at most one design-system enrichment
+ * ("AI Optimize") pass at a time.
+ *
+ * The enrichment turn is a hidden, seeded prompt that refines the SAME
+ * registered design system in place, so two concurrent passes bill twice and
+ * race on identical files. Incident 2026-07-28: one double-triggered UI
+ * affordance created two enrichment runs 383 ms apart in one conversation and
+ * both were billed. Ordinary chat turns are deliberately NOT gated here — the
+ * web composer already queues them while the conversation is busy, and a
+ * "send now" interrupt may legitimately overlap the run it is cancelling.
+ *
+ * Returns the non-terminal run that already owns the conversation's
+ * enrichment pass, or null when the request may proceed.
+ */
+function activeRunBlockingDesignSystemEnrichment(
+  runs: Pick<ChatRunService, 'list'>,
+  input: {
+    conversationId: unknown;
+    analyticsHints: unknown;
+    /** The optimistically created run for this request; it never blocks itself. */
+    excludeRunId?: string | null;
+  },
+): ChatRun | null {
+  const hints = input.analyticsHints;
+  const isEnrichment =
+    hints !== null
+    && typeof hints === 'object'
+    && !Array.isArray(hints)
+    && (hints as Record<string, unknown>).dsEnrichment === true;
+  if (!isEnrichment) return null;
+  if (typeof input.conversationId !== 'string' || !input.conversationId) return null;
+  const active = runs
+    .list({ conversationId: input.conversationId, status: 'active' })
+    .filter((run) => run.id !== input.excludeRunId);
+  return active[0] ?? null;
+}
+
 interface RunListFilters {
   projectId?: unknown;
   conversationId?: unknown;
@@ -1757,6 +1795,29 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         'IDEMPOTENCY_CONFLICT',
         'clientRequestId is already associated with a different logical run request',
       );
+    }
+    if (creation.kind === 'created') {
+      const blockingRun = activeRunBlockingDesignSystemEnrichment(design.runs, {
+        conversationId: meta.conversationId,
+        analyticsHints: meta.analyticsHints,
+        excludeRunId: creation.run.id,
+      });
+      if (blockingRun) {
+        design.runs.drop(creation.run);
+        return sendApiError(
+          res,
+          409,
+          'DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS',
+          'a design-system enrichment run is already active for this conversation',
+          {
+            details: {
+              kind: 'design_system_enrichment_in_progress',
+              runId: blockingRun.id,
+              conversationId: blockingRun.conversationId ?? '',
+            },
+          },
+        );
+      }
     }
     const run = creation.run;
     const analyticsAttributionMismatch =
@@ -3232,6 +3293,29 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         'IDEMPOTENCY_CONFLICT',
         'clientRequestId is already associated with a different logical run request',
       );
+    }
+    if (creation.kind === 'created') {
+      const blockingRun = activeRunBlockingDesignSystemEnrichment(design.runs, {
+        conversationId: meta.conversationId,
+        analyticsHints: meta.analyticsHints,
+        excludeRunId: creation.run.id,
+      });
+      if (blockingRun) {
+        design.runs.drop(creation.run);
+        return sendApiError(
+          res,
+          409,
+          'DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS',
+          'a design-system enrichment run is already active for this conversation',
+          {
+            details: {
+              kind: 'design_system_enrichment_in_progress',
+              runId: blockingRun.id,
+              conversationId: blockingRun.conversationId ?? '',
+            },
+          },
+        );
+      }
     }
     const run = creation.run;
     if (creation.kind === 'reused') {

--- a/apps/daemon/tests/run-enrichment-dedupe.test.ts
+++ b/apps/daemon/tests/run-enrichment-dedupe.test.ts
@@ -1,0 +1,199 @@
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { promises as fsp } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { startServer } from '../src/server.js';
+
+/**
+ * Red spec for the 2026-07-28 double-enrichment incident: one "AI Optimize"
+ * affordance fired twice 383 ms apart and the daemon created TWO concurrent
+ * design-system enrichment runs in the same conversation, both billed.
+ * The daemon must admit at most one active enrichment run per conversation
+ * while leaving ordinary chat turns untouched.
+ */
+
+const FAKE_SLOW_OPENCODE = `
+if (process.argv.includes('--version')) { console.log('opencode 0.0.0'); process.exit(0); }
+if (process.argv[2] === 'models') { console.log('test/model'); process.exit(0); }
+console.log(JSON.stringify({ type: 'step_start', sessionID: 'dedupe-session' }));
+console.log(JSON.stringify({ type: 'text', sessionID: 'dedupe-session', part: { text: 'working' } }));
+setTimeout(() => {
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+}, 2500);
+`;
+
+async function withFakeAgent<T>(
+  binName: string,
+  script: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const dir = await fsp.mkdtemp(join(tmpdir(), 'od-enrich-dedupe-bin-'));
+  const oldPath = process.env.PATH;
+  try {
+    if (process.platform === 'win32') {
+      const runner = join(dir, `${binName}-test-runner.cjs`);
+      await fsp.writeFile(runner, script);
+      await fsp.writeFile(join(dir, `${binName}.cmd`), `@echo off\r\nnode "${runner}" %*\r\n`);
+    } else {
+      const bin = join(dir, binName);
+      await fsp.writeFile(bin, `#!/usr/bin/env node\n${script}`);
+      await fsp.chmod(bin, 0o755);
+    }
+    process.env.PATH = `${dir}${delimiter}${oldPath ?? ''}`;
+    return await run();
+  } finally {
+    process.env.PATH = oldPath;
+    killProcessesUsingPath(dir);
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+function killProcessesUsingPath(pathFragment: string): void {
+  if (process.platform === 'win32') return;
+  let output = '';
+  try {
+    output = execFileSync('pgrep', ['-f', pathFragment], { encoding: 'utf8' });
+  } catch {
+    return;
+  }
+  for (const line of output.split('\n')) {
+    const pid = Number(line.trim());
+    if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) continue;
+    try {
+      process.kill(-pid, 'SIGKILL');
+    } catch {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+  }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe('design-system enrichment run dedupe', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  const originalPath = process.env.PATH;
+
+  beforeAll(async () => {
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterEach(() => {
+    if (originalPath == null) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+  });
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function createProject(name: string): Promise<{ projectId: string; conversationId: string }> {
+    const projectId = `project_${randomUUID()}`;
+    const response = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name, metadata: { kind: 'prototype' } }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json() as { conversationId: string };
+    return { projectId, conversationId: body.conversationId };
+  }
+
+  function postRun(
+    endpoint: '/api/runs' | '/api/chat',
+    body: Record<string, unknown>,
+  ): Promise<Response> {
+    return fetch(`${baseUrl}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function listRuns(conversationId: string): Promise<Array<{ id: string; status: string }>> {
+    const response = await fetch(
+      `${baseUrl}/api/runs?conversationId=${encodeURIComponent(conversationId)}`,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as { runs: Array<{ id: string; status: string }> };
+    return body.runs;
+  }
+
+  async function waitForQuiescence(conversationId: string): Promise<void> {
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const runs = await listRuns(conversationId);
+      if (runs.every((run) => ['succeeded', 'failed', 'canceled'].includes(run.status))) return;
+      await delay(100);
+    }
+  }
+
+  it('admits only one active enrichment run per conversation (second request is a 409, not a second billed run)', async () => {
+    const { projectId, conversationId } = await createProject('Enrichment dedupe');
+    await withFakeAgent('opencode', FAKE_SLOW_OPENCODE, async () => {
+      const enrichment = {
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'Refine the design system',
+        analyticsHints: { dsEnrichment: true },
+      };
+      const first = await postRun('/api/runs', enrichment);
+      expect(first.status).toBe(202);
+      const firstBody = await first.json() as { runId: string };
+
+      // Incident shape: the same affordance fires again 383 ms later.
+      await delay(300);
+      const second = await postRun('/api/runs', enrichment);
+      const secondBody = await second.json() as {
+        runId?: string;
+        error?: { code?: string; details?: { runId?: string } };
+      };
+      expect(second.status, JSON.stringify(secondBody)).toBe(409);
+      expect(secondBody.error?.code).toBe('DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS');
+      expect(secondBody.error?.details?.runId).toBe(firstBody.runId);
+
+      // The streaming entry point shares the invariant.
+      const streamed = await postRun('/api/chat', enrichment);
+      const streamedBody = await streamed.json() as { error?: { code?: string } };
+      expect(streamed.status, JSON.stringify(streamedBody)).toBe(409);
+      expect(streamedBody.error?.code).toBe('DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS');
+
+      const runs = await listRuns(conversationId);
+      expect(runs.map((run) => run.id)).toEqual([firstBody.runId]);
+      await waitForQuiescence(conversationId);
+    });
+  });
+
+  it('leaves ordinary chat turns ungated (the composer queues those itself)', async () => {
+    const { projectId, conversationId } = await createProject('Enrichment dedupe control');
+    await withFakeAgent('opencode', FAKE_SLOW_OPENCODE, async () => {
+      const first = await postRun('/api/runs', {
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'first turn',
+      });
+      expect(first.status).toBe(202);
+      await delay(300);
+      const second = await postRun('/api/runs', {
+        agentId: 'opencode',
+        projectId,
+        conversationId,
+        message: 'second turn',
+      });
+      expect(second.status).toBe(202);
+      expect((await listRuns(conversationId)).length).toBe(2);
+      await waitForQuiescence(conversationId);
+    });
+  });
+});

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -173,6 +173,7 @@ import {
   installedBrandEnrichmentSkillIds,
   isProgrammaticBrandExtractionProject,
 } from '../runtime/brand-enrichment';
+import { useSingleFlightCallback } from '../runtime/useSingleFlightCallback';
 import { useBrandReadyPrompt } from '../runtime/useBrandReadyPrompt';
 import {
   buildDesignSystemPackageAuditRepairPrompt,
@@ -7681,8 +7682,15 @@ export function ProjectView({
           textBuffer.flush();
           textBuffer.cancel();
           cancelSendTextBuffer();
+          // The daemon refused a duplicate design-system enrichment because the
+          // conversation already runs one (HTTP 409
+          // DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS). The surviving run is the one
+          // the user asked for, so this is not a failure worth a global banner;
+          // only the duplicate turn itself records why it went nowhere.
+          const duplicateEnrichmentRejected =
+            errorCode === 'DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS';
           if (runMayFinalize) {
-            setRunError(err.message, assistantId);
+            if (!duplicateEnrichmentRejected) setRunError(err.message, assistantId);
             appendAssistantErrorEvent(assistantId, err.message, errorCode, failure);
             updateAssistant((prev) => ({
               ...prev,
@@ -10569,8 +10577,11 @@ export function ProjectView({
   // brand: send the hidden seeded enrichment prompt + the default design-system
   // skill bundle, refining the SAME registered design system in place. Shared by
   // the chat "Continue" affordance and the ready-toast "AI Optimize" nudge.
-  const handleBrandEnrichment = useCallback(() => {
-    if (brandEnrichmentStarting || config.mode !== 'daemon') return;
+  // The synchronous single-flight wrapper below (not this state flag) is what
+  // stops a double trigger: `brandEnrichmentStarting` only updates after a
+  // re-render, so it cannot reject a second call inside the same tick.
+  const startBrandEnrichment = useCallback(() => {
+    if (config.mode !== 'daemon') return;
     const system = designSystemProject ?? activeDesignSystemSummary;
     const skillIds = installedBrandEnrichmentSkillIds(skills);
     trackDesignSystemEnrichClick(analytics.track, {
@@ -10581,7 +10592,7 @@ export function ProjectView({
       project_kind: 'design_system',
     });
     setBrandEnrichmentStarting(true);
-    void handleSend(
+    return handleSend(
       buildBrandEnrichmentPrompt(brandEnrichmentPromptSeed || brandEnrichmentPromptSeedCache, {
         metadata: currentProject.metadata,
         designSystemId: system?.id,
@@ -10597,7 +10608,6 @@ export function ProjectView({
     analytics,
     brandEnrichmentPromptSeed,
     brandEnrichmentPromptSeedCache,
-    brandEnrichmentStarting,
     config.mode,
     designSystemProject,
     handleSend,
@@ -10606,6 +10616,7 @@ export function ProjectView({
     projectFiles,
     skills,
   ]);
+  const handleBrandEnrichment = useSingleFlightCallback(startBrandEnrichment);
 
   const handleCreateDesignFromActiveDesignSystem = useCallback(() => {
     if (brandCreateDesignStarting) return;

--- a/apps/web/src/runtime/useSingleFlightCallback.ts
+++ b/apps/web/src/runtime/useSingleFlightCallback.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Wraps an action so overlapping invocations collapse into a single in-flight
+ * call: the first caller runs `action`, every caller that arrives before it
+ * settles is ignored, and the slot reopens once the returned promise settles.
+ *
+ * The guard is a ref, not state. A `useState` "starting" flag only becomes
+ * visible after React re-renders, so two triggers inside the same tick (the
+ * design-system ready-toast nudge and the chat "Continue" affordance both
+ * firing "AI Optimize") each read the stale `false` and both pass. That is
+ * how the 2026-07-28 incident started two billed enrichment runs 383 ms
+ * apart. A ref flips synchronously, so the second trigger is rejected before
+ * any network call is made.
+ *
+ * Returns `true` when the call was admitted, `false` when it was dropped.
+ */
+export function useSingleFlightCallback<TArgs extends unknown[]>(
+  action: (...args: TArgs) => Promise<unknown> | unknown,
+): (...args: TArgs) => boolean {
+  const inFlightRef = useRef(false);
+  return useCallback(
+    (...args: TArgs): boolean => {
+      if (inFlightRef.current) return false;
+      inFlightRef.current = true;
+      let result: unknown;
+      try {
+        result = action(...args);
+      } catch (err) {
+        inFlightRef.current = false;
+        throw err;
+      }
+      // Release on settle either way; the caller still owns the original
+      // promise, so a rejection is not swallowed for it — only this guard
+      // chain stays quiet instead of surfacing a second unhandled rejection.
+      const release = () => {
+        inFlightRef.current = false;
+      };
+      void Promise.resolve(result).then(release, release);
+      return true;
+    },
+    [action],
+  );
+}

--- a/apps/web/tests/runtime/useSingleFlightCallback.test.tsx
+++ b/apps/web/tests/runtime/useSingleFlightCallback.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useSingleFlightCallback } from '../../src/runtime/useSingleFlightCallback';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useSingleFlightCallback', () => {
+  it('admits only the first of two triggers fired inside the same tick', async () => {
+    let settle: () => void = () => {};
+    const action = vi.fn(() => new Promise<void>((resolve) => { settle = resolve; }));
+    const { result } = renderHook(() => useSingleFlightCallback(action));
+
+    // Incident shape: the ready-toast nudge and the chat "Continue" affordance
+    // both fire "AI Optimize" before React has re-rendered any state flag.
+    let admitted: boolean[] = [];
+    act(() => {
+      admitted = [result.current(), result.current()];
+    });
+    expect(admitted).toEqual([true, false]);
+    expect(action).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      settle();
+      await Promise.resolve();
+    });
+    // The slot reopens once the in-flight action settles.
+    let again = false;
+    act(() => {
+      again = result.current();
+    });
+    expect(again).toBe(true);
+    expect(action).toHaveBeenCalledTimes(2);
+  });
+
+  it('reopens the slot when the action rejects or throws synchronously', async () => {
+    const rejecting = vi.fn(() => Promise.reject(new Error('boom')));
+    const { result } = renderHook(() => useSingleFlightCallback(rejecting));
+    await act(async () => {
+      expect(result.current()).toBe(true);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current()).toBe(true);
+    expect(rejecting).toHaveBeenCalledTimes(2);
+
+    const throwing = vi.fn(() => { throw new Error('sync'); });
+    const thrown = renderHook(() => useSingleFlightCallback(throwing));
+    expect(() => thrown.result.current()).toThrow('sync');
+    expect(() => thrown.result.current()).toThrow('sync');
+    expect(throwing).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes arguments through and returns false while a call is in flight', () => {
+    const action = vi.fn((value: string) => new Promise<void>(() => { void value; }));
+    const { result } = renderHook(() => useSingleFlightCallback(action));
+    expect(result.current('first')).toBe(true);
+    expect(result.current('second')).toBe(false);
+    expect(action).toHaveBeenCalledWith('first');
+    expect(action).not.toHaveBeenCalledWith('second');
+  });
+});

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -442,6 +442,18 @@ export interface ChatRunCreateResponse {
   analyticsAttributionMismatch?: boolean;
 }
 
+/**
+ * `ApiError.details` for `DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS` (HTTP 409 from
+ * `POST /api/runs` and `POST /api/chat`): the run that already owns the
+ * conversation's enrichment pass. Clients should treat the rejected request
+ * as a no-op and keep following `runId` rather than surfacing a failure.
+ */
+export interface DesignSystemEnrichmentInProgressDetails {
+  kind: 'design_system_enrichment_in_progress';
+  runId: string;
+  conversationId: string;
+}
+
 export type NativeSessionRecoveryState =
   | 'not_applicable'
   | 'no_recoverable_session'

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -139,6 +139,16 @@ export const API_ERROR_CODES = [
   // registered owner unshares the project, so clients must not render it as
   // a "try again later" error.
   'TEAM_PROJECT_OWNER_CONFLICT',
+  // A design-system enrichment ("AI Optimize") run was requested while the
+  // same conversation already has a non-terminal run. The enrichment turn is
+  // a hidden seeded prompt that refines the registered design system in
+  // place, so a second concurrent pass bills twice and races on the same
+  // files (2026-07-28: one double-triggered affordance billed two runs). The
+  // daemon rejects the newcomer with HTTP 409 and names the run that already
+  // owns the conversation in `details` (`DesignSystemEnrichmentInProgressDetails`)
+  // so a client can attach to it instead of starting another. Not retryable
+  // while that run is active; ordinary chat turns are never gated by this.
+  'DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS',
   'INTERNAL_ERROR',
 ] as const;
 


### PR DESCRIPTION
## Why

**Use case.** Diagnosing a paying user's complaint ("$20 gone in half an hour, the design-spec extraction never worked") — full write-up: https://powerformer.feishu.cn/docx/Ith4d1BGToTBzExxdqjcwn8bnHc. On 2026-07-28 the user clicked the design-system **AI Optimize** affordance once and the daemon created **two** enrichment runs 383 ms apart in the same conversation (`7c5271da` / `1b8c43ee`, `dsEnrichment: true`), both spawned agents, both billed, and the user cancelled both in confusion before retrying.

**Pain.** The enrichment turn is a hidden seeded prompt that refines the *same* registered design system in place — a second concurrent pass is pure double billing plus a write race on identical files. Two things let it through:

1. `ProjectView.tsx:handleBrandEnrichment` is reachable from two entry points (the ready-toast nudge and the chat "Continue" affordance) and its only guard was a `useState` flag, which cannot reject a second call inside the same render tick.
2. The daemon had no invariant: `POST /api/runs` / `POST /api/chat` happily created a second run for a conversation that already had an active one.

## What users will see

- Clicking **AI Optimize** twice (or from both affordances) starts exactly one enrichment run; the second click is dropped before any request is sent.
- If a duplicate enrichment still reaches the daemon (another window/tab, an external client), the daemon answers `409 DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS` naming the run that already owns the conversation. The web client records that on the duplicate turn only and does **not** raise the global run-failure banner — the run the user asked for keeps going.
- Ordinary chat sends are untouched: the composer still queues them while the conversation is busy, and "send now" interrupts behave as before.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — new `ApiErrorCode` `DESIGN_SYSTEM_ENRICHMENT_IN_PROGRESS` and `DesignSystemEnrichmentInProgressDetails` in `packages/contracts` (`POST /api/runs`, `POST /api/chat`)
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a second concurrent *enrichment* request for the same conversation is now rejected (409) instead of starting another billed run. Only `analyticsHints.dsEnrichment === true` requests are gated.
- [ ] **None**

## Screenshots

No new UI surface — the change removes a duplicate run; the entry points (design-system ready toast → "AI Optimize", chat "Continue") are unchanged.

## Bug fix verification

- Red spec: `apps/daemon/tests/run-enrichment-dedupe.test.ts` — fires two enrichment `POST /api/runs` 300 ms apart against a slow fake `opencode` and asserts the second is a 409 naming the first run, that `POST /api/chat` shares the invariant, and (control) that two ordinary turns are still both admitted.
- Red on `main` / green on this branch: **yes**. On `main` the second request returned `202 {"runId":"b6238bac-…","reused":false,…}` → `expected 202 to be 409`; on this branch `Tests 2 passed (2)`.
- Web: `apps/web/tests/runtime/useSingleFlightCallback.test.tsx` — two triggers in one tick admit exactly one call (`[true, false]`), the slot reopens after settle/reject/throw.

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` (root, exit 0, 25 packages Done) ✅
- `pnpm --filter @open-design/contracts build && typecheck` ✅
- `apps/daemon`: `vitest run tests/chat-route.test.ts tests/headless-runs.test.ts tests/run-create-workspace-gate.test.ts tests/run-enrichment-dedupe.test.ts` → 4 files, 146 tests passed ✅
- `apps/web`: `vitest run tests/components/ProjectView.run-isolation.test.tsx tests/components/ProjectView.pendingPrompt.test.tsx tests/components/ProjectView.run-cleanup.test.tsx tests/runtime/useSingleFlightCallback.test.tsx` → 4 files, 184 tests passed; `tests/components/NextStepActions.test.tsx` 25 passed ✅
- `pnpm --filter @open-design/web typecheck` ✅

## Adjacent issues (not in this PR)

- **Session rollover mis-estimate is not on `main`.** The incident's 4th/5th turns were forced into a new agent session because `prior_session_input_tokens` (a cumulative per-call sum, 817,942) exceeded `rollover_threshold_tokens` (698,700). That logic (PR #5816, `runtimes/model-context-budget.ts`, `SESSION_ROLLOVER_RATIO`) was only cherry-picked into the 0.16.1 release branch (`archive/release-v0.16.1-recut-ready`) and lives on `agent/model-context-budget` / `agent/session-context-rollover`; it never merged to `main` and is absent from 0.17+. `runtimes/prompt-budget.ts` on `main` is the CLI argv byte budget, unrelated. PostHog still receives these fields only from 0.16.x clients. No fix needed on `main`; the branches should not be re-landed without switching the estimate to the last call's context size.
- **Balance gate / turn-boundary stop (proposal for product + backend).** Today the only pre-run balance check is web-side (`runtime/amr-balance-gate.ts`): hard block at balance ≤ $0, soft warning at ≤ $2 (user can opt out), otherwise allow; the daemon has no pre-run check and only classifies vela's `insufficient_balance` into `AMR_INSUFFICIENT_BALANCE` + `failureAction: 'recharge'` (resumable via the same request with `resume: true`). Run 5 started at $3.57 (above the $2 warn line), spent it across ~35 model calls, and Link rejected the next call mid-turn. A boundary stop needs the party that sees per-request cost and balance — vela Link/CLI — to refuse at a tool-loop boundary and surface a resumable "paused: recharge" state, while the daemon/web side could project the next turn's cost from the previous turn's billed cost (and context size) and warn when balance < that projection. Thresholds and copy are product decisions; nothing here is implemented.
- The enrichment run hang (model finished at 15:28, process killed by the 10-min inactivity watchdog at 15:53) needs client diagnostics to locate; tracked separately.
