### PR TITLE
feat(analytics): report why an installed agent CLI cannot be used

### DIFF
--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -28,7 +28,16 @@ import { atomcodeAgentDef } from './defs/atomcode.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
-const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
+/**
+ * The agents this build ships, before anything a particular machine adds.
+ *
+ * `AGENT_DEFS` below appends whatever local profiles the user has declared, so
+ * it answers "what can this machine run" — a different question from "what do
+ * we ship", and the wrong list for anything that must hold everywhere. A local
+ * profile id is required not to collide with one of these (see
+ * `createLocalAgentDef`), so it is always an id we have never heard of.
+ */
+export const SHIPPED_AGENT_DEFS: RuntimeAgentDef[] = [
   amrAgentDef,
   claudeAgentDef,
   codexAgentDef,
@@ -59,14 +68,14 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
 ];
 
 export function readLocalAgentProfileDefs(
-  baseDefs: RuntimeAgentDef[] = BASE_AGENT_DEFS,
+  baseDefs: RuntimeAgentDef[] = SHIPPED_AGENT_DEFS,
 ): RuntimeAgentDef[] {
   return readLocalAgentProfileDefsFromFile(baseDefs);
 }
 
 export const AGENT_DEFS: RuntimeAgentDef[] = [
-  ...BASE_AGENT_DEFS,
-  ...readLocalAgentProfileDefs(BASE_AGENT_DEFS),
+  ...SHIPPED_AGENT_DEFS,
+  ...readLocalAgentProfileDefs(SHIPPED_AGENT_DEFS),
 ];
 
 const ids = new Set();

--- a/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
+++ b/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
 import { agentIdToTracking } from '@open-design/contracts/analytics';
 import { SHIPPED_AGENT_DEFS } from '../../src/runtimes/registry.js';
 
@@ -29,5 +32,43 @@ describe('every shipped agent has its own analytics id', () => {
     expect(agentIdToTracking('my-custom-agent')).toBe('other');
     expect(agentIdToTracking('not-a-shipped-agent')).toBe('other');
     expect(agentIdToTracking(null)).toBe('other');
+  });
+
+  // The regression that made this guard worth rewriting: whose machine it runs
+  // on must not change the answer. Walking AGENT_DEFS instead of
+  // SHIPPED_AGENT_DEFS fails here with `expected [ 'my-custom-agent' ] to
+  // deeply equal []` — a developer's personal config wearing the costume of a
+  // missing mapper case. Registry lists are built once at module load, so the
+  // profile has to exist before the import to be part of it.
+  it('stays green on a machine that declares a local agent profile', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'od-local-agent-profile-'));
+    const profilesFile = path.join(dir, 'agents.local.json');
+    writeFileSync(
+      profilesFile,
+      JSON.stringify({ agents: [{ id: 'my-custom-agent', baseAgent: 'claude' }] }),
+    );
+    vi.stubEnv('OD_AGENT_PROFILES_CONFIG', profilesFile);
+    vi.resetModules();
+
+    try {
+      const registry = await import('../../src/runtimes/registry.js');
+
+      // Guards the assertions below against passing for the boring reason that
+      // the profile never loaded at all.
+      expect(registry.AGENT_DEFS.map((def) => def.id)).toContain('my-custom-agent');
+      expect(registry.SHIPPED_AGENT_DEFS.map((def) => def.id)).not.toContain(
+        'my-custom-agent',
+      );
+
+      const collapsed = registry.SHIPPED_AGENT_DEFS.map((def) => def.id)
+        .filter((id) => agentIdToTracking(id) === 'other')
+        .sort();
+
+      expect(collapsed).toEqual([]);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });

--- a/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
+++ b/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
@@ -1,22 +1,32 @@
 import { describe, expect, it } from 'vitest';
 import { agentIdToTracking } from '@open-design/contracts/analytics';
-import { AGENT_DEFS } from '../../src/runtimes/registry.js';
+import { SHIPPED_AGENT_DEFS } from '../../src/runtimes/registry.js';
 
 // `other` is the honest answer for an agent id analytics has never heard of.
 // It is the wrong answer for one we ship: an agent that lands there is invisible
 // to any breakdown or alert asking *which* CLI failed, which is the only
 // question worth asking when a CLI someone installed cannot be used. Adding a
 // runtime def without teaching the tracking enum about it fails here.
+//
+// This asserts against SHIPPED_AGENT_DEFS rather than AGENT_DEFS on purpose.
+// AGENT_DEFS also carries the local profiles declared in the developer's own
+// `agents.local.json`, whose ids are required not to collide with a shipped one
+// and so correctly collapse to `other`. Walking that list would turn anyone's
+// personal config into a failure that reads exactly like a missing mapper case,
+// and the next person to hit it could not tell the two apart.
 describe('every shipped agent has its own analytics id', () => {
-  it('maps no registered agent to the catch-all bucket', () => {
-    const collapsed = AGENT_DEFS.map((def) => def.id)
+  it('maps no shipped agent to the catch-all bucket', () => {
+    const collapsed = SHIPPED_AGENT_DEFS.map((def) => def.id)
       .filter((id) => agentIdToTracking(id) === 'other')
       .sort();
 
     expect(collapsed).toEqual([]);
   });
 
+  // A locally declared agent is not ours to name. PostHog should never learn an
+  // id out of someone's `agents.local.json`, so collapsing it is the intent.
   it('still buckets an unknown id as other', () => {
+    expect(agentIdToTracking('my-custom-agent')).toBe('other');
     expect(agentIdToTracking('not-a-shipped-agent')).toBe('other');
     expect(agentIdToTracking(null)).toBe('other');
   });

--- a/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
+++ b/apps/daemon/tests/runtimes/agent-tracking-ids.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { agentIdToTracking } from '@open-design/contracts/analytics';
+import { AGENT_DEFS } from '../../src/runtimes/registry.js';
+
+// `other` is the honest answer for an agent id analytics has never heard of.
+// It is the wrong answer for one we ship: an agent that lands there is invisible
+// to any breakdown or alert asking *which* CLI failed, which is the only
+// question worth asking when a CLI someone installed cannot be used. Adding a
+// runtime def without teaching the tracking enum about it fails here.
+describe('every shipped agent has its own analytics id', () => {
+  it('maps no registered agent to the catch-all bucket', () => {
+    const collapsed = AGENT_DEFS.map((def) => def.id)
+      .filter((id) => agentIdToTracking(id) === 'other')
+      .sort();
+
+    expect(collapsed).toEqual([]);
+  });
+
+  it('still buckets an unknown id as other', () => {
+    expect(agentIdToTracking('not-a-shipped-agent')).toBe('other');
+    expect(agentIdToTracking(null)).toBe('other');
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, typ
 import { flushSync } from 'react-dom';
 import { AnimatePresence, motion, MotionConfig } from 'motion/react';
 import { Button } from '@open-design/components';
+import { reportAgentDetectDiagnostics } from './analytics/agent-detect';
 import { useAnalytics } from './analytics/provider';
 import {
   trackExperienceSurveyDismissed,
@@ -2052,6 +2053,7 @@ function AppInner() {
       })
         .then((list) => {
           if (cancelled || !isCurrentAgentStreamRequest(agentRequestId)) return;
+          reportAgentDetectDiagnostics(analytics.track, list);
           setAgents(
             mergeAmrModelsIntoAgents(
               orderAgentsByRegistry(list),
@@ -2855,6 +2857,7 @@ function AppInner() {
           },
         });
         const ordered = orderAgentsByRegistry(next);
+        reportAgentDetectDiagnostics(analytics.track, ordered);
         if (isCurrentAgentStreamRequest(agentRequestId)) {
           setAgents(mergeAmrModelsIntoAgents(ordered, amrModelsRef.current));
           setAgentsLoading(false);

--- a/apps/web/src/analytics/agent-detect.ts
+++ b/apps/web/src/analytics/agent-detect.ts
@@ -1,0 +1,50 @@
+import { agentIdToTracking } from '@open-design/contracts/analytics';
+import type { AgentInfo } from '@open-design/contracts';
+import { trackAgentDetectDiagnostic, type Track } from './events';
+
+/**
+ * Report what agent detection found wrong, so a CLI someone installed and
+ * cannot use is visible without them filing a report.
+ *
+ * Every diagnostic detection produces is worth reporting, not only blocking
+ * ones: an `untested-version` warning across many installs is the signal that
+ * our supported-version list has fallen behind what our own installer ships,
+ * which is exactly how that goes unnoticed. `info` diagnostics are excluded —
+ * they describe healthy states.
+ *
+ * Reported once per `(agent, reason, version)` per page session. Detection runs
+ * on cold start and on every rescan, and a user staring at Settings would
+ * otherwise inflate the count for one broken install into dozens of events.
+ * Deduped, the number means "installs affected", which is the denominator any
+ * decision here actually needs. The version is part of the key so a user who
+ * upgrades a CLI and still fails is counted again.
+ */
+const reported = new Set<string>();
+
+/** Drop the dedupe memory. Exported for tests; production sessions never reset. */
+export function resetAgentDetectDiagnosticReporting(): void {
+  reported.clear();
+}
+
+export function reportAgentDetectDiagnostics(
+  track: Track,
+  agents: readonly AgentInfo[],
+): void {
+  for (const agent of agents) {
+    for (const diagnostic of agent.diagnostics ?? []) {
+      if (diagnostic.severity === 'info') continue;
+      const key = `${agent.id}|${diagnostic.reason}|${agent.version ?? ''}`;
+      if (reported.has(key)) continue;
+      reported.add(key);
+      trackAgentDetectDiagnostic(track, {
+        area: 'runtime_detection',
+        cli_provider_id: agentIdToTracking(agent.id),
+        reason: diagnostic.reason,
+        severity: diagnostic.severity,
+        agent_available: agent.available,
+        has_path: Boolean(agent.path),
+        ...(agent.version ? { agent_version: agent.version } : {}),
+      });
+    }
+  }
+}

--- a/apps/web/src/analytics/events.ts
+++ b/apps/web/src/analytics/events.ts
@@ -149,6 +149,7 @@ import type {
   SettingsConnectorAuthResultProps,
   ByokPreflightBlockedProps,
   OnboardingClickProps,
+  AgentDetectDiagnosticProps,
   OnboardingRuntimeScanResultProps,
   OnboardingCompleteResultProps,
   OnboardingPromptPrefilledProps,
@@ -182,7 +183,7 @@ import type {
 } from '@open-design/contracts/analytics';
 
 type TrackOptions = { requestId?: string; insertId?: string };
-type Track = (
+export type Track = (
   event: string,
   properties: Record<string, unknown>,
   options?: TrackOptions,
@@ -1319,6 +1320,13 @@ export function trackOnboardingClick(
   props: OnboardingClickProps,
 ): void {
   send(track, 'ui_click', props);
+}
+
+export function trackAgentDetectDiagnostic(
+  track: Track,
+  props: AgentDetectDiagnosticProps,
+): void {
+  send(track, 'agent_detect_diagnostic', props);
 }
 
 export function trackOnboardingRuntimeScanResult(

--- a/apps/web/tests/analytics/agent-detect.test.ts
+++ b/apps/web/tests/analytics/agent-detect.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentInfo } from '@open-design/contracts';
+import {
+  reportAgentDetectDiagnostics,
+  resetAgentDetectDiagnosticReporting,
+} from '../../src/analytics/agent-detect';
+
+function agent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    id: 'deepseek-harness',
+    name: 'DeepSeek Harness',
+    bin: 'dsh',
+    available: false,
+    ...overrides,
+  };
+}
+
+describe('agent detection diagnostics reporting', () => {
+  beforeEach(() => {
+    resetAgentDetectDiagnosticReporting();
+  });
+
+  it('names the agent instead of collapsing it into "other"', () => {
+    const track = vi.fn();
+    reportAgentDetectDiagnostics(track, [
+      agent({
+        path: '/Users/someone/.local/bin/dsh',
+        version: '0.1.0-rc.8',
+        diagnostics: [
+          { reason: 'untested-version', severity: 'warning', message: 'untested' },
+        ],
+      }),
+    ]);
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track.mock.calls[0]?.[0]).toBe('agent_detect_diagnostic');
+    expect(track.mock.calls[0]?.[1]).toMatchObject({
+      area: 'runtime_detection',
+      cli_provider_id: 'deepseek_harness',
+      reason: 'untested-version',
+      severity: 'warning',
+      agent_available: false,
+      agent_version: '0.1.0-rc.8',
+      has_path: true,
+    });
+  });
+
+  // An agent binary path contains the OS username, so it must never leave the
+  // machine. `has_path` carries the only thing the analysis needs: whether the
+  // row was renderable at all.
+  it('never sends the resolved path', () => {
+    const track = vi.fn();
+    reportAgentDetectDiagnostics(track, [
+      agent({
+        path: '/Users/someone/.local/bin/dsh',
+        diagnostics: [{ reason: 'shim-broken', severity: 'error', message: 'broken' }],
+      }),
+    ]);
+
+    expect(JSON.stringify(track.mock.calls[0]?.[1])).not.toContain('someone');
+    expect(track.mock.calls[0]?.[1]).toMatchObject({ has_path: true });
+  });
+
+  // Detection runs on cold start and on every rescan. Counting each pass would
+  // turn one broken install into dozens of events and make the number mean
+  // "times Settings was opened" instead of "installs affected".
+  it('reports one install once, however many times detection runs', () => {
+    const track = vi.fn();
+    const scanned = [
+      agent({
+        version: '0.1.0-rc.6',
+        diagnostics: [{ reason: 'shim-broken', severity: 'error', message: 'broken' }],
+      }),
+    ];
+
+    reportAgentDetectDiagnostics(track, scanned);
+    reportAgentDetectDiagnostics(track, scanned);
+    reportAgentDetectDiagnostics(track, scanned);
+
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  // ...but a user who upgrades the CLI and still fails is a different fact.
+  it('reports again when the version changed', () => {
+    const track = vi.fn();
+    const diagnostics: AgentInfo['diagnostics'] = [
+      { reason: 'shim-broken', severity: 'error', message: 'broken' },
+    ];
+
+    reportAgentDetectDiagnostics(track, [agent({ version: '0.1.0-rc.6', diagnostics })]);
+    reportAgentDetectDiagnostics(track, [agent({ version: '0.1.0-rc.8', diagnostics })]);
+
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores healthy agents and info-level notes', () => {
+    const track = vi.fn();
+    reportAgentDetectDiagnostics(track, [
+      agent({ id: 'claude', available: true }),
+      agent({
+        id: 'codex',
+        available: true,
+        diagnostics: [{ reason: 'auth-unknown', severity: 'info', message: 'fyi' }],
+      }),
+    ]);
+
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/contracts/src/analytics/events/event-names.ts
+++ b/packages/contracts/src/analytics/events/event-names.ts
@@ -70,6 +70,10 @@ export type AnalyticsEventName =
   | 'settings_byok_models_fetch_result'
   | 'byok_preflight_blocked'
   | 'settings_connector_auth_result'
+  // Fleet health for locally installed agent CLIs. Detection is the only stage
+  // that learns an installed CLI cannot actually be used; without this, the
+  // only way we hear about it is a user filing a report with a diagnostics zip.
+  | 'agent_detect_diagnostic'
   // AMR (hosted model) account auth result.
   | 'amr_auth_stage'
   | 'amr_auth_result'

--- a/packages/contracts/src/analytics/events/event-payload.ts
+++ b/packages/contracts/src/analytics/events/event-payload.ts
@@ -7,7 +7,8 @@ import type { AmrAuthStageProps } from './amr-auth.js';
 import type { DesignSystemApplyResultProps, DesignSystemCreateResultProps, DesignSystemEnrichResultProps, DesignSystemReviewResultProps, DesignSystemSourceIngestResultProps, DesignSystemStatusResultProps } from './design-systems.js';
 import type { OnboardingCompletedProps, OnboardingCompleteResultProps, OnboardingFirstGenerationCompletedProps, OnboardingFirstPromptSentProps, OnboardingPromptPrefilledProps, OnboardingRuntimeScanResultProps } from './onboarding.js';
 import type { PageViewProps } from './page-view.js';
-import type { ArtifactDeployResultProps, ArtifactExportResultProps, ArtifactPublishResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ByokPreflightBlockedProps, ContextLinkResultProps, ConversationForkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, MediaGenerationResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateCheckResultProps, UpdateInstallResultProps } from './result-events.js';
+import type {
+  AgentDetectDiagnosticProps, ArtifactDeployResultProps, ArtifactExportResultProps, ArtifactPublishResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ByokPreflightBlockedProps, ContextLinkResultProps, ConversationForkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, MediaGenerationResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateCheckResultProps, UpdateInstallResultProps } from './result-events.js';
 import type { SurfaceViewProps } from './surface-view.js';
 import type { AmrAuthResultProps, UiClickProps } from './ui-click.js';
 import type {
@@ -77,6 +78,7 @@ export type AnalyticsEventPayload =
     }
   | { event: 'byok_preflight_blocked'; props: ByokPreflightBlockedProps }
   | { event: 'settings_connector_auth_result'; props: SettingsConnectorAuthResultProps }
+  | { event: 'agent_detect_diagnostic'; props: AgentDetectDiagnosticProps }
   | { event: 'amr_auth_stage'; props: AmrAuthStageProps }
   | { event: 'amr_auth_result'; props: AmrAuthResultProps }
   | { event: 'onboarding_runtime_scan_result'; props: OnboardingRuntimeScanResultProps }

--- a/packages/contracts/src/analytics/events/mappers.ts
+++ b/packages/contracts/src/analytics/events/mappers.ts
@@ -194,6 +194,34 @@ export function agentIdToTracking(agentId: string | null | undefined): TrackingC
       return 'pi';
     case 'kilo':
       return 'kilo';
+    case 'kiro':
+      return 'kiro';
+    case 'vibe':
+      return 'vibe';
+    case 'amp':
+      return 'amp';
+    case 'aider':
+      return 'aider';
+    case 'trae-cli':
+      return 'trae_cli';
+    case 'grok-build':
+      return 'grok_build';
+    case 'antigravity':
+      return 'antigravity';
+    case 'codebuddy':
+      return 'codebuddy';
+    case 'reasonix':
+      return 'reasonix';
+    case 'mimo':
+      return 'mimo';
+    case 'atomcode':
+      return 'atomcode';
+    case 'byok-opencode':
+      return 'byok_opencode';
+    case 'deepseek':
+      return 'deepseek';
+    case 'deepseek-harness':
+      return 'deepseek_harness';
     case 'amr':
       return 'amr';
     default:

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -12,6 +12,7 @@ import type {
 } from '../public-params.js';
 import type { ReleaseChannel } from '@open-design/release';
 import type { ArtifactOriginEntrySurface, ArtifactOriginStatus } from '../../api/files.js';
+import type { AgentDiagnosticReason, AgentDiagnosticSeverity } from '../../api/registry.js';
 import type { TrackingDesignSystemEditSurface, TrackingDesignSystemKind, TrackingDesignSystemLengthBucket, TrackingDesignSystemOrigin, TrackingDesignSystemRunEntryFrom } from './design-systems.js';
 import type { TrackingSettingsPage } from './event-names.js';
 import type { TrackingAmrOpenCodeErrorPhase, TrackingAmrOpenCodeLastEventType, TrackingAmrOpenCodeLastToolKind, TrackingAmrOpenCodeLastToolStatus, TrackingArtifactKind, TrackingArtifactWriteSource, TrackingArtifactWriteStatus, TrackingByokPreflightBlockReason, TrackingByokProviderId, TrackingCliProviderId, TrackingDesignSystemSource, TrackingExecutionMode, TrackingExportFormat, TrackingExportResult, TrackingFeedbackAction, TrackingFeedbackProviderId, TrackingFeedbackRating, TrackingFeedbackRatingWithNone, TrackingFeedbackReasonCode, TrackingFidelity, TrackingFileSizeBucket, TrackingFileType, TrackingFirstModelEventType, TrackingLangfuseDeliveryStatus, TrackingLangfuseDropReason, TrackingLangfuseReportResult, TrackingLangfuseReportSkipReason, TrackingProjectKind, TrackingProjectSource, TrackingPublishErrorCode, TrackingResult, TrackingRunCancelOrigin, TrackingRunCloseReason, TrackingRunDiagnosticSource, TrackingRunFailureCategory, TrackingRunFailureDetail, TrackingRunFailureStage, TrackingRunFailureUserAction, TrackingRunLifecyclePhase, TrackingRunPhaseTimingStatus, TrackingRunResult, TrackingRunRetryFinalResult, TrackingRunRetryStrategy, TrackingRunRetrySuppressedReason, TrackingRunTerminalTrigger, TrackingStderrLineCountBucket, TrackingTestResult, TrackingTokenCountSource } from './shared-enums.js';
@@ -999,6 +1000,31 @@ export interface AssistantFeedbackReasonSubmitProps
 export interface SettingsViewProps {
   page_name: TrackingSettingsPage;
   area: TrackingSettingsArea;
+}
+
+/**
+ * One diagnostic detection produced for one agent CLI. Answers, fleet-wide, the
+ * question a single bug report can only answer for one machine: how many
+ * installs of an agent someone installed cannot actually be used, and why.
+ *
+ * Carries no `page_name` on purpose. Detection is a daemon fact reported to
+ * whichever surface asked for the agent list; the surface is incidental to the
+ * failure and splitting by it would fragment the only number that matters.
+ *
+ * Carries no resolved path on purpose either — an agent binary path contains
+ * the OS username.
+ */
+export interface AgentDetectDiagnosticProps {
+  area: 'runtime_detection';
+  cli_provider_id: TrackingCliProviderId;
+  reason: AgentDiagnosticReason;
+  severity: AgentDiagnosticSeverity;
+  /** Warnings are not blocking, so availability is what separates them. */
+  agent_available: boolean;
+  /** The version detection read, when it read one. */
+  agent_version?: string;
+  /** A row with no path is hidden entirely — the user sees nothing to fix. */
+  has_path: boolean;
 }
 
 export interface SettingsCliTestResultProps {

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -170,12 +170,17 @@ export type TrackingByokProviderId =
 // v2 CLI provider catalogue (CSV row 63 + image 59). Adds `qoder_cli` and
 // `kilo` over v1, plus `amr` (the vela CLI runtime) so AMR runs no longer
 // fold into the `other` catch-all bucket.
+// Every agent the daemon can detect needs its own id here. An agent that falls
+// through to `other` is invisible to any breakdown or alert that asks *which*
+// CLI failed — which is the only question worth asking when an install someone
+// followed our own instructions for cannot be used.
 export type TrackingCliProviderId =
   | 'claude_code'
   | 'codex_cli'
   | 'devin_for_terminal'
   | 'gemini_cli'
   | 'opencode'
+  | 'byok_opencode'
   | 'hermes'
   | 'kimi_cli'
   | 'cursor_agent'
@@ -184,6 +189,19 @@ export type TrackingCliProviderId =
   | 'github_copilot_cli'
   | 'pi'
   | 'kilo'
+  | 'kiro'
+  | 'vibe'
+  | 'amp'
+  | 'aider'
+  | 'trae_cli'
+  | 'grok_build'
+  | 'antigravity'
+  | 'codebuddy'
+  | 'reasonix'
+  | 'mimo'
+  | 'atomcode'
+  | 'deepseek'
+  | 'deepseek_harness'
   | 'amr'
   | 'other';
 


### PR DESCRIPTION
## Why

A user installed DeepSeek Harness correctly on Windows and OpenDesign showed nothing — no row, no diagnostic, no entry point. We only found out because they said so and sent a diagnostics zip. #7153 fixes the four defects behind that, but the reason it took a bug report to surface is separate and unfixed: **detection is the one stage that knows an installed CLI cannot be used, and it tells nobody.**

There is no way today to ask how many installs are in that state, which CLI, or why. That gap is what let the same class of problem sit unnoticed: #7153 also found that our own installer had been moved to `0.1.0-rc.8` while the agent def still named `0.1.0-rc.6`, so every user who followed our instructions got an "untested version" warning — a spike that would have been obvious in a chart and was invisible without one.

I hit this while chasing that report, so this is a scratch-your-own-itch PR: I want the next one of these to show up on a dashboard before a colleague has to write it up.

## What users will see

Nothing, directly. This adds one analytics event; there is no UI, no setting, and no change to what any surface renders. It rides the existing consent path — an install with analytics off sends nothing, exactly as before.

For us: `agent_detect_diagnostic` answers "how many installs cannot use an agent they installed, and why", broken down by CLI, reason, severity, and version.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — new analytics event `agent_detect_diagnostic` in `packages/contracts`; `TrackingCliProviderId` gains the 14 agent ids that were missing
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Not applicable — no UI surface.

## Bug fix verification

Not a bug fix, but both guards were verified by breaking them on purpose:

- `apps/daemon/tests/runtimes/agent-tracking-ids.test.ts` — removing the `deepseek-harness` mapper case goes red with `expected [ 'deepseek-harness' ] to deeply equal []`.
- `apps/web/tests/analytics/agent-detect.test.ts` — five cases covering the dedupe, the version re-key, the severity filter, and the path never leaving the machine.

## Validation

- `pnpm typecheck` — exit 0 across all packages
- `pnpm guard` — exit 0
- `pnpm --filter @open-design/web exec vitest run tests/analytics/` — 11 files, 128 passed
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/` — 51 files, 750 passed / 2 skipped

## Design notes for reviewers

Three choices worth a look, each of which could reasonably have gone the other way.

**Half the registry was invisible before this started.** `TrackingCliProviderId` listed 14 ids while the daemon ships 28 runtime defs, so DeepSeek Harness, Antigravity, Grok Build, BYOK OpenCode, Kiro, Vibe, Amp, Aider, Trae, CodeBuddy, Reasonix, Mimo, AtomCode and DeepSeek TUI all collapsed into `other`. A breakdown that cannot name the failing CLI answers nothing, so the enum is now complete and a test fails when a new runtime def arrives without an id. This is additive for existing consumers, but it does change what they see: rows that used to read `other` will now name their agent. That is the point, and it is worth knowing before it shows up on a chart.

**Reported once per `(agent, reason, version)` per page session.** Detection runs on cold start and on every rescan, so counting passes would turn one broken install into dozens of events and make the number mean "times Settings was opened". Deduped, it means "installs affected". The version is in the key so a user who upgrades a CLI and still fails is counted again.

**Emitted from the web client, not the daemon.** The daemon is where the fact originates, and that was my first instinct. But the event contract expects a `page_name` the daemon cannot know — detection answers whichever surface asked — and routing it daemon-side would have meant a new deps slice on the agents route for no gain. The web client already funnels every agent scan through two call sites in `App.tsx`, so both are covered. The tradeoff: a machine that only ever drives OpenDesign through the `od` CLI reports nothing. That is acceptable for now — the symptom this measures is a row missing from a picker — but it is a real limit and I would rather name it than have a reviewer find it.

**Warnings are reported, not just blocking errors.** An `untested-version` warning is not a broken install, so it is tempting to filter it out. It is also exactly the signal that our supported-version list has fallen behind what our own installer ships, which is the failure this PR exists to make visible. `info` diagnostics are excluded — they describe healthy states.

**No path, ever.** An agent binary path contains the OS username. `has_path` carries the only part the analysis needs: whether the row was renderable at all, since the picker hides a row that has none.
