### PR TITLE
fix(web): hide empty user skill source filter

### DIFF
--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -238,6 +238,12 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }:
   const searchQuery = search.toLowerCase().trim();
   const hasUserSkills = skills.some((skill) => skill.source === 'user');
 
+  useEffect(() => {
+    if (!hasUserSkills) {
+      setSourceFilter((current) => (current === 'user' ? 'all' : current));
+    }
+  }, [hasUserSkills]);
+
   const sourceCounts = useMemo(() => {
     const counts = new Map<SourceFilter, number>([
       ['all', 0],

--- a/apps/web/src/components/SkillsSection.tsx
+++ b/apps/web/src/components/SkillsSection.tsx
@@ -236,6 +236,7 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }:
   );
 
   const searchQuery = search.toLowerCase().trim();
+  const hasUserSkills = skills.some((skill) => skill.source === 'user');
 
   const sourceCounts = useMemo(() => {
     const counts = new Map<SourceFilter, number>([
@@ -654,7 +655,10 @@ export function SkillsSection({ cfg, setCfg, onSkillsRefresh, onSkillsChanged }:
               <option value="all">
                 {t('settings.libraryAll')} ({sourceCounts.get('all') ?? 0})
               </option>
-              {(['user', 'built-in'] as const).map((s) => {
+              {(hasUserSkills
+                ? (['user', 'built-in'] as const)
+                : (['built-in'] as const)
+              ).map((s) => {
                 const count = sourceCounts.get(s) ?? 0;
                 return (
                   <option key={s} value={s}>

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -87,6 +87,8 @@ function renderSkillsSection(
       );
     }
     if (url.startsWith('/api/skills/') && init?.method === 'DELETE') {
+      const id = decodeURIComponent(url.split('/').pop() ?? '');
+      catalog = catalog.filter((skill) => skill.id !== id);
       return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -178,6 +180,39 @@ describe('SkillsSection', () => {
     ]);
 
     expect(await screen.findByRole('option', { name: 'user (1)' })).toBeTruthy();
+  });
+
+  it('returns to all sources after deleting the final user skill', async () => {
+    renderSkillsSection([
+      makeSkill({
+        id: 'user-skill',
+        name: 'User skill',
+        source: 'user',
+      }),
+      makeSkill({
+        id: 'builtin-skill',
+        name: 'Built-in skill',
+        source: 'built-in',
+      }),
+    ]);
+
+    await screen.findByRole('option', { name: 'user (1)' });
+    const sourceFilter = screen.getByLabelText('Source');
+    fireEvent.change(sourceFilter, { target: { value: 'user' } });
+
+    expect(sourceFilter).toHaveValue('user');
+    expect(screen.queryByTestId('skill-row-builtin-skill')).toBeNull();
+
+    const userRow = screen.getByTestId('skill-row-user-skill');
+    fireEvent.click(within(userRow).getByTestId('skills-delete'));
+    fireEvent.click(within(userRow).getByTestId('skills-delete-confirm'));
+
+    await waitFor(() => {
+      expect(sourceFilter).toHaveValue('all');
+      expect(sourceFilter).not.toHaveAttribute('data-active');
+      expect(screen.getByTestId('skill-row-builtin-skill')).toBeTruthy();
+    });
+    expect(screen.queryByRole('option', { name: /^user \(/ })).toBeNull();
   });
 
   it('does not expose delete actions for built-in skills', async () => {

--- a/apps/web/tests/components/SkillsSection.test.tsx
+++ b/apps/web/tests/components/SkillsSection.test.tsx
@@ -155,6 +155,31 @@ describe('SkillsSection', () => {
     vi.restoreAllMocks();
   });
 
+  it('hides the user source filter when the catalog only contains built-in skills', async () => {
+    renderSkillsSection([
+      makeSkill({
+        id: 'builtin-skill',
+        name: 'Built-in skill',
+        source: 'built-in',
+      }),
+    ]);
+
+    await screen.findByRole('option', { name: 'built-in (1)' });
+    expect(screen.queryByRole('option', { name: /^user \(/ })).toBeNull();
+  });
+
+  it('shows the user source filter when a user skill exists', async () => {
+    renderSkillsSection([
+      makeSkill({
+        id: 'user-skill',
+        name: 'User skill',
+        source: 'user',
+      }),
+    ]);
+
+    expect(await screen.findByRole('option', { name: 'user (1)' })).toBeTruthy();
+  });
+
   it('does not expose delete actions for built-in skills', async () => {
     renderSkillsSection([
       makeSkill({


### PR DESCRIPTION
Fixes #1374

## Why

I picked this up from the community `good first issue` queue after the previous implementation PRs became inactive. On a fresh Skills catalog, the Source control advertised `user (0)`, which made user-provided skills look broken or incorrectly classified even though the empty count was accurate.

## What users will see

Settings → Skills no longer shows the `user` source option when the catalog contains only built-in skills. The option appears as soon as at least one user skill exists. Its visibility is based on the full catalog, so a search or another active filter cannot make an existing user source option disappear temporarily.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No layout or styling changes. The visible difference is one native `<select>` option being omitted for an empty catalog; the before/after states are asserted directly in the regression test below.

## Bug fix verification

- Test path: `apps/web/tests/components/SkillsSection.test.tsx`
- Red on `main`: the built-in-only case found `user (0)` and failed.
- Green on this branch: the built-in-only case hides the option, while a catalog with one user skill shows `user (1)`.

## Validation

- `pnpm install --frozen-lockfile` (Node 24.16.0 / pnpm 10.33.2)
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SkillsSection.test.tsx --maxWorkers=2` — 14/14 passed
- `pnpm --filter @open-design/web test` — 637 files passed; 6,784 tests passed, 1 expected failure, 11 skipped
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
