### PR TITLE
fix(daemon): terminate an OD Next turn whose whole reply is the machine block

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11578,8 +11578,18 @@ export async function startServer({
       if (strategyProtocol && event === 'agent' && data?.type === 'tool_use') {
         strategyToolUseCount += 1;
       }
+      // Only agent output goes through the protocol stream, and only while that
+      // stream is open. `finish()` runs in this attempt's close handler, after
+      // the child has exited, so once it has run there is no model output left
+      // to parse — what the daemon still emits (the filesystem empty-answer
+      // autofill below, an error payload) is text the daemon wrote itself.
+      // Feeding that back into a finished stream is what used to throw
+      // `already finished` out of an uncaught close handler and strand the run
+      // in `running` forever, with the user watching a spinner that never ended
+      // while the files sat finished on disk.
+      const streamingAgentOutput = Boolean(strategyProtocol) && !strategyProtocol.isFinished;
       if (
-        strategyProtocol
+        streamingAgentOutput
         && event === 'agent'
         && data?.type === 'text_delta'
         && typeof data.delta === 'string'
@@ -11589,7 +11599,7 @@ export async function startServer({
         strategyVisibleEmitted += delta;
         data = { ...data, delta };
       } else if (
-        strategyProtocol
+        streamingAgentOutput
         && event === 'stdout'
         && typeof data?.chunk === 'string'
       ) {

--- a/apps/daemon/src/strategies/od-next/protocol.ts
+++ b/apps/daemon/src/strategies/od-next/protocol.ts
@@ -197,6 +197,26 @@ export class OdNextMachineProtocolStream {
     this.maxMachineBlockBytes = max;
   }
 
+  /**
+   * Whether `finish()` has already run.
+   *
+   * This separates the two windows a run's output stream has. While the stream
+   * is open every byte is agent output, so it must go through `push` and the
+   * protocol withholds anything that might still turn out to be a reserved
+   * `<open-design-…>` block. `finish()` closes that window: it is called from
+   * the child's close handler, so the agent has stopped producing and no model
+   * bytes remain. Whatever the daemon still emits on this run afterwards — the
+   * filesystem empty-answer autofill, an error payload — is daemon-authored
+   * text that was never model output and must not be fed back into the parser.
+   *
+   * Callers emitting on a run's stream check this instead of pushing blindly;
+   * `push` and `finish` keep throwing so a genuine mid-stream misuse still
+   * fails loudly.
+   */
+  get isFinished(): boolean {
+    return this.finished;
+  }
+
   push(chunk: string): string {
     if (this.finished) throw new Error('OD Next machine protocol stream is already finished.');
     if (typeof chunk !== 'string' || chunk.length === 0) return '';

--- a/apps/daemon/tests/od-next-machine-block-only-turn.test.ts
+++ b/apps/daemon/tests/od-next-machine-block-only-turn.test.ts
@@ -1,0 +1,226 @@
+import type { Server } from 'node:http';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDatabase, openDatabase } from '../src/db.js';
+import { startServer, type StartServerOptions } from '../src/server.js';
+import { clearOdNextRolloutStop } from '../src/strategies/od-next/rollout.js';
+
+/**
+ * A production-stage OD Next turn routinely answers with the machine block the
+ * contract asks for and nothing else: the model wrote the files, so the reply
+ * carries the Runtime State and no prose. That reply is well formed — there is
+ * no malformed markup anywhere in it — and the run must still terminate.
+ *
+ * The close handler used to finish the protocol stream first and only then run
+ * the empty-output guard that autofills "I generated these files". The autofill
+ * goes back out through `send`, `send` pushes into the finished protocol stream,
+ * and `push` throws once finished. The close handler is `try/finally` with no
+ * `catch`, so the throw escaped as an unhandled rejection and the run never
+ * reached a terminal status: the user watched a spinner forever while the files
+ * sat finished on disk.
+ */
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  eventsLogPath: string;
+  error?: string | null;
+  errorCode?: string | null;
+};
+
+const EXECUTION_PREFLIGHT = {
+  productionRoutes: [{ id: 'html', available: true }],
+  dependencies: [],
+  inputs: [{ id: 'request', available: true }],
+  renderers: [],
+  exporters: [],
+  templates: [],
+  outputKinds: [{ id: 'prototype', supported: true }],
+};
+
+const RUNTIME_STATE = {
+  schema: 'open-design.strategy-state/v2',
+  route: 'full_plan',
+  inputStage: 'request',
+  outcome: 'plan_ready',
+  executionMode: 'simple',
+  reasonCodes: [],
+};
+
+/** The whole reply: the contract's machine block, no prose around it. */
+const MACHINE_BLOCK_ONLY = `<open-design-runtime-state>\n${JSON.stringify(
+  RUNTIME_STATE,
+)}\n</open-design-runtime-state>`;
+
+function database() {
+  const dataDir = process.env.OD_DATA_DIR;
+  if (!dataDir) throw new Error('OD_DATA_DIR is required');
+  return openDatabase(process.cwd(), { dataDir });
+}
+
+/**
+ * A fake `claude` that writes a real file and then answers with nothing but the
+ * machine block — the exact shape a production-stage OD Next turn produces.
+ */
+async function writeFakeClaude(dir: string): Promise<string> {
+  const bin = path.join(dir, 'claude-machine-block-only');
+  await writeFile(
+    bin,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const argv = process.argv.slice(2);
+if (argv.includes('--version')) { fs.writeSync(1, '2.1.233 (Claude Code)\\n'); process.exit(0); }
+if (argv.includes('--help')) { fs.writeSync(1, 'Usage: claude -p [--add-dir] [--include-partial-messages] [--forward-subagent-text] [--agents JSON] [--resume ID]\\n'); process.exit(0); }
+let stdin = '';
+let finished = false;
+function w(v) { fs.writeSync(1, JSON.stringify(v) + '\\n'); }
+function finish() {
+  if (finished || stdin.length === 0) return;
+  finished = true;
+  const target = path.join(process.cwd(), 'index.html');
+  fs.writeFileSync(target, '<!doctype html><title>Machine block only</title>');
+  w({ type: 'system', subtype: 'init', model: 'claude-haiku-4-5', session_id: 'machine-block-only-session', claude_code_version: '2.1.233' });
+  w({ type: 'assistant', parent_tool_use_id: null, message: { id: 'w1', stop_reason: 'tool_use', content: [
+    { type: 'tool_use', id: 'tool-write-1', name: 'Write', input: { file_path: target, content: 'x' } },
+  ] } });
+  w({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 'tool-write-1', content: 'ok' }] } });
+  w({ type: 'assistant', parent_tool_use_id: null, message: { id: 'final', stop_reason: 'end_turn', content: [
+    { type: 'text', text: ${JSON.stringify(MACHINE_BLOCK_ONLY)} },
+  ] } });
+  w({ type: 'result', subtype: 'success', is_error: false, session_id: 'machine-block-only-session', stop_reason: 'end_turn', usage: { input_tokens: 10, output_tokens: 5 }, duration_ms: 30 });
+  setTimeout(() => process.exit(0), 10);
+}
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (c) => { stdin += c; setTimeout(finish, 0); });
+process.stdin.on('end', finish);
+process.stdin.on('error', finish);
+setTimeout(finish, 1500);
+`,
+    'utf8',
+  );
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+describe('OD Next turn whose whole reply is the machine block', () => {
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+  const savedRollout = process.env.OD_NEXT_STRATEGY_ROLLOUT;
+  const savedCanary = process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY;
+
+  afterEach(async () => {
+    if (savedRollout === undefined) delete process.env.OD_NEXT_STRATEGY_ROLLOUT;
+    else process.env.OD_NEXT_STRATEGY_ROLLOUT = savedRollout;
+    if (savedCanary === undefined) delete process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY;
+    else process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY = savedCanary;
+    if (started) {
+      await Promise.resolve(started.shutdown?.());
+      if (started.server.listening) {
+        // This suite polls the run over `fetch`, which keeps its sockets alive.
+        // `close()` alone would wait on them until the hook timed out, so drop
+        // the idle connections it is waiting for.
+        await new Promise<void>((resolve) => {
+          started!.server.close(() => resolve());
+          started!.server.closeAllConnections?.();
+        });
+      }
+    }
+    started = null;
+    closeDatabase();
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+  });
+
+  it('terminates the run instead of hanging forever', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-next-machine-block-'));
+    const bin = await writeFakeClaude(binDir);
+
+    started = (await startServer({
+      port: 0,
+      returnServer: true,
+      odNextExecutionPreflightResolver: () => EXECUTION_PREFLIGHT,
+      odNextComplexProductionResolver: null,
+    } as StartServerOptions)) as StartedServer;
+    const url = started.url;
+
+    const config = await fetch(`${url}/api/app-config`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'claude',
+        agentCliEnv: { claude: { CLAUDE_BIN: bin } },
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+        privacyDecisionAt: Date.now(),
+      }),
+    });
+    expect(config.status).toBe(200);
+    await fetch(`${url}/api/agents`);
+
+    // OD Next is opt-in, so this suite asks for it explicitly rather than
+    // relying on whatever the shipped default happens to be.
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'active';
+    process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY = '1';
+    clearOdNextRolloutStop(database());
+
+    const projectId = `machine-block-only-${Date.now()}`;
+    const projectResponse = await fetch(`${url}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'machine block only',
+        metadata: { kind: 'prototype' },
+        conversationMode: 'design',
+        automaticStrategyTaskProfile: 'prototype',
+        skipDiscoveryBrief: true,
+      }),
+    });
+    expect(projectResponse.status, await projectResponse.clone().text()).toBe(200);
+    const { conversationId } = (await projectResponse.json()) as { conversationId: string };
+
+    const message = 'Create an OD Next prototype.';
+    const runResponse = await fetch(`${url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId,
+        conversationId,
+        agentId: 'claude',
+        userMessageId: 'user-machine-block-only',
+        assistantMessageId: 'assistant-machine-block-only',
+        clientRequestId: `machine-block-only-${Date.now()}`,
+        message,
+        currentPrompt: message,
+      }),
+    });
+    const created = (await runResponse.json()) as { runId: string; strategyTask?: unknown };
+    expect(runResponse.status, JSON.stringify(created)).toBe(202);
+    // Guards the premise: a run OD Next never admitted would terminate for
+    // reasons that have nothing to do with the protocol stream.
+    expect(created.strategyTask, JSON.stringify(created)).toBeTruthy();
+
+    let status: RunStatus | null = null;
+    const deadline = Date.now() + 12_000;
+    while (Date.now() < deadline) {
+      const response = await fetch(`${url}/api/runs/${encodeURIComponent(created.runId)}`);
+      status = (await response.json()) as RunStatus;
+      if (['succeeded', 'failed', 'canceled'].includes(status.status)) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    expect(
+      status?.status,
+      `run never reached a terminal status; last seen ${JSON.stringify(status)}`,
+    ).toBe('succeeded');
+  }, 60_000);
+});

--- a/apps/daemon/tests/strategies/od-next/protocol.test.ts
+++ b/apps/daemon/tests/strategies/od-next/protocol.test.ts
@@ -291,4 +291,21 @@ describe('OD Next machine protocol stream', () => {
     });
     expect(result.issues).toEqual([]);
   });
+
+  it('reports whether it is finished so emitters can stop routing through it', () => {
+    const stream = new OdNextMachineProtocolStream();
+    expect(stream.isFinished).toBe(false);
+    stream.push('Visible text.');
+    expect(stream.isFinished).toBe(false);
+
+    stream.finish();
+
+    // The daemon still emits on a run after the child closes (the filesystem
+    // empty-answer autofill, error payloads). Those emitters read this instead
+    // of pushing into a finished stream, which throws.
+    expect(stream.isFinished).toBe(true);
+    expect(() => stream.push('daemon-authored text')).toThrow(
+      'OD Next machine protocol stream is already finished.',
+    );
+  });
 });


### PR DESCRIPTION
## Why

**My use case.** I was chasing a report that OD Next runs sometimes never finish — the user watches a spinner that never stops, gets no answer and no error, and the task never terminates, while the files are already written correctly on disk. I wanted to know which reply shape triggers it.

**The pain.** The trigger is not exotic. It is a *completely valid* reply containing only the `<open-design-runtime-state>` block the contract requires, with no prose around it — the typical shape of a production-stage OD Next turn once the model has written the files and has nothing left to narrate. On an install with OD Next enabled, any user can hit this on an ordinary turn. The work succeeds and the product still looks broken: the run stays in `running` forever, the turn never closes, the conversation cannot move on, and nothing tells the user their prototype is actually finished.

Not a recent regression — the same probe behaves identically on the parent commit.

### Mechanism

```
strategyProtocol.finish()                    server.ts:15330 (close handler, under status === 'succeeded')
  ↓
empty-output guard sees "no visible text but files were written"
and autofills the "I generated these files" fallback        server.ts:12127
  (executionProfile === 'filesystem' && result === 'success' && visibleAssistantText.trim() === '')
  ↓
send('agent', { type: 'text_delta' }) → strategyProtocol.push() → already finished → throw
  ↓
close handler is try/finally with no catch → unhandled rejection → run never reaches a terminal status
```

Captured from the real daemon by the red spec below, before the fix:

```
OD Next machine protocol stream is already finished.
    at OdNextMachineProtocolStream.push (apps/daemon/src/strategies/od-next/protocol.ts:201:30)
    at send (apps/daemon/src/server.ts:11587:40)
    at finishWithRetryDecision (apps/daemon/src/server.ts:12137:11)
    at ChildProcess.<anonymous> (apps/daemon/src/server.ts:15595:23)
```

### The fix

Route output through the protocol stream **only while that stream is open**.

The protocol stream exists to withhold bytes that might still turn out to be a reserved `<open-design-…>` block. `finish()` is what finally rules that out, and it runs in the child's close handler — *after* the agent has exited. Past `finish()` there is no model output left to parse, so whatever the daemon still emits on that run (the filesystem empty-answer autofill, an error payload) is text the daemon wrote itself, and it passes through untouched instead of being fed back into the parser.

`push()` and `finish()` keep throwing, so a genuine mid-stream misuse still fails loudly — the strict guard is retained for the window where it means something.

Why not the alternatives:

- **Make `push()` pass through after `finish()`.** Smallest diff, but it makes the guard permissive everywhere and silently accepts any late push. Scoping the decision to the emit site keeps the guard meaningful and names the one window where a bypass is correct.
- **Move the autofill before `finish()`.** Not possible without breaking it: the guard's condition is "no visible text", and the close-time tail that `finish()` releases is part of that visible text. Running the guard first would misjudge emptiness. The autofill genuinely has to come after.
- **Wrap the close handler in `catch`.** Treats the symptom, and would mask unrelated throws in a large handler.

Why the pass-through cannot swallow agent output: `strategyProtocol` is constructed per attempt (`server.ts:10259`, inside `startChatRun`). A retry re-enters `startChatRun` through `spawnRetryAttempt` and gets a fresh stream, while the previous attempt's close handler bails out via `attemptStillOwnsRun()`. So the post-`finish()` window always belongs to an attempt whose child has already exited and can never carry model bytes.

### Adjacent issues (deliberately not fixed here)

- **`finish()` only runs under `status === 'succeeded'`, so a failed run discards its withheld tail.** I checked what that tail can hold. In `finish()`, an *unclosed* reserved block's body is absorbed into the machine block and flagged malformed — never released as visible text — and the only thing released down the `else if (this.pending)` path is a leftover partial reserved prefix. `drainVisible` withholds at most `longestReservedPrefixSuffix(...)` bytes, bounded by the longest reserved prefix (`<open-design-plan-contract`, 26 bytes). So a failed run drops at most 26 bytes of a partial `<open-design-…` marker — junk the user should never see. **Conclusion: not worth a behavior change**, and changing it would mean running protocol finalization on failure paths that deliberately skip it. Worth revisiting only if the withholding rule changes.
- The four accumulators (`visibleAssistantText` / `memoryReplyText` / `clarifyingQuestionText` / `plainArtifactStdout`) bypassing the close-time tail share that same ≤26-byte bound and are out of scope here.

## What users will see

A design turn that ends with the machine block and no prose now finishes. The spinner stops, the turn closes with the daemon's "I generated these files" summary listing what was written, and the conversation can continue. Previously that turn hung until the user gave up and reloaded.

Installs that have not opted into OD Next are unaffected either way.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — daemon-internal bug fix plus its specs. No new endpoint, contract shape, CLI subcommand, env var, or UI surface; the only behavior change is that a run which used to hang now terminates as it always should have.

## Screenshots

n/a — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/od-next-machine-block-only-turn.test.ts`
- Did the test go red on `main` and green on this branch? **yes**

Red on `origin/main` (`2862a47f84`) with unmodified sources and this exact test file:

```
FAIL  tests/od-next-machine-block-only-turn.test.ts > OD Next turn whose whole reply is the machine block > terminates the run instead of hanging forever
AssertionError: run never reached a terminal status; last seen {... "status":"running" ...}
Expected: "succeeded"
Received: "running"
```

Green on this branch.

The spec sets `OD_NEXT_STRATEGY_ROLLOUT=active` **explicitly** rather than riding the shipped default, so it keeps covering the OD Next path if that default is ever changed.

`apps/daemon/tests/strategies/od-next/protocol.test.ts` gains a unit case pinning `isFinished` and confirming `push()` still throws after `finish()`.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `apps/daemon` targeted (`tests/strategies/`, `od-next-advertised-capability-admission`, `run-create-workspace-gate`, and the new spec) — 14 files / 229 tests pass
- `apps/daemon` full suite — **730 files, 9512 tests: 2 files / 2 tests failed**, both pre-existing:
  - `tests/langfuse-trace.test.ts > readRunTelemetrySinkConfig > describes relay, direct, and disabled sinks through the same allowlist` — fails identically with the sources checked out at `origin/main`.
  - `tests/od-next-automatic-simple-server.test.ts` — flaky, not a fixed failure. Re-running that one file gave a *different* failing set each time (6 failures, then 2), and the `origin/main` baseline produced 2 failures that do not overlap the branch's. The branch's set is not a superset of the baseline's, so nothing here is new.
  - Baselined by checking out `apps/daemon/src/server.ts` and `apps/daemon/src/strategies/od-next/protocol.ts` at `origin/main` and re-running those two files: **2 files / 3 tests failed** — i.e. the branch fails *fewer* tests than the baseline.
- `pnpm --filter @open-design/daemon build`, then `startServer` from `dist/`: `GET /api/health` → `200 {"ok":true,...}`, `GET /api/strategies/od-next/rollout` → `200`. Green tests were not treated as proof it runs.
