### PR TITLE
fix(web): stop the Website-clone scaffold from following the user between tabs

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -716,6 +716,12 @@ export function HomeView({
   const [promptEditedByUser, setPromptEditedByUser] = useState(
     () => restoredDraft.prompt.trim().length > 0,
   );
+  // The exact Website-clone scaffold currently sitting in the composer, or null.
+  // Storing the string we wrote — rather than re-deriving it from `t()` when we
+  // need to compare — keeps the release below correct across a locale switch,
+  // which would otherwise translate the scaffold out from under the check and
+  // leave it stranded in the composer.
+  const webCloneScaffoldRef = useRef<string | null>(null);
   // Persist the composer draft on every change so it survives the unmount that
   // a tab switch triggers (see the module note above). Empty values clear the
   // key rather than storing "".
@@ -2472,6 +2478,26 @@ export function HomeView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingAuthoringChipId, pendingAuthoringPrompt, pendingAuthoringInputs, pluginsLoading, plugins]);
 
+  /**
+   * Website clone is the only create chip that writes into the composer, and
+   * what it writes is host-authored scaffolding standing in for an empty
+   * composer — not something the user typed. Every other create chip preserves
+   * the draft on switch, so a scaffold left behind rides along into Slide deck,
+   * Image, Document and every other type it means nothing in.
+   *
+   * Leaving the chip hands the composer back the empty state the scaffold
+   * replaced. The moment the user types into it, it stops being ours and the
+   * draft-preserving rule that governs every other chip takes over.
+   */
+  function releaseWebCloneScaffold(nextChipId: string) {
+    const scaffold = webCloneScaffoldRef.current;
+    if (scaffold === null || nextChipId === 'web-clone') return;
+    webCloneScaffoldRef.current = null;
+    if (prompt !== scaffold) return;
+    setPrompt('');
+    setPromptEditedByUser(false);
+  }
+
   // Stage B of plugin-driven-flow-plan: the chip rail dispatcher.
   // Pure UI-state mapping — the heavy lifting is delegated back to
   // existing handlers. Migration chips that don't have a bound plugin
@@ -2487,6 +2513,7 @@ export function HomeView({
     },
   ) {
     setError(null);
+    releaseWebCloneScaffold(chip.id);
     const activeChipId = chip.id;
     const prototypeSubtypeId = selection?.prototypeSubtypeId ?? null;
     // P0 ui_click area=chat_composer element=plugin_chip|action_chip. The
@@ -2577,6 +2604,12 @@ export function HomeView({
             ? t('homeHero.chip.webClonePromptSeed')
             : null;
         if (chip.group === 'create') {
+          // Only claim ownership when we actually wrote the scaffold. Re-picking
+          // Website clone while the scaffold is already there produces no seed
+          // (the composer is not empty), and clearing the ref on that pass would
+          // orphan the scaffold — leaving it to ride into the next chip after
+          // all. Releasing is the release path's job, not this one's.
+          if (promptSeed !== null) webCloneScaffoldRef.current = promptSeed;
           void usePlugin(record, promptSeed ?? undefined, {
             ...pluginOptions,
             suppressPromptUpdate: promptSeed === null,

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1008,7 +1008,7 @@ export const ar: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'رابط الموقع المراد استنساخه: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1008,7 +1008,7 @@ export const de: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'Website-URL zum Klonen: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1008,7 +1008,7 @@ export const esES: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'URL del sitio web que quieres clonar: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1008,7 +1008,7 @@ export const fa: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'نشانی وب‌سایت برای شبیه‌سازی: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1008,7 +1008,7 @@ export const hu: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'A klónozandó webhely URL-címe: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1008,7 +1008,7 @@ export const id: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'URL situs web yang ingin dikloning: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1008,7 +1008,7 @@ export const it: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'URL del sito da clonare: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1008,7 +1008,7 @@ export const ja: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': '複製したいサイトの URL：',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1008,7 +1008,7 @@ export const ko: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': '복제할 웹사이트 링크: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1008,7 +1008,7 @@ export const pl: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'Adres URL witryny do sklonowania: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1008,7 +1008,7 @@ export const ptBR: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'URL do site que você quer clonar: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1008,7 +1008,7 @@ export const ru: Dict = {
   'homeHero.chip.imageNext': 'Откроет чат для генерации брендовых изображений с возможностью итераций.',
   'homeHero.chip.videoNext': 'Откроет чат для короткого видео, которое можно дорабатывать.',
   'homeHero.chip.audioNext': 'Откроет чат для озвучки, музыки или звуковых эффектов.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'Ссылка на сайт для копирования: ',
   'homeWorkingDir.trigger': 'Выбрать рабочую папку',
   'homeWorkingDir.triggerShort': 'Рабочая папка',
   'homeWorkingDir.pick': 'Выбрать папку',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1008,7 +1008,7 @@ export const th: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'ลิงก์เว็บไซต์ที่ต้องการโคลน: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1008,7 +1008,7 @@ export const tr: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'Klonlanacak web sitesi bağlantısı: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1008,7 +1008,7 @@ export const uk: Dict = {
   'homeHero.chip.imageNext': 'Open a chat that generates on-brand images you can iterate on.',
   'homeHero.chip.videoNext': 'Open a chat that produces a short video you can refine.',
   'homeHero.chip.audioNext': 'Open a chat that creates voiceover, music, or sound effects.',
-  'homeHero.chip.webClonePromptSeed': 'Website URL to clone: ',
+  'homeHero.chip.webClonePromptSeed': 'Посилання на сайт для копіювання: ',
   'homeWorkingDir.trigger': 'Select working directory',
   'homeWorkingDir.triggerShort': 'Working directory',
   'homeWorkingDir.pick': 'Choose folder',

--- a/apps/web/tests/components/HomeView.web-clone-seed-scope.test.tsx
+++ b/apps/web/tests/components/HomeView.web-clone-seed-scope.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+//
+// The Website-clone chip is the one create chip that writes into the composer:
+// an empty composer gets a localized "clone this site:" scaffold, because the
+// scenario is meaningless without a target URL. Every other create chip is a
+// pure mode switch that preserves whatever draft is already there.
+//
+// Those two rules collide unless the scaffold is distinguishable from a draft:
+// left in place, host-authored text follows the user into Slide deck, Image,
+// Document and every other tab it means nothing in.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { HomeView } from '../../src/components/HomeView';
+import { I18nProvider } from '../../src/i18n';
+import type { Dict } from '../../src/i18n/types';
+import { ar } from '../../src/i18n/locales/ar';
+import { de } from '../../src/i18n/locales/de';
+import { en } from '../../src/i18n/locales/en';
+import { esES } from '../../src/i18n/locales/es-ES';
+import { fa } from '../../src/i18n/locales/fa';
+import { fr } from '../../src/i18n/locales/fr';
+import { hu } from '../../src/i18n/locales/hu';
+import { id } from '../../src/i18n/locales/id';
+// Aliased: the bare `it` export would shadow vitest's own `it`.
+import { it as itIT } from '../../src/i18n/locales/it';
+import { ja } from '../../src/i18n/locales/ja';
+import { ko } from '../../src/i18n/locales/ko';
+import { pl } from '../../src/i18n/locales/pl';
+import { ptBR } from '../../src/i18n/locales/pt-BR';
+import { ru } from '../../src/i18n/locales/ru';
+import { th } from '../../src/i18n/locales/th';
+import { tr } from '../../src/i18n/locales/tr';
+import { uk } from '../../src/i18n/locales/uk';
+import { zhCN } from '../../src/i18n/locales/zh-CN';
+import { zhTW } from '../../src/i18n/locales/zh-TW';
+import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+import { setHomeHeroPrompt } from '../helpers/home-hero-lexical';
+
+const analyticsMocks = vi.hoisted(() => ({ track: vi.fn() }));
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return {
+    ...actual,
+    useAnalytics: () => ({
+      track: analyticsMocks.track,
+      newRequestId: () => 'request-1',
+      setConfigureGlobals: vi.fn(),
+      setConsent: vi.fn(),
+      setIdentity: vi.fn(),
+    }),
+  };
+});
+
+// en's copy for `homeHero.chip.webClonePromptSeed`. Asserting the rendered
+// string (rather than re-deriving it through `t`) is what makes this a test of
+// what the user sees in the composer.
+const SEED = 'Website URL to clone: ';
+
+// Named individually rather than read off the app's internal dict registry, so
+// a locale dropped from that registry still fails here instead of silently
+// falling out of the contract.
+const NON_ENGLISH_LOCALES: ReadonlyArray<readonly [string, Dict]> = [
+  ['ar', ar], ['de', de], ['es-ES', esES], ['fa', fa], ['fr', fr],
+  ['hu', hu], ['id', id], ['it', itIT], ['ja', ja], ['ko', ko],
+  ['pl', pl], ['pt-BR', ptBR], ['ru', ru], ['th', th], ['tr', tr],
+  ['uk', uk], ['zh-CN', zhCN], ['zh-TW', zhTW],
+];
+
+function scenarioPlugin(id: string, title: string) {
+  return {
+    id,
+    title,
+    version: '0.1.0',
+    trust: 'bundled' as const,
+    sourceKind: 'bundled' as const,
+    source: `/tmp/${id}`,
+    capabilitiesGranted: ['prompt:inject'],
+    fsPath: `/tmp/${id}`,
+    installedAt: 0,
+    updatedAt: 0,
+    manifest: {
+      name: id,
+      title,
+      version: '0.1.0',
+      description: title,
+      od: { kind: 'scenario', taskKind: 'new-generation', useCase: { query: `${title} brief.` } },
+    },
+  };
+}
+
+function stubPlugins() {
+  const plugins = [
+    scenarioPlugin('example-web-clone', 'Website clone'),
+    scenarioPlugin('example-simple-deck', 'Slide deck'),
+    scenarioPlugin('example-web-prototype', 'Prototype'),
+  ];
+  vi.stubGlobal('fetch', vi.fn(async (url: RequestInfo | URL) => {
+    const href = typeof url === 'string' ? url : url.toString();
+    if (href === '/api/plugins') {
+      return new Response(JSON.stringify({ plugins }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }));
+}
+
+function renderHome() {
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />
+    </I18nProvider>,
+  );
+}
+
+async function pickTypePill(id: string) {
+  const pill = await screen.findByTestId(`home-hero-type-pill-${id}`);
+  fireEvent.click(pill);
+}
+
+function composerText(): string {
+  return (screen.getByTestId('home-hero-input').textContent ?? '');
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  analyticsMocks.track.mockClear();
+  cleanup();
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+describe('Website-clone composer scaffold is host-authored, not a draft', () => {
+  it('seeds an empty composer when the Website-clone chip is picked', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    renderHome();
+
+    await pickTypePill('web-clone');
+
+    await waitFor(() => expect(composerText()).toContain(SEED));
+  });
+
+  it('takes the untouched scaffold back out when another type is picked', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    renderHome();
+
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(SEED));
+
+    await pickTypePill('deck');
+
+    // The scaffold stood in for an empty composer, so releasing it restores
+    // exactly that — Slide deck must not inherit a prompt about cloning a site.
+    await waitFor(() => expect(composerText().trim()).toBe(''));
+  });
+
+  it('keeps the draft when the user has typed into the scaffold', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    renderHome();
+
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(SEED));
+
+    const typed = `${SEED}https://example.com`;
+    setHomeHeroPrompt(typed);
+    await waitFor(() => expect(composerText()).toContain('https://example.com'));
+
+    await pickTypePill('deck');
+
+    // Once the user makes it theirs it is a draft like any other, and the
+    // draft-preserving rule that governs every other chip applies.
+    await waitFor(() => expect(composerText()).toContain('https://example.com'));
+  });
+
+  it('still releases the scaffold after Website clone is re-picked', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    renderHome();
+
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(SEED));
+    // A second pick writes no seed — the composer is no longer empty — so this
+    // pass must not be mistaken for the scaffold having been handed back.
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(SEED));
+
+    await pickTypePill('deck');
+
+    await waitFor(() => expect(composerText().trim()).toBe(''));
+  });
+
+  // The scaffold is the one piece of host-authored text this product types into
+  // the user's composer, so it has to arrive in their language — and the
+  // release above has to recognize it there too, not just in English.
+  it('seeds and releases the localized scaffold outside English', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    render(
+      <I18nProvider initial="ja">
+        <HomeView
+          projects={[]}
+          onSubmit={() => undefined}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+        />
+      </I18nProvider>,
+    );
+
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(ja['homeHero.chip.webClonePromptSeed']));
+
+    await pickTypePill('deck');
+
+    await waitFor(() => expect(composerText().trim()).toBe(''));
+  });
+
+  it('seeds again when the user returns to Website clone', async () => {
+    writeHomeGuideStage('done');
+    stubPlugins();
+    renderHome();
+
+    await pickTypePill('web-clone');
+    await waitFor(() => expect(composerText()).toContain(SEED));
+    await pickTypePill('deck');
+    await waitFor(() => expect(composerText().trim()).toBe(''));
+
+    await pickTypePill('web-clone');
+
+    await waitFor(() => expect(composerText()).toContain(SEED));
+  });
+});
+
+// This key is unusual: most copy is *shown* to the user, but this one is typed
+// into their composer and becomes the opening line of the prompt they send. An
+// English fallback here doesn't just read as untranslated chrome — it puts
+// English into a Japanese user's own message. Lock every locale to real copy.
+describe('Website-clone scaffold copy is translated everywhere', () => {
+  it('ships no locale still carrying the English fallback', () => {
+    const KEY = 'homeHero.chip.webClonePromptSeed' as const;
+    const untranslated = NON_ENGLISH_LOCALES.filter(
+      ([, dict]) => dict[KEY] === en[KEY],
+    ).map(([name]) => name);
+
+    expect(untranslated).toEqual([]);
+  });
+
+  it('ships a non-empty scaffold that ends in a separator in every locale', () => {
+    const KEY = 'homeHero.chip.webClonePromptSeed' as const;
+    // The user pastes a URL directly after this text, so a scaffold that lost
+    // its trailing colon/space would run straight into the URL they type.
+    const malformed = [['en', en] as const, ...NON_ENGLISH_LOCALES]
+      .filter(([, dict]) => !/[:\uff1a]\s*$/.test(dict[KEY]))
+      .map(([name]) => name);
+
+    expect(malformed).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

Reported by 孙庆雨 with a screen recording, summarized as: *"首次「网站复刻」Tab 会自动写入引导语，其他 Tab 会保留输入草稿"*. That sentence is the whole bug — it names two rules that are each correct and that collide.

**Rule 1.** Website clone is the only create chip that writes into the composer. `HomeView` seeds an empty composer with a localized `"clone this site:"` scaffold, because the scenario is meaningless without a target URL. The existing comment states the intent exactly: *"an empty composer gets the localized scaffold instead of staying blank. A non-empty draft is the user's — leave it alone."*

**Rule 2.** Every other create chip is a pure mode switch and passes `suppressPromptUpdate: true`, so it never touches the draft the user already typed.

Once written, the scaffold is indistinguishable from something the user typed — so rule 2 faithfully carries it along. In the recording, `想要复刻的网站链接：` follows the user from Website clone into Slide deck → Image → Document → HyperFrames → Audio → Prototype without ever clearing; they end up selecting it and deleting it by hand.

The word **首次** in the report is this bug's fingerprint: the seed only ever fires once, because after that first write the composer is never empty again and the condition stops matching. That one stale line then rides along forever.

## What users will see

Leaving **网站复刻** with the untouched guide text in the composer hands the composer back the empty state it replaced, so Slide deck / Image / Document / HyperFrames / Video / Audio no longer open with a prompt about cloning a website. Returning to 网站复刻 with an empty composer seeds the guide text again.

Type a URL after the guide text and it becomes yours: switching tabs preserves the whole line exactly as before.

Separately, the guide text now arrives in the user's own language in 15 locales that were previously served the raw English string.

## Surface area

- [x] **UI** — Home composer's type-chip rail in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — no new keys; `homeHero.chip.webClonePromptSeed` translated in the 15 locales still carrying the English fallback (`ar de es-ES fa hu id it ja ko pl pt-BR ru th tr uk`)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Composer contents captured live in Chrome at each step, same runtime, same chip rail:

| step | before | after |
| --- | --- | --- |
| pick 网站复刻 | `想要复刻的网站链接：` | `想要复刻的网站链接：` |
| switch to 幻灯片 | `想要复刻的网站链接：` ← leaked | `` (empty) |
| switch to 文档 | `想要复刻的网站链接：` | `` (empty) |
| back to 网站复刻 | (no reseed — never empty again) | `想要复刻的网站链接：` |
| type `https://stripe.com`, switch to 幻灯片 | preserved | preserved |

In Japanese the same sequence seeds `複製したいサイトの URL：` and releases it — before this PR it seeded `Website URL to clone: `.

Entry point is the type-chip rail directly above the Home composer.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeView.web-clone-seed-scope.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — on `main`, "takes the untouched scaffold back out when another type is picked" fails with the composer still reading `Website URL to clone:`, and "seeds again when the user returns" fails alongside it. The two cases that describe behavior `main` already gets right (first seed, and preserving a draft the user typed into) pass on both sides, which is what keeps this a targeted spec rather than a rewrite of the chip's contract.

Two further red-proofs, each verified by reverting only the line it guards:

- **`still releases the scaffold after Website clone is re-picked`** — caught during self-review, not in the original report. A second pick writes no seed (the composer is no longer empty); the first draft of the fix cleared its ownership marker on that pass anyway, which orphaned the scaffold and brought the leak straight back. Double-clicking the chip would have defeated the whole fix.
- **`ships no locale still carrying the English fallback`** — red with 15 locales listed before the translations.

Verified end-to-end in real Chrome against a local `tools-dev` runtime on an isolated `OD_DATA_DIR`, driving the real chip rail. Every click in the final pass was gated on `document.elementFromPoint()` returning the target — the same hit-test the browser uses to route a real click — so a control hidden behind an overlay is reported instead of silently driven. That gate earned its keep immediately: on a fresh install the Go campaign modal sits over the chip rail, and the first attempt to pick Website clone was refused as `COVERED by <DIV class="DeepSeekV4FlashCampaign_goWelcomeCopy…">`. Dismissing the modal first, as a user would, the sequence ran: seeded → released across 幻灯片/文档 → reseeded on return → preserved once a URL was typed, then the same sequence again with the UI switched to 日本語. Before/after was captured by reverting the source change and letting HMR reload, not by simulating it.

## Adjacent issues

Out of this bug's boundary, found while tracing it, left for a follow-up rather than widened into this PR:

- The composer draft is persisted on every change, and on remount a non-empty restored draft is classified as user-edited. So a scaffold that survives a remount (navigate to 社区 and back, or reload) is **promoted** to a real draft — the replacement-confirmation guard then protects it as if the user had written it. Observed live: reloading the page restored `想要复刻的网站链接：` into a fresh mount, where this PR's release path no longer recognizes it. Fixing that means deciding whether the scaffold should be excluded from persistence at all, which is a product call about what a "draft" is, not a mechanical one.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` (full suite: 651 files / 6966 tests, green)
- Real-Chrome E2E on `pnpm tools-dev run web --namespace seedfix`, isolated `OD_DATA_DIR`, in both 简体中文 and 日本語
