### PR TITLE
fix(viewer): stabilize Electron HTML previews

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -10,6 +10,13 @@ import {
   buildPreviewObservabilityBridge,
 } from '@open-design/contracts/runtime/preview-observability';
 import {
+  buildPreviewFocusGuard,
+  buildPreviewRedirectGuard,
+  buildPreviewSandboxShim,
+  PREVIEW_URL_GUARD_MAX_HTML_BYTES,
+  previewHtmlHasLoadTimeLocationNavigation,
+} from '@open-design/contracts/runtime/preview-guards';
+import {
   automaticStrategyTaskProfileForProjectMetadata,
   defaultScenarioPluginIdForProjectMetadata,
   type ChatSessionMode,
@@ -1424,6 +1431,18 @@ function wantsUrlPreviewObservabilityBridge(value: unknown): boolean {
   return previewBridgeTokens(value).some((token) => token === 'observability' || token === 'errors' || token === 'diagnostics');
 }
 
+function wantsUrlPreviewSandboxGuard(value: unknown): boolean {
+  return previewBridgeTokens(value).some((token) => token === 'sandbox' || token === 'storage');
+}
+
+function wantsUrlPreviewFocusGuard(value: unknown): boolean {
+  return previewBridgeTokens(value).some((token) => token === 'focus');
+}
+
+function wantsUrlPreviewRedirectGuard(value: unknown): boolean {
+  return previewBridgeTokens(value).some((token) => token === 'redirect');
+}
+
 function injectBeforeBodyClose(html: string, marker: string, injection: string): string {
   if (html.includes(marker)) return html;
   const bodyCloseIndex = html.search(/<\/body\s*>/i);
@@ -1444,7 +1463,25 @@ function injectAfterHeadOpen(html: string, marker: string, injection: string): s
   return `${injection}${html}`;
 }
 
-function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | 'snapshot' | 'observability'): string {
+function injectUrlPreviewBridge(
+  html: string,
+  bridge: 'scroll' | 'selection' | 'snapshot' | 'observability' | 'sandbox' | 'focus' | 'redirect',
+): string {
+  if (bridge === 'sandbox') {
+    return injectAfterHeadOpen(html, 'data-od-sandbox-shim', buildPreviewSandboxShim());
+  }
+  if (bridge === 'focus') {
+    return injectAfterHeadOpen(html, 'data-od-preview-focus-guard', buildPreviewFocusGuard());
+  }
+  if (bridge === 'redirect') {
+    return injectAfterHeadOpen(
+      html,
+      'data-od-preview-redirect-guard',
+      buildPreviewRedirectGuard({
+        blockLoadTimeScriptRedirect: previewHtmlHasLoadTimeLocationNavigation(html),
+      }),
+    );
+  }
   if (bridge === 'observability') {
     return injectAfterHeadOpen(
       html,
@@ -1471,7 +1508,10 @@ function applyUrlPreviewBridgesToHtml(
       wantsUrlPreviewScrollBridge(requestedBridge) ||
       wantsUrlPreviewSelectionBridge(requestedBridge) ||
       wantsUrlPreviewSnapshotBridge(requestedBridge) ||
-      wantsUrlPreviewObservabilityBridge(requestedBridge)
+      wantsUrlPreviewObservabilityBridge(requestedBridge) ||
+      wantsUrlPreviewSandboxGuard(requestedBridge) ||
+      wantsUrlPreviewFocusGuard(requestedBridge) ||
+      wantsUrlPreviewRedirectGuard(requestedBridge)
     ) ||
     !/^text\/html(?:;|$)/i.test(mime)
   ) {
@@ -1483,8 +1523,20 @@ function applyUrlPreviewBridgesToHtml(
   // filename. URL-load iframes cannot rely on the host rewriting the document
   // title after load, and powered previews are intentionally cross-origin.
   html = daemonSanitizeTitleInDoc(html);
+  // Guards must run before authored scripts. injectAfterHeadOpen prepends at
+  // the start of <head>; apply in reverse runtime order so the final document
+  // executes sandbox -> redirect -> observability -> focus.
+  if (wantsUrlPreviewFocusGuard(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'focus');
+  }
   if (wantsUrlPreviewObservabilityBridge(requestedBridge)) {
     html = injectUrlPreviewBridge(html, 'observability');
+  }
+  if (wantsUrlPreviewRedirectGuard(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'redirect');
+  }
+  if (wantsUrlPreviewSandboxGuard(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'sandbox');
   }
   if (wantsUrlPreviewScrollBridge(requestedBridge)) {
     html = injectUrlPreviewBridge(html, 'scroll');
@@ -5390,7 +5442,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
   const { validateArtifactManifestInput } = ctx.artifacts;
   const { projectPreviewScopes } = ctx;
   const projectPreviewIframeSandbox = 'allow-scripts allow-forms';
-  const HTML_PREVIEW_BRIDGE_MAX_BYTES = 2 * 1024 * 1024;
   const HTML_POWERED_PREVIEW_HINT_SCAN_MAX_BYTES = 128 * 1024 * 1024;
   const projectPreviewCsp = [
     `sandbox ${projectPreviewIframeSandbox}`,
@@ -6520,7 +6571,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         project?.metadata,
       );
       const skipHtmlPreviewBridge =
-        /^text\/html(?:;|$)/i.test(meta.mime) && meta.size > HTML_PREVIEW_BRIDGE_MAX_BYTES;
+        /^text\/html(?:;|$)/i.test(meta.mime) && meta.size > PREVIEW_URL_GUARD_MAX_HTML_BYTES;
 
       await sendProjectFile(
         req,
@@ -6635,7 +6686,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         project?.metadata,
       );
       const skipPoweredTransform =
-        /^text\/html(?:;|$)/i.test(meta.mime) && meta.size > HTML_PREVIEW_BRIDGE_MAX_BYTES;
+        /^text\/html(?:;|$)/i.test(meta.mime) && meta.size > PREVIEW_URL_GUARD_MAX_HTML_BYTES;
       await sendProjectFile(
         req,
         res,

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -199,6 +199,52 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     );
     await writeFile(path.join(dir, 'body.html'), Buffer.from('<html><body><main>Preview</main></body></html>'));
     await writeFile(
+      path.join(dir, 'guarded.html'),
+      Buffer.from('<!doctype html><html><head><script src="./boot.js"></script></head><body><input autofocus></body></html>'),
+    );
+    const complexPreviewDir = path.join(dir, 'prototypes', 'booking');
+    await mkdir(path.join(complexPreviewDir, 'styles'), { recursive: true });
+    await mkdir(path.join(complexPreviewDir, 'scripts'), { recursive: true });
+    await mkdir(path.join(complexPreviewDir, 'components'), { recursive: true });
+    await mkdir(path.join(complexPreviewDir, 'assets'), { recursive: true });
+    const babelScripts = Array.from(
+      { length: 43 },
+      (_, index) => `<script type="text/babel" src="./components/screen-${index + 1}.jsx"></script>`,
+    ).join('');
+    await writeFile(
+      path.join(complexPreviewDir, 'index.html'),
+      Buffer.from([
+        '<!doctype html><html><head>',
+        '<link rel="stylesheet" href="./styles/app.css">',
+        '<script src="./scripts/support.js"></script>',
+        babelScripts,
+        '<script type="module" src="./scripts/module.js"></script>',
+        '</head><body>',
+        '<img src="./assets/card.svg" srcset="./assets/card.svg 1x, ./assets/card@2x.svg 2x">',
+        '<main id="root"></main>',
+        '</body></html>',
+      ].join('')),
+    );
+    await writeFile(
+      path.join(complexPreviewDir, 'styles', 'app.css'),
+      '@import "./theme.css"; .card { background-image: url("../assets/card.svg"); }',
+    );
+    await writeFile(path.join(complexPreviewDir, 'styles', 'theme.css'), ':root { --accent: #0a7; }');
+    await writeFile(
+      path.join(complexPreviewDir, 'scripts', 'support.js'),
+      'window.__supportLoaded = true; fetch("./data.json").then((response) => response.json());',
+    );
+    await writeFile(path.join(complexPreviewDir, 'scripts', 'module.js'), 'export const ready = true;');
+    for (let index = 1; index <= 43; index += 1) {
+      await writeFile(
+        path.join(complexPreviewDir, 'components', `screen-${index}.jsx`),
+        `window.__screen${index} = () => <section>Screen ${index}</section>;`,
+      );
+    }
+    await writeFile(path.join(complexPreviewDir, 'data.json'), '{"ready":true}');
+    await writeFile(path.join(complexPreviewDir, 'assets', 'card.svg'), '<svg xmlns="http://www.w3.org/2000/svg"/>');
+    await writeFile(path.join(complexPreviewDir, 'assets', 'card@2x.svg'), '<svg xmlns="http://www.w3.org/2000/svg" width="2"/>');
+    await writeFile(
       path.join(dir, 'bridged.html'),
       Buffer.from('<html><body><script data-od-url-scroll-bridge></script><main>Preview</main></body></html>'),
     );
@@ -416,6 +462,57 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain("send('runtime_error'");
     expect(html).toContain("send('white_screen'");
     expect(html.indexOf('data-od-preview-observability')).toBeLessThan(html.indexOf('<body>'));
+  });
+
+  it('injects passive URL guards before authored scripts', async () => {
+    const bridged = await fetch(
+      `${rawUrl('guarded.html')}?odPreviewBridge=sandbox&odPreviewBridge=focus&odPreviewBridge=redirect`,
+    );
+    expect(bridged.status).toBe(200);
+    const html = await bridged.text();
+    const authorScriptIndex = html.indexOf('<script src="./boot.js">');
+    expect(authorScriptIndex).toBeGreaterThan(-1);
+    expect(html).toContain('data-od-sandbox-shim');
+    expect(html).toContain('data-od-preview-focus-guard');
+    expect(html).toContain('data-od-preview-redirect-guard');
+    expect(html.indexOf('data-od-sandbox-shim')).toBeLessThan(authorScriptIndex);
+    expect(html.indexOf('data-od-preview-focus-guard')).toBeLessThan(authorScriptIndex);
+    expect(html.indexOf('data-od-preview-redirect-guard')).toBeLessThan(authorScriptIndex);
+  });
+
+  it('preserves and serves complex nested external resources through a guarded URL preview', async () => {
+    const response = await fetch(
+      `${rawUrl('prototypes/booking/index.html')}?odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability&odPreviewBridge=sandbox&odPreviewBridge=focus`,
+    );
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    const firstAuthorScript = html.indexOf('<script src="./scripts/support.js">');
+    expect(firstAuthorScript).toBeGreaterThan(-1);
+    expect(html.indexOf('data-od-sandbox-shim')).toBeLessThan(firstAuthorScript);
+    expect(html.indexOf('data-od-preview-focus-guard')).toBeLessThan(firstAuthorScript);
+    expect(html.match(/type="text\/babel"/g)).toHaveLength(43);
+    expect(html).toContain('<script type="module" src="./scripts/module.js"></script>');
+    expect(html).toContain('srcset="./assets/card.svg 1x, ./assets/card@2x.svg 2x"');
+
+    const baseHref = html.match(/<base href="([^"]+)" data-od-project-preview-base>/)?.[1];
+    expect(baseHref).toBeTruthy();
+    const previewBase = new URL(baseHref!, baseUrl);
+    const expectedResources = new Map([
+      ['./styles/app.css', '@import "./theme.css"; .card { background-image: url("../assets/card.svg"); }'],
+      ['./styles/theme.css', ':root { --accent: #0a7; }'],
+      ['./scripts/support.js', 'window.__supportLoaded = true; fetch("./data.json").then((response) => response.json());'],
+      ['./scripts/module.js', 'export const ready = true;'],
+      ['./components/screen-43.jsx', 'window.__screen43 = () => <section>Screen 43</section>;'],
+      ['./data.json', '{"ready":true}'],
+      ['./assets/card.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>'],
+      ['./assets/card@2x.svg', '<svg xmlns="http://www.w3.org/2000/svg" width="2"/>'],
+    ]);
+    for (const [relativePath, expectedBody] of expectedResources) {
+      const assetResponse = await fetch(new URL(relativePath, previewBase));
+      expect(assetResponse.status, relativePath).toBe(200);
+      expect(await assetResponse.text(), relativePath).toBe(expectedBody);
+    }
   });
 
   it('serves built dist HTML for Vite dev entries so previews do not load /src from daemon root', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -26,6 +26,7 @@ import {
   type WorkspaceCollabContext,
 } from '@open-design/contracts';
 import { PREVIEW_OBSERVABILITY_HOST_STATE_MESSAGE_TYPE } from '@open-design/contracts/runtime/preview-observability';
+import { PREVIEW_URL_GUARD_MAX_HTML_BYTES } from '@open-design/contracts/runtime/preview-guards';
 import {
   appendResourceQuery,
   workspaceIdentityCacheKey,
@@ -379,16 +380,7 @@ const POWERED_PREVIEW_SANDBOX =
   'allow-scripts allow-same-origin allow-downloads allow-popups allow-forms allow-modals allow-pointer-lock';
 const POWERED_PREVIEW_ALLOW =
   'accelerometer; autoplay; camera; cross-origin-isolated; fullscreen; gamepad; gyroscope; microphone; xr-spatial-tracking';
-const PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability';
-// Electron can finish navigating an iframe under a fully transparent retained
-// file viewer without committing its latest compositor surface when the viewer
-// becomes visible again. Adding this layer only while the file is active makes
-// activation itself invalidate that surface. It does not reload the document,
-// so runtime state and warm-tab switching remain intact.
-const ACTIVE_PREVIEW_REPAINT_STYLE = {
-  transform: 'translateZ(0)',
-  willChange: 'transform',
-} satisfies CSSProperties;
+const BASE_PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot&odPreviewBridge=observability';
 // Generic runtime UI state carried across the URL-load -> srcDoc transport
 // switch. This preserves the current page of multi-page prototypes while
 // leaving artifact scripts and business state inside their sandboxed frames.
@@ -650,7 +642,6 @@ const PREVIEW_SCOPE_RETRY_MS = 15 * 1000;
 const SRC_DOC_PREVIEW_FRAME_NAME_PREFIX = 'od-artifact-preview-srcdoc-';
 const SRC_DOC_PREVIEW_FAILURE_FRESHNESS_MS = 10_000;
 const MAX_CACHED_SRC_DOC_TRANSPORTS = 128;
-const MAX_CACHED_PREVIEW_DOCUMENT_URLS = 16;
 let previewContentMeasurementDocumentEpochSequence = 0;
 let previewContentMeasurementHostInstanceSequence = 0;
 let previewTransportGenerationSequence = 0;
@@ -660,7 +651,12 @@ type SrcDocTransportCacheEntry = {
   srcDoc: string;
 };
 const htmlPreviewSrcDocTransportState = new Map<string, SrcDocTransportCacheEntry>();
-const htmlPreviewDocumentUrlState = new Map<string, string>();
+type SharedPreviewBootstrapUrl = {
+  createObjectURL: typeof URL.createObjectURL;
+  html: string;
+  url: string;
+};
+let sharedPreviewBootstrapUrl: SharedPreviewBootstrapUrl | null = null;
 function nextPreviewContentMeasurementDocumentEpoch(): string {
   previewContentMeasurementDocumentEpochSequence += 1;
   return `preview-document-${previewContentMeasurementDocumentEpochSequence}`;
@@ -688,7 +684,7 @@ function cacheSrcDocTransport(key: string, entry: SrcDocTransportCacheEntry) {
     if (oldest != null) htmlPreviewSrcDocTransportState.delete(oldest);
   }
 }
-function previewDocumentUrl(key: string, html: string): string | null {
+function persistentPreviewBootstrapUrl(html: string): string | null {
   if (
     !html
     || typeof navigator === 'undefined'
@@ -697,24 +693,39 @@ function previewDocumentUrl(key: string, html: string): string | null {
     || typeof URL.createObjectURL !== 'function'
     || typeof Blob === 'undefined'
   ) return null;
-  const cacheKey = `${key}\0${previewSourceFingerprint(html)}`;
-  const cached = htmlPreviewDocumentUrlState.get(cacheKey);
-  if (cached) {
-    htmlPreviewDocumentUrlState.delete(cacheKey);
-    htmlPreviewDocumentUrlState.set(cacheKey, cached);
-    return cached;
-  }
-  const url = URL.createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }));
-  htmlPreviewDocumentUrlState.set(cacheKey, url);
-  if (htmlPreviewDocumentUrlState.size > MAX_CACHED_PREVIEW_DOCUMENT_URLS) {
-    const oldest = htmlPreviewDocumentUrlState.keys().next().value;
-    if (oldest != null) {
-      const staleUrl = htmlPreviewDocumentUrlState.get(oldest);
-      htmlPreviewDocumentUrlState.delete(oldest);
-      if (staleUrl && typeof URL.revokeObjectURL === 'function') URL.revokeObjectURL(staleUrl);
-    }
-  }
+  const createObjectURL = URL.createObjectURL;
+  if (
+    sharedPreviewBootstrapUrl?.createObjectURL === createObjectURL
+    && sharedPreviewBootstrapUrl.html === html
+  ) return sharedPreviewBootstrapUrl.url;
+
+  // The bootstrap is intentionally tiny and immutable. Electron reliably
+  // paints a Blob-backed document after the activation bridge replaces its
+  // contents; the equivalent data: document can remain visually stale until
+  // the user interacts even though its DOM is already complete. This URL is
+  // shared for the app lifetime and never revoked because retained viewers can
+  // keep referencing it while they are parked behind another file/project.
+  // The full artifact never appears in the Blob; it arrives only through the
+  // generation-checked activation bridge after this listener is ready.
+  const url = createObjectURL(new Blob([html], { type: 'text/html;charset=utf-8' }));
+  sharedPreviewBootstrapUrl = { createObjectURL, html, url };
   return url;
+}
+
+/**
+ * Resolve a daemon resource against the actual app runtime origin.
+ *
+ * `projectRawUrl` intentionally returns a root-relative path for normal host
+ * fetches. Injected documents are different: Electron loads them through an
+ * origin-less bootstrap document, where `/api/...` has no useful project
+ * origin. Pinning an absolute runtime URL keeps relative CSS, scripts, images,
+ * and recovery navigation on the same daemon-backed origin as the app shell.
+ */
+function previewRuntimeUrl(href: string): string {
+  const runtimeHref = typeof globalThis.location?.href === 'string'
+    ? globalThis.location.href
+    : 'http://open-design.local/';
+  return new URL(href, runtimeHref).href;
 }
 type PreviewContentWidthCacheEntry = {
   version: typeof PREVIEW_CONTENT_WIDTH_CACHE_VERSION;
@@ -9933,12 +9944,9 @@ function HtmlViewer({
   const manualEditRequiresSrcDoc = manualEditMode || manualEditSrcDocActive;
   // When we URL-load the iframe directly, skip every in-host inlining /
   // srcDoc-rebuilding step. The browser does the asset resolution itself,
-  // which is the whole point of the URL-load path.
-  // Auto-fall back to the srcDoc path when the artifact will crash under
-  // the URL-load iframe's bare `sandbox="allow-scripts"` — Babel-standalone
-  // React prototypes and any HTML that reads Web Storage at mount throw
-  // SecurityError without `allow-same-origin`. The srcDoc path runs
-  // `injectSandboxShim` before any user script, so those artifacts render.
+  // while the daemon injects passive document guards before authored scripts.
+  // Fall back to srcDoc whenever the URL response cannot carry those guards
+  // (streaming/in-memory HTML or an intentionally unbuffered large document).
   // Memoized on `source` so HtmlViewer's frequent re-renders (board/inspect/
   // edit mode toggles, slide nav) don't re-scan the HTML each time.
   const needsSandboxShim = useMemo(() => {
@@ -9951,14 +9959,15 @@ function HtmlViewer({
     const s = routingHtmlSource;
     return s != null && htmlNeedsFocusGuard(s);
   }, [passiveLargeHtmlPreview, routingHtmlSource]);
-  // A self-redirecting artifact must render through srcDoc so buildSrcdoc's
-  // redirect-loop guard is present; on the raw URL-load path the iframe reloads
-  // itself forever and freezes the workspace (nexu-io/open-design#710).
+  // A self-redirecting artifact needs the redirect-loop guard on whichever
+  // transport owns the document (nexu-io/open-design#710).
   const needsRedirectGuard = useMemo(() => {
     if (passiveLargeHtmlPreview) return false;
     const s = routingHtmlSource;
     return s != null && htmlNeedsRedirectGuard(s);
   }, [passiveLargeHtmlPreview, routingHtmlSource]);
+  const urlDocumentGuardsAvailable =
+    liveHtml === undefined && file.size <= PREVIEW_URL_GUARD_MAX_HTML_BYTES;
   // Set by the injected guard's `od:redirect-loop-blocked` postMessage. The
   // browser makes `window.location` unforgeable, so a runaway reload can only be
   // stopped host-side — parking the srcDoc iframe on static content below. File-
@@ -10088,6 +10097,16 @@ function HtmlViewer({
     const s = routingHtmlSource;
     return s != null && htmlNeedsPoweredPreview(s);
   }, [routingHtmlSource, serverPoweredPreviewRequired]);
+  const previewBridgeQuery = useMemo(() => {
+    const query = [BASE_PREVIEW_BRIDGE_QUERY];
+    // Preserve the old URL-load behavior for ordinary passive documents. Only
+    // request a guard when the source heuristic says this artifact needs it;
+    // this avoids suppressing authored focus/navigation in unrelated pages.
+    if (needsSandboxShim && !needsPowered) query.push('odPreviewBridge=sandbox');
+    if (needsFocusGuard && !needsPowered) query.push('odPreviewBridge=focus');
+    if (needsRedirectGuard && !needsPowered) query.push('odPreviewBridge=redirect');
+    return query.join('&');
+  }, [needsFocusGuard, needsPowered, needsRedirectGuard, needsSandboxShim]);
   const [urlSelectionBridgeReady, setUrlSelectionBridgeReady] = useState(false);
   const urlLoadDecision: UrlLoadDecision = {
     mode,
@@ -10099,12 +10118,23 @@ function HtmlViewer({
     urlModeBridge,
     inspectMode,
     drawMode: drawOverlayOpen,
-    forceInline: (forceInline || needsSandboxShim) && !needsPowered,
+    forceInline: forceInline && !needsPowered,
+    needsSandboxShim: needsSandboxShim && !needsPowered,
+    // Daemon guards wrap the settled on-disk response. Streaming/in-memory
+    // HTML has no matching URL representation, so keep it on srcDoc until it
+    // lands on disk instead of showing stale bytes from the raw route.
+    urlSandboxGuard: urlDocumentGuardsAvailable,
     needsFocusGuard: needsFocusGuard && !needsPowered,
+    urlFocusGuard: urlDocumentGuardsAvailable,
     needsRedirectGuard: needsRedirectGuard && !needsPowered,
+    urlRedirectGuard: urlDocumentGuardsAvailable,
     projectRootAssetRefs: projectRootAssetRefs || scopedRelativeAssetRefs,
   };
-  const useUrlLoadPreview = shouldUrlLoadHtmlPreview(urlLoadDecision) && !manualEditRequiresSrcDoc;
+  const urlLoadPreviewSupported = shouldUrlLoadHtmlPreview({
+    ...urlLoadDecision,
+    mode: 'preview',
+  }) && !manualEditRequiresSrcDoc;
+  const useUrlLoadPreview = mode === 'preview' && urlLoadPreviewSupported;
   const setSrcDocPreviewIframe = useCallback((frame: HTMLIFrameElement | null) => {
     if (srcDocPreviewIframeRef.current !== frame) {
       srcDocNavigationCommittedRef.current = null;
@@ -10298,9 +10328,9 @@ function HtmlViewer({
   const basePreviewSrcUrl = useMemo(
     () => appendResourceQuery(
       projectRawUrl(projectId, file.name, workspaceContext),
-      `v=${Math.round(file.mtime)}&r=${reloadKey}&${PREVIEW_BRIDGE_QUERY}`,
+      `v=${Math.round(file.mtime)}&r=${reloadKey}&${previewBridgeQuery}`,
     ),
-    [projectId, file.name, file.mtime, reloadKey, workspaceContext],
+    [projectId, file.name, file.mtime, previewBridgeQuery, reloadKey, workspaceContext],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
   // Hold the iframe URL still (it carries file.mtime) while the user is mid
@@ -10499,7 +10529,7 @@ function HtmlViewer({
       if (cancelled) return;
       setPowered({
         resolved: true,
-        url: base ? `${base}?v=${Math.round(file.mtime)}&r=${reloadKey}&${PREVIEW_BRIDGE_QUERY}` : null,
+        url: base ? `${base}?v=${Math.round(file.mtime)}&r=${reloadKey}&${previewBridgeQuery}` : null,
       });
     });
     return () => {
@@ -10511,6 +10541,7 @@ function HtmlViewer({
     projectId,
     file.name,
     file.mtime,
+    previewBridgeQuery,
     reloadKey,
   ]);
   const usePoweredPreview = needsPowered && useUrlLoadPreview && powered.url != null;
@@ -10629,7 +10660,7 @@ function HtmlViewer({
   ]);
 
   const srcDocBaseSeedHref = effectiveScopedSrcDocPreviewBase?.href
-    ?? projectRawUrl(projectId, baseDirFor(file.name), workspaceContext);
+    ?? previewRuntimeUrl(projectRawUrl(projectId, baseDirFor(file.name), workspaceContext));
   const srcDocBaseSelectionIdentity = [
     srcDocPreviewBaseIdentity,
     sourceSnapshotRefreshKey,
@@ -10946,6 +10977,17 @@ function HtmlViewer({
     goToSlideRef.current(index);
   }, []);
   const lazySrcDocTransport = useMemo(() => buildLazySrcdocTransport(), []);
+  // Electron keeps one stable, tiny bootstrap document for the lifetime of
+  // this retained file viewer. The fully enhanced artifact (deck/edit/comment
+  // bridges included) is written into that browsing context after the shell's
+  // ready handshake. Content generations therefore do not mutate the parent
+  // iframe's `src` or React key, which removes Chromium's competing Blob
+  // navigations instead of recovering after ERR_ABORTED.
+  const persistentSrcDocTransportUrl = useMemo(
+    () => persistentPreviewBootstrapUrl(lazySrcDocTransport),
+    [lazySrcDocTransport],
+  );
+  const usesPersistentSrcDocTransport = persistentSrcDocTransportUrl !== null;
   const [srcDocTransportResetKey, setSrcDocTransportResetKey] = useState(0);
   const [srcDocShellReady, setSrcDocShellReady] = useState(false);
   const [srcDocRecoveryGeneration, setSrcDocRecoveryGeneration] = useState<string | null>(null);
@@ -10991,10 +11033,24 @@ function HtmlViewer({
     verifiedSrcDocTransportRef.current = null;
     readySrcDocTransportRef.current = null;
     activatedSrcDocTransportHtmlRef.current = null;
-    setSrcDocShellReady(false);
-    setSrcDocRecoveryGeneration(generation);
+    if (!usesPersistentSrcDocTransport) {
+      setSrcDocShellReady(false);
+      setSrcDocRecoveryGeneration(generation);
+    }
+    // The enhanced Electron document installs the same activation listener as
+    // the bootstrap shell. Re-send the exact generation in place; the stable
+    // iframe key below deliberately ignores this nonce so recovery never
+    // replaces its browsing context. Non-Electron transports still use the
+    // nonce as their existing remount key.
     setSrcDocTransportResetKey((key) => key + 1);
-  }, [cancelPendingSrcDocTransport, file.kind, file.name, handoffArtifactKind, projectId]);
+  }, [
+    cancelPendingSrcDocTransport,
+    file.kind,
+    file.name,
+    handoffArtifactKind,
+    projectId,
+    usesPersistentSrcDocTransport,
+  ]);
   useEffect(() => {
     if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !srcDoc) return;
     const generation = srcDocTransportGeneration;
@@ -11172,8 +11228,16 @@ function HtmlViewer({
   // next shell will post `od:srcdoc-transport-ready` (or fire onLoad) and
   // flip this back to true. See #2253.
   useEffect(() => {
+    if (!usesPersistentSrcDocTransport) setSrcDocShellReady(false);
+  }, [srcDocTransportResetKey, usesPersistentSrcDocTransport]);
+  // The workspace keeps FileViewer mounted when a user switches between
+  // projects that expose the same file tab. The frame name still changes with
+  // the project identity, so React replaces the actual iframe. Never let that
+  // new shell inherit the previous frame's ready latch: its first activation
+  // would otherwise race ahead of the bootstrap listener and be dropped.
+  useLayoutEffect(() => {
     setSrcDocShellReady(false);
-  }, [srcDocTransportResetKey]);
+  }, [srcDocPreviewFrameName]);
   // Listen for the shell's ready handshake. Gating activation on this is
   // what fixes the #2253 race: opening Tweaks right after a key-driven
   // re-mount used to post `activate` before the shell's listener was
@@ -11367,42 +11431,35 @@ function HtmlViewer({
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
   }, [workspaceActive]);
-  // Lazy transport preloads an empty shell only while URL-load is the active
-  // transport. Once srcdoc becomes active (sandbox shim, Draw, Screenshot,
-  // Tweaks, etc.), mount the real artifact HTML directly so we do not depend on
-  // a postMessage activation that can race (#2253) and strand the iframe blank
-  // (#2361, #2791).
+  // Non-Electron runtimes retain the historical lazy-shell/direct-srcDoc
+  // split. Electron always keeps the stable bootstrap shell and activates the
+  // enhanced document in place through the handshake above.
   const captureModeActive = drawOverlayOpen;
   // Once `srcDocMaterialized` is set (after the first mode entry), keep the
-  // srcDoc iframe on the real artifact even when hidden behind URL-load, so
-  // re-entering a mode is an instant visibility swap rather than a re-mount +
-  // re-load. Direct-mount path (no #2361/#2791 postMessage race).
+  // srcDoc iframe warm behind URL-load so re-entering a mode is an instant
+  // visibility swap rather than a remount and reload.
   const useLazySrcDocTransport =
-    srcDocRecoveryGeneration === srcDocTransportGeneration
+    usesPersistentSrcDocTransport
+    || srcDocRecoveryGeneration === srcDocTransportGeneration
     || (!manualEditRequiresSrcDoc && !captureModeActive && useUrlLoadPreview && !srcDocMaterialized);
   // Park on a static "loop detected" document once the guard reports a runaway
   // redirect. A self-redirecting artifact is forced onto the srcDoc iframe by
   // `needsRedirectGuard`, so swapping this content is the reliable stop — the
   // placeholder carries no redirect, so the frame settles the moment it loads.
   const redirectLoopBlockedDoc = useMemo(() => buildRedirectLoopBlockedDoc(), []);
-  const srcDocTransportContent = redirectLoopBlocked
+  const srcDocActivationContent = redirectLoopBlocked
     ? redirectLoopBlockedDoc
+    : srcDoc;
+  const srcDocTransportContent = usesPersistentSrcDocTransport
+    ? lazySrcDocTransport
     : useLazySrcDocTransport
       ? lazySrcDocTransport
       : srcDoc;
-  // Chromium can abort an `about:srcdoc` navigation while a retained iframe
-  // is being attached, moved between file tabs, or replaced after an
-  // authorization/base-resolution pass. Load the exact same injected document
-  // through a stable local blob URL instead. This preserves the opaque sandbox
-  // and every injected bridge, but turns the preview into one ordinary URL
-  // navigation and removes the fragile srcdoc commit race entirely.
-  const srcDocTransportUrl = useMemo(
-    () => previewDocumentUrl(
-      `${srcDocTransportGeneration}:${srcDocTransportResetKey}`,
-      srcDocTransportContent,
-    ),
-    [srcDocTransportContent, srcDocTransportGeneration, srcDocTransportResetKey],
-  );
+  // Electron loads only the immutable bootstrap URL here. Full enhanced
+  // documents move through the activation bridge, so a content generation,
+  // project activation, or file-tab switch cannot supersede an in-flight
+  // parent-frame navigation.
+  const srcDocTransportUrl = persistentSrcDocTransportUrl;
   // Materialize the srcDoc iframe the first time it actually becomes the active
   // (visible) transport — i.e. the first Mark/Edit/Comment/Inspect entry. We do
   // NOT pre-render it while hidden/idle: that ran a second live copy during
@@ -11425,9 +11482,17 @@ function HtmlViewer({
     drawOverlayOpen &&
     !manualEditRequiresSrcDoc &&
     shouldUrlLoadHtmlPreview({ ...urlLoadDecision, drawMode: false });
+  // Source mode visually hides the artifact, but it must not destroy a URL
+  // document that is otherwise eligible for passive preview. Replacing the
+  // URL with about:blank on every Preview -> Code transition creates a fresh
+  // navigation on the way back; rapid toggles can abort that navigation in
+  // Electron and leave a structurally active iframe with no painted content.
+  // Keep that one browsing context warm so Code -> Preview is a visibility
+  // swap, just like returning to an already-open file tab.
+  const keepUrlTransportWarmInSourceMode = mode === 'source' && urlLoadPreviewSupported;
   const urlTransportSrc = projectResourceReadBlocked
     ? 'about:blank'
-    : useUrlLoadPreview || srcDocForcedOnlyByDraw
+    : useUrlLoadPreview || srcDocForcedOnlyByDraw || keepUrlTransportWarmInSourceMode
       ? activePreviewSrcUrl
       : 'about:blank';
   const activePoweredPreviewSrcOverride = poweredPreviewSrcOverride
@@ -11474,13 +11539,33 @@ function HtmlViewer({
     setUrlPreviewFirstLoadPending(!urlPreviewLoadedKeysRef.current.has(urlPreviewKeepAliveKey));
   }, [useUrlLoadPreview, urlFrameSrc, urlPreviewKeepAliveKey]);
   const activateSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!canActivateSrcDocTransport({
-      srcDoc,
-      useUrlLoadPreview,
+    const activationInputs = {
+      srcDoc: srcDocActivationContent,
+      useUrlLoadPreview: useUrlLoadPreview && !srcDocMaterialized,
       useLazySrcDocTransport,
       shellReady: srcDocShellReady,
       activatedHtml: activatedSrcDocTransportHtmlRef.current,
-    })) return false;
+    };
+    if (!canActivateSrcDocTransport(activationInputs)) {
+      // A shared Electron Blob can finish its cached bootstrap navigation
+      // before React attaches either the iframe onLoad callback or the parent
+      // message listener. If real content is otherwise ready to activate,
+      // challenge the shell explicitly. A live shell echoes `ready` and this
+      // callback reruns with shellReady=true; a shell that has not installed
+      // its listener yet still has its normal load/ready paths. This closes
+      // the missed-one-shot handshake without a timer or iframe navigation.
+      if (
+        activationInputs.srcDoc
+        && !activationInputs.useUrlLoadPreview
+        && activationInputs.useLazySrcDocTransport
+        && !activationInputs.shellReady
+      ) {
+        target?.contentWindow?.postMessage({
+          type: 'od:srcdoc-transport-shell-probe',
+        }, '*');
+      }
+      return false;
+    }
     // A SECOND activation while Comment mode is on would document.open +
     // write over the iframe's existing document. The window-level message
     // listener survives, but iframe.onLoad does NOT refire for
@@ -11494,7 +11579,11 @@ function HtmlViewer({
     // Skip the remount path in Manual Edit, where the postMessage
     // activate carries the patched HTML and host-side scroll/slide
     // state intentionally stays put across the patch.
-    if (boardMode && activatedSrcDocTransportHtmlRef.current !== null) {
+    if (
+      !usesPersistentSrcDocTransport
+      && boardMode
+      && activatedSrcDocTransportHtmlRef.current !== null
+    ) {
       activatedSrcDocTransportHtmlRef.current = null;
       setSrcDocTransportResetKey((key) => key + 1);
       return true;
@@ -11503,16 +11592,25 @@ function HtmlViewer({
     if (!win) return false;
     win.postMessage({
       type: 'od:srcdoc-transport-activate',
-      html: srcDoc,
+      html: srcDocActivationContent,
       generation: srcDocTransportGeneration,
     }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
+    activatedSrcDocTransportHtmlRef.current = srcDocActivationContent;
     return true;
-  }, [srcDoc, srcDocTransportGeneration, useLazySrcDocTransport, useUrlLoadPreview, srcDocShellReady, boardMode]);
+  }, [
+    boardMode,
+    srcDocActivationContent,
+    srcDocMaterialized,
+    srcDocShellReady,
+    srcDocTransportGeneration,
+    useLazySrcDocTransport,
+    useUrlLoadPreview,
+    usesPersistentSrcDocTransport,
+  ]);
   const activateLoadedSrcDocTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
     if (!canActivateSrcDocTransport({
-      srcDoc,
-      useUrlLoadPreview,
+      srcDoc: srcDocActivationContent,
+      useUrlLoadPreview: useUrlLoadPreview && !srcDocMaterialized,
       useLazySrcDocTransport,
       shellReady: true,
       activatedHtml: activatedSrcDocTransportHtmlRef.current,
@@ -11521,23 +11619,29 @@ function HtmlViewer({
     if (!win) return false;
     win.postMessage({
       type: 'od:srcdoc-transport-activate',
-      html: srcDoc,
+      html: srcDocActivationContent,
       generation: srcDocTransportGeneration,
     }, '*');
-    activatedSrcDocTransportHtmlRef.current = srcDoc;
+    activatedSrcDocTransportHtmlRef.current = srcDocActivationContent;
     return true;
-  }, [srcDoc, srcDocTransportGeneration, useLazySrcDocTransport, useUrlLoadPreview]);
+  }, [
+    srcDocActivationContent,
+    srcDocMaterialized,
+    srcDocTransportGeneration,
+    useLazySrcDocTransport,
+    useUrlLoadPreview,
+  ]);
   const activateSrcDocSnapshotTransport = useCallback((target: HTMLIFrameElement | null = srcDocPreviewIframeRef.current) => {
-    if (!srcDoc) return false;
+    if (!srcDocActivationContent) return false;
     const win = target?.contentWindow;
     if (!win) return false;
     win.postMessage({
       type: 'od:srcdoc-transport-activate',
-      html: srcDoc,
+      html: srcDocActivationContent,
       generation: srcDocTransportGeneration,
     }, '*');
     return true;
-  }, [srcDoc, srcDocTransportGeneration]);
+  }, [srcDocActivationContent, srcDocTransportGeneration]);
   function verifyLoadedSrcDocTransport(target: HTMLIFrameElement | null) {
     if (!target || target !== srcDocPreviewIframeRef.current) return;
     const generation = srcDocTransportGeneration;
@@ -11545,7 +11649,9 @@ function HtmlViewer({
   }
   useEffect(() => {
     if (useUrlLoadPreview) {
-      activatedSrcDocTransportHtmlRef.current = null;
+      if (!usesPersistentSrcDocTransport) {
+        activatedSrcDocTransportHtmlRef.current = null;
+      }
       // Remounting the srcDoc iframe on a render-mode flip resets it to a fresh
       // lazy shell — needed ONLY for the lazy postMessage-activation path
       // (#2253 shell-ready handshake). When the srcDoc iframe is direct-mounted
@@ -11555,19 +11661,33 @@ function HtmlViewer({
       // (URL-load) ↔ Mark (srcDoc): each flip remounted and reloaded. Keep the
       // iframe alive in the direct-mount case so the toggle is a pure
       // visibility swap.
-      if (!wasUrlLoadPreviewRef.current && useLazySrcDocTransport) {
+      if (
+        !usesPersistentSrcDocTransport
+        && !wasUrlLoadPreviewRef.current
+        && useLazySrcDocTransport
+      ) {
         setSrcDocTransportResetKey((key) => key + 1);
       }
       wasUrlLoadPreviewRef.current = true;
       return;
     }
-    if (wasUrlLoadPreviewRef.current && useLazySrcDocTransport) {
+    if (
+      !usesPersistentSrcDocTransport
+      && wasUrlLoadPreviewRef.current
+      && useLazySrcDocTransport
+    ) {
       setSrcDocTransportResetKey((key) => key + 1);
       activatedSrcDocTransportHtmlRef.current = null;
     }
     wasUrlLoadPreviewRef.current = false;
     activateSrcDocTransport();
-  }, [activateSrcDocTransport, useUrlLoadPreview, useLazySrcDocTransport]);
+  }, [
+    activateSrcDocTransport,
+    srcDocTransportResetKey,
+    useLazySrcDocTransport,
+    useUrlLoadPreview,
+    usesPersistentSrcDocTransport,
+  ]);
   // Recovery for a deck that parsed into the srcdoc iframe while the browser
   // tab was hidden: on the first return to a visible document, remount the
   // iframe for a fresh srcdoc parse (the mechanism Comment re-activation
@@ -13174,6 +13294,17 @@ function HtmlViewer({
     win.postMessage({ type: 'od:slide', action: 'go', index: active }, '*');
   }
 
+  useEffect(() => {
+    if (!workspaceActive || mode !== 'preview' || useUrlLoadPreview || !effectiveDeck) return;
+    // Retained project/file viewers keep their iframe browsing context while
+    // hidden. Chromium can repaint that context before the deck bridge has
+    // restored which authored slide is visible, leaving the rail and counter
+    // correct while the main canvas is blank until the user clicks a slide.
+    // Replay the already-cached index when the viewer becomes active; this is
+    // an idempotent bridge message and does not navigate or replace the frame.
+    syncCachedSlideStateToIframe(srcDocPreviewIframeRef.current);
+  }, [effectiveDeck, mode, previewStateKey, useUrlLoadPreview, workspaceActive]);
+
   function fireSpeakerNotesSaveResult(
     editSurface: 'preview' | 'presenter',
     result: 'success' | 'failed',
@@ -14126,8 +14257,10 @@ function HtmlViewer({
       // (PR #4652 / issue #4650 mrcfps review).
       setAnnotationFrozenSource(null);
       activatedSrcDocTransportHtmlRef.current = null;
-      setSrcDocShellReady(false);
-      setSrcDocTransportResetKey((key) => key + 1);
+      if (!usesPersistentSrcDocTransport) {
+        setSrcDocShellReady(false);
+        setSrcDocTransportResetKey((key) => key + 1);
+      }
     }
   }
 
@@ -16861,7 +16994,6 @@ function HtmlViewer({
                             : `artifact-preview-frame-retained-${file.name}`}
                           data-od-render-mode="url-load"
                           data-od-active={mode === 'preview' && useUrlLoadPreview ? 'true' : 'false'}
-                          style={workspaceActive ? ACTIVE_PREVIEW_REPAINT_STYLE : undefined}
                           aria-hidden={workspaceActive && mode === 'preview' && useUrlLoadPreview ? undefined : true}
                           tabIndex={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 0 : -1}
                           title={file.name}
@@ -16905,7 +17037,6 @@ function HtmlViewer({
                             : `artifact-preview-frame-retained-${file.name}`}
                           data-od-render-mode="url-load"
                           data-od-active={mode === 'preview' && useUrlLoadPreview ? 'true' : 'false'}
-                          style={workspaceActive ? ACTIVE_PREVIEW_REPAINT_STYLE : undefined}
                           aria-hidden={workspaceActive && mode === 'preview' && useUrlLoadPreview ? undefined : true}
                           tabIndex={workspaceActive && mode === 'preview' && useUrlLoadPreview ? 0 : -1}
                           title={file.name}
@@ -16943,7 +17074,9 @@ function HtmlViewer({
                         />
                       )}
                       <iframe
-                        key={srcDocTransportResetKey}
+                        key={usesPersistentSrcDocTransport
+                          ? `${srcDocPreviewFrameName}:persistent`
+                          : srcDocTransportResetKey}
                         ref={setSrcDocPreviewIframe}
                         name={srcDocPreviewFrameName}
                         data-testid={workspaceActive
@@ -16951,7 +17084,6 @@ function HtmlViewer({
                           : `artifact-preview-frame-srcdoc-retained-${file.name}`}
                         data-od-render-mode="srcdoc"
                         data-od-active={mode === 'preview' && !useUrlLoadPreview ? 'true' : 'false'}
-                        style={workspaceActive ? ACTIVE_PREVIEW_REPAINT_STYLE : undefined}
                         aria-hidden={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? undefined : true}
                         tabIndex={workspaceActive && mode === 'preview' && !useUrlLoadPreview ? 0 : -1}
                         title={file.name}
@@ -17060,7 +17192,7 @@ function HtmlViewer({
                           <CenteredLoader label={t('fileViewer.loading')} />
                         </div>
                       ) : null}
-                      {!useUrlLoadPreview && !srcDocTransportContent && previewSource === null ? (
+                      {!useUrlLoadPreview && previewSource === null ? (
                         // srcDoc-path twin of the cover above: while the
                         // preview content is still PENDING — the scoped-asset
                         // rewrite waiting on the project file list (deck on a

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -50,6 +50,10 @@ export interface UrlLoadDecision {
   tweaksBridge?: boolean;
   /** User explicitly opted into the inline path via ?forceInline=1. */
   forceInline: boolean;
+  /** The artifact needs the opaque-origin Web Storage/history sandbox shim. */
+  needsSandboxShim?: boolean;
+  /** The daemon-served URL response includes the sandbox shim. */
+  urlSandboxGuard?: boolean;
   /**
    * The source references project files by site-root path (`/assets/x.css`),
    * confirmed against the project's file list (see
@@ -64,6 +68,8 @@ export interface UrlLoadDecision {
    * so `injectPreviewFocusGuard` can suppress the focus grab.
    */
   needsFocusGuard?: boolean;
+  /** The daemon-served URL response includes the focus guard. */
+  urlFocusGuard?: boolean;
   /**
    * The HTML source contains a self-redirecting directive (a
    * `<meta http-equiv="refresh">`, or a load-time `location` navigation /
@@ -72,6 +78,8 @@ export interface UrlLoadDecision {
    * buildSrcdoc) is present to detect and break the loop.
    */
   needsRedirectGuard?: boolean;
+  /** The daemon-served URL response includes the redirect-loop guard. */
+  urlRedirectGuard?: boolean;
 }
 
 /**
@@ -112,11 +120,12 @@ export function shouldUrlLoadHtmlPreview(d: UrlLoadDecision): boolean {
   // the artifact ships a `.tw-panel`.
   if (d.tweaksBridge) return false;
   if (d.forceInline) return false;
-  if (d.needsFocusGuard) return false;
-  // A self-redirecting document must go through srcDoc so buildSrcdoc's
-  // redirect-loop guard is in place; URL-load serves it raw with no guard and
-  // the iframe reloads itself forever (nexu-io/open-design#710).
-  if (d.needsRedirectGuard) return false;
+  if (d.needsSandboxShim && !d.urlSandboxGuard) return false;
+  if (d.needsFocusGuard && !d.urlFocusGuard) return false;
+  // A self-redirecting document needs the redirect-loop guard on whichever
+  // transport owns the document, or the iframe can reload itself forever
+  // (nexu-io/open-design#710).
+  if (d.needsRedirectGuard && !d.urlRedirectGuard) return false;
   // Root-relative project asset refs only resolve after the srcDoc pipeline
   // normalizes them (normalizeRootRelativeProjectAssetRefs); the URL-load
   // path serves the document untouched and the browser 404s each asset.
@@ -148,16 +157,14 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  * Return true when the HTML source contains patterns that fail under the
  * URL-load iframe's bare `sandbox="allow-scripts"` (no `allow-same-origin`).
  *
- * The srcDoc path runs `injectSandboxShim` (see
- * `apps/web/src/runtime/srcdoc.ts`) before any user script, which polyfills
- * `localStorage` / `sessionStorage` so artifacts that read them at mount
- * don't throw `SecurityError` and unmount the React tree. The URL-load path
- * serves raw HTML untouched, so artifacts that touch sandbox-blocked Web
- * Storage at startup go blank.
+ * The preview needs `injectSandboxShim` before any user script, which
+ * polyfills `localStorage` / `sessionStorage` so artifacts that read them at
+ * mount don't throw `SecurityError` and unmount the React tree. Settled,
+ * bounded on-disk HTML can receive this guard from the daemon URL response;
+ * in-memory or large streaming HTML remains on srcDoc.
  *
  * Scope is narrow on purpose. This helper detects three reliable signals
- * visible in the *document* source and routes those artifacts back through
- * srcDoc by toggling `forceInline`:
+ * visible in the *document* source and requests the corresponding guard:
  *
  *   - `<script type="text/babel">` (quoted or unquoted): Babel-standalone
  *     XHR-fetches and evals sibling `.jsx`/`.tsx` files at runtime.
@@ -169,12 +176,11 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  *     parent string scan can't see the linked subresource's body, and
  *     agent-emitted artifacts commonly read Web Storage from an external
  *     `boot.js` / `app.js` at module eval (issue #2361). Conservatively
- *     route any external script through srcDoc so the shim is in place
+ *     guard any external script response so the shim is in place
  *     before that read happens. The alternative — fetching every script
  *     URL ahead of the iframe and scanning it — would duplicate work the
  *     browser is about to do and add round trips on every preview load,
- *     so the heuristic favors a few extra srcDoc-mode previews over those
- *     additional requests.
+ *     so the heuristic favors a passive guard over those additional requests.
  *
  * Remaining known limitation: dynamically injected scripts
  * (`document.createElement('script'); s.src = '…'; head.appendChild(s)`)
@@ -186,14 +192,13 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  *
  * Pure string scan — caller passes the same `source` already fetched for
  * preview rendering, so this adds no extra I/O. Heuristic by design: false
- * positives just take the (slightly slower but safer) srcDoc path; false
- * negatives are the same blank-preview the user already hits.
+ * positives add a passive guard to that preview; false negatives are the same
+ * blank-preview the user already hits.
  */
 /**
  * Return true when the HTML source may call `.focus()` at load time, which
- * would steal focus from the host page in a URL-loaded iframe. The srcDoc
- * path injects `injectPreviewFocusGuard` to suppress this; URL-load has no
- * such guard, so we force the srcDoc path instead.
+ * would steal focus from the host page in a URL-loaded iframe. The daemon URL
+ * response or srcDoc path injects `injectPreviewFocusGuard` to suppress this.
  *
  * Detection covers two cases:
  *
@@ -202,8 +207,7 @@ export function parseForceInline(search: string | URLSearchParams | null | undef
  *   2. External `<script src=...>` references — we cannot inspect the linked
  *      file's content, so we conservatively assume it may call focus.
  *
- * False positives just route the artifact through the slightly slower srcDoc
- * path, which is the safe direction.
+ * False positives add a passive focus guard, which is the safe direction.
  */
 export function htmlNeedsFocusGuard(source: string): boolean {
   if (/\.\s*focus\s*\(/i.test(source)) return true;
@@ -273,26 +277,22 @@ export function htmlNeedsSandboxShim(source: string): boolean {
 /**
  * Return true when the HTML source contains a self-redirecting directive that
  * can loop forever and freeze the preview iframe (nexu-io/open-design#710).
- * When true, FileViewer forces the srcDoc path so buildSrcdoc's
- * `injectPreviewRedirectGuard` is present to detect and break the loop — the
- * URL-load path serves the document untouched and has no such guard.
+ * When true, FileViewer requires `injectPreviewRedirectGuard` on whichever
+ * transport owns the document so the loop can be detected and broken.
  *
  * Detection covers the two families that produce the freeze:
  *
  *   1. `<meta http-equiv="refresh">` — the canonical HTML redirect; a
  *      self-target or a cycle reloads the frame endlessly.
- *   2. Load-time `location` navigation — `location.reload()`,
+ *   2. Inline load-time `location` navigation — `location.reload()`,
  *      `location.replace(...)`, `location.assign(...)`, or assigning
  *      `location`/`location.href`/`window.location`. Any of these run at parse
- *      time can re-navigate the frame in a loop. External `<script src=...>`
- *      already routes through srcDoc via `htmlNeedsSandboxShim` /
- *      `htmlNeedsFocusGuard`, so a redirect hidden in a linked file is covered
- *      too.
+ *      time can re-navigate the frame in a loop. A redirect hidden exclusively
+ *      in an external script is not statically visible to this source scan.
  *
  * Pure string scan over the same `source` already fetched for preview — no
- * extra I/O. Heuristic by design: a false positive just takes the (guarded,
- * slightly slower) srcDoc path, which is the safe direction; a false negative
- * is the same unguarded preview as before.
+ * extra I/O. Heuristic by design: a false positive adds a passive guard; a
+ * false negative is the same unguarded preview as before.
  */
 export function htmlNeedsRedirectGuard(source: string | null | undefined): boolean {
   if (!source) return false;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1038,15 +1038,23 @@ export async function exportProjectAsPptx(opts: {
 // a plain `.slide` class as proof of a deck: ordinary pages often use that token
 // for carousels/testimonials and still need full-page/scroll-stitch capture.
 function sourceLooksLikeStructuredDeck(source: string): boolean {
+  // Inspect markup, not examples or compatibility notes embedded in the
+  // document. Print bridges commonly mention `<deck-stage>` in comments or
+  // script strings while guarding optional deck behavior; treating those
+  // literals as real elements turns ordinary reports into a one-slide deck and
+  // incorrectly mounts navigation and speaker notes.
+  const markup = source
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
   return (
     /<deck-stage[\s/>]|class\s*=\s*['"](?:[^'"]*\s)?(?:deck-slide|ppt-slide)(?:\s|['"])/i.test(
-      source,
+      markup,
     ) ||
     /<[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])[^>]*\bdata-title\s*=|<[^>]*\bdata-title\s*=[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(
-      source,
+      markup,
     ) ||
     /<[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?deck(?:\s|['"])[^>]*>\s*<[^>]*\bclass\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(
-      source,
+      markup,
     )
   );
 }

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -26,6 +26,19 @@ import {
   buildPreviewBaseHrefBridge,
   buildPreviewObservabilityBridge,
 } from '@open-design/contracts/runtime/preview-observability';
+import {
+  PREVIEW_REDIRECT_GUARD_MAX_HOPS,
+  PREVIEW_REDIRECT_GUARD_SELF_REFRESH_MIN_DELAY_MS,
+  PREVIEW_REDIRECT_GUARD_WINDOW_MS,
+  PREVIEW_REDIRECT_LOOP_MESSAGE,
+} from '@open-design/contracts/runtime/preview-guards';
+
+export {
+  PREVIEW_REDIRECT_GUARD_MAX_HOPS,
+  PREVIEW_REDIRECT_GUARD_SELF_REFRESH_MIN_DELAY_MS,
+  PREVIEW_REDIRECT_GUARD_WINDOW_MS,
+  PREVIEW_REDIRECT_LOOP_MESSAGE,
+} from '@open-design/contracts/runtime/preview-guards';
 
 import {
   buildManualEditBridge,
@@ -101,18 +114,6 @@ export type SrcdocOptions = {
 // unforgeable, so a JS `location.reload()` storm can only be halted host-side
 // by swapping the iframe to static content (see FileViewer). The in-iframe half
 // still fully covers the canonical meta-refresh redirect loop on its own.
-
-/** Meta-refresh hops allowed inside one window before the loop is broken. */
-export const PREVIEW_REDIRECT_GUARD_MAX_HOPS = 15;
-/** Sliding window (ms). A refresh landing after this many ms with no prior
- *  refresh restarts the count from zero, so a slow auto-refresh never trips. */
-export const PREVIEW_REDIRECT_GUARD_WINDOW_MS = 4000;
-/** A self-refresh (reload the same document) whose delay is at or under this
- *  threshold is a guaranteed freeze in a static preview and is killed on the
- *  first hop, without waiting for the hop budget. */
-export const PREVIEW_REDIRECT_GUARD_SELF_REFRESH_MIN_DELAY_MS = 2000;
-/** postMessage type the injected guard sends the host when it trips. */
-export const PREVIEW_REDIRECT_LOOP_MESSAGE = 'od:redirect-loop-blocked';
 
 export interface RedirectGuardState {
   /** Meta-refresh navigations counted in the current window. */
@@ -496,18 +497,46 @@ export function buildLazySrcdocTransport(): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script data-od-lazy-srcdoc-transport>(function(){
+      var readyInterval = null;
+      var readyAttempts = 0;
+      function stopReadyAnnouncements(){
+        if (readyInterval !== null && typeof clearInterval === 'function') {
+          clearInterval(readyInterval);
+        }
+        readyInterval = null;
+      }
+      function announceReady(){
+        try {
+          if (window.parent && window.parent !== window) {
+            window.parent.postMessage({ type: 'od:srcdoc-transport-ready' }, '*');
+          }
+        } catch (_) { /* sandboxed parent — host falls back to onLoad */ }
+      }
       window.addEventListener('message', function(ev){
         var data = ev && ev.data;
+        if (data && data.type === 'od:srcdoc-transport-shell-probe') {
+          announceReady();
+          return;
+        }
         if (!data || data.type !== 'od:srcdoc-transport-activate' || typeof data.html !== 'string' || typeof data.generation !== 'string' || !data.generation) return;
+        stopReadyAnnouncements();
         document.open();
         document.write(data.html);
         document.close();
       });
-      try {
-        if (window.parent && window.parent !== window) {
-          window.parent.postMessage({ type: 'od:srcdoc-transport-ready' }, '*');
-        }
-      } catch (_) { /* sandboxed parent — host falls back to onLoad */ }
+      announceReady();
+      // A cached app-lifetime Blob can finish long before React attaches the
+      // parent's listener. Keep announcing until activation instead of
+      // guessing a host-mount delay; cap the retries so a broken host cannot
+      // leave a background timer running forever. The host's probe remains a
+      // recovery path after this ten-second window.
+      if (window.parent && window.parent !== window && typeof setInterval === 'function') {
+        readyInterval = setInterval(function(){
+          announceReady();
+          readyAttempts += 1;
+          if (readyAttempts >= 100) stopReadyAnnouncements();
+        }, 100);
+      }
     })();</script>
   </head>
   <body></body>

--- a/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
@@ -595,15 +595,12 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
   });
 
   // ---------------------------------------------------------------------------
-  // Race 4 (P2): routing decision must not flip to URL-load during the
-  // source=null window opened by a Reload click on an artifact whose srcDoc
-  // path is driven by a source-derived predicate (htmlNeedsSandboxShim).
+  // Settled sandbox-shim artifacts now use the daemon-guarded URL path. A
+  // reload must keep that transport stable while the source probe is pending.
   // ---------------------------------------------------------------------------
-  it('keeps the srcDoc iframe active (does not flip to URL-load) while source is null after a Reload click on an htmlNeedsSandboxShim artifact', async () => {
-    // An HTML file that uses localStorage — triggers htmlNeedsSandboxShim and
-    // therefore forces the srcDoc path (forceInline=true).  No .slide class so
-    // looksLikeDeck stays false and isDeck is passed as false; the ONLY reason
-    // this file takes the srcDoc path is the sandbox-shim predicate.
+  it('keeps the guarded URL iframe active while source is null after Reload', async () => {
+    // localStorage requires the sandbox shim, but settled on-disk HTML can now
+    // receive that shim from the daemon without taking the srcDoc transport.
     const shimFile: ProjectFile = {
       name: 'app.html',
       path: 'app.html',
@@ -616,8 +613,7 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
     const shimHtml =
       '<html><body><script>localStorage.setItem("key","val");</script><p>loaded</p></body></html>';
 
-    // Step 1: mount with shimHtml — source is non-null, needsSandboxShim=true,
-    // forceInline=true, useUrlLoadPreview=false → srcDoc iframe is active.
+    // Step 1: mount with shimHtml and wait for the guarded URL lane.
     vi.stubGlobal('fetch', fetchReturning(shimHtml));
 
     render(
@@ -631,17 +627,14 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
 
     // Wait for the source fetch to resolve so the component has non-null source.
     await waitFor(() => {
-      // The srcDoc iframe is active: its testid is 'artifact-preview-frame'
-      // (not 'artifact-preview-frame-srcdoc') when useUrlLoadPreview=false.
       const frame = screen.queryByTestId('artifact-preview-frame');
       expect(frame).not.toBeNull();
-      expect((frame as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect((frame as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('url-load');
+      expect((frame as HTMLIFrameElement).getAttribute('src')).toContain('odPreviewBridge=sandbox');
     });
 
-    // Step 2: click Reload — source goes null synchronously.  Without the fix,
-    // needsSandboxShim(null)=false → forceInline flips → useUrlLoadPreview
-    // becomes true → the URL-load iframe hijacks testid 'artifact-preview-frame'
-    // and the srcDoc iframe is renamed to 'artifact-preview-frame-srcdoc'.
+    // Step 2: click Reload. The source probe is deferred so we observe the
+    // intermediate source=null window.
     const { handle: reloadHandle, stub: reloadStub } = deferredFetch();
     vi.stubGlobal('fetch', reloadStub);
 
@@ -649,29 +642,75 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
       fireEvent.click(screen.getByRole('button', { name: /reload preview/i }));
     });
 
-    // Step 3: assert BEFORE the fetch resolves — this is the reload window
-    // where the source=null race can expose the bug.
-    //
-    // The srcDoc iframe must remain the active iframe: its testid stays
-    // 'artifact-preview-frame' and its data-od-render-mode is 'srcdoc'.
-    // If the routing flipped, a URL-load iframe would have taken the
-    // 'artifact-preview-frame' testid and data-od-active='true' instead.
+    // Step 3: the same URL transport remains active; it must not fall through
+    // to the dormant srcDoc/bootstrap iframe while the probe is pending.
     const activeFrame = screen.getByTestId('artifact-preview-frame');
-    expect(activeFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+    expect(activeFrame.getAttribute('data-od-render-mode')).toBe('url-load');
     expect(activeFrame.getAttribute('data-od-active')).toBe('true');
+    expect(activeFrame.getAttribute('src')).toContain('odPreviewBridge=sandbox');
 
-    // Confirm the URL-load iframe is NOT the active one (it would carry
-    // data-od-render-mode='url-load' and data-od-active='true' on a buggy build).
-    const urlLoadFrame = screen.queryByTestId('artifact-preview-frame-url-load');
-    if (urlLoadFrame) {
-      expect(urlLoadFrame.getAttribute('data-od-active')).toBe('false');
-    }
+    const srcDocFrame = screen.queryByTestId('artifact-preview-frame-srcdoc');
+    expect(srcDocFrame?.getAttribute('data-od-active')).toBe('false');
 
     // Drain the deferred fetch so it doesn't leak into subsequent tests.
     await act(async () => {
       reloadHandle.resolve(shimHtml);
       await Promise.resolve();
     });
+  });
+
+  it('keeps a 43-file Babel prototype on the guarded real-URL transport', async () => {
+    const externalScripts = Array.from(
+      { length: 43 },
+      (_, index) => `<script type="text/babel" src="./components/screen-${index + 1}.jsx"></script>`,
+    ).join('');
+    const html = [
+      '<!doctype html><html><head>',
+      '<link rel="stylesheet" href="./styles/app.css">',
+      '<script src="./scripts/support.js"></script>',
+      externalScripts,
+      '<script type="module" src="./scripts/module.js"></script>',
+      '</head><body>',
+      '<img src="./assets/card.svg" srcset="./assets/card.svg 1x, ./assets/card@2x.svg 2x">',
+      '<main id="root"></main>',
+      '</body></html>',
+    ].join('');
+    vi.stubGlobal('fetch', fetchReturning(html));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={{
+          name: 'prototypes/booking/index.html',
+          path: 'prototypes/booking/index.html',
+          type: 'file',
+          size: 64 * 1024,
+          mtime: 1710000002,
+          kind: 'html',
+          mime: 'text/html',
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(frame.getAttribute('data-od-active')).toBe('true');
+      const src = new URL(frame.getAttribute('src') ?? '', 'http://localhost');
+      expect(src.pathname).toBe('/api/projects/project-1/raw/prototypes/booking/index.html');
+      expect(src.searchParams.getAll('odPreviewBridge')).toEqual([
+        'scroll',
+        'selection',
+        'snapshot',
+        'observability',
+        'sandbox',
+        'focus',
+      ]);
+      expect(src.searchParams.getAll('odPreviewBridge')).not.toContain('redirect');
+    });
+
+    expect(screen.getByTestId('artifact-preview-frame-srcdoc').getAttribute('data-od-active')).toBe('false');
   });
 
   // ---------------------------------------------------------------------------
@@ -1178,7 +1217,7 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
 
     vi.stubGlobal('fetch', fetchMock);
 
-    // Step 1: mount and wait for source V1 to land in the preview.
+    // Step 1: settled source starts on the daemon-guarded URL lane.
     render(
       <FileViewer
         projectId="project-1"
@@ -1189,12 +1228,19 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
 
     await waitFor(() => {
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-      expect(frame.srcdoc).toContain('Hello');
+      expect(frame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(frame.getAttribute('src')).toContain('odPreviewBridge=sandbox');
     });
 
     // Step 2: enter Manual Edit mode — manualEditFrozenSource captures V1.
     act(() => {
       fireEvent.click(screen.getByTestId('manual-edit-mode-toggle'));
+    });
+
+    await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(frame.srcdoc).toContain('Hello');
     });
 
     // Step 3: select a target so the panel (and onApplyPatch) is available.

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -824,7 +824,7 @@ describe('FileViewer preview scale', () => {
     expect(rawReads[0]?.init?.headers).toBeUndefined();
   });
 
-  it('warms a newly retained inactive HTML viewer before its first activation', async () => {
+  it('warms a newly retained inactive HTML viewer without forcing a GPU layer on activation', async () => {
     const file = baseFile({
       name: 'inactive-first-open.html',
       path: 'inactive-first-open.html',
@@ -888,8 +888,8 @@ describe('FileViewer preview scale', () => {
     expect(document.querySelector('iframe[data-testid="artifact-preview-frame"]')).toBe(retainedFrame);
     expect(container.querySelector<HTMLElement>('.viewer-toolbar')?.style.visibility).toBe('');
     expect(retainedFrame.style.visibility).toBe('');
-    expect(retainedFrame.style.transform).toBe('translateZ(0)');
-    expect(retainedFrame.style.willChange).toBe('transform');
+    expect(retainedFrame.style.transform).toBe('');
+    expect(retainedFrame.style.willChange).toBe('');
     expect(rawReads).toHaveLength(1);
   });
 
@@ -1760,6 +1760,41 @@ describe('FileViewer SVG artifacts', () => {
     expect(parkedFrames).not.toContain(firstFrame);
   });
 
+  it('recreates an evicted preview iframe at its artifact URL when revisited', () => {
+    function Harness({ activeKey }: { activeKey: string | null }) {
+      return (
+        <IframeKeepAliveProvider maxEntries={1}>
+          {activeKey ? (
+            <PooledIframe
+              cacheKey={previewIframeKeepAliveKey('project-1', `${activeKey}.html`)}
+              src={`/api/projects/project-1/raw/${activeKey}.html?v=1&r=0`}
+              title={`${activeKey}.html`}
+              data-testid="pooled-frame"
+              data-od-render-mode="url-load"
+              data-od-active="true"
+            />
+          ) : null}
+        </IframeKeepAliveProvider>
+      );
+    }
+
+    const { rerender } = render(<Harness activeKey="one" />);
+    const firstFrame = screen.getByTestId('pooled-frame') as HTMLIFrameElement;
+
+    rerender(<Harness activeKey={null} />);
+    rerender(<Harness activeKey="two" />);
+    expect(document.body.contains(firstFrame)).toBe(false);
+
+    rerender(<Harness activeKey={null} />);
+    rerender(<Harness activeKey="one" />);
+    const recreatedFrame = screen.getByTestId('pooled-frame') as HTMLIFrameElement;
+
+    expect(recreatedFrame).not.toBe(firstFrame);
+    expect(recreatedFrame.getAttribute('src')).toBe(
+      '/api/projects/project-1/raw/one.html?v=1&r=0',
+    );
+  });
+
   it('parks a newly pooled iframe before starting its srcDoc navigation', () => {
     const originalSetAttribute = HTMLIFrameElement.prototype.setAttribute;
     const navigationAttributes: string[] = [];
@@ -1866,10 +1901,10 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByTestId('artifact-preview-first-load')).not.toBeInTheDocument();
   });
 
-  it('loads an inline preview through a blob URL when the browser supports it', () => {
+  it('keeps one Electron bootstrap URL while enhanced content generations update in place', async () => {
     const originalCreateObjectURL = URL.createObjectURL;
     const originalRevokeObjectURL = URL.revokeObjectURL;
-    const createObjectURL = vi.fn(() => 'blob:od://app/preview-document');
+    const createObjectURL = vi.fn((_blob: Blob) => 'blob:od://app/shared-preview-bootstrap');
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
       value: createObjectURL,
@@ -1881,26 +1916,133 @@ describe('FileViewer SVG artifacts', () => {
     const userAgent = vi.spyOn(window.navigator, 'userAgent', 'get')
       .mockReturnValue('OpenDesign/0.20 Electron/41.3.0');
     try {
-      render(
+      const renderViewer = (liveHtml: string, workspaceActive = true) => (
         <FileViewer
           projectId="blob-preview-project"
           projectKind="prototype"
           file={baseFile({
-            name: 'blob-preview.html',
-            path: 'blob-preview.html',
+            name: 'pages/blob-preview.html',
+            path: 'pages/blob-preview.html',
             mime: 'text/html',
             kind: 'html',
           })}
-          liveHtml={'<!doctype html><html><body><main>Blob preview</main><script>location.reload()</script></body></html>'}
-          workspaceActive
-        />,
+          liveHtml={liveHtml}
+          workspaceActive={workspaceActive}
+        />
       );
+      const firstSource = '<!doctype html><html><head><link rel="stylesheet" href="app.css"></head><body><main>Blob preview v1</main><img src="art.png"><script src="app.jsx"></script><script>location.reload()</script></body></html>';
+      const secondSource = '<!doctype html><html><body><main>Blob preview v2</main><script>location.reload()</script></body></html>';
+      const { rerender } = render(renderViewer(firstSource));
 
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
       expect(createObjectURL).toHaveBeenCalledTimes(1);
-      expect(frame.getAttribute('src')).toBe('blob:od://app/preview-document');
+      const bootstrapUrl = frame.getAttribute('src');
+      expect(bootstrapUrl).toBe('blob:od://app/shared-preview-bootstrap');
+      const bootstrapBlob = createObjectURL.mock.calls[0]?.[0] as Blob;
+      expect(await bootstrapBlob.text()).toContain('data-od-lazy-srcdoc-transport');
       expect(frame.hasAttribute('srcdoc')).toBe(false);
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+      fireEvent.load(frame);
+      const activations = () => postMessage.mock.calls
+        .map(([message]) => message as { type?: unknown; html?: string; generation?: string })
+        .filter((message) => message.type === 'od:srcdoc-transport-activate');
+      await waitFor(() => expect(activations()).toHaveLength(1));
+      expect(activations()[0]?.html).toContain('Blob preview v1');
+      expect(activations()[0]?.html).toContain(
+        '<base href="http://localhost:3000/api/projects/blob-preview-project/raw/pages/" data-od-project-preview-base>',
+      );
+      expect(activations()[0]?.html).toContain('src="app.jsx"');
+      expect(activations()[0]?.html).toContain('data-od-edit-bridge');
+      expect(activations()[0]?.html).toContain('data-od-srcdoc-transport-activation');
+
+      rerender(renderViewer(secondSource));
+      await waitFor(() => expect(activations()).toHaveLength(2));
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(frame.getAttribute('src')).toBe(bootstrapUrl);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(activations()[1]?.html).toContain('Blob preview v2');
+      expect(activations()[1]?.generation).not.toBe(activations()[0]?.generation);
+
+      rerender(renderViewer(secondSource, false));
+      rerender(renderViewer(secondSource, true));
+      expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+      expect(frame.getAttribute('src')).toBe(bootstrapUrl);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(activations()).toHaveLength(2);
     } finally {
+      userAgent.mockRestore();
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, 'createObjectURL', {
+          configurable: true,
+          value: originalCreateObjectURL,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'createObjectURL');
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, 'revokeObjectURL', {
+          configurable: true,
+          value: originalRevokeObjectURL,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'revokeObjectURL');
+      }
+    }
+  });
+
+  it('re-challenges the shared Electron shell when the same file tab changes projects', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = vi.fn((_blob: Blob) => 'blob:od://app/shared-project-bootstrap');
+    const postMessage = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const userAgent = vi.spyOn(window.navigator, 'userAgent', 'get')
+      .mockReturnValue('OpenDesign/0.20 Electron/41.3.0');
+    const contentWindow = { postMessage } as unknown as Window;
+    const contentWindowGetter = vi.spyOn(
+      HTMLIFrameElement.prototype,
+      'contentWindow',
+      'get',
+    ).mockReturnValue(contentWindow);
+    try {
+      const renderViewer = (projectId: string) => (
+        <FileViewer
+          projectId={projectId}
+          projectKind="prototype"
+          file={baseFile({
+            name: 'index.html',
+            path: 'index.html',
+            mime: 'text/html',
+            kind: 'html',
+          })}
+          liveHtml={'<!doctype html><html><body><main>Project preview</main><script>location.reload()</script></body></html>'}
+          workspaceActive
+        />
+      );
+      const { rerender } = render(renderViewer('project-a'));
+      const firstFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      fireEvent.load(firstFrame);
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'od:srcdoc-transport-activate' }),
+        '*',
+      );
+
+      postMessage.mockClear();
+      rerender(renderViewer('project-b'));
+      expect(screen.getByTestId('artifact-preview-frame')).not.toBe(firstFrame);
+      expect(postMessage).toHaveBeenCalledWith(
+        { type: 'od:srcdoc-transport-shell-probe' },
+        '*',
+      );
+    } finally {
+      contentWindowGetter.mockRestore();
       userAgent.mockRestore();
       if (originalCreateObjectURL) {
         Object.defineProperty(URL, 'createObjectURL', {
@@ -4395,6 +4537,83 @@ describe('FileViewer SVG artifacts', () => {
     expect(srcDocFrame?.srcdoc).toContain('data-od-sandbox-shim');
   });
 
+  it('uses an absolute personal-project base for injected Electron previews', () => {
+    const file = baseFile({
+      name: 'pages/index.html',
+      path: 'pages/index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'pages/index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml='<html><head><link rel="stylesheet" href="app.css"></head><body><script src="app.js"></script><main>Preview</main></body></html>'
+      />,
+    );
+
+    const srcDocFrame = container.querySelector(
+      'iframe[data-od-render-mode="srcdoc"]',
+    ) as HTMLIFrameElement | null;
+    expect(srcDocFrame?.getAttribute('data-od-active')).toBe('true');
+    expect(srcDocFrame?.srcdoc).toContain(
+      '<base href="http://localhost:3000/api/projects/project-1/raw/pages/" data-od-project-preview-base>',
+    );
+  });
+
+  it('keeps the URL document warm across repeated Code and Preview switches', async () => {
+    const file = baseFile({
+      name: 'page.html',
+      path: 'page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml='<html><body><main>Warm URL preview</main></body></html>'
+      />,
+    );
+
+    const initialFrame = container.querySelector(
+      'iframe[data-od-render-mode="url-load"]',
+    ) as HTMLIFrameElement;
+    const initialSrc = initialFrame.getAttribute('src');
+    expect(initialSrc).toContain('/raw/');
+
+    for (let index = 0; index < 6; index += 1) {
+      fireEvent.click(screen.getByRole('tab', { name: 'Code' }));
+      expect(initialFrame.getAttribute('data-od-active')).toBe('false');
+      expect(initialFrame.getAttribute('src')).toBe(initialSrc);
+
+      fireEvent.click(screen.getByRole('tab', { name: 'Preview' }));
+      expect(initialFrame.getAttribute('data-od-active')).toBe('true');
+      expect(initialFrame.getAttribute('src')).toBe(initialSrc);
+    }
+
+    expect(container.querySelector('iframe[data-od-render-mode="url-load"]')).toBe(initialFrame);
+  });
+
   it('keeps srcDoc HTML previews available with a compact Code action', async () => {
     const file = baseFile({
       name: 'page.html',
@@ -4847,6 +5066,31 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByTestId('artifact-preview-frame')).toBeTruthy();
   });
 
+  it('does not show deck notes for a report whose print bridge only mentions deck-stage', () => {
+    const file = baseFile({
+      name: 'annual-report.dc.html',
+      path: 'annual-report.dc.html',
+      mime: 'text/html',
+      kind: 'html',
+    });
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={file}
+        liveHtml={
+          '<main class="doc"><h1>Annual report</h1></main>' +
+          '<!-- await a <deck-stage> only when the optional deck runtime exists -->' +
+          '<script>const example = "<deck-stage></deck-stage>";</script>'
+        }
+      />,
+    );
+
+    expect(screen.queryByTestId('speaker-notes-panel')).toBeNull();
+    expect(screen.queryByTestId('deck-thumbnail-rail')).toBeNull();
+  });
+
   it('keeps deck thumbnail resource URLs independent of shell Workspace changes', async () => {
     const file = baseFile({
       name: 'deck.html',
@@ -4949,6 +5193,57 @@ describe('FileViewer SVG artifacts', () => {
     const editor = panel.querySelector('.speaker-notes-editor textarea') as HTMLTextAreaElement | null;
     expect(editor).toBeTruthy();
     expect(editor?.value).toBe('Intro note');
+  });
+
+  it('replays the cached deck slide when a retained project viewer reactivates', () => {
+    const file = baseFile({
+      name: 'retained-deck.html',
+      path: 'retained-deck.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'deck',
+        title: 'Retained deck',
+        entry: 'retained-deck.html',
+        renderer: 'deck-html',
+        exports: ['html'],
+      },
+    });
+    const renderViewer = (workspaceActive: boolean) => (
+      <FileViewer
+        projectId="project-1"
+        projectKind="slide_deck"
+        file={file}
+        isDeck
+        liveHtml={[
+          '<!doctype html><html><body>',
+          '<section class="slide">one</section>',
+          '<section class="slide">two</section>',
+          '<section class="slide">three</section>',
+          '</body></html>',
+        ].join('')}
+        workspaceActive={workspaceActive}
+      />
+    );
+
+    const { rerender } = render(renderViewer(true));
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: { type: 'od:slide-state', active: 2, count: 3 },
+    }));
+
+    rerender(renderViewer(false));
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage');
+    postMessage.mockClear();
+    rerender(renderViewer(true));
+
+    expect(screen.getByTestId('artifact-preview-frame')).toBe(frame);
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'od:slide', action: 'go', index: 2 },
+      '*',
+    );
   });
 
   it('does not reload deck preview or thumbnails when speaker notes save on blur', async () => {
@@ -10509,7 +10804,12 @@ describe('FileViewer tweaks toolbar', () => {
       );
       expect(src.searchParams.get('v')).toBe('1710000000');
       expect(src.searchParams.get('r')).toBe('0');
-      expect(src.searchParams.getAll('odPreviewBridge')).toEqual(['scroll', 'selection', 'snapshot', 'observability']);
+      expect(src.searchParams.getAll('odPreviewBridge')).toEqual([
+        'scroll',
+        'selection',
+        'snapshot',
+        'observability',
+      ]);
       expect(src.searchParams.get('odPreviewEpoch')).toMatch(/^preview-document-\d+$/);
     });
 

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -65,8 +65,25 @@ describe('shouldUrlLoadHtmlPreview', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, forceInline: true })).toBe(false);
   });
 
+  it('URL-loads sandbox-shim artifacts only when the daemon guard is present', () => {
+    expect(shouldUrlLoadHtmlPreview({ ...base, needsSandboxShim: true })).toBe(false);
+    expect(shouldUrlLoadHtmlPreview({
+      ...base,
+      needsSandboxShim: true,
+      urlSandboxGuard: true,
+    })).toBe(true);
+  });
+
   it('falls back to srcDoc when the HTML source needs a focus guard', () => {
     expect(shouldUrlLoadHtmlPreview({ ...base, needsFocusGuard: true })).toBe(false);
+  });
+
+  it('URL-loads focus-guard artifacts only when the daemon guard is present', () => {
+    expect(shouldUrlLoadHtmlPreview({
+      ...base,
+      needsFocusGuard: true,
+      urlFocusGuard: true,
+    })).toBe(true);
   });
 
   it('falls back to srcDoc when the HTML source needs a redirect guard (issue #710)', () => {
@@ -74,6 +91,14 @@ describe('shouldUrlLoadHtmlPreview', () => {
     // the iframe forever and freezes the workspace. The srcDoc path carries
     // buildSrcdoc's redirect-loop guard.
     expect(shouldUrlLoadHtmlPreview({ ...base, needsRedirectGuard: true })).toBe(false);
+  });
+
+  it('URL-loads redirecting artifacts only when the daemon guard is present', () => {
+    expect(shouldUrlLoadHtmlPreview({
+      ...base,
+      needsRedirectGuard: true,
+      urlRedirectGuard: true,
+    })).toBe(true);
   });
 
   it('falls back to srcDoc when the source references project files by site-root path', () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -144,6 +144,14 @@ describe('sourceLooksLikeNavigableDeck', () => {
     )).toBe(false);
   });
 
+  it('ignores deck-shaped text inside report comments and scripts', () => {
+    expect(sourceLooksLikeNavigableDeck(
+      '<main class="doc"><h1>Annual report</h1></main>' +
+      '<!-- print support waits for a <deck-stage> when one exists -->' +
+      '<script>const example = "<deck-stage></deck-stage>";</script>',
+    )).toBe(false);
+  });
+
   it('keeps explicit and multi-screen persisted decks navigable', () => {
     expect(sourceLooksLikeNavigableDeck(
       '<deck-stage><section data-screen-label="Cover">A</section></deck-stage>',

--- a/apps/web/tests/runtime/srcdoc-transport.test.ts
+++ b/apps/web/tests/runtime/srcdoc-transport.test.ts
@@ -21,6 +21,8 @@ function extractShellScript(shellHtml: string): string {
 
 interface RunShellResult {
   parentMessages: unknown[];
+  runScheduledCallbacks: () => void;
+  triggerMessage: (data: unknown) => void;
   triggerActivate: (html: string, generation?: string) => void;
 }
 
@@ -28,6 +30,9 @@ function runShellInSandbox(shellHtml: string): RunShellResult {
   const script = extractShellScript(shellHtml);
   const parentMessages: unknown[] = [];
   const messageListeners: Array<(ev: { data: unknown }) => void> = [];
+  const scheduledCallbacks: Array<() => void> = [];
+  const intervalCallbacks = new Map<number, () => void>();
+  let nextIntervalId = 1;
   const parentMock = {
     postMessage: (data: unknown) => {
       parentMessages.push(data);
@@ -46,12 +51,30 @@ function runShellInSandbox(shellHtml: string): RunShellResult {
   };
   const sandbox: Record<string, unknown> = {
     document: documentMock,
+    setTimeout: (callback: () => void) => {
+      scheduledCallbacks.push(callback);
+    },
+    setInterval: (callback: () => void) => {
+      const intervalId = nextIntervalId++;
+      intervalCallbacks.set(intervalId, callback);
+      return intervalId;
+    },
+    clearInterval: (intervalId: number) => {
+      intervalCallbacks.delete(intervalId);
+    },
     window: win,
   };
   vm.createContext(sandbox);
   vm.runInContext(script, sandbox);
   return {
     parentMessages,
+    runScheduledCallbacks: () => {
+      for (const callback of scheduledCallbacks.splice(0)) callback();
+      for (const callback of intervalCallbacks.values()) callback();
+    },
+    triggerMessage: (data: unknown) => {
+      for (const listener of messageListeners) listener({ data });
+    },
     triggerActivate: (html: string, generation = 'generation-1') => {
       for (const listener of messageListeners) {
         listener({ data: { type: 'od:srcdoc-transport-activate', html, generation } });
@@ -65,6 +88,34 @@ describe('buildLazySrcdocTransport (#2253)', () => {
     const shell = buildLazySrcdocTransport();
     const { parentMessages } = runShellInSandbox(shell);
     expect(parentMessages).toContainEqual({ type: 'od:srcdoc-transport-ready' });
+  });
+
+  it('replies when the host probes after missing the initial ready message', () => {
+    const shell = buildLazySrcdocTransport();
+    const result = runShellInSandbox(shell);
+    result.parentMessages.length = 0;
+
+    result.triggerMessage({ type: 'od:srcdoc-transport-shell-probe' });
+
+    expect(result.parentMessages).toEqual([{ type: 'od:srcdoc-transport-ready' }]);
+  });
+
+  it('reannounces ready until a late host activates the cached bootstrap', () => {
+    const shell = buildLazySrcdocTransport();
+    const result = runShellInSandbox(shell);
+    result.parentMessages.length = 0;
+
+    result.runScheduledCallbacks();
+    expect(result.parentMessages).toContainEqual({ type: 'od:srcdoc-transport-ready' });
+
+    result.parentMessages.length = 0;
+    result.runScheduledCallbacks();
+    expect(result.parentMessages).toContainEqual({ type: 'od:srcdoc-transport-ready' });
+
+    result.triggerActivate('<html><body>activated</body></html>');
+    result.parentMessages.length = 0;
+    result.runScheduledCallbacks();
+    expect(result.parentMessages).toEqual([]);
   });
 
   it('skips the ready post when window.parent equals window (top-level load)', () => {

--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -16,6 +16,7 @@ await build({
     "./src/api/research.ts",
     "./src/runtime/deck-stage-fallback.ts",
     "./src/runtime/preview-observability.ts",
+    "./src/runtime/preview-guards.ts",
     "./src/design-systems/components-manifest.ts",
     "./src/design-systems/derived-token-outputs.ts",
     "./src/design-systems/token-schema.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -54,6 +54,10 @@
       "types": "./dist/runtime/preview-observability.d.ts",
       "default": "./dist/runtime/preview-observability.mjs"
     },
+    "./runtime/preview-guards": {
+      "types": "./dist/runtime/preview-guards.d.ts",
+      "default": "./dist/runtime/preview-guards.mjs"
+    },
     "./design-systems/components-manifest": {
       "types": "./dist/design-systems/components-manifest.d.ts",
       "default": "./dist/design-systems/components-manifest.mjs"

--- a/packages/contracts/src/runtime/preview-guards.ts
+++ b/packages/contracts/src/runtime/preview-guards.ts
@@ -1,0 +1,254 @@
+/**
+ * Cross-runtime preview guard constants plus daemon-safe script builders.
+ *
+ * The srcDoc runtime consumes the shared redirect protocol constants; the
+ * daemon uses the inert script builders to install equivalent passive guards
+ * in a real-URL response without importing browser-app private source.
+ */
+
+export const PREVIEW_REDIRECT_GUARD_MAX_HOPS = 15;
+export const PREVIEW_REDIRECT_GUARD_WINDOW_MS = 4000;
+export const PREVIEW_REDIRECT_GUARD_SELF_REFRESH_MIN_DELAY_MS = 2000;
+export const PREVIEW_REDIRECT_LOOP_MESSAGE = 'od:redirect-loop-blocked';
+/**
+ * URL preview responses above this size stay byte-for-byte streamable so the
+ * daemon can honor Range requests and avoid buffering a very large document.
+ * Callers must not claim URL guards are installed above this boundary.
+ */
+export const PREVIEW_URL_GUARD_MAX_HTML_BYTES = 2 * 1024 * 1024;
+
+export function previewHtmlHasLoadTimeLocationNavigation(source: string): boolean {
+  if (/\blocation\s*\.\s*(?:reload|replace|assign)\s*\(/i.test(source)) return true;
+  if (/\blocation\s*\.\s*href\s*=[^=]/i.test(source)) return true;
+  if (/\b(?:window|document|self|top|parent)\s*\.\s*location\s*=[^=]/i.test(source)) return true;
+  return false;
+}
+
+export function buildPreviewSandboxShim(): string {
+  return `<script data-od-sandbox-shim>(function(){
+  function makeStore(){
+    var data = {};
+    var api = {
+      getItem: function(k){ return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null; },
+      setItem: function(k, v){ data[k] = String(v); },
+      removeItem: function(k){ delete data[k]; },
+      clear: function(){ data = {}; },
+      key: function(i){ return Object.keys(data)[i] || null; }
+    };
+    Object.defineProperty(api, 'length', { get: function(){ return Object.keys(data).length; } });
+    return api;
+  }
+  function tryShim(name){
+    var works = false;
+    try { works = !!window[name] && typeof window[name].getItem === 'function'; void window[name].length; }
+    catch (_) { works = false; }
+    if (works) return;
+    try { Object.defineProperty(window, name, { configurable: true, value: makeStore() }); }
+    catch (_) { try { window[name] = makeStore(); } catch (__) {} }
+  }
+  tryShim('localStorage');
+  tryShim('sessionStorage');
+  function shimHistoryMethod(name){
+    try {
+      var h = window.history;
+      var original = h && h[name];
+      if (typeof original !== 'function') return;
+      h[name] = function(state, title, url){
+        try { return original.call(h, state, title, url); }
+        catch (_) { return undefined; }
+      };
+    } catch (_) {}
+  }
+  shimHistoryMethod('pushState');
+  shimHistoryMethod('replaceState');
+  document.addEventListener('click', function(e){
+    if (!e.target || !(e.target instanceof Element)) return;
+    var link = e.target.closest('a[href]');
+    if (!link) return;
+    var href = link.getAttribute('href');
+    if (href === null) return;
+    var isAnchor = href.indexOf('#') === 0 || href === '';
+    if (isAnchor) {
+      e.preventDefault();
+      if (href === '' || href === '#') {
+        window.scrollTo({ top: 0 });
+        history.replaceState(null, '', ' ');
+      } else {
+        var targetId = href.slice(1);
+        var target = targetId ? document.getElementById(targetId) : null;
+        if (target) {
+          target.scrollIntoView();
+          if (location.hash === href) history.replaceState(null, '', ' ');
+          location.hash = href;
+        }
+      }
+    } else if (link.getAttribute('target') === '_blank') {
+      e.preventDefault();
+      var safe = false;
+      try {
+        var parsedUrl = new URL(href, location.href);
+        safe = parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'mailto:';
+      } catch (_) {}
+      if (safe) window.open(href, '_blank', 'noopener,noreferrer');
+    }
+  });
+})();</script>`;
+}
+
+export function buildPreviewFocusGuard(): string {
+  return `<script data-od-preview-focus-guard>(function(){
+  var lastTrustedInputAt = 0;
+  function userActivated(){ return Date.now() - lastTrustedInputAt < 1000; }
+  function markTrustedInput(event){ if (event && event.isTrusted) lastTrustedInputAt = Date.now(); }
+  document.addEventListener('pointerdown', function(event){ markTrustedInput(event); }, true);
+  document.addEventListener('keydown', function(event){ markTrustedInput(event); }, true);
+  try {
+    var nativeWindowFocus = window.focus && window.focus.bind(window);
+    Object.defineProperty(window, 'focus', {
+      configurable: true,
+      writable: true,
+      value: function(){ if (userActivated() && nativeWindowFocus) return nativeWindowFocus(); }
+    });
+  } catch (_) {}
+  try {
+    var nativeElementFocus = HTMLElement.prototype.focus;
+    Object.defineProperty(HTMLElement.prototype, 'focus', {
+      configurable: true,
+      writable: true,
+      value: function(options){ if (userActivated()) return nativeElementFocus.call(this, options); }
+    });
+  } catch (_) {}
+})();</script>`;
+}
+
+export function buildPreviewRedirectGuard(
+  options: { blockLoadTimeScriptRedirect?: boolean } = {},
+): string {
+  return `<script data-od-preview-redirect-guard>(function(){
+  var NAME_PREFIX = '__odRedirectGuard=';
+  var MAX_HOPS = ${PREVIEW_REDIRECT_GUARD_MAX_HOPS};
+  var WINDOW_MS = ${PREVIEW_REDIRECT_GUARD_WINDOW_MS};
+  var SELF_MIN_DELAY_MS = ${PREVIEW_REDIRECT_GUARD_SELF_REFRESH_MIN_DELAY_MS};
+  var MESSAGE_TYPE = ${JSON.stringify(PREVIEW_REDIRECT_LOOP_MESSAGE)};
+  var BLOCK_LOAD_TIME_SCRIPT_REDIRECT = ${options.blockLoadTimeScriptRedirect ? 'true' : 'false'};
+  function nowMs(){ try { return Date.now(); } catch (_) { return 0; } }
+  function readState(){
+    try {
+      var raw = window.name;
+      if (typeof raw === 'string' && raw.indexOf(NAME_PREFIX) === 0) {
+        var parsed = JSON.parse(raw.slice(NAME_PREFIX.length));
+        if (parsed && typeof parsed.hops === 'number' && typeof parsed.windowStart === 'number') return parsed;
+      }
+    } catch (_) {}
+    return null;
+  }
+  function writeState(state){
+    try { window.name = NAME_PREFIX + JSON.stringify({ hops: state.hops, windowStart: state.windowStart }); } catch (_) {}
+  }
+  function clearState(){
+    try { if (typeof window.name === 'string' && window.name.indexOf(NAME_PREFIX) === 0) window.name = ''; } catch (_) {}
+  }
+  function nextState(){
+    var t = nowMs();
+    var prev = readState();
+    var withinWindow = prev && (t - prev.windowStart) <= WINDOW_MS;
+    return { hops: (withinWindow ? prev.hops : 0) + 1, windowStart: withinWindow ? prev.windowStart : t };
+  }
+  function scheduleCandidateReset(state){
+    try {
+      if (typeof setTimeout !== 'function') return;
+      setTimeout(function(){
+        try {
+          var current = readState();
+          if (current && current.hops === state.hops && current.windowStart === state.windowStart) clearState();
+        } catch (_) {}
+      }, WINDOW_MS + 1);
+    } catch (_) {}
+  }
+  function report(hops){
+    try {
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage({ type: MESSAGE_TYPE, hops: hops }, '*');
+      }
+    } catch (_) {}
+  }
+  function recordScriptRedirectCandidate(){
+    if (!BLOCK_LOAD_TIME_SCRIPT_REDIRECT) return;
+    var state = nextState();
+    if (state.hops > MAX_HOPS) {
+      clearState();
+      report(state.hops);
+      return;
+    }
+    writeState(state);
+    scheduleCandidateReset(state);
+  }
+  function metaRefreshes(){
+    var out = [];
+    try {
+      var metas = document.getElementsByTagName('meta');
+      for (var i = 0; i < metas.length; i++) {
+        var equiv = metas[i].getAttribute ? metas[i].getAttribute('http-equiv') : null;
+        if (equiv && String(equiv).toLowerCase() === 'refresh') out.push(metas[i]);
+      }
+    } catch (_) {}
+    return out;
+  }
+  function parseContent(meta){
+    var content = '';
+    try { content = String(meta.getAttribute('content') || ''); } catch (_) {}
+    var delayMatch = content.match(/^\\s*([0-9]+(?:\\.[0-9]+)?)/);
+    var delayMs = delayMatch ? Math.round(parseFloat(delayMatch[1]) * 1000) : 0;
+    var urlMatch = content.match(/[;,]\\s*url\\s*=\\s*['"]?\\s*([^'"\\s]+)/i);
+    return { delayMs: delayMs, url: urlMatch ? urlMatch[1] : '' };
+  }
+  function currentArtifactHref(){
+    try {
+      var href = String(location.href || '');
+      if (href === 'about:srcdoc') return String(document.baseURI || href);
+      return href;
+    } catch (_) { return ''; }
+  }
+  function isSelfTarget(url){
+    if (!url) return true;
+    try {
+      var base = document.baseURI || location.href;
+      return new URL(url, base).href === currentArtifactHref();
+    } catch (_) { return false; }
+  }
+  function isFastSrcdocUrlHop(parsed){
+    if (!parsed.url || parsed.delayMs > SELF_MIN_DELAY_MS) return false;
+    try { return String(location.href || '') === 'about:srcdoc'; } catch (_) { return false; }
+  }
+  function neutralize(metas){
+    for (var i = 0; i < metas.length; i++) {
+      try { if (metas[i].parentNode) metas[i].parentNode.removeChild(metas[i]); } catch (_) {}
+    }
+    try { if (window.stop) window.stop(); } catch (_) {}
+  }
+  function evaluate(){
+    var metas = metaRefreshes();
+    if (!metas.length) {
+      if (!BLOCK_LOAD_TIME_SCRIPT_REDIRECT) clearState();
+      return;
+    }
+    var selfLoop = false;
+    for (var i = 0; i < metas.length; i++) {
+      var parsed = parseContent(metas[i]);
+      if (parsed.delayMs <= SELF_MIN_DELAY_MS && isSelfTarget(parsed.url)) { selfLoop = true; break; }
+      if (isFastSrcdocUrlHop(parsed)) { selfLoop = true; break; }
+    }
+    var state = nextState();
+    if (selfLoop || state.hops > MAX_HOPS) {
+      neutralize(metas);
+      clearState();
+      report(state.hops);
+      return;
+    }
+    writeState(state);
+  }
+  recordScriptRedirectCandidate();
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', evaluate);
+  else evaluate();
+})();</script>`;
+}

--- a/packages/contracts/tests/runtime/preview-guards.test.ts
+++ b/packages/contracts/tests/runtime/preview-guards.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPreviewFocusGuard,
+  buildPreviewRedirectGuard,
+  buildPreviewSandboxShim,
+  PREVIEW_URL_GUARD_MAX_HTML_BYTES,
+  previewHtmlHasLoadTimeLocationNavigation,
+} from '../../src/runtime/preview-guards';
+
+describe('preview document guards', () => {
+  it('builds inert scripts with stable markers for transport-level deduplication', () => {
+    expect(buildPreviewSandboxShim()).toContain('<script data-od-sandbox-shim>');
+    expect(buildPreviewFocusGuard()).toContain('<script data-od-preview-focus-guard>');
+    expect(buildPreviewRedirectGuard()).toContain('<script data-od-preview-redirect-guard>');
+  });
+
+  it('embeds the load-time redirect decision in the redirect guard', () => {
+    expect(buildPreviewRedirectGuard()).toContain('BLOCK_LOAD_TIME_SCRIPT_REDIRECT = false');
+    expect(buildPreviewRedirectGuard({ blockLoadTimeScriptRedirect: true }))
+      .toContain('BLOCK_LOAD_TIME_SCRIPT_REDIRECT = true');
+  });
+
+  it('detects authored load-time location navigation without matching comparisons', () => {
+    expect(previewHtmlHasLoadTimeLocationNavigation('<script>location.reload()</script>')).toBe(true);
+    expect(previewHtmlHasLoadTimeLocationNavigation('<script>window.location = "/next"</script>')).toBe(true);
+    expect(previewHtmlHasLoadTimeLocationNavigation('<script>if (location.href === expected) ready()</script>')).toBe(false);
+  });
+
+  it('keeps the URL injection limit aligned with the streaming boundary', () => {
+    expect(PREVIEW_URL_GUARD_MAX_HTML_BYTES).toBe(2 * 1024 * 1024);
+  });
+});


### PR DESCRIPTION
Refs #7278
Supersedes the narrow Blob-base fix in #7307 by retaining that invariant and covering the additional Electron navigation/compositor failures found during installed-app reproduction.

## Why

Desktop users can end up with a permanently white HTML preview after remixing a multi-file artifact, switching projects/files, or toggling Code and Preview. The same artifact may have a complete, non-empty DOM while Electron paints no iframe surface, and Blob-backed enhanced previews can also lose their directory base so sibling scripts, styles, images, JSX, and runtime fetches silently fail.

This was reproduced in an installed macOS Electron build, including the multi-file shape from #7278. The affected code had accumulated several independent recovery paths, so this PR fixes the transport invariants instead of adding another timeout/reload fallback.

## What users will see

- Multi-file HTML artifacts keep relative `support.js`, JSX, CSS, images, `srcset`, nested `@import`, modules, and `fetch()` resources working in desktop preview.
- Switching projects, file tabs, and Code/Preview keeps an already-valid iframe warm instead of navigating it through `about:blank` again.
- Enhanced previews use one stable Electron bootstrap browsing context; content generations activate in place instead of racing competing Blob/srcdoc navigations.
- Deck page state, live agent edits, manual edits, comments/selection bridges, and LRU-recreated tabs keep their existing behavior.
- Active preview iframes no longer force a `translateZ(0)` compositor layer. In packaged Electron that layer could produce a complete DOM backed by a missing shared-image mailbox and leave the user looking at white pixels.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Behavior-only fix with no new UI entry point. Verification was performed in a freshly packaged and installed Electron app; the scenarios and observable assertions are listed below.

## Bug fix verification

- Red specs:
  - `apps/web/tests/components/FileViewer.test.tsx` — retained iframe activation must not force the GPU layer that reproduced a complete-DOM/white-surface failure in packaged Electron; LRU revisit must recreate the iframe at the artifact URL.
  - `apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx` — project/file/generation reactivation must preserve one stable enhanced-preview navigation.
  - `apps/daemon/tests/project-file-range.test.ts` — guarded real-URL preview must preserve and serve nested external resources, including 43 sibling Babel scripts and `support.js`.
  - `apps/web/tests/components/file-viewer-render-mode.test.ts` — passive guarded documents stay eligible for real-URL rendering while in-memory/large unsafe documents retain the safe path.
- Did the tests go red on `main` and green on this branch? **Yes.** The compositor test observed `translateZ(0)` on `main`; transport/routing/resource tests fail before the new invariants and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- Web focused suite: **495/495** tests green across FileViewer, srcdoc reload races, render-mode, exports, and srcdoc transport.
- Daemon focused suite: **51/51** project file/range/guard/resource tests green.
- Contracts suite: **439/439** tests green.
- `git diff --check`
- Fresh macOS package/install/start through `pnpm tools-pack` using an isolated namespace and data root.
- Installed Electron E2E:
  - complex multi-file artifact: external `support.js`, external/module/43 JSX scripts, CSS + nested `@import`, image + `srcset`, CSS background, and relative `fetch()` all rendered;
  - Code/Preview: 8 cycles, same iframe/src and 0 iframe loads;
  - file tabs: 16 switches, same retained frames and 0 reloads;
  - LRU eviction/revisit recreated the frame at the exact artifact URL and rendered;
  - project dropdown: 6 cross-project switches, expected artifact visible each time;
  - Deck direct slide 1 → 3, thumbnail/counter sync, and Code/Preview state preservation;
  - agent file update appeared immediately with external assets intact;
  - manual edit/save/exit/re-enter persisted to disk with the same iframe and 0 reloads.

