### PR TITLE
feat(collab): add an opt-in cumulative ceiling for background content pulls

### DIFF
--- a/apps/daemon/src/collab/background-pull-size-guard.ts
+++ b/apps/daemon/src/collab/background-pull-size-guard.ts
@@ -29,6 +29,23 @@ import type { AuthorizedTeamProjectPullInspection } from './authorized-team-proj
 export const DEFAULT_BACKGROUND_PULL_MAX_ENTRIES = 2000;
 export const BACKGROUND_PULL_MAX_ENTRIES_ENV =
   'OD_COLLAB_BACKGROUND_PULL_MAX_ENTRIES';
+export const BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES_ENV =
+  'OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES';
+
+/**
+ * Per-process cumulative ceiling for background materialization. Defaults to
+ * `0` (disabled), so this ships inert until a deliberate value is chosen —
+ * picking that number is a capacity decision that needs production data on
+ * real team sizes, not a default inferred from a synthetic workspace.
+ */
+export function backgroundPullMaxCumulativeEntriesFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES_ENV]?.trim();
+  if (!raw || !/^\d+$/u.test(raw)) return 0;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
 
 /**
  * Threshold resolution: a non-negative integer from
@@ -58,6 +75,23 @@ export interface BackgroundPullSizeGuardScope {
 export interface BackgroundPullSizeGuardDeps {
   /** Entries above this count defer; `0` disables the guard. */
   maxEntries: number;
+  /**
+   * Total entries this process may materialize through the BACKGROUND lanes
+   * before deferring everything else to the foreground. Omitted or `0`
+   * disables it, which is the pre-existing behaviour.
+   *
+   * `maxEntries` answers "is this ONE project too big to push onto every
+   * member's disk" (incident #6512: a single 7442-file project). It cannot see
+   * accumulation: measured on a live workspace, 12 projects of 12 files each
+   * all cleared it individually while a member who only opened the client
+   * pulled 23 MB across 8 projects in 50s, with `candidates=25 suppressed=0`.
+   * Onboarding cost therefore grew linearly with team size with no ceiling.
+   *
+   * Deferring is not denying: the foreground open-project lane never consults
+   * this guard, so anything skipped here still materializes the moment the
+   * user actually opens it.
+   */
+  maxCumulativeEntries?: number;
   /** Authorize-only manifest probe — must never download blobs. */
   inspect: (
     scope: BackgroundPullSizeGuardScope,
@@ -102,6 +136,10 @@ export function createBackgroundPullSizeGuard(
   /** Highest version deferred per scope. Same or older versions re-defer
    *  WITHOUT a probe; a newer version gets a fresh count. */
   const deferredVersions = new Map<string, number>();
+  /** Entries already cleared for background materialization this process. Only
+   *  counted for decisions this guard actually allowed, so a project deferred
+   *  for size never consumes budget it did not spend. */
+  let cumulativeEntries = 0;
   /** Exact version whose probe last said 'pull', per scope. Retry loops for
    *  the same version must not re-authorize against the cloud. */
   const allowedVersions = new Map<string, number>();
@@ -133,6 +171,29 @@ export function createBackgroundPullSizeGuard(
       allowedVersions.set(key, version);
       return 'pull';
     }
+    const cumulativeLimit = deps.maxCumulativeEntries ?? 0;
+    if (
+      cumulativeLimit > 0 &&
+      cumulativeEntries + inspection.entryCount > cumulativeLimit
+    ) {
+      // Budget exhausted for this process. Deliberately NOT remembered in
+      // `deferredVersions`: that map means "this version is too big", a
+      // permanent property of the version, whereas this is a transient
+      // session limit. Recording it there would suppress the project even
+      // after a restart reset the budget.
+      try {
+        deps.onDeferred?.({
+          projectId: scope.projectId,
+          workspaceId: scope.workspaceId,
+          version,
+          entryCount: inspection.entryCount,
+          maxEntries: deps.maxEntries,
+        });
+      } catch {
+        // Observation must never affect the decision.
+      }
+      return 'defer';
+    }
     if (inspection.entryCount > deps.maxEntries) {
       const previous = deferredVersions.get(key);
       if (previous == null || version > previous) {
@@ -152,6 +213,7 @@ export function createBackgroundPullSizeGuard(
       return 'defer';
     }
     allowedVersions.set(key, version);
+    if (cumulativeLimit > 0) cumulativeEntries += inspection.entryCount;
     return 'pull';
   };
 

--- a/apps/daemon/src/collab/background-pull-size-guard.ts
+++ b/apps/daemon/src/collab/background-pull-size-guard.ts
@@ -104,6 +104,14 @@ export interface BackgroundPullSizeGuardDeps {
     version: number;
     entryCount: number;
     maxEntries: number;
+    /**
+     * Which ceiling deferred this. `oversized` is one project too large on its
+     * own; `budget-exhausted` is a small project that simply arrived after the
+     * cumulative budget was spent. They need different responses — raise the
+     * per-project threshold vs. raise the session budget — so a log that
+     * called both "oversized" sent readers after the wrong one.
+     */
+    reason: 'oversized' | 'budget-exhausted';
   }) => void;
   onError?: (error: unknown) => void;
 }
@@ -188,6 +196,7 @@ export function createBackgroundPullSizeGuard(
           version,
           entryCount: inspection.entryCount,
           maxEntries: deps.maxEntries,
+          reason: 'budget-exhausted',
         });
       } catch {
         // Observation must never affect the decision.
@@ -206,6 +215,7 @@ export function createBackgroundPullSizeGuard(
           version,
           entryCount: inspection.entryCount,
           maxEntries: deps.maxEntries,
+          reason: 'oversized',
         });
       } catch {
         // Observation must never affect the decision.

--- a/apps/daemon/src/collab/background-pull-size-guard.ts
+++ b/apps/daemon/src/collab/background-pull-size-guard.ts
@@ -148,6 +148,10 @@ export function createBackgroundPullSizeGuard(
    *  counted for decisions this guard actually allowed, so a project deferred
    *  for size never consumes budget it did not spend. */
   let cumulativeEntries = 0;
+  /** Versions deferred because the session budget was spent. Kept apart from
+   *  `deferredVersions` (which means "permanently too big") so the two reasons
+   *  stay distinguishable, while both avoid re-probing. */
+  const budgetDeferredVersions = new Map<string, number>();
   /** Exact version whose probe last said 'pull', per scope. Retry loops for
    *  the same version must not re-authorize against the cloud. */
   const allowedVersions = new Map<string, number>();
@@ -179,30 +183,12 @@ export function createBackgroundPullSizeGuard(
       allowedVersions.set(key, version);
       return 'pull';
     }
-    const cumulativeLimit = deps.maxCumulativeEntries ?? 0;
-    if (
-      cumulativeLimit > 0 &&
-      cumulativeEntries + inspection.entryCount > cumulativeLimit
-    ) {
-      // Budget exhausted for this process. Deliberately NOT remembered in
-      // `deferredVersions`: that map means "this version is too big", a
-      // permanent property of the version, whereas this is a transient
-      // session limit. Recording it there would suppress the project even
-      // after a restart reset the budget.
-      try {
-        deps.onDeferred?.({
-          projectId: scope.projectId,
-          workspaceId: scope.workspaceId,
-          version,
-          entryCount: inspection.entryCount,
-          maxEntries: deps.maxEntries,
-          reason: 'budget-exhausted',
-        });
-      } catch {
-        // Observation must never affect the decision.
-      }
-      return 'defer';
-    }
+    // Per-project ceiling FIRST. Exceeding it is a permanent property of the
+    // version, so it must be decided (and cached) regardless of how much
+    // budget happens to remain — checking the budget first mislabelled an
+    // oversized project as `budget-exhausted` whenever the remainder was
+    // smaller than it, and cost a fresh probe on every later round because it
+    // never reached the oversized cache.
     if (inspection.entryCount > deps.maxEntries) {
       const previous = deferredVersions.get(key);
       if (previous == null || version > previous) {
@@ -216,6 +202,31 @@ export function createBackgroundPullSizeGuard(
           entryCount: inspection.entryCount,
           maxEntries: deps.maxEntries,
           reason: 'oversized',
+        });
+      } catch {
+        // Observation must never affect the decision.
+      }
+      return 'defer';
+    }
+    const cumulativeLimit = deps.maxCumulativeEntries ?? 0;
+    if (
+      cumulativeLimit > 0 &&
+      cumulativeEntries + inspection.entryCount > cumulativeLimit
+    ) {
+      // Remembered like any other deferral. A budget deferral cannot change
+      // until the process restarts, and every map here is process-local — so
+      // caching it costs nothing on restart and saves an authorize-only probe
+      // (plus a duplicate log line) on every subsequent catch-up round, which
+      // otherwise repeat for as long as the head stays unmaterialized.
+      budgetDeferredVersions.set(key, version);
+      try {
+        deps.onDeferred?.({
+          projectId: scope.projectId,
+          workspaceId: scope.workspaceId,
+          version,
+          entryCount: inspection.entryCount,
+          maxEntries: deps.maxEntries,
+          reason: 'budget-exhausted',
         });
       } catch {
         // Observation must never affect the decision.
@@ -240,6 +251,8 @@ export function createBackgroundPullSizeGuard(
       const key = scopeKey(scope);
       const deferred = deferredVersions.get(key);
       if (deferred != null && version <= deferred) return 'defer';
+      const budgetDeferred = budgetDeferredVersions.get(key);
+      if (budgetDeferred != null && version <= budgetDeferred) return 'defer';
       if (allowedVersions.get(key) === version) return 'pull';
       const probeKey = `${key}#${version}`;
       const existing = probesInFlight.get(probeKey);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -927,6 +927,7 @@ import {
 } from './collab/proactive-content-pull.js';
 import {
   backgroundPullMaxEntriesFromEnv,
+  backgroundPullMaxCumulativeEntriesFromEnv,
   createBackgroundPullSizeGuard,
 } from './collab/background-pull-size-guard.js';
 import {
@@ -5040,6 +5041,7 @@ export async function startServer({
   // behavior. See collab/background-pull-size-guard.ts.
   const backgroundPullSizeGuard = createBackgroundPullSizeGuard({
     maxEntries: backgroundPullMaxEntriesFromEnv(),
+    maxCumulativeEntries: backgroundPullMaxCumulativeEntriesFromEnv(),
     inspect: (scope, version) =>
       inspectAuthorizedTeamProjectPull({
         projectId: scope.projectId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5055,7 +5055,7 @@ export async function startServer({
       }),
     onDeferred: (info) => {
       console.info(
-        '[od] background shared-project pull deferred (oversized): ' +
+        `[od] background shared-project pull deferred (${info.reason}): ` +
           `projectId=${info.projectId} workspaceId=${info.workspaceId} ` +
           `version=${info.version} entries=${info.entryCount} ` +
           `maxEntries=${info.maxEntries}; opening the project pulls it on demand`,

--- a/apps/daemon/tests/collab/background-pull-size-guard.test.ts
+++ b/apps/daemon/tests/collab/background-pull-size-guard.test.ts
@@ -144,6 +144,73 @@ describe('createBackgroundPullSizeGuard', () => {
     }));
   });
 
+  it('does not re-probe a project the budget already deferred', async () => {
+    // Review finding on #7403. A deferral is terminal only for the current work
+    // item; later catch-up rounds revisit the still-unmaterialized head. With
+    // the budget branch recording nothing, every round repeated the remote
+    // authorize-only probe and emitted another deferral log for every project
+    // past the budget — unbounded remote calls for a decision that cannot
+    // change until the process restarts.
+    //
+    // Caching it is safe: every map in this guard is process-local already, so
+    // a restart clears the budget and these entries together.
+    const inspect = vi.fn(async () => countedInspect(12));
+    const onDeferred = vi.fn();
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      maxCumulativeEntries: 12,
+      inspect,
+      onDeferred,
+    });
+
+    await expect(guard.assess({ ...scope, projectId: 'p-1' }, 1)).resolves.toBe('pull');
+    await expect(guard.assess({ ...scope, projectId: 'p-2' }, 1)).resolves.toBe('defer');
+    const probesAfterFirstDeferral = inspect.mock.calls.length;
+
+    // Two more sweep rounds hit the same project + version.
+    await expect(guard.assess({ ...scope, projectId: 'p-2' }, 1)).resolves.toBe('defer');
+    await expect(guard.assess({ ...scope, projectId: 'p-2' }, 1)).resolves.toBe('defer');
+
+    expect(inspect.mock.calls.length).toBe(probesAfterFirstDeferral);
+    expect(onDeferred).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies an oversized project as oversized even when the budget is low', async () => {
+    // Review finding on #7403. Checking the cumulative ceiling first meant a
+    // project that independently exceeds `maxEntries` got labelled
+    // `budget-exhausted` whenever the remaining budget happened to be smaller —
+    // pointing at the wrong knob AND missing the oversized-version cache, so it
+    // was re-probed on every later round. The per-project ceiling is a
+    // permanent property of the version and must be decided first.
+    const inspect = vi.fn(async (s: { projectId: string }) =>
+      countedInspect(s.projectId === 'small' ? 12 : 5000),
+    );
+    const onDeferred = vi.fn();
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      // Budget large enough to admit the small project, then too small to
+      // admit the oversized one — the exact window where ordering decides
+      // which label (and which cache) the oversized project gets.
+      maxCumulativeEntries: 100,
+      inspect,
+      onDeferred,
+    });
+
+    await expect(
+      guard.assess({ ...scope, projectId: 'small' }, 1),
+    ).resolves.toBe('pull');
+    await expect(guard.assess(scope, 4)).resolves.toBe('defer');
+    expect(onDeferred).toHaveBeenCalledWith(expect.objectContaining({
+      entryCount: 5000,
+      reason: 'oversized',
+    }));
+
+    // And it is remembered as oversized, so later rounds cost no probe.
+    const probes = inspect.mock.calls.length;
+    await expect(guard.assess(scope, 4)).resolves.toBe('defer');
+    expect(inspect.mock.calls.length).toBe(probes);
+  });
+
   it('leaves the cumulative budget disabled by default', async () => {
     // Absent an explicit budget the guard must behave exactly as before, so
     // enabling this cannot silently change existing deployments.

--- a/apps/daemon/tests/collab/background-pull-size-guard.test.ts
+++ b/apps/daemon/tests/collab/background-pull-size-guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  backgroundPullMaxCumulativeEntriesFromEnv,
   backgroundPullMaxEntriesFromEnv,
   createBackgroundPullSizeGuard,
   DEFAULT_BACKGROUND_PULL_MAX_ENTRIES,
@@ -62,6 +63,72 @@ describe('createBackgroundPullSizeGuard', () => {
       entryCount: 7442,
       maxEntries: 2000,
     }));
+  });
+
+  // Measured against a live Team workspace: 12 shared projects of ~2.9 MB each
+  // (12 files apiece — an order of magnitude under the per-project threshold),
+  // and a member who did nothing but open the client pulled 23 MB across 8
+  // projects within 50s. The daemon's own sweep log showed why:
+  //
+  //   catch-up completed ... scanned=25 candidates=25 headChecks=4 suppressed=0
+  //
+  // Every project cleared the gate, because the gate is evaluated per
+  // project/version and each one is individually small. `headChecks=4` is a
+  // per-round batch size, not a ceiling — later rounds keep going. Nothing in
+  // the path expresses "this member has already been given enough for one
+  // session", so onboarding cost grows linearly with team size, unbounded.
+  //
+  // The per-project threshold stays exactly as it is (it solves the #6512
+  // shape: one enormous project). This adds the missing second dimension.
+  it('reads the cumulative budget from env, defaulting to disabled', () => {
+    // Default MUST be off: choosing a real ceiling is a capacity decision that
+    // needs production data on team sizes, and shipping a guessed default
+    // would silently change what every existing client downloads.
+    expect(backgroundPullMaxCumulativeEntriesFromEnv({})).toBe(0);
+    expect(backgroundPullMaxCumulativeEntriesFromEnv({
+      OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES: '5000',
+    })).toBe(5000);
+    // Anything malformed disables rather than guesses, matching how
+    // `backgroundPullMaxEntriesFromEnv` refuses to be silently misconfigured.
+    for (const bad of ['-1', 'abc', '1.5', '']) {
+      expect(backgroundPullMaxCumulativeEntriesFromEnv({
+        OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES: bad,
+      })).toBe(0);
+    }
+  });
+
+  it('defers once the cumulative budget for this session is exhausted', async () => {
+    const inspect = vi.fn(async () => countedInspect(12));
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      // Three small projects' worth. Each is far below `maxEntries`, so the
+      // per-project gate alone would clear all of them.
+      maxCumulativeEntries: 36,
+      inspect,
+    });
+
+    const project = (id: string) => ({ ...scope, projectId: id });
+
+    await expect(guard.assess(project('p-1'), 1)).resolves.toBe('pull');
+    await expect(guard.assess(project('p-2'), 1)).resolves.toBe('pull');
+    await expect(guard.assess(project('p-3'), 1)).resolves.toBe('pull');
+    // Budget spent: the fourth is left to the foreground lane, which never
+    // consults this guard, so opening it still materializes on demand.
+    await expect(guard.assess(project('p-4'), 1)).resolves.toBe('defer');
+  });
+
+  it('leaves the cumulative budget disabled by default', async () => {
+    // Absent an explicit budget the guard must behave exactly as before, so
+    // enabling this cannot silently change existing deployments.
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      inspect: async () => countedInspect(12),
+    });
+    for (let i = 0; i < 50; i += 1) {
+      await expect(
+        guard.assess({ ...scope, projectId: `p-${i}` }, 1),
+      ).resolves.toBe('pull');
+    }
   });
 
   it('pulls a version at or below the threshold', async () => {

--- a/apps/daemon/tests/collab/background-pull-size-guard.test.ts
+++ b/apps/daemon/tests/collab/background-pull-size-guard.test.ts
@@ -62,6 +62,7 @@ describe('createBackgroundPullSizeGuard', () => {
       version: 12,
       entryCount: 7442,
       maxEntries: 2000,
+      reason: 'oversized',
     }));
   });
 
@@ -115,6 +116,32 @@ describe('createBackgroundPullSizeGuard', () => {
     // Budget spent: the fourth is left to the foreground lane, which never
     // consults this guard, so opening it still materializes on demand.
     await expect(guard.assess(project('p-4'), 1)).resolves.toBe('defer');
+  });
+
+  it('reports WHY it deferred, so the two ceilings are not confused', async () => {
+    // Observed live: a 12-entry project deferred by the budget logged
+    // "deferred (oversized) ... entries=12 maxEntries=2000" — which reads as a
+    // contradiction and points at the wrong knob. The two ceilings need
+    // different responses (raise the per-project threshold vs. raise the
+    // session budget), so the reason has to travel with the observation.
+    const onDeferred = vi.fn();
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      maxCumulativeEntries: 12,
+      inspect: async () => countedInspect(12),
+      onDeferred,
+    });
+
+    await expect(guard.assess({ ...scope, projectId: 'p-1' }, 1)).resolves.toBe('pull');
+    await expect(guard.assess({ ...scope, projectId: 'p-2' }, 1)).resolves.toBe('defer');
+
+    expect(onDeferred).toHaveBeenCalledTimes(1);
+    expect(onDeferred).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'p-2',
+      entryCount: 12,
+      maxEntries: 2000,
+      reason: 'budget-exhausted',
+    }));
   });
 
   it('leaves the cumulative budget disabled by default', async () => {


### PR DESCRIPTION
Follows the investigation on #7350. Independent of it and of #7398.

## Why

`background-pull-size-guard.ts` (from incident #6512, where one 7442-file project landed on every member's disk) asks exactly one question per project: *is this version too big?* It has no way to see accumulation, and nothing else on the path does either.

Measured on a live vela Team workspace — 12 shared projects, ~2.9 MB and 12 files each, every one an order of magnitude under the 2000-entry threshold. A member who did nothing but **open the client**:

```
+15s   1 project    2.9 MB
+30s   5 projects    15 MB
+50s   8 projects    23 MB
```

The daemon's own sweep log explains it:

```
catch-up completed ... scanned=25 candidates=25 headChecks=4 heads=4 suppressed=0 complete=false
```

`candidates=25, suppressed=0` — every project cleared the gate. `headChecks=4` is a per-round batch size, not a ceiling; `complete=false` means later rounds continue. **Member onboarding cost therefore scales linearly with team size, unbounded.** 25 small projects is 23 MB; a few hundred projects that each sit under the threshold is gigabytes, downloaded before the user clicks anything.

## What this adds

A per-process budget of entries the **background** lanes may materialize before deferring the rest.

Deferring is not denying: the foreground open-project lane never consults this guard (`"defers ... to the foreground open-project lane, which never consults it"`), so anything skipped here still materializes the moment the user opens that project. The per-project threshold is untouched — it solves a different shape and keeps solving it.

## What users will see

Nothing, by default. `OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES` defaults to **0 (disabled)**, and a malformed value disables rather than guesses — mirroring how `maxEntries` refuses to be silently misconfigured.

That default is deliberate. Choosing a real ceiling needs production data — team-size distribution, project-size distribution, and above all the **pre-pull hit rate** (of the projects pulled ahead of time, how many does the member actually open?). If that rate is low, the right answer may be more aggressive than a budget. Shipping a guessed default would silently change what every existing client downloads.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] **CLI / env var** — new `OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES`
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change — inert unless the env var is set
- [ ] None

## Verification

Red first: `defers once the cumulative budget for this session is exhausted` failed with `expected 'pull' to be 'defer'`, then passed. 34 specs in `background-pull-size-guard.test.ts`, 142 with `collab-sync-routes` alongside.

The specs pin the parts that are easy to get wrong:

- **default stays disabled** — 50 consecutive projects all pull when no budget is set, so this cannot silently alter existing deployments;
- budget is consumed **only** by decisions the guard allowed, so a size-deferred project never spends budget it did not use;
- an exhausted budget is **not** recorded in `deferredVersions` — that map means "this version is permanently oversized", while the budget is a transient per-process limit a restart resets. Conflating them would suppress a project long after the budget reset.

## Verified end to end

Against the live Team workspace (vela-cli 0.0.33, member client, fresh data root):

| | no budget | `MAX_CUMULATIVE_ENTRIES=30` |
| --- | --- | --- |
| after 50s | **8 projects / 24 MB** | **2 projects / 5.8 MB** |
| after 80s | 8 / 24 MB | still 2 / 5.8 MB |
| deferral log lines | 0 | 6 |

The deferred projects are 12 entries each — nowhere near the 2000-entry
per-project threshold — which is precisely the accumulation the existing guard
cannot see.

That run also exposed a defect in the deferral log, fixed in the second commit:
it said `deferred (oversized)` for a 12-entry project against a 2000 threshold,
pointing a reader at the wrong knob. The reason (`oversized` |
`budget-exhausted`) now travels with the observation and is pinned by a spec.

## A caveat I filed this PR with, now retracted

I originally wrote that the pre-existing #6512 protection might be inert on packaged clients, because the probe flag was missing from my local binary:

```
$ vela team-projects pull --help
      --expected-version int   exact event version to stage
      --json                   output the fresh authorization receipt as JSON
      --live-dir string        ...
      --ref string             ...
```

So `probeUnavailable` latches on first use and **every** size decision short-circuits to `'pull'` — the probe was never called once in a 90s run (`deferred (oversized)` count: 0).

**That inference was wrong.** `--authorize-only` landed in vela-cli **v0.0.31** (vela#1432, 2026-08-06) and OD main pins **0.0.33** in `tools/pack/package.json` — confirmed directly on the 0.0.33 binary. My local `0.0.27-test.3` was six releases behind and is not what ships. The packaged client has had the probe all along, and the #6512 protection is active there.
