### PR TITLE
fix(daemon): hide ACP metadata updates from transcript

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -60,6 +60,12 @@ import {
 } from './models.js';
 import { buildAcpSessionNewParams, buildPromptBlocks, type AcpMcpServerInput } from './session-params.js';
 
+const NON_DISPLAYABLE_ACP_SESSION_UPDATES = new Set([
+  'usage_update',
+  'session_info_update',
+  'available_commands_update',
+]);
+
 /**
  * Options for `attachAcpSession`. All fields except `child`, `prompt`, and
  * `send` are optional and carry sensible defaults.
@@ -713,6 +719,12 @@ export function attachAcpSession({
         }
       }
       if (emitAcpExecutionObservability(update)) {
+        return;
+      }
+      if (
+        typeof update.sessionUpdate === 'string' &&
+        NON_DISPLAYABLE_ACP_SESSION_UPDATES.has(update.sessionUpdate)
+      ) {
         return;
       }
       if (update.sessionUpdate !== 'agent_message_chunk' && update.sessionUpdate !== 'agent_thought_chunk') {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2082,6 +2082,63 @@ test('attachAcpSession surfaces non-text ACP updates as status progress', () => 
   );
 });
 
+test('attachAcpSession does not surface stabilized ACP metadata updates as status', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'make a simple deck',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  for (const sessionUpdate of ['usage_update', 'session_info_update', 'available_commands_update']) {
+    writeAcpUpdate(child, { sessionUpdate });
+  }
+  writeAcpUpdate(child, {
+    sessionUpdate: 'context_compaction',
+    status: 'in_progress',
+    message: 'Compacting conversation history',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { text: 'Visible answer' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_thought_chunk',
+    content: { text: 'Private reasoning' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const statuses = events
+    .filter((entry) => entry.event === 'agent')
+    .map((entry) => entry.payload as { type?: string; label?: string; detail?: string })
+    .filter((payload) => payload.type === 'status');
+  assert.deepEqual(
+    statuses.filter((payload) =>
+      ['usage_update', 'session_info_update', 'available_commands_update'].includes(payload.label ?? ''),
+    ),
+    [],
+  );
+  assert.equal(
+    statuses.find((payload) => payload.label === 'context_compaction')?.detail,
+    'Compacting conversation history',
+  );
+  assert.deepEqual(
+    events
+      .filter((entry) => entry.event === 'agent')
+      .map((entry) => entry.payload as { type?: string; delta?: string })
+      .filter((payload) => payload.type === 'text_delta' || payload.type === 'thinking_delta')
+      .map((payload) => payload.delta),
+    ['Visible answer', 'Private reasoning'],
+  );
+});
+
 function parseRpcWrites(writes: string[]): Array<Record<string, unknown>> {
   return writes
     .join('')


### PR DESCRIPTION
Fixes #7308

## Why

ACP agents emit stabilized session metadata updates such as usage_update, session_info_update, and available_commands_update. These protocol-internal events were being forwarded as raw status labels, so users could see implementation details in the conversation transcript.

## What users will see

The three stabilized ACP metadata updates no longer appear as raw transcript status labels. Normal assistant messages, thoughts, tool progress, and display-worthy session updates remain unchanged.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

Not applicable: this is daemon transcript event filtering with no UI implementation.

## Bug fix verification

- Test path: apps/daemon/tests/acp.test.ts
- Did the test go red on main and green on this branch? Yes.
- Red on main: the focused test observed usage_update, session_info_update, and available_commands_update as transcript statuses.
- Green on this branch: the focused test confirms those statuses are absent while visible ACP updates and message/thought deltas remain present.

## Validation

- PASS — focused ACP regression test.
- PASS — full ACP suite: 77 tests.
- PASS — pnpm --filter @open-design/daemon typecheck.
- PASS — root pnpm typecheck.
- PASS — root pnpm guard.
- PASS — git diff --check.
- FAIL / unrelated baseline — full daemon test run encountered external OpenAI/Anthropic authentication responses and unrelated brand/collab timeout fixtures; the connection/proxy failures were reproduced on main.
- NOT RUN — manual ACP smoke test; no ACP runtime was configured in this environment.
