### PR TITLE
fix(daemon): preserve explicit DESIGN.md tokens on paste import

### DIFF
--- a/apps/daemon/src/brands/design-md-input.ts
+++ b/apps/daemon/src/brands/design-md-input.ts
@@ -1,4 +1,4 @@
-import type { Brand, BrandColor, BrandColorRole, BrandFontSpec } from '@open-design/contracts';
+import type { Brand, BrandColor, BrandColorRole, BrandFontSpec, BrandSeedOverrides } from '@open-design/contracts';
 
 import { luminance, normalizeHex, saturation } from './seed.js';
 import { validateBrand } from './validate.js';
@@ -29,6 +29,8 @@ const DEFAULT_BACKGROUND = '#ffffff';
 const DEFAULT_FOREGROUND = '#111111';
 const DEFAULT_ACCENT = '#1677ff';
 const SANS_FALLBACKS = ['system-ui', '-apple-system', 'Segoe UI', 'Helvetica Neue', 'Arial', 'sans-serif'];
+const CSS_GENERIC_FAMILY_RE =
+  /\b(system-ui|ui-sans-serif|ui-serif|ui-monospace|ui-rounded|sans-serif|serif|monospace|cursive|fantasy)\b/i;
 
 export function sourceUrlForDesignMd(markdown: string, fallbackName = 'Design System'): string {
   const parsed = parseDesignMd(markdown);
@@ -53,7 +55,9 @@ export function brandFromDesignMd(input: BrandFromDesignMdInput): Brand | null {
   const overview = firstSection(parsed.body, ['overview', 'brand & style', 'brand and style']) ?? firstParagraph(parsed.body);
   const description = input.description?.trim() || scalarString(parsed.frontmatter.description) || overview || '';
   const tagline = firstSentence(overview || description);
-  const colors = resolveColors(collectColors(parsed));
+  const colorCandidates = collectColors(parsed);
+  const colors = resolveColors(colorCandidates);
+  const seedOverrides = semanticSeedOverrides(colorCandidates, colors);
   const fonts = collectFonts(parsed.frontmatter, parsed.body);
   const display = fontSpec(
     fonts.find((font) => /display|heading|headline|h1|title/i.test(font.key))?.family ??
@@ -75,6 +79,7 @@ export function brandFromDesignMd(input: BrandFromDesignMdInput): Brand | null {
     tagline,
     description,
     sourceUrl: input.sourceUrl,
+    ...(seedOverrides ? { seed: seedOverrides } : {}),
     logo: {
       primary: null,
       alternates: [],
@@ -249,6 +254,24 @@ function resolveColors(candidates: DesignMdColor[]): BrandColor[] {
   return picked;
 }
 
+function semanticSeedOverrides(
+  candidates: DesignMdColor[],
+  colors: BrandColor[],
+): BrandSeedOverrides | undefined {
+  const overrides: BrandSeedOverrides = {};
+  const warning = candidates.find((item) => /warning|caution/i.test(item.key));
+  if (warning) overrides.colorWarning = warning.hex;
+  const error = candidates.find((item) => /error|danger/i.test(item.key));
+  if (error) overrides.colorError = error.hex;
+  const success = candidates.find((item) => /success/i.test(item.key));
+  // Success already rides the accent-secondary role when the resolver picked
+  // the same hex; duplicating it in the override channel would leak a field.
+  if (success && !colors.some((c) => c.role === 'accent-secondary' && c.hex === success.hex)) {
+    overrides.colorSuccess = success.hex;
+  }
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
 function collectFonts(frontmatter: Record<string, unknown>, body: string): FontCandidate[] {
   const out: FontCandidate[] = [];
   const seen = new Set<string>();
@@ -260,10 +283,18 @@ function collectFonts(frontmatter: Record<string, unknown>, body: string): FontC
   };
   collectFontValues(frontmatter.typography ?? frontmatter.fonts ?? frontmatter.type, [], add);
   for (const line of body.split('\n')) {
+    // Explicit declarations win: a line like `font-family: Inter, system-ui,
+    // sans-serif;` must resolve to Inter, never to the generic keyword that
+    // happens to appear later in the same stack.
     const familyMatch =
       /(?:font-family|fontFamily|family)\s*[:=-]\s*`?["']?([^`"',;()]+(?:\s+[^`"',;()]+){0,3})/i.exec(line) ??
       /\b([A-Z][A-Za-z0-9]+(?:Sans|Serif|Mono|Display|Text|Grotesk|Gothic|Humanist|Roman|UI)\b(?:\s+[A-Z][A-Za-z0-9]+)*)/.exec(line);
-    if (familyMatch?.[1]) add(line.slice(0, 48), familyMatch[1]);
+    if (familyMatch?.[1]) {
+      add(line.slice(0, 48), familyMatch[1]);
+      continue;
+    }
+    const genericFamily = CSS_GENERIC_FAMILY_RE.exec(line)?.[0];
+    if (genericFamily) add(line.slice(0, 48), genericFamily);
   }
   return out;
 }

--- a/apps/daemon/src/brands/design-md-input.ts
+++ b/apps/daemon/src/brands/design-md-input.ts
@@ -1,6 +1,7 @@
 import type { Brand, BrandColor, BrandColorRole, BrandFontSpec, BrandSeedOverrides } from '@open-design/contracts';
 
 import { luminance, normalizeHex, saturation } from './seed.js';
+import { derivedColorSuccess } from './engine/seed.js';
 import { validateBrand } from './validate.js';
 
 export interface BrandFromDesignMdInput {
@@ -13,6 +14,15 @@ export interface BrandFromDesignMdInput {
 interface DesignMdColor {
   key: string;
   hex: string;
+}
+
+interface CollectedColors {
+  /** Hex-deduped palette candidates feeding role resolution. */
+  candidates: DesignMdColor[];
+  /** Every labelled occurrence, retained independently of palette dedupe so
+   *  semantic labels sharing a hex with another role (Primary and Error both
+   *  #b30000) still reach the seed override channel. */
+  labelled: DesignMdColor[];
 }
 
 interface FontCandidate {
@@ -55,9 +65,9 @@ export function brandFromDesignMd(input: BrandFromDesignMdInput): Brand | null {
   const overview = firstSection(parsed.body, ['overview', 'brand & style', 'brand and style']) ?? firstParagraph(parsed.body);
   const description = input.description?.trim() || scalarString(parsed.frontmatter.description) || overview || '';
   const tagline = firstSentence(overview || description);
-  const colorCandidates = collectColors(parsed);
-  const colors = resolveColors(colorCandidates);
-  const seedOverrides = semanticSeedOverrides(colorCandidates, colors);
+  const collectedColors = collectColors(parsed);
+  const colors = resolveColors(collectedColors.candidates);
+  const seedOverrides = semanticSeedOverrides(collectedColors.labelled, colors);
   const fonts = collectFonts(parsed.frontmatter, parsed.body);
   const display = fontSpec(
     fonts.find((font) => /display|heading|headline|h1|title/i.test(font.key))?.family ??
@@ -178,14 +188,17 @@ function scalarString(value: unknown): string | null {
   return trimmed ? trimmed : null;
 }
 
-function collectColors(parsed: ParsedDesignMd): DesignMdColor[] {
-  const out: DesignMdColor[] = [];
+function collectColors(parsed: ParsedDesignMd): CollectedColors {
+  const candidates: DesignMdColor[] = [];
+  const labelled: DesignMdColor[] = [];
   const seen = new Set<string>();
   const add = (key: string, raw: string) => {
     const hex = normalizeHex(raw);
-    if (!hex || seen.has(hex)) return;
+    if (!hex) return;
+    labelled.push({ key, hex });
+    if (seen.has(hex)) return;
     seen.add(hex);
-    out.push({ key, hex });
+    candidates.push({ key, hex });
   };
   collectHexValues(parsed.frontmatter, [], add);
   for (const line of parsed.body.split('\n')) {
@@ -195,7 +208,7 @@ function collectColors(parsed: ParsedDesignMd): DesignMdColor[] {
       add(key, hex);
     }
   }
-  return out;
+  return { candidates, labelled };
 }
 
 function collectHexValues(value: unknown, path: string[], add: (key: string, raw: string) => void): void {
@@ -255,19 +268,24 @@ function resolveColors(candidates: DesignMdColor[]): BrandColor[] {
 }
 
 function semanticSeedOverrides(
-  candidates: DesignMdColor[],
+  labelled: DesignMdColor[],
   colors: BrandColor[],
 ): BrandSeedOverrides | undefined {
   const overrides: BrandSeedOverrides = {};
-  const warning = candidates.find((item) => /warning|caution/i.test(item.key));
+  const warning = labelled.find((item) => /warning|caution/i.test(item.key));
   if (warning) overrides.colorWarning = warning.hex;
-  const error = candidates.find((item) => /error|danger/i.test(item.key));
+  const error = labelled.find((item) => /error|danger/i.test(item.key));
   if (error) overrides.colorError = error.hex;
-  const success = candidates.find((item) => /success/i.test(item.key));
-  // Success already rides the accent-secondary role when the resolver picked
-  // the same hex; duplicating it in the override channel would leak a field.
-  if (success && !colors.some((c) => c.role === 'accent-secondary' && c.hex === success.hex)) {
-    overrides.colorSuccess = success.hex;
+  const success = labelled.find((item) => /success/i.test(item.key));
+  // Only override when the engine would not derive this exact value anyway:
+  // seedFromBrand maps accent-secondary onto success solely when it reads
+  // green, so a non-green authored Success would otherwise be lost to the
+  // Ant default.
+  if (success) {
+    const accentSecondaryHex = colors.find((c) => c.role === 'accent-secondary')?.hex;
+    if (derivedColorSuccess(accentSecondaryHex) !== success.hex) {
+      overrides.colorSuccess = success.hex;
+    }
   }
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }

--- a/apps/daemon/src/brands/engine/derive.ts
+++ b/apps/daemon/src/brands/engine/derive.ts
@@ -349,9 +349,11 @@ export function deriveTokens(seed: SeedToken, algorithm: ThemeAlgorithm = "defau
   // --- geometry ---------------------------------------------------------------
   const borderRadius = seed.borderRadius;
   // XS / SM / LG ratios off the seed radius (Ant: ~0.33× / ~0.66× / +2px).
-  const borderRadiusXS = Math.max(1, Math.round(borderRadius / 3)); // 6 -> 2
-  const borderRadiusSM = Math.max(2, Math.round((borderRadius * 2) / 3)); // 6 -> 4
-  const borderRadiusLG = borderRadius + 2; // 6 -> 8
+  // An explicit 0 means square corners — the ratios would otherwise floor
+  // back to nonzero, so zero stays zero across the whole radius ladder.
+  const borderRadiusXS = borderRadius === 0 ? 0 : Math.max(1, Math.round(borderRadius / 3)); // 6 -> 2
+  const borderRadiusSM = borderRadius === 0 ? 0 : Math.max(2, Math.round((borderRadius * 2) / 3)); // 6 -> 4
+  const borderRadiusLG = borderRadius === 0 ? 0 : borderRadius + 2; // 6 -> 8
 
   // Compact shrinks the control height; XS/SM/LG keep their ratios off it.
   const controlHeight = isCompact ? 28 : seed.controlHeight;

--- a/apps/daemon/src/brands/engine/seed.ts
+++ b/apps/daemon/src/brands/engine/seed.ts
@@ -220,6 +220,18 @@ function fontStack(primaryFamily: string | undefined, fallbacks: string[]): stri
 }
 
 /**
+ * The colorSuccess value `seedFromBrand` derives for a brand whose
+ * accent-secondary role carries `accentSecondaryHex`: that hex only stands in
+ * for success when it reads green; otherwise the Ant default survives.
+ * Importers that author explicit success overrides compare against this so a
+ * value is only overridden when it would otherwise be lost.
+ */
+export function derivedColorSuccess(accentSecondaryHex: string | undefined): string {
+  const linkHex = normalizeHex(accentSecondaryHex ?? "");
+  return linkHex && isGreenish(linkHex) ? linkHex : defaultSeed.colorSuccess;
+}
+
+/**
  * Map an already-synthesized Brand kit onto a SeedToken.
  *  - colorPrimary  ← role "accent" (else the first non-neutral color, else default)
  *  - colorInfo     ← same as primary
@@ -230,7 +242,7 @@ function fontStack(primaryFamily: string | undefined, fallbacks: string[]): stri
  *                    otherwise light foregrounds fall back to black and dark
  *                    canvases fall back to white as before
  *  - fontFamily    ← body face + fallbacks + system tail
- *  - borderRadius  ← parseInt(layout.radius) when >= 0, else 6
+ *  - borderRadius  ← layout.radius when it parses to a whole number >= 0, else 6
  *  - everything else ← defaultSeed
  */
 export function seedFromBrand(brand: Brand): SeedToken {
@@ -255,20 +267,23 @@ export function seedFromBrand(brand: Brand): SeedToken {
     defaultSeed.colorPrimary;
 
   const linkHex = normalizeHex(accentSecondary?.hex ?? "");
-  const successHex =
-    linkHex && isGreenish(linkHex) ? linkHex : defaultSeed.colorSuccess;
 
-  const radius = parseInt(brand.layout?.radius ?? "", 10);
+  // The radius seed is an integer pixel count; a fractional authored dimension
+  // ("0.5rem", "0.25em") cannot be represented and must fall back to the
+  // default instead of truncating to square corners.
+  const radius = Number.parseFloat(brand.layout?.radius ?? "");
+  const radiusSeed =
+    Number.isFinite(radius) && Number.isInteger(radius) && radius >= 0 ? radius : defaultSeed.borderRadius;
 
   return {
     ...defaultSeed,
     colorPrimary: primaryHex,
     colorInfo: primaryHex,
     colorLink: linkHex ?? "",
-    colorSuccess: successHex,
+    colorSuccess: derivedColorSuccess(accentSecondary?.hex),
     ...neutralBases(background?.hex, surface?.hex, foreground?.hex),
     fontFamily: fontStack(brand.typography?.body?.family, brand.typography?.body?.fallbacks ?? []),
-    borderRadius: Number.isFinite(radius) && radius >= 0 ? radius : defaultSeed.borderRadius,
+    borderRadius: radiusSeed,
   };
 }
 

--- a/apps/daemon/src/brands/engine/seed.ts
+++ b/apps/daemon/src/brands/engine/seed.ts
@@ -230,7 +230,7 @@ function fontStack(primaryFamily: string | undefined, fallbacks: string[]): stri
  *                    otherwise light foregrounds fall back to black and dark
  *                    canvases fall back to white as before
  *  - fontFamily    ← body face + fallbacks + system tail
- *  - borderRadius  ← parseInt(layout.radius) || 6
+ *  - borderRadius  ← parseInt(layout.radius) when >= 0, else 6
  *  - everything else ← defaultSeed
  */
 export function seedFromBrand(brand: Brand): SeedToken {
@@ -268,7 +268,7 @@ export function seedFromBrand(brand: Brand): SeedToken {
     colorSuccess: successHex,
     ...neutralBases(background?.hex, surface?.hex, foreground?.hex),
     fontFamily: fontStack(brand.typography?.body?.family, brand.typography?.body?.fallbacks ?? []),
-    borderRadius: Number.isFinite(radius) && radius > 0 ? radius : defaultSeed.borderRadius,
+    borderRadius: Number.isFinite(radius) && radius >= 0 ? radius : defaultSeed.borderRadius,
   };
 }
 

--- a/apps/daemon/tests/design-md-import-tokens.test.ts
+++ b/apps/daemon/tests/design-md-import-tokens.test.ts
@@ -238,4 +238,95 @@ Use system-ui for all interface text.
     ) as Record<string, unknown>;
     expect(tokens.colorError).toBe('#b30000');
   });
+
+  it('keeps a later Error label even when it shares the Primary hex', async () => {
+    const markdown = `---
+name: Duplicate Hex System
+radius: 8px
+spacing: 8px
+---
+
+# Duplicate Hex System
+
+## Colors
+- Background: #ffffff
+- Foreground: #161616
+- Primary: #b30000
+- Error: #b30000
+
+## Typography
+Use system-ui for all interface text.
+`;
+    const brand = brandFromDesignMd({ markdown, sourceUrl: 'designmd://duplicate-hex-system' });
+    if (!brand) throw new Error('duplicate-hex fixture failed to parse');
+
+    // The Error-labelled occurrence shares its hex with Primary, but the label
+    // is explicit — the seed override channel must still carry colorError.
+    expect(brand.seed).toEqual({ colorError: '#b30000' });
+
+    const brandsRoot = path.join(tempDir, 'brands');
+    writeBrand(brandsRoot, 'duplicate-hex-system', brand);
+    await rebuildSystem(brandsRoot, 'duplicate-hex-system');
+
+    const tokens = JSON.parse(
+      readFileSync(path.join(brandsRoot, 'duplicate-hex-system', 'system', 'tokens.default.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(tokens.colorError).toBe('#b30000');
+  });
+
+  it('preserves an explicit non-green Success color as the colorSuccess seed override', async () => {
+    const markdown = `---
+name: Blue Success System
+radius: 8px
+spacing: 8px
+---
+
+# Blue Success System
+
+## Colors
+- Background: #ffffff
+- Foreground: #161616
+- Primary accent: #0055cc
+- Success: #2563eb
+
+## Typography
+Use system-ui for all interface text.
+`;
+    const brand = brandFromDesignMd({ markdown, sourceUrl: 'designmd://blue-success-system' });
+    if (!brand) throw new Error('blue-success fixture failed to parse');
+
+    // Success rides the accent-secondary role, but seedFromBrand only derives
+    // success from that role when it reads green — an authored non-green
+    // Success must survive through the explicit override channel instead.
+    expect(brand.seed).toEqual({ colorSuccess: '#2563eb' });
+
+    const brandsRoot = path.join(tempDir, 'brands');
+    writeBrand(brandsRoot, 'blue-success-system', brand);
+    await rebuildSystem(brandsRoot, 'blue-success-system');
+
+    const tokens = JSON.parse(
+      readFileSync(path.join(brandsRoot, 'blue-success-system', 'system', 'tokens.default.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(tokens.colorSuccess).toBe('#2563eb');
+  });
+
+  it('accepts a true zero radius but falls back to the default for fractional radii', () => {
+    const seedRadiusFor = (radius: string): number => {
+      const brand = brandFromDesignMd({
+        markdown: DESIGN_MD.replace('radius: 0px', `radius: ${radius}`),
+        sourceUrl: SOURCE_URL,
+      });
+      if (!brand) throw new Error(`radius fixture ${radius} failed to parse`);
+      return seedFromBrand(brand).borderRadius;
+    };
+
+    // Whole numbers keep their authored value, including true zero...
+    expect(seedRadiusFor('0px')).toBe(0);
+    expect(seedRadiusFor('12px')).toBe(12);
+    // ...while fractional dimensions cannot be represented in the integer
+    // seed and must fall back to 6 instead of truncating to square corners.
+    expect(seedRadiusFor('0.5rem')).toBe(6);
+    expect(seedRadiusFor('0.25em')).toBe(6);
+    expect(seedRadiusFor('0.5px')).toBe(6);
+  });
 });

--- a/apps/daemon/tests/design-md-import-tokens.test.ts
+++ b/apps/daemon/tests/design-md-import-tokens.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Brand } from '@open-design/contracts';
+
+import { brandFromDesignMd } from '../src/brands/design-md-input.js';
+import { deriveTokens, seedFromBrand } from '../src/brands/engine/index.js';
+import { writeBrand } from '../src/brands/store.js';
+import { rebuildSystem } from '../src/brands/system.js';
+
+// Synthetic locked design system from issue #7409: every value below is
+// explicit and must survive the paste → brand → seed → system pipeline
+// unchanged (square corners, 8px grid, system-ui, authored warning color).
+const DESIGN_MD = `---
+name: Rectilinear Test System
+radius: 0px
+spacing: 8px
+---
+# Rectilinear Test System
+
+This is a locked design system. Explicit values must be preserved exactly.
+
+## Colors
+- Background: #ffffff
+- Foreground: #161616
+- Primary accent: #0055cc
+- Success: #006b3c
+- Warning: #8e6a00
+- Border: #8d8d8d
+
+## Typography
+Use system-ui for all interface text.
+
+## Geometry
+All corner radii are exactly 0px. Buttons, inputs, cards, tags, and panels must remain square. Never create pills.
+
+## Depth
+Use no shadows.
+
+## Motion
+Use linear easing only. Do not use cubic-bezier easing.
+
+## Components
+Buttons and controls must use 0px radius and the explicit semantic colors above.
+`;
+
+const BRAND_ID = 'rectilinear-test-system';
+const SOURCE_URL = 'designmd://rectilinear-test-system';
+
+function parseFixture(): Brand {
+  const brand = brandFromDesignMd({ markdown: DESIGN_MD, sourceUrl: SOURCE_URL });
+  if (!brand) throw new Error('DESIGN.md fixture failed to parse');
+  return brand;
+}
+
+function writeRectilinearBrand(brandsRoot: string): Brand {
+  const brand = parseFixture();
+  writeBrand(brandsRoot, BRAND_ID, brand);
+  return brand;
+}
+
+function systemFile(brandsRoot: string, file: string): string {
+  return readFileSync(path.join(brandsRoot, BRAND_ID, 'system', file), 'utf8');
+}
+
+describe('design-md import preserves explicit tokens', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'design-md-tokens-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('parses explicit radius, spacing, fonts, palette and semantic seed overrides from pasted DESIGN.md', () => {
+    const brand = parseFixture();
+
+    expect(brand.layout.radius).toBe('0px');
+    expect(brand.layout.spacing).toBe('8px');
+    expect(brand.typography.body.family).toBe('system-ui');
+    expect(brand.typography.display.family).toBe('system-ui');
+
+    const hexByRole = new Map(brand.colors.map((color) => [color.role, color.hex] as const));
+    expect(hexByRole.get('accent')).toBe('#0055cc');
+    expect(hexByRole.get('background')).toBe('#ffffff');
+    expect(hexByRole.get('foreground')).toBe('#161616');
+    expect(hexByRole.get('border')).toBe('#8d8d8d');
+
+    // Exact payload: success rides the accent-secondary role and the fixture
+    // carries no error color, so nothing else may leak into the override channel.
+    expect(brand.seed).toEqual({ colorWarning: '#8e6a00' });
+  });
+
+  it('maps the parsed brand onto a seed that keeps radius zero and the system-ui face', () => {
+    const brand = parseFixture();
+    const seed = seedFromBrand(brand);
+
+    expect(seed.borderRadius).toBe(0);
+    expect(seed.fontFamily.startsWith('system-ui')).toBe(true);
+  });
+
+  it('rebuilds the registered system with square geometry and the authored warning color', async () => {
+    const brandsRoot = path.join(tempDir, 'brands');
+    writeRectilinearBrand(brandsRoot);
+
+    await rebuildSystem(brandsRoot, BRAND_ID);
+
+    const seed = JSON.parse(systemFile(brandsRoot, 'seed.json')) as Record<string, unknown>;
+    expect(seed.borderRadius).toBe(0);
+    expect(seed.colorWarning).toBe('#8e6a00');
+    expect(String(seed.fontFamily).startsWith('system-ui')).toBe(true);
+
+    const tokens = JSON.parse(systemFile(brandsRoot, 'tokens.default.json')) as Record<string, unknown>;
+    expect(tokens.borderRadius).toBe(0);
+    expect(tokens.borderRadiusXS).toBe(0);
+    expect(tokens.borderRadiusSM).toBe(0);
+    expect(tokens.borderRadiusLG).toBe(0);
+    expect(tokens.colorWarning).toBe('#8e6a00');
+
+    // Square geometry must hold across every shipped theme file, not just the
+    // default algorithm — rebuildSystem re-derives dark/compact from the seed.
+    const darkTokens = JSON.parse(systemFile(brandsRoot, 'tokens.dark.json')) as Record<string, unknown>;
+    expect(darkTokens.borderRadius).toBe(0);
+  });
+
+  it('produces byte-identical system output when rebuilt twice from the same brand.json', async () => {
+    const brandsRoot = path.join(tempDir, 'brands');
+    writeRectilinearBrand(brandsRoot);
+
+    await rebuildSystem(brandsRoot, BRAND_ID);
+    const seedFirst = systemFile(brandsRoot, 'seed.json');
+    const tokensFirst = systemFile(brandsRoot, 'tokens.default.json');
+
+    await rebuildSystem(brandsRoot, BRAND_ID);
+
+    expect(systemFile(brandsRoot, 'seed.json')).toBe(seedFirst);
+    expect(systemFile(brandsRoot, 'tokens.default.json')).toBe(tokensFirst);
+  });
+
+  it('falls back to default radii when the explicit radius is negative', () => {
+    const markdown = DESIGN_MD.replace('radius: 0px', 'radius: -2px');
+    const brand = brandFromDesignMd({ markdown, sourceUrl: SOURCE_URL });
+    if (!brand) throw new Error('negative-radius fixture failed to parse');
+
+    const seed = seedFromBrand(brand);
+    expect(seed.borderRadius).toBe(6);
+
+    const tokens = deriveTokens(seed, 'default');
+    expect(tokens.borderRadius).toBe(6);
+    expect(tokens.borderRadiusXS).toBe(2);
+    expect(tokens.borderRadiusSM).toBe(4);
+    expect(tokens.borderRadiusLG).toBe(8);
+  });
+
+  it('leaves brands without semantic color keys or generic font words untouched', () => {
+    const markdown = `---
+name: Plain System
+radius: fluid
+spacing: 4px
+---
+
+# Plain System
+
+## Colors
+- Background: #f8f9fa
+- Foreground: #212529
+- Primary accent: #3b5bdb
+
+## Typography
+font-family: Public Sans
+`;
+    const brand = brandFromDesignMd({ markdown, sourceUrl: 'designmd://plain-system' });
+    if (!brand) throw new Error('minimal fixture failed to parse');
+
+    expect(brand.seed).toBeUndefined();
+    expect(brand.typography.body.family).toBe('Public Sans');
+
+    const seed = seedFromBrand(brand);
+    expect(seed.borderRadius).toBe(6);
+    expect(seed.fontFamily.startsWith("'Public Sans'")).toBe(true);
+  });
+
+  it('prefers an explicit font-family declaration over a generic keyword later in the same stack', () => {
+    const markdown = `---
+name: Inter Stack System
+radius: 8px
+spacing: 8px
+---
+
+# Inter Stack System
+
+## Typography
+font-family: Inter, system-ui, sans-serif;
+`;
+    const brand = brandFromDesignMd({ markdown, sourceUrl: 'designmd://inter-stack-system' });
+    if (!brand) throw new Error('Inter-stack fixture failed to parse');
+
+    // Explicit declaration wins over the generic keyword on the same line.
+    expect(brand.typography.body.family).toBe('Inter');
+    expect(brand.typography.display.family).toBe('Inter');
+
+    const seed = seedFromBrand(brand);
+    expect(seed.fontFamily.startsWith('Inter')).toBe(true);
+  });
+
+  it('captures a bulleted Error color as the colorError seed override and token', async () => {
+    const markdown = `---
+name: Error Seed System
+radius: 8px
+spacing: 8px
+---
+
+# Error Seed System
+
+## Colors
+- Background: #ffffff
+- Foreground: #161616
+- Primary accent: #0055cc
+- Error: #b30000
+
+## Typography
+Use system-ui for all interface text.
+`;
+    const brand = brandFromDesignMd({ markdown, sourceUrl: 'designmd://error-seed-system' });
+    if (!brand) throw new Error('error-seed fixture failed to parse');
+
+    expect(brand.seed).toEqual({ colorError: '#b30000' });
+
+    const brandsRoot = path.join(tempDir, 'brands');
+    writeBrand(brandsRoot, 'error-seed-system', brand);
+    await rebuildSystem(brandsRoot, 'error-seed-system');
+
+    const tokens = JSON.parse(
+      readFileSync(path.join(brandsRoot, 'error-seed-system', 'system', 'tokens.default.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(tokens.colorError).toBe('#b30000');
+  });
+});


### PR DESCRIPTION
Fixes #7409

## Why

Pasting a DESIGN.md into Design Systems → Create is advertised as creating a system "directly from tokens", but the import chain silently replaced explicitly authored values with Ant Design defaults: an explicit `borderRadius: 0` was rejected by `seedFromBrand()`'s `radius > 0` guard, Warning/Error colors named in the document had no carrier into the engine, and prose-declared generic families like `system-ui` were missed by the font collector. Rebuilds then re-derived the same defaults, so corrections never stuck. The red spec built on the issue's synthetic DESIGN.md failed on `main` (`4 failed | 4 passed`: borderRadius 6≠0, colorWarning #faad14≠#8e6a00, colorError #ff4d4f unmapped, Inter lead) and passes here.

## What users will see

Importing a pasted DESIGN.md now keeps the radius, semantic colors, and font families the document explicitly states:

- zero corner radius stays zero across the whole derived radius ladder (`borderRadiusXS/SM/LG` included),
- Warning/Error colors flow into the generated palette instead of Ant defaults,
- generic font stacks like `system-ui` are used as declared, while explicit `font-family:` declarations still win over generic keywords appearing later in the same stack.

Documents that declare none of these produce byte-identical output to before.

Not addressed here (follow-up, out of scope): the fixture's linear-easing-only Motion directive is still ignored — motion easings have no carrier from DESIGN.md to SeedToken today.

## Surface area

- [ ] **UI** — not applicable: no UI code changed; the existing paste flow simply produces faithful output.
- [ ] **Keyboard shortcut** — not applicable.
- [ ] **CLI / env var** — not applicable: `od brand` commands consume the same rebuilt system unchanged.
- [ ] **API / contract** — not applicable: reuses the existing optional `Brand.seed` override field; no shape change in `packages/contracts`.
- [ ] **Extension point** — not applicable: `design-systems/`, `design-templates/`, `skills/`, `craft/` untouched.
- [ ] **i18n keys** — none added.
- [ ] **New top-level dependency** — none.
- [x] **Default behavior change** — paste-imported DESIGN.md systems keep explicitly authored radius/warning/error/generic-font values instead of Ant defaults; documents declaring none are byte-identical (control-covered).
- [ ] **None**

## Screenshots

Not applicable — no UI surface checked.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/design-md-import-tokens.test.ts`
- Did the test go red on `main` and green on this branch? Yes — red @ `1246ca3d`, green here (11 passed), including duplicate-hex labels, non-green Success, and fractional-radius edge cases. Mutation checks re-redden each fix hunk independently.

## Validation

`pnpm exec vitest run -c vitest.config.ts tests/design-md-import-tokens.test.ts` in `apps/daemon` (11 passed); related suites `brand-extraction-engine`, `design-systems/import`, `tools-connectors-cli` (95 passed); `pnpm --filter @open-design/daemon typecheck` clean; `pnpm guard` clean.
