### PR TITLE
fix(pack): expose the od CLI through a bundled-runtime shim on Windows

### DIFF
--- a/tools/pack/CACHE.md
+++ b/tools/pack/CACHE.md
@@ -122,6 +122,12 @@ version identity reaches it only indirectly through the upstream `sourceKey`;
 the final `win.launcher-payload` archive explicitly carries the
 version-bearing `manifest` and `configBody`.
 
+Every Windows app bundle also stages an `od.cmd` CLI shim beside the
+executable. `win.nsis-payload-base` folds the generated shim text into its
+input hash (`odCmdScript`, together with base payload input hash cache
+version 3), and `win.portable-zip` folds the same field into its key, so any
+change to the shim invalidates both artifacts.
+
 **Requirement.** A value may be a materialization-time parameter only when
 both hold:
 

--- a/tools/pack/src/win/builder.ts
+++ b/tools/pack/src/win/builder.ts
@@ -71,7 +71,7 @@ import type {
 const execFileAsync = promisify(execFile);
 const WIN_ARCHIVE_CACHE_VERSION = 3;
 const WIN_ELECTRON_BUILDER_DIR_CACHE_VERSION = 8;
-const WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION = 2;
+const WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION = 3;
 
 async function hashWinNsisInstallerImplementation(config: ToolPackConfig): Promise<string> {
   const sourceModulePath = join(config.workspaceRoot, "tools", "pack", "src", "win", "custom-installer.ts");
@@ -332,6 +332,7 @@ async function resolveCachedNsisBasePayloadInputHash(
     : hashJson({
       cacheEntryPath: builtApp.cacheEntryPath,
       excludedOverlayPaths: resolveWinNsisOverlayRequiredPaths(),
+      odCmdScript: createWinOdCmdScript(),
       version: WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION,
     });
   await writeFile(
@@ -443,6 +444,26 @@ async function assertWinUnpackedNodePtyRuntime(unpackedRoot: string): Promise<vo
     arch: "x64",
     platform: "win32",
   });
+}
+
+export function createWinOdCmdScript(): string {
+  const daemonCliPath = join("resources", WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).split("/").join("\\");
+  return [
+    "@echo off",
+    "setlocal",
+    'set "ELECTRON_RUN_AS_NODE=1"',
+    `"%~dp0${PRODUCT_NAME}.exe" "%~dp0${daemonCliPath}" %*`,
+    "",
+  ].join("\r\n");
+}
+
+export async function writeWinOdCmdShim(unpackedRoot: string): Promise<void> {
+  const shimPath = join(unpackedRoot, "od.cmd");
+  const script = createWinOdCmdScript();
+  await writeFile(shimPath, script, "utf8");
+  if ((await readFile(shimPath, "utf8")) !== script) {
+    throw new Error("staged od.cmd shim content mismatch");
+  }
 }
 
 export async function materializeCachedUnpackedForInstaller(
@@ -844,7 +865,9 @@ export async function runElectronBuilder(
       if (materializedManifest == null) {
         throw new Error("electron builder cache entry disappeared before installer materialization");
       }
-      return materializeCachedUnpackedForInstaller(paths, packagedVersion);
+      const builtApp = await materializeCachedUnpackedForInstaller(paths, packagedVersion);
+      await writeWinOdCmdShim(paths.unpackedRoot);
+      return builtApp;
     });
     let signedUnpacked = false;
     const ensureSignedUnpacked = async (): Promise<void> => {
@@ -872,6 +895,7 @@ export async function runElectronBuilder(
           key: hashJson({
             archiveCacheVersion: WIN_ARCHIVE_CACHE_VERSION,
             namespace: config.namespace,
+            odCmdScript: createWinOdCmdScript(),
             packagedAppKey,
             packagedVersion,
             signing: signingCacheKey,

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -582,6 +582,126 @@ ${createLauncherRuntimeSyncScript(
   launcherRuntimeSyncScriptPath,
 )}
 
+Function AddOdCliToUserPath
+  ; Keep $INSTDIR on the per-user PATH so od.cmd resolves in new shells.
+  ; Rebuilding the value segment-by-segment keeps reinstalls, upgrades, and
+  ; sibling channel installs idempotent without owning shared PATH state.
+  Push $R0
+  Push $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  Push $R5
+  ClearErrors
+  ReadRegStr $R0 HKCU "Environment" "PATH"
+  \${If} \${Errors}
+    StrCpy $R0 ""
+  \${EndIf}
+  StrCpy $R1 ""
+  StrCpy $R2 "$R0;"
+  StrCpy $R5 0
+od_path_scan_segments:
+  StrCpy $R3 ""
+od_path_scan_chars:
+  StrCpy $R4 "$R2" 1
+  StrCpy $R2 "$R2" "" 1
+  \${If} $R4 == ""
+    Goto od_path_emit
+  \${EndIf}
+  \${If} $R4 == ";"
+    Goto od_path_emit
+  \${EndIf}
+  StrCpy $R3 "$R3$R4"
+  Goto od_path_scan_chars
+od_path_emit:
+  \${If} $R3 == "$INSTDIR"
+    StrCpy $R5 1
+  \${EndIf}
+  \${If} $R3 != ""
+    \${If} $R1 == ""
+      StrCpy $R1 "$R3"
+    \${Else}
+      StrCpy $R1 "$R1;$R3"
+    \${EndIf}
+  \${EndIf}
+  \${If} $R4 == ""
+    Goto od_path_finish
+  \${EndIf}
+  Goto od_path_scan_segments
+od_path_finish:
+  \${If} $R5 == 0
+    \${If} $R1 == ""
+      StrCpy $R1 "$INSTDIR"
+    \${Else}
+      StrCpy $R1 "$R1;$INSTDIR"
+    \${EndIf}
+    WriteRegExpandStr HKCU "Environment" "PATH" $R1
+    SendMessage \${HWND_BROADCAST} \${WM_SETTINGCHANGE} 0 "STR:Environment"
+  \${EndIf}
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Pop $R0
+FunctionEnd
+
+Function un.RemoveOdCliFromUserPath
+  ; Drop only PATH segments equal to this install directory; other entries
+  ; (user edits, sibling channels) survive untouched.
+  Push $R0
+  Push $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  ClearErrors
+  ReadRegStr $R0 HKCU "Environment" "PATH"
+  \${If} \${Errors}
+    StrCpy $R0 ""
+  \${EndIf}
+  StrCpy $R1 ""
+  StrCpy $R2 "$R0;"
+od_unpath_scan_segments:
+  StrCpy $R3 ""
+od_unpath_scan_chars:
+  StrCpy $R4 "$R2" 1
+  StrCpy $R2 "$R2" "" 1
+  \${If} $R4 == ""
+    Goto od_unpath_emit
+  \${EndIf}
+  \${If} $R4 == ";"
+    Goto od_unpath_emit
+  \${EndIf}
+  StrCpy $R3 "$R3$R4"
+  Goto od_unpath_scan_chars
+od_unpath_emit:
+  \${If} $R3 != ""
+    \${If} $R3 == "$INSTDIR"
+      Goto od_unpath_next
+    \${EndIf}
+    \${If} $R1 == ""
+      StrCpy $R1 "$R3"
+    \${Else}
+      StrCpy $R1 "$R1;$R3"
+    \${EndIf}
+  \${EndIf}
+od_unpath_next:
+  \${If} $R4 == ""
+    Goto od_unpath_finish
+  \${EndIf}
+  Goto od_unpath_scan_segments
+od_unpath_finish:
+  \${If} $R1 != $R0
+    WriteRegExpandStr HKCU "Environment" "PATH" $R1
+    SendMessage \${HWND_BROADCAST} \${WM_SETTINGCHANGE} 0 "STR:Environment"
+  \${EndIf}
+  Pop $R4
+  Pop $R3
+  Pop $R2
+  Pop $R1
+  Pop $R0
+FunctionEnd
+
 Function un.LogInstallerEvent
   Exch $0
   Push $1
@@ -1002,6 +1122,9 @@ skip_silent_desktop_shortcut:
   Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"
   Call LogInstallerEvent
   Call SyncLauncherRuntime
+  Push "event=od_cli_user_path_updated"
+  Call LogInstallerEvent
+  Call AddOdCliToUserPath
   Push "install section done"
   Call LogInstallerEvent
 SectionEnd
@@ -1034,6 +1157,7 @@ after_desktop_shortcut:
   StrCmp $3 $1 0 preserve_invite_protocol
   DeleteRegKey HKCU "${inviteProtocolKey}"
 preserve_invite_protocol:
+  Call un.RemoveOdCliFromUserPath
   Push "event=registry_after_delete key=${registryKey} appPathsKey=${appPathsKey}"
   Call un.LogInstallerEvent
   \${If} $RemoveCacheDataState == \${BST_CHECKED}

--- a/tools/pack/tests/win-builder.test.ts
+++ b/tools/pack/tests/win-builder.test.ts
@@ -9,9 +9,15 @@ import { describe, expect, it } from "vitest";
 
 import winBuildSource from "@/win/build.ts?raw";
 import winBuilderSource from "@/win/builder.ts?raw";
-import { materializeCachedUnpackedForInstaller } from "@/win/builder.js";
+import {
+  createWinOdCmdScript,
+  materializeCachedUnpackedForInstaller,
+  writeWinOdCmdShim,
+} from "@/win/builder.js";
+import { PRODUCT_NAME } from "@/win/constants.js";
 import winCustomInstallerSource from "@/win/custom-installer.ts?raw";
 import { createLauncherRuntimeSyncPowerShellScript } from "@/win/custom-installer.js";
+import { WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH } from "@/win/prebundle.js";
 import winPayloadSource from "@/win/payload.ts?raw";
 import type { WinPaths } from "@/win/types.js";
 import { readWinExecutableVersionSnapshot } from "@/win/version-resource.js";
@@ -176,7 +182,7 @@ describe("Windows pack artifact boundaries", () => {
   });
 
   it("invalidates Windows payload caches when the archive method changes", () => {
-    expect(winBuilderSource).toContain("const WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION = 2");
+    expect(winBuilderSource).toContain("const WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION = 3");
     expect(winPayloadSource).toContain("const WIN_LAUNCHER_PAYLOAD_BASE_CACHE_VERSION = 2");
     expect(winPayloadSource).toContain("const WIN_LAUNCHER_PAYLOAD_ARCHIVE_CACHE_VERSION = 2");
   });
@@ -284,3 +290,34 @@ async function createVersionedExecutable(packagedVersion: string): Promise<Buffe
   resource.outputResource(executable);
   return Buffer.from(executable.generate());
 }
+
+describe("win od.cmd shim staging", () => {
+  it("routes the daemon CLI through the bundled Electron runtime", () => {
+    const script = createWinOdCmdScript();
+    const daemonCli = WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH.split("/").join("\\");
+    expect(script.split("\r\n")).toEqual([
+      "@echo off",
+      "setlocal",
+      'set "ELECTRON_RUN_AS_NODE=1"',
+      `"%~dp0${PRODUCT_NAME}.exe" "%~dp0resources\\${daemonCli}" %*`,
+      "",
+    ]);
+  });
+
+  it("stages the shim beside the executable and verifies the bytes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-od-cmd-"));
+    try {
+      await writeWinOdCmdShim(root);
+      await expect(readFile(join(root, "od.cmd"), "utf8")).resolves.toBe(createWinOdCmdScript());
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("folds the shim into every cache key whose artifact embeds it", () => {
+    expect(winBuilderSource).toContain("odCmdScript: createWinOdCmdScript()");
+    expect(winBuilderSource).toContain("await writeWinOdCmdShim(paths.unpackedRoot)");
+    expect(winBuilderSource).toMatch(/WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION = 3;/);
+    expect(winBuilderSource).toContain("version: WIN_NSIS_BASE_PAYLOAD_INPUT_HASH_CACHE_VERSION");
+  });
+});

--- a/tools/pack/tests/win-custom-installer.test.ts
+++ b/tools/pack/tests/win-custom-installer.test.ts
@@ -132,3 +132,40 @@ describe("buildCustomWinNsisInstaller logging", () => {
     }
   });
 });
+
+describe("buildCustomWinNsisInstaller od CLI exposure", () => {
+  it("keeps the install directory on the per-user PATH for new shells", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-custom-installer-"));
+    try {
+      const script = await generateInstallerScript(root, false);
+
+      expect(nsisFunction(script, "AddOdCliToUserPath"))
+        .toContain('WriteRegExpandStr HKCU "Environment" "PATH"');
+      expect(nsisFunction(script, "AddOdCliToUserPath")).toContain("${WM_SETTINGCHANGE}");
+      // Dedupe guard: skip when this exact directory is already present.
+      expect(nsisFunction(script, "AddOdCliToUserPath")).toContain('$R3 == "$INSTDIR"');
+      // Install wires the call after the launcher runtime sync.
+      expect(script.indexOf("Call SyncLauncherRuntime"))
+        .toBeLessThan(script.indexOf("Call AddOdCliToUserPath"));
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("reverses the PATH entry on uninstall without touching other entries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-custom-installer-"));
+    try {
+      const script = await generateInstallerScript(root, false);
+      const uninstallSection = script.slice(script.indexOf('Section "Uninstall"'));
+
+      expect(uninstallSection).toContain("Call un.RemoveOdCliFromUserPath");
+      const removeFn = nsisFunction(script, "un.RemoveOdCliFromUserPath");
+      expect(removeFn).toContain('WriteRegExpandStr HKCU "Environment" "PATH"');
+      expect(removeFn).toContain("${WM_SETTINGCHANGE}");
+      // Ownership: only the segment equal to $INSTDIR is dropped.
+      expect(removeFn).toContain('$R3 == "$INSTDIR"');
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6388

## Why

After installing the Windows desktop app there is no shell-resolvable `od` entry point, and hand-running the prebundled CLI under system Node dies with ERR_DLOPEN_FAILED because `better_sqlite3.node` is compiled against the bundled Electron ABI (NODE_MODULE_VERSION 145 vs system Node 137). I hit this while setting up `od mcp` drivers on a Windows machine: the GUI works fine because it spawns the daemon sidecar through Open Design.exe with `ELECTRON_RUN_AS_NODE=1`, but nothing exposes that invocation outside the app, even though the README documents `od mcp install <agent>` and `od plugin list` as first-class flows.

## What users will see

After installing or upgrading on Windows, `od --version`, `od mcp install <agent>`, and `od plugin list` resolve from any new cmd/PowerShell window without manual PATH edits. The uninstaller removes only the PATH entry it added, and the shim disappears with the install directory. Portable zips carry the same od.cmd next to Open Design.exe.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — no new subcommand or flag; this makes the existing `od` CLI shell-resolvable on Windows by putting an `od.cmd` shim on the per-user PATH — the embeddability surface external agents drive
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — installs now put the install directory on the per-user PATH so `od` resolves out of the box; the uninstaller reverses exactly what it added
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — installer/CLI behavior; no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug:
  - `tools/pack/tests/win-custom-installer.test.ts` — "buildCustomWinNsisInstaller od CLI exposure"
  - `tools/pack/tests/win-builder.test.ts` — "win od.cmd shim staging"
- Did the test go red on `main` and green on this branch? yes (missing NSIS functions / missing exports before the source change)

## Validation

pnpm guard; pnpm typecheck; pnpm --filter @open-design/tools-pack typecheck; pnpm --filter @open-design/tools-pack test (291 passed, 8 skipped). The generated installer script compiles under makensis in the test harness; running the real NSIS installer end to end needs a Windows host, so the install → new-shell `od --version` → uninstall → PATH-restored user-flow pass from tools/pack/AGENTS.md is still worth running before release.