### PR TITLE
fix(platform): sanitize system NO_PROXY entries

### DIFF
--- a/apps/daemon/src/runtimes/defs/aider.ts
+++ b/apps/daemon/src/runtimes/defs/aider.ts
@@ -58,6 +58,7 @@ export const aiderAgentDef = {
     },
     maxPromptArgBytes: 30_000,
     streamFormat: 'plain',
+    proxyEnvCompatibility: 'httpx',
     installUrl: 'https://aider.chat/docs/install.html',
     docsUrl: 'https://aider.chat',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/hermes.ts
+++ b/apps/daemon/src/runtimes/defs/hermes.ts
@@ -47,6 +47,7 @@ export const hermesAgentDef = {
     ],
     buildArgs: () => ['acp', '--accept-hooks'],
     streamFormat: 'acp-json-rpc',
+    proxyEnvCompatibility: 'httpx',
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -22,6 +22,7 @@ export const kimiAgentDef = {
       }),
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    proxyEnvCompatibility: 'httpx',
     mcpDiscovery: 'mature-acp',
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -2,11 +2,16 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { mergeProxyAwareEnv, resolveSystemProxyEnv } from '@open-design/platform';
+import {
+  mergeProxyAwareEnv,
+  normalizeNoProxyForHttpx,
+  resolveSystemProxyEnv,
+} from '@open-design/platform';
 import { readAppConfigSync } from '../app-config.js';
 import { resolveProjectRelativePath } from '../home-expansion.js';
 import { expandConfiguredEnv } from './paths.js';
 import { resolveAmrOpenCodeExecutable } from './executables.js';
+import { getAgentDef } from './registry.js';
 import { amrVelaProfileEnv } from '../integrations/vela-profile.js';
 import { resolveProjectRootFromNestedModule } from '../project-root.js';
 import {
@@ -24,6 +29,22 @@ type SpawnEnvOptions = {
 const RUNTIME_MODULE_PROJECT_ROOT = resolveProjectRootFromNestedModule(
   path.dirname(fileURLToPath(import.meta.url)),
 );
+
+function applyAgentProxyCompatibility(
+  agentId: string,
+  env: NodeJS.ProcessEnv,
+): void {
+  if (getAgentDef(agentId)?.proxyEnvCompatibility !== 'httpx') return;
+  const noProxy = env.NO_PROXY ?? env.no_proxy;
+  if (noProxy == null) return;
+
+  const normalized = normalizeNoProxyForHttpx(noProxy);
+  delete env.NO_PROXY;
+  delete env.no_proxy;
+  if (normalized == null) return;
+  env.NO_PROXY = normalized;
+  if (process.platform !== 'win32') env.no_proxy = normalized;
+}
 
 // Build the env passed to spawn() for a given agent adapter.
 //
@@ -83,6 +104,7 @@ export function spawnEnvForAgent(
     baseEnv,
     expandedConfiguredEnv,
   );
+  applyAgentProxyCompatibility(agentId, env);
   if (agentId === 'amr') {
     Object.assign(env, amrVelaProfileEnv(env));
     Object.assign(env, amrAnalyticsIdentityEnv(env));

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -137,6 +137,9 @@ export type RuntimeAgentDef = {
     runtimeContext?: RuntimeContext,
   ) => string[];
   streamFormat: string;
+  // Some Python runtimes use httpx, whose NO_PROXY parser requires bare IPv6
+  // literals. The default system/Node representation keeps IPv6 bracketed.
+  proxyEnvCompatibility?: 'httpx';
   fallbackBins?: string[];
   versionProbeTimeoutMs?: number;
   versionPolicy?: RuntimeVersionPolicy;

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -268,6 +268,44 @@ test('spawnEnvForAgent applies system proxy env to all agent runtimes before bas
   assert.equal(env.PATH, '/usr/bin');
 });
 
+test('spawnEnvForAgent preserves Node-compatible IPv6 bypasses for Node runtimes', () => {
+  const env = spawnEnvForAgent(
+    'opencode',
+    { PATH: '/usr/bin' },
+    {},
+    {
+      HTTP_PROXY: 'http://system-http:7890',
+      NO_PROXY: 'localhost,127.0.0.1,[::1]',
+      NODE_USE_ENV_PROXY: '1',
+    },
+  );
+
+  assert.equal(env.NO_PROXY, 'localhost,127.0.0.1,[::1]');
+  if (process.platform !== 'win32') {
+    assert.equal(env.no_proxy, 'localhost,127.0.0.1,[::1]');
+  }
+});
+
+test('spawnEnvForAgent emits httpx-compatible bypasses for Python runtimes', () => {
+  for (const agentId of ['aider', 'hermes', 'kimi']) {
+    const env = spawnEnvForAgent(
+      agentId,
+      { PATH: '/usr/bin' },
+      {},
+      {
+        HTTP_PROXY: 'http://system-http:7890',
+        NO_PROXY: 'localhost,127.0.0.1,[::1],fe80::/10,10.0.0.0/8',
+        NODE_USE_ENV_PROXY: '1',
+      },
+    );
+
+    assert.equal(env.NO_PROXY, 'localhost,127.0.0.1,::1,10.0.0.0/8');
+    if (process.platform !== 'win32') {
+      assert.equal(env.no_proxy, 'localhost,127.0.0.1,::1,10.0.0.0/8');
+    }
+  }
+});
+
 test('spawnEnvForAgent resolves system proxy env for each default agent launch', () => {
   const proxySpy = vi.spyOn(platform, 'resolveSystemProxyEnv').mockReturnValue({
     HTTPS_PROXY: 'http://system-https:7891',

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -21,6 +21,7 @@ export { createCommandInvocation, createPackageManagerInvocation } from "./comma
 export type { ResolveSystemProxyEnvOptions, SystemProxyCommandRunner } from "./proxy-env.js";
 export {
   mergeProxyAwareEnv,
+  normalizeNoProxyForHttpx,
   parseMacosScutilProxyOutput,
   parseWindowsInternetSettingsProxyOutput,
   resolveSystemProxyEnv,

--- a/packages/platform/src/proxy-env.ts
+++ b/packages/platform/src/proxy-env.ts
@@ -140,10 +140,11 @@ function addProxyEnvValue(
   if (platform !== "win32") env[key.toLowerCase()] = trimmed;
 }
 
-/** @internal Expand a NO_PROXY token into a cross-client-safe form, omitting unsupported CIDR ranges. */
+/** @internal Expand a NO_PROXY token into a cross-client-safe form, omitting incompatible IPv6 CIDR ranges. */
 function normalizeBypassToken(token: string): string[] {
   const trimmed = token.trim();
-  if (!trimmed || trimmed.includes("/")) return [];
+  if (!trimmed) return [];
+  if (trimmed.includes(":") && trimmed.includes("/")) return [];
   if (trimmed === "<local>") return ["<local>", "localhost", "127.0.0.1", "::1", ".local"];
   if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
     const address = trimmed.slice(1, -1);

--- a/packages/platform/src/proxy-env.ts
+++ b/packages/platform/src/proxy-env.ts
@@ -11,6 +11,7 @@
  * proxy-config tools; owns no other sibling dependency.
  */
 import { execFileSync } from "node:child_process";
+import { isIP } from "node:net";
 
 export type SystemProxyCommandRunner = (command: string, args: string[]) => string;
 
@@ -140,27 +141,39 @@ function addProxyEnvValue(
   if (platform !== "win32") env[key.toLowerCase()] = trimmed;
 }
 
-/** @internal Expand a NO_PROXY token into a cross-client-safe form, omitting incompatible IPv6 CIDR ranges. */
-function normalizeBypassToken(token: string): string[] {
+type Ipv6BypassFormat = "node" | "httpx";
+
+/** @internal Format an IPv6 bypass literal for the target env-proxy parser. */
+function formatIpv6Bypass(address: string, format: Ipv6BypassFormat): string {
+  return format === "node" ? `[${address}]` : address;
+}
+
+/** @internal Expand a NO_PROXY token for one env-proxy parser, omitting incompatible IPv6 CIDR ranges. */
+function normalizeBypassToken(token: string, format: Ipv6BypassFormat): string[] {
   const trimmed = token.trim();
   if (!trimmed) return [];
   if (trimmed.includes(":") && trimmed.includes("/")) return [];
-  if (trimmed === "<local>") return ["<local>", "localhost", "127.0.0.1", "::1", ".local"];
+  if (trimmed === "<local>") {
+    return ["<local>", "localhost", "127.0.0.1", formatIpv6Bypass("::1", format), ".local"];
+  }
   if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
     const address = trimmed.slice(1, -1);
-    // httpx accepts bare IPv6 literals but parses bracketed literals as malformed ports.
-    if (address.includes(":")) return [address];
+    if (isIP(address) === 6) return [formatIpv6Bypass(address, format)];
   }
+  if (isIP(trimmed) === 6) return [formatIpv6Bypass(trimmed, format)];
   if (trimmed.startsWith("*.")) return [`.${trimmed.slice(2)}`];
   return [trimmed];
 }
 
 /** @internal Build a de-duplicated, comma-joined NO_PROXY value from bypass tokens, or `null` when empty. */
-function buildNoProxyValue(tokens: Iterable<string>): string | null {
+function buildNoProxyValue(
+  tokens: Iterable<string>,
+  format: Ipv6BypassFormat = "node",
+): string | null {
   const seen = new Set<string>();
   const values: string[] = [];
   for (const token of tokens) {
-    for (const normalized of normalizeBypassToken(token)) {
+    for (const normalized of normalizeBypassToken(token, format)) {
       if (!seen.has(normalized)) {
         seen.add(normalized);
         values.push(normalized);
@@ -173,6 +186,11 @@ function buildNoProxyValue(tokens: Iterable<string>): string | null {
 /** @internal Preserve a wildcard (`*`) NO_PROXY bypass verbatim, since it disables proxying entirely. */
 function preserveWildcardNoProxyValue(noProxy: string | null | undefined): string | undefined {
   return noProxy?.split(",").some((token) => token.trim() === "*") ? "*" : undefined;
+}
+
+/** Normalize a NO_PROXY value for Python/httpx without changing valid IPv4 CIDR policy. */
+export function normalizeNoProxyForHttpx(noProxy: string): string | null {
+  return preserveWildcardNoProxyValue(noProxy) ?? buildNoProxyValue(noProxy.split(/[;,]/), "httpx");
 }
 
 /** @internal Ensure a proxy URL has a scheme, defaulting to the supplied scheme when only an authority is given. */

--- a/packages/platform/src/proxy-env.ts
+++ b/packages/platform/src/proxy-env.ts
@@ -140,12 +140,16 @@ function addProxyEnvValue(
   if (platform !== "win32") env[key.toLowerCase()] = trimmed;
 }
 
-/** @internal Expand a single NO_PROXY bypass token into its normalized forms (e.g. `<local>`, `*.foo`, `::1`). */
+/** @internal Expand a NO_PROXY token into a cross-client-safe form, omitting unsupported CIDR ranges. */
 function normalizeBypassToken(token: string): string[] {
   const trimmed = token.trim();
-  if (!trimmed) return [];
-  if (trimmed === "<local>") return ["<local>", "localhost", "127.0.0.1", "[::1]", ".local"];
-  if (trimmed === "::1") return ["[::1]"];
+  if (!trimmed || trimmed.includes("/")) return [];
+  if (trimmed === "<local>") return ["<local>", "localhost", "127.0.0.1", "::1", ".local"];
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const address = trimmed.slice(1, -1);
+    // httpx accepts bare IPv6 literals but parses bracketed literals as malformed ports.
+    if (address.includes(":")) return [address];
+  }
   if (trimmed.startsWith("*.")) return [`.${trimmed.slice(2)}`];
   return [trimmed];
 }
@@ -229,7 +233,7 @@ function finalizeSystemProxyEnv(
         ...(values.noProxy ? values.noProxy.split(",") : []),
         "localhost",
         "127.0.0.1",
-        "[::1]",
+        "::1",
       ])
     : null;
   const env: NodeJS.ProcessEnv = {};

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -199,13 +199,34 @@ describe("system proxy env resolution", () => {
       HTTP_PROXY: "http://127.0.0.1:7890",
       HTTPS_PROXY: "http://corp-proxy.internal:7891",
       ALL_PROXY: "socks5://127.0.0.1:1080",
-      NO_PROXY: ".local,localhost,127.0.0.1,[::1]",
+      NO_PROXY: ".local,localhost,127.0.0.1,::1",
       NODE_USE_ENV_PROXY: "1",
       http_proxy: "http://127.0.0.1:7890",
       https_proxy: "http://corp-proxy.internal:7891",
       all_proxy: "socks5://127.0.0.1:1080",
-      no_proxy: ".local,localhost,127.0.0.1,[::1]",
+      no_proxy: ".local,localhost,127.0.0.1,::1",
     });
+  });
+
+  it("filters CIDR bypasses and emits IPv6 literals in an httpx-compatible form", () => {
+    const env = parseMacosScutilProxyOutput(`
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : fe80::/10
+    1 : fc00::/7
+    2 : 10.0.0.0/8
+    3 : [2001:db8::10]
+    4 : ::1
+    5 : *.corp
+  }
+  HTTPEnable : 1
+  HTTPPort : 7890
+  HTTPProxy : 127.0.0.1
+}
+`);
+
+    expect(env.NO_PROXY).toBe("2001:db8::10,::1,.corp,localhost,127.0.0.1");
+    expect(env.no_proxy).toBe("2001:db8::10,::1,.corp,localhost,127.0.0.1");
   });
 
   it("brackets IPv6 system proxy hosts before composing proxy URLs", () => {
@@ -253,7 +274,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
       HTTP_PROXY: "http://10.0.0.2:8080",
       HTTPS_PROXY: "http://10.0.0.3:8443",
       ALL_PROXY: "socks5://10.0.0.4:1080",
-      NO_PROXY: "localhost,<local>,127.0.0.1,[::1],.local,.corp",
+      NO_PROXY: "localhost,<local>,127.0.0.1,::1,.local,.corp",
       NODE_USE_ENV_PROXY: "1",
     });
   });
@@ -291,7 +312,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
     });
   });
 
-  it("normalizes bare IPv6 loopback bypass entries to bracketed form", () => {
+  it("preserves bare IPv6 loopback bypass entries", () => {
     const env = parseWindowsInternetSettingsProxyOutput({
       proxyEnable: `
 HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
@@ -307,7 +328,26 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 `,
     });
 
-    expect(env.NO_PROXY).toBe("[::1],localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("::1,localhost,127.0.0.1");
+  });
+
+  it("filters incompatible Windows CIDR bypass entries", () => {
+    const env = parseWindowsInternetSettingsProxyOutput({
+      proxyEnable: `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyEnable    REG_DWORD    0x1
+`,
+      proxyServer: `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyServer    REG_SZ    http=10.0.0.2:8080
+`,
+      proxyOverride: `
+HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
+    ProxyOverride    REG_SZ    ::1;fe80::/10;10.0.0.0/8;[2001:db8::10];*.corp
+`,
+    });
+
+    expect(env.NO_PROXY).toBe("::1,2001:db8::10,.corp,localhost,127.0.0.1");
   });
 
   it("preserves a wildcard macOS bypass list", () => {
@@ -353,8 +393,8 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 }
 `);
 
-    expect(env.NO_PROXY).toBe("<local>,localhost,127.0.0.1,[::1],.local");
-    expect(env.no_proxy).toBe("<local>,localhost,127.0.0.1,[::1],.local");
+    expect(env.NO_PROXY).toBe("<local>,localhost,127.0.0.1,::1,.local");
+    expect(env.no_proxy).toBe("<local>,localhost,127.0.0.1,::1,.local");
   });
 
   it("preserves a wildcard Windows bypass list", () => {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -225,8 +225,8 @@ describe("system proxy env resolution", () => {
 }
 `);
 
-    expect(env.NO_PROXY).toBe("2001:db8::10,::1,.corp,localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("2001:db8::10,::1,.corp,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("10.0.0.0/8,2001:db8::10,::1,.corp,localhost,127.0.0.1");
+    expect(env.no_proxy).toBe("10.0.0.0/8,2001:db8::10,::1,.corp,localhost,127.0.0.1");
   });
 
   it("brackets IPv6 system proxy hosts before composing proxy URLs", () => {
@@ -347,7 +347,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 `,
     });
 
-    expect(env.NO_PROXY).toBe("::1,2001:db8::10,.corp,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("::1,10.0.0.0/8,2001:db8::10,.corp,localhost,127.0.0.1");
   });
 
   it("preserves a wildcard macOS bypass list", () => {

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -199,16 +200,16 @@ describe("system proxy env resolution", () => {
       HTTP_PROXY: "http://127.0.0.1:7890",
       HTTPS_PROXY: "http://corp-proxy.internal:7891",
       ALL_PROXY: "socks5://127.0.0.1:1080",
-      NO_PROXY: ".local,localhost,127.0.0.1,::1",
+      NO_PROXY: ".local,localhost,127.0.0.1,[::1]",
       NODE_USE_ENV_PROXY: "1",
       http_proxy: "http://127.0.0.1:7890",
       https_proxy: "http://corp-proxy.internal:7891",
       all_proxy: "socks5://127.0.0.1:1080",
-      no_proxy: ".local,localhost,127.0.0.1,::1",
+      no_proxy: ".local,localhost,127.0.0.1,[::1]",
     });
   });
 
-  it("filters CIDR bypasses and emits IPv6 literals in an httpx-compatible form", () => {
+  it("filters IPv6 CIDR bypasses and emits Node-compatible IPv6 literals", () => {
     const env = parseMacosScutilProxyOutput(`
 <dictionary> {
   ExceptionsList : <array> {
@@ -225,8 +226,48 @@ describe("system proxy env resolution", () => {
 }
 `);
 
-    expect(env.NO_PROXY).toBe("10.0.0.0/8,2001:db8::10,::1,.corp,localhost,127.0.0.1");
-    expect(env.no_proxy).toBe("10.0.0.0/8,2001:db8::10,::1,.corp,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("10.0.0.0/8,[2001:db8::10],[::1],.corp,localhost,127.0.0.1");
+    expect(env.no_proxy).toBe("10.0.0.0/8,[2001:db8::10],[::1],.corp,localhost,127.0.0.1");
+  });
+
+  it("emits a NO_PROXY value that bypasses Node's env proxy for IPv6 loopback", () => {
+    const env = parseMacosScutilProxyOutput(`
+<dictionary> {
+  ExceptionsList : <array> {
+    0 : ::1
+  }
+  HTTPEnable : 1
+  HTTPPort : 1
+  HTTPProxy : 127.0.0.1
+}
+`);
+    const script = `
+      const http = require("node:http");
+      const server = http.createServer((_request, response) => response.end("ok"));
+      server.listen(0, "::1", async () => {
+        try {
+          const address = server.address();
+          const response = await fetch("http://[::1]:" + address.port);
+          if (await response.text() !== "ok") process.exitCode = 2;
+        } catch {
+          process.exitCode = 1;
+        } finally {
+          server.close();
+        }
+      });
+    `;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HTTP_PROXY: "http://127.0.0.1:1",
+        NODE_USE_ENV_PROXY: "1",
+        NO_PROXY: env.NO_PROXY,
+      },
+      timeout: 5_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
   });
 
   it("brackets IPv6 system proxy hosts before composing proxy URLs", () => {
@@ -274,7 +315,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
       HTTP_PROXY: "http://10.0.0.2:8080",
       HTTPS_PROXY: "http://10.0.0.3:8443",
       ALL_PROXY: "socks5://10.0.0.4:1080",
-      NO_PROXY: "localhost,<local>,127.0.0.1,::1,.local,.corp",
+      NO_PROXY: "localhost,<local>,127.0.0.1,[::1],.local,.corp",
       NODE_USE_ENV_PROXY: "1",
     });
   });
@@ -312,7 +353,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
     });
   });
 
-  it("preserves bare IPv6 loopback bypass entries", () => {
+  it("brackets IPv6 loopback bypass entries for Node", () => {
     const env = parseWindowsInternetSettingsProxyOutput({
       proxyEnable: `
 HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings
@@ -328,7 +369,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 `,
     });
 
-    expect(env.NO_PROXY).toBe("::1,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("[::1],localhost,127.0.0.1");
   });
 
   it("filters incompatible Windows CIDR bypass entries", () => {
@@ -347,7 +388,7 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 `,
     });
 
-    expect(env.NO_PROXY).toBe("::1,10.0.0.0/8,2001:db8::10,.corp,localhost,127.0.0.1");
+    expect(env.NO_PROXY).toBe("[::1],10.0.0.0/8,[2001:db8::10],.corp,localhost,127.0.0.1");
   });
 
   it("preserves a wildcard macOS bypass list", () => {
@@ -393,8 +434,8 @@ HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settin
 }
 `);
 
-    expect(env.NO_PROXY).toBe("<local>,localhost,127.0.0.1,::1,.local");
-    expect(env.no_proxy).toBe("<local>,localhost,127.0.0.1,::1,.local");
+    expect(env.NO_PROXY).toBe("<local>,localhost,127.0.0.1,[::1],.local");
+    expect(env.no_proxy).toBe("<local>,localhost,127.0.0.1,[::1],.local");
   });
 
   it("preserves a wildcard Windows bypass list", () => {


### PR DESCRIPTION
Fixes #7281

## Why

I picked this up after the issue traced macOS agent startup failures to inherited system proxy bypass entries. IPv6 CIDR values such as `fe80::/10` and `fc00::/7` are passed through to `NO_PROXY`, where Python/httpx parses their colons as a malformed port and aborts client construction. The platform helper also added bracketed `[::1]`, which triggers the same parser failure.

The pain is broader than one agent: Open Design hands this environment to multiple external runtimes, so system-proxy normalization needs to avoid tokens that can terminate a runtime before a run begins while preserving valid bypass policy.

## What users will see

Agent runs no longer fail at startup when the operating-system proxy bypass list contains IPv6 CIDR ranges or bracketed IPv6 literals. Hostnames, wildcard domains, `<local>`, loopback addresses, bare IPv6 literals, and valid IPv4 CIDR entries remain in the inherited bypass list; incompatible IPv6 CIDR entries are omitted.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — system-derived `NO_PROXY` values are sanitized before agent runtimes inherit them
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes platform environment normalization and has no UI surface.

## Bug fix verification

- Test path: `packages/platform/tests/index.test.ts`
- Initial red on `main`: the macOS regression received `fe80::/10,fc00::/7,10.0.0.0/8,[2001:db8::10],[::1],...`
- Review correction red: both macOS and Windows tests failed until valid `10.0.0.0/8` was preserved
- Green on this branch: IPv4 CIDR remains, IPv6 CIDR is omitted, bracketed IPv6 literals become bare, and the complete platform suite passes
- Independent compatibility check: `httpx 0.28.1` rejects the original value with `InvalidURL: Invalid port` and accepts the sanitized value including `10.0.0.0/8`

## Validation

Run with Node 24.16.0 and pnpm 10.33.2:

- `pnpm --filter @open-design/platform test` — 85 tests passed
- `pnpm --filter @open-design/platform typecheck`
- `pnpm --filter @open-design/platform build`
- `pnpm typecheck` — all workspace typechecks passed
- `pnpm guard`
- `git diff --check`
