### PR TITLE
fix(desktop): wait for embedded export frames

### DIFF
--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -381,27 +381,16 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
 
       function waitForEmbeddedFrames() {
         return Promise.all(Array.from(document.querySelectorAll('iframe')).map(function(frame) {
-          // Same-origin/srcdoc frames expose readiness directly. For an
-          // already-loaded cross-origin frame, Resource Timing is the only
-          // parent-readable completion signal; otherwise subscribe before its
-          // load/error event and retain the same bounded-wait behavior as
-          // images and fonts.
+          // Same-origin/srcdoc frames expose readiness directly. Cross-origin
+          // frames must settle through this specific element's load/error
+          // lifecycle; a URL-level resource entry is not proof that this frame
+          // finished, because another frame (or an older navigation) can share
+          // the same URL.
           try {
             if (frame.contentDocument && frame.contentDocument.readyState === 'complete') {
               return Promise.resolve();
             }
           } catch {}
-          var frameUrl = frame.src;
-          if (
-            frameUrl &&
-            typeof performance !== 'undefined' &&
-            typeof performance.getEntriesByName === 'function' &&
-            performance.getEntriesByName(frameUrl).some(function(entry) {
-              return Number(entry.responseEnd) > 0;
-            })
-          ) {
-            return Promise.resolve();
-          }
           return withDeadline(new Promise(function(resolve) {
             frame.addEventListener('load', resolve, { once: true });
             frame.addEventListener('error', resolve, { once: true });

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -218,7 +218,7 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
     },
     async waitUntilReady(nonce) {
       if (!window) throw new Error("PDF render window has not been loaded");
-      await waitForPrintReadyHandshake(window.webContents, nonce);
+      await waitForPrintReadyPdfContent(window, nonce);
     },
     async measurePageSize() {
       if (!window) throw new Error("PDF render window has not been loaded");
@@ -239,6 +239,23 @@ export function createElectronPdfTarget(): PrintReadyPdfTarget {
       window = null;
     },
   };
+}
+
+/**
+ * Gate direct desktop PDF capture on both readiness signals. The wrapper
+ * handshake says the artifact has rendered its outer document, while the
+ * printable-content wait covers resources and embedded adapter frames that
+ * can still be loading at that point. Start both waits together so a child
+ * frame cannot finish in the gap between two sequential subscriptions.
+ */
+export async function waitForPrintReadyPdfContent(
+  window: BrowserWindow,
+  nonce: string,
+): Promise<void> {
+  await Promise.all([
+    waitForPrintReadyHandshake(window.webContents, nonce),
+    waitForPrintableContent(window),
+  ]);
 }
 
 function printToPdfOptions(pageSize: PageSize): PrintToPdfOptions {

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "node:fs/promises";
 
-import { BrowserWindow, dialog } from "electron";
+import { BrowserWindow, dialog, type WebContents, type WebFrameMain } from "electron";
 import type { DesktopExportPdfInput, DesktopExportPdfResult } from "@open-design/sidecar-proto";
 
 export type PageSize = { height: number; width: number };
@@ -321,7 +321,74 @@ export const PRINTABLE_CONTENT_WAIT_TIMEOUT_MS = 15_000;
  *  normally, instead of every export paying the full outer timeout. */
 const IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS = 10_000;
 
+type EmbeddedFrameWaitResult = { stalled: boolean };
+
+/**
+ * Wait for each current child-frame navigation by Electron frame identity.
+ *
+ * DOM access cannot inspect an already-loaded cross-origin frame, while
+ * Resource Timing is scoped only to a URL. WebFrameMain gives us both the
+ * current document readiness and the process/routing pair emitted when that
+ * exact frame finishes navigation, so two frames sharing one URL cannot
+ * release each other.
+ */
+export async function waitForEmbeddedFrames(
+  webContents: WebContents,
+): Promise<EmbeddedFrameWaitResult> {
+  const mainFrame = webContents.mainFrame;
+  if (!mainFrame || !Array.isArray(mainFrame.framesInSubtree)) return { stalled: false };
+
+  const frames = mainFrame.framesInSubtree.filter((frame) => frame !== mainFrame);
+  const outcomes = await Promise.all(
+    frames.map((frame) => waitForEmbeddedFrame(webContents, frame)),
+  );
+  return { stalled: outcomes.some((outcome) => outcome === "timeout") };
+}
+
+function waitForEmbeddedFrame(
+  webContents: WebContents,
+  frame: WebFrameMain,
+): Promise<"settled" | "timeout"> {
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let done = false;
+    const finish = (outcome: "settled" | "timeout") => {
+      if (done) return;
+      done = true;
+      webContents.off("did-frame-finish-load", onFrameFinished);
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(outcome);
+    };
+    const onFrameFinished = (
+      _event: Electron.Event,
+      isMainFrame: boolean,
+      frameProcessId: number,
+      frameRoutingId: number,
+    ) => {
+      if (
+        !isMainFrame &&
+        frameProcessId === frame.processId &&
+        frameRoutingId === frame.routingId
+      ) {
+        finish("settled");
+      }
+    };
+
+    // Subscribe before checking readiness so a frame completing between the
+    // snapshot and executeJavaScript cannot be missed.
+    webContents.on("did-frame-finish-load", onFrameFinished);
+    timer = setTimeout(() => finish("timeout"), IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS);
+    void frame.executeJavaScript("document.readyState").then(
+      (readyState) => {
+        if (readyState === "complete") finish("settled");
+      },
+      () => finish("settled"),
+    );
+  });
+}
+
 export async function waitForPrintableContent(window: BrowserWindow): Promise<void> {
+  const embeddedFramesSettled = waitForEmbeddedFrames(window.webContents);
   const pageSettled = window.webContents.executeJavaScript(
     `(function() {
       var RESOURCE_TIMEOUT_MS = ${IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS};
@@ -379,25 +446,6 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
         }));
       }
 
-      function waitForEmbeddedFrames() {
-        return Promise.all(Array.from(document.querySelectorAll('iframe')).map(function(frame) {
-          // Same-origin/srcdoc frames expose readiness directly. Cross-origin
-          // frames must settle through this specific element's load/error
-          // lifecycle; a URL-level resource entry is not proof that this frame
-          // finished, because another frame (or an older navigation) can share
-          // the same URL.
-          try {
-            if (frame.contentDocument && frame.contentDocument.readyState === 'complete') {
-              return Promise.resolve();
-            }
-          } catch {}
-          return withDeadline(new Promise(function(resolve) {
-            frame.addEventListener('load', resolve, { once: true });
-            frame.addEventListener('error', resolve, { once: true });
-          }));
-        }));
-      }
-
       function nextFrame() {
         return new Promise(function(resolve) { requestAnimationFrame(function() { resolve(true); }); });
       }
@@ -407,8 +455,7 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
           ? withDeadline(document.fonts.ready.catch(function(){}))
           : Promise.resolve(),
         waitForImages(),
-        waitForCssBackgroundImages(),
-        waitForEmbeddedFrames()
+        waitForCssBackgroundImages()
       ])
         .then(nextFrame)
         .then(nextFrame)
@@ -426,7 +473,7 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
   let raced: unknown;
   try {
     raced = await Promise.race([
-      pageSettled,
+      Promise.all([pageSettled, embeddedFramesSettled]),
       new Promise<symbol>((resolve) => {
         timer = setTimeout(() => resolve(OUTER_TIMEOUT), PRINTABLE_CONTENT_WAIT_TIMEOUT_MS);
       }),
@@ -442,9 +489,18 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
   // healthy, so the page-side deadline fires first and the outer timer never
   // runs. Keying only off the outer timer would skip cancellation in exactly
   // that case and leave the requests in flight.
+  const settledResults = Array.isArray(raced) ? raced : [];
+  const inPageResult = settledResults[0];
+  const embeddedFrameResult = settledResults[1];
   const inPageStalled =
-    typeof raced === "object" && raced !== null && (raced as { stalled?: unknown }).stalled === true;
-  const gaveUp = raced === OUTER_TIMEOUT || inPageStalled;
+    typeof inPageResult === "object" &&
+    inPageResult !== null &&
+    (inPageResult as { stalled?: unknown }).stalled === true;
+  const embeddedFrameStalled =
+    typeof embeddedFrameResult === "object" &&
+    embeddedFrameResult !== null &&
+    (embeddedFrameResult as { stalled?: unknown }).stalled === true;
+  const gaveUp = raced === OUTER_TIMEOUT || inPageStalled || embeddedFrameStalled;
 
   // Giving up on the wait is not enough on its own: the requests we stopped
   // waiting for are still in flight, and every later `executeJavaScript` in

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -379,6 +379,36 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
         }));
       }
 
+      function waitForEmbeddedFrames() {
+        return Promise.all(Array.from(document.querySelectorAll('iframe')).map(function(frame) {
+          // Same-origin/srcdoc frames expose readiness directly. For an
+          // already-loaded cross-origin frame, Resource Timing is the only
+          // parent-readable completion signal; otherwise subscribe before its
+          // load/error event and retain the same bounded-wait behavior as
+          // images and fonts.
+          try {
+            if (frame.contentDocument && frame.contentDocument.readyState === 'complete') {
+              return Promise.resolve();
+            }
+          } catch {}
+          var frameUrl = frame.src;
+          if (
+            frameUrl &&
+            typeof performance !== 'undefined' &&
+            typeof performance.getEntriesByName === 'function' &&
+            performance.getEntriesByName(frameUrl).some(function(entry) {
+              return Number(entry.responseEnd) > 0;
+            })
+          ) {
+            return Promise.resolve();
+          }
+          return withDeadline(new Promise(function(resolve) {
+            frame.addEventListener('load', resolve, { once: true });
+            frame.addEventListener('error', resolve, { once: true });
+          }));
+        }));
+      }
+
       function nextFrame() {
         return new Promise(function(resolve) { requestAnimationFrame(function() { resolve(true); }); });
       }
@@ -388,7 +418,8 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
           ? withDeadline(document.fonts.ready.catch(function(){}))
           : Promise.resolve(),
         waitForImages(),
-        waitForCssBackgroundImages()
+        waitForCssBackgroundImages(),
+        waitForEmbeddedFrames()
       ])
         .then(nextFrame)
         .then(nextFrame)

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -337,6 +337,8 @@ export const PRINTABLE_CONTENT_WAIT_TIMEOUT_MS = 15_000;
  *  stalled image drops out while the rest of the document still settles
  *  normally, instead of every export paying the full outer timeout. */
 const IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS = 10_000;
+const EMBEDDED_FRAME_RECONCILE_INTERVAL_MS = 50;
+const EMBEDDED_FRAME_MISSING_GRACE_MS = 150;
 
 type EmbeddedFrameWaitResult = { stalled: boolean };
 
@@ -349,6 +351,7 @@ type PendingEmbeddedFrame = {
   frame: WebFrameMain;
   frameTreeNodeId: number | null;
   key: string;
+  missingSince: number | null;
   probedIdentities: Set<string>;
 };
 
@@ -379,16 +382,24 @@ export async function waitForEmbeddedFrames(
         const key = embeddedFrameKey(frame, frameTreeNodeId);
         return [
           key,
-          { frame, frameTreeNodeId, key, probedIdentities: new Set<string>() },
+          {
+            frame,
+            frameTreeNodeId,
+            key,
+            missingSince: null,
+            probedIdentities: new Set<string>(),
+          },
         ];
       }),
     );
+    let reconcileTimer: ReturnType<typeof setTimeout> | undefined;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let done = false;
     const finish = (stalled: boolean) => {
       if (done) return;
       done = true;
       webContents.off("did-frame-finish-load", onFrameFinished);
+      if (reconcileTimer !== undefined) clearTimeout(reconcileTimer);
       if (timer !== undefined) clearTimeout(timer);
       resolve({ stalled });
     };
@@ -462,16 +473,45 @@ export async function waitForEmbeddedFrames(
     ) => {
       if (done || !pending.has(entry.key)) return;
       const current = currentEmbeddedFrame(webContents, entry);
-      // A cross-process navigation can transiently disappear from the frame
-      // snapshot between renderer detach and replacement registration. Missing
-      // here is therefore not proof that the iframe was removed; keep the wait
-      // pending for its finish event or the shared deadline.
-      if (!current) return;
+      if (!current) {
+        entry.missingSince ??= Date.now();
+        return;
+      }
+      entry.missingSince = null;
       if (
         current.processId !== previous.processId ||
         current.routingId !== previous.routingId
       ) {
         probe(entry, current);
+      }
+    };
+
+    const reconcileFrames = () => {
+      if (done) return;
+      reconcileTimer = undefined;
+      const now = Date.now();
+      for (const entry of Array.from(pending.values())) {
+        const current = currentEmbeddedFrame(webContents, entry);
+        if (!current) {
+          entry.missingSince ??= now;
+          if (now - entry.missingSince >= EMBEDDED_FRAME_MISSING_GRACE_MS) {
+            settle(entry.key);
+          }
+          continue;
+        }
+        entry.missingSince = null;
+        if (
+          current.processId !== entry.frame.processId ||
+          current.routingId !== entry.frame.routingId
+        ) {
+          probe(entry, current);
+        }
+      }
+      if (!done) {
+        reconcileTimer = setTimeout(
+          reconcileFrames,
+          EMBEDDED_FRAME_RECONCILE_INTERVAL_MS,
+        );
       }
     };
 
@@ -481,6 +521,10 @@ export async function waitForEmbeddedFrames(
     // by probing the current frame with the same stable frameTreeNodeId.
     webContents.on("did-frame-finish-load", onFrameFinished);
     timer = setTimeout(() => finish(true), Math.max(0, deadlineAt - Date.now()));
+    reconcileTimer = setTimeout(
+      reconcileFrames,
+      EMBEDDED_FRAME_RECONCILE_INTERVAL_MS,
+    );
     for (const entry of pending.values()) probe(entry, entry.frame);
   });
 }

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -340,41 +340,61 @@ const IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS = 10_000;
 
 type EmbeddedFrameWaitResult = { stalled: boolean };
 
+type EmbeddedFrameDocumentState = {
+  readyState: unknown;
+  url: unknown;
+};
+
+type PendingEmbeddedFrame = {
+  frame: WebFrameMain;
+  frameTreeNodeId: number | null;
+  key: string;
+  probedIdentities: Set<string>;
+};
+
 /**
  * Wait for each current child-frame navigation by Electron frame identity.
  *
  * DOM access cannot inspect an already-loaded cross-origin frame, while
  * Resource Timing is scoped only to a URL. WebFrameMain gives us both the
- * current document readiness and the process/routing pair emitted when that
- * exact frame finishes navigation, so two frames sharing one URL cannot
- * release each other.
+ * current document readiness and the browser-stable frame-tree identity of
+ * the frame that finishes navigation, so neither two frames sharing one URL
+ * nor a renderer-process swap can release the wrong wait.
  */
 export async function waitForEmbeddedFrames(
   webContents: WebContents,
+  deadlineAt: number = Date.now() + IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS,
 ): Promise<EmbeddedFrameWaitResult> {
   const mainFrame = webContents.mainFrame;
   if (!mainFrame || !Array.isArray(mainFrame.framesInSubtree)) return { stalled: false };
 
   const frames = mainFrame.framesInSubtree.filter((frame) => frame !== mainFrame);
-  const outcomes = await Promise.all(
-    frames.map((frame) => waitForEmbeddedFrame(webContents, frame)),
-  );
-  return { stalled: outcomes.some((outcome) => outcome === "timeout") };
-}
+  if (frames.length === 0) return { stalled: false };
 
-function waitForEmbeddedFrame(
-  webContents: WebContents,
-  frame: WebFrameMain,
-): Promise<"settled" | "timeout"> {
   return new Promise((resolve) => {
+    const pending = new Map<string, PendingEmbeddedFrame>(
+      frames.map((frame) => {
+        const frameTreeNodeId =
+          typeof frame.frameTreeNodeId === "number" ? frame.frameTreeNodeId : null;
+        const key = embeddedFrameKey(frame, frameTreeNodeId);
+        return [
+          key,
+          { frame, frameTreeNodeId, key, probedIdentities: new Set<string>() },
+        ];
+      }),
+    );
     let timer: ReturnType<typeof setTimeout> | undefined;
     let done = false;
-    const finish = (outcome: "settled" | "timeout") => {
+    const finish = (stalled: boolean) => {
       if (done) return;
       done = true;
       webContents.off("did-frame-finish-load", onFrameFinished);
       if (timer !== undefined) clearTimeout(timer);
-      resolve(outcome);
+      resolve({ stalled });
+    };
+    const settle = (key: string) => {
+      pending.delete(key);
+      if (pending.size === 0) finish(false);
     };
     const onFrameFinished = (
       _event: Electron.Event,
@@ -382,30 +402,142 @@ function waitForEmbeddedFrame(
       frameProcessId: number,
       frameRoutingId: number,
     ) => {
-      if (
-        !isMainFrame &&
-        frameProcessId === frame.processId &&
-        frameRoutingId === frame.routingId
-      ) {
-        finish("settled");
+      if (isMainFrame) return;
+      const navigatedFrame = embeddedFramesInSubtree(webContents).find(
+        (candidate) =>
+          candidate.processId === frameProcessId && candidate.routingId === frameRoutingId,
+      );
+      const key =
+        navigatedFrame && typeof navigatedFrame.frameTreeNodeId === "number"
+          ? `tree:${navigatedFrame.frameTreeNodeId}`
+          : `route:${frameProcessId}:${frameRoutingId}`;
+      const entry = pending.get(key);
+      if (entry && navigatedFrame) {
+        // The main-process frame URL can advance independently of the document
+        // whose finish event is being handled. Re-evaluate URL and readyState
+        // together inside the frame before accepting this event.
+        probe(entry, navigatedFrame, true);
       }
     };
 
-    // Subscribe before checking readiness so a frame completing between the
-    // snapshot and executeJavaScript cannot be missed.
+    const probe = (
+      entry: PendingEmbeddedFrame,
+      candidate: WebFrameMain,
+      force = false,
+    ) => {
+      if (done || !pending.has(entry.key)) return;
+      const identity = `${candidate.processId}:${candidate.routingId}`;
+      if (!force && entry.probedIdentities.has(identity)) return;
+      entry.probedIdentities.add(identity);
+      void candidate
+        .executeJavaScript("({ readyState: document.readyState, url: location.href })")
+        .then(
+          (value) => {
+            if (done || !pending.has(entry.key)) return;
+            const state = normalizeEmbeddedFrameDocumentState(value);
+            if (
+              state.readyState === "complete" &&
+              !isInitialBlankFrameDocument(state.url)
+            ) {
+              settle(entry.key);
+              return;
+            }
+            probeReplacementFrame(entry, candidate);
+          },
+          () => probeReplacementFrame(entry, candidate),
+        );
+    };
+
+    const probeReplacementFrame = (
+      entry: PendingEmbeddedFrame,
+      previous: WebFrameMain,
+    ) => {
+      if (done || !pending.has(entry.key)) return;
+      const current = currentEmbeddedFrame(webContents, entry);
+      // A cross-process navigation can transiently disappear from the frame
+      // snapshot between renderer detach and replacement registration. Missing
+      // here is therefore not proof that the iframe was removed; keep the wait
+      // pending for its finish event or the shared deadline.
+      if (!current) return;
+      if (
+        current.processId !== previous.processId ||
+        current.routingId !== previous.routingId
+      ) {
+        probe(entry, current);
+      }
+    };
+
+    // One shared listener avoids EventEmitter warnings and O(frames²) listener
+    // dispatch on iframe-heavy documents. It is installed before any readiness
+    // probes; a renderer swap in the small snapshot-to-listener gap is recovered
+    // by probing the current frame with the same stable frameTreeNodeId.
     webContents.on("did-frame-finish-load", onFrameFinished);
-    timer = setTimeout(() => finish("timeout"), IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS);
-    void frame.executeJavaScript("document.readyState").then(
-      (readyState) => {
-        if (readyState === "complete") finish("settled");
-      },
-      () => finish("settled"),
-    );
+    timer = setTimeout(() => finish(true), Math.max(0, deadlineAt - Date.now()));
+    for (const entry of pending.values()) probe(entry, entry.frame);
   });
 }
 
+function embeddedFrameKey(frame: WebFrameMain, frameTreeNodeId: number | null): string {
+  return frameTreeNodeId === null
+    ? `route:${frame.processId}:${frame.routingId}`
+    : `tree:${frameTreeNodeId}`;
+}
+
+function embeddedFramesInSubtree(webContents: WebContents): WebFrameMain[] {
+  try {
+    const mainFrame = webContents.mainFrame;
+    return Array.isArray(mainFrame.framesInSubtree)
+      ? mainFrame.framesInSubtree.filter((frame) => frame !== mainFrame)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function currentEmbeddedFrame(
+  webContents: WebContents,
+  entry: PendingEmbeddedFrame,
+): WebFrameMain | undefined {
+  const frames = embeddedFramesInSubtree(webContents);
+  return entry.frameTreeNodeId === null
+    ? frames.find(
+        (candidate) =>
+          candidate.processId === entry.frame.processId &&
+          candidate.routingId === entry.frame.routingId,
+      )
+    : frames.find((candidate) => candidate.frameTreeNodeId === entry.frameTreeNodeId);
+}
+
+function normalizeEmbeddedFrameDocumentState(
+  value: unknown,
+): { readyState: unknown; url: string } {
+  if (typeof value === "object" && value !== null) {
+    const state = value as Partial<EmbeddedFrameDocumentState>;
+    return {
+      readyState: state.readyState,
+      url: typeof state.url === "string" ? state.url : "",
+    };
+  }
+  // Never pair a malformed result with the separately observed main-process
+  // frame URL: doing so would recreate the readyState/URL race this atomic
+  // renderer evaluation exists to eliminate.
+  return { readyState: undefined, url: "" };
+}
+
+function isInitialBlankFrameDocument(url: string): boolean {
+  return url === "" || url === "about:blank" || url.startsWith("about:blank#");
+}
+
 export async function waitForPrintableContent(window: BrowserWindow): Promise<void> {
-  const embeddedFramesSettled = waitForEmbeddedFrames(window.webContents);
+  // Both the initial snapshot and the post-page-settle rescan share one frame
+  // budget. Without a shared deadline, a late frame could start a fresh 10s
+  // timer after the initial pass and leave listeners running in the background
+  // after the outer 15s capture bound had already released the export.
+  const embeddedFrameDeadlineAt = Date.now() + IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS;
+  const initialEmbeddedFramesSettled = waitForEmbeddedFrames(
+    window.webContents,
+    embeddedFrameDeadlineAt,
+  );
   const pageSettled = window.webContents.executeJavaScript(
     `(function() {
       var RESOURCE_TIMEOUT_MS = ${IN_PAGE_RESOURCE_WAIT_TIMEOUT_MS};
@@ -480,6 +612,13 @@ export async function waitForPrintableContent(window: BrowserWindow): Promise<vo
     })()`,
     true,
   ) as Promise<unknown>;
+  const embeddedFramesSettled = Promise.all([
+    initialEmbeddedFramesSettled,
+    pageSettled,
+  ]).then(async ([initial]) => {
+    if (initial.stalled) return initial;
+    return waitForEmbeddedFrames(window.webContents, embeddedFrameDeadlineAt);
+  });
 
   // Outer backstop for the case the in-page bound can never fire: a renderer
   // whose event loop is wedged never runs our setTimeout either, and
@@ -545,12 +684,13 @@ export async function waitForPrintReadyHandshake(webContents: Electron.WebConten
   // The nonce is a per-export random UUID embedded in the artifact's
   // handshake script; we verify it here to prevent spoofed messages
   // from untrusted artifact code.
+  const serializedNonce = JSON.stringify(nonce);
   const handshake = webContents.executeJavaScript(
     `(function() {
       if (window.__odPrintReady) return Promise.resolve(true);
       return new Promise(function(resolve) {
         window.addEventListener('message', function handler(event) {
-          if (event.data && event.data.type === 'OD_PRINT_READY' && event.data.nonce === '${nonce}') {
+          if (event.data && event.data.type === 'OD_PRINT_READY' && event.data.nonce === ${serializedNonce}) {
             window.__odPrintReady = true;
             window.removeEventListener('message', handler);
             resolve(true);
@@ -563,11 +703,16 @@ export async function waitForPrintReadyHandshake(webContents: Electron.WebConten
 
   // Prevent indefinite hangs if the document is malformed or the
   // injected handshake script was blocked (e.g. by a CSP violation).
-  const timeout = new Promise<never>((_, reject) =>
-    setTimeout(() => reject(new Error('Print handshake timed out')), 30_000),
-  );
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('Print handshake timed out')), 30_000);
+  });
 
-  await Promise.race([handshake, timeout]);
+  try {
+    await Promise.race([handshake, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 export async function inferPageSize(window: BrowserWindow): Promise<PageSize> {

--- a/apps/desktop/src/main/pdf-export.ts
+++ b/apps/desktop/src/main/pdf-export.ts
@@ -435,14 +435,22 @@ export async function waitForEmbeddedFrames(
           (value) => {
             if (done || !pending.has(entry.key)) return;
             const state = normalizeEmbeddedFrameDocumentState(value);
-            if (
-              state.readyState === "complete" &&
-              !isInitialBlankFrameDocument(state.url)
-            ) {
+            if (state.readyState !== "complete") {
+              probeReplacementFrame(entry, candidate);
+              return;
+            }
+            if (!isInitialBlankFrameDocument(state.url)) {
               settle(entry.key);
               return;
             }
-            probeReplacementFrame(entry, candidate);
+            void blankFrameTargetState(candidate).then((targetState) => {
+              if (done || !pending.has(entry.key)) return;
+              if (targetState === "intentional-blank") {
+                settle(entry.key);
+                return;
+              }
+              probeReplacementFrame(entry, candidate);
+            });
           },
           () => probeReplacementFrame(entry, candidate),
         );
@@ -526,6 +534,58 @@ function normalizeEmbeddedFrameDocumentState(
 
 function isInitialBlankFrameDocument(url: string): boolean {
   return url === "" || url === "about:blank" || url.startsWith("about:blank#");
+}
+
+type BlankFrameTargetState = "intentional-blank" | "pending-nonblank" | "unknown";
+
+/**
+ * Distinguish the initial about:blank document of an assigned navigation from
+ * an iframe whose intended document is actually blank.
+ *
+ * A sandboxed child cannot read `window.frameElement`, but its parent owns the
+ * element and can read the authored target. Electron's `parent.frames` order
+ * follows the document's child browsing-context order; require its count to
+ * match the parent's iframe/frame elements before using the index so an
+ * unusual embedding shape fails closed instead of releasing the wrong frame.
+ */
+async function blankFrameTargetState(frame: WebFrameMain): Promise<BlankFrameTargetState> {
+  try {
+    const parent = frame.parent;
+    if (!parent) return "unknown";
+    const siblings = parent.frames;
+    const index = siblings.findIndex((candidate) =>
+      candidate.frameTreeNodeId === frame.frameTreeNodeId
+    );
+    if (index < 0) return "unknown";
+    const value = await parent.executeJavaScript(
+      `(function(){
+        var elements = Array.from(document.querySelectorAll('iframe,frame'));
+        if (elements.length !== ${siblings.length}) return null;
+        var element = elements[${index}];
+        if (!element) return null;
+        return {
+          hasSrc: element.hasAttribute('src'),
+          rawSrc: element.getAttribute('src'),
+          resolvedSrc: typeof element.src === 'string' ? element.src : ''
+        };
+      })()`,
+    );
+    if (typeof value !== "object" || value === null) return "unknown";
+    const target = value as { hasSrc?: unknown; rawSrc?: unknown; resolvedSrc?: unknown };
+    if (target.hasSrc !== true) return "intentional-blank";
+    const rawSrc = typeof target.rawSrc === "string" ? target.rawSrc : "";
+    const resolvedSrc = typeof target.resolvedSrc === "string" ? target.resolvedSrc : rawSrc;
+    if (
+      rawSrc === "" ||
+      isInitialBlankFrameDocument(resolvedSrc) ||
+      resolvedSrc.startsWith("javascript:")
+    ) {
+      return "intentional-blank";
+    }
+    return "pending-nonblank";
+  } catch {
+    return "unknown";
+  }
 }
 
 export async function waitForPrintableContent(window: BrowserWindow): Promise<void> {

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -374,6 +374,42 @@ describe('waitForPrintableContent', () => {
     expect(settled).toBe(true);
   });
 
+  test('recognizes an already-loaded sandboxed frame without timing out or stopping the renderer', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = new EventEmitter();
+      const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+      const sandboxedFrame = {
+        url: 'https://example.test/sandboxed-adapter.html',
+        processId: 12,
+        routingId: 30,
+        // Electron executes inside the child frame, so cross-origin DOM
+        // unreadability in the parent does not hide its current readyState.
+        executeJavaScript: vi.fn().mockResolvedValue('complete'),
+      };
+      mainFrame.framesInSubtree = [mainFrame, sandboxedFrame];
+      const stop = vi.fn();
+      const webContents = Object.assign(events, {
+        mainFrame,
+        executeJavaScript: vi.fn().mockResolvedValue({ stalled: false }),
+        stop,
+      });
+
+      const waiting = waitForPrintableContent(
+        { webContents } as unknown as Parameters<typeof waitForPrintableContent>[0],
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await waiting;
+
+      expect(sandboxedFrame.executeJavaScript).toHaveBeenCalledWith('document.readyState');
+      expect(stop).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Regression boundary for the packaged export hang.
   //
   // The injected script waits on `document.fonts.ready`, every `<img>`'s

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -23,6 +23,7 @@ import {
   savePrintReadyDocumentAsPdf,
   waitForEmbeddedFrames,
   waitForPrintableContent,
+  waitForPrintReadyHandshake,
   waitForPrintReadyPdfContent,
   type PrintReadyPdfTarget,
 } from '../../src/main/pdf-export.js';
@@ -127,9 +128,14 @@ describe('savePrintReadyDocumentAsPdf', () => {
     const events = new EventEmitter();
     const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
     const pendingFrame = {
+      frameTreeNodeId: 73,
+      url: 'https://example.test/adapter.html',
       processId: 41,
       routingId: 73,
-      executeJavaScript: vi.fn().mockResolvedValue('loading'),
+      executeJavaScript: vi.fn().mockResolvedValue({
+        readyState: 'loading',
+        url: 'https://example.test/adapter.html',
+      }),
     };
     mainFrame.framesInSubtree = [mainFrame, pendingFrame];
     const webContents = Object.assign(events, {
@@ -155,6 +161,10 @@ describe('savePrintReadyDocumentAsPdf', () => {
     expect(calls).toContain('waitUntilReady');
     expect(calls).not.toContain('printToPdf');
 
+    pendingFrame.executeJavaScript.mockResolvedValue({
+      readyState: 'complete',
+      url: pendingFrame.url,
+    });
     events.emit(
       'did-frame-finish-load',
       {},
@@ -173,6 +183,87 @@ describe('savePrintReadyDocumentAsPdf', () => {
       'write',
       'dispose',
     ]);
+  });
+
+  test('does not accept an initial about:blank document before the iframe target commits', async () => {
+    const events = new EventEmitter();
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const provisionalFrame = {
+      frameTreeNodeId: 91,
+      url: '',
+      processId: 50,
+      routingId: 60,
+      // Electron reports the initial about:blank document as complete even
+      // while an assigned, delayed src has not committed.
+      executeJavaScript: vi.fn().mockResolvedValue({
+        readyState: 'complete',
+        url: 'about:blank',
+      }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, provisionalFrame];
+    const webContents = Object.assign(events, {
+      mainFrame,
+      executeJavaScript: vi.fn(async (script: string) =>
+        script.includes('__odPrintReady') ? true : { stalled: false },
+      ),
+      stop: vi.fn(),
+    });
+    const window = { webContents };
+    const { target, calls } = createStubTarget();
+    target.waitUntilReady = async (nonce) => {
+      calls.push('waitUntilReady');
+      await waitForPrintReadyPdfContent(
+        window as unknown as Parameters<typeof waitForPrintReadyPdfContent>[0],
+        nonce,
+      );
+    };
+
+    const saving = savePrintReadyDocumentAsPdf(
+      '<iframe src="https://example.test/delayed-adapter.html"></iframe>',
+      'nonce-provisional-frame',
+      target,
+    );
+    await vi.waitFor(() => expect(provisionalFrame.executeJavaScript).toHaveBeenCalled());
+
+    expect(calls).not.toContain('printToPdf');
+
+    // Creating the iframe can finish its initial about:blank document after
+    // the readiness observer is installed. That event is not the assigned
+    // target src and must not release capture either.
+    events.emit(
+      'did-frame-finish-load',
+      {},
+      false,
+      provisionalFrame.processId,
+      provisionalFrame.routingId,
+    );
+    await Promise.resolve();
+    expect(calls).not.toContain('printToPdf');
+
+    // A cross-origin commit may replace process/routing IDs. Electron's
+    // frameTreeNodeId stays fixed for the iframe element's lifetime.
+    const committedFrame = {
+      ...provisionalFrame,
+      url: 'https://example.test/delayed-adapter.html',
+      processId: 51,
+      routingId: 61,
+      executeJavaScript: vi.fn().mockResolvedValue({
+        readyState: 'complete',
+        url: 'https://example.test/delayed-adapter.html',
+      }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, committedFrame];
+    events.emit(
+      'did-frame-finish-load',
+      {},
+      false,
+      committedFrame.processId,
+      committedFrame.routingId,
+    );
+    await saving;
+
+    expect(calls).toContain('printToPdf');
+    expect(calls.indexOf('waitUntilReady')).toBeLessThan(calls.indexOf('printToPdf'));
   });
 
   test('renders with CSS page size preference, zero margins, and inferred page size by default', async () => {
@@ -392,16 +483,21 @@ describe('waitForPrintableContent', () => {
     const sharedUrl = 'https://example.test/adapter.html';
     const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
     const loadedFrame = {
+      frameTreeNodeId: 20,
       url: sharedUrl,
       processId: 10,
       routingId: 20,
-      executeJavaScript: vi.fn().mockResolvedValue('complete'),
+      executeJavaScript: vi.fn().mockResolvedValue({ readyState: 'complete', url: sharedUrl }),
     };
     const pendingFrame = {
+      frameTreeNodeId: 21,
       url: sharedUrl,
       processId: 10,
       routingId: 21,
-      executeJavaScript: vi.fn().mockResolvedValue('loading'),
+      executeJavaScript: vi
+        .fn()
+        .mockResolvedValueOnce({ readyState: 'loading', url: sharedUrl })
+        .mockResolvedValue({ readyState: 'complete', url: sharedUrl }),
     };
     mainFrame.framesInSubtree = [mainFrame, loadedFrame, pendingFrame];
     const webContents = Object.assign(events, { mainFrame });
@@ -433,12 +529,16 @@ describe('waitForPrintableContent', () => {
       const events = new EventEmitter();
       const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
       const sandboxedFrame = {
+        frameTreeNodeId: 30,
         url: 'https://example.test/sandboxed-adapter.html',
         processId: 12,
         routingId: 30,
         // Electron executes inside the child frame, so cross-origin DOM
         // unreadability in the parent does not hide its current readyState.
-        executeJavaScript: vi.fn().mockResolvedValue('complete'),
+        executeJavaScript: vi.fn().mockResolvedValue({
+          readyState: 'complete',
+          url: 'https://example.test/sandboxed-adapter.html',
+        }),
       };
       mainFrame.framesInSubtree = [mainFrame, sandboxedFrame];
       const stop = vi.fn();
@@ -455,12 +555,257 @@ describe('waitForPrintableContent', () => {
       await Promise.resolve();
       await waiting;
 
-      expect(sandboxedFrame.executeJavaScript).toHaveBeenCalledWith('document.readyState');
+      expect(sandboxedFrame.executeJavaScript).toHaveBeenCalledWith(
+        '({ readyState: document.readyState, url: location.href })',
+      );
       expect(stop).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test('binds readyState to the document URL observed in the same renderer evaluation', async () => {
+    const events = new EventEmitter();
+    const targetUrl = 'https://example.test/same-process-target.html';
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const frame = {
+      frameTreeNodeId: 40,
+      // Models frame.url advancing after the evaluated initial document state
+      // was captured but before the main-process promise callback runs.
+      url: targetUrl,
+      processId: 13,
+      routingId: 31,
+      executeJavaScript: vi
+        .fn()
+        .mockResolvedValueOnce({ readyState: 'complete', url: 'about:blank' })
+        .mockResolvedValue({ readyState: 'complete', url: targetUrl }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, frame];
+    const webContents = Object.assign(events, { mainFrame });
+    let settled = false;
+
+    const waiting = waitForEmbeddedFrames(
+      webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+    ).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    events.emit('did-frame-finish-load', {}, false, frame.processId, frame.routingId);
+    await waiting;
+    expect(settled).toBe(true);
+  });
+
+  test('does not combine a malformed renderer result with the main-process frame URL', async () => {
+    const events = new EventEmitter();
+    const targetUrl = 'https://example.test/malformed-state.html';
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const frame = {
+      frameTreeNodeId: 401,
+      url: targetUrl,
+      processId: 131,
+      routingId: 311,
+      executeJavaScript: vi
+        .fn()
+        .mockResolvedValueOnce('complete')
+        .mockResolvedValue({ readyState: 'complete', url: targetUrl }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, frame];
+    const webContents = Object.assign(events, { mainFrame });
+    let settled = false;
+    const waiting = waitForEmbeddedFrames(
+      webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+    ).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    events.emit('did-frame-finish-load', {}, false, frame.processId, frame.routingId);
+    await waiting;
+    expect(settled).toBe(true);
+  });
+
+  test('re-probes the replacement renderer when the target commits before its finish event is observed', async () => {
+    const events = new EventEmitter();
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const provisionalFrame = {
+      frameTreeNodeId: 41,
+      url: 'about:blank',
+      processId: 14,
+      routingId: 32,
+      executeJavaScript: vi.fn().mockRejectedValue(new Error('frame detached')),
+    };
+    mainFrame.framesInSubtree = [mainFrame, provisionalFrame];
+    const webContents = Object.assign(events, { mainFrame });
+    const waiting = waitForEmbeddedFrames(
+      webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+    );
+    const committedFrame = {
+      ...provisionalFrame,
+      url: 'https://example.test/replacement.html',
+      processId: 15,
+      routingId: 33,
+      executeJavaScript: vi.fn().mockResolvedValue({
+        readyState: 'complete',
+        url: 'https://example.test/replacement.html',
+      }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, committedFrame];
+
+    await expect(waiting).resolves.toEqual({ stalled: false });
+    expect(committedFrame.executeJavaScript).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not treat a transiently missing renderer as a removed iframe', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = new EventEmitter();
+      const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+      const provisionalFrame = {
+        frameTreeNodeId: 42,
+        url: 'about:blank',
+        processId: 16,
+        routingId: 34,
+        executeJavaScript: vi.fn().mockRejectedValue(new Error('renderer detached')),
+      };
+      mainFrame.framesInSubtree = [mainFrame, provisionalFrame];
+      const webContents = Object.assign(events, { mainFrame });
+      const waiting = waitForEmbeddedFrames(
+        webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+      );
+      let settled = false;
+      void waiting.then(() => {
+        settled = true;
+      });
+
+      // Electron can expose a short gap between detaching the old renderer and
+      // registering its cross-process replacement. That gap must not be mistaken
+      // for DOM removal and release capture early.
+      mainFrame.framesInSubtree = [mainFrame];
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      const committedFrame = {
+        ...provisionalFrame,
+        url: 'https://example.test/committed.html',
+        processId: 17,
+        routingId: 35,
+        executeJavaScript: vi.fn().mockResolvedValue({
+          readyState: 'complete',
+          url: 'https://example.test/committed.html',
+        }),
+      };
+      mainFrame.framesInSubtree = [mainFrame, committedFrame];
+      events.emit(
+        'did-frame-finish-load',
+        {},
+        false,
+        committedFrame.processId,
+        committedFrame.routingId,
+      );
+
+      await expect(waiting).resolves.toEqual({ stalled: false });
+      expect(committedFrame.executeJavaScript).toHaveBeenCalledTimes(1);
+      expect(events.listenerCount('did-frame-finish-load')).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('uses one shared finish listener for iframe-heavy documents', async () => {
+    const events = new EventEmitter();
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const frames = Array.from({ length: 20 }, (_, index) => ({
+      frameTreeNodeId: 100 + index,
+      url: `https://example.test/frame-${index}.html`,
+      processId: 20,
+      routingId: 100 + index,
+      executeJavaScript: vi
+        .fn()
+        .mockResolvedValueOnce({
+          readyState: 'loading',
+          url: `https://example.test/frame-${index}.html`,
+        })
+        .mockResolvedValue({
+          readyState: 'complete',
+          url: `https://example.test/frame-${index}.html`,
+        }),
+    }));
+    mainFrame.framesInSubtree = [mainFrame, ...frames];
+    const webContents = Object.assign(events, { mainFrame });
+    const waiting = waitForEmbeddedFrames(
+      webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+    );
+
+    expect(events.listenerCount('did-frame-finish-load')).toBe(1);
+    for (const frame of frames) {
+      events.emit('did-frame-finish-load', {}, false, frame.processId, frame.routingId);
+    }
+
+    await expect(waiting).resolves.toEqual({ stalled: false });
+    expect(events.listenerCount('did-frame-finish-load')).toBe(0);
+  });
+
+  test('rescans for frames inserted while the page-side resource wait is settling', async () => {
+    const events = new EventEmitter();
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    let releasePage: ((value: { stalled: boolean }) => void) | undefined;
+    const pageSettled = new Promise<{ stalled: boolean }>((resolve) => {
+      releasePage = resolve;
+    });
+    const stop = vi.fn();
+    const webContents = Object.assign(events, {
+      mainFrame,
+      executeJavaScript: vi.fn().mockReturnValue(pageSettled),
+      stop,
+    });
+    let settled = false;
+    const waiting = waitForPrintableContent(
+      { webContents } as unknown as Parameters<typeof waitForPrintableContent>[0],
+    ).then(() => {
+      settled = true;
+    });
+    const lateFrame = {
+      frameTreeNodeId: 200,
+      url: 'https://example.test/late-frame.html',
+      processId: 30,
+      routingId: 200,
+      executeJavaScript: vi
+        .fn()
+        .mockResolvedValueOnce({
+          readyState: 'loading',
+          url: 'https://example.test/late-frame.html',
+        })
+        .mockResolvedValue({
+          readyState: 'complete',
+          url: 'https://example.test/late-frame.html',
+        }),
+    };
+    mainFrame.framesInSubtree = [mainFrame, lateFrame];
+    releasePage?.({ stalled: false });
+    await vi.waitFor(() => expect(lateFrame.executeJavaScript).toHaveBeenCalled());
+
+    expect(settled).toBe(false);
+
+    events.emit(
+      'did-frame-finish-load',
+      {},
+      false,
+      lateFrame.processId,
+      lateFrame.routingId,
+    );
+    await waiting;
+
+    expect(settled).toBe(true);
+    expect(stop).not.toHaveBeenCalled();
   });
 
   // Regression boundary for the packaged export hang.
@@ -653,5 +998,91 @@ describe('waitForPrintableContent', () => {
     // stalled single resource drop out while the rest of the page still
     // finishes normally, instead of every export paying the full outer bound.
     expect(scripts[0]).toContain('setTimeout');
+  });
+
+  test('shares one frame deadline across the initial and post-page-settle scans', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = new EventEmitter();
+      const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+      const pendingFrame = {
+        frameTreeNodeId: 300,
+        url: 'https://example.test/never-finishes.html',
+        processId: 40,
+        routingId: 300,
+        executeJavaScript: vi.fn().mockResolvedValue({
+          readyState: 'loading',
+          url: 'https://example.test/never-finishes.html',
+        }),
+      };
+      mainFrame.framesInSubtree = [mainFrame, pendingFrame];
+      const stop = vi.fn();
+      const webContents = Object.assign(events, {
+        mainFrame,
+        executeJavaScript: vi.fn().mockResolvedValue({ stalled: false }),
+        stop,
+      });
+      const waiting = waitForPrintableContent(
+        { webContents } as unknown as Parameters<typeof waitForPrintableContent>[0],
+      );
+
+      await vi.advanceTimersByTimeAsync(10_001);
+      await waiting;
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(events.listenerCount('did-frame-finish-load')).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('waitForPrintReadyHandshake', () => {
+  test('serializes an untrusted nonce instead of interpolating executable JavaScript', async () => {
+    const nonce = `x' || (window.pwned = true) || '`;
+    let messageHandler: ((event: unknown) => void) | undefined;
+    const browserWindow = {
+      __odPrintReady: false,
+      pwned: false,
+      addEventListener(_type: string, handler: (event: unknown) => void) {
+        messageHandler = handler;
+      },
+      removeEventListener() {},
+    };
+    const webContents = {
+      executeJavaScript(script: string) {
+        const evaluate = new Function('window', `return ${script};`);
+        return evaluate(browserWindow) as Promise<boolean>;
+      },
+    };
+
+    const waiting = waitForPrintReadyHandshake(
+      webContents as unknown as Parameters<typeof waitForPrintReadyHandshake>[0],
+      nonce,
+    );
+    expect(messageHandler).toBeTypeOf('function');
+    messageHandler?.({ data: { type: 'OD_PRINT_READY', nonce } });
+    await waiting;
+
+    expect(browserWindow.pwned).toBe(false);
+  });
+
+  test('clears its timeout after the cached handshake resolves', async () => {
+    vi.useFakeTimers();
+    try {
+      const webContents = {
+        executeJavaScript: vi.fn().mockResolvedValue(true),
+      };
+
+      await waitForPrintReadyHandshake(
+        webContents as unknown as Parameters<typeof waitForPrintReadyHandshake>[0],
+        'nonce',
+      );
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -308,7 +308,7 @@ describe('pdfFilenameFromDocument', () => {
 });
 
 describe('waitForPrintableContent', () => {
-  test('waits for fonts, document images, CSS image URLs, and stable animation frames', async () => {
+  test('waits for fonts, images, CSS URLs, embedded frames, and stable animation frames', async () => {
     const scripts: string[] = [];
     const window = {
       webContents: {
@@ -325,6 +325,10 @@ describe('waitForPrintableContent', () => {
     expect(scripts[0]).toContain('document.fonts.ready');
     expect(scripts[0]).toContain('document.images');
     expect(scripts[0]).toContain('waitForCssBackgroundImages');
+    expect(scripts[0]).toContain('waitForEmbeddedFrames');
+    expect(scripts[0]).toContain("document.querySelectorAll('iframe')");
+    expect(scripts[0]).toContain("frame.addEventListener('load'");
+    expect(scripts[0]).toContain("frame.addEventListener('error'");
     expect(scripts[0]).toContain('style.backgroundImage');
     expect(scripts[0]).toContain('style.borderImageSource');
     expect(scripts[0]).toContain('style.listStyleImage');

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -200,6 +200,15 @@ describe('savePrintReadyDocumentAsPdf', () => {
         url: 'about:blank',
       }),
     };
+    Object.assign(mainFrame, {
+      frames: [provisionalFrame],
+      executeJavaScript: vi.fn().mockResolvedValue({
+        hasSrc: true,
+        rawSrc: 'https://example.test/delayed-adapter.html',
+        resolvedSrc: 'https://example.test/delayed-adapter.html',
+      }),
+    });
+    Object.assign(provisionalFrame, { parent: mainFrame });
     mainFrame.framesInSubtree = [mainFrame, provisionalFrame];
     const webContents = Object.assign(events, {
       mainFrame,
@@ -252,6 +261,8 @@ describe('savePrintReadyDocumentAsPdf', () => {
         url: 'https://example.test/delayed-adapter.html',
       }),
     };
+    Object.assign(committedFrame, { parent: mainFrame });
+    mainFrame.frames = [committedFrame];
     mainFrame.framesInSubtree = [mainFrame, committedFrame];
     events.emit(
       'did-frame-finish-load',
@@ -558,6 +569,50 @@ describe('waitForPrintableContent', () => {
       expect(sandboxedFrame.executeJavaScript).toHaveBeenCalledWith(
         '({ readyState: document.readyState, url: location.href })',
       );
+      expect(stop).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('accepts a completed intentionally blank iframe without consuming the deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = new EventEmitter();
+      const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+      const blankFrame: Record<string, unknown> = {
+        frameTreeNodeId: 301,
+        url: 'about:blank',
+        processId: 12,
+        routingId: 301,
+        executeJavaScript: vi.fn().mockResolvedValue({
+          readyState: 'complete',
+          url: 'about:blank',
+        }),
+      };
+      Object.assign(mainFrame, {
+        frames: [blankFrame],
+        executeJavaScript: vi.fn().mockResolvedValue({
+          hasSrc: false,
+          rawSrc: null,
+          resolvedSrc: '',
+        }),
+      });
+      blankFrame.parent = mainFrame;
+      mainFrame.framesInSubtree = [mainFrame, blankFrame];
+      const stop = vi.fn();
+      const webContents = Object.assign(events, {
+        mainFrame,
+        executeJavaScript: vi.fn().mockResolvedValue({ stalled: false }),
+        stop,
+      });
+
+      await waitForPrintableContent(
+        { webContents } as unknown as Parameters<typeof waitForPrintableContent>[0],
+      );
+
+      expect(mainFrame.executeJavaScript).toHaveBeenCalledTimes(2);
       expect(stop).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
     } finally {

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -14,12 +14,14 @@
 // reintroduced without a type error.
 
 import { describe, expect, test, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
 
 import {
   PRINTABLE_CONTENT_WAIT_TIMEOUT_MS,
   inferPageSize,
   pdfFilenameFromDocument,
   savePrintReadyDocumentAsPdf,
+  waitForEmbeddedFrames,
   waitForPrintableContent,
   type PrintReadyPdfTarget,
 } from '../../src/main/pdf-export.js';
@@ -325,10 +327,6 @@ describe('waitForPrintableContent', () => {
     expect(scripts[0]).toContain('document.fonts.ready');
     expect(scripts[0]).toContain('document.images');
     expect(scripts[0]).toContain('waitForCssBackgroundImages');
-    expect(scripts[0]).toContain('waitForEmbeddedFrames');
-    expect(scripts[0]).toContain("document.querySelectorAll('iframe')");
-    expect(scripts[0]).toContain("frame.addEventListener('load'");
-    expect(scripts[0]).toContain("frame.addEventListener('error'");
     expect(scripts[0]).not.toContain('performance.getEntriesByName');
     expect(scripts[0]).toContain('style.backgroundImage');
     expect(scripts[0]).toContain('style.borderImageSource');
@@ -336,83 +334,44 @@ describe('waitForPrintableContent', () => {
     expect(scripts[0]).toContain('.then(nextFrame)');
   });
 
-  test('does not treat another completed frame with the same URL as proof a pending frame loaded', async () => {
-    vi.useFakeTimers();
-    try {
-      const pendingListeners: Record<string, (() => void) | undefined> = {};
-      const sharedUrl = 'https://example.test/adapter.html';
-      const loadedFrame = {
-        src: sharedUrl,
-        contentDocument: { readyState: 'complete' },
-        addEventListener: vi.fn(),
-      };
-      const pendingFrame = {
-        src: sharedUrl,
-        get contentDocument() {
-          throw new Error('cross-origin');
-        },
-        addEventListener(event: string, listener: () => void) {
-          pendingListeners[event] = listener;
-        },
-      };
-      const document = {
-        fonts: undefined,
-        images: [],
-        querySelectorAll(selector: string) {
-          return selector === 'iframe' ? [loadedFrame, pendingFrame] : [];
-        },
-      };
-      const browserWindow = {
-        getComputedStyle() {
-          return { backgroundImage: 'none', borderImageSource: 'none', listStyleImage: 'none' };
-        },
-      };
-      const resourceTiming = {
-        getEntriesByName(url: string) {
-          return url === sharedUrl ? [{ responseEnd: 1 }] : [];
-        },
-      };
-      let settled = false;
-      const window = {
-        webContents: {
-          async executeJavaScript(script: string) {
-            const evaluate = new Function(
-              'document',
-              'window',
-              'Image',
-              'requestAnimationFrame',
-              'performance',
-              `return ${script};`,
-            );
-            return evaluate(
-              document,
-              browserWindow,
-              class {},
-              (callback: () => void) => callback(),
-              resourceTiming,
-            ) as Promise<unknown>;
-          },
-        },
-      };
+  test('does not let a completed frame release a pending frame with the same URL', async () => {
+    const events = new EventEmitter();
+    const sharedUrl = 'https://example.test/adapter.html';
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const loadedFrame = {
+      url: sharedUrl,
+      processId: 10,
+      routingId: 20,
+      executeJavaScript: vi.fn().mockResolvedValue('complete'),
+    };
+    const pendingFrame = {
+      url: sharedUrl,
+      processId: 10,
+      routingId: 21,
+      executeJavaScript: vi.fn().mockResolvedValue('loading'),
+    };
+    mainFrame.framesInSubtree = [mainFrame, loadedFrame, pendingFrame];
+    const webContents = Object.assign(events, { mainFrame });
+    let settled = false;
 
-      const waiting = waitForPrintableContent(
-        window as unknown as Parameters<typeof waitForPrintableContent>[0],
-      ).then(() => {
-        settled = true;
-      });
-      await Promise.resolve();
-      await Promise.resolve();
+    const waiting = waitForEmbeddedFrames(
+      webContents as unknown as Parameters<typeof waitForEmbeddedFrames>[0],
+    ).then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
 
-      expect(settled).toBe(false);
-      expect(pendingListeners.load).toBeTypeOf('function');
+    expect(settled).toBe(false);
 
-      pendingListeners.load?.();
-      await waiting;
+    events.emit('did-frame-finish-load', {}, false, loadedFrame.processId, loadedFrame.routingId);
+    await Promise.resolve();
+    expect(settled).toBe(false);
 
-      expect(settled).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
+    events.emit('did-frame-finish-load', {}, false, pendingFrame.processId, pendingFrame.routingId);
+    await waiting;
+
+    expect(settled).toBe(true);
   });
 
   // Regression boundary for the packaged export hang.

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -23,6 +23,7 @@ import {
   savePrintReadyDocumentAsPdf,
   waitForEmbeddedFrames,
   waitForPrintableContent,
+  waitForPrintReadyPdfContent,
   type PrintReadyPdfTarget,
 } from '../../src/main/pdf-export.js';
 
@@ -110,6 +111,58 @@ describe('savePrintReadyDocumentAsPdf', () => {
     const { target, calls } = createStubTarget();
 
     await savePrintReadyDocumentAsPdf('<html></html>', 'nonce-2', target);
+
+    expect(calls).toEqual([
+      'promptSavePath',
+      'load',
+      'waitUntilReady',
+      'measurePageSize',
+      'printToPdf',
+      'write',
+      'dispose',
+    ]);
+  });
+
+  test('does not capture the direct desktop PDF until an embedded frame settles', async () => {
+    const events = new EventEmitter();
+    const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+    const pendingFrame = {
+      processId: 41,
+      routingId: 73,
+      executeJavaScript: vi.fn().mockResolvedValue('loading'),
+    };
+    mainFrame.framesInSubtree = [mainFrame, pendingFrame];
+    const webContents = Object.assign(events, {
+      mainFrame,
+      executeJavaScript: vi.fn(async (script: string) =>
+        script.includes('__odPrintReady') ? true : { stalled: false },
+      ),
+      stop: vi.fn(),
+    });
+    const window = { webContents };
+    const { target, calls } = createStubTarget();
+    target.waitUntilReady = async (nonce) => {
+      calls.push('waitUntilReady');
+      await waitForPrintReadyPdfContent(
+        window as unknown as Parameters<typeof waitForPrintReadyPdfContent>[0],
+        nonce,
+      );
+    };
+
+    const saving = savePrintReadyDocumentAsPdf('<html></html>', 'nonce-frame', target);
+    await vi.waitFor(() => expect(pendingFrame.executeJavaScript).toHaveBeenCalled());
+
+    expect(calls).toContain('waitUntilReady');
+    expect(calls).not.toContain('printToPdf');
+
+    events.emit(
+      'did-frame-finish-load',
+      {},
+      false,
+      pendingFrame.processId,
+      pendingFrame.routingId,
+    );
+    await saving;
 
     expect(calls).toEqual([
       'promptSavePath',

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -329,10 +329,90 @@ describe('waitForPrintableContent', () => {
     expect(scripts[0]).toContain("document.querySelectorAll('iframe')");
     expect(scripts[0]).toContain("frame.addEventListener('load'");
     expect(scripts[0]).toContain("frame.addEventListener('error'");
+    expect(scripts[0]).not.toContain('performance.getEntriesByName');
     expect(scripts[0]).toContain('style.backgroundImage');
     expect(scripts[0]).toContain('style.borderImageSource');
     expect(scripts[0]).toContain('style.listStyleImage');
     expect(scripts[0]).toContain('.then(nextFrame)');
+  });
+
+  test('does not treat another completed frame with the same URL as proof a pending frame loaded', async () => {
+    vi.useFakeTimers();
+    try {
+      const pendingListeners: Record<string, (() => void) | undefined> = {};
+      const sharedUrl = 'https://example.test/adapter.html';
+      const loadedFrame = {
+        src: sharedUrl,
+        contentDocument: { readyState: 'complete' },
+        addEventListener: vi.fn(),
+      };
+      const pendingFrame = {
+        src: sharedUrl,
+        get contentDocument() {
+          throw new Error('cross-origin');
+        },
+        addEventListener(event: string, listener: () => void) {
+          pendingListeners[event] = listener;
+        },
+      };
+      const document = {
+        fonts: undefined,
+        images: [],
+        querySelectorAll(selector: string) {
+          return selector === 'iframe' ? [loadedFrame, pendingFrame] : [];
+        },
+      };
+      const browserWindow = {
+        getComputedStyle() {
+          return { backgroundImage: 'none', borderImageSource: 'none', listStyleImage: 'none' };
+        },
+      };
+      const resourceTiming = {
+        getEntriesByName(url: string) {
+          return url === sharedUrl ? [{ responseEnd: 1 }] : [];
+        },
+      };
+      let settled = false;
+      const window = {
+        webContents: {
+          async executeJavaScript(script: string) {
+            const evaluate = new Function(
+              'document',
+              'window',
+              'Image',
+              'requestAnimationFrame',
+              'performance',
+              `return ${script};`,
+            );
+            return evaluate(
+              document,
+              browserWindow,
+              class {},
+              (callback: () => void) => callback(),
+              resourceTiming,
+            ) as Promise<unknown>;
+          },
+        },
+      };
+
+      const waiting = waitForPrintableContent(
+        window as unknown as Parameters<typeof waitForPrintableContent>[0],
+      ).then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(settled).toBe(false);
+      expect(pendingListeners.load).toBeTypeOf('function');
+
+      pendingListeners.load?.();
+      await waiting;
+
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // Regression boundary for the packaged export hang.

--- a/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
+++ b/apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts
@@ -746,6 +746,7 @@ describe('waitForPrintableContent', () => {
       mainFrame.framesInSubtree = [mainFrame];
       await Promise.resolve();
       await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(100);
       expect(settled).toBe(false);
 
       const committedFrame = {
@@ -770,6 +771,46 @@ describe('waitForPrintableContent', () => {
       await expect(waiting).resolves.toEqual({ stalled: false });
       expect(committedFrame.executeJavaScript).toHaveBeenCalledTimes(1);
       expect(events.listenerCount('did-frame-finish-load')).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('settles a pending frame after its browsing context is actually removed', async () => {
+    vi.useFakeTimers();
+    try {
+      const events = new EventEmitter();
+      const mainFrame: Record<string, unknown> = { framesInSubtree: [] };
+      const removedFrame = {
+        frameTreeNodeId: 43,
+        url: 'https://example.test/removed.html',
+        processId: 18,
+        routingId: 36,
+        executeJavaScript: vi.fn().mockResolvedValue({
+          readyState: 'loading',
+          url: 'https://example.test/removed.html',
+        }),
+      };
+      mainFrame.framesInSubtree = [mainFrame, removedFrame];
+      const stop = vi.fn();
+      const webContents = Object.assign(events, {
+        mainFrame,
+        executeJavaScript: vi.fn().mockResolvedValue({ stalled: false }),
+        stop,
+      });
+      const waiting = waitForPrintableContent(
+        { webContents } as unknown as Parameters<typeof waitForPrintableContent>[0],
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      mainFrame.framesInSubtree = [mainFrame];
+      await vi.advanceTimersByTimeAsync(250);
+      await waiting;
+
+      expect(stop).not.toHaveBeenCalled();
+      expect(events.listenerCount('did-frame-finish-load')).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Why

While validating a responsive OpenDesign artifact through Local Codex, the first export rendered the outer page but left all three embedded desktop, tablet, and mobile adapters blank. Capture waited for the wrapper document, images, fonts, and CSS resources, but not for the individual iframe navigations that contained those adapters.

Print readiness now enumerates Electron `WebFrameMain` instances and observes each child document by its stable frame-tree identity. Readiness accepts only an atomic in-frame observation of `document.readyState` and `location.href`, rejects the provisional `about:blank` document, follows renderer-process swaps, and rechecks the final frame set after page resources settle. One shared listener and deadline keep iframe-heavy or dynamically changing documents bounded.

## What users will see

Responsive PDF and image exports wait for each embedded adapter before capture, so the exported file should contain populated desktop, tablet, and mobile previews instead of a rendered outer page with blank panels. If an adapter never loads, export still proceeds after the existing bounded wait rather than hanging indefinitely; only that stalled adapter may remain absent from the output.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The default behavior box is checked because existing desktop exports now wait for each embedded frame automatically.

## Screenshots

Not applicable. This changes generated export contents and does not add or alter a UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/save-print-ready-document-as-pdf.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** `main` does not wait for embedded frames.
- The direct-save regressions prove capture remains blocked for both a pending target and the initial `about:blank` document.
- The duplicate-URL regression proves one completed frame cannot release a different pending frame with the same URL.
- The preloaded-sandbox regression proves an already-complete cross-origin frame returns without advancing the deadline or calling `webContents.stop()`.
- Adversarial cases cover same-renderer URL/state races, renderer-process replacement, transient frame-snapshot gaps, removed pending frames, malformed renderer results, late frame insertion, intentional blank frames, shared deadlines, and iframe-heavy documents using one listener.
- Electron 41.3.0 behavioral probes: a 2,000 ms delayed sandboxed child began as `about:blank` in process/routing `4/4`, committed in `5/5` with the same `frameTreeNodeId`, and resolved after 2,033 ms with populated content; an intentionally blank sandboxed child resolved in 20 ms without consuming the deadline; a pending child removed after 100 ms reconciled in 260 ms with zero remaining children and no `webContents.stop()` call.

## Adjacent issues

- The daemon PDF and CLI artifact exporters still await raw Electron `loadURL()`, unlike the deck capture path's bounded document loader. A permanently stalled subresource can therefore prevent those paths from reaching `waitForPrintableContent()`. This is a confirmed adjacent lifecycle defect, but repository policy requires its own red-spec follow-up rather than expanding this iframe-readiness PR.

## Validation

- `pnpm guard` — passed.
- `pnpm --filter @open-design/desktop typecheck` — passed.
- `pnpm --filter @open-design/desktop build` — passed.
- Full desktop suite: 40 files passed; 415 tests passed, 1 skipped (416 total).
- Focused suite: 2 files passed; 42 tests passed.
- `tsc -p scripts/tsconfig.json --noEmit` — passed.
- Electron 41.3.0 delayed-iframe behavioral probe — passed.
