### PR TITLE
fix(daemon): report fatal MCP stdio process errors

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1775,19 +1775,62 @@ function mcpDeliveryFacts(
   };
 }
 
-export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
-  const daemonTarget = createMcpDaemonTarget(options);
-  const briefStore = createLocalMcpBriefStore();
-  let observabilityPromise: Promise<McpObservabilitySession> | null = null;
-  let closeTransportForIdle: (() => void) | null = null;
-  const idleExit = _createMcpIdleExitController({
-    idleMs: MCP_STDIO_IDLE_EXIT_MS,
-    onIdle: () => closeTransportForIdle?.(),
+export function _installMcpFatalErrorHandlers(options: {
+  writeStderr?: (message: string) => void;
+  exit?: (code: number) => void;
+} = {}): () => void {
+  const writeStderr = options.writeStderr ?? ((message: string) => {
+    process.stderr.write(message);
   });
-  const withMcpActivity =
-    <Args extends unknown[], Result>(handler: (...args: Args) => Result | Promise<Result>) =>
-      (...args: Args) =>
-        idleExit.trackRequest(() => handler(...args));
+  const exit = options.exit ?? ((code: number) => {
+    process.exit(code);
+  });
+  let exiting = false;
+  const reportAndExit = (kind: string, reason: unknown) => {
+    if (exiting) return;
+    exiting = true;
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    writeStderr(`[od mcp] ${kind}: ${error.stack ?? error.message}\n`);
+    exit(1);
+  };
+  const onUncaughtException = (error: Error) => {
+    reportAndExit('uncaught exception', error);
+  };
+  const onUnhandledRejection = (reason: unknown) => {
+    reportAndExit('unhandled rejection', reason);
+  };
+  process.on('uncaughtException', onUncaughtException);
+  process.on('unhandledRejection', onUnhandledRejection);
+  return () => {
+    process.off('uncaughtException', onUncaughtException);
+    process.off('unhandledRejection', onUnhandledRejection);
+  };
+}
+
+export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
+  const disposeFatalErrorHandlers = _installMcpFatalErrorHandlers();
+  try {
+    await runMcpStdioImplementation(options);
+  } finally {
+    disposeFatalErrorHandlers();
+  }
+}
+
+async function runMcpStdioImplementation(options: RunMcpOptions): Promise<void> {
+  let closeTransportForIdle: (() => void) | null = null;
+  let idleExit: ReturnType<typeof _createMcpIdleExitController> | null = null;
+  try {
+    const daemonTarget = createMcpDaemonTarget(options);
+    const briefStore = createLocalMcpBriefStore();
+    let observabilityPromise: Promise<McpObservabilitySession> | null = null;
+    idleExit = _createMcpIdleExitController({
+      idleMs: MCP_STDIO_IDLE_EXIT_MS,
+      onIdle: () => closeTransportForIdle?.(),
+    });
+    const withMcpActivity =
+      <Args extends unknown[], Result>(handler: (...args: Args) => Result | Promise<Result>) =>
+        (...args: Args) =>
+          idleExit!.trackRequest(() => handler(...args));
 
   const server = new Server(
     { name: SERVER_NAME, version: SERVER_VERSION },
@@ -1954,7 +1997,7 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
 
     const sdkOnMessage = transport.onmessage;
     transport.onmessage = (...args) => {
-      idleExit.noteActivity();
+      idleExit!.noteActivity();
       sdkOnMessage?.(...args);
     };
 
@@ -1968,7 +2011,7 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
       const done = () => {
         if (finished) return;
         finished = true;
-        idleExit.dispose();
+        idleExit!.dispose();
         resolve();
       };
       transport.onclose = () => {
@@ -1982,8 +2025,11 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
       process.stdin.once('close', closeTransportForStdin);
     });
   } finally {
-    idleExit.dispose();
+    idleExit?.dispose();
     closeTransportForIdle = null;
+  }
+  } finally {
+    idleExit?.dispose();
   }
 }
 

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1803,19 +1803,62 @@ function mcpDeliveryFacts(
   };
 }
 
-export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
-  const daemonTarget = createMcpDaemonTarget(options);
-  const briefStore = createLocalMcpBriefStore();
-  let observabilityPromise: Promise<McpObservabilitySession> | null = null;
-  let closeTransportForIdle: (() => void) | null = null;
-  const idleExit = _createMcpIdleExitController({
-    idleMs: _resolveMcpStdioIdleExitMs(),
-    onIdle: () => closeTransportForIdle?.(),
+export function _installMcpFatalErrorHandlers(options: {
+  writeStderr?: (message: string) => void;
+  exit?: (code: number) => void;
+} = {}): () => void {
+  const writeStderr = options.writeStderr ?? ((message: string) => {
+    process.stderr.write(message);
   });
-  const withMcpActivity =
-    <Args extends unknown[], Result>(handler: (...args: Args) => Result | Promise<Result>) =>
-      (...args: Args) =>
-        idleExit.trackRequest(() => handler(...args));
+  const exit = options.exit ?? ((code: number) => {
+    process.exit(code);
+  });
+  let exiting = false;
+  const reportAndExit = (kind: string, reason: unknown) => {
+    if (exiting) return;
+    exiting = true;
+    const error = reason instanceof Error ? reason : new Error(String(reason));
+    writeStderr(`[od mcp] ${kind}: ${error.stack ?? error.message}\n`);
+    exit(1);
+  };
+  const onUncaughtException = (error: Error) => {
+    reportAndExit('uncaught exception', error);
+  };
+  const onUnhandledRejection = (reason: unknown) => {
+    reportAndExit('unhandled rejection', reason);
+  };
+  process.on('uncaughtException', onUncaughtException);
+  process.on('unhandledRejection', onUnhandledRejection);
+  return () => {
+    process.off('uncaughtException', onUncaughtException);
+    process.off('unhandledRejection', onUnhandledRejection);
+  };
+}
+
+export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
+  const disposeFatalErrorHandlers = _installMcpFatalErrorHandlers();
+  try {
+    await runMcpStdioImplementation(options);
+  } finally {
+    disposeFatalErrorHandlers();
+  }
+}
+
+async function runMcpStdioImplementation(options: RunMcpOptions): Promise<void> {
+  let closeTransportForIdle: (() => void) | null = null;
+  let idleExit: ReturnType<typeof _createMcpIdleExitController> | null = null;
+  try {
+    const daemonTarget = createMcpDaemonTarget(options);
+    const briefStore = createLocalMcpBriefStore();
+    let observabilityPromise: Promise<McpObservabilitySession> | null = null;
+    idleExit = _createMcpIdleExitController({
+      idleMs: _resolveMcpStdioIdleExitMs(),
+      onIdle: () => closeTransportForIdle?.(),
+    });
+    const withMcpActivity =
+      <Args extends unknown[], Result>(handler: (...args: Args) => Result | Promise<Result>) =>
+        (...args: Args) =>
+          idleExit!.trackRequest(() => handler(...args));
 
   const server = new Server(
     { name: SERVER_NAME, version: SERVER_VERSION },
@@ -1982,7 +2025,7 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
 
     const sdkOnMessage = transport.onmessage;
     transport.onmessage = (...args) => {
-      idleExit.noteActivity();
+      idleExit!.noteActivity();
       sdkOnMessage?.(...args);
     };
 
@@ -1996,7 +2039,7 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
       const done = () => {
         if (finished) return;
         finished = true;
-        idleExit.dispose();
+        idleExit!.dispose();
         resolve();
       };
       transport.onclose = () => {
@@ -2010,8 +2053,11 @@ export async function runMcpStdio(options: RunMcpOptions): Promise<void> {
       process.stdin.once('close', closeTransportForStdin);
     });
   } finally {
-    idleExit.dispose();
+    idleExit?.dispose();
     closeTransportForIdle = null;
+  }
+  } finally {
+    idleExit?.dispose();
   }
 }
 

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1814,12 +1814,45 @@ export function _installMcpFatalErrorHandlers(options: {
     process.exit(code);
   });
   let exiting = false;
+  const finish = () => {
+    try {
+      exit(1);
+    } catch {
+      process.exitCode = 1;
+    }
+  };
+  // process.exit() does not wait for a pending pipe write, so the diagnostic
+  // can be lost on the MCP client's stderr pipe (see flushStreamsAndExit in
+  // cli.ts). Injected streams are synchronous, so those exit immediately.
+  const flushThenExit = () => {
+    if (options.writeStderr || options.exit) {
+      finish();
+      return;
+    }
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const done = () => {
+      if (timeout) clearTimeout(timeout);
+      finish();
+    };
+    try {
+      timeout = setTimeout(done, 250);
+      timeout.unref?.();
+      process.stderr.write('', done);
+    } catch {
+      done();
+    }
+  };
   const reportAndExit = (kind: string, reason: unknown) => {
     if (exiting) return;
     exiting = true;
-    const error = reason instanceof Error ? reason : new Error(String(reason));
-    writeStderr(`[od mcp] ${kind}: ${error.stack ?? error.message}\n`);
-    exit(1);
+    try {
+      const error = reason instanceof Error ? reason : new Error(String(reason));
+      writeStderr(`[od mcp] ${kind}: ${error.stack ?? error.message}\n`);
+    } catch {
+      // A diagnostic that cannot be written must not block the fatal exit.
+    } finally {
+      flushThenExit();
+    }
   };
   const onUncaughtException = (error: Error) => {
     reportAndExit('uncaught exception', error);

--- a/apps/daemon/tests/mcp-fatal-errors.test.ts
+++ b/apps/daemon/tests/mcp-fatal-errors.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { _installMcpFatalErrorHandlers, runMcpStdio } from "../src/mcp.js";
+
+describe("MCP stdio fatal error handlers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports uncaught exceptions to stderr and exits unsuccessfully", () => {
+    const writeStderr = vi.fn();
+    const exit = vi.fn();
+    const dispose = _installMcpFatalErrorHandlers({ writeStderr, exit });
+
+    (
+      process as unknown as {
+        emit(name: string, ...values: unknown[]): boolean;
+      }
+    ).emit("uncaughtException", new Error("stdio crashed"));
+
+    expect(writeStderr).toHaveBeenCalledWith(
+      expect.stringContaining("stdio crashed"),
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+    dispose();
+  });
+
+  it("uses stderr for default reporting without writing protocol stdout", () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const exit = vi.fn();
+    const dispose = _installMcpFatalErrorHandlers({ exit });
+
+    (
+      process as unknown as {
+        emit(name: string, ...values: unknown[]): boolean;
+      }
+    ).emit("uncaughtException", new Error("default reporter crashed"));
+
+    expect(stderrWrite).toHaveBeenCalledWith(
+      expect.stringContaining("default reporter crashed"),
+    );
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+    dispose();
+  });
+
+  it("reports non-Error unhandled rejections and removes both handlers", () => {
+    const writeStderr = vi.fn();
+    const exit = vi.fn();
+    const listenerCount = (event: string) =>
+      (process as unknown as { listeners(name: string): unknown[] }).listeners(
+        event,
+      ).length;
+    const emitProcessEvent = (event: string, ...args: unknown[]) =>
+      (
+        process as unknown as {
+          emit(name: string, ...values: unknown[]): boolean;
+        }
+      ).emit(event, ...args);
+    const exceptionListeners = listenerCount("uncaughtException");
+    const rejectionListeners = listenerCount("unhandledRejection");
+    const dispose = _installMcpFatalErrorHandlers({ writeStderr, exit });
+
+    expect(listenerCount("uncaughtException")).toBe(exceptionListeners + 1);
+    expect(listenerCount("unhandledRejection")).toBe(rejectionListeners + 1);
+    emitProcessEvent("unhandledRejection", "rejected value");
+    expect(writeStderr).toHaveBeenCalledWith(
+      expect.stringContaining("rejected value"),
+    );
+    expect(exit).toHaveBeenCalledWith(1);
+
+    dispose();
+    expect(listenerCount("uncaughtException")).toBe(exceptionListeners);
+    expect(listenerCount("unhandledRejection")).toBe(rejectionListeners);
+  });
+
+  it("cleans up handlers when startup initialization fails", async () => {
+    const exceptionListeners = process.listeners("uncaughtException").length;
+    const rejectionListeners = process.listeners("unhandledRejection").length;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(() => {
+      expect(process.listeners("uncaughtException").length).toBe(
+        exceptionListeners + 1,
+      );
+      expect(process.listeners("unhandledRejection").length).toBe(
+        rejectionListeners + 1,
+      );
+      throw new Error("idle controller initialization failed");
+    });
+
+    await expect(
+      runMcpStdio({ daemonUrl: "http://127.0.0.1:1234" }),
+    ).rejects.toThrow("idle controller initialization failed");
+    expect(process.listeners("uncaughtException").length).toBe(
+      exceptionListeners,
+    );
+    expect(process.listeners("unhandledRejection").length).toBe(
+      rejectionListeners,
+    );
+  });
+});

--- a/apps/daemon/tests/mcp-fatal-errors.test.ts
+++ b/apps/daemon/tests/mcp-fatal-errors.test.ts
@@ -48,6 +48,44 @@ describe("MCP stdio fatal error handlers", () => {
     dispose();
   });
 
+  it("still exits when the stderr diagnostic write throws", () => {
+    const writeStderr = vi.fn(() => {
+      throw new Error("ERR_STREAM_DESTROYED");
+    });
+    const exit = vi.fn();
+    const dispose = _installMcpFatalErrorHandlers({ writeStderr, exit });
+
+    (
+      process as unknown as {
+        emit(name: string, ...values: unknown[]): boolean;
+      }
+    ).emit("uncaughtException", new Error("stdio crashed"));
+
+    expect(writeStderr).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+    dispose();
+  });
+
+  it("still exits when the fatal reason cannot be stringified", () => {
+    const writeStderr = vi.fn();
+    const exit = vi.fn();
+    const dispose = _installMcpFatalErrorHandlers({ writeStderr, exit });
+
+    (
+      process as unknown as {
+        emit(name: string, ...values: unknown[]): boolean;
+      }
+    ).emit("unhandledRejection", {
+      toString() {
+        throw new Error("unstringifiable reason");
+      },
+    });
+
+    expect(writeStderr).not.toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(1);
+    dispose();
+  });
+
   it("reports non-Error unhandled rejections and removes both handlers", () => {
     const writeStderr = vi.fn();
     const exit = vi.fn();

--- a/apps/daemon/tests/mcp-fatal-wiring.test.ts
+++ b/apps/daemon/tests/mcp-fatal-wiring.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  listenersDuringConnect: 0,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+  Server: class {
+    setRequestHandler() {}
+
+    getClientVersion() {
+      return undefined;
+    }
+
+    async connect() {
+      state.listenersDuringConnect =
+        process.listeners("uncaughtException").length;
+      throw new Error("transport initialization failed");
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/stdio.js", () => ({
+  StdioServerTransport: class {},
+}));
+
+vi.mock("@modelcontextprotocol/sdk/types.js", () => ({
+  CallToolRequestSchema: {},
+  ListResourcesRequestSchema: {},
+  ListToolsRequestSchema: {},
+  ReadResourceRequestSchema: {},
+}));
+
+describe("runMcpStdio fatal handler wiring", () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("installs handlers before transport startup and removes them on startup failure", async () => {
+    const before = process.listeners("uncaughtException").length;
+    const beforeRejection = process.listeners("unhandledRejection").length;
+    const { runMcpStdio } = await import("../src/mcp.js");
+
+    await expect(
+      runMcpStdio({ daemonUrl: "http://127.0.0.1:1234" }),
+    ).rejects.toThrow("transport initialization failed");
+
+    expect(state.listenersDuringConnect).toBe(before + 1);
+    expect(process.listeners("uncaughtException").length).toBe(before);
+    expect(process.listeners("unhandledRejection").length).toBe(
+      beforeRejection,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #7273

## Why

The `od mcp` stdio server can die without leaving any diagnostic: the daemon stays healthy, the client just sees a dropped connection, and there is no crash report or signal to explain the exit. The daemon HTTP route already reports process-level fatal errors before exiting; the stdio path had no equivalent handling.

## What users will see

On a fatal uncaught exception or unhandled rejection, the `od mcp` stdio process now prints a labelled stack trace to stderr and exits with code 1 instead of dying silently. Stdout stays reserved for MCP protocol traffic.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — daemon error-path handling with no visual surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/mcp-fatal-errors.test.ts`, `apps/daemon/tests/mcp-fatal-wiring.test.ts`
- Did the test go red on `main` and green on this branch? yes

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/mcp-fatal-errors.test.ts tests/mcp-fatal-wiring.test.ts` from `apps/daemon` — 5 passed, red on `main` and green here.
- `pnpm guard`, `pnpm typecheck`, and the full daemon suite were not run locally (local environment has Node 22; this repo requires Node ~24 with built workspace dependencies) — please let CI run them.

