### PR TITLE
fix(web): keep resize hitbox off chat scroll edge

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -2495,8 +2495,10 @@ a.avatar-item:visited {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -10px;
-  right: -10px;
+  /* Keep the chat-side scroll edge entirely outside the resize hitbox in
+     both directions; extra grab room belongs on the workspace side only. */
+  inset-inline-start: 0;
+  inset-inline-end: -8px;
   cursor: col-resize;
 }
 .split-resize-handle::after {

--- a/e2e/ui/split-resize-scrollbar-hitbox.test.ts
+++ b/e2e/ui/split-resize-scrollbar-hitbox.test.ts
@@ -2,9 +2,8 @@ import { expect, test } from '@/playwright/suite';
 import { openNewProjectModal } from '@/playwright/rail';
 import type { Locator, Page } from '@playwright/test';
 import { applyStandardMocks } from '@/playwright/mock-factory';
-import { openSettingsDialog } from '../lib/playwright/amr.js';
 
-// Red spec for issue #548 (Plane): the split resize handle's extended hitbox
+// Red spec for OPEND-321 (duplicated by OPEND-548): the split resize handle's extended hitbox
 // (`.split-resize-handle::before`) must never cross the handle's inline-start
 // edge, because the chat panel's scrollbar gutter sits flush against it. When
 // it does, clicks aimed at the scrollbar start a panel resize instead, and
@@ -19,7 +18,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('[P1] chat scrollbar gutter edge belongs to the chat panel, not the resize handle', async ({ page }) => {
-  test.fail(true, 'Known #548 regression: the resize handle still overlaps the chat scrollbar gutter.');
   await gotoEntryHome(page);
   await createProject(page, 'Scrollbar hitbox LTR');
   await expectWorkspaceReady(page);
@@ -29,23 +27,21 @@ test('[P1] chat scrollbar gutter edge belongs to the chat panel, not the resize 
   const y = box.y + box.height / 2;
 
   // Red probe: 1px inside the chat-log edge that faces the handle. On main
-  // the handle's ::before overhangs 2px into the scrollbar gutter, so this
+  // the handle's ::before overhangs 10px into the scroll edge, so this
   // point hit-tests to the handle (red); after the fix it belongs to the
   // chat panel (green).
   const redProbe = await probeHit(page, box.x + box.width - 1, y);
   expect(redProbe.hitHandle, `expected chat panel at 1px probe, hit <${redProbe.tag} class="${redProbe.className}">`).toBe(false);
   expect(redProbe.insideChatLog).toBe(true);
 
-  // Control probe: 3px inside — beyond main's 2px overhang, so it must hit
-  // the chat panel before AND after the fix. Guards against over-shrinking
-  // the handle or introducing a new overlay on the gutter.
+  // A second probe farther into the scroll edge guards the rest of the
+  // interaction lane against another overlay.
   const controlProbe = await probeHit(page, box.x + box.width - 3, y);
   expect(controlProbe.hitHandle).toBe(false);
   expect(controlProbe.insideChatLog).toBe(true);
 });
 
 test('[P1] hovering and dragging on the scrollbar gutter does not enter resize posture', async ({ page }) => {
-  test.fail(true, 'Known #548 regression: the resize handle still overlaps the chat scrollbar gutter.');
   await gotoEntryHome(page);
   await createProject(page, 'Scrollbar hover posture');
   await expectWorkspaceReady(page);
@@ -99,16 +95,12 @@ test('[P1] resize handle body still drags the chat panel width', async ({ page }
 });
 
 test('[P1] RTL: chat scrollbar gutter is not covered by the resize handle', async ({ page }) => {
-  test.fail(true, 'Known #548 regression: the resize handle still overlaps the RTL chat scrollbar gutter.');
   await gotoEntryHome(page);
   await createProject(page, 'Scrollbar hitbox RTL');
   await expectWorkspaceReady(page);
-  // Switch to Arabic through the in-project settings UI. Seeding the locale
-  // via localStorage before navigation is unreliable here: the initial-locale
-  // detection can transiently lose a persisted manual locale during the hard
-  // navigation that project creation performs (adjacent issue, not part of
-  // this fix). setLocale from the settings dialog applies synchronously.
-  await switchLocaleToArabic(page);
+  // Directionality is the precondition under test; setting the document's
+  // public dir attribute keeps this spec independent from settings routing.
+  await page.locator('html').evaluate((element) => element.setAttribute('dir', 'rtl'));
   await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
 
   const chatLog = page.locator('.chat-log');
@@ -160,20 +152,6 @@ async function readChatPanelWidth(handle: Locator): Promise<number> {
   const parsed = Number.parseInt(raw ?? '', 10);
   expect(Number.isFinite(parsed)).toBeTruthy();
   return parsed;
-}
-
-// Switch the app language to Arabic from inside the project view: avatar
-// menu → full settings → General → the language select. #5517 folded Language
-// into General and replaced the locale tile grid with one compact <select>, so
-// this drives the select. All selectors are class/testid based so they survive
-// the locale change.
-async function switchLocaleToArabic(page: Page) {
-  const dialog = await openSettingsDialog(page);
-  await dialog.locator('.settings-nav-item', { hasText: 'General' }).click();
-  await dialog.locator('.settings-general-select select').selectOption('ar');
-  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
-  await dialog.getByRole('button', { name: 'Back to home', exact: true }).click();
-  await expect(dialog).toBeHidden();
 }
 
 async function gotoEntryHome(page: Page) {


### PR DESCRIPTION
Plane: [OPEND-321](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/ab97ef31-e92d-4b85-b43d-507ef1324598)

## Why

I investigated the paid-insight report in OPEND-321 and reproduced it on current `main` in the project workspace. The chat/workspace split handle extended its pseudo-element hitbox 10px into the adjacent chat scroll edge, so hovering or pressing the scroll interaction lane targeted the resize handle instead. A gutter drag could therefore resize the chat panel and prevent normal scroll interaction.

This restores the boundary that was previously covered by the near-duplicate OPEND-548: the scroll edge belongs to ChatPane, while resize starts only from the explicit separator handle.

## What users will see

Hovering, clicking, or dragging the chat scroll edge no longer shows the column-resize posture or changes the panel width. Dragging the 8px separator itself continues to resize the chat panel. The same boundary holds in RTL layouts.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — the split handle no longer captures the adjacent chat scroll interaction edge
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: this changes pointer hit-testing without changing visible chrome. Browser assertions cover the entry point, hover posture, gutter drag, separator drag, narrow viewport, and RTL behavior.

## Bug fix verification

- Test path: `e2e/ui/split-resize-scrollbar-hitbox.test.ts`
- Red on `main`: yes — the 1px chat-edge probe failed with `expected chat panel ... hit <DIV class="split-resize-handle">`.
- Green on this branch: yes — all four focused Playwright cases pass.
- Manual browser reproduction at 900x720: before, gutter drag resized 460px to 492px; after, it remains 460px, while direct handle drag remains functional.
- Platform note: current ChatPane uses a custom message rail and hides the native scrollbar. macOS headless Chromium remained overlay-style even with OverlayScrollbar disabled, so a genuine Windows/Linux classic scrollbar thumb could not be exercised locally. The logical hitbox invariant itself is covered in both LTR and RTL.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard`
- `pnpm typecheck`
- `OD_PLAYWRIGHT_TIMEOUT=120000 pnpm exec playwright test -c playwright.config.ts ui/split-resize-scrollbar-hitbox.test.ts --workers=1 --reporter=line` from `e2e/` — 4 passed
- `git diff --check`
