### PR TITLE
docs: clarify Docker build resource requirements

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,8 +54,33 @@ Defaults:
 - Runtime data: before documenting, changing, or choosing persistent daemon
   storage, you MUST read root [`AGENTS.md`](../AGENTS.md) → **Daemon data
   directory contract**. This README MUST NOT restate it.
-- Node heap cap: `--max-old-space-size=192`
-- Compose memory cap: `384m` (`OPEN_DESIGN_MEM_LIMIT=256m` to override)
+- Node heap cap (runtime container): `--max-old-space-size=192`
+- Compose memory cap (runtime container): `384m` (`OPEN_DESIGN_MEM_LIMIT=256m`
+  to override)
+
+These caps describe the runtime container for an already-built image, not the
+resources needed to produce one — see [Resource
+requirements](#resource-requirements) before building the image from source.
+
+### Resource requirements
+
+The two requirements are different:
+
+**Running a prebuilt image** — a small host is acceptable; the runtime caps
+above apply as-is.
+
+**Building the image from source** (for example, when `ghcr.io/nexu-io/od`
+cannot be pulled and you must build locally) needs substantially more RAM and
+CPU than running the resulting container. The production web/Next.js build step
+can exhaust memory and fail or hang on small hosts.
+
+- A ~1 GB VPS is not recommended for source builds.
+- Use at least 4 GB RAM for a practical build; 8 GB is recommended for
+  additional headroom. These are recommendations, not guaranteed minimums for
+  every system.
+- If your runtime server must stay small, build the image on a larger machine,
+  push it to a registry you can pull from, then deploy that image to the
+  smaller server.
 
 Do not publish the daemon directly on a public or shared LAN interface. The shared
 API token is single-tenant authentication, not user-level access control, and both

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -28,6 +28,24 @@ The installer checks for Docker or Podman and, on Ubuntu/Debian, Fedora, and mac
 
 > **MCP note:** Docker/Compose installs run the daemon inside the container. The MCP client snippets shown in Settings are stdio/local-path based and require a local/source install for now. Container-friendly MCP transport will be added in a follow-up.
 
+## Resource requirements
+
+The sizes in this guide — the `384m` memory limit prompt, `OPEN_DESIGN_MEM_LIMIT`, and the
+`--max-old-space-size=192` Node heap cap — are **runtime** requirements for running the
+already-built `ghcr.io/nexu-io/od` image. A small VPS can run that container.
+
+They are **not** build-machine requirements. Building the image from source (for example,
+when `ghcr.io/nexu-io/od` cannot be pulled) needs substantially more RAM than running it:
+the production web/Next.js build step can exhaust memory and fail or hang on small hosts.
+
+- A ~1 GB VPS is not recommended for source builds.
+- Use at least 4 GB RAM for a practical source build; 8 GB is recommended for additional
+  headroom. These are recommendations, not guaranteed minimums for every system.
+- If your runtime server must stay small, build the image on a larger machine, push it to a
+  registry you can pull from, then deploy that image to the smaller server.
+
+See [`deploy/README.md`](../deploy/README.md#resource-requirements) for details.
+
 ## Interactive install walkthrough
 
 Running the installer without flags launches an interactive wizard:
@@ -176,8 +194,8 @@ All settings live in `deploy/.env`. Edit it directly or re-run the installer to 
 | `OPEN_DESIGN_IMAGE` | `ghcr.io/nexu-io/od:latest` | Full image reference |
 | `OPEN_DESIGN_PORT` | `7456` | Host-side port (bound to `127.0.0.1`) |
 | `OPEN_DESIGN_ALLOWED_ORIGINS` | _(empty)_ | CORS origins for reverse-proxy setups |
-| `OPEN_DESIGN_MEM_LIMIT` | `384m` | Container memory cap |
-| `NODE_OPTIONS` | `--max-old-space-size=192` | Node.js heap cap inside the container |
+| `OPEN_DESIGN_MEM_LIMIT` | `384m` | Runtime container memory cap (not a build-machine requirement) |
+| `NODE_OPTIONS` | `--max-old-space-size=192` | Node.js heap cap inside the runtime container |
 
 The container always binds `127.0.0.1:<port>:7456` — the daemon is never directly exposed to the network. To allow remote access, put an authenticated reverse proxy in front. See [`deploy/README.md`](../deploy/README.md) for the authentication and allowed-origin contract.
 


### PR DESCRIPTION
Fixes #5568

## Summary

Documentation-only fix that separates two resource requirements the Docker/self-hosting docs previously blurred together:

- **Running a prebuilt image (runtime)** — a small host is fine. The documented values `OPEN_DESIGN_MEM_LIMIT=384m` and Node heap cap `--max-old-space-size=192` describe the already-built container.
- **Building the image from source** — needs substantially more RAM than running the result. The production web/Next.js build step can exhaust memory on small hosts, which is exactly what happens after a GHCR pull fails and users fall back to a local build on the same tiny VPS.

Practical guidance now documented: ~1 GB VPS instances are **not recommended** for source builds; use at least **4 GB RAM**, **8 GB preferred** (phrased as recommendations, not guarantees); if your runtime server must stay small, build on a larger machine, push the image, then deploy it to the smaller server.

GHCR availability itself is out of scope here — tracked by #4645 and #4940. This PR only makes the fallback path honest about what a source build costs.

## Why

Self-hosters who cannot pull `ghcr.io/nexu-io/od` fall back to building from source on the same small VPS they intend to run the container on. Because the docs only mention the small runtime limits, build-host sizing looks equivalent to runtime sizing, and users hit confusing failures during `next build` inside the Docker build. Issue #5568 asks the docs to separate the two.

## What users will see

### `deploy/README.md`

- The Defaults bullets now label the Node heap cap and Compose memory cap as **runtime container** values.
- A new **Resource requirements** section (under *Local compose*) splits into:
  - **Running a prebuilt image** — small host acceptable; existing caps apply as-is.
  - **Building the image from source** — warning about memory exhaustion in the web/Next.js build step, the ~1 GB / 4 GB / 8 GB sizing recommendations, and the build-large-deploy-small pattern.

### `docs/install-guide.md`

- A matching **Resource requirements** section right after *Prerequisites*, cross-linked to `deploy/README.md#resource-requirements`.
- The Configuration table now describes `OPEN_DESIGN_MEM_LIMIT` as “Runtime container memory cap (not a build-machine requirement)” and `NODE_OPTIONS` as applying “inside the runtime container”.

Diff footprint: `2 files changed, 47 insertions(+), 4 deletions(-)`. No behavior changes anywhere.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

None — documentation-only change, no UI surface touched.


## Bug fix verification

Not a bug fix; documentation clarification only.


## Validation

- Reviewed the complete diff manually; both changed files are Markdown documentation only.
- Re-searched `deploy/README.md` and `docs/install-guide.md` for `OPEN_DESIGN_MEM_LIMIT`, `--max-old-space-size`, and `ghcr.io/nexu-io/od` after editing — no contradictory statements remain; the existing GHCR visibility note keeps its current factual wording.
- Verified the `#resource-requirements` anchor used by cross-links matches the new heading.
- Ran `pnpm guard` (repo-wide checks including the product-neutrality check over public docs): all checks passed.
- The repository has no dedicated Markdown lint/test for these files, so none was run and no new tooling was introduced.

## Scope

Documentation only (`deploy/README.md`, `docs/install-guide.md`). No Docker runtime, Compose defaults, Dockerfile, CI, GHCR configuration, or application behavior changes.

Adjacent observation, intentionally **not** fixed here to keep this PR narrow: `QUICKSTART.md`, `CONTRIBUTING.md`, and their i18n mirrors also list `OPEN_DESIGN_MEM_LIMIT=384m` without build-host context. They do not duplicate the resource guidance, so they were left untouched per the scope of #5568 and can get the same note in a follow-up if maintainers want it.
