### PR TITLE
fix(daemon): isolate task observation manifest env

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -130,6 +130,7 @@ export interface BuildSafeRunQualityProjectionFromDaemonOpts {
   run: SafeRunQualityDaemonRunRecord;
   prefs: TelemetryPrefs;
   installationId?: string | null;
+  env?: NodeJS.ProcessEnv;
   fetchImpl?: typeof fetch;
 }
 
@@ -1087,6 +1088,7 @@ export async function buildSafeRunQualityProjectionFromDaemon(
     artifacts: buildTraceObjectArtifactSources(traceObjectFilesRaw),
     prompt: run.userPrompt ?? '',
     prefs: opts.prefs,
+    ...(opts.env ? { env: opts.env } : {}),
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
     uploadMode: 'manifest-only',
   });

--- a/apps/daemon/src/observability/task-observation-rollout.ts
+++ b/apps/daemon/src/observability/task-observation-rollout.ts
@@ -506,6 +506,7 @@ async function taskAggregate(
           ...(telemetry.installationId !== undefined
             ? { installationId: telemetry.installationId }
             : {}),
+          ...(options.env ? { env: options.env } : {}),
           ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
         })
       : undefined;

--- a/apps/daemon/tests/observability/task-observation-rollout.test.ts
+++ b/apps/daemon/tests/observability/task-observation-rollout.test.ts
@@ -253,6 +253,7 @@ describe('task observation rollout', () => {
   afterEach(() => {
     closeDatabase();
     fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 
@@ -547,6 +548,10 @@ describe('task observation rollout', () => {
   });
 
   it('rebuilds safe Run quality from durable facts before exporting the Task payload', async () => {
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
     upsertMessage(db, 'conversation-1', {
       id: 'user-quality',
       role: 'user',


### PR DESCRIPTION
## Why

The `release/v0.21.0` prerelease pipeline is blocked before packaging because the task-observation rollout test reads the release runner's global `OPEN_DESIGN_TELEMETRY_RELAY_URL` while the rollout service itself is configured with an explicit test environment. That makes manifest-only registration report `unavailable` instead of the fixture's expected fallback completeness.

This change keeps the rollout's explicit environment authoritative all the way through manifest construction. Production callers that do not inject an environment continue to use `process.env`.

Failed release runs:

- https://github.com/nexu-io/open-design/actions/runs/32811276694
- https://github.com/nexu-io/open-design/actions/runs/32817251229

## What users will see

No product UI or runtime behavior change. After this fix is merged and backported to `release/v0.21.0`, prerelease validation can reach the platform packaging jobs again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is an internal test-environment isolation fix.

## Bug fix verification

- Test path: `apps/daemon/tests/observability/task-observation-rollout.test.ts`
- Red on `main`: yes — with the release relay environment, expected `manifestCompleteness: complete` but received `unavailable`.
- Green on this branch: yes — the focused test and all 55 tests in the file pass with the same release relay environment.

## Validation

- `env OPEN_DESIGN_TELEMETRY_RELAY_URL=https://telemetry.open-design.ai/api/langfuse pnpm exec vitest run -c vitest.config.ts tests/observability/task-observation-rollout.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
