### PR TITLE
fix(desktop): recover the version check when a downloaded release vanishes

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -111,6 +111,7 @@ export type {
   DeferredLaunchResult,
 } from "./updater/deferred-launch.js";
 import {
+  revalidateReleaseCleanupState,
   runUpdateReleaseLifecycle,
   scheduleBackCleanup,
 } from "./updater/release-lifecycle.js";
@@ -744,6 +745,40 @@ export function createDesktopUpdater(
     return opened.root;
   }
 
+  /**
+   * Drop a release we verified earlier in this process but that is no longer
+   * on disk.
+   *
+   * `restoreStoreState()` runs at most once per process and only while the
+   * updater is still idle, so after the first successful check the in-memory
+   * `activeRelease` is never re-examined. A release deleted while the app is
+   * open would keep being offered as a ready install pointing at a file that
+   * is gone. Forgetting it here lets the check fall through to re-adoption or
+   * a fresh download instead.
+   */
+  async function discardVanishedActiveRelease(): Promise<void> {
+    const current = activeRelease;
+    if (current == null) return;
+    const present = await stat(current.path).then(
+      (entry) => entry.isFile(),
+      (error: unknown) => !isVanishedPathError(error),
+    );
+    if (present) return;
+    logUpdateEvent("active-release-vanished", {
+      key: current.ref.key,
+      version: current.ref.version,
+    });
+    activeRelease = null;
+    metadata = null;
+    reinstallRequirement = undefined;
+    await writeMetadataPatch((stored) => ({
+      ...stored,
+      active: undefined,
+      incoming: undefined,
+      version: STORE_METADATA_VERSION,
+    }));
+  }
+
   async function checkForCandidate(options: ActionOptions = {}): Promise<DesktopUpdateStatusSnapshot> {
     const unsupported = unsupportedStatus();
     if (unsupported != null) return unsupported;
@@ -753,6 +788,7 @@ export function createDesktopUpdater(
       if (restored?.state === DESKTOP_UPDATE_STATES.ERROR) return restored;
       if (installFrozen || installResult != null) return snapshot();
     }
+    await discardVanishedActiveRelease();
     const keepDownloadedVisible = activeRelease != null;
     if (!keepDownloadedVisible) setState(DESKTOP_UPDATE_STATES.CHECKING);
     try {
@@ -765,6 +801,20 @@ export function createDesktopUpdater(
         lastCheckedAt,
       }));
       if (root != null) scheduleBackCleanup(root.realRoot, logger);
+      // Descriptor bookkeeping only, so it runs after the network round-trip
+      // and never delays the check itself.
+      if (root != null) {
+        const revalidatedLifecycle = await revalidateReleaseCleanupState({
+          config,
+          layout: root.layout,
+          logger,
+          now,
+        }).catch((lifecycleError: unknown) => {
+          logger.warn("[open-design updater] failed to revalidate release cleanup state", lifecycleError);
+          return null;
+        });
+        if (revalidatedLifecycle != null) lifecycleSummary = revalidatedLifecycle;
+      }
       const launcherPayloadContextValid = await hasValidLauncherPayloadContext(config);
       const installedOuterVersion = launcherPayloadContextValid ? await resolveInstalledOuterVersion(config) : null;
       reinstallRequirement = launcherPayloadContextValid

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -124,6 +124,7 @@ import {
   ensureOwnedUpdateRoot,
   isResolvedChecksumSnapshot,
   isUpdateStoreMetadata,
+  isVanishedPathError,
   logStoreError,
   rebuildOwnedUpdateRootForManualClear,
   storeShapeError,
@@ -344,6 +345,19 @@ async function loadActiveRelease(
       return { ok: false, error };
     }
   } catch (error) {
+    // The artifact is gone rather than unreadable: an outside cleanup, disk
+    // tooling, AV quarantine, or a partial write after a crash removed it.
+    // There is no downloaded release any more, and no retry will bring one
+    // back, so report "nothing downloaded" and let the caller drop the stale
+    // pointer instead of wedging every future check behind a store error.
+    if (isVanishedPathError(error)) {
+      logger.warn("[open-design updater] active release artifact vanished; discarding stale pointer", {
+        artifactPath,
+        key: active.key,
+        version: active.version,
+      });
+      return { ok: true, active: null };
+    }
     const storeError = storeShapeError(root.realRoot, "active release artifact is missing", {
       artifactPath,
       reason: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -534,6 +534,42 @@ export async function cleanupDeprecatedReleaseEntries(input: {
   };
 }
 
+/**
+ * Cheap descriptor revalidation, safe to run on every version check.
+ *
+ * The full lifecycle only runs on cold start, when a new version becomes
+ * ready, and on manual clear. A long-running app that merely re-checks would
+ * otherwise keep trusting a descriptor written when it launched, so a release
+ * deleted while the app is open stays `retained` for the rest of the session.
+ * This takes the same lock and drops only entries whose directory has
+ * vanished; it never rescans, deprecates, or removes anything, and it leaves
+ * the recorded trigger alone so lifecycle telemetry still reports what last
+ * performed a real pass.
+ */
+export async function revalidateReleaseCleanupState(input: {
+  config: DesktopUpdaterConfig;
+  layout: DesktopUpdaterStoreLayout;
+  logger: DesktopUpdaterLogger;
+  now: () => Date;
+}): Promise<DesktopUpdateCacheLifecycleSummary | null> {
+  const { config, layout, logger, now } = input;
+  return await withUpdaterLifecycleLock(layout, logger, async () => {
+    const current = await readReleaseCleanupDescriptor(layout);
+    if (current == null) return null;
+    const revalidated = await revalidateRetainedReleaseEntries({
+      descriptor: current,
+      layout,
+      logger,
+      nowIso: now().toISOString(),
+    });
+    const unchanged = revalidated.releases.length === current.releases.length
+      && revalidated.releases.every((entry, index) => entry === current.releases[index]);
+    if (unchanged) return summarizeReleaseCleanupDescriptor(current, config.platform);
+    await writeJson(layout.cleanupPath, revalidated);
+    return summarizeReleaseCleanupDescriptor(revalidated, config.platform);
+  });
+}
+
 export async function runUpdateReleaseLifecycle(input: {
   config: DesktopUpdaterConfig;
   layout: DesktopUpdaterStoreLayout;

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -419,9 +419,17 @@ export async function scanReleaseCleanupEntries(input: {
  * exists. Such an entry is moved to the same terminal `cleanup-removed` state
  * the app's own pruning produces.
  *
+ * A retained release counts as present only when its directory is a plain
+ * directory and its `metadata.json` is still there — the record is what lets
+ * the app identify the release, so a surviving directory with no metadata is
+ * just as unusable as no directory at all. Both land on the same
+ * `metadata-missing` reason `scanReleaseCleanupEntries` already uses.
+ *
  * Only a path that is genuinely gone is downgraded. An entry that merely
  * cannot be read at this moment is left untouched, so a transient filesystem
- * failure never erases the record of a real release.
+ * failure never erases the record of a real release. A directory whose shape
+ * is wrong is not "removed" either: it is marked `unknown`, matching what a
+ * full rescan would record.
  */
 export async function revalidateRetainedReleaseEntries(input: {
   descriptor: ReleaseCleanupDescriptor;
@@ -441,17 +449,46 @@ export async function revalidateRetainedReleaseEntries(input: {
       releases.push(entry);
       continue;
     }
-    // Unreadable counts as present: only a path we positively know is gone
-    // may drop a retained release.
-    const present = await lstat(releaseDir).then(
-      () => true,
-      (error: unknown) => !isVanishedPathError(error),
+    // Unreadable counts as intact: only state we positively know is gone may
+    // drop a retained release.
+    const releaseEntry = await lstat(releaseDir).then(
+      (stats) => stats,
+      (error: unknown) => (isVanishedPathError(error) ? null : "unreadable" as const),
     );
-    if (present) {
+    if (releaseEntry === "unreadable") {
       releases.push(entry);
       continue;
     }
-    logger.warn("[open-design updater] retained release directory vanished; marking it removed", {
+    if (releaseEntry != null && (!releaseEntry.isDirectory() || releaseEntry.isSymbolicLink())) {
+      releases.push({
+        ...entry,
+        error: releaseCleanupError("release-path-invalid", "release entry is not a plain directory", {
+          path: releaseDir,
+        }),
+        reason: "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    if (releaseEntry != null) {
+      const metadataPath = entry.metadataPath == null
+        ? join(releaseDir, "metadata.json")
+        : resolve(layout.root, entry.metadataPath);
+      if (!containsPath(layout.releasesRoot, metadataPath)) {
+        releases.push(entry);
+        continue;
+      }
+      const metadataPresent = await lstat(metadataPath).then(
+        () => true,
+        (error: unknown) => !isVanishedPathError(error),
+      );
+      if (metadataPresent) {
+        releases.push(entry);
+        continue;
+      }
+    }
+    logger.warn("[open-design updater] retained release is no longer on disk; marking it removed", {
       key: entry.key,
       path: releaseDir,
     });

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, readdir, realpath, rename, rm, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 
 import type {
@@ -408,6 +408,49 @@ export async function scanReleaseCleanupEntries(input: {
   return nextEntries;
 }
 
+type RetainedMetadataVerdict = "intact" | "invalid" | "missing";
+
+/**
+ * Decide whether a retained release's metadata record is still usable.
+ *
+ * `lstat` only proves a directory entry exists — it succeeds for a dangling
+ * symlink and for a file holding unparseable bytes. `scanReleaseCleanupEntries`
+ * already reads and validates the record, so the per-check pass has to reach
+ * the same verdict or the two paths disagree about whether a release is usable.
+ *
+ * Anything we cannot positively fault is reported `intact`: a metadata file
+ * that is merely unreadable at this moment must never cost a real release its
+ * record.
+ */
+async function inspectRetainedMetadata(metadataPath: string): Promise<RetainedMetadataVerdict> {
+  const link = await lstat(metadataPath).then(
+    (stats) => stats,
+    (error: unknown) => (isVanishedPathError(error) ? null : "unreadable" as const),
+  );
+  if (link === "unreadable") return "intact";
+  if (link == null) return "missing";
+  if (link.isSymbolicLink()) {
+    // A dangling link is a missing record; a live one still is not the regular
+    // file this store is supposed to hold.
+    const target = await stat(metadataPath).then(
+      () => "present" as const,
+      (error: unknown) => (isVanishedPathError(error) ? null : "unreadable" as const),
+    );
+    if (target === "unreadable") return "intact";
+    return target == null ? "missing" : "invalid";
+  }
+  if (!link.isFile()) return "invalid";
+  let metadata: unknown;
+  try {
+    metadata = await readJsonStrict<unknown>(metadataPath);
+  } catch (error) {
+    if (isVanishedPathError(error)) return "missing";
+    // Unparseable bytes are a fault we can name; any other read failure is not.
+    return error instanceof SyntaxError ? "invalid" : "intact";
+  }
+  return isRecord(metadata) ? "intact" : "invalid";
+}
+
 /**
  * Downgrade retained entries whose backing release directory is gone.
  *
@@ -420,7 +463,7 @@ export async function scanReleaseCleanupEntries(input: {
  * the app's own pruning produces.
  *
  * A retained release counts as present only when its directory is a plain
- * directory and its `metadata.json` is still there — the record is what lets
+ * directory and its `metadata.json` is still a readable record — the record is what lets
  * the app identify the release, so a surviving directory with no metadata is
  * just as unusable as no directory at all. Both land on the same
  * `metadata-missing` reason `scanReleaseCleanupEntries` already uses.
@@ -479,12 +522,21 @@ export async function revalidateRetainedReleaseEntries(input: {
         releases.push(entry);
         continue;
       }
-      const metadataPresent = await lstat(metadataPath).then(
-        () => true,
-        (error: unknown) => !isVanishedPathError(error),
-      );
-      if (metadataPresent) {
+      const verdict = await inspectRetainedMetadata(metadataPath);
+      if (verdict === "intact") {
         releases.push(entry);
+        continue;
+      }
+      if (verdict === "invalid") {
+        releases.push({
+          ...entry,
+          error: releaseCleanupError("release-metadata-invalid", "retained release metadata.json is not a usable record", {
+            path: metadataPath,
+          }),
+          reason: "metadata-invalid",
+          state: "unknown",
+          updatedAt: nowIso,
+        });
         continue;
       }
     }

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -12,6 +12,7 @@ import type {
 import type { DesktopUpdaterConfig } from "./config.js";
 import {
   BACK_DIR,
+  isVanishedPathError,
   LOCK_OWNER_FILE,
   type DesktopUpdaterStoreLayout,
 } from "./store.js";
@@ -407,6 +408,65 @@ export async function scanReleaseCleanupEntries(input: {
   return nextEntries;
 }
 
+/**
+ * Downgrade retained entries whose backing release directory is gone.
+ *
+ * Only `next-version-ready` and `manual` rescan the releases directory; every
+ * other trigger carries `cleanup.json` forward as written. A retained entry is
+ * therefore trusted indefinitely, so a release removed from outside the app —
+ * disk-space tooling, antivirus quarantine, a partial write after a crash, or
+ * manual pruning — keeps being counted as a local release that no longer
+ * exists. Such an entry is moved to the same terminal `cleanup-removed` state
+ * the app's own pruning produces.
+ *
+ * Only a path that is genuinely gone is downgraded. An entry that merely
+ * cannot be read at this moment is left untouched, so a transient filesystem
+ * failure never erases the record of a real release.
+ */
+export async function revalidateRetainedReleaseEntries(input: {
+  descriptor: ReleaseCleanupDescriptor;
+  layout: DesktopUpdaterStoreLayout;
+  logger: DesktopUpdaterLogger;
+  nowIso: string;
+}): Promise<ReleaseCleanupDescriptor> {
+  const { descriptor, layout, logger, nowIso } = input;
+  const releases: ReleaseCleanupEntry[] = [];
+  for (const entry of descriptor.releases) {
+    if (entry.state !== "retained") {
+      releases.push(entry);
+      continue;
+    }
+    const releaseDir = resolve(layout.root, entry.path);
+    if (!containsPath(layout.releasesRoot, releaseDir)) {
+      releases.push(entry);
+      continue;
+    }
+    // Unreadable counts as present: only a path we positively know is gone
+    // may drop a retained release.
+    const present = await lstat(releaseDir).then(
+      () => true,
+      (error: unknown) => !isVanishedPathError(error),
+    );
+    if (present) {
+      releases.push(entry);
+      continue;
+    }
+    logger.warn("[open-design updater] retained release directory vanished; marking it removed", {
+      key: entry.key,
+      path: releaseDir,
+    });
+    releases.push({
+      ...entry,
+      error: undefined,
+      reason: "metadata-missing",
+      removedAt: entry.removedAt ?? nowIso,
+      state: "cleanup-removed",
+      updatedAt: nowIso,
+    });
+  }
+  return { ...descriptor, releases, updatedAt: nowIso };
+}
+
 export async function cleanupDeprecatedReleaseEntries(input: {
   descriptor: ReleaseCleanupDescriptor;
   layout: DesktopUpdaterStoreLayout;
@@ -517,7 +577,7 @@ export async function runUpdateReleaseLifecycle(input: {
       };
     }
 
-    const cleaned = await cleanupDeprecatedReleaseEntries({
+    const revalidated = await revalidateRetainedReleaseEntries({
       descriptor: {
         ...next,
         currentVersion: config.currentVersion,
@@ -525,6 +585,12 @@ export async function runUpdateReleaseLifecycle(input: {
         trigger,
         updatedAt: startedAt,
       },
+      layout,
+      logger,
+      nowIso: now().toISOString(),
+    });
+    const cleaned = await cleanupDeprecatedReleaseEntries({
+      descriptor: revalidated,
       layout,
       logger,
       nowIso: now().toISOString(),

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -462,17 +462,15 @@ async function inspectRetainedMetadata(metadataPath: string): Promise<RetainedMe
  * exists. Such an entry is moved to the same terminal `cleanup-removed` state
  * the app's own pruning produces.
  *
- * A retained release counts as present only when its directory is a plain
- * directory and its `metadata.json` is still a readable record — the record is what lets
- * the app identify the release, so a surviving directory with no metadata is
- * just as unusable as no directory at all. Both land on the same
- * `metadata-missing` reason `scanReleaseCleanupEntries` already uses.
+ * Only a release whose directory is gone is recorded as `cleanup-removed`:
+ * that state means the payload is off the disk, and this pass never calls
+ * `rm()` — removal belongs to `cleanupDeprecatedReleaseEntries`. A directory
+ * that survives while its `metadata.json` is missing, unreadable, or not a
+ * usable record is marked `unknown` instead, matching what a full rescan would
+ * say and leaving the orphan visible to the cleanup pass.
  *
- * Only a path that is genuinely gone is downgraded. An entry that merely
- * cannot be read at this moment is left untouched, so a transient filesystem
- * failure never erases the record of a real release. A directory whose shape
- * is wrong is not "removed" either: it is marked `unknown`, matching what a
- * full rescan would record.
+ * An entry that merely cannot be read at this moment is left untouched, so a
+ * transient filesystem failure never erases the record of a real release.
  */
 export async function revalidateRetainedReleaseEntries(input: {
   descriptor: ReleaseCleanupDescriptor;
@@ -515,30 +513,34 @@ export async function revalidateRetainedReleaseEntries(input: {
       continue;
     }
     if (releaseEntry != null) {
-      const metadataPath = entry.metadataPath == null
-        ? join(releaseDir, "metadata.json")
-        : resolve(layout.root, entry.metadataPath);
-      if (!containsPath(layout.releasesRoot, metadataPath)) {
-        releases.push(entry);
-        continue;
-      }
+      // Derived from the release directory, never from entry.metadataPath: the
+      // stored field is only shape-checked when cleanup.json is read, so a
+      // tampered entry could otherwise point at a sibling release's valid
+      // record and vouch for itself. scanReleaseCleanupEntries() derives it the
+      // same way.
+      const metadataPath = join(releaseDir, "metadata.json");
       const verdict = await inspectRetainedMetadata(metadataPath);
       if (verdict === "intact") {
         releases.push(entry);
         continue;
       }
-      if (verdict === "invalid") {
-        releases.push({
-          ...entry,
-          error: releaseCleanupError("release-metadata-invalid", "retained release metadata.json is not a usable record", {
-            path: metadataPath,
-          }),
-          reason: "metadata-invalid",
-          state: "unknown",
-          updatedAt: nowIso,
-        });
-        continue;
-      }
+      // The directory is still on disk, so nothing was cleaned up here. Flag it
+      // the way a full rescan would and leave removal to the pass that actually
+      // calls rm().
+      releases.push({
+        ...entry,
+        error: releaseCleanupError(
+          verdict === "missing" ? "release-metadata-missing" : "release-metadata-invalid",
+          verdict === "missing"
+            ? "retained release metadata.json could not be read"
+            : "retained release metadata.json is not a usable record",
+          { path: metadataPath },
+        ),
+        reason: verdict === "missing" ? "metadata-missing" : "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
     }
     logger.warn("[open-design updater] retained release is no longer on disk; marking it removed", {
       key: entry.key,

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -422,7 +422,10 @@ type RetainedMetadataVerdict = "intact" | "invalid" | "missing";
  * that is merely unreadable at this moment must never cost a real release its
  * record.
  */
-async function inspectRetainedMetadata(metadataPath: string): Promise<RetainedMetadataVerdict> {
+async function inspectRetainedMetadata(
+  metadataPath: string,
+  channel: DesktopUpdaterConfig["channel"],
+): Promise<RetainedMetadataVerdict> {
   const link = await lstat(metadataPath).then(
     (stats) => stats,
     (error: unknown) => (isVanishedPathError(error) ? null : "unreadable" as const),
@@ -448,7 +451,13 @@ async function inspectRetainedMetadata(metadataPath: string): Promise<RetainedMe
     // Unparseable bytes are a fault we can name; any other read failure is not.
     return error instanceof SyntaxError ? "invalid" : "intact";
   }
-  return isRecord(metadata) ? "intact" : "invalid";
+  if (!isRecord(metadata)) return "invalid";
+  // scanReleaseCleanupEntries() only accepts a record once
+  // releaseVersionForChannel() resolves a version for the configured channel.
+  // Without the same check here an object such as `{}` stays `retained` on every
+  // per-check pass while a full rescan would fault it, so the stale entry could
+  // survive indefinitely between rescans.
+  return releaseVersionForChannel(metadata, channel) == null ? "invalid" : "intact";
 }
 
 /**
@@ -473,12 +482,13 @@ async function inspectRetainedMetadata(metadataPath: string): Promise<RetainedMe
  * transient filesystem failure never erases the record of a real release.
  */
 export async function revalidateRetainedReleaseEntries(input: {
+  channel: DesktopUpdaterConfig["channel"];
   descriptor: ReleaseCleanupDescriptor;
   layout: DesktopUpdaterStoreLayout;
   logger: DesktopUpdaterLogger;
   nowIso: string;
 }): Promise<ReleaseCleanupDescriptor> {
-  const { descriptor, layout, logger, nowIso } = input;
+  const { channel, descriptor, layout, logger, nowIso } = input;
   const releases: ReleaseCleanupEntry[] = [];
   for (const entry of descriptor.releases) {
     if (entry.state !== "retained") {
@@ -519,7 +529,7 @@ export async function revalidateRetainedReleaseEntries(input: {
       // record and vouch for itself. scanReleaseCleanupEntries() derives it the
       // same way.
       const metadataPath = join(releaseDir, "metadata.json");
-      const verdict = await inspectRetainedMetadata(metadataPath);
+      const verdict = await inspectRetainedMetadata(metadataPath, channel);
       if (verdict === "intact") {
         releases.push(entry);
         continue;
@@ -648,6 +658,7 @@ export async function revalidateReleaseCleanupState(input: {
     const current = await readReleaseCleanupDescriptor(layout);
     if (current == null) return null;
     const revalidated = await revalidateRetainedReleaseEntries({
+      channel: config.channel,
       descriptor: current,
       layout,
       logger,
@@ -705,6 +716,7 @@ export async function runUpdateReleaseLifecycle(input: {
     }
 
     const revalidated = await revalidateRetainedReleaseEntries({
+      channel: config.channel,
       descriptor: {
         ...next,
         currentVersion: config.currentVersion,

--- a/apps/desktop/src/main/updater/store.ts
+++ b/apps/desktop/src/main/updater/store.ts
@@ -144,6 +144,21 @@ export function storeShapeError(root: string, message: string, details?: unknown
   });
 }
 
+/**
+ * True when a filesystem error means the path is simply not there any more,
+ * as opposed to being unreadable for a reason that could resolve itself.
+ *
+ * A vanished path is a fact the updater can act on: whatever the store points
+ * at is gone and is not coming back, so the pointer is stale rather than the
+ * store being corrupt. Permission, I/O, and lock errors stay fatal, because
+ * discarding a downloaded release that is merely unreadable right now would
+ * silently throw away a verified update.
+ */
+export function isVanishedPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
 export function logStoreError(logger: DesktopUpdaterLogger, error: DesktopUpdateErrorSnapshot): void {
   logger.error("[open-design updater] invalid update store", error);
 }

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -396,12 +396,74 @@ describe("desktop updater", () => {
     expect(isVanishedPathError(null)).toBe(false);
   });
 
+  // cleanup.json is only shape-checked when it is read, so entry.metadataPath
+  // is not evidence about this release. Pointed at a sibling release's valid
+  // record, it must not be able to vouch for an entry whose own metadata is
+  // gone.
+  it("ignores a retained entry's stored metadata path and derives the canonical one", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      const seeded = await updater.checkForUpdates();
+      expect(seeded.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const realKey = seeded.active?.key ?? "";
+      expect(existsSync(join(layout.releasesRoot, realKey, "metadata.json"))).toBe(true);
+
+      // Stale release: directory present, its own metadata.json never written.
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      const staleDir = join(layout.releasesRoot, staleKey);
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "artifact.bin"), "0.9.0", "utf8");
+
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        // Borrowed from the real release — in root, so a containment check alone
+        // would accept it.
+        metadataPath: `releases/${realKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+
+      expect((await updater.checkForUpdates()).state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; reason?: string; state: string }[];
+      };
+      const stale = descriptor.releases.find((entry) => entry.key === staleKey);
+      expect(stale?.state).toBe("unknown");
+      expect(stale?.reason).toBe("metadata-missing");
+
+      // The borrowed record's own release is untouched.
+      const real = descriptor.releases.find((entry) => entry.key === realKey);
+      expect(real?.state).toBe("retained");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   // lstat() only proves a directory entry exists. A retained release whose
   // metadata is a dangling symlink or unparseable JSON is just as unusable as
   // one with no metadata at all, and the full rescan already says so; the
   // per-check pass must not disagree with it.
   it.each([
-    { expectedReason: "metadata-missing", expectedState: "cleanup-removed", label: "dangling symlink" },
+    { expectedReason: "metadata-missing", expectedState: "unknown", label: "dangling symlink" },
     { expectedReason: "metadata-invalid", expectedState: "unknown", label: "malformed json" },
   ])("drops a retained cleanup entry whose metadata is a $label", async ({ expectedReason, expectedState, label }) => {
     const root = makeRoot();
@@ -547,11 +609,15 @@ describe("desktop updater", () => {
       expect((await updater.checkForUpdates()).state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
 
       const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
-        releases: { key: string; reason?: string; state: string }[];
+        releases: { key: string; reason?: string; removedAt?: string; state: string }[];
       };
       const stale = descriptor.releases.find((entry) => entry.key === staleKey);
-      expect(stale?.state).toBe("cleanup-removed");
+      expect(stale?.state).toBe("unknown");
       expect(stale?.reason).toBe("metadata-missing");
+      // Nothing was cleaned up, so the payload must still be there and the
+      // entry must not claim a removal that never happened.
+      expect(stale?.removedAt).toBeUndefined();
+      expect(existsSync(staleDir)).toBe(true);
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -396,6 +396,65 @@ describe("desktop updater", () => {
     expect(isVanishedPathError(null)).toBe(false);
   });
 
+  // lstat() only proves a directory entry exists. A retained release whose
+  // metadata is a dangling symlink or unparseable JSON is just as unusable as
+  // one with no metadata at all, and the full rescan already says so; the
+  // per-check pass must not disagree with it.
+  it.each([
+    { expectedReason: "metadata-missing", expectedState: "cleanup-removed", label: "dangling symlink" },
+    { expectedReason: "metadata-invalid", expectedState: "unknown", label: "malformed json" },
+  ])("drops a retained cleanup entry whose metadata is a $label", async ({ expectedReason, expectedState, label }) => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      expect((await updater.checkForUpdates()).state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      const staleDir = join(layout.releasesRoot, staleKey);
+      await mkdir(staleDir, { recursive: true });
+      const metadataPath = join(staleDir, "metadata.json");
+      if (label === "dangling symlink") {
+        symlinkSync(join(staleDir, "gone.json"), metadataPath);
+      } else {
+        await writeFile(metadataPath, "{ not json", "utf8");
+      }
+
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        metadataPath: `releases/${staleKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+
+      expect((await updater.checkForUpdates()).state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; reason?: string; state: string }[];
+      };
+      const stale = descriptor.releases.find((entry) => entry.key === staleKey);
+      expect(stale?.state).toBe(expectedState);
+      expect(stale?.reason).toBe(expectedReason);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   // A retained path that is no longer a plain directory was not "removed", so
   // it is flagged rather than claimed as cleaned — the same call a full rescan
   // would make.

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -396,6 +396,64 @@ describe("desktop updater", () => {
     expect(isVanishedPathError(null)).toBe(false);
   });
 
+  // #7258 deletes the release while the app is running, so the recovery has to
+  // hold on the retry path too: restoreStoreState() runs at most once per
+  // process, and checkForCandidate() only reaches it while the updater is
+  // still IDLE. A second "Check again" on the same instance therefore never
+  // revisits the store, and the in-memory active release is trusted as-is.
+  it("recovers on a retry with the same updater instance after the release is deleted", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const first = await updater.checkForUpdates();
+      expect(first.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(existsSync(first.downloadPath ?? "")).toBe(true);
+
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        metadataPath: `releases/${staleKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+
+      // The app keeps running; the release is removed underneath it.
+      await rm(layout.releasesRoot, { force: true, recursive: true });
+
+      const retried = await updater.checkForUpdates();
+      expect(retried.state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(retried.error).toBeUndefined();
+      // Must not keep advertising a ready install whose file is gone.
+      if (retried.state === DESKTOP_UPDATE_STATES.DOWNLOADED) {
+        expect(existsSync(retried.downloadPath ?? "")).toBe(true);
+      }
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; state: string }[];
+      };
+      expect(descriptor.releases.find((entry) => entry.key === staleKey)?.state).toBe("cleanup-removed");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   // The reported shape of #7258: a release the app itself decided to keep
   // (state "retained") whose backing directory was removed from outside. The
   // cold-start lifecycle carries the descriptor forward without rescanning, so

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -396,6 +396,109 @@ describe("desktop updater", () => {
     expect(isVanishedPathError(null)).toBe(false);
   });
 
+  // A retained path that is no longer a plain directory was not "removed", so
+  // it is flagged rather than claimed as cleaned — the same call a full rescan
+  // would make.
+  it("flags a retained cleanup entry whose path is no longer a plain directory", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      expect((await updater.checkForUpdates()).state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      // Outside the update root: an extra directory inside it would trip the
+      // store's own ownership check before the revalidation ever runs.
+      const decoy = makeRoot();
+      symlinkSync(decoy, join(layout.releasesRoot, staleKey));
+
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        metadataPath: `releases/${staleKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+
+      expect((await updater.checkForUpdates()).state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; removedAt?: string; state: string }[];
+      };
+      const stale = descriptor.releases.find((entry) => entry.key === staleKey);
+      expect(stale?.state).toBe("unknown");
+      expect(stale?.removedAt).toBeUndefined();
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  // #7258 describes the backing directory *or* its metadata.json going
+  // missing. A directory that survives with its metadata removed is still a
+  // release the app can no longer identify, so it must not stay retained.
+  it("drops a retained cleanup entry whose release metadata is missing", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+      expect((await updater.checkForUpdates()).state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      const staleDir = join(layout.releasesRoot, staleKey);
+      await mkdir(staleDir, { recursive: true });
+      await writeFile(join(staleDir, "artifact.bin"), "0.9.0", "utf8");
+      expect(existsSync(staleDir)).toBe(true);
+      expect(existsSync(join(staleDir, "metadata.json"))).toBe(false);
+
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        metadataPath: `releases/${staleKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+
+      expect((await updater.checkForUpdates()).state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; reason?: string; state: string }[];
+      };
+      const stale = descriptor.releases.find((entry) => entry.key === staleKey);
+      expect(stale?.state).toBe("cleanup-removed");
+      expect(stale?.reason).toBe("metadata-missing");
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   // #7258 deletes the release while the app is running, so the recovery has to
   // hold on the retry path too: restoreStoreState() runs at most once per
   // process, and checkForCandidate() only reaches it while the updater is

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -30,7 +30,7 @@ import {
   resolveInstalledOuterVersion,
 } from "../../src/main/updater.js";
 import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
-import { isVanishedPathError } from "../../src/main/updater/store.js";
+import { isVanishedPathError, resolveDesktopUpdaterStoreLayout } from "../../src/main/updater/store.js";
 
 type FixtureServer = {
   artifactRequests: () => number;
@@ -394,6 +394,71 @@ describe("desktop updater", () => {
     expect(isVanishedPathError(Object.assign(new Error("io"), { code: "EIO" }))).toBe(false);
     expect(isVanishedPathError(new Error("no code"))).toBe(false);
     expect(isVanishedPathError(null)).toBe(false);
+  });
+
+  // The reported shape of #7258: a release the app itself decided to keep
+  // (state "retained") whose backing directory was removed from outside. The
+  // cold-start lifecycle carries the descriptor forward without rescanning, so
+  // without revalidation the store keeps advertising a local release that is
+  // not there.
+  it("drops a retained cleanup entry whose backing release directory is gone", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      // Let the updater build and own the store the normal way first.
+      const seeded = await createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      }).checkForUpdates();
+      expect(seeded.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      // Record a retained release whose directory is not on disk, the way an
+      // outside cleanup leaves the descriptor behind.
+      const layout = resolveDesktopUpdaterStoreLayout(root);
+      const staleKey = "0.9.0-mac-arm64-deadbeef";
+      const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: Record<string, unknown>[];
+      };
+      seededDescriptor.releases.push({
+        currentVersion: "1.0.0",
+        key: staleKey,
+        metadataPath: `releases/${staleKey}/metadata.json`,
+        path: `releases/${staleKey}`,
+        reason: "current-version-or-newer",
+        state: "retained",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        version: "0.9.0",
+      });
+      await writeFile(layout.cleanupPath, `${JSON.stringify(seededDescriptor)}\n`, "utf8");
+      expect(existsSync(join(layout.releasesRoot, staleKey))).toBe(false);
+
+      // Cold start: this is the path that currently carries the descriptor
+      // forward without ever revalidating it.
+      const checked = await createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      }).checkForUpdates();
+      expect(checked.state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+
+      const descriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {
+        releases: { key: string; reason?: string; removedAt?: string; state: string }[];
+      };
+      const stale = descriptor.releases.find((entry) => entry.key === staleKey);
+      expect(stale?.state).toBe("cleanup-removed");
+      expect(stale?.reason).toBe("metadata-missing");
+      expect(stale?.removedAt).toEqual(expect.any(String));
+
+      // The real downloaded release is still retained and untouched.
+      expect(existsSync(join(layout.releasesRoot, seeded.active?.key ?? ""))).toBe(true);
+      expect(checked.cache?.lifecycle?.releases.retained).toBe(1);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   // A downloaded release can vanish from disk without the updater's own cleanup

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -30,6 +30,7 @@ import {
   resolveInstalledOuterVersion,
 } from "../../src/main/updater.js";
 import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
+import { isVanishedPathError } from "../../src/main/updater/store.js";
 
 type FixtureServer = {
   artifactRequests: () => number;
@@ -377,6 +378,71 @@ describe("desktop updater", () => {
         sessionId: "2026-06-09T07:50:51.000Z-12345",
         source: SIDECAR_SOURCES.PACKAGED,
       }));
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("treats only a vanished path as recoverable, keeping unreadable stores fatal", () => {
+    expect(isVanishedPathError(Object.assign(new Error("gone"), { code: "ENOENT" }))).toBe(true);
+    expect(isVanishedPathError(Object.assign(new Error("not a directory"), { code: "ENOTDIR" }))).toBe(true);
+
+    // A release we merely cannot read right now must not be discarded.
+    expect(isVanishedPathError(Object.assign(new Error("denied"), { code: "EACCES" }))).toBe(false);
+    expect(isVanishedPathError(Object.assign(new Error("busy"), { code: "EBUSY" }))).toBe(false);
+    expect(isVanishedPathError(Object.assign(new Error("io"), { code: "EIO" }))).toBe(false);
+    expect(isVanishedPathError(new Error("no code"))).toBe(false);
+    expect(isVanishedPathError(null)).toBe(false);
+  });
+
+  // A downloaded release can vanish from disk without the updater's own cleanup
+  // having run: manual pruning of the data directory, disk-space tooling, AV
+  // quarantine, or a partial write after a crash. The stored active pointer
+  // then names files that will never come back, so trusting it must not be
+  // able to wedge the version check.
+  it("recovers the version check when a downloaded release disappears from disk", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const downloaded = await createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      }).checkForUpdates();
+      expect(downloaded.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+
+      // Remove the release payload the way an outside cleanup would, leaving
+      // the store's active pointer behind.
+      await rm(join(root, "releases"), { force: true, recursive: true });
+
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: root,
+        env: updaterEnv(fixture.metadataUrl),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(checked.error).toBeUndefined();
+      expect(checked.availableVersion).toBe("1.0.1");
+
+      // Retrying must not replay the same terminal failure forever.
+      const rechecked = await updater.checkForUpdates();
+      expect(rechecked.state).not.toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(rechecked.error).toBeUndefined();
+
+      // The stale pointer does not survive: whatever the store points at after
+      // recovery must be a release that actually exists on disk.
+      const persisted = JSON.parse(await readFile(join(root, "metadata.json"), "utf8")) as {
+        active?: { artifactPath?: string };
+      };
+      const persistedArtifact = persisted.active?.artifactPath;
+      if (persistedArtifact != null) {
+        expect(existsSync(join(root, persistedArtifact))).toBe(true);
+      }
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -459,12 +459,14 @@ describe("desktop updater", () => {
   });
 
   // lstat() only proves a directory entry exists. A retained release whose
-  // metadata is a dangling symlink or unparseable JSON is just as unusable as
-  // one with no metadata at all, and the full rescan already says so; the
-  // per-check pass must not disagree with it.
+  // metadata is a dangling symlink, unparseable JSON, or a record that carries
+  // no version for the configured channel is just as unusable as one with no
+  // metadata at all, and the full rescan already says so; the per-check pass
+  // must not disagree with it.
   it.each([
     { expectedReason: "metadata-missing", expectedState: "unknown", label: "dangling symlink" },
     { expectedReason: "metadata-invalid", expectedState: "unknown", label: "malformed json" },
+    { expectedReason: "metadata-invalid", expectedState: "unknown", label: "record without a channel version" },
   ])("drops a retained cleanup entry whose metadata is a $label", async ({ expectedReason, expectedState, label }) => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
@@ -484,8 +486,14 @@ describe("desktop updater", () => {
       const metadataPath = join(staleDir, "metadata.json");
       if (label === "dangling symlink") {
         symlinkSync(join(staleDir, "gone.json"), metadataPath);
-      } else {
+      } else if (label === "malformed json") {
         await writeFile(metadataPath, "{ not json", "utf8");
+      } else {
+        // Parses as an object, but exposes no version for the configured
+        // channel. scanReleaseCleanupEntries() faults exactly this shape with
+        // release-version-missing, so the per-check pass has to agree or the
+        // entry stays retained until the next full rescan.
+        await writeFile(metadataPath, `${JSON.stringify({ notes: "no version for this channel" })}\n`, "utf8");
       }
 
       const seededDescriptor = JSON.parse(await readFile(layout.cleanupPath, "utf8")) as {


### PR DESCRIPTION
Fixes #7258

## Why

I was looking for a reported bug I could reproduce deterministically before touching anything, and this one turned out to have a clean mechanical cause worth closing.

@mixxer reported that Check for Update fails with a generic "try again later" message after a local release directory was removed from outside the app, and that retrying never helps. @lefarcen confirmed the gap and pointed at the release lifecycle: `deprecated` entries got hardening in #4524, but there is no equivalent revalidation for a release that is simply gone.

Tracing the check path, the wedge is upstream of `cleanup.json`, in the store's `active` pointer:

1. `loadActiveRelease()` (`apps/desktop/src/main/updater.ts`) `stat`s the stored active artifact and turns **any** failure into `storeShapeError("active release artifact is missing")` — including plain `ENOENT`.
2. `restoreStoreState()` returns `setState(ERROR, loadedActive.error)` on that.
3. `restoreStoreStateOnce()` only sets `storeStateRestored = true` when the restore did **not** end in `ERROR`.

So once the artifact is gone, every `checkForCandidate()` re-runs the restore, fails identically, and returns the terminal error before it ever reaches the network. That is exactly the reported symptom: the message says "try again later", but no retry can ever succeed, because the missing file is never coming back.

The reporter's `retained` framing and this `active` pointer are the same deletion — removing `updates/releases/<key>/` takes the release `metadata.json` and the artifact together. Notably `scanReleaseCleanupEntries()` already handles the vanished case gracefully (it rescans the directory and drops entries that are no longer on disk); the store pointer was the one place still treating "gone" as "corrupt".

## What users will see

Check for Update works again on an installation where a previously downloaded release was deleted outside the app — by manual cleanup, disk-space tooling, AV quarantine, or a partial write after a crash. Instead of a permanent "업데이트를 확인하지 못했습니다 / could not check for updates" that retrying cannot clear, the app notices the download is gone, forgets it, and completes the check normally — offering the update again if one is available.

Nothing changes for users whose update store is intact.

## Surface area

- [ ] **UI** — no new or changed UI surface; the existing dialog simply stops showing a permanent error in this case
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — affected installs go from a permanently failing check to a recovering one, without opting in. No new setting; the old behavior was the bug.
- [ ] **None**

Scope is desktop main-process updater logic (`apps/desktop/src/main/updater.ts`, `apps/desktop/src/main/updater/store.ts`) plus tests. No renderer, contract, or CLI surface is involved, so the UI/CLI dual-track rule does not apply — this changes no capability, only the failure handling of an existing one.

## Screenshots

Not applicable — no visual surface changes. The user-visible difference is the absence of the error dialog, which the regression test asserts directly.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/updater.test.ts` → `recovers the version check when a downloaded release disappears from disk`
- Did the test go red on `main` and green on this branch? **yes**

Red on `main` (source reverted, spec kept):

```
AssertionError: expected 'error' not to be 'error' // Object.is equality
  Tests  1 failed | 75 skipped (76)
```

The spec drives the real updater against the existing fixture server: download a release, delete `releases/` the way an outside cleanup would, construct a fresh updater over the same root (an app restart), then check. It asserts the check does not end in `ERROR`, that it still reports the available version, that a **second** check does not replay the failure, and that whatever the store points at afterwards is a file that actually exists.

A second test pins the fail-closed half of the invariant: `isVanishedPathError` accepts `ENOENT`/`ENOTDIR` only, and rejects `EACCES`/`EBUSY`/`EIO`/code-less errors, so a release that is merely unreadable at this moment is never silently discarded.

On the issue's second ask — a message that reflects the real failure instead of the generic retry copy — recovering removes the dialog from this path entirely, so there is no misleading message left to rewrite here. The generic copy still covers the errors that genuinely are retryable. Happy to follow up separately if you would rather also differentiate the copy for the remaining fatal cases.

## Validation

- `pnpm guard` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)
- `pnpm --filter @open-design/desktop test` — 40 files, 402 passed / 1 skipped
- `pnpm --filter @open-design/desktop build` — pass (exit 0)

**Pre-existing flake, not from this change:** `apps/desktop/tests/main/pptx-layered-background.test.ts` intermittently fails 37 of its 50 tests. I reproduced it on a clean stash of `main` with the identical 37-failure signature (6 consecutive runs of that file alone: 5 green, 1 with 37 failed). It is unrelated to the updater; flagging it here rather than widening this PR.
