### PR TITLE
fix(daemon): extend AMR first-output deadline to 150s

### DIFF
--- a/apps/daemon/src/runtimes/defs/amr.ts
+++ b/apps/daemon/src/runtimes/defs/amr.ts
@@ -672,7 +672,7 @@ export const amrAgentDef = {
   inactivityTimeoutMs: 30 * 60 * 1000,
   // Once the ACP handshake has completed and session/prompt is waiting on the
   // provider, transport/status heartbeats must not leave the UI in Preparing
-  // indefinitely. Two minutes leaves conservative provider-startup headroom
-  // while still bounding the user's wait and one safe same-run retry.
-  firstOutputTimeoutMs: 2 * 60 * 1000,
+  // indefinitely. 150 seconds (2.5 minutes) leaves enough provider-startup
+  // headroom while still bounding the user's wait and one safe same-run retry.
+  firstOutputTimeoutMs: 150_000,
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -309,7 +309,9 @@ describe('same-run retry runtime', () => {
     delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
     process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
     process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
-    process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS = '100';
+    // Keep both watchdog attempts fast while proving the user-facing stall text
+    // is derived from the configured deadline, rather than a stale literal.
+    process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS = '1200';
     process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
     process.env.OD_ACP_STAGE_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
 
@@ -323,7 +325,7 @@ describe('same-run retry runtime', () => {
 
     const run = await createAndWaitForRun(started.url, 'amr');
     expect(run.status).toBe('failed');
-    expect(run.error).toContain('without emitting a first output');
+    expect(run.error).toContain('Agent stalled without emitting a first output for 1s.');
     expect(run.terminalTrigger).toBe('first_output_deadline');
 
     const events = await readRunEvents(run.eventsLogPath);

--- a/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
+++ b/apps/daemon/tests/runtimes/chat-run-inactivity-timeout.test.ts
@@ -194,13 +194,13 @@ describe('resolveChatRunFirstOutputTimeoutMs', () => {
 
   it('uses the runtime default and lets the operator override or disable it', () => {
     delete process.env[FIRST_OUTPUT_ENV_KEY];
-    expect(resolveChatRunFirstOutputTimeoutMs(120_000)).toBe(120_000);
+    expect(resolveChatRunFirstOutputTimeoutMs(150_000)).toBe(150_000);
 
     process.env[FIRST_OUTPUT_ENV_KEY] = '90000';
-    expect(resolveChatRunFirstOutputTimeoutMs(120_000)).toBe(90_000);
+    expect(resolveChatRunFirstOutputTimeoutMs(150_000)).toBe(90_000);
 
     process.env[FIRST_OUTPUT_ENV_KEY] = '0';
-    expect(resolveChatRunFirstOutputTimeoutMs(120_000)).toBe(0);
+    expect(resolveChatRunFirstOutputTimeoutMs(150_000)).toBe(0);
   });
 
   it('rejects an invalid checked-in runtime default', () => {
@@ -222,8 +222,8 @@ describe('amrAgentDef.inactivityTimeoutMs', () => {
     expect(amrAgentDef.inactivityTimeoutMs).toBe(THIRTY_MINUTES_MS);
   });
 
-  it('ships a two-minute absolute first-output deadline', () => {
-    expect(amrAgentDef.firstOutputTimeoutMs).toBe(120_000);
+  it('ships a 150-second (2.5-minute) absolute first-output deadline', () => {
+    expect(amrAgentDef.firstOutputTimeoutMs).toBe(150_000);
   });
 });
 


### PR DESCRIPTION
## Summary

- extend the AMR absolute first-output deadline from 120 seconds to 150 seconds
- update the runtime default contract and comments to 2.5 minutes
- keep the operator override/disable path and one same-run retry unchanged
- assert the user-facing stall duration is derived from the configured timeout rather than a stale literal

## Motivation

OPEND-2133 captured a cloud Fable5 run that was cancelled after the outer 120-second deadline. Production correlation showed that runtime startup left the provider about 116 seconds, while a nearby successful Fable5 request produced its first token at 119.464 seconds.

A 150-second outer deadline leaves roughly 146 seconds of provider startup budget and should cover that observed long-tail success without changing the broader 30-minute inactivity policy.

Related:
- [OPEND-2133](https://plane.powerformer.net/open-design/browse/OPEND-2133/)
- Vela establishment observability: [powerformer/vela#1756](https://github.com/powerformer/vela/pull/1756)

## Behavior and trade-off

Unchanged:

- 30-minute inactivity timeout
- `OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS` override and `0` disable semantics
- ACP stage timeout
- one safe same-run retry
- timeout/failure classification and terminal trigger
- routing, fallback, billing, and provider behavior

Trade-off: two completely silent attempts can now take about 300 seconds instead of about 240 seconds before terminal failure. The new Vela establishment metrics will provide the rollout evidence needed to evaluate this tail.

## Validation

Passed:

- focused first-output timeout/retry/failure tests
- daemon typecheck
- root typecheck
- `pnpm guard`
- fresh scope/behavior review: no P0/P1/P2 findings

The full daemon suite exceeded the 1200-second command limit and its partial output contained unrelated pre-existing Codex model-preflight/media route failures plus post-close SQLite watcher warnings, so it is reported as inconclusive rather than passed.
