### PR TITLE
fix(web): localize missing bundled scenario error

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -2511,9 +2511,7 @@ export function HomeView({
         const targetId = chip.action.pluginId;
         const record = plugins.find((p) => p.id === targetId);
         if (!record) {
-          setError(
-            `Bundled scenario "${targetId}" is not installed. Reinstall the daemon to restore the default plugin set.`,
-          );
+          setError(t('home.bundledScenarioMissing', { scenarioId: targetId }));
           return;
         }
         const mediaSurface = homeMediaSurfaceForChipId(chip.id);

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -866,6 +866,7 @@ export const ar: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "سجّل الدخول لاستخدام OpenDesign Cloud والتعاون عبر السحابة",
   "entry.cloudCalloutDismissAria": "إغلاق ملاحظة OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -866,6 +866,7 @@ export const de: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Melden Sie sich an, um OpenDesign Cloud zu nutzen und in der Cloud zusammenzuarbeiten",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud-Hinweis schließen",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -866,6 +866,7 @@ export const en: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Sign in to use OpenDesign Cloud and collaborate in the cloud",
   "entry.cloudCalloutDismissAria": "Dismiss OpenDesign Cloud note",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -866,6 +866,7 @@ export const esES: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Inicia sesión para usar OpenDesign Cloud y colaborar en la nube",
   "entry.cloudCalloutDismissAria": "Cerrar el aviso de OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -866,6 +866,7 @@ export const fa: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "برای استفاده از OpenDesign Cloud و همکاری در فضای ابری وارد شوید",
   "entry.cloudCalloutDismissAria": "بستن یادداشت OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -866,6 +866,7 @@ export const fr: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Connectez-vous pour utiliser OpenDesign Cloud et collaborer dans le cloud",
   "entry.cloudCalloutDismissAria": "Fermer la note OpenDesign Cloud",
   'entry.workspaceLockedNote': "Cet espace de travail est verrouillé. Rétablissez la facturation pour reprendre la modification des projets partagés.",

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -866,6 +866,7 @@ export const hu: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Jelentkezzen be az OpenDesign Cloud használatához és a felhőalapú együttműködéshez",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud értesítés bezárása",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -866,6 +866,7 @@ export const id: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Masuk untuk menggunakan OpenDesign Cloud dan berkolaborasi di cloud",
   "entry.cloudCalloutDismissAria": "Tutup catatan OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -866,6 +866,7 @@ export const it: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Accedi per usare OpenDesign Cloud e collaborare nel cloud",
   "entry.cloudCalloutDismissAria": "Chiudi l'avviso di OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -866,6 +866,7 @@ export const ja: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "サインインして OpenDesign Cloud を利用し、クラウドでコラボレーションしましょう",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud の案内を閉じる",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -866,6 +866,7 @@ export const ko: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "로그인하여 OpenDesign Cloud를 사용하고 클라우드에서 협업하세요",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud 안내 닫기",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -866,6 +866,7 @@ export const pl: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Zaloguj się, aby korzystać z OpenDesign Cloud i współpracować w chmurze",
   "entry.cloudCalloutDismissAria": "Zamknij powiadomienie OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -866,6 +866,7 @@ export const ptBR: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Entre para usar o OpenDesign Cloud e colaborar na nuvem",
   "entry.cloudCalloutDismissAria": "Dispensar o aviso do OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -866,6 +866,7 @@ export const ru: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Войдите, чтобы использовать OpenDesign Cloud и работать совместно в облаке",
   "entry.cloudCalloutDismissAria": "Закрыть уведомление OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -866,6 +866,7 @@ export const th: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "ลงชื่อเข้าใช้เพื่อใช้ OpenDesign Cloud และทำงานร่วมกันบนคลาวด์",
   "entry.cloudCalloutDismissAria": "ปิดข้อความ OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -866,6 +866,7 @@ export const tr: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "OpenDesign Cloud'u kullanmak ve bulutta iş birliği yapmak için oturum açın",
   "entry.cloudCalloutDismissAria": "OpenDesign Cloud notunu kapat",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -866,6 +866,7 @@ export const uk: Dict = {
   'entry.authExpiredBody': 'Your sign-in has expired. Sign in to continue using OpenDesign Cloud.',
   'home.createFailed': 'Failed to start the run. Try again.',
   'home.daemonRecovering': 'Local service connection interrupted. Recovering automatically…',
+  'home.bundledScenarioMissing': 'Bundled scenario "{scenarioId}" is not installed. Reinstall the daemon to restore the default plugin set.',
   "entry.cloudCalloutBody": "Увійдіть, щоб використовувати OpenDesign Cloud і співпрацювати в хмарі",
   "entry.cloudCalloutDismissAria": "Закрити повідомлення OpenDesign Cloud",
   'entry.workspaceLockedNote': 'This workspace is locked. Restore billing to resume editing shared projects.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -871,6 +871,7 @@ export const zhCN: Dict = {
   'entry.authExpiredBody': '登录状态已过期。登录后即可继续使用 OpenDesign Cloud。',
   'home.createFailed': '启动任务失败，请重试。',
   'home.daemonRecovering': '本地服务连接中断，正在自动恢复…',
+  'home.bundledScenarioMissing': '内置场景“{scenarioId}”未安装。请重新安装 OpenDesign，以恢复默认插件。',
   "entry.cloudCalloutBody": "登录即可享受云端协作",
   "entry.cloudCalloutDismissAria": "关闭 OpenDesign Cloud 版说明",
   "entry.workspaceLockedNote": "工作区已锁定，恢复账单后可继续编辑共享项目。",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -873,6 +873,7 @@ export const zhTW: Dict = {
   'entry.authExpiredBody': '登入狀態已過期。登入後即可繼續使用 OpenDesign Cloud。',
   'home.createFailed': '啟動任務失敗，請再試一次。',
   'home.daemonRecovering': '本機服務連線中斷，正在自動恢復…',
+  'home.bundledScenarioMissing': '內建場景「{scenarioId}」未安裝。請重新安裝 OpenDesign，以還原預設外掛。',
   "entry.cloudCalloutBody": "登入即可享受雲端協作",
   "entry.cloudCalloutDismissAria": "關閉 OpenDesign Cloud 版說明",
   "entry.workspaceLockedNote": "工作區已鎖定，恢復帳單後可繼續編輯共享專案。",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1261,6 +1261,7 @@ export interface Dict {
   'entry.authExpiredBody': string;
   'home.createFailed': string;
   'home.daemonRecovering': string;
+  'home.bundledScenarioMissing': string;
   'entry.cloudCalloutBody': string;
   'entry.cloudCalloutDismissAria': string;
   'entry.workspaceLockedNote': string;

--- a/apps/web/tests/components/HomeView.missing-bundled-scenario-i18n.test.tsx
+++ b/apps/web/tests/components/HomeView.missing-bundled-scenario-i18n.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/components/home-hero/PlaceholderCarousel', () => ({
+  PlaceholderCarousel: () => null,
+}));
+
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>();
+  return {
+    ...actual,
+    useWorkspaceContext: () => ({
+      context: null,
+      loading: false,
+      failure: 'unsupported' as const,
+    }),
+  };
+});
+
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+
+async function renderMissingImageScenario(locale: 'en' | 'zh-CN') {
+  vi.stubGlobal('fetch', vi.fn<typeof fetch>(async (url) => {
+    if (typeof url === 'string' && url === '/api/plugins') {
+      return new Response(JSON.stringify({ plugins: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  }));
+
+  render(
+    <I18nProvider initial={locale}>
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />
+    </I18nProvider>,
+  );
+
+  const trigger = await screen.findByTestId('home-hero-template-trigger');
+  await waitFor(() => expect((trigger as HTMLButtonElement).disabled).toBe(false));
+  fireEvent.click(trigger);
+  fireEvent.click(await screen.findByTestId('home-hero-template-wedge-image'));
+  return screen.findByRole('alert');
+}
+
+describe('HomeView missing bundled scenario error', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('explains the missing scenario and recovery step in Chinese while retaining its id', async () => {
+    const alert = await renderMissingImageScenario('zh-CN');
+    expect(alert.textContent).toBe(
+      '内置场景“od-media-generation”未安装。请重新安装 OpenDesign，以恢复默认插件。',
+    );
+    expect(alert.textContent).not.toContain('Bundled scenario');
+  });
+
+  it('preserves the existing English guidance and diagnostic scenario id', async () => {
+    const alert = await renderMissingImageScenario('en');
+    expect(alert.textContent).toBe(
+      'Bundled scenario "od-media-generation" is not installed. Reinstall the daemon to restore the default plugin set.',
+    );
+  });
+});


### PR DESCRIPTION
## Why

Plane work item OPEND-2099 reports that Chinese users who select a Home creation type backed by a missing bundled scenario see an English-only error. The message is generated in the browser before any daemon request, so users cannot understand either the failure or the recovery step even though the rest of the interface is in Chinese.

This PR keeps the fix limited to that missing bundled-scenario path. It does not attempt to localize unrelated system errors.

## What users will see

In the Simplified Chinese UI, selecting a creation type whose bundled scenario is absent now shows:

> 内置场景“od-media-generation”未安装。请重新安装 OpenDesign，以恢复默认插件。

The scenario id remains visible for diagnostics. Traditional Chinese receives matching localized guidance, while English and the other locale fallbacks retain the previous message and recovery semantics.

## Surface area

- [x] **UI** — localized Home error state
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Captured from the real local Home page in zh-CN with the browser-level `/api/plugins` response set to an empty catalog so the shipped UI path deterministically reaches the missing-scenario alert. Attachment will be added to this section after PR creation.

## Bug fix verification

- Test path: `apps/web/tests/components/HomeView.missing-bundled-scenario-i18n.test.tsx`
- Red on `main`: yes — expected Chinese guidance but received `Bundled scenario "od-media-generation" is not installed. Reinstall the daemon to restore the default plugin set.`
- Green on this branch: yes — both zh-CN and English behavior pass.
- The test drives the real `HomeView` creation-type picker and asserts the rendered `role="alert"`, while mocking only the public plugin-catalog response.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/i18n/locales.test.ts tests/components/HomeHero.rail.test.tsx tests/components/HomeView.missing-bundled-scenario-i18n.test.tsx --maxWorkers=2` — 46/46 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm i18n:check` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed (workspace-wide; landing-page emitted existing Astro hints only)
- `git diff --check` — passed
- Local zh-CN Home UI verification — passed; exact localized alert and diagnostic scenario id confirmed
