### PR TITLE
docs(release): add 0.21.0 release notes

### DIFF
--- a/docs/CHANGELOG/v0.21.0/en.md
+++ b/docs/CHANGELOG/v0.21.0/en.md
@@ -1,15 +1,13 @@
 ---
-title: OpenDesign 0.21.0 — Built to Recover
-description: OpenDesign 0.21.0 keeps everyday failures from becoming dead ends, with resilient agent discovery, stable Electron previews, safer session recovery, honest model entitlements, and cleaner everyday interactions.
+title: Open Design 0.21.0 — Reliable, Start to Finish
+description: From Agent connections to live HTML previews and app relaunches, Open Design 0.21.0 makes the entire creation experience more reliable—and easier to recover when something goes wrong.
 ---
 
-### 🌟 Codename: *Built to Recover*
+### 🌟 Codename: *Reliable, Start to Finish*
 
-🛡️ **42 PRs · 13 contributors · 4 days** — **0.21.0 keeps everyday failures
-from becoming dead ends.** A broken CLI shim, a new agent release, a stale
-sidecar or a white Electron frame could each stop the work cold. OpenDesign now
-detects the failure, preserves what is still good and gives you a way forward —
-from app startup to the agent run to the preview you hand off. 🚀
+🛡️ **42 PRs · 13 contributors · 4 days** — **From Agent connections to live
+HTML previews and app relaunches, Open Design 0.21.0 makes the entire creation
+experience more reliable—and easier to recover when something goes wrong.** 🚀
 
 ## 🔥 Highlights
 

--- a/docs/CHANGELOG/v0.21.0/en.md
+++ b/docs/CHANGELOG/v0.21.0/en.md
@@ -1,25 +1,17 @@
 ---
-title: OpenDesign 0.21.0 — Stay in the Flow
-description: OpenDesign 0.21.0 keeps the path from prompt to preview intact, with opt-in OD Next, resilient agent discovery, stable Electron previews, honest model entitlements, and a cleaner path through everyday work.
+title: OpenDesign 0.21.0 — Built to Recover
+description: OpenDesign 0.21.0 keeps everyday failures from becoming dead ends, with resilient agent discovery, stable Electron previews, safer session recovery, honest model entitlements, and cleaner everyday interactions.
 ---
 
-### 🌟 Codename: *Stay in the Flow*
+### 🌟 Codename: *Built to Recover*
 
-🧭 **42 PRs · 13 contributors · 4 days** — **0.21.0 keeps the path from prompt
-to preview intact.** A broken CLI shim, a new agent release, a stale sidecar or
-a white Electron frame could each stop the work cold; OpenDesign now finds a
-route through, keeps the session honest and gets you back to designing. And for
-teams ready to try the next design strategy, OD Next is now one command away
-without changing everyone else's default. 🚀
+🛡️ **42 PRs · 13 contributors · 4 days** — **0.21.0 keeps everyday failures
+from becoming dead ends.** A broken CLI shim, a new agent release, a stale
+sidecar or a white Electron frame could each stop the work cold. OpenDesign now
+detects the failure, preserves what is still good and gives you a way forward —
+from app startup to the agent run to the preview you hand off. 🚀
 
 ## 🔥 Highlights
-
-- 🧭 **OD Next is ready to opt into, without moving anyone's defaults.** The new
-  task-focused strategy can own Prototype, Slide Deck, Marketing and HyperFrames
-  runs from planning through delivery, while explicit Plugins, Skills and
-  templates stay under your control. Turn it on with
-  `od config set odNextStrategyMode active`; turn it off just as quickly, with no
-  restart and no surprise rollout for the rest of the team. (#7016, #7362)
 
 - 🖼️ **HTML previews stay visible, live and correctly wired.** Multi-file
   artifacts keep their scripts, styles, images, modules and relative requests;
@@ -85,10 +77,6 @@ without changing everyone else's default. 🚀
 
 ### 🧠 Agents, runtimes and automation
 
-- OD Next can be enabled per installation with
-  `od config set odNextStrategyMode active`, takes effect on the next run without
-  a restart, and reports whether app config, environment or the default selected
-  the effective mode. (#7016, #7362)
 - `OD_MCP_STDIO_IDLE_EXIT_MS` configures the stdio MCP idle lifetime; `0` keeps
   the process alive until the client disconnects. (#7288) Thanks @huytdps13400.
 

--- a/docs/CHANGELOG/v0.21.0/en.md
+++ b/docs/CHANGELOG/v0.21.0/en.md
@@ -1,0 +1,191 @@
+---
+title: OpenDesign 0.21.0 — Stay in the Flow
+description: OpenDesign 0.21.0 keeps the path from prompt to preview intact, with opt-in OD Next, resilient agent discovery, stable Electron previews, honest model entitlements, and a cleaner path through everyday work.
+---
+
+### 🌟 Codename: *Stay in the Flow*
+
+🧭 **42 PRs · 13 contributors · 4 days** — **0.21.0 keeps the path from prompt
+to preview intact.** A broken CLI shim, a new agent release, a stale sidecar or
+a white Electron frame could each stop the work cold; OpenDesign now finds a
+route through, keeps the session honest and gets you back to designing. And for
+teams ready to try the next design strategy, OD Next is now one command away
+without changing everyone else's default. 🚀
+
+## 🔥 Highlights
+
+- 🧭 **OD Next is ready to opt into, without moving anyone's defaults.** The new
+  task-focused strategy can own Prototype, Slide Deck, Marketing and HyperFrames
+  runs from planning through delivery, while explicit Plugins, Skills and
+  templates stay under your control. Turn it on with
+  `od config set odNextStrategyMode active`; turn it off just as quickly, with no
+  restart and no surprise rollout for the rest of the team. (#7016, #7362)
+
+- 🖼️ **HTML previews stay visible, live and correctly wired.** Multi-file
+  artifacts keep their scripts, styles, images, modules and relative requests;
+  switching projects, files or Code/Preview no longer sends Electron through the
+  navigation races that could leave a complete document painted as a white
+  frame. Presentation mode also gains a dependable way out, and clicking the
+  preview dismisses its viewport menu like clicking anywhere else. (#7336,
+  #7358) Thanks @lefarcen.
+
+- 🧰 **A working agent no longer disappears behind a broken shim.** OpenDesign
+  keeps searching when an earlier executable on PATH is stale, leaves a real
+  diagnostic and repair action when nothing can launch, and supports the
+  DeepSeek Harness release line users actually receive. The one-line installer
+  finishes instead of getting trapped in dependency resolution. (#7153, #7339)
+  Thanks @lefarcen.
+
+- 🌙 **Kimi works again on 0.37 and newer.** Those releases stopped accepting the
+  stdio MCP transport that OpenDesign attached to every session, turning nearly
+  every run into an opaque handshake error. OpenDesign now sends only the
+  transports each Kimi build accepts, so a message produces a streamed reply
+  again instead of failing before the work begins. (#7313) Thanks @lefarcen.
+
+- 🚪 **Relaunching the app recovers from a stale local engine.** A web sidecar
+  left behind by a crash could hold the app's socket and make every later launch
+  quit at startup. OpenDesign now reclaims that stale owner safely, and its
+  daemon and web processes shut down with the desktop app instead of haunting
+  the next launch. (#7279) Thanks @mrcfps.
+
+- 🤖 **Coding Plan model access follows the account you are actually signed
+  into.** The model picker and unlimited-use badges now read the authenticated
+  entitlement list instead of relying on a hard-coded tier snapshot. DeepSeek V4
+  Flash Vision Exp also joins the unlimited lineup across paid Personal plans,
+  with clearer activation guidance when an older client has not picked up the
+  entitlement yet. (#7289, #7250) Thanks @Siri-Ray.
+
+- 🧠 **AI Optimize runs once, even when the click happens twice.** Two entry
+  points could start the same hidden design-system refinement within
+  milliseconds, charging twice and racing to rewrite the same files. The client
+  now stops the duplicate before it leaves, and the daemon enforces the same
+  single-run boundary across tabs and external clients. (#7271) Thanks
+  @lefarcen.
+
+- 💳 **Pricing actions now tell the truth before checkout does.** Current
+  interval, pending changes, cancellation state, unavailable moves and Team
+  billing all appear where the decision is made. Go is clearly sold out, its old
+  in-app campaign is gone, and the remaining DeepSeek campaign gives paid and
+  unpaid users one consistent path instead of competing promotions. (#7228,
+  #7239, #7240, #7352, #7361) Thanks @Siri-Ray.
+
+- 🌐 **Website Clone leaves its prompt behind when you leave the tab.** The
+  localized “clone this site” scaffold no longer follows you into Slide Deck,
+  Image, Document, HyperFrames, Video or Audio. Add your own URL and the draft is
+  still yours; leave the guide untouched and the next creation mode starts
+  clean. (#7344) Thanks @lefarcen.
+
+- 🔌 **Long-running MCP sessions can stay alive as long as the work requires.**
+  The familiar 30-minute idle behavior remains the default, while
+  `OD_MCP_STDIO_IDLE_EXIT_MS` can choose a longer boundary — up to 24 hours — or
+  disable idle exit for clients that deliberately keep a session quiet between
+  calls. (#7288) Thanks @huytdps13400.
+
+## ✨ Added
+
+### 🧠 Agents, runtimes and automation
+
+- OD Next can be enabled per installation with
+  `od config set odNextStrategyMode active`, takes effect on the next run without
+  a restart, and reports whether app config, environment or the default selected
+  the effective mode. (#7016, #7362)
+- `OD_MCP_STDIO_IDLE_EXIT_MS` configures the stdio MCP idle lifetime; `0` keeps
+  the process alive until the client disconnects. (#7288) Thanks @huytdps13400.
+
+### 🔑 Models, plans and media
+
+- Coding Plan model availability and unlimited badges now follow the live,
+  authenticated entitlement list. (#7289) Thanks @Siri-Ray.
+- DeepSeek V4 Flash Vision Exp is unlimited on Go, Plus, Pro and Max, and the
+  Pricing page explains how to refresh a delayed entitlement on older clients.
+  (#7250)
+
+## 🔁 Changed
+
+- The public Pricing page follows the signed-in subscription's interval and
+  state, disables moves checkout would reject, restores the account entry where
+  billing context matters, and makes plan/model details easier to expand and
+  compare. (#7228, #7239, #7240) Thanks @Siri-Ray.
+- Go remains visible to existing subscribers but is marked sold out for new
+  purchases; the client no longer shows its old campaign badge or welcome modal.
+  (#7352, #7361) Thanks @Siri-Ray.
+- Every community entry now leads to Discord, including the Chinese desktop,
+  site and documentation surfaces that previously split the community across
+  Feishu and Discord. (#7295) Thanks @joeylee12629-star.
+- The account avatar's first click now pins its menu open; a second click,
+  Escape, an outside press or navigation closes it explicitly. (#7330) Thanks
+  @Siri-Ray.
+- Empty Skills sources disappear from the filter and return automatically when
+  they contain something to browse. (#7298) Thanks @nettee.
+
+## 🐛 Fixed
+
+### 🎨 Studio, previews and export
+
+- Multi-file Electron previews resolve relative scripts, styles, images,
+  modules, imports and requests; active previews stay warm across project, file
+  and Code/Preview switches instead of navigating into a white frame. (#7336)
+  Thanks @lefarcen.
+- The viewport menu closes when the preview itself is clicked, presentation mode
+  has an exit control that still works after focus enters the slide, and version
+  history says clearly when a preview opens in a new window. (#7358) Thanks
+  @lefarcen.
+- Headless and container deployments no longer offer a PPTX export path that
+  their daemon cannot render; desktop keeps the export, and connection failures
+  stop masquerading as missing capability. (#7224) Thanks @jiulongche.
+- The Website Clone starter text returns the composer to empty when untouched,
+  stays when the user adds a URL, and is localized across the supported creation
+  surfaces. (#7344) Thanks @lefarcen.
+
+### 🧠 Agents, runtimes and conversations
+
+- DeepSeek Harness detection walks past broken PATH shims, keeps unusable agents
+  visible with a diagnostic and repair action, and accepts the current
+  `0.1.1-rc.x` line. (#7153, #7339) Thanks @lefarcen.
+- Kimi 0.37+ sessions omit the stdio MCP transport those builds reject, restoring
+  normal ACP startup and streamed replies. (#7313) Thanks @lefarcen.
+- Antigravity receives the real user prompt instead of a literal `-`. (#7205)
+  Thanks @mturac.
+- Native resume and transcript replay now share one cross-agent safety decision:
+  resume only when the stored session still matches the visible conversation;
+  otherwise clear the stale handle and reseed once with the full transcript.
+  (#5269) Thanks @alucero270.
+- ACP usage, session-info and command metadata no longer leak into the visible
+  conversation as raw status text. (#7309) Thanks @helsome.
+- An ACP stage timeout keeps the real silence duration and names the watchdog
+  that ended the run, making a costly stall diagnosable instead of looking like
+  the user interrupted it. (#7310) Thanks @lefarcen.
+- Design-system AI Optimize admits one active refinement per conversation, so a
+  double click, another tab or an external client cannot create a duplicate
+  billed run against the same files. (#7271) Thanks @lefarcen.
+
+### 🖥️ Desktop, navigation and interface polish
+
+- Packaged clients reclaim an unresponsive web sidecar during startup and clean
+  up their daemon and web children when the desktop owner exits. (#7279) Thanks
+  @mrcfps.
+- Foreground failures no longer raise a redundant system notification while the
+  result is already on screen; background notifications and enabled completion
+  sounds keep their existing behavior. (#7329) Thanks @Siri-Ray.
+- The account menu remains open after its avatar is clicked, Local CLI choices
+  align consistently during onboarding, and empty Skills source filters stay out
+  of the way. (#7330, #7338, #7298) Thanks @Siri-Ray, @lefarcen, @nettee.
+- DeepSeek campaigns use the official provider mark with an accessible,
+  readable fallback when the image cannot load. (#7326) Thanks @Siri-Ray.
+
+### 💳 Plans and campaigns
+
+- Pricing actions follow the real subscription state and interval before sending
+  anyone to checkout; pending, canceling, unavailable and downgrade states are
+  explicit. (#7239) Thanks @Siri-Ray.
+- Model ordering, plan copy, recommendation colors and campaign colors now stay
+  consistent between Pricing and the homepage. (#7228) Thanks @Siri-Ray.
+- Go no longer offers a checkout after inventory closed, and the local client
+  stops surfacing its retired campaign alongside the active DeepSeek offer.
+  (#7352, #7361) Thanks @Siri-Ray.
+
+## 🙏 Thanks to everyone who shipped 0.21.0
+
+@alucero270 · @helsome · @huytdps13400 · @jiulongche ·
+@joeylee12629-star · @lefarcen · @mrcfps · @mturac · @nettee · @OctoBored ·
+@PerishCode · @Siri-Ray · @UnknownObject777

--- a/docs/CHANGELOG/v0.21.0/zh-CN.md
+++ b/docs/CHANGELOG/v0.21.0/zh-CN.md
@@ -1,23 +1,16 @@
 ---
-title: OpenDesign 0.21.0 — 保持心流
-description: OpenDesign 0.21.0 打通从提示词到预览的完整路径，带来可主动开启的 OD Next、更可靠的 Agent 发现与 Electron 预览、更准确的模型权益，以及更顺畅的日常设计流程。
+title: OpenDesign 0.21.0 — 内建恢复力
+description: OpenDesign 0.21.0 让日常故障不再变成死路，带来更可靠的 Agent 发现与 Electron 预览、更安全的会话恢复、更准确的模型权益，以及更清晰的日常交互。
 ---
 
-### 🌟 Codename: *Stay in the Flow*
+### 🌟 Codename: *Built to Recover*
 
-🧭 **42 个 PR · 13 位贡献者 · 4 天** — **0.21.0 让从提示词到预览的整条路径
-保持连贯。** 一个损坏的 CLI shim、一次 Agent 升级、遗留的 sidecar，或 Electron
-里的一块白屏，过去都可能让工作突然停住；现在 OpenDesign 会继续找到可用路径，
-保持会话状态可信，让你回到设计本身。准备体验下一代设计策略的团队，也可以用一条
-命令开启 OD Next，而不会悄悄改变其他人的默认行为。🚀
+🛡️ **42 个 PR · 13 位贡献者 · 4 天** — **0.21.0 让日常故障不再变成死路。**
+一个损坏的 CLI shim、一次 Agent 升级、遗留的 sidecar，或 Electron 里的一块白屏，
+过去都可能让工作突然停住。现在 OpenDesign 会识别故障、保住仍然正确的状态，并从
+App 启动、Agent 运行一路到最终交付的预览，为你留下继续向前的路径。🚀
 
 ## 🔥 亮点
-
-- 🧭 **OD Next 现在可以主动开启，而不会改变所有人的默认设置。** 新的任务策略可以
-  接管 Prototype、Slide Deck、Marketing 与 HyperFrames，从规划一直走到交付；你
-  明确选择的 Plugin、Skill 和 template 仍由你决定。运行
-  `od config set odNextStrategyMode active` 即可开启，再切回 `off` 也不需要重启。
-  (#7016, #7362)
 
 - 🖼️ **HTML 预览保持可见、可交互，资源也能正确连接。** 多文件 artifact 中的
   script、样式、图片、module 和相对请求可以继续工作；切换项目、文件或
@@ -69,9 +62,6 @@ description: OpenDesign 0.21.0 打通从提示词到预览的完整路径，带�
 
 ### 🧠 Agent、runtime 与自动化
 
-- 每个安装实例都可以用 `od config set odNextStrategyMode active` 开启 OD Next；
-  下一次运行立即生效，无需重启，并能查看当前模式来自 app config、环境变量还是
-  默认值。 (#7016, #7362)
 - `OD_MCP_STDIO_IDLE_EXIT_MS` 可以配置 stdio MCP 的空闲生命周期；设为 `0` 时，
   进程会一直保持到客户端断开。 (#7288) 感谢 @huytdps13400。
 

--- a/docs/CHANGELOG/v0.21.0/zh-CN.md
+++ b/docs/CHANGELOG/v0.21.0/zh-CN.md
@@ -1,0 +1,159 @@
+---
+title: OpenDesign 0.21.0 — 保持心流
+description: OpenDesign 0.21.0 打通从提示词到预览的完整路径，带来可主动开启的 OD Next、更可靠的 Agent 发现与 Electron 预览、更准确的模型权益，以及更顺畅的日常设计流程。
+---
+
+### 🌟 Codename: *Stay in the Flow*
+
+🧭 **42 个 PR · 13 位贡献者 · 4 天** — **0.21.0 让从提示词到预览的整条路径
+保持连贯。** 一个损坏的 CLI shim、一次 Agent 升级、遗留的 sidecar，或 Electron
+里的一块白屏，过去都可能让工作突然停住；现在 OpenDesign 会继续找到可用路径，
+保持会话状态可信，让你回到设计本身。准备体验下一代设计策略的团队，也可以用一条
+命令开启 OD Next，而不会悄悄改变其他人的默认行为。🚀
+
+## 🔥 亮点
+
+- 🧭 **OD Next 现在可以主动开启，而不会改变所有人的默认设置。** 新的任务策略可以
+  接管 Prototype、Slide Deck、Marketing 与 HyperFrames，从规划一直走到交付；你
+  明确选择的 Plugin、Skill 和 template 仍由你决定。运行
+  `od config set odNextStrategyMode active` 即可开启，再切回 `off` 也不需要重启。
+  (#7016, #7362)
+
+- 🖼️ **HTML 预览保持可见、可交互，资源也能正确连接。** 多文件 artifact 中的
+  script、样式、图片、module 和相对请求可以继续工作；切换项目、文件或
+  Code/Preview 时，也不会再触发 Electron 导航竞态，把已经完整加载的页面画成白屏。
+  演示模式新增可靠的退出入口，点击预览本身也能像点击其他区域一样关闭 viewport
+  菜单。 (#7336, #7358) 感谢 @lefarcen。
+
+- 🧰 **可用的 Agent 不会再被损坏的 shim 挡住。** PATH 前面出现失效的可执行文件
+  时，OpenDesign 会继续寻找真正可用的版本；确实无法启动时，Settings 会保留
+  Agent、说明原因并给出修复入口。DeepSeek Harness 也支持用户实际安装到的新版
+  release line，一键安装不再卡在依赖解析里。 (#7153, #7339) 感谢 @lefarcen。
+
+- 🌙 **Kimi 0.37 及以上版本可以重新正常运行。** 新版 Kimi 不再接受 OpenDesign
+  过去附带的 stdio MCP transport，导致任务在握手时直接失败。OpenDesign 现在只
+  发送当前 Kimi build 能接受的 transport，消息会重新得到正常的流式回复，而不是
+  在工作开始前报错。 (#7313) 感谢 @lefarcen。
+
+- 🚪 **遗留的本地引擎不再让 App 重启失败。** 崩溃后残留的 web sidecar 可能继续
+  占用 socket，让之后每次启动都在启动页退出。OpenDesign 现在会安全接管失效的
+  owner；桌面 App 退出时，daemon 与 web 子进程也会一同结束，不再影响下一次启动。
+  (#7279) 感谢 @mrcfps。
+
+- 🤖 **Coding Plan 模型权益以当前登录账号为准。** 模型选择器与 Unlimited 标记会
+  读取经过认证的实时权益列表，不再依赖写死的套餐快照。DeepSeek V4 Flash Vision
+  Exp 也加入所有付费 Personal 套餐的不限量模型列表；旧客户端暂未刷新权益时，
+  页面会说明如何完成激活。 (#7289, #7250) 感谢 @Siri-Ray。
+
+- 🧠 **AI Optimize 即使连点两次，也只会运行一次。** 过去两个入口可能在几百毫秒
+  内启动相同的隐藏设计系统优化，重复计费并同时改写同一批文件。现在客户端会在
+  请求发出前拦住重复操作，daemon 也会为其他 tab 和外部客户端守住同一条边界。
+  (#7271) 感谢 @lefarcen。
+
+- 💳 **Pricing 在进入 checkout 前就如实说明可执行的操作。** 当前计费周期、待生效
+  变更、取消状态、不可用的变更和 Team 计费都会直接显示在决策位置。Go 已明确标记
+  售罄，旧的 App 内活动入口也已下线；仍在进行的 DeepSeek 活动为付费和未付费用户
+  提供一致的升级路径。 (#7228, #7239, #7240, #7352, #7361) 感谢 @Siri-Ray。
+
+- 🌐 **离开 Website Clone 后，它的引导词也会留在原处。** 未修改的“复刻这个网站”
+  scaffold 不再跟着你进入 Slide Deck、Image、Document、HyperFrames、Video 或
+  Audio。填入自己的 URL 后，草稿仍会完整保留；没有修改引导词时，下一个创建模式
+  会从空白开始。 (#7344) 感谢 @lefarcen。
+
+- 🔌 **长时间运行的 MCP session 可以按实际工作节奏保持在线。** 默认仍会在空闲
+  30 分钟后退出；需要更长 session 的客户端可以通过
+  `OD_MCP_STDIO_IDLE_EXIT_MS` 设置最长 24 小时的边界，或禁用 idle exit。
+  (#7288) 感谢 @huytdps13400。
+
+## ✨ 新增
+
+### 🧠 Agent、runtime 与自动化
+
+- 每个安装实例都可以用 `od config set odNextStrategyMode active` 开启 OD Next；
+  下一次运行立即生效，无需重启，并能查看当前模式来自 app config、环境变量还是
+  默认值。 (#7016, #7362)
+- `OD_MCP_STDIO_IDLE_EXIT_MS` 可以配置 stdio MCP 的空闲生命周期；设为 `0` 时，
+  进程会一直保持到客户端断开。 (#7288) 感谢 @huytdps13400。
+
+### 🔑 模型、套餐与媒体
+
+- Coding Plan 的可用模型与 Unlimited 标记会跟随当前账号的实时权益列表。
+  (#7289) 感谢 @Siri-Ray。
+- DeepSeek V4 Flash Vision Exp 在 Go、Plus、Pro 和 Max 中不限量使用；Pricing
+  页面也会说明如何在旧客户端中刷新延迟出现的权益。 (#7250)
+
+## 🔁 变更
+
+- 公开 Pricing 页面会跟随登录订阅的计费周期与状态，禁用 checkout 会拒绝的操作，
+  在需要订阅上下文的位置恢复账号入口，并让套餐与模型详情更容易展开和比较。
+  (#7228, #7239, #7240) 感谢 @Siri-Ray。
+- Go 对已有订阅者仍然可见，但新购买入口已标记售罄；客户端不再展示旧的 Go 活动
+  badge 与 welcome modal。 (#7352, #7361) 感谢 @Siri-Ray。
+- 所有社区入口统一指向 Discord；中文客户端、网站和文档不再把社区分散在飞书与
+  Discord 两处。 (#7295) 感谢 @joeylee12629-star。
+- 首次点击账号头像会固定展开菜单；再次点击、按 Escape、点击外部或导航后才会
+  明确关闭。 (#7330) 感谢 @Siri-Ray。
+- 没有任何 Skill 的来源不会再显示为空筛选项；加入对应 Skill 后，它会自动重新
+  出现。 (#7298) 感谢 @nettee。
+
+## 🐛 修复
+
+### 🎨 Studio、预览与导出
+
+- 多文件 Electron 预览可以解析相对 script、样式、图片、module、import 与请求；
+  切换项目、文件和 Code/Preview 时，已激活的预览会保持 warm，不再跳转成白屏。
+  (#7336) 感谢 @lefarcen。
+- 点击预览本身可以关闭 viewport 菜单；演示模式在焦点进入 slide 后仍有可用的退出
+  按钮；版本历史也会明确说明预览将在新窗口打开。 (#7358) 感谢 @lefarcen。
+- headless 与 container 部署不再提供 daemon 无法渲染的 PPTX 导出入口；桌面端保留
+  原有导出，连接失败也不会再被误报为当前 runtime 不支持。 (#7224) 感谢
+  @jiulongche。
+- Website Clone 的起始引导词在未修改时会把 composer 还原为空；加入 URL 后则会
+  完整保留，并在所有支持的创建入口中使用本地化文案。 (#7344) 感谢 @lefarcen。
+
+### 🧠 Agent、runtime 与对话
+
+- DeepSeek Harness 检测会跳过 PATH 中损坏的 shim，让不可用的 Agent 保持可见并
+  给出诊断与修复操作，同时支持当前 `0.1.1-rc.x` release line。
+  (#7153, #7339) 感谢 @lefarcen。
+- Kimi 0.37+ session 不再携带这些版本会拒绝的 stdio MCP transport，ACP 可以正常
+  启动并返回流式回复。 (#7313) 感谢 @lefarcen。
+- Antigravity 现在会收到真实的用户 prompt，而不是字面量 `-`。 (#7205) 感谢
+  @mturac。
+- native resume 与 transcript replay 使用同一套跨 Agent 安全决策：只有存储的
+  session 与当前可见对话一致时才 resume，否则清理失效 handle，并只用完整
+  transcript 重新开始一次。 (#5269) 感谢 @alucero270。
+- ACP usage、session info 和 command metadata 不再以原始状态文本混入可见对话。
+  (#7309) 感谢 @helsome。
+- ACP stage timeout 会保留真实静默时长，并明确记录终止任务的 watchdog；昂贵的卡死
+  不再看起来像用户主动中断。 (#7310) 感谢 @lefarcen。
+- 同一个 conversation 只允许一个 Design System AI Optimize refinement；双击、另一个
+  tab 或外部客户端都不会再创建作用于同一批文件的重复计费 run。 (#7271) 感谢
+  @lefarcen。
+
+### 🖥️ 桌面端、导航与界面细节
+
+- 打包客户端会在启动时接管失去响应的 web sidecar，并在桌面 owner 退出时清理
+  daemon 与 web 子进程。 (#7279) 感谢 @mrcfps。
+- App 位于前台、结果已经显示时，失败任务不再额外弹出系统通知；后台通知与已启用
+  的完成提示音保持原有行为。 (#7329) 感谢 @Siri-Ray。
+- 点击头像后账号菜单会保持打开；Onboarding 中的 Local CLI 选项保持对齐；空的
+  Skills 来源筛选也不会占据界面。 (#7330, #7338, #7298) 感谢 @Siri-Ray、
+  @lefarcen、@nettee。
+- DeepSeek 活动使用官方 provider logo；图片无法加载时，会回退到可访问、可辨认的
+  文本缩写。 (#7326) 感谢 @Siri-Ray。
+
+### 💳 套餐与活动
+
+- Pricing 操作会在进入 checkout 前遵循真实订阅状态和计费周期；待生效、取消中、
+  不可用和降级状态都有明确说明。 (#7239) 感谢 @Siri-Ray。
+- Pricing 与首页之间的模型顺序、套餐文案、推荐颜色和活动颜色保持一致。
+  (#7228) 感谢 @Siri-Ray。
+- Go 库存关闭后不再提供 checkout；本地客户端也不会把已经结束的 Go 活动与当前
+  DeepSeek 活动同时展示。 (#7352, #7361) 感谢 @Siri-Ray。
+
+## 🙏 感谢所有参与 0.21.0 的贡献者
+
+@alucero270 · @helsome · @huytdps13400 · @jiulongche ·
+@joeylee12629-star · @lefarcen · @mrcfps · @mturac · @nettee · @OctoBored ·
+@PerishCode · @Siri-Ray · @UnknownObject777

--- a/docs/CHANGELOG/v0.21.0/zh-CN.md
+++ b/docs/CHANGELOG/v0.21.0/zh-CN.md
@@ -1,14 +1,12 @@
 ---
-title: OpenDesign 0.21.0 — 内建恢复力
-description: OpenDesign 0.21.0 让日常故障不再变成死路，带来更可靠的 Agent 发现与 Electron 预览、更安全的会话恢复、更准确的模型权益，以及更清晰的日常交互。
+title: Open Design 0.21.0 — Reliable, Start to Finish
+description: 从 Agent 连接、实时 HTML 预览到 App 重新启动，Open Design 0.21.0 让整个创作体验更加可靠；遇到问题时，也更容易恢复。
 ---
 
-### 🌟 Codename: *Built to Recover*
+### 🌟 Codename: *Reliable, Start to Finish*
 
-🛡️ **42 个 PR · 13 位贡献者 · 4 天** — **0.21.0 让日常故障不再变成死路。**
-一个损坏的 CLI shim、一次 Agent 升级、遗留的 sidecar，或 Electron 里的一块白屏，
-过去都可能让工作突然停住。现在 OpenDesign 会识别故障、保住仍然正确的状态，并从
-App 启动、Agent 运行一路到最终交付的预览，为你留下继续向前的路径。🚀
+🛡️ **42 个 PR · 13 位贡献者 · 4 天** — **从 Agent 连接、实时 HTML 预览到 App
+重新启动，Open Design 0.21.0 让整个创作体验更加可靠；遇到问题时，也更容易恢复。** 🚀
 
 ## 🔥 亮点
 


### PR DESCRIPTION
## Summary

- add the English OpenDesign 0.21.0 release note
- add the required zh-CN localization
- include the stable release-note front matter consumed by release-stable

## Validation

- stable release-note policy: prepared stable 0.21.0 release notes: en, zh-CN
- git diff --check

## Release sequencing

This supersedes the closed direct-to-release PR #7390. After this PR merges to main, the backport label should carry the changelog to release/v0.21.0. Build and validate a new prerelease from that final release commit; prerelease.3 must not be promoted as stable.