### PR TITLE
fix(web): keep Home tabs active when switching to Image

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -2574,6 +2574,7 @@ export function HomeView({
             // template/preset or types their own prompt.
             suppressPromptUpdate: true,
             replaceWithoutConfirmation: true,
+            deferApply: true,
           });
           return;
         }

--- a/apps/web/tests/components/HomeView.media-options.test.tsx
+++ b/apps/web/tests/components/HomeView.media-options.test.tsx
@@ -85,6 +85,22 @@ afterEach(() => {
 });
 
 describe('HomeView media composer options', () => {
+  it('keeps the type tabs interactive while switching to Image', async () => {
+    const mediaApplyResponse = new Promise<Response>(() => undefined);
+    stubFetch({ mediaApplyResponse });
+    renderHome();
+
+    const imageTab = await screen.findByTestId('home-hero-type-pill-image');
+    const prototypeTab = await screen.findByTestId('home-hero-type-pill-prototype');
+    await waitFor(() => expect((imageTab as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(imageTab);
+
+    await waitFor(() => expect(imageTab.getAttribute('aria-selected')).toBe('true'));
+    expect((imageTab as HTMLButtonElement).disabled).toBe(false);
+    expect((prototypeTab as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it('shows the Home composer mode picker and still defaults to Design mode', async () => {
     stubFetch();
     const onSubmit = vi.fn();
@@ -563,6 +579,7 @@ describe('HomeView media composer options', () => {
       emptyWorkspaceDirectory: true,
       teamMediaPlugin: true,
     });
+    const onSubmit = vi.fn();
     workspaceContextMock.state = {
       context: null,
       resourceReadIdentity: null,
@@ -570,13 +587,12 @@ describe('HomeView media composer options', () => {
       identityChangePending: false,
       failure: undefined,
     };
-    renderHome();
+    renderHome({ onSubmit });
 
     await clickHomeRailChip('video');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('home-hero-submit').getAttribute('aria-busy')).toBe('false');
-    });
+    await setHomePrompt('Create a launch teaser.');
+    await submitHome();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     const apply = fetchMock.mock.calls.find(([url]) => (
       typeof url === 'string' && url.includes('/api/plugins/od-media-generation/apply')
     ));
@@ -584,11 +600,14 @@ describe('HomeView media composer options', () => {
     expect(new Headers(apply?.[1]?.headers).has('x-od-workspace-id')).toBe(false);
   });
 
-  it('preserves od-media-generation required inputs when applying media chips', async () => {
+  it('preserves od-media-generation required inputs when submitting media chips', async () => {
     const fetchMock = stubFetch();
-    renderHome();
+    const onSubmit = vi.fn();
+    renderHome({ onSubmit });
 
     await clickHomeRailChip('image');
+    await setHomePrompt('Create a campaign image.');
+    await submitHome();
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some(([url, init]) => (
@@ -605,7 +624,6 @@ describe('HomeView media composer options', () => {
       subject: 'a polished product concept',
       style: 'cinematic, high-quality, on-brand',
       aspect: '16:9',
-      ratio: '16:9',
     });
   });
 });
@@ -629,6 +647,7 @@ function stubFetch(options: {
   elevenLabsVoices?: Array<{ voiceId: string; name: string; category?: string }>;
   elevenLabsVoiceError?: string;
   emptyWorkspaceDirectory?: boolean;
+  mediaApplyResponse?: Promise<Response>;
   teamMediaPlugin?: boolean;
   workspaceDirectoryStatus?: number;
 } = {}) {
@@ -673,6 +692,7 @@ function stubFetch(options: {
         if (!inputs.subject) {
           return json({ error: 'missing_inputs', fields: ['subject'] }, 422);
         }
+        if (options.mediaApplyResponse) return options.mediaApplyResponse;
       }
       return json(applyResult(pluginId));
     }


### PR DESCRIPTION
## Why

OPEND-2169 reports that switching from another Home creation type to Image briefly grays out the entire type-tab row and makes the switch feel slow. The Image path was eagerly applying the media plugin while the other creation types already treat a tab click as a local mode switch, so ordinary network latency surfaced as a disabled UI state.

## What users will see

Switching from Prototype, Slide deck, or another Home creation type to Image now selects Image immediately without dimming or disabling the full tab row. Plugin application still happens when the user submits the composer.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the OPEND-2169 reporter screenshots show Image selected while every type tab is disabled and rendered at reduced opacity.

After: verified locally on the Home entry point after a clean `tools-dev` restart. Image is selected and the entire type row remains enabled. Local screenshot was captured during validation but is not attached to the PR.

## Bug fix verification

- Test path: `apps/web/tests/components/HomeView.media-options.test.tsx` — `keeps the type tabs interactive while switching to Image`
- Red on `main`: yes. With the media apply response held pending, both Image and Prototype became `disabled=true`.
- Green on this branch: yes. The same delayed-response test keeps both tabs enabled, and the full media composer test file passes.

## Validation

- `pnpm --filter @open-design/web exec vitest run --maxWorkers=2 tests/components/HomeView.media-options.test.tsx` — 21 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed (existing landing-page hints only)
- Browser: clean `pnpm tools-dev` run at `http://127.0.0.1:17770/`; immediately after clicking Image, all eight type tabs and the All button remained enabled, Image was active, and example cards loaded normally
