### PR TITLE
test(e2e): retire the Pricing campaign-unlimited assertion with its source

### DIFF
--- a/e2e/tests/pricing-unlimited-models.test.ts
+++ b/e2e/tests/pricing-unlimited-models.test.ts
@@ -1,8 +1,14 @@
-// Pricing keeps a static marketing snapshot of the campaign models it advertises.
-// The workbench no longer duplicates those sets: it reads Vela's authenticated
+// Pricing keeps a static marketing snapshot of the models it advertises. The
+// workbench no longer duplicates those sets: it reads Vela's authenticated
 // Coding Plan model endpoint at runtime. This test therefore validates the
 // Pricing snapshot internally without turning it back into a runtime source of
 // truth.
+//
+// The campaign-unlimited assertion that used to live here was retired with the
+// page data it read: #7349 removed `campaignUnlimitedModelNames` along with the
+// per-model access markers, and `apps/landing-page/tests/pricing-contract.ts`
+// now asserts those markers stay absent. What remains here is the part that
+// still spans two packages, which is why it belongs in e2e at all.
 
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -59,29 +65,7 @@ async function pricingPopularModelNames(): Promise<string[]> {
   return captureAll(block, /name: '([^']+)'/g);
 }
 
-/** The page's campaign-only unlimited models, resolved to AMR model ids. */
-async function pricingCampaignUnlimitedIds(): Promise<string[]> {
-  const source = stripLineComments(await readFile(PRICING_PAGE, 'utf8'));
-  const block = captureOne(
-    source,
-    /const campaignUnlimitedModelNames = \[([\s\S]*?)\] as const;/,
-    'campaignUnlimitedModelNames on the Pricing page',
-  );
-  return captureAll(block, /'([^']+)'/g).map((name) => {
-    const id = MODEL_ID_BY_DISPLAY_NAME[name];
-    expect(id, `no AMR model id mapped for the Pricing name "${name}"`).toBeTruthy();
-    return id ?? name;
-  });
-}
-
 describe('Pricing unlimited-model snapshot', () => {
-  it('advertises only the two active DeepSeek campaign models', async () => {
-    expect(await pricingCampaignUnlimitedIds()).toEqual([
-      'deepseek-v4-pro',
-      'deepseek-v4-flash',
-    ]);
-  });
-
   it('puts DeepSeek V4 Flash Vision Exp first in the popular-model list', async () => {
     expect((await pricingPopularModelNames())[0]).toBe('DeepSeek V4 Flash Vision Exp');
   });


### PR DESCRIPTION
## Why

**My use case.** `main` is red and the merge queue is rejecting everything queued after 08:43. #7367 was already dropped from the queue by it, and #7366 / #7368 are failing the same check on their heads. The drop reason is not visible on any PR — it only appears in the `merge_group` run:

```
FAIL tests/pricing-unlimited-models.test.ts > Pricing unlimited-model snapshot
     > advertises only the two active DeepSeek campaign models
Error: campaignUnlimitedModelNames on the Pricing page not found — did it get renamed?
```

`Validate workspace` fails alongside it only as the aggregator (`e2e_vitest=failure`). There is exactly one real failure.

**The pain.** Nobody can merge, and the cause is invisible from the PRs it blocks — each one looks green on its own head while the queue keeps ejecting it.

**This is not a regression to revert.** #7349 retired the contract on purpose: it removed `campaignUnlimitedModelNames` and the per-model access markers from `pricing-individual-plans.astro`, and updated `apps/landing-page/tests/pricing-contract.ts` to assert those markers now stay **absent** (`assert.doesNotMatch(individualPlans, /popularAccessStatus|unlimitedByTier|class="model-access-status"/)`). What it missed is that the same contract had a second copy in `e2e/`, which still scrapes the astro source for a symbol that no longer exists.

## What users will see

Nothing. This is a test-only change; no product surface is touched.

## What changed

Removed the one obsolete case and the helper only it used (`pricingCampaignUnlimitedIds`). The two remaining cases are the ones that genuinely span packages, which is why the file belongs in `e2e/` at all rather than next to the page:

- `puts DeepSeek V4 Flash Vision Exp first in the popular-model list`
- `maps every popular model the Pricing page lists to an AMR model id`

Both read `popularModels`, which #7349 kept.

The header comment now records why the campaign assertion left, so the next person does not "restore" it by reading the file alone.

## Validation

- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/pricing-unlimited-models.test.ts` — 2 passed
- `pnpm --filter @open-design/e2e exec tsc -p tsconfig.json --noEmit` — clean
- `pnpm guard` — pass

## Surface area

- [x] Tests (`e2e/`)

## Adjacent issues

- `pricing-individual-plans.astro` still ships the `.limited-time-unlimited-module` CSS (around lines 730, 737, 849, 1124) with no markup rendering it any more. Dead style left behind by the same simplification; not touched here because it is a landing-page cleanup with its own reviewer, and this PR should stay the minimum that unblocks the queue.
- Worth asking whether a source-scraping contract test should live in two places at all. The duplication is exactly what let one copy go stale.

Refs #7349.
