### PR TITLE
fix(web): restore manual edit undo/redo affordances

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12471,6 +12471,11 @@ function HtmlViewer({
         // save is never silently torn down.
         return;
       }
+      if (data.type === 'od-edit-history') {
+        if (data.op === 'redo') void redoManualEdit();
+        else void undoManualEdit();
+        return;
+      }
       if (data.type === 'od-edit-drag-commit') {
         // Free drag-to-reposition dropped: route the new translate() through
         // the same pending-style pipeline the inspector uses, so the panel's
@@ -12491,6 +12496,28 @@ function HtmlViewer({
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
   }, [isRetainedPreviewIframeSource, manualEditMode, source, workspaceActive]);
+
+  // Undo/redo shortcuts while edit mode is active and host chrome has focus.
+  // Keys pressed inside the preview iframe are forwarded by the edit bridge as
+  // `od-edit-history` messages instead — a host listener cannot see them.
+  // Deliberately re-registered every render: the handler calls into history
+  // state that a stale closure would read from the wrong revision.
+  useEffect(() => {
+    if (!manualEditMode) return;
+    function onKeyDown(ev: KeyboardEvent) {
+      if (!(ev.metaKey || ev.ctrlKey) || ev.altKey) return;
+      if (ev.key.toLowerCase() !== 'z') return;
+      // A focused field owns its own undo stack; stealing it would drop the
+      // user's in-progress typing instead of reverting a committed edit.
+      const target = ev.target as HTMLElement | null;
+      if (target?.closest?.('input,textarea,select,[role="textbox"],[contenteditable]')) return;
+      ev.preventDefault();
+      if (ev.shiftKey) void redoManualEdit();
+      else void undoManualEdit();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  });
 
   function nextManualEditPreviewVersion(): number {
     manualEditPreviewVersionRef.current += 1;
@@ -16103,6 +16130,40 @@ function HtmlViewer({
               >
                 <RemixIcon name="edit-line" size={15} />
               </button>
+              {manualEditMode ? (
+                <>
+                  <button
+                    className="viewer-action viewer-action-icon od-tooltip"
+                    type="button"
+                    data-testid="manual-edit-undo"
+                    data-tooltip={t('manualEdit.undo')}
+                    data-tooltip-placement="bottom"
+                    title={t('manualEdit.undo')}
+                    aria-label={t('manualEdit.undo')}
+                    disabled={manualEditSaving || manualEditHistory.length === 0}
+                    onClick={() => {
+                      void undoManualEdit();
+                    }}
+                  >
+                    <RemixIcon name="arrow-go-back-line" size={15} />
+                  </button>
+                  <button
+                    className="viewer-action viewer-action-icon od-tooltip"
+                    type="button"
+                    data-testid="manual-edit-redo"
+                    data-tooltip={t('manualEdit.redo')}
+                    data-tooltip-placement="bottom"
+                    title={t('manualEdit.redo')}
+                    aria-label={t('manualEdit.redo')}
+                    disabled={manualEditSaving || manualEditUndone.length === 0}
+                    onClick={() => {
+                      void redoManualEdit();
+                    }}
+                  >
+                    <RemixIcon name="arrow-go-forward-line" size={15} />
+                  </button>
+                </>
+              ) : null}
               <span className="viewer-toolbar-tool-divider" aria-hidden />
               <button
                 ref={commentPanelToggleRef}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -12472,8 +12472,7 @@ function HtmlViewer({
         return;
       }
       if (data.type === 'od-edit-history') {
-        if (data.op === 'redo') void redoManualEdit();
-        else void undoManualEdit();
+        void requestManualEditHistory(data.op === 'redo' ? 'redo' : 'undo');
         return;
       }
       if (data.type === 'od-edit-drag-commit') {
@@ -12511,9 +12510,11 @@ function HtmlViewer({
       // user's in-progress typing instead of reverting a committed edit.
       const target = ev.target as HTMLElement | null;
       if (target?.closest?.('input,textarea,select,[role="textbox"],[contenteditable]')) return;
+      // A retained inactive viewer is still mounted on this same window; only
+      // the active one may claim the key.
+      if (!workspaceActiveRef.current) return;
       ev.preventDefault();
-      if (ev.shiftKey) void redoManualEdit();
-      else void undoManualEdit();
+      void requestManualEditHistory(ev.shiftKey ? 'redo' : 'undo');
     }
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
@@ -13156,6 +13157,46 @@ function HtmlViewer({
   ): string {
     const status = saved.status ? ` (${saved.status}${saved.code ? ` ${saved.code}` : ''})` : '';
     return `${prefix}${status}: ${saved.message}`;
+  }
+
+  // Single entry point for every undo/redo affordance (toolbar buttons, host
+  // shortcut, and the bridge's forwarded `od-edit-history`). Undo/redo write a
+  // whole revision, so they must never run while a newer edit is still only
+  // live in a ref: `manualEditPendingStyleRef` holds an uncommitted inspector
+  // preview and an inline text session holds an uncommitted DOM edit. Saving an
+  // older source underneath either one lets the later flush re-apply an edit the
+  // user just undid, or commit text onto the wrong revision.
+  async function requestManualEditHistory(op: 'undo' | 'redo') {
+    // Retained inactive viewers stay mounted, and the lifecycle keeps their
+    // manual-edit session alive through a pending or failed safe exit. The
+    // shortcut listener is on the shared window, so without this guard the
+    // active tab's Cmd/Ctrl+Z would make a hidden instance write its own file.
+    if (!workspaceActiveRef.current) return;
+    if (manualEditSavingRef.current) return;
+    const latestTextCommit = manualEditTextLatestCommitRef.current;
+    const hadPendingText = manualEditTextSessionIdRef.current != null
+      || (latestTextCommit != null && latestTextCommit.result == null);
+    if (!(await settlePendingManualEditCommit())) return;
+    // Settling committed text and moved the stack under this call's closure;
+    // act on the settled stack from the next press rather than an older one.
+    if (hadPendingText) return;
+    if (manualEditPendingStyleRef.current) {
+      clearManualEditStyleTimer();
+      if (op === 'undo') {
+        // The uncommitted preview IS the newest edit, so undo drops it. Popping
+        // committed history instead would save an older source that the pending
+        // flush then re-applies on top.
+        cancelManualEditStyleDraft();
+        return;
+      }
+      // A newer uncommitted edit invalidates redo exactly like a committed one
+      // does (applyManualEdit clears the undone stack). Commit it rather than
+      // restoring a revision the pending preview would immediately overwrite.
+      await flushManualEditStyleSave();
+      return;
+    }
+    if (op === 'redo') await redoManualEdit();
+    else await undoManualEdit();
   }
 
   async function undoManualEdit() {
@@ -16142,7 +16183,7 @@ function HtmlViewer({
                     aria-label={t('manualEdit.undo')}
                     disabled={manualEditSaving || manualEditHistory.length === 0}
                     onClick={() => {
-                      void undoManualEdit();
+                      void requestManualEditHistory('undo');
                     }}
                   >
                     <RemixIcon name="arrow-go-back-line" size={15} />
@@ -16157,7 +16198,7 @@ function HtmlViewer({
                     aria-label={t('manualEdit.redo')}
                     disabled={manualEditSaving || manualEditUndone.length === 0}
                     onClick={() => {
-                      void redoManualEdit();
+                      void requestManualEditHistory('redo');
                     }}
                   >
                     <RemixIcon name="arrow-go-forward-line" size={15} />

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -1238,6 +1238,24 @@ export function buildManualEditBridge(enabled: boolean): string {
       renderHoverRelation(targetFrom(lastHoverEl, false));
     });
   }, true);
+  // Undo/redo hotkey (Cmd/Ctrl+Z, +Shift to redo). Keyboard focus lives inside
+  // this iframe after any canvas click, so the host's own shortcut listener
+  // never hears the keys — forward them to the host's manual-edit history.
+  // Registered on documentElement for the same reason as the screenshot tap
+  // below: the keyboard guard wraps window/document keydown listeners.
+  document.documentElement.addEventListener('keydown', function(ev){
+    if (!enabled) return;
+    if (!(ev.metaKey || ev.ctrlKey) || ev.altKey) return;
+    if (!ev.key || ev.key.toLowerCase() !== 'z') return;
+    // A focused field owns its own undo stack — including the inline text
+    // session, which is a contenteditable. Routing to file history there would
+    // discard the user's in-progress typing instead of undoing a canvas edit.
+    var target = ev.target;
+    if (target && target.closest && target.closest('input,textarea,select,[role="textbox"],[contenteditable]')) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    window.parent.postMessage({ type: 'od-edit-history', op: ev.shiftKey ? 'redo' : 'undo' }, '*');
+  }, true);
   // Double-tap Command screenshot hotkey (edit mode only). Keyboard focus can
   // live inside the sandboxed iframe, where the host's window listener never
   // hears the keys — detect here and delegate the capture to the host. Two

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -189,7 +189,16 @@ export interface ManualEditDragCommitMessage {
   display?: string;
 }
 
+/** Cmd/Ctrl+Z pressed on the canvas. Keyboard focus lives inside the sandboxed
+ *  iframe after any click there, so the host's own shortcut listener never
+ *  hears these keys — the bridge forwards them as this message instead. */
+export interface ManualEditHistoryMessage {
+  type: 'od-edit-history';
+  op: 'undo' | 'redo';
+}
+
 export type ManualEditBridgeMessage =
+  | ManualEditHistoryMessage
   | ManualEditTargetMessage
   | ManualEditSelectMessage
   | ManualEditHoverMessage

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -96,6 +96,39 @@ async function selectManualEditTarget(target = heroTarget()) {
     }));
   });
   await waitFor(() => expect(panelState.props).not.toBeNull());
+  return frame;
+}
+
+// Persisting harness: every manual-edit save is echoed back as the file's raw
+// content, so history round-trips (undo → redo → follow-up edit) read what the
+// previous step actually wrote.
+function stubManualEditHistoryFetch(initialSource: string) {
+  const savedSources: string[] = [];
+  let persistedSource = initialSource;
+  const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.includes('/api/projects/project-1/deployments')) {
+      return new Response(JSON.stringify({ deployments: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+      const payload = JSON.parse(String(init.body)) as { content: string };
+      persistedSource = payload.content;
+      savedSources.push(payload.content);
+      return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/projects/project-1/raw/preview.html')) {
+      return new Response(persistedSource, { status: 200 });
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return { savedSources };
 }
 
 afterEach(() => {
@@ -432,6 +465,116 @@ describe('FileViewer manual edit history regressions', () => {
       expect((screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement).srcdoc)
         .not.toContain('data-od-id="hero"');
     });
+  });
+
+  it('keeps toolbar undo/redo affordances in manual edit mode and drives history from them', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
+    const { savedSources } = stubManualEditHistoryFetch(initialSource);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+
+    const undoButton = () => screen.getByTestId('manual-edit-undo') as HTMLButtonElement;
+    const redoButton = () => screen.getByTestId('manual-edit-redo') as HTMLButtonElement;
+    expect(undoButton().disabled).toBe(true);
+    expect(redoButton().disabled).toBe(true);
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { kind: 'set-style', id: 'hero', styles: { color: '#ef4444' } },
+        'Style: Hero',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    await waitFor(() => expect(undoButton().disabled).toBe(false));
+
+    fireEvent.click(undoButton());
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toBe(initialSource);
+    await waitFor(() => expect(redoButton().disabled).toBe(false));
+
+    fireEvent.click(redoButton());
+    await waitFor(() => expect(savedSources).toHaveLength(3));
+    expect(savedSources[2]).toContain('rgb(239, 68, 68)');
+  });
+
+  it('undoes on Ctrl/Cmd+Z from host chrome but never from a focused field', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
+    const { savedSources } = stubManualEditHistoryFetch(initialSource);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { kind: 'set-style', id: 'hero', styles: { color: '#ef4444' } },
+        'Style: Hero',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+
+    // A focused input owns its own undo stack; stealing it loses the user's
+    // in-progress typing instead of reverting a committed canvas edit.
+    const field = document.createElement('input');
+    document.body.appendChild(field);
+    field.focus();
+    act(() => {
+      fireEvent.keyDown(field, { key: 'z', metaKey: true });
+    });
+    expect(savedSources).toHaveLength(1);
+    field.remove();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'z', metaKey: true });
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toBe(initialSource);
+  });
+
+  it('undoes a deleted element after the inspector unmounts, via the canvas hotkey bridge', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero">Hero</h1><p data-od-id="body">Body</p></body></html>';
+    const { savedSources } = stubManualEditHistoryFetch(initialSource);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    const frame = await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch({ kind: 'remove-element', id: 'hero' }, 'Delete element');
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).not.toContain('data-od-id="hero"');
+
+    // Deleting clears the selection, so the inspector — and any listener it
+    // owned — is gone. The toolbar and the canvas hotkey must still undo.
+    await waitFor(() => expect(screen.queryByTestId('mock-manual-edit-panel')).toBeNull());
+    expect((screen.getByTestId('manual-edit-undo') as HTMLButtonElement).disabled).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-history', op: 'undo' },
+        source: frame.contentWindow,
+      }));
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(savedSources[1]).toBe(initialSource);
   });
 });
 

--- a/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit-history.test.tsx
@@ -576,6 +576,161 @@ describe('FileViewer manual edit history regressions', () => {
     await waitFor(() => expect(savedSources).toHaveLength(2));
     expect(savedSources[1]).toBe(initialSource);
   });
+
+  it('ignores the shared-window shortcut while the viewer is retained inactive', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
+    let persistedSource = initialSource;
+    let failSaves = false;
+    const savedSources: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/files') && init?.method === 'POST') {
+        const payload = JSON.parse(String(init.body)) as { content: string };
+        savedSources.push(payload.content);
+        if (failSaves) {
+          return new Response(JSON.stringify({ message: 'save failed' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        persistedSource = payload.content;
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/preview.html')) {
+        return new Response(persistedSource, { status: 200 });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { rerender } = render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+        workspaceActive
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { kind: 'set-style', id: 'hero', styles: { color: '#ef4444' } },
+        'Style: Hero',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+
+    // A retained viewer only keeps its manual-edit session when the safe exit
+    // cannot complete. An uncommitted inspector preview whose save fails is
+    // exactly that case — edit mode survives the switch to another tab.
+    act(() => {
+      panelState.props?.onStyleChange?.('hero', { color: '#22c55e' }, 'Style: Hero');
+    });
+    failSaves = true;
+    rerender(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+        workspaceActive={false}
+      />,
+    );
+    await waitFor(() => expect(savedSources).toHaveLength(2));
+    expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('true');
+
+    // The listener lives on the shared window, so the active tab's Cmd+Z would
+    // otherwise reach this hidden instance and write its file.
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'z', metaKey: true });
+      await Promise.resolve();
+    });
+    expect(savedSources).toHaveLength(2);
+    expect(persistedSource).toBe(savedSources[0]);
+  });
+
+  it('drops a pending inspector preview instead of saving an older revision on undo', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
+    const { savedSources } = stubManualEditHistoryFetch(initialSource);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+
+    // Inspector previews stay in a ref until Save, so the history stack is
+    // still empty while the canvas already shows the change.
+    act(() => {
+      panelState.props?.onStyleChange?.('hero', { color: '#ef4444' }, 'Style: Hero');
+    });
+    expect(savedSources).toHaveLength(0);
+    expect((screen.getByTestId('manual-edit-undo') as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'z', metaKey: true });
+      await Promise.resolve();
+    });
+
+    // Undo reverted the live preview. Leaving edit mode must then have nothing
+    // left to flush — otherwise the undone edit lands after the undo.
+    clickManualTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('false');
+    });
+    expect(savedSources).toHaveLength(0);
+  });
+
+  it('does not re-apply a pending inspector preview after a toolbar undo', async () => {
+    const initialSource = '<!doctype html><html><body><h1 data-od-id="hero" style="color: #111111">Hero</h1></body></html>';
+    const { savedSources } = stubManualEditHistoryFetch(initialSource);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={initialSource}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+
+    act(() => {
+      panelState.props?.onApplyPatch(
+        { kind: 'set-style', id: 'hero', styles: { color: '#ef4444' } },
+        'Style: Hero',
+      );
+    });
+    await waitFor(() => expect(savedSources).toHaveLength(1));
+    expect(savedSources[0]).toContain('rgb(239, 68, 68)');
+
+    act(() => {
+      panelState.props?.onStyleChange?.('hero', { color: '#22c55e' }, 'Style: Hero');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('manual-edit-undo'));
+      await Promise.resolve();
+    });
+
+    clickManualTool('manual-edit-mode-toggle');
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('false');
+    });
+    // The undo consumed the uncommitted preview, so the committed revision is
+    // untouched and no later flush re-applies the discarded colour.
+    expect(savedSources).toHaveLength(1);
+    expect(savedSources[0]).not.toContain('rgb(34, 197, 94)');
+  });
 });
 
 function htmlPreviewFile(): ProjectFile {

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -792,6 +792,34 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('forwards the history hotkey from the canvas but leaves native undo to editable fields', () => {
+    const posts: Array<{ type?: string; op?: string }> = [];
+    const dom = new JSDOM(
+      `<main data-od-source-path="path-0"><h1 data-od-source-path="path-0-0">Plain title</h1><input data-od-source-path="path-0-1" /></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    dom.window.parent.postMessage = ((message: unknown) => {
+      posts.push(message as { type?: string; op?: string });
+    }) as typeof dom.window.parent.postMessage;
+    const press = (from: Element, init: { shiftKey?: boolean } = {}) =>
+      from.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+        key: 'z', code: 'KeyZ', metaKey: true, bubbles: true, ...init,
+      }));
+    const ops = () => posts.filter((message) => message.type === 'od-edit-history').map((message) => message.op);
+
+    press(dom.window.document.body);
+    expect(ops()).toEqual(['undo']);
+
+    press(dom.window.document.body, { shiftKey: true });
+    expect(ops()).toEqual(['undo', 'redo']);
+
+    // A focused field owns its own undo stack — the host must never steal it.
+    press(dom.window.document.querySelector('input')!);
+    expect(ops()).toEqual(['undo', 'redo']);
+
+    dom.window.close();
+  });
+
   it('posts the screenshot hotkey on a double Command tap but not on the both-Metas chord', () => {
     const posts: Array<{ type?: string }> = [];
     const dom = new JSDOM(


### PR DESCRIPTION
Fixes #6609
Fixes #2866

## Why

I hit this while using manual edit mode on 0.18.x: the Undo/Redo buttons were gone from the viewer toolbar and Ctrl/Cmd+Z did nothing, so any mis-edit meant redoing the work by hand. #6609 reports exactly that, and #2866 is the same underlying loss seen from the other side (no way to undo after deleting an element).

The regression came in with #6142 (`356c8c364`, "workspace-team + #5517 redesign"), which removed four things in one merge: the two toolbar buttons added in #5890 (`b99a9fdc3`), the host `keydown` listener in `FileViewer`, the bridge's `od-edit-history` forwarding, and `apps/web/src/edit-mode/shortcuts.ts`. On current `main`, `od-edit-history` and `manual-edit-undo` both have zero hits.

**A note on where the fix does not go.** `ManualEditPanel` declares `history` / `canUndo` / `canRedo` / `onUndo` / `onRedo` in its props type without destructuring them, which makes it look like the panel lost its wiring. `git log -S canUndo -- ManualEditPanel.tsx` shows those five have never been rendered, going back to the inspector's first version in #1448 — they are declared-but-dead, not disconnected. Putting buttons in the panel would invent an affordance the product never shipped, and since the inspector unmounts once the selection is cleared, it would also fail to fix #2866. This PR restores the original surface instead, which covers both issues from one place.

The history state machine itself (`undoManualEdit`, the `manualEditHistory` stack) survived #6142 untouched — only the affordances that drove it were removed.

## What users will see

Undo and Redo buttons are back in the viewer toolbar while manual edit mode is active, disabled until there is something to undo or redo. Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z work again, including when focus is inside the preview iframe, and including after deleting an element (when the inspector has unmounted). Typing inside a text field still uses the browser's own undo stack, unchanged.

## Surface area

- [x] **UI** — Undo/Redo buttons restored in the `apps/web` viewer toolbar (manual edit mode only)
- [x] **Keyboard shortcut** — Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z restored for manual edit history
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new keys; `manualEdit.undo` / `manualEdit.redo` already exist in all 19 locales (#6142 removed only the call sites)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Toolbar states — three shots, because "after one edit" only shows Undo enabled; Redo's enabled state needs a further undo:

| Entering manual edit (nothing to undo) | After one edit | After undoing that edit |
|---|---|---|
| ![undo disabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/undo-disabled-closeup.png) | ![undo enabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/undo-enabled-closeup.png) | ![redo enabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/redo-enabled-closeup.png) |

Full-viewport versions: [disabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/undo-disabled.png) · [undo enabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/undo-enabled.png) · [redo enabled](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/redo-enabled.png)

Keyboard undo → redo with focus inside the preview iframe (the case @nettee raised on #6629 — the click anchor is an `<img>` so focus lands in the iframe without opening an inline text session):

![keyboard undo redo](https://raw.githubusercontent.com/maxmilian/open-design/pr-assets-6609/keyboard-undo-redo.gif)

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/components/FileViewer.manual-edit-history.test.tsx`
  - `apps/web/tests/edit-mode/bridge.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — 4 failing before the source change:
  - `forwards the history hotkey from the canvas but leaves native undo to editable fields` → `expected [] to deeply equal [ 'undo' ]`
  - `keeps toolbar undo/redo affordances in manual edit mode and drives history from them` → `Unable to find an element by: [data-testid="manual-edit-undo"]`
  - `undoes on Ctrl/Cmd+Z from host chrome but never from a focused field` → `expected [ Array(1) ] to have a length of 2 but got 1`
  - `undoes a deleted element after the inspector unmounts, via the canvas hotkey bridge` → same missing testid

  After the change: `2 passed (2) / 60 passed (60)` for those two files.

## Validation

- `pnpm typecheck` — rc=0 (all packages)
- `pnpm guard` — rc=0
- `pnpm --filter @open-design/web test` — rc=0, **650/650 files, 6962 passed | 1 expected fail | 11 skipped**
- Node 24.14.0, pnpm 10.33.2

## Addressing the review on #6629

That PR was closed by its author on 2026-08-19 without merging. @nettee's three blockers there apply to any fix in this area, so for the record:

1. **No new panel buttons.** The toolbar buttons return where they were. The five dead props on `ManualEditPanel` are deliberately left in place — `FileViewer.manual-edit-history.test.tsx` currently reaches through `panelState.props?.onUndo()`, so removing them belongs in its own cleanup PR rather than widening this diff.
2. **Native undo is left alone.** Host and iframe both bail out via `closest()` on `input, textarea, select, [role="textbox"], [contenteditable]`, which covers `contenteditable="false"` and keeps inline text editing (`plaintext-only`) on the browser's undo stack. One regression test each.
3. **Shortcut ownership crosses the iframe.** The bridge listens on `documentElement` in the capture phase and posts `od-edit-history` to the host, following the existing `od-edit-screenshot-hotkey` pattern (same reason it can't sit on `window`/`document`: the keyboard guard wraps those). The host handler lives at `FileViewer`'s manual-edit level, not in the panel — which is what keeps undo working after the inspector unmounts, asserted directly in the deleted-element test.
