### PR TITLE
fix(web): preserve Shift+Enter layout in manual edit

### DIFF
--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -273,6 +273,9 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isTextLeaf(el){
     var text = (el.textContent || '').trim();
     if (!text) return false;
+    return hasOnlyTextAndBreakNodes(el);
+  }
+  function hasOnlyTextAndBreakNodes(el){
     return Array.prototype.every.call(el.children, function(child){ return child.tagName && child.tagName.toLowerCase() === 'br'; });
   }
   function inferKind(el){
@@ -1047,7 +1050,7 @@ export function buildManualEditBridge(enabled: boolean): string {
       // anyway. When an inline session is live on the same element, its save and
       // cancel paths still reconcile against the current model and original HTML.
       var ptEl = findById(ev.data.id || '');
-      if (ptEl && ptEl !== document.body && isTextLeaf(ptEl)) {
+      if (ptEl && ptEl !== document.body && hasOnlyTextAndBreakNodes(ptEl)) {
         renderPlainText(ptEl, String(ev.data.value == null ? '' : ev.data.value));
       }
       return;

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -66,7 +66,7 @@ export function isSourceMappableManualEditElement(el: Element): boolean {
 export function manualEditElementIsTextLeaf(el: Element): boolean {
   const text = (el.textContent || '').trim();
   if (!text) return false;
-  return el.children.length === 0;
+  return Array.from(el.children).every((child) => child.tagName.toLowerCase() === 'br');
 }
 
 /**
@@ -273,7 +273,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   function isTextLeaf(el){
     var text = (el.textContent || '').trim();
     if (!text) return false;
-    return el.children.length === 0;
+    return Array.prototype.every.call(el.children, function(child){ return child.tagName && child.tagName.toLowerCase() === 'br'; });
   }
   function inferKind(el){
     var explicit = el.getAttribute('data-od-edit');
@@ -800,6 +800,37 @@ export function buildManualEditBridge(enabled: boolean): string {
   // another target, clicking empty background, leaving edit mode, or an
   // od-edit-text-finish message from the host.
   var activeTextEdit = null;
+  function plainTextForEdit(el){
+    var value = '';
+    Array.prototype.forEach.call(el.childNodes, function(node){
+      if (node.nodeType === 3) value += node.nodeValue || '';
+      else if (node.nodeType === 1 && node.tagName && node.tagName.toLowerCase() === 'br') value += '\\n';
+      else value += node.textContent || '';
+    });
+    return value;
+  }
+  function renderPlainText(el, value){
+    var parts = String(value == null ? '' : value).split('\\n');
+    el.replaceChildren();
+    for (var i = 0; i < parts.length; i++) {
+      if (i > 0) el.appendChild(document.createElement('br'));
+      if (parts[i]) el.appendChild(document.createTextNode(parts[i]));
+    }
+  }
+  function insertSoftLineBreak(el){
+    var selection = window.getSelection && window.getSelection();
+    if (!selection || selection.rangeCount < 1) return false;
+    var range = selection.getRangeAt(0);
+    if (!el.contains(range.commonAncestorContainer) && range.commonAncestorContainer !== el) return false;
+    range.deleteContents();
+    var newline = document.createTextNode('\\n');
+    range.insertNode(newline);
+    range.setStart(newline, 1);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return true;
+  }
   function postTextSession(el, active, extra){
     if (!el) return;
     window.parent.postMessage(Object.assign({
@@ -816,9 +847,11 @@ export function buildManualEditBridge(enabled: boolean): string {
     el.removeAttribute('contenteditable');
     el.removeAttribute('data-od-editing');
     el.removeEventListener('keydown', session.onKey);
+    el.style.whiteSpace = session.originalWhiteSpace;
     if (guard) guard.editingEl = null;
-    var value = (el.textContent || '').trim();
+    var value = plainTextForEdit(el).trim();
     var changed = value !== session.originalText.trim();
+    renderPlainText(el, value);
     if (commit && changed) {
       window.parent.postMessage({
         type: 'od-edit-text-commit',
@@ -826,7 +859,7 @@ export function buildManualEditBridge(enabled: boolean): string {
         value: value
       }, '*');
     } else if (!commit) {
-      el.textContent = session.originalText;
+      el.innerHTML = session.originalHtml;
     }
     postTextSession(el, false, { committed: !!commit, changed: changed });
     return true;
@@ -839,14 +872,24 @@ export function buildManualEditBridge(enabled: boolean): string {
     }
     if (activeTextEdit) finishActiveTextEdit(true);
     if (el.getAttribute('contenteditable') === 'true') return;
-    var originalText = el.textContent || '';
+    var originalHtml = el.innerHTML;
+    var originalText = plainTextForEdit(el);
+    var originalWhiteSpace = el.style.whiteSpace;
     clearSelectedTarget();
+    el.textContent = originalText;
     el.setAttribute('contenteditable', 'plaintext-only');
     el.setAttribute('data-od-editing', 'true');
+    el.style.whiteSpace = 'pre-wrap';
     if (guard) guard.editingEl = el;
     try { el.focus(); } catch (e) {}
     placeCaretFromClick(clickEvent, el);
     function onKey(ev){
+      if (ev.isComposing || ev.keyCode === 229) return;
+      if (ev.key === 'Enter' && ev.shiftKey) {
+        ev.preventDefault();
+        insertSoftLineBreak(el);
+        return;
+      }
       if (ev.key === 'Enter' && !ev.shiftKey) {
         ev.preventDefault();
         finishActiveTextEdit(true);
@@ -856,7 +899,13 @@ export function buildManualEditBridge(enabled: boolean): string {
         finishActiveTextEdit(false);
       }
     }
-    activeTextEdit = { el: el, originalText: originalText, onKey: onKey };
+    activeTextEdit = {
+      el: el,
+      originalHtml: originalHtml,
+      originalText: originalText,
+      originalWhiteSpace: originalWhiteSpace,
+      onKey: onKey
+    };
     el.addEventListener('keydown', onKey);
     postTextSession(el, true);
   }
@@ -990,17 +1039,16 @@ export function buildManualEditBridge(enabled: boolean): string {
     }
     if (ev.data.type === 'od-edit-preview-text') {
       // Live text preview from the host panel's 文本 textarea — the counterpart
-      // to od-edit-preview-style. Setting textContent on the (blurred, the host
-      // textarea holds focus) element mirrors exactly what the set-text patch
-      // will persist, so a newline typed in the panel shows immediately instead
-      // of only after Save. Guarded to text leaves (no element children) so it
-      // can never clobber nested markup — set-text rejects those anyway. When an
-      // inline session is live on the same element, updating its textContent is
-      // safe: the session commits the current textContent on save and restores
-      // its own originalText on cancel, so both paths still reconcile.
+      // to od-edit-preview-style. Rendering the plain-text model on the (blurred,
+      // the host textarea holds focus) element mirrors exactly what the set-text
+      // patch will persist, so a newline typed in the panel shows immediately
+      // instead of only after Save. Guarded to text leaves (text plus soft-break
+      // nodes) so it can never clobber nested markup — set-text rejects those
+      // anyway. When an inline session is live on the same element, its save and
+      // cancel paths still reconcile against the current model and original HTML.
       var ptEl = findById(ev.data.id || '');
-      if (ptEl && ptEl !== document.body && ptEl.children.length === 0) {
-        ptEl.textContent = String(ev.data.value == null ? '' : ev.data.value);
+      if (ptEl && ptEl !== document.body && isTextLeaf(ptEl)) {
+        renderPlainText(ptEl, String(ev.data.value == null ? '' : ev.data.value));
       }
       return;
     }

--- a/apps/web/src/edit-mode/source-patches.ts
+++ b/apps/web/src/edit-mode/source-patches.ts
@@ -128,14 +128,16 @@ export function applyManualEditPatch(source: string, patch: ManualEditPatch): Ma
   }
 
   if (patch.kind === 'set-text') {
-    if (hasElementChildren(el)) {
+    if (hasOnlyTextAndLineBreaks(el)) {
+      replaceTextWithLineBreaks(el, patch.value);
+    } else if (hasElementChildren(el)) {
       const soleText = findSoleMeaningfulTextNode(el);
       if (!soleText) {
         return { ok: false, source, error: 'This element contains nested markup. Use the HTML tab instead.' };
       }
       soleText.nodeValue = patch.value;
     } else {
-      el.textContent = patch.value;
+      replaceTextWithLineBreaks(el, patch.value);
     }
   } else if (patch.kind === 'set-link') {
     if (hasElementChildren(el)) {
@@ -191,7 +193,7 @@ export function readManualEditFields(source: string, id: string): ManualEditFiel
   const kind = inferKind(el);
   if (kind === 'link') {
     return {
-      text: el.textContent?.trim() ?? '',
+      text: readTextWithLineBreaks(el).trim(),
       href: el.getAttribute('href') ?? '',
     };
   }
@@ -201,7 +203,30 @@ export function readManualEditFields(source: string, id: string): ManualEditFiel
       alt: el.getAttribute('alt') ?? '',
     };
   }
-  return { text: el.textContent?.trim() ?? '' };
+  return { text: readTextWithLineBreaks(el).trim() };
+}
+
+function hasOnlyTextAndLineBreaks(el: Element): boolean {
+  return Array.from(el.childNodes).every((node) =>
+    node.nodeType === node.TEXT_NODE
+    || (node.nodeType === node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'br'));
+}
+
+function readTextWithLineBreaks(el: Element): string {
+  return Array.from(el.childNodes).map((node) => {
+    if (node.nodeType === node.TEXT_NODE) return node.nodeValue ?? '';
+    if (node.nodeType === node.ELEMENT_NODE && (node as Element).tagName.toLowerCase() === 'br') return '\n';
+    return node.textContent ?? '';
+  }).join('');
+}
+
+function replaceTextWithLineBreaks(el: Element, value: string): void {
+  const parts = value.split('\n');
+  el.replaceChildren();
+  parts.forEach((part, index) => {
+    if (index > 0) el.appendChild(el.ownerDocument.createElement('br'));
+    if (part) el.appendChild(el.ownerDocument.createTextNode(part));
+  });
 }
 
 export function readManualEditStyles(source: string, id: string): ManualEditStyles {

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -521,6 +521,66 @@ describe('FileViewer manual edit regressions', () => {
     }
   });
 
+  it('preserves consecutive panel text breaks after save and reload', async () => {
+    let persistedSource = '<!doctype html><html><body><p data-od-id="hero">First</p></body></html>';
+    const savedSources: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        const payload = JSON.parse(String(init.body)) as { content: string };
+        persistedSource = payload.content;
+        savedSources.push(payload.content);
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(persistedSource, { status: 200, headers: { 'Content-Type': 'text/html' } });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={persistedSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget({
+      ...heroTarget(),
+      tagName: 'p',
+      text: 'First',
+      fields: { text: 'First' },
+      outerHtml: '<p data-od-id="hero">First</p>',
+    });
+
+    fireEvent.change(screen.getByLabelText('Text'), {
+      target: { value: 'First\nSecond\n\nFourth' },
+    });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(savedSources).toHaveLength(1);
+      expect(document.querySelector('.manual-edit-right')).toBeNull();
+    });
+    expect(savedSources[0]).toContain('<p data-od-id="hero">First<br>Second<br><br>Fourth</p>');
+
+    view.unmount();
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Code' }));
+    await waitFor(() => {
+      expect(document.querySelector('.viewer-source')?.textContent).toContain(
+        '<p data-od-id="hero">First<br>Second<br><br>Fourth</p>',
+      );
+    });
+  });
+
   it('applies a saved panel text edit to the retained iframe without waiting for a style change', async () => {
     const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main></body></html>';
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {

--- a/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
+++ b/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
@@ -427,6 +427,39 @@ describe('LexicalComposerInput', () => {
     await waitFor(() => expect(onEnterSend).toHaveBeenCalledTimes(1));
   });
 
+  it('inserts a soft line break with Shift+Enter without sending', async () => {
+    const { ref, onEnterSend, getByTestId } = setup({ draft: 'hithere' });
+    const editable = getByTestId('chat-composer-input') as HTMLElement & {
+      __lexicalEditor?: import('lexical').LexicalEditor;
+    };
+    const editor = editable.__lexicalEditor;
+    expect(editor).toBeTruthy();
+    act(() => {
+      editor?.update(() => {
+        const paragraph = $getRoot().getFirstChild();
+        const first = $isElementNode(paragraph) ? paragraph.getFirstChild() : null;
+        if ($isTextNode(first)) first.select(2, 2);
+      }, { discrete: true });
+    });
+
+    const shiftEnter = () => ({
+      key: 'Enter',
+      shiftKey: true,
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      repeat: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    const first = shiftEnter();
+    act(() => {
+      editor?.dispatchCommand(KEY_ENTER_COMMAND, first);
+    });
+    await waitFor(() => expect(ref.current?.getText()).toBe('hi\nthere'));
+    expect(first.preventDefault).toHaveBeenCalledTimes(1);
+    expect(onEnterSend).not.toHaveBeenCalled();
+  });
+
   it('does not send when the browser repeats a held Enter key', async () => {
     const { onEnterSend, getByTestId } = setup({ draft: 'hi' });
     const editable = getByTestId('chat-composer-input') as HTMLElement & {

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -1005,6 +1005,85 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('treats Shift+Enter as repeatable soft line breaks without committing the inline edit', () => {
+    const dom = new JSDOM(
+      `<main><p data-od-id="body">First line</p></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const body = dom.window.document.querySelector('[data-od-id="body"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const firstBreak = new dom.window.KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+      shiftKey: true,
+    });
+    const secondBreak = new dom.window.KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+      shiftKey: true,
+    });
+
+    body.dispatchEvent(firstBreak);
+    body.dispatchEvent(secondBreak);
+
+    expect(firstBreak.defaultPrevented).toBe(true);
+    expect(secondBreak.defaultPrevented).toBe(true);
+    expect(body.textContent).toBe('First line\n\n');
+    expect(body.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'od-edit-text-commit',
+    }), '*');
+
+    body.textContent = 'First line\n\nThird line';
+    body.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+    }));
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-text-commit',
+      id: 'body',
+      value: 'First line\n\nThird line',
+    }, '*');
+    expect(body.innerHTML).toBe('First line<br><br>Third line');
+
+    body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    expect(body.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(body.textContent).toBe('First line\n\nThird line');
+
+    dom.window.close();
+  });
+
+  it('leaves Enter to the IME while inline text composition is active', () => {
+    const dom = new JSDOM(
+      `<main><p data-od-id="body">输入中</p></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const body = dom.window.document.querySelector('[data-od-id="body"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    const composingEnter = new dom.window.KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+      isComposing: true,
+    });
+    body.dispatchEvent(composingEnter);
+
+    expect(composingEnter.defaultPrevented).toBe(false);
+    expect(body.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: 'od-edit-text-commit',
+    }), '*');
+
+    dom.window.close();
+  });
+
   // #3646 focus-loss half: once editing, blurring the iframe (e.g. moving the
   // pointer to the host's floating inspector) must NOT end the session or
   // commit. Only an explicit finish (Enter/Escape/od-edit-text-finish) commits.

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -1005,6 +1005,26 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('keeps an emptied text target eligible for a later preview update', () => {
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-preview-text', id: 'title', value: '' },
+    }));
+    expect(title.textContent).toBe('');
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-preview-text', id: 'title', value: 'Retyped' },
+    }));
+    expect(title.textContent).toBe('Retyped');
+
+    dom.window.close();
+  });
+
   it('treats Shift+Enter as repeatable soft line breaks without committing the inline edit', () => {
     const dom = new JSDOM(
       `<main><p data-od-id="body">First line</p></main>${buildManualEditBridge(true)}`,

--- a/apps/web/tests/edit-mode/source-patches.test.ts
+++ b/apps/web/tests/edit-mode/source-patches.test.ts
@@ -214,6 +214,19 @@ describe('manual edit source patches', () => {
     expect(result.source).not.toContain('<body');
   });
 
+  it('persists consecutive soft line breaks as br elements and reads them back as newlines', () => {
+    const source = '<main><p data-od-id="body">Original body</p></main>';
+    const result = applyManualEditPatch(source, {
+      kind: 'set-text',
+      id: 'body',
+      value: 'First line\n\nThird line',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.source).toContain('First line<br><br>Third line');
+    expect(readManualEditFields(result.source, 'body').text).toBe('First line\n\nThird line');
+  });
+
   it('detects full documents after leading comments and keeps fragments distinct', () => {
     expect(isManualEditFullHtmlDocument('<!-- generated -->\n<!doctype html><html></html>')).toBe(true);
     expect(isManualEditFullHtmlDocument('<?xml version="1.0"?>\n<html></html>')).toBe(true);


### PR DESCRIPTION
## Why

I audited Plane work item OPEND-167 against the current editor surfaces. The issue description and historical title point to text editing inside the design workspace, not the chat composer. The design preview's Manual edit bridge still delegated Shift+Enter to native `contenteditable` behavior and persisted raw newline characters into HTML, so soft line breaks could collapse after save/reopen. IME Enter could also commit the edit while composition was active.

This PR keeps the fix scoped to that editor while adding coverage that confirms the already-correct chat composer behavior.

## What users will see

In a design preview's Manual edit mode, Shift+Enter inserts a soft line break without saving the edit. Consecutive soft line breaks survive save and reopen, Enter still commits, Escape still cancels, and Enter during IME composition stays with the IME instead of committing.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes keyboard and document-model behavior inside the existing Manual edit surface without changing its visual entry point. A local runtime fixture was started for interaction verification, but the browser-control session timed out before a verifiable capture; the keyboard paths are covered by the focused tests below.

## Bug fix verification

- Test paths: `apps/web/tests/edit-mode/bridge.test.ts`, `apps/web/tests/edit-mode/source-patches.test.ts`, and `apps/web/tests/components/composer/LexicalComposerInput.test.tsx`
- Yes. Before the source change, the new regression specs produced 3 failures and 74 passes: Shift+Enter was not intercepted, IME Enter committed, and persisted HTML contained collapsing raw newlines. They are green on this branch.
- The tests define the model explicitly: inline editing uses `\n`, committed HTML uses `<br>`, consecutive breaks round-trip, Shift+Enter does not send/commit, and IME Enter is not intercepted.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/contracts build` (refresh workspace declarations after syncing latest `main`)
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run tests/edit-mode/bridge.test.ts tests/edit-mode/source-patches.test.ts tests/components/composer/LexicalComposerInput.test.tsx tests/components/BoardComposerPopover.keyboard-submit.test.tsx tests/components/PreviewDrawOverlay.test.tsx` — 5 files passed, 130 tests passed, 1 pre-existing test skipped; jsdom emitted its non-fatal canvas `getContext` warning

