### PR TITLE
feat(nix): add Nix desktop packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 .tmp/
 .DS_Store
 *.log
+/result
 /Open Design.exe
 .vite
 .astro/

--- a/apps/daemon/src/cwd-aliases.ts
+++ b/apps/daemon/src/cwd-aliases.ts
@@ -85,13 +85,62 @@ async function copyTreeDereferenced(srcDir: string, destDir: string): Promise<vo
       // restore the source's permission bits (notably the exec bit on
       // skill helper scripts) and mtime — `fs.cp` preserves these, and
       // skills shell out to staged scripts. Mask to 0o777 so the
-      // agent-writable staging copy never inherits setuid/setgid/sticky.
-      await chmod(to, entryStat.mode & 0o777);
+      // agent-writable staging copy never inherits setuid/setgid/sticky,
+      // and OR owner-write back on: read-only sources (a Nix store skill
+      // folder is the canonical case) would otherwise stage as an
+      // unwritable dead copy.
+      await chmod(to, (entryStat.mode & 0o777) | 0o200);
       await utimes(to, entryStat.atime, entryStat.mtime);
     }
     // Sockets, FIFOs, and devices can't appear in a sane skill folder and
     // copying them would hang or fail — skip them.
   }
+}
+
+// Read-only skill sources stage too faithfully: both copy paths preserve
+// the source's permission bits, so a skill shipped from a
+// content-addressable store lands as a read-only tree. That breaks this
+// module's own contract twice over — the next turn's wholesale
+// replacement cannot unlink from a read-only directory (EACCES), and
+// agents cannot treat `.od-skills/` as their private working copy.
+// Owner-write is granted additively so exec bits and group/other bits
+// survive untouched, and symlinks are never chmod'd (the staged tree has
+// none, but stay defensive against future callers).
+async function grantOwnerWrite(rootDir: string): Promise<void> {
+  const rootMode = (await lstat(rootDir)).mode & 0o777;
+  await chmod(rootDir, rootMode | 0o700);
+  for (const entry of await readdir(rootDir, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+    const child = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      await grantOwnerWrite(child);
+    } else {
+      const childMode = (await lstat(child)).mode & 0o777;
+      await chmod(child, childMode | 0o200);
+    }
+  }
+}
+
+// Removes the previous turn's staged copy. `force: true` only ignores
+// ENOENT — a read-only tree left by an earlier daemon build still fails
+// unlink with EACCES/EPERM, so grant owner write (the same defect fresh
+// copies below no longer produce) and retry once before giving up.
+async function removeStaleStagedCopy(
+  stagedPath: string,
+  log: SkillStagingLogger,
+): Promise<void> {
+  try {
+    await rm(stagedPath, { recursive: true, force: true });
+    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? '';
+    if (code !== 'EACCES' && code !== 'PERM' && code !== 'EPERM') throw err;
+    log(
+      '[od] skill-stage: stale copy is read-only; granting owner write to replace it',
+    );
+  }
+  await grantOwnerWrite(stagedPath);
+  await rm(stagedPath, { recursive: true, force: true });
 }
 
 /**
@@ -169,7 +218,7 @@ export async function stageActiveSkill(
     // Wipe a stale per-skill copy first so a removed source file is
     // reflected and a partially-failed previous run cannot leave junk
     // behind.
-    await rm(stagedPath, { recursive: true, force: true });
+    await removeStaleStagedCopy(stagedPath, log);
     try {
       await nativeCopy(sourceDir, stagedPath, {
         recursive: true,
@@ -190,6 +239,10 @@ export async function stageActiveSkill(
       await rm(stagedPath, { recursive: true, force: true });
       await copyTreeDereferenced(sourceDir, stagedPath);
     }
+    // Both copy paths preserve the source's permission bits; normalize
+    // the finished tree so read-only sources still stage as an
+    // agent-writable working copy that the next turn can replace.
+    await grantOwnerWrite(stagedPath);
     return { staged: true, stagedPath };
   } catch (err) {
     log(`[od] skill-stage failed: ${(err as Error).message}`);

--- a/apps/daemon/src/daemon-paths.ts
+++ b/apps/daemon/src/daemon-paths.ts
@@ -63,6 +63,13 @@ export function resolveProcessResourcesPath(): string | null {
   return null;
 }
 
+export function resolveSiblingPackagedResourceRootBase(projectRoot: string): string | null {
+  const resolvedProjectRoot = path.resolve(projectRoot);
+  if (path.basename(resolvedProjectRoot) !== 'open-design') return null;
+  if (path.basename(path.dirname(resolvedProjectRoot)) !== 'lib') return null;
+  return path.resolve(resolvedProjectRoot, '..', '..', 'share', 'open-design');
+}
+
 export interface ResolveDaemonResourceRootOptions {
   configured?: string;
   safeBases?: Array<string | null | undefined>;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -48,12 +48,14 @@ import {
   resolveDaemonResourceRoot,
   resolveDataDir,
   resolveProcessResourcesPath,
+  resolveSiblingPackagedResourceRootBase,
 } from './daemon-paths.js';
 export {
   resolveDaemonCliPath,
   resolveDaemonPluginPreviewsDir,
   resolveDaemonResourceRoot,
   resolveDataDir,
+  resolveSiblingPackagedResourceRootBase,
 } from './daemon-paths.js';
 import {
   isStaticSpaFallbackRequest,
@@ -276,6 +278,7 @@ import {
   listSkills,
   resolveSkillId,
   splitDerivedSkillId,
+  withSkillRootPreamble,
 } from './skills.js';
 import {
   activateWorkspaceTeamSkillIfStillShared,
@@ -1050,6 +1053,7 @@ const DAEMON_RESOURCE_ROOT = resolveDaemonResourceRoot({
     PROJECT_ROOT,
     resolveProcessResourcesPath(),
     process.env.OD_INSTALLATION_DIR,
+    resolveSiblingPackagedResourceRootBase(PROJECT_ROOT),
   ],
 });
 // Built web app lives in `out/` — that's where Next.js writes the static
@@ -9459,9 +9463,27 @@ export async function startServer({
     // object both composes the prompt and feeds section-level drift
     // attribution — a second, hand-maintained copy of these inputs would drift
     // from the real ones and mislabel the telemetry it exists to explain.
+    //
+    // The skill body is wrapped with the skill-root preamble here, at the
+    // single point where every skill source has already resolved into
+    // `skillBody` + `activeSkillDir`. Without the preamble the prompt tells
+    // the agent to read `assets/template.html` "via the path written in the
+    // skill-root preamble" but never actually writes that path, so embedded
+    // runtimes (opencode/ACP family) probe for side files with
+    // filesystem-wide globs (`path: "/"`), their permission layer declines
+    // every call, and the whole run aborts with AGENT_EXECUTION_FAILED.
+    const skillPromptBody =
+      skillBody && skillBody.trim().length > 0 && activeSkillDir
+        ? skillBody.includes('> **Skill root (relative to project):**')
+          // Global skills with side files are preambled upstream by
+          // `listSkills()` (see the `hasAttachments` branch there);
+          // plugin-local SKILL.md bodies reach this point raw.
+          ? skillBody
+          : withSkillRootPreamble(skillBody, activeSkillDir)
+        : skillBody;
     const systemPromptInputs = {
       agentId,
-      skillBody,
+      skillBody: skillPromptBody,
       skillName,
       skillMode,
       skillModes: skillModes.size > 0 ? Array.from(skillModes) : undefined,
@@ -9532,7 +9554,7 @@ export async function startServer({
         digest: designSystemDigest,
       },
       promptTelemetryParts: {
-        skillPrompt: skillBody ?? '',
+        skillPrompt: skillPromptBody ?? '',
         designSystemPrompt: designSystemBody ?? '',
         pluginStagePrompt: [pluginBlock, ...(activeStageBlocks ?? [])]
           .filter((part) => typeof part === 'string' && part.trim().length > 0)

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -553,7 +553,7 @@ export function splitDerivedSkillId(id: unknown): DerivedSkillIdParts | null {
 //
 // Authoring guidance lives in the preamble itself so an agent can pick
 // the right form on its own without daemon-side feature detection.
-function withSkillRootPreamble(body: string, dir: string): string {
+export function withSkillRootPreamble(body: string, dir: string): string {
   const referencedFiles = collectReferencedSideFiles(body);
   const folder = skillCwdAliasSegment(dir);
   const skillRootRel = `${SKILLS_CWD_ALIAS}/${folder}`;

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1664,6 +1664,108 @@ process.stdin.on('end', () => {
     );
   });
 
+  it('wraps plugin-local skill bodies with the skill-root preamble advertising the staged cwd alias', async () => {
+    // REGRESSION: `withSkillRootPreamble()` existed but nothing on the
+    // run path called it for plugin-local SKILL.md bodies (global skills
+    // are preambled upstream by `listSkills()`). Plugin-bound prompts told
+    // agents to open skill side files "via the path written in the
+    // skill-root preamble" without ever writing that path. Embedded
+    // runtimes (opencode/ACP family) then probed for the files with
+    // filesystem-wide globs (`path: "/"`), their permission layer declined
+    // every call, and the run aborted with AGENT_EXECUTION_FAILED /
+    // "Step interrupted".
+    const pluginId = `plugin-preamble-${randomUUID()}`;
+    const pluginFixtureDir = await createPluginFixture({
+      pluginId,
+      dirName: `plugin-preamble-${randomUUID()}`,
+      localSkillPath: './SKILL.md',
+    });
+    const installResponse = await fetch(`${baseUrl}/api/plugins/install`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', accept: 'text/event-stream' },
+      body: JSON.stringify({ source: pluginFixtureDir }),
+    });
+    const installBody = await installResponse.text();
+
+    expect(installResponse.status).toBe(200);
+    expect(installBody).toContain(`"id":"${pluginId}"`);
+
+    const installedPluginResponse = await fetch(`${baseUrl}/api/plugins/${pluginId}`);
+    const installedPluginBody = await installedPluginResponse.json() as { fsPath: string };
+    const pluginAlias = skillCwdAliasSegment(installedPluginBody.fsPath);
+
+    const projectId = `project-${randomUUID()}`;
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Plugin-local skill preamble project',
+        pluginId,
+        pluginInputs: { topic: 'agentic design' },
+      }),
+    });
+    const createProjectBody = await createProjectResponse.json() as {
+      appliedPluginSnapshotId?: string;
+    };
+
+    expect(createProjectResponse.ok).toBe(true);
+    expect(createProjectBody.appliedPluginSnapshotId).toBeTruthy();
+
+    await withFakeAgent(
+      'opencode',
+      `
+let prompt = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  prompt += chunk;
+});
+process.stdin.on('end', () => {
+  const checks = [
+    prompt.includes('> **Skill root (relative to project):**')
+      ? 'has-skill-root-relative'
+      : 'missing-skill-root-relative',
+    prompt.includes('.od-skills/${pluginAlias}/')
+      ? 'has-staged-alias-path'
+      : 'missing-staged-alias-path',
+    prompt.includes('> **Skill root (absolute fallback):**')
+      ? 'has-skill-root-absolute'
+      : 'missing-skill-root-absolute',
+  ];
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: checks.join('\\n') } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const createRunResponse = await fetch(`${baseUrl}/api/runs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            projectId,
+            message: 'build a plugin-backed page',
+            appliedPluginSnapshotId: createProjectBody.appliedPluginSnapshotId,
+          }),
+        });
+        const createRunBody = await createRunResponse.json() as { runId: string };
+
+        expect(createRunResponse.status).toBe(202);
+
+        const eventsResponse = await fetch(`${baseUrl}/api/runs/${createRunBody.runId}/events`);
+        const body = await readSseUntil(eventsResponse, 'event: final');
+
+        expect(body).toContain('has-skill-root-relative');
+        expect(body).toContain('has-staged-alias-path');
+        expect(body).toContain('has-skill-root-absolute');
+        expect(body).not.toContain('missing-skill-root-relative');
+        expect(body).not.toContain('missing-staged-alias-path');
+        expect(body).not.toContain('missing-skill-root-absolute');
+      },
+    );
+  });
+
   it('stages ad-hoc skill side files into the project cwd', async () => {
     const projectId = `project-${randomUUID()}`;
     const stagedRelativePath = `.od-skills/${skillCwdAliasSegment(resolve(process.cwd(), '..', '..', 'skills', 'release-notes-one-pager'))}/references/checklist.md`;

--- a/apps/daemon/tests/cwd-aliases.test.ts
+++ b/apps/daemon/tests/cwd-aliases.test.ts
@@ -27,6 +27,11 @@ function fresh(): string {
 const dirLinkType: 'dir' | 'junction' =
   process.platform === 'win32' ? 'junction' : 'dir';
 
+// Permission-bit fixtures are POSIX-only: Windows collapses 0444 to the
+// read-only attribute and does not model owner/group/other bits, so the
+// Nix-store regression test below cannot express its precondition there.
+const itPosix = process.platform === 'win32' ? it.skip : it;
+
 function writeSampleSkill(root: string, folder: string): string {
   const dir = path.join(root, folder);
   mkdirSync(path.join(dir, 'assets'), { recursive: true });
@@ -330,6 +335,49 @@ describe('stageActiveSkill', () => {
     expect(statSync(path.join(result.stagedPath!, 'SKILL.md')).mode & 0o111).toBe(
       0,
     );
+  });
+
+  itPosix('REGRESSION: stages a read-only source (Nix store) as an owner-writable copy that can be replaced', async () => {
+    // Skills bundled into the Nix desktop package live in the read-only
+    // Nix store (files 0444, directories 0555, mtime epoch). Both copy
+    // paths used to preserve those bits verbatim, so the staged copy was
+    // itself read-only: the next turn's wholesale replacement failed
+    // unlink with EACCES and the run degraded to absolute-path skill
+    // delivery — agents then probed for skill files with filesystem-wide
+    // globs that the embedded runtime declines.
+    const fs = fresh();
+    const cwd = path.join(fs, 'project');
+    const sourceDir = writeSampleSkill(path.join(fs, 'skills'), 'blog-post');
+    chmodSync(path.join(sourceDir, 'SKILL.md'), 0o444);
+    chmodSync(path.join(sourceDir, 'assets', 'template.html'), 0o444);
+    chmodSync(path.join(sourceDir, 'references', 'checklist.md'), 0o444);
+    chmodSync(path.join(sourceDir, 'assets'), 0o555);
+    chmodSync(path.join(sourceDir, 'references'), 0o555);
+    chmodSync(sourceDir, 0o555);
+    mkdirSync(cwd);
+
+    const first = await stageActiveSkill(cwd, 'blog-post', sourceDir);
+
+    expect(first.staged).toBe(true);
+    const staged = first.stagedPath!;
+    // Files are owner-writable…
+    expect(statSync(path.join(staged, 'SKILL.md')).mode & 0o200).not.toBe(0);
+    expect(
+      statSync(path.join(staged, 'assets', 'template.html')).mode & 0o200,
+    ).not.toBe(0);
+    // …and directories stay traversable AND writable so the next turn
+    // can replace the copy wholesale.
+    expect(statSync(staged).mode & 0o700).toBe(0o700);
+    expect(statSync(path.join(staged, 'assets')).mode & 0o700).toBe(0o700);
+
+    // The replacement itself is the operation that used to fail with
+    // EACCES when the previous copy had been staged from a read-only
+    // source by an earlier daemon build.
+    const second = await stageActiveSkill(cwd, 'blog-post', sourceDir);
+    expect(second.staged).toBe(true);
+    expect(
+      readFileSync(path.join(second.stagedPath!, 'SKILL.md'), 'utf8'),
+    ).toContain('original SKILL');
   });
 
   it('degrades to the absolute-path fallback on a non-recoverable copy error', async () => {

--- a/apps/daemon/tests/server-paths.test.ts
+++ b/apps/daemon/tests/server-paths.test.ts
@@ -5,6 +5,7 @@ import {
   resolveDaemonPluginPreviewsDir,
   resolveDaemonResourceRoot,
   resolveProjectRoot,
+  resolveSiblingPackagedResourceRootBase,
 } from '../src/server.js';
 
 describe('resolveProjectRoot', () => {
@@ -94,6 +95,14 @@ describe('resolveDaemonResourceRoot', () => {
 
     expect(() => resolveDaemonResourceRoot({ configured, safeBases: [safeBase] })).toThrow(
       /OD_RESOURCE_ROOT must be under/,
+    );
+  });
+
+  it('derives the Nix desktop packaged resource base from a lib/open-design project root', () => {
+    const projectRoot = '/nix/store/hash-open-design-desktop/lib/open-design';
+
+    expect(resolveSiblingPackagedResourceRootBase(projectRoot)).toBe(
+      '/nix/store/hash-open-design-desktop/share/open-design',
     );
   });
 });

--- a/apps/packaged/src/config.ts
+++ b/apps/packaged/src/config.ts
@@ -30,6 +30,7 @@ export type RawPackagedConfig = {
   daemonSidecarEntryRelative?: string;
   namespace?: string;
   namespaceBaseRoot?: string;
+  nodeCommand?: string;
   nodeCommandRelative?: string;
   resourceRoot?: string;
   // Baked by tools/pack from OPEN_DESIGN_TELEMETRY_RELAY_URL and forwarded to
@@ -194,12 +195,15 @@ export async function readPackagedConfig(): Promise<PackagedConfig> {
     electronApp.getPath("userData"),
   );
   const resourceRoot = resolveOptionalPath(raw.resourceRoot) ?? join(process.resourcesPath, "open-design");
+  const explicitNodeCommand = resolveOptionalPath(raw.nodeCommand);
   const relativeNodeCommand =
     raw.nodeCommandRelative == null || raw.nodeCommandRelative.length === 0
       ? join("open-design", "bin", "node")
       : raw.nodeCommandRelative;
   const nodeCommandCandidate = join(process.resourcesPath, relativeNodeCommand);
-  const nodeCommand = (await pathExists(nodeCommandCandidate)) ? nodeCommandCandidate : null;
+  const nodeCommand = explicitNodeCommand != null
+    ? explicitNodeCommand
+    : (await pathExists(nodeCommandCandidate)) ? nodeCommandCandidate : null;
   const allowWebOutputModeOverride = isTruthyEnv(process.env[PACKAGED_WEB_OUTPUT_MODE_OVERRIDE_ENV]);
   const webOutputMode = resolvePackagedWebOutputMode(
     allowWebOutputModeOverride

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { access, appendFile, mkdir, open, rename, type FileHandle } from "node:fs/promises";
+import { access, appendFile, chmod, cp, lstat, mkdir, open, readdir, rename, rm, type FileHandle } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { delimiter, dirname, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -135,6 +135,64 @@ type PackagedDaemonManagedPathEnv = {
 
 function resolveSidecarEntry(packageName: string, exportName: string): string {
   return require.resolve(`${packageName}/${exportName}`);
+}
+
+function resolvePackagedWebDistSource(webSidecarEntry: string): string {
+  // `@open-design/web/sidecar` resolves to `<webPkg>/dist/sidecar/index.js` in
+  // packaged builds. The matching Next output lives under `<webPkg>/.next`.
+  return join(dirname(dirname(dirname(webSidecarEntry))), ".next");
+}
+
+function resolvePackagedWebDistRuntimeRoot(paths: Pick<PackagedNamespacePaths, "runtimeRoot">): string {
+  return join(paths.runtimeRoot, "web-dist");
+}
+
+export async function preparePackagedWebDistDir(
+  paths: Pick<PackagedNamespacePaths, "runtimeRoot">,
+  webSidecarEntry: string,
+): Promise<string> {
+  const target = resolvePackagedWebDistRuntimeRoot(paths);
+  await removeTreeMakingWritable(target);
+  await cp(resolvePackagedWebDistSource(webSidecarEntry), target, {
+    force: true,
+    recursive: true,
+  });
+  await makeTreeUserWritable(target);
+  return target;
+}
+
+// A previous launch can leave runtime/web-dist fully read-only when its
+// process died between the copy step and makeTreeUserWritable (or an older
+// runtime shipped the tree without user write bits, as Nix store modes do).
+// rm({ recursive: true, force: true }) skips missing paths but still reports
+// EACCES/EPERM when it must unlink below a non-writable directory, so widen
+// the stale tree first and retry once; anything else is a real failure.
+async function removeTreeMakingWritable(target: string): Promise<void> {
+  try {
+    await rm(target, { force: true, recursive: true });
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null | undefined)?.code;
+    if (code !== "EACCES" && code !== "EPERM") throw error;
+  }
+  await makeTreeUserWritable(target).catch(() => undefined);
+  await rm(target, { force: true, recursive: true });
+}
+
+async function makeTreeUserWritable(root: string): Promise<void> {
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (current == null) continue;
+    const stats = await lstat(current);
+    if (stats.isSymbolicLink()) continue;
+    await chmod(current, stats.mode | 0o200);
+    if (!stats.isDirectory()) continue;
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      pending.push(join(current, entry.name));
+    }
+  }
 }
 
 function logPathFor(paths: PackagedNamespacePaths, app: AppKey): string {
@@ -929,6 +987,9 @@ export async function startPackagedSidecars(
     options.daemonSidecarEntry ?? resolveSidecarEntry("@open-design/daemon", "sidecar");
   const webSidecarEntry =
     options.webSidecarEntry ?? resolveSidecarEntry("@open-design/web", "sidecar");
+  const webDistDir = options.webOutputMode === "server"
+    ? await preparePackagedWebDistDir(paths, webSidecarEntry)
+    : null;
   const prewarmLog = (message: string): void => {
     void appendSidecarLifecycleLog(join(paths.logsRoot, "launcher", "latest.log"), message);
   };
@@ -1019,6 +1080,7 @@ export async function startPackagedSidecars(
         entryPath: webSidecarEntry,
         env: {
           [SIDECAR_ENV.DAEMON_PORT]: daemonPort,
+          ...(webDistDir == null ? {} : { [SIDECAR_ENV.WEB_DIST_DIR]: webDistDir }),
           [SIDECAR_ENV.WEB_PORT]: "0",
           ...(options.webStandaloneRoot == null ? {} : { OD_WEB_STANDALONE_ROOT: options.webStandaloneRoot }),
           OD_WEB_OUTPUT_MODE: options.webOutputMode,

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -16,7 +16,7 @@
  * @see https://github.com/nexu-io/open-design/issues/710
  */
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -30,6 +30,7 @@ import {
   createRestartPolicy,
   createWebSidecarSupervisor,
   openLog,
+  preparePackagedWebDistDir,
   registerPackagedWebUrl,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
@@ -1152,6 +1153,88 @@ describe('packaged sidecar log rotation', () => {
       expect(merged).toContain('incident line that must survive');
       expect(merged).toContain('post-rotation-failure line');
     } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('preparePackagedWebDistDir', () => {
+  it('makes the runtime web-dist copy writable for a later relaunch', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-web-dist-'));
+    const source = join(root, 'webpkg', '.next');
+    const runtimeRoot = join(root, 'runtime');
+    const webSidecarEntry = join(root, 'webpkg', 'dist', 'sidecar', 'index.js');
+    try {
+      mkdirSync(join(source, 'server'), { recursive: true });
+      mkdirSync(dirname(webSidecarEntry), { recursive: true });
+      writeFileSync(join(source, 'BUILD_ID'), 'build-1\n', 'utf8');
+      writeFileSync(join(source, 'server', 'index.js'), 'export {};\n', 'utf8');
+      writeFileSync(webSidecarEntry, 'export {};\n', 'utf8');
+
+      chmodSync(source, 0o555);
+      chmodSync(join(source, 'server'), 0o555);
+      chmodSync(join(source, 'BUILD_ID'), 0o444);
+      chmodSync(join(source, 'server', 'index.js'), 0o444);
+
+      const target = await preparePackagedWebDistDir({ runtimeRoot }, webSidecarEntry);
+      const copiedBuildId = join(target, 'BUILD_ID');
+
+      writeFileSync(copiedBuildId, 'build-2\n', 'utf8');
+      unlinkSync(copiedBuildId);
+      expect(readFileSync(join(target, 'server', 'index.js'), 'utf8')).toContain('export');
+    } finally {
+      for (const dir of [source, join(source, 'server'), join(runtimeRoot, 'web-dist'), join(runtimeRoot, 'web-dist', 'server')]) {
+        try {
+          chmodSync(dir, 0o755);
+        } catch {}
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('recovers when a previous launch left the runtime web-dist copy read-only', async () => {
+    // Regression spec for an interrupted launch: a run that died between the
+    // cp step and makeTreeUserWritable leaves runtime/web-desc fully
+    // read-only (Nix store modes). The next launch must still be able to
+    // replace that tree instead of failing with EACCES before any sidecar
+    // starts.
+    const root = mkdtempSync(join(tmpdir(), 'od-web-dist-ro-'));
+    const source = join(root, 'webpkg', '.next');
+    const runtimeRoot = join(root, 'runtime');
+    const staleTarget = join(runtimeRoot, 'web-dist');
+    const webSidecarEntry = join(root, 'webpkg', 'dist', 'sidecar', 'index.js');
+    try {
+      mkdirSync(join(source, 'server'), { recursive: true });
+      mkdirSync(dirname(webSidecarEntry), { recursive: true });
+      writeFileSync(join(source, 'BUILD_ID'), 'build-2\n', 'utf8');
+      writeFileSync(join(source, 'server', 'index.js'), 'export {};\n', 'utf8');
+      writeFileSync(webSidecarEntry, 'export {};\n', 'utf8');
+
+      // Stale read-only tree from a previous interrupted launch.
+      mkdirSync(join(staleTarget, 'server'), { recursive: true });
+      writeFileSync(join(staleTarget, 'BUILD_ID'), 'build-1\n', 'utf8');
+      writeFileSync(join(staleTarget, 'server', 'index.js'), 'stale;\n', 'utf8');
+      chmodSync(staleTarget, 0o555);
+      chmodSync(join(staleTarget, 'server'), 0o555);
+      chmodSync(join(staleTarget, 'BUILD_ID'), 0o444);
+      chmodSync(join(staleTarget, 'server', 'index.js'), 0o444);
+
+      const target = await preparePackagedWebDistDir({ runtimeRoot }, webSidecarEntry);
+
+      expect(target).toBe(staleTarget);
+      expect(readFileSync(join(target, 'BUILD_ID'), 'utf8')).toContain('build-2');
+      expect(readFileSync(join(target, 'server', 'index.js'), 'utf8')).toContain('export');
+    } finally {
+      for (const dir of [
+        source,
+        join(source, 'server'),
+        staleTarget,
+        join(staleTarget, 'server'),
+      ]) {
+        try {
+          chmodSync(dir, 0o755);
+        } catch {}
+      }
       rmSync(root, { recursive: true, force: true });
     }
   });

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,26 @@
         "packages/sidecar-proto"
         "apps/web"
       ];
+      desktopWorkspacePaths = [
+        "packages/release"
+        "packages/components"
+        "packages/contracts"
+        "packages/registry-protocol"
+        "packages/agui-adapter"
+        "packages/plugin-runtime"
+        "packages/sidecar-proto"
+        "packages/launcher-proto"
+        "packages/sidecar"
+        "packages/platform"
+        "packages/download"
+        "packages/host"
+        "packages/diagnostics"
+        "packages/dsh-runtime"
+        "apps/daemon"
+        "apps/web"
+        "apps/desktop"
+        "apps/packaged"
+      ];
       daemonSrc = filterProjectSource ([
         "package.json"
         "pnpm-lock.yaml"
@@ -90,6 +110,21 @@
         "tsconfig.json"
       ]
       ++ webWorkspacePaths);
+      desktopSrc = filterProjectSource ([
+        "package.json"
+        "pnpm-lock.yaml"
+        "pnpm-workspace.yaml"
+        "tsconfig.json"
+        "assets"
+        "plugins"
+        "skills"
+        "design-systems"
+        "design-templates"
+        "craft"
+        "prompt-templates"
+        "data"
+      ]
+      ++ desktopWorkspacePaths);
       pnpmDepsBaseInputs = [
         "package.json"
         "pnpm-lock.yaml"
@@ -100,6 +135,9 @@
       );
       webPnpmDepsSrc = filterProjectSource (
         pnpmDepsBaseInputs ++ workspacePackageManifests webWorkspacePaths
+      );
+      desktopPnpmDepsSrc = filterProjectSource (
+        pnpmDepsBaseInputs ++ workspacePackageManifests desktopWorkspacePaths
       );
 
       # nixpkgs ships pnpm 10.33.0; the repo's package.json declares
@@ -134,26 +172,39 @@
         pnpmDepsSrc = webPnpmDepsSrc;
         workspacePaths = webWorkspacePaths;
       };
+      desktop =
+        if pkgs.stdenv.isLinux
+        then pkgs.callPackage ./nix/package-desktop.nix {
+          inherit nodejs pnpm_10;
+          electron = pkgs.electron;
+          src = desktopSrc;
+          pnpmDepsSrc = desktopPnpmDepsSrc;
+          workspacePaths = desktopWorkspacePaths;
+        }
+        else null;
     in {
       packages = {
         inherit daemon web;
         default = daemon;
+      } // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        inherit desktop;
       };
 
-      # Wrap `od` with `--no-open` for `nix run`: the daemon package
-      # builds the daemon workspace only, not `apps/web/out/`, so the
-      # browser would otherwise auto-open onto an empty static dir.
-      #
-      # Set OD_DATA_DIR to a writable location when unset. The Nix store
-      # is read-only at runtime, so the daemon cannot write to its default
-      # `<projectRoot>/.od` location under `nix run`.
-      apps.default = {
-        type = "app";
-        program = "${pkgs.writeShellScript "od-nix-run" ''
-          export OD_DATA_DIR="''${OD_DATA_DIR:-$HOME/.od}"
-          exec ${daemon}/bin/od --no-open "$@"
-        ''}";
-        meta.description = "OpenDesign local daemon (`od`)";
+      apps = {
+        default = {
+          type = "app";
+          program = "${pkgs.writeShellScript "od-nix-run" ''
+            export OD_DATA_DIR="''${OD_DATA_DIR:-$HOME/.od}"
+            exec ${daemon}/bin/od --no-open "$@"
+          ''}";
+          meta.description = "OpenDesign local daemon (`od`)";
+        };
+      } // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        desktop = {
+          type = "app";
+          program = "${desktop}/bin/open-design-desktop";
+          meta.description = "OpenDesign desktop runtime";
+        };
       };
 
       devShells.default = pkgs.mkShell {
@@ -178,6 +229,8 @@
       checks = {
         daemon = daemon;
         web = web;
+      } // nixpkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        desktop = desktop;
       };
 
       formatter = pkgs.nixpkgs-fmt;

--- a/nix/copy-bundled-vela-cli.nix
+++ b/nix/copy-bundled-vela-cli.nix
@@ -1,0 +1,27 @@
+{ resourceRoot, velaTarball }:
+''
+  # Mirror the packaged runtime contract from tools/pack: the daemon resolves
+  # bundled AMR through OD_RESOURCE_ROOT/bin/vela and the OpenCode companion at
+  # OD_RESOURCE_ROOT/bin/libexec/opencode/...
+  #
+  # The pinned platform tarball is an explicit derivation input because the
+  # filtered Nix workspace install intentionally excludes tools/pack, the only
+  # manifest declaring @powerformer/vela-cli; discovering the binary through
+  # node_modules would silently skip the copy on a clean install. Fail fast
+  # here rather than shipping a desktop without the bundled AMR contract.
+  vela_extracted=$TMPDIR/vela-cli-platform
+  mkdir -p "$vela_extracted"
+  tar -xzf ${velaTarball} -C "$vela_extracted" --strip-components=1
+
+  if [ ! -f "$vela_extracted/bin/vela" ]; then
+    echo "open-design-desktop: bundled vela binary missing from ${velaTarball}" >&2
+    exit 1
+  fi
+
+  mkdir -p ${resourceRoot}/bin/libexec
+  install -m0755 "$vela_extracted/bin/vela" ${resourceRoot}/bin/vela
+  # The OpenCode companion ships inside the platform package at bin/libexec/.
+  if [ -d "$vela_extracted/bin/libexec" ]; then
+    cp -r "$vela_extracted/bin/libexec"/. ${resourceRoot}/bin/libexec/
+  fi
+''

--- a/nix/package-daemon.nix
+++ b/nix/package-daemon.nix
@@ -48,6 +48,7 @@ let
 
   pnpmDepsHash = (import ./pnpm-deps.nix).daemonHash;
   pnpmWorkspaceFilters = map (workspacePath: "./${workspacePath}") workspacePaths;
+  rebuildNativeAddons = import ./rebuild-native-addons.nix { inherit lib nodejs; };
 in
   stdenv.mkDerivation (finalAttrs: {
     inherit pname version src;
@@ -59,8 +60,8 @@ in
       pnpm_10
       pnpmConfigHook
       makeWrapper
-      # Required to rebuild better-sqlite3's native binding from source.
-      # node-gyp drives this via Python; gnumake/pkg-config + the C++
+      # Required to rebuild native addons (better-sqlite3, node-pty) from
+      # source. node-gyp drives this via Python; gnumake/pkg-config + the C++
       # compiler from stdenv complete the toolchain.
       python3
       gnumake
@@ -88,60 +89,13 @@ in
     buildPhase = ''
       runHook preBuild
 
-      # Build better-sqlite3's native binding from source.
+      # Build native addons (better-sqlite3, node-pty) from source.
       #
-      # Why from source on Node 24:
-      #   better-sqlite3 (even 12.9.0, latest as of 2026-05) only
-      #   publishes prebuilds up to node-v131 (Node 22). No v137
-      #   (Node 24) prebuild exists. `prebuild-install` would itself
-      #   fail the GitHub fetch and fall through to a compile, so we
-      #   skip the download attempt entirely and compile.
-      #
-      # Why not `pnpm rebuild`:
-      #   In pnpm 10, `onlyBuiltDependencies` interacts with the
-      #   "approve-builds" consent gate; `pnpm rebuild <pkg>` silently
-      #   no-ops in some configurations. Invoke node-gyp directly to
-      #   sidestep all of that.
-      #
-      # Env vars:
-      #   * npm_config_nodedir → use the headers shipped with the
-      #     nixpkgs nodejs we're already building against, so node-gyp
-      #     doesn't try to fetch them from nodejs.org/dist (no network
-      #     in the build sandbox).
-      #   * npm_config_build_from_source → tell better-sqlite3's
-      #     prebuild-install fallback chain to skip the CDN download
-      #     and compile.
-      #
-      # node-gyp lookup:
-      #   nixpkgs nodejs ships node-gyp bundled inside npm at
-      #   ${nodejs}/lib/node_modules/npm/bin/node-gyp-bin. Putting
-      #   that on PATH gives us a `node-gyp` shim without depending
-      #   on pnpm-exec resolving from inside better-sqlite3's tree
-      #   (better-sqlite3 doesn't list node-gyp as a direct dep).
-      export npm_config_nodedir=${nodejs}
-      export npm_config_build_from_source=true
-      export PATH="${nodejs}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
-
-      bsq_dir=$(find node_modules/.pnpm -mindepth 2 -maxdepth 4 \
-        -type d -path '*/better-sqlite3@*/node_modules/better-sqlite3' \
-        -print -quit)
-      if [ -z "$bsq_dir" ]; then
-        echo "ERROR: better-sqlite3 not found under node_modules/.pnpm — pnpm install may have failed" >&2
-        exit 1
-      fi
-
-      echo "Building better-sqlite3 from source at $bsq_dir"
-      ( cd "$bsq_dir" && node-gyp rebuild --release --build-from-source )
-
-      # Fail fast if the .node file didn't land where bindings.js
-      # looks for it. Without this assertion, a silent skip produces
-      # a "valid" derivation that crashes at runtime with
-      # "Could not locate the bindings file".
-      if [ ! -f "$bsq_dir/build/Release/better_sqlite3.node" ]; then
-        echo "ERROR: better_sqlite3.node was not produced at $bsq_dir/build/Release/" >&2
-        find "$bsq_dir" -name '*.node' -print >&2 || true
-        exit 1
-      fi
+      # Shared with nix/package-desktop.nix via rebuild-native-addons.nix;
+      # that file documents why each addon must be compiled here (no usable
+      # prebuild for our Node target / platform) and why node-gyp is invoked
+      # directly instead of `pnpm rebuild`.
+      ${rebuildNativeAddons { messageSuffix = "pnpm install may have failed"; }}
 
       for target in ${lib.escapeShellArgs workspacePaths}; do
         pnpm -C "$target" run --if-present build

--- a/nix/package-desktop.nix
+++ b/nix/package-desktop.nix
@@ -1,0 +1,370 @@
+{
+  lib,
+  stdenv,
+  nodejs,
+  pnpm_10,
+  fetchPnpmDeps,
+  fetchurl,
+  pnpmConfigHook,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  writeShellScript,
+  src,
+  pnpmDepsSrc ? src,
+  python3,
+  gnumake,
+  pkg-config,
+  workspacePaths,
+}:
+let
+  pname = "open-design-desktop";
+  version = (lib.importJSON ../package.json).version;
+  dshRuntimeVersion = (lib.importJSON ../packages/dsh-runtime/package.json).version;
+  webOutputMode = "server";
+  copyBundledVelaCli = import ./copy-bundled-vela-cli.nix;
+  pruneWorkspaceRuntimeCopy = import ./prune-workspace-runtime-copy.nix { inherit lib; };
+  rebuildNativeAddons = import ./rebuild-native-addons.nix { inherit lib nodejs; };
+
+  pnpmDepsHash = (import ./pnpm-deps.nix).desktopHash;
+  pnpmWorkspaceFilters = map (workspacePath: "./${workspacePath}") workspacePaths;
+
+  # Bundled Vela CLI (AMR). tools/pack is the only workspace manifest that
+  # declares @powerformer/vela-cli, and it is intentionally excluded from the
+  # filtered Nix install, so the pinned platform package is fetched as an
+  # explicit derivation input instead of being discovered through
+  # node_modules. Keep version + hashes in sync with:
+  # - version: tools/pack/package.json optionalDependencies["@powerformer/vela-cli"]
+  # - hashes:  pnpm-lock.yaml snapshots for @powerformer/vela-cli-linux-{x64,arm64}
+  velaCliVersion =
+    (lib.importJSON ../tools/pack/package.json).optionalDependencies."@powerformer/vela-cli";
+  velaCliArch =
+    if stdenv.hostPlatform.isAarch64
+    then "arm64"
+    else "x64";
+  velaCliTarball = fetchurl {
+    url = "https://registry.npmjs.org/@powerformer/vela-cli-linux-${velaCliArch}/-/vela-cli-linux-${velaCliArch}-${velaCliVersion}.tgz";
+    hash =
+      if stdenv.hostPlatform.isAarch64
+      then "sha512-+DHifD5ylfjfsaWCo0NuPwl+D0lxkOs+apDCaxrj4EkSABkzjryrh2yIBncopZbz3GmDw+43AKNfTyDx6yr4fg=="
+      else "sha512-uBAeeTUEUaLMe5DtO1RjfiH7egvljfUJoUEkGOqle2O83wX2zulXkQzDhh+br5EvKsZo9RtSHzCcsiRPaNeo/g==";
+  };
+
+  desktopIcon = ../tools/pack/resources/linux/icon.png;
+  desktopIconName = "open-design-desktop";
+  dshRuntimeManifestBase = builtins.toJSON {
+    packageName = "@open-design/dsh-runtime";
+    schemaVersion = 1;
+    version = dshRuntimeVersion;
+  };
+  dshRuntimeManifestWriter = builtins.toFile "open-design-write-dsh-runtime-manifest.mjs" ''
+    import { writeFileSync } from "node:fs";
+
+    const outputPath = process.argv[2];
+    const base = JSON.parse(process.argv[3]);
+    const payload = {
+      file: process.argv[4],
+      ...base,
+      sha256: process.argv[5],
+    };
+
+    writeFileSync(outputPath, JSON.stringify(payload, null, 2) + "\n");
+  '';
+  packagedConfigWriter = builtins.toFile "open-design-write-packaged-config.mjs" ''
+    import { writeFileSync } from "node:fs";
+
+    const outputPath = process.argv[2];
+    const payload = {
+      appVersion: process.argv[3],
+      namespaceBaseRoot: process.argv[4],
+      nodeCommand: process.argv[5],
+      resourceRoot: process.argv[6],
+      webOutputMode: process.argv[7],
+    };
+
+    writeFileSync(outputPath, JSON.stringify(payload, null, 2) + "\n");
+  '';
+  launcherScript = writeShellScript "open-design-desktop-launcher" ''
+    #!${stdenv.shell}
+    set -euo pipefail
+
+    # Resolve the launcher through any symlink chain first. After
+    # `nix profile install .#desktop`, bin/open-design-desktop is a symlink
+    # into /nix/store, so dirname "$0" alone would point at the profile's bin
+    # instead of this derivation. `pwd -P` canonicalizes only the directory
+    # and never the executable itself, hence readlink -f on the script path.
+    script_path="$(readlink -f -- "$0")"
+    script_dir="$(dirname "$script_path")"
+    package_root="$(dirname "$script_dir")"
+    app_root="$package_root/lib/open-design/apps/packaged"
+    resource_root="$package_root/share/open-design"
+
+    # Packaging self-check hook: prints the resolved derivation prefix and exits.
+    # Used by installCheckPhase to prove path resolution survives invocation
+    # through a profile symlink chain (see below); no side effects before this.
+    if [ "''${1:-}" = "--print-package-root" ]; then
+      printf '%s\n' "$package_root"
+      exit 0
+    fi
+
+    xdg_data_home="''${XDG_DATA_HOME:-$HOME/.local/share}"
+    namespace_base_root="''${OD_PACKAGED_NAMESPACE_BASE_ROOT:-$xdg_data_home/open-design/namespaces}"
+    installation_root="$(dirname "$namespace_base_root")"
+    runtime_config_root="$installation_root/runtime"
+    config_path="$runtime_config_root/open-design-config.json"
+
+    mkdir -p "$namespace_base_root" "$runtime_config_root"
+
+    ${lib.getExe nodejs} ${packagedConfigWriter} \
+      "$config_path" \
+      ${lib.escapeShellArg version} \
+      "$namespace_base_root" \
+      ${lib.escapeShellArg (lib.getExe nodejs)} \
+      "$resource_root" \
+      ${lib.escapeShellArg webOutputMode}
+
+    if [ -z "''${VELA_BIN:-}" ]; then
+      if [ -x "$resource_root/bin/vela" ]; then
+        export VELA_BIN="$resource_root/bin/vela"
+      else
+        vela_path="$(command -v vela 2>/dev/null || true)"
+        if [ -n "$vela_path" ]; then
+          export VELA_BIN="$vela_path"
+        fi
+      fi
+    fi
+    export OD_PACKAGED_CONFIG_PATH="$config_path"
+    exec ${lib.getExe electron} "$app_root" "$@"
+  '';
+in
+  stdenv.mkDerivation (finalAttrs: {
+    inherit pname version src;
+
+    pnpmWorkspaces = pnpmWorkspaceFilters;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10
+      pnpmConfigHook
+      copyDesktopItems
+      python3
+      gnumake
+      pkg-config
+    ];
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = desktopIconName;
+        desktopName = "Open Design";
+        genericName = "Open Design";
+        comment = "Open Design desktop runtime";
+        exec = "${placeholder "out"}/bin/open-design-desktop %U";
+        icon = desktopIconName;
+        categories = [
+          "Development"
+          "Utility"
+        ];
+        mimeTypes = [ "x-scheme-handler/od" ];
+        startupNotify = true;
+        startupWMClass = "Open Design";
+        terminal = false;
+        type = "Application";
+      })
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version;
+      src = pnpmDepsSrc;
+      hash = pnpmDepsHash;
+      pnpm = pnpm_10;
+      pnpmWorkspaces = pnpmWorkspaceFilters;
+      fetcherVersion = 3;
+    };
+
+    env = {
+      NODE_ENV = "production";
+      OD_WEB_OUTPUT_MODE = webOutputMode;
+    };
+
+    doInstallCheck = true;
+
+    # Smoke test: after `nix profile install .#desktop`, bin/open-design-desktop
+    # is reached through a profile symlink, so the launcher must resolve its own
+    # real path (readlink -f) rather than trusting $0. This check reproduces the
+    # profile layout and fails if the derivation prefix resolves outside $out.
+    # The launcher's package_root IS the derivation prefix ($out); app_root and
+    # resource_root append their lib/ and share/ suffixes from it.
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      profile_bin="$TMPDIR/nix-profile/bin"
+      mkdir -p "$profile_bin"
+      ln -s "$out/bin/open-design-desktop" "$profile_bin/open-design-desktop"
+
+      resolved_package_root="$("$profile_bin/open-design-desktop" --print-package-root)"
+      if [ "$resolved_package_root" != "$out" ]; then
+        echo "open-design-desktop: launcher resolved package root to '$resolved_package_root' instead of '$out' when invoked through a symlink" >&2
+        exit 1
+      fi
+
+      # Bundled AMR contract: the daemon resolves vela through
+      # OD_RESOURCE_ROOT/bin/vela and its OpenCode companion at
+      # OD_RESOURCE_ROOT/bin/libexec/opencode/... (see
+      # copy-bundled-vela-cli.nix). Fail the build rather than shipping a
+      # desktop where collab/AMR is silently unavailable on a clean install.
+      if [ ! -x "$out/share/open-design/bin/vela" ]; then
+        echo "open-design-desktop: installed tree is missing share/open-design/bin/vela; the bundled Vela CLI contract would be broken" >&2
+        exit 1
+      fi
+      if [ ! -x "$out/share/open-design/bin/libexec/opencode/opencode" ]; then
+        echo "open-design-desktop: installed tree is missing share/open-design/bin/libexec/opencode/opencode; the bundled Vela OpenCode companion would be broken" >&2
+        exit 1
+      fi
+
+      runHook postInstallCheck
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      ${rebuildNativeAddons { messageSuffix = "pnpm install may have failed"; }}
+
+      pnpm --filter @open-design/release run build
+      pnpm --filter @open-design/components run build
+      pnpm --filter @open-design/contracts run build
+      pnpm --filter @open-design/registry-protocol run build
+      pnpm --filter @open-design/sidecar-proto run build
+      pnpm --filter @open-design/launcher-proto run build
+      pnpm --filter @open-design/sidecar run build
+      pnpm --filter @open-design/platform run build
+      pnpm --filter @open-design/download run build
+      pnpm --filter @open-design/host run build
+      pnpm --filter @open-design/agui-adapter run build
+      pnpm --filter @open-design/plugin-runtime run build
+      pnpm --filter @open-design/diagnostics run build
+      pnpm --filter @open-design/dsh-runtime run build
+      pnpm --filter @open-design/daemon run build
+      OD_WEB_OUTPUT_MODE=${lib.escapeShellArg webOutputMode} pnpm --filter @open-design/web run build
+      pnpm --filter @open-design/web run build:sidecar
+      pnpm --filter @open-design/desktop run build
+      pnpm --filter @open-design/packaged run build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      workspaceRoot=$out/lib/open-design
+      resourceRoot=$out/share/open-design
+      desktopIconRoot=$out/share/icons/hicolor/512x512/apps
+
+      mkdir -p \
+        $workspaceRoot \
+        $desktopIconRoot \
+        $resourceRoot/agent-runtimes/deepseek-harness \
+        $resourceRoot/skills \
+        $resourceRoot/design-templates \
+        $resourceRoot/design-systems \
+        $resourceRoot/craft \
+        $resourceRoot/plugins/_official \
+        $resourceRoot/plugins/registry \
+        $resourceRoot/frames \
+        $resourceRoot/community-pets \
+        $resourceRoot/prompt-templates \
+        $resourceRoot/data/plugin-previews \
+        $out/bin
+
+      cp -r . $workspaceRoot/
+
+      ${pruneWorkspaceRuntimeCopy {
+        workspaceRoot = "$workspaceRoot";
+        inherit workspacePaths;
+        extraKeepsByTarget = {
+          "apps/daemon" = [ "bin" ];
+          "apps/desktop" = [ "vendor" ];
+          # next.config.ts must survive pruning: the packaged web sidecar
+          # hands the writable runtime copy to Next.js through OD_WEB_DIST_DIR
+          # and that mapping (env -> distDir) lives only in this config. The
+          # sidecar starts Next via dir: webRoot, so without the file Next
+          # falls back to <webRoot>/.next and runs against the read-only
+          # Nix-store build, reintroducing EACCES on relaunch.
+          "apps/web" = [ ".next" "next.config.ts" "public" ];
+        };
+        rootNodeModulesRemovals = [
+          "@open-design/tools-dev"
+          "@open-design/tools-pack"
+          "@open-design/tools-release"
+          "@open-design/tools-serve"
+          ".bin/tools-dev"
+          ".bin/tools-pack"
+          ".bin/tools-release"
+          ".bin/tools-serve"
+        ];
+      }}
+
+      # Linux terminal contract: the daemon spawns terminals through
+      # node-pty, which has no Linux prebuilds, so the compiled addon must
+      # exist in the installed tree AND load under the same Node the
+      # packaged sidecars run with.
+      pty_dir=$(find "$out/lib/open-design/node_modules/.pnpm" -mindepth 2 -maxdepth 4 \
+        -type d -path '*/node-pty@*/node_modules/node-pty' -print -quit)
+      if [ -z "$pty_dir" ] || [ ! -f "$pty_dir/build/Release/pty.node" ]; then
+        echo "open-design-desktop: installed tree has no compiled Linux node-pty addon; /api/projects/:id/terminals would fail with TERMINAL_SPAWN_FAILED" >&2
+        exit 1
+      fi
+      # Load the addon through its own package entry point so this exercises
+      # exactly what the daemon's dynamic import does at runtime.
+      ${lib.getExe nodejs} -e "require(process.argv[1])" "$pty_dir"
+
+      # Packaging guard: the writable OD_WEB_DIST_DIR handoff only takes
+      # effect when next.config.ts is present in the installed apps/web tree
+      # (see the keep-list comment above). Fail the build here rather than
+      # shipping a desktop that runs against the read-only store copy.
+      if [ ! -f "$workspaceRoot/apps/web/next.config.ts" ]; then
+        echo "open-design-desktop: installed apps/web is missing next.config.ts; OD_WEB_DIST_DIR would be ignored" >&2
+        exit 1
+      fi
+
+      # Packaged desktop resolves preload relative to app.getAppPath().
+      install -m0644 apps/desktop/dist/main/preload.cjs $workspaceRoot/apps/packaged/preload.cjs
+      install -m0644 ${desktopIcon} $desktopIconRoot/${desktopIconName}.png
+
+      cp -r skills/. $resourceRoot/skills/
+      cp -r design-templates/. $resourceRoot/design-templates/
+      cp -r design-systems/. $resourceRoot/design-systems/
+      cp -r craft/. $resourceRoot/craft/
+      cp -r plugins/_official/. $resourceRoot/plugins/_official/
+      cp -r plugins/registry/. $resourceRoot/plugins/registry/
+      cp -r assets/frames/. $resourceRoot/frames/
+      cp -r assets/community-pets/. $resourceRoot/community-pets/
+      cp -r prompt-templates/. $resourceRoot/prompt-templates/
+      cp -r data/plugin-previews/. $resourceRoot/data/plugin-previews/
+
+      ${copyBundledVelaCli {
+        resourceRoot = "$resourceRoot";
+        velaTarball = velaCliTarball;
+      }}
+
+      pnpm -C packages/dsh-runtime pack --pack-destination $resourceRoot/agent-runtimes/deepseek-harness >/dev/null
+      dsh_tarball=$(basename "$resourceRoot"/agent-runtimes/deepseek-harness/*.tgz)
+      dsh_sha256=$(sha256sum "$resourceRoot/agent-runtimes/deepseek-harness/$dsh_tarball" | cut -d' ' -f1)
+      ${lib.getExe nodejs} ${dshRuntimeManifestWriter} \
+        "$resourceRoot/agent-runtimes/deepseek-harness/manifest.json" \
+        ${lib.escapeShellArg dshRuntimeManifestBase} \
+        "$dsh_tarball" \
+        "$dsh_sha256"
+
+      install -m0755 ${launcherScript} $out/bin/open-design-desktop
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "OpenDesign desktop runtime for Linux via Nix";
+      homepage = "https://github.com/nexu-io/open-design";
+      license = lib.licenses.asl20;
+      mainProgram = "open-design-desktop";
+      platforms = lib.platforms.linux;
+    };
+  })

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -11,4 +11,5 @@
   # 3. Copy the expected hash printed by Nix into the matching field below
   daemonHash = "sha256-ujXjphrP9TvyLvIFaiplOfWMhQEbMsy74KkCmqALkus=";
   webHash = "sha256-OfTksoOcxLu6OairFxQEYLQomj1JFCDEA3maKiH+9bQ=";
+  desktopHash = "sha256-3DWPRmVLcBRc+U3k6NT6bLNYfWbJ306aH+XE7gn5ZIM=";
 }

--- a/nix/prune-workspace-runtime-copy.nix
+++ b/nix/prune-workspace-runtime-copy.nix
@@ -1,0 +1,40 @@
+{ lib }:
+{
+  workspaceRoot,
+  workspacePaths,
+  extraKeepsByTarget ? { },
+  rootNodeModulesRemovals ? [ ],
+}:
+let
+  defaultKeeps = [ "dist" "node_modules" "package.json" ];
+  renderFindKeepArgs = keeps:
+    lib.concatMapStringsSep " \\\n" (keep: "              ! -name ${lib.escapeShellArg keep}") keeps;
+  renderCaseArm = target: let
+    keeps = defaultKeeps ++ (extraKeepsByTarget.${target} or [ ]);
+  in ''
+          ${target})
+            find "${workspaceRoot}/$target" -mindepth 1 -maxdepth 1 \
+${renderFindKeepArgs keeps} \
+              -exec rm -rf {} +
+            ;;
+'';
+  caseArms = lib.concatStringsSep "" (map renderCaseArm (builtins.attrNames extraKeepsByTarget));
+  rootNodeModulesRemovalLines = lib.concatMapStringsSep " \\\n" (entry: "        ${workspaceRoot}/node_modules/${entry}") rootNodeModulesRemovals;
+in
+  ''
+      for target in ${lib.escapeShellArgs workspacePaths}; do
+        case "$target" in
+${caseArms}          *)
+            find "${workspaceRoot}/$target" -mindepth 1 -maxdepth 1 \
+${renderFindKeepArgs defaultKeeps} \
+              -exec rm -rf {} +
+            ;;
+        esac
+      done
+
+''
+  + lib.optionalString (rootNodeModulesRemovals != [ ]) ''
+      rm -f \
+${rootNodeModulesRemovalLines}
+
+''

--- a/nix/rebuild-native-addons.nix
+++ b/nix/rebuild-native-addons.nix
@@ -1,0 +1,83 @@
+# Build native Node addons from source inside a Nix pnpm workspace install.
+#
+# Why from source:
+#   Neither addon ships a usable prebuild for our runtime target, so the
+#   packaged daemon/runtime must compile them during the derivation build:
+#   - better-sqlite3 publishes prebuilds only up to node-v131 (Node 22);
+#     there is no v137 (Node 24) prebuild, so `prebuild-install` would
+#     fail its CDN/GitHub fetch and fall through to a compile anyway.
+#   - node-pty@1.1.0 ships prebuilds for Darwin and Windows only; on Linux
+#     the addon must always be compiled or `require("node-pty")` fails at
+#     runtime and the daemon's /api/projects/:id/terminals route reports
+#     TERMINAL_SPAWN_FAILED for every packaged terminal.
+#
+# Why not `pnpm rebuild`:
+#   In pnpm 10, `onlyBuiltDependencies` interacts with the
+#   "approve-builds" consent gate; `pnpm rebuild <pkg>` can silently
+#   no-op. Invoke node-gyp directly to sidestep that path.
+#
+# Env vars:
+#   * npm_config_nodedir → use the headers shipped with the nixpkgs nodejs
+#     we're already building against, so node-gyp does not fetch them
+#     (there is no network in the build sandbox).
+#   * npm_config_build_from_source → skip prebuilt-binary download attempts.
+#
+# node-gyp lookup:
+#   nixpkgs nodejs ships node-gyp bundled inside npm at
+#   ${nodejs}/lib/node_modules/npm/bin/node-gyp-bin.
+{ lib, nodejs }:
+{
+  # Human-readable context appended to "not found" errors.
+  messageSuffix ? null,
+}:
+let
+  suffix = lib.optionalString (messageSuffix != null && messageSuffix != "") " - ${messageSuffix}";
+
+  addons = [
+    {
+      dirVar = "bsq_dir";
+      findPath = "*/better-sqlite3@*/node_modules/better-sqlite3";
+      artifact = "build/Release/better_sqlite3.node";
+    }
+    {
+      dirVar = "pty_dir";
+      findPath = "*/node-pty@*/node_modules/node-pty";
+      artifact = "build/Release/pty.node";
+    }
+  ];
+
+  renderAddon = addon:
+    let
+      # Bash variable reference for this addon's directory, built by
+      # concatenation so the emitted script reads e.g. "$bsq_dir".
+      dollarDirVar = "$" + addon.dirVar;
+    in ''
+      ${addon.dirVar}=$(find node_modules/.pnpm -mindepth 2 -maxdepth 4 \
+        -type d -path '${addon.findPath}' \
+        -print -quit)
+      if [ -z "${dollarDirVar}" ]; then
+        echo "ERROR: ${addon.findPath} not found under node_modules/.pnpm${suffix}" >&2
+        exit 1
+      fi
+
+      echo "Building native addon from source at ${dollarDirVar}"
+      ( cd "${dollarDirVar}" && node-gyp rebuild --release --build-from-source )
+
+      # Fail fast if the .node file did not land where require() expects it.
+      if [ ! -f "${dollarDirVar}/${addon.artifact}" ]; then
+        echo "ERROR: ${addon.artifact} was not produced at ${dollarDirVar}/build/Release/" >&2
+        find "${dollarDirVar}" -name '*.node' -print >&2 || true
+        exit 1
+      fi
+    '';
+in
+  lib.concatStringsSep "\n" (
+    [
+      ''
+        export npm_config_nodedir=${nodejs}
+        export npm_config_build_from_source=true
+        export PATH="${nodejs}/lib/node_modules/npm/bin/node-gyp-bin:$PATH"
+      ''
+    ]
+    ++ map renderAddon addons
+  )

--- a/scripts/update-nix-pnpm-deps-hash.ts
+++ b/scripts/update-nix-pnpm-deps-hash.ts
@@ -21,7 +21,27 @@ const consumers = [
     consumerPath: path.join(repoRoot, "nix/package-web.nix"),
     nixCommand: ["build", ".#web", "--print-build-logs"],
   },
+  {
+    hashKey: "desktopHash",
+    consumerPath: path.join(repoRoot, "nix/package-desktop.nix"),
+    nixCommand: ["build", ".#desktop", "--print-build-logs"],
+    // The desktop derivation is Linux-only (flake exposes packages.desktop
+    // behind linux platforms). Building it unconditionally would abort the
+    // whole refresh on a macOS maintainer machine before the daemon/web
+    // hashes get updated.
+    systems: ["x86_64-linux", "aarch64-linux"],
+  },
 ] as const;
+
+function currentNixSystem(): string | null {
+  const result = spawnSync(
+    "nix",
+    ["eval", "--impure", "--raw", "--expr", "builtins.currentSystem"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+  if (result.status !== 0) return null;
+  return result.stdout.trim() || null;
+}
 
 function extractExpectedHash(output: string): string | null {
   const matches = [...output.matchAll(/got:\s*(sha256-[A-Za-z0-9+/=]+)/g)];
@@ -30,8 +50,18 @@ function extractExpectedHash(output: string): string | null {
 
 async function main(): Promise<void> {
   const updates: string[] = [];
+  const nixSystem = currentNixSystem();
 
   for (const consumer of consumers) {
+    const allowedSystems = "systems" in consumer ? consumer.systems : undefined;
+    if (allowedSystems && (!nixSystem || !(allowedSystems as readonly string[]).includes(nixSystem))) {
+      process.stdout.write(
+        `Skipping ${consumer.hashKey}: ${consumer.nixCommand[1]} is not buildable on ` +
+          `${nixSystem ?? "<unknown nix system>"} (buildable: ${allowedSystems.join(", ")}).\n`,
+      );
+      continue;
+    }
+
     const originalConsumer = await readFile(consumer.consumerPath, "utf8");
     if (!originalConsumer.includes(consumerHashLine)) {
       throw new Error(


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->


## Why

I was working on bringing `.#desktop` up as a real Linux-native Nix desktop output and needed a packaged desktop layout that actually boots under Nix without changing the existing packaged contract used by the rest of the repo.

The pain here was that OpenDesign already had strong packaged runtime assumptions around `OD_PACKAGED_CONFIG_PATH`, `OD_RESOURCE_ROOT`, bundled `vela`, packaged Electron preload placement, and server-mode web sidecar startup, but there was no maintained Nix desktop derivation that respected those assumptions end to end. Getting `.#desktop` working required wiring a Linux-only packaged desktop output without dragging the whole `tools/pack` pipeline into Nix or regressing the existing packaged Linux/AppImage behavior.

## What users will see

Linux users consuming OpenDesign through Nix get a new desktop app output from the flake. Installing `.#desktop` gives them a launchable desktop app and `.desktop` entry that starts the packaged Electron runtime with the expected daemon and web sidecars.

From a runtime perspective, the packaged Nix desktop now behaves like a real installed app instead of a partial wrapper:
- the daemon and web sidecars boot successfully under the Nix layout
- packaged resources, bundled `vela`, preload, and desktop vendor assets are found in the expected places
- repeated launches reuse the namespace runtime successfully instead of failing on a read-only copied web dist

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test paths that reproduce the startup/runtime regressions:
  - `apps/daemon/tests/server-paths.test.ts`
  - `apps/packaged/tests/sidecars.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Additional verification:
  - built and launched `nix build .#desktop`
  - verified a first-run smoke boot under a fresh `XDG_DATA_HOME`
  - verified a second launch against the same namespace/runtime root to confirm the copied `web-dist` stays writable and no longer fails with `EACCES`

## Validation

- `nix-instantiate --parse nix/package-desktop.nix`
- `nix-instantiate --parse nix/prune-workspace-runtime-copy.nix`
- `git diff --check`
- `nix develop -c pnpm --filter @open-design/packaged typecheck`
- `nix develop -c pnpm --filter @open-design/daemon build`
- `nix develop -c pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/server-paths.test.ts`
- `nix develop -c pnpm --dir apps/packaged exec vitest run -c vitest.config.ts tests/sidecars.test.ts`
- `nix build .#desktop`
- Verified output layout:
  - `result/lib/open-design/apps/packaged/preload.cjs`
  - `result/lib/open-design/apps/desktop/vendor/dom-to-pptx/dom-to-pptx.bundle.js.gz`
  - `result/bin/open-design-desktop`
  - `result/share/applications/open-design-desktop.desktop`
- Smoke-verified packaged runtime boot from the built Nix output:
  - daemon started and reported a URL
  - web started and reported a URL
  - desktop loaded `od://app/`
- Smoke-verified two consecutive launches on the same `XDG_DATA_HOME` to confirm the second launch no longer fails on `runtime/web-dist/BUILD_ID`