### PR TITLE
fix(web): keep browser exports ready to save

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3408,6 +3408,8 @@ type ExportToastState = {
   tone: 'default' | 'success' | 'error' | 'loading';
 };
 
+type ShareExportCompletion = 'saved' | 'ready_to_save' | 'cancelled';
+
 export type DeckKeyboardShortcut = 'next' | 'prev' | 'first' | 'last' | 'reset';
 
 type DeckKeyboardShortcutEvent = Pick<
@@ -7542,10 +7544,9 @@ function HtmlViewer({
     }
   };
   // Shared helper for the share menu: emit studio_click share_option on
-  // entry and artifact_export_result on resolution. Sync exports report
-  // success immediately after the call returns; async exports get .then
-  // / .catch. The same request_id threads both events so PostHog can
-  // stitch click → result via $insert_id correlation.
+  // entry, then report a terminal result only when persistence is known.
+  // Browser-managed downloads stop at ready_to_save because the user can
+  // still cancel the save dialog after the download handoff resolves.
   const fireShareExport = (
     format:
       | 'pdf'
@@ -7557,7 +7558,7 @@ function HtmlViewer({
       | 'template'
       | 'share_link'
       | 'share_page',
-    fn: () => Promise<unknown> | unknown,
+    fn: () => Promise<ShareExportCompletion> | ShareExportCompletion,
     context?: HtmlVersionExportContext | null,
   ) => {
     if (!workspaceActive) return;
@@ -7649,35 +7650,26 @@ function HtmlViewer({
       const message = err instanceof Error && err.message ? err.message : t('fileViewer.exportFailed');
       if (toastFormats.has(format)) setExportToast({ message, tone: 'error' });
     };
-    try {
-      const out = fn();
-      if (out && typeof (out as Promise<unknown>).then === 'function') {
-        (out as Promise<unknown>).then(
-          (result) => {
-            stopTicker();
-            if (result === 'cancelled') {
-              void finish('cancelled');
-              if (toastFormats.has(format)) setExportToast(null);
-              return;
-            }
-            void finish('success');
-            if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
-          },
-          (err) => {
-            void finish('failed', exportErrorCode(err));
-            failToast(err);
-          },
-        );
-      } else {
-        stopTicker();
-        if (out === 'cancelled') {
-          void finish('cancelled');
-          if (toastFormats.has(format)) setExportToast(null);
-          return;
-        }
+    const complete = (completion: ShareExportCompletion) => {
+      stopTicker();
+      if (completion === 'cancelled') {
+        void finish('cancelled');
+        if (toastFormats.has(format)) setExportToast(null);
+        return;
+      }
+      if (completion === 'saved') {
         void finish('success');
         if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportDone'), tone: 'success' });
+        return;
       }
+      if (toastFormats.has(format)) setExportToast({ message: t('fileViewer.exportReady'), tone: 'default' });
+    };
+    try {
+      const out = fn();
+      void Promise.resolve(out).then(complete, (err) => {
+        void finish('failed', exportErrorCode(err));
+        failToast(err);
+      });
     } catch (err) {
       void finish('failed', exportErrorCode(err));
       failToast(err);
@@ -14701,7 +14693,9 @@ function HtmlViewer({
     return isDeckArtifact || sourceLooksLikeExportableDeck(context.content);
   }, [deckExportSignal, isDeckArtifact]);
 
-  async function exportHtmlPdf(context?: HtmlVersionExportContext | null) {
+  async function exportHtmlPdf(
+    context?: HtmlVersionExportContext | null,
+  ): Promise<ShareExportCompletion> {
     const pdfTitle = context?.title ?? exportTitle;
     const pdfSource = context?.content ?? source ?? '';
     const pdfDeck = deckExportSignalForContext(context);
@@ -14718,14 +14712,14 @@ function HtmlViewer({
         deck: pdfDeck,
         ...(context?.versionId ? { versionId: context.versionId } : {}),
       });
-      if (res.ok) return;
+      if (res.ok) return 'ready_to_save' as const;
       // A SEMANTIC failure (bad deck routing, unreadable renderer output,
       // renderer 502, ...) must surface, not silently downgrade to the vector
       // PDF, which can reintroduce the fidelity bugs the screenshot path
       // exists to avoid. Only a genuinely unavailable renderer falls through.
       if (!('unavailable' in res)) throw new Error(res.error);
     }
-    await exportProjectAsPdf({
+    const result = await exportProjectAsPdf({
       deck: pdfDeck,
       fallbackPdf: () => exportAsPdf(pdfSource, pdfTitle, { deck: pdfDeck, onProgress: onExportProgress }),
       filePath: file.name,
@@ -14734,6 +14728,8 @@ function HtmlViewer({
       workspaceContext,
       ...(context?.versionId ? { versionId: context.versionId } : {}),
     });
+    if (result === 'cancelled') return 'cancelled';
+    return result === 'desktop' ? 'saved' : 'ready_to_save';
   }
 
   function triggerPdfExport(context?: HtmlVersionExportContext) {
@@ -14741,24 +14737,30 @@ function HtmlViewer({
   }
 
   function triggerZipExport(context?: HtmlVersionExportContext) {
-    fireShareExport('zip', () => exportProjectAsZip({
-      projectId,
-      filePath: file.name,
-      fallbackHtml: context?.content ?? source ?? '',
-      fallbackTitle: context?.title ?? exportTitle,
-      workspaceContext,
-      ...(context?.versionId ? { versionId: context.versionId } : {}),
-    }), context);
+    fireShareExport('zip', async () => {
+      await exportProjectAsZip({
+        projectId,
+        filePath: file.name,
+        fallbackHtml: context?.content ?? source ?? '',
+        fallbackTitle: context?.title ?? exportTitle,
+        workspaceContext,
+        ...(context?.versionId ? { versionId: context.versionId } : {}),
+      });
+      return 'ready_to_save' as const;
+    }, context);
   }
 
   function triggerHtmlExport(context?: HtmlVersionExportContext) {
-    fireShareExport('html', () => exportProjectAsHtml({
-      projectId,
-      filePath: file.name,
-      fallbackTitle: context?.title ?? exportTitle,
-      workspaceContext,
-      ...(context?.versionId ? { versionId: context.versionId } : {}),
-    }), context);
+    fireShareExport('html', async () => {
+      await exportProjectAsHtml({
+        projectId,
+        filePath: file.name,
+        fallbackTitle: context?.title ?? exportTitle,
+        workspaceContext,
+        ...(context?.versionId ? { versionId: context.versionId } : {}),
+      });
+      return 'ready_to_save' as const;
+    }, context);
   }
 
   useEffect(() => {
@@ -16784,39 +16786,7 @@ function HtmlViewer({
                       // packaged runtime (no embedded fonts) — unacceptable for a
                       // Chinese-first product. Falls back to the vector/browser
                       // print path on web or on failure.
-                      fireShareExport('pdf', async () => {
-                        if (isOpenDesignHostAvailable()) {
-                          const res = await exportProjectScreenshotPdf({
-                            projectId,
-                            fileName: file.name,
-                            title: exportTitle,
-                            workspaceContext,
-                            // Broader deck signal than the viewer's nav so
-                            // runtime-managed decks (<deck-stage>) paginate per
-                            // slide; the vector fallback below uses the SAME
-                            // signal, so an artifact exports identically with or
-                            // without a desktop host (no per-host divergence).
-                            deck: deckExportSignal,
-                          });
-                          if (res.ok) return;
-                          // A SEMANTIC failure (bad deck routing, unreadable
-                          // renderer output, renderer 502, …) must surface — NOT
-                          // silently downgrade to the vector PDF, which can
-                          // reintroduce the CJK-glyph / fidelity bugs the
-                          // screenshot path exists to avoid. Only a genuinely
-                          // unavailable renderer (no host / 501 / transport)
-                          // falls through to the vector path below.
-                          if (!('unavailable' in res)) throw new Error(res.error);
-                        }
-                        await exportProjectAsPdf({
-                          deck: deckExportSignal,
-                          fallbackPdf: () => exportAsPdf(source ?? '', exportTitle, { deck: deckExportSignal, onProgress: onExportProgress }),
-                          filePath: file.name,
-                          projectId,
-                          title: exportTitle,
-                          workspaceContext,
-                        });
-                      });
+                      fireShareExport('pdf', () => exportHtmlPdf());
                     }}
                   >
                     <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
@@ -16868,13 +16838,7 @@ function HtmlViewer({
                     title={viewerOnly ? viewerOnlyDisabledTitle : undefined}
                     onClick={() => {
                       setDeployMenuOpen(false);
-                      fireShareExport('zip', () => exportProjectAsZip({
-                        projectId,
-                        filePath: file.name,
-                        fallbackHtml: source ?? '',
-                        fallbackTitle: exportTitle,
-                        workspaceContext,
-                      }));
+                      triggerZipExport();
                     }}
                   >
                     <span className="share-menu-icon"><RemixIcon name="file-zip-line" size={15} /></span>
@@ -16888,12 +16852,7 @@ function HtmlViewer({
                     title={viewerOnly ? viewerOnlyDisabledTitle : undefined}
                     onClick={() => {
                       setDeployMenuOpen(false);
-                      fireShareExport('html', () => exportProjectAsHtml({
-                        projectId,
-                        filePath: file.name,
-                        fallbackTitle: exportTitle,
-                        workspaceContext,
-                      }));
+                      triggerHtmlExport();
                     }}
                   >
                     <span className="share-menu-icon"><RemixIcon name="file-code-line" size={15} /></span>
@@ -16906,7 +16865,10 @@ function HtmlViewer({
                       role="menuitem"
                       onClick={() => {
                         setDeployMenuOpen(false);
-                        fireShareExport('markdown', () => exportAsMd(source ?? '', exportTitle));
+                        fireShareExport('markdown', () => {
+                          exportAsMd(source ?? '', exportTitle);
+                          return 'ready_to_save' as const;
+                        });
                       }}
                     >
                       <span className="share-menu-icon"><RemixIcon name="file-line" size={15} /></span>
@@ -17650,6 +17612,7 @@ function HtmlViewer({
                             : t('fileViewer.exportPptxNa'),
                       );
                     }
+                    return 'ready_to_save' as const;
                   });
                 }}
               >

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7580,10 +7580,9 @@ function HtmlViewer({
       { requestId },
     );
     const started = performance.now();
-    const originPromise = resolveArtifactExportOrigin(context)
-      .catch(() => unknownExportOrigin());
     const finish = async (result: 'success' | 'failed' | 'cancelled', errorCode?: string) => {
-      const originProps = await originPromise;
+      const originProps = await resolveArtifactExportOrigin(context)
+        .catch(() => unknownExportOrigin());
       trackArtifactExportResult(
         analytics.track,
         {
@@ -14729,6 +14728,7 @@ function HtmlViewer({
       ...(context?.versionId ? { versionId: context.versionId } : {}),
     });
     if (result === 'cancelled') return 'cancelled';
+    if (result === 'failed') throw new Error(t('fileViewer.exportFailed'));
     return result === 'desktop' ? 'saved' : 'ready_to_save';
   }
 

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3280,6 +3280,7 @@ export const ar: Dict = {
   'fileViewer.exportingElapsed': 'جارٍ التصدير… {seconds}ث',
   'fileViewer.exportSlideEta': 'الشريحة {current}/{total} · يتبقى ~{seconds}ث',
   'fileViewer.exportFailed': 'فشل التصدير. يرجى المحاولة مرة أخرى.',
+  'fileViewer.exportReady': 'جاهز للحفظ',
   'fileViewer.exportDone': 'اكتمل التصدير',
   'fileViewer.exportImageFailed': 'فشل التقاط الصورة. يرجى المحاولة مرة أخرى أو استخدام أداة لقطة الشاشة في المتصفح.',
   'fileViewer.exportImageModalSubtitle': 'اختر تنسيقًا، ثم نزّل المعاينة الحالية كصورة.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3280,6 +3280,7 @@ export const de: Dict = {
   'fileViewer.exportingElapsed': 'Exportieren… {seconds}s',
   'fileViewer.exportSlideEta': 'Folie {current}/{total} · noch ca. {seconds}s',
   'fileViewer.exportFailed': 'Export fehlgeschlagen. Bitte erneut versuchen.',
+  'fileViewer.exportReady': 'Zum Speichern bereit',
   'fileViewer.exportDone': 'Export abgeschlossen',
   'fileViewer.exportImageFailed': 'Bildaufnahme fehlgeschlagen. Bitte versuchen Sie es erneut oder verwenden Sie das Screenshot-Tool Ihres Browsers.',
   'fileViewer.exportImageModalSubtitle': 'Wählen Sie ein Format und laden Sie dann die aktuelle Vorschau als Bild herunter.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3294,6 +3294,7 @@ export const en: Dict = {
   'fileViewer.exportingElapsed': 'Exporting… {seconds}s',
   'fileViewer.exportSlideEta': 'Exporting slide {current}/{total} · ~{seconds}s left',
   'fileViewer.exportFailed': 'Export failed. Please try again.',
+  'fileViewer.exportReady': 'Ready to save',
   'fileViewer.exportDone': 'Export complete',
   'fileViewer.exportImageFailed': 'Image capture failed. Please try again or use your browser\'s screenshot tool.',
   'fileViewer.exportImageModalSubtitle': 'Choose a format, then download the current preview as an image.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3280,6 +3280,7 @@ export const esES: Dict = {
   'fileViewer.exportingElapsed': 'Exportando… {seconds}s',
   'fileViewer.exportSlideEta': 'Diapositiva {current}/{total} · quedan ~{seconds}s',
   'fileViewer.exportFailed': 'La exportación falló. Inténtalo de nuevo.',
+  'fileViewer.exportReady': 'Listo para guardar',
   'fileViewer.exportDone': 'Exportación completada',
   'fileViewer.exportImageFailed': 'Error al capturar la imagen. Inténtalo de nuevo o usa la herramienta de captura de pantalla de tu navegador.',
   'fileViewer.exportImageModalSubtitle': 'Elige un formato y descarga la vista previa actual como imagen.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3280,6 +3280,7 @@ export const fa: Dict = {
   'fileViewer.exportingElapsed': 'در حال خروجی‌گرفتن… {seconds}ثانیه',
   'fileViewer.exportSlideEta': 'اسلاید {current}/{total} · ~{seconds}ثانیه مانده',
   'fileViewer.exportFailed': 'خروجی‌گرفتن ناموفق بود. لطفاً دوباره تلاش کنید.',
+  'fileViewer.exportReady': 'آماده ذخیره',
   'fileViewer.exportDone': 'خروجی کامل شد',
   'fileViewer.exportImageFailed': 'گرفتن تصویر ناموفق بود. لطفاً دوباره تلاش کنید یا از ابزار اسکرین‌شات مرورگرتان استفاده کنید.',
   'fileViewer.exportImageModalSubtitle': 'یک قالب انتخاب کنید، سپس پیش‌نمایش فعلی را به‌صورت تصویر دانلود کنید.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3280,6 +3280,7 @@ export const fr: Dict = {
   'fileViewer.exportingElapsed': 'Exportation… {seconds}s',
   'fileViewer.exportSlideEta': 'Diapositive {current}/{total} · ~{seconds}s restantes',
   'fileViewer.exportFailed': 'Échec de l’exportation. Veuillez réessayer.',
+  'fileViewer.exportReady': 'Prêt à enregistrer',
   'fileViewer.exportDone': 'Exportation terminée',
   'fileViewer.exportImageFailed': 'La capture d\'image a échoué. Veuillez réessayer ou utiliser l\'outil de capture d\'écran de votre navigateur.',
   'fileViewer.exportImageModalSubtitle': 'Choisissez un format, puis téléchargez l’aperçu actuel en image.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3280,6 +3280,7 @@ export const hu: Dict = {
   'fileViewer.exportingElapsed': 'Exportálás… {seconds}mp',
   'fileViewer.exportSlideEta': '{current}/{total}. dia · ~{seconds}mp van hátra',
   'fileViewer.exportFailed': 'Az exportálás nem sikerült. Próbáld újra.',
+  'fileViewer.exportReady': 'Mentésre kész',
   'fileViewer.exportDone': 'Exportálás kész',
   'fileViewer.exportImageFailed': 'A képrögzítés sikertelen. Kérjük, próbálja újra, vagy használja a böngészője képernyőkép eszközét.',
   'fileViewer.exportImageModalSubtitle': 'Válasszon formátumot, majd töltse le az aktuális előnézetet képként.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3280,6 +3280,7 @@ export const id: Dict = {
   'fileViewer.exportingElapsed': 'Mengekspor… {seconds}d',
   'fileViewer.exportSlideEta': 'Slide {current}/{total} · ~{seconds}d lagi',
   'fileViewer.exportFailed': 'Ekspor gagal. Silakan coba lagi.',
+  'fileViewer.exportReady': 'Siap disimpan',
   'fileViewer.exportDone': 'Ekspor selesai',
   'fileViewer.exportImageFailed': 'Gagal menangkap gambar. Silakan coba lagi atau gunakan alat tangkapan layar browser Anda.',
   'fileViewer.exportImageModalSubtitle': 'Pilih format, lalu unduh pratinjau saat ini sebagai gambar.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3280,6 +3280,7 @@ export const it: Dict = {
   'fileViewer.exportingElapsed': 'Esportazione… {seconds}s',
   'fileViewer.exportSlideEta': 'Diapositiva {current}/{total} · ~{seconds}s rimanenti',
   'fileViewer.exportFailed': 'Esportazione non riuscita. Riprova.',
+  'fileViewer.exportReady': 'Pronto per il salvataggio',
   'fileViewer.exportDone': 'Esportazione completata',
   'fileViewer.exportImageFailed': 'Acquisizione immagine non riuscita. Riprova o usa lo strumento screenshot del browser.',
   'fileViewer.exportImageModalSubtitle': 'Scegli un formato, poi scarica l\'anteprima corrente come immagine.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3280,6 +3280,7 @@ export const ja: Dict = {
   'fileViewer.exportingElapsed': '書き出し中… {seconds}秒',
   'fileViewer.exportSlideEta': 'スライド {current}/{total} を書き出し中 · 残り約 {seconds}秒',
   'fileViewer.exportFailed': '書き出しに失敗しました。もう一度お試しください。',
+  'fileViewer.exportReady': '保存する準備ができました',
   'fileViewer.exportDone': '書き出しが完了しました',
   'fileViewer.exportImageFailed': '画像のキャプチャに失敗しました。再試行するか、ブラウザのスクリーンショット機能をご利用ください。',
   'fileViewer.exportImageModalSubtitle': '形式を選択して、現在のプレビューを画像としてダウンロードします。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3280,6 +3280,7 @@ export const ko: Dict = {
   'fileViewer.exportingElapsed': '내보내는 중… {seconds}초',
   'fileViewer.exportSlideEta': '슬라이드 {current}/{total} 내보내는 중 · 약 {seconds}초 남음',
   'fileViewer.exportFailed': '내보내기에 실패했습니다. 다시 시도해 주세요.',
+  'fileViewer.exportReady': '저장할 준비가 되었습니다',
   'fileViewer.exportDone': '내보내기 완료',
   'fileViewer.exportImageFailed': '이미지 캡처에 실패했습니다. 다시 시도하거나 브라우저의 스크린샷 도구를 사용하세요.',
   'fileViewer.exportImageModalSubtitle': '형식을 선택한 다음 현재 미리보기를 이미지로 다운로드합니다.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3280,6 +3280,7 @@ export const pl: Dict = {
   'fileViewer.exportingElapsed': 'Eksportowanie… {seconds}s',
   'fileViewer.exportSlideEta': 'Slajd {current}/{total} · pozostało ~{seconds}s',
   'fileViewer.exportFailed': 'Eksport nie powiódł się. Spróbuj ponownie.',
+  'fileViewer.exportReady': 'Gotowe do zapisania',
   'fileViewer.exportDone': 'Eksport zakończony',
   'fileViewer.exportImageFailed': 'Przechwytywanie obrazu nie powiodło się. Spróbuj ponownie lub użyj narzędzia do zrzutów ekranu w przeglądarce.',
   'fileViewer.exportImageModalSubtitle': 'Wybierz format, a następnie pobierz bieżący podgląd jako obraz.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3280,6 +3280,7 @@ export const ptBR: Dict = {
   'fileViewer.exportingElapsed': 'Exportando… {seconds}s',
   'fileViewer.exportSlideEta': 'Slide {current}/{total} · ~{seconds}s restantes',
   'fileViewer.exportFailed': 'Falha na exportação. Tente novamente.',
+  'fileViewer.exportReady': 'Pronto para salvar',
   'fileViewer.exportDone': 'Exportação concluída',
   'fileViewer.exportImageFailed': 'Falha ao capturar a imagem. Tente novamente ou use a ferramenta de captura de tela do seu navegador.',
   'fileViewer.exportImageModalSubtitle': 'Escolha um formato e baixe a prévia atual como imagem.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3280,6 +3280,7 @@ export const ru: Dict = {
   'fileViewer.exportingElapsed': 'Экспорт… {seconds}с',
   'fileViewer.exportSlideEta': 'Слайд {current}/{total} · осталось ~{seconds}с',
   'fileViewer.exportFailed': 'Не удалось экспортировать. Повторите попытку.',
+  'fileViewer.exportReady': 'Готово к сохранению',
   'fileViewer.exportDone': 'Экспорт завершён',
   'fileViewer.exportImageFailed': 'Не удалось сделать снимок. Попробуйте ещё раз или воспользуйтесь инструментом скриншотов вашего браузера.',
   'fileViewer.exportImageModalSubtitle': 'Выберите формат, затем скачайте текущий предпросмотр как изображение.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3280,6 +3280,7 @@ export const th: Dict = {
   'fileViewer.exportingElapsed': 'กำลังส่งออก… {seconds} วินาที',
   'fileViewer.exportSlideEta': 'สไลด์ {current}/{total} · เหลือ ~{seconds} วินาที',
   'fileViewer.exportFailed': 'การส่งออกล้มเหลว โปรดลองอีกครั้ง',
+  'fileViewer.exportReady': 'พร้อมบันทึก',
   'fileViewer.exportDone': 'ส่งออกเสร็จสิ้น',
   'fileViewer.exportImageFailed': 'การจับภาพล้มเหลว กรุณาลองอีกครั้งหรือใช้เครื่องมือจับภาพหน้าจอของเบราว์เซอร์',
   'fileViewer.exportImageModalSubtitle': 'เลือกรูปแบบ แล้วดาวน์โหลดตัวอย่างปัจจุบันเป็นรูปภาพ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3280,6 +3280,7 @@ export const tr: Dict = {
   'fileViewer.exportingElapsed': 'Dışa aktarılıyor… {seconds}sn',
   'fileViewer.exportSlideEta': '{current}/{total} slayt · ~{seconds}sn kaldı',
   'fileViewer.exportFailed': 'Dışa aktarma başarısız. Lütfen tekrar deneyin.',
+  'fileViewer.exportReady': 'Kaydetmeye hazır',
   'fileViewer.exportDone': 'Dışa aktarma tamamlandı',
   'fileViewer.exportImageFailed': 'Görsel yakalama başarısız oldu. Lütfen tekrar deneyin veya tarayıcınızın ekran görüntüsü aracını kullanın.',
   'fileViewer.exportImageModalSubtitle': 'Bir biçim seçin, ardından geçerli önizlemeyi resim olarak indirin.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3280,6 +3280,7 @@ export const uk: Dict = {
   'fileViewer.exportingElapsed': 'Експортування… {seconds}с',
   'fileViewer.exportSlideEta': 'Слайд {current}/{total} · залишилось ~{seconds}с',
   'fileViewer.exportFailed': 'Не вдалося експортувати. Спробуйте ще раз.',
+  'fileViewer.exportReady': 'Готово до збереження',
   'fileViewer.exportDone': 'Експорт завершено',
   'fileViewer.exportImageFailed': 'Не вдалося захопити зображення. Спробуйте ще раз або скористайтеся інструментом знімків екрана вашого браузера.',
   'fileViewer.exportImageModalSubtitle': 'Виберіть формат, а потім завантажте поточний попередній перегляд як зображення.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3455,6 +3455,7 @@ export const zhCN: Dict = {
   "fileViewer.exportSlideEta":
     "正在导出第 {current}/{total} 页 · 约剩 {seconds} 秒",
   "fileViewer.exportFailed": "导出失败，请重试。",
+  "fileViewer.exportReady": "可以保存了",
   "fileViewer.exportDone": "导出完成",
   "fileViewer.exportImageFailed":
     "图片捕获失败，请重试或使用浏览器的截图工具。",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3464,6 +3464,7 @@ export const zhTW: Dict = {
   "fileViewer.exportSlideEta":
     "正在匯出第 {current}/{total} 張 · 約剩 {seconds} 秒",
   "fileViewer.exportFailed": "匯出失敗，請重試。",
+  "fileViewer.exportReady": "可以儲存了",
   "fileViewer.exportDone": "匯出完成",
   "fileViewer.exportImageFailed":
     "圖片擷取失敗，請重試或使用瀏覽器的截圖工具。",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -4140,6 +4140,7 @@ export interface Dict {
   'fileViewer.exportingElapsed': string;
   'fileViewer.exportSlideEta': string;
   'fileViewer.exportFailed': string;
+  'fileViewer.exportReady': string;
   'fileViewer.exportDone': string;
   'fileViewer.exportImageFailed': string;
   'fileViewer.exportImageModalSubtitle': string;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -770,11 +770,13 @@ export function exportAsImage(dataUrl: string, title: string): void {
   }
 }
 
-export type ProjectPdfExportResult = 'desktop' | 'fallback' | 'cancelled';
+export type PdfExportCompletion = 'ready_to_save' | 'failed';
+
+export type ProjectPdfExportResult = 'desktop' | 'fallback' | 'cancelled' | 'failed';
 
 export async function exportProjectAsPdf(opts: {
   deck: boolean;
-  fallbackPdf: () => void | Promise<void>;
+  fallbackPdf: () => PdfExportCompletion | Promise<PdfExportCompletion>;
   filePath: string;
   projectId: string;
   title: string;
@@ -804,8 +806,8 @@ export async function exportProjectAsPdf(opts: {
     return 'desktop';
   } catch (err) {
     console.warn('[exportProjectAsPdf] falling back to programmatic PDF:', err);
-    await opts.fallbackPdf();
-    return 'fallback';
+    const fallbackResult = await opts.fallbackPdf();
+    return fallbackResult === 'failed' ? 'failed' : 'fallback';
   }
 }
 
@@ -1397,7 +1399,7 @@ export async function exportAsPdf(
   html: string,
   title: string,
   opts?: SrcdocOptions & { sandboxedPreview?: boolean; onProgress?: ExportProgress },
-): Promise<void> {
+): Promise<PdfExportCompletion> {
   const sandboxedPreview = opts?.sandboxedPreview ?? true;
   // Generate a per-export nonce so the print-ready handshake is resistant to
   // spoofing by untrusted scripts inside the exported artifact.
@@ -1420,7 +1422,7 @@ export async function exportAsPdf(
     doc = injectParentPrintReadyCache(doc, nonce);
     try {
       const result = await printHostPdf(doc, nonce, opts?.deck ? { deck: true } : undefined);
-      if (result.ok) return;
+      if (result.ok) return 'ready_to_save';
       if (typeof alert !== 'undefined') {
         alert('Print failed. Please try Export PDF again or use the browser version.');
       }
@@ -1429,7 +1431,7 @@ export async function exportAsPdf(
         alert('Print failed. Please try Export PDF again or use the browser version.');
       }
     }
-    return;
+    return 'failed';
   }
 
   // Browser fallback (pure web): assemble the PDF programmatically — capture
@@ -1438,7 +1440,7 @@ export async function exportAsPdf(
   // below is kept only as a last-resort fallback if the capture path throws.
   try {
     await exportArtifactAsPdf(html, title, { deck: !!opts?.deck, onProgress: opts?.onProgress });
-    return;
+    return 'ready_to_save';
   } catch (err) {
     console.warn('[exportAsPdf] programmatic PDF failed, falling back to print popup:', err);
   }
@@ -1467,7 +1469,7 @@ export async function exportAsPdf(
       alert('Popup blocked! Click the popup-blocked icon in your browser address bar (or browser menu), choose "Always allow pop-ups" for this site, then retry Export PDF.');
     }
     URL.revokeObjectURL(url);
-    return;
+    return 'failed';
   }
 
   if (sandboxedPreview) {
@@ -1482,6 +1484,7 @@ export async function exportAsPdf(
   // the Blob URL after the tab has had time to start loading it.
   win.location.href = url;
   setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  return 'ready_to_save';
 }
 
 /**

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7767,6 +7767,94 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByText('Export started')).toBeNull();
   });
 
+  it('keeps browser-managed exports ready to save without reporting success', async () => {
+    const originalCreateObjectUrl = URL.createObjectURL;
+    const originalRevokeObjectUrl = URL.revokeObjectURL;
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:html-export'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const exportResponse = deferredResponse();
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/projects/project-1/export/html') return exportResponse.promise;
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={file}
+          liveHtml="<html><body><h1>Hello</h1></body></html>"
+        />,
+      );
+
+      await openUnifiedExportTab();
+      fireEvent.click(screen.getByRole('menuitem', { name: /Export as standalone HTML/i }));
+
+      const loadingToast = (await screen.findByText('Exporting…')).closest('.od-toast');
+      expect(loadingToast).toBeTruthy();
+      expect(loadingToast?.classList.contains('placement-top')).toBe(true);
+
+      await act(async () => {
+        exportResponse.resolve(new Response('<html><body>Hello</body></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        }));
+        await exportResponse.promise;
+      });
+
+      const readyToast = (await screen.findByText('Ready to save')).closest('.od-toast');
+      expect(readyToast).toBe(loadingToast);
+      expect(readyToast?.classList.contains('placement-top')).toBe(true);
+      expect(readyToast?.classList.contains('tone-default')).toBe(true);
+      expect(screen.queryByText('Export complete')).toBeNull();
+      expect(
+        analyticsTrackMock.mock.calls.filter(([eventName]) => eventName === 'artifact_export_result'),
+      ).toEqual([]);
+    } finally {
+      if (originalCreateObjectUrl) {
+        Object.defineProperty(URL, 'createObjectURL', {
+          configurable: true,
+          value: originalCreateObjectUrl,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'createObjectURL');
+      }
+      if (originalRevokeObjectUrl) {
+        Object.defineProperty(URL, 'revokeObjectURL', {
+          configurable: true,
+          value: originalRevokeObjectUrl,
+        });
+      } else {
+        Reflect.deleteProperty(URL, 'revokeObjectURL');
+      }
+    }
+  });
+
   it('disables share link actions while the artifact is still streaming', async () => {
     const file = baseFile({
       name: 'index.html',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -7767,6 +7767,67 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.queryByText('Export started')).toBeNull();
   });
 
+  it('reports a failed browser PDF fallback instead of showing ready to save', async () => {
+    const restoreHost = installMockOpenDesignHost({
+      host: { pdf: { print: vi.fn().mockResolvedValue({ ok: false }) } },
+    });
+    vi.stubGlobal('alert', vi.fn());
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/projects/project-1/export/pdf-image' || url === '/api/projects/project-1/export/pdf') {
+        return new Response(JSON.stringify({ error: { message: 'unavailable' } }), { status: 501 });
+      }
+      if (url.includes('/versions')) {
+        return new Response(JSON.stringify({ versions: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Page',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    try {
+      render(
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={file}
+          liveHtml="<html><body><h1>Hello</h1></body></html>"
+        />,
+      );
+
+      await openUnifiedExportTab();
+      fireEvent.click(screen.getByRole('menuitem', { name: /Export as PDF/i }));
+
+      expect(await screen.findByText('Export failed. Please try again.')).toBeTruthy();
+      expect(screen.queryByText('Ready to save')).toBeNull();
+      await waitFor(() => {
+        const resultEvents = analyticsTrackMock.mock.calls.filter(
+          ([eventName]) => eventName === 'artifact_export_result',
+        );
+        expect(resultEvents).toHaveLength(1);
+        expect(resultEvents[0]?.[1]).toEqual(expect.objectContaining({
+          export_format: 'pdf',
+          result: 'failed',
+        }));
+      });
+    } finally {
+      restoreHost();
+    }
+  });
+
   it('keeps browser-managed exports ready to save without reporting success', async () => {
     const originalCreateObjectUrl = URL.createObjectURL;
     const originalRevokeObjectUrl = URL.revokeObjectURL;
@@ -7835,6 +7896,10 @@ describe('FileViewer SVG artifacts', () => {
       expect(
         analyticsTrackMock.mock.calls.filter(([eventName]) => eventName === 'artifact_export_result'),
       ).toEqual([]);
+      expect(fetchMock.mock.calls.some(([input]) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        return url.includes('/versions');
+      })).toBe(false);
     } finally {
       if (originalCreateObjectUrl) {
         Object.defineProperty(URL, 'createObjectURL', {

--- a/apps/web/tests/i18n/locales.test.ts
+++ b/apps/web/tests/i18n/locales.test.ts
@@ -195,6 +195,13 @@ describe('i18n locales', () => {
     }
   });
 
+  it('keeps Chinese export handoff copy focused on saving', () => {
+    expect(zhCN['fileViewer.exportReady']).toBe('可以保存了');
+    expect(zhTW['fileViewer.exportReady']).toBe('可以儲存了');
+    expect(zhCN['fileViewer.exportReady']).not.toMatch(/加载|載入/);
+    expect(zhTW['fileViewer.exportReady']).not.toMatch(/加载|載入/);
+  });
+
   it('keeps the recharge recovery action concise enough to sit beside retry', async () => {
     const expected: Record<Locale, string> = {
       ar: 'شحن',

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -545,7 +545,7 @@ describe('exportProjectAsPdf', () => {
   });
 
   it('falls back to browser print when the desktop PDF export API is unavailable', async () => {
-    const fallback = vi.fn();
+    const fallback = vi.fn().mockResolvedValue('ready_to_save');
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ error: { message: 'unavailable' } }), { status: 501 })));
 
@@ -558,6 +558,23 @@ describe('exportProjectAsPdf', () => {
     });
 
     expect(result).toBe('fallback');
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a failed browser PDF fallback', async () => {
+    const fallback = vi.fn().mockResolvedValue('failed');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ error: { message: 'unavailable' } }), { status: 501 })));
+
+    const result = await exportProjectAsPdf({
+      deck: false,
+      fallbackPdf: fallback,
+      filePath: 'index.html',
+      projectId: 'proj-1',
+      title: 'Landing',
+    });
+
+    expect(result).toBe('failed');
     expect(fallback).toHaveBeenCalledTimes(1);
   });
 });
@@ -1295,8 +1312,9 @@ describe('sandboxed preview Blob exports', () => {
     const revokeSpy = URL.revokeObjectURL as ReturnType<typeof vi.fn>;
     revokeSpy.mockClear();
 
-    await exportAsPdf('<p>test</p>', 'Blocked');
+    const result = await exportAsPdf('<p>test</p>', 'Blocked');
 
+    expect(result).toBe('failed');
     expect(alert).toHaveBeenCalledWith('Popup blocked! Click the popup-blocked icon in your browser address bar (or browser menu), choose "Always allow pop-ups" for this site, then retry Export PDF.');
     expect(revokeSpy).toHaveBeenCalledWith('blob:test');
   });


### PR DESCRIPTION
Fixes #5368

## Why

I followed up on the still-open issue and the unresolved lifecycle review from #5424. Browser-managed downloads resolve when Open Design hands bytes to the browser, before the user confirms a save location. Treating that handoff as success showed misleading copy, emitted `artifact_export_result: success`, and could close the onboarding delivery loop even when the save dialog was canceled.

The export feedback needs to distinguish a prepared browser download from a file whose persistence Open Design can actually confirm.

## What users will see

Browser-managed PDF, PPTX, ZIP, HTML, and Markdown exports now transition from the existing top loading toast to a neutral localized “Ready to save” toast. The same toast DOM node and `placement-top` class are retained, so the feedback no longer jumps between states.

Confirmed persisted exports still show “Export complete”. Failed and canceled exports keep their existing behavior. The new ready state is translated across all 19 UI locales, including save-focused Chinese copy (`可以保存了` / `可以儲存了`).

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The existing CLI/API export contract is unchanged; this fixes feedback and analytics around the existing web browser handoff rather than adding a capability.

## Screenshots

The original position jump is visible in the recording on #5368. This change does not modify CSS or layout. The regression test asserts that loading → ready reuses the exact same `.od-toast` DOM node with `placement-top` before and after the state transition.

I also started the real app with `pnpm tools-dev run web --daemon-port 25468 --web-port 25469` and seeded the QA project through production HTTP APIs. The current web entry requires cloud sign-in before workspace access, so I did not bypass the gate or reuse credentials to manufacture an after screenshot. CI visual regression remains the browser-level layout check for this no-CSS diff.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` — `keeps browser-managed exports ready to save without reporting success`
- Did the test go red on `main` and green on this branch? **yes**
  - RED: failed because “Ready to save” was absent; `main` rendered “Export complete”.
  - GREEN: asserts neutral ready copy, same toast DOM node/top placement, no premature success copy, and no `artifact_export_result` success event.
- Chinese review regression: `apps/web/tests/i18n/locales.test.ts` pins save-focused zh-CN/zh-TW copy and rejects loading-oriented wording.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm i18n:check`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` — 663 files, 7,008 passed, 1 expected failure, 11 skipped
- `pnpm --filter @open-design/web build`
- focused FileViewer suite — 312/312 passed
- focused locale suite — 20/20 passed
- `git diff --check`

Local verification used Node 24.19.0 and the pinned pnpm 10.33.2; the repository emits its existing exact-patch warning for `shells/terminal` (24.18.0) but every command above completed successfully.