### PR TITLE
fix(web): return to the originating conversation from design-system create

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4241,6 +4241,23 @@ function AppInner() {
     [iframeKeepAlivePool, refreshDesignSystems],
   );
 
+  /**
+   * Invariant: leaving `/design-systems/create` returns the user to whatever
+   * surface opened it — the project conversation they were mid-task in, the
+   * composer's design-system picker, the Library, a home card — instead of a
+   * fixed destination. The page is reachable from all of those, so a hardcoded
+   * exit route silently abandons the work the user was in the middle of
+   * (OPEND-2249: creating a design system from inside a project conversation
+   * dropped them on the Design systems tab).
+   *
+   * The Design systems tab stays the fallback: it is where the standalone
+   * entry lives, so a deep link or fresh load — the only case with no in-app
+   * layer to step back to — still lands somewhere that makes sense.
+   */
+  const handleDesignSystemCreateBack = useCallback(() => {
+    goBack({ kind: 'home', view: 'design-systems' });
+  }, []);
+
   const handlePluginsChanged = useCallback((
     context: WorkspaceCollabContext | null,
     accountGeneration: number,
@@ -5062,7 +5079,7 @@ function AppInner() {
   } else if (route.kind === 'design-system-create') {
     appMain = (
       <DesignSystemCreationFlow
-        onBack={() => navigate({ kind: 'home', view: 'design-systems' })}
+        onBack={handleDesignSystemCreateBack}
         designSystems={enabledDS}
         onCreated={(projectId, project, conversationId) => {
           if (project) {

--- a/apps/web/tests/components/App.design-system-create-back.test.tsx
+++ b/apps/web/tests/components/App.design-system-create-back.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for OPEND-2249 — "用户在项目会话中新建设计系统时，不应跳出会话，
+ * 返回按钮应能回到原会话，避免任务中断".
+ *
+ * The `/design-systems/create` page is reachable from several surfaces: the
+ * Design systems tab, the composer's design-system picker, the Library, a home
+ * card — and, per the report, the project canvas' 新建设计体系 button while a
+ * conversation is running. App.tsx wired the page's Back control to a fixed
+ * `navigate({ kind: 'home', view: 'design-systems' })`, so whichever surface
+ * opened the page, Back always dumped the user on the Design systems tab and
+ * abandoned the conversation they were in the middle of.
+ *
+ * Back must step back to the surface that opened the page, and still land on
+ * the Design systems tab when there is no in-app layer behind it.
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import { navigate } from '../../src/router';
+import type { AppConfig, Project } from '../../src/types';
+import { fetchDaemonConfig, loadConfig, mergeDaemonConfig } from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgentsStream,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { fetchAmrModels, fetchVelaLoginStatus } from '../../src/providers/daemon';
+import { listProjects, listTemplates } from '../../src/state/projects';
+import { resetWorkspaceContextCache } from '../../src/collab/useWorkspaceContext';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
+import { workspaceDirectoryFixture } from '../helpers/workspace-context';
+
+// The real router is deliberately NOT mocked: this spec is about which history
+// layer Back lands on, which only the real pushState/popstate bookkeeping can
+// answer.
+
+vi.mock('../../src/components/DesignSystemFlow', () => ({
+  DesignSystemCreationFlow: ({ onBack }: { onBack: () => void }) => (
+    <button type="button" data-testid="ds-create-back" onClick={onBack}>
+      Back
+    </button>
+  ),
+  DesignSystemDetailView: () => <div data-testid="ds-detail-view" />,
+}));
+
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: () => <div data-testid="entry-view">Entry view</div>,
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: () => <div data-testid="project-view">Project view</div>,
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+}));
+
+vi.mock('../../src/components/AmrArtifactUpgradeGate', () => ({
+  AmrArtifactUpgradeGate: () => null,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgentsStream: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/providers/daemon', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/daemon')>(
+    '../../src/providers/daemon',
+  );
+  return {
+    ...actual,
+    fetchAmrModels: vi.fn(),
+    fetchVelaLoginStatus: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
+    loadConfig: vi.fn(),
+    mergeDaemonConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    fetchDaemonConfig: vi.fn().mockResolvedValue({}),
+    fetchMediaProvidersFromDaemon: vi.fn().mockResolvedValue({ status: 'ok', providers: null }),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+    syncMediaProvidersToDaemon: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const baseConfig: AppConfig = {
+  mode: 'api',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: null,
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  composio: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+const project: Project = {
+  id: 'project-1',
+  name: 'Web Prototype',
+  skillId: null,
+  designSystemId: null,
+  customInstructions: '',
+  createdAt: 1,
+  updatedAt: 1,
+  workspaceId: null,
+};
+
+const CONVERSATION_PATH = '/projects/project-1/conversations/conversation-1';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function flushNavigation(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function openCreatePageAndGoBack(): Promise<void> {
+  await act(async () => {
+    navigate({ kind: 'design-system-create' });
+  });
+  await waitFor(() => expect(window.location.pathname).toBe('/design-systems/create'));
+  const back = await screen.findByTestId('ds-create-back');
+  fireEvent.click(back);
+}
+
+describe('design-system create page — Back destination', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    vi.mocked(daemonIsLive).mockResolvedValue(true);
+    vi.mocked(fetchAgentsStream).mockResolvedValue([]);
+    vi.mocked(fetchSkills).mockResolvedValue([]);
+    vi.mocked(fetchDesignSystems).mockResolvedValue([]);
+    vi.mocked(fetchPromptTemplates).mockResolvedValue([]);
+    vi.mocked(fetchAppVersionInfo).mockResolvedValue(null);
+    vi.mocked(listProjects).mockResolvedValue([project]);
+    vi.mocked(listTemplates).mockResolvedValue([]);
+    vi.mocked(loadConfig).mockReturnValue({ ...baseConfig });
+    vi.mocked(mergeDaemonConfig).mockImplementation((local) => local);
+    vi.mocked(fetchDaemonConfig).mockResolvedValue({});
+    vi.mocked(fetchAmrModels).mockResolvedValue({
+      source: 'preset',
+      refreshing: false,
+      models: [],
+    });
+    vi.mocked(fetchVelaLoginStatus).mockResolvedValue({
+      loggedIn: false,
+      loginInFlight: false,
+      profile: 'prod',
+      user: null,
+      configPath: '/tmp/amr-config.json',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/api/workspace/directory')) {
+          return jsonResponse(workspaceDirectoryFixture([]));
+        }
+        return jsonResponse({});
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('returns to the project conversation the user opened it from', async () => {
+    await act(async () => {
+      navigate({
+        kind: 'project',
+        projectId: 'project-1',
+        conversationId: 'conversation-1',
+        fileName: null,
+      });
+    });
+    await flushNavigation();
+    expect(window.location.pathname).toBe(CONVERSATION_PATH);
+
+    render(<App />);
+    await screen.findByTestId('project-view');
+
+    await openCreatePageAndGoBack();
+
+    // The conversation is mid-task; Back must put the user back in it rather
+    // than dumping them on the Design systems tab.
+    await waitFor(() => expect(window.location.pathname).toBe(CONVERSATION_PATH));
+    await screen.findByTestId('project-view');
+  });
+
+  it('still returns to the Design systems tab for the standalone entry', async () => {
+    await act(async () => {
+      navigate({ kind: 'home', view: 'design-systems' });
+    });
+    await flushNavigation();
+    expect(window.location.pathname).toBe('/design-systems');
+
+    render(<App />);
+    await screen.findByTestId('entry-view');
+
+    await openCreatePageAndGoBack();
+
+    await waitFor(() => expect(window.location.pathname).toBe('/design-systems'));
+  });
+
+  it('falls back to the Design systems tab when the page was deep-linked', async () => {
+    window.history.replaceState(null, '', '/design-systems/create');
+
+    render(<App />);
+    const back = await screen.findByTestId('ds-create-back');
+    fireEvent.click(back);
+
+    await waitFor(() => expect(window.location.pathname).toBe('/design-systems'));
+  });
+});


### PR DESCRIPTION
Plane: **OPEND-2249** — 用户在项目会话中新建设计系统时，不应跳出会话，返回按钮应能回到原会话，避免任务中断
(reported by 李锦威; not a GitHub issue, so no `Fixes #`).

## Why

**Use case.** Picked this up from the OPEND-2249 report. The reporter was mid-run in a
project conversation ("Web Prototype", Claude 执行中), used the design-files empty-state
`新建设计体系` button to start a design system, then hit `← 返回` on the create page —
and landed on the Design systems tab instead of back in the conversation.

**The pain.** `/design-systems/create` is reachable from five different surfaces: the
Design systems tab, the composer's design-system picker, the Library's asset selection,
a home card, and the project canvas' `新建设计体系` button. App.tsx wired the page's Back
control to one fixed destination — `navigate({ kind: 'home', view: 'design-systems' })` —
so no matter which surface opened it, Back dropped the user on the Design systems tab.
From inside a running conversation that reads as being thrown out of your own task: the
project, the chat, and the file the user was working on are all gone, and getting back
means re-navigating by hand. Nothing carried the originating surface into the page, so
Back had no way to honour it.

## What users will see

Leaving the design-system creation page now returns you to wherever you opened it from.

- Start a design system from inside a project conversation → `← 返回` puts you back in
  that conversation, with the run and the open file exactly as you left them.
- Start one from the composer's design-system picker, from the Library, or from a home
  card → Back returns to that surface rather than to the Design systems tab.
- Start one from the sidebar `设计体系` tab → Back still returns to the Design systems
  tab, unchanged.
- Open `/design-systems/create` directly by URL (no in-app screen behind it) → Back still
  falls back to the Design systems tab, so it can never escape the app.

No visual change: same button, same label, same position. Only where it lands.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

`UI` is ticked for the behaviour of an existing control, not a new surface; `Default
behavior change` because the Back destination changes for four of the five entry points
without anyone opting in.

## Screenshots

No visual diff to show — the control, its label and its position are untouched; only its
destination changed. The entry point is the project canvas' design-files empty state
(`data-testid="design-files-empty-create-design-system"`, rendered as `新建设计体系` next
to 新建草图 / 新建文档 / 上传 / 新建浏览器) and the create page's top-left `← 返回`; both
are captured in the reporter's screenshots on OPEND-2249. `needs-validation` is set so
the change is confirmed by hand in a real client.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/App.design-system-create-back.test.tsx`
- Did the test go red on `main` and green on this branch? **yes**

Red, on the unmodified branch (the test renders the real `App` with the real router, walks
`/projects/project-1/conversations/conversation-1` → `/design-systems/create`, and clicks
the create page's Back control):

```
Expected: "/projects/project-1/conversations/conversation-1"
Received: "/design-systems"

 ❯ tests/components/App.design-system-create-back.test.tsx:254:58

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

The two passing cases are the deliberate regression guards — the standalone Design
systems tab entry and the deep-linked page — which must keep their current destination
and did, before and after. Green on this branch: `Tests 3 passed (3)`.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all packages)
- `pnpm --filter @open-design/web test` — full suite green:
  `Test Files 654 passed (654)` / `Tests 6981 passed | 1 expected fail | 11 skipped (6993)`

  A first run of the full suite showed one failure in
  `tests/components/ProjectView.reattach-restore.test.tsx` — a `waitFor` timeout while
  three vitest suites were sharing the machine. That file passes 43/43 in isolation and
  the whole suite is green on the re-run above; the diff here touches only the
  design-system create route's Back handler and cannot reach ProjectView's chat stream.

## Notes on the fix

`goBack(fallback)` already exists in `apps/web/src/router.ts` for exactly this shape —
it pops the history layer the user actually came from and only falls back to a fixed
route when the current entry is the first in-app one (deep link / fresh load).
`PluginDetailView` already uses it. This change routes the create page's Back through
the same helper, behind a named `handleDesignSystemCreateBack` whose docblock states the
invariant, so the call site reads as intent instead of a hardcoded route.

## Adjacent issues (out of scope, no change here)

- `/design-systems/:id` (the design-system **detail** page) has the same hardcoded
  `onBack` in App.tsx. It is reachable from the Design systems tab and from the Library,
  neither of which is a mid-task conversation, so it is outside OPEND-2249's boundary —
  but it is the same latent shape and worth its own red spec.
- After a successful generation the flow pushes the new project onto history rather than
  replacing the create entry, so a browser Back from the generated design system lands on
  the stale create form. Pre-existing, unchanged by this PR.

## Open product question

The report only names the project-conversation entry. Routing Back through history also
changes the destination for the composer picker, the Library and the home card (they now
return to their own surface instead of the Design systems tab). That is the least
surprising reading of a Back control and it is what every other full-page surface in the
app does — but if product wants those three to keep landing on the Design systems tab,
that needs an explicit per-entry destination rather than history semantics.
