### PR TITLE
fix(daemon): allow sequential plugin workflow runs

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -2364,13 +2364,14 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       );
       if (
         existingWorkflowRun
+        && !TERMINAL_RUN_STATUSES.has(existingWorkflowRun.status)
         && existingWorkflowRun.clientRequestId !== meta.clientRequestId
       ) {
         return sendApiError(
           res,
           409,
           'PLUGIN_WORKFLOW_CONFLICT',
-          'pluginWorkflowId is already bound to a different logical run request',
+          'pluginWorkflowId already has a different logical run request in progress',
         );
       }
     }

--- a/apps/daemon/tests/run-request-idempotency.test.ts
+++ b/apps/daemon/tests/run-request-idempotency.test.ts
@@ -153,7 +153,7 @@ describe('run request idempotency', () => {
       .toEqual(generationInvocationsBeforeRetry);
   });
 
-  it('persists one immutable workflow-to-run binding across daemon restarts', async () => {
+  it('deduplicates a workflow request and permits its next generation after completion', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-plugin-workflow-bin-'));
     const { bin } = await writeSuccessfulClaude(binDir);
     started = await startWithFakeClaude(bin);
@@ -196,6 +196,19 @@ describe('run request idempotency', () => {
     );
     await expect(acceptedRun.json()).resolves.toMatchObject({
       clientType: 'external_mcp',
+      externalPluginAnalytics: { pluginWorkflowId },
+    });
+
+    const retried = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+    expect(retried.status).toBe(202);
+    await expect(retried.json()).resolves.toMatchObject({
+      runId: firstBody.runId,
+      reused: true,
+      clientRequestId,
     });
 
     const bindingBeforeRestart = await fetch(
@@ -230,15 +243,91 @@ describe('run request idempotency', () => {
 
     const conflictingRequestId = randomUUID();
     const conflictLogical = logicalPluginRequestDigest(conflictingRequestId);
-    const conflict = await fetch(`${started.url}/api/runs`, {
+    const second = await fetch(`${started.url}/api/runs`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         ...request,
         clientRequestId: conflictingRequestId,
+        assistantMessageId: `assistant_${randomUUID()}`,
+        message: 'refine the completed artifact',
+        currentPrompt: 'refine the completed artifact',
         analyticsHints: {
           ...request.analyticsHints,
           logicalRequestDigest: conflictLogical.digest,
+        },
+      }),
+    });
+    expect(second.status).toBe(202);
+    const secondBody = await second.json() as { runId: string };
+    expect(secondBody.runId).not.toBe(firstBody.runId);
+    await waitForRun(started.url, secondBody.runId);
+
+    const firstAttributed = await fetch(
+      `${started.url}/api/runs/${encodeURIComponent(firstBody.runId)}`,
+    );
+    await expect(firstAttributed.json()).resolves.toMatchObject({
+      clientRequestId,
+      externalPluginAnalytics: { pluginWorkflowId },
+    });
+    const secondAttributed = await fetch(
+      `${started.url}/api/runs/${encodeURIComponent(secondBody.runId)}`,
+    );
+    await expect(secondAttributed.json()).resolves.toMatchObject({
+      clientRequestId: conflictingRequestId,
+      externalPluginAnalytics: { pluginWorkflowId },
+    });
+    const latestBinding = await fetch(
+      `${started.url}/api/runs/by-plugin-workflow/${pluginWorkflowId}`,
+    );
+    await expect(latestBinding.json()).resolves.toMatchObject({
+      runId: secondBody.runId,
+      pluginWorkflowId,
+    });
+  });
+
+  it('rejects a concurrent generation for a workflow that already has an active run', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-plugin-workflow-active-bin-'));
+    const { bin } = await writeSuccessfulClaude(binDir, { exitDelayMs: 1_000 });
+    started = await startWithFakeClaude(bin);
+    const base = await createRunRequest(started.url);
+    const pluginWorkflowId = randomUUID();
+    const firstRequestId = randomUUID();
+    const firstLogical = logicalPluginRequestDigest(firstRequestId);
+    const analyticsHints = {
+      entrySurface: 'external_mcp',
+      hostProduct: 'codex_unknown',
+      externalPluginId: 'open-design',
+      externalPluginVersion: '0.4.0',
+      distributionMechanism: 'git_marketplace',
+      publisherClass: 'open_design_first_party',
+      attributionQuality: 'self_reported',
+      pluginWorkflowId,
+      logicalRequestDigest: firstLogical.digest,
+      logicalRequestDigestVersion: firstLogical.version,
+      briefState: 'not_applicable',
+    };
+    const first = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...base, clientRequestId: firstRequestId, analyticsHints }),
+    });
+    expect(first.status).toBe(202);
+
+    const secondRequestId = randomUUID();
+    const secondLogical = logicalPluginRequestDigest(secondRequestId);
+    const conflict = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ...base,
+        clientRequestId: secondRequestId,
+        assistantMessageId: `assistant_${randomUUID()}`,
+        message: 'concurrent refinement',
+        currentPrompt: 'concurrent refinement',
+        analyticsHints: {
+          ...analyticsHints,
+          logicalRequestDigest: secondLogical.digest,
         },
       }),
     });
@@ -372,14 +461,14 @@ async function writeSuccessfulClaude(dir: string): Promise<{
 }>;
 async function writeSuccessfulClaude(
   dir: string,
-  options: { writeHtml?: boolean },
+  options: { writeHtml?: boolean; exitDelayMs?: number },
 ): Promise<{
   bin: string;
   invocationPath: string;
 }>;
 async function writeSuccessfulClaude(
   dir: string,
-  options: { writeHtml?: boolean } = {},
+  options: { writeHtml?: boolean; exitDelayMs?: number } = {},
 ): Promise<{
   bin: string;
   invocationPath: string;
@@ -404,7 +493,7 @@ console.log(JSON.stringify({
     stop_reason: 'end_turn'
   }
 }));
-setTimeout(() => process.exit(0), 20);
+setTimeout(() => process.exit(0), ${options.exitDelayMs ?? 20});
 `,
     'utf8',
   );


### PR DESCRIPTION
## Why

While iterating on one attributed OpenDesign plugin workflow in Local Codex, the first logical generation completed successfully, but a second generation with a new request ID and changed prompt was rejected with HTTP 409 `PLUGIN_WORKFLOW_CONFLICT`. The daemon treated `pluginWorkflowId` as though it permanently identified one logical request instead of attributing the full plugin journey.

This change restricts `PLUGIN_WORKFLOW_CONFLICT` to a different request competing with an active, non-terminal run. Once a run is terminal, the same workflow can start its next logical generation. `clientRequestId` remains the idempotency key for an individual generation, so identical retries deduplicate and reusing one request ID with different arguments remains rejected.

## What users will see

Users can refine a design repeatedly within the same OpenDesign plugin task after each generation completes. They no longer need to start a new plugin workflow merely because the next prompt or request ID differs. Retrying the same request still returns the original logical run, while concurrent generations in one workflow remain protected from conflicts.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The API / contract box is checked because this changes conflict semantics for the existing `POST /api/runs` endpoint without changing its request or response shape.

## Screenshots

Not applicable. This changes daemon API behavior and does not add or alter a UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-request-idempotency.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, a new request ID in a completed workflow is rejected with `PLUGIN_WORKFLOW_CONFLICT`; this branch accepts it.
- Coverage includes identical request retries, sequential generations after completion and daemon restart, reuse of one request ID with changed arguments, concurrent workflow conflicts, and retained plugin attribution.

## Validation

- `pnpm guard` — passed.
- `pnpm --dir apps/daemon run typecheck` — passed.
- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/run-request-idempotency.test.ts` — 1 file passed, 7 tests passed.
- `pnpm typecheck` — attempted; the daemon package passed, but the repository-wide command currently fails in unchanged `apps/packaged/src/sidecars.ts` at lines 971 and 993 because `ShutdownResult.deferred` is missing.
