### PR TITLE
fix(daemon): resolve trace-object relay from the injected env

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -131,6 +131,14 @@ export interface BuildSafeRunQualityProjectionFromDaemonOpts {
   prefs: TelemetryPrefs;
   installationId?: string | null;
   fetchImpl?: typeof fetch;
+  /**
+   * Environment that decides trace-object relay resolution. Callers that carry
+   * their own env (the Task observation rollout service) must have that env
+   * decide the projection too — reading `process.env` here instead would let
+   * ambient relay configuration change the projection behind the caller's back.
+   * Defaults to `process.env` when omitted.
+   */
+  env?: NodeJS.ProcessEnv;
 }
 
 /** Minimal durable Run surface required to rebuild the Task-safe projection. */
@@ -1088,6 +1096,7 @@ export async function buildSafeRunQualityProjectionFromDaemon(
     prompt: run.userPrompt ?? '',
     prefs: opts.prefs,
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    ...(opts.env ? { env: opts.env } : {}),
     uploadMode: 'manifest-only',
   });
   const manifests = mergeTraceSafeManifests(fallbackManifests, registrationManifests);

--- a/apps/daemon/src/observability/task-observation-rollout.ts
+++ b/apps/daemon/src/observability/task-observation-rollout.ts
@@ -507,6 +507,7 @@ async function taskAggregate(
             ? { installationId: telemetry.installationId }
             : {}),
           ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+          ...(options.env ? { env: options.env } : {}),
         })
       : undefined;
     const modelId = run.resolvedModelId ?? run.model ?? undefined;

--- a/apps/daemon/tests/observability/task-observation-rollout.test.ts
+++ b/apps/daemon/tests/observability/task-observation-rollout.test.ts
@@ -254,6 +254,7 @@ describe('task observation rollout', () => {
     closeDatabase();
     fs.rmSync(tempDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   function service(input: {
@@ -546,7 +547,11 @@ describe('task observation rollout', () => {
     expect(batch.filter((event) => event.type === 'span-create')).toHaveLength(1);
   });
 
-  it('rebuilds safe Run quality from durable facts before exporting the Task payload', async () => {
+  /**
+   * Seeds the durable Run/message facts the safe-quality projection reads and
+   * returns the matching Run record.
+   */
+  function seedRunQualityFacts(): SyntheticRunLike {
     upsertMessage(db, 'conversation-1', {
       id: 'user-quality',
       role: 'user',
@@ -566,7 +571,7 @@ describe('task observation rollout', () => {
       producedFiles: [{ path: '/Users/alice/result.html', size: 84, kind: 'html' }],
       createdAt: 1_900,
     });
-    const run: SyntheticRunLike = {
+    return {
       ...syntheticRun(),
       status: 'failed',
       assistantMessageId: 'assistant-quality',
@@ -599,8 +604,13 @@ describe('task observation rollout', () => {
         ...syntheticRun().events,
       ],
     };
-    const fetchImpl = vi.fn<typeof fetch>(async () => acceptedResponse());
+  }
 
+  async function exportRunQualityBatch(run: SyntheticRunLike): Promise<Array<{
+    type: string;
+    body: Record<string, unknown>;
+  }>> {
+    const fetchImpl = vi.fn<typeof fetch>(async () => acceptedResponse());
     await expect(service({
       mode: 'send',
       dataDir: tempDir,
@@ -608,11 +618,11 @@ describe('task observation rollout', () => {
       fetchImpl,
       getRun: (runId) => runId === 'run-1' ? run : null,
     }).finalizeForRun('run-1')).resolves.toMatchObject({ action: 'sent' });
+    return JSON.parse(String(fetchImpl.mock.calls[0]![1]!.body)).batch;
+  }
 
-    const batch = JSON.parse(String(fetchImpl.mock.calls[0]![1]!.body)).batch as Array<{
-      type: string;
-      body: Record<string, unknown>;
-    }>;
+  it('rebuilds safe Run quality from durable facts before exporting the Task payload', async () => {
+    const batch = await exportRunQualityBatch(seedRunQualityFacts());
     const runSpan = batch.find((event) => event.body.name === 'strategy-stage:request')!;
     const toolSpan = batch.find((event) => (
       (event.body.metadata as Record<string, unknown> | undefined)?.toolName === 'Bash'
@@ -633,6 +643,26 @@ describe('task observation rollout', () => {
     expect(serialized).not.toContain('/Users/alice');
     expect(serialized).not.toContain('/home/alice');
     expect(serialized).not.toContain('private artifact body');
+  });
+
+  it('resolves trace-object relay configuration from the injected env, not process.env', async () => {
+    // The release workflows export OPEN_DESIGN_TELEMETRY_RELAY_URL so the
+    // packaged build ships with a relay; ci.yml does not. Any telemetry path
+    // that reads process.env instead of the env handed to the service reports
+    // a different Task payload in those two runs for the same durable facts.
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.example.test/api/langfuse',
+    );
+
+    const batch = await exportRunQualityBatch(seedRunQualityFacts());
+    const runSpan = batch.find((event) => event.body.name === 'strategy-stage:request')!;
+
+    expect(runSpan.body.metadata).toMatchObject({
+      manifestCompleteness: 'complete',
+      attachmentManifest: [{ object_class: 'attachment', size_bytes: 42 }],
+      artifactManifest: [{ object_class: 'artifact', size_bytes: 84, type: 'html' }],
+    });
   });
 
   it('exports the mapped raw hostComposed identity and bounded exact-text payload', async () => {


### PR DESCRIPTION
## Why

Every push to a `release/**` branch since 2026-08-24 has failed to cut a prerelease. `notify-release-feishu` reuses `release-prerelease.yml`, and its **Daemon tests (2/4)** shard dies on one assertion, which skips the mac/win/linux build and publish jobs — the Feishu card still posts (its `notify` job runs on `!cancelled()`), so the failure reads as "0.21.0-prerelease.1 shipped" when in fact nothing was built. `release/v0.20.3` and `release/v0.21.0` are both blocked by this.

```
tests/observability/task-observation-rollout.test.ts
  > rebuilds safe Run quality from durable facts before exporting the Task payload
  - manifestCompleteness: "complete"    (expected)
  + manifestCompleteness: "unavailable" (received)
```

The failure is an env-injection leak, not a flake. `release-prerelease.yml` exports `OPEN_DESIGN_TELEMETRY_RELAY_URL` at workflow level so the packaged build ships with a relay; `ci.yml` does not (only the five release workflows set it). The Task observation rollout service takes an injected `env`, but that injection stopped short of `buildSafeRunQualityProjectionFromDaemon`, which forwarded no `env` to `buildTraceObjectManifests` — so the manifest builder fell back to `process.env`. With a relay visible there it takes the registration path and returns entries marked `status: 'unavailable'`, which `mergeTraceSafeManifests` then prefers over the fully-described local manifest, downgrading `manifestCompleteness` to `unavailable`.

Net effect: the same durable Run facts produced two different Task payloads depending on whether the surrounding process happened to have a relay URL exported. This PR makes the injected env authoritative, so it doesn't.

`BuildTraceObjectManifestsOptions` already had the optional `env` field; the two call sites just never passed it.

## What users will see

Nothing at runtime. In the daemon the injected env is `process.env` in production, so the resolved relay configuration and every telemetry payload are byte-identical. The user-visible effect is that release branches can cut prereleases again.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/observability/task-observation-rollout.test.ts` → `resolves trace-object relay configuration from the injected env, not process.env`
- Did the test go red on `main` and green on this branch? **yes**

The new spec stubs `process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL` while the service's injected env carries no relay, and asserts the injected env decides. It is red on `main` under plain `ci.yml` conditions — it does not depend on the runner happening to export the variable — and green here.

```
# red, on main, with the source change reverted (no ambient relay var):
-   "manifestCompleteness": "complete"
+   "manifestCompleteness": "unavailable"

# green, on this branch, both with and without the release-workflow env
```

The pre-existing `rebuilds safe Run quality …` test is unchanged in intent; its fixture setup is extracted into `seedRunQualityFacts()` / `exportRunQualityBatch()` so both specs share it.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run tests/observability/task-observation-rollout.test.ts` — 56 passed, run twice: once with the release-workflow env (`OPEN_DESIGN_TELEMETRY_RELAY_URL=https://telemetry.open-design.ai/api/langfuse`, `OPEN_DESIGN_AMR_PROFILE=`, `OD_VELA_WEB_URL=`) and once with it unset. Both green; on `main` the first combination is the exact CI failure.
- Full `--shard=2/4` under the release-workflow env, both sides:
  - pristine `main`: `3 failed | 179 passed` — includes `task-observation-rollout > rebuilds safe Run quality …`, i.e. the exact CI failure reproduced at shard level.
  - this branch: `task-observation-rollout` passes. The shard reported unrelated failures in `routes/handoff`, `amr-session-resume`, `opencode-session-resume`, `workspace-billing-server-wiring` and `routes/live-artifacts`; all five pass on re-run (`5 passed | 50 tests`) and none of them overlap with `main`'s own flaky set (`cli-phase2c`, `run-atomic-ownership`). Local flakiness under a full serial shard, not attributable to this change.

## Adjacent issues

Kept out of this PR, listed for follow-up:

1. **The Task projection reports `manifestCompleteness: 'unavailable'` in production.** `buildSafeRunQualityProjectionFromDaemon` only ever runs `uploadMode: 'manifest-only'`, whose entries are unconditionally `status: 'unavailable'`, and `mergeTraceSafeManifests` prefers those over the local manifest. Packaged builds always have a relay configured, so the field is effectively pinned to `unavailable` there and carries no signal. Whether a registration-only pass should be allowed to downgrade a fully-described local manifest is a semantics call worth making deliberately.
2. **`reportRunCompletedFromDaemon` has the same shape.** Its two `buildTraceObjectManifests` call sites and its `readRunTelemetrySinkConfig(process.env, …)` read ambient env directly. No caller injects an env today, so adding the parameter now would be dead code — but it is the same hazard waiting for the next injected-env caller.
