### PR TITLE
fix(runtimes): support the dsh release line users are actually served

### DIFF
--- a/.github/scripts/dsh-upstream-drift.ts
+++ b/.github/scripts/dsh-upstream-drift.ts
@@ -1,0 +1,264 @@
+/**
+ * Watch upstream DeepSeek Harness releases and say something when we fall behind.
+ *
+ * Twice in one week the same failure shipped: `@deepseek-ai/dsh` published a new
+ * release line, and nothing in this repo noticed. The first time it was a pin on
+ * one release candidate; the second, a pin on one patch line. Both were found by
+ * a person reporting that their install did not work.
+ *
+ * The existing drift check (`e2e/tests/dsh-installer-version-policy.test.ts`)
+ * compares our installers against our agent def — the two halves of *our*
+ * config. It stays green while both are equally out of date, which is exactly
+ * what happened. This one compares them against the registry.
+ *
+ * Three places have to move together when upstream ships a new line, and this
+ * names all three, because forgetting the third is the one that actually breaks
+ * an install rather than merely warning about it:
+ *
+ *   1. `apps/landing-page/public/install-dsh.{sh,ps1}` — the version and the
+ *      `--before` resolution window.
+ *   2. `apps/daemon/src/runtimes/defs/deepseek-harness.ts` — the accepted
+ *      release line.
+ *   3. `packages/dsh-runtime/package.json` — the peer ranges. semver only lets a
+ *      prerelease satisfy a range when a comparator carries the same
+ *      major.minor.patch tuple AND its own prerelease tag, so every new upstream
+ *      prerelease line needs its own comparator or the connection component
+ *      cannot install at all.
+ *
+ * Commands:
+ *   run [--dry-run]   Compare against the live registry; post to Feishu on drift.
+ *                     `--dry-run` prints what it would post and exits 0.
+ *   self-check        Exercise the classification against fixtures. No network.
+ */
+import { createHmac } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const PACKAGE = "@deepseek-ai/dsh";
+const REGISTRY = "https://registry.npmjs.org";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
+const INSTALLER_SH = "apps/landing-page/public/install-dsh.sh";
+const AGENT_DEF = "apps/daemon/src/runtimes/defs/deepseek-harness.ts";
+const PEER_MANIFEST = "packages/dsh-runtime/package.json";
+
+export type DriftSeverity = "in-sync" | "behind" | "unsupported";
+
+export interface DriftVerdict {
+  severity: DriftSeverity;
+  pinned: string;
+  latest: string;
+  /** Whether the agent def would accept `latest` without an untested warning. */
+  accepted: boolean;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim() ?? "";
+  if (value.length === 0) throw new Error(`${name} is required`);
+  return value;
+}
+
+function readRepoFile(relative: string): string {
+  return readFileSync(path.join(REPO_ROOT, relative), "utf8");
+}
+
+/** The version our one-line installer hands a user today. */
+export function readPinnedVersion(installerSource: string): string {
+  const found = /DSH_VERSION='([^']+)'/u.exec(installerSource)?.[1];
+  if (!found) throw new Error(`could not read DSH_VERSION from ${INSTALLER_SH}`);
+  return found;
+}
+
+/**
+ * The release line the agent def accepts, rebuilt from the literal in source.
+ * Absent is valid — it means the def only accepts the versions it lists.
+ */
+export function readAcceptedPattern(defSource: string): RegExp | null {
+  const found = /supportedVersionPattern:\s*\/(.+?)\/([a-z]*)\s*,/u.exec(defSource);
+  const body = found?.[1];
+  if (!body) return null;
+  return new RegExp(body, found?.[2] ?? "");
+}
+
+export function readListedVersions(defSource: string): string[] {
+  const list = /supportedVersions:\s*\[([^\]]*)\]/u.exec(defSource)?.[1] ?? "";
+  return [...list.matchAll(/'([^']+)'/gu)]
+    .map((entry) => entry[1])
+    .filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * How badly we have fallen behind.
+ *
+ * `behind` means a user who takes our installer gets an older version than the
+ * registry serves — annoying, but everything works. `unsupported` means a user
+ * who has what npm serves is outside what we claim to support: Settings calls
+ * their CLI untested, and the peer ranges very likely do not resolve either.
+ */
+export function classifyDrift(args: {
+  accepted: boolean;
+  latest: string;
+  pinned: string;
+}): DriftVerdict {
+  const { accepted, latest, pinned } = args;
+  if (!accepted) return { accepted, latest, pinned, severity: "unsupported" };
+  if (latest !== pinned) return { accepted, latest, pinned, severity: "behind" };
+  return { accepted, latest, pinned, severity: "in-sync" };
+}
+
+async function fetchLatestVersion(): Promise<string> {
+  const response = await fetch(`${REGISTRY}/${encodeURIComponent(PACKAGE)}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  });
+  if (!response.ok) {
+    throw new Error(`registry returned HTTP ${response.status} for ${PACKAGE}`);
+  }
+  const body = (await response.json()) as { "dist-tags"?: Record<string, string> };
+  const latest = body["dist-tags"]?.latest;
+  if (!latest) throw new Error(`${PACKAGE} has no dist-tag "latest"`);
+  return latest;
+}
+
+export function buildCard(verdict: DriftVerdict): Record<string, unknown> {
+  const blocking = verdict.severity === "unsupported";
+  const headline = blocking
+    ? `DeepSeek Harness ${verdict.latest} 不在我们支持的范围内`
+    : `DeepSeek Harness 已发布 ${verdict.latest}，我们还钉在 ${verdict.pinned}`;
+  const consequence = blocking
+    ? [
+        `装到 \`${verdict.latest}\` 的用户会被告知「未经测试」，`,
+        "而且 `packages/dsh-runtime` 的 peer 范围很可能直接解析失败——",
+        "semver 要求同 major.minor.patch 且自身带 prerelease 的比较器，",
+        "所以每条新的 prerelease 线都得单独加一个比较器，组件才装得上。",
+      ].join("")
+    : `按我们安装脚本装的用户会拿到 \`${verdict.pinned}\`，比 registry 的 \`latest\` 旧。`;
+
+  return {
+    config: { wide_screen_mode: true },
+    elements: [
+      {
+        tag: "div",
+        text: { tag: "lark_md", content: `${consequence}` },
+      },
+      { tag: "hr" },
+      {
+        tag: "div",
+        text: {
+          tag: "lark_md",
+          content: [
+            "**三处要一起改**（漏掉第三条会让组件装不上，不只是警告）：",
+            `1. \`${INSTALLER_SH}\` 和 \`.ps1\` — 版本 + \`--before\` 时间窗`,
+            `2. \`${AGENT_DEF}\` — 接受的发布线`,
+            `3. \`${PEER_MANIFEST}\` — peer 范围加一条比较器`,
+          ].join("\n"),
+        },
+      },
+    ],
+    header: {
+      template: blocking ? "red" : "orange",
+      title: { content: headline, tag: "plain_text" },
+    },
+  };
+}
+
+function signedEnvelope(card: Record<string, unknown>): Record<string, unknown> {
+  const body = { card, msg_type: "interactive" };
+  const signSecret = process.env.FEISHU_SIGN_SECRET?.trim() ?? "";
+  if (signSecret.length === 0) return body;
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const sign = createHmac("sha256", `${timestamp}\n${signSecret}`).update("").digest("base64");
+  return { sign, timestamp, ...body };
+}
+
+async function postFeishu(card: Record<string, unknown>): Promise<void> {
+  const webhook = requiredEnv("FEISHU_WEBHOOK");
+  const response = await fetch(webhook, {
+    body: JSON.stringify(signedEnvelope(card)),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Feishu returned HTTP ${response.status}: ${text.slice(0, 200)}`);
+  }
+}
+
+async function run(dryRun: boolean): Promise<void> {
+  const pinned = readPinnedVersion(readRepoFile(INSTALLER_SH));
+  const defSource = readRepoFile(AGENT_DEF);
+  const pattern = readAcceptedPattern(defSource);
+  const listed = readListedVersions(defSource);
+  const latest = await fetchLatestVersion();
+  const accepted = listed.includes(latest) || (pattern?.test(latest) ?? false);
+  const verdict = classifyDrift({ accepted, latest, pinned });
+
+  console.log(
+    `[dsh-drift] pinned=${verdict.pinned} latest=${verdict.latest} ` +
+      `accepted=${verdict.accepted} severity=${verdict.severity}`,
+  );
+
+  if (verdict.severity === "in-sync") return;
+  const card = buildCard(verdict);
+  if (dryRun) {
+    console.log(JSON.stringify(card, null, 2));
+    return;
+  }
+  await postFeishu(card);
+  console.log("[dsh-drift] posted to Feishu");
+}
+
+function selfCheck(): void {
+  const installer = "NODE_VERSION='24.19.0'\nDSH_VERSION='0.1.1-rc.2'\n";
+  if (readPinnedVersion(installer) !== "0.1.1-rc.2") {
+    throw new Error("self-check could not read the pinned version");
+  }
+
+  const def = [
+    "    supportedVersions: ['0.1.0-rc.8', '0.1.1-rc.2'],",
+    "    supportedVersionPattern: /^0\\.1\\.\\d+(?:-rc\\.\\d+)?$/u,",
+  ].join("\n");
+  const pattern = readAcceptedPattern(def);
+  if (!pattern) throw new Error("self-check could not rebuild the accepted pattern");
+  if (!pattern.test("0.1.1-rc.2") || pattern.test("0.2.0-rc.1")) {
+    throw new Error("self-check rebuilt a pattern that does not match the source literal");
+  }
+  if (!readListedVersions(def).includes("0.1.0-rc.8")) {
+    throw new Error("self-check could not read the listed versions");
+  }
+
+  // The state that shipped twice: the installer and the def agreed with each
+  // other and both were behind the registry. Anything that reports this as
+  // healthy has lost the only thing this check is for.
+  const missed = classifyDrift({
+    accepted: false,
+    latest: "0.1.1-rc.2",
+    pinned: "0.1.0-rc.8",
+  });
+  if (missed.severity !== "unsupported") {
+    throw new Error("self-check expected the shipped-twice state to be unsupported");
+  }
+  if (String(buildCard(missed).header).length === 0) {
+    throw new Error("self-check expected a card for a drifted verdict");
+  }
+
+  const behind = classifyDrift({ accepted: true, latest: "0.1.2", pinned: "0.1.1-rc.2" });
+  if (behind.severity !== "behind") {
+    throw new Error("self-check expected an accepted-but-older latest to be behind");
+  }
+  const synced = classifyDrift({ accepted: true, latest: "0.1.1-rc.2", pinned: "0.1.1-rc.2" });
+  if (synced.severity !== "in-sync") {
+    throw new Error("self-check expected an exact match to be in-sync");
+  }
+
+  console.log("[dsh-drift] self-check passed");
+}
+
+const command = process.argv[2] ?? "run";
+if (command === "self-check") {
+  selfCheck();
+} else if (command === "run") {
+  await run(process.argv.includes("--dry-run"));
+} else {
+  console.error(`unknown command: ${command}`);
+  process.exit(2);
+}

--- a/.github/scripts/dsh-upstream-drift.ts
+++ b/.github/scripts/dsh-upstream-drift.ts
@@ -170,16 +170,68 @@ function signedEnvelope(card: Record<string, unknown>): Record<string, unknown> 
   return { sign, timestamp, ...body };
 }
 
+export interface FeishuDelivery {
+  code: number | null;
+  delivered: boolean;
+  retryable: boolean;
+}
+
+/**
+ * Decide whether Feishu actually accepted the card.
+ *
+ * A rejected webhook request still comes back HTTP 200 with a nonzero `code`,
+ * so treating every 2xx as success loses the one message this workflow exists
+ * to send — silently, which is the worst way to lose an alert. Same contract as
+ * the landing notifier: code 0 (or absent) is delivered; 429, 5xx and Feishu's
+ * 9499 are worth another attempt.
+ */
+export function interpretFeishuResponse(args: {
+  status: number;
+  text: string;
+}): FeishuDelivery {
+  let code: number | null = null;
+  try {
+    const parsed = JSON.parse(args.text) as { StatusCode?: unknown; code?: unknown };
+    const raw = parsed.code ?? parsed.StatusCode ?? null;
+    code = typeof raw === "number" ? raw : null;
+  } catch {
+    // Feishu normally returns JSON; fall back to the HTTP status alone.
+  }
+  const ok = args.status >= 200 && args.status < 300;
+  if (ok && (code === 0 || code === null)) {
+    return { code, delivered: true, retryable: false };
+  }
+  return {
+    code,
+    delivered: false,
+    retryable: args.status === 429 || args.status >= 500 || code === 9499,
+  };
+}
+
 async function postFeishu(card: Record<string, unknown>): Promise<void> {
   const webhook = requiredEnv("FEISHU_WEBHOOK");
-  const response = await fetch(webhook, {
-    body: JSON.stringify(signedEnvelope(card)),
-    headers: { "content-type": "application/json" },
-    method: "POST",
-  });
-  const text = await response.text();
-  if (!response.ok) {
-    throw new Error(`Feishu returned HTTP ${response.status}: ${text.slice(0, 200)}`);
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const response = await fetch(webhook, {
+      body: JSON.stringify(signedEnvelope(card)),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const text = await response.text();
+    const delivery = interpretFeishuResponse({ status: response.status, text });
+    if (delivery.delivered) {
+      console.log(`[dsh-drift] delivered (HTTP ${response.status}, code ${delivery.code ?? "n/a"})`);
+      return;
+    }
+    console.warn(
+      `[dsh-drift] attempt ${attempt}/5 failed: HTTP ${response.status} ` +
+        `code ${String(delivery.code)} ${text.slice(0, 300)}`,
+    );
+    if (!delivery.retryable || attempt === 5) {
+      throw new Error(
+        `Feishu webhook failed: HTTP ${response.status} code ${String(delivery.code)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
   }
 }
 
@@ -253,12 +305,21 @@ function selfCheck(): void {
   console.log("[dsh-drift] self-check passed");
 }
 
-const command = process.argv[2] ?? "run";
-if (command === "self-check") {
-  selfCheck();
-} else if (command === "run") {
-  await run(process.argv.includes("--dry-run"));
-} else {
-  console.error(`unknown command: ${command}`);
-  process.exit(2);
+// Only dispatch when this file is the process entrypoint. Without the guard,
+// importing it to reuse the pure helpers executes `run`: a live registry
+// request during test collection, and — once drift exists — an attempted
+// Feishu post before a single assertion has run.
+const entry = process.argv[1];
+const invokedDirectly = entry !== undefined && path.resolve(entry) === import.meta.filename;
+
+if (invokedDirectly) {
+  const command = process.argv[2] ?? "run";
+  if (command === "self-check") {
+    selfCheck();
+  } else if (command === "run") {
+    await run(process.argv.includes("--dry-run"));
+  } else {
+    console.error(`unknown command: ${command}`);
+    process.exit(2);
+  }
 }

--- a/.github/workflows/dsh-upstream-drift.yml
+++ b/.github/workflows/dsh-upstream-drift.yml
@@ -49,6 +49,6 @@ jobs:
 
       - name: Compare against the npm registry
         env:
-          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_SIGN_SECRET }}
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_LANDING_SIGN_SECRET || secrets.FEISHU_RELEASE_SIGN_SECRET }}
           FEISHU_WEBHOOK: ${{ secrets.FEISHU_LANDING_WEBHOOK || secrets.FEISHU_RELEASE_WEBHOOK }}
         run: node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts run

--- a/.github/workflows/dsh-upstream-drift.yml
+++ b/.github/workflows/dsh-upstream-drift.yml
@@ -1,0 +1,54 @@
+name: dsh-upstream-drift
+
+# Watch upstream DeepSeek Harness releases and say something when we fall behind.
+#
+# `@deepseek-ai/dsh` has twice published a new release line while this repo kept
+# pinning the old one, and both times a person reporting a broken install was the
+# detection mechanism. The in-repo check compares our installers against our
+# agent def — both halves of our own config — so it stays green while both are
+# equally stale. This compares them against the registry instead.
+#
+# Standalone and outside the merge gate, like nix.yml and docker-image.yml: an
+# upstream release is not a reason to fail a PR.
+
+on:
+  schedule:
+    # 01:30 UTC = 09:30 Asia/Shanghai, after the landing summary so the two
+    # morning cards do not arrive at the same minute.
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dsh-upstream-drift
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Compare pinned DeepSeek Harness against the registry
+    if: github.repository == 'nexu-io/open-design' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # Fails on a logic regression before anything reaches the registry or a
+      # webhook, so a broken checker is loud rather than silently in-sync.
+      - name: Check drift script
+        run: node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts self-check
+
+      - name: Compare against the npm registry
+        env:
+          FEISHU_SIGN_SECRET: ${{ secrets.FEISHU_SIGN_SECRET }}
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_LANDING_WEBHOOK || secrets.FEISHU_RELEASE_WEBHOOK }}
+        run: node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts run

--- a/apps/daemon/src/runtimes/defs/deepseek-harness.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek-harness.ts
@@ -62,10 +62,17 @@ export const deepseekHarnessAgentDef = {
     supportedVersions: ['0.1.0-rc.8', '0.1.1-rc.2'],
     // The line, not one point on it. Scoping this to `0.1.0-rc.N` was still a
     // pin: upstream shipped `0.1.1-rc.1` two days later and every user on it
-    // was told their CLI was untested. Patch lines within 0.1.x carry the same
-    // profile protocol, and a stable release on the line is not "untested"
-    // either — a genuinely new minor still is.
-    supportedVersionPattern: /^0\.1\.\d+(?:-rc\.\d+)?$/u,
+    // was told their CLI was untested.
+    //
+    // Prerelease acceptance may never exceed what `packages/dsh-runtime`'s peer
+    // ranges can install, or this suppresses the warning for a version whose
+    // companion cannot resolve — a worse failure than the warning, and silent.
+    // semver admits a prerelease only against a comparator sharing its exact
+    // major.minor.patch AND carrying a prerelease, so the accepted release
+    // candidates are precisely the peers' tuples and floors: `0.1.0-rc.6+` and
+    // any `0.1.1-rc.N`. Stable releases on the line need no such comparator.
+    // `e2e/tests/dsh-installer-version-policy.test.ts` holds the two together.
+    supportedVersionPattern: /^0\.1\.\d+$|^0\.1\.0-rc\.(?:[6-9]|[1-9]\d+)$|^0\.1\.1-rc\.\d+$/u,
     requireVersion: true,
     parse: parseDeepSeekHarnessVersion,
   },

--- a/apps/daemon/src/runtimes/defs/deepseek-harness.ts
+++ b/apps/daemon/src/runtimes/defs/deepseek-harness.ts
@@ -59,8 +59,13 @@ export const deepseekHarnessAgentDef = {
     // who followed our instructions land on an "untested version" warning the
     // week after we bumped the installer. Accept the release line; a version
     // off it still warns.
-    supportedVersions: ['0.1.0-rc.6', '0.1.0-rc.8'],
-    supportedVersionPattern: /^0\.1\.0-rc\.\d+$/u,
+    supportedVersions: ['0.1.0-rc.8', '0.1.1-rc.2'],
+    // The line, not one point on it. Scoping this to `0.1.0-rc.N` was still a
+    // pin: upstream shipped `0.1.1-rc.1` two days later and every user on it
+    // was told their CLI was untested. Patch lines within 0.1.x carry the same
+    // profile protocol, and a stable release on the line is not "untested"
+    // either — a genuinely new minor still is.
+    supportedVersionPattern: /^0\.1\.\d+(?:-rc\.\d+)?$/u,
     requireVersion: true,
     parse: parseDeepSeekHarnessVersion,
   },

--- a/apps/daemon/tests/runtimes/version-policy.test.ts
+++ b/apps/daemon/tests/runtimes/version-policy.test.ts
@@ -115,6 +115,16 @@ describe('runtime version policy', () => {
     ['0.1.0-rc.6', undefined],
     ['0.1.0-rc.8', undefined],
     ['0.1.0-rc.14', undefined],
+    // Upstream moved to a new patch line while a policy scoped to `0.1.0-rc.N`
+    // was in flight, which is how "supported" quietly stopped meaning "what
+    // the registry serves". These are the versions actually published there.
+    ['0.1.1-rc.1', undefined],
+    ['0.1.1-rc.2', undefined],
+    // A stable release on a line we support should not read as untested.
+    ['0.1.1', undefined],
+    // Still off the line, still warns. The point is to stop pinning, not to
+    // stop checking.
+    ['0.2.0-rc.1', 'untested-version'],
     ['0.0.9', 'untested-version'],
   ] as const)('accepts %s on the shipped DeepSeek Harness policy', async (version, reason) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'od-dsh-version-'));

--- a/apps/landing-page/public/install-dsh.ps1
+++ b/apps/landing-page/public/install-dsh.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 $NodeVersion = '24.19.0'
-$DshVersion = '0.1.0-rc.8'
+$DshVersion = '0.1.1-rc.2'
 $PnpmVersion = '11.7.0'
 # Freeze npm's view of the registry to just after $DshVersion was published.
 #
@@ -21,7 +21,7 @@ $PnpmVersion = '11.7.0'
 #
 # The cutoff must stay LATER than $DshVersion's publish time and EARLIER than
 # the next release candidate's. Update both values together.
-$DshResolutionCutoff = '2026-08-19T16:00:00Z'
+$DshResolutionCutoff = '2026-08-21T13:00:00Z'
 
 function Fail([string]$Message) {
   throw "DeepSeek Harness installer: $Message"

--- a/apps/landing-page/public/install-dsh.sh
+++ b/apps/landing-page/public/install-dsh.sh
@@ -2,7 +2,7 @@
 set -eu
 
 NODE_VERSION='24.19.0'
-DSH_VERSION='0.1.0-rc.8'
+DSH_VERSION='0.1.1-rc.2'
 PNPM_VERSION='11.7.0'
 # Freeze npm's view of the registry to just after DSH_VERSION was published.
 #
@@ -17,7 +17,7 @@ PNPM_VERSION='11.7.0'
 #
 # The cutoff must stay LATER than DSH_VERSION's publish time and EARLIER than
 # the next release candidate's. Update both values together.
-DSH_RESOLUTION_CUTOFF='2026-08-19T16:00:00Z'
+DSH_RESOLUTION_CUTOFF='2026-08-21T13:00:00Z'
 
 NO_LAUNCH=0
 

--- a/apps/landing-page/tests/install-dsh-static.test.ts
+++ b/apps/landing-page/tests/install-dsh-static.test.ts
@@ -25,14 +25,14 @@ test('publishes pinned cross-platform DeepSeek Harness installers', () => {
 
   assert.match(shell, /^#!\/usr\/bin\/env sh\n/);
   assert.match(shell, /NODE_VERSION=['"]?24\.19\.0/);
-  assert.match(shell, /DSH_VERSION=['"]?0\.1\.0-rc\.8/);
+  assert.match(shell, /DSH_VERSION=['"]?0\.1\.1-rc\.2/);
   assert.match(shell, /PNPM_VERSION=['"]?11\.7\.0/);
   assert.match(shell, /SHASUMS256\.txt/);
   assert.match(shell, /--no-launch/);
   assert.doesNotMatch(shell, /npm\s+(?:install|i)\s+-g/);
 
   assert.match(powershell, /NodeVersion\s*=\s*'24\.19\.0'/);
-  assert.match(powershell, /DshVersion\s*=\s*'0\.1\.0-rc\.8'/);
+  assert.match(powershell, /DshVersion\s*=\s*'0\.1\.1-rc\.2'/);
   assert.match(powershell, /PnpmVersion\s*=\s*'11\.7\.0'/);
   assert.match(powershell, /Get-FileHash/);
   assert.match(powershell, /NoLaunch/);
@@ -110,7 +110,7 @@ mkdir -p "$prefix/node_modules/@deepseek-ai/dsh/lib" "$prefix/node_modules/.bin"
 : > "$prefix/node_modules/@deepseek-ai/dsh/lib/bin.js"
 cat > "$prefix/node_modules/.bin/dsh" <<'EOF'
 #!/bin/sh
-if [ "$1" = "--version" ]; then printf '%s\\n' '0.1.0-rc.8'; exit 0; fi
+if [ "$1" = "--version" ]; then printf '%s\\n' '0.1.1-rc.2'; exit 0; fi
 if [ "$1" = "plugin" ]; then pnpm --version; exit $?; fi
 printf '%s\\n' "dsh:$*"
 EOF
@@ -151,11 +151,11 @@ printf '%s\\n' '10.33.2'
   try {
     const first = spawnSync('sh', [posixInstaller, '--no-launch'], { encoding: 'utf8', env });
     assert.equal(first.status, 0, first.stderr);
-    assert.match(first.stdout, /DeepSeek Harness 0\.1\.0-rc\.8 is ready/);
+    assert.match(first.stdout, /DeepSeek Harness 0\.1\.1-rc\.2 is ready/);
 
     const version = spawnSync(join(binDir, 'dsh'), ['--version'], { encoding: 'utf8', env });
     assert.equal(version.status, 0, version.stderr);
-    assert.equal(version.stdout.trim(), '0.1.0-rc.8');
+    assert.equal(version.stdout.trim(), '0.1.1-rc.2');
 
     const pluginPnpm = spawnSync(join(binDir, 'dsh'), ['plugin'], { encoding: 'utf8', env });
     assert.equal(pluginPnpm.status, 0, pluginPnpm.stderr);
@@ -178,7 +178,7 @@ test('POSIX installer reuses a complete compatible toolchain without downloading
   mkdirSync(pathDir, { recursive: true });
   for (const [name, version] of [
     ['node', 'v24.19.0'],
-    ['dsh', '0.1.0-rc.8'],
+    ['dsh', '0.1.1-rc.2'],
     ['pnpm', '11.7.0'],
   ] as const) {
     const executable = join(pathDir, name);
@@ -201,7 +201,7 @@ test('POSIX installer reuses a complete compatible toolchain without downloading
     assert.doesNotMatch(result.stdout + result.stderr, /Downloading/);
     const version = spawnSync(join(binDir, 'dsh'), ['--version'], { encoding: 'utf8', env });
     assert.equal(version.status, 0, version.stderr);
-    assert.equal(version.stdout.trim(), '0.1.0-rc.8');
+    assert.equal(version.stdout.trim(), '0.1.1-rc.2');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/e2e/tests/dsh-installer-version-policy.test.ts
+++ b/e2e/tests/dsh-installer-version-policy.test.ts
@@ -19,6 +19,7 @@ const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
 const INSTALL_SH = `${repoRoot}apps/landing-page/public/install-dsh.sh`;
 const INSTALL_PS1 = `${repoRoot}apps/landing-page/public/install-dsh.ps1`;
 const AGENT_DEF = `${repoRoot}apps/daemon/src/runtimes/defs/deepseek-harness.ts`;
+const PEER_MANIFEST = `${repoRoot}packages/dsh-runtime/package.json`;
 
 function requireMatch(source: string, pattern: RegExp, what: string): string {
   const found = pattern.exec(source);
@@ -79,5 +80,92 @@ describe('DeepSeek Harness installer and daemon version policy agree', () => {
 
     expect(accepts(def, '0.0.9')).toBe(false);
     expect(accepts(def, 'not-a-version')).toBe(false);
+  });
+});
+
+/**
+ * The peer ranges in `packages/dsh-runtime/package.json`, reduced to the only
+ * thing that decides whether a prerelease can install: for each
+ * `major.minor.patch` tuple that carries a prerelease comparator, the lowest
+ * release candidate it admits.
+ *
+ * semver refuses a prerelease unless some comparator shares its exact tuple AND
+ * carries a prerelease of its own, so a tuple missing from this map cannot
+ * install at all, however high its number.
+ */
+function peerPrereleaseFloors(manifest: string): Map<string, number> {
+  const floors = new Map<string, number>();
+  for (const match of manifest.matchAll(/>=(\d+\.\d+\.\d+)-rc\.(\d+)/gu)) {
+    const tuple = match[1];
+    const floor = Number(match[2]);
+    if (!tuple || Number.isNaN(floor)) continue;
+    const current = floors.get(tuple);
+    if (current === undefined || floor < current) floors.set(tuple, floor);
+  }
+  return floors;
+}
+
+function peerCanInstall(floors: Map<string, number>, version: string): boolean {
+  const parsed = /^(\d+\.\d+\.\d+)-rc\.(\d+)$/u.exec(version);
+  if (!parsed) return true; // stable releases need no prerelease comparator
+  const tuple = parsed[1];
+  const candidate = Number(parsed[2]);
+  if (tuple === undefined || Number.isNaN(candidate)) return false;
+  const floor = floors.get(tuple);
+  return floor !== undefined && candidate >= floor;
+}
+
+// Two authorities decide whether a DeepSeek Harness version works, and they can
+// disagree silently in the direction that hurts: the daemon suppressing the
+// "untested" warning for a version whose companion cannot install is worse than
+// the warning, because the user is told everything is fine and then it is not.
+//
+// Widening the accepted line without widening the peers is exactly how that
+// happens, so the matrix runs both sides over the versions upstream has shipped
+// or plausibly will.
+describe('accepted DeepSeek Harness versions can actually install their companion', () => {
+  const MATRIX = [
+    '0.1.0-rc.2',
+    '0.1.0-rc.3',
+    '0.1.0-rc.6',
+    '0.1.0-rc.8',
+    '0.1.0-rc.12',
+    '0.1.1-rc.1',
+    '0.1.1-rc.2',
+    '0.1.1',
+    '0.1.2',
+    '0.1.2-rc.1',
+    '0.2.0-rc.1',
+  ];
+
+  it('never claims support for a version the peer ranges reject', async () => {
+    const [def, manifest] = await Promise.all([
+      readFile(AGENT_DEF, 'utf8'),
+      readFile(PEER_MANIFEST, 'utf8'),
+    ]);
+    const floors = peerPrereleaseFloors(manifest);
+    expect(floors.size).toBeGreaterThan(0);
+
+    const overclaimed = MATRIX.filter(
+      (version) => accepts(def, version) && !peerCanInstall(floors, version),
+    );
+
+    expect(overclaimed).toEqual([]);
+  });
+
+  // The two versions the review named, pinned explicitly so a future widening
+  // has to face them rather than quietly passing a filter that matches nothing.
+  it('accepts what upstream serves and refuses the line the peers cannot reach', async () => {
+    const [def, manifest] = await Promise.all([
+      readFile(AGENT_DEF, 'utf8'),
+      readFile(PEER_MANIFEST, 'utf8'),
+    ]);
+    const floors = peerPrereleaseFloors(manifest);
+
+    expect(accepts(def, '0.1.1-rc.2')).toBe(true);
+    expect(peerCanInstall(floors, '0.1.1-rc.2')).toBe(true);
+
+    expect(peerCanInstall(floors, '0.1.2-rc.1')).toBe(false);
+    expect(accepts(def, '0.1.2-rc.1')).toBe(false);
   });
 });

--- a/e2e/tests/dsh-installer-version-policy.test.ts
+++ b/e2e/tests/dsh-installer-version-policy.test.ts
@@ -84,35 +84,58 @@ describe('DeepSeek Harness installer and daemon version policy agree', () => {
 });
 
 /**
- * The peer ranges in `packages/dsh-runtime/package.json`, reduced to the only
- * thing that decides whether a prerelease can install: for each
- * `major.minor.patch` tuple that carries a prerelease comparator, the lowest
- * release candidate it admits.
+ * The peer ranges that track the DeepSeek Harness version, one entry per
+ * package.
  *
- * semver refuses a prerelease unless some comparator shares its exact tuple AND
- * carries a prerelease of its own, so a tuple missing from this map cannot
- * install at all, however high its number.
+ * Kept per dependency on purpose. Merging every comparator in the manifest into
+ * one table lets a single updated peer vouch for the other four, so a
+ * half-finished bump reads as compatible — the exact partial state this file is
+ * supposed to catch. `@deepseek-ai/cordis*` is excluded: it has its own version
+ * line and never moves with dsh.
  */
-function peerPrereleaseFloors(manifest: string): Map<string, number> {
-  const floors = new Map<string, number>();
-  for (const match of manifest.matchAll(/>=(\d+\.\d+\.\d+)-rc\.(\d+)/gu)) {
-    const tuple = match[1];
-    const floor = Number(match[2]);
-    if (!tuple || Number.isNaN(floor)) continue;
-    const current = floors.get(tuple);
-    if (current === undefined || floor < current) floors.set(tuple, floor);
-  }
-  return floors;
+function dshPeerRanges(manifestSource: string): Record<string, string> {
+  const manifest = JSON.parse(manifestSource) as {
+    peerDependencies?: Record<string, string>;
+  };
+  const peers = manifest.peerDependencies ?? {};
+  return Object.fromEntries(
+    Object.entries(peers).filter(([name]) => name.startsWith('@deepseek-ai/dsh-')),
+  );
 }
 
-function peerCanInstall(floors: Map<string, number>, version: string): boolean {
+/**
+ * The lowest release candidate one range admits for a given
+ * `major.minor.patch`, or undefined when it carries no prerelease comparator
+ * for that tuple at all.
+ *
+ * semver refuses a prerelease unless some comparator shares its exact tuple AND
+ * carries a prerelease of its own, so a missing tuple cannot install however
+ * high the candidate number.
+ */
+function prereleaseFloor(range: string, tuple: string): number | undefined {
+  let floor: number | undefined;
+  for (const match of range.matchAll(/>=(\d+\.\d+\.\d+)-rc\.(\d+)/gu)) {
+    if (match[1] !== tuple) continue;
+    const candidate = Number(match[2]);
+    if (Number.isNaN(candidate)) continue;
+    if (floor === undefined || candidate < floor) floor = candidate;
+  }
+  return floor;
+}
+
+/** Installable only when *every* dsh peer admits the version. */
+function peerCanInstall(ranges: Record<string, string>, version: string): boolean {
   const parsed = /^(\d+\.\d+\.\d+)-rc\.(\d+)$/u.exec(version);
   if (!parsed) return true; // stable releases need no prerelease comparator
   const tuple = parsed[1];
   const candidate = Number(parsed[2]);
   if (tuple === undefined || Number.isNaN(candidate)) return false;
-  const floor = floors.get(tuple);
-  return floor !== undefined && candidate >= floor;
+  const entries = Object.values(ranges);
+  if (entries.length === 0) return false;
+  return entries.every((range) => {
+    const floor = prereleaseFloor(range, tuple);
+    return floor !== undefined && candidate >= floor;
+  });
 }
 
 // Two authorities decide whether a DeepSeek Harness version works, and they can
@@ -143,11 +166,11 @@ describe('accepted DeepSeek Harness versions can actually install their companio
       readFile(AGENT_DEF, 'utf8'),
       readFile(PEER_MANIFEST, 'utf8'),
     ]);
-    const floors = peerPrereleaseFloors(manifest);
-    expect(floors.size).toBeGreaterThan(0);
+    const ranges = dshPeerRanges(manifest);
+    expect(Object.keys(ranges).length).toBeGreaterThan(0);
 
     const overclaimed = MATRIX.filter(
-      (version) => accepts(def, version) && !peerCanInstall(floors, version),
+      (version) => accepts(def, version) && !peerCanInstall(ranges, version),
     );
 
     expect(overclaimed).toEqual([]);
@@ -160,12 +183,40 @@ describe('accepted DeepSeek Harness versions can actually install their companio
       readFile(AGENT_DEF, 'utf8'),
       readFile(PEER_MANIFEST, 'utf8'),
     ]);
-    const floors = peerPrereleaseFloors(manifest);
+    const ranges = dshPeerRanges(manifest);
 
     expect(accepts(def, '0.1.1-rc.2')).toBe(true);
-    expect(peerCanInstall(floors, '0.1.1-rc.2')).toBe(true);
+    expect(peerCanInstall(ranges, '0.1.1-rc.2')).toBe(true);
 
-    expect(peerCanInstall(floors, '0.1.2-rc.1')).toBe(false);
+    expect(peerCanInstall(ranges, '0.1.2-rc.1')).toBe(false);
     expect(accepts(def, '0.1.2-rc.1')).toBe(false);
+  });
+
+  // A bump that updates one peer and forgets the rest is the realistic way this
+  // goes wrong — and reading the manifest as one blob hides it, because the
+  // updated peer's comparator answers for everyone. All five ranges being
+  // identical today is a coincidence, not a guarantee.
+  it('does not let one updated peer vouch for the others', () => {
+    const partial = JSON.stringify({
+      peerDependencies: {
+        '@deepseek-ai/cordis': '>=4.0.1',
+        '@deepseek-ai/dsh-agent': '>=0.1.0-rc.6 || >=0.1.1-rc.0',
+        '@deepseek-ai/dsh-llm': '>=0.1.0-rc.6',
+        '@deepseek-ai/dsh-session': '>=0.1.0-rc.6',
+      },
+    });
+    const ranges = dshPeerRanges(partial);
+
+    expect(Object.keys(ranges)).not.toContain('@deepseek-ai/cordis');
+    expect(peerCanInstall(ranges, '0.1.1-rc.2')).toBe(false);
+    expect(peerCanInstall(ranges, '0.1.0-rc.8')).toBe(true);
+  });
+
+  // The floor is part of the contract, not just the tuple.
+  it('respects each range\'s own floor', () => {
+    const ranges = { '@deepseek-ai/dsh-agent': '>=0.1.0-rc.6' };
+
+    expect(peerCanInstall(ranges, '0.1.0-rc.6')).toBe(true);
+    expect(peerCanInstall(ranges, '0.1.0-rc.3')).toBe(false);
   });
 });

--- a/e2e/tests/scripts/dsh-upstream-drift.test.ts
+++ b/e2e/tests/scripts/dsh-upstream-drift.test.ts
@@ -7,11 +7,12 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildCard,
   classifyDrift,
+  interpretFeishuResponse,
   readAcceptedPattern,
   readListedVersions,
   readPinnedVersion,
@@ -81,6 +82,49 @@ describe('DeepSeek Harness upstream drift', () => {
     expect(readAcceptedPattern("    supportedVersions: ['0.1.0-rc.8'],")).toBeNull();
   });
 
+
+  // Importing the module used to run the CLI: collecting this very file fetched
+  // the live registry and, once drift existed, would have tried to post to
+  // Feishu before a single assertion ran. A watcher that fires from a test run
+  // is worse than no watcher.
+  it('does not touch the network when imported', async () => {
+    const realFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: unknown) => {
+      calls.push(String(input));
+      throw new Error('the drift script must not fetch on import');
+    }) as typeof globalThis.fetch;
+
+    try {
+      vi.resetModules();
+      await import('../../../.github/scripts/dsh-upstream-drift.ts');
+      expect(calls).toEqual([]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  // Feishu answers a rejected webhook with HTTP 200 and a nonzero code, so
+  // "2xx means delivered" throws the alert away and reports success doing it.
+  it('only counts a Feishu response as delivered when the app-level code says so', () => {
+    expect(interpretFeishuResponse({ status: 200, text: '{"code":0}' })).toMatchObject({
+      delivered: true,
+    });
+    expect(interpretFeishuResponse({ status: 200, text: '{"StatusCode":0}' })).toMatchObject({
+      delivered: true,
+    });
+    expect(
+      interpretFeishuResponse({ status: 200, text: '{"code":19021,"msg":"sign match fail"}' }),
+    ).toMatchObject({ code: 19021, delivered: false, retryable: false });
+  });
+
+  it('retries only what is worth retrying', () => {
+    expect(interpretFeishuResponse({ status: 429, text: '' }).retryable).toBe(true);
+    expect(interpretFeishuResponse({ status: 503, text: '' }).retryable).toBe(true);
+    expect(interpretFeishuResponse({ status: 200, text: '{"code":9499}' }).retryable).toBe(true);
+    expect(interpretFeishuResponse({ status: 400, text: '{"code":19001}' }).retryable).toBe(false);
+  });
+
   // A watch that only runs on a green PR would never fire, since an upstream
   // release does not touch this repo.
   it('runs on a schedule and stays outside the merge gate', async () => {
@@ -90,5 +134,19 @@ describe('DeepSeek Harness upstream drift', () => {
     expect(workflow).toContain('workflow_dispatch');
     expect(workflow).toContain('dsh-upstream-drift.ts self-check');
     expect(workflow).not.toContain('pull_request');
+  });
+
+  // The webhook and its signing secret are a pair. Selecting the landing bot
+  // while signing with the release bot's secret sends a card Feishu rejects,
+  // which is a silent loss of the only message this workflow exists to send.
+  it('signs with the secret belonging to the webhook it chose', async () => {
+    const workflow = await readFile(WORKFLOW, 'utf8');
+
+    expect(workflow).toContain(
+      'secrets.FEISHU_LANDING_WEBHOOK || secrets.FEISHU_RELEASE_WEBHOOK',
+    );
+    expect(workflow).toContain(
+      'secrets.FEISHU_LANDING_SIGN_SECRET || secrets.FEISHU_RELEASE_SIGN_SECRET',
+    );
   });
 });

--- a/e2e/tests/scripts/dsh-upstream-drift.test.ts
+++ b/e2e/tests/scripts/dsh-upstream-drift.test.ts
@@ -1,0 +1,94 @@
+// The upstream watch exists because the in-repo drift check cannot see the one
+// thing that actually went wrong twice: our installers and our agent def
+// agreeing with each other while both sat behind what npm serves. These cases
+// pin that distinction, plus the parsing that lets the checker read either side
+// out of source rather than being told the versions twice.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCard,
+  classifyDrift,
+  readAcceptedPattern,
+  readListedVersions,
+  readPinnedVersion,
+} from '../../../.github/scripts/dsh-upstream-drift.ts';
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const INSTALLER_SH = `${repoRoot}apps/landing-page/public/install-dsh.sh`;
+const AGENT_DEF = `${repoRoot}apps/daemon/src/runtimes/defs/deepseek-harness.ts`;
+const WORKFLOW = `${repoRoot}.github/workflows/dsh-upstream-drift.yml`;
+
+describe('DeepSeek Harness upstream drift', () => {
+  it('reads what we currently ship out of the real files', async () => {
+    const [installer, def] = await Promise.all([
+      readFile(INSTALLER_SH, 'utf8'),
+      readFile(AGENT_DEF, 'utf8'),
+    ]);
+
+    const pinned = readPinnedVersion(installer);
+    expect(pinned).toMatch(/^\d+\.\d+\.\d+/u);
+
+    // Whatever the installer hands a user has to be a version the daemon
+    // accepts, or we ship an "untested" warning to anyone who follows our own
+    // instructions. The dedicated guard for that pairing is
+    // `e2e/tests/dsh-installer-version-policy.test.ts`; this asserts the
+    // checker can see both sides, which is what makes its verdict meaningful.
+    const pattern = readAcceptedPattern(def);
+    const listed = readListedVersions(def);
+    expect(listed.length).toBeGreaterThan(0);
+    expect(listed.includes(pinned) || (pattern?.test(pinned) ?? false)).toBe(true);
+  });
+
+  // The state that shipped twice. Both halves of our config agree, so the
+  // in-repo check is green, and a user on what npm serves is outside what we
+  // support — Settings calls their CLI untested and the peer ranges will not
+  // resolve. Anything that reports this as healthy has lost the point.
+  it('calls an accepted-nowhere latest unsupported, not merely behind', () => {
+    const verdict = classifyDrift({
+      accepted: false,
+      latest: '0.1.1-rc.2',
+      pinned: '0.1.0-rc.8',
+    });
+
+    expect(verdict.severity).toBe('unsupported');
+    expect(JSON.stringify(buildCard(verdict))).toContain('0.1.1-rc.2');
+  });
+
+  it('separates "we ship an older version" from "we do not support theirs"', () => {
+    expect(
+      classifyDrift({ accepted: true, latest: '0.1.2', pinned: '0.1.1-rc.2' }).severity,
+    ).toBe('behind');
+    expect(
+      classifyDrift({ accepted: true, latest: '0.1.1-rc.2', pinned: '0.1.1-rc.2' }).severity,
+    ).toBe('in-sync');
+  });
+
+  it('rebuilds the accepted pattern from source rather than restating it', () => {
+    const pattern = readAcceptedPattern(
+      "    supportedVersionPattern: /^0\\.1\\.\\d+(?:-rc\\.\\d+)?$/u,",
+    );
+
+    expect(pattern?.test('0.1.1-rc.2')).toBe(true);
+    expect(pattern?.test('0.1.9')).toBe(true);
+    expect(pattern?.test('0.2.0-rc.1')).toBe(false);
+  });
+
+  it('treats a def with no pattern as accepting only what it lists', () => {
+    expect(readAcceptedPattern("    supportedVersions: ['0.1.0-rc.8'],")).toBeNull();
+  });
+
+  // A watch that only runs on a green PR would never fire, since an upstream
+  // release does not touch this repo.
+  it('runs on a schedule and stays outside the merge gate', async () => {
+    const workflow = await readFile(WORKFLOW, 'utf8');
+
+    expect(workflow).toMatch(/^on:\n\s+schedule:/mu);
+    expect(workflow).toContain('workflow_dispatch');
+    expect(workflow).toContain('dsh-upstream-drift.ts self-check');
+    expect(workflow).not.toContain('pull_request');
+  });
+});

--- a/packages/dsh-runtime/package.json
+++ b/packages/dsh-runtime/package.json
@@ -42,26 +42,26 @@
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
-    "@deepseek-ai/dsh-cmdline": "0.1.0-rc.8",
+    "@deepseek-ai/dsh-cmdline": "0.1.1-rc.2",
     "commander": "15.0.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.1",
     "@deepseek-ai/cordis-plugin-loader": ">=1.0.2",
-    "@deepseek-ai/dsh-agent": ">=0.1.0-rc.6",
-    "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6",
-    "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.6",
-    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6",
-    "@deepseek-ai/dsh-session": ">=0.1.0-rc.6"
+    "@deepseek-ai/dsh-agent": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
+    "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
+    "@deepseek-ai/dsh-invariants": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
+    "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 || >=0.1.1-rc.0",
+    "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 || >=0.1.1-rc.0"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",
     "@deepseek-ai/cordis-plugin-loader": "1.0.2",
-    "@deepseek-ai/dsh-agent": "0.1.0-rc.8",
-    "@deepseek-ai/dsh-agent-default-model": "0.1.0-rc.8",
-    "@deepseek-ai/dsh-invariants": "0.1.0-rc.8",
-    "@deepseek-ai/dsh-llm": "0.1.0-rc.8",
-    "@deepseek-ai/dsh-session": "0.1.0-rc.8",
+    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-invariants": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.1-rc.2",
     "@types/node": "24.12.2",
     "esbuild": "0.28.0",
     "tsx": "4.22.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,8 +585,8 @@ importers:
   packages/dsh-runtime:
     dependencies:
       '@deepseek-ai/dsh-cmdline':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       commander:
         specifier: 15.0.0
         version: 15.0.0
@@ -598,20 +598,20 @@ importers:
         specifier: 1.0.2
         version: 1.0.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-agent':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(4a95ed5857065bbd0ed98b4ab4a1c608)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(e35bd92879db1f082ad59c7c23426b82)
       '@deepseek-ai/dsh-agent-default-model':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(11098d5dd6ff9dba46449805d66d52e2)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(d4f08d35b1f5acfd9b5b3764fe995e31)
       '@deepseek-ai/dsh-invariants':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session':
-        specifier: 0.1.0-rc.8
-        version: 0.1.0-rc.8(4345a04528ba5fe6fca14c14c75a9257)
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(dcc89a15c4a3b9718c7c9b47f06b8614)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -1254,25 +1254,25 @@ packages:
   '@deepseek-ai/cosmokit@1.8.2':
     resolution: {integrity: sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==}
 
-  '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.8':
-    resolution: {integrity: sha512-FSmgVy8yeVYx3krUwfWZR3JokLD202FSuEd/ZfGdxA+BhOKAOfhNv539kujatVqXyzCG3XiRNda7zWxCh2h7/A==}
+  '@deepseek-ai/dsh-agent-default-model@0.1.1-rc.2':
+    resolution: {integrity: sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-agent': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-llm': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-settings': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-agent': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-settings': ^0.1.1-rc.2
 
-  '@deepseek-ai/dsh-agent@0.1.0-rc.8':
-    resolution: {integrity: sha512-fOl46ZvzoYHalrlyfOJAHNhzyKeVDTUnZZKNSJEr9GY/98WJTjcV21agVEofTXldkJ7a/ws2HpJkVNJVFMtslg==}
+  '@deepseek-ai/dsh-agent@0.1.1-rc.2':
+    resolution: {integrity: sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-llm': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-scope': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-session': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-session': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-system-prompt': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-attachment@0.1.0-rc.6':
     resolution: {integrity: sha512-3P6N17NQ8jqSQGzeCs+svCIqArU8oq0YmgEAo+axN9aVuUDferWU4DLRSX59UGpmyldX4LQn81toA+c+DqMcHg==}
@@ -1287,26 +1287,26 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
 
-  '@deepseek-ai/dsh-cmdline@0.1.0-rc.8':
-    resolution: {integrity: sha512-xsnNFm2XpMD9wpBBLq80x8yXTi664DHywkLwxgAhDsWyp9tB2aSWaWVKxugPWSWwrB3F4nfloWqaeUfgXRFtBQ==}
+  '@deepseek-ai/dsh-cmdline@0.1.1-rc.2':
+    resolution: {integrity: sha512-0/dEVUm7Xy0aBo0DBqC5F3kxC5ahzKcmHOF+Q6E1lBqTwN2xytGYTh0TSfj+6rS31jDqxeIvWxy35bLl83n/Sg==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/cordis-plugin-loader': ^1.0.2
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
 
-  '@deepseek-ai/dsh-invariants@0.1.0-rc.8':
-    resolution: {integrity: sha512-u0lYqyxOYwfsVnbsfGXZos5vFvA4cqFnBEW3/ezgljNwkYwzeUP/Y5wjPnQjP+ZzBn3CnVeIF6s2N2Vk3iA5mQ==}
+  '@deepseek-ai/dsh-invariants@0.1.1-rc.2':
+    resolution: {integrity: sha512-l+1Om/EDFyMjhgSuEx2WDLLA2fia/+ga9mBTCoT/MMslsnWaK5G0/lWwbwlTBSaJ6OfmYc3DuBgox8DbgIGHRQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
 
-  '@deepseek-ai/dsh-llm@0.1.0-rc.8':
-    resolution: {integrity: sha512-hf6RmX2Stn1UtzpktSHQLkIktQkBm9i/3yFfJlbGSkwyw5Cv9sTYJbyoHzsSnnh6i8nRRcMcBhvMgm23I00oIw==}
+  '@deepseek-ai/dsh-llm@0.1.1-rc.2':
+    resolution: {integrity: sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-attachment': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-brand': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-timeout': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-attachment': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-timeout': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-scope@0.1.0-rc.6':
     resolution: {integrity: sha512-UlDLV4syLoJinNg9imhXrSAHrdaTa5Ff8gg46rzjFJGPUOhAk3DZff0hryT5OhrBi0A5Tj92qVpg2pRVvxnUzQ==}
@@ -1314,15 +1314,15 @@ packages:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
 
-  '@deepseek-ai/dsh-session@0.1.0-rc.8':
-    resolution: {integrity: sha512-Qs5Mgn32WPPVB4rKHjsZBgLOkh0TQurUAcc9GaDVudK4dUkpno2HDh++qu/PrwRA3CZ/iwPAoFHCpB3AMMaoLg==}
+  '@deepseek-ai/dsh-session@0.1.1-rc.2':
+    resolution: {integrity: sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
-      '@deepseek-ai/dsh-brand': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-llm': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-scope': ^0.1.0-rc.8
-      '@deepseek-ai/dsh-typert-protocol': ^0.1.0-rc.8
+      '@deepseek-ai/dsh-brand': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-typert-protocol': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-settings@0.1.0-rc.6':
     resolution: {integrity: sha512-5ZlH2FNRU0kkdcCoEJohvdb2fiNnxM+iZqN3icbR3WQbMm8RPRrXlZlps5YUaQKPRbNRHA2LkOXW998QRlhHcA==}
@@ -7863,94 +7863,94 @@ snapshots:
 
   '@deepseek-ai/cosmokit@1.8.2': {}
 
-  '@deepseek-ai/dsh-agent-default-model@0.1.0-rc.8(11098d5dd6ff9dba46449805d66d52e2)':
+  '@deepseek-ai/dsh-agent-default-model@0.1.1-rc.2(d4f08d35b1f5acfd9b5b3764fe995e31)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-agent': 0.1.0-rc.8(4a95ed5857065bbd0ed98b4ab4a1c608)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-settings': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
+      '@deepseek-ai/dsh-agent': 0.1.1-rc.2(e35bd92879db1f082ad59c7c23426b82)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-settings': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-agent@0.1.0-rc.8(4a95ed5857065bbd0ed98b4ab4a1c608)':
+  '@deepseek-ai/dsh-agent@0.1.1-rc.2(e35bd92879db1f082ad59c7c23426b82)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-session': 0.1.0-rc.8(4345a04528ba5fe6fca14c14c75a9257)
-      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session': 0.1.1-rc.2(dcc89a15c4a3b9718c7c9b47f06b8614)
+      '@deepseek-ai/dsh-system-prompt': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-cmdline@0.1.0-rc.8(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-cmdline@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)':
+  '@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-timeout': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-attachment': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-timeout': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-session@0.1.0-rc.8(4345a04528ba5fe6fca14c14c75a9257)':
+  '@deepseek-ai/dsh-session@0.1.1-rc.2(dcc89a15c4a3b9718c7c9b47f06b8614)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-typert-protocol': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-settings@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
+  '@deepseek-ai/dsh-settings@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-brand': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-system-prompt@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-typert-protocol@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/schemastery@3.18.1':
     dependencies:


### PR DESCRIPTION
## Why

A product colleague asked for support for the latest DeepSeek Harness. We do not have it, and checking why turned up something worse than a stale warning.

#7153 replaced a pin on one release candidate with the `0.1.0-rc.N` line. Two days later upstream published `0.1.1-rc.1`, then `0.1.1-rc.2`, and pointed the `latest` tag at it. So the line we support is no longer the line the registry serves, in three places at once:

| | on `main` | against `0.1.1-rc.2` |
|---|---|---|
| version policy | `/^0\.1\.0-rc\.\d+$/` | no match → "has not been tested with this OpenDesign build" |
| installers | pinned `0.1.0-rc.8` | hands out a version two releases behind `latest` |
| `dsh-runtime` peers | `>=0.1.0-rc.6` | **does not resolve** |

The third row is the one that matters. It is not a cosmetic warning — it is the connection component failing to install against the host the user actually has, which is exactly the defect #7153 existed to fix, recurring one version line over.

The mechanism is the semver rule this project has now been bitten by twice: a prerelease version satisfies a range only when some comparator carries the **same** `major.minor.patch` tuple **and** its own prerelease tag. `>=0.1.0-rc.6` has the tuple `0.1.0`, so nothing on the `0.1.1` line can match it:

```
satisfies('0.1.0-rc.8', '>=0.1.0-rc.6')  => true
satisfies('0.1.1-rc.2', '>=0.1.0-rc.6')  => false   ← what users install today
satisfies('0.1.1',      '>=0.1.0-rc.6')  => true    ← stable is fine, prereleases are not
```

## What users will see

- Installing DeepSeek Harness with our one-line installer now gives `0.1.1-rc.2`, the version npm serves as `latest`, instead of `0.1.0-rc.8`.
- Settings stops calling a current install "untested".
- The DeepSeek Harness connection component installs against a `0.1.1-rc.x` host instead of failing peer resolution.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the installers pin `0.1.1-rc.2` (was `0.1.0-rc.8`) and the resolution window moves with it; the agent def accepts the whole `0.1.x` line
- [x] **GitHub automation** — new standalone scheduled workflow `dsh-upstream-drift.yml` plus `.github/scripts/dsh-upstream-drift.ts`; reuses the existing Feishu webhook secrets, adds none
- [ ] **None**

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/version-policy.test.ts`
- Red before, green after: the three cases for what upstream actually publishes — `0.1.1-rc.1`, `0.1.1-rc.2`, `0.1.1` — fail on `main` with `expected 'untested-version' to be undefined`, and pass here.
- The check did not get weaker: `0.2.0-rc.1` and `0.0.9` still warn. The point is to stop pinning, not to stop checking.
- `e2e/tests/dsh-installer-version-policy.test.ts` (added in #7153) keeps the installers and the agent def pinned to each other, and passes on the new pair.

## Validation

Everything below ran on this head.

- `pnpm typecheck` — exit 0 across all packages
- `pnpm guard` — exit 0
- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/` — 59 files, 917 passed / 2 skipped
- `pnpm --filter @open-design/landing-page test` — 234 passed
- `pnpm --filter @open-design/dsh-runtime typecheck && build && test` — exit 0, 12 passed, **with its dev pins raised to `0.1.1-rc.2`**, so compatibility with the newer host is compiler-verified rather than asserted

End-to-end, against the real registry and a real daemon:

- Ran the patched `install-dsh.sh` for real into an isolated root: `added 454 packages in 10m`, exit 0, **zero ERESOLVE lines**, launcher reports `0.1.1-rc.2`.
- Started a real daemon with that install first on PATH:

  ```
  GET  /api/agents            → available: true, version 0.1.1-rc.2, diagnostics: []
  POST /api/test/connection   → ok: true, kind: "success", sample: "ok"
  ```

  The connection test spawns the agent for real and takes a model reply back, so this is the whole path and not just detection.

- Baseline on the same machine, same install, with only the agent def checked out from `origin/main` and recompiled:

  ```
  GET /api/agents → available: true, version 0.1.1-rc.2, diagnostics: ["untested-version"]
  ```

## The watch that stops this recurring

The version bump above is the third time this class of problem has been fixed by hand, so this PR also adds what would have caught it.

`e2e/tests/dsh-installer-version-policy.test.ts` compares our installers against our agent def. Both are our own config, so it is green exactly when they are equally out of date — the state that shipped twice. Nothing in the repo looked at the registry.

`.github/workflows/dsh-upstream-drift.yml` runs daily and does. It separates the two failures worth telling apart:

- **behind** — our installer hands out an older version than `latest`; everything still works
- **unsupported** — a user who has what npm serves is outside what we claim to support: an "untested" warning in Settings, and peer ranges that do not resolve

The Feishu card names all three files that have to move together, because forgetting the peer manifest is the one that breaks an install rather than warning about it.

Standalone and outside the merge gate, like `nix.yml` and `docker-image.yml` — an upstream release is not a reason to fail someone's PR. The workflow runs `self-check` before touching the registry, so a broken checker is loud instead of quietly reporting in-sync.

### Verified end to end, against the live registry

Not just unit-tested — the checker was run both ways:

```
# on this branch, after the bump
$ node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts run --dry-run
[dsh-drift] pinned=0.1.1-rc.2 latest=0.1.1-rc.2 accepted=true severity=in-sync

# with both files checked out from origin/main — the exact state that shipped
$ node --experimental-strip-types .github/scripts/dsh-upstream-drift.ts run --dry-run
[dsh-drift] pinned=0.1.0-rc.8 latest=0.1.1-rc.2 accepted=false severity=unsupported
```

The second run is the proof that matters: our installer and our agent def agreed with each other, the in-repo check would have been green, and this one still fires.

- `node ... dsh-upstream-drift.ts self-check` — passes
- `pnpm --filter @open-design/e2e exec vitest run tests/scripts/` — 17 files, 127 passed
- `pnpm --filter @open-design/e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 73 passed / 1 skipped, so the workflow topology checks still hold
- `pnpm guard` and `pnpm typecheck` — exit 0

### What it still cannot do

A comparator per prerelease line is the most semver allows, so `0.1.2-rc.1` will still need someone to add one to `packages/dsh-runtime/package.json`. This does not make the fix automatic — it makes the need visible the morning after upstream ships, instead of whenever someone files a bug.
