### PR TITLE
fix(landing-page): allow studio cards to shrink below 420px on narrow screens

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
Fixes #6097

The `.ha-showcase-wide` grid on `/codex-slides/` used a fixed 420px minimum track, which overflowed its container on phones narrower than 420px. The global `html { overflow-x: clip }` rule hides the horizontal scrollbar, so the clipping was invisible except for the content loss at the card edge.

## Fix

Wrap the `minmax` lower bound in `min(100%, 420px)` so the track shrinks to the available container width when the viewport is narrower than the cell minimum. Desktop layout is preserved: a gallery width of 859px remains one column; 860px remains two 420px columns.

## Validation (from issue #6097)

- Patched static output: zero viewport clipping and zero container overflow at 320-1280px on both /codex-slides/ and /ko/codex-slides/.
- Existing desktop transition preserved: 859px gallery = one column, 860px = two 420px columns.
- `pnpm --filter @open-design/landing-page typecheck`: 0 errors on Node 24.18.0.
- `pnpm --filter @open-design/landing-page build:static`: 5,247 pages built successfully.

## Diff

```diff
 .ha-showcase-wide {
-  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
 }
```

This is a one-line CSS change. No behavior change on desktop; narrow-screen overflow fixed.