### PR TITLE
fix(packaged): report the daemon log tail when startup failure is unparseable

### DIFF
--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -200,6 +200,37 @@ export function parseDaemonLogTail(logText: string): {
   return out;
 }
 
+// Bounds for the raw-tail fallback below. 40 lines is enough to carry a thrown
+// stack plus the lines around it; 4000 chars is the hard cap — 2x ERROR_STACK_MAX
+// because for this bucket the tail is the ONLY signal (there is no parsed error
+// and no stack worth sending), while still staying far under the 16 KiB we read
+// off disk so a chatty daemon cannot balloon the payload.
+const LOG_TAIL_SAMPLE_MAX_LINES = 40;
+const LOG_TAIL_SAMPLE_MAX = 4000;
+
+// The fallback for logs `parseDaemonLogTail` cannot name.
+//
+// Production (14 days to 2026-08-22): the single largest startup-failure bucket
+// is macOS `daemon-start` — 968 events across 293 people — where the daemon
+// exits code=1, the native module IS present, and error_code / missing_module /
+// daemon_error all come back null. The reason was printed in a log tail we had
+// already read and then discarded, because the parser only names shapes we
+// already know. Shipping the tail itself turns that bucket from undiagnosable
+// into readable.
+//
+// Scrub BEFORE truncating so no username can survive in the slice, and keep the
+// END of the tail: it is chronological, so the fatal line sits nearest the exit
+// (the same reasoning that makes parseDaemonLogTail take the LAST match).
+export function buildDaemonLogTailSample(logText: string): string | null {
+  const lines = logText.split(/\r?\n/);
+  while (lines.length > 0 && (lines[lines.length - 1] ?? "").trim() === "") lines.pop();
+  if (lines.length === 0) return null;
+  const scrubbed = scrubUserPaths(lines.slice(-LOG_TAIL_SAMPLE_MAX_LINES).join("\n"));
+  if (scrubbed.length <= LOG_TAIL_SAMPLE_MAX) return scrubbed;
+  const dropped = scrubbed.length - LOG_TAIL_SAMPLE_MAX;
+  return `…[+${dropped} chars]${scrubbed.slice(-LOG_TAIL_SAMPLE_MAX)}`;
+}
+
 // Reduce `syscall` to the bare operation token.
 //
 // Node does NOT guarantee this is only the operation name: a failed
@@ -431,6 +462,12 @@ export async function reportStartupFailure(
     let errorCode: string | undefined;
     let missingModule: string | undefined;
     let daemonError: string | undefined;
+    // Only populated when the parse above found NOTHING (see
+    // buildDaemonLogTailSample). Narrow on purpose: when we can already name the
+    // cause, the raw tail is bytes and privacy surface for no new information,
+    // and keeping it narrow makes the field itself a signal — its presence means
+    // "this log defeated the parser".
+    let daemonLogTail: string | null = null;
     if (classification.logPath) {
       const tail = await (deps.readLogTail ?? defaultReadLogTail)(classification.logPath);
       if (tail) {
@@ -438,6 +475,9 @@ export async function reportStartupFailure(
         errorCode = parsed.errorCode;
         missingModule = parsed.missingModule;
         daemonError = parsed.daemonError;
+        if (!errorCode && !missingModule && !daemonError) {
+          daemonLogTail = buildDaemonLogTailSample(tail);
+        }
       }
     }
     const rawMessage =
@@ -487,6 +527,7 @@ export async function reportStartupFailure(
       daemon_error: daemonError
         ? truncateForTelemetry(scrubUserPaths(daemonError), ERROR_MESSAGE_MAX)
         : null,
+      daemon_log_tail: daemonLogTail,
       sys_code: sys.code,
       sys_errno: sys.errno,
       sys_syscall: sys.syscall,

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -666,3 +666,102 @@ describe('errno triplet privacy', () => {
     expect(classifyStartupFailure(err, false).failureKind).toBe('spawn-failed');
   });
 });
+
+// The blind bucket (production, 14 days to 2026-08-22): macOS `daemon-start`
+// with 968 events across 293 people where the daemon exits code=1, the native
+// module IS present, and error_code / missing_module / daemon_error all come
+// back empty. `parseDaemonLogTail` only names patterns we already know
+// (`ERR_*`, a missing module, an `XError:` headline); when a daemon dies of
+// anything else, the reason is sitting in a log tail we ALREADY READ and then
+// threw away. These tests pin the recovery: when parsing yields nothing, send
+// the tail itself — scrubbed and bounded — so the largest startup-failure
+// bucket stops being undiagnosable.
+describe('daemon_log_tail (unparseable log recovery)', () => {
+  // Nothing here matches ERR_*, "Cannot find module/package", or the
+  // `XError: …` headline — exactly the shape that reports all-null today.
+  const UNPARSEABLE_LOG = [
+    '[open-design packaged] starting app=daemon',
+    'loading config from /Users/liudetao/Library/Application Support/Open Design/config.json',
+    'cache dir C:\\Users\\John Doe\\AppData\\Roaming\\Open Design\\cache',
+    'something we have never seen went wrong while binding the port',
+    '[open-design packaged] exited app=daemon pid=45305 code=1 signal=none',
+  ].join('\n');
+
+  async function captureProps(
+    readLogTail: () => Promise<string | null>,
+  ): Promise<Record<string, unknown>> {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.20.2',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch, readLogTail },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    return (JSON.parse(init.body as string) as { properties: Record<string, unknown> }).properties;
+  }
+
+  it('ships the scrubbed tail when the log matches no known pattern', async () => {
+    const props = await captureProps(async () => UNPARSEABLE_LOG);
+    // Precondition: this really is the blind case — every parsed field is null.
+    expect(props.error_code).toBeNull();
+    expect(props.missing_module).toBeNull();
+    expect(props.daemon_error).toBeNull();
+    // The recovery: the line that names the failure actually reaches us.
+    expect(String(props.daemon_log_tail)).toContain(
+      'something we have never seen went wrong while binding the port',
+    );
+  });
+
+  it('redacts POSIX and Windows home dirs in the tail it ships', async () => {
+    const props = await captureProps(async () => UNPARSEABLE_LOG);
+    const tail = String(props.daemon_log_tail);
+    expect(tail).not.toContain('liudetao');
+    expect(tail).not.toContain('John Doe');
+    expect(tail).toContain('/Users/<redacted>');
+    expect(tail).toContain('C:\\Users\\<redacted>');
+  });
+
+  it('bounds the shipped tail and keeps the lines nearest the exit', async () => {
+    // A daemon that logged a lot before dying must not blow the payload up, and
+    // the part worth keeping is the END: the tail is chronological, so the
+    // fatal line sits nearest the exit.
+    const noisy = [
+      ...Array.from({ length: 500 }, (_, i) => `noise line ${i} ${'x'.repeat(200)}`),
+      'the actual last words before the daemon died',
+    ].join('\n');
+    const props = await captureProps(async () => noisy);
+    const tail = String(props.daemon_log_tail);
+    expect(tail).toContain('the actual last words before the daemon died');
+    expect(tail).not.toContain('noise line 0 ');
+    expect(tail.length).toBeLessThanOrEqual(4200);
+  });
+
+  it('sends no tail when the log already parsed into a known signal', async () => {
+    // Guard against ballooning every event: when we can already name the cause
+    // (#4638 shape), the raw tail adds bytes and privacy surface for nothing.
+    const props = await captureProps(async () => ISSUE_4638_LOG);
+    expect(props.error_code).toBe('ERR_MODULE_NOT_FOUND');
+    expect(props.daemon_log_tail).toBeNull();
+  });
+
+  it('sends no tail when there is no log to read (status-timeout / spawn buckets)', async () => {
+    const props = await captureProps(async () => null);
+    expect(props.daemon_log_tail).toBeNull();
+  });
+
+  it('sends no tail for a log file that exists but is blank', async () => {
+    // A daemon that opened its log and died before writing anything: the read
+    // succeeds and the string is truthy, so this reaches the builder. Sending
+    // "\n\n" would be residue that reads like real evidence on a dashboard.
+    const props = await captureProps(async () => '\n   \n\n');
+    expect(props.daemon_log_tail).toBeNull();
+  });
+});

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -1100,6 +1100,16 @@ export interface PackagedRuntimeFailedProps {
   // though the reason was sitting in a log we had already read. Scrubbed and
   // truncated like the other free-form fields.
   daemon_error?: string | null;
+  // The scrubbed, bounded tail of that same log, sent ONLY when the parse above
+  // produced nothing (no error_code, no missing_module, no daemon_error). That
+  // all-null combination is the largest startup-failure bucket in production
+  // (macOS daemon-start, 968 events / 293 people over the 14 days to
+  // 2026-08-22) and was previously undiagnosable: the reason was printed in a
+  // log we had already read and discarded because it matched no known pattern.
+  // Narrow by design — when the cause is already named, the raw tail is bytes
+  // and privacy surface for nothing, so a present value also *means* "this log
+  // defeated the parser".
+  daemon_log_tail?: string | null;
   // Node's system-error triplet read off the THROWN error object, as opposed to
   // `error_code`, which is parsed out of the sidecar log. A failed spawn or
   // socket op carries its real cause here (`UNKNOWN`/-4094/`spawn`,


### PR DESCRIPTION
## Why

I was diagnosing a user report of "the app closes itself on the splash screen at 2/7 Starting the local engine" and went to the `packaged_runtime_failed` data to find out which failure they hit. It turned out the largest bucket cannot be answered at all.

Production, 14 days to 2026-08-22: `packaged_runtime_failed` fires for roughly 150–180 people/day (0.6–0.9% of daily active people); 1690 people in the window, 611 of whom never completed a single run — they installed something that does not open. The **single largest bucket is macOS `daemon-start`: 968 events across 293 people** where the daemon exits `code=1`, `native_module_present=true` (the native module is right there), and `error_code` / `missing_module` / `daemon_error` are all null.

That bucket is undiagnosable for a silly reason: `reportStartupFailure` already reads the daemon log tail, hands it to `parseDaemonLogTail`, and then throws it away when nothing matches. `parseDaemonLogTail` only names shapes we already know (`ERR_*`, `Cannot find module/package`, an `XError: …` headline), so a daemon that died of anything else reports "no idea" while the reason sits in a log we had in memory a line earlier.

This PR ships that tail. It is the cheapest possible move on the biggest bucket: no new code path, no new I/O, no new dependency — just stop discarding evidence we already hold.

Full analysis (three buckets, per-platform breakdown, the other actions): https://powerformer.feishu.cn/docx/HOjpd11BSoZQ1txIPuec2tovnCf

## What users will see

Nothing. This is failure-path-only telemetry in the packaged main process; a successful startup never touches it. What changes is our side: for the ~293-person macOS bucket the crash event now carries the daemon's own last words instead of a row of nulls, so the next person triaging it can name the cause instead of guessing.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — one optional field, `daemon_log_tail`, added to `PackagedRuntimeFailedProps` in `packages/contracts`. Optional-field-only, so `EVENT_SCHEMA_VERSION` is not bumped (same convention as #5224, which added `error_message` / `error_stack` / `native_module_*` to this event).
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

n/a — no UI.

## Bug fix verification

- Test path that reproduces the gap: `apps/packaged/tests/startup-telemetry.test.ts` → `describe('daemon_log_tail (unparseable log recovery)')`
- Did the test go red on `main` and green on this branch? **yes** — 5 new tests failed on clean `origin/main` (`expected undefined to be null` / the tail assertions), all green after the change. Baseline diffed first: `origin/main` was already failing 3 `desktop-*.test.ts` files at collection before I touched anything, and those resolve once `@open-design/desktop` is built.
- What the tests pin:
  - a log matching **no** known pattern ships its tail, and the line naming the failure actually arrives;
  - both `/Users/liudetao/…` and `C:\Users\John Doe\…` are redacted in the shipped tail (the Windows case matters — a profile dir can contain spaces);
  - a 500-line noisy log is bounded and keeps the lines **nearest the exit**, dropping the old noise;
  - a log that **did** parse (the #4638 `ERR_MODULE_NOT_FOUND` shape) sends **no** tail — the guard against this quietly ballooning every event;
  - no log to read (status-timeout / spawn buckets) → no tail;
  - a log file that exists but is blank → no tail, rather than shipping `"\n\n"` as if it were evidence.

## Validation

- `pnpm guard` → exit 0
- `pnpm typecheck` (root) → exit 0
- `pnpm --filter @open-design/packaged test` → 22 files, **306 passed**
- `pnpm --filter @open-design/contracts` build → exit 0, typecheck → exit 0, test → 39 files / 282 passed

## Privacy

Unchanged consent behavior. This event already rides the existing stability-telemetry bypass (`captureSafety` policy in `apps/daemon/src/analytics.ts`) and this PR does not widen it. The shipped tail goes through the module's existing `scrubUserPaths` **before** truncation, so no username can survive in the slice, and it is hard-capped at 4000 chars. Worth stating plainly: this is daemon log output, which is startup/module/OS text rather than user content — but it is freer-form than the fields we sent before, so it is bounded and sent only for the bucket that has no other signal.

Separately and not addressed here: `PRIVACY.md` still does not disclose the stability-telemetry bypass (#5540). That gap predates this PR and I did not silently change policy to paper over it.

## Adjacent issues

Other buckets from the same investigation, each its own fix, none in this PR:

- #6147 — Windows: app closes on the boot screen. The biggest bucket overall (551 people): the daemon never binds its named pipe inside the 35s `DAEMON_STATUS_TIMEOUT_MS`, most likely AV scanning a freshly written binary. Wants a wait strategy that keeps waiting while the process is alive rather than a flat deadline.
- #6088 — macOS: dependencies shipped under `node_modules/.ignored`, so the daemon cannot resolve `better-sqlite3` (172 people, `native_module_present=false`). A packaging fix; the codesign evidence in that issue says the relocation happens *after* signing.
- #7260 — Linux AppImage cold-launch race crashing the packaged daemon.
- Startup failure is also silent by construction: the main process `exit(1)`s with no dialog, which is why users can only report it as "it closes itself". A failure dialog with the log path and a retry was slice A of the crash-governance spec and still is not built.
