### PR TITLE
feat(mcp): make stdio idle exit configurable

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -2272,6 +2272,14 @@ Options:
                        daemon changes ports, so an existing task can
                        survive an OpenDesign restart.
 
+Environment:
+  OD_MCP_STDIO_IDLE_EXIT_MS
+                       Milliseconds without MCP activity before this
+                       stdio process exits. Defaults to 1800000 (30
+                       minutes), is capped at 86400000 (24 hours), and
+                       can be set to 0 to keep the process alive until
+                       the MCP client disconnects.
+
 Tools exposed:
   list_projects                  list every OpenDesign project
   get_active_context             what project/file the user has open right now

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -65,7 +65,8 @@ import {
 
 const SERVER_NAME = 'open-design';
 const SERVER_VERSION = '0.2.0';
-const MCP_STDIO_IDLE_EXIT_MS = 30 * 60 * 1000;
+const DEFAULT_MCP_STDIO_IDLE_EXIT_MS = 30 * 60 * 1000;
+const MAX_MCP_STDIO_IDLE_EXIT_MS = 24 * 60 * 60 * 1000;
 export const OPEN_DESIGN_BRIEF_APP_RESOURCE =
   'ui://open-design/artifact-card-v8.html';
 
@@ -210,6 +211,17 @@ interface McpIdleExitControllerOptions {
   onIdle: () => void;
 }
 
+export function _resolveMcpStdioIdleExitMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const raw = env.OD_MCP_STDIO_IDLE_EXIT_MS?.trim();
+  const parsed = Number(raw);
+  if (!raw || !Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_MCP_STDIO_IDLE_EXIT_MS;
+  }
+  return Math.min(MAX_MCP_STDIO_IDLE_EXIT_MS, Math.floor(parsed));
+}
+
 export function _createMcpIdleExitController({
   idleMs,
   onIdle,
@@ -226,7 +238,7 @@ export function _createMcpIdleExitController({
   };
 
   const schedule = () => {
-    if (disposed) return;
+    if (disposed || idleMs <= 0) return;
     clear();
     timer = setTimeout(() => {
       timer = null;
@@ -1781,7 +1793,7 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
   let observabilityPromise: Promise<McpObservabilitySession> | null = null;
   let closeTransportForIdle: (() => void) | null = null;
   const idleExit = _createMcpIdleExitController({
-    idleMs: MCP_STDIO_IDLE_EXIT_MS,
+    idleMs: _resolveMcpStdioIdleExitMs(),
     onIdle: () => closeTransportForIdle?.(),
   });
   const withMcpActivity =

--- a/apps/daemon/tests/mcp-stdio-idle.test.ts
+++ b/apps/daemon/tests/mcp-stdio-idle.test.ts
@@ -1,5 +1,39 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { _createMcpIdleExitController } from '../src/mcp.js';
+import {
+  _createMcpIdleExitController,
+  _resolveMcpStdioIdleExitMs,
+} from '../src/mcp.js';
+
+describe('MCP stdio idle exit timeout', () => {
+  it('defaults to 30 minutes', () => {
+    expect(_resolveMcpStdioIdleExitMs({})).toBe(30 * 60 * 1_000);
+  });
+
+  it('normalizes an environment override', () => {
+    expect(
+      _resolveMcpStdioIdleExitMs({ OD_MCP_STDIO_IDLE_EXIT_MS: '1234.9' }),
+    ).toBe(1_234);
+    expect(
+      _resolveMcpStdioIdleExitMs({
+        OD_MCP_STDIO_IDLE_EXIT_MS: String(48 * 60 * 60 * 1_000),
+      }),
+    ).toBe(24 * 60 * 60 * 1_000);
+  });
+
+  it('uses zero to disable idle exit', () => {
+    expect(
+      _resolveMcpStdioIdleExitMs({ OD_MCP_STDIO_IDLE_EXIT_MS: '0' }),
+    ).toBe(0);
+  });
+
+  it('falls back to the default for invalid values', () => {
+    for (const value of ['', '   ', '-1', 'not-a-number']) {
+      expect(
+        _resolveMcpStdioIdleExitMs({ OD_MCP_STDIO_IDLE_EXIT_MS: value }),
+      ).toBe(30 * 60 * 1_000);
+    }
+  });
+});
 
 describe('MCP stdio idle exit controller', () => {
   afterEach(() => {
@@ -70,6 +104,21 @@ describe('MCP stdio idle exit controller', () => {
     idleExit.dispose();
     vi.advanceTimersByTime(1_000);
 
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('does not schedule an exit when disabled', async () => {
+    vi.useFakeTimers();
+    const onIdle = vi.fn();
+    const idleExit = _createMcpIdleExitController({ idleMs: 0, onIdle });
+
+    expect(vi.getTimerCount()).toBe(0);
+
+    idleExit.noteActivity();
+    await idleExit.trackRequest(async () => undefined);
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
+
+    expect(vi.getTimerCount()).toBe(0);
     expect(onIdle).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #7287

## Why

Long-running coding-agent sessions can be quiet for more than 30 minutes between OpenDesign MCP calls. The fixed stdio idle-exit timeout then closes an otherwise healthy MCP process and makes OpenDesign tools unavailable until the client respawns it.

Issue #7287 aligned on keeping the existing 30-minute behavior by default while allowing operators to override or disable it for longer sessions.

## What users will see

The default remains unchanged: `od mcp` exits after 30 minutes without MCP activity.

Users can now set `OD_MCP_STDIO_IDLE_EXIT_MS` to choose a timeout in milliseconds. Values are capped at 24 hours, and `0` disables idle exit so the process stays alive until the MCP client disconnects. Invalid, blank, or negative values fall back to the 30-minute default. The setting is documented in `od mcp --help`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a CLI environment variable and the discoverability surface is `od mcp --help`.

## Bug fix verification

- Regression coverage: `apps/daemon/tests/mcp-stdio-idle.test.ts`
- The new resolver/disabled-timeout assertions were run before the implementation and failed (5 failures), then passed after the source change (9/9).
- Coverage includes the unchanged default, fractional overrides, the 24-hour cap, explicit zero disablement, blank/negative/invalid fallback, and ensuring disabled controllers never schedule a timer.

## Validation

- `pnpm install --frozen-lockfile` (Node 24 / pnpm 10.33.2)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-stdio-idle.test.ts` — 9/9 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/daemon build` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed on Node 24.16.0 / pnpm 10.33.2
- `node apps/daemon/dist/cli.js mcp --help` — verified the environment documentation at runtime
- Full daemon suite: 8,692 passed / 6 skipped; one unrelated order-sensitive assertion in `run-create-workspace-gate.test.ts` failed in the full run (expected 202, received 200). Re-running that complete file passed 53/53; this change does not touch workspace-gate/server behavior.
- `git diff --check` — passed