### PR TITLE
fix(web): left-align onboarding Local CLI chips

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -3526,6 +3526,10 @@
 .onboarding-view__agent-chip {
   display: flex;
   align-items: center;
+  /* The global `button` primitive centers its flex line. These chips are
+     fixed-width grid cells, so a centered line offsets each icon+name group
+     by a different amount and the two columns read ragged. */
+  justify-content: flex-start;
   gap: 9px;
   min-width: 0;
   min-height: 48px;

--- a/apps/web/tests/styles/onboarding-cli-chip-alignment.test.tsx
+++ b/apps/web/tests/styles/onboarding-cli-chip-alignment.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { useState } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryShell } from '../../src/components/EntryShell';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+// The onboarding Local CLI chips inherit `justify-content: center` from the
+// global `button` primitive unless `entry-layout.css` opts out, so the cascade
+// is only observable with both stylesheets loaded in their app order
+// (`index.css` pulls primitives, `home/index.css` pulls entry-layout).
+const GLOBAL_STYLESHEETS = [
+  '../../src/styles/primitives.css',
+  '../../src/styles/home/entry-layout.css',
+];
+
+const analyticsMocks = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return {
+    ...actual,
+    useAnalytics: () => ({
+      newRequestId: vi.fn(() => 'request-1'),
+      setConfigureGlobals: vi.fn(),
+      setConsent: vi.fn(),
+      setIdentity: vi.fn(),
+      track: analyticsMocks.track,
+    }),
+    useAppVersion: () => null,
+  };
+});
+
+const originalFetch = globalThis.fetch;
+const originalResizeObserver = globalThis.ResizeObserver;
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function loadGlobalStyles() {
+  for (const relativePath of GLOBAL_STYLESHEETS) {
+    const style = document.createElement('style');
+    style.setAttribute('data-stylesheet', relativePath);
+    style.textContent = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+    document.head.appendChild(style);
+  }
+}
+
+const agents: AgentInfo[] = [
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    bin: 'claude',
+    available: true,
+    version: '2.1.131',
+    models: [{ id: 'sonnet', label: 'Sonnet' }],
+  },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    bin: 'codex',
+    available: true,
+    version: 'codex-cli 0.147.0',
+    models: [{ id: 'gpt-5', label: 'GPT-5' }],
+  },
+];
+
+function baseConfig(): AppConfig {
+  return {
+    mode: 'daemon',
+    agentId: 'claude-code',
+    agentModels: { 'claude-code': { model: 'sonnet' } },
+    apiProtocol: 'anthropic',
+    apiKey: '',
+    baseUrl: '',
+    model: '',
+    skillId: null,
+    designSystemId: null,
+    onboardingCompleted: false,
+  };
+}
+
+function renderOnboarding() {
+  window.history.replaceState(null, '', '/onboarding');
+  const props: React.ComponentProps<typeof EntryShell> = {
+    skills: [],
+    designTemplates: [],
+    designSystems: [],
+    projects: [],
+    templates: [],
+    promptTemplates: [],
+    defaultDesignSystemId: null,
+    connectors: [],
+    connectorsLoading: false,
+    config: baseConfig(),
+    agents,
+    daemonLive: true,
+    onModeChange: vi.fn(),
+    onAgentChange: vi.fn(),
+    onAgentModelChange: vi.fn(),
+    onApiProtocolChange: vi.fn(),
+    onApiModelChange: vi.fn(),
+    onConfigPersist: vi.fn(),
+    onRefreshAgents: vi.fn(() => agents),
+    onCreateProject: vi.fn(),
+    onCreatePluginShareProject: vi.fn(),
+    onImportClaudeDesign: vi.fn(),
+    onOpenProject: vi.fn(),
+    onOpenLiveArtifact: vi.fn(),
+    onDeleteProject: vi.fn(),
+    onRenameProject: vi.fn(),
+    onChangeDefaultDesignSystem: vi.fn(),
+    onPersistComposioKey: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onCompleteOnboarding: vi.fn(),
+  };
+
+  function Harness() {
+    const [config, setConfig] = useState(props.config);
+    return (
+      <I18nProvider initial="en">
+        <EntryShell
+          {...props}
+          config={config}
+          onConfigPersist={(next) => setConfig(next as AppConfig)}
+        />
+      </I18nProvider>
+    );
+  }
+
+  render(<Harness />);
+}
+
+async function openLocalCliStep() {
+  fireEvent.click(
+    await screen.findByRole('button', { name: /Continue \(signed in\)/i }),
+  );
+  await waitFor(() => {
+    expect(screen.getByRole('heading', { name: 'Choose your model source' })).toBeTruthy();
+  });
+  fireEvent.click(screen.getByRole('radio', { name: /Local Agent/i }));
+  fireEvent.click(screen.getByRole('button', { name: /^Continue$/i }));
+  expect(await screen.findByText('Local CLI')).toBeTruthy();
+}
+
+afterEach(() => {
+  cleanup();
+  document.head.querySelectorAll('style[data-stylesheet]').forEach((node) => node.remove());
+  globalThis.fetch = originalFetch;
+  globalThis.ResizeObserver = originalResizeObserver;
+  analyticsMocks.track.mockReset();
+  window.sessionStorage.clear();
+});
+
+beforeEach(() => {
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+  globalThis.fetch = vi.fn(async (input) => {
+    const url = String(input);
+    if (url.endsWith('/api/integrations/vela/status')) {
+      return jsonResponse({
+        loggedIn: true,
+        profile: 'prod',
+        configPath: '/x',
+        user: { id: 'u', email: 'user@example.com' },
+      });
+    }
+    return jsonResponse({});
+  }) as typeof fetch;
+});
+
+describe('onboarding Local CLI chip alignment', () => {
+  it('starts each detected CLI chip at the card start instead of centering it', async () => {
+    loadGlobalStyles();
+    renderOnboarding();
+    await openLocalCliStep();
+
+    const chips = Array.from(
+      document.querySelectorAll<HTMLElement>('.onboarding-view__agent-chip'),
+    );
+    expect(chips.length).toBeGreaterThan(1);
+
+    for (const chip of chips) {
+      // Every chip is a fixed-width grid cell, so a centered flex line makes
+      // the icon+name group float by a different amount per card and the
+      // column reads ragged.
+      expect(getComputedStyle(chip).justifyContent).toBe('flex-start');
+    }
+  });
+});

--- a/e2e/ui/visual-entry.test.ts
+++ b/e2e/ui/visual-entry.test.ts
@@ -47,6 +47,48 @@ test('[P2] captures the onboarding cloud sign-in surface', async ({ page }) => {
   await captureVisual(page, 'visual-onboarding-cloud');
 });
 
+// The step past sign-in had no baseline at all, so the one surface whose whole
+// job is to line up a two-column grid of detected CLIs was invisible to the
+// visual suite. `visual-avatar-local-agent-list` covers the avatar menu's agent
+// list — a different component — and stayed 0px through an alignment change to
+// this one.
+test('[P2] captures the onboarding Local Agent CLI list surface', async ({ page }) => {
+  test.setTimeout(T.xlong);
+
+  await configureVisualPage(page, {
+    projects: [],
+    agents: [VISUAL_AMR_AGENT, ...VISUAL_CLI_AGENTS],
+    config: {
+      onboardingCompleted: false,
+    },
+  });
+  await mockSignedInVelaAccount(page);
+
+  await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
+
+  await page
+    .getByRole('button', { name: /Continue \(signed in\)|继续（已登录）/i })
+    .click();
+  await expect(
+    page.getByRole('heading', { name: /Choose your model source|选择模型来源/i }),
+  ).toBeVisible({ timeout: T.medium });
+  await page.getByRole('radio', { name: /Local Agent|本地 Agent/i }).click();
+  await page.getByRole('button', { name: /^(Continue|继续)$/ }).click();
+
+  const panel = page.locator('.onboarding-view__setup-panel');
+  await expect(panel).toBeVisible({ timeout: T.medium });
+  const chips = page.locator('.onboarding-view__agent-chip');
+  // More than one chip is the point: a single card cannot show whether the
+  // column shares an alignment line.
+  await expect(chips.first()).toBeVisible();
+  expect(await chips.count()).toBeGreaterThan(1);
+  await waitForVisualFonts(page);
+
+  await captureVisual(page, 'visual-onboarding-local-agent');
+  await captureVisualTarget(page, 'visual-onboarding-local-agent-panel', panel);
+});
+
 test('[P2] captures the visual home harness', async ({ page }) => {
   await configureVisualPage(page, { projects: [] });
   await gotoVisualHome(page);


### PR DESCRIPTION
## Why

Reported by 孙庆雨 with a screenshot of onboarding's **本地 Agent** step: the detected local CLIs render as a two-column grid of cards, but each card's icon + name floats somewhere in the middle of its own card rather than starting at the card's left edge. Because every card has a different amount of slack, no two rows line up — the whole list reads ragged, and the eye has nowhere to scan down.

The cards are `<button>` elements. They set `display: flex` but never set `justify-content`, so they inherit `justify-content: center` from the global `button` primitive in `styles/primitives.css`. Each card is a fixed-width grid cell, so centering pushes the icon+name group in by half the row's leftover space — a different amount per CLI.

Measured live in Chrome on this step, the icon's offset from the card's left edge ranged **114.2px to 157.5px** across seven detected CLIs. After the fix all seven sit at 10.8px (the card's own padding), spread `0`.

`entry-layout.css` already carries the same opt-out for the onboarding Back link, with a comment naming the same cause — this is the second place the primitive's centering leaks into onboarding.

## What users will see

On onboarding → **本地 Agent** → **本机 CLI**, each detected CLI's icon and name now start at the left edge of its card, so both columns share one alignment line. Nothing about which CLIs are listed, how they're selected, or the panel's size changes.

## Surface area

- [x] **UI** — onboarding Local Agent step's detected-CLI list in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Captured but not attached — the change is a pure alignment shift, and the measurement below pins it more precisely than an image would. Same step, same seven detected CLIs, measuring each icon's offset from its card's left edge:

| | icon offset from card edge | spread |
| --- | --- | --- |
| before | 129 / 143.9 / 157.5 / 114.2 / 156.2 / 137.4 / 133.2 px | **43.3px** |
| after | 10.8px on all seven | **0** |

Entry point is onboarding → **本地 Agent** → **本机 CLI**; reachable on an existing install through Settings → 关于 → 重置引导流程.

The visual suite had no baseline for this screen at all — it stops at the onboarding sign-in step. The nearest-sounding case, `visual-avatar-local-agent-list`, captures the avatar menu's agent list (a different component) and reported 0px through this change, which is how the gap stayed invisible. This PR adds `visual-onboarding-local-agent` + `visual-onboarding-local-agent-panel` so the screen has pixel coverage going forward.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/onboarding-cli-chip-alignment.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — red on `main` with `AssertionError: expected 'center' to be 'flex-start'`, green after the one-line CSS change.

The spec renders the real onboarding flow through `EntryShell` (Cloud continue → Local Agent → Continue), loads `primitives.css` and `entry-layout.css` into the document in the order the app imports them (`index.css` then `home/index.css`), and asserts each chip's **computed** `justify-content`. So it fails on the cascade that actually produced the bug, not on the text of a stylesheet — dropping the `justify-content` line or re-introducing the centering from any other selector both turn it red.

Also verified end-to-end in real Chrome against a local `tools-dev` runtime on an isolated `OD_DATA_DIR`, reaching the step through the production path only (Settings → 关于 → 重置引导流程 → 继续（已登录）→ 本地 Agent → 继续). Before/after measurements are the numbers quoted above.

Reproduced independently a second time on a different branch's runtime (a worktree off `main` without this fix), reaching the same step through onboarding rather than the settings reset, with every click gated on `document.elementFromPoint()` returning the target so an overlay-blocked control is reported instead of silently driven. All seven chips came back `reachable: true` and `justify-content: center`, icon offsets 111.9 / 126.4 / 130.6 / 134.7 / 141.1 / 153 / 154.4 px — the same ragged spread from a clean second environment, which rules out the first setup as the cause.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` (full suite: 651 files / 6946 tests, green)
- Real-Chrome E2E on `pnpm tools-dev run web --namespace cli-align`, isolated `OD_DATA_DIR`
- **Not run locally:** the two new Playwright visual cases. This machine has no Playwright browsers installed and installing them here previously filled the disk, so CI is their first execution — the visual bot should report them as new-without-baseline. Every selector they use was cross-checked against the live DOM during the Chrome session above (`.onboarding-view__setup-panel`, `.onboarding-view__agent-chip`) or against the existing `EntryShell.onboarding` specs (the sign-in / model-source / Local Agent controls).
