### PR TITLE
fix(daemon): stamp first_visible_output when output is emitted, not decoded

### DIFF
--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -110,6 +110,10 @@ export interface RunTelemetryTimestamps {
   firstModelResponseAt?: number;
   firstModelEventType?: TrackingFirstModelEventType;
   firstTokenAt?: number;
+  // When user-visible model output actually LEFT the daemon, which is later
+  // than `firstTokenAt` by however long the title-marker stripper, the
+  // fabricated-role-marker guard, or close-time stdout buffering held the bytes
+  // back. Equal to `firstTokenAt` on the common straight-through path.
   firstVisibleOutputAt?: number;
   firstArtifactWriteAt?: number;
   finalizeStartAt?: number;
@@ -1203,6 +1207,13 @@ export function summarizeRunTimingAnalytics(args: {
     telemetry.firstModelEventType ??
     firstObservedModelEventType ??
     (telemetry.firstTokenAt !== undefined ? 'text_delta' : undefined);
+  // `firstVisibleOutputAt` is stamped at the daemon's emission choke point, so
+  // it exists whenever the run put anything on screen and is >= the first token
+  // by construction. It is absent only when a run produced a token that the
+  // title-marker stripper or the role-marker guard withheld forever — no
+  // measurement to report, so fall back to the first token rather than dropping
+  // the field. The fallback cannot flatten a real gap: any run with visible
+  // output carries its own stamp and never reaches it.
   const firstVisibleOutputAt = telemetry.firstVisibleOutputAt ?? telemetry.firstTokenAt;
   const firstArtifactWriteAt =
     telemetry.firstArtifactWriteAt ??

--- a/apps/daemon/src/run-lifecycle-tracer.ts
+++ b/apps/daemon/src/run-lifecycle-tracer.ts
@@ -51,6 +51,11 @@ export interface RunLifecycleStreamEventMarkers {
   // Stamping the anchor from arrival would measure a tool-only ACP turn as
   // runtime init, which is the case this whole boundary change exists for.
   firstModelEventAt?: number;
+  // True when THIS event is user-visible model output leaving the daemon.
+  // Callers mark `first_visible_output` from it at the single emission choke
+  // point, so the mark lands after every filter that can withhold bytes
+  // (`<od-title>` stripping, the fabricated-role-marker guard, close-time
+  // buffering) rather than when the daemon first recognised a token.
   firstVisibleOutput: boolean;
   firstArtifactWrite: boolean;
 }
@@ -96,7 +101,15 @@ export function runLifecycleMarkersForStreamEvent(
     };
   }
   return {
-    firstVisibleOutput: false,
+    // The plain / BYOK / antigravity family has no structured `agent` stream —
+    // its reply reaches the user as `stdout` chunks, already control-stripped,
+    // title-stripped and role-guarded by the time they are sent. Without this,
+    // those runs would report no visible output at all and fall back to the
+    // first token, which is exactly wrong for antigravity: it buffers stdout
+    // until close, so its first token and its first visible byte can be a whole
+    // run apart. `stderr` stays out — it is a diagnostic channel, not the
+    // model's answer.
+    firstVisibleOutput: event === 'stdout',
     firstArtifactWrite: event === 'live_artifact',
   };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13947,8 +13947,16 @@ export async function startServer({
       noteAgentActivity();
       // Role-marker guard for qoder / json-event-stream / pi-rpc (#3247).
       if (ev?.type === 'text_delta' && typeof ev.delta === 'string') {
+        // Decode time, captured BEFORE the emit. The gate has to run first to
+        // learn whether these bytes are a token at all, but the emit inside it
+        // fans the delta out to every SSE client and stamps
+        // `first_visible_output` on the way — reading the clock afterwards
+        // charges our own write latency to TTFT and can leave the visible-output
+        // mark a millisecond AHEAD of the token that produced it. See the
+        // matching sites in the Copilot and ACP handlers.
+        const decodedAt = Date.now();
         if (emitTitleFilteredGuardedTextDelta(ev.delta)) {
-          noteFirstTokenAt();
+          noteFirstTokenAt(decodedAt);
           agentProducedOutput = true;
         }
         return;
@@ -14167,8 +14175,10 @@ export async function startServer({
         lastAgentEventPhase = summarizeAgentEventForInactivity(ev);
         noteAgentActivity();
         if (ev?.type === 'text_delta' && typeof ev.delta === 'string') {
+          // Decode time, read before the emit — see `sendAgentEvent`.
+          const decodedAt = Date.now();
           if (emitTitleFilteredGuardedTextDelta(ev.delta)) {
-            noteFirstTokenAt();
+            noteFirstTokenAt(decodedAt);
           }
           return;
         }
@@ -14351,8 +14361,10 @@ export async function startServer({
             return;
           }
           if (event === 'agent' && data?.type === 'text_delta' && typeof data.delta === 'string') {
+            // Decode time, read before the emit — see `sendAgentEvent`.
+            const decodedAt = Date.now();
             if (emitTitleFilteredGuardedTextDelta(data.delta)) {
-              noteFirstTokenAt();
+              noteFirstTokenAt(decodedAt);
             }
             return;
           }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -530,6 +530,7 @@ import { runtimeResumesSessionById } from './runtimes/types.js';
 import {
   createRunLifecycleTracer,
   runLifecycleMarkersForStreamEvent,
+  type RunLifecycleStreamEventMarkers,
 } from './run-lifecycle-tracer.js';
 import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { classifyRunFailure, isResumableFailure } from './run-failure-classification.js';
@@ -11488,6 +11489,50 @@ export async function startServer({
     // by the artifact finalizer (see the emit handler below). 8 MiB comfortably
     // covers realistic artifact-bearing runs while bounding per-run memory.
     const PLAIN_ARTIFACT_STDOUT_CAP = 8 * 1024 * 1024;
+    // Run instrumentation sits ON the path the model's bytes travel: `send`
+    // is the single choke point every stream event passes through on its way
+    // to the user, and the strategy's close-time tail is broadcast from the
+    // child-close handler. A throw from instrumentation there does not cost an
+    // analytics field, it costs the user the entire reply — so every mark goes
+    // through here and its failures are contained to itself. The guard is
+    // scoped to the marks alone; nothing that decides what the user receives
+    // is inside it.
+    let lifecycleTelemetryFaultWarned = false;
+    const recordRunTelemetry = (label: string, record: () => void): void => {
+      try {
+        record();
+      } catch (error) {
+        // One line per run, not per event: a broken classifier would otherwise
+        // log once per delta and bury the runs around it.
+        if (lifecycleTelemetryFaultWarned) return;
+        lifecycleTelemetryFaultWarned = true;
+        console.warn(
+          `[telemetry] run lifecycle instrumentation failed (${label}); run timing will be incomplete`,
+          error,
+        );
+      }
+    };
+    // The single rule for "did the user actually receive something". Both
+    // emission paths apply it: `send` for the live stream, and the strategy's
+    // close-time tail, which cannot re-enter `send` because the protocol is
+    // already finished. Keeping one rule is what stops the two paths from
+    // disagreeing about what counts as visible output.
+    const applyVisibleOutputMarks = (
+      markers: RunLifecycleStreamEventMarkers,
+    ): void => {
+      // Sole owner of `first_visible_output`. A mark here means the bytes
+      // really did leave the daemon — past the title-marker stripper, past the
+      // role-marker guard, past the strategy protocol, past close-time
+      // buffering. Do not stamp this mark from a decode site: doing so is what
+      // made `time_to_first_visible_output_ms` identical to
+      // `time_to_first_token_ms` on every run.
+      if (markers.firstVisibleOutput) {
+        lifecycle.mark('first_visible_output');
+      }
+      if (markers.firstArtifactWrite) {
+        lifecycle.mark('first_artifact_write');
+      }
+    };
     const send = (event, data) => {
       if (strategyProtocol && event === 'agent' && data?.type === 'tool_use') {
         strategyToolUseCount += 1;
@@ -11512,29 +11557,25 @@ export async function startServer({
         strategyVisibleEmitted += chunk;
         data = { ...data, chunk };
       }
-      const lifecycleMarkers = runLifecycleMarkersForStreamEvent(event, data);
-      if (lifecycleMarkers.firstModelEventType) {
-        // Second argument is the PRODUCER's start, used only for the phase
-        // anchor. ACP emits `tool_use` at terminal status, so without it the
-        // anchor lands at tool completion. `time_to_first_model_event_ms`
-        // still measures to arrival and is unaffected.
-        lifecycle.markFirstModelEvent(
-          lifecycleMarkers.firstModelEventType,
-          lifecycleMarkers.firstModelEventAt,
-        );
-      }
-      // Sole owner of `first_visible_output`. `send` is the last thing every
-      // stream handler goes through, so a mark here means the bytes really did
-      // leave the daemon — past the title-marker stripper, past the role-marker
-      // guard, past close-time buffering. Do not stamp this mark from a decode
-      // site: doing so is what made `time_to_first_visible_output_ms` identical
-      // to `time_to_first_token_ms` on every run.
-      if (lifecycleMarkers.firstVisibleOutput) {
-        lifecycle.mark('first_visible_output');
-      }
-      if (lifecycleMarkers.firstArtifactWrite) {
-        lifecycle.mark('first_artifact_write');
-      }
+      recordRunTelemetry(`stream event ${event}`, () => {
+        const lifecycleMarkers = runLifecycleMarkersForStreamEvent(event, data);
+        if (lifecycleMarkers.firstModelEventType) {
+          // Second argument is the PRODUCER's start, used only for the phase
+          // anchor. ACP emits `tool_use` at terminal status, so without it the
+          // anchor lands at tool completion. `time_to_first_model_event_ms`
+          // still measures to arrival and is unaffected.
+          //
+          // Stamped only from this live path. It records when the daemon SAW
+          // the model respond, so the close-time tail below — a re-emission of
+          // something seen long before — must not claim it, or a withheld
+          // reply would drag every phase boundary to the end of the run.
+          lifecycle.markFirstModelEvent(
+            lifecycleMarkers.firstModelEventType,
+            lifecycleMarkers.firstModelEventAt,
+          );
+        }
+        applyVisibleOutputMarks(lifecycleMarkers);
+      });
       if (
         event === 'agent' &&
         data &&
@@ -13661,8 +13702,13 @@ export async function startServer({
     // they diverge exactly when the daemon HOLDS bytes back, which is the
     // window the metric exists to measure.
     const noteFirstTokenAt = (timestamp = Date.now()) => {
-      if (run.analyticsTelemetry?.firstTokenAt) return;
-      lifecycle.mark('first_token', timestamp);
+      // Telemetry-only, and every call site sits inside a live stream handler
+      // that is mid-way through delivering a delta. Same contract as the marks
+      // in `send`: a fault here costs a timing field, never the reply.
+      recordRunTelemetry('first token', () => {
+        if (run.analyticsTelemetry?.firstTokenAt) return;
+        lifecycle.mark('first_token', timestamp);
+      });
     };
     // Subsegment markers inside `processSpawnedAt -> firstTokenAt` (#3408 §4).
     // `cliReadyAt` is the first well-formed adapter output and is stamped for
@@ -15226,6 +15272,21 @@ export async function startServer({
             const tailData = tailEvent === 'stdout'
               ? { chunk: tail }
               : { type: 'text_delta', delta: tail };
+            // The protocol withholds any text that might still turn out to be
+            // a reserved `<open-design-…>` block; `finish()` is what finally
+            // rules that out, so this tail is the first moment those bytes are
+            // user-visible. It cannot go back through `send` — `push` throws
+            // once the protocol is finished — so it applies the same visible
+            // output rule here. For a reply whose visible text was withheld in
+            // its entirety this is the ONLY thing the run ever puts on screen;
+            // without the mark the run reports no visible output at all and
+            // the analytics fallback collapses a real close-time wait back to
+            // `firstTokenAt`.
+            recordRunTelemetry('strategy close-time tail', () => {
+              applyVisibleOutputMarks(
+                runLifecycleMarkersForStreamEvent(tailEvent, tailData),
+              );
+            });
             persistRunEventToAssistantMessage(db, run, tailEvent, tailData);
             design.runs.emit(run, tailEvent, tailData);
             strategyVisibleEmitted += tail;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11523,6 +11523,12 @@ export async function startServer({
           lifecycleMarkers.firstModelEventAt,
         );
       }
+      // Sole owner of `first_visible_output`. `send` is the last thing every
+      // stream handler goes through, so a mark here means the bytes really did
+      // leave the daemon — past the title-marker stripper, past the role-marker
+      // guard, past close-time buffering. Do not stamp this mark from a decode
+      // site: doing so is what made `time_to_first_visible_output_ms` identical
+      // to `time_to_first_token_ms` on every run.
       if (lifecycleMarkers.firstVisibleOutput) {
         lifecycle.mark('first_visible_output');
       }
@@ -13644,10 +13650,19 @@ export async function startServer({
       'text_delta',
       'thinking_delta',
     ]);
+    // Stamps ONLY `first_token`. `first_visible_output` deliberately does not
+    // ride along: it belongs to the single emission choke point in `send()`,
+    // which runs after the title-marker stripper and the fabricated-role-marker
+    // guard have decided whether these bytes reach the client at all. Stamping
+    // both here made `time_to_first_visible_output_ms` a byte-for-byte copy of
+    // `time_to_first_token_ms` — the mark is first-write-wins, so this call
+    // always won and the `send()` mark could never fire. The two are equal
+    // whenever output streams straight through (the common case, and correct);
+    // they diverge exactly when the daemon HOLDS bytes back, which is the
+    // window the metric exists to measure.
     const noteFirstTokenAt = (timestamp = Date.now()) => {
       if (run.analyticsTelemetry?.firstTokenAt) return;
       lifecycle.mark('first_token', timestamp);
-      lifecycle.mark('first_visible_output', timestamp);
     };
     // Subsegment markers inside `processSpawnedAt -> firstTokenAt` (#3408 §4).
     // `cliReadyAt` is the first well-formed adapter output and is stamped for

--- a/apps/daemon/tests/first-visible-output-harness.ts
+++ b/apps/daemon/tests/first-visible-output-harness.ts
@@ -1,0 +1,395 @@
+// Shared wiring for the `first_visible_output` regression suites.
+//
+// Both suites drive the REAL daemon (`startServer` + a fake agent CLI on the
+// real spawn path) and read the two timing fields off the real PostHog
+// `run_finished` payload, because the bug this instrumentation exists for was
+// never in a helper — it was in which call site owns the mark. Anything that
+// stubs the emission path would prove the wrong thing.
+import type { Server } from 'node:http';
+import { createServer } from 'node:http';
+import { gunzipSync } from 'node:zlib';
+import { randomUUID } from 'node:crypto';
+import { chmod, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { expect } from 'vitest';
+
+/**
+ * Per-test timeout every case in these suites is declared with. Every wait
+ * below is a slice of THIS budget, so no step can silently outlive the timeout
+ * and no step needs an arbitrary cutoff of its own.
+ */
+export const TEST_BUDGET_MS = 90_000;
+/** Spawn the CLI, stream the turn, reach a terminal run row. */
+export const RUN_TERMINAL_WAIT_MS = 30_000;
+/**
+ * The daemon captures `run_finished` from an async chain that only starts once
+ * the run row is terminal; posthog-node then posts it (flushAt: 1). Neither
+ * step is synchronous with the status flip, so the sink is polled rather than
+ * sampled once.
+ */
+export const CAPTURE_WAIT_MS = 30_000;
+/**
+ * Grace after the daemon's analytics flush has been awaited. Past this point a
+ * missing event is a missing EVENT, not batching latency.
+ */
+export const FLUSHED_CAPTURE_WAIT_MS = 5_000;
+
+// Leaves room for daemon boot, project/config setup and teardown inside the
+// same budget. A future edit that grows a phase past the timeout fails here,
+// at import, instead of as an unexplained timeout in one case.
+if (
+  RUN_TERMINAL_WAIT_MS + CAPTURE_WAIT_MS + FLUSHED_CAPTURE_WAIT_MS
+  >= TEST_BUDGET_MS
+) {
+  throw new Error(
+    'first_visible_output harness: phase waits exceed the per-test budget.',
+  );
+}
+
+export type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+export type RunStatus = { id: string; status: string };
+
+export type RunTiming = {
+  time_to_first_token_ms?: number;
+  time_to_first_visible_output_ms?: number;
+};
+
+export type CaptureSink = {
+  url: string;
+  /**
+   * Resolve the run's `run_finished` timing, or throw. `flush` must drive the
+   * daemon's own analytics shutdown (`startServer(...).shutdown`), which awaits
+   * posthog-node's drain — that is what makes delivery deterministic instead of
+   * hostage to an arbitrary sleep. The throw is preserved on purpose: a run
+   * that never reports is a real regression, not something to wait out.
+   */
+  waitForRunFinished(runId: string, flush: () => Promise<void>): Promise<RunTiming>;
+  close(): Promise<void>;
+};
+
+/**
+ * `firstVisibleOutputAt` is stamped after `firstTokenAt` by construction: the
+ * daemon cannot show bytes before it has the token they are made of. That held
+ * only by accident while both marks shared one timestamp, so every case asserts
+ * it now that they are stamped independently.
+ */
+export function expectVisibleOutputNotBeforeFirstToken(timing: RunTiming): void {
+  expect(timing.time_to_first_token_ms).toBeTypeOf('number');
+  expect(timing.time_to_first_visible_output_ms).toBeTypeOf('number');
+  expect(
+    timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!,
+  ).toBeGreaterThanOrEqual(0);
+}
+
+// Minimal stand-in for PostHog ingestion. posthog-node runs with `flushAt: 1`,
+// so each daemon capture arrives as its own `/batch/` POST.
+export async function startCaptureSink(): Promise<CaptureSink> {
+  const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      // posthog-node gzips its batch payloads.
+      const raw = Buffer.concat(chunks);
+      let body = '';
+      try {
+        body = /gzip/iu.test(req.headers['content-encoding'] ?? '')
+          ? gunzipSync(raw).toString('utf8')
+          : raw.toString('utf8');
+      } catch {
+        body = '';
+      }
+      try {
+        const parsed = JSON.parse(body) as {
+          batch?: Array<{ event?: unknown; properties?: unknown }>;
+        };
+        for (const record of parsed.batch ?? []) {
+          if (typeof record.event !== 'string') continue;
+          events.push({
+            event: record.event,
+            properties: (record.properties ?? {}) as Record<string, unknown>,
+          });
+        }
+      } catch {
+        // Non-batch probes (flags, etc.) are not interesting here.
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"status":1}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no capture port');
+
+  const find = (runId: string): RunTiming | null => {
+    const match = events.find(
+      (record) =>
+        record.event === 'run_finished' && record.properties.run_id === runId,
+    );
+    return match ? (match.properties as RunTiming) : null;
+  };
+  const poll = async (runId: string, budgetMs: number): Promise<RunTiming | null> => {
+    const deadline = Date.now() + budgetMs;
+    for (;;) {
+      const match = find(runId);
+      if (match) return match;
+      if (Date.now() >= deadline) return null;
+      await delay(100);
+    }
+  };
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    async waitForRunFinished(runId, flush): Promise<RunTiming> {
+      const captured = await poll(runId, CAPTURE_WAIT_MS);
+      if (captured) return captured;
+      // Force it rather than waiting longer: the daemon's shutdown awaits
+      // `analytics.shutdown()`, which drains posthog-node, so once this
+      // resolves the sink holds everything the daemon will ever send.
+      await flush();
+      const afterFlush = await poll(runId, FLUSHED_CAPTURE_WAIT_MS);
+      if (afterFlush) return afterFlush;
+      throw new Error(
+        `no run_finished captured for ${runId} after the daemon analytics flush; saw ${
+          events.map((record) => record.event).join(', ') || '<nothing>'
+        }`,
+      );
+    },
+    close(): Promise<void> {
+      return new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+/**
+ * A fake `opencode` on the real json-event-stream spawn path. `body` is the
+ * script that emits the turn; it runs with `emit()` and `finishTurn()` in
+ * scope.
+ */
+export async function writeFakeOpencode(
+  dir: string,
+  name: string,
+  body: string,
+): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+const SESSION = 'ses_first_visible_output_0001';
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('1.17.7'); process.exit(0); }
+if (argv.includes('--help')) { console.log('opencode run [message..]'); process.exit(0); }
+if (argv[0] === 'models') { console.log('anthropic/claude-sonnet-4-5'); process.exit(0); }
+let stdin = '';
+let done = false;
+function emit(obj) {
+  console.log(JSON.stringify({ ...obj, sessionID: SESSION }));
+}
+function finishTurn() {
+  emit({ type: 'step_finish', part: { type: 'step-finish', tokens: { input: 9, output: 4, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 0 } });
+  setTimeout(() => process.exit(0), 10);
+}
+function finish() {
+  if (done) return; done = true;
+  run();
+}
+function run() {
+  emit({ type: 'step_start', part: { type: 'step-start' } });
+${body}
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { stdin += d; });
+process.stdin.on('end', finish);
+process.stdin.on('error', finish);
+setTimeout(finish, 1500);
+`,
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+export const TELEMETRY_ENV_KEYS = [
+  'LANGFUSE_PUBLIC_KEY',
+  'LANGFUSE_SECRET_KEY',
+  'LANGFUSE_BASE_URL',
+  'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+  'POSTHOG_KEY',
+  'POSTHOG_HOST',
+  'OD_NEXT_STRATEGY_ROLLOUT',
+  'OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY',
+] as const;
+
+export function snapshotEnv(): Record<string, string | undefined> {
+  return Object.fromEntries(
+    TELEMETRY_ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
+}
+
+export function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+export function clearTelemetryEnv(): void {
+  for (const key of TELEMETRY_ENV_KEYS) delete process.env[key];
+}
+
+export async function putConfig(
+  url: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+  // Populates the runtime/agent inventory the OD Next admission gate reads.
+  await fetch(`${url}/api/agents`);
+}
+
+export type Conversation = { projectId: string; conversationId: string };
+
+/** Ordinary chat project: the OD Next strategy has nothing to bind to. */
+export async function createChatProject(
+  url: string,
+  label: string,
+): Promise<Conversation> {
+  return await createProject(url, label, {
+    metadata: { kind: 'prototype' },
+  });
+}
+
+/**
+ * Design project carrying an `automatic_default` strategy binding — the shape
+ * the OD Next rollout admits. The binding is asserted rather than assumed, so
+ * a project-creation change that silently drops it fails here instead of
+ * quietly turning the strategy case into an ordinary run.
+ */
+export async function createOdNextDesignProject(
+  url: string,
+  label: string,
+): Promise<Conversation> {
+  const created = await createProject(url, label, {
+    metadata: { kind: 'prototype' },
+    conversationMode: 'design',
+    automaticStrategyTaskProfile: 'prototype',
+  });
+  expect(created.strategyBinding).toMatchObject({
+    provenance: 'automatic_default',
+    taskProfile: 'prototype',
+  });
+  return created;
+}
+
+async function createProject(
+  url: string,
+  label: string,
+  extra: Record<string, unknown>,
+): Promise<Conversation & { strategyBinding?: unknown }> {
+  const projectId = `fvo_${label.replace(/[^a-z0-9]+/giu, '_')}_${randomUUID()}`;
+  const response = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'first visible output smoke',
+      skipDiscoveryBrief: true,
+      ...extra,
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    conversationId: string;
+    project?: { metadata?: { strategyBinding?: unknown } };
+  };
+  return {
+    projectId,
+    conversationId: body.conversationId,
+    strategyBinding: body.project?.metadata?.strategyBinding,
+  };
+}
+
+export type StartedRun = { run: RunStatus; created: Record<string, unknown> };
+
+export async function sendRunAndWait(
+  url: string,
+  conversation: Conversation,
+  message: string,
+): Promise<StartedRun> {
+  const response = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'first-visible-output-test',
+      'x-od-analytics-session-id': 'first-visible-output-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId: conversation.projectId,
+      conversationId: conversation.conversationId,
+      userMessageId: `user_fvo_${randomUUID()}`,
+      assistantMessageId: `assistant_fvo_${randomUUID()}`,
+      clientRequestId: `client_fvo_${randomUUID()}`,
+      agentId: 'opencode',
+      message,
+      currentPrompt: message,
+    }),
+  });
+  expect(response.status).toBe(202);
+  const created = (await response.json()) as Record<string, unknown>;
+  return {
+    created,
+    run: await waitForRun(url, created.runId as string),
+  };
+}
+
+export async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const deadline = Date.now() + RUN_TERMINAL_WAIT_MS;
+  while (Date.now() < deadline) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (
+      run.status === 'failed'
+      || run.status === 'succeeded'
+      || run.status === 'canceled'
+    ) {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+/** The reply as the user's client received it, reassembled by the daemon. */
+export async function readAssistantMessage(
+  url: string,
+  conversation: Conversation,
+  assistantMessageId: string,
+): Promise<string> {
+  const response = await fetch(
+    `${url}/api/projects/${encodeURIComponent(conversation.projectId)}`
+      + `/conversations/${encodeURIComponent(conversation.conversationId)}/messages`,
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    messages: Array<{ id: string; role: string; content: string }>;
+  };
+  const message = body.messages.find((entry) => entry.id === assistantMessageId);
+  return message?.content ?? '';
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/daemon/tests/first-visible-output-mark.test.ts
+++ b/apps/daemon/tests/first-visible-output-mark.test.ts
@@ -1,13 +1,26 @@
-import type { Server } from 'node:http';
-import { createServer } from 'node:http';
-import { gunzipSync } from 'node:zlib';
-import { randomUUID } from 'node:crypto';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { startServer } from '../src/server.js';
+import {
+  type CaptureSink,
+  type Conversation,
+  type RunTiming,
+  type StartedServer,
+  TEST_BUDGET_MS,
+  clearTelemetryEnv,
+  createChatProject,
+  createOdNextDesignProject,
+  expectVisibleOutputNotBeforeFirstToken,
+  putConfig,
+  restoreEnv,
+  sendRunAndWait,
+  snapshotEnv,
+  startCaptureSink,
+  writeFakeOpencode,
+} from './first-visible-output-harness.js';
 
 // `time_to_first_visible_output_ms` is supposed to answer "once the model
 // started producing, how long until the user could actually SEE something?".
@@ -18,17 +31,22 @@ import { startServer } from '../src/server.js';
 // p90 = p99 = max = 0).
 //
 // The daemon does NOT emit every token it decodes. Between "this is a token"
-// and "these bytes left the daemon" sit two filters that can withhold output:
-// the `<od-title>` marker stripper and the fabricated-role-marker safety guard
-// (#3247). The guard is the one that can hold bytes across chunks: when a
-// chunk ENDS on a complete-but-unconfirmed marker keyword (`## user`), the
-// guard withholds it until the next chunk proves it was ordinary prose
-// (`## usernames …`) or a real fabricated marker. During that window the run
-// has a first token and the user has an empty bubble.
+// and "these bytes left the daemon" sit filters that can withhold output: the
+// `<od-title>` marker stripper, the fabricated-role-marker safety guard
+// (#3247), and — when the OD Next strategy is running the turn — the machine
+// protocol, which withholds any text that might still turn out to be a
+// reserved `<open-design-…>` block.
 //
 // These tests drive the REAL wiring (`startServer` + a fake opencode CLI) and
 // read the two fields off the real PostHog `run_finished` payload, because the
-// bug was never in a helper — it was in which call site owned the mark.
+// bug was never in a helper — it was in which call site owns the mark.
+//
+// Every case names the OD Next rollout mode it runs under. Neither the
+// strategy-off nor the strategy-active coverage may rest on whatever
+// `OD_NEXT_STRATEGY_ROLLOUT` happens to default to: that default has already
+// been `active`, is expected to flip to disabled after 0.21.0, and is a
+// user-facing switch besides. A suite that inherited it would silently stop
+// covering the path it was written for the day the default moved.
 describe('first_visible_output is stamped at emission, not at first token', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
@@ -43,7 +61,7 @@ describe('first_visible_output is stamped at emission, not at first token', () =
     started = null;
     if (posthog) await posthog.close();
     posthog = null;
-    if (binDir) await removeTempDir(binDir);
+    if (binDir) await rm(binDir, { force: true, recursive: true });
     binDir = null;
     restoreEnv(originalEnv);
   });
@@ -61,16 +79,19 @@ describe('first_visible_output is stamped at emission, not at first token', () =
     finishTurn();
   }, ${WITHHOLD_MS});`);
 
-    const timing = await runOnceAndReadTiming(bin, 'guard-withheld');
+    const timing = await runOnceAndReadTiming({
+      bin,
+      label: 'guard-withheld',
+      strategyRollout: 'off',
+    });
 
-    expect(timing.time_to_first_token_ms).toBeTypeOf('number');
-    expect(timing.time_to_first_visible_output_ms).toBeTypeOf('number');
+    expectVisibleOutputNotBeforeFirstToken(timing);
     const gap =
       timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
     // The withheld window is the whole point of the metric. Allow generous
     // slack under load; the pre-fix value is exactly 0.
     expect(gap).toBeGreaterThanOrEqual(WITHHOLD_MS - 100);
-  }, 90_000);
+  }, TEST_BUDGET_MS);
 
   it('does not manufacture a gap when the first token is emitted straight through', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-direct-'));
@@ -78,22 +99,24 @@ describe('first_visible_output is stamped at emission, not at first token', () =
   emit({ type: 'text', part: { type: 'text', text: 'Here is your answer.' } });
   finishTurn();`);
 
-    const timing = await runOnceAndReadTiming(bin, 'direct-text');
+    const timing = await runOnceAndReadTiming({
+      bin,
+      label: 'direct-text',
+      strategyRollout: 'off',
+    });
 
-    expect(timing.time_to_first_token_ms).toBeTypeOf('number');
-    expect(timing.time_to_first_visible_output_ms).toBeTypeOf('number');
-    const gap =
-      timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
     // Never negative: the daemon cannot show bytes before it has the token they
     // are made of. This held only by accident while both marks shared one
     // timestamp; now that they are stamped independently it is enforced by
     // reading the decode clock BEFORE the emit at every text_delta site.
-    expect(gap).toBeGreaterThanOrEqual(0);
+    expectVisibleOutputNotBeforeFirstToken(timing);
+    const gap =
+      timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
     // And no manufactured gap. The residue is the daemon's own SSE fan-out for
     // one delta — sub-millisecond when idle, a few ms on a loaded box — which is
     // an order of magnitude below the withheld window the metric reports.
     expect(gap).toBeLessThan(100);
-  }, 90_000);
+  }, TEST_BUDGET_MS);
 
   it('keeps the first-token fallback when the run never emits visible output', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-never-'));
@@ -105,273 +128,112 @@ describe('first_visible_output is stamped at emission, not at first token', () =
   emit({ type: 'text', part: { type: 'text', text: '## user' } });
   finishTurn();`);
 
-    const timing = await runOnceAndReadTiming(bin, 'never-visible');
+    const timing = await runOnceAndReadTiming({
+      bin,
+      label: 'never-visible',
+      strategyRollout: 'off',
+    });
 
     expect(timing.time_to_first_token_ms).toBeTypeOf('number');
     expect(timing.time_to_first_visible_output_ms).toBe(
       timing.time_to_first_token_ms,
     );
-  }, 90_000);
+  }, TEST_BUDGET_MS);
 
-  async function runOnceAndReadTiming(
-    bin: string,
-    label: string,
-  ): Promise<RunTiming> {
+  // The OD Next machine protocol is a THIRD thing that can withhold visible
+  // bytes, and unlike the other two it can hold them past the end of the
+  // stream: text that might still turn out to be a reserved `<open-design-…>`
+  // block is only released when `finish()` proves it was prose, at child
+  // close. That release does not go through the daemon's ordinary emission
+  // choke point — it persists and broadcasts the tail directly — so the mark
+  // has to be applied there too. Without it the run reports no visible output
+  // at all and the analytics fallback collapses a real close-time wait back to
+  // `firstTokenAt`, which is precisely the dead-field failure this whole
+  // change exists to end.
+  it('reports the close-time wait when the strategy releases the reply at finish', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-strategy-'));
+    // Every visible byte of this reply is withheld until close. The machine
+    // block is suppressed by design (it is protocol, not prose) and the only
+    // remaining text is `<o` — a prefix of a reserved opening tag, which the
+    // protocol must hold because the next chunk could complete
+    // `<open-design-plan-contract`. The next chunk never comes, so `finish()`
+    // is what finally rules it out and releases it.
+    const bin = await writeFakeOpencode(binDir, 'opencode-strategy-tail', `
+  emit({ type: 'text', part: { type: 'text', text: [
+    '<open-design-runtime-state>',
+    '{"schemaVersion":2}',
+    '</open-design-runtime-state>',
+  ].join('\\n') + '<o' } });
+  setTimeout(finishTurn, ${WITHHOLD_MS});`);
+
+    const timing = await runOnceAndReadTiming({
+      bin,
+      label: 'strategy-tail',
+      strategyRollout: 'active',
+    });
+
+    expectVisibleOutputNotBeforeFirstToken(timing);
+    const gap =
+      timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
+    expect(gap).toBeGreaterThanOrEqual(WITHHOLD_MS - 100);
+  }, TEST_BUDGET_MS);
+
+  async function runOnceAndReadTiming(options: {
+    bin: string;
+    label: string;
+    /**
+     * Required, never inherited. `off` exercises the daemon's generic emission
+     * choke point; `active` additionally puts the OD Next machine protocol in
+     * front of it, which is the only way the close-time release path exists at
+     * all.
+     */
+    strategyRollout: 'off' | 'active';
+  }): Promise<RunTiming> {
     posthog = await startCaptureSink();
     clearTelemetryEnv();
     process.env.POSTHOG_KEY = 'phc_first_visible_output_test';
     process.env.POSTHOG_HOST = posthog.url;
-    // The OD Next strategy protocol adds its own text-withholding layer and a
-    // machine-contract gate on top of the stream. This suite is about the
-    // daemon's generic emission choke point, so keep the strategy out of it.
-    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = options.strategyRollout;
+    if (options.strategyRollout === 'active') {
+      // Local-only escape hatch for the runtime-capability fixture gate, which
+      // a fake CLI cannot satisfy. It does not weaken anything this case
+      // asserts: admission still has to resolve a real bundled strategy
+      // package, task type and agent, which is what the `strategyTask`
+      // assertion below checks.
+      process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY = '1';
+    }
 
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'opencode',
-      agentCliEnv: { opencode: { OPENCODE_BIN: bin } },
+      agentCliEnv: { opencode: { OPENCODE_BIN: options.bin } },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
 
-    const conversation = await createConversation(started.url, label);
-    const run = await sendRunAndWait(started.url, conversation, `render ${label}`);
+    const conversation: Conversation = options.strategyRollout === 'active'
+      ? await createOdNextDesignProject(started.url, options.label)
+      : await createChatProject(started.url, options.label);
+    const { created, run } = await sendRunAndWait(
+      started.url,
+      conversation,
+      `render ${options.label}`,
+    );
+    // Prove the mode the case claims to be in. Without this the strategy case
+    // could quietly degrade into an ordinary run — admission has many gates —
+    // and keep passing for the wrong reason.
+    if (options.strategyRollout === 'active') {
+      expect(created.pluginId).toBe('od-next-strategy');
+      expect(created.strategyTask).toBeDefined();
+    } else {
+      expect(created.strategyTask).toBeUndefined();
+    }
     expect(run.status).toBe('succeeded');
-    return await posthog.waitForRunFinished(run.id);
+    const flush = async () => {
+      await Promise.resolve(started?.shutdown?.());
+    };
+    return await posthog.waitForRunFinished(run.id, flush);
   }
 });
 
 const WITHHOLD_MS = 400;
-
-type StartedServer = {
-  url: string;
-  server: Server;
-  shutdown?: () => Promise<void> | void;
-};
-
-type RunStatus = { id: string; status: string };
-
-type RunTiming = {
-  time_to_first_token_ms?: number;
-  time_to_first_visible_output_ms?: number;
-};
-
-type CaptureSink = {
-  url: string;
-  waitForRunFinished(runId: string): Promise<RunTiming>;
-  close(): Promise<void>;
-};
-
-// Minimal stand-in for PostHog ingestion. posthog-node runs with `flushAt: 1`,
-// so each daemon capture arrives as its own `/batch/` POST.
-async function startCaptureSink(): Promise<CaptureSink> {
-  const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
-  const server = createServer((req, res) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-    req.on('end', () => {
-      // posthog-node gzips its batch payloads.
-      const raw = Buffer.concat(chunks);
-      let body = '';
-      try {
-        body = /gzip/iu.test(req.headers['content-encoding'] ?? '')
-          ? gunzipSync(raw).toString('utf8')
-          : raw.toString('utf8');
-      } catch {
-        body = '';
-      }
-      try {
-        const parsed = JSON.parse(body) as {
-          batch?: Array<{ event?: unknown; properties?: unknown }>;
-        };
-        for (const record of parsed.batch ?? []) {
-          if (typeof record.event !== 'string') continue;
-          events.push({
-            event: record.event,
-            properties: (record.properties ?? {}) as Record<string, unknown>,
-          });
-        }
-      } catch {
-        // Non-batch probes (flags, etc.) are not interesting here.
-      }
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end('{"status":1}');
-    });
-  });
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('no capture port');
-  return {
-    url: `http://127.0.0.1:${address.port}`,
-    async waitForRunFinished(runId: string): Promise<RunTiming> {
-      const deadline = Date.now() + 15_000;
-      while (Date.now() < deadline) {
-        const match = events.find(
-          (record) =>
-            record.event === 'run_finished' && record.properties.run_id === runId,
-        );
-        if (match) return match.properties as RunTiming;
-        await delay(100);
-      }
-      throw new Error(
-        `no run_finished captured for ${runId}; saw ${events
-          .map((record) => record.event)
-          .join(', ')}`,
-      );
-    },
-    close(): Promise<void> {
-      return new Promise<void>((resolve) => server.close(() => resolve()));
-    },
-  };
-}
-
-async function writeFakeOpencode(
-  dir: string,
-  name: string,
-  body: string,
-): Promise<string> {
-  const bin = path.join(dir, name);
-  await writeFile(
-    bin,
-    `#!/usr/bin/env node
-const SESSION = 'ses_first_visible_output_0001';
-const argv = process.argv.slice(2);
-if (argv.includes('--version')) { console.log('1.17.7'); process.exit(0); }
-if (argv.includes('--help')) { console.log('opencode run [message..]'); process.exit(0); }
-if (argv[0] === 'models') { console.log('anthropic/claude-sonnet-4-5'); process.exit(0); }
-let stdin = '';
-let done = false;
-function emit(obj) {
-  console.log(JSON.stringify({ ...obj, sessionID: SESSION }));
-}
-function finishTurn() {
-  emit({ type: 'step_finish', part: { type: 'step-finish', tokens: { input: 9, output: 4, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 0 } });
-  setTimeout(() => process.exit(0), 10);
-}
-function finish() {
-  if (done) return; done = true;
-  run();
-}
-function run() {
-  emit({ type: 'step_start', part: { type: 'step-start' } });
-${body}
-}
-process.stdin.setEncoding('utf8');
-process.stdin.on('data', (d) => { stdin += d; });
-process.stdin.on('end', finish);
-process.stdin.on('error', finish);
-setTimeout(finish, 1500);
-`,
-    'utf8',
-  );
-  await chmod(bin, 0o755);
-  return bin;
-}
-
-function snapshotEnv(): Record<string, string | undefined> {
-  return {
-    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
-    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
-    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
-    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
-    POSTHOG_KEY: process.env.POSTHOG_KEY,
-    POSTHOG_HOST: process.env.POSTHOG_HOST,
-    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
-  };
-}
-
-function restoreEnv(env: Record<string, string | undefined>): void {
-  for (const [key, value] of Object.entries(env)) {
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
-  }
-}
-
-function clearTelemetryEnv(): void {
-  delete process.env.OD_NEXT_STRATEGY_ROLLOUT;
-  delete process.env.POSTHOG_KEY;
-  delete process.env.POSTHOG_HOST;
-  delete process.env.LANGFUSE_PUBLIC_KEY;
-  delete process.env.LANGFUSE_SECRET_KEY;
-  delete process.env.LANGFUSE_BASE_URL;
-  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
-}
-
-async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
-  const response = await fetch(`${url}/api/app-config`, {
-    method: 'PUT',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(patch),
-  });
-  expect(response.status).toBe(200);
-}
-
-async function createConversation(url: string, label: string): Promise<string> {
-  const projectId = `fvo_${label.replace(/[^a-z0-9]+/giu, '_')}_${randomUUID()}`;
-  const response = await fetch(`${url}/api/projects`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      id: projectId,
-      name: 'first visible output smoke',
-      metadata: { kind: 'prototype' },
-      skipDiscoveryBrief: true,
-    }),
-  });
-  expect(response.status).toBe(200);
-  const body = (await response.json()) as { conversationId: string };
-  return `${projectId}::${body.conversationId}`;
-}
-
-async function sendRunAndWait(
-  url: string,
-  encoded: string,
-  message: string,
-): Promise<RunStatus> {
-  const [projectId, conversationId] = encoded.split('::');
-  const response = await fetch(`${url}/api/runs`, {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      'x-od-analytics-device-id': 'first-visible-output-test',
-      'x-od-analytics-session-id': 'first-visible-output-session',
-      'x-od-analytics-client-type': 'web',
-    },
-    body: JSON.stringify({
-      projectId,
-      conversationId,
-      assistantMessageId: `assistant_fvo_${randomUUID()}`,
-      clientRequestId: `client_fvo_${randomUUID()}`,
-      agentId: 'opencode',
-      message,
-      currentPrompt: message,
-    }),
-  });
-  expect(response.status).toBe(202);
-  const body = (await response.json()) as { runId: string };
-  return await waitForRun(url, body.runId);
-}
-
-async function waitForRun(url: string, runId: string): Promise<RunStatus> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < 15_000) {
-    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
-    expect(response.status).toBe(200);
-    const run = (await response.json()) as RunStatus;
-    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
-      return run;
-    }
-    await delay(100);
-  }
-  throw new Error(`run ${runId} did not finish`);
-}
-
-async function removeTempDir(dir: string): Promise<void> {
-  await rm(dir, { force: true, recursive: true });
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/apps/daemon/tests/first-visible-output-mark.test.ts
+++ b/apps/daemon/tests/first-visible-output-mark.test.ts
@@ -1,0 +1,368 @@
+import type { Server } from 'node:http';
+import { createServer } from 'node:http';
+import { gunzipSync } from 'node:zlib';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+// `time_to_first_visible_output_ms` is supposed to answer "once the model
+// started producing, how long until the user could actually SEE something?".
+// It was published for months as a copy of `time_to_first_token_ms`, because
+// `noteFirstTokenAt()` stamped BOTH `first_token` and `first_visible_output`
+// from the same call with the same timestamp — so the difference was 0 for
+// every run ever recorded (205,795 `run_finished` events over 7 days, p50 =
+// p90 = p99 = max = 0).
+//
+// The daemon does NOT emit every token it decodes. Between "this is a token"
+// and "these bytes left the daemon" sit two filters that can withhold output:
+// the `<od-title>` marker stripper and the fabricated-role-marker safety guard
+// (#3247). The guard is the one that can hold bytes across chunks: when a
+// chunk ENDS on a complete-but-unconfirmed marker keyword (`## user`), the
+// guard withholds it until the next chunk proves it was ordinary prose
+// (`## usernames …`) or a real fabricated marker. During that window the run
+// has a first token and the user has an empty bubble.
+//
+// These tests drive the REAL wiring (`startServer` + a fake opencode CLI) and
+// read the two fields off the real PostHog `run_finished` payload, because the
+// bug was never in a helper — it was in which call site owned the mark.
+describe('first_visible_output is stamped at emission, not at first token', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+  let posthog: CaptureSink | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (posthog) await posthog.close();
+    posthog = null;
+    if (binDir) await removeTempDir(binDir);
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('reports a real gap when the safety guard withholds the first bytes', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-withheld-'));
+    // The model opens a markdown heading whose keyword lands exactly on a
+    // chunk boundary. The role-marker guard cannot classify `## user` until it
+    // sees the next character, so it withholds the whole chunk. The daemon has
+    // its first token; the user still has nothing on screen.
+    const bin = await writeFakeOpencode(binDir, 'opencode-withheld', `
+  emit({ type: 'text', part: { type: 'text', text: '## user' } });
+  setTimeout(() => {
+    emit({ type: 'text', part: { type: 'text', text: 'names are listed below.' } });
+    finishTurn();
+  }, ${WITHHOLD_MS});`);
+
+    const timing = await runOnceAndReadTiming(bin, 'guard-withheld');
+
+    expect(timing.time_to_first_token_ms).toBeTypeOf('number');
+    expect(timing.time_to_first_visible_output_ms).toBeTypeOf('number');
+    const gap =
+      timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
+    // The withheld window is the whole point of the metric. Allow generous
+    // slack under load; the pre-fix value is exactly 0.
+    expect(gap).toBeGreaterThanOrEqual(WITHHOLD_MS - 100);
+  }, 90_000);
+
+  it('does not manufacture a gap when the first token is emitted straight through', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-direct-'));
+    const bin = await writeFakeOpencode(binDir, 'opencode-direct', `
+  emit({ type: 'text', part: { type: 'text', text: 'Here is your answer.' } });
+  finishTurn();`);
+
+    const timing = await runOnceAndReadTiming(bin, 'direct-text');
+
+    expect(timing.time_to_first_token_ms).toBeTypeOf('number');
+    expect(timing.time_to_first_visible_output_ms).toBe(
+      timing.time_to_first_token_ms,
+    );
+  }, 90_000);
+
+  it('keeps the first-token fallback when the run never emits visible output', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-never-'));
+    // The guard withholds `## user` and the CLI exits before the next chunk
+    // could release it, so nothing visible ever reaches the client. There is
+    // no measurement to report, and the documented fallback keeps the field
+    // pinned to the first token rather than dropping it.
+    const bin = await writeFakeOpencode(binDir, 'opencode-never', `
+  emit({ type: 'text', part: { type: 'text', text: '## user' } });
+  finishTurn();`);
+
+    const timing = await runOnceAndReadTiming(bin, 'never-visible');
+
+    expect(timing.time_to_first_token_ms).toBeTypeOf('number');
+    expect(timing.time_to_first_visible_output_ms).toBe(
+      timing.time_to_first_token_ms,
+    );
+  }, 90_000);
+
+  async function runOnceAndReadTiming(
+    bin: string,
+    label: string,
+  ): Promise<RunTiming> {
+    posthog = await startCaptureSink();
+    clearTelemetryEnv();
+    process.env.POSTHOG_KEY = 'phc_first_visible_output_test';
+    process.env.POSTHOG_HOST = posthog.url;
+    // The OD Next strategy protocol adds its own text-withholding layer and a
+    // machine-contract gate on top of the stream. This suite is about the
+    // daemon's generic emission choke point, so keep the strategy out of it.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversation = await createConversation(started.url, label);
+    const run = await sendRunAndWait(started.url, conversation, `render ${label}`);
+    expect(run.status).toBe('succeeded');
+    return await posthog.waitForRunFinished(run.id);
+  }
+});
+
+const WITHHOLD_MS = 400;
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = { id: string; status: string };
+
+type RunTiming = {
+  time_to_first_token_ms?: number;
+  time_to_first_visible_output_ms?: number;
+};
+
+type CaptureSink = {
+  url: string;
+  waitForRunFinished(runId: string): Promise<RunTiming>;
+  close(): Promise<void>;
+};
+
+// Minimal stand-in for PostHog ingestion. posthog-node runs with `flushAt: 1`,
+// so each daemon capture arrives as its own `/batch/` POST.
+async function startCaptureSink(): Promise<CaptureSink> {
+  const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      // posthog-node gzips its batch payloads.
+      const raw = Buffer.concat(chunks);
+      let body = '';
+      try {
+        body = /gzip/iu.test(req.headers['content-encoding'] ?? '')
+          ? gunzipSync(raw).toString('utf8')
+          : raw.toString('utf8');
+      } catch {
+        body = '';
+      }
+      try {
+        const parsed = JSON.parse(body) as {
+          batch?: Array<{ event?: unknown; properties?: unknown }>;
+        };
+        for (const record of parsed.batch ?? []) {
+          if (typeof record.event !== 'string') continue;
+          events.push({
+            event: record.event,
+            properties: (record.properties ?? {}) as Record<string, unknown>,
+          });
+        }
+      } catch {
+        // Non-batch probes (flags, etc.) are not interesting here.
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{"status":1}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('no capture port');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    async waitForRunFinished(runId: string): Promise<RunTiming> {
+      const deadline = Date.now() + 15_000;
+      while (Date.now() < deadline) {
+        const match = events.find(
+          (record) =>
+            record.event === 'run_finished' && record.properties.run_id === runId,
+        );
+        if (match) return match.properties as RunTiming;
+        await delay(100);
+      }
+      throw new Error(
+        `no run_finished captured for ${runId}; saw ${events
+          .map((record) => record.event)
+          .join(', ')}`,
+      );
+    },
+    close(): Promise<void> {
+      return new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function writeFakeOpencode(
+  dir: string,
+  name: string,
+  body: string,
+): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+const SESSION = 'ses_first_visible_output_0001';
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { console.log('1.17.7'); process.exit(0); }
+if (argv.includes('--help')) { console.log('opencode run [message..]'); process.exit(0); }
+if (argv[0] === 'models') { console.log('anthropic/claude-sonnet-4-5'); process.exit(0); }
+let stdin = '';
+let done = false;
+function emit(obj) {
+  console.log(JSON.stringify({ ...obj, sessionID: SESSION }));
+}
+function finishTurn() {
+  emit({ type: 'step_finish', part: { type: 'step-finish', tokens: { input: 9, output: 4, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 0 } });
+  setTimeout(() => process.exit(0), 10);
+}
+function finish() {
+  if (done) return; done = true;
+  run();
+}
+function run() {
+  emit({ type: 'step_start', part: { type: 'step-start' } });
+${body}
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (d) => { stdin += d; });
+process.stdin.on('end', finish);
+process.stdin.on('error', finish);
+setTimeout(finish, 1500);
+`,
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    OD_NEXT_STRATEGY_ROLLOUT: process.env.OD_NEXT_STRATEGY_ROLLOUT,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.OD_NEXT_STRATEGY_ROLLOUT;
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createConversation(url: string, label: string): Promise<string> {
+  const projectId = `fvo_${label.replace(/[^a-z0-9]+/giu, '_')}_${randomUUID()}`;
+  const response = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'first visible output smoke',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { conversationId: string };
+  return `${projectId}::${body.conversationId}`;
+}
+
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  message: string,
+): Promise<RunStatus> {
+  const [projectId, conversationId] = encoded.split('::');
+  const response = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'first-visible-output-test',
+      'x-od-analytics-session-id': 'first-visible-output-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId: `assistant_fvo_${randomUUID()}`,
+      clientRequestId: `client_fvo_${randomUUID()}`,
+      agentId: 'opencode',
+      message,
+      currentPrompt: message,
+    }),
+  });
+  expect(response.status).toBe(202);
+  const body = (await response.json()) as { runId: string };
+  return await waitForRun(url, body.runId);
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 15_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = (await response.json()) as RunStatus;
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await delay(100);
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { force: true, recursive: true });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/daemon/tests/first-visible-output-mark.test.ts
+++ b/apps/daemon/tests/first-visible-output-mark.test.ts
@@ -81,9 +81,18 @@ describe('first_visible_output is stamped at emission, not at first token', () =
     const timing = await runOnceAndReadTiming(bin, 'direct-text');
 
     expect(timing.time_to_first_token_ms).toBeTypeOf('number');
-    expect(timing.time_to_first_visible_output_ms).toBe(
-      timing.time_to_first_token_ms,
-    );
+    expect(timing.time_to_first_visible_output_ms).toBeTypeOf('number');
+    const gap =
+      timing.time_to_first_visible_output_ms! - timing.time_to_first_token_ms!;
+    // Never negative: the daemon cannot show bytes before it has the token they
+    // are made of. This held only by accident while both marks shared one
+    // timestamp; now that they are stamped independently it is enforced by
+    // reading the decode clock BEFORE the emit at every text_delta site.
+    expect(gap).toBeGreaterThanOrEqual(0);
+    // And no manufactured gap. The residue is the daemon's own SSE fan-out for
+    // one delta — sub-millisecond when idle, a few ms on a loaded box — which is
+    // an order of magnitude below the withheld window the metric reports.
+    expect(gap).toBeLessThan(100);
   }, 90_000);
 
   it('keeps the first-token fallback when the run never emits visible output', async () => {

--- a/apps/daemon/tests/first-visible-output-telemetry-isolation.test.ts
+++ b/apps/daemon/tests/first-visible-output-telemetry-isolation.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { RunLifecycleMark } from '../src/run-lifecycle-tracer.js';
+
+// The `first_visible_output` / `first_token` marks are stamped from inside
+// `send()` — the single choke point EVERY stream event passes through on its
+// way to the user — and from the strategy's close-time tail emission. That
+// places pure instrumentation directly on the product's critical path, so the
+// failure mode of a bug in it is not "one analytics field is missing", it is
+// "the user never receives the reply".
+//
+// Today nothing in that block realistically throws: the classifier is written
+// defensively and `mark` only spreads an object. But "safe because it is
+// currently written carefully" is not an invariant — the next line added there
+// can break it, and it would break the product, silently, for every run.
+//
+// So the fault is injected rather than argued about: the marker classifier and
+// every mark this change owns are made to throw, and the run must still deliver
+// its complete reply and reach `succeeded`. The blast radius of broken
+// telemetry has to be the telemetry.
+const FAULTED_MARKS = new Set<RunLifecycleMark>([
+  'first_token',
+  'first_visible_output',
+  'first_artifact_write',
+]);
+
+vi.mock('../src/run-lifecycle-tracer.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/run-lifecycle-tracer.js')>();
+  return {
+    ...actual,
+    runLifecycleMarkersForStreamEvent: () => {
+      throw new Error('injected telemetry fault: stream-event marker classification');
+    },
+    createRunLifecycleTracer: (run: Parameters<typeof actual.createRunLifecycleTracer>[0]) => {
+      const tracer = actual.createRunLifecycleTracer(run);
+      return {
+        ...tracer,
+        mark(mark: RunLifecycleMark, timestamp?: number) {
+          // Only the marks this change owns. The run-start marks stay real so
+          // this case cannot pass by breaking the run before it ever streams.
+          if (FAULTED_MARKS.has(mark)) {
+            throw new Error(`injected telemetry fault: ${mark}`);
+          }
+          tracer.mark(mark, timestamp);
+        },
+        markFirstModelEvent() {
+          throw new Error('injected telemetry fault: first model event');
+        },
+      };
+    },
+  };
+});
+
+const { startServer } = await import('../src/server.js');
+const {
+  TEST_BUDGET_MS,
+  clearTelemetryEnv,
+  createChatProject,
+  putConfig,
+  readAssistantMessage,
+  restoreEnv,
+  sendRunAndWait,
+  snapshotEnv,
+  writeFakeOpencode,
+} = await import('./first-visible-output-harness.js');
+type StartedServer = import('./first-visible-output-harness.js').StartedServer;
+
+const REPLY = 'Here is your answer, in full, exactly as the model produced it.';
+
+describe('lifecycle instrumentation cannot cost the user their reply', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { force: true, recursive: true });
+    binDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('delivers the whole reply when every lifecycle mark throws', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-fvo-fault-'));
+    // Two deltas, so the assertion covers both the first event (which is what
+    // carries the marks) and the ones after it.
+    const bin = await writeFakeOpencode(binDir, 'opencode-fault', `
+  emit({ type: 'text', part: { type: 'text', text: ${JSON.stringify(REPLY.slice(0, 21))} } });
+  emit({ type: 'text', part: { type: 'text', text: ${JSON.stringify(REPLY.slice(21))} } });
+  finishTurn();`);
+
+    clearTelemetryEnv();
+    // No telemetry sink: this case is about the product surface surviving, and
+    // a keyless daemon takes the same emission path.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: bin } },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversation = await createChatProject(started.url, 'telemetry-fault');
+    const { created, run } = await sendRunAndWait(
+      started.url,
+      conversation,
+      'render telemetry-fault',
+    );
+
+    expect(run.status).toBe('succeeded');
+    expect(
+      await readAssistantMessage(
+        started.url,
+        conversation,
+        created.assistantMessageId as string,
+      ),
+    ).toBe(REPLY);
+  }, TEST_BUDGET_MS);
+});

--- a/apps/daemon/tests/run-lifecycle-tracer.test.ts
+++ b/apps/daemon/tests/run-lifecycle-tracer.test.ts
@@ -23,6 +23,30 @@ describe('runLifecycleMarkersForStreamEvent', () => {
       firstArtifactWrite: false,
     });
   });
+
+  // The plain / BYOK / antigravity family answers on `stdout`, not on the
+  // structured `agent` stream. Without this the whole family reports no visible
+  // output and falls back to its first token — which for antigravity (stdout is
+  // buffered until close) hides the entire wait the user actually sat through.
+  it('counts stdout chunks as visible model output', () => {
+    expect(
+      runLifecycleMarkersForStreamEvent('stdout', { chunk: 'Here is your answer.' }),
+    ).toEqual({
+      firstVisibleOutput: true,
+      firstArtifactWrite: false,
+    });
+  });
+
+  // stderr is a diagnostic channel. A CLI warning is not the model's answer and
+  // must not satisfy "the user can see something".
+  it('does not count stderr as visible model output', () => {
+    expect(
+      runLifecycleMarkersForStreamEvent('stderr', { chunk: 'warning: slow start' }),
+    ).toEqual({
+      firstVisibleOutput: false,
+      firstArtifactWrite: false,
+    });
+  });
 });
 
 describe('createRunLifecycleTracer', () => {


### PR DESCRIPTION
## Why

A user pointed a custom model endpoint at Open Design and got responses that take more than twice the fleet average — deepseek-v4-flash p50 **37s** vs **17.2s** across all runs. During that wait the UI shows a spinner and nothing else: it never says what is being waited on. He read "the model is slow" as "the product is stuck". Product and design are now designing the waiting-state copy off the back of that report ([context doc](https://powerformer.feishu.cn/docx/PoIwdvVkCoAXSGx4GmTclSvYnNc)).

The problem for that work: **we cannot produce a single number for the "first token → the user sees something" segment**, because the field that is supposed to hold it has been publishing a constant. `run_finished` carries two same-origin fields that should subtract to that segment:

- `time_to_first_token_ms` — `startAt` → `telemetry.firstTokenAt`
- `time_to_first_visible_output_ms` — `startAt` → `firstVisibleOutputAt`

Across **205,795** `run_finished` events in the last 7 days, the difference is **0 for every single run** — p50, p90, p99 and max are all 0. The field has never carried information.

The cause is a single line. `noteFirstTokenAt()` in `apps/daemon/src/server.ts` stamped **both** marks from one call with one timestamp:

```ts
const noteFirstTokenAt = (timestamp = Date.now()) => {
  if (run.analyticsTelemetry?.firstTokenAt) return;
  lifecycle.mark('first_token', timestamp);
  lifecycle.mark('first_visible_output', timestamp);   // ← same call, same timestamp
};
```

There is a second, correct mark inside `send()` — the daemon's single emission choke point — but `lifecycle.mark` is first-write-wins, and the decode-site call always got there first. So the emission mark could never fire, and the two fields were identical by construction.

That gap is not hypothetical. The daemon does not emit every token it decodes. Between "this is a token" and "these bytes left the daemon" sit the `<od-title>` marker stripper, the fabricated-role-marker safety guard (#3247), and — for the antigravity family — stdout buffering that holds the whole reply until child close. Each of those can leave a run with a first token and the user with an empty bubble.

## What users will see

**Nothing.** This is an observability-only fix: one analytics field that was constant now carries a real measurement. No UI, no CLI, no API shape, no behavior change, no new contract fields.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract** — `time_to_first_visible_output_ms` already exists in `packages/contracts`; its wire shape is unchanged
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — daemon-internal instrumentation + tests

## Screenshots

n/a — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/first-visible-output-mark.test.ts`
- Did the test go red on `main` and green on this branch? **yes**

The spec drives the real wiring — `startServer` plus a fake opencode CLI — and reads the two fields off the actual PostHog `run_finished` payload (the suite stands up a local capture sink and points `POSTHOG_HOST` at it). The bug was never in a helper; it was in which call site owned the mark, so a pure-function test would have passed against the broken code.

Red, against unmodified `main` source with only the spec file added:

```
 ❯ tests/first-visible-output-mark.test.ts (3 tests | 1 failed) 14259ms
     × reports a real gap when the safety guard withholds the first bytes 5474ms

 FAIL  tests/first-visible-output-mark.test.ts > first_visible_output is stamped at emission,
       not at first token > reports a real gap when the safety guard withholds the first bytes
AssertionError: expected 0 to be greater than or equal to 300
 ❯ tests/first-visible-output-mark.test.ts:72:17

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

`expected 0` is the bug verbatim: the daemon withheld the first bytes for 400ms and still reported the two timestamps as identical.

The other two cases are the invariants that must not regress. They are green before the fix as well as after — deliberately, so the fix cannot buy the gap by inventing one:

1. **straight-through text** — a model that streams ordinary prose keeps the gap at `>= 0` and `< 100ms`. No manufactured difference on the common path.
2. **never visible** — a run whose only token is withheld forever still reports the field via the documented `?? firstTokenAt` fallback rather than dropping it.

Green after the fix:

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Re-verified after the second commit below: the final spec was run once more against `origin/main` source (source files checked out, spec kept) and produced the same `expected 0 to be greater than or equal to 300`, then green again on the branch, then five consecutive green runs on a heavily loaded box.

## What changed

### Commit 1 — the mark moves to the emission choke point

Three source edits, all daemon-internal:

- `apps/daemon/src/server.ts` — `noteFirstTokenAt` stamps only `first_token`. `send()` becomes the sole owner of `first_visible_output`, with a comment at both sites saying why the mark may never move back to a decode site.
- `apps/daemon/src/run-lifecycle-tracer.ts` — `stdout` events now count as visible model output. The plain / BYOK / antigravity family has no structured `agent` stream, so without this the whole family reports no visible output and silently falls back to its first token. For antigravity that is exactly backwards: it buffers stdout until child close, so its first token and its first visible byte can be a whole run apart. `stderr` stays excluded — a CLI warning is not the model's answer.
- `apps/daemon/src/run-analytics-observability.ts` — comments only, pinning down the `?? firstTokenAt` fallback contract.

### Commit 2 — read the decode clock before emitting

Splitting the two marks exposed an ordering flaw the shared timestamp had been hiding. On the qoder / json-event-stream / pi-rpc, Copilot and ACP paths the gate reads:

```ts
if (emitTitleFilteredGuardedTextDelta(delta)) noteFirstTokenAt();
```

The gate has to run first to learn whether these bytes are a token at all — but the emit inside it fans the delta out to every SSE client and stamps `first_visible_output` on the way, so the clock for the token is read *after* our own write completes. Two consequences: `time_to_first_token_ms` silently included daemon write latency, and on a loaded box the visible-output mark could land a millisecond **ahead** of the token that produced it, making the gap negative. It surfaced as a flake in the straight-through spec during a full-suite run.

Fix is to capture the decode timestamp before the gate and pass it to `noteFirstTokenAt`. The Claude and plain-stdout paths already stamped the token first and are untouched. With all five sites token-first, `firstVisibleOutputAt >= firstTokenAt` holds by construction rather than by both marks sharing one call — and the straight-through spec now asserts that invariant explicitly instead of relying on exact equality.

Two invariants worth calling out for review:

- **`first_token` keeps its meaning.** It still marks the moment the daemon had the first visible token, and every field derived from it (`time_to_first_token_ms`, `spawn_to_first_token_ms`, `runtime_init_to_first_token_ms`, `generation_duration_ms`) keeps reading the same thing. Commit 2 does shift it by the emission cost of one delta — sub-millisecond idle, a few ms under load — because that cost was our own SSE fan-out being charged to the model. Against TTFT values in the seconds this is below the noise floor, and it is a correction rather than a redefinition; flagged here so nobody is surprised by a hairline move in the dashboards.
- **`last_observed_phase` keeps its labels.** The ladder in `run-analytics-observability.ts` compares these timestamps pairwise. `firstVisibleOutputAt` can now only be *equal to or later than* before, never earlier, so the only reachable change is a run moving from `tool_execution` to `stream_output` — which is the more accurate answer when the visible output genuinely landed after the last tool call. The `laterThan(firstVisibleOutputAt, firstTokenAt) → stream_output` rung was previously dead code and now fires, returning the same label the next rung already returned.

## Adjacent issues

Two things found while verifying, both deliberately left out of this PR:

1. **The title-marker path does not produce a measurable gap, contrary to the obvious reading.** Every `text_delta` handler gates `noteFirstTokenAt()` behind the title stripper succeeding (`if (emitTitleFilteredGuardedTextDelta(ev.delta)) noteFirstTokenAt()`), so a chunk eaten entirely by `<od-title>` delays *both* marks equally. Making that window visible would require a separate raw-arrival mark — a new field with its own definition — rather than a change to `first_token`. Worth doing if product wants "model started producing → user saw it" rather than "daemon accepted a token → user saw it", but it is a data-definition decision, not a bug fix.
2. **`time_to_first_visible_output_ms` is not in the tracking doc.** Rows 18 and 45 of 「Open Design 埋点文档2.0」 list `time_to_first_token_ms`, `generation_duration_ms` and `total_duration_ms` for `run_finished`, but not this field. It needs a row before anyone builds a dashboard on it.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all workspaces)
- `pnpm --filter @open-design/daemon build` — pass, then booted the built daemon from `dist/` in real Node ESM and served `/api/health` → `200 {"ok":true,"version":"0.20.3"}`. Vitest runs through esbuild and tolerates module-shape problems that real ESM rejects, so a green suite is not on its own proof the daemon starts.
- `apps/daemon` targeted suites, all green:
  - `tests/first-visible-output-mark.test.ts` (new), `tests/run-lifecycle-tracer.test.ts`, `tests/run-analytics-observability.test.ts`, `tests/runtimes/runs.test.ts`, `tests/run-diagnostics.test.ts`, `tests/langfuse-bridge.test.ts` — 187 passed
  - `tests/observability/main-run-observation.test.ts`, `tests/retry-orphan-process-group.test.ts`, `tests/run-failure-classification.test.ts`, `tests/run-retry-policy.test.ts`, `tests/run-retry-runtime.test.ts`, `tests/runtimes/acp-stall-last-progress-age.test.ts` — 217 passed
- Full local `apps/daemon` suite — 9239 passed / 16 failed across 5 files. Two are the pre-existing reds on `main` (`od-next-automatic-simple-server.test.ts`, `langfuse-trace.test.ts`). Two more (`chat-route.test.ts`, `integrations/vela.routes.test.ts`) are `beforeAll` hook timeouts at 10s on a box that was running a dozen concurrent vitest processes — neither touches analytics, and both are green on CI. The fifth was the straight-through flake that commit 2 fixes.
- No `apps/web` or `packages/contracts` source changed, so no web-side test delta.


---

## Review round 2 — `09e4bbfb8c`

### 1. The strategy's close-time tail bypassed the mark

The OD Next machine protocol is a third thing that can withhold visible bytes, and unlike the title stripper and the role-marker guard it can hold them *past the end of the stream*: text that might still complete a reserved `<open-design-…>` block is released only when `finish()` rules that out, at child close. That release is persisted and broadcast directly (`server.ts:15221`), never through `send()` — so a reply whose visible text was withheld in its entirety recorded no visible output at all, and the `?? firstTokenAt` fallback collapsed a real close-time wait back to zero. The same dead field, one layer down.

Red first, with the strategy explicitly **on** (the daemon logged `sourceKind: 'bundled'`, `assignmentClass: 'included'`, `primaryReasonCode: 'od_next_rollout_eligible'`, and the run POST returned `pluginId: 'od-next-strategy'` plus a `strategyTask`):

```
 FAIL  tests/first-visible-output-mark.test.ts > first_visible_output is stamped at emission,
       not at first token > reports the close-time wait when the strategy releases the reply at finish
AssertionError: expected 0 to be greater than or equal to 300
```

`send()` and the tail now share one rule — `applyVisibleOutputMarks` — so neither path can decide on its own what counts as visible output. `first_model_event` deliberately does *not* ride along: it records when the daemon **saw** the model respond, and stamping it from a close-time re-emission would replace the summarizer's `?? firstToolUseAt ?? firstTokenAt` fallback with a run-end value and drag every phase boundary with it.

Two notes on severity, so the record is honest:

- The path exists only when OD Next is admitted for the run — `strategyProtocol` is constructed only when a task execution exists, and `routes/runs.ts` creates one only under `effectiveMode === 'active'`. That is the current default, and it is a switch that is expected to move.
- A tail that arrives *after* prose already streamed loses nothing (the mark is first-write-wins). The mark is lost only when the withheld text is the run's **first** visible output.

### 2. Broken telemetry could take the user's reply with it

These marks sit on `send()` — the choke point every stream event passes through on its way to the user — and on the close-time tail. That is pure instrumentation on the product's critical path, so a throw there does not cost an analytics field, it costs the user the whole reply. Nothing in the block realistically throws today, but "safe because it is currently written carefully" is not an invariant, and the thing it protects is the product.

So it is a gate now, not a code-review opinion. `tests/first-visible-output-telemetry-isolation.test.ts` injects a tracer whose marker classification and every mark this change owns throw, then requires the run to deliver its complete reply and reach `succeeded`. Before the fix:

```
 FAIL  tests/first-visible-output-telemetry-isolation.test.ts > lifecycle instrumentation cannot
       cost the user their reply > delivers the whole reply when every lifecycle mark throws
AssertionError: expected 'failed' to be 'succeeded'
```

The marks now run inside `recordRunTelemetry`, a failure-isolated helper scoped to the marks alone — nothing that decides what the user receives is inside the guard — logging once per run rather than swallowing silently. Run-start marks are deliberately left un-injected in the test so the case cannot pass by breaking the run before it ever streams.

### 3. The suite no longer inherits the OD Next rollout default

The original suite forced `OD_NEXT_STRATEGY_ROLLOUT=off`, which is why it could not see any of this. Pinning it to `active` instead would rot the day the default moves — and it is expected to move after 0.21.0. Every case now names its own mode as a required argument, and the strategy case asserts admission actually happened rather than assuming it, so a silent degradation into an ordinary run fails instead of passing for the wrong reason.

### 4. `run_finished` delivery is awaited, not guessed

The 15-second sink cutoff is replaced by the daemon's own analytics flush (`shutdown()` → `analytics.shutdown()` → posthog-node drain). Phase budgets are asserted at module load to stay inside the per-test timeout, and a genuinely missing event still fails.

### Verification

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon build`, then `startServer` from `dist/` — `/api/health` 200, `/api/agents` 200, clean shutdown. Green vitest is not proof the daemon boots; esbuild tolerates module shapes Node's real ESM loader rejects.

### Adjacent issues (not fixed here)

The close-time tail also bypasses `send()`'s accumulators — `visibleAssistantText`, `memoryReplyText`, `clarifyingQuestionText`, `plainArtifactStdout`. A reply released entirely at close therefore contributes nothing to the empty-output guard or the memory extractor. Out of scope for an instrumentation fix; filed here rather than smuggled into this diff.
