### PR TITLE
fix(web): reset Home composer on new tab

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -31,6 +31,7 @@ import { homeHeroChipLabel } from './home-hero/chip-labels';
 import { useGlideIndicator } from '../hooks/useGlideIndicator';
 import { useLiquidGlass } from '../hooks/useLiquidGlass';
 
+import { seedHomeComposerPrompt } from './HomeView';
 type WorkspaceChromeTab =
   | {
       id: string;
@@ -1433,27 +1434,33 @@ export function WorkspaceTabsBar({
   }
 
   function createNewTab() {
-    // Onboarding gate — see `onboardingActive`. Covers the "+" button and the
-    // Cmd/Ctrl+T keyboard shortcut, since both funnel through here.
-    if (onboardingActive) return;
-    const normalized = normalizeTabsState(state);
-    const existingEntryTab = normalized.tabs.find((tab) => tab.kind === 'entry');
-    if (existingEntryTab) {
-      setState({
-        ...normalized,
-        activeTabId: existingEntryTab.id,
-      });
-      navigate({ kind: 'home', view: 'home' });
-    } else {
-      const tab = createEntryTab('home');
-      setState({
-        tabs: [...normalized.tabs, tab],
-        activeTabId: tab.id,
-      });
-      navigate({ kind: 'home', view: 'home' });
-    }
-  }
+  // Onboarding gate — see `onboardingActive`. Covers the "+" button and the
+  // Cmd/Ctrl+T keyboard shortcut, since both funnel through here.
+  if (onboardingActive) return;
 
+  // A newly opened Home tab should start with an empty composer.
+  seedHomeComposerPrompt('');
+
+  const normalized = normalizeTabsState(state);
+  const existingEntryTab = normalized.tabs.find((tab) => tab.kind === 'entry');
+
+  if (existingEntryTab) {
+    setState({
+      ...normalized,
+      activeTabId: existingEntryTab.id,
+    });
+    navigate({ kind: 'home', view: 'home' });
+  } else {
+    const tab = createEntryTab('home');
+
+    setState({
+      tabs: [...normalized.tabs, tab],
+      activeTabId: tab.id,
+    });
+
+    navigate({ kind: 'home', view: 'home' });
+  }
+}
   function closeTab(tabId: string) {
     const normalized = normalizeTabsState(state);
     const closingIndex = normalized.tabs.findIndex((tab) => tab.id === tabId);

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -14,6 +14,12 @@ import { navigate, type Route } from '../../src/router';
 import type { Project } from '../../src/types';
 import { setWorkspaceTabsDock } from '../../src/components/workspaceTabsDock';
 
+const seedHomeComposerPromptMock = vi.fn();
+
+vi.mock('../../src/components/HomeView', () => ({
+  seedHomeComposerPrompt: (prompt: string) => seedHomeComposerPromptMock(prompt),
+}));
+
 afterEach(() => {
   setWorkspaceTabsDock(null);
 });
@@ -1841,6 +1847,27 @@ describe('WorkspaceTabsBar identity-scope tab reset', () => {
       expect(JSON.stringify(parsed.scopes?.['user-1::ws-a'] ?? {})).toContain(
         'project-alpha',
       );
+    });
+  });
+
+  it('clears the Home composer when creating a new tab', async () => {
+    render(
+      <WorkspaceTabsBar
+        route={{ kind: 'home', view: 'home' }}
+        projects={[project]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(1);
+    });
+
+    seedHomeComposerPromptMock.mockClear();
+
+    fireEvent.keyDown(document, { key: 't', ctrlKey: true });
+
+    await waitFor(() => {
+      expect(seedHomeComposerPromptMock).toHaveBeenCalledWith('');
     });
   });
 });


### PR DESCRIPTION
 ## What does this PR do?

Fixes #2622.

### What users will see

When opening a new Home tab, the composer now starts empty instead of showing the prompt from the previous Home session.

This makes the new Home tab feel like a fresh start, while the normal draft persistence behavior stays unchanged.

## What changed

- Reset the Home composer when creating a new Home tab
- Reuse the existing `seedHomeComposerPrompt` flow
- Make sure the reset also works when `HomeView` is already mounted

## Surface area

- [x] UI
- [ ] CLI
- [ ] Daemon
- [ ] Desktop shell
- [ ] Packaged app
- [ ] Contracts or `.github`
- [ ] Design systems / skills / craft / design templates
- [ ] Docs / i18n
- [ ] New dependency

## Testing

- `pnpm typecheck` — passed with 0 errors
- `HomeView.first-run-guide.test.tsx` — passed (6/6)
- `git diff --check` — passed
