### PR TITLE
fix(web): restore theme tokens on the full-screen present-exit button

### DIFF
--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -370,12 +370,18 @@
   align-items: center;
   padding: 6px 12px;
   font-size: 12px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   cursor: pointer;
+  transition: background var(--dur-quick) var(--ease-out);
 }
-.present-exit:hover { background: white; }
+.present-exit:hover { background: var(--bg-muted); }
+.present-exit:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* Picker (legacy in some surfaces) */
 .picker {

--- a/apps/web/tests/styles/present-exit-theme-tokens.test.ts
+++ b/apps/web/tests/styles/present-exit-theme-tokens.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const composioCss = readFileSync(
+  new URL('../../src/styles/viewer/composio.css', import.meta.url),
+  'utf8',
+);
+
+const presentExitRule = /\.present-exit\s*\{[\s\S]*?\}/;
+
+describe('full-screen present-exit button', () => {
+  it('paints its surface from theme tokens so dark mode does not get a white block', () => {
+    expect(composioCss).toMatch(
+      /\.present-exit\s*\{[\s\S]*?background:\s*var\(--bg-elevated\);/,
+    );
+    expect(composioCss).toMatch(
+      /\.present-exit:hover\s*\{\s*background:\s*var\(--bg-muted\);\s*\}/,
+    );
+  });
+
+  it('keeps every colour in the base rule tokenized', () => {
+    const rule = composioCss.match(presentExitRule)?.[0] ?? '';
+    expect(rule).not.toBe('');
+    expect(rule).not.toMatch(/rgba\(255,\s*255,\s*255/);
+    expect(rule).not.toMatch(/background:\s*white/);
+  });
+
+  it('stays keyboard-discoverable over arbitrary presented content', () => {
+    expect(composioCss).toMatch(
+      /\.present-exit:focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--accent\);/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4592

## Why

I went looking for an open issue I could verify end-to-end before writing any code, and #4592 turned out to still be reproducible on current `main` — even though its fix already merged.

PR #4593 landed the theme-token treatment for the full-screen `.present-exit` button on 2026-07-05 (`e7d344d01`). Comparing that commit's blob with `origin/main` shows the rule is back to its pre-fix form:

| ref | `background: var(--bg-elevated)` | `rgba(255, 255, 255, 0.92)` |
|---|---|---|
| `e7d344d01` (#4593 merge) | 1 | 0 |
| `ad5a7d6ba` (2026-07-27) | 1 | 1 |
| `356c8c364` (#6142, 2026-08-05) | **0** | **2** |
| `origin/main` today | 0 | 2 |

`apps/web/src/styles/viewer/composio.css` was rewritten wholesale in #6142, and the `.present-exit` rule was carried over from a pre-#4593 copy. So this is a silent regression of an already-reviewed fix, not a new design decision — which is also why #4592 is still open: the last maintainer note asked for a fullscreen dark-mode re-check, and that check now fails again.

## What users will see

In dark theme, exiting a full-screen presentation no longer shows a bright white rectangle floating over the dark artifact. The exit button now sits on the elevated surface colour like every other chrome control, and it gets a visible focus ring when tabbed to.

Light theme is visually unchanged (`--bg-elevated` is `#fafafa`, which reads the same as the old near-white).

## Surface area

- [x] **UI** — restores theme-aware colours on the full-screen presentation exit button in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Dark theme, full-screen presentation. Left is current `main`, right is this branch. Both panes use the real `[data-theme="dark"]` values from `apps/web/src/styles/tokens.css`.

<!-- attach: present-exit-dark-before-after.png -->

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/present-exit-theme-tokens.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — 3 failed / 3 passed respectively.

The new spec asserts three things, matching the shape of the neighbouring tests in `apps/web/tests/styles/`: the base rule paints from `--bg-elevated`, the hover state from `--bg-muted`, and the base rule contains no literal white at all. That last assertion is the one that actually guards the regression — a future rewrite that drops the tokens fails the spec instead of shipping a white block.

The CSS diff is byte-identical to what #4593 merged, so this restores the reviewed treatment rather than proposing a new one.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)
- `pnpm --filter @open-design/web test` — 638 test files passed, 6785 passed / 1 expected fail / 11 skipped
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles` — 36 files, 86 tests passed

## Adjacent issues (not fixed here)

While confirming the regression I noticed `composio.css` still carries other hardcoded whites that never went through #4593's review — `background: white` on the preview iframe (L437) and on several deck/slide surfaces (L2269–L2295, L2473). They may well be intentional (an artifact canvas usually wants a real white page, independent of app chrome), so I left them alone rather than widening this PR past the issue's scope.
