### PR TITLE
fix(collab): stop reporting cancelled team pulls as failures

### DIFF
--- a/apps/daemon/src/integrations/aborted-error.ts
+++ b/apps/daemon/src/integrations/aborted-error.ts
@@ -1,0 +1,26 @@
+// Deliberately dependency-free: consumers of this predicate (collab-sync's
+// pull path, the proactive-pull error sink) must be able to tell a cancelled
+// child from a failed one WITHOUT pulling in a command runner and its whole
+// module graph. Importing `vela-command.ts` for this instead dragged
+// `runtimes/env` + `runtimes/registry` into route tests whose vela mocks are
+// deliberately partial, turning a successful pull into `register_failed`.
+
+/**
+ * Whether a rejection is an operation WE cancelled, rather than one that
+ * failed.
+ *
+ * `runVelaCommand` marks a deliberate abort with `name: 'AbortError'` and
+ * `code: 'ABORT_ERR'`, and keeps a separate `timeout` termination for real
+ * deadline breaches. The proactive team-pull scheduler cancels in-flight pulls
+ * as ordinary control flow — a higher published version supersedes the one
+ * being fetched (`mergeIntentUpdate`), or the intent is cleared
+ * (`clearIntent`) — so those must never be logged or counted as faults.
+ *
+ * Deliberately narrow: a real timeout and any transport error stay failures,
+ * so a genuine fault can never be swallowed as "we meant to do that".
+ */
+export function isAbortedOperationError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return candidate.code === 'ABORT_ERR' || candidate.name === 'AbortError';
+}

--- a/apps/daemon/src/integrations/vela-command.ts
+++ b/apps/daemon/src/integrations/vela-command.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { isAbortedOperationError } from './aborted-error.js';
 
 import {
   collectProcessTreePids,
@@ -340,3 +341,7 @@ export function runVelaCommand(
     }
   });
 }
+
+// Re-exported so the vela-facing name stays available to callers that already
+// think in terms of vela commands; the implementation carries no dependencies.
+export { isAbortedOperationError as isAbortedVelaCommandError };

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -56,6 +56,7 @@ import {
   type PublicFilePublicationStore,
 } from '../collab/public-file-publication-store.js';
 import { readVelaControlApiContext } from '../integrations/vela.js';
+import { isAbortedOperationError } from '../integrations/aborted-error.js';
 import { readProjectManifest } from '../project-locations.js';
 import { redactSecrets } from '../redact.js';
 
@@ -1704,11 +1705,21 @@ export function registerCollabSyncRoutes(
             if (await shouldRetryStaleReceipt(error, authorizedAttempt)) {
               continue;
             }
-            console.warn('[od] authorized proactive team pull failed closed:', {
-              projectId,
-              version: expectedVersion,
-              ...errorLogFields(error),
-            });
+            // A cancelled child is not a fault: the scheduler aborts this pull
+            // on purpose when a higher version supersedes it, or when the
+            // intent is cleared. Logging that as "failed closed" put a
+            // fault-shaped warning in the log on ordinary version churn and
+            // sent an investigation chasing a phantom failure. The scheduler
+            // already handles the cancellation itself (a superseded intent
+            // bumps `revision` and re-loops; a cleared one is gone), so this
+            // only stops mislabelling it.
+            if (!isAbortedOperationError(error)) {
+              console.warn('[od] authorized proactive team pull failed closed:', {
+                projectId,
+                version: expectedVersion,
+                ...errorLogFields(error),
+              });
+            }
             return complete({ status: 'register_failed' });
           }
           // Old CLIs can materialize successfully while returning no version.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -261,6 +261,7 @@ import {
   readVelaLoginStatus,
   resolveAmrProfile,
 } from './integrations/vela.js';
+import { isAbortedOperationError } from './integrations/aborted-error.js';
 import { projectResourceIdFor } from './integrations/vela-team-projects.js';
 import {
   getTeamProjectMaterialization,
@@ -5183,8 +5184,16 @@ export async function startServer({
           onTiming: emitSharedProjectPullTiming,
         }
       : {}),
-    onError: (error) =>
-      console.warn('[od] proactive shared-project pull failed (web polling remains the fallback):', String(error)),
+    // A cancelled `vela` child is this scheduler's own doing, not a fault: it
+    // aborts the in-flight pull when a higher published version supersedes it
+    // (`mergeIntentUpdate`) or when the intent is cleared (`clearIntent`).
+    // Reporting those as failures put a fault-shaped warning in the log on
+    // ordinary version churn. `proactive-content-pull.ts` stays dependency-free
+    // by design, so the distinction is drawn here, at its only error sink.
+    onError: (error) => {
+      if (isAbortedOperationError(error)) return;
+      console.warn('[od] proactive shared-project pull failed (web polling remains the fallback):', String(error));
+    },
     onCatchUp: (event) => {
       if (
         event.phase === 'retry-scheduled' ||

--- a/apps/daemon/tests/aborted-error.test.ts
+++ b/apps/daemon/tests/aborted-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAbortedOperationError } from '../src/integrations/aborted-error.js';
+
+// A cancelled `vela` child is NOT a failure. The proactive team-pull scheduler
+// aborts in-flight pulls on purpose in two places
+// (`collab/proactive-content-pull.ts`):
+//
+//   - `mergeIntentUpdate` aborts the current pull the moment a HIGHER version
+//     arrives, so the newer content is fetched instead of the stale one;
+//   - `clearIntent` aborts when the intent is superseded or already satisfied.
+//
+// `runVelaCommand` marks exactly this case with `name: 'AbortError'` and
+// `code: 'ABORT_ERR'` (and keeps a separate `reason: 'timeout'` path for real
+// deadline breaches). Nothing downstream ever read those markers, so every
+// deliberate cancellation surfaced as `[od] authorized proactive team pull
+// failed closed:` — observed live while investigating a first-open trace, where
+// it sent the investigation after a phantom failure.
+//
+// This predicate is the seam the pull path uses to tell the two apart. It must
+// never classify a real timeout or transport failure as a cancellation, or a
+// genuine fault would be silently swallowed.
+describe('isAbortedOperationError', () => {
+  it('recognizes a deliberately aborted vela command', () => {
+    const error = new Error('vela command aborted', {
+      cause: 'This operation was aborted',
+    });
+    error.name = 'AbortError';
+    Object.assign(error, { code: 'ABORT_ERR' });
+
+    expect(isAbortedOperationError(error)).toBe(true);
+  });
+
+  it('recognizes an abort identified only by its code', () => {
+    // DOMException-shaped aborts from other layers carry the code but may not
+    // preserve the name across a structured clone.
+    const error = Object.assign(new Error('aborted'), { code: 'ABORT_ERR' });
+    expect(isAbortedOperationError(error)).toBe(true);
+  });
+
+  it('does NOT treat a timeout as a cancellation', () => {
+    // `runVelaCommand`'s other termination reason. This is a real failure and
+    // must keep reaching the failure logging + retry accounting.
+    const error = new Error('vela command timed out after 30000ms');
+    error.name = 'TimeoutError';
+    expect(isAbortedOperationError(error)).toBe(false);
+  });
+
+  it('does NOT treat a transport failure as a cancellation', () => {
+    // The shape seen from the vela CLI itself when the API is unreachable.
+    const error = new Error(
+      'list team projects: context deadline exceeded (Client.Timeout exceeded while awaiting headers)',
+    );
+    expect(isAbortedOperationError(error)).toBe(false);
+  });
+
+  it('does NOT treat an arbitrary rejection as a cancellation', () => {
+    expect(isAbortedOperationError(new Error('boom'))).toBe(false);
+    expect(isAbortedOperationError('aborted')).toBe(false);
+    expect(isAbortedOperationError(null)).toBe(false);
+    expect(isAbortedOperationError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Replaces #7350, which had accumulated three commits for a first-open indicator that was reverted mid-review. Same net change, clean history, rebased onto current main — and now verified end to end.

Found while investigating OPEND-2095 (Plane, dogfooding report).

## Why

A cancelled `vela` child was being reported as a failure.

`runVelaCommand` marks a deliberate abort with `name: 'AbortError'` / `code: 'ABORT_ERR'`, and keeps a separate `timeout` termination for real deadline breaches. Nothing downstream ever read those markers. Meanwhile the proactive pull scheduler cancels in-flight pulls as **ordinary control flow**:

- `mergeIntentUpdate` aborts the current pull the moment a higher published version supersedes it, so the newer content is fetched instead of the stale one;
- `clearIntent` aborts when an intent is superseded or already satisfied.

So routine version churn produced:

```
[od] authorized proactive team pull failed closed: {
  projectId: 'bulk175623', version: 1,
  errorName: 'AbortError', errorMessage: 'vela command aborted'
}
```

I hit this live and spent real time chasing it as a pull failure before realising it was the scheduler replacing its own work. A log that cries fault on healthy behaviour costs whoever reads it next the same detour.

## What changes

`isAbortedOperationError` draws the line at both sinks:

- `collab-sync.ts` — the `failed closed` warning is skipped for aborts;
- `server.ts` — the single `onError` sink backing `proactive-content-pull.ts`'s three raise sites. That module is deliberately import-free, so the distinction belongs at its consumer rather than inside it.

**Behaviour is unchanged; this is log correctness only.** I traced the downstream to be sure: an aborted intent already bumps `revision` and re-loops, or is removed outright, so it never reached the retry/backoff accounting in `runIntent`. I had initially suspected it polluted backoff state — tracing showed that was wrong.

Other error classes were audited and are all classified correctly today: `timeout` (separate termination reason), `capabilityUnavailable` (old CLI → degrade), stale receipt (→ retry), transport/authorization (→ failure). Abort was the only one mishandled, and it was mishandled everywhere.

## Verification

**Unit:** red first — 5 failures (predicate did not exist) → 5 passing. The spec pins the *narrowness* as hard as the fix: a timeout, a transport failure (`context deadline exceeded`), and arbitrary errors must all still classify as failures, so a real fault can never be swallowed as intentional. 113 passing alongside `collab-sync-routes`.

**End to end**, against a live Team workspace (vela-cli 0.0.33, owner + member daemons, two distinct accounts). Publishing four versions in rapid succession forces the scheduler to abort its own in-flight pulls:

```
[od] vela_command_termination phase=scheduled  reason=abort childPid=87102
[od] vela_command_termination phase=completed  reason=abort childPid=87102
```

Aborts demonstrably happened. In the failure logs:

```
failed closed containing AbortError:  0
pull failed containing "aborted":     0
```

And the failures that *did* log are genuine ones the rapid publishing provoked — `team_project_pull_drift` (409) and `Command failed: vela team-projects pull` — every one carrying `errorName: 'Error'`. That is the important half: real faults still report, so the fix silences the misreport without blunting the signal.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — daemon-internal log classification + tests

## Note for review

The predicate lives in a dependency-free `integrations/aborted-error.ts` for a reason worth knowing. It first lived in `vela-command.ts`; importing it from `collab-sync.ts` dragged `runtimes/env` + `runtimes/registry` into the route module graph, where `collab-sync-routes.test.ts` mocks `integrations/vela.js` with a single export — turning a passing pull into `register_failed`. That regression was caught only by running the neighbouring suite, not my own new spec.
