### PR TITLE
fix(packaged): recover from stale web sidecars

### DIFF
--- a/apps/daemon/src/sidecar/parent-monitor-gate.ts
+++ b/apps/daemon/src/sidecar/parent-monitor-gate.ts
@@ -1,0 +1,60 @@
+import { SIDECAR_ENV } from "@open-design/sidecar-proto";
+
+let parentMonitorExitHolds = 0;
+
+export function holdParentMonitorExit(): () => void {
+  parentMonitorExitHolds += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    parentMonitorExitHolds = Math.max(0, parentMonitorExitHolds - 1);
+  };
+}
+
+export function isParentMonitorExitHeld(): boolean {
+  return parentMonitorExitHolds > 0;
+}
+
+export function resetParentMonitorExitHoldForTests(): void {
+  parentMonitorExitHolds = 0;
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function attachParentMonitor(
+  stop: () => Promise<void>,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    exit?: (code?: number) => void;
+    intervalMs?: number;
+    isProcessAlive?: (pid: number) => boolean;
+  } = {},
+): () => void {
+  const env = options.env ?? process.env;
+  const parentPid = Number(env[SIDECAR_ENV.TOOLS_DEV_PARENT_PID]);
+  if (!Number.isInteger(parentPid) || parentPid <= 0) return () => undefined;
+
+  const isAlive = options.isProcessAlive ?? defaultIsProcessAlive;
+  const exit = options.exit ?? ((code) => process.exit(code));
+  const intervalMs = options.intervalMs ?? 1000;
+  let exiting = false;
+
+  const timer = setInterval(() => {
+    if (isAlive(parentPid) || isParentMonitorExitHeld() || exiting) return;
+    exiting = true;
+    clearInterval(timer);
+    void stop().finally(() => exit(0));
+  }, intervalMs);
+  timer.unref();
+  return () => {
+    clearInterval(timer);
+  };
+}

--- a/apps/daemon/src/sidecar/parent-monitor-gate.ts
+++ b/apps/daemon/src/sidecar/parent-monitor-gate.ts
@@ -1,6 +1,13 @@
 import { SIDECAR_ENV } from "@open-design/sidecar-proto";
 
 let parentMonitorExitHolds = 0;
+const releaseWaiters: Array<() => void> = [];
+
+function notifyReleaseWaiters(): void {
+  if (parentMonitorExitHolds > 0) return;
+  const waiters = releaseWaiters.splice(0);
+  for (const waiter of waiters) waiter();
+}
 
 export function holdParentMonitorExit(): () => void {
   parentMonitorExitHolds += 1;
@@ -9,6 +16,7 @@ export function holdParentMonitorExit(): () => void {
     if (released) return;
     released = true;
     parentMonitorExitHolds = Math.max(0, parentMonitorExitHolds - 1);
+    notifyReleaseWaiters();
   };
 }
 
@@ -16,8 +24,27 @@ export function isParentMonitorExitHeld(): boolean {
   return parentMonitorExitHolds > 0;
 }
 
+export function waitForParentMonitorRelease(): Promise<void> {
+  if (parentMonitorExitHolds === 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    releaseWaiters.push(resolve);
+  });
+}
+
 export function resetParentMonitorExitHoldForTests(): void {
   parentMonitorExitHolds = 0;
+  notifyReleaseWaiters();
+}
+
+export function scheduleHeldDaemonExit(
+  stop: () => Promise<void>,
+  exit: (code?: number) => void = (code) => process.exit(code),
+): void {
+  setImmediate(() => {
+    void waitForParentMonitorRelease()
+      .then(() => stop())
+      .finally(() => exit(0));
+  });
 }
 
 function defaultIsProcessAlive(pid: number): boolean {

--- a/apps/daemon/src/sidecar/parent-monitor-gate.ts
+++ b/apps/daemon/src/sidecar/parent-monitor-gate.ts
@@ -39,12 +39,14 @@ export function resetParentMonitorExitHoldForTests(): void {
 export function scheduleHeldDaemonExit(
   stop: () => Promise<void>,
   exit: (code?: number) => void = (code) => process.exit(code),
-): void {
+): boolean {
+  const deferred = isParentMonitorExitHeld();
   setImmediate(() => {
     void waitForParentMonitorRelease()
       .then(() => stop())
       .finally(() => exit(0));
   });
+  return deferred;
 }
 
 function defaultIsProcessAlive(pid: number): boolean {

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -31,6 +31,7 @@ import {
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_ENV,
   SIDECAR_MESSAGES,
   SIDECAR_MODES,
   SIDECAR_SOURCES,
@@ -49,6 +50,10 @@ const SIDECAR_ONLY_ENV_KEYS = [
   "OD_SIDECAR_IPC_PATH",
   "OD_SIDECAR_NAMESPACE",
   "OD_SIDECAR_SOURCE",
+  // Packaged daemon/web now inherit OD_TOOLS_DEV_PARENT_PID so they exit with
+  // the outer Electron. The replacement payload desktop waits for that same
+  // PID to die, then must not treat it as its own lifecycle owner.
+  SIDECAR_ENV.TOOLS_DEV_PARENT_PID,
 ] as const;
 
 type DesktopRootIdentity = {

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -522,9 +522,9 @@ export async function executeLegacyPayloadDesktopHandoff(
 
   // Packaged daemons now monitor OD_TOOLS_DEV_PARENT_PID and exit when the
   // outer Electron dies. Desktop SHUTDOWN acks before asynchronously exiting,
-  // so the parent can disappear while these journal writes are still pending.
-  // Hold the parent-death exit from shutdown acceptance through the three
-  // commits so the replacement payload can still resume the armed target.
+  // then beforeShutdown -> sidecars.close() sends daemon SHUTDOWN. Hold both
+  // the parent-death timer and that explicit exit from shutdown acceptance
+  // through the three commits so the replacement payload can still resume.
   const persist = options.writeJsonFile ?? writeJsonFile;
   const releaseParentMonitor = holdParentMonitorExit();
   try {

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -40,6 +40,8 @@ import {
   type SidecarStamp,
 } from "@open-design/sidecar-proto";
 
+import { holdParentMonitorExit } from "./parent-monitor-gate.js";
+
 const HANDOFF_CONFIRM_TIMEOUT_MS = 60_000;
 const HANDOFF_POLL_INTERVAL_MS = 100;
 const HANDOFF_PAYLOAD_WAIT_TIMEOUT_MS = 60_000;
@@ -430,6 +432,7 @@ export async function executeLegacyPayloadDesktopHandoff(
     requestDesktop?: (message: "shutdown" | "status") => Promise<unknown>;
     sleep?: (durationMs: number) => Promise<unknown>;
     spawn?: typeof spawn;
+    writeJsonFile?: typeof writeJsonFile;
   } = {},
 ): Promise<LegacyPayloadDesktopHandoffResult> {
   const desktopIpcPath = resolveAppIpcPath({
@@ -517,23 +520,34 @@ export async function executeLegacyPayloadDesktopHandoff(
     return { kind: "aborted", reason: "spawn-failed" };
   }
 
+  // Packaged daemons now monitor OD_TOOLS_DEV_PARENT_PID and exit when the
+  // outer Electron dies. Desktop SHUTDOWN acks before asynchronously exiting,
+  // so the parent can disappear while these journal writes are still pending.
+  // Hold the parent-death exit from shutdown acceptance through the three
+  // commits so the replacement payload can still resume the armed target.
+  const persist = options.writeJsonFile ?? writeJsonFile;
+  const releaseParentMonitor = holdParentMonitorExit();
   try {
-    await requestDesktop("shutdown");
-  } catch {
-    return { kind: "aborted", reason: "shutdown-failed" };
+    try {
+      await requestDesktop("shutdown");
+    } catch {
+      return { kind: "aborted", reason: "shutdown-failed" };
+    }
+
+    // Commit the armed journal and rewritten runtime/attempt state only after both
+    // the payload child has actually spawned and the old desktop has accepted the
+    // shutdown. Writing earlier would strand an "armed" journal on disk when
+    // `spawn()` throws or the shutdown request fails: the next cold start bails out
+    // of prepareLegacyPayloadDesktopHandoff() with reason "already-armed" and the
+    // install stays pinned to the old desktop generation. The old desktop is still
+    // alive while it acks the shutdown, and the payload waits for its pid to exit
+    // before resuming, so these writes still land before the payload reads them.
+    await persist(prepared.launcherPaths.handoffPath, armed);
+    await persist(prepared.launcherPaths.attemptsPath, attempt);
+    await persist(prepared.launcherPaths.runtimePath, runtime);
+
+    return { kind: "scheduled", target };
+  } finally {
+    releaseParentMonitor();
   }
-
-  // Commit the armed journal and rewritten runtime/attempt state only after both
-  // the payload child has actually spawned and the old desktop has accepted the
-  // shutdown. Writing earlier would strand an "armed" journal on disk when
-  // `spawn()` throws or the shutdown request fails: the next cold start bails out
-  // of prepareLegacyPayloadDesktopHandoff() with reason "already-armed" and the
-  // install stays pinned to the old desktop generation. The old desktop is still
-  // alive while it acks the shutdown, and the payload waits for its pid to exit
-  // before resuming, so these writes still land before the payload reads them.
-  await writeJsonFile(prepared.launcherPaths.handoffPath, armed);
-  await writeJsonFile(prepared.launcherPaths.attemptsPath, attempt);
-  await writeJsonFile(prepared.launcherPaths.runtimePath, runtime);
-
-  return { kind: "scheduled", target };
 }

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -502,32 +502,34 @@ export async function executeLegacyPayloadDesktopHandoff(
     ...buildLauncherHandoffResumeArgs({ handoffId: prepared.descriptor.handoffId }),
     ...createProcessStampArgs(desktopStamp, OPEN_DESIGN_SIDECAR_CONTRACT),
   ];
-  let child: ReturnType<typeof spawn>;
-  try {
-    child = (options.spawn ?? spawn)(prepared.descriptor.payloadExecutablePath, args, {
-      cwd: dirname(prepared.descriptor.payloadExecutablePath),
-      detached: true,
-      env: desktopProcessEnv(options.env ?? process.env, prepared.runtimeRoot),
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    await new Promise<void>((resolveSpawn, rejectSpawn) => {
-      child.once("spawn", () => resolveSpawn());
-      child.once("error", rejectSpawn);
-    });
-    child.unref();
-  } catch {
-    return { kind: "aborted", reason: "spawn-failed" };
-  }
-
   // Packaged daemons now monitor OD_TOOLS_DEV_PARENT_PID and exit when the
-  // outer Electron dies. Desktop SHUTDOWN acks before asynchronously exiting,
-  // then beforeShutdown -> sidecars.close() sends daemon SHUTDOWN. Hold both
-  // the parent-death timer and that explicit exit from shutdown acceptance
-  // through the three commits so the replacement payload can still resume.
+  // outer Electron dies. Hold before spawn: a crash after the child emits
+  // `spawn` but before the hold would let the parent monitor stop the daemon
+  // while the journal is still `prepared`, and the detached replacement then
+  // rejects resume. Desktop SHUTDOWN also acks before asynchronously exiting,
+  // then beforeShutdown -> sidecars.close() sends daemon SHUTDOWN. Keep the
+  // hold through the three commits so the replacement can still resume.
   const persist = options.writeJsonFile ?? writeJsonFile;
   const releaseParentMonitor = holdParentMonitorExit();
   try {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = (options.spawn ?? spawn)(prepared.descriptor.payloadExecutablePath, args, {
+        cwd: dirname(prepared.descriptor.payloadExecutablePath),
+        detached: true,
+        env: desktopProcessEnv(options.env ?? process.env, prepared.runtimeRoot),
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      await new Promise<void>((resolveSpawn, rejectSpawn) => {
+        child.once("spawn", () => resolveSpawn());
+        child.once("error", rejectSpawn);
+      });
+      child.unref();
+    } catch {
+      return { kind: "aborted", reason: "spawn-failed" };
+    }
+
     try {
       await requestDesktop("shutdown");
     } catch {

--- a/apps/daemon/src/sidecar/server.ts
+++ b/apps/daemon/src/sidecar/server.ts
@@ -218,7 +218,11 @@ export async function startDaemonSidecar(
 
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.on(signal, () => {
-      void stop().finally(() => process.exit(0));
+      // Packaged beforeShutdown sends SHUTDOWN, then closeManagedChild waits
+      // five seconds and stopProcesses() delivers SIGTERM. Keep that path on
+      // the same hold as SHUTDOWN so a slow handoff journal commit cannot be
+      // cut off mid-write.
+      scheduleHeldDaemonExit(stop, options.exit);
     });
   }
 

--- a/apps/daemon/src/sidecar/server.ts
+++ b/apps/daemon/src/sidecar/server.ts
@@ -186,9 +186,10 @@ export async function startDaemonSidecar(
           // request so `tools-dev start desktop` sees the live value
           // (the flag flips after REGISTER_DESKTOP_AUTH and stays sticky).
           return withCurrentDesktopAuthGate(state);
-        case SIDECAR_MESSAGES.SHUTDOWN:
-          scheduleHeldDaemonExit(stop, options.exit);
-          return { accepted: true };
+        case SIDECAR_MESSAGES.SHUTDOWN: {
+          const deferred = scheduleHeldDaemonExit(stop, options.exit);
+          return deferred ? { accepted: true, deferred: true } : { accepted: true };
+        }
         case SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH:
           // PR #974: the desktop main process registers its per-process
           // auth secret here at startup. From this point on the HTTP
@@ -218,10 +219,10 @@ export async function startDaemonSidecar(
 
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.on(signal, () => {
-      // Packaged beforeShutdown sends SHUTDOWN, then closeManagedChild waits
-      // five seconds and stopProcesses() delivers SIGTERM. Keep that path on
-      // the same hold as SHUTDOWN so a slow handoff journal commit cannot be
-      // cut off mid-write.
+      // Packaged beforeShutdown sends SHUTDOWN. When the handoff hold is
+      // active the SHUTDOWN ack includes deferred:true so closeManagedChild
+      // waits a longer bounded grace before stopProcesses(). SIGTERM from
+      // that escalation still uses this hold; SIGKILL remains the ceiling.
       scheduleHeldDaemonExit(stop, options.exit);
     });
   }

--- a/apps/daemon/src/sidecar/server.ts
+++ b/apps/daemon/src/sidecar/server.ts
@@ -32,6 +32,7 @@ import {
   setDesktopAuthSecret,
   signDesktopImportToken,
 } from "../desktop-auth.js";
+import { attachParentMonitor } from "./parent-monitor-gate.js";
 
 /**
  * PR #974 round 6 (mrcfps): pure wrapper that overlays the live
@@ -48,7 +49,6 @@ export function withCurrentDesktopAuthGate(snapshot: DaemonStatusSnapshot): Daem
 
 const DAEMON_PORT_ENV = SIDECAR_ENV.DAEMON_PORT;
 const WEB_PORT_ENV = SIDECAR_ENV.WEB_PORT;
-const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 const DESKTOP_IMPORT_TOKEN_TTL_MS = 60_000;
 
 export type DaemonSidecarHandle = {
@@ -69,27 +69,6 @@ function parsePort(value: string | undefined): number {
 function parseOptionalTrustedWebPort(value: string | undefined): number | null {
   const port = parsePort(value);
   return port > 0 ? port : null;
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function attachParentMonitor(stop: () => Promise<void>): void {
-  const parentPid = Number(process.env[TOOLS_DEV_PARENT_PID_ENV]);
-  if (!Number.isInteger(parentPid) || parentPid <= 0) return;
-
-  const timer = setInterval(() => {
-    if (isProcessAlive(parentPid)) return;
-    clearInterval(timer);
-    void stop().finally(() => process.exit(0));
-  }, 1000);
-  timer.unref();
 }
 
 export function mintImportTokenForCli(baseDir: string): MintImportTokenResult {

--- a/apps/daemon/src/sidecar/server.ts
+++ b/apps/daemon/src/sidecar/server.ts
@@ -32,7 +32,7 @@ import {
   setDesktopAuthSecret,
   signDesktopImportToken,
 } from "../desktop-auth.js";
-import { attachParentMonitor } from "./parent-monitor-gate.js";
+import { attachParentMonitor, scheduleHeldDaemonExit } from "./parent-monitor-gate.js";
 
 /**
  * PR #974 round 6 (mrcfps): pure wrapper that overlays the live
@@ -98,7 +98,10 @@ export function mintImportTokenForCli(baseDir: string): MintImportTokenResult {
   };
 }
 
-export async function startDaemonSidecar(runtime: SidecarRuntimeContext<SidecarStamp>): Promise<DaemonSidecarHandle> {
+export async function startDaemonSidecar(
+  runtime: SidecarRuntimeContext<SidecarStamp>,
+  options: { exit?: (code?: number) => void } = {},
+): Promise<DaemonSidecarHandle> {
   const serverHandle: StartedDaemonRuntime = await startDaemonRuntime({
     desktopPdfExporter: async (input: DesktopExportPdfInput): Promise<DesktopExportPdfResult> => {
       const desktopIpc = resolveAppIpcPath({
@@ -184,9 +187,7 @@ export async function startDaemonSidecar(runtime: SidecarRuntimeContext<SidecarS
           // (the flag flips after REGISTER_DESKTOP_AUTH and stays sticky).
           return withCurrentDesktopAuthGate(state);
         case SIDECAR_MESSAGES.SHUTDOWN:
-          setImmediate(() => {
-            void stop().finally(() => process.exit(0));
-          });
+          scheduleHeldDaemonExit(stop, options.exit);
           return { accepted: true };
         case SIDECAR_MESSAGES.REGISTER_DESKTOP_AUTH:
           // PR #974: the desktop main process registers its per-process

--- a/apps/daemon/tests/sidecar-startup.test.ts
+++ b/apps/daemon/tests/sidecar-startup.test.ts
@@ -133,11 +133,12 @@ describe('daemon sidecar startup', () => {
     }, { exit });
 
     try {
-      await requestJsonIpc(
+      const shutdown = await requestJsonIpc(
         ipc,
         { type: SIDECAR_MESSAGES.SHUTDOWN },
         { timeoutMs: 1_000 },
       );
+      expect(shutdown).toEqual({ accepted: true, deferred: true });
       await new Promise((resolve) => setTimeout(resolve, 30));
       expect(exit).not.toHaveBeenCalled();
       expect(stopRuntime).not.toHaveBeenCalled();

--- a/apps/daemon/tests/sidecar-startup.test.ts
+++ b/apps/daemon/tests/sidecar-startup.test.ts
@@ -32,7 +32,9 @@ describe('daemon sidecar startup', () => {
 
   afterEach(async () => {
     const { resetDesktopAuthForTests } = await import('../src/desktop-auth.js');
+    const { resetParentMonitorExitHoldForTests } = await import('../src/sidecar/parent-monitor-gate.js');
     resetDesktopAuthForTests();
+    resetParentMonitorExitHoldForTests();
     delete process.env.OD_WEB_PORT;
   });
 
@@ -108,6 +110,45 @@ describe('daemon sidecar startup', () => {
       expect(process.env.OD_WEB_PORT).toBe('53421');
       expect((await handle.status()).trustedWebOriginPort).toBe(53421);
     } finally {
+      await handle.stop();
+      await handle.waitUntilStopped();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('defers explicit SHUTDOWN exit while a handoff journal hold is active', async () => {
+    const { holdParentMonitorExit } = await import('../src/sidecar/parent-monitor-gate.js');
+    const { startDaemonSidecar } = await import('../src/sidecar/server.js');
+    const root = await mkdtemp(join(tmpdir(), 'od-daemon-sidecar-shutdown-hold-'));
+    const ipc = join(root, 'daemon.sock');
+    const exit = vi.fn();
+    const release = holdParentMonitorExit();
+    const handle = await startDaemonSidecar({
+      app: APP_KEYS.DAEMON,
+      base: root,
+      ipc,
+      mode: SIDECAR_MODES.RUNTIME,
+      namespace: 'packaged-shutdown-hold',
+      source: SIDECAR_SOURCES.PACKAGED,
+    }, { exit });
+
+    try {
+      await requestJsonIpc(
+        ipc,
+        { type: SIDECAR_MESSAGES.SHUTDOWN },
+        { timeoutMs: 1_000 },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(exit).not.toHaveBeenCalled();
+      expect(stopRuntime).not.toHaveBeenCalled();
+
+      release();
+      await vi.waitFor(() => {
+        expect(exit).toHaveBeenCalledWith(0);
+      });
+      expect(stopRuntime).toHaveBeenCalled();
+    } finally {
+      release();
       await handle.stop();
       await handle.waitUntilStopped();
       await rm(root, { recursive: true, force: true });

--- a/apps/daemon/tests/sidecar-startup.test.ts
+++ b/apps/daemon/tests/sidecar-startup.test.ts
@@ -154,4 +154,57 @@ describe('daemon sidecar startup', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('defers SIGTERM exit while a handoff journal hold is active', async () => {
+    const { holdParentMonitorExit } = await import('../src/sidecar/parent-monitor-gate.js');
+    const { startDaemonSidecar } = await import('../src/sidecar/server.js');
+    const root = await mkdtemp(join(tmpdir(), 'od-daemon-sidecar-sigterm-hold-'));
+    const exit = vi.fn();
+    const release = holdParentMonitorExit();
+    const signalListeners = new Map<NodeJS.Signals, Array<(...args: unknown[]) => void>>();
+    const originalOn = process.on.bind(process);
+    const onSpy = vi.spyOn(process, 'on');
+    onSpy.mockImplementation(((event: string | symbol, listener: (...args: unknown[]) => void) => {
+      if (event === 'SIGINT' || event === 'SIGTERM') {
+        const listeners = signalListeners.get(event) ?? [];
+        listeners.push(listener);
+        signalListeners.set(event, listeners);
+        return process;
+      }
+      return originalOn(event, listener);
+    }) as typeof process.on);
+
+    try {
+      const handle = await startDaemonSidecar({
+        app: APP_KEYS.DAEMON,
+        base: root,
+        ipc: join(root, 'daemon.sock'),
+        mode: SIDECAR_MODES.RUNTIME,
+        namespace: 'packaged-sigterm-hold',
+        source: SIDECAR_SOURCES.PACKAGED,
+      }, { exit });
+
+      try {
+        const sigterm = signalListeners.get('SIGTERM')?.[0];
+        expect(sigterm).toEqual(expect.any(Function));
+        sigterm?.();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(exit).not.toHaveBeenCalled();
+        expect(stopRuntime).not.toHaveBeenCalled();
+
+        release();
+        await vi.waitFor(() => {
+          expect(exit).toHaveBeenCalledWith(0);
+        });
+        expect(stopRuntime).toHaveBeenCalled();
+      } finally {
+        release();
+        await handle.stop();
+        await handle.waitUntilStopped();
+      }
+    } finally {
+      onSpy.mockRestore();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -418,6 +418,52 @@ describe("legacy payload desktop handoff", () => {
     }
   });
 
+  it("releases the parent-monitor hold when payload desktop spawn fails", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    let disposeMonitor = () => {};
+    try {
+      let parentAlive = true;
+      let daemonExited = false;
+      disposeMonitor = attachParentMonitor(async () => undefined, {
+        env: { [SIDECAR_ENV.TOOLS_DEV_PARENT_PID]: "4321" },
+        exit: () => {
+          daemonExited = true;
+        },
+        intervalMs: 10,
+        isProcessAlive: () => parentAlive,
+      });
+      const spawn = vi.fn(() => {
+        parentAlive = false;
+        throw new Error("spawn ENOENT");
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => (
+        message === "status"
+          ? { pid: 4321, state: "running" }
+          : { accepted: true }
+      ));
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+      });
+
+      expect(result).toEqual({ kind: "aborted", reason: "spawn-failed" });
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        state: "prepared",
+      });
+      await vi.waitFor(() => {
+        expect(daemonExited).toBe(true);
+      });
+    } finally {
+      disposeMonitor();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("does not strand launcher state when the old desktop shutdown fails", async () => {
     const { launcherPaths, prepared, root } = await armedHandoffFixture();
     try {
@@ -506,6 +552,84 @@ describe("legacy payload desktop handoff", () => {
       const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
         if (message === "status") return { pid: 4321, state: "running" };
         parentAlive = false;
+        await new Promise((resolve) => setTimeout(resolve, 35));
+        return { accepted: true };
+      });
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+        writeJsonFile: persist,
+      });
+
+      expect(result).toMatchObject({
+        kind: "scheduled",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(daemonExited).toBe(false);
+      expect(persist).toHaveBeenCalledTimes(3);
+
+      const handoff = JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"));
+      const attempt = JSON.parse(await readFile(launcherPaths.attemptsPath, "utf8"));
+      const runtime = JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"));
+      expect(handoff).toMatchObject({
+        state: "armed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(selectLauncherRuntimeTarget({
+        attempted: attempt,
+        resume: handoff.target,
+        runtime,
+      })).toEqual({
+        pointer: { generation: 2, version: "1.2.3-beta.5" },
+        reason: "active-resume",
+        selected: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 35));
+      expect(daemonExited).toBe(true);
+    } finally {
+      disposeMonitor();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("commits the armed journal when the outer parent dies after payload spawn", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    let disposeMonitor = () => {};
+    try {
+      let parentAlive = true;
+      let daemonExited = false;
+      disposeMonitor = attachParentMonitor(async () => undefined, {
+        env: { [SIDECAR_ENV.TOOLS_DEV_PARENT_PID]: "4321" },
+        exit: () => {
+          daemonExited = true;
+        },
+        intervalMs: 10,
+        isProcessAlive: () => parentAlive,
+      });
+
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") {
+            parentAlive = false;
+            queueMicrotask(callback);
+          }
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      const spawn = vi.fn(() => child);
+      const persist = vi.fn(async (filePath: string, payload: unknown) => {
+        expect(daemonExited, "parent monitor exited before journal commit").toBe(false);
+        await writeJsonFile(filePath, payload);
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
+        if (message === "status") return { pid: 4321, state: "running" };
         await new Promise((resolve) => setTimeout(resolve, 35));
         return { accepted: true };
       });

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -13,6 +13,7 @@ import { readProcessStamp } from "@open-design/platform";
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_ENV,
   SIDECAR_SOURCES,
 } from "@open-design/sidecar-proto";
 import { describe, expect, it, vi } from "vitest";
@@ -149,6 +150,7 @@ describe("legacy payload desktop handoff", () => {
         env: {
           ELECTRON_RUN_AS_NODE: "1",
           OD_SIDECAR_BASE: runtimeRoot,
+          [SIDECAR_ENV.TOOLS_DEV_PARENT_PID]: "4321",
           PATH: "/usr/bin",
         },
         now: () => new Date("2026-07-15T02:00:00.000Z"),
@@ -176,6 +178,7 @@ describe("legacy payload desktop handoff", () => {
       expect(spawn).toHaveBeenCalledOnce();
       expect(launchedEnv).not.toHaveProperty("ELECTRON_RUN_AS_NODE");
       expect(launchedEnv).not.toHaveProperty("OD_SIDECAR_BASE");
+      expect(launchedEnv).not.toHaveProperty(SIDECAR_ENV.TOOLS_DEV_PARENT_PID);
       expect(launchedEnv).toMatchObject({
         OD_PACKAGED_NAMESPACE_BASE_ROOT: join(root, "namespaces"),
         PATH: "/usr/bin",

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -626,6 +626,83 @@ describe("legacy payload desktop handoff", () => {
     }
   });
 
+  it("commits the armed journal before packaged SIGTERM escalation can exit the daemon", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    try {
+      let daemonExited = false;
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") queueMicrotask(callback);
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      const spawn = vi.fn(() => child);
+      const persist = vi.fn(async (filePath: string, payload: unknown) => {
+        expect(daemonExited, "daemon SIGTERM exited before journal commit").toBe(false);
+        // closeManagedChild waits 5s then stopProcesses() sends SIGTERM. Keep
+        // each write in flight across that escalation without a real 5s sleep.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await writeJsonFile(filePath, payload);
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
+        if (message === "status") return { pid: 4321, state: "running" };
+        const exit = () => {
+          daemonExited = true;
+        };
+        scheduleHeldDaemonExit(async () => undefined, exit);
+        // Model the 5s force-stop: SIGTERM uses the same hold-aware helper as
+        // SHUTDOWN, so a write still in flight must finish first.
+        scheduleHeldDaemonExit(async () => undefined, exit);
+        return { accepted: true };
+      });
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+        writeJsonFile: persist,
+      });
+
+      expect(result).toMatchObject({
+        kind: "scheduled",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(persist).toHaveBeenCalledTimes(3);
+      expect(persist.mock.calls.map(([filePath]) => filePath)).toEqual([
+        launcherPaths.handoffPath,
+        launcherPaths.attemptsPath,
+        launcherPaths.runtimePath,
+      ]);
+
+      const handoff = JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"));
+      const attempt = JSON.parse(await readFile(launcherPaths.attemptsPath, "utf8"));
+      const runtime = JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"));
+      expect(handoff).toMatchObject({
+        state: "armed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(selectLauncherRuntimeTarget({
+        attempted: attempt,
+        resume: handoff.target,
+        runtime,
+      })).toEqual({
+        pointer: { generation: 2, version: "1.2.3-beta.5" },
+        reason: "active-resume",
+        selected: true,
+      });
+
+      await vi.waitFor(() => {
+        expect(daemonExited).toBe(true);
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("does nothing outside the packaged desktop runtime", async () => {
     await expect(prepareLegacyPayloadDesktopHandoff({
       env: {},

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -750,7 +750,7 @@ describe("legacy payload desktop handoff", () => {
     }
   });
 
-  it("commits the armed journal before packaged SIGTERM escalation can exit the daemon", async () => {
+  it("commits the armed journal before a second held SIGTERM exit runs", async () => {
     const { launcherPaths, prepared, root } = await armedHandoffFixture();
     try {
       let daemonExited = false;

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -27,6 +27,7 @@ import {
 import {
   attachParentMonitor,
   resetParentMonitorExitHoldForTests,
+  scheduleHeldDaemonExit,
 } from "../../src/sidecar/parent-monitor-gate.js";
 
 describe("legacy payload desktop handoff", () => {
@@ -547,6 +548,80 @@ describe("legacy payload desktop handoff", () => {
       expect(daemonExited).toBe(true);
     } finally {
       disposeMonitor();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("commits the armed journal before packaged sidecar SHUTDOWN can exit the daemon", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    try {
+      let daemonExited = false;
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") queueMicrotask(callback);
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      const spawn = vi.fn(() => child);
+      const persist = vi.fn(async (filePath: string, payload: unknown) => {
+        expect(daemonExited, "daemon SHUTDOWN exited before journal commit").toBe(false);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await writeJsonFile(filePath, payload);
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
+        if (message === "status") return { pid: 4321, state: "running" };
+        // Packaged desktop acks SHUTDOWN, then beforeShutdown -> sidecars.close()
+        // sends daemon SHUTDOWN. Use the same deferred-exit helper the sidecar
+        // SHUTDOWN handler uses so delayed journal writes still finish first.
+        scheduleHeldDaemonExit(async () => undefined, () => {
+          daemonExited = true;
+        });
+        return { accepted: true };
+      });
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+        writeJsonFile: persist,
+      });
+
+      expect(result).toMatchObject({
+        kind: "scheduled",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(persist).toHaveBeenCalledTimes(3);
+      expect(persist.mock.calls.map(([filePath]) => filePath)).toEqual([
+        launcherPaths.handoffPath,
+        launcherPaths.attemptsPath,
+        launcherPaths.runtimePath,
+      ]);
+
+      const handoff = JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"));
+      const attempt = JSON.parse(await readFile(launcherPaths.attemptsPath, "utf8"));
+      const runtime = JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"));
+      expect(handoff).toMatchObject({
+        state: "armed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(selectLauncherRuntimeTarget({
+        attempted: attempt,
+        resume: handoff.target,
+        runtime,
+      })).toEqual({
+        pointer: { generation: 2, version: "1.2.3-beta.5" },
+        reason: "active-resume",
+        selected: true,
+      });
+
+      await vi.waitFor(() => {
+        expect(daemonExited).toBe(true);
+      });
+    } finally {
       await rm(root, { force: true, recursive: true });
     }
   });

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -8,22 +8,32 @@ import {
   parseLauncherHandoffResumeArgs,
   resolveLauncherPaths,
   resolveLauncherVersionPaths,
+  selectLauncherRuntimeTarget,
 } from "@open-design/launcher-proto";
 import { readProcessStamp } from "@open-design/platform";
+import { writeJsonFile } from "@open-design/sidecar";
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_ENV,
   SIDECAR_SOURCES,
 } from "@open-design/sidecar-proto";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   executeLegacyPayloadDesktopHandoff,
   prepareLegacyPayloadDesktopHandoff,
 } from "../../src/sidecar/payload-desktop-handoff.js";
+import {
+  attachParentMonitor,
+  resetParentMonitorExitHoldForTests,
+} from "../../src/sidecar/parent-monitor-gate.js";
 
 describe("legacy payload desktop handoff", () => {
+  afterEach(() => {
+    resetParentMonitorExitHoldForTests();
+  });
+
   it("captures the real previous pointer before old outer confirm, then arms and launches payload desktop", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-daemon-payload-handoff-"));
     try {
@@ -461,6 +471,82 @@ describe("legacy payload desktop handoff", () => {
       });
       expect(retry.kind).toBe("prepared");
     } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("commits the armed journal when the outer parent dies at shutdown acknowledgement", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    let disposeMonitor = () => {};
+    try {
+      let parentAlive = true;
+      let daemonExited = false;
+      disposeMonitor = attachParentMonitor(async () => undefined, {
+        env: { [SIDECAR_ENV.TOOLS_DEV_PARENT_PID]: "4321" },
+        exit: () => {
+          daemonExited = true;
+        },
+        intervalMs: 10,
+        isProcessAlive: () => parentAlive,
+      });
+
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") queueMicrotask(callback);
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      const spawn = vi.fn(() => child);
+      const persist = vi.fn(async (filePath: string, payload: unknown) => {
+        expect(daemonExited, "parent monitor exited before journal commit").toBe(false);
+        await writeJsonFile(filePath, payload);
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
+        if (message === "status") return { pid: 4321, state: "running" };
+        parentAlive = false;
+        await new Promise((resolve) => setTimeout(resolve, 35));
+        return { accepted: true };
+      });
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+        writeJsonFile: persist,
+      });
+
+      expect(result).toMatchObject({
+        kind: "scheduled",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(daemonExited).toBe(false);
+      expect(persist).toHaveBeenCalledTimes(3);
+
+      const handoff = JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"));
+      const attempt = JSON.parse(await readFile(launcherPaths.attemptsPath, "utf8"));
+      const runtime = JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"));
+      expect(handoff).toMatchObject({
+        state: "armed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(selectLauncherRuntimeTarget({
+        attempted: attempt,
+        resume: handoff.target,
+        runtime,
+      })).toEqual({
+        pointer: { generation: 2, version: "1.2.3-beta.5" },
+        reason: "active-resume",
+        selected: true,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 35));
+      expect(daemonExited).toBe(true);
+    } finally {
+      disposeMonitor();
       await rm(root, { force: true, recursive: true });
     }
   });

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -24,8 +24,11 @@ import {
   type SidecarRuntimeContext,
 } from "@open-design/sidecar";
 import {
+  collectProcessTreePids,
   createProcessStampArgs,
   isProcessAlive,
+  listProcessSnapshots,
+  matchesStampedProcess,
   mergeProxyAwareEnv,
   resolveSystemProxyEnv,
   stopProcesses,
@@ -562,6 +565,37 @@ export async function waitForStatus<T>(
   }
 }
 
+async function stopStampedWebSidecarOwner(ipcPath: string, logPath: string): Promise<void> {
+  const processes = await listProcessSnapshots();
+  const rootPids = processes
+    .filter((processInfo) =>
+      matchesStampedProcess(
+        processInfo,
+        { app: APP_KEYS.WEB, ipc: ipcPath },
+        OPEN_DESIGN_SIDECAR_CONTRACT,
+      ),
+    )
+    .map((processInfo) => processInfo.pid);
+  if (rootPids.length === 0) return;
+
+  // Stop the whole tree before unlinking. A later SIGTERM on the old owner
+  // would run JsonIpcServer.close(), which unconditionally removes this
+  // pathname and can delete the replacement socket after rebind.
+  const pids = collectProcessTreePids(processes, rootPids);
+  await appendSidecarLifecycleLog(
+    logPath,
+    `[open-design packaged] stopping unresponsive stamped web sidecar before socket takeover ipc=${ipcPath} pids=${pids.join(",")}`,
+  );
+  try {
+    await stopProcesses(pids, { killGraceMs: 1_500, termGraceMs: 1_500 });
+  } catch (error) {
+    await appendSidecarLifecycleLog(
+      logPath,
+      `[open-design packaged] failed to stop unresponsive stamped web sidecar ipc=${ipcPath} error=${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 export async function retireExistingSidecarEndpoint(
   ipcPath: string,
   logPath: string,
@@ -583,6 +617,7 @@ export async function retireExistingSidecarEndpoint(
     // is safe; daemon recovery remains conservative because starting a second
     // daemon beside a hung first owner could put two writers on the same DB.
     if (app !== APP_KEYS.WEB || isWindowsNamedPipePath(ipcPath)) return;
+    await stopStampedWebSidecarOwner(ipcPath, logPath);
     try {
       const stat = await lstat(ipcPath);
       if (!stat.isSocket()) return;

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -565,8 +565,21 @@ export async function waitForStatus<T>(
   }
 }
 
-async function stopStampedWebSidecarOwner(ipcPath: string, logPath: string): Promise<void> {
-  const processes = await listProcessSnapshots();
+type StopStampedWebSidecarOwnerDeps = {
+  listProcessSnapshots?: typeof listProcessSnapshots;
+  stopProcesses?: typeof stopProcesses;
+};
+
+type StampedWebSidecarRetirement = "absent" | "stopped" | "still-running";
+
+async function stopStampedWebSidecarOwner(
+  ipcPath: string,
+  logPath: string,
+  deps: StopStampedWebSidecarOwnerDeps = {},
+): Promise<StampedWebSidecarRetirement> {
+  const listSnapshots = deps.listProcessSnapshots ?? listProcessSnapshots;
+  const stop = deps.stopProcesses ?? stopProcesses;
+  const processes = await listSnapshots();
   const rootPids = processes
     .filter((processInfo) =>
       matchesStampedProcess(
@@ -576,7 +589,10 @@ async function stopStampedWebSidecarOwner(ipcPath: string, logPath: string): Pro
       ),
     )
     .map((processInfo) => processInfo.pid);
-  if (rootPids.length === 0) return;
+  // No stamped owner: leftover or unstamped hung socket. Unlink remains the
+  // original recovery. A live JsonIpcServer.close() race requires a stamped
+  // sidecar, which this helper would have found.
+  if (rootPids.length === 0) return "absent";
 
   // Stop the whole tree before unlinking. A later SIGTERM on the old owner
   // would run JsonIpcServer.close(), which unconditionally removes this
@@ -587,12 +603,21 @@ async function stopStampedWebSidecarOwner(ipcPath: string, logPath: string): Pro
     `[open-design packaged] stopping unresponsive stamped web sidecar before socket takeover ipc=${ipcPath} pids=${pids.join(",")}`,
   );
   try {
-    await stopProcesses(pids, { killGraceMs: 1_500, termGraceMs: 1_500 });
+    const result = await stop(pids, { killGraceMs: 1_500, termGraceMs: 1_500 });
+    if (result.remainingPids.length > 0) {
+      await appendSidecarLifecycleLog(
+        logPath,
+        `[open-design packaged] unresponsive stamped web sidecar still running after stop ipc=${ipcPath} remainingPids=${result.remainingPids.join(",")}`,
+      );
+      return "still-running";
+    }
+    return "stopped";
   } catch (error) {
     await appendSidecarLifecycleLog(
       logPath,
       `[open-design packaged] failed to stop unresponsive stamped web sidecar ipc=${ipcPath} error=${error instanceof Error ? error.message : String(error)}`,
     );
+    return "still-running";
   }
 }
 
@@ -600,6 +625,7 @@ export async function retireExistingSidecarEndpoint(
   ipcPath: string,
   logPath: string,
   app: AppKey,
+  deps: StopStampedWebSidecarOwnerDeps = {},
 ): Promise<void> {
   let status: { pid?: number | null } | null = null;
   try {
@@ -617,7 +643,8 @@ export async function retireExistingSidecarEndpoint(
     // is safe; daemon recovery remains conservative because starting a second
     // daemon beside a hung first owner could put two writers on the same DB.
     if (app !== APP_KEYS.WEB || isWindowsNamedPipePath(ipcPath)) return;
-    await stopStampedWebSidecarOwner(ipcPath, logPath);
+    const retirement = await stopStampedWebSidecarOwner(ipcPath, logPath, deps);
+    if (retirement === "still-running") return;
     try {
       const stat = await lstat(ipcPath);
       if (!stat.isSocket()) return;

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -13,6 +13,7 @@ import {
   type AppKey,
   type DaemonStatusSnapshot,
   type RegisterWebUrlResult,
+  type ShutdownResult,
   type SidecarStamp,
   type WebStatusSnapshot,
 } from "@open-design/sidecar-proto";
@@ -34,6 +35,7 @@ import {
   stopProcesses,
   waitForProcessExit,
   wellKnownUserToolchainBins,
+  type StopProcessesOptions,
 } from "@open-design/platform";
 
 import type { PackagedWebOutputMode } from "./config.js";
@@ -113,7 +115,7 @@ export type PackagedSidecarHandle = {
   web: WebStatusSnapshot;
 };
 
-type ManagedSidecarChild = {
+export type ManagedSidecarChild = {
   app: AppKey;
   child: ChildProcess;
   ipcPath: string;
@@ -951,18 +953,50 @@ export function createPackagedSidecarSpawnOptions(input: {
   };
 }
 
-async function closeManagedChild(child: ManagedSidecarChild): Promise<void> {
+export const MANAGED_CHILD_EXIT_GRACE_MS = 5_000;
+export const DEFERRED_MANAGED_CHILD_EXIT_GRACE_MS = 30_000;
+
+export type CloseManagedChildDeps = {
+  deferredExitGraceMs?: number;
+  exitGraceMs?: number;
+  requestIpc?: typeof requestJsonIpc;
+  stopOptions?: StopProcessesOptions;
+  stopProcesses?: typeof stopProcesses;
+  waitForExit?: typeof waitForProcessExit;
+};
+
+export function resolveManagedChildExitGraceMs(
+  shutdown: ShutdownResult | null | undefined,
+): number {
+  return shutdown?.deferred === true
+    ? DEFERRED_MANAGED_CHILD_EXIT_GRACE_MS
+    : MANAGED_CHILD_EXIT_GRACE_MS;
+}
+
+export async function closeManagedChild(
+  child: ManagedSidecarChild,
+  deps: CloseManagedChildDeps = {},
+): Promise<void> {
   const appendLifecycleLog = async (message: string): Promise<void> => appendSidecarLifecycleLog(child.logPath, message);
   await appendLifecycleLog(`[open-design packaged] shutdown requested app=${child.app} pid=${child.child.pid ?? "unknown"}`);
+  let shutdown: ShutdownResult | undefined;
   try {
-    await requestJsonIpc(child.ipcPath, { type: SIDECAR_MESSAGES.SHUTDOWN }, { timeoutMs: 1200 });
+    shutdown = await (deps.requestIpc ?? requestJsonIpc)<ShutdownResult>(
+      child.ipcPath,
+      { type: SIDECAR_MESSAGES.SHUTDOWN },
+      { timeoutMs: 1200 },
+    );
   } catch {
     // Fall through to process cleanup.
   }
 
-  if (!(await waitForProcessExit(child.child.pid, 5000))) {
+  const exitGraceMs = shutdown?.deferred === true
+    ? (deps.deferredExitGraceMs ?? resolveManagedChildExitGraceMs(shutdown))
+    : (deps.exitGraceMs ?? resolveManagedChildExitGraceMs(shutdown));
+
+  if (!(await (deps.waitForExit ?? waitForProcessExit)(child.child.pid, exitGraceMs))) {
     await appendLifecycleLog(`[open-design packaged] shutdown timeout app=${child.app} pid=${child.child.pid ?? "unknown"}; forcing stop`);
-    await stopProcesses([child.child.pid]);
+    await (deps.stopProcesses ?? stopProcesses)([child.child.pid], deps.stopOptions);
   }
 
   await appendLifecycleLog(`[open-design packaged] exited app=${child.app} pid=${child.child.pid ?? "unknown"} code=${child.child.exitCode ?? "unknown"} signal=${child.child.signalCode ?? "none"}`);

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { access, appendFile, mkdir, open, rename, type FileHandle } from "node:fs/promises";
+import { access, appendFile, lstat, mkdir, open, rename, rm, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -18,6 +18,7 @@ import {
 } from "@open-design/sidecar-proto";
 import {
   createSidecarLaunchEnv,
+  isWindowsNamedPipePath,
   requestJsonIpc,
   resolveAppIpcPath,
   type SidecarRuntimeContext,
@@ -561,7 +562,11 @@ export async function waitForStatus<T>(
   }
 }
 
-async function retireExistingSidecarEndpoint(ipcPath: string, logPath: string): Promise<void> {
+export async function retireExistingSidecarEndpoint(
+  ipcPath: string,
+  logPath: string,
+  app: AppKey,
+): Promise<void> {
   let status: { pid?: number | null } | null = null;
   try {
     status = await requestJsonIpc<{ pid?: number | null }>(
@@ -569,7 +574,30 @@ async function retireExistingSidecarEndpoint(ipcPath: string, logPath: string): 
       { type: SIDECAR_MESSAGES.STATUS },
       { timeoutMs: 350 },
     );
-  } catch {
+  } catch (error) {
+    // A web sidecar can survive an abruptly-terminated desktop while becoming
+    // too wedged to answer STATUS. A plain connect probe still sees its Unix
+    // socket as live, so the generic JSON-IPC stale-socket cleanup cannot
+    // distinguish it from a healthy endpoint and the replacement dies with
+    // EADDRINUSE. Web is stateless, so taking over this exact namespace socket
+    // is safe; daemon recovery remains conservative because starting a second
+    // daemon beside a hung first owner could put two writers on the same DB.
+    if (app !== APP_KEYS.WEB || isWindowsNamedPipePath(ipcPath)) return;
+    try {
+      const stat = await lstat(ipcPath);
+      if (!stat.isSocket()) return;
+      await rm(ipcPath, { force: true });
+      const message =
+        `[open-design packaged] unresponsive web sidecar endpoint removed before relaunch ipc=${ipcPath} error=${error instanceof Error ? error.message : String(error)}`;
+      await appendSidecarLifecycleLog(logPath, message);
+      // The child log handle is already open and may overwrite a pre-spawn
+      // append from offset zero. Also emit through the packaged desktop logger,
+      // whose append-only file is the durable startup-recovery record.
+      console.warn(message);
+    } catch {
+      // ENOENT means the endpoint disappeared during the probe. Other failures
+      // are left for the real bind to report without deleting an unknown path.
+    }
     return;
   }
 
@@ -630,9 +658,16 @@ export function resolvePackagedChildBaseEnv(
       forwardedEnv[key] = value;
     }
   }
-  return includeSystemProxyEnv
+  const mergedEnv = includeSystemProxyEnv
     ? mergeProxyAwareEnv(process.platform, systemProxyEnv, forwardedEnv)
     : mergeProxyAwareEnv(process.platform, forwardedEnv);
+  return {
+    ...mergedEnv,
+    // Daemon and web already monitor this protocol-owned parent PID. Packaged
+    // launches must provide it too so a SIGKILL/crash of the Electron owner
+    // cannot leave sidecars holding namespace IPC endpoints indefinitely.
+    [SIDECAR_ENV.TOOLS_DEV_PARENT_PID]: String(process.pid),
+  };
 }
 
 function createPackagedDaemonManagedPathEnv(
@@ -778,7 +813,7 @@ async function spawnSidecarChild(options: {
   } satisfies SidecarStamp;
   const logPath = logPathFor(options.paths, options.app);
   const logHandle = await openLog(logPath);
-  await retireExistingSidecarEndpoint(ipcPath, logPath);
+  await retireExistingSidecarEndpoint(ipcPath, logPath, options.app);
   const usesElectronAsNode = options.nodeCommand == null;
   const command = options.nodeCommand
     ?? options.electronNodeCommand

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -570,7 +570,7 @@ type StopStampedWebSidecarOwnerDeps = {
   stopProcesses?: typeof stopProcesses;
 };
 
-type StampedWebSidecarRetirement = "absent" | "stopped" | "still-running";
+type StampedWebSidecarRetirement = "absent" | "stopped" | "still-running" | "discovery-failed";
 
 async function stopStampedWebSidecarOwner(
   ipcPath: string,
@@ -579,7 +579,25 @@ async function stopStampedWebSidecarOwner(
 ): Promise<StampedWebSidecarRetirement> {
   const listSnapshots = deps.listProcessSnapshots ?? listProcessSnapshots;
   const stop = deps.stopProcesses ?? stopProcesses;
-  const processes = await listSnapshots();
+  let processes: Awaited<ReturnType<typeof listProcessSnapshots>>;
+  try {
+    processes = await listSnapshots();
+  } catch (error) {
+    await appendSidecarLifecycleLog(
+      logPath,
+      `[open-design packaged] failed to enumerate processes before web socket takeover ipc=${ipcPath} error=${error instanceof Error ? error.message : String(error)}`,
+    );
+    return "discovery-failed";
+  }
+  // listProcessSnapshots returns [] on enumeration failure, so an empty table
+  // is not proof that no stamped owner exists. Leave the live socket in place.
+  if (processes.length === 0) {
+    await appendSidecarLifecycleLog(
+      logPath,
+      `[open-design packaged] process discovery failed before web socket takeover ipc=${ipcPath}`,
+    );
+    return "discovery-failed";
+  }
   const rootPids = processes
     .filter((processInfo) =>
       matchesStampedProcess(
@@ -589,9 +607,9 @@ async function stopStampedWebSidecarOwner(
       ),
     )
     .map((processInfo) => processInfo.pid);
-  // No stamped owner: leftover or unstamped hung socket. Unlink remains the
-  // original recovery. A live JsonIpcServer.close() race requires a stamped
-  // sidecar, which this helper would have found.
+  // Successful discovery, no stamped owner: leftover or unstamped hung socket.
+  // Unlink remains the original recovery. A live JsonIpcServer.close() race
+  // requires a stamped sidecar, which this helper would have found.
   if (rootPids.length === 0) return "absent";
 
   // Stop the whole tree before unlinking. A later SIGTERM on the old owner
@@ -644,7 +662,7 @@ export async function retireExistingSidecarEndpoint(
     // daemon beside a hung first owner could put two writers on the same DB.
     if (app !== APP_KEYS.WEB || isWindowsNamedPipePath(ipcPath)) return;
     const retirement = await stopStampedWebSidecarOwner(ipcPath, logPath, deps);
-    if (retirement === "still-running") return;
+    if (retirement === "still-running" || retirement === "discovery-failed") return;
     try {
       const stat = await lstat(ipcPath);
       if (!stat.isSocket()) return;

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -23,7 +23,7 @@ import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createProcessStampArgs, isProcessAlive, waitForProcessExit } from '@open-design/platform';
+import { createProcessStampArgs, isProcessAlive, stopProcesses, waitForProcessExit } from '@open-design/platform';
 import { createJsonIpcServer, resolveAppIpcPath } from '@open-design/sidecar';
 import {
   APP_KEYS,
@@ -35,11 +35,15 @@ import {
 
 import {
   buildPackagedDaemonSpawnEnv,
+  closeManagedChild,
   createPackagedSidecarSpawnOptions,
   createRestartPolicy,
   createWebSidecarSupervisor,
+  DEFERRED_MANAGED_CHILD_EXIT_GRACE_MS,
+  MANAGED_CHILD_EXIT_GRACE_MS,
   openLog,
   registerPackagedWebUrl,
+  resolveManagedChildExitGraceMs,
   retireExistingSidecarEndpoint,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
@@ -1464,3 +1468,156 @@ describe('packaged sidecar log rotation', () => {
     }
   });
 });
+
+describe('packaged managed-child shutdown grace', () => {
+  it('keeps the ordinary 5s grace unless shutdown is deferred', () => {
+    expect(resolveManagedChildExitGraceMs(undefined)).toBe(MANAGED_CHILD_EXIT_GRACE_MS);
+    expect(resolveManagedChildExitGraceMs({ accepted: true })).toBe(MANAGED_CHILD_EXIT_GRACE_MS);
+    expect(resolveManagedChildExitGraceMs({ accepted: true, deferred: false })).toBe(
+      MANAGED_CHILD_EXIT_GRACE_MS,
+    );
+    expect(resolveManagedChildExitGraceMs({ accepted: true, deferred: true })).toBe(
+      DEFERRED_MANAGED_CHILD_EXIT_GRACE_MS,
+    );
+  });
+});
+
+describe.runIf(process.platform !== 'win32')(
+  'packaged deferred shutdown vs stopProcesses SIGKILL',
+  () => {
+    const journalNames = ['handoff.json', 'attempts.json', 'runtime.json'] as const;
+
+    async function spawnSlowJournalChild(journalDir: string, writeDelayMs: number): Promise<{
+      child: ChildProcess;
+      pid: number;
+    }> {
+      mkdirSync(journalDir, { recursive: true });
+      const child = spawn(
+        process.execPath,
+        [
+          '-e',
+          [
+            "process.on('SIGTERM',()=>{});",
+            "const fs=require('fs');",
+            "const path=require('path');",
+            "const dir=process.env.OD_TEST_JOURNAL_DIR;",
+            "const delay=Number(process.env.OD_TEST_WRITE_DELAY_MS);",
+            "const files=['handoff.json','attempts.json','runtime.json'];",
+            '(async()=>{',
+            '  for (const file of files) {',
+            '    await new Promise((resolve)=>setTimeout(resolve, delay));',
+            "    fs.writeFileSync(path.join(dir, file), JSON.stringify({ committed: file }) + '\\n');",
+            '  }',
+            '})();',
+            'setInterval(()=>{}, 1000);',
+          ].join(''),
+        ],
+        {
+          env: {
+            ...process.env,
+            OD_TEST_JOURNAL_DIR: journalDir,
+            OD_TEST_WRITE_DELAY_MS: String(writeDelayMs),
+          },
+          stdio: 'ignore',
+        },
+      );
+      const pid = child.pid;
+      if (pid == null) {
+        child.kill('SIGKILL');
+        throw new Error('slow journal child did not start');
+      }
+      return { child, pid };
+    }
+
+    function committedJournalCount(journalDir: string): number {
+      return journalNames.filter((name) => existsSync(join(journalDir, name))).length;
+    }
+
+    it('lets real stopProcesses SIGKILL truncate a non-deferred journal', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'od-packaged-sigkill-trunc-'));
+      const ipcPath = join(root, 'daemon.sock');
+      const logPath = join(root, 'daemon.log');
+      const journalDir = join(root, 'journal');
+      const server = await createJsonIpcServer({
+        socketPath: ipcPath,
+        handler: async () => ({ accepted: true }),
+      });
+      const { child, pid } = await spawnSlowJournalChild(journalDir, 200);
+      const logHandle = await openLog(logPath);
+      let stopResult: Awaited<ReturnType<typeof stopProcesses>> | undefined;
+
+      try {
+        await closeManagedChild(
+          {
+            app: APP_KEYS.DAEMON,
+            child,
+            ipcPath,
+            logHandle,
+            logPath,
+          },
+          {
+            exitGraceMs: 0,
+            stopOptions: { killGraceMs: 1_000, termGraceMs: 0 },
+            stopProcesses: async (pids, options) => {
+              stopResult = await stopProcesses(pids, options);
+              return stopResult;
+            },
+          },
+        );
+
+        expect(committedJournalCount(journalDir)).toBeLessThan(journalNames.length);
+        expect(stopResult?.forcedPids).toContain(pid);
+        expect(isProcessAlive(pid)).toBe(false);
+      } finally {
+        child.kill('SIGKILL');
+        await waitForProcessExit(pid, 1_000);
+        await server.close();
+        rmSync(root, { recursive: true, force: true });
+      }
+    }, 10_000);
+
+    it('commits all three journal files before deferred stopProcesses SIGKILL', async () => {
+      const root = mkdtempSync(join(tmpdir(), 'od-packaged-sigkill-hold-'));
+      const ipcPath = join(root, 'daemon.sock');
+      const logPath = join(root, 'daemon.log');
+      const journalDir = join(root, 'journal');
+      const server = await createJsonIpcServer({
+        socketPath: ipcPath,
+        handler: async () => ({ accepted: true, deferred: true }),
+      });
+      const { child, pid } = await spawnSlowJournalChild(journalDir, 100);
+      const logHandle = await openLog(logPath);
+      let stopResult: Awaited<ReturnType<typeof stopProcesses>> | undefined;
+
+      try {
+        await closeManagedChild(
+          {
+            app: APP_KEYS.DAEMON,
+            child,
+            ipcPath,
+            logHandle,
+            logPath,
+          },
+          {
+            deferredExitGraceMs: 1_500,
+            exitGraceMs: 0,
+            stopOptions: { killGraceMs: 1_000, termGraceMs: 0 },
+            stopProcesses: async (pids, options) => {
+              stopResult = await stopProcesses(pids, options);
+              return stopResult;
+            },
+          },
+        );
+
+        expect(committedJournalCount(journalDir)).toBe(journalNames.length);
+        expect(stopResult?.forcedPids).toContain(pid);
+        expect(isProcessAlive(pid)).toBe(false);
+      } finally {
+        child.kill('SIGKILL');
+        await waitForProcessExit(pid, 1_000);
+        await server.close();
+        rmSync(root, { recursive: true, force: true });
+      }
+    }, 10_000);
+  },
+);

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -15,6 +15,7 @@
  * @see apps/daemon/src/legacy-data-migrator.ts
  * @see https://github.com/nexu-io/open-design/issues/710
  */
+import { spawn, type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Socket } from 'node:net';
@@ -22,8 +23,15 @@ import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
+import { createProcessStampArgs, isProcessAlive, waitForProcessExit } from '@open-design/platform';
 import { createJsonIpcServer, resolveAppIpcPath } from '@open-design/sidecar';
-import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT, SIDECAR_ENV } from '@open-design/sidecar-proto';
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_ENV,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+} from '@open-design/sidecar-proto';
 
 import {
   buildPackagedDaemonSpawnEnv,
@@ -43,6 +51,46 @@ import type { PackagedNamespacePaths } from '../src/paths.js';
 
 function slashPath(value: string): string {
   return value.replaceAll('\\', '/');
+}
+
+async function spawnStampedHungWebOwner(
+  socketPath: string,
+  ipcPath = socketPath,
+): Promise<{ child: ChildProcess; pid: number }> {
+  const stamp = {
+    app: APP_KEYS.WEB,
+    ipc: ipcPath,
+    mode: SIDECAR_MODES.RUNTIME,
+    namespace: 'packaged-stale-web-test',
+    source: SIDECAR_SOURCES.PACKAGED,
+  };
+  const child = spawn(
+    process.execPath,
+    [
+      '-e',
+      "process.on('SIGTERM',()=>{});require('net').createServer(s=>s.resume()).listen(process.env.OD_TEST_SOCK,()=>process.stdout.write('ready\\n'));setInterval(()=>{},1000)",
+      '--',
+      ...createProcessStampArgs(stamp, OPEN_DESIGN_SIDECAR_CONTRACT),
+    ],
+    {
+      env: { ...process.env, OD_TEST_SOCK: socketPath },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const pid = child.pid;
+  if (pid == null) throw new Error('test child did not start');
+  await new Promise<void>((resolve, reject) => {
+    const fail = (error: Error): void => {
+      child.kill('SIGKILL');
+      reject(error);
+    };
+    child.once('error', fail);
+    child.once('exit', (code, signal) => {
+      fail(new Error(`stamped hung web owner exited before ready code=${code} signal=${signal}`));
+    });
+    child.stdout?.once('data', () => resolve());
+  });
+  return { child, pid };
 }
 
 describe('resolveDaemonStatusTimeoutMs', () => {
@@ -359,6 +407,67 @@ describe.runIf(process.platform !== 'win32')('packaged stale web endpoint recove
       rmSync(root, { force: true, recursive: true });
     }
   });
+
+  it('stops the stamped web owner before unlinking its unresponsive socket', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-owner-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { child, pid } = await spawnStampedHungWebOwner(socketPath);
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB);
+      expect(isProcessAlive(pid)).toBe(false);
+      expect(existsSync(socketPath)).toBe(false);
+      expect(readFileSync(logPath, 'utf8')).toContain(
+        'stopping unresponsive stamped web sidecar before socket takeover',
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('unresponsive web sidecar endpoint removed before relaunch'),
+      );
+    } finally {
+      warn.mockRestore();
+      child.kill('SIGKILL');
+      await waitForProcessExit(pid, 1_000);
+      rmSync(root, { force: true, recursive: true });
+    }
+  }, 10_000);
+
+  it('does not stop a stamped web owner of a different ipc path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-other-'));
+    const ownerSocketPath = join(root, 'owner.sock');
+    const targetSocketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const sockets = new Set<Socket>();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { child, pid } = await spawnStampedHungWebOwner(ownerSocketPath);
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.resume();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(targetSocketPath, () => {
+        server.off('error', rejectListen);
+        resolveListen();
+      });
+    });
+
+    try {
+      await retireExistingSidecarEndpoint(targetSocketPath, logPath, APP_KEYS.WEB);
+      expect(isProcessAlive(pid)).toBe(true);
+      expect(existsSync(ownerSocketPath)).toBe(true);
+      expect(existsSync(targetSocketPath)).toBe(false);
+    } finally {
+      warn.mockRestore();
+      child.kill('SIGKILL');
+      await waitForProcessExit(pid, 1_000);
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      rmSync(root, { force: true, recursive: true });
+    }
+  }, 10_000);
 
   it('does not unlink an unresponsive daemon socket', async () => {
     const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-daemon-'));

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -433,6 +433,62 @@ describe.runIf(process.platform !== 'win32')('packaged stale web endpoint recove
     }
   }, 10_000);
 
+  it('does not unlink when the stamped web owner survives stopProcesses', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-remaining-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { child, pid } = await spawnStampedHungWebOwner(socketPath);
+    const stopProcesses = vi.fn(async () => ({
+      alreadyStopped: false,
+      forcedPids: [],
+      matchedPids: [pid],
+      remainingPids: [pid],
+      stoppedPids: [],
+    }));
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB, { stopProcesses });
+      expect(isProcessAlive(pid)).toBe(true);
+      expect(existsSync(socketPath)).toBe(true);
+      expect(readFileSync(logPath, 'utf8')).toContain(
+        'unresponsive stamped web sidecar still running after stop',
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      child.kill('SIGKILL');
+      await waitForProcessExit(pid, 1_000);
+      rmSync(root, { force: true, recursive: true });
+    }
+  }, 10_000);
+
+  it('does not unlink when stopping the stamped web owner throws', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-stop-throw-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { child, pid } = await spawnStampedHungWebOwner(socketPath);
+    const stopProcesses = vi.fn(async () => {
+      throw new Error('stop-failed');
+    });
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB, { stopProcesses });
+      expect(isProcessAlive(pid)).toBe(true);
+      expect(existsSync(socketPath)).toBe(true);
+      expect(readFileSync(logPath, 'utf8')).toContain(
+        'failed to stop unresponsive stamped web sidecar',
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      child.kill('SIGKILL');
+      await waitForProcessExit(pid, 1_000);
+      rmSync(root, { force: true, recursive: true });
+    }
+  }, 10_000);
+
   it('does not stop a stamped web owner of a different ipc path', async () => {
     const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-other-'));
     const ownerSocketPath = join(root, 'owner.sock');

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -16,13 +16,14 @@
  * @see https://github.com/nexu-io/open-design/issues/710
  */
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createJsonIpcServer, resolveAppIpcPath } from '@open-design/sidecar';
-import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT } from '@open-design/sidecar-proto';
+import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT, SIDECAR_ENV } from '@open-design/sidecar-proto';
 
 import {
   buildPackagedDaemonSpawnEnv,
@@ -31,6 +32,7 @@ import {
   createWebSidecarSupervisor,
   openLog,
   registerPackagedWebUrl,
+  retireExistingSidecarEndpoint,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
@@ -146,6 +148,12 @@ describe('packaged web URL registration', () => {
 });
 
 describe('packaged child Vite+ environment forwarding', () => {
+  it('pins packaged sidecars to the packaged desktop parent process', () => {
+    const env = resolvePackagedChildBaseEnv({}, false, {}, false);
+
+    expect(env[SIDECAR_ENV.TOOLS_DEV_PARENT_PID]).toBe(String(process.pid));
+  });
+
   it('forwards CODEX_HOME so isolated and managed Codex installs never fall back to another user config', () => {
     const env = resolvePackagedChildBaseEnv({
       CODEX_HOME: '/tmp/isolated-codex-home',
@@ -314,6 +322,69 @@ describe('packaged child Vite+ environment forwarding', () => {
       if (originalVpHome == null) delete process.env.VP_HOME;
       else process.env.VP_HOME = originalVpHome;
       rmSync(vpHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe.runIf(process.platform !== 'win32')('packaged stale web endpoint recovery', () => {
+  it('unlinks a web socket whose owner accepts connections but never answers IPC', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const sockets = new Set<Socket>();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.resume();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(socketPath, () => {
+        server.off('error', rejectListen);
+        resolveListen();
+      });
+    });
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB);
+      expect(existsSync(socketPath)).toBe(false);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('unresponsive web sidecar endpoint removed before relaunch'),
+      );
+    } finally {
+      warn.mockRestore();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('does not unlink an unresponsive daemon socket', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-daemon-'));
+    const socketPath = join(root, 'daemon.sock');
+    const logPath = join(root, 'daemon.log');
+    const sockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.resume();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(socketPath, () => {
+        server.off('error', rejectListen);
+        resolveListen();
+      });
+    });
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.DAEMON);
+      expect(existsSync(socketPath)).toBe(true);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      rmSync(root, { force: true, recursive: true });
     }
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -463,6 +463,78 @@ describe.runIf(process.platform !== 'win32')('packaged stale web endpoint recove
     }
   }, 10_000);
 
+  it('does not unlink when process discovery returns no snapshots', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-empty-list-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const sockets = new Set<Socket>();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.resume();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(socketPath, () => {
+        server.off('error', rejectListen);
+        resolveListen();
+      });
+    });
+    const listProcessSnapshots = vi.fn(async () => []);
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB, { listProcessSnapshots });
+      expect(existsSync(socketPath)).toBe(true);
+      expect(readFileSync(logPath, 'utf8')).toContain(
+        'process discovery failed before web socket takeover',
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('does not unlink when process discovery throws', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-list-throw-'));
+    const socketPath = join(root, 'web.sock');
+    const logPath = join(root, 'web.log');
+    const sockets = new Set<Socket>();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.resume();
+    });
+    await new Promise<void>((resolveListen, rejectListen) => {
+      server.once('error', rejectListen);
+      server.listen(socketPath, () => {
+        server.off('error', rejectListen);
+        resolveListen();
+      });
+    });
+    const listProcessSnapshots = vi.fn(async () => {
+      throw new Error('ps-failed');
+    });
+
+    try {
+      await retireExistingSidecarEndpoint(socketPath, logPath, APP_KEYS.WEB, { listProcessSnapshots });
+      expect(existsSync(socketPath)).toBe(true);
+      expect(readFileSync(logPath, 'utf8')).toContain(
+        'failed to enumerate processes before web socket takeover',
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it('does not unlink when stopping the stamped web owner throws', async () => {
     const root = mkdtempSync(join(tmpdir(), 'od-packaged-stale-web-stop-throw-'));
     const socketPath = join(root, 'web.sock');

--- a/packages/sidecar-proto/src/index.ts
+++ b/packages/sidecar-proto/src/index.ts
@@ -596,6 +596,12 @@ export type DesktopSidecarMessage =
 
 export type ShutdownResult = {
   accepted: true;
+  /**
+   * When true, the sidecar accepted shutdown but is holding process exit for
+   * critical work (for example a handoff journal commit). The owner should
+   * wait a longer bounded grace for self-exit before force-stopping.
+   */
+  deferred?: boolean;
 };
 
 export type SidecarStamp = {


### PR DESCRIPTION
Partially addresses #4441

## Why

A local stable packaged client repeatedly exited during startup after an older next-server process survived and kept the namespace web socket open without answering sidecar IPC. The replacement web sidecar then failed with EADDRINUSE, while the desktop surfaced only a startup timeout and quit.

This change hardens packaged startup against that stale-owner state and prevents normal Electron crashes or forced exits from leaving future daemon and web sidecars orphaned.

## What users will see

Packaged clients recover automatically when an unresponsive web sidecar still owns the namespace Unix socket. Relaunching the client proceeds instead of immediately exiting. When the Electron owner terminates, its packaged daemon and web sidecars now shut themselves down as well.

Daemon socket takeover remains conservative so recovery cannot introduce two writers against the same database.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — packaged startup now recovers from an unresponsive stale web socket, and sidecars monitor the packaged Electron parent
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes packaged process lifecycle and startup recovery without changing UI.

## Bug fix verification

- Test path that reproduces the bug: apps/packaged/tests/sidecars.test.ts
- The focused tests went red on main: packaged children had no parent PID, and an IPC-unresponsive web socket remained present.
- The same tests are green on this branch, including the daemon safety boundary that rejects automatic daemon socket removal.

## Validation

- corepack pnpm --filter @open-design/packaged test — 22 files and 303 tests passed
- corepack pnpm --filter @open-design/packaged typecheck — passed
- corepack pnpm --filter @open-design/packaged build — passed
- corepack pnpm tools-pack mac build --to app --namespace orphan-rg --json — passed
- Fault-injection smoke: started the packaged macOS app with an IPC-unresponsive web.sock already bound; startup reached running state
- Parent-death smoke: sent SIGKILL to Electron and verified the managed daemon and web processes exited
- git diff --check — passed
- corepack pnpm guard — repository baseline currently fails on pre-existing landing-page residual JavaScript findings and a missing apps/standalone/package.json lookup; this patch does not touch those paths