### PR TITLE
fix(daemon): resolve scheme-less custom OpenAI hosts through @ai-sdk/openai-compatible

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -18,7 +18,7 @@ const DEFAULT_BASE_URL_BY_PROTOCOL: Record<ByokChatProviderConfig['protocol'], s
   aihubmix: 'https://aihubmix.com/v1',
 };
 
-type ProviderPackage =
+export type ProviderPackage =
   | '@ai-sdk/anthropic'
   | '@ai-sdk/openai'
   | '@ai-sdk/openai-compatible'
@@ -97,27 +97,78 @@ export function buildOpenCodeByokProviderConfig(
   };
 }
 
+export interface OpenCodeByokResolutionInfo {
+  baseUrlHost: string | null;
+  npm: ProviderPackage;
+  modelId: string;
+  baseURL: string;
+  requestPath: string;
+}
+
+export function describeOpenCodeByokResolution(
+  provider: ByokChatProviderConfig | null | undefined,
+  model: string | null | undefined,
+): OpenCodeByokResolutionInfo | null {
+  const resolved = buildOpenCodeByokProviderConfig(provider, model);
+  if (!resolved) return null;
+  const entry = (
+    resolved.config as {
+      provider: Record<
+        string,
+        { npm: ProviderPackage; options?: { baseURL?: unknown } }
+      >;
+    }
+  ).provider[BYOK_OPENCODE_PROVIDER_ID];
+  if (!entry) return null;
+  const baseURL =
+    typeof entry.options?.baseURL === 'string' ? entry.options.baseURL : '';
+  let baseUrlHost: string | null = null;
+  try {
+    baseUrlHost = baseURL ? new URL(baseURL).hostname : null;
+  } catch {
+    baseUrlHost = null;
+  }
+  const requestPath =
+    entry.npm === '@ai-sdk/openai' ? '/responses' : '/chat/completions';
+  return { baseUrlHost, npm: entry.npm, modelId: resolved.modelId, baseURL, requestPath };
+}
+
 function normalizeProviderBaseUrl(
   protocol: ByokChatProviderConfig['protocol'],
   baseUrl: string,
 ): string {
   const trimmed = baseUrl.trim().replace(/\/+$/, '');
   if (!trimmed) return trimmed;
-  if (protocol === 'anthropic' && !hasVersionedApiPath(trimmed)) {
-    return appendVersionedApiPath(trimmed);
+  const withScheme = withCompletedUrlScheme(trimmed);
+  if (protocol === 'anthropic' && !hasVersionedApiPath(withScheme)) {
+    return appendVersionedApiPath(withScheme);
   }
-  if (protocol === 'openai' && isExactOrigin(trimmed, 'https://api.openai.com')) {
+  if (protocol === 'openai' && isExactOrigin(withScheme, 'https://api.openai.com')) {
     return 'https://api.openai.com/v1';
   }
-  if (protocol === 'google' && isExactOrigin(trimmed, 'https://generativelanguage.googleapis.com')) {
+  if (protocol === 'google' && isExactOrigin(withScheme, 'https://generativelanguage.googleapis.com')) {
     return 'https://generativelanguage.googleapis.com/v1beta';
   }
   if (protocol === 'ollama') {
-    if (isExactOrigin(trimmed, 'https://ollama.com')) return 'https://ollama.com/v1';
-    if (isLocalOllamaOriginPath(trimmed)) return `${trimmed}/v1`;
-    if (trimmed.endsWith('/api')) return `${trimmed.slice(0, -4)}/v1`;
+    if (isExactOrigin(withScheme, 'https://ollama.com')) return 'https://ollama.com/v1';
+    if (isLocalOllamaOriginPath(withScheme)) return `${withScheme}/v1`;
+    if (withScheme.endsWith('/api')) return `${withScheme.slice(0, -4)}/v1`;
   }
-  return trimmed;
+  return withScheme;
+}
+
+function withCompletedUrlScheme(value: string): string {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(value);
+  } catch {
+    parsed = null;
+  }
+  if (parsed && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+    return value;
+  }
+  return `https://${value}`;
 }
 
 function requiresApiKey(
@@ -161,11 +212,10 @@ function isExactOrigin(value: string, origin: string): boolean {
 }
 
 function isRealOpenAIHost(baseUrl: string): boolean {
-  if (!baseUrl) return true;
   try {
     return new URL(baseUrl).hostname === 'api.openai.com';
   } catch {
-    return true;
+    return false;
   }
 }
 

--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -25,6 +25,16 @@ export type ProviderPackage =
   | '@ai-sdk/azure'
   | '@ai-sdk/google';
 
+// Endpoint the resolved package actually calls, so the pre-spawn breadcrumb
+// stays accurate for non-OpenAI protocols.
+const REQUEST_PATH_BY_PACKAGE: Record<ProviderPackage, string> = {
+  '@ai-sdk/openai': '/responses',
+  '@ai-sdk/openai-compatible': '/chat/completions',
+  '@ai-sdk/anthropic': '/messages',
+  '@ai-sdk/google': '/models',
+  '@ai-sdk/azure': '/chat/completions',
+};
+
 export interface OpenCodeByokProviderConfig {
   providerId: string;
   modelId: string;
@@ -128,8 +138,7 @@ export function describeOpenCodeByokResolution(
   } catch {
     baseUrlHost = null;
   }
-  const requestPath =
-    entry.npm === '@ai-sdk/openai' ? '/responses' : '/chat/completions';
+  const requestPath = REQUEST_PATH_BY_PACKAGE[entry.npm];
   return { baseUrlHost, npm: entry.npm, modelId: resolved.modelId, baseURL, requestPath };
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -251,6 +251,7 @@ import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js'
 import {
   buildOpenCodeByokProviderConfig,
   BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE,
+  describeOpenCodeByokResolution,
 } from './runtimes/byok-opencode.js';
 import {
   extractPlainStreamArtifacts,
@@ -10387,6 +10388,19 @@ export async function startServer({
         BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE,
       );
     }
+    if (def.id === 'byok-opencode' && byokOpenCodeProvider) {
+      const resolution = describeOpenCodeByokResolution(
+        byokProvider,
+        typeof model === 'string' ? model : null,
+      );
+      console.log(
+        `[byok-opencode] run ${run.id}`
+          + ` provider=${resolution?.npm ?? 'none'}`
+          + ` model=${resolution?.modelId ?? 'none'}`
+          + ` host=${resolution?.baseUrlHost ?? 'none'}`
+          + ` endpoint=POST ${resolution?.baseURL ?? ''}${resolution?.requestPath ?? ''}`,
+      );
+    }
     const requestedRuntimeModel = def.id === 'byok-opencode'
       ? byokOpenCodeProvider?.modelId ?? null
       : model;
@@ -13229,6 +13243,13 @@ export async function startServer({
         def.streamFormat === 'dsh-profile-jsonl'
           ? 'pipe'
           : 'ignore';
+      if (def.id === 'byok-opencode' && byokOpenCodeProvider && !opencodeConfigContent) {
+        console.warn(
+          `[byok-opencode] run ${run.id} spawning without OPENCODE_CONFIG_CONTENT`
+            + ' — provider config was dropped (mcp-config build failure);'
+            + ' the agent will start without the BYOK provider',
+        );
+      }
       const env = applyAgentLaunchEnv({
         ...agentSpawnEnv,
         ...(mmdRouteLaunchEnv || {}),

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -14,7 +14,7 @@ import {
 import { execFileSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { delimiter, join, resolve } from 'node:path';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
 import {
   bufferedAntigravityGeminiFirstTokenAt,
   composeLiveInstructionPrompt,
@@ -625,6 +625,75 @@ process.stdin.on('end', () => {
         });
         expect(provider?.options).not.toHaveProperty('apiKey');
         expect(rawConfig).not.toContain('OPEN_DESIGN_BYOK_API_KEY');
+      },
+    );
+  });
+
+  it('logs a redacted resolution breadcrumb when spawning byok-opencode runs', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for BYOK OpenCode config tests');
+    }
+
+    const projectId = `proj-${randomUUID()}`;
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'BYOK breadcrumb fixture' }),
+    });
+    expect(createProjectResponse.ok).toBe(true);
+
+    await withFakeAgent(
+      'opencode',
+      `
+console.log(JSON.stringify({ type: 'step_start' }));
+console.log(JSON.stringify({ type: 'text', part: { text: 'byok-opencode-breadcrumb-ok' } }));
+console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+process.exit(0);
+`,
+      async () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        let body = '';
+        let loggedLines: string[] = [];
+        let warnedLines: string[] = [];
+        try {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'byok-opencode',
+              projectId,
+              message: 'hello',
+              model: 'deepseek-v4-flash',
+              byokProvider: {
+                protocol: 'openai',
+                apiKey: 'sk-breadcrumb-secret',
+                baseUrl: 'api.deepseek.com/v1',
+                model: 'deepseek-v4-flash',
+              },
+            }),
+          });
+          expect(response.ok).toBe(true);
+          body = await response.text();
+          loggedLines = logSpy.mock.calls.map((args) => args.map(String).join(' '));
+          warnedLines = warnSpy.mock.calls.map((args) => args.map(String).join(' '));
+        } finally {
+          logSpy.mockRestore();
+          warnSpy.mockRestore();
+        }
+
+        expect(body).toContain('byok-opencode-breadcrumb-ok');
+
+        const breadcrumb = loggedLines.find((line) =>
+          line.includes('[byok-opencode] run ') && line.includes('provider=@ai-sdk/openai-compatible'),
+        );
+        expect(breadcrumb).toBeTruthy();
+        expect(breadcrumb).toContain('host=api.deepseek.com');
+        expect(breadcrumb).toContain('model=open-design-byok/deepseek-v4-flash');
+        expect(breadcrumb).toContain('endpoint=POST https://api.deepseek.com/v1/chat/completions');
+        expect(loggedLines.join('\n')).not.toContain('sk-breadcrumb-secret');
+        expect(warnedLines.join('\n'))
+          .not.toContain('spawning without OPENCODE_CONFIG_CONTENT');
       },
     );
   });

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -5,6 +5,7 @@ import {
   BYOK_OPENCODE_API_KEY_ENV,
   BYOK_OPENCODE_PROVIDER_ID,
   buildOpenCodeByokProviderConfig,
+  describeOpenCodeByokResolution,
   opencodeByokModelId,
 } from '../../src/runtimes/byok-opencode.js';
 import { byokOpenCodeAgentDef } from '../../src/runtimes/defs/byok-opencode.js';
@@ -426,5 +427,146 @@ describe('byok-opencode runtime config', () => {
     const provider = (out?.config.provider as Record<string, { options?: Record<string, unknown> }> | undefined)
       ?.[BYOK_OPENCODE_PROVIDER_ID];
     expect(provider?.options).not.toHaveProperty('apiKey');
+  });
+
+  it('completes schemeless DeepSeek base URLs for the OpenAI-compatible package', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-deepseek', baseUrl: 'api.deepseek.com/v1' },
+      'deepseek-v4-pro',
+    );
+
+    expect(out?.modelId).toBe('open-design-byok/deepseek-v4-pro');
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://api.deepseek.com/v1',
+          },
+        },
+      },
+    });
+  });
+
+  it('keeps hosts that stay unparseable after scheme completion on the OpenAI-compatible package', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-relay', baseUrl: 'https://exa mple.com/v1' },
+      'model',
+    );
+
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://exa mple.com/v1',
+          },
+        },
+      },
+    });
+  });
+
+  it('completes schemeless native OpenAI origins before applying exact-origin rules', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-openai', baseUrl: 'api.openai.com' },
+      'gpt-5.5',
+    );
+
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai',
+          options: {
+            baseURL: 'https://api.openai.com/v1',
+          },
+        },
+      },
+    });
+  });
+
+  it('completes scheme-like custom-host URLs that URL parsing treats as protocols', () => {
+    expect(buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-local', baseUrl: 'localhost:1147/v1' },
+      'model',
+    )?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://localhost:1147/v1',
+          },
+        },
+      },
+    });
+  });
+
+  it('describes the OpenCode BYOK resolution without exposing credentials', () => {
+    const info = describeOpenCodeByokResolution(
+      { protocol: 'openai', apiKey: 'sk-deepseek-secret', baseUrl: 'api.deepseek.com/v1' },
+      'deepseek-v4-pro',
+    );
+
+    expect(info).toEqual({
+      baseUrlHost: 'api.deepseek.com',
+      npm: '@ai-sdk/openai-compatible',
+      modelId: 'open-design-byok/deepseek-v4-pro',
+      baseURL: 'https://api.deepseek.com/v1',
+      requestPath: '/chat/completions',
+    });
+    expect(describeOpenCodeByokResolution(null, 'deepseek-v4-pro')).toBeNull();
+    expect(describeOpenCodeByokResolution(undefined, undefined)).toBeNull();
+    expect(JSON.stringify(info)).not.toContain('sk-deepseek-secret');
+  });
+
+  it('completes schemeless loopback hosts to https before local-ollama rules apply', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      { protocol: 'ollama', apiKey: '', baseUrl: 'localhost:11434' },
+      'model',
+    );
+
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://localhost:11434/v1',
+          },
+        },
+      },
+    });
+  });
+
+  it('keeps explicit-scheme base URLs byte-identical', () => {
+    expect(buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'openai',
+        apiKey: '',
+        baseUrl: 'http://localhost:4000/v1',
+        requiresApiKey: false,
+      },
+      'model',
+    )?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'http://localhost:4000/v1',
+          },
+        },
+      },
+    });
+    expect(buildOpenCodeByokProviderConfig(
+      { protocol: 'openai', apiKey: 'sk-gateway', baseUrl: 'https://x.dev/v1' },
+      'model',
+    )?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://x.dev/v1',
+          },
+        },
+      },
+    });
   });
 });

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -518,6 +518,29 @@ describe('byok-opencode runtime config', () => {
     expect(JSON.stringify(info)).not.toContain('sk-deepseek-secret');
   });
 
+  it('labels the request path by resolved provider package', () => {
+    expect(describeOpenCodeByokResolution(
+      { protocol: 'anthropic', apiKey: 'sk-anthropic', baseUrl: 'https://api.anthropic.com' },
+      'claude-sonnet-4',
+    )).toMatchObject({ npm: '@ai-sdk/anthropic', requestPath: '/messages' });
+    expect(describeOpenCodeByokResolution(
+      { protocol: 'google', apiKey: 'sk-google', baseUrl: 'https://generativelanguage.googleapis.com' },
+      'gemini-2.5-pro',
+    )).toMatchObject({ npm: '@ai-sdk/google', requestPath: '/models' });
+    expect(describeOpenCodeByokResolution(
+      { protocol: 'openai', apiKey: 'sk-openai', baseUrl: 'api.openai.com' },
+      'gpt-5.5',
+    )).toMatchObject({ npm: '@ai-sdk/openai', requestPath: '/responses' });
+    expect(describeOpenCodeByokResolution(
+      { protocol: 'azure', apiKey: 'sk-azure', baseUrl: 'https://example.openai.azure.com' },
+      'gpt-4o',
+    )).toMatchObject({ npm: '@ai-sdk/azure', requestPath: '/chat/completions' });
+    expect(describeOpenCodeByokResolution(
+      { protocol: 'openai', apiKey: 'sk-relay', baseUrl: 'api.deepseek.com/v1' },
+      'deepseek-v4-pro',
+    )).toMatchObject({ npm: '@ai-sdk/openai-compatible', requestPath: '/chat/completions' });
+  });
+
   it('completes schemeless loopback hosts to https before local-ollama rules apply', () => {
     const out = buildOpenCodeByokProviderConfig(
       { protocol: 'ollama', apiKey: '', baseUrl: 'localhost:11434' },


### PR DESCRIPTION
Refs #6143

## Why

Since v0.15.0, BYOK agents pointed at third-party OpenAI-compatible endpoints (DeepSeek/Kimi/relays) can finish as "Agent completed without producing any output" while the same endpoint works everywhere else. A custom OpenAI-protocol base URL saved without a URL scheme (for example `api.deepseek.com/v1`, exactly what Settings stores) fails `new URL()` parsing inside `isRealOpenAIHost`; that failure fell back to treat-as-first-party, so the run was pointed at the Responses-API client (`@ai-sdk/openai`) instead of the chat-completions client the relay actually serves. Nothing logged the resolved provider, so these runs died silently.

## What users will see

Scheme-less custom OpenAI-protocol base URLs now resolve to `@ai-sdk/openai-compatible` against the https-completed URL, hitting `{baseURL}/chat/completions` like every other non-first-party host. Every byok-opencode run leaves one pre-spawn daemon log line (resolved package, model id, host, request endpoint — never the API key), and if the injected config content is dropped before spawn the daemon warns loudly instead of spawning a provider-less agent. Base URLs that already carry a scheme are byte-identical to before.

## Surface area

- [ ] **UI** — no UI change
- [ ] **Keyboard shortcut** — no
- [ ] **CLI / env var** — none
- [ ] **API / contract** — none
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — only for previously-broken scheme-less base URLs; schemed inputs are byte-identical
- [ ] **None**

## Screenshots

Not applicable — no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/byok-opencode.test.ts` (scheme-less DeepSeek / unparseable-host specs) plus the spawn-path wiring spec in `apps/daemon/tests/chat-route.test.ts`
- Did the test go red on `main` and green on this branch? yes — scheme-less inputs resolved to `@ai-sdk/openai` on main; all new specs fail there and pass here.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/byok-opencode.test.ts tests/chat-route.test.ts tests/mcp-config.test.ts tests/connection-test.test.ts` — byok suite 27/27; the one failure (`chat-route.test.ts > surfaces Claude auth diagnostics through the SSE error channel`) fails identically on pristine main
- `pnpm guard` clean · `pnpm --filter @open-design/daemon typecheck` clean
- Mock OpenAI-compatible SSE server replay (no real providers) confirms `/responses` 404-empty vs healthy `/chat/completions` streaming depending on the resolved package

## Adjacent issues

- Scheme-less loopback hosts (e.g. ollama on `localhost:11434`) now complete to `https://localhost:11434/v1`; plain-HTTP local servers will surface a TLS error instead of the previous visible BYOK-provider rejection. Deferring http-awareness deliberately to keep this slice minimal.
- The empty-output classification itself is tracked separately and intentionally untouched here.

