### PR TITLE
fix(web): hide Go campaign touchpoints

### DIFF
--- a/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
+++ b/apps/web/src/components/DeepSeekV4FlashCampaign.tsx
@@ -6,8 +6,13 @@ import {
   formatDeepSeekV4FlashCampaignCountdown,
   type DeepSeekV4FlashCampaignAudience,
 } from '../campaigns/deepseek-v4-flash';
-import { getGoPlanCampaignCopy } from '../campaigns/go-plan-content';
-import { GO_PLAN_CAMPAIGN, goPlanPricingUrl } from '../campaigns/go-plan';
+import { goPlanPricingUrl } from '../campaigns/go-plan';
+import {
+  amrHandoffDeviceId,
+  attributedAmrUrl,
+  recordAmrEntry,
+} from '../analytics/amr-attribution';
+import { getResolvedDeviceId } from '../analytics/client';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackDeepSeekCampaignModalClick,
@@ -17,12 +22,6 @@ import { useI18n } from '../i18n';
 import { Icon } from './Icon';
 import { modelProviderIconSrc } from './modelProviderIcon';
 import styles from './DeepSeekV4FlashCampaign.module.css';
-
-const GO_PLAN_DEEPSEEK_ICON = '/agent-icons/deepseek.svg';
-const GO_PLAN_KIMI_ICON = '/agent-icons/kimi.svg';
-const GO_PLAN_MINIMAX_ICON = '/model-icons/minimax.svg';
-const GO_PLAN_MIMO_ICON = '/go-plan/mimo-logo-user-CWOWEwG5.png';
-const GO_PLAN_ZHIPU_ICON = '/go-plan/zai-logo-official-Byn-xbrp.png';
 
 interface Props {
   /**
@@ -47,7 +46,7 @@ interface Props {
   onUseCampaignModel?: (agentId: string, modelId: string) => void;
   /**
    * Telemetry opt-in (config.telemetry.metrics). Gates the AMR analytics
-   * mirror of the recorded entry AND the od_device_id on the plans URL —
+   * mirror of the recorded entry AND the od_device_id on the Pricing URL —
    * the same treatment the workbench badge and the model-switcher upgrade
    * already apply to this campaign's other touchpoints.
    */
@@ -144,7 +143,6 @@ export function DeepSeekV4FlashCampaign({
   installationId = null,
 }: Props) {
   const { locale, t } = useI18n();
-  const goPlanCopy = getGoPlanCampaignCopy(locale);
   const analytics = useAnalytics();
   const [modalOpen, setModalOpen] = useState(false);
   const [countdownNow, setCountdownNow] = useState(() => Date.now());
@@ -152,7 +150,7 @@ export function DeepSeekV4FlashCampaign({
   const titleId = useId();
   const descriptionId = useId();
   const paid = audience === 'paid';
-  const activeCampaignId = paid ? campaign.id : GO_PLAN_CAMPAIGN.id;
+  const activeCampaignId = campaign.id;
 
   useEffect(() => {
     if (!active) {
@@ -168,15 +166,13 @@ export function DeepSeekV4FlashCampaign({
 
   useEffect(() => {
     if (!modalOpen) return;
-    if (paid) {
-      trackDeepSeekCampaignModalSurfaceView(analytics.track, {
-        page_name: 'home',
-        area: 'deepseek_campaign_modal',
-        element: 'modal',
-        campaign_id: 'deepseek_v4_pro',
-        user_state: 'paid',
-      });
-    }
+    trackDeepSeekCampaignModalSurfaceView(analytics.track, {
+      page_name: 'home',
+      area: 'deepseek_campaign_modal',
+      element: 'modal',
+      campaign_id: 'deepseek_v4_pro',
+      user_state: paid ? 'paid' : 'unpaid',
+    });
     const panel = document.getElementById(dialogId);
     if (!panel) return;
     const previouslyFocused =
@@ -192,14 +188,14 @@ export function DeepSeekV4FlashCampaign({
   }, [analytics.track, audience, dialogId, modalOpen, paid]);
 
   useEffect(() => {
-    if (!modalOpen || !paid) return;
+    if (!modalOpen) return;
     // The countdown always runs against the real `window.endAtExclusive`
     // boundary (via formatDeepSeekV4FlashCampaignCountdown) — there is no
     // synthetic per-open countdown.
     setCountdownNow(Date.now());
     const countdownTimer = window.setInterval(() => setCountdownNow(Date.now()), 1_000);
     return () => window.clearInterval(countdownTimer);
-  }, [modalOpen, paid]);
+  }, [modalOpen]);
 
   const dismissModal = () => {
     markCampaignSeen(activeCampaignId);
@@ -213,18 +209,17 @@ export function DeepSeekV4FlashCampaign({
         cta: t('campaign.deepseekV4Flash.paid.cta'),
       }
     : {
-        eyebrow: '',
-        status: '',
-        cta: '',
+        eyebrow: t('campaign.deepseekV4Flash.unpaid.eyebrow'),
+        status: t('campaign.deepseekV4Flash.unpaid.status'),
+        cta: t('campaign.deepseekV4Flash.unpaid.cta'),
       };
   const trackModalClick = (element: 'close' | 'later' | 'use_now' | 'upgrade') => {
-    if (!paid) return;
     trackDeepSeekCampaignModalClick(analytics.track, {
       page_name: 'home',
       area: 'deepseek_campaign_modal',
       element,
       campaign_id: 'deepseek_v4_pro',
-      user_state: 'paid',
+      user_state: paid ? 'paid' : 'unpaid',
     });
   };
   const closeModal = () => {
@@ -245,8 +240,23 @@ export function DeepSeekV4FlashCampaign({
       window.setTimeout(highlightModelSwitcher, 0);
       return;
     }
+    const attribution = recordAmrEntry(
+      analytics.track,
+      'deepseek_unpaid_modal',
+      new Date(),
+      {
+        metricsConsent,
+        campaignId: 'deepseek_v4_pro',
+        conversionSource: 'deepseek_unpaid_modal',
+      },
+    );
+    const deviceId = amrHandoffDeviceId({
+      metricsConsent,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId,
+    });
     window.open(
-      goPlanPricingUrl(locale),
+      attributedAmrUrl(goPlanPricingUrl(locale), attribution, deviceId),
       '_blank',
       'noopener,noreferrer',
     );
@@ -254,154 +264,6 @@ export function DeepSeekV4FlashCampaign({
 
   if (!active || !modalOpen || audience === 'unknown' || typeof document === 'undefined') {
     return null;
-  }
-
-  if (!paid) {
-    return createPortal(
-      <Dialog
-        id={dialogId}
-        ariaLabelledBy={titleId}
-        ariaDescribedBy={descriptionId}
-        onClose={closeModal}
-        closeOnEscape
-        className={styles.goWelcomeModal}
-        backdropClassName={styles.goWelcomeBackdrop}
-        data-testid="deepseek-v4-flash-campaign-dialog"
-      >
-        <Button
-          variant="ghost"
-          size="icon"
-          className={styles.goWelcomeClose}
-          aria-label={goPlanCopy.closeAria}
-          onClick={closeModal}
-        >
-          <Icon name="close" size={16} />
-        </Button>
-
-        <div className={styles.goWelcomeVisual}>
-          <span>{goPlanCopy.newBadge}</span>
-          <div className={styles.goWelcomeLockup} aria-hidden="true">
-            <strong>GO</strong>
-            <b><small>$</small>5</b>
-          </div>
-          <small>{goPlanCopy.eyebrow}</small>
-        </div>
-
-        <div className={styles.goWelcomeCopy}>
-          <h2 id={titleId}>{goPlanCopy.headline}</h2>
-          <p id={descriptionId} className={styles.goWelcomeSubtitle}>
-            {goPlanCopy.description}
-          </p>
-
-          <div
-            className={styles.goWelcomeModelLogos}
-            role="group"
-            aria-label={goPlanCopy.providersAria}
-          >
-            {[
-              {
-                providerId: 'deepseek/v4-pro',
-                src: GO_PLAN_DEEPSEEK_ICON,
-                label: 'DeepSeek',
-                fallback: 'DS',
-              },
-              {
-                providerId: 'zhipu/glm-5.2',
-                src: GO_PLAN_ZHIPU_ICON,
-                label: 'GLM',
-                fallback: 'GLM',
-                className: styles.goWelcomeZhipuLogo,
-              },
-              {
-                providerId: 'kimi/k2.6',
-                src: GO_PLAN_KIMI_ICON,
-                label: 'Kimi',
-                fallback: 'KM',
-              },
-              {
-                providerId: 'minimax/m2.5',
-                src: GO_PLAN_MINIMAX_ICON,
-                label: 'MiniMax',
-                fallback: 'MM',
-              },
-              {
-                providerId: 'mimo/v2-pro',
-                src: GO_PLAN_MIMO_ICON,
-                label: 'MiMo',
-                fallback: 'MI',
-                className: styles.goWelcomeMimoLogo,
-              },
-            ].map(({ providerId, src, label, fallback, className }) => (
-              <CampaignProviderMark
-                key={providerId}
-                providerId={providerId}
-                src={src}
-                label={label}
-                fallback={fallback}
-                className={className ?? ''}
-                fallbackClassName={styles.goWelcomeProviderFallback}
-              />
-            ))}
-          </div>
-
-          <div className={styles.goWelcomePlanBenefit}>
-            <strong>{goPlanCopy.benefit}</strong>
-            <ul>
-              {[
-                {
-                  providerId: 'deepseek/v4-flash',
-                  src: GO_PLAN_DEEPSEEK_ICON,
-                  label: 'DeepSeek V4 Flash',
-                  fallback: 'DS',
-                },
-                {
-                  providerId: 'deepseek/v4-pro',
-                  src: GO_PLAN_DEEPSEEK_ICON,
-                  label: 'DeepSeek V4 Pro',
-                  fallback: 'DS',
-                },
-                {
-                  providerId: 'zhipu/glm-5.2',
-                  src: GO_PLAN_ZHIPU_ICON,
-                  label: 'GLM-5.2',
-                  fallback: 'GLM',
-                  className: styles.goWelcomeBenefitZhipu,
-                },
-              ].map(({ providerId, src, label, fallback, className }) => (
-                <li key={label}>
-                  <span className={styles.goWelcomeBenefitModel}>
-                    <CampaignProviderMark
-                      providerId={providerId}
-                      src={src}
-                      label={label}
-                      fallback={fallback}
-                      className={[styles.goWelcomeBenefitIcon, className]
-                        .filter(Boolean)
-                        .join(' ')}
-                      fallbackClassName={styles.goWelcomeBenefitFallback}
-                      decorative
-                    />
-                    {label}
-                  </span>
-                  <small>{goPlanCopy.status}</small>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          <p className={styles.goWelcomeTerms}>
-            <span>{goPlanCopy.renewal}</span>
-            <span>{goPlanCopy.boundary}</span>
-          </p>
-
-          <Button className={styles.goWelcomePrimary} onClick={takeAction}>
-            {goPlanCopy.cta}
-            <Icon name="arrow-right" size={15} />
-          </Button>
-        </div>
-      </Dialog>,
-      document.body,
-    );
   }
 
   return createPortal(
@@ -439,8 +301,10 @@ export function DeepSeekV4FlashCampaign({
           <strong>{t('campaign.deepseekV4Flash.benefit')}</strong>
           <small>{presentation.status}</small>
         </span>
-        <span className={styles.available}>
-          {t('campaign.deepseekV4Flash.unlocked')}
+        <span className={paid ? styles.available : styles.locked}>
+          {paid
+            ? t('campaign.deepseekV4Flash.unlocked')
+            : t('campaign.deepseekV4Flash.locked')}
         </span>
       </div>
 
@@ -457,9 +321,11 @@ export function DeepSeekV4FlashCampaign({
       </div>
       <p className={styles.boundary}>{t('campaign.deepseekV4Flash.boundary')}</p>
       <div className={styles.actions}>
-        <Button variant="ghost" className={styles.laterAction} onClick={postponeModal}>
-          {t('campaign.deepseekV4Flash.later')}
-        </Button>
+        {paid ? (
+          <Button variant="ghost" className={styles.laterAction} onClick={postponeModal}>
+            {t('campaign.deepseekV4Flash.later')}
+          </Button>
+        ) : null}
         <Button className={styles.primaryAction} onClick={takeAction}>
           {presentation.cta}
         </Button>

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -77,8 +77,6 @@ import { amrPlansUrlForProfile } from '../runtime/amr-guidance';
 import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import { resolveDeepSeekV4FlashCampaignAudience } from '../campaigns/deepseek-v4-flash';
 import { useDeepSeekV4FlashCampaignVisibility } from '../campaigns/use-deepseek-v4-flash-campaign';
-import { resolveSubscriptionAudience } from '../campaigns/go-plan';
-import { useGoPlanCampaignVisibility } from '../campaigns/use-go-plan-campaign';
 import type { EntryHomeView } from '../router';
 import type {
   AccountMenuClickProps,
@@ -1083,7 +1081,6 @@ export function WorkspaceTopRightAccountCluster({
   const billing = workspaceBillingSummaryForContext(billingResponse, context);
   const balanceUsd = workspaceBillingBalanceUsd(billingResponse, context);
   const deepSeekCampaignVisibility = useDeepSeekV4FlashCampaignVisibility();
-  const goPlanCampaignVisibility = useGoPlanCampaignVisibility();
   const campaignPlan = resolvePlanLabelTier({
     billing,
     context,
@@ -1097,27 +1094,19 @@ export function WorkspaceTopRightAccountCluster({
     loggedIn: amrLoggedIn,
     now: deepSeekCampaignVisibility.now,
   });
-  const subscriptionAudience = resolveSubscriptionAudience({
-    plan: campaignPlan,
-    loggedIn: amrLoggedIn,
-  });
-  const campaignKind =
-    subscriptionAudience === 'unpaid'
-      ? goPlanCampaignVisibility.visible
-        ? 'go'
-        : null
-      : deepSeekCampaignAudience === 'paid'
-        ? 'deepseek'
-        : null;
+  const campaignAudience =
+    deepSeekCampaignAudience === 'unknown'
+      ? null
+      : deepSeekCampaignAudience;
   return (
     <EntryTopRightCluster
       page="project"
       context={context}
       billing={billing}
       balanceUsd={balanceUsd}
-      leadingSlot={campaignKind ? (
+      leadingSlot={campaignAudience ? (
         <WorkbenchCampaignBadge
-          kind={campaignKind}
+          audience={campaignAudience}
           page="project"
           metricsConsent={metricsConsent}
           installationId={installationId}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -161,10 +161,6 @@ import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import { resolvePlanLabelTier } from '../collab/team-plan';
 import { resolveDeepSeekV4FlashCampaignAudience } from '../campaigns/deepseek-v4-flash';
 import { useDeepSeekV4FlashCampaignVisibility } from '../campaigns/use-deepseek-v4-flash-campaign';
-import {
-  resolveSubscriptionAudience,
-} from '../campaigns/go-plan';
-import { useGoPlanCampaignVisibility } from '../campaigns/use-go-plan-campaign';
 import { WorkbenchCampaignBadge } from './WorkbenchCampaignBadge';
 import {
   beginWorkspaceScopedRead,
@@ -663,7 +659,6 @@ export function EntryShell({
     workspaceContext,
   );
   const deepSeekCampaignVisibility = useDeepSeekV4FlashCampaignVisibility();
-  const goPlanCampaignVisibility = useGoPlanCampaignVisibility();
   // Same personal-vs-team accountPlan rule as App's `resolvedAmrPlan`.
   const deepSeekCampaignPlan = resolvePlanLabelTier({
     billing: workspaceBilling,
@@ -681,24 +676,10 @@ export function EntryShell({
     loggedIn: amrLoggedIn,
     now: deepSeekCampaignVisibility.now,
   });
-  const subscriptionAudience = resolveSubscriptionAudience({
-    plan: deepSeekCampaignPlan,
-    loggedIn: amrLoggedIn,
-  });
-  const homeCampaignModalAudience =
-    subscriptionAudience === 'unpaid' && goPlanCampaignVisibility.visible
-      ? 'unpaid'
-      : deepSeekV4FlashCampaignAudience === 'paid'
-        ? 'paid'
-        : 'unknown';
-  const topRightCampaignKind =
-    subscriptionAudience === 'unpaid'
-      ? goPlanCampaignVisibility.visible
-        ? 'go'
-        : null
-      : deepSeekV4FlashCampaignAudience === 'paid'
-        ? 'deepseek'
-        : null;
+  const topRightCampaignAudience =
+    deepSeekV4FlashCampaignAudience === 'unknown'
+      ? null
+      : deepSeekV4FlashCampaignAudience;
   const workspaceBalanceUsd = workspaceBillingBalanceUsd(
     workspaceBillingResponse,
     workspaceContext,
@@ -1642,9 +1623,9 @@ export function EntryShell({
           onOpenSearch={() => setProjectSearchOpen(true)}
           open={railOpen}
           topRightSlot={
-            topRightCampaignKind ? (
+            topRightCampaignAudience ? (
               <WorkbenchCampaignBadge
-                kind={topRightCampaignKind}
+                audience={topRightCampaignAudience}
                 page="home"
                 metricsConsent={config.telemetry?.metrics === true}
                 installationId={config.installationId}
@@ -1744,7 +1725,7 @@ export function EntryShell({
                 promptTemplates={promptTemplates}
                 executionSwitcher={view === 'home' ? homeExecutionSwitcher : undefined}
                 artifactUpgradeSlot={artifactUpgradeSlot}
-                deepSeekV4FlashCampaignAudience={homeCampaignModalAudience}
+                deepSeekV4FlashCampaignAudience={deepSeekV4FlashCampaignAudience}
                 onDeepSeekV4FlashCampaignUseNow={applyDeepSeekCampaignModel}
                 deepSeekV4FlashCampaignMetricsConsent={config.telemetry?.metrics === true}
                 deepSeekV4FlashCampaignInstallationId={config.installationId ?? null}

--- a/apps/web/src/components/WorkbenchCampaignBadge.tsx
+++ b/apps/web/src/components/WorkbenchCampaignBadge.tsx
@@ -10,55 +10,48 @@ import {
 } from '../analytics/amr-attribution';
 import { getResolvedDeviceId } from '../analytics/client';
 import { useAnalytics } from '../analytics/provider';
+import type { DeepSeekV4FlashCampaignAudience } from '../campaigns/deepseek-v4-flash';
 import { goPlanPricingUrl } from '../campaigns/go-plan';
-import { getGoPlanCampaignCopy } from '../campaigns/go-plan-content';
 import { useI18n } from '../i18n';
 import { Icon } from './Icon';
 
-export type WorkbenchCampaignKind = 'go' | 'deepseek';
-
 export function WorkbenchCampaignBadge({
-  kind,
+  audience,
   page,
   metricsConsent,
   installationId,
 }: {
-  kind: WorkbenchCampaignKind;
+  audience: Exclude<DeepSeekV4FlashCampaignAudience, 'unknown'>;
   page: 'home' | 'project';
   metricsConsent: boolean;
   installationId?: string | null;
 }) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
-  const goPlanCopy = getGoPlanCampaignCopy(locale);
 
   useEffect(() => {
     // The current campaign analytics contract scopes badge impressions to
     // Home. Project-detail visibility is intentionally UI-only until that
     // contract gains a project page variant.
-    if (kind !== 'deepseek' || page !== 'home') return;
+    if (page !== 'home') return;
     trackDeepSeekCampaignBadgeSurfaceView(analytics.track, {
       page_name: 'home',
       area: 'campaign_badge',
       element: 'deepseek_v4_pro',
       campaign_id: 'deepseek_v4_pro',
-      user_state: 'paid',
+      user_state: audience,
     });
-  }, [analytics.track, kind, page]);
+  }, [analytics.track, audience, page]);
 
   const openCampaignPricing = useCallback(() => {
     const pricingUrl = goPlanPricingUrl(locale);
-    if (kind === 'go') {
-      window.open(pricingUrl, '_blank', 'noopener,noreferrer');
-      return;
-    }
     if (page === 'home') {
       trackDeepSeekCampaignBadgeClick(analytics.track, {
         page_name: 'home',
         area: 'campaign_badge',
         element: 'open_pricing',
         campaign_id: 'deepseek_v4_pro',
-        user_state: 'paid',
+        user_state: audience,
       });
     }
     const attribution = recordAmrEntry(
@@ -81,21 +74,17 @@ export function WorkbenchCampaignBadge({
       '_blank',
       'noopener,noreferrer',
     );
-  }, [analytics.track, installationId, kind, locale, metricsConsent, page]);
+  }, [analytics.track, audience, installationId, locale, metricsConsent, page]);
 
   return (
     <button
       type="button"
       className="entry-deepseek-campaign-badge"
       onClick={openCampaignPricing}
-      aria-label={kind === 'go'
-        ? goPlanCopy.workbenchBadgeAria
-        : t('campaign.deepseekV4Flash.workbenchBadgeAria')}
+      aria-label={t('campaign.deepseekV4Flash.workbenchBadgeAria')}
       data-testid="deepseek-campaign-pricing-badge"
     >
-      <span>{kind === 'go'
-        ? goPlanCopy.workbenchBadge
-        : t('campaign.deepseekV4Flash.workbenchBadge')}</span>
+      <span>{t('campaign.deepseekV4Flash.workbenchBadge')}</span>
       <Icon name="arrow-right" size={13} />
     </button>
   );

--- a/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx
@@ -18,7 +18,6 @@
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getGoPlanCampaignCopy } from '../../src/campaigns/go-plan-content';
 import { DeepSeekV4FlashCampaign } from '../../src/components/DeepSeekV4FlashCampaign';
 import { I18nProvider } from '../../src/i18n';
 
@@ -150,37 +149,32 @@ describe('the modal never re-opens for a seen campaign (no URL override left)', 
   });
 });
 
-describe('unpaid Go path opens public Pricing', () => {
-  it('renders the complete modal and accessible labels from the active locale', () => {
-    const copy = getGoPlanCampaignCopy('fr');
-
+describe('unpaid DeepSeek path opens public Pricing', () => {
+  it('renders the DeepSeek upgrade offer without any Go campaign content', () => {
     render(
-      <I18nProvider initial="fr">
+      <I18nProvider initial="en">
         <DeepSeekV4FlashCampaign audience="unpaid" active />
       </I18nProvider>,
     );
 
-    expect(screen.getByRole('button', { name: copy.closeAria })).toBeVisible();
-    expect(screen.getByText(copy.newBadge, { exact: true })).toBeVisible();
-    expect(screen.getByText(copy.eyebrow, { exact: true })).toBeVisible();
-    expect(screen.getByRole('heading', { name: copy.headline })).toBeVisible();
-    expect(screen.getByText(copy.description, { exact: true })).toBeVisible();
-    expect(screen.getByRole('group', { name: copy.providersAria })).toBeVisible();
-    expect(screen.getByText(copy.benefit, { exact: true })).toBeVisible();
-    expect(screen.getAllByText(copy.status, { exact: true })).toHaveLength(3);
-    expect(screen.getByText(copy.renewal, { exact: true })).toBeVisible();
-    expect(screen.getByText(copy.boundary, { exact: true })).toBeVisible();
-    expect(screen.getByRole('button', { name: copy.cta })).toBeVisible();
+    expect(screen.getByRole('heading', {
+      name: 'This time, put top-tier intelligence to work. Unlimited.',
+    })).toBeVisible();
+    expect(screen.getByText('Free for paid plans')).toBeVisible();
+    expect(screen.getByText('Upgrade to unlock · through Aug 27')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Upgrade and use' })).toBeVisible();
+    expect(screen.queryByText('GO', { exact: true })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^View Go plan/ })).toBeNull();
   });
 
-  it('keeps provider identity visible when a Go-plan logo fails to load', () => {
+  it('keeps provider identity visible when the unpaid DeepSeek logo fails to load', () => {
     render(<DeepSeekV4FlashCampaign audience="unpaid" active />);
 
-    const providerLogo = screen.getByRole('img', { name: 'MiniMax' });
+    const providerLogo = screen.getByRole('img', { name: 'DeepSeek' });
     fireEvent.error(providerLogo.querySelector('img')!);
 
-    expect(screen.getByRole('img', { name: 'MiniMax' })).toBeVisible();
-    expect(screen.getByText('MM', { exact: true })).toBeVisible();
+    expect(screen.getByRole('img', { name: 'DeepSeek' })).toBeVisible();
+    expect(screen.getByText('DS', { exact: true })).toBeVisible();
   });
 
   it('opens the locale-neutral comparison page', () => {
@@ -195,12 +189,16 @@ describe('unpaid Go path opens public Pricing', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^View Go plan/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Upgrade and use' }));
 
     expect(open).toHaveBeenCalledTimes(1);
     const url = new URL(String(open.mock.calls[0]?.[0]));
     expect(url.origin + url.pathname).toBe('https://open-design.ai/pricing/');
     expect(url.searchParams.get('od_locale')).toBe('en');
+    expect(url.searchParams.get('od_entry_source')).toBe('deepseek_unpaid_modal');
+    expect(url.searchParams.get('od_campaign_id')).toBe('deepseek_v4_pro');
+    expect(url.searchParams.get('od_conversion_source')).toBe('deepseek_unpaid_modal');
+    expect(url.searchParams.get('od_device_id')).toBe('install-abc123');
   });
 
   it('keeps the same target without metrics consent', () => {
@@ -215,7 +213,7 @@ describe('unpaid Go path opens public Pricing', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^View Go plan/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Upgrade and use' }));
 
     expect(open).toHaveBeenCalledTimes(1);
     const url = new URL(String(open.mock.calls[0]?.[0]));
@@ -223,17 +221,17 @@ describe('unpaid Go path opens public Pricing', () => {
     expect(url.origin + url.pathname).toBe('https://open-design.ai/pricing/');
   });
 
-  it('uses an independent frequency key from the paid DeepSeek campaign', () => {
+  it('shares the DeepSeek frequency key with the paid campaign', () => {
     vi.stubGlobal('open', vi.fn());
     render(<DeepSeekV4FlashCampaign audience="unpaid" active />);
 
-    fireEvent.click(screen.getByRole('button', { name: /^View Go plan/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Upgrade and use' }));
 
     expect(window.localStorage.getItem(
-      'open-design:campaign-seen:go-plan-launch-2026',
+      'open-design:campaign-seen:deepseek-v4-dual-unlimited-2026',
     )).toBe('1');
     expect(window.localStorage.getItem(
-      'open-design:campaign-seen:deepseek-v4-dual-unlimited-2026',
+      'open-design:campaign-seen:go-plan-launch-2026',
     )).toBeNull();
   });
 });

--- a/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
+++ b/apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts
@@ -40,78 +40,33 @@ const campaignModalStyles = readFileSync(
 );
 
 describe('DeepSeek V4 Flash workbench campaign entry', () => {
-  it('uses checked-in Go modal model marks without network dependencies', () => {
-    for (const assetPath of [
-      'public/agent-icons/deepseek.svg',
-      'public/agent-icons/kimi.svg',
-      'public/model-icons/minimax.svg',
-      'public/go-plan/mimo-logo-user-CWOWEwG5.png',
-      'public/go-plan/zai-logo-official-Byn-xbrp.png',
-    ]) {
-      expect(readFileSync(resolve(process.cwd(), assetPath)).byteLength).toBeGreaterThan(0);
-    }
+  it('removes the Go-only media branch from the active campaign modal', () => {
     expect(campaignModalSource).not.toContain('unpkg.com');
-    expect(campaignModalSource).toContain('/agent-icons/deepseek.svg');
-    expect(campaignModalSource).toContain('/agent-icons/kimi.svg');
-    expect(campaignModalSource).toContain('/model-icons/minimax.svg');
-    expect(campaignModalSource).toContain(
-      '/go-plan/mimo-logo-user-CWOWEwG5.png',
-    );
-    expect(campaignModalSource).toContain(
-      '/go-plan/zai-logo-official-Byn-xbrp.png',
-    );
-    expect(campaignModalSource).toContain('styles.goWelcomeMimoLogo');
-    expect(campaignModalSource).toContain('styles.goWelcomeZhipuLogo');
-    expect(campaignModalSource).toContain('styles.goWelcomeBenefitZhipu');
-    expect(campaignModalStyles).toContain('.goWelcomeMimoLogo img');
-    expect(campaignModalStyles).toContain('.goWelcomeZhipuLogo img');
-    expect(campaignModalStyles).toContain(
-      '.goWelcomeBenefitZhipu img',
-    );
-    expect(campaignModalStyles).not.toContain(
-      '.goWelcomeBenefitModel.goWelcomeBenefitZhipu img',
-    );
-    expect(campaignModalStyles).toMatch(
-      /\.goWelcomeBenefitModel img\s*\{[\s\S]*?filter: brightness\(0\) invert\(1\);[\s\S]*?\}/,
-    );
+    expect(campaignModalSource).not.toContain('/go-plan/');
+    expect(campaignModalSource).not.toContain('styles.goWelcome');
   });
 
-  it('collapses the Go modal before its fixed tracks overflow and scrolls short viewports', () => {
-    const baseModalRule = campaignModalStyles.match(
-      /\.goWelcomeModal\s*\{([^}]*)\}/,
-    )?.[1];
-
-    expect(baseModalRule).toContain(
-      'min-height: min(430px, calc(100dvh - 48px))',
-    );
-    expect(campaignModalStyles).toMatch(
-      /@media \(max-width: 658px\)[\s\S]*?\.goWelcomeModal\s*\{[\s\S]*?grid-template-columns: 1fr;[\s\S]*?overflow: auto;/,
-    );
-    expect(campaignModalStyles).toMatch(
-      /@media \(max-height: 477px\)[\s\S]*?\.goWelcomeModal\s*\{[\s\S]*?min-height: 0;[\s\S]*?overflow: auto;/,
-    );
-  });
-
-  it('reuses the top-right campaign slot for Go and DeepSeek audiences', () => {
+  it('uses the top-right campaign slot only for the active DeepSeek audience', () => {
     expect(entryShellSource).toContain('<WorkbenchCampaignBadge');
     expect(workbenchCampaignBadgeSource).toContain('deepseek-campaign-pricing-badge');
-    expect(workbenchCampaignBadgeSource).toContain("kind === 'go'");
-    expect(workbenchCampaignBadgeSource).toContain('goPlanCopy.workbenchBadge');
+    expect(workbenchCampaignBadgeSource).not.toContain("kind === 'go'");
+    expect(workbenchCampaignBadgeSource).not.toContain('goPlanCopy.workbenchBadge');
     expect(workbenchCampaignBadgeSource).toContain("t('campaign.deepseekV4Flash.workbenchBadge')");
     expect(workbenchCampaignBadgeSource).toContain("t('campaign.deepseekV4Flash.workbenchBadgeAria')");
-    expect(entryShellSource).toContain("subscriptionAudience === 'unpaid'");
-    expect(entryShellSource).toContain('goPlanCampaignVisibility.visible');
+    expect(entryShellSource).not.toContain("subscriptionAudience === 'unpaid'");
+    expect(entryShellSource).not.toContain('goPlanCampaignVisibility.visible');
+    expect(entryShellSource).toContain("deepSeekV4FlashCampaignAudience === 'unknown'");
   });
 
   it('keeps the top-right campaign entry visible across entry tabs and project detail', () => {
     expect(entryShellSource).toMatch(
-      /topRightSlot=\{\s*topRightCampaignKind \? \(/,
+      /topRightSlot=\{\s*topRightCampaignAudience \? \(/,
     );
     expect(entryShellSource).not.toMatch(
       /topRightSlot=\{\s*view === 'home'/,
     );
     expect(entryNavRailSource).toMatch(
-      /export function WorkspaceTopRightAccountCluster[\s\S]*?leadingSlot=\{campaignKind \? \([\s\S]*?<WorkbenchCampaignBadge[\s\S]*?page="project"/,
+      /export function WorkspaceTopRightAccountCluster[\s\S]*?leadingSlot=\{campaignAudience \? \([\s\S]*?<WorkbenchCampaignBadge[\s\S]*?audience=\{campaignAudience\}[\s\S]*?page="project"/,
     );
     expect(appSource).toMatch(
       /<WorkspaceTopRightAccountCluster[\s\S]*?amrLoggedIn=\{amrLoginStatus\?\.loggedIn \?\? null\}[\s\S]*?metricsConsent=\{config\.telemetry\?\.metrics === true\}/,
@@ -211,10 +166,11 @@ describe('DeepSeek V4 Flash workbench campaign entry', () => {
     expect(modelSwitcherSource).toContain('const campaignNeedsUpgrade = false;');
   });
 
-  it('keeps existing DeepSeek analytics while the Go pass stays UI-only', () => {
+  it('keeps DeepSeek analytics for paid and unpaid campaign audiences', () => {
     expect(workbenchCampaignBadgeSource).toContain('trackDeepSeekCampaignBadgeSurfaceView');
     expect(workbenchCampaignBadgeSource).toContain('trackDeepSeekCampaignBadgeClick');
-    expect(workbenchCampaignBadgeSource).toContain("window.open(pricingUrl, '_blank', 'noopener,noreferrer')");
+    expect(workbenchCampaignBadgeSource).toContain('attributedAmrUrl(pricingUrl, attribution, deviceId)');
+    expect(workbenchCampaignBadgeSource).toContain('user_state: audience');
     expect(workbenchCampaignBadgeSource).toContain("page !== 'home'");
     expect(modelSwitcherSource).toContain('trackDeepSeekCampaignModelBenefitSurfaceView');
     expect(modelSwitcherSource).toContain('trackExecutionSettingsPopoverClick');

--- a/apps/web/tests/campaigns/deepseek-v4-flash.test.ts
+++ b/apps/web/tests/campaigns/deepseek-v4-flash.test.ts
@@ -151,13 +151,11 @@ describe('DeepSeek V4 Flash campaign', () => {
     expect(campaignDialogSource).toContain('styles.boundary');
   });
 
-  it('reuses the modal shell for Go without showing the paid secondary action', () => {
-    expect(campaignDialogSource).toContain('styles.goWelcomePrimary');
+  it('keeps the unpaid DeepSeek upgrade on Pricing without rendering Go', () => {
     expect(campaignDialogSource).toContain('goPlanPricingUrl');
-    expect(campaignDialogSource).not.toContain("'go_plan_modal'");
-    expect(campaignDialogSource.indexOf('styles.goWelcomePrimary')).toBeLessThan(
-      campaignDialogSource.indexOf('styles.laterAction'),
-    );
+    expect(campaignDialogSource).toContain("'deepseek_unpaid_modal'");
+    expect(campaignDialogSource).toContain("t('campaign.deepseekV4Flash.unpaid.cta')");
+    expect(campaignDialogSource).not.toContain('styles.goWelcome');
   });
 
   it('keeps campaign visibility free of every URL review backdoor (product decision)', () => {
@@ -174,7 +172,7 @@ describe('DeepSeek V4 Flash campaign', () => {
     expect(campaignDialogSource).not.toContain('location.search');
   });
 
-  it('opens for every paid user only inside the shared half-open window', () => {
+  it('opens for paid and unpaid users only inside the shared half-open window', () => {
     const start = Date.parse(DEEPSEEK_V4_FLASH_CAMPAIGN.window.startAt);
     const end = Date.parse(DEEPSEEK_V4_FLASH_CAMPAIGN.window.endAtExclusive);
 
@@ -190,6 +188,9 @@ describe('DeepSeek V4 Flash campaign', () => {
     })).toBe('unknown');
     expect(resolveDeepSeekV4FlashCampaignAudience({
       plan: 'plus', loggedIn: true, now: end,
+    })).toBe('unknown');
+    expect(resolveDeepSeekV4FlashCampaignAudience({
+      plan: 'free', loggedIn: true, now: end,
     })).toBe('unknown');
     // Inside the window the plan decides the audience; outside it nothing does.
     expect(resolveDeepSeekV4FlashCampaignAudience({

--- a/apps/web/tests/campaigns/workbench-campaign-badge.test.tsx
+++ b/apps/web/tests/campaigns/workbench-campaign-badge.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkbenchCampaignBadge } from '../../src/components/WorkbenchCampaignBadge';
+import { I18nProvider } from '../../src/i18n';
+
+const trackSpy = vi.fn();
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({ track: trackSpy }),
+}));
+
+vi.mock('../../src/analytics/client', () => ({
+  getResolvedDeviceId: () => null,
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  trackSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('DeepSeek workbench campaign badge', () => {
+  it('shows the DeepSeek offer to an unpaid user and opens localized Pricing', () => {
+    const open = vi.fn();
+    vi.stubGlobal('open', open);
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <WorkbenchCampaignBadge
+          audience="unpaid"
+          page="home"
+          metricsConsent={false}
+        />
+      </I18nProvider>,
+    );
+
+    const badge = screen.getByRole('button', {
+      name: 'DeepSeek V4 Pro 与 V4 Flash 无限免费用，查看官网 Pricing',
+    });
+    expect(badge).toHaveTextContent('DeepSeek V4 Pro + V4 Flash 无限免费用');
+    expect(badge).not.toHaveTextContent('Go');
+
+    fireEvent.click(badge);
+
+    const url = new URL(String(open.mock.calls[0]?.[0]));
+    expect(url.origin + url.pathname).toBe('https://open-design.ai/zh/pricing/');
+    expect(url.searchParams.get('od_locale')).toBe('zh');
+    expect(url.searchParams.get('od_entry_source')).toBe('deepseek_workbench_badge');
+    expect(url.searchParams.get('od_device_id')).toBeNull();
+    expect(trackSpy).toHaveBeenCalledWith(
+      'surface_view',
+      expect.objectContaining({ user_state: 'unpaid' }),
+      undefined,
+    );
+    expect(trackSpy).toHaveBeenCalledWith(
+      'ui_click',
+      expect.objectContaining({ element: 'open_pricing', user_state: 'unpaid' }),
+      undefined,
+    );
+  });
+});

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -145,7 +145,7 @@ async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null
 }
 
 describe('standalone updater rocket placement after the account capsule', () => {
-  it('shows the shared Go campaign badge on an unpaid project detail route', () => {
+  it('shows the shared DeepSeek campaign badge on an unpaid project detail route', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-20T10:00:00.000Z'));
 
@@ -161,7 +161,7 @@ describe('standalone updater rocket placement after the account capsule', () => 
     );
 
     expect(screen.getByTestId('deepseek-campaign-pricing-badge').textContent).toContain(
-      '全新 Go 套餐 · 首月 ¥5 · 模型无限用',
+      'DeepSeek V4 Pro + V4 Flash 无限免费用',
     );
   });
 

--- a/e2e/lib/playwright/campaign-dismissals.ts
+++ b/e2e/lib/playwright/campaign-dismissals.ts
@@ -25,8 +25,6 @@ export const CAMPAIGN_DISMISSAL_STORAGE: Record<string, string> = {
   // id, so a new campaign needs its own entry here — otherwise its modal opens
   // over every spec on the first home render, exactly what this file prevents.
   'open-design:campaign-seen:deepseek-v4-dual-unlimited-2026': '1',
-  // Live 8/20-9/3 Go plan launch window.
-  'open-design:campaign-seen:go-plan-launch-2026': '1',
 };
 
 export async function seedCampaignDismissals(context: BrowserContext): Promise<void> {

--- a/e2e/ui/visual-entry.test.ts
+++ b/e2e/ui/visual-entry.test.ts
@@ -100,7 +100,7 @@ test('[P2] captures the visual home harness', async ({ page }) => {
   await captureVisual(page, 'visual-home');
 });
 
-test('[P2] captures the Go campaign at narrow and short viewport boundaries', async ({ page }) => {
+test('[P2] captures the unpaid DeepSeek campaign at narrow and short viewport boundaries', async ({ page }) => {
   test.setTimeout(T.xlong);
 
   await page.clock.setFixedTime('2026-08-21T00:00:00+08:00');
@@ -110,9 +110,9 @@ test('[P2] captures the Go campaign at narrow and short viewport boundaries', as
   await gotoVisualHome(page);
   // Functional specs seed campaign dismissals globally so marketing surfaces
   // cannot interrupt unrelated flows. This visual contract deliberately opts
-  // back into the Go modal after establishing the page's same-origin storage.
+  // back into the DeepSeek modal after establishing same-origin storage.
   await page.evaluate(() => {
-    window.localStorage.removeItem('open-design:campaign-seen:go-plan-launch-2026');
+    window.localStorage.removeItem('open-design:campaign-seen:deepseek-v4-dual-unlimited-2026');
   });
   await ensureRailOpen(page);
   await page.getByTestId('entry-nav-community').evaluate((element: HTMLButtonElement) => {
@@ -124,15 +124,15 @@ test('[P2] captures the Go campaign at narrow and short viewport boundaries', as
   });
 
   const dialog = page.getByTestId('deepseek-v4-flash-campaign-dialog');
-  const close = page.getByRole('button', { name: 'Close dialog' });
-  const cta = page.getByRole('button', { name: 'View Go plan' });
+  const close = page.getByRole('button', { name: 'Close' });
+  const cta = page.getByRole('button', { name: 'Upgrade and use' });
   await expect(dialog).toBeVisible();
   await expect(close).toBeVisible();
   await expect(cta).toBeVisible();
   await expectInsideViewport(page, dialog);
   await expectInsideViewport(page, close);
   await expectInsideViewport(page, cta);
-  await captureVisual(page, 'visual-go-campaign-600');
+  await captureVisual(page, 'visual-deepseek-unpaid-campaign-600');
 
   await page.setViewportSize({ width: 760, height: 400 });
   await expect(close).toBeVisible();
@@ -141,7 +141,7 @@ test('[P2] captures the Go campaign at narrow and short viewport boundaries', as
   await expect.poll(async () => dialog.evaluate((element) => (
     element.scrollHeight > element.clientHeight
   ))).toBe(true);
-  await captureVisual(page, 'visual-go-campaign-short-height');
+  await captureVisual(page, 'visual-deepseek-unpaid-campaign-short-height');
   await cta.scrollIntoViewIfNeeded();
   await expect(cta).toBeVisible();
   await expectInsideViewport(page, cta);


### PR DESCRIPTION
## Why

The local client was still routing unpaid users to the Go campaign badge and welcome modal while the active product decision is to stop promoting Go in the client and continue the DeepSeek V4 Pro + V4 Flash campaign through its existing August 27 window.

That mismatch exposed two competing campaign messages and made the unpaid path diverge from the paid DeepSeek experience. This change gives both audiences one campaign source of truth while preserving the existing Pricing handoff for users who need to upgrade.

## What users will see

- The top-right Go campaign badge and Go welcome modal no longer appear in the local client.
- Until `2026-08-27 20:00 +08:00`, paid and unpaid users see the DeepSeek V4 Pro + V4 Flash campaign.
- Unpaid users see the locked DeepSeek upgrade presentation; its CTA opens localized Pricing with the existing attribution and consent boundaries.
- At and after the campaign end boundary, unpaid users see neither a campaign modal nor a campaign badge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Automated visual coverage captures the unpaid DeepSeek entry point at both a narrow viewport (`600x720`) and a short viewport (`760x400`). Screenshots are attached below.

**Narrow viewport (`600x720`)**

<img width="600" height="720" alt="Unpaid DeepSeek campaign at a 600 by 720 viewport" src="https://github.com/user-attachments/assets/b8d06722-16ed-4b7c-858b-7f234560924b" />

**Short viewport (`760x400`)**

<img width="760" height="400" alt="Unpaid DeepSeek campaign at a 760 by 400 viewport" src="https://github.com/user-attachments/assets/312cff3b-1da6-47d1-ba82-591a8da48d0f" />

## Bug fix verification

- Test paths: `apps/web/tests/campaigns/deepseek-v4-flash-modal.test.tsx`, `apps/web/tests/campaigns/deepseek-v4-flash-ui-contract.test.ts`, and `apps/web/tests/campaigns/workbench-campaign-badge.test.tsx`
- Red on `main`, green on this branch: yes. The unpaid modal initially rendered Go, the badge routing selected `kind === 'go'`, and the Pricing attribution assertion was initially missing `od_entry_source`.
- Boundary coverage explicitly verifies that a free user resolves to no campaign at the exclusive August 27 end time.

## Validation

- `pnpm --filter @open-design/web test` — 654 files passed; 6974 tests passed, 1 expected fail, 11 skipped (before the final campaign-provider rebase)
- `pnpm exec vitest run -c vitest.config.ts tests/campaigns/deepseek-v4-flash-modal.test.tsx tests/campaigns/deepseek-v4-flash-ui-contract.test.ts tests/campaigns/deepseek-v4-flash.test.ts tests/campaigns/workbench-campaign-badge.test.tsx tests/components/EntryNavRail.updater-after-avatar.test.tsx --maxWorkers=1` — 5 files and 43 tests passed after the final rebase
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm exec playwright test -c playwright.visual.config.ts ui/visual-entry.test.ts --grep "unpaid DeepSeek campaign" --workers=1`
- `git diff --check`
- `pnpm guard` — the changed-scope checks pass, but the repository command exits on existing `apps/landing-page/public/enhancers/cobe.js` and `matter.min.js` residual JavaScript files outside this PR
- `pnpm typecheck` — the changed Web and E2E packages pass; the repository aggregate currently exits in `apps/packaged/src/sidecars.ts` because the current `ShutdownResult` declaration lacks `deferred`, outside this PR
