### PR TITLE
perf(web): stop the hidden Automations tab fetching on launch

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1763,6 +1763,7 @@ export function EntryShell({
                 designTemplates={designTemplates}
                 connectors={connectors}
                 connectorsLoading={connectorsLoading}
+                isActive={view === 'tasks'}
               />
             </div>
             <div data-testid="entry-view-plugins" data-active={view === 'plugins' ? 'true' : 'false'} {...inactiveViewProps(view === 'plugins')}>

--- a/apps/web/src/components/TasksView.tsx
+++ b/apps/web/src/components/TasksView.tsx
@@ -60,6 +60,16 @@ interface Props {
   designTemplates?: SkillSummary[];
   connectors?: ConnectorDetail[];
   connectorsLoading?: boolean;
+  /**
+   * Whether this view is the one on screen. `EntryShell` keeps every entry view
+   * mounted and hides the inactive ones with `display: none` + `inert`, so
+   * without this flag Automations loads its whole data set on every Home launch
+   * for a tab the user has not opened.
+   *
+   * Defaults to active: several suites and any other caller render this view
+   * directly, and the gate is opt-in rather than a new requirement.
+   */
+  isActive?: boolean;
 }
 
 function buildStaticTemplates(t: TranslateFn): ReadonlyArray<AutomationTemplate> {
@@ -384,7 +394,7 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-export function TasksView({ skills = [], designTemplates = [], connectors = [] }: Props) {
+export function TasksView({ skills = [], designTemplates = [], connectors = [], isActive = true }: Props) {
   const t = useT();
   const analytics = useAnalytics();
   // Attaches the same workspace identity headers project reads already carry,
@@ -514,8 +524,18 @@ export function TasksView({ skills = [], designTemplates = [], connectors = [] }
   }, [routineHeaders, tasksWorkspaceIdentity]);
 
   useEffect(() => {
+    // Hidden views do not fetch. This one is mounted from the first paint of
+    // Home, and `refresh` pulls four endpoints — the automation catalog, pending
+    // proposals, routines and the project picker. It also runs twice per launch,
+    // because `refresh` is keyed on `tasksWorkspaceIdentity` and that changes
+    // when `/api/workspace/context` resolves.
+    //
+    // Re-running on activation is what keeps this a delay rather than a
+    // suppression: an identity change while hidden re-enters this effect,
+    // returns early, and the fetch happens when the user opens the tab.
+    if (!isActive) return;
     void refresh();
-  }, [refresh]);
+  }, [isActive, refresh]);
 
   const projectsById = useMemo(() => {
     const map = new Map<string, string>();

--- a/apps/web/tests/components/TasksView.inactive-view.test.tsx
+++ b/apps/web/tests/components/TasksView.inactive-view.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TasksView } from '../../src/components/TasksView';
+
+const originalFetch = globalThis.fetch;
+
+const LAUNCH_ENDPOINTS = [
+  '/api/automation-templates',
+  '/api/automation-proposals?status=pending-review',
+  '/api/routines',
+];
+
+function trackedFetch(seen: string[]) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    seen.push(url);
+    if (url.startsWith('/api/routines')) {
+      return new Response(JSON.stringify({ routines: [] }), { status: 200 });
+    }
+    if (url.startsWith('/api/automation-templates')) {
+      return new Response(JSON.stringify({ templates: [] }), { status: 200 });
+    }
+    if (url.startsWith('/api/automation-proposals')) {
+      return new Response(JSON.stringify({ proposals: [] }), { status: 200 });
+    }
+    if (url.startsWith('/api/projects') || url.includes('/projects')) {
+      return new Response(JSON.stringify({ projects: [] }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe('TasksView inactive view', () => {
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('does not fetch automation data while the view is hidden', async () => {
+    // `EntryShell` keeps every entry view mounted and hides the inactive ones
+    // with `display: none` + `inert`, so Automations loads its catalog, its
+    // proposals, its routines and the project picker on every Home launch —
+    // for a tab the user has not opened. Worse, the whole set runs twice,
+    // because `tasksWorkspaceIdentity` changes when `/api/workspace/context`
+    // resolves and `refresh` is keyed on it.
+    const seen: string[] = [];
+    globalThis.fetch = trackedFetch(seen);
+
+    render(<TasksView isActive={false} />);
+
+    // Give the mount effects a chance to run before asserting the absence.
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Automations' })).toBeTruthy());
+    for (const endpoint of LAUNCH_ENDPOINTS) {
+      expect(seen).not.toContain(endpoint);
+    }
+  });
+
+  it('fetches once the view becomes active', async () => {
+    // The gate must not turn into "never loads": opening the tab has to fill it.
+    const seen: string[] = [];
+    globalThis.fetch = trackedFetch(seen);
+
+    const { rerender } = render(<TasksView isActive={false} />);
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Automations' })).toBeTruthy());
+    expect(seen).not.toContain('/api/routines');
+
+    rerender(<TasksView isActive />);
+    await waitFor(() => expect(seen).toContain('/api/routines'));
+    for (const endpoint of LAUNCH_ENDPOINTS) {
+      expect(seen).toContain(endpoint);
+    }
+  });
+
+  it('still loads for callers that do not pass the flag', async () => {
+    // Six existing suites render `<TasksView />` bare, and so may other callers;
+    // the gate is opt-in, not a new requirement.
+    const seen: string[] = [];
+    globalThis.fetch = trackedFetch(seen);
+
+    render(<TasksView />);
+
+    await waitFor(() => expect(seen).toContain('/api/routines'));
+  });
+});


### PR DESCRIPTION
## Why

Dogfooding the launch path: a cold Home load fetches the whole Automations data
set even when the user never opens that tab — and fetches it twice.

`EntryShell` keeps every entry view mounted and hides the inactive ones with
`display: none` + `inert` + `aria-hidden`. `TasksView` is therefore live from the
first paint of Home, and its mount effect pulls four endpoints: the automation
catalog, pending proposals, routines, and the project picker.

The doubling is the launch's two-pass shape. `refresh` is keyed on
`tasksWorkspaceIdentity`, which changes when `/api/workspace/context` resolves,
so the post-context pass repeats every request the pre-context pass made. (The
dependency itself is correct and deliberate — the callback is partitioned on the
authority fields, and the comment above it says so. Nothing is wrong with
`refresh`; it simply should not have been running at all.)

The repository already has the answer: `ProjectsView` receives `isActive`, and
`DesignSystemsTab` early-returns on it. `TasksView` was never given the prop.

## What users will see

Nothing on the Automations tab changes. Opening it loads the same content, and
because the fetch now starts on activation rather than at launch, the first open
shows its loading state briefly where before the data was already warm — the same
trade `DesignSystemsTab` already makes.

What changes for everyone else is that a Home launch stops spending six requests
— and six of the browser's ~6-connections-per-host slots — on a tab nobody
opened, while the visible surfaces are queued behind them.

## Measured

Cold Home load against a local `tools-dev` runtime (isolated `OD_DATA_DIR`,
namespace `dsdup`), `reactStrictMode` off so effect behaviour matches production:

| endpoint | before | after |
| --- | --- | --- |
| `/api/automation-templates` | 2 | **0** |
| `/api/automation-proposals` | 2 | **0** |
| `/api/routines` | 2 | **0** |
| endpoints requested more than once | 15 | **10** |

Measuring note: the dev server defaults to `reactStrictMode: true`, which
double-invokes effects and inflates every count on this page. All figures above
are with it off.

## Surface area

- [ ] **UI** — no new surface; an existing view's data load is deferred to first activation
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the Automations tab loads on open rather than at launch
- [ ] **None**

## Bug fix verification

- Red specs in `apps/web/tests/components/TasksView.inactive-view.test.tsx`:
  `does not fetch automation data while the view is hidden` and
  `fetches once the view becomes active`. Both red before the change.
- The third spec in that file was green before and after: it pins that a caller
  which does not pass the flag still loads, so the gate stays opt-in.

## Why this is a delay and not a suppression

The effect depends on `isActive` as well as `refresh`. An identity change while
the view is hidden re-enters the effect, returns early, and the fetch happens
when the tab is opened with the current identity — so a workspace switch made
while Automations is hidden is still reflected when it is next shown. The second
spec covers exactly this.

`isActive` defaults to true. Six existing suites render `<TasksView />` directly,
and only `EntryShell` passes the real value, so this is opt-in rather than a new
requirement on callers.

Nothing outside the component depends on it having loaded: `TasksView` takes no
callbacks, reports no counts upward, and has a single mount site.

## Adjacent issues (not in this PR)

The same launch still shows ten endpoints requested more than once. Attributed
with stack-tagged fetch probes, the remainder is not this bug and does not take
this fix:

- `/api/integrations/vela/status` ×4 and `/api/integrations/vela/message-center/messages`
  ×2 come from `MessageCenter`. `EntryNavRail` renders two mutually-exclusive
  instances gated on `context`, so when `/api/workspace/context` resolves the
  signed-out instance unmounts and the signed-in one mounts and re-syncs. Merging
  them is a focus-management change in the nav rail and wants its own PR.
- `/api/analytics/config` ×6 already uses the client GET coalescer with `ttl = 0`;
  those calls are sequential, so single-flight cannot help them.
- `/api/plugins` ×3 is three reads under three different catalog keys as the
  identity resolves — legitimately different requests, not duplicates.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — 664 files / 7010 tests, **exit 0**
- The six existing `TasksView.*` suites plus `EntryShell.onboarding` — 79 tests, all pass
