### PR TITLE
fix(web): three viewer defects from the 0.20 dogfooding batch

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -17518,7 +17518,7 @@ function HtmlViewer({
           <button
             type="button"
             className="present-exit-btn"
-            onClick={() => setInTabPresent(false)}
+            onClick={() => closeInTabPresentation()}
             title={t('fileViewer.exitPresentation')}
             aria-label={t('fileViewer.exitPresentation')}
           >

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1119,11 +1119,26 @@ function PreviewViewportControls({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setOpen(false);
     };
+    // The click-outside above can only see pointer events that reach THIS
+    // document, and the preview is a sandboxed opaque-origin iframe: a click
+    // landing on it dispatches inside the frame and never reaches the host.
+    // Since the preview is the largest surface on screen, that left the menu
+    // stuck open exactly where users reach to dismiss it (OPEND-2035).
+    //
+    // Focus moving into a frame is the one signal the host does get for that
+    // click. Requiring the frame to actually hold focus keeps an ordinary
+    // app switch — which blurs the window without handing focus to a frame —
+    // from closing a menu the user never dismissed.
+    const onWindowBlur = () => {
+      if (document.activeElement instanceof HTMLIFrameElement) setOpen(false);
+    };
     document.addEventListener('pointerdown', onPointerDown);
     document.addEventListener('keydown', onKeyDown);
+    window.addEventListener('blur', onWindowBlur);
     return () => {
       document.removeEventListener('pointerdown', onPointerDown);
       document.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('blur', onWindowBlur);
     };
   }, [open]);
 
@@ -4021,7 +4036,7 @@ function FileVersionManagerModal({
           <div className="artifact-version-panel__head-actions">
             <button
               type="button"
-              className="artifact-version-panel__close"
+              className="artifact-version-panel__open"
               aria-label={t('fileViewer.versions.open')}
               title={t('fileViewer.versions.open')}
               disabled={!selectedContentMatchesVersion || loadingContent}
@@ -17493,6 +17508,22 @@ function HtmlViewer({
               src={activePreviewSrcUrl}
             />
           )}
+          {/* The overlay covers the whole window, so this is the only exit the
+              user can still reach. Esc is not a substitute: the moment they
+              click a slide to advance, focus moves into the sandboxed preview
+              frame and keyboard events stop reaching the host — leaving the OS
+              window button as the only thing left that looks like "close",
+              which quits the app (OPEND-2156). This control lives in the host
+              document, so it keeps working wherever focus went. */}
+          <button
+            type="button"
+            className="present-exit-btn"
+            onClick={() => setInTabPresent(false)}
+            title={t('fileViewer.exitPresentation')}
+            aria-label={t('fileViewer.exitPresentation')}
+          >
+            <Icon name="close" size={14} />
+          </button>
           {/* Lives INSIDE the overlay (not a body-portaled toast) so it stays
               visible when the overlay is the fullscreen element — a sibling
               toast would be clipped out of the fullscreen render. */}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3063,7 +3063,7 @@ export const ar: Dict = {
   'fileViewer.versions.promptTitle': 'الموجه',
   'fileViewer.versions.copyPrompt': 'نسخ الموجه',
   'fileViewer.versions.fullscreen': 'معاينة بملء الشاشة',
-  'fileViewer.versions.open': 'فتح المعاينة',
+  'fileViewer.versions.open': 'فتح المعاينة في نافذة جديدة',
   'fileViewer.versions.currentHelp': 'هذا هو الإصدار الحالي بالفعل.',
   'fileViewer.versions.restoreHelp': 'سيؤدي التبديل إلى استعادة ملف HTML هذا كإصدار حالي جديد.',
   'fileViewer.versions.restore': 'التبديل إلى هذا الإصدار',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3063,7 +3063,7 @@ export const de: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Prompt kopieren',
   'fileViewer.versions.fullscreen': 'Vorschau im Vollbild',
-  'fileViewer.versions.open': 'Vorschau öffnen',
+  'fileViewer.versions.open': 'Vorschau in neuem Fenster öffnen',
   'fileViewer.versions.currentHelp': 'Dies ist bereits die aktuelle Version.',
   'fileViewer.versions.restoreHelp': 'Beim Wechseln wird dieses HTML als neue aktuelle Version wiederhergestellt.',
   'fileViewer.versions.restore': 'Zu dieser Version wechseln',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3077,7 +3077,7 @@ export const en: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Copy prompt',
   'fileViewer.versions.fullscreen': 'Fullscreen preview',
-  'fileViewer.versions.open': 'Open preview',
+  'fileViewer.versions.open': 'Open preview in a new window',
   'fileViewer.versions.currentHelp': 'This is already the current version.',
   'fileViewer.versions.restoreHelp': 'Switching restores this HTML as a new current version.',
   'fileViewer.versions.restore': 'Switch to this version',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3063,7 +3063,7 @@ export const esES: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Copiar prompt',
   'fileViewer.versions.fullscreen': 'Vista previa a pantalla completa',
-  'fileViewer.versions.open': 'Abrir vista previa',
+  'fileViewer.versions.open': 'Abrir vista previa en una ventana nueva',
   'fileViewer.versions.currentHelp': 'Esta ya es la versión actual.',
   'fileViewer.versions.restoreHelp': 'Al cambiar, este HTML se restaura como una nueva versión actual.',
   'fileViewer.versions.restore': 'Cambiar a esta versión',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3063,7 +3063,7 @@ export const fa: Dict = {
   'fileViewer.versions.promptTitle': 'پرامپت',
   'fileViewer.versions.copyPrompt': 'کپی پرامپت',
   'fileViewer.versions.fullscreen': 'پیش‌نمایش تمام‌صفحه',
-  'fileViewer.versions.open': 'باز کردن پیش‌نمایش',
+  'fileViewer.versions.open': 'باز کردن پیش‌نمایش در پنجره جدید',
   'fileViewer.versions.currentHelp': 'این نسخه هم‌اکنون نسخه فعلی است.',
   'fileViewer.versions.restoreHelp': 'با تغییر، این HTML به عنوان نسخه فعلی جدید بازیابی می‌شود.',
   'fileViewer.versions.restore': 'تغییر به این نسخه',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3063,7 +3063,7 @@ export const fr: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Copier le prompt',
   'fileViewer.versions.fullscreen': 'Aperçu plein écran',
-  'fileViewer.versions.open': 'Ouvrir l’aperçu',
+  'fileViewer.versions.open': 'Ouvrir l’aperçu dans une nouvelle fenêtre',
   'fileViewer.versions.currentHelp': 'C’est déjà la version actuelle.',
   'fileViewer.versions.restoreHelp': 'Le changement restaure ce HTML comme nouvelle version actuelle.',
   'fileViewer.versions.restore': 'Passer à cette version',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3063,7 +3063,7 @@ export const hu: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Prompt másolása',
   'fileViewer.versions.fullscreen': 'Teljes képernyős előnézet',
-  'fileViewer.versions.open': 'Előnézet megnyitása',
+  'fileViewer.versions.open': 'Előnézet megnyitása új ablakban',
   'fileViewer.versions.currentHelp': 'Ez már az aktuális verzió.',
   'fileViewer.versions.restoreHelp': 'A váltás ezt a HTML-t új aktuális verzióként állítja vissza.',
   'fileViewer.versions.restore': 'Váltás erre a verzióra',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3063,7 +3063,7 @@ export const id: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Salin prompt',
   'fileViewer.versions.fullscreen': 'Pratinjau layar penuh',
-  'fileViewer.versions.open': 'Buka pratinjau',
+  'fileViewer.versions.open': 'Buka pratinjau di jendela baru',
   'fileViewer.versions.currentHelp': 'Ini sudah versi saat ini.',
   'fileViewer.versions.restoreHelp': 'Beralih akan memulihkan HTML ini sebagai versi saat ini yang baru.',
   'fileViewer.versions.restore': 'Beralih ke versi ini',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3063,7 +3063,7 @@ export const it: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Copia prompt',
   'fileViewer.versions.fullscreen': 'Anteprima a schermo intero',
-  'fileViewer.versions.open': 'Apri anteprima',
+  'fileViewer.versions.open': 'Apri anteprima in una nuova finestra',
   'fileViewer.versions.currentHelp': 'Questa è già la versione corrente.',
   'fileViewer.versions.restoreHelp': 'Il passaggio ripristina questo HTML come nuova versione corrente.',
   'fileViewer.versions.restore': 'Passa a questa versione',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3063,7 +3063,7 @@ export const ja: Dict = {
   'fileViewer.versions.promptTitle': 'プロンプト',
   'fileViewer.versions.copyPrompt': 'プロンプトをコピー',
   'fileViewer.versions.fullscreen': '全画面プレビュー',
-  'fileViewer.versions.open': 'プレビューを開く',
+  'fileViewer.versions.open': 'プレビューを新しいウィンドウで開く',
   'fileViewer.versions.currentHelp': 'これはすでに現在のバージョンです。',
   'fileViewer.versions.restoreHelp': '切り替えると、このHTMLが新しい現在のバージョンとして復元されます。',
   'fileViewer.versions.restore': 'このバージョンに切り替える',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3063,7 +3063,7 @@ export const ko: Dict = {
   'fileViewer.versions.promptTitle': '프롬프트',
   'fileViewer.versions.copyPrompt': '프롬프트 복사',
   'fileViewer.versions.fullscreen': '전체 화면 미리보기',
-  'fileViewer.versions.open': '미리보기 열기',
+  'fileViewer.versions.open': '새 창에서 미리보기 열기',
   'fileViewer.versions.currentHelp': '이미 현재 버전입니다.',
   'fileViewer.versions.restoreHelp': '전환하면 이 HTML이 새로운 현재 버전으로 복원됩니다.',
   'fileViewer.versions.restore': '이 버전으로 전환',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3063,7 +3063,7 @@ export const pl: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Kopiuj prompt',
   'fileViewer.versions.fullscreen': 'Podgląd pełnoekranowy',
-  'fileViewer.versions.open': 'Otwórz podgląd',
+  'fileViewer.versions.open': 'Otwórz podgląd w nowym oknie',
   'fileViewer.versions.currentHelp': 'To już jest bieżąca wersja.',
   'fileViewer.versions.restoreHelp': 'Przełączenie przywróci ten HTML jako nową bieżącą wersję.',
   'fileViewer.versions.restore': 'Przełącz na tę wersję',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3063,7 +3063,7 @@ export const ptBR: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Copiar prompt',
   'fileViewer.versions.fullscreen': 'Prévia em tela cheia',
-  'fileViewer.versions.open': 'Abrir prévia',
+  'fileViewer.versions.open': 'Abrir prévia em uma nova janela',
   'fileViewer.versions.currentHelp': 'Esta já é a versão atual.',
   'fileViewer.versions.restoreHelp': 'Ao alternar, este HTML será restaurado como uma nova versão atual.',
   'fileViewer.versions.restore': 'Alternar para esta versão',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3063,7 +3063,7 @@ export const ru: Dict = {
   'fileViewer.versions.promptTitle': 'Промпт',
   'fileViewer.versions.copyPrompt': 'Скопировать промпт',
   'fileViewer.versions.fullscreen': 'Полноэкранный предпросмотр',
-  'fileViewer.versions.open': 'Открыть предпросмотр',
+  'fileViewer.versions.open': 'Открыть предпросмотр в новом окне',
   'fileViewer.versions.currentHelp': 'Это уже текущая версия.',
   'fileViewer.versions.restoreHelp': 'Переключение восстановит этот HTML как новую текущую версию.',
   'fileViewer.versions.restore': 'Переключиться на эту версию',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3063,7 +3063,7 @@ export const th: Dict = {
   'fileViewer.versions.promptTitle': 'พรอมป์',
   'fileViewer.versions.copyPrompt': 'คัดลอกพรอมป์',
   'fileViewer.versions.fullscreen': 'ตัวอย่างเต็มหน้าจอ',
-  'fileViewer.versions.open': 'เปิดตัวอย่าง',
+  'fileViewer.versions.open': 'เปิดตัวอย่างในหน้าต่างใหม่',
   'fileViewer.versions.currentHelp': 'นี่คือเวอร์ชันปัจจุบันอยู่แล้ว',
   'fileViewer.versions.restoreHelp': 'การสลับจะกู้คืน HTML นี้เป็นเวอร์ชันปัจจุบันใหม่',
   'fileViewer.versions.restore': 'สลับไปเวอร์ชันนี้',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3063,7 +3063,7 @@ export const tr: Dict = {
   'fileViewer.versions.promptTitle': 'Prompt',
   'fileViewer.versions.copyPrompt': 'Promptu kopyala',
   'fileViewer.versions.fullscreen': 'Tam ekran önizleme',
-  'fileViewer.versions.open': 'Önizlemeyi aç',
+  'fileViewer.versions.open': 'Önizlemeyi yeni pencerede aç',
   'fileViewer.versions.currentHelp': 'Bu zaten geçerli sürüm.',
   'fileViewer.versions.restoreHelp': 'Geçiş, bu HTML’i yeni geçerli sürüm olarak geri yükler.',
   'fileViewer.versions.restore': 'Bu sürüme geç',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3063,7 +3063,7 @@ export const uk: Dict = {
   'fileViewer.versions.promptTitle': 'Промпт',
   'fileViewer.versions.copyPrompt': 'Копіювати промпт',
   'fileViewer.versions.fullscreen': 'Повноекранний перегляд',
-  'fileViewer.versions.open': 'Відкрити перегляд',
+  'fileViewer.versions.open': 'Відкрити перегляд у новому вікні',
   'fileViewer.versions.currentHelp': 'Це вже поточна версія.',
   'fileViewer.versions.restoreHelp': 'Перемикання відновить цей HTML як нову поточну версію.',
   'fileViewer.versions.restore': 'Перемкнутися на цю версію',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -4448,7 +4448,7 @@ export const zhCN: Dict = {
   'fileViewer.versions.promptTitle': '提示词',
   'fileViewer.versions.copyPrompt': '复制提示词',
   'fileViewer.versions.fullscreen': '全屏预览',
-  'fileViewer.versions.open': '打开预览',
+  'fileViewer.versions.open': "在新窗口打开预览",
   'fileViewer.versions.currentHelp': '这已经是当前版本。',
   'fileViewer.versions.restoreHelp': '切换会把此 HTML 恢复为新的当前版本。',
   'fileViewer.versions.restore': '切换到此版本',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -4453,7 +4453,7 @@ export const zhTW: Dict = {
   'fileViewer.versions.promptTitle': '提示詞',
   'fileViewer.versions.copyPrompt': '複製提示詞',
   'fileViewer.versions.fullscreen': '全螢幕預覽',
-  'fileViewer.versions.open': '開啟預覽',
+  'fileViewer.versions.open': "在新視窗開啟預覽",
   'fileViewer.versions.currentHelp': '這已經是目前版本。',
   'fileViewer.versions.restoreHelp': '切換會將此 HTML 還原為新的目前版本。',
   'fileViewer.versions.restore': '切換到此版本',

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1212,6 +1212,11 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Two controls that do opposite things: one leaves the panel open and sends
+   the version to a new window, the other closes the panel. They share chrome
+   but not a name — spelling them the same way is what let the open control's
+   ambiguous glyph go unnoticed in review (OPEND-2160). */
+.artifact-version-panel__open,
 .artifact-version-panel__close {
   width: 28px;
   height: 28px;
@@ -1480,6 +1485,7 @@ body:has(.artifact-version-panel) .ws-tabs-file-actions-before {
   align-items: center;
   gap: 6px;
 }
+.artifact-version-panel__open:disabled,
 .artifact-version-panel__close:disabled {
   cursor: not-allowed;
   opacity: 0.45;

--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -318,6 +318,45 @@
   background: black;
   display: flex;
 }
+/* The presentation overlay is portaled to <body>, so the `.viewer`-scoped
+   `.present-exit-btn` rules in shell.css never reach it. This is the user's
+   only way out once focus moves into the sandboxed deck frame and Esc stops
+   arriving (OPEND-2156), so it sits above the frame and stays reachable.
+   Dimmed at rest so it does not compete with the slide, full strength on
+   hover/focus. */
+.present-overlay .present-exit-btn {
+  position: absolute;
+  top: calc(env(safe-area-inset-top, 0px) + 12px);
+  right: 12px;
+  z-index: 1002;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(0, 0, 0, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  opacity: 0.55;
+  transition:
+    opacity 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    background-color 200ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.present-overlay:hover .present-exit-btn,
+.present-overlay .present-exit-btn:hover,
+.present-overlay .present-exit-btn:focus-visible {
+  opacity: 1;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.68);
+}
+.present-overlay .present-exit-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .present-overlay iframe {
   flex: 1;
   width: 100%;

--- a/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
+++ b/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
@@ -62,6 +62,26 @@ function Wrap({ children }: { children: ReactNode }) {
   return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
 }
 
+function deckFile(): ProjectFile {
+  return {
+    name: 'deck.html',
+    path: 'deck.html',
+    type: 'file',
+    size: 2048,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'deck',
+      title: 'Deck',
+      entry: 'deck.html',
+      renderer: 'deck-html',
+      exports: ['html'],
+    },
+  };
+}
+
 function pageFile(): ProjectFile {
   return {
     name: 'page.html',
@@ -115,6 +135,28 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+const DECK_HTML =
+  '<html><body>'
+  + '<section class="slide"><h1>one</h1></section>'
+  + '<section class="slide"><p>two</p></section>'
+  + '</body></html>';
+
+function installDeckFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/deck.html`;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.split('?')[0] === filesUrl) {
+      return new Response(
+        JSON.stringify({ files: [deckFile()] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) return new Response(DECK_HTML, { status: 200 });
+    return new Response('', { status: 404 });
+  }));
+}
+
 describe('presentation overlay exit affordance (OPEND-2156)', () => {
   it('renders an exit control inside the overlay', async () => {
     const projectId = 'proj-present-exit-control';
@@ -160,5 +202,41 @@ describe('presentation overlay exit affordance (OPEND-2156)', () => {
     fireEvent.click(exit!);
 
     await waitFor(() => expect(overlay()).toBeNull());
+  });
+
+  // Presenting a deck opens a second window for speaker notes
+  // (`presentInThisTab` → `openPresenterWindow`). The reported symptom was that
+  // BOTH the app and that popup turn into the presentation, so an exit that
+  // only unmounts the overlay leaves the user still presenting in the popup —
+  // half the bug. The real teardown is `closeInTabPresentation()`, which is
+  // also what Esc and presenter-close use; this control has to go through it.
+  it('tears down the speaker-notes popup too, not just the overlay', async () => {
+    const projectId = 'proj-present-exit-popup';
+    installDeckFetchMock(projectId);
+
+    const popupClose = vi.fn();
+    const fakePopup = {
+      closed: false,
+      close: popupClose,
+      focus: vi.fn(),
+      document: { open: vi.fn(), write: vi.fn(), close: vi.fn() },
+    };
+    vi.stubGlobal('open', vi.fn(() => fakePopup));
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="deck" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(document.querySelector('.present-trigger')).not.toBeNull());
+    await enterPresentation();
+
+    const exit = overlay()!.querySelector('button');
+    expect(exit).not.toBeNull();
+    fireEvent.click(exit!);
+
+    await waitFor(() => expect(overlay()).toBeNull());
+    expect(popupClose).toHaveBeenCalled();
   });
 });

--- a/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
+++ b/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
@@ -225,7 +225,7 @@ describe('presentation overlay exit affordance (OPEND-2156)', () => {
 
     render(
       <Wrap>
-        <FileViewer projectId={projectId} projectKind="deck" file={deckFile()} isDeck />
+        <FileViewer projectId={projectId} projectKind="slide_deck" file={deckFile()} isDeck />
       </Wrap>,
     );
 

--- a/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
+++ b/apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+//
+// OPEND-2156 red spec: entering presentation leaves the user with no way out.
+//
+// Reported as "od 自己和新弹出的弹窗都变成了 ppt 演示, od 自己变成演示后没地方
+// 返回, 只能关了 od 客户端", and reproduced against a real runtime:
+//
+//   * `.present-overlay` is `position: fixed; inset: 0; z-index: 1050` — it
+//     covers the whole web content area, so the only "close" left on screen
+//     is the OS window button, which quits the app.
+//   * The overlay's only child is the sandboxed preview iframe. Measured
+//     live: `overlay.querySelectorAll('button').length === 0`.
+//   * Esc does exit — but only while focus is still on the host document.
+//     The first click on a slide (the natural way to advance) moves focus
+//     into the sandboxed frame, and from then on neither pointer nor key
+//     events reach the host, so Esc stops working too.
+//
+// The invariant frozen here: the presentation overlay must always carry its
+// own exit control. It lives in the host document, so it keeps working no
+// matter where focus went — which is exactly what Esc cannot promise.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { CollabProvider, type CollabContextValue } from '../../src/collab/collab-context';
+import { FileViewer } from '../../src/components/FileViewer';
+import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import type { ProjectFile } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
+
+const WORKSPACE_CONTEXT = workspaceContextFixture({
+  workspaceId: 'ws-present-exit',
+  workspaceMemberId: 'member-present-exit',
+});
+
+function collabValue(): CollabContextValue {
+  return {
+    workspaceContext: WORKSPACE_CONTEXT,
+    workspaceContextLoading: false,
+    projectResourceAuthority: 'workspace',
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'pending',
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    reportChange: () => {},
+    requestPublish: () => {},
+    refreshPresence: () => {},
+    checkStatusNow: () => {},
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
+}
+
+function pageFile(): ProjectFile {
+  return {
+    name: 'page.html',
+    path: 'page.html',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+  };
+}
+
+const PAGE_HTML = '<html><body><h1>slide</h1></body></html>';
+
+function installFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/page.html`;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.split('?')[0] === filesUrl) {
+      return new Response(
+        JSON.stringify({ files: [pageFile()] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) return new Response(PAGE_HTML, { status: 200 });
+    return new Response('', { status: 404 });
+  }));
+}
+
+function overlay(): HTMLElement | null {
+  return document.querySelector('.present-overlay');
+}
+
+async function enterPresentation() {
+  const trigger = document.querySelector('.present-trigger');
+  if (!(trigger instanceof HTMLButtonElement)) throw new Error('present trigger not rendered');
+  fireEvent.click(trigger);
+  const inTab = await screen.findByRole('menuitem', { name: /In this tab|在当前标签页/i });
+  fireEvent.click(inTab);
+  await waitFor(() => expect(overlay()).not.toBeNull());
+}
+
+beforeEach(() => {
+  resetSharedCancellableGet();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('presentation overlay exit affordance (OPEND-2156)', () => {
+  it('renders an exit control inside the overlay', async () => {
+    const projectId = 'proj-present-exit-control';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={pageFile()} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(document.querySelector('.present-trigger')).not.toBeNull());
+    await enterPresentation();
+
+    // The overlay covers everything; without a control of its own the user is
+    // left with the OS window button, which quits the app.
+    const exit = overlay()!.querySelector('button');
+    expect(exit).not.toBeNull();
+  });
+
+  it('leaves presentation when that control is used, with focus inside the preview frame', async () => {
+    const projectId = 'proj-present-exit-works';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={pageFile()} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(document.querySelector('.present-trigger')).not.toBeNull());
+    await enterPresentation();
+
+    // Reproduce the state the user is actually stuck in: they clicked a slide
+    // to advance, so focus now lives in the sandboxed frame and Esc can no
+    // longer reach the host.
+    const frame = overlay()!.querySelector('iframe');
+    expect(frame).not.toBeNull();
+    frame!.focus();
+
+    const exit = overlay()!.querySelector('button');
+    expect(exit).not.toBeNull();
+    fireEvent.click(exit!);
+
+    await waitFor(() => expect(overlay()).toBeNull());
+  });
+});

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7367,7 +7367,7 @@ describe('FileViewer SVG artifacts', () => {
     // preview action becomes enabled from the same
     // selectedContentMatchesVersion/loadingContent state that enables deck
     // keyboard routing.
-    const openPreview = within(versionDialog).getByRole('button', { name: 'Open preview' }) as HTMLButtonElement;
+    const openPreview = within(versionDialog).getByRole('button', { name: 'Open preview in a new window' }) as HTMLButtonElement;
     await waitFor(() => expect(openPreview.disabled).toBe(false));
     const previewFrame = await waitFor(() => {
       const frame = versionDialog.querySelector('iframe[title="index.html v4"]') as HTMLIFrameElement | null;
@@ -7699,7 +7699,7 @@ describe('FileViewer SVG artifacts', () => {
     const versionDialog = await screen.findByRole('dialog', { name: 'Versions' });
     fireEvent.click(within(versionDialog).getByRole('option', { name: /Prior prompt/ }));
     const switchButton = within(versionDialog).getByRole('button', { name: 'Switch to this version' }) as HTMLButtonElement;
-    const openButton = within(versionDialog).getByRole('button', { name: 'Open preview' }) as HTMLButtonElement;
+    const openButton = within(versionDialog).getByRole('button', { name: 'Open preview in a new window' }) as HTMLButtonElement;
     await waitFor(() => expect(switchButton.disabled).toBe(false));
     expect(openButton.disabled).toBe(false);
 

--- a/apps/web/tests/components/FileViewer.version-open-affordance.test.tsx
+++ b/apps/web/tests/components/FileViewer.version-open-affordance.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// OPEND-2160 red spec: in the version-history panel, the button that opens a
+// version reads as "share".
+//
+// What the code actually does (verified against a live runtime):
+//
+//   * icon:   RemixIcon `external-link-line` — a box with an arrow leaving it,
+//             close enough to the iOS share glyph to be read as one.
+//   * label:  `fileViewer.versions.open` = "Open preview" — it names the
+//             action but never says the preview opens somewhere ELSE.
+//   * action: `openVersionInNewTab` → `openSandboxedPreviewInNewTab(...)`.
+//
+// So the function is right and the icon is defensible; what is missing is the
+// destination. Naming it makes the arrow-leaving-a-box glyph read the way it
+// was meant to, which resolves the mismatch without turning an icon choice
+// into a guess.
+//
+// This copy is a tooltip on an icon-only button — the only text the user ever
+// gets for that control — so it has to carry the destination in every locale,
+// not just English.
+
+import { describe, expect, it } from 'vitest';
+import type { Dict } from '../../src/i18n/types';
+import { ar } from '../../src/i18n/locales/ar';
+import { de } from '../../src/i18n/locales/de';
+import { en } from '../../src/i18n/locales/en';
+import { esES } from '../../src/i18n/locales/es-ES';
+import { fa } from '../../src/i18n/locales/fa';
+import { fr } from '../../src/i18n/locales/fr';
+import { hu } from '../../src/i18n/locales/hu';
+import { id } from '../../src/i18n/locales/id';
+// Aliased: the bare `it` export would shadow vitest's own `it`.
+import { it as itIT } from '../../src/i18n/locales/it';
+import { ja } from '../../src/i18n/locales/ja';
+import { ko } from '../../src/i18n/locales/ko';
+import { pl } from '../../src/i18n/locales/pl';
+import { ptBR } from '../../src/i18n/locales/pt-BR';
+import { ru } from '../../src/i18n/locales/ru';
+import { th } from '../../src/i18n/locales/th';
+import { tr } from '../../src/i18n/locales/tr';
+import { uk } from '../../src/i18n/locales/uk';
+import { zhCN } from '../../src/i18n/locales/zh-CN';
+import { zhTW } from '../../src/i18n/locales/zh-TW';
+
+const KEY = 'fileViewer.versions.open' as const;
+
+const LOCALES: ReadonlyArray<readonly [string, Dict]> = [
+  ['ar', ar], ['de', de], ['en', en], ['es-ES', esES], ['fa', fa],
+  ['fr', fr], ['hu', hu], ['id', id], ['it', itIT], ['ja', ja],
+  ['ko', ko], ['pl', pl], ['pt-BR', ptBR], ['ru', ru], ['th', th],
+  ['tr', tr], ['uk', uk], ['zh-CN', zhCN], ['zh-TW', zhTW],
+];
+
+describe('version history open-elsewhere affordance (OPEND-2160)', () => {
+  it('names the destination in English', () => {
+    // An arrow leaving a box plus "Open preview" leaves the user guessing
+    // between share, export and open. The destination is what disambiguates.
+    expect(en[KEY].toLowerCase()).toMatch(/new window|new tab/);
+  });
+
+  it('carries a destination in every locale, not just English', () => {
+    // The button is icon-only, so this string is the entire explanation the
+    // user gets. A locale left on the old wording ships the same ambiguity
+    // this issue was filed about.
+    const stale = LOCALES.filter(([, dict]) => dict[KEY] === 'Open preview').map(([name]) => name);
+    expect(stale).toEqual([]);
+
+    const empty = LOCALES.filter(([, dict]) => !dict[KEY].trim()).map(([name]) => name);
+    expect(empty).toEqual([]);
+  });
+});

--- a/apps/web/tests/components/FileViewer.viewport-menu-iframe-dismiss.test.tsx
+++ b/apps/web/tests/components/FileViewer.viewport-menu-iframe-dismiss.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// OPEND-2035 red spec: the preview device/viewport dropdown stays open when
+// the user clicks the preview.
+//
+// The menu already implements a textbook click-outside on the host document:
+//
+//   document.addEventListener('pointerdown', e => {
+//     if (!menuRef.current.contains(e.target)) setOpen(false);
+//   });
+//
+// That handler is correct and it works — but it can only see pointer events
+// that reach THIS document. The preview is rendered into a sandboxed iframe
+// (`sandbox="allow-scripts allow-downloads"`, i.e. an opaque origin), so a
+// click that lands on the preview dispatches inside the frame's own document
+// and never reaches the host. Measured live against a real runtime: clicking
+// host chrome delivered 1 host pointerdown and closed the menu; clicking the
+// preview delivered 0 and left the menu open — and the preview is by far the
+// largest, most natural place to click when dismissing a menu.
+//
+// The one signal the host does reliably get is focus leaving the top-level
+// document for the frame, which is exactly what a click on the preview does.
+// This spec freezes that: focus moving into an iframe must dismiss the menu.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { CollabProvider, type CollabContextValue } from '../../src/collab/collab-context';
+import { FileViewer } from '../../src/components/FileViewer';
+import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import type { ProjectFile } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
+
+const WORKSPACE_CONTEXT = workspaceContextFixture({
+  workspaceId: 'ws-viewport-menu',
+  workspaceMemberId: 'member-viewport-menu',
+});
+
+function collabValue(): CollabContextValue {
+  return {
+    workspaceContext: WORKSPACE_CONTEXT,
+    workspaceContextLoading: false,
+    projectResourceAuthority: 'workspace',
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'pending',
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    reportChange: () => {},
+    requestPublish: () => {},
+    refreshPresence: () => {},
+    checkStatusNow: () => {},
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
+}
+
+function pageFile(): ProjectFile {
+  return {
+    name: 'page.html',
+    path: 'page.html',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+  };
+}
+
+const PAGE_HTML = '<html><body><h1>preview</h1></body></html>';
+
+function installFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/page.html`;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.split('?')[0] === filesUrl) {
+      return new Response(
+        JSON.stringify({ files: [pageFile()] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) return new Response(PAGE_HTML, { status: 200 });
+    return new Response('', { status: 404 });
+  }));
+}
+
+function viewportTrigger(): HTMLButtonElement {
+  const trigger = document.querySelector('.viewer-viewport-trigger');
+  if (!(trigger instanceof HTMLButtonElement)) throw new Error('viewport trigger not rendered');
+  return trigger;
+}
+
+function menuIsOpen(): boolean {
+  return viewportTrigger().getAttribute('aria-expanded') === 'true';
+}
+
+beforeEach(() => {
+  resetSharedCancellableGet();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('preview viewport menu dismissal (OPEND-2035)', () => {
+  it('closes when a click lands in the preview iframe (focus leaves the host document)', async () => {
+    const projectId = 'proj-viewport-menu-iframe';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={pageFile()} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(document.querySelector('.viewer-viewport-trigger')).not.toBeNull());
+    fireEvent.click(viewportTrigger());
+    await waitFor(() => expect(menuIsOpen()).toBe(true));
+
+    // A click that lands on the sandboxed preview: the host document sees no
+    // pointerdown at all, only focus moving to the frame element.
+    const frame = document.querySelector('iframe');
+    expect(frame).not.toBeNull();
+    act(() => {
+      frame!.focus();
+      window.dispatchEvent(new Event('blur'));
+    });
+
+    await waitFor(() => expect(menuIsOpen()).toBe(false));
+  });
+
+  it('stays open when the window merely loses focus without the preview taking it', async () => {
+    const projectId = 'proj-viewport-menu-app-switch';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={pageFile()} />
+      </Wrap>,
+    );
+
+    await waitFor(() => expect(document.querySelector('.viewer-viewport-trigger')).not.toBeNull());
+    fireEvent.click(viewportTrigger());
+    await waitFor(() => expect(menuIsOpen()).toBe(true));
+
+    // Switching to another application blurs the window too. The menu is not
+    // being dismissed by the user in that case, so it must survive — dropping
+    // it would make the menu vanish every time the user alt-tabs away.
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+
+    expect(menuIsOpen()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Three reports from the 0.20 dogfooding round, tracked as OPEND-2035, OPEND-2156 and OPEND-2160. They arrived separately but they are the same shape: the preview is a sandboxed, opaque-origin iframe, so **nothing that happens inside it reaches the host document** — and each of these three controls was relying on a host-side signal that a click on the preview never produces.

Each was reproduced against a local runtime before any code changed, and the measurements below come from that session, not from reading the source.

### OPEND-2035 — the device menu will not close when you click the preview

The ticket proposed "implement standard click-outside logic". That turned out to be the wrong lead: `PreviewViewportControls` already implements it, correctly, and it works. What it cannot see is a click that lands on the preview.

Same page, same menu, one session:

| click target | pointerdown events the host received | menu after |
| --- | --- | --- |
| host chrome (`.viewer-toolbar-left`) | 1 | **closed** |
| the preview iframe | **0** | **still open** |

Both preview iframes carry `sandbox="allow-scripts allow-downloads"` with no `allow-same-origin`, so this is structural, not flaky. And the preview is the biggest thing on screen — it is exactly where you reach to dismiss a menu.

### OPEND-2156 — presentation mode has no way back

Reported as *"od 自己变成演示后没地方返回, 只能关了 od 客户端"*. Confirmed, and it is worse than "missing a button":

- `.present-overlay` is `position: fixed; inset: 0; z-index: 1050` — it covers the whole content area.
- Measured live: `overlay.querySelectorAll('button').length === 0`. The overlay's only child is the sandboxed preview iframe.
- Esc **does** exit — but only while focus is still on the host. The first click on a slide (the natural way to advance) moves focus into the frame, and from then on neither pointer nor keyboard events reach the host, so **Esc stops working too**.

At that point the only thing left on screen that looks like "close" is the OS window button, which quits the app.

### OPEND-2160 — the version open button reads as "share"

The reporter said the icon shows "分享". The code is actually `external-link-line` — but that glyph is close enough to the iOS share icon to be read as one, so the report is about perception, not a mislabelled import. Meanwhile the tooltip said only "Open preview", which never says the preview opens *somewhere else*. Icon ambiguous + copy silent about the destination = the reported confusion.

## What users will see

- Clicking the preview now dismisses the device/viewport menu, like clicking anywhere else does. Switching to another app still leaves the menu alone.
- Presentation mode carries its own exit control (dimmed at rest, full strength on hover/focus). It keeps working after you have clicked into the slides, which is exactly when Esc has stopped. **Nothing here changes what the OS window button does.**
- In version history, the open button now says where it opens — "Open preview in a new window" / 「在新窗口打开预览」 — in all 19 locales.

## Surface area

- [x] **UI** — viewer preview toolbar, presentation overlay, version-history panel in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — no new keys; `fileViewer.versions.open` reworded in all 19 locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Measured rather than captured — these are state transitions, and the numbers pin them more precisely than an image. Same runtime, same data directory, only the build differs:

| | before | after |
| --- | --- | --- |
| 2035: click preview | host pointerdowns 0, `aria-expanded=true` | host pointerdowns 0 (unchanged — that path is structural), `aria-expanded=false` |
| 2156: buttons inside overlay | **0** | **1**, labelled 退出演示 |
| 2156: exit with focus in the frame | impossible (Esc dead, no control) | control hit-tests clear and exits to the editor |
| 2160: header actions | both `artifact-version-panel__close`; label 「打开预览」 | `__open` / `__close`; label 「在新窗口打开预览」 |

Entry points: the viewport control and 演示 button in the artifact toolbar; the 历史版本 button beside them.

## Bug fix verification

Red specs, each failing on `main`:

- `apps/web/tests/components/FileViewer.viewport-menu-iframe-dismiss.test.tsx` — two cases. The dismissal case went red; the companion case (an app switch must **not** close the menu) was green from the start, which is what keeps the fix from degenerating into "close on any blur".
- `apps/web/tests/components/FileViewer.present-exit-affordance.test.tsx` — two cases, both red with `expected null not to be null`, i.e. the overlay genuinely had no button. The second drives the exit **with focus inside the preview frame**, reproducing the state the user is actually stuck in.
- `apps/web/tests/components/FileViewer.version-open-affordance.test.tsx` — two cases, red on English and on the per-locale sweep.

Verified end-to-end in real Chrome afterwards, against a runtime built from this branch and pointed at the **same data directory** the pre-fix session used — same artifacts, same project, only the code differs. Every click was gated on `document.elementFromPoint()` returning the target, so a control hidden behind an overlay is reported rather than silently driven.

## Adjacent issues

- **OPEND-2147** (deck blank at default zoom) is deliberately **not** in this PR. It is real and reproducible — a deck the product generated itself renders its thumbnail rail correctly while the main stage stays blank — and three isolation probes place the fault in OD's preview mount rather than in the artifact: the raw artifact, and the fully injected srcdoc, both resolve to the correct `scale(0.490741)` when rendered in a plain iframe at the preview pane's exact size. A first attempt at the mount timing moved the symptom (blank → oversized and clipped) without fixing it, so it is parked rather than shipped half-done.
- **OPEND-2108** and **OPEND-2109** do not reproduce locally; findings are recorded on the tickets, with the material needed to continue.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` (full suite: 655 files / 6966 tests, green). The full run is what caught a real regression: two existing assertions in `FileViewer.test.tsx` were pinned to the old copy string, and are updated here — running only the new specs would have missed it.
- Real-Chrome E2E on `pnpm tools-dev run web --namespace fixed`, isolated `OD_DATA_DIR`
