### PR TITLE
fix(web): confirm successful conversation forks

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -9724,6 +9724,14 @@ export function ProjectView({
         setFailedMessagesConversationId(null);
         setConversations((curr) => [fresh, ...curr.filter((c) => c.id !== fresh.id)]);
         setActiveConversationId(fresh.id);
+        setProjectActionsToast({
+          message: t('chat.forkConversationSucceeded', {
+            title: fresh.title?.trim() || t('chat.untitledConversation'),
+          }),
+          details: null,
+          tone: 'success',
+          scope: 'chat-pane',
+        });
         navigate(
           {
             kind: 'project',

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -2183,6 +2183,7 @@ export const ar: Dict = {
   'chat.deleteConversationConfirm': 'هل تريد حذف "{title}"؟ سيؤدي هذا لإزالة رسائلها.',
   'chat.untitledConversation': 'محادثة بدون عنوان',
   'chat.forkedConversationTitle': 'تفرع {title}',
+  'chat.forkConversationSucceeded': 'تم إنشاء التفرع. أنت الآن في «{title}».',
   'chat.forkConversationFailed': 'تعذر تفرع هذه المحادثة.',
   'chat.startTitle': 'ابدأ محادثة',
   'chat.startHint': 'صِف ما تريد إنشاءه، أو ابدأ من أحد هذه الأمثلة:',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -2183,6 +2183,7 @@ export const de: Dict = {
   'chat.deleteConversationConfirm': '„{title}“ löschen? Dadurch werden die Nachrichten entfernt.',
   'chat.untitledConversation': 'Konversation ohne Titel',
   'chat.forkedConversationTitle': '{title} Fork',
+  'chat.forkConversationSucceeded': 'Fork erstellt. Du bist jetzt in „{title}“.',
   'chat.forkConversationFailed': 'Diese Konversation konnte nicht geforkt werden.',
   'chat.startTitle': 'Konversation starten',
   'chat.startHint': 'Beschreiben Sie, was Sie generieren möchten, oder starten Sie mit einem dieser Beispiele:',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2183,6 +2183,7 @@ export const en: Dict = {
   'chat.deleteConversationConfirm': 'Delete "{title}"? This removes its messages.',
   'chat.untitledConversation': 'Untitled conversation',
   'chat.forkedConversationTitle': '{title} fork',
+  'chat.forkConversationSucceeded': 'Fork created. You’re now in {title}.',
   'chat.forkConversationFailed': 'Could not fork this conversation.',
   'chat.startTitle': 'Start a conversation',
   'chat.startHint': 'Describe what you want to generate, or start from one of these examples:',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -2183,6 +2183,7 @@ export const esES: Dict = {
   'chat.deleteConversationConfirm': '¿Eliminar «{title}»? Se borrarán sus mensajes.',
   'chat.untitledConversation': 'Conversación sin título',
   'chat.forkedConversationTitle': 'Bifurcación de {title}',
+  'chat.forkConversationSucceeded': 'Bifurcación creada. Ahora estás en «{title}».',
   'chat.forkConversationFailed': 'No se pudo bifurcar esta conversación.',
   'chat.startTitle': 'Empieza una conversación',
   'chat.startHint': 'Describe lo que quieres generar o empieza con uno de estos ejemplos:',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -2183,6 +2183,7 @@ export const fa: Dict = {
   'chat.deleteConversationConfirm': 'آیا «{title}» حذف شود؟ این کار پیام‌های آن را حذف می‌کند.',
   'chat.untitledConversation': 'مکالمه بدون عنوان',
   'chat.forkedConversationTitle': 'فورک {title}',
+  'chat.forkConversationSucceeded': 'فورک ساخته شد. اکنون در «{title}» هستید.',
   'chat.forkConversationFailed': 'فورک کردن این مکالمه ممکن نبود.',
   'chat.startTitle': 'یک مکالمه شروع کنید',
   'chat.startHint': 'آنچه می‌خواهید بسازید را توصیف کنید، یا از یکی از این نمونه‌ها شروع کنید:',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -2183,6 +2183,7 @@ export const fr: Dict = {
   'chat.deleteConversationConfirm': 'Supprimer « {title} » ? Cela supprime ses messages.',
   'chat.untitledConversation': 'Conversation sans titre',
   'chat.forkedConversationTitle': 'Fork de {title}',
+  'chat.forkConversationSucceeded': 'Fork créé. Vous êtes maintenant dans « {title} ».',
   'chat.forkConversationFailed': 'Impossible de créer un fork de cette conversation.',
   'chat.startTitle': 'Démarrer une conversation',
   'chat.startHint': 'Décrivez ce que vous voulez générer, ou partez de l’un de ces exemples :',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -2183,6 +2183,7 @@ export const hu: Dict = {
   'chat.deleteConversationConfirm': 'Törlöd a(z) „{title}" beszélgetést? Ez eltávolítja az üzeneteit.',
   'chat.untitledConversation': 'Cím nélküli beszélgetés',
   'chat.forkedConversationTitle': '{title} elágazás',
+  'chat.forkConversationSucceeded': 'Az elágazás létrejött. Most itt van: „{title}”.',
   'chat.forkConversationFailed': 'Nem sikerült forkot létrehozni ebből a beszélgetésből.',
   'chat.startTitle': 'Indíts beszélgetést',
   'chat.startHint': 'Írd le, mit szeretnél létrehozni, vagy indulj ki az egyik példából:',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -2183,6 +2183,7 @@ export const id: Dict = {
   'chat.deleteConversationConfirm': 'Hapus "{title}"? Semua pesannya ikut dihapus.',
   'chat.untitledConversation': 'Percakapan tanpa judul',
   'chat.forkedConversationTitle': 'Fork {title}',
+  'chat.forkConversationSucceeded': 'Fork dibuat. Anda sekarang berada di “{title}”.',
   'chat.forkConversationFailed': 'Tidak dapat membuat fork percakapan ini.',
   'chat.startTitle': 'Mulai percakapan',
   'chat.startHint': 'Jelaskan apa yang ingin kamu hasilkan, atau mulai dari salah satu contoh ini:',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -2183,6 +2183,7 @@ export const it: Dict = {
   'chat.deleteConversationConfirm': 'Eliminare « {title} » ? Questo elimina i suoi messaggi.',
   'chat.untitledConversation': 'Conversazione senza titolo',
   'chat.forkedConversationTitle': 'Fork di {title}',
+  'chat.forkConversationSucceeded': 'Fork creato. Ora sei in “{title}”.',
   'chat.forkConversationFailed': 'Impossibile creare un fork di questa conversazione.',
   'chat.startTitle': 'Inizia una conversazione',
   'chat.startHint': 'Descrivi ciò che vuoi generare oppure parti da uno di questi esempi:',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -2183,6 +2183,7 @@ export const ja: Dict = {
   'chat.deleteConversationConfirm': '"{title}" を削除しますか？メッセージも削除されます。',
   'chat.untitledConversation': '無題の会話',
   'chat.forkedConversationTitle': '{title} のフォーク',
+  'chat.forkConversationSucceeded': 'フォークを作成し、「{title}」に切り替えました。',
   'chat.forkConversationFailed': 'この会話をフォークできませんでした。',
   'chat.startTitle': '会話を始める',
   'chat.startHint': '生成したい内容を説明するか、以下の例から始めてください:',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -2183,6 +2183,7 @@ export const ko: Dict = {
   'chat.deleteConversationConfirm': '"{title}" 대화를 삭제하시겠습니까? 관련 메시지가 모두 삭제됩니다.',
   'chat.untitledConversation': '제목 없는 대화',
   'chat.forkedConversationTitle': '{title} 포크',
+  'chat.forkConversationSucceeded': '포크를 만들고 “{title}” 대화로 전환했습니다.',
   'chat.forkConversationFailed': '이 대화를 포크할 수 없습니다.',
   'chat.startTitle': '대화 시작하기',
   'chat.startHint': '생성하고 싶은 내용을 설명하거나 아래 예시에서 시작하세요:',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -2183,6 +2183,7 @@ export const pl: Dict = {
   'chat.deleteConversationConfirm': 'Usunąć „{title}”? Spowoduje to usunięcie wszystkich wiadomości.',
   'chat.untitledConversation': 'Rozmowa bez tytułu',
   'chat.forkedConversationTitle': 'Fork {title}',
+  'chat.forkConversationSucceeded': 'Utworzono fork. Jesteś teraz w „{title}”.',
   'chat.forkConversationFailed': 'Nie udało się sforkować tej rozmowy.',
   'chat.startTitle': 'Zacznij rozmowę',
   'chat.startHint': 'Opisz, co chcesz wygenerować, albo zacznij od jednego z tych przykładów:',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -2183,6 +2183,7 @@ export const ptBR: Dict = {
   'chat.deleteConversationConfirm': 'Excluir "{title}"? Isso remove as mensagens.',
   'chat.untitledConversation': 'Conversa sem título',
   'chat.forkedConversationTitle': 'Fork de {title}',
+  'chat.forkConversationSucceeded': 'Fork criado. Agora você está em “{title}”.',
   'chat.forkConversationFailed': 'Não foi possível bifurcar esta conversa.',
   'chat.startTitle': 'Comece uma conversa',
   'chat.startHint': 'Descreva o que você quer gerar ou comece por um destes exemplos:',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -2183,6 +2183,7 @@ export const ru: Dict = {
   'chat.deleteConversationConfirm': 'Удалить «{title}»? Это удалит его сообщения.',
   'chat.untitledConversation': 'Разговор без названия',
   'chat.forkedConversationTitle': 'Форк {title}',
+  'chat.forkConversationSucceeded': 'Форк создан. Вы перешли в «{title}».',
   'chat.forkConversationFailed': 'Не удалось создать форк этого разговора.',
   'chat.startTitle': 'Начать разговор',
   'chat.startHint': 'Опишите, что хотите сгенерировать, или начните с одного из этих примеров:',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -2183,6 +2183,7 @@ export const th: Dict = {
   'chat.deleteConversationConfirm': 'ลบ "{title}" หรือไม่?',
   'chat.untitledConversation': 'บทสนทนาที่ไม่มีชื่อ',
   'chat.forkedConversationTitle': 'ฟอร์กของ {title}',
+  'chat.forkConversationSucceeded': 'สร้างฟอร์กแล้ว ตอนนี้คุณอยู่ใน “{title}”',
   'chat.forkConversationFailed': 'ไม่สามารถ fork บทสนทนานี้ได้',
   'chat.startTitle': 'เริ่มแชทได้เลย',
   'chat.startHint': 'อธิบายสิ่งที่ต้องการสร้าง หรือเริ่มจากตัวอย่างเหล่านี้:',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -2183,6 +2183,7 @@ export const tr: Dict = {
   'chat.deleteConversationConfirm': '"{title}"’ı sil? Bu mesajları silecektir.',
   'chat.untitledConversation': 'Başlıksız konuşma',
   'chat.forkedConversationTitle': '{title} çatallaması',
+  'chat.forkConversationSucceeded': 'Fork oluşturuldu. Artık “{title}” sohbetindesiniz.',
   'chat.forkConversationFailed': 'Bu konuşma fork edilemedi.',
   'chat.startTitle': 'Bir konuşma başlat',
   'chat.startHint': 'Oluşturmak istediğiniz şeyi açıklayın veya bu örneklerden biriyle başlayın:',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -2183,6 +2183,7 @@ export const uk: Dict = {
   'chat.deleteConversationConfirm': 'Видалити "{title}"? Це видалить усі її повідомлення.',
   'chat.untitledConversation': 'Розмова без назви',
   'chat.forkedConversationTitle': 'Форк {title}',
+  'chat.forkConversationSucceeded': 'Форк створено. Ви перейшли до «{title}».',
   'chat.forkConversationFailed': 'Не вдалося створити форк цієї розмови.',
   'chat.startTitle': 'Почніть розмову',
   'chat.startHint': 'Опишіть, що хочете згенерувати, або почніть з одного з цих прикладів:',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -2276,6 +2276,7 @@ export const zhCN: Dict = {
   "chat.deleteConversationConfirm": "确定删除「{title}」？该操作会删除其消息。",
   "chat.untitledConversation": "未命名对话",
   "chat.forkedConversationTitle": "{title} 分叉",
+  "chat.forkConversationSucceeded": "分支对话已创建，已切换到“{title}”。",
   "chat.forkConversationFailed": "无法分叉这个对话。",
   "chat.startTitle": "开始一个对话",
   "chat.startHint": "描述你想生成的内容，或从下面的示例开始：",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -2284,6 +2284,7 @@ export const zhTW: Dict = {
   "chat.deleteConversationConfirm": "確定刪除「{title}」？該操作會刪除其訊息。",
   "chat.untitledConversation": "未命名對話",
   "chat.forkedConversationTitle": "{title} 分叉",
+  "chat.forkConversationSucceeded": "分支對話已建立，已切換至「{title}」。",
   "chat.forkConversationFailed": "無法分叉這個對話。",
   "chat.startTitle": "開始一個對話",
   "chat.startHint": "描述你想生成的內容，或從下面的範例開始：",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3012,6 +3012,7 @@ export interface Dict {
   'chat.deleteConversationConfirm': string;
   'chat.untitledConversation': string;
   'chat.forkedConversationTitle': string;
+  'chat.forkConversationSucceeded': string;
   'chat.forkConversationFailed': string;
   'chat.startTitle': string;
   'chat.startHint': string;

--- a/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
+++ b/apps/web/tests/components/ProjectView.deleteConversation.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView } from '../../src/components/ProjectView';
 import type { QuestionForm } from '../../src/artifacts/question-form';
@@ -11,6 +11,7 @@ const analyticsMocks = vi.hoisted(() => ({
   newRequestId: vi.fn(() => 'fork-request-1'),
   track: vi.fn(),
 }));
+const navigate = vi.hoisted(() => vi.fn());
 
 const listConversations = vi.fn();
 const listMessages = vi.fn();
@@ -51,6 +52,7 @@ const chatPaneProps: {
   activeConversationId?: string | null;
   conversations?: Array<{ id: string; title?: string | null }>;
   messages?: ChatMessage[];
+  chatLogTray?: React.ReactNode;
 } = {};
 
 const fileWorkspaceProps: {
@@ -102,7 +104,7 @@ vi.mock('../../src/providers/registry', () => ({
 }));
 
 vi.mock('../../src/router', () => ({
-  navigate: vi.fn(),
+  navigate: (...args: unknown[]) => navigate(...args),
 }));
 
 vi.mock('../../src/state/projects', () => ({
@@ -145,6 +147,7 @@ vi.mock('../../src/components/ChatPane', () => ({
     activeConversationId?: string | null;
     conversations?: Array<{ id: string; title?: string | null }>;
     messages?: ChatMessage[];
+    chatLogTray?: React.ReactNode;
   }) => {
     chatPaneProps.onDeleteConversation = props.onDeleteConversation;
     chatPaneProps.onForkFromMessage = props.onForkFromMessage;
@@ -153,7 +156,8 @@ vi.mock('../../src/components/ChatPane', () => ({
     chatPaneProps.activeConversationId = props.activeConversationId;
     chatPaneProps.conversations = props.conversations;
     chatPaneProps.messages = props.messages;
-    return null;
+    chatPaneProps.chatLogTray = props.chatLogTray;
+    return props.chatLogTray ?? null;
   },
 }));
 
@@ -212,6 +216,7 @@ describe('ProjectView conversation delete', () => {
     chatPaneProps.activeConversationId = undefined;
     chatPaneProps.conversations = undefined;
     chatPaneProps.messages = undefined;
+    chatPaneProps.chatLogTray = undefined;
     fileWorkspaceProps.questionForm = undefined;
   });
 
@@ -545,6 +550,34 @@ describe('ProjectView conversation fork analytics', () => {
         duration_ms: expect.any(Number),
       }),
       { requestId: 'fork-request-1' },
+    );
+  });
+
+  it('confirms a successful fork while selecting and listing the new conversation', async () => {
+    prepareForkHarness();
+    createConversation.mockResolvedValue({ id: 'conv-fork', title: 'Conversation 1 fork' });
+
+    renderProjectView(vi.fn());
+
+    await waitFor(() => expect(chatPaneProps.messages).toEqual(sourceMessages));
+    await act(async () => {
+      await chatPaneProps.onForkFromMessage?.(sourceMessages[1]!);
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('chat.forkConversationSucceeded');
+    expect(chatPaneProps.activeConversationId).toBe('conv-fork');
+    expect(chatPaneProps.conversations?.map((conversation) => conversation.id)).toEqual([
+      'conv-fork',
+      'conv-1',
+    ]);
+    expect(navigate).toHaveBeenLastCalledWith(
+      {
+        kind: 'project',
+        projectId: 'project-1',
+        conversationId: 'conv-fork',
+        fileName: null,
+      },
+      { replace: true },
     );
   });
 

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -2701,6 +2701,15 @@ test('[P1] project detail assistant completion actions support copy, fork, and f
   await expect
     .poll(() => getProjectContextFromUrl(page).conversationId)
     .not.toBe(conversationId);
+  const forkConversationId = getProjectContextFromUrl(page).conversationId;
+  expect(forkConversationId).toBeTruthy();
+  await expect(page.locator('.od-toast[role="status"]')).toContainText('Fork created');
+
+  await page.getByTestId('conversation-history-trigger').click();
+  const forkHistoryItem = page.getByTestId(`conversation-item-${forkConversationId}`);
+  await expect(forkHistoryItem).toHaveClass(/active/);
+  await expect(page.getByTestId('conversation-list').locator('.chat-conv-item').first())
+    .toHaveAttribute('data-testid', `conversation-item-${forkConversationId}`);
 });
 
 test('[P1] project detail fork emits correlated click and result analytics', async ({ page }) => {


### PR DESCRIPTION
Plane work item: OPEND-2149

## Why

Forking from an assistant message already created, selected, and routed to the new conversation, but the successful transition had no visible confirmation. While dogfooding that made a completed fork look like a no-op unless the user inspected the URL or opened conversation history.

This PR intentionally addresses only that feedback gap. It does not rename conversation terminology globally or change adjacent chat interactions.

## What users will see

After a conversation fork succeeds, the chat pane shows a localized success toast naming the conversation the user has entered. Conversation history still opens with the new conversation selected, highlighted, and placed first.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- Before: a successful fork changed route and history state without any visible success surface.
- After: locally reviewed at 1280×720 and 1024×768. The green success toast stays inside the chat column above the composer; at 1024×768, the history popover shows the fork as the first active row without overflow. Screenshot attachment is intentionally left for the Draft review pass; the assertions below cover the same entry point and state.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ProjectView.deleteConversation.test.tsx` — `confirms a successful fork while selecting and listing the new conversation`
- Did the test go red on `main` and green on this branch? **Yes.** Red: `Unable to find an accessible element with the role "status"`. Green: the success status is visible while the new conversation remains active, first in history, and reflected in navigation.
- Browser witness: `e2e/ui/project-management-flows.test.ts` now verifies the success toast, fork route, active history highlight, and first-row placement through the running product.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test tests/components/ProjectView.deleteConversation.test.tsx`
- `pnpm --filter @open-design/web test tests/i18n/locales.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --dir e2e typecheck`
- `pnpm exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts -g "project detail assistant completion actions support copy, fork, and feedback" --workers=1`
- Visual review: 1280×720 and 1024×768; no toast overflow or obstruction observed.
