### PR TITLE
fix(web): answer /api paths with a connection failure when no daemon origin is configured

### DIFF
--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -42,6 +42,11 @@ const WEB_OUTPUT_MODE_ENV = "OD_WEB_OUTPUT_MODE";
 const WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 const STANDALONE_PARENT_PID_ENV = "OD_STANDALONE_PARENT_PID";
 const STANDALONE_STARTUP_TIMEOUT_ENV = "OD_STANDALONE_STARTUP_TIMEOUT_MS";
+// Synthesized for daemon-routed paths when no daemon origin is configured:
+// same plain-text errno shape as a dead-daemon proxy failure so the web app's
+// isDaemonProxyConnectionFailure recognizes it as an outage.
+const DAEMON_PROXY_UNAVAILABLE_MESSAGE =
+  `connect ECONNREFUSED (${DAEMON_PORT_ENV} is not set; the web runtime has no daemon origin)`;
 const SHUTDOWN_TIMEOUT_MS = 3000;
 const STANDALONE_READINESS_POLL_MS = 150;
 const STANDALONE_TCP_READINESS_GRACE_MS = STANDALONE_READINESS_POLL_MS;
@@ -215,7 +220,23 @@ function shouldUseStandaloneOutput(runtime: SidecarRuntimeContext<SidecarStamp>)
 
 function resolveDaemonOrigin(): string | null {
   const port = parsePort(process.env[DAEMON_PORT_ENV]);
-  return port === 0 ? null : `http://${DAEMON_HOST}:${port}`;
+  if (port === 0) {
+    console.warn(
+      `[open-design web] ${DAEMON_PORT_ENV} is not set; /api, /artifacts and /frames will answer ${DAEMON_PROXY_UNAVAILABLE_MESSAGE}`,
+    );
+    return null;
+  }
+  return `http://${DAEMON_HOST}:${port}`;
+}
+
+function resolveRequestPathname(requestUrl: string | undefined): string | null {
+  if (requestUrl == null) return null;
+
+  try {
+    return new URL(requestUrl, `http://${HOST}`).pathname;
+  } catch {
+    return null;
+  }
 }
 
 function isDaemonProxyPathname(pathname: string): boolean {
@@ -1018,6 +1039,20 @@ export function createDaemonProxyHandler(
         response.statusCode = 502;
         response.end(error instanceof Error ? error.message : String(error));
       });
+      return;
+    }
+
+    // Daemon-routed pathnames must never fall through to the SPA shell: the
+    // Next.js catch-all answers every path with 200 text/html, which browser
+    // callers parse as JSON and crash on. With no daemon origin there is no
+    // proxy target, so answer as the connection-level outage it is.
+    if (
+      daemonOrigin == null &&
+      isDaemonProxyPathname(resolveRequestPathname(request.url) ?? "")
+    ) {
+      response.statusCode = 502;
+      response.setHeader("content-type", "text/plain; charset=utf-8");
+      response.end(DAEMON_PROXY_UNAVAILABLE_MESSAGE);
       return;
     }
 

--- a/apps/web/tests/sidecar-proxy-daemon-unavailable.test.ts
+++ b/apps/web/tests/sidecar-proxy-daemon-unavailable.test.ts
@@ -1,0 +1,112 @@
+// Red spec for issue #6074 (HTML instead of JSON on /api/*).
+//
+// When the web sidecar starts without a usable daemon origin (`OD_PORT`
+// missing or 0), `createDaemonProxyHandler` fell `/api`, `/artifacts`, and
+// `/frames` requests through to the Next.js fallback, whose catch-all route
+// answers every path with 200 text/html. Browser API calls then died parsing
+// HTML ("Unexpected token '<'") and agent detection silently came back empty.
+//
+// The spec: daemon-routed pathnames with no configured daemon origin must be
+// answered as the connection-level outage they are, using the same plain-text
+// 502 shape the proxy already synthesizes for a dead daemon, so the client's
+// isDaemonProxyConnectionFailure recognizes them. Non-daemon paths keep
+// falling through to the SPA shell.
+
+import { createServer as createHttpServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDaemonProxyHandler } from '../sidecar/server';
+
+type FallbackBehavior = (request: IncomingMessage, response: ServerResponse) => void;
+
+const cleanups: (() => Promise<void>)[] = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()!();
+});
+
+async function startProxy(
+  daemonOrigin: string | null,
+  fallback: FallbackBehavior,
+): Promise<{ port: number; fallbackCalls: () => number }> {
+  let calls = 0;
+  const proxy: HttpServer = createHttpServer(
+    createDaemonProxyHandler(daemonOrigin, async (request, response) => {
+      calls += 1;
+      await fallback(request, response);
+    }),
+  );
+  await new Promise<void>((resolve) => {
+    proxy.listen(0, '127.0.0.1', () => resolve());
+  });
+  cleanups.push(async () => {
+    await new Promise<void>((resolve) => {
+      proxy.close(() => resolve());
+    });
+    proxy.closeAllConnections();
+  });
+  return {
+    port: (proxy.address() as AddressInfo).port,
+    fallbackCalls: () => calls,
+  };
+}
+
+function spaShellFallback(_request: IncomingMessage, response: ServerResponse): void {
+  response.statusCode = 200;
+  response.setHeader('content-type', 'text/html; charset=utf-8');
+  response.end('<!DOCTYPE html><html><body>app shell</body></html>');
+}
+
+async function startJsonUpstream(): Promise<number> {
+  const upstream = createHttpServer((_request, response) => {
+    response.statusCode = 200;
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise<void>((resolve) => {
+    upstream.listen(0, '127.0.0.1', () => resolve());
+  });
+  cleanups.push(async () => {
+    await new Promise<void>((resolve) => {
+      upstream.close(() => resolve());
+    });
+    upstream.closeAllConnections();
+  });
+  return (upstream.address() as AddressInfo).port;
+}
+
+describe('createDaemonProxyHandler without a daemon origin', () => {
+  it('answers daemon-routed paths with a connection failure instead of the SPA shell', async () => {
+    const proxy = await startProxy(null, spaShellFallback);
+
+    const response = await fetch(`http://127.0.0.1:${proxy.port}/api/auth/session`, { method: 'POST' });
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get('content-type') ?? '').toContain('text/plain');
+    expect(await response.text()).toContain('ECONNREFUSED');
+    expect(proxy.fallbackCalls()).toBe(0);
+  });
+
+  it('keeps serving non-daemon paths through the SPA fallback', async () => {
+    const proxy = await startProxy(null, spaShellFallback);
+
+    const response = await fetch(`http://127.0.0.1:${proxy.port}/settings`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type') ?? '').toContain('text/html');
+    expect(proxy.fallbackCalls()).toBe(1);
+  });
+
+  it('still proxies daemon-routed paths once a daemon origin is configured', async () => {
+    const upstreamPort = await startJsonUpstream();
+    const proxy = await startProxy(`http://127.0.0.1:${upstreamPort}`, spaShellFallback);
+
+    const response = await fetch(`http://127.0.0.1:${proxy.port}/api/version`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(proxy.fallbackCalls()).toBe(0);
+  });
+});


### PR DESCRIPTION
Related to #6074

## Why

A packaged user opened their instance's localhost URL in a regular browser and every API call came back as HTML: sign-in died with `Unexpected token '<', "<!DOCTYPE"...` and the local-agents panel stayed empty no matter how often they rescanned (#6074). Tracing the request path, the only component that can answer `/api/*` with `<!DOCTYPE html>` is Next.js's catch-all page — meaning the request hit the web sidecar while it had no daemon origin to proxy to (`OD_PORT` unset or 0), and `createDaemonProxyHandler` fell daemon-routed paths straight through to the SPA shell.

Whatever leaves a web runtime proxy-less (a raced startup, a stale process from an earlier session, a hand-edited launch), the caller-visible result today is a JSON parse error far away from the real cause. One diagnosable response at the routing seam turns that whole class of states into an outage the app already understands.

Adjacent, deliberately out of scope: requests aimed directly at the internal standalone Next backend port (not the sidecar listener) still serve the shell; handling those in-app would require route handlers that are incompatible with the static-export build used by `od serve`.

## What users will see

If the web UI ever comes up without a reachable daemon origin, API calls now fail immediately with the same plain-text connection failure (502, ECONNREFUSED-shaped) the proxy already synthesizes for a dead daemon, so sign-in and agent panels show the recognizable retryable-outage state instead of throwing JSON parse errors. When `OD_PORT` is present — every normal launch — behavior is byte-identical.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — no new env var, but `OD_PORT`-missing handling in the web sidecar changes (daemon-routed paths now fail loudly instead of serving the shell)
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — healthy launches are byte-identical; only launches that were already misconfigured (`OD_PORT` absent/0) see different responses
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI surface; responses are transport-level errors.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/sidecar-proxy-daemon-unavailable.test.ts`
- Did the test go red on `main` and green on this branch? yes — with the source guard stashed, the outage case fails (fallback serves 200 text/html where 502 is asserted); with the guard restored, all three cases pass.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/sidecar-proxy-daemon-unavailable.test.ts tests/sidecar-proxy.test.ts tests/sidecar-proxy-keepalive.test.ts` — 26 passed
- `tsc -b --noEmit` for `@open-design/web`: no new errors versus baseline (pre-existing missing-dist errors identical on both sides of a stash diff)
- `git diff --check` clean
- Full workspace `pnpm guard` / `pnpm typecheck` and upstream CI lanes not runnable in the local environment used to prepare this patch (partial filtered install) — left to CI