### PR TITLE
test(daemon): stop the telemetry-sink spec reading a real AMR login

### DIFF
--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -293,6 +293,11 @@ describe('readRunTelemetrySinkConfig', () => {
       protocol: 'http',
     });
     expect(describeRunTelemetrySink(readRunTelemetrySinkConfig({
+      // Same opt-out the relay case above passes. Without it the vela branch is
+      // enabled by default and `readVelaControlApiContext` falls through to the
+      // developer's real `~/.amr/config.json`, so this asserted 'vela' on any
+      // machine with an AMR login and only passed on a CI runner without one.
+      OPEN_DESIGN_VELA_TELEMETRY: 'off',
       LANGFUSE_PUBLIC_KEY: 'pk',
       LANGFUSE_SECRET_KEY: 'sk',
       LANGFUSE_BASE_URL: 'https://langfuse.example.test/private?key=secret',


### PR DESCRIPTION
## Why

While triaging the daemon suite for #7398, one failure kept showing up and kept
needing to be explained away on every branch:

```
× langfuse-trace > readRunTelemetrySinkConfig
  > describes relay, direct, and disabled sinks through the same allowlist
AssertionError: expected { kind: 'vela', … } to deeply equal { kind: 'langfuse', … }
```

It is not flaky and the build is not broken. The spec is not hermetic: it reads
the developer's real AMR login.

The langfuse case passes only `LANGFUSE_*` keys. Without
`OPEN_DESIGN_VELA_TELEMETRY: 'off'`, the vela branch of
`readRunTelemetrySinkConfig` is enabled by default, and
`readVelaControlApiContext` falls through `readVelaProfileConfigSnapshot` to the
real `~/.amr/config.json` on disk. Where that file exists with a control key,
the sink resolves to `kind: 'vela'`. A CI runner has no such file, so CI is
green and every AMR-signed-in developer sees a red suite.

The relay assertion immediately above it already passes that opt-out — the two
halves of one test disagree, which is what made this look like a product bug at
first glance rather than a fixture leak.

## What users will see

Nothing. Test-only.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — one line in one spec.

## Bug fix verification

- Reproduces on any machine with `~/.amr/config.json` present and carrying a
  control key; that is the only condition.
- `pnpm --filter @open-design/daemon exec vitest run tests/langfuse-trace.test.ts`
  — 100/100 pass after the change, on a machine where it failed before it.

## Why not fix the source instead

Because the source is behaving as designed: vela telemetry defaults on, and
falling back to the stored profile is what makes it work without env wiring. The
spec is asserting the langfuse arm of the allowlist, so it should say so rather
than depend on the ambient machine — which is exactly what its sibling
assertion already does.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/langfuse-trace.test.ts` — 100 tests, pass
- Daemon typecheck — exit 0
