### PR TITLE
fix(daemon): add Fable and the Claude 5 ids to the model picker

### DIFF
--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -3,20 +3,15 @@ import { DEFAULT_MODEL_OPTION } from './shared.js';
 import { loadMmdRouteModels } from '../mmd-routes.js';
 import type { RuntimeAgentDef } from '../types.js';
 
-// Aliases resolve to whatever the CLI currently treats as "latest" for that
-// tier, so they stay correct across model generations and are the entries to
-// prefer. `claude --help` documents `fable`, `opus`, `sonnet` and `haiku`.
-// The pinned ids below are for users who deliberately want one exact
-// generation; the older ones stay listed because they still serve.
 const CLAUDE_FALLBACK_MODELS = [
   DEFAULT_MODEL_OPTION,
-  { id: 'fable', label: 'Fable (alias)' },
-  { id: 'opus', label: 'Opus (alias)' },
   { id: 'sonnet', label: 'Sonnet (alias)' },
+  { id: 'opus', label: 'Opus (alias)' },
   { id: 'haiku', label: 'Haiku (alias)' },
-  { id: 'claude-fable-5', label: 'claude-fable-5' },
+  { id: 'fable', label: 'Fable (alias)' },
   { id: 'claude-opus-5', label: 'claude-opus-5' },
   { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
+  { id: 'claude-fable-5', label: 'claude-fable-5' },
   { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
   { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
   { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },

--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -3,11 +3,20 @@ import { DEFAULT_MODEL_OPTION } from './shared.js';
 import { loadMmdRouteModels } from '../mmd-routes.js';
 import type { RuntimeAgentDef } from '../types.js';
 
+// Aliases resolve to whatever the CLI currently treats as "latest" for that
+// tier, so they stay correct across model generations and are the entries to
+// prefer. `claude --help` documents `fable`, `opus`, `sonnet` and `haiku`.
+// The pinned ids below are for users who deliberately want one exact
+// generation; the older ones stay listed because they still serve.
 const CLAUDE_FALLBACK_MODELS = [
   DEFAULT_MODEL_OPTION,
-  { id: 'sonnet', label: 'Sonnet (alias)' },
+  { id: 'fable', label: 'Fable (alias)' },
   { id: 'opus', label: 'Opus (alias)' },
+  { id: 'sonnet', label: 'Sonnet (alias)' },
   { id: 'haiku', label: 'Haiku (alias)' },
+  { id: 'claude-fable-5', label: 'claude-fable-5' },
+  { id: 'claude-opus-5', label: 'claude-opus-5' },
+  { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
   { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
   { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
   { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },


### PR DESCRIPTION
## Why

I hit this building an external agent on top of Open Design: I drive runs through `od run start --agent claude` and wanted to pin a specific model per run. Fable simply isn't in the picker — and the pinned Claude ids that *are* there all stop at the 4.5 generation.

The CLI has supported it for a while. `claude --help` says so outright:

> `--model <model>` — Provide an alias for the latest model (e.g. **'fable'**, 'opus', or 'sonnet') or a model's full name (e.g. **'claude-fable-5'**).

`CLAUDE_FALLBACK_MODELS` in `apps/daemon/src/runtimes/defs/claude.ts` has no `fable` entry, so a model the runtime can already launch is unreachable from the UI. The pinned ids are a subtler problem: someone picking `claude-opus-4-5` because it looks like the explicit, careful choice silently gets the previous generation, while the `opus` alias right above it resolves to `claude-opus-5`.

## What users will see

The model picker for Claude Code gains **Fable (alias)** plus pinned `claude-fable-5`, `claude-opus-5` and `claude-sonnet-5`. Aliases now sort before pinned ids, since aliases stay correct as generations move.

Nothing is removed and no default changes — the 4.5 ids still work and stay listed for anyone who wants that exact generation.

## Surface area

- [x] **UI** — model picker entries for the Claude runtime
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

No screenshot attached because the change is list content, not layout: the picker gains four rows and the alias rows move above the pinned ones.

## Bug fix verification

No red spec. The change is data, not logic — a test asserting "the array contains `fable`" would restate the literal it guards rather than pin behavior, and `CLAUDE_FALLBACK_MODELS` is currently referenced by no test. (The `claude-opus-4-5` hits elsewhere in the tree are the token-limit table and icon mapping, which this doesn't touch.)

Verified against the CLI instead, resolving each alias with `claude --model <id> -p` and asking the model to name itself:

| passed to `--model` | model that answered |
|---|---|
| `fable` | `claude-fable-5` |
| `opus` | `claude-opus-5` |
| `sonnet` | `claude-sonnet-5` |
| `claude-fable-5` | ok |
| `claude-opus-5` | ok |
| `claude-opus-4-5` | ok (still serves) |
| `claude-sonnet-4-5` | ok (still serves) |

Tested end to end through the daemon as well: `od run start --agent claude --model fable` returned *"Ich bin Claude Fable 5 (Modell-ID `claude-fable-5`)"*. So the runtime already passes the value through untouched — only the picker was missing it.

CLI version tested: `2.1.241 (Claude Code)`, daemon 0.20.2 on macOS.

## Adjacent issue, not fixed here

`apps/web/src/state/litellm-models.json` carries no context-window entries for any Claude 5 id — it is a generated snapshot of BerriAI/litellm stamped `"_generated_at": "2026-05-02"`. Models added here will fall back to the default max-tokens value until that file is regenerated. I left it alone since hand-editing a generated file seemed like the wrong fix; happy to open a separate issue if a refresh is wanted.
