### PR TITLE
fix(web): keep account menu open after avatar click

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -612,7 +612,11 @@ export function EntryTopRightCluster({
     workspaceType: context?.workspaceType,
   });
 
-  const [accountOpen, setAccountOpen] = useState(false);
+  const [accountMenuMode, setAccountMenuMode] = useState<'closed' | 'hover' | 'pinned'>(
+    'closed',
+  );
+  const accountOpen = accountMenuMode !== 'closed';
+  const closeAccountMenu = () => setAccountMenuMode('closed');
   useEffect(() => {
     if (!accountOpen) return;
     trackWorkspaceSurfaceView(analytics.track, {
@@ -665,11 +669,13 @@ export function EntryTopRightCluster({
   };
   const openAccountMenu = () => {
     cancelAccountClose();
-    setAccountOpen(true);
+    setAccountMenuMode((mode) => (mode === 'closed' ? 'hover' : mode));
   };
   const scheduleAccountClose = () => {
     cancelAccountClose();
-    accountCloseTimer.current = window.setTimeout(() => setAccountOpen(false), 220);
+    accountCloseTimer.current = window.setTimeout(() => {
+      setAccountMenuMode((mode) => (mode === 'hover' ? 'closed' : mode));
+    }, 220);
   };
   useEffect(() => cancelAccountClose, []);
   // While open, track the pointer at the document level: anywhere outside the
@@ -689,14 +695,14 @@ export function EntryTopRightCluster({
     return () => document.removeEventListener('pointerover', onDocPointerOver, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountOpen]);
-  // Hover-out alone leaves the menu open for anyone who never hovers: a touch
-  // user, or a click that lands somewhere else without the pointer crossing
-  // this container. Press-outside closes it now rather than 220ms later, and
+  // Hover-out does not cover anyone who never hovers: a touch user, or a click
+  // that lands somewhere else without the pointer crossing this container.
+  // Press-outside closes it immediately, and
   // Escape gives the keyboard the same exit. Still a listener, not a backdrop,
   // so the pointerover tracking above keeps receiving its events.
   useDismissOnOutsideInteraction(accountOpen, accountContainerRef, () => {
     cancelAccountClose();
-    setAccountOpen(false);
+    closeAccountMenu();
   });
 
   // One public comparison destination shared with the rail's invite dialog.
@@ -816,9 +822,11 @@ export function EntryTopRightCluster({
                     entry_from: 'sidebar',
                     ...workspaceDimensions,
                   });
-                  setAccountOpen((v) => !v);
+                  cancelAccountClose();
+                  setAccountMenuMode((mode) => (mode === 'pinned' ? 'closed' : 'pinned'));
                 }}
                 onMouseEnter={openAccountMenu}
+                aria-haspopup="menu"
                 aria-expanded={accountOpen}
                 aria-label={accountName}
                 data-testid="entry-nav-account"
@@ -860,7 +868,7 @@ export function EntryTopRightCluster({
                               className="entry-nav-rail__menu-credits-upgrade"
                               onClick={() => {
                                 trackAccountAction('upgrade');
-                                setAccountOpen(false);
+                                closeAccountMenu();
                                 openBillingUpgrade();
                               }}
                             >
@@ -877,7 +885,7 @@ export function EntryTopRightCluster({
                           data-testid="entry-nav-credits-row"
                           onClick={() => {
                             trackAccountAction('credits');
-                            setAccountOpen(false);
+                            closeAccountMenu();
                             if (billingConsoleUrl) {
                               window.open(billingConsoleUrl, '_blank', 'noopener,noreferrer');
                             }
@@ -899,7 +907,7 @@ export function EntryTopRightCluster({
                       role="menuitem"
                       onClick={() => {
                         trackAccountAction('settings');
-                        setAccountOpen(false);
+                        closeAccountMenu();
                         onOpenSettings?.();
                       }}
                     >
@@ -914,7 +922,7 @@ export function EntryTopRightCluster({
                       data-testid="account-menu-message-center"
                       onClick={() => {
                         trackAccountAction('message_center');
-                        setAccountOpen(false);
+                        closeAccountMenu();
                         setMessageCenterOpen(true);
                       }}
                     >
@@ -935,7 +943,7 @@ export function EntryTopRightCluster({
                       {...externalLinkProps}
                       onClick={() => {
                         trackAccountAction('github_help');
-                        setAccountOpen(false);
+                        closeAccountMenu();
                       }}
                     >
                       <Icon name="comment" size={15} /> {t('entry.accountGithubHelp')}
@@ -947,7 +955,7 @@ export function EntryTopRightCluster({
                       {...externalLinkProps}
                       onClick={() => {
                         trackAccountAction('feature_request');
-                        setAccountOpen(false);
+                        closeAccountMenu();
                       }}
                     >
                       <Icon name="sparkles" size={15} /> {t('entry.accountFeatureRequest')}
@@ -963,7 +971,7 @@ export function EntryTopRightCluster({
                       role="menuitem"
                       onClick={() => {
                         trackAccountAction('logout');
-                        setAccountOpen(false);
+                        closeAccountMenu();
                         // recvqgMWpJZqhL: never sign out on this click alone —
                         // arm the confirmation dialog and let it run the logout.
                         setConfirmSignOut(true);

--- a/apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+
+function teamContext(): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team_plus',
+    displayName: 'Leaf',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: { canInviteMembers: true, canViewWorkspaceSettings: true },
+  } as unknown as WorkspaceCollabContext;
+}
+
+function renderRail() {
+  return render(
+    <I18nProvider initial="zh-CN">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={teamContext()}
+        billing={null}
+      />
+    </I18nProvider>,
+  );
+}
+
+function stubFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/messages?')) {
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      if (url.includes('/status')) return Response.json({ loggedIn: false });
+      return Response.json({ items: [] });
+    }),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+  resetWorkspaceDirectoryCache();
+  stubFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+async function advancePastHoverClose() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(220);
+  });
+}
+
+describe('EntryNavRail account menu interaction state', () => {
+  it('pins a hover-open menu when the avatar is clicked', async () => {
+    renderRail();
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    fireEvent.mouseEnter(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.mouseLeave(trigger.closest('.entry-nav-rail__account') as HTMLElement);
+    await advancePastHoverClose();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('still closes a hover-only menu after the pointer leaves', async () => {
+    renderRail();
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger.closest('.entry-nav-rail__account') as HTMLElement);
+    await advancePastHoverClose();
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('treats a second avatar click as an explicit close', () => {
+    renderRail();
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not treat focus loss as a close action after a click pins the menu', () => {
+    renderRail();
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.click(trigger);
+    fireEvent.blur(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it.each([
+    ['Escape', () => fireEvent.keyDown(document, { key: 'Escape' })],
+    ['an outside press', () => fireEvent.pointerDown(document.body)],
+  ])('keeps %s as an explicit close action', (_label, close) => {
+    renderRail();
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.click(trigger);
+    close();
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps selecting a menu item as an explicit close action', () => {
+    const onOpenSettings = vi.fn();
+    render(
+      <I18nProvider initial="zh-CN">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          onOpenSettings={onOpenSettings}
+          open
+          context={teamContext()}
+          billing={null}
+        />
+      </I18nProvider>,
+    );
+    const trigger = screen.getByTestId('entry-nav-account');
+    fireEvent.mouseEnter(trigger);
+    fireEvent.click(trigger);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: '设置' }));
+
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
## Why

Plane dogfooding item `OPEND-2102` reports that clicking the account avatar should leave its panel expanded. On current `main`, a real pointer enters the avatar before the click lands: hover opens the account menu, then the click toggles the same boolean back to closed. This makes the primary account/settings entry disappear precisely when the user tries to pin it open.

This PR fixes that interaction without adopting the broad account-cluster redesign from open, conflicting PR #6638.

## What users will see

Clicking the top-right account avatar now pins the account menu open. Moving the pointer away or losing focus no longer collapses a click-pinned menu.

Existing explicit close actions are unchanged: a second avatar click, Escape, an outside press, selecting a menu item, or navigating away still closes the menu. Hover-only menus still close after the existing delay.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Behavior-only change; the avatar and menu have no visual or layout change, so static before/after screenshots are identical. Real Chromium interaction verification covered the visible entry point at default size and 390×844.

## Bug fix verification

- Test path: `apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx`
- Red on `main`: yes — 3 failures reproduced the hover-open → click-close inversion, reversed second-click behavior, and the resulting missing menu item.
- Green on this branch: yes — the focused state-machine spec passes, including hover-only close, click pinning, focus loss, second click, Escape, outside press, and menu-item selection.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryNavRail.*.test.tsx --maxWorkers=2` — 17 files, 99 tests passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed after refreshing workspace build artifacts with `pnpm install --frozen-lockfile`
- Real Chromium: hover opened one menu; click kept `aria-expanded=true` and focus on the avatar; pointer leave kept it open; Escape closed with focus retained; hover-only leave, second click, outside press, and Settings selection retained their close behavior
- Real Chromium at 390×844: avatar remained visible; click opened one menu; Escape closed it
- `git diff --check` — passed

## Overlap

PR #6638 also changes `EntryNavRail.tsx`, but it is currently conflicting and Changes Requested. This patch is independently based on current `main` and only introduces the minimal `closed` / `hover` / `pinned` account-menu state distinction plus focused regression coverage.
