### PR TITLE
fix web foreground completion notifications

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3280,12 +3280,11 @@ export function ProjectView({
     }
 
     if (cfg.desktopEnabled) {
-      // Successes only interrupt when the user is on another tab/window.
-      // Failures alert regardless — losing a long agent run silently is
-      // worse than a small interruption when the page is in focus.
+      // System notifications are useful only when the task is not already in
+      // front of the user. Sounds remain independent feedback for both states.
       const isHidden = typeof document !== 'undefined' && document.hidden;
       const isFocused = typeof document === 'undefined' ? true : document.hasFocus();
-      if (status === 'failed' || isHidden || !isFocused) {
+      if (isHidden || !isFocused) {
         const title = status === 'succeeded'
           ? t('notify.successTitle')
           : t('notify.failureTitle');

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -908,6 +908,7 @@ describe('ProjectView conversation run isolation', () => {
     cleanup();
     window.localStorage.clear();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -1075,6 +1076,35 @@ describe('ProjectView conversation run isolation', () => {
       );
     },
   );
+
+  it('preserves the configured system notification for a background completion', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+
+    renderProjectView({
+      ...config,
+      notifications: {
+        ...config.notifications!,
+        desktopEnabled: true,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+    fireEvent.click(screen.getByTestId('conversation-select-conv-b'));
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-b'));
+    resolveConversationBMessages?.([]);
+    await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('idle'));
+
+    conversationAMessages = [succeededAssistant];
+    fireEvent.click(screen.getByTestId('conversation-select-conv-a'));
+
+    await waitFor(() => expect(playSound).toHaveBeenCalledWith('success-sound'));
+    expect(showCompletionNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'succeeded', body: 'done' }),
+    );
+  });
 
   // An OpenDesign Cloud run is billed to the CALLER's own wallet. The gate must
   // therefore ask about the caller's identity, not about this project's
@@ -1822,6 +1852,48 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(playSound).toHaveBeenCalledWith('success-sound'));
     expect(showCompletionNotification).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      label: 'run failure',
+      terminalMessage: { ...succeededAssistant, runStatus: 'failed' as const },
+    },
+    {
+      label: 'delivery failure',
+      terminalMessage: {
+        ...succeededAssistant,
+        resultDeliveryState: 'delivery_failed' as const,
+      },
+    },
+  ])(
+    'keeps the foreground $label system notification silent while preserving its sound',
+    async ({ terminalMessage }) => {
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+      vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+
+      renderProjectView({
+        ...config,
+        notifications: {
+          ...config.notifications!,
+          desktopEnabled: true,
+        },
+      });
+
+      await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+      await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
+
+      fireEvent.click(screen.getByTestId('conversation-select-conv-b'));
+      await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-b'));
+      resolveConversationBMessages?.([]);
+      await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('idle'));
+
+      conversationAMessages = [terminalMessage];
+      fireEvent.click(screen.getByTestId('conversation-select-conv-a'));
+
+      await waitFor(() => expect(playSound).toHaveBeenCalledWith('failure-sound'));
+      expect(showCompletionNotification).not.toHaveBeenCalled();
+    },
+  );
 
   it('downgrades a reloaded terminal Design run whose file writes never landed', async () => {
     conversationAMessages = [


### PR DESCRIPTION
## Why

While auditing the OPEND-2162 dogfooding report, I reproduced a foreground completion path that still requested a system notification whenever a run failed or its result delivery failed. Design runs that completed without landed output are mapped to the same failure status, so macOS could request app-level attention even while the user was already looking at the task.

The user pain is unnecessary system-level attention from Open Design at the exact moment the completion state is already visible in the foreground. Background completion reminders should continue to work according to the existing notification setting.

## What users will see

When Open Design is focused and the current task ends in a run, delivery, or no-result failure, it no longer posts a redundant desktop notification. Completion sounds still play when enabled. When Open Design is hidden or unfocused, success and failure notifications continue to use the existing desktop notification setting.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this removes an OS notification request when the task is already visible; it adds no UI entry point or visual component. Verification used foreground/background focus state and notification call assertions instead.

## Bug fix verification

- Test path: `apps/web/tests/components/ProjectView.run-isolation.test.tsx`
- The new foreground run-failure and delivery-failure cases went red before the source change: both observed one `showCompletionNotification` call.
- The same cases are green after the fix, while the added background case and the existing notification utility tests confirm background delivery, sound behavior, Service Worker fallback, browser fallback, and completion deduplication remain intact.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/ProjectView.run-isolation.test.tsx tests/utils/notifications.test.ts` — 87 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `git diff --check origin/main...HEAD` — passed
- Real macOS validation: current-main web/Codex completion plus installed packaged Electron foreground/background notification checks; the packaged notification was accepted while unfocused and did not activate or focus the app.
- `pnpm typecheck` — currently blocked by two errors on unchanged latest `origin/main` code: `apps/packaged/src/sidecars.ts:971` and `:993` access `ShutdownResult.deferred`. `pnpm --filter @open-design/packaged typecheck` reproduces the same base-branch failure; this PR has no diff under `apps/packaged` or the sidecar packages.
