### PR TITLE
Add MiniMax music generation

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -723,6 +723,15 @@ export async function generateMedia(args: {
       bytes = result.bytes;
       providerNote = result.providerNote;
       suggestedExt = result.suggestedExt;
+    } else if (
+      def.provider === 'minimax'
+      && surface === 'audio'
+      && ctx.audioKind === 'music'
+    ) {
+      const result = await renderMinimaxMusic(ctx, credentials);
+      bytes = result.bytes;
+      providerNote = result.providerNote;
+      suggestedExt = result.suggestedExt;
     } else if (def.provider === 'minimax' && surface === 'audio') {
       const result = await renderMinimaxTTS(ctx, credentials);
       bytes = result.bytes;
@@ -2713,6 +2722,89 @@ const MINIMAX_IMAGE_DEFAULT_BASE_URL = 'https://api.minimax.io';
 const MINIMAX_IMAGE_MODEL_MAP = {
   'minimax-image-01': 'image-01',
 } as Record<string, string>;
+
+const MINIMAX_MUSIC_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+const MINIMAX_MUSIC_MODEL_MAP = {
+  'minimax-music-3.0': 'music-3.0',
+  'minimax-music-2.6': 'music-2.6',
+} as Record<string, string>;
+
+/** Generate music through MiniMax's synchronous music_generation endpoint. */
+async function renderMinimaxMusic(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
+  if (!credentials.apiKey) {
+    throw new Error(
+      `no MiniMax API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_MINIMAX_API_KEY`,
+    );
+  }
+  const configuredBase = (credentials.baseUrl || MINIMAX_MUSIC_DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const endpoint = configuredBase.endsWith('/music_generation')
+    ? configuredBase
+    : `${configuredBase}/music_generation`;
+  const wireModel = (
+    credentials.model
+    || MINIMAX_MUSIC_MODEL_MAP[ctx.wireModel]
+    || ctx.wireModel
+  ).trim();
+  const body = {
+    model: wireModel,
+    prompt: (ctx.prompt && ctx.prompt.trim()) || 'An instrumental musical composition.',
+    stream: false,
+    output_format: 'hex',
+    audio_setting: {
+      format: 'mp3',
+      sample_rate: 44100,
+      bitrate: 256000,
+    },
+    lyrics_optimizer: true,
+  };
+  const resp = await fetch(endpoint, withMediaRequestInit(ctx, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${credentials.apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  }));
+  const respText = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`minimax music ${resp.status}: ${truncate(respText, 240)}`);
+  }
+  let data: any;
+  try {
+    data = JSON.parse(respText);
+  } catch {
+    throw new Error(`minimax music non-JSON: ${truncate(respText, 200)}`);
+  }
+  const statusCode = data?.base_resp?.status_code;
+  if (typeof statusCode === 'number' && statusCode !== 0) {
+    throw new Error(
+      `minimax music api error ${statusCode}: ${data?.base_resp?.status_msg || 'unknown'}`,
+    );
+  }
+  const status = data?.data?.status;
+  if (status !== undefined && status !== 2) {
+    throw new Error(`minimax music generation incomplete (status=${String(status)})`);
+  }
+  const audio = data?.data?.audio;
+  if (typeof audio !== 'string' || !audio) {
+    throw new Error('minimax music response missing data.audio');
+  }
+  let bytes: Buffer;
+  if (/^https?:\/\//i.test(audio)) {
+    const audioResp = await assertAndFetchExternalAsset(audio, withMediaRequestInit(ctx));
+    bytes = Buffer.from(await audioResp.arrayBuffer());
+  } else {
+    bytes = Buffer.from(audio, 'hex');
+  }
+  if (bytes.length === 0) {
+    throw new Error('minimax music decoded zero bytes');
+  }
+  return {
+    bytes,
+    providerNote: `minimax/${wireModel} · ${bytes.length} bytes`,
+    suggestedExt: '.mp3',
+  };
+}
 
 async function renderMinimaxTTS(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -2729,6 +2729,14 @@ const MINIMAX_MUSIC_MODEL_MAP = {
   'minimax-music-2.6': 'music-2.6',
 } as Record<string, string>;
 
+/** Keep the shared Settings default for TTS from leaking into music requests. */
+function resolveMinimaxMusicBaseUrl(credentials: ProviderConfig): string {
+  const configuredBase = credentials.baseUrl?.trim().replace(/\/+$/, '') || '';
+  return !configuredBase || configuredBase === MINIMAX_DEFAULT_BASE_URL
+    ? MINIMAX_MUSIC_DEFAULT_BASE_URL
+    : configuredBase;
+}
+
 /** Generate music through MiniMax's synchronous music_generation endpoint. */
 async function renderMinimaxMusic(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
   if (!credentials.apiKey) {
@@ -2736,7 +2744,7 @@ async function renderMinimaxMusic(ctx: MediaContext, credentials: ProviderConfig
       `no MiniMax API key — configure it in ${SETTINGS_MEDIA_PROVIDERS_PATH} or set OD_MINIMAX_API_KEY`,
     );
   }
-  const configuredBase = (credentials.baseUrl || MINIMAX_MUSIC_DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const configuredBase = resolveMinimaxMusicBaseUrl(credentials);
   const endpoint = configuredBase.endsWith('/music_generation')
     ? configuredBase
     : `${configuredBase}/music_generation`;
@@ -2792,6 +2800,9 @@ async function renderMinimaxMusic(ctx: MediaContext, credentials: ProviderConfig
   let bytes: Buffer;
   if (/^https?:\/\//i.test(audio)) {
     const audioResp = await assertAndFetchExternalAsset(audio, withMediaRequestInit(ctx));
+    if (!audioResp.ok) {
+      throw new Error(`minimax music fetch ${audioResp.status}`);
+    }
     bytes = Buffer.from(await audioResp.arrayBuffer());
   } else {
     bytes = Buffer.from(audio, 'hex');

--- a/apps/daemon/src/media/models.ts
+++ b/apps/daemon/src/media/models.ts
@@ -198,6 +198,8 @@ export const VIDEO_MODELS: MediaModel[] = [
 
 export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
   music: [
+    { id: 'minimax-music-3.0', label: 'music-3.0', hint: 'MiniMax · music generation', provider: 'minimax', caps: ['music'], default: true },
+    { id: 'minimax-music-2.6', label: 'music-2.6', hint: 'MiniMax · music generation', provider: 'minimax', caps: ['music'] },
     { id: 'suno-v5', label: 'suno-v5', hint: 'Suno · default', provider: 'suno', caps: ['music'], default: true },
     { id: 'suno-v4-5', label: 'suno-v4.5', hint: 'Suno', provider: 'suno', caps: ['music'] },
     { id: 'udio-v2', label: 'udio-v2', hint: 'Udio', provider: 'udio', caps: ['music'] },

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -9,6 +9,51 @@ const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8
 const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
 const TEST_MINIMAX_TTS_BASE_URL = 'https://api.minimaxi.chat/v1';
 
+describe('minimax music generation', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  const realFetch = globalThis.fetch;
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-minimax-music-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    await mkdir(projectsRoot, { recursive: true });
+    process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
+  });
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    delete process.env.OD_MINIMAX_API_KEY;
+    await rm(root, { recursive: true, force: true });
+  });
+  it('posts to music_generation and decodes hex audio', async () => {
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://api.minimax.io/v1/music_generation');
+      expect(init?.headers).toMatchObject({ authorization: 'Bearer minimax-test-key' });
+      const body = JSON.parse(String(init?.body));
+      expect(body).toMatchObject({
+        model: 'music-3.0', prompt: 'A bright synthwave instrumental', stream: false,
+        output_format: 'hex', lyrics_optimizer: true,
+        audio_setting: { format: 'mp3', sample_rate: 44100, bitrate: 256000 },
+      });
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0 }, data: { status: 2, audio: '00010203' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await generateMedia({
+      projectRoot, projectsRoot, projectId: 'project-1', surface: 'audio',
+      audioKind: 'music', model: 'minimax-music-3.0',
+      prompt: 'A bright synthwave instrumental', output: 'music.mp3',
+    });
+    expect(result.providerId).toBe('minimax');
+    expect(result.name).toBe('music.mp3');
+    expect((await readFile(path.join(projectsRoot, 'project-1', 'music.mp3'))).length).toBe(4);
+  });
+});
+
 describe('minimax image generation', () => {
   let root: string;
   let projectRoot: string;

--- a/apps/daemon/tests/media-minimax-image.test.ts
+++ b/apps/daemon/tests/media-minimax-image.test.ts
@@ -14,6 +14,7 @@ describe('minimax music generation', () => {
   let projectRoot: string;
   let projectsRoot: string;
   const realFetch = globalThis.fetch;
+
   beforeEach(async () => {
     root = await mkdtemp(path.join(tmpdir(), 'od-minimax-music-'));
     projectRoot = path.join(root, 'project-root');
@@ -28,6 +29,13 @@ describe('minimax music generation', () => {
     delete process.env.OD_MINIMAX_API_KEY;
     await rm(root, { recursive: true, force: true });
   });
+
+  async function writeConfig(data: unknown) {
+    const file = path.join(projectRoot, '.od', 'media-config.json');
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, JSON.stringify(data), 'utf8');
+  }
+
   it('posts to music_generation and decodes hex audio', async () => {
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       expect(String(input)).toBe('https://api.minimax.io/v1/music_generation');
@@ -51,6 +59,76 @@ describe('minimax music generation', () => {
     expect(result.providerId).toBe('minimax');
     expect(result.name).toBe('music.mp3');
     expect((await readFile(path.join(projectsRoot, 'project-1', 'music.mp3'))).length).toBe(4);
+  });
+
+  it('uses the music endpoint when Settings persisted the legacy MiniMax base URL', async () => {
+    delete process.env.OD_MINIMAX_API_KEY;
+    await writeConfig({
+      providers: {
+        minimax: {
+          apiKey: 'minimax-test-key',
+          baseUrl: TEST_MINIMAX_TTS_BASE_URL,
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://api.minimax.io/v1/music_generation');
+      expect(init?.headers).toMatchObject({ authorization: 'Bearer minimax-test-key' });
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0 }, data: { status: 2, audio: '00010203' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot, projectsRoot, projectId: 'project-1', surface: 'audio',
+      audioKind: 'music', model: 'minimax-music-3.0',
+      prompt: 'A bright synthwave instrumental', output: 'music.mp3',
+    })).resolves.toMatchObject({ providerId: 'minimax' });
+  });
+
+  it('downloads successful URL audio responses', async () => {
+    const audioUrl = 'http://93.184.216.34/music.mp3';
+    const fetchMock = vi.fn(async (input: unknown) => {
+      if (String(input) === audioUrl) {
+        return new Response(new Uint8Array([0, 1, 2, 3]), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0 }, data: { status: 2, audio: audioUrl },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot, projectsRoot, projectId: 'project-1', surface: 'audio',
+      audioKind: 'music', model: 'minimax-music-3.0',
+      prompt: 'A bright synthwave instrumental', output: 'music.mp3',
+    })).resolves.toMatchObject({ providerId: 'minimax' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((await readFile(path.join(projectsRoot, 'project-1', 'music.mp3'))).length).toBe(4);
+  });
+
+  it('rejects failed URL audio responses before writing the body', async () => {
+    const audioUrl = 'http://93.184.216.34/music.mp3';
+    const fetchMock = vi.fn(async (input: unknown) => {
+      if (String(input) === audioUrl) {
+        return new Response('not found', { status: 404 });
+      }
+      return new Response(JSON.stringify({
+        base_resp: { status_code: 0 }, data: { status: 2, audio: audioUrl },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot, projectsRoot, projectId: 'project-1', surface: 'audio',
+      audioKind: 'music', model: 'minimax-music-3.0',
+      prompt: 'A bright synthwave instrumental', output: 'music.mp3',
+    })).rejects.toThrow(/minimax music fetch 404/);
+    await expect(
+      readFile(path.join(projectsRoot, 'project-1', 'music.mp3')),
+    ).rejects.toThrow();
   });
 });
 

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -48,7 +48,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48046,
+    "totalChars": 48088,
   },
   "critique-enabled": {
     "sections": [
@@ -237,7 +237,7 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "clarifying-questions",
       "role-marker-guard",
     ],
-    "totalChars": 48044,
+    "totalChars": 48086,
   },
   "memory-hooks-off": {
     "sections": [

--- a/apps/web/src/media/models.ts
+++ b/apps/web/src/media/models.ts
@@ -642,6 +642,8 @@ export const VIDEO_MODELS: MediaModel[] = [
 
 export const AUDIO_MODELS_BY_KIND: Record<AudioKind, MediaModel[]> = {
   music: [
+    { id: 'minimax-music-3.0', label: 'music-3.0', hint: 'MiniMax · music generation', provider: 'minimax', caps: ['music'], default: true },
+    { id: 'minimax-music-2.6', label: 'music-2.6', hint: 'MiniMax · music generation', provider: 'minimax', caps: ['music'] },
     { id: 'suno-v5', label: 'suno-v5', hint: 'Suno · default', provider: 'suno', caps: ['music'], default: true },
     { id: 'suno-v4-5', label: 'suno-v4.5', hint: 'Suno', provider: 'suno', caps: ['music'] },
     { id: 'udio-v2', label: 'udio-v2', hint: 'Udio', provider: 'udio', caps: ['music'] },


### PR DESCRIPTION
## Why

OpenDesign listed MiniMax for speech, image, and legacy video workflows, but users with a MiniMax key could not generate music through the existing media workflow. This adds the native synchronous music endpoint so those users do not need to route music prompts through the speech renderer or an unintegrated provider.

## What users will see

The music model picker now includes MiniMax `music-3.0` and `music-2.6`. Selecting either model sends the prompt to MiniMax music generation, accepts hex or URL audio responses, and saves the resulting MP3; `music-3.0` is the default music selection.

## Surface area

- [x] **UI** — adds two options to the existing music model picker
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [ ] **API / contract** — new endpoint or changed shared contract
- [ ] **Extension point** — skills, design systems, templates, or craft
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — root dependency change
- [x] **Default behavior change** — MiniMax `music-3.0` becomes the default music model
- [ ] **None** — internal-only change

## Screenshots

The UI change is limited to options in the existing model picker. The automated visual-regression job covers the updated Settings dropdown.

## Bug fix verification

- Test path: `apps/daemon/tests/media-minimax-image.test.ts`
- The persisted Settings base-URL and failed URL-download specs failed before the follow-up fix and pass after it.

## Validation

- `node scripts/verify-media-models.mjs`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media-minimax-image.test.ts tests/prompts/system-prompt-matrix.test.ts`
- `pnpm guard`
- `pnpm typecheck`