### PR TITLE
fix web image tab modal flash

### DIFF
--- a/apps/web/src/styles/home/new-project-modal.css
+++ b/apps/web/src/styles/home/new-project-modal.css
@@ -18,6 +18,10 @@
 .new-project-modal {
   width: 100%;
   max-width: 840px;
+  /* Keep one responsive frame while tabs swap forms of different natural
+     heights. Without an explicit height, Prototype -> Media/Image shrinks the
+     dialog on the first committed frame and reads as a flash. */
+  height: min(820px, calc(100vh - 80px));
   max-height: calc(100vh - 80px);
   background: var(--bg-panel);
   border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -294,6 +294,32 @@ test.describe('new project modal from left rail', () => {
     await expect(page.getByTestId('new-project-media-surface-audio')).toHaveAttribute('aria-selected', 'true');
     await expect(page.locator('.newproj-title')).toContainText('New audio');
   });
+
+  test('[P1] new project frame stays stable when switching from prototype to image', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await stubEmptyProjectsNewProjectData(page);
+    await openNewProjectFromProjectsView(page);
+
+    const modal = page.locator('.new-project-modal');
+    const stableModalHeight = async (): Promise<number> => modal.evaluate(async (element) => {
+      let previous = -1;
+      let stableFrames = 0;
+      while (stableFrames < 3) {
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        const current = element.getBoundingClientRect().height;
+        stableFrames = Math.abs(current - previous) < 0.01 ? stableFrames + 1 : 0;
+        previous = current;
+      }
+      return previous;
+    });
+
+    const prototypeHeight = await stableModalHeight();
+    await page.getByTestId('new-project-tab-media').click();
+    await expect(page.locator('.newproj-title')).toContainText('New image');
+    const imageHeight = await stableModalHeight();
+
+    expect(imageHeight).toBeCloseTo(prototypeHeight, 0);
+  });
 });
 
 test('[P0] projects empty state create action opens the new project flow', async ({ page }) => {


### PR DESCRIPTION
## Why

While auditing Plane work item OPEND-2169, I reproduced a visible flash when switching the New project dialog from Prototype to Media/Image. At 1440×900, the dialog shrank from 820px to 749.5px on the first committed frame because its height followed each tab's natural content height.

This makes the primary creation flow feel unstable even though no blank frame, loading state, remount, or repeated request occurs.

## What users will see

The New project dialog now keeps one responsive outer frame while switching between Prototype and Media/Image. Smaller viewports still use the available viewport height, while larger viewports cap the dialog at 820px. Image quality and media-generation behavior are unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — existing users get a stable dialog frame without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Prototype and Media/Image at 1440×900 were verified locally; GitHub-hosted attachments are pending upload.

## Bug fix verification

- Test path: `e2e/ui/project-management-flows.test.ts` — `[P1] new project frame stays stable when switching from prototype to image`
- Red on `main`: yes — expected 820px, received 749.5px
- Green on this branch: yes — 1 passed

## Validation

- `cd e2e && pnpm exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts --grep "frame stays stable" --workers=1`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/NewProjectPanel.test.tsx tests/components/NewProjectPanel.media.test.tsx` — 35 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm guard`
- `pnpm typecheck`

Plane: OPEND-2169
