### PR TITLE
fix web campaign provider logos

### DIFF
--- a/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.module.css
@@ -179,6 +179,19 @@
   filter: brightness(0) saturate(100%);
 }
 
+.goWelcomeProviderFallback {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  color: #fff;
+  font-size: 8px;
+  font-weight: 800;
+  letter-spacing: -.02em;
+  background: #20231f;
+  border-radius: 6px;
+}
+
 .goWelcomeMimoLogo {
   width: 32px !important;
 }
@@ -237,7 +250,7 @@
   min-width: 0;
 }
 
-.goWelcomeBenefitModel i {
+.goWelcomeBenefitIcon {
   display: grid;
   flex: 0 0 20px;
   place-items: center;
@@ -245,6 +258,14 @@
   height: 20px;
   background: #20231f;
   border-radius: 5px;
+}
+
+.goWelcomeBenefitFallback {
+  color: #fff;
+  font-size: 7px;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: -.03em;
 }
 
 .goWelcomeBenefitModel img {
@@ -401,11 +422,28 @@
   place-items: center;
   width: 42px;
   height: 42px;
+  overflow: hidden;
+  border: 1px solid var(--border);
   border-radius: var(--radius);
   color: var(--brand-text);
-  background: var(--brand);
+  background: var(--bg-panel);
   font-size: 12px;
   font-weight: 900;
+}
+
+.modelMark img {
+  display: block;
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
+.modelMarkFallback {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  background: var(--brand);
 }
 
 .modelCopy {

--- a/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
@@ -15,6 +15,7 @@ import {
 } from '../analytics/events';
 import { useI18n } from '../i18n';
 import { Icon } from './Icon';
+import { modelProviderIconSrc } from './modelProviderIcon';
 import styles from './DeepSeekV4FlashCampaign.module.css';
 
 const GO_PLAN_DEEPSEEK_ICON = '/agent-icons/deepseek.svg';
@@ -53,6 +54,50 @@ interface Props {
   metricsConsent?: boolean;
   /** config.installationId — the preferred consent-gated AMR join key. */
   installationId?: string | null;
+}
+
+function CampaignProviderMark({
+  providerId,
+  label,
+  fallback,
+  src: preferredSrc,
+  className = styles.modelMark,
+  fallbackClassName = styles.modelMarkFallback,
+  decorative = false,
+}: {
+  providerId: string;
+  label: string;
+  fallback: string;
+  src?: string;
+  className?: string;
+  fallbackClassName?: string;
+  decorative?: boolean;
+}) {
+  const src = preferredSrc ?? modelProviderIconSrc(providerId);
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const showLogo = src !== null && failedSrc !== src;
+
+  return (
+    <span
+      className={className}
+      role={decorative ? undefined : 'img'}
+      aria-label={decorative ? undefined : label}
+      aria-hidden={decorative || undefined}
+      title={decorative ? undefined : label}
+    >
+      {showLogo ? (
+        <img
+          src={src}
+          alt=""
+          onError={() => setFailedSrc(src)}
+        />
+      ) : (
+        <span className={fallbackClassName} aria-hidden="true">
+          {fallback}
+        </span>
+      )}
+    </span>
+  );
 }
 
 function hasSeenCampaign(campaignId: string): boolean {
@@ -254,13 +299,48 @@ export function DeepSeekV4FlashCampaign({
             aria-label={goPlanCopy.providersAria}
           >
             {[
-              { src: GO_PLAN_DEEPSEEK_ICON, label: 'DeepSeek' },
-              { src: GO_PLAN_ZHIPU_ICON, label: 'GLM', className: styles.goWelcomeZhipuLogo },
-              { src: GO_PLAN_KIMI_ICON, label: 'Kimi' },
-              { src: GO_PLAN_MINIMAX_ICON, label: 'MiniMax' },
-              { src: GO_PLAN_MIMO_ICON, label: 'MiMo', className: styles.goWelcomeMimoLogo },
-            ].map(({ src, label, className }) => (
-              <span key={label} className={className} title={label}><img src={src} alt={label} /></span>
+              {
+                providerId: 'deepseek/v4-pro',
+                src: GO_PLAN_DEEPSEEK_ICON,
+                label: 'DeepSeek',
+                fallback: 'DS',
+              },
+              {
+                providerId: 'zhipu/glm-5.2',
+                src: GO_PLAN_ZHIPU_ICON,
+                label: 'GLM',
+                fallback: 'GLM',
+                className: styles.goWelcomeZhipuLogo,
+              },
+              {
+                providerId: 'kimi/k2.6',
+                src: GO_PLAN_KIMI_ICON,
+                label: 'Kimi',
+                fallback: 'KM',
+              },
+              {
+                providerId: 'minimax/m2.5',
+                src: GO_PLAN_MINIMAX_ICON,
+                label: 'MiniMax',
+                fallback: 'MM',
+              },
+              {
+                providerId: 'mimo/v2-pro',
+                src: GO_PLAN_MIMO_ICON,
+                label: 'MiMo',
+                fallback: 'MI',
+                className: styles.goWelcomeMimoLogo,
+              },
+            ].map(({ providerId, src, label, fallback, className }) => (
+              <CampaignProviderMark
+                key={providerId}
+                providerId={providerId}
+                src={src}
+                label={label}
+                fallback={fallback}
+                className={className ?? ''}
+                fallbackClassName={styles.goWelcomeProviderFallback}
+              />
             ))}
           </div>
 
@@ -268,13 +348,40 @@ export function DeepSeekV4FlashCampaign({
             <strong>{goPlanCopy.benefit}</strong>
             <ul>
               {[
-                { src: GO_PLAN_DEEPSEEK_ICON, label: 'DeepSeek V4 Flash' },
-                { src: GO_PLAN_DEEPSEEK_ICON, label: 'DeepSeek V4 Pro' },
-                { src: GO_PLAN_ZHIPU_ICON, label: 'GLM-5.2', className: styles.goWelcomeBenefitZhipu },
-              ].map(({ src, label, className }) => (
+                {
+                  providerId: 'deepseek/v4-flash',
+                  src: GO_PLAN_DEEPSEEK_ICON,
+                  label: 'DeepSeek V4 Flash',
+                  fallback: 'DS',
+                },
+                {
+                  providerId: 'deepseek/v4-pro',
+                  src: GO_PLAN_DEEPSEEK_ICON,
+                  label: 'DeepSeek V4 Pro',
+                  fallback: 'DS',
+                },
+                {
+                  providerId: 'zhipu/glm-5.2',
+                  src: GO_PLAN_ZHIPU_ICON,
+                  label: 'GLM-5.2',
+                  fallback: 'GLM',
+                  className: styles.goWelcomeBenefitZhipu,
+                },
+              ].map(({ providerId, src, label, fallback, className }) => (
                 <li key={label}>
                   <span className={styles.goWelcomeBenefitModel}>
-                    <i className={className}><img src={src} alt="" /></i>{label}
+                    <CampaignProviderMark
+                      providerId={providerId}
+                      src={src}
+                      label={label}
+                      fallback={fallback}
+                      className={[styles.goWelcomeBenefitIcon, className]
+                        .filter(Boolean)
+                        .join(' ')}
+                      fallbackClassName={styles.goWelcomeBenefitFallback}
+                      decorative
+                    />
+                    {label}
                   </span>
                   <small>{goPlanCopy.status}</small>
                 </li>
@@ -323,7 +430,11 @@ export function DeepSeekV4FlashCampaign({
       <p id={descriptionId} className={styles.lead}>{t('campaign.deepseekV4Flash.description')}</p>
 
       <div className={styles.modelCard}>
-        <span className={styles.modelMark} aria-hidden="true">DS</span>
+        <CampaignProviderMark
+          providerId={campaign.modelId}
+          label="DeepSeek"
+          fallback="DS"
+        />
         <span className={styles.modelCopy}>
           <strong>{t('campaign.deepseekV4Flash.benefit')}</strong>
           <small>{presentation.status}</small>

--- a/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
@@ -58,6 +58,22 @@ afterEach(() => {
 });
 
 describe('paid 立即使用 switches the workbench onto the campaign model', () => {
+  it('shows the model provider logo and restores the abbreviation if the asset fails', () => {
+    render(<DeepSeekV4FlashCampaign audience="paid" active />);
+
+    const providerLogo = screen.getByRole('img', { name: 'DeepSeek' });
+    expect(providerLogo.querySelector('img')).toHaveAttribute(
+      'src',
+      '/agent-icons/deepseek.svg',
+    );
+    expect(screen.queryByText('DS', { exact: true })).toBeNull();
+
+    fireEvent.error(providerLogo.querySelector('img')!);
+
+    expect(screen.getByRole('img', { name: 'DeepSeek' })).toBeVisible();
+    expect(screen.getByText('DS', { exact: true })).toBeVisible();
+  });
+
   it('applies agent amr + model deepseek-v4-flash and pulses the chip without opening the picker', () => {
     vi.useFakeTimers();
     const onUseCampaignModel = vi.fn();
@@ -157,6 +173,16 @@ describe('unpaid Go path opens public Pricing', () => {
     expect(screen.getByRole('button', { name: copy.cta })).toBeVisible();
   });
 
+  it('keeps provider identity visible when a Go-plan logo fails to load', () => {
+    render(<DeepSeekV4FlashCampaign audience="unpaid" active />);
+
+    const providerLogo = screen.getByRole('img', { name: 'MiniMax' });
+    fireEvent.error(providerLogo.querySelector('img')!);
+
+    expect(screen.getByRole('img', { name: 'MiniMax' })).toBeVisible();
+    expect(screen.getByText('MM', { exact: true })).toBeVisible();
+  });
+
   it('opens the locale-neutral comparison page', () => {
     const open = vi.fn();
     vi.stubGlobal('open', open);
@@ -213,6 +239,17 @@ describe('unpaid Go path opens public Pricing', () => {
 });
 
 describe('campaign modal only interrupts the active home view', () => {
+  it('keeps the shared dialog Escape behavior and records the dismissal', () => {
+    render(<DeepSeekV4FlashCampaign audience="paid" active />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByTestId(DIALOG)).toBeNull();
+    expect(window.localStorage.getItem(
+      'open-design:campaign-seen:deepseek-v4-dual-unlimited-2026',
+    )).toBe('1');
+  });
+
   it('stays silent on non-home views even when the campaign is unseen', () => {
     render(<DeepSeekV4FlashCampaign audience="paid" active={false} />);
 


### PR DESCRIPTION
## Why

Plane work item OPEND-2131 reports that the model promotion modal shows only vendor abbreviation tiles, making providers harder to identify at a glance. Auditing the current `main` showed that the unpaid Go-plan variant had partially adopted checked-in provider artwork, while the paid DeepSeek campaign still hard-coded `DS`; existing image paths also had no load-error fallback.

This keeps the fix inside the existing campaign component and reuses the repository's provider icon lookup and checked-in campaign assets. It does not change campaign eligibility, pricing, model selection, or promotion copy.

## What users will see

The paid DeepSeek promotion now shows the official checked-in DeepSeek logo instead of a `DS` color tile. Go-plan provider marks continue to use their existing checked-in artwork. If an asset is unavailable, fails to load, or the provider is unknown, the existing readable abbreviation remains visible.

The modal remains responsive at narrow widths, preserves the shared Escape-key dismissal behavior, and exposes a provider label to assistive technology.

## Surface area

- [x] **UI** — existing campaign dialog in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — existing campaign users see the provider logo by default
- [ ] **None**

This is a rendering-only correction to an existing UI capability, so no CLI surface is applicable.

## Screenshots

Local before/after, narrow-width, asset-failure fallback, and legacy dark-token screenshots were captured during verification. They are retained outside the repository and are not committed with this PR.

- Before: paid campaign displayed the `DS` abbreviation tile.
- After: paid campaign displays the checked-in DeepSeek whale logo.
- Fallback: blocking `/agent-icons/deepseek.svg` restores the visible `DS` tile.
- Responsive: verified at 390 × 720 without horizontal overflow.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** The focused spec initially failed because no accessible DeepSeek provider image existed; it passes after the source change. The same spec covers image-load failure fallback for the paid DeepSeek and unpaid MiniMax paths, plus Escape-key dismissal.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/campaigns/deepseek-v4-flash-modal.test.tsx tests/campaigns/deepseek-v4-flash-ui-contract.test.ts tests/components/modelProviderIcon.test.ts --maxWorkers=2` — 30 tests passed
- `pnpm --filter @open-design/components exec vitest run tests/Dialog.test.tsx --maxWorkers=2` — 6 tests passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- Browser verification: light theme, legacy dark tokens, 390 × 720 narrow viewport, failed-image fallback, dialog semantics, and keyboard dismissal