### PR TITLE
fix(web): suppress hydration-mismatch warning on theme-init script

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -38,7 +38,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       {/* eslint-disable-next-line @next/next/no-sync-scripts */}
       <head>
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: intentional theme-init inline script to prevent FOUC */}
-        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {/* suppressHydrationWarning: browser extensions (e.g. script-injecting
+            popup helpers) rewrite this node before React hydrates, which
+            otherwise raises a spurious hydration-mismatch console error. */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} suppressHydrationWarning />
       </head>
       <body suppressHydrationWarning>
         <I18nProvider>


### PR DESCRIPTION
## Why

- **Use case:** Running OpenDesign from source with a script-injecting browser
  extension installed (observed: a "popups" helper, extension id
  `lgblnfidahcdcjddiepkckcfdhpknnjh`, file `content/popups-script.js`) produces
  a React hydration-mismatch console error on every page load, pointed at
  `app/layout.tsx`.
- **Pain:** The error is console noise, but it reads like an app bug to
  developers and gets copy-pasted into issue reports. The extension rewrites
  the theme-init `<script>` node before React hydrates — it injects its own
  `src` attribute and empties `__html` — which is exactly React's documented
  "a browser extension … messes with the HTML before React loaded" case.
  Suppressing hydration checks on that node removes the noise without touching
  product behavior. There is no issue opened for this; it is a small hygiene
  fix.

## What users will see

Nothing visible changes — the app looks and behaves the same. Developers who
run script-injecting extensions no longer see a spurious
"A tree hydrated but some attributes of the server rendered HTML didn't match"
console error on every load.

## Surface area

- [x] **None** — internal refactor: adds `suppressHydrationWarning` to the
  theme-init `<script>` in the root layout, consistent with the existing
  `suppressHydrationWarning` on `<html>`/`<body>`. No new/removed UI, no
  dependency, API, contract, CLI flag, env var, i18n key, or default-behavior
  change.

## Screenshots

N/A — no UI surface checked.

## Bug fix verification

- Test path: intentionally none.
- Red on `main` / green on this branch: not applicable — a unit test cannot
  cheaply reproduce the failure: it requires a browser extension to rewrite
  the SSR-ed DOM before React hydrates. A Playwright spec could approximate
  the tampering via `addInitScript` DOM surgery, but this fix is a
  console-noise suppression with no functional surface, so extending that
  suite was judged disproportionate for this patch.
- Verified instead: with the extension active the console error reproduces on
  `main`; after the patch the page still serves HTTP 200 with the theme-init
  script intact, `pnpm --filter @open-design/web typecheck` passes, and the
  mismatch error no longer appears.

## Validation

- `pnpm --filter @open-design/web typecheck` ✅
- Manual: page loads (HTTP 200) with the theme script intact; mismatch error
  gone with the reported extension active.