### PR TITLE
fix(web): localize skill card descriptions in the plugin library

### DIFF
--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -29,7 +29,8 @@ import {
   type SkillImportInput,
   type SkillImportError,
 } from '../providers/registry';
-import { localizeSkillName } from '../i18n/content';
+import { localizeSkillDescription, localizeSkillName } from '../i18n/content';
+import type { Locale } from '../i18n/types';
 import { useAnalytics } from '../analytics/provider';
 import {
   trackPageView,
@@ -922,6 +923,26 @@ function skillCardCategory(skill: SkillSummary): MarketCardCategory | null {
   const slug = skill.category?.trim();
   if (!slug) return null;
   return { slug, label: humanizeCategory(slug) };
+}
+
+/**
+ * A card's headline and its summary always resolve through the SAME locale.
+ * A skill carries both halves — `displayName` from the `en_name` / `zh_name`
+ * frontmatter and `descriptionI18n` from `en_description` / `zh_description`,
+ * plus the built-in `skillCopy` translation tables in `i18n/content` — so
+ * pairing a localized title with the raw frontmatter `description` is what
+ * produced OPEND-2250's Chinese-title / English-summary card. The plugin
+ * builder above already holds this invariant through `localizePluginTitle` +
+ * `localizePluginDescription`; skills go through here for the same reason.
+ */
+function localizeSkillCardCopy(
+  locale: Locale,
+  skill: SkillSummary,
+): { title: string; description: string } {
+  return {
+    title: localizeSkillName(locale, skill),
+    description: localizeSkillDescription(locale, skill),
+  };
 }
 
 type MarketCardAction =
@@ -1838,13 +1859,13 @@ export function ExtensionsMarketplace({
       };
     };
     const skillCard = (skill: SkillSummary, personal: boolean): MarketCard => {
-      const title = localizeSkillName(locale, skill);
+      const { title, description } = localizeSkillCardCopy(locale, skill);
       const shared = sharedSkillIds.has(skill.id);
       const canUnshare = sharedSkillMeta.get(skill.id)?.canUnshare === true;
       return {
         id: skill.id,
         title,
-        description: skill.description || '',
+        description,
         accent: marketAccent(skill.id),
         // #5517's skill row carries a "试一试" action just like a plugin row;
         // the port dropped it, which left every skill card with no way to use
@@ -1946,11 +1967,15 @@ export function ExtensionsMarketplace({
       const meta = sharedSkillMeta.get(id);
       const canUnshare = meta?.canUnshare === true;
       const skill = skills.find((row) => row.id === id) ?? null;
-      const title = skill ? localizeSkillName(locale, skill) : meta?.title || id;
+      // A team-shared skill that is also on this machine resolves through the
+      // same locale invariant as a local one; a shared row we have no local
+      // copy of falls back to the share record, which carries no translations.
+      const localized = skill ? localizeSkillCardCopy(locale, skill) : null;
+      const title = localized?.title ?? (meta?.title || id);
       return {
         id,
         title,
-        description: skill?.description || meta?.description || '',
+        description: localized?.description || meta?.description || '',
         accent: marketAccent(id),
         action: skill ? { kind: 'use-skill', skill } : { kind: 'none' },
         detail: skill ? { kind: 'skill', skill } : null,

--- a/apps/web/tests/components/ExtensionsMarketplace.skill-card-i18n.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.skill-card-i18n.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+// Red spec for OPEND-2250: a skill card in 插件 → 技能 rendered its title
+// through `localizeSkillName` but handed the raw English frontmatter
+// `description` straight to the card, so a zh-CN user saw a Chinese title
+// stacked on an English summary in the same card (screenshot: 「杂志文章」 +
+// "Huashu / huashu-md-html-inspired magazine article layout…").
+//
+// The neighbouring plugin card has always resolved BOTH halves through the
+// locale (`localizePluginTitle` + `localizePluginDescription`); only the skill
+// card builder was half-wired.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { ExtensionsMarketplace } from '../../src/components/PluginsView';
+import { I18nProvider } from '../../src/i18n';
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return { ...actual, useAnalytics: () => ({ track: vi.fn() }) };
+});
+
+// Spread the real module — see the note in ExtensionsMarketplace.team-scope.test.tsx.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
+  useWorkspaceContext: () => ({ context: null, loading: false, refresh: vi.fn() }),
+  useWorkspaceBilling: () => null,
+}));
+
+// Mirrors `skills/article-magazine/SKILL.md`, the card in the OPEND-2250
+// screenshot: it carries `zh_name` / `zh_description` frontmatter, which the
+// daemon projects onto `displayName` / `descriptionI18n` (apps/daemon/src/skills.ts).
+const LOCALIZED_SKILL = {
+  id: 'article-magazine-fixture',
+  name: 'article-magazine-fixture',
+  displayName: { en: 'Magazine Article', 'zh-CN': '杂志文章' },
+  description: 'Magazine article layout for turning Markdown into a long-form HTML essay.',
+  descriptionI18n: {
+    en: 'Magazine article layout for turning Markdown into a long-form HTML essay.',
+    'zh-CN': '杂志文章版式，将 Markdown 或笔记转成精排长文 HTML。',
+  },
+  triggers: [],
+  mode: 'prototype',
+  surface: 'web',
+  source: 'built-in',
+  category: 'documents',
+  previewType: 'html',
+  designSystemRequired: false,
+  defaultFor: [],
+  examplePrompt: 'Turn these notes into a magazine article.',
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url === '/api/skills') return jsonResponse({ skills: [LOCALIZED_SKILL] });
+    if (url.startsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+    if (url.startsWith('/api/marketplaces')) return jsonResponse({ marketplaces: [] });
+    if (url.includes('/api/workspace/')) return jsonResponse({ ids: [], resources: [] });
+    return jsonResponse({});
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** Switches the catalog from 专家套件 to 技能; the landing scope stays official. */
+async function showOfficialSkills(container: HTMLElement) {
+  const modeButtons = container.querySelectorAll('.plugin-marketplace__switch button');
+  const skillsTab = modeButtons[modeButtons.length - 1] as HTMLElement;
+  skillsTab.click();
+  await waitFor(() => {
+    expect(container.querySelector('.plugin-marketplace__item--skill')).toBeTruthy();
+  });
+}
+
+describe('OPEND-2250 — skill card title and description share one locale', () => {
+  it('renders the zh-CN description alongside the zh-CN title', async () => {
+    const { container } = render(
+      <I18nProvider initial="zh-CN">
+        <ExtensionsMarketplace onCreatePlugin={vi.fn()} onUsePlugin={vi.fn()} />
+      </I18nProvider>,
+    );
+
+    await showOfficialSkills(container);
+
+    const card = container.querySelector('.plugin-marketplace__item--skill') as HTMLElement;
+    expect(card.textContent).toContain('杂志文章');
+    // The defect: the summary line stayed on the English frontmatter string.
+    expect(card.textContent).toContain('杂志文章版式，将 Markdown 或笔记转成精排长文 HTML。');
+    expect(card.textContent).not.toContain(
+      'Magazine article layout for turning Markdown into a long-form HTML essay.',
+    );
+  });
+
+  it('keeps the English description for an English UI', async () => {
+    const { container } = render(
+      <I18nProvider initial="en">
+        <ExtensionsMarketplace onCreatePlugin={vi.fn()} onUsePlugin={vi.fn()} />
+      </I18nProvider>,
+    );
+
+    await showOfficialSkills(container);
+
+    const card = container.querySelector('.plugin-marketplace__item--skill') as HTMLElement;
+    expect(card.textContent).toContain('Magazine Article');
+    expect(card.textContent).toContain(
+      'Magazine article layout for turning Markdown into a long-form HTML essay.',
+    );
+  });
+});


### PR DESCRIPTION
Refs OPEND-2250.

## Why

Reported on OPEND-2250 (李锦威): *「用户浏览 Skill 库时遇到中英文混用不一致，期望 Skill 标题与描述按用户语言统一呈现」* — browsing the Skill library on a Chinese UI, a card shows a Chinese title above an English summary.

I traced the screenshot to a single half-wired call site rather than a content gap. In `PluginsView.tsx`, the skill card builder resolved the **title** through `localizeSkillName(locale, skill)` but assigned the **description** straight from `skill.description` — the raw frontmatter string. The plugin card builder sitting three lines above it has always resolved both halves (`localizePluginTitle` + `localizePluginDescription`); only skills were half-wired.

That contradicts two rules already written down in this repo:

- `docs/skills-protocol.md` — `zh_description` / `en_description` are the *"localized picker description; falls back to `description`"*.
- `docs/skills-contributing.md` — *"Keep `description` and `od.example_prompt` in English because those are the fallback fields for every locale without localized copy."*

So the field the card was rendering is, by design, the English fallback. Reading it directly skipped the whole resolution chain the daemon and the i18n layer already build: `apps/daemon/src/skills.ts` projects `zh_description`/`en_description` onto `SkillSummary.descriptionI18n`, and `apps/web/src/i18n/content.*.ts` ships a `skillCopy` table on top of it.

The translations were already there and simply not read: **155 of 164 built-in skills have a zh-CN description in `apps/web/src/i18n/content.zh-CN.ts`**, including all ten cards visible in the reporter's screenshot. Every non-English locale (18 bundles) is affected the same way, not just Chinese.

## What users will see

In 插件 → 技能, a skill card's summary line now renders in the UI language instead of always in English — e.g. 「杂志文章」 is now described as 「杂志文章版式，将 Markdown 或笔记转成精排长文 HTML。」 instead of "Huashu / huashu-md-html-inspired magazine article layout…". Title and summary on one card can no longer disagree about which language they are in.

The catalog's search box matches the text the user can actually see, which is the behavior plugin cards already had.

Skills with no translation for the active locale are unchanged — they keep falling back to the English `description`, exactly as `docs/skills-contributing.md` specifies.

### What this PR deliberately does NOT fix

Two other things on that screen are still mixed-language, and both need a product decision rather than a patch:

1. **The category chip row** ("Marketing Creative", "Design Engineering", "3d Shaders", …) stays English while the 全部 chip next to it is translated. Those labels are not translated anywhere — `skillCardCategory` (`PluginsView.tsx`) mechanically Title-Cases the `od.category` frontmatter slug via `humanizeCategory` (`SkillsSection.tsx`), and the plugin-mode labels come from a hardcoded English table in `plugins-home/facets.ts`. Unlike design-system and prompt-template categories, skill categories have no localized table at all. Building one needs a product call first: the slug set is open-ended (~42 distinct slugs are in use across `skills/` and `design-templates/`, while `skills/AGENTS.md` documents only 14 as the intended taxonomy), so someone has to decide the canonical taxonomy and its display names before they can be translated into 18 locales.

2. **Skill card titles are slugs** (`ad-creative`, `apple-hig`) for every skill except the handful that author `zh_name`/`en_name`, which is why exactly one card in the screenshot has a Chinese title. Whether the library should show human display names — and in which language — is a content decision about `SKILL.md` authoring, not a code bug. I found no rule in the repo requiring skill titles to be localized, or requiring skills to be authored in English.

## Surface area

- [x] **UI** — 插件 → 技能 catalog card copy in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (no new keys; this consumes translations that already ship in `apps/web/src/i18n/content.*.ts`)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — non-English users see localized skill summaries in the library without opting in

## Screenshots

Entry point is 插件 → 技能 (the catalog in the OPEND-2250 report). The affected element is the summary line under each card title.

Before (from the report, zh-CN UI): card reads 「杂志文章」 / "Huashu / huashu-md-html-inspired magazine article layout for turning Markdown or notes into a polished long-form HTML essay."

After: card reads 「杂志文章」 / 「Huashu / huashu-md-html 风格杂志文章版式, 将 Markdown 或笔记转成精排长文 HTML。」

This is asserted directly in `apps/web/tests/components/ExtensionsMarketplace.skill-card-i18n.test.tsx`, which renders the real `ExtensionsMarketplace` under `I18nProvider initial="zh-CN"` and reads the rendered card text.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ExtensionsMarketplace.skill-card-i18n.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — it was written first and run against unmodified `origin/main` source.

Red (unmodified source, full web suite run):

```
FAIL  tests/components/ExtensionsMarketplace.skill-card-i18n.test.tsx > OPEND-2250 — skill card title and description share one locale > renders the zh-CN description alongside the zh-CN title
AssertionError: expected '杂志杂志文章Magazine article layout for tur…' to contain '杂志文章版式，将 Markdown 或笔记转成精排长文 HTML。'

Expected: "杂志文章版式，将 Markdown 或笔记转成精排长文 HTML。"
Received: "杂志杂志文章Magazine article layout for turning Markdown into a long-form HTML essay."

Test Files  1 failed | 653 passed (654)
     Tests  1 failed | 6979 passed | 1 expected fail | 11 skipped (6992)
```

The received string is the defect itself: the localized title (`杂志文章`, plus its `杂志` avatar initials) rendered next to the English fallback description. The companion English-UI case passed on both sides, so the assertion is not vacuous — it pins the locale-sensitive half only.

Green (this branch, full web suite):

```
Test Files  654 passed (654)
     Tests  6980 passed | 1 expected fail | 11 skipped (6992)
```

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all packages)
- `pnpm --filter @open-design/web test` — 654 files / 6980 passed / 1 expected fail / 11 skipped, no regressions against the pre-change baseline of the same run
