### PR TITLE
fix(desktop): retry empty Chromium captures in PPTX layered export

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1887,10 +1887,8 @@ async function nextFrames(window: BrowserWindow): Promise<void> {
 
 export function pngInspectionHasPaint(png: {
   maxAlpha: number;
-  opaquePixels: number;
-  translucentPixels: number;
 }): boolean {
-  return png.maxAlpha > 0 && png.opaquePixels + png.translucentPixels > 0;
+  return png.maxAlpha > 0;
 }
 
 export async function captureUntilPainted<T>(
@@ -1908,21 +1906,16 @@ export async function captureUntilPainted<T>(
   throw new Error(`transparent chromium capture: ${options.label}`);
 }
 
-export function pngBufferHasPaint(data: Buffer): boolean {
-  const image = nativeImage.createFromBuffer(data);
-  const bitmap = image.toBitmap();
-  let maxAlpha = 0;
-  let paintedPixels = 0;
+export function bgraBitmapHasPaint(bitmap: Buffer): boolean {
+  if (bitmap.length < 4) return false;
   for (let offset = 3; offset < bitmap.length; offset += 4) {
-    const alpha = bitmap[offset];
-    if (alpha > maxAlpha) maxAlpha = alpha;
-    if (alpha >= 16) paintedPixels += 1;
+    if (bitmap[offset] > 0) return true;
   }
-  return pngInspectionHasPaint({
-    maxAlpha,
-    opaquePixels: paintedPixels,
-    translucentPixels: 0,
-  });
+  return false;
+}
+
+export function pngBufferHasPaint(data: Buffer): boolean {
+  return bgraBitmapHasPaint(nativeImage.createFromBuffer(data).toBitmap());
 }
 
 function injectBaseHref(doc: string, baseHref: string | undefined): string {

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1360,21 +1360,28 @@ export async function captureEditablePptxLayeredBackgrounds(
       )) as LayeredPptxBackgroundGeometry | null;
       if (!geometry) throw new Error(`could not isolate layered PPTX background ${target.id}`);
       await nextFrames(window);
-      const screenshot = (await dbg.sendCommand("Page.captureScreenshot", {
-        captureBeyondViewport: true,
-        clip: {
-          height: geometry.height,
-          scale: captureScale,
-          width: geometry.width,
-          x: geometry.pageX,
-          y: geometry.pageY,
+      const screenshotData = await captureUntilPainted(
+        async () => {
+          const screenshot = (await dbg.sendCommand("Page.captureScreenshot", {
+            captureBeyondViewport: true,
+            clip: {
+              height: geometry.height,
+              scale: captureScale,
+              width: geometry.width,
+              x: geometry.pageX,
+              y: geometry.pageY,
+            },
+            format: "png",
+            fromSurface: true,
+          })) as { data?: string };
+          if (!screenshot.data) throw new Error(`Chromium returned no layered PPTX capture for ${target.id}`);
+          return screenshot.data;
         },
-        format: "png",
-        fromSurface: true,
-      })) as { data?: string };
-      if (!screenshot.data) throw new Error(`Chromium returned no layered PPTX capture for ${target.id}`);
+        (data) => pngBufferHasPaint(Buffer.from(data, "base64")),
+        { label: target.id, onRetry: () => nextFrames(window) },
+      );
       captures[target.id] = {
-        dataUrl: `data:image/png;base64,${screenshot.data}`,
+        dataUrl: `data:image/png;base64,${screenshotData}`,
         height: geometry.height,
         left: geometry.left,
         slideIndex: geometry.slideIndex,
@@ -1876,6 +1883,46 @@ async function nextFrames(window: BrowserWindow): Promise<void> {
     "new Promise(function(r){requestAnimationFrame(function(){requestAnimationFrame(function(){r(true)})})})",
     true,
   );
+}
+
+export function pngInspectionHasPaint(png: {
+  maxAlpha: number;
+  opaquePixels: number;
+  translucentPixels: number;
+}): boolean {
+  return png.maxAlpha > 0 && png.opaquePixels + png.translucentPixels > 0;
+}
+
+export async function captureUntilPainted<T>(
+  capture: () => Promise<T>,
+  isPainted: (value: T) => boolean,
+  options: { attempts?: number; label: string; onRetry?: () => Promise<void> },
+): Promise<T> {
+  const attempts = options.attempts ?? 3;
+  let last: T | undefined;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await capture();
+    if (isPainted(last)) return last;
+    if (attempt < attempts - 1 && options.onRetry) await options.onRetry();
+  }
+  throw new Error(`transparent chromium capture: ${options.label}`);
+}
+
+export function pngBufferHasPaint(data: Buffer): boolean {
+  const image = nativeImage.createFromBuffer(data);
+  const bitmap = image.toBitmap();
+  let maxAlpha = 0;
+  let paintedPixels = 0;
+  for (let offset = 3; offset < bitmap.length; offset += 4) {
+    const alpha = bitmap[offset];
+    if (alpha > maxAlpha) maxAlpha = alpha;
+    if (alpha >= 16) paintedPixels += 1;
+  }
+  return pngInspectionHasPaint({
+    maxAlpha,
+    opaquePixels: paintedPixels,
+    translucentPixels: 0,
+  });
 }
 
 function injectBaseHref(doc: string, baseHref: string | undefined): string {

--- a/apps/desktop/tests/main/pptx-layered-background.test.ts
+++ b/apps/desktop/tests/main/pptx-layered-background.test.ts
@@ -8,12 +8,12 @@ import { promisify } from 'node:util';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  bgraBitmapHasPaint,
   cjkPromotedFontFamily,
   captureEditablePptxLayeredBackgrounds,
   captureUntilPainted,
   collectLayeredPptxBackgroundTargets,
   isolateLayeredPptxBackground,
-  pngBufferHasPaint,
   pngInspectionHasPaint,
   restoreLayeredPptxBackgroundIsolation,
   runDomToPptx,
@@ -22,9 +22,20 @@ import {
 const execFileP = promisify(execFile);
 const desktopRoot = fileURLToPath(new URL('../..', import.meta.url));
 
+function bgraWithUniformAlpha(alpha: number): Buffer {
+  const bitmap = Buffer.alloc(16);
+  for (let pixel = 0; pixel < 4; pixel += 1) {
+    bitmap[pixel * 4] = 18;
+    bitmap[pixel * 4 + 1] = 54;
+    bitmap[pixel * 4 + 2] = 99;
+    bitmap[pixel * 4 + 3] = alpha;
+  }
+  return bitmap;
+}
+
 const ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE = `
 function pngInspectionHasPaint(png) {
-  return png.maxAlpha > 0 && png.opaquePixels + png.translucentPixels > 0;
+  return png.maxAlpha > 0;
 }
 async function captureUntilPainted(capture, isPainted, options) {
   const attempts = options.attempts == null ? 3 : options.attempts;
@@ -36,21 +47,15 @@ async function captureUntilPainted(capture, isPainted, options) {
   }
   throw new Error('transparent chromium capture: ' + options.label);
 }
-function pngBufferHasPaint(data) {
-  const image = nativeImage.createFromBuffer(data);
-  const bitmap = image.toBitmap();
-  let maxAlpha = 0;
-  let paintedPixels = 0;
+function bgraBitmapHasPaint(bitmap) {
+  if (bitmap.length < 4) return false;
   for (let offset = 3; offset < bitmap.length; offset += 4) {
-    const alpha = bitmap[offset];
-    if (alpha > maxAlpha) maxAlpha = alpha;
-    if (alpha >= 16) paintedPixels += 1;
+    if (bitmap[offset] > 0) return true;
   }
-  return pngInspectionHasPaint({
-    maxAlpha: maxAlpha,
-    opaquePixels: paintedPixels,
-    translucentPixels: 0,
-  });
+  return false;
+}
+function pngBufferHasPaint(data) {
+  return bgraBitmapHasPaint(nativeImage.createFromBuffer(data).toBitmap());
 }
 `;
 
@@ -214,10 +219,70 @@ async function runExport(
 
 describe('chromium empty-capture retry', () => {
   test('treats fully transparent inspections as unpainted', () => {
-    expect(pngInspectionHasPaint({ maxAlpha: 0, opaquePixels: 0, translucentPixels: 0 })).toBe(false);
-    expect(pngInspectionHasPaint({ maxAlpha: 255, opaquePixels: 12, translucentPixels: 0 })).toBe(true);
-    expect(pngInspectionHasPaint({ maxAlpha: 80, opaquePixels: 0, translucentPixels: 4 })).toBe(true);
+    expect(pngInspectionHasPaint({ maxAlpha: 0 })).toBe(false);
+    expect(pngInspectionHasPaint({ maxAlpha: 8 })).toBe(true);
+    expect(pngInspectionHasPaint({ maxAlpha: 255 })).toBe(true);
   });
+
+  test('treats BGRA bitmaps with any visible alpha as painted', () => {
+    expect(bgraBitmapHasPaint(bgraWithUniformAlpha(0))).toBe(false);
+    expect(bgraBitmapHasPaint(bgraWithUniformAlpha(1))).toBe(true);
+    expect(bgraBitmapHasPaint(bgraWithUniformAlpha(15))).toBe(true);
+    expect(bgraBitmapHasPaint(bgraWithUniformAlpha(255))).toBe(true);
+  });
+
+  test('treats real PNG buffers with any visible alpha as painted', async () => {
+    const probeDir = await mkdtemp(join(tmpdir(), 'od-pptx-png-paint-'));
+    await writeFile(join(probeDir, 'package.json'), '{"main":"main.cjs"}\n');
+    await writeFile(
+      join(probeDir, 'main.cjs'),
+      `
+const { app, nativeImage } = require('electron');
+${ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE}
+function pngWithUniformAlpha(alpha) {
+  const bitmap = Buffer.alloc(16);
+  for (let pixel = 0; pixel < 4; pixel += 1) {
+    bitmap[pixel * 4] = 18;
+    bitmap[pixel * 4 + 1] = 54;
+    bitmap[pixel * 4 + 2] = 99;
+    bitmap[pixel * 4 + 3] = alpha;
+  }
+  return nativeImage.createFromBitmap(bitmap, { height: 2, width: 2 }).toPNG();
+}
+app.whenReady().then(() => {
+  process.stdout.write('OD_PNG_PAINT:' + JSON.stringify({
+    0: pngBufferHasPaint(pngWithUniformAlpha(0)),
+    1: pngBufferHasPaint(pngWithUniformAlpha(1)),
+    15: pngBufferHasPaint(pngWithUniformAlpha(15)),
+    255: pngBufferHasPaint(pngWithUniformAlpha(255)),
+  }) + '\\n');
+  app.quit();
+});
+`,
+    );
+    try {
+      const electronRelativePath = (await readFile(
+        join(desktopRoot, 'node_modules', 'electron', 'path.txt'),
+        'utf8',
+      )).trim();
+      const electronPath = join(desktopRoot, 'node_modules', 'electron', 'dist', electronRelativePath);
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      delete env.ELECTRON_RUN_AS_NODE;
+      const command = process.platform === 'linux' ? 'xvfb-run' : electronPath;
+      const args = process.platform === 'linux' ? ['-a', electronPath, probeDir] : [probeDir];
+      const { stdout, stderr } = await execFileP(command, args, { env, timeout: 10_000 });
+      const marker = stdout.split(/\r?\n/).find((line) => line.startsWith('OD_PNG_PAINT:'));
+      if (!marker) throw new Error(`Electron paint probe returned no result: ${stdout || stderr}`);
+      expect(JSON.parse(marker.slice('OD_PNG_PAINT:'.length))).toEqual({
+        0: false,
+        1: true,
+        15: true,
+        255: true,
+      });
+    } finally {
+      await rm(probeDir, { force: true, recursive: true });
+    }
+  }, 15_000);
 
   test('retries a transparent capture then returns paint', async () => {
     const retries: number[] = [];

--- a/apps/desktop/tests/main/pptx-layered-background.test.ts
+++ b/apps/desktop/tests/main/pptx-layered-background.test.ts
@@ -10,14 +10,49 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   cjkPromotedFontFamily,
   captureEditablePptxLayeredBackgrounds,
+  captureUntilPainted,
   collectLayeredPptxBackgroundTargets,
   isolateLayeredPptxBackground,
+  pngBufferHasPaint,
+  pngInspectionHasPaint,
   restoreLayeredPptxBackgroundIsolation,
   runDomToPptx,
 } from '../../src/main/deck-capture.js';
 
 const execFileP = promisify(execFile);
 const desktopRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+const ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE = `
+function pngInspectionHasPaint(png) {
+  return png.maxAlpha > 0 && png.opaquePixels + png.translucentPixels > 0;
+}
+async function captureUntilPainted(capture, isPainted, options) {
+  const attempts = options.attempts == null ? 3 : options.attempts;
+  let last;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await capture();
+    if (isPainted(last)) return last;
+    if (attempt < attempts - 1 && options.onRetry) await options.onRetry();
+  }
+  throw new Error('transparent chromium capture: ' + options.label);
+}
+function pngBufferHasPaint(data) {
+  const image = nativeImage.createFromBuffer(data);
+  const bitmap = image.toBitmap();
+  let maxAlpha = 0;
+  let paintedPixels = 0;
+  for (let offset = 3; offset < bitmap.length; offset += 4) {
+    const alpha = bitmap[offset];
+    if (alpha > maxAlpha) maxAlpha = alpha;
+    if (alpha >= 16) paintedPixels += 1;
+  }
+  return pngInspectionHasPaint({
+    maxAlpha: maxAlpha,
+    opaquePixels: paintedPixels,
+    translucentPixels: 0,
+  });
+}
+`;
 
 class FakeStyle {
   private readonly values = new Map<string, { priority: string; value: string }>();
@@ -176,6 +211,38 @@ async function runExport(
   const result = await runDomToPptx('.slide', layeredBackgrounds);
   expect(result.error).toBeUndefined();
 }
+
+describe('chromium empty-capture retry', () => {
+  test('treats fully transparent inspections as unpainted', () => {
+    expect(pngInspectionHasPaint({ maxAlpha: 0, opaquePixels: 0, translucentPixels: 0 })).toBe(false);
+    expect(pngInspectionHasPaint({ maxAlpha: 255, opaquePixels: 12, translucentPixels: 0 })).toBe(true);
+    expect(pngInspectionHasPaint({ maxAlpha: 80, opaquePixels: 0, translucentPixels: 4 })).toBe(true);
+  });
+
+  test('retries a transparent capture then returns paint', async () => {
+    const retries: number[] = [];
+    let attempts = 0;
+    const result = await captureUntilPainted(
+      async () => {
+        attempts += 1;
+        return attempts === 1 ? { maxAlpha: 0, opaquePixels: 0, translucentPixels: 0 } : { maxAlpha: 255, opaquePixels: 8, translucentPixels: 0 };
+      },
+      pngInspectionHasPaint,
+      { label: 'retry-fixture', onRetry: async () => { retries.push(attempts); } },
+    );
+    expect(attempts).toBe(2);
+    expect(retries).toEqual([1]);
+    expect(result.opaquePixels).toBe(8);
+  });
+
+  test('throws a transparent-capture error after exhausted retries', async () => {
+    await expect(captureUntilPainted(
+      async () => ({ maxAlpha: 0, opaquePixels: 0, translucentPixels: 0 }),
+      pngInspectionHasPaint,
+      { attempts: 3, label: 'chromium-slide-filter-foreground.png' },
+    )).rejects.toThrow('transparent chromium capture: chromium-slide-filter-foreground.png');
+  });
+});
 
 describe('editable PPTX layered backgrounds', () => {
   afterEach(() => {
@@ -1142,6 +1209,7 @@ const collectLayeredPptxBackgroundTargets = ${collectLayeredPptxBackgroundTarget
 const isolateLayeredPptxBackground = ${isolateLayeredPptxBackground.toString()};
 const restoreLayeredPptxBackgroundIsolation = ${restoreLayeredPptxBackgroundIsolation.toString()};
 const captureEditablePptxLayeredBackgrounds = ${captureEditablePptxLayeredBackgrounds.toString()};
+${ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE}
 
 async function nextFrames(window) {
   await window.webContents.executeJavaScript(
@@ -1166,6 +1234,23 @@ function rgbAt(image, logicalX, logicalY, logicalWidth, logicalHeight) {
   const bitmap = image.toBitmap();
   const offset = (y * size.width + x) * 4;
   return [bitmap[offset + 2], bitmap[offset + 1], bitmap[offset]];
+}
+
+async function captureCdpPngUntilPainted(dbg, clip, label, window) {
+  return captureUntilPainted(
+    async () => {
+      const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
+        captureBeyondViewport: true,
+        clip,
+        format: 'png',
+        fromSurface: true,
+      });
+      if (!screenshot.data) throw new Error('Chromium returned no capture for ' + label);
+      return screenshot.data;
+    },
+    (data) => pngBufferHasPaint(Buffer.from(data, 'base64')),
+    { label, onRetry: () => nextFrames(window) },
+  );
 }
 
 app.whenReady().then(async () => {
@@ -1194,12 +1279,7 @@ app.whenReady().then(async () => {
     dbg.attach('1.3');
     await dbg.sendCommand('Page.enable');
     const stripeClip = { height: 1, scale: 1, width: 1, x: 7, y: 540 };
-    const largeReferenceShot = await dbg.sendCommand('Page.captureScreenshot', {
-      captureBeyondViewport: true,
-      clip: stripeClip,
-      format: 'png',
-      fromSurface: true,
-    });
+    const largeReferenceShot = { data: await captureCdpPngUntilPainted(dbg, stripeClip, 'dpr2-large-reference', window) };
     const [largeTarget] = await window.webContents.executeJavaScript(
       '(' + collectLayeredPptxBackgroundTargets.toString() + ')(".slide")',
       true,
@@ -1214,12 +1294,7 @@ app.whenReady().then(async () => {
     );
     if (!largeGeometry) throw new Error('Could not isolate the large layered background target');
     await nextFrames(window);
-    const largeExportedShot = await dbg.sendCommand('Page.captureScreenshot', {
-      captureBeyondViewport: true,
-      clip: stripeClip,
-      format: 'png',
-      fromSurface: true,
-    });
+    const largeExportedShot = { data: await captureCdpPngUntilPainted(dbg, stripeClip, 'dpr2-large-exported', window) };
     await window.webContents.executeJavaScript(
       '(' + restoreLayeredPptxBackgroundIsolation.toString() + ')()',
       true,
@@ -1337,6 +1412,15 @@ async function probePseudoTextClipCaptures(): Promise<{
     `
 const { app, BrowserWindow, nativeImage } = require('electron');
 
+${ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE}
+
+async function nextFrames(window) {
+  await window.webContents.executeJavaScript(
+    'new Promise(function(r){requestAnimationFrame(function(){requestAnimationFrame(function(){r(true)})})})',
+    true,
+  );
+}
+
 app.whenReady().then(async () => {
   const window = new BrowserWindow({
     height: 180,
@@ -1375,23 +1459,28 @@ app.whenReady().then(async () => {
         ${JSON.stringify(isolateSource)} + '(' + JSON.stringify(target.id) + ')',
         true,
       );
-      await window.webContents.executeJavaScript(
-        'new Promise(function(r){requestAnimationFrame(function(){requestAnimationFrame(function(){r(true)})})})',
-        true,
-      );
-      const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
-        captureBeyondViewport: true,
-        clip: {
-          height: geometry.height,
-          scale: 1 / devicePixelRatio,
-          width: geometry.width,
-          x: geometry.pageX,
-          y: geometry.pageY,
+      await nextFrames(window);
+      const screenshotData = await captureUntilPainted(
+        async () => {
+          const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
+            captureBeyondViewport: true,
+            clip: {
+              height: geometry.height,
+              scale: 1 / devicePixelRatio,
+              width: geometry.width,
+              x: geometry.pageX,
+              y: geometry.pageY,
+            },
+            format: 'png',
+            fromSurface: true,
+          });
+          if (!screenshot.data) throw new Error('Chromium returned no capture for ' + target.id);
+          return screenshot.data;
         },
-        format: 'png',
-        fromSurface: true,
-      });
-      const bitmap = nativeImage.createFromBuffer(Buffer.from(screenshot.data, 'base64')).toBitmap();
+        (data) => pngBufferHasPaint(Buffer.from(data, 'base64')),
+        { label: target.id, onRetry: () => nextFrames(window) },
+      );
+      const bitmap = nativeImage.createFromBuffer(Buffer.from(screenshotData, 'base64')).toBitmap();
       let paintedPixels = 0;
       let transparentPixels = 0;
       for (let offset = 3; offset < bitmap.length; offset += 4) {
@@ -1480,6 +1569,8 @@ async function runLayeredBackgroundMediaProbe(): Promise<LayeredBackgroundProbe>
 const { app, BrowserWindow, nativeImage } = require('electron');
 const { readFile } = require('node:fs/promises');
 const { gunzipSync, inflateRawSync } = require('node:zlib');
+
+${ELECTRON_CAPTURE_UNTIL_PAINTED_SOURCE}
 
 const fixtures = {
   supported: '<div class="supported"></div>',
@@ -2456,6 +2547,12 @@ app.whenReady().then(async () => {
     // under Linux/Xvfb instead of suspending rAF for a hidden window.
     window.setOpacity(0);
     window.showInactive();
+    async function waitForPaintedFrames() {
+      await window.webContents.executeJavaScript(
+        'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))',
+        true,
+      );
+    }
     await window.webContents.executeJavaScript(bundle, true);
     const dbg = window.webContents.debugger;
     dbg.attach('1.3');
@@ -2521,69 +2618,36 @@ app.whenReady().then(async () => {
     probeStage = 'normalize export DOM';
     const prepared = await window.webContents.executeJavaScript(${JSON.stringify(prepareSource)}, true);
     if (!prepared?.prepared || prepared.error) throw new Error(prepared?.error || 'PPTX DOM normalization failed');
-    await window.webContents.executeJavaScript('new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))', true);
-    const compositedPseudoContentCapture = await window.webContents.executeJavaScript(
-      '(() => { const rect = document.querySelector(".composited-pseudo-content").getBoundingClientRect(); return { geometry: { height: rect.height, width: rect.width, x: rect.left + window.scrollX, y: rect.top + window.scrollY }, pixelRatio: window.devicePixelRatio }; })()',
-      true,
-    );
-    const compositedPseudoContentScreenshot = await dbg.sendCommand('Page.captureScreenshot', {
-      captureBeyondViewport: true,
-      clip: {
-        ...compositedPseudoContentCapture.geometry,
-        scale: 2 / compositedPseudoContentCapture.pixelRatio,
-      },
-      format: 'png',
-      fromSurface: true,
-    });
-    const compositedPseudoContentChromiumData = Buffer.from(compositedPseudoContentScreenshot.data, 'base64');
-    const compositedPseudoContentChromium = inspectPng(
-      compositedPseudoContentChromiumData,
+    await waitForPaintedFrames();
+    async function captureChromiumReference(selector, name, padding = 0) {
+      return captureUntilPainted(async () => {
+        const capture = await window.webContents.executeJavaScript(
+          '(() => { const element = document.querySelector(' + JSON.stringify(selector) + '); const rect = element.getBoundingClientRect(); const slideRect = element.closest(".slide").getBoundingClientRect(); const left = Math.max(slideRect.left, rect.left - ' + padding + '); const top = Math.max(slideRect.top, rect.top - ' + padding + '); const right = Math.min(slideRect.right, rect.right + ' + padding + '); const bottom = Math.min(slideRect.bottom, rect.bottom + ' + padding + '); return { geometry: { height: bottom - top, width: right - left, x: left + window.scrollX, y: top + window.scrollY }, pixelRatio: window.devicePixelRatio }; })()',
+          true,
+        );
+        await waitForPaintedFrames();
+        const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
+          captureBeyondViewport: true,
+          clip: { ...capture.geometry, scale: 2 / capture.pixelRatio },
+          format: 'png',
+          fromSurface: true,
+        });
+        const data = Buffer.from(screenshot.data, 'base64');
+        return { data, png: inspectPng(data, name) };
+      }, (result) => pngInspectionHasPaint(result.png), { label: name, onRetry: waitForPaintedFrames });
+    }
+    const compositedPseudoContent = await captureChromiumReference(
+      '.composited-pseudo-content',
       'chromium-composited-pseudo-content.png',
     );
-    const realBlendCapture = await window.webContents.executeJavaScript(
-      '(() => { const rect = document.querySelector(".real-blend-target").getBoundingClientRect(); return { geometry: { height: rect.height, width: rect.width, x: rect.left + window.scrollX, y: rect.top + window.scrollY }, pixelRatio: window.devicePixelRatio }; })()',
-      true,
-    );
-    const realBlendScreenshot = await dbg.sendCommand('Page.captureScreenshot', {
-      captureBeyondViewport: true,
-      clip: {
-        ...realBlendCapture.geometry,
-        scale: 2 / realBlendCapture.pixelRatio,
-      },
-      format: 'png',
-      fromSurface: true,
-    });
-    const realBlendChromiumData = Buffer.from(realBlendScreenshot.data, 'base64');
-    const realBlendChromium = inspectPng(realBlendChromiumData, 'chromium-real-blend.png');
-    const nestedOpacityCapture = await window.webContents.executeJavaScript(
-      '(() => { const rect = document.querySelector(".nested-opacity").getBoundingClientRect(); return { geometry: { height: rect.height, width: rect.width, x: rect.left + window.scrollX, y: rect.top + window.scrollY }, pixelRatio: window.devicePixelRatio }; })()',
-      true,
-    );
-    const nestedOpacityScreenshot = await dbg.sendCommand('Page.captureScreenshot', {
-      captureBeyondViewport: true,
-      clip: {
-        ...nestedOpacityCapture.geometry,
-        scale: 2 / nestedOpacityCapture.pixelRatio,
-      },
-      format: 'png',
-      fromSurface: true,
-    });
-    const nestedOpacityChromiumData = Buffer.from(nestedOpacityScreenshot.data, 'base64');
-    const nestedOpacityChromium = inspectPng(nestedOpacityChromiumData, 'chromium-nested-opacity.png');
-    async function captureChromiumReference(selector, name, padding = 0) {
-      const capture = await window.webContents.executeJavaScript(
-        '(() => { const element = document.querySelector(' + JSON.stringify(selector) + '); const rect = element.getBoundingClientRect(); const slideRect = element.closest(".slide").getBoundingClientRect(); const left = Math.max(slideRect.left, rect.left - ' + padding + '); const top = Math.max(slideRect.top, rect.top - ' + padding + '); const right = Math.min(slideRect.right, rect.right + ' + padding + '); const bottom = Math.min(slideRect.bottom, rect.bottom + ' + padding + '); return { geometry: { height: bottom - top, width: right - left, x: left + window.scrollX, y: top + window.scrollY }, pixelRatio: window.devicePixelRatio }; })()',
-        true,
-      );
-      const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
-        captureBeyondViewport: true,
-        clip: { ...capture.geometry, scale: 2 / capture.pixelRatio },
-        format: 'png',
-        fromSurface: true,
-      });
-      const data = Buffer.from(screenshot.data, 'base64');
-      return { data, png: inspectPng(data, name) };
-    }
+    const compositedPseudoContentChromiumData = compositedPseudoContent.data;
+    const compositedPseudoContentChromium = compositedPseudoContent.png;
+    const realBlend = await captureChromiumReference('.real-blend-target', 'chromium-real-blend.png');
+    const realBlendChromiumData = realBlend.data;
+    const realBlendChromium = realBlend.png;
+    const nestedOpacity = await captureChromiumReference('.nested-opacity', 'chromium-nested-opacity.png');
+    const nestedOpacityChromiumData = nestedOpacity.data;
+    const nestedOpacityChromium = nestedOpacity.png;
     const textClipStandardChromium = await captureChromiumReference(
       '.text-clip-standard',
       'chromium-text-clip-standard.png',
@@ -2636,20 +2700,28 @@ app.whenReady().then(async () => {
     for (const target of targets) {
       probeStage = 'isolate target ' + target.id;
       const geometry = await window.webContents.executeJavaScript(${JSON.stringify(isolateSource)} + '(' + JSON.stringify(target.id) + ')', true);
-      await window.webContents.executeJavaScript('new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))', true);
-      const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
-        captureBeyondViewport: true,
-        clip: {
-          x: geometry.pageX,
-          y: geometry.pageY,
-          width: geometry.width,
-          height: geometry.height,
-          scale: Math.min(2, 2 / devicePixelRatio),
+      await waitForPaintedFrames();
+      const screenshotData = await captureUntilPainted(
+        async () => {
+          const screenshot = await dbg.sendCommand('Page.captureScreenshot', {
+            captureBeyondViewport: true,
+            clip: {
+              x: geometry.pageX,
+              y: geometry.pageY,
+              width: geometry.width,
+              height: geometry.height,
+              scale: Math.min(2, 2 / devicePixelRatio),
+            },
+            format: 'png',
+            fromSurface: true,
+          });
+          if (!screenshot.data) throw new Error('Chromium returned no capture for ' + target.id);
+          return screenshot.data;
         },
-        format: 'png',
-        fromSurface: true,
-      });
-      captures[target.id] = { ...geometry, dataUrl: 'data:image/png;base64,' + screenshot.data };
+        (data) => pngBufferHasPaint(Buffer.from(data, 'base64')),
+        { label: target.id, onRetry: waitForPaintedFrames },
+      );
+      captures[target.id] = { ...geometry, dataUrl: 'data:image/png;base64,' + screenshotData };
       await window.webContents.executeJavaScript(${JSON.stringify(restoreSource)}, true);
     }
     probeStage = 'export deck';


### PR DESCRIPTION
## Why

Merge-queue run 32710833984 failed `Workspace unit tests` on `captures slide-root filter effects with layered backgrounds and native foreground`. The Chromium reference PNG was fully transparent (`opaquePixels=0`) while the exported PPTX layer was the correct navy `[18,54,99]`, so `meanChannelDelta` blew past 8.

I hit this while landing unrelated work. Software GL / Xvfb can return an empty `Page.captureScreenshot` for CSS filter layers. The test then compared that empty frame to a good export, and production could embed the same empty PNG in a PPTX.

## What users will see

Exporting a deck with CSS filters or layered backgrounds to editable PPTX is less likely to produce a blank layer. If Chromium still returns an empty frame after retries, export fails with `transparent chromium capture: …` instead of silently shipping a transparent image.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

Internal desktop capture retry plus tests. Export failure is louder only when Chromium returns a fully empty frame after retries.

## Screenshots

N/A — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/pptx-layered-background.test.ts` (`chromium empty-capture retry`, plus the existing slide-filter comparison)
- Did the test go red on `main` and green on this branch? The original Xvfb empty-frame flake is not cheap to reproduce locally as a deterministic red spec. The new tests encode the contract that was missing: fully transparent inspections/buffers are unpainted, alpha 1–15 still counts as paint, retry then succeed, and exhausted retries throw `transparent chromium capture: …`.
- Local file run on this branch: 55/55 passed.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/main/pptx-layered-background.test.ts` from `apps/desktop` — 55/55 passed
- Independent review of the two commits: mergeable; remaining items are follow-ups (probe helper drift, Xvfb retry not a compositor-ready guarantee, `captureDeckSlide` still unhardened)
