### PR TITLE
fix(daemon): pass noninteractive permission bypass to Antigravity

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -9,7 +9,10 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import { DEFAULT_MODEL_OPTION } from './shared.js';
+import { agentCapabilities } from '../capabilities.js';
 import type { RuntimeAgentDef } from '../types.js';
+
+const ANTIGRAVITY_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 
 // `agy` v1.0.3 still has no `--model` flag (upstream issue #35), but the
 // TUI's Switch-Model picker writes the choice to its settings.json, and
@@ -171,6 +174,10 @@ export const antigravityAgentDef = {
   name: 'Antigravity',
   bin: 'agy',
   versionArgs: ['--version'],
+  helpArgs: ['--help'],
+  capabilityFlags: {
+    [ANTIGRAVITY_SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
+  },
   fallbackModels: [
     DEFAULT_MODEL_OPTION,
     { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
@@ -233,6 +240,10 @@ export const antigravityAgentDef = {
     // so diagnostics (model override / auth / quota) land in the log.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
+    }
+    // Daemon-managed print-mode runs have no interactive approval channel.
+    if (agentCapabilities.get('antigravity')?.skipPermissions) {
+      args.push(ANTIGRAVITY_SKIP_PERMISSIONS_FLAG);
     }
     args.push('-p', prompt);
     return args;

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -743,6 +743,26 @@ test('antigravity passes prompt via -p argument (print mode)', () => {
   assert.equal(antigravity.supportsCustomModel, false);
 });
 
+test('antigravity gates non-interactive permission bypass on the detected CLI capability', () => {
+  agentCapabilities.delete('antigravity');
+  assert.deepEqual(antigravity.helpArgs, ['--help']);
+  assert.deepEqual(antigravity.capabilityFlags, {
+    '--dangerously-skip-permissions': 'skipPermissions',
+  });
+  assert.deepEqual(antigravity.buildArgs('', [], [], {}), ['-p', '-']);
+
+  agentCapabilities.set('antigravity', { skipPermissions: true });
+  try {
+    assert.deepEqual(antigravity.buildArgs('', [], [], {}), [
+      '--dangerously-skip-permissions',
+      '-p',
+      '-',
+    ]);
+  } finally {
+    agentCapabilities.delete('antigravity');
+  }
+});
+
 // `agy` reads `~/.gemini/antigravity-cli/settings.json` on every CLI
 // startup — verified by capturing the `--log-file` line `Propagating
 // selected model override to backend: label=…`. Routing OD's model

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -749,15 +749,49 @@ test('antigravity gates non-interactive permission bypass on the detected CLI ca
   assert.deepEqual(antigravity.capabilityFlags, {
     '--dangerously-skip-permissions': 'skipPermissions',
   });
-  assert.deepEqual(antigravity.buildArgs('', [], [], {}), ['-p', '-']);
+  assert.deepEqual(antigravity.buildArgs('', [], [], {}), ['-p', '']);
 
   agentCapabilities.set('antigravity', { skipPermissions: true });
   try {
     assert.deepEqual(antigravity.buildArgs('', [], [], {}), [
       '--dangerously-skip-permissions',
       '-p',
-      '-',
+      '',
     ]);
+  } finally {
+    agentCapabilities.delete('antigravity');
+  }
+});
+
+test('antigravity keeps log argv order when permission bypass is unavailable', () => {
+  agentCapabilities.set('antigravity', { skipPermissions: false });
+  try {
+    assert.deepEqual(
+      antigravity.buildArgs('', [], [], {}, {
+        agentLogFilePath: '/tmp/od-agy-test.log',
+      }),
+      ['--log-file', '/tmp/od-agy-test.log', '-p', ''],
+    );
+  } finally {
+    agentCapabilities.delete('antigravity');
+  }
+});
+
+test('antigravity places permission bypass after log args', () => {
+  agentCapabilities.set('antigravity', { skipPermissions: true });
+  try {
+    assert.deepEqual(
+      antigravity.buildArgs('', [], [], {}, {
+        agentLogFilePath: '/tmp/od-agy-test.log',
+      }),
+      [
+        '--log-file',
+        '/tmp/od-agy-test.log',
+        '--dangerously-skip-permissions',
+        '-p',
+        '',
+      ],
+    );
   } finally {
     agentCapabilities.delete('antigravity');
   }

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -5,9 +5,10 @@ import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as platform from '@open-design/platform';
 import {
-  assert, chmodSync, detectAgents, detectAgentsStream, inspectAgentExecutableResolution, join, minimalAgentDef, mkdirSync, mkdtempSync, opencode, resolveAgentExecutable, rmSync, spawnEnvForAgent, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
+  antigravity, assert, chmodSync, detectAgents, detectAgentsStream, inspectAgentExecutableResolution, join, minimalAgentDef, mkdirSync, mkdtempSync, opencode, resolveAgentExecutable, rmSync, spawnEnvForAgent, tmpdir, withEnvSnapshot, withPlatform, writeFileSync,
 } from './helpers/test-helpers.js';
 import { isCursorAuthFailureText } from '../../src/runtimes/auth.js';
+import { agentCapabilities } from '../../src/runtimes/capabilities.js';
 import { getRememberedLiveModels } from '../../src/runtimes/models.js';
 
 const fsTest = process.platform === 'win32' ? test.skip : test;
@@ -993,6 +994,40 @@ test('detectAgents applies configured env while probing the CLI', async () => {
       assert.equal(detected?.version, '/tmp/claude-config-probe');
     });
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectAgents records Antigravity permission capability from stderr help output', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-antigravity-capability-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const bin = join(dir, 'agy');
+      writeFileSync(
+        bin,
+        '#!/bin/sh\n' +
+          'if [ "$1" = "--version" ]; then echo "agy 1.0.3"; exit 0; fi\n' +
+          'if [ "$1" = "--help" ]; then echo "--dangerously-skip-permissions" >&2; exit 0; fi\n' +
+          'exit 0\n',
+      );
+      chmodSync(bin, 0o755);
+      process.env.PATH = dir;
+      process.env.OD_AGENT_HOME = dir;
+      agentCapabilities.delete('antigravity');
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'antigravity');
+
+      assert.equal(detected?.available, true);
+      assert.deepEqual(agentCapabilities.get('antigravity'), {
+        skipPermissions: true,
+      });
+      assert.ok(
+        antigravity.buildArgs('', [], [], {}).includes('--dangerously-skip-permissions'),
+      );
+    });
+  } finally {
+    agentCapabilities.delete('antigravity');
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes #7312

## Why

Antigravity runs through the daemon in non-interactive print mode (agy -p -), but the runtime definition did not declare or pass the CLI flag --dangerously-skip-permissions. A headless run could therefore enter an approval flow with no interactive channel available.

The existing capability architecture is reused. Antigravity now probes agy --help, and the shared capability probe checks both stdout and stderr because current agy builds advertise this flag on stderr.

## What users will see

Antigravity runs launched through Open Design can execute without blocking on an interactive permission prompt.

This PR intentionally does not change model discovery or fallbackModels. That work remains separate.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Bug fix verification

- Test paths: apps/daemon/tests/runtimes/agent-args.test.ts and apps/daemon/tests/runtimes/env-and-detection.test.ts
- Red on base: the Antigravity argv assertion observed [-p, -] without the required flag.
- Green on this branch: capability-gated argv coverage verifies the safe omit/include cases, stderr-only help detection, and exact --log-file plus permission-flag ordering.

## Validation

- PASS — focused Antigravity and detection tests: 112 tests.
- PASS — related runtime tests: 152 tests.
- PASS — added argv-order hardening: agent-args.test.ts 48/48.
- PASS — pnpm --filter @open-design/daemon typecheck.
- PASS — pnpm typecheck.
- PASS — pnpm guard.
- PASS — git diff --check.
- ATTEMPTED, unrelated baseline failures — pnpm --filter @open-design/daemon test reached existing OpenAI/Anthropic authentication failures, brand-route timeouts, a collab LRU timeout, and a media proxy failure; it was stopped after those failures were confirmed.
- NOT RUN — manual Antigravity smoke test; no configured paid/runtime credentials were available.

## Scope

Only the non-interactive permission-bypass slice of #7312 is included. Stale Antigravity model lists and fallbackModels are intentionally deferred.