### PR TITLE
fix(web): resolve Blob preview base URLs

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -123,6 +123,7 @@ import {
   uploadProjectFiles,
   liveArtifactPreviewUrl,
   projectFileUrl,
+  projectRawBaseHref,
   projectRawUrl,
   renewProjectPreviewBaseScope,
   publishProjectFilePublic,
@@ -10571,7 +10572,7 @@ function HtmlViewer({
   ]);
 
   const srcDocBaseSeedHref = effectiveScopedSrcDocPreviewBase?.href
-    ?? projectRawUrl(projectId, baseDirFor(file.name), workspaceContext);
+    ?? projectRawBaseHref(projectId, baseDirFor(file.name), workspaceContext);
   const srcDocBaseSelectionIdentity = [
     srcDocPreviewBaseIdentity,
     sourceSnapshotRefreshKey,

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -3072,6 +3072,14 @@ export function projectRawUrl(
   return `/api/projects/${encodeURIComponent(projectId)}/raw/${safePath}`;
 }
 
+export function projectRawBaseHref(
+  projectId: string,
+  filePath: string,
+  workspaceContext?: WorkspaceCollabContext | null,
+): string {
+  return previewCapabilityHref(projectRawUrl(projectId, filePath, workspaceContext));
+}
+
 export function designSystemStaticUrl(
   designSystemId: string,
   filePath: string,

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1866,10 +1866,14 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByTestId('artifact-preview-first-load')).not.toBeInTheDocument();
   });
 
-  it('loads an inline preview through a blob URL when the browser supports it', () => {
+  it('keeps project-relative assets resolvable in an Electron blob preview', async () => {
     const originalCreateObjectURL = URL.createObjectURL;
     const originalRevokeObjectURL = URL.revokeObjectURL;
-    const createObjectURL = vi.fn(() => 'blob:od://app/preview-document');
+    let previewBlob: Blob | null = null;
+    const createObjectURL = vi.fn((blob: Blob) => {
+      previewBlob = blob;
+      return 'blob:od://app/preview-document';
+    });
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
       value: createObjectURL,
@@ -1900,6 +1904,10 @@ describe('FileViewer SVG artifacts', () => {
       expect(createObjectURL).toHaveBeenCalledTimes(1);
       expect(frame.getAttribute('src')).toBe('blob:od://app/preview-document');
       expect(frame.hasAttribute('srcdoc')).toBe(false);
+      expect(previewBlob).not.toBeNull();
+      expect(await previewBlob!.text()).toContain(
+        '<base href="http://localhost:3000/api/projects/blob-preview-project/raw/" data-od-project-preview-base>',
+      );
     } finally {
       userAgent.mockRestore();
       if (originalCreateObjectURL) {


### PR DESCRIPTION
Fixes #7278

## Why

The Open Design Electron preview transports injected HTML through a blob:od://... URL. Personal-project previews were still injecting a root-relative raw-file base such as /api/projects/<project-id>/raw/. Chromium cannot resolve that base against the Blob document, so relative images, stylesheets, scripts, and video sources remain attached to the Blob URL and fail to load.

The team preview-capability path already resolves its base against the host document. This change applies the same invariant to the personal raw-file fallback instead of requiring artifacts to inline or rewrite their own resources.

## What users will see

Project-relative assets continue to load when a design enters the Electron Blob-backed srcDoc preview path. Artifacts can keep portable relative references; no HTML fallback or base64 conversion is required.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** - new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** - new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** - the existing preview now resolves project-relative assets correctly
- [ ] **None**

## Screenshots

N/A - this restores resource loading in the existing preview without changing UI chrome.

## Bug fix verification

- Test path: apps/web/tests/components/FileViewer.test.tsx
- Red on main: the Electron Blob payload contained <base href="/api/projects/<project-id>/raw/">.
- Green on this branch: the payload contains an absolute host-resolved base (http://localhost:3000/... in the test and od://app/... in the packaged app).
- Manual runtime proof on packaged 0.20.2: changing only the in-memory base from root-relative to absolute loaded three relative images and a relative MP4; the video reached readyState = 4 with no media error.

## Validation

- pnpm guard
- pnpm typecheck
- Focused red/green Vitest regression
- pnpm --filter @open-design/web test - 638 files passed; 6,785 tests passed; 1 expected failure; 11 skipped
- pnpm --filter @open-design/web build
