### PR TITLE
perf(web): collapse the launch burst of catalog reads

### DIFF
--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -31,7 +31,10 @@ import {
 } from './team-projects-catalog';
 import { useWorkspaceInvalidation } from './workspace-events';
 import {
+  advanceWorkspaceAccountGeneration,
   beginWorkspaceScopedRead,
+  currentWorkspaceAccountGeneration,
+  resetWorkspaceAccountGeneration,
   workspaceIdentityCacheKey,
   type WorkspaceResourceReadIdentity,
 } from './workspace-identity';
@@ -576,8 +579,7 @@ export function resetWorkspaceContextCache(): void {
   localIdentityChangeSeq = 0;
   seededWorkspaceContext = null;
   workspaceContextIdentityChangePending = false;
-  workspaceAccountGeneration = 0;
-  workspaceAccountGenerationStamp = 'initial';
+  resetWorkspaceAccountGeneration();
   resetWorkspaceContextRetrySchedules();
   inMemoryWorkspaceSelection = undefined;
   writeWorkspaceSelection(null);
@@ -1040,24 +1042,17 @@ let seededWorkspaceContext: {
   token: string;
   context: WorkspaceCollabContext;
 } | null = null;
-let workspaceAccountGeneration = 0;
-let workspaceAccountGenerationStamp = 'initial';
-
-function advanceWorkspaceAccountGeneration(stamp: string): void {
-  if (workspaceAccountGenerationStamp === stamp) return;
-  workspaceAccountGenerationStamp = stamp;
-  workspaceAccountGeneration += 1;
-}
-
 /**
  * Monotonic account boundary independent from ambient Workspace selection.
  * Fresh project binding witnesses survive A -> B navigation, but must be
  * discarded across sign-in/sign-out when another account may own the same
  * local project id.
+ *
+ * The counter itself lives in `workspace-identity` so shared catalog modules can
+ * partition their caches on it without importing this React hook module; this
+ * re-export keeps every existing caller pointed here.
  */
-export function currentWorkspaceAccountGeneration(): number {
-  return workspaceAccountGeneration;
-}
+export { currentWorkspaceAccountGeneration };
 
 /** The seed published for the CURRENT identity generation, if any. */
 function seededContextForCurrentGeneration(): WorkspaceCollabContext | null {

--- a/apps/web/src/collab/workspace-identity.ts
+++ b/apps/web/src/collab/workspace-identity.ts
@@ -94,11 +94,17 @@ export function resetWorkspaceAccountGeneration(): void {
 /**
  * Cache partition for a Workspace-scoped read: the context fields that go on
  * the wire, plus the account boundary they were captured under.
+ *
+ * A caller that makes several dependent reads should capture the generation ONCE
+ * and pass it to each, so the whole operation is keyed as of one boundary. Left
+ * to default, two reads a few hundred ms apart can straddle a boundary and mix a
+ * pre-boundary answer into a post-boundary one.
  */
 export function workspaceAccountScopedCacheKey(
   context: WorkspaceCollabContext | null | undefined,
+  generation: number = currentWorkspaceAccountGeneration(),
 ): string {
-  return `${currentWorkspaceAccountGeneration()}:${workspaceIdentityCacheKey(context)}`;
+  return `${generation}:${workspaceIdentityCacheKey(context)}`;
 }
 
 /**

--- a/apps/web/src/collab/workspace-identity.ts
+++ b/apps/web/src/collab/workspace-identity.ts
@@ -62,6 +62,46 @@ export function workspaceIdentityCacheKey(
 }
 
 /**
+ * Monotonic account boundary, independent from ambient Workspace selection.
+ *
+ * Lives here rather than in `useWorkspaceContext` so shared catalog modules can
+ * partition their caches on it without importing a React hook module — the same
+ * reason `workspaceProjectHeaders` lives here. `useWorkspaceContext` re-exports
+ * the reader so existing callers are unaffected.
+ *
+ * A sign-in/sign-out cycle can leave every context field identical while the
+ * authority behind them has changed, so any cache keyed only on the context
+ * fields would let a post-boundary reader adopt a pre-boundary answer.
+ */
+let workspaceAccountGeneration = 0;
+let workspaceAccountGenerationStamp = 'initial';
+
+export function currentWorkspaceAccountGeneration(): number {
+  return workspaceAccountGeneration;
+}
+
+export function advanceWorkspaceAccountGeneration(stamp: string): void {
+  if (workspaceAccountGenerationStamp === stamp) return;
+  workspaceAccountGenerationStamp = stamp;
+  workspaceAccountGeneration += 1;
+}
+
+export function resetWorkspaceAccountGeneration(): void {
+  workspaceAccountGeneration = 0;
+  workspaceAccountGenerationStamp = 'initial';
+}
+
+/**
+ * Cache partition for a Workspace-scoped read: the context fields that go on
+ * the wire, plus the account boundary they were captured under.
+ */
+export function workspaceAccountScopedCacheKey(
+  context: WorkspaceCollabContext | null | undefined,
+): string {
+  return `${currentWorkspaceAccountGeneration()}:${workspaceIdentityCacheKey(context)}`;
+}
+
+/**
  * Exact authority for a read-only Workspace resource request. The generation
  * is intentionally part of the identity even when every context field stays
  * unchanged: a newer directory witness must supersede work issued under the

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -103,6 +103,7 @@ import {
   workspaceIdentityCacheKey,
   workspaceResourceUrl,
   workspaceAccountScopedCacheKey,
+  currentWorkspaceAccountGeneration,
 } from '../collab/workspace-identity';
 import { PublicFilePublishError } from '../collab/public-file-publish';
 
@@ -596,6 +597,7 @@ export interface FetchDesignSystemsOptions {
 
 async function materializeTeamDesignSystems(
   workspaceContext: WorkspaceCollabContext | null | undefined,
+  accountGeneration: number,
   options?: FetchDesignSystemsOptions,
 ): Promise<ReadonlySet<string>> {
   if (!workspaceContext || !workspaceContextHasTeamIdentity(workspaceContext)) {
@@ -614,9 +616,14 @@ async function materializeTeamDesignSystems(
   // workspace" lookup. One account can have multiple clients open in different
   // Workspaces; a backend-global active Workspace would let either client
   // retarget the other's catalog request.
-  const identity = workspaceIdentityCacheKey(workspaceContext);
   try {
-    const cacheKey = `design-system-team-materialization:${identity}`;
+    // Account-scoped for the same reason the catalog key is, and with the SAME
+    // captured generation: this witness decorates the catalog rows, so a `/team`
+    // request still in flight across a sign-out/sign-in must not be joined by a
+    // post-boundary reader — that would stamp the new account's rows with the
+    // previous account's Team-share flags.
+    const cacheKey = `design-system-team-materialization:`
+      + `${workspaceAccountScopedCacheKey(workspaceContext, accountGeneration)}`;
     const readTeamIndex = async () => {
       const response = await fetch('/api/workspace/design-systems/team', {
         cache: 'no-store',
@@ -698,6 +705,7 @@ function noteDesignSystemCatalogMutation(): void {
 
 async function readDesignSystemCatalog(
   workspaceContext: WorkspaceCollabContext | null | undefined,
+  accountGeneration: number,
   options?: FetchDesignSystemsOptions,
 ): Promise<DesignSystemSummary[]> {
   // Keyed by the exact identity the request will carry, PLUS the account
@@ -711,7 +719,7 @@ async function readDesignSystemCatalog(
   // settled-result reuse, not a post-boundary reader joining a request issued
   // before the boundary.
   const cacheKey = `design-system-catalog:${designSystemCatalogMutationGeneration}`
-    + `:${workspaceAccountScopedCacheKey(workspaceContext)}`;
+    + `:${workspaceAccountScopedCacheKey(workspaceContext, accountGeneration)}`;
   // Same rule as the Team index above: a forced call is an authoritative read
   // for one mutation and must never join a snapshot issued before it.
   //
@@ -742,9 +750,23 @@ export async function fetchDesignSystemsResult(
   workspaceContext?: WorkspaceCollabContext | null,
   options?: FetchDesignSystemsOptions,
 ): Promise<DesignSystemsResult> {
+  // Capture the account boundary ONCE. The Team witness and the catalog are two
+  // awaited reads; letting each resolve the generation at its own call time lets
+  // them straddle a sign-out/sign-in, which would decorate post-boundary rows
+  // with pre-boundary Team-share flags. Keyed as of one boundary, a stale pair
+  // is simply discarded by the caller's own generation check.
+  const accountGeneration = currentWorkspaceAccountGeneration();
   try {
-    const teamSharedIds = await materializeTeamDesignSystems(workspaceContext, options);
-    const designSystems = await readDesignSystemCatalog(workspaceContext, options);
+    const teamSharedIds = await materializeTeamDesignSystems(
+      workspaceContext,
+      accountGeneration,
+      options,
+    );
+    const designSystems = await readDesignSystemCatalog(
+      workspaceContext,
+      accountGeneration,
+      options,
+    );
     return {
       ok: true,
       // Mapped per caller: readers sharing one catalog read still resolve the

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -753,8 +753,19 @@ export async function fetchDesignSystemsResult(
   // Capture the account boundary ONCE. The Team witness and the catalog are two
   // awaited reads; letting each resolve the generation at its own call time lets
   // them straddle a sign-out/sign-in, which would decorate post-boundary rows
-  // with pre-boundary Team-share flags. Keyed as of one boundary, a stale pair
-  // is simply discarded by the caller's own generation check.
+  // with pre-boundary Team-share flags. Keyed as of one boundary, the pair is at
+  // least internally consistent.
+  //
+  // What this does NOT do, stated because the opposite is easy to assume: it
+  // does not stop a late result from being COMMITTED after a boundary. Only
+  // `App`'s `refreshDesignSystems` re-checks the generation after awaiting;
+  // `DesignSystemSwitchPicker`, `DesignSystemsSection` and `LibrarySection` key
+  // their effects on workspace identity alone, and the Workspace hook
+  // deliberately retains the old context while an identity change is pending, so
+  // those fields can be unchanged across the boundary. That exposure predates
+  // coalescing — each of those readers had it when every call made its own
+  // request — and closing it means giving those three readers a generation
+  // guard, which is its own change.
   const accountGeneration = currentWorkspaceAccountGeneration();
   try {
     const teamSharedIds = await materializeTeamDesignSystems(

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -636,20 +636,61 @@ async function materializeTeamDesignSystems(
   }
 }
 
+/**
+ * Read the unified catalog once per burst of identical concurrent readers.
+ *
+ * Several independent surfaces want this catalog on the same launch or
+ * navigation pass: bootstrap, the Workspace-identity effect, the home-route
+ * effect, plus LibrarySection, DesignSystemsSection and DesignSystemSwitchPicker
+ * as they mount. None of them can drop its read — each owns its own latest-wins
+ * bookkeeping and must settle its own loading state — but on the wire they are
+ * one request, and the browser's ~6-connections-per-host cap makes the extra
+ * copies queue behind everything else the launch is already fetching.
+ *
+ * SINGLE-FLIGHT ONLY (ttl 0, no shared settled result). Some of those call
+ * sites exist precisely to observe a change that just happened out of band:
+ * returning home re-reads so an in-project brand extraction appears, and a
+ * `forceTeamMaterialization` caller is announcing a realtime mutation. Sharing
+ * a settled answer — for even a second — would hand exactly those reads the
+ * state they were fired to replace.
+ */
+const CATALOG_SINGLE_FLIGHT_ONLY_MS = 0;
+
+async function readDesignSystemCatalog(
+  workspaceContext: WorkspaceCollabContext | null | undefined,
+  options?: FetchDesignSystemsOptions,
+): Promise<DesignSystemSummary[]> {
+  // Keyed by the exact identity the request will carry. `/api/design-systems`
+  // is fail-closed on a missing scope, so a headerless read is a different,
+  // smaller catalog — never an answer a Workspace-scoped read may join.
+  const cacheKey = `design-system-catalog:${workspaceIdentityCacheKey(workspaceContext)}`;
+  // Same rule as the Team index above: a forced call is an authoritative read
+  // for one mutation and must never join a snapshot issued before it.
+  if (options?.forceTeamMaterialization) evictCoalescedGet(cacheKey);
+  return coalescedGet(cacheKey, async () => {
+    const resp = await fetch('/api/design-systems', {
+      ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),
+    });
+    // Throw rather than return a sentinel: `coalescedGet` never caches a
+    // failure, so the next reader retries instead of joining a dead entry.
+    if (!resp.ok) throw new Error(`design-systems ${resp.status}`);
+    const json = (await resp.json()) as { designSystems?: DesignSystemSummary[] };
+    return json.designSystems ?? [];
+  }, CATALOG_SINGLE_FLIGHT_ONLY_MS);
+}
+
 export async function fetchDesignSystemsResult(
   workspaceContext?: WorkspaceCollabContext | null,
   options?: FetchDesignSystemsOptions,
 ): Promise<DesignSystemsResult> {
   try {
     const teamSharedIds = await materializeTeamDesignSystems(workspaceContext, options);
-    const resp = await fetch('/api/design-systems', {
-      ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),
-    });
-    if (!resp.ok) return { ok: false };
-    const json = (await resp.json()) as { designSystems?: DesignSystemSummary[] };
+    const designSystems = await readDesignSystemCatalog(workspaceContext, options);
     return {
       ok: true,
-      designSystems: (json.designSystems ?? []).map((system) => (
+      // Mapped per caller: readers sharing one catalog read still resolve the
+      // Team-shared flag against their own Team-index witness.
+      designSystems: designSystems.map((system) => (
         teamSharedIds.has(system.id)
           ? { ...system, teamShared: true }
           : system

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -657,6 +657,27 @@ async function materializeTeamDesignSystems(
  */
 const CATALOG_SINGLE_FLIGHT_ONLY_MS = 0;
 
+/**
+ * Bumped by every successful LOCAL catalog mutation, and part of the read key.
+ *
+ * `ttl = 0` stops a settled result from being reused; it does not stop a new
+ * caller from JOINING a request that is still in flight. The callers that follow
+ * a mutation are exactly the ones that must not join: `DesignSystemsTab` awaits
+ * `deleteDesignSystemDraft` / `updateDesignSystemDraft` and then calls its plain
+ * `onSystemsRefresh()` — no `forceTeamMaterialization`, because nothing remote
+ * changed — and the daemon answers `/api/design-systems` from a snapshot taken
+ * when the request arrived. Joining a pre-mutation GET would leave the deleted
+ * system on screen, or show the old published/draft status.
+ *
+ * Every mutating export below must bump this on success. `forceTeamMaterialization`
+ * stays as it is: that is the REMOTE (team-invalidation) signal, this is the local one.
+ */
+let designSystemCatalogMutationGeneration = 0;
+
+function noteDesignSystemCatalogMutation(): void {
+  designSystemCatalogMutationGeneration += 1;
+}
+
 async function readDesignSystemCatalog(
   workspaceContext: WorkspaceCollabContext | null | undefined,
   options?: FetchDesignSystemsOptions,
@@ -671,7 +692,8 @@ async function readDesignSystemCatalog(
   // authority behind them has changed, and ttl 0 would not catch it — it stops
   // settled-result reuse, not a post-boundary reader joining a request issued
   // before the boundary.
-  const cacheKey = `design-system-catalog:${workspaceAccountScopedCacheKey(workspaceContext)}`;
+  const cacheKey = `design-system-catalog:${designSystemCatalogMutationGeneration}`
+    + `:${workspaceAccountScopedCacheKey(workspaceContext)}`;
   // Same rule as the Team index above: a forced call is an authoritative read
   // for one mutation and must never join a snapshot issued before it.
   if (options?.forceTeamMaterialization) evictCoalescedGet(cacheKey);
@@ -810,6 +832,7 @@ export async function createDesignSystemDraft(
       body: JSON.stringify(input),
     });
     if (!resp.ok) return null;
+    noteDesignSystemCatalogMutation();
     return parseDesignSystemDetail(await resp.json());
   } catch {
     return null;
@@ -910,6 +933,7 @@ export async function updateDesignSystemRevisionStatus(
       },
     );
     if (!resp.ok) return null;
+    noteDesignSystemCatalogMutation();
     const json = (await resp.json()) as { revision?: DesignSystemRevision };
     return json.revision ?? null;
   } catch {
@@ -975,6 +999,7 @@ export async function updateDesignSystemDraft(
       body: JSON.stringify(input),
     });
     if (!resp.ok) return null;
+    noteDesignSystemCatalogMutation();
     return parseDesignSystemDetail(await resp.json());
   } catch {
     return null;
@@ -1004,6 +1029,7 @@ export async function syncDesignSystemAssetsFromWorkspace(
       },
     });
     if (!resp.ok) return null;
+    noteDesignSystemCatalogMutation();
     return (await resp.json()) as { synced: string[] };
   } catch {
     return null;
@@ -1041,6 +1067,7 @@ export async function deleteDesignSystemDraft(
         ?? (/^[A-Z][A-Z0-9_]+$/.test(errorBody.message) ? errorBody.message : undefined);
       throw new DesignSystemDeleteError(errorBody.message, resp.status, code);
     }
+    if (resp.ok) noteDesignSystemCatalogMutation();
     return resp.ok;
   } catch (error) {
     if (error instanceof DesignSystemDeleteError) throw error;
@@ -1060,6 +1087,7 @@ export async function importLocalDesignSystem(
     if (!resp.ok) {
       return { error: await readImportError(resp) };
     }
+    noteDesignSystemCatalogMutation();
     return (await resp.json()) as ImportLocalDesignSystemResponse;
   } catch (err) {
     return {
@@ -1080,6 +1108,7 @@ export async function importGitHubDesignSystem(
       body: JSON.stringify(input),
     });
     if (!resp.ok) return { error: await readImportError(resp) };
+    noteDesignSystemCatalogMutation();
     return (await resp.json()) as ImportGitHubDesignSystemResponse;
   } catch (err) {
     return {
@@ -1100,6 +1129,7 @@ export async function importShadcnDesignSystem(
       body: JSON.stringify(input),
     });
     if (!resp.ok) return { error: await readImportError(resp) };
+    noteDesignSystemCatalogMutation();
     return (await resp.json()) as ImportShadcnDesignSystemResponse;
   } catch (err) {
     return {
@@ -3514,6 +3544,7 @@ export async function installDesignSystem(
     });
     const json = await resp.json();
     if (!resp.ok) return { error: json.error ?? 'Install failed' };
+    noteDesignSystemCatalogMutation();
     return json as InstallDesignSystemResponse;
   } catch {
     return { error: 'Network error' };

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -102,6 +102,7 @@ import {
   appendResourceQuery,
   workspaceIdentityCacheKey,
   workspaceResourceUrl,
+  workspaceAccountScopedCacheKey,
 } from '../collab/workspace-identity';
 import { PublicFilePublishError } from '../collab/public-file-publish';
 
@@ -660,10 +661,17 @@ async function readDesignSystemCatalog(
   workspaceContext: WorkspaceCollabContext | null | undefined,
   options?: FetchDesignSystemsOptions,
 ): Promise<DesignSystemSummary[]> {
-  // Keyed by the exact identity the request will carry. `/api/design-systems`
-  // is fail-closed on a missing scope, so a headerless read is a different,
-  // smaller catalog — never an answer a Workspace-scoped read may join.
-  const cacheKey = `design-system-catalog:${workspaceIdentityCacheKey(workspaceContext)}`;
+  // Keyed by the exact identity the request will carry, PLUS the account
+  // boundary it was captured under — the same two-part identity the app uses
+  // for this catalog and the team-project catalog carries as its request
+  // generation. `/api/design-systems` is fail-closed on a missing scope, so a
+  // headerless read is a different, smaller catalog and never an answer a
+  // Workspace-scoped read may join. The generation is load-bearing on its own:
+  // a sign-out/sign-in cycle can leave every context field identical while the
+  // authority behind them has changed, and ttl 0 would not catch it — it stops
+  // settled-result reuse, not a post-boundary reader joining a request issued
+  // before the boundary.
+  const cacheKey = `design-system-catalog:${workspaceAccountScopedCacheKey(workspaceContext)}`;
   // Same rule as the Team index above: a forced call is an authoritative read
   // for one mutation and must never join a snapshot issued before it.
   if (options?.forceTeamMaterialization) evictCoalescedGet(cacheKey);

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -669,8 +669,21 @@ const CATALOG_SINGLE_FLIGHT_ONLY_MS = 0;
  * when the request arrived. Joining a pre-mutation GET would leave the deleted
  * system on screen, or show the old published/draft status.
  *
- * Every mutating export below must bump this on success. `forceTeamMaterialization`
- * stays as it is: that is the REMOTE (team-invalidation) signal, this is the local one.
+ * The rule, stated so it stays checkable: every export that SYNCHRONOUSLY changes
+ * catalog membership or a summary field bumps this on success — create, update,
+ * update-revision-status, delete, uninstall, the three imports, install, and
+ * asset sync.
+ *
+ * Two groups deliberately do not, and should not be "fixed" later:
+ *   - the job starters (`startDesignSystemGenerationJob`,
+ *     `startDesignSystemRevisionJob`,
+ *     `startDesignSystemTokenContractRebuildJob`) — nothing has changed when they
+ *     return; the finished job arrives through the invalidation path;
+ *   - `ensureDesignSystemWorkspace` — it materializes an editing workspace and
+ *     leaves the catalog rows alone.
+ *
+ * `forceTeamMaterialization` also stays as it is: that is the REMOTE
+ * (team-invalidation) signal, this is the local one.
  */
 let designSystemCatalogMutationGeneration = 0;
 
@@ -3562,9 +3575,15 @@ export async function uninstallDesignSystem(
         ? { headers: workspaceProjectHeaders(workspaceContext) }
         : {}),
     });
-    const json = await resp.json();
-    if (!resp.ok) return { error: json.error ?? 'Uninstall failed' };
-    return { ok: true };
+    // Success is decided by the status, not by a parsed body: this route can
+    // answer an empty 204, and parsing first threw straight into the catch —
+    // which also made any bump placed on the success path unreachable.
+    if (resp.ok) {
+      noteDesignSystemCatalogMutation();
+      return { ok: true };
+    }
+    const json = (await resp.json().catch(() => null)) as { error?: string } | null;
+    return { error: json?.error ?? 'Uninstall failed' };
   } catch {
     return { error: 'Network error' };
   }

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -585,6 +585,11 @@ export interface FetchDesignSystemsOptions {
    * Exact Team ids returned by a workspace-scoped Team-index read that just
    * completed in the caller. Reuse that witness while reading the unified
    * catalog instead of issuing a duplicate `/team` materialization request.
+   *
+   * Supplying it also declares the catalog read itself authoritative: the only
+   * caller passes it when its fresh `/team` witness disagrees with the rows it
+   * holds, or straight after a share/unshare. So the catalog read starts fresh
+   * rather than joining one issued before that change.
    */
   materializedTeamIds?: readonly string[];
 }
@@ -709,7 +714,18 @@ async function readDesignSystemCatalog(
     + `:${workspaceAccountScopedCacheKey(workspaceContext)}`;
   // Same rule as the Team index above: a forced call is an authoritative read
   // for one mutation and must never join a snapshot issued before it.
-  if (options?.forceTeamMaterialization) evictCoalescedGet(cacheKey);
+  //
+  // `materializedTeamIds` counts too, and it is not obvious from the name.
+  // `DesignSystemsTab.refreshTeamShared` is the only caller that supplies it,
+  // and it does so exactly when the fresh `/team` witness disagrees with the
+  // catalog it holds — or immediately after a share/unshare. Carrying that
+  // witness therefore means "what I hold is out of date"; joining a catalog GET
+  // issued before the share would omit the newly shared system or keep a
+  // retired mirror on screen. Routine mounts do not pass it, so ordinary
+  // readers still collapse onto the shared key.
+  if (options?.forceTeamMaterialization || options?.materializedTeamIds) {
+    evictCoalescedGet(cacheKey);
+  }
   return coalescedGet(cacheKey, async () => {
     const resp = await fetch('/api/design-systems', {
       ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1010,6 +1010,23 @@ export async function importClaudeDesignZip(
 
 // ---------- templates ----------
 
+/**
+ * Bumped by every successful local template mutation, and part of the read key.
+ *
+ * `ttl = 0` stops a settled result from being reused; it does not stop a new
+ * caller from JOINING a request that is still in flight — and the caller that
+ * follows a mutation is exactly the one that must not join. `handleDeleteTemplate`
+ * awaits `deleteTemplate` and then refreshes, and the daemon answers
+ * `/api/templates` from a snapshot taken when the request arrived, so joining a
+ * pre-delete GET would leave the deleted template on screen until something
+ * else happened to refetch.
+ */
+let templateListMutationGeneration = 0;
+
+function noteTemplateListMutation(): void {
+  templateListMutationGeneration += 1;
+}
+
 export async function listTemplates(): Promise<ProjectTemplate[]> {
   // Same launch-burst shape as the design-system catalog: App's one-shot
   // bootstrap and the home-route effect both want this list on the same pass,
@@ -1028,7 +1045,7 @@ export async function listTemplates(): Promise<ProjectTemplate[]> {
   // Throwing inside keeps a transient failure out of the shared entry, so the
   // next caller retries instead of joining a dead read.
   try {
-    return await coalescedGet('project-templates', async () => {
+    return await coalescedGet(`project-templates:${templateListMutationGeneration}`, async () => {
       const resp = await fetch('/api/templates');
       if (!resp.ok) throw new Error(`templates ${resp.status}`);
       const json = (await resp.json()) as { templates: ProjectTemplate[] };
@@ -1062,6 +1079,7 @@ export async function saveTemplate(input: {
       body: JSON.stringify(input),
     });
     if (!resp.ok) return null;
+    noteTemplateListMutation();
     const json = (await resp.json()) as { template: ProjectTemplate };
     return json.template;
   } catch {
@@ -1074,6 +1092,7 @@ export async function deleteTemplate(id: string): Promise<boolean> {
     const resp = await fetch(`/api/templates/${encodeURIComponent(id)}`, {
       method: 'DELETE',
     });
+    if (resp.ok) noteTemplateListMutation();
     return resp.ok;
   } catch {
     return false;

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1011,11 +1011,29 @@ export async function importClaudeDesignZip(
 // ---------- templates ----------
 
 export async function listTemplates(): Promise<ProjectTemplate[]> {
+  // Same launch-burst shape as the design-system catalog: App's one-shot
+  // bootstrap and the home-route effect both want this list on the same pass,
+  // and both must keep their own read — one settles the entry view, the other
+  // exists to pick up a template saved inside a project. Neither can drop its
+  // read; on the wire they are one request, and on a cold Home load they land
+  // together and take two of the browser's ~6 connection slots.
+  //
+  // SINGLE-FLIGHT ONLY (ttl 0). The home-route effect and the save handler's
+  // own refresh both exist to observe a change that just happened, so a shared
+  // settled answer would hand them the list they were fired to replace.
+  //
+  // One global key, deliberately not partitioned by Workspace identity: the
+  // daemon handler ignores the request entirely (`(_req, res) =>`) and answers
+  // from its local store, so this response cannot vary by caller identity.
+  // Throwing inside keeps a transient failure out of the shared entry, so the
+  // next caller retries instead of joining a dead read.
   try {
-    const resp = await fetch('/api/templates');
-    if (!resp.ok) return [];
-    const json = (await resp.json()) as { templates: ProjectTemplate[] };
-    return json.templates ?? [];
+    return await coalescedGet('project-templates', async () => {
+      const resp = await fetch('/api/templates');
+      if (!resp.ok) throw new Error(`templates ${resp.status}`);
+      const json = (await resp.json()) as { templates: ProjectTemplate[] };
+      return json.templates ?? [];
+    }, 0);
   } catch {
     return [];
   }

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -525,6 +525,46 @@ describe('design-system Workspace scope', () => {
     expect(catalogReads).toBe(2);
   });
 
+  it('starts a fresh catalog read when a local mutation lands mid-flight', async () => {
+    // Review catch. `DesignSystemsTab` awaits `deleteDesignSystemDraft` (and
+    // `updateDesignSystemDraft` for publish/unpublish) and then calls its plain
+    // `onSystemsRefresh()` — no `forceTeamMaterialization`, because nothing
+    // remote changed. That refresh is precisely the caller that must not join a
+    // GET issued before the mutation: `ttl = 0` stops settled-result reuse, not
+    // in-flight joining, so the tab would commit the pre-mutation rows and leave
+    // the deleted system on screen.
+    const context = personalWorkspaceContext();
+    const pending = deferred<Response>();
+    let rows = [{ id: 'user:doomed', title: 'Doomed', source: 'user', status: 'published' }];
+    let catalogGets = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      if ((init?.method ?? 'GET') === 'DELETE') {
+        rows = [];
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      }
+      catalogGets += 1;
+      if (catalogGets === 1) return pending.promise;
+      return Promise.resolve(new Response(JSON.stringify({ designSystems: rows }), { status: 200 }));
+    }));
+
+    const inFlightBeforeMutation = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(catalogGets).toBe(1));
+    await expect(deleteDesignSystemDraft('user:doomed', context)).resolves.toBeTruthy();
+
+    const afterMutation = fetchDesignSystemsResult(context);
+    pending.resolve(new Response(
+      JSON.stringify({ designSystems: [{ id: 'user:doomed', title: 'Doomed', source: 'user', status: 'published' }] }),
+      { status: 200 },
+    ));
+
+    await expect(afterMutation).resolves.toMatchObject({ ok: true, designSystems: [] });
+    await inFlightBeforeMutation;
+  });
+
   it('never lets a pre-account-boundary catalog read answer a post-boundary one', async () => {
     // A sign-out/sign-in cycle can leave every context field identical while the
     // authority behind them has changed — that is exactly why the app keys the

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -13,6 +13,7 @@ import {
   connectConnector,
   DEFAULT_DEPLOY_PROVIDER_ID,
   deleteDesignSystemDraft,
+  uninstallDesignSystem,
   DesignSystemDeleteError,
   deletePreviewComment,
   deployProjectFile,
@@ -558,6 +559,48 @@ describe('design-system Workspace scope', () => {
     const afterMutation = fetchDesignSystemsResult(context);
     pending.resolve(new Response(
       JSON.stringify({ designSystems: [{ id: 'user:doomed', title: 'Doomed', source: 'user', status: 'published' }] }),
+      { status: 200 },
+    ));
+
+    await expect(afterMutation).resolves.toMatchObject({ ok: true, designSystems: [] });
+    await inFlightBeforeMutation;
+  });
+
+  it('starts a fresh catalog read after an uninstall, including on an empty 204', async () => {
+    // `uninstallDesignSystem` sends the same `DELETE /api/design-systems/:id` as
+    // the draft-delete helper, so it is a catalog mutation and the generation
+    // must advance for it too. It has no callers today; the spec exists so the
+    // invariant holds the moment one is wired up.
+    //
+    // The 204 is the load-bearing half: the function used to `await resp.json()`
+    // before checking `resp.ok`, so an empty success body threw straight into
+    // the catch and the success path — and therefore any bump placed on it —
+    // was unreachable.
+    const context = personalWorkspaceContext();
+    const pending = deferred<Response>();
+    let rows = [{ id: 'user:installed', title: 'Installed', source: 'user', status: 'published' }];
+    let catalogGets = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      if ((init?.method ?? 'GET') === 'DELETE') {
+        rows = [];
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      catalogGets += 1;
+      if (catalogGets === 1) return pending.promise;
+      return Promise.resolve(new Response(JSON.stringify({ designSystems: rows }), { status: 200 }));
+    }));
+
+    const inFlightBeforeMutation = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(catalogGets).toBe(1));
+    await expect(uninstallDesignSystem('user:installed', context)).resolves.toEqual({ ok: true });
+
+    const afterMutation = fetchDesignSystemsResult(context);
+    pending.resolve(new Response(
+      JSON.stringify({ designSystems: [{ id: 'user:installed', title: 'Installed', source: 'user', status: 'published' }] }),
       { status: 200 },
     ));
 

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installMockOpenDesignHost } from '@open-design/host/testing';
+import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 import {
   buildWorkspacePermissions,
   buildWorkspaceSeatSummary,
@@ -522,6 +523,40 @@ describe('design-system Workspace scope', () => {
     await fetchDesignSystemsResult(context);
     await fetchDesignSystemsResult(context);
     expect(catalogReads).toBe(2);
+  });
+
+  it('never lets a pre-account-boundary catalog read answer a post-boundary one', async () => {
+    // A sign-out/sign-in cycle can leave every context field identical while the
+    // authority behind them has changed — that is exactly why the app keys the
+    // catalog on [accountGeneration, workspaceIdentity] and the team-project
+    // catalog carries a request generation. `ttl = 0` does not cover this: it
+    // disables settled-result reuse, but a post-boundary reader could still JOIN
+    // the promise of a request issued before the boundary and adopt its answer.
+    const context = personalWorkspaceContext();
+    const gates: Array<ReturnType<typeof deferred<Response>>> = [];
+    let catalogReads = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      catalogReads += 1;
+      const gate = deferred<Response>();
+      gates.push(gate);
+      return gate.promise;
+    }));
+
+    const beforeBoundary = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(catalogReads).toBe(1));
+
+    advanceWorkspaceAccountGeneration('account-boundary');
+
+    const afterBoundary = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(catalogReads).toBe(2));
+
+    for (const gate of gates) {
+      gate.resolve(new Response(JSON.stringify({ designSystems: [] }), { status: 200 }));
+    }
+    await Promise.all([beforeBoundary, afterBoundary]);
   });
 
   it('never lets a headerless catalog read answer a Workspace-scoped one', async () => {

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -608,6 +608,55 @@ describe('design-system Workspace scope', () => {
     await inFlightBeforeMutation;
   });
 
+  it('starts a fresh catalog read when the caller brings a newer Team witness', async () => {
+    // Review catch, and a regression this PR introduced: before coalescing, this
+    // path always made its own catalog request.
+    //
+    // `DesignSystemsTab.refreshTeamShared` passes `materializedTeamIds` — never
+    // `forceTeamMaterialization` — and it only does so when the fresh `/team`
+    // read disagrees with the catalog it holds, or right after a share/unshare
+    // (`refreshSystems: true`). So supplying that witness always means "what I
+    // hold is out of date", and joining a catalog GET issued before the
+    // share/unshare would omit the newly shared system or keep a retired mirror.
+    const context = teamWorkspaceContext();
+    const pending = deferred<Response>();
+    let catalogGets = 0;
+    const rowsAfterShare = [
+      { id: 'user:brand', title: 'Brand', source: 'user', status: 'published' },
+      { id: 'user:newly-shared', title: 'Newly shared', source: 'user', status: 'published' },
+    ];
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/workspace/design-systems/team') {
+        // Must not be reached: the caller already has the witness.
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      catalogGets += 1;
+      if (catalogGets === 1) return pending.promise;
+      return Promise.resolve(new Response(JSON.stringify({ designSystems: rowsAfterShare }), { status: 200 }));
+    }));
+
+    const issuedBeforeShare = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(catalogGets).toBe(1));
+
+    const afterShare = fetchDesignSystemsResult(context, {
+      materializedTeamIds: ['user:newly-shared'],
+    });
+    pending.resolve(new Response(
+      JSON.stringify({ designSystems: [{ id: 'user:brand', title: 'Brand', source: 'user', status: 'published' }] }),
+      { status: 200 },
+    ));
+
+    await expect(afterShare).resolves.toMatchObject({
+      ok: true,
+      designSystems: [
+        expect.objectContaining({ id: 'user:brand' }),
+        expect.objectContaining({ id: 'user:newly-shared', teamShared: true }),
+      ],
+    });
+    await issuedBeforeShare;
+  });
+
   it('never lets a pre-account-boundary catalog read answer a post-boundary one', async () => {
     // A sign-out/sign-in cycle can leave every context field identical while the
     // authority behind them has changed — that is exactly why the app keys the

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -466,6 +466,99 @@ describe('design-system Workspace scope', () => {
       }),
     }));
   });
+
+  it('collapses concurrent catalog reads for one identity into a single request', async () => {
+    // Bootstrap, the workspace-identity effect and the home-route effect all
+    // want the catalog on the same launch pass, and LibrarySection /
+    // DesignSystemsSection / DesignSystemSwitchPicker each read it again as
+    // they mount. Every one of those owns its own latest-wins bookkeeping, so
+    // none can drop its read — but on the wire they are one request.
+    const context = personalWorkspaceContext();
+    const gate = deferred<Response>();
+    let catalogReads = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      catalogReads += 1;
+      return gate.promise;
+    }));
+
+    const reads = [
+      fetchDesignSystemsResult(context),
+      fetchDesignSystemsResult(context),
+      fetchDesignSystemsResult(context),
+    ];
+    await vi.waitFor(() => expect(catalogReads).toBeGreaterThan(0));
+    expect(catalogReads).toBe(1);
+
+    gate.resolve(new Response(
+      JSON.stringify({ designSystems: [{ id: 'user:brand', title: 'Brand', source: 'user', status: 'published' }] }),
+      { status: 200 },
+    ));
+    for (const read of reads) {
+      await expect(read).resolves.toMatchObject({
+        ok: true,
+        designSystems: [expect.objectContaining({ id: 'user:brand' })],
+      });
+    }
+  });
+
+  it('re-reads the catalog for a read issued after the previous one settled', async () => {
+    // Single-flight ONLY: several call sites exist precisely to observe a
+    // change that just happened out of band — returning home re-reads so an
+    // in-project brand extraction shows up. Sharing a settled answer for even
+    // a second would hand those reads the state they were fired to replace.
+    const context = personalWorkspaceContext();
+    let catalogReads = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      catalogReads += 1;
+      return Promise.resolve(new Response(JSON.stringify({ designSystems: [] }), { status: 200 }));
+    }));
+
+    await fetchDesignSystemsResult(context);
+    await fetchDesignSystemsResult(context);
+    expect(catalogReads).toBe(2);
+  });
+
+  it('never lets a headerless catalog read answer a Workspace-scoped one', async () => {
+    // A read issued before `/api/workspace/context` settles carries no identity
+    // headers, and `/api/design-systems` is fail-closed on a missing scope — it
+    // is a different, smaller catalog, not a cheaper copy of the scoped answer.
+    const context = personalWorkspaceContext();
+    const scopedIds: string[] = [];
+    let headerlessReads = 0;
+    // Each read gets its own Response: a shared body can only be read once, so
+    // reusing one would hide a join behind a parse error instead of a count.
+    const gates: Array<ReturnType<typeof deferred<Response>>> = [];
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/api/workspace/design-systems/team') {
+        return Promise.resolve(new Response(JSON.stringify({ ids: [] }), { status: 200 }));
+      }
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const workspaceId = headers['x-od-workspace-id'];
+      if (workspaceId) scopedIds.push(workspaceId);
+      else headerlessReads += 1;
+      const gate = deferred<Response>();
+      gates.push(gate);
+      return gate.promise;
+    }));
+
+    const headerless = fetchDesignSystemsResult(null);
+    const scoped = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(headerlessReads + scopedIds.length).toBe(2));
+    expect(headerlessReads).toBe(1);
+    expect(scopedIds).toEqual([context.workspaceId]);
+
+    for (const gate of gates) {
+      gate.resolve(new Response(JSON.stringify({ designSystems: [] }), { status: 200 }));
+    }
+    await Promise.all([headerless, scoped]);
+  });
+
 });
 
 describe('fetchAgentsStream', () => {

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -691,6 +691,49 @@ describe('design-system Workspace scope', () => {
     await Promise.all([beforeBoundary, afterBoundary]);
   });
 
+  it('never lets a pre-boundary Team witness decorate a post-boundary catalog', async () => {
+    // The catalog key carries the account generation, but the Team-index read it
+    // awaits first did not. A `/team` request still in flight across a
+    // sign-out/sign-in would be joined by the post-boundary caller, so the fresh
+    // catalog got decorated with the previous account's Team-share flags — the
+    // account-boundary guarantee held for the rows and not for the flags.
+    const context = teamWorkspaceContext();
+    const firstTeamRead = deferred<Response>();
+    let teamReads = 0;
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL) => {
+      if (String(input) === '/api/workspace/design-systems/team') {
+        teamReads += 1;
+        if (teamReads === 1) return firstTeamRead.promise;
+        return Promise.resolve(new Response(JSON.stringify({ ids: ['user:b'] }), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({
+        designSystems: [
+          { id: 'user:a', title: 'A', source: 'user', status: 'published' },
+          { id: 'user:b', title: 'B', source: 'user', status: 'published' },
+        ],
+      }), { status: 200 }));
+    }));
+
+    const beforeBoundary = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(teamReads).toBe(1));
+
+    advanceWorkspaceAccountGeneration('team-witness-boundary');
+
+    const afterBoundary = fetchDesignSystemsResult(context);
+    await vi.waitFor(() => expect(teamReads).toBe(2));
+
+    firstTeamRead.resolve(new Response(JSON.stringify({ ids: ['user:a'] }), { status: 200 }));
+
+    await expect(afterBoundary).resolves.toMatchObject({
+      ok: true,
+      designSystems: [
+        expect.not.objectContaining({ teamShared: true }),
+        expect.objectContaining({ id: 'user:b', teamShared: true }),
+      ],
+    });
+    await beforeBoundary;
+  });
+
   it('never lets a headerless catalog read answer a Workspace-scoped one', async () => {
     // A read issued before `/api/workspace/context` settles carries no identity
     // headers, and `/api/design-systems` is fail-closed on a missing scope — it

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -16,6 +16,7 @@ import {
   importClaudeDesignZip,
   importFolderProject,
   invalidateWorkspaceProjectLists,
+  listTemplates,
   installGeneratedPluginFolder,
   installPluginSource,
   listPlugins,
@@ -2479,5 +2480,84 @@ describe('read-only project tabs cache', () => {
     expect(loaded.active).toBe('local.html');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[1]?.method).toBeUndefined();
+  });
+});
+
+describe('listTemplates request coalescing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((done) => { resolve = done; });
+    return { promise, resolve };
+  }
+
+  it('collapses concurrent template-list reads into a single request', async () => {
+    // Same launch-burst shape as the design-system catalog: App's one-shot
+    // bootstrap and the home-route effect both want the list on the same pass,
+    // and both must keep their own read — one settles the entry view, the other
+    // exists to pick up a template saved inside a project. On the wire they are
+    // one request, and on a cold Home load they land together.
+    const gate = deferred<Response>();
+    let reads = 0;
+    vi.stubGlobal('fetch', vi.fn(() => {
+      reads += 1;
+      return gate.promise;
+    }));
+
+    const inFlight = [listTemplates(), listTemplates(), listTemplates()];
+    await vi.waitFor(() => expect(reads).toBeGreaterThan(0));
+    expect(reads).toBe(1);
+
+    gate.resolve(new Response(
+      JSON.stringify({ templates: [{ id: 'tpl-1', name: 'Landing page' }] }),
+      { status: 200 },
+    ));
+    for (const read of inFlight) {
+      await expect(read).resolves.toEqual([
+        expect.objectContaining({ id: 'tpl-1' }),
+      ]);
+    }
+  });
+
+  it('re-reads the template list for a call issued after the previous settled', async () => {
+    // Single-flight only, never a shared settled answer: returning Home re-reads
+    // precisely so a template saved inside a project shows up, and the save
+    // handler awaits its own refresh. A cached list would hand both of them the
+    // list they were fired to replace.
+    let reads = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      reads += 1;
+      return new Response(
+        JSON.stringify({ templates: reads > 1 ? [{ id: 'tpl-new', name: 'Saved' }] : [] }),
+        { status: 200 },
+      );
+    }));
+
+    await expect(listTemplates()).resolves.toEqual([]);
+    await expect(listTemplates()).resolves.toEqual([
+      expect.objectContaining({ id: 'tpl-new' }),
+    ]);
+    expect(reads).toBe(2);
+  });
+
+  it('lets the next caller retry instead of joining a failed read', async () => {
+    // Failures are never cached: a transient 500 must not leave the entry view
+    // with an empty template list until something else happens to refetch.
+    let reads = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      reads += 1;
+      return reads === 1
+        ? new Response('nope', { status: 500 })
+        : new Response(JSON.stringify({ templates: [{ id: 'tpl-2', name: 'Deck' }] }), { status: 200 });
+    }));
+
+    await expect(listTemplates()).resolves.toEqual([]);
+    await expect(listTemplates()).resolves.toEqual([
+      expect.objectContaining({ id: 'tpl-2' }),
+    ]);
+    expect(reads).toBe(2);
   });
 });

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -15,6 +15,7 @@ import {
   getProjectDetail,
   importClaudeDesignZip,
   importFolderProject,
+  deleteTemplate,
   invalidateWorkspaceProjectLists,
   listTemplates,
   installGeneratedPluginFolder,
@@ -2541,6 +2542,50 @@ describe('listTemplates request coalescing', () => {
       expect.objectContaining({ id: 'tpl-new' }),
     ]);
     expect(reads).toBe(2);
+  });
+
+  it('starts a fresh template read when a mutation lands mid-flight', async () => {
+    // Review catch. `ttl = 0` stops settled-result reuse but not in-flight
+    // joining, and the post-mutation refresh is exactly the caller that must
+    // never join: `handleDeleteTemplate` awaits `deleteTemplate` and then calls
+    // `refreshTemplates`. The daemon answers `/api/templates` from a synchronous
+    // `listTemplates(db)` snapshot, so a GET issued before the DELETE returns
+    // the row that was just deleted — and joining it would leave the deleted
+    // template on screen until something else happened to refetch.
+    const pending = deferred<Response>();
+    const urls: string[] = [];
+    let templateRows = [{ id: 'tpl-doomed', name: 'Doomed' }];
+    vi.stubGlobal('fetch', vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      urls.push(`${init?.method ?? 'GET'} ${url}`);
+      if ((init?.method ?? 'GET') === 'DELETE') {
+        templateRows = [];
+        return Promise.resolve(new Response(null, { status: 204 }));
+      }
+      // The first GET is issued before the delete and answers the pre-delete
+      // snapshot; it stays pending across the mutation.
+      if (urls.filter((u) => u.startsWith('GET')).length === 1) return pending.promise;
+      return Promise.resolve(new Response(
+        JSON.stringify({ templates: templateRows }),
+        { status: 200 },
+      ));
+    }));
+
+    const inFlightBeforeMutation = listTemplates();
+    await expect(deleteTemplate('tpl-doomed')).resolves.toBe(true);
+
+    const afterMutation = listTemplates();
+    // Release the pre-delete GET. If the refresh joined it, it now resolves to
+    // the stale row instead of issuing its own read.
+    pending.resolve(new Response(
+      JSON.stringify({ templates: [{ id: 'tpl-doomed', name: 'Doomed' }] }),
+      { status: 200 },
+    ));
+
+    await expect(afterMutation).resolves.toEqual([]);
+    await expect(inFlightBeforeMutation).resolves.toEqual([
+      expect.objectContaining({ id: 'tpl-doomed' }),
+    ]);
   });
 
   it('lets the next caller retry instead of joining a failed read', async () => {


### PR DESCRIPTION
## Why

Dogfooding the launch path with the network panel open: a single Home load fires
**five requests to `GET /api/design-systems`** — three before `/api/workspace/context`
settles and two after — with the same-identity copies issued in the same
millisecond. They queue against the browser's ~6-connections-per-host cap
alongside the other ~55 API requests the same launch fires, so the later copies
are not slow on the server, they are waiting for a connection.

The duplicates are not a bug in any one caller. Bootstrap, the Workspace-identity
effect and the home-route effect each need the catalog on the same pass, and
LibrarySection / DesignSystemsSection / DesignSystemSwitchPicker each read it
again as they mount. Every one of them owns its own latest-wins bookkeeping and
its own loading state, so none of them can simply drop its read. They are
distinct *readers*; they are one *request*.

The neighbouring Team-index read (`/api/workspace/design-systems/team`) has been
coalesced since it was written — the unified catalog read next to it was simply
never given the same treatment.

### The same shape, one endpoint over: `/api/templates`

`listTemplates` is read by exactly the same two owners on the same pass — App's
one-shot bootstrap and the home-route effect — and fires **three times** per cold
Home load, going to **two** with the same treatment. One difference worth
stating: its key is *not* partitioned by Workspace identity, because the daemon
handler ignores the request entirely (`app.get('/api/templates', (_req, res) => ...)`)
and answers from its local store, so the response cannot vary by caller and an
account boundary cannot stale it.

### A note on how this was measured

The first numbers I took were from the dev server with its default
`reactStrictMode: true`, which double-invokes effects and inflated the count to
seven. Everything below is re-measured with StrictMode off so the effect
behaviour matches production; both sets are given so the difference is visible:

| | `/api/design-systems` | `/api/templates` | total API requests |
| --- | --- | --- | --- |
| dev default (StrictMode on) | 7 → 2 | — | 68 |
| StrictMode off (production-like) | **5 → 2** | **3 → 2** | 58 → 54 |

## What users will see

Nothing changes on screen. The Home and Design systems views show the same
catalog they did before; the launch just stops spending three extra round trips —
and three of the browser's scarce connection slots — re-asking a question it has
already asked.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal: one read routed through the existing client-side GET coalescer.

## Bug fix verification

- Red spec: `apps/web/tests/providers/registry.test.ts` →
  `collapses concurrent catalog reads for one identity into a single request`.
- Red on `main` (`expected 3 to be 1`), green on this branch. The other two specs
  in the same block are guard rails that were green before and after — they pin
  the two things this change must NOT do (see below).

## Why single-flight only, and not a shared result

`coalescedGet` also shares a settled result for a TTL. This change passes
`ttl = 0`, so it collapses only reads that are genuinely in flight together and
never serves a cached answer.

That is deliberate. Several of these call sites exist *precisely* to observe a
change that just happened out of band:

- the home-route effect re-reads so an in-project brand extraction shows up when
  the user returns Home — its own comment says so;
- `forceTeamMaterialization` callers are announcing a realtime team mutation, and
  `FetchDesignSystemsOptions` already documents that "distinct mutations must
  never join an older in-flight snapshot". Forced calls evict the key first, the
  same way the Team-index read next to it already does.

Sharing a settled answer for even a second would hand exactly those readers the
state they were fired to replace. Two specs pin this: one asserts a sequential
read after a settled one still hits the network, and the existing two-mutation
spec still gets two authoritative catalog answers.

## What the key is made of

Two review rounds established that `ttl = 0` alone is not enough, because it
stops a settled result from being *reused* but not a new caller from *joining*
something still in flight. The read key therefore carries both boundaries that
can invalidate an in-flight answer:

`design-system-catalog:<mutationGeneration>:<accountGeneration>:<workspaceIdentity>`

- **workspace identity** — a headerless read is a different, smaller catalog
  (`/api/design-systems` is fail-closed on a missing scope), never a cheaper copy
  of the scoped one.
- **account generation** — a sign-out/sign-in cycle can leave every context field
  identical while the authority behind them has changed. This is the same
  two-part identity the app already uses in its own bookkeeping, and that
  `optimistic-project-ownership` and `team-members-store` key on.
- **mutation generation** — bumped by every successful local mutation, so the
  refresh that follows one cannot share a key with a read issued before it.
  `DesignSystemsTab` awaits `deleteDesignSystemDraft` / `updateDesignSystemDraft`
  and then calls its plain `onSystemsRefresh()`; `handleDeleteTemplate` awaits
  `deleteTemplate` and then refreshes. Both daemon handlers answer from a
  snapshot taken when the request arrived, so joining a pre-mutation GET left the
  deleted row on screen. Nine mutating exports bump it for the catalog, two for
  templates.

`forceTeamMaterialization` is untouched and keeps its explicit evict — that is
the *remote* team-invalidation signal; the mutation generation is the local one.
Ordinary concurrent readers stay on one shared key, which is the point.

## Why two requests remain, and why they must

Both endpoints settle at two requests per cold launch, and coalescing cannot
take either lower. Verified with a `window.fetch` probe installed before app JS
via `Page.addScriptToEvaluateOnNewDocument`, which tags each call with its source
frames — both surviving calls do go through `coalescedGet`:

| t | endpoint | `x-od-workspace-id` |
| --- | --- | --- |
| 4478ms | `/api/templates` | n/a (endpoint is not scoped) |
| 4494ms | `/api/design-systems` | *(absent)* |
| 6302ms | `/api/templates` | n/a |
| 6302ms | `/api/design-systems` | `zef2o9…` |

They are 1.8 seconds apart because the launch makes **two passes**: one before
`/api/workspace/context` settles and one after. Single-flight only collapses
readers that overlap, and these do not.

For the catalog the split is also load-bearing: the first read carries no
identity headers, and `/api/design-systems` is fail-closed on a missing scope, so
that answer is a different, smaller catalog — never a cheaper copy of the scoped
one. The coalescing key is the account-scoped workspace identity precisely so the
two can never answer for each other, and two specs pin it (headerless vs scoped,
and pre- vs post-account-boundary).

## Adjacent issues (not in this PR)

Two pre-existing account-boundary gaps surfaced during review. Both are real;
neither is introduced or worsened here, and each wants its own red spec through
the surface that actually has the gap rather than a provider-level spec standing
in for it.

- **Three catalog readers have no generation guard.** `DesignSystemSwitchPicker`,
  `DesignSystemsSection` and `LibrarySection` key their effects on workspace
  identity alone, and the Workspace hook deliberately retains the old context
  while an identity change is pending — so an A-era result can be committed after
  B is active. On `origin/main` none of the three mentions
  `currentWorkspaceAccountGeneration`, and none appears in this branch's diff;
  before coalescing each issued its own request and had the identical exposure.
- **`DesignSystemsTab`'s Team read is account-blind.** Its key is
  `workspace-design-systems-team:${scopedWorkspaceIdentity}` — unchanged from
  `main` — so a pre-boundary witness can be accepted after the boundary and passed
  on as `materializedTeamIds`. That path bypasses the Team read exactly as it did
  before; what this branch added to it is an eviction, which makes it fresher
  than `main`, not staler.

### From the original measurement



- **The headerless bootstrap read itself.** `App.tsx` already learned this lesson
  for `/api/skills` — it deliberately does *not* read skills at bootstrap because
  the pre-context answer is the fail-closed one — but the design-system read next
  to it still does. Removing it would take the launch to a single catalog read.
  That change lives in `App.tsx`'s latest-wins bookkeeping, which has its own
  dedicated race suite; it deserves its own red spec and its own PR.
- **The rest of the launch burst.** The same production-like measurement shows 52
  API requests on one Home load with 15 endpoints requested more than once. The
  remaining ones are not the same bug and do not take the same fix — checked
  individually with stack-tagged fetch probes:
  - `/api/integrations/vela/status` ×4 = 2 from `MessageCenter` + 2 from
    `fetchVelaLoginStatus`. Neither pair is concurrent, so coalescing removes
    nothing. The `MessageCenter` pair is a remount: `EntryNavRail` renders two
    mutually-exclusive instances gated on `context`, so when
    `/api/workspace/context` resolves the signed-out instance unmounts, the
    signed-in one mounts, and it re-runs a full sync. That also accounts for
    `/api/integrations/vela/message-center/messages` ×2.
  - `/api/analytics/config` ×4 **already uses this exact coalescer with ttl 0** —
    those calls are sequential, so single-flight cannot help, and its own comment
    explains why the TTL has to stay 0.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — 663 files / 7010 tests passed, **exit 0**
- Full `@open-design/web` suite after the latest round: 663 files / 7016 tests,
  **exit 0**; `pnpm typecheck` exit 0; `pnpm guard` exit 0. (One intermediate run showed 10 failures across 4 files
  — all timeouts at 5s under heavy machine contention; those four files pass in
  isolation and the clean re-run is green.)
- Real-browser before/after against a local `tools-dev` runtime (isolated
  `OD_DATA_DIR`, namespace `dsdup`), measured with
  `performance.getEntriesByType('resource')` plus a stack-tagging `window.fetch`
  probe installed before app JS, StrictMode off: `/api/design-systems`
  **5 → 2**, `/api/templates` **3 → 2**. Design systems tab still renders the
  full catalog (152 official presets) after the change.
