### PR TITLE
fix(landing): force compatible vision-router installs

### DIFF
--- a/apps/landing-page/app/_lib/deepseek-design.ts
+++ b/apps/landing-page/app/_lib/deepseek-design.ts
@@ -266,7 +266,7 @@ export const DEEPSEEK_SKILLS: readonly DeepseekSkill[] = [
     repo: 'ysr666/dsh-vision-router',
     install: {
       kind: 'installer',
-      command: 'npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router',
+      command: 'npx @deepseek-ai/dsh plugin --profile web add dsh-vision-router@latest',
     },
     license: MIT,
     upstreamDescription:

--- a/apps/landing-page/tests/deepseek-vision-router-compat.test.ts
+++ b/apps/landing-page/tests/deepseek-vision-router-compat.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { DEEPSEEK_SKILLS } from '../app/_lib/deepseek-design';
+
+test('dsh-vision-router install resolves a compatibility-fixed release', () => {
+  const plugin = DEEPSEEK_SKILLS.find((skill) => skill.slug === 'dsh-vision-router');
+
+  assert.ok(plugin, 'dsh-vision-router must remain in the curated catalog');
+  assert.equal(plugin.install.kind, 'installer');
+  assert.match(plugin.install.command, /\bdsh-vision-router@latest\b/);
+});


### PR DESCRIPTION
Fixes #7124

## Why

I picked this up after the issue identified a concrete recovery path for users whose DeepSeek Harness profile can no longer open. `dsh-vision-router` versions before 1.5.2 can fail the keyed `settings.plugin.item` slot registration, while the curated Open Design command used an unversioned package spec that may preserve an older profile resolution.

The upstream package is actively maintained and its current npm `latest` release is 1.7.6, so the catalog should explicitly request that dist-tag when users install or repair the plugin.

## What users will see

The dsh-vision-router detail page now shows an install command ending in `dsh-vision-router@latest`. Re-running it forces the package resolver onto the compatibility-fixed release line instead of leaving an old cached install in place.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — focused catalog guidance and regression coverage only

## Screenshots

Not applicable: no layout or component changes. The generated canonical and zh detail pages were both checked for the new command.

## Bug fix verification

- Red spec: `apps/landing-page/tests/deepseek-vision-router-compat.test.ts`
- Red on main: yes — the existing command failed the `dsh-vision-router@latest` assertion.
- Green on this branch: yes.

## Validation

- `pnpm --filter @open-design/landing-page test` — 204 tests passed
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- `pnpm --filter @open-design/landing-page build:static` — 6,739 pages built
- `pnpm typecheck` — passed across the workspace
- `pnpm guard` — passed
- generated `/plugins/dsh-vision-router/` and `/zh/plugins/dsh-vision-router/` HTML both contain `dsh-vision-router@latest`
