### PR TITLE
fix(web): keep Settings autosave feedback clear of CLI controls

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4186,22 +4186,11 @@ export function SettingsDialog({
         aria-labelledby="settings-dialog-title"
         onClick={pageMode ? undefined : (e) => e.stopPropagation()}
       >
-        {/* Top-right chrome strip — anchored to the modal corner so the
-            autosave indicator and the close button float above the
-            sidebar/content rhythm without competing with the title.
-            We use `position: absolute` instead of putting these inside
-            `.modal-head` so the welcome variant's tall hero (kicker /
-            title / subtitle / pet teaser) keeps its centred reading
-            measure, and the close button always lands at the same
-            optical location regardless of how much copy the header
-            renders. */}
-        <div className="settings-chrome" aria-hidden={false}>
-          {/* Autosave status pill. Only renders something while a save
-              is in flight or has just completed — idle = invisible so
-              first-open feels calm. The chrome strip itself stays
-              mounted so the close button never shifts when the pill
-              appears, and the pill is announced via aria-live for
-              assistive tech. */}
+        {/* Autosave feedback is viewport-level rather than part of the
+            top-right dialog chrome. Local CLI pickers and the page-mode
+            content both occupy that upper band, so keeping this passive
+            status at the bottom avoids obscuring the active controls. */}
+        <div className="settings-autosave-layer">
           <div
             className={`settings-autosave is-${autosaveStatus}`}
             role="status"
@@ -4224,6 +4213,11 @@ export function SettingsDialog({
               </>
             ) : null}
           </div>
+        </div>
+        {/* Top-right chrome strip — anchored to the modal corner so the
+            close and fullscreen controls stay at a stable optical location
+            regardless of the header copy. */}
+        <div className="settings-chrome" aria-hidden={false}>
           {pageMode ? null : (
             <button
               type="button"

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -722,9 +722,9 @@
   padding: 0;
   gap: 0;
   overflow: hidden;
-  /* Anchor for the absolutely-positioned `.settings-chrome` strip
-     (close button + autosave indicator). Without this the chrome
-     would escape to the viewport on long-scrolling sections. */
+  /* Anchor for the absolutely-positioned `.settings-chrome` strip. Without
+     this the close/fullscreen controls would escape to the viewport on
+     long-scrolling sections. */
   position: relative;
 }
 .modal-settings.settings-fullscreen {
@@ -757,15 +757,10 @@
   box-shadow: none;
   background: transparent;
 }
-/* recvq4iEq1Esno: this used to hide `.settings-chrome` itself — the whole
-   corner strip, autosave "Saved" pill included — because the close/fullscreen
-   buttons inside it don't belong on a full page (there's a "返回首页" link
-   instead). That blanket rule took the save confirmation down with them: a
-   media-provider edit (or any settings change) on the full-page presentation
-   saved silently, with nothing telling the user it had. Target the buttons
-   specifically (`.settings-chrome-btn` covers both `.settings-close` and
-   `.settings-fullscreen-toggle`) and leave the sibling `.settings-autosave`
-   pill visible in both presentations. */
+/* recvq4iEq1Esno: full-page Settings has its own back navigation, so hide only
+   the close/fullscreen buttons. Autosave feedback now lives outside this
+   strip in `.settings-autosave-layer` and remains visible in both
+   presentations. */
 .settings-page-shell .settings-chrome-btn,
 .settings-page-shell .settings-sidebar-toggle {
   display: none;
@@ -865,13 +860,9 @@
   flex-shrink: 0;
 }
 
-/* Top-right chrome strip for the Settings dialog. Floats above the
-   sidebar/content rhythm so the close affordance and the autosave
-   indicator never compete with the title or sidebar nav. The strip
-   is a flex row right-anchored to the modal corner; the autosave
-   pill comes first so the close button keeps a stable optical
-   position and the user's eye returns to the same place after a
-   save settles. */
+/* Top-right chrome strip for the Settings dialog. Autosave feedback has its
+   own viewport-level layer below, leaving this strip to the close/fullscreen
+   controls so status changes cannot expand across active Settings content. */
 .settings-chrome {
   position: absolute;
   top: 24px;
@@ -880,20 +871,6 @@
   display: flex;
   align-items: center;
   gap: 6px;
-}
-/* Full-page presentation: the chrome strip holds only the autosave pill
-   (the close/fullscreen buttons are hidden above), so it reads as a page
-   toast rather than corner chrome — center it under the top nav instead
-   of leaving it stranded in the panel's top-right corner. 32px keeps a
-   clear band of air below the workspace tabs bar hairline; at 12px the
-   pill visually collided with it (dogfood 2026-07-24). As a transient
-   blurred toast it may briefly float over section content — that is
-   normal toast behavior and reads better than hugging the nav line. */
-.settings-page-shell .settings-chrome {
-  top: 32px;
-  right: auto;
-  left: 50%;
-  transform: translateX(-50%);
 }
 .settings-chrome > * {
   pointer-events: auto;
@@ -947,13 +924,22 @@
   .settings-chrome-btn { transition: color 80ms linear, border-color 80ms linear; transform: none !important; }
 }
 
-/* Autosave status pill. Lives in the chrome strip now (next to the
-   close button) instead of a footer. Renders nothing while idle so
-   the chrome reads as a single close button until something is
-   actually saving; settles to a green check on success and red on
-   failure. The pill never takes focus and never blocks input — it
-   is a passive system message announced to assistive tech via
-   aria-live on the wrapper. */
+/* Keep passive save feedback out of dialog/page layout and below the
+   body-portaled model picker (z-index 10500). This leaves Local CLI controls
+   unobscured in dialog, page, and narrow presentations while the full status
+   copy remains readable. */
+.settings-autosave-layer {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  z-index: 9000;
+  transform: translateX(-50%);
+  max-width: calc(100vw - 32px);
+  pointer-events: none;
+}
+
+/* Autosave status pill. Renders nothing while idle, settles to a green check
+   on success and red on failure, and is announced via aria-live. */
 .settings-autosave {
   display: inline-flex;
   align-items: center;
@@ -977,8 +963,7 @@
 .settings-autosave.is-idle {
   opacity: 0;
   transform: translateY(-2px);
-  /* Collapse the visual weight so the chrome strip is just the
-     close button when nothing is happening. */
+  /* Collapse the detached feedback layer when nothing is happening. */
   padding: 0;
   border-color: transparent;
   background: transparent;
@@ -1010,19 +995,6 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .settings-autosave { transition: opacity 80ms linear; animation: none !important; }
-}
-
-/* Hide the verbose error copy on narrow viewports so the chrome
-   strip doesn't crowd the close button. The icon + tooltip carry
-   the meaning, and the screen-reader announcement still fires. */
-@media (max-width: 720px) {
-  .settings-autosave.is-error span,
-  .settings-autosave.is-saved span,
-  .settings-autosave.is-pending span,
-  .settings-autosave.is-saving span {
-    display: none;
-  }
-  .settings-autosave.is-idle { padding: 0; }
 }
 
 /* Make sure header copy doesn't crash into the close button on

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1248,7 +1248,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     );
   });
 
-  it('surfaces autosave progress, success, and failure states in the modal chrome', async () => {
+  it('surfaces autosave progress, success, and failure states outside the modal chrome', async () => {
     const first = renderSettingsDialog();
 
     fireEvent.change(screen.getByLabelText('API key'), {
@@ -1261,6 +1261,9 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     await waitFor(() => {
       expect(screen.getByText('All changes saved')).toBeTruthy();
     });
+    const savedStatus = screen.getByText('All changes saved').closest('[role="status"]');
+    expect(savedStatus?.parentElement).toHaveClass('settings-autosave-layer');
+    expect(savedStatus?.closest('.settings-chrome')).toBeNull();
     expect(first.onPersist).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: 'sk-ant-saved' }),
       expect.any(Object),
@@ -1281,6 +1284,8 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     await waitFor(() => {
       expect(screen.getByText(/Couldn’t save changes/i)).toBeTruthy();
     });
+    const errorStatus = screen.getByText(/Couldn’t save changes/i).closest('[role="status"]');
+    expect(errorStatus?.parentElement).toHaveClass('settings-autosave-layer');
   });
 
   it('closes BYOK via the close button or backdrop', () => {

--- a/apps/web/tests/styles/acceptance-visual-fixes.test.ts
+++ b/apps/web/tests/styles/acceptance-visual-fixes.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-// Six independent visual/interaction acceptance fixes. Each `it` is scoped to
+// Independent visual/interaction acceptance fixes. Each `it` is scoped to
 // one Feishu acceptance-sheet row and only asserts the rule(s) that row's fix
 // touched, so a regression in one area fails only its own test.
 
@@ -134,24 +134,33 @@ describe('recvpZpbZcu4iy — design-file tab bar has no border separating it fro
 
 describe('recvq4iEq1Esno — settings full page swallowed the autosave "Saved" pill', () => {
   it('hides only the close/fullscreen chrome buttons on the full-page presentation, not the autosave pill', () => {
-    // The old rule targeted `.settings-chrome` itself — the shared corner
-    // strip that also contains `.settings-autosave` — so hiding the
-    // close/fullscreen buttons for page mode took the save confirmation
-    // down with them. #6156 re-introduced the bare selector to centre the
-    // pill under the top nav, which is fine: what must never come back is a
-    // page-mode rule that hides the whole strip. Absent is fine too, hence the
-    // tolerant read.
-    let chromeStrip = '';
-    try {
-      chromeStrip = cssDeclarations(mentionHomeCss, '.settings-page-shell .settings-chrome');
-    } catch {
-      chromeStrip = '';
-    }
-    expect(chromeStrip).not.toMatch(/display\s*:\s*none/);
+    // The status now lives outside `.settings-chrome`, so page-mode button
+    // suppression cannot accidentally take the save confirmation with it.
+    const feedbackLayer = cssDeclarations(mentionHomeCss, '.settings-autosave-layer');
+    expect(feedbackLayer).not.toMatch(/display\s*:\s*none/);
 
     // The fix must still hide the buttons that don't belong on a full page
     // (there's a "返回首页" link instead of a floating close/fullscreen pair).
     const hiddenButtons = cssDeclarations(mentionHomeCss, '.settings-page-shell .settings-chrome-btn');
     expect(ruleValue(hiddenButtons, 'display')).toBe('none');
+  });
+});
+
+describe('OPEND-2148 — Settings autosave feedback obscures Local CLI controls', () => {
+  it('keeps autosave feedback in a viewport-level layer below model popovers', () => {
+    const feedbackLayer = cssDeclarations(mentionHomeCss, '.settings-autosave-layer');
+
+    expect(ruleValue(feedbackLayer, 'position')).toBe('fixed');
+    expect(ruleValue(feedbackLayer, 'left')).toBe('50%');
+    expect(ruleValue(feedbackLayer, 'bottom')).toBe('24px');
+    expect(ruleValue(feedbackLayer, 'transform')).toBe('translateX(-50%)');
+    const feedbackZIndex = Number(ruleValue(feedbackLayer, 'z-index'));
+    expect(feedbackZIndex).toBeGreaterThan(1700);
+    expect(feedbackZIndex).toBeLessThan(10500);
+
+    // The feedback copy used to disappear below 720px because it shared the
+    // cramped top-right close/fullscreen strip. A detached feedback layer has
+    // room for the message and must keep it readable on narrow viewports.
+    expect(mentionHomeCss).not.toContain('.settings-autosave.is-saved span');
   });
 });


### PR DESCRIPTION
## Why

Plane OPEND-2148 reports that Settings autosave feedback appears in the same upper chrome band as the Local CLI controls. While a CLI selection is being saved, the status can compete with or cover the picker and primary configuration area, especially in page mode and narrow viewports.

The autosave state is passive feedback, so it should stay visible without occupying the active control region.

## What users will see

- `Saving…`, `All changes saved`, and save errors now appear in a centered viewport-level layer near the bottom of Settings.
- Local CLI cards, model pickers, and the main Settings content remain unobscured while a selection is saved.
- The full status text remains visible on narrow viewports instead of collapsing to an icon-only message.
- Dialog and full-page Settings use the same feedback placement.

## Surface area

- [x] UI
- [ ] CLI
- [ ] API / contracts
- [ ] Agent runtime
- [ ] Skills
- [ ] Design systems
- [ ] Design templates
- [ ] Craft
- [ ] Documentation
- [ ] Environment variables
- [ ] Dependencies
- [ ] i18n
- [x] Default behavior change

## Screenshots

Local Playwright evidence was captured at `e2e/ui/reports/visual-screenshots/visual-settings-local-cli.png` (generated report artifact, intentionally not committed). It shows the Local CLI page with the `Saving…` pill centered at the bottom, clear of the CLI card and model control.

This PR is opened as a draft because the generated screenshot still needs to be attached through the GitHub UI before review.

## Bug fix verification

- Red spec: `apps/web/tests/styles/acceptance-visual-fixes.test.ts` (`OPEND-2148 — Settings autosave feedback obscures Local CLI controls`)
- Baseline result: failed before the production change with `Missing CSS block for .settings-autosave-layer`.
- Branch result: green after moving feedback out of `.settings-chrome` and adding the viewport-level layer.
- Component coverage verifies autosave progress/success/failure are outside modal chrome and verifies switching to Local CLI, selecting an installed agent, and autosaving.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/acceptance-visual-fixes.test.ts` — 8 passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx -t "surfaces autosave progress"` — 1 passed
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx -t "lets users switch to Local CLI, select an installed agent, and autosave"` — 1 passed
- `OD_PLAYWRIGHT_WORKERS=1 pnpm --filter @open-design/e2e exec playwright test -c playwright.visual.config.ts ui/visual-settings.test.ts --grep "captures the settings local CLI surface"` — 1 passed
- `pnpm --filter @open-design/contracts build` — passed (refreshed declarations after rebasing onto current `main`)
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed

Plane OPEND-2148 was read only and was not updated by this PR workflow.
