### PR TITLE
fix(daemon): report terminal AMR Runs to Vela

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -18,6 +18,7 @@ import { eventsEndedWithUnfinishedWork } from '@open-design/contracts';
 import { migrateCollabSyncSnapshots } from './collab/sync-snapshot-store.js';
 import { migrateCommentRelayOutbox } from './collab/comment-relay-outbox.js';
 import { migratePublicFilePublications } from './collab/public-file-publication-store.js';
+import { migrateAmrTerminalReportOutbox } from './storage/amr-terminal-report-outbox.js';
 import {
   collapseWorkspaceProjectHomes,
   type WorkspaceProjectHomeRow,
@@ -568,6 +569,7 @@ function migrate(db: SqliteDb): void {
   migrateOdNextRolloutStore(db);
   migrateCollabSyncSnapshots(db);
   migrateCommentRelayOutbox(db);
+  migrateAmrTerminalReportOutbox(db);
   migratePublicFilePublications(db);
 }
 

--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -175,11 +175,13 @@ export function classifyAmrAccountFailure(text: string): AmrAccountFailure | nul
     value.includes('not logged in') ||
     value.includes('login missing') ||
     value.includes('sign in again') ||
+    value.includes('sign-in-again') ||
     value.includes('sign-in required') ||
     value.includes('signin required') ||
     value.includes('token has expired') ||
     value.includes('expired token') ||
     value.includes('invalid session') ||
+    value.includes('expired session') ||
     value.includes('session expired')
   ) {
     return {

--- a/apps/daemon/src/runtimes/run-restart-recovery.ts
+++ b/apps/daemon/src/runtimes/run-restart-recovery.ts
@@ -14,6 +14,7 @@ export interface RestartRecoverableDurableRunState {
   status: string;
   terminalTrigger?: TrackingRunTerminalTrigger | null;
   terminalRecoveryReason?: 'daemon_restart' | 'analytics_incomplete';
+  terminalAt?: number | null;
   updatedAt: number;
 }
 
@@ -24,6 +25,7 @@ export function interruptDurableRunAfterDaemonRestart(
   if (TERMINAL_STATUSES.has(state.status)) return false;
   state.status = 'failed';
   state.updatedAt = now;
+  state.terminalAt = now;
   state.exitCode = 1;
   state.signal = null;
   state.error = RESTART_ERROR_MESSAGE;

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -102,6 +102,7 @@ interface ReconciliationOptions {
     completion: Promise<unknown>;
   };
   runsLogDir: string;
+  finalizeTerminalLocally?: (run: DurableRunState, status: string, terminalAt: number) => void;
 }
 
 export interface RunTerminalReconciliationResult {
@@ -300,6 +301,24 @@ export async function reconcileDurableRunTerminals(
     writeState(entry.filePath, entry.state);
     interruptedRunIds.add(entry.state.id);
     result.interrupted += 1;
+  }
+
+  // Repair both newly interrupted Runs and terminal state snapshots that may
+  // have survived a crash before their local terminal outbox write.
+  for (const { state } of states) {
+    if (state.status !== 'failed' && state.status !== 'canceled') continue;
+    try {
+      options.finalizeTerminalLocally?.(
+        state,
+        state.status,
+        state.terminalAt ?? state.updatedAt,
+      );
+    } catch (error) {
+      console.warn(
+        '[runs] terminal local finalizer failed during restart reconciliation',
+        error,
+      );
+    }
   }
 
   const statesByRunId = new Map(states.map((entry) => [entry.state.id, entry.state]));

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1339,6 +1339,10 @@ export function createChatRunService({
       run.onFinalize = null;
       try { finalize(); } catch { /* best-effort */ }
     }
+    // Terminal finalizers can add artifact metadata after the authoritative
+    // terminal timestamp snapshot. Persist once more before publishing `end`
+    // so restart hydration sees the same artifact result as live clients.
+    persistState(run);
     emit(run, 'end', {
       code,
       signal,

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -525,6 +525,7 @@ function durableRunState(run) {
     status: run.status,
     createdAt: run.createdAt,
     updatedAt: run.updatedAt,
+    terminalAt: run.terminalAt ?? null,
     exitCode: run.exitCode,
     signal: run.signal,
     error: run.error,
@@ -669,18 +670,42 @@ export function createChatRunService({
   // hook here covers startup failures and daemon shutdown in addition to the
   // normal child-close path.
   beforeFinish = null,
+  // Optional synchronous terminal hook. It runs after the terminal state is
+  // durable but before the terminal SSE event is published, so local outbox
+  // writes share the exact terminal timestamp without delaying on delivery.
+  onTerminal = null,
 }) {
   const runs = new Map();
   const runIdsByClientRequestId = new Map();
   const runIdsByPluginWorkflowId = new Map();
 
+  const finalizeTerminalLocally = (run, status, terminalAt) => {
+    if (!onTerminal) return;
+    try {
+      onTerminal(run, status, terminalAt);
+    } catch (error) {
+      console.warn('[runs] terminal local finalizer failed', error);
+    }
+  };
+
+  const backfillDurableTerminal = (state) => {
+    if (!TERMINAL_RUN_STATUSES.has(state?.status)) return;
+    const terminalAt = Number.isFinite(state.terminalAt)
+      ? state.terminalAt
+      : state.updatedAt;
+    if (!Number.isFinite(terminalAt)) return;
+    finalizeTerminalLocally(state, state.status, terminalAt);
+  };
+
   if (runsLogDir) {
     try {
       for (const entry of fs.readdirSync(runsLogDir, { withFileTypes: true })) {
         if (!entry.isDirectory()) continue;
-        const state = readDurableRunState(path.join(runsLogDir, entry.name, 'state.json'));
+        const statePath = path.join(runsLogDir, entry.name, 'state.json');
+        const state = readDurableRunState(statePath);
+        if (!state) continue;
         if (
-          typeof state?.clientRequestId === 'string'
+          typeof state.clientRequestId === 'string'
           && state.clientRequestId
           && typeof state.id === 'string'
         ) {
@@ -709,11 +734,15 @@ export function createChatRunService({
     const interruptedAfterRestart =
       interruptDurableRunAfterDaemonRestart(state);
     if (interruptedAfterRestart) atomicWriteJson(statePath, state);
+    backfillDurableTerminal(state);
     if (!TERMINAL_RUN_STATUSES.has(state.status)) return null;
     const eventsLogPath = path.join(runsLogDir, id, 'events.jsonl');
     const events = readDurableRunEvents(eventsLogPath);
-    if (interruptedAfterRestart) {
-      const timestamp = state.updatedAt;
+    if (
+      interruptedAfterRestart
+      || state.terminalRecoveryReason === 'daemon_restart'
+    ) {
+      const timestamp = state.terminalAt ?? state.updatedAt;
       const nextEventId =
         events.reduce((max, record) => Math.max(max, record.id), 0) + 1;
       events.push(
@@ -736,6 +765,7 @@ export function createChatRunService({
             code: 1,
             signal: null,
             status: 'failed',
+            terminalAt: timestamp,
             resumable: false,
             endedWithUnfinishedWork: Boolean(state.endedWithUnfinishedWork),
           },
@@ -850,6 +880,7 @@ export function createChatRunService({
       status: 'queued',
       createdAt: now,
       updatedAt: now,
+      terminalAt: null,
       events: [],
       nextEventId: 1,
       clients: new Set(),
@@ -1067,6 +1098,7 @@ export function createChatRunService({
     run.cleanupGeneration = (run.cleanupGeneration ?? 0) + 1;
     run.status = 'queued';
     run.updatedAt = resumedAt;
+    run.terminalAt = null;
     run.exitCode = null;
     run.signal = null;
     run.error = null;
@@ -1158,14 +1190,14 @@ export function createChatRunService({
     }
   };
 
-  const emit = (run, event, data) => {
+  const emit = (run, event, data, timestamp = Date.now(), persistLifecycle = true) => {
     if (event === 'error') {
       const details = extractErrorDetails(data);
       if (details.error) run.error = details.error;
       if (details.errorCode) run.errorCode = details.errorCode;
     }
     const id = run.nextEventId++;
-    const record = { id, event, data, timestamp: Date.now() };
+    const record = { id, event, data, timestamp };
     // Fold committed side effects BEFORE the ring buffer can drop this record,
     // so the finalization-time verdict survives truncation of run.events.
     if (onEventEmitted) {
@@ -1173,11 +1205,11 @@ export function createChatRunService({
     }
     run.events.push(record);
     if (run.events.length > maxEvents) run.events.splice(0, run.events.length - maxEvents);
-    run.updatedAt = Date.now();
+    run.updatedAt = timestamp;
     // State writes are synchronous so they survive process termination. Keep
     // them on lifecycle boundaries only: agent/text deltas can arrive many
     // times per second and are already streamed to events.jsonl.
-    if (event === 'start' || event === 'error' || event === 'end') persistState(run);
+    if (persistLifecycle && (event === 'start' || event === 'error' || event === 'end')) persistState(run);
     const stream = ensureLogStream(run);
     if (stream) {
       try {
@@ -1208,6 +1240,7 @@ export function createChatRunService({
     status: run.status,
     createdAt: run.createdAt,
     updatedAt: run.updatedAt,
+    terminalAt: run.terminalAt ?? null,
     cancelRequested: !!run.cancelRequested,
     cancelOrigin: run.cancelOrigin ?? null,
     terminalTrigger: run.terminalTrigger ?? null,
@@ -1270,10 +1303,12 @@ export function createChatRunService({
   const finish = (run, status, code: number | null = null, signal: string | null = null) => {
     if (TERMINAL_RUN_STATUSES.has(run.status)) return;
     if (beforeFinish) beforeFinish(run, status, code, signal);
+    const terminalAt = Date.now();
     run.status = status;
     run.exitCode = code;
     run.signal = signal;
-    run.updatedAt = Date.now();
+    run.updatedAt = terminalAt;
+    run.terminalAt = terminalAt;
     // Derive the work-completeness flag once, at the single terminal choke point,
     // from the signals the agent-event handler folded onto the run. Uses the
     // canonical predicate so it can never diverge from the web chat footer
@@ -1290,6 +1325,10 @@ export function createChatRunService({
       Boolean(run.truncatedMidTurn)
       || (!strategyTaskProvesDelivery(run.strategyTask)
         && todoSnapshotHasUnfinishedWork(run.lastTodoSnapshot));
+    // Commit the terminal Run snapshot before exposing its terminal event. The
+    // optional outbox hook is local-only and synchronous by contract.
+    persistState(run);
+    finalizeTerminalLocally(run, status, terminalAt);
     // Release run-scoped resources the starter registered (e.g. the minted
     // tool-token grant + agent event-sink entries). This runs on EVERY
     // terminal path — including a startup throw that never reached the child
@@ -1304,6 +1343,7 @@ export function createChatRunService({
       code,
       signal,
       status,
+      terminalAt,
       resumable: run.resumable ?? false,
       endedWithUnfinishedWork: run.endedWithUnfinishedWork,
       ...(Number.isFinite(run.artifactCount) ? { artifactCount: run.artifactCount } : {}),
@@ -1311,7 +1351,7 @@ export function createChatRunService({
       failureCategory: run.failureCategory ?? null,
       failureDetail: run.failureDetail ?? null,
       ...(run.strategyTask ? { strategyTask: run.strategyTask } : {}),
-    });
+    }, terminalAt, false);
     for (const sse of run.clients) sse.end();
     run.clients.clear();
     for (const waiter of run.waiters) waiter(statusBody(run));

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -496,6 +496,10 @@ import { importFigmaFromBytes } from './figma/figma-import.js';
 import { renderDesignSystemPreview } from './design-systems/preview.js';
 import { renderDesignSystemShowcase } from './design-systems/showcase.js';
 import { createChatRunService } from './runtimes/runs.js';
+import {
+  createAmrTerminalReportFinalizer,
+  createAmrTerminalReportOutboxStore,
+} from './storage/amr-terminal-report-outbox.js';
 import { createInternalRunCreationService } from './services/internal-run-service.js';
 import {
   createOdNextRunInputProjection,
@@ -3155,6 +3159,7 @@ export async function startServer({
     next();
   });
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
+  const amrTerminalReportOutbox = createAmrTerminalReportOutboxStore(db);
   const commentAnchorRepair = repairTeamProjectCommentAnchorConversations(db);
   if (commentAnchorRepair.created > 0) {
     console.warn(
@@ -7472,6 +7477,7 @@ export async function startServer({
         if (!run.sideEffectLedger) run.sideEffectLedger = createRunSideEffectLedger();
         foldEventIntoRunSideEffectLedger(run.sideEffectLedger, record);
       },
+      onTerminal: createAmrTerminalReportFinalizer(amrTerminalReportOutbox),
       beforeFinish: (run, status) => {
         if (status !== 'failed' && status !== 'canceled') return;
         try {
@@ -7534,6 +7540,7 @@ export async function startServer({
     appVersionInfo: telemetry.getCachedAppVersion(),
     db,
     reportLangfuse: reportRunCompletedFromDaemon,
+    finalizeTerminalLocally: createAmrTerminalReportFinalizer(amrTerminalReportOutbox),
     taskObservationModeForRun: (runId) => taskObservationRollout.modeForRun(runId),
     taskObservationRepresentationForRun: (runId) =>
       taskObservationRollout.representationForRun(runId),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7697,10 +7697,25 @@ export async function startServer({
 
   app.get('/api/health', async (_req, res) => {
     const versionInfo = await readCurrentAppVersionInfo();
+    const {
+      pending,
+      delivered,
+      unsupported,
+      terminalFailed,
+      oldestPendingAgeMs,
+    } = amrTerminalReportOutbox.diagnostics();
+    res.setHeader('Cache-Control', 'no-store');
     res.json({
       ok: true,
       version: versionInfo.version,
-      amrTerminalReporter: { status: 'active' },
+      amrTerminalReporter: {
+        status: 'active',
+        pending,
+        delivered,
+        unsupported,
+        terminalFailed,
+        oldestPendingAgeMs,
+      },
     });
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -497,8 +497,10 @@ import { renderDesignSystemPreview } from './design-systems/preview.js';
 import { renderDesignSystemShowcase } from './design-systems/showcase.js';
 import { createChatRunService } from './runtimes/runs.js';
 import {
+  createAmrTerminalReportDeliveryService,
   createAmrTerminalReportFinalizer,
   createAmrTerminalReportOutboxStore,
+  type AmrTerminalReportDeliveryService,
 } from './storage/amr-terminal-report-outbox.js';
 import { createInternalRunCreationService } from './services/internal-run-service.js';
 import {
@@ -2828,6 +2830,15 @@ export interface StartServerOptions {
   odNextComplexProductionResolver?: OdNextComplexProductionResolver | null;
 }
 
+export function startAmrTerminalReportDeliveryAfterBind(
+  delivery: Pick<AmrTerminalReportDeliveryService, 'start'>,
+  boundPort: number | null,
+): boolean {
+  if (!Number.isInteger(boundPort) || Number(boundPort) <= 0) return false;
+  delivery.start();
+  return true;
+}
+
 export interface StartServerResult {
   url: string;
   server: import('node:http').Server;
@@ -3160,6 +3171,9 @@ export async function startServer({
   });
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
   const amrTerminalReportOutbox = createAmrTerminalReportOutboxStore(db);
+  const amrTerminalReportDelivery = createAmrTerminalReportDeliveryService({
+    store: amrTerminalReportOutbox,
+  });
   const commentAnchorRepair = repairTeamProjectCommentAnchorConversations(db);
   if (commentAnchorRepair.created > 0) {
     console.warn(
@@ -7682,7 +7696,11 @@ export async function startServer({
 
   app.get('/api/health', async (_req, res) => {
     const versionInfo = await readCurrentAppVersionInfo();
-    res.json({ ok: true, version: versionInfo.version });
+    res.json({
+      ok: true,
+      version: versionInfo.version,
+      amrTerminalReporter: { status: 'active' },
+    });
   });
 
   app.get('/api/ready', async (_req, res) => {
@@ -7779,6 +7797,13 @@ export async function startServer({
     requireLocalDaemonRequest,
     composio: composioConnectorProvider,
   });
+
+  // Detailed terminal-report activity is local diagnostics, not public health.
+  app.get(
+    '/api/diagnostics/amr-terminal-reports',
+    requireLocalDaemonRequest,
+    (_req, res) => res.json(amrTerminalReportOutbox.diagnostics()),
+  );
 
   // Gate the diagnostics export behind requireLocalDaemonRequest so it stays
   // unreachable when daemon binds to a non-loopback address (Tailscale,
@@ -16474,6 +16499,7 @@ export async function startServer({
     };
     const cleanupDaemonBackgroundWork = () => {
       clearTerminalTelemetryFallbackTimers();
+      amrTerminalReportDelivery.stop();
       telemetry.disposeFatalHandlers();
       composioConnectorProvider.stopCatalogRefreshLoop();
       orbitService.stop();
@@ -16490,6 +16516,7 @@ export async function startServer({
       if (daemonShutdownStarted) return;
       daemonShutdownStarted = true;
       daemonShuttingDown = true;
+      amrTerminalReportDelivery.stop();
       clearTerminalTelemetryFallbackTimers();
       await design.runs.shutdownActive({ graceMs: resolveChatRunShutdownGraceMs() });
       await terminalService.shutdownActive();
@@ -16540,6 +16567,7 @@ export async function startServer({
           return;
         }
         resolvedPort = boundPort;
+        startAmrTerminalReportDeliveryAfterBind(amrTerminalReportDelivery, boundPort);
         // When binding to all interfaces report localhost for local callers;
         // when binding to a specific address (e.g. a Tailscale IP) report that
         // address so remote callers and the sidecar use the correct URL.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3173,6 +3173,7 @@ export async function startServer({
   const amrTerminalReportOutbox = createAmrTerminalReportOutboxStore(db);
   const amrTerminalReportDelivery = createAmrTerminalReportDeliveryService({
     store: amrTerminalReportOutbox,
+    env: { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
   });
   const commentAnchorRepair = repairTeamProjectCommentAnchorConversations(db);
   if (commentAnchorRepair.created > 0) {

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -344,16 +344,21 @@ function canonicalReceipt(
   stdout: string,
 ): string | null {
   const receipt = jsonObject(stdout.trim());
+  const receiptTerminalAt = typeof receipt?.terminalAt === 'string'
+    ? Date.parse(receipt.terminalAt)
+    : Number.NaN;
   if (
     receipt?.runId !== record.runId
     || receipt.outcome !== record.outcome
-    || receipt.terminalAt !== record.terminalAtIso
+    || !Number.isFinite(receiptTerminalAt)
+    || receiptTerminalAt !== record.terminalAt
+    || typeof receipt.recorded !== 'boolean'
   ) return null;
   return JSON.stringify({
     runId: record.runId,
     outcome: record.outcome,
     terminalAt: record.terminalAtIso,
-    ...(typeof receipt.replay === 'boolean' ? { replay: receipt.replay } : {}),
+    recorded: receipt.recorded,
   });
 }
 

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -386,11 +386,21 @@ export function createAmrTerminalReportDeliveryService(input: {
   let timer: NodeJS.Timeout | null = null;
   let controller = new AbortController();
 
+  const logStorageFailure = (
+    stage: 'claim' | 'persist_result',
+    record?: ClaimedAmrTerminalReport,
+  ): void => {
+    console.warn(
+      `[od] amr_terminal_delivery_storage stage=${stage} runId=${record?.runId ?? 'none'} code=local_storage`,
+    );
+  };
   const schedule = (): void => {
     if (stopped || timer) return;
     timer = setTimeout(() => {
       timer = null;
-      void processDue().finally(schedule);
+      void processDue()
+        .catch(() => console.warn('[od] amr_terminal_delivery_background code=unexpected'))
+        .finally(schedule);
     }, Math.max(1, pollIntervalMs));
     timer.unref();
   };
@@ -402,9 +412,17 @@ export function createAmrTerminalReportDeliveryService(input: {
       // startup sweep until no due row remains.
       while (true) {
         if (stopped && controller.signal.aborted) break;
-        const [record] = input.store.claimDue(now(), leaseMs, 1);
+        let record: ClaimedAmrTerminalReport | undefined;
+        try {
+          [record] = input.store.claimDue(now(), leaseMs, 1);
+        } catch {
+          logStorageFailure('claim');
+          break;
+        }
         if (!record) break;
         const args = ['run', 'terminal', '--run-id', record.runId, '--outcome', record.outcome, '--terminal-at', record.terminalAtIso, '--json'];
+        let storedReceipt: string | null = null;
+        let commandFailure: ReturnType<typeof failureFrom> | null = null;
         try {
           const receipt = await run(args, {
             configuredEnv: { VELA_INVOCATION_SOURCE: 'open-design' },
@@ -412,21 +430,29 @@ export function createAmrTerminalReportDeliveryService(input: {
             maxBuffer: 64 * 1024,
             signal: controller.signal,
           });
-          const storedReceipt = canonicalReceipt(record, receipt);
-          if (storedReceipt) {
+          storedReceipt = canonicalReceipt(record, receipt);
+        } catch (error) {
+          commandFailure = failureFrom(error);
+          console.warn(`[od] amr_terminal_delivery runId=${record.runId} outcome=${record.outcome} attempt=${record.attemptCount} code=${safeErrorCode(commandFailure.code)}`);
+        }
+
+        try {
+          if (commandFailure?.terminal) {
+            input.store.fail(record, commandFailure.code, commandFailure.message);
+          } else if (commandFailure) {
+            const exponent = Math.max(0, Math.min(30, record.attemptCount - 1));
+            const delay = Math.min(maxBackoffMs, baseBackoffMs * (2 ** exponent));
+            input.store.defer(record, now() + delay, commandFailure.code, commandFailure.message);
+          } else if (storedReceipt) {
             input.store.deliver(record, storedReceipt);
           } else {
             input.store.fail(record, 'invalid_receipt', 'Vela returned a malformed or mismatched terminal receipt');
           }
-        } catch (error) {
-          const failure = failureFrom(error);
-          if (failure.terminal) input.store.fail(record, failure.code, failure.message);
-          else {
-            const exponent = Math.max(0, Math.min(30, record.attemptCount - 1));
-            const delay = Math.min(maxBackoffMs, baseBackoffMs * (2 ** exponent));
-            input.store.defer(record, now() + delay, failure.code, failure.message);
-          }
-          console.warn(`[od] amr_terminal_delivery runId=${record.runId} outcome=${record.outcome} attempt=${record.attemptCount} code=${safeErrorCode(failure.code)}`);
+        } catch {
+          // The claim lease keeps the original tuple durable. Once it expires,
+          // a later sweep safely replays the idempotent Vela terminal command.
+          logStorageFailure('persist_result', record);
+          break;
         }
       }
     })().finally(() => { active = null; });
@@ -437,7 +463,9 @@ export function createAmrTerminalReportDeliveryService(input: {
       if (!stopped) return;
       stopped = false;
       if (controller.signal.aborted) controller = new AbortController();
-      void processDue().finally(schedule);
+      void processDue()
+        .catch(() => console.warn('[od] amr_terminal_delivery_background code=unexpected'))
+        .finally(schedule);
     },
     stop() {
       stopped = true;

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -1,22 +1,15 @@
-// Durable local handoff for AMR terminal outcomes. Delivery is intentionally
-// deferred to the separately owned runner; this store only preserves the first
-// terminal outcome so a late child callback cannot rewrite what will be sent.
+import type Database from 'better-sqlite3';
 
-interface SqliteRunResult {
-  changes: number;
-}
-
-interface SqliteStatement {
-  run(...values: unknown[]): SqliteRunResult;
-  all(...values: unknown[]): unknown[];
-}
-
-interface SqliteDb {
-  exec(sql: string): void;
-  prepare(sql: string): SqliteStatement;
-}
+import {
+  runVelaCommand,
+  velaCommandStdout,
+  type VelaCommandOptions,
+} from '../integrations/vela-command.js';
+import { classifyAmrAccountFailure } from '../integrations/vela-errors.js';
+import { redactSecrets } from '../redact.js';
 
 export type AmrTerminalReportOutcome = 'failed' | 'canceled';
+export type AmrTerminalReportState = 'pending' | 'delivered' | 'terminal_failed';
 
 export interface PendingAmrTerminalReport {
   runId: string;
@@ -24,9 +17,28 @@ export interface PendingAmrTerminalReport {
   terminalAt: number;
 }
 
+export interface ClaimedAmrTerminalReport extends PendingAmrTerminalReport {
+  terminalAtIso: string;
+  attemptCount: number;
+  version: number;
+}
+
+export interface AmrTerminalReportDiagnostics {
+  pending: number;
+  delivered: number;
+  unsupported: number;
+  terminalFailed: number;
+  oldestPendingAgeMs: number | null;
+}
+
 export interface AmrTerminalReportOutboxStore {
   enqueue(report: PendingAmrTerminalReport): void;
   listPending(): PendingAmrTerminalReport[];
+  claimDue(now: number, leaseMs: number, limit?: number): ClaimedAmrTerminalReport[];
+  deliver(record: ClaimedAmrTerminalReport, receipt: string): boolean;
+  defer(record: ClaimedAmrTerminalReport, nextAttemptAt: number, code: string, message: string): boolean;
+  fail(record: ClaimedAmrTerminalReport, code: string, message: string): boolean;
+  diagnostics(now?: number): AmrTerminalReportDiagnostics;
 }
 
 export interface AmrTerminalReportRun {
@@ -48,48 +60,371 @@ export function isBillingTerminalAmrRun(
     && run.errorCode !== 'AMR_INSUFFICIENT_BALANCE';
 }
 
-export function migrateAmrTerminalReportOutbox(db: SqliteDb): void {
+function hasColumn(db: Database.Database, name: string): boolean {
+  return (db.prepare('PRAGMA table_info(amr_terminal_report_outbox)').all() as Array<{ name: string }>)
+    .some((column) => column.name === name);
+}
+
+/** Upgrade both fresh databases and the three-column table shipped by #7392. */
+export function migrateAmrTerminalReportOutbox(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS amr_terminal_report_outbox (
       run_id TEXT PRIMARY KEY,
       outcome TEXT NOT NULL CHECK (outcome IN ('failed', 'canceled')),
       terminal_at INTEGER NOT NULL
     );
-
+  `);
+  const additions: Array<[string, string]> = [
+    ['terminal_at_iso', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN terminal_at_iso TEXT'],
+    ['state', "ALTER TABLE amr_terminal_report_outbox ADD COLUMN state TEXT NOT NULL DEFAULT 'pending'"],
+    ['attempt_count', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0'],
+    ['next_attempt_at', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN next_attempt_at INTEGER NOT NULL DEFAULT 0'],
+    ['version', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN version INTEGER NOT NULL DEFAULT 0'],
+    ['lease_until', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN lease_until INTEGER'],
+    ['last_error_code', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN last_error_code TEXT'],
+    ['last_error', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN last_error TEXT'],
+    ['receipt', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN receipt TEXT'],
+    ['created_at', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN created_at INTEGER NOT NULL DEFAULT 0'],
+    ['updated_at', 'ALTER TABLE amr_terminal_report_outbox ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0'],
+  ];
+  for (const [name, statement] of additions) {
+    if (!hasColumn(db, name)) db.exec(statement);
+  }
+  const missingIso = db.prepare(`
+    SELECT run_id AS runId, terminal_at AS terminalAt
+      FROM amr_terminal_report_outbox
+     WHERE terminal_at_iso IS NULL OR terminal_at_iso = ''
+  `).all() as Array<{ runId: string; terminalAt: number }>;
+  const backfill = db.prepare(`
+    UPDATE amr_terminal_report_outbox
+       SET terminal_at_iso = ?,
+           next_attempt_at = CASE WHEN next_attempt_at = 0 THEN terminal_at ELSE next_attempt_at END,
+           created_at = CASE WHEN created_at = 0 THEN terminal_at ELSE created_at END,
+           updated_at = CASE WHEN updated_at = 0 THEN terminal_at ELSE updated_at END
+     WHERE run_id = ?
+  `);
+  const transaction = db.transaction(() => {
+    for (const row of missingIso) backfill.run(new Date(row.terminalAt).toISOString(), row.runId);
+  });
+  transaction();
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_amr_terminal_report_outbox_due
+      ON amr_terminal_report_outbox(state, next_attempt_at, lease_until, run_id);
     CREATE INDEX IF NOT EXISTS idx_amr_terminal_report_outbox_terminal_at
       ON amr_terminal_report_outbox(terminal_at, run_id);
   `);
 }
 
+const bounded = (value: string, limit: number): string => value.replace(/[\r\n\t]+/gu, ' ').slice(0, limit);
+
+const STORED_ERROR_CODES = new Set([
+  'auth_required',
+  'forbidden',
+  'http_error',
+  'invalid_input',
+  'invalid_receipt',
+  'non_retryable',
+  'rate_limited',
+  'retryable',
+  'server_error',
+  'timeout',
+  'transport',
+  'unsupported',
+  'user_banned',
+]);
+
+function safeErrorCode(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return /^[a-z][a-z0-9_]{0,63}$/u.test(normalized) && STORED_ERROR_CODES.has(normalized)
+    ? normalized
+    : 'transport';
+}
+
+function safeEvidence(value: string, limit: number): string {
+  return bounded(redactSecrets(value), limit);
+}
+
 export function createAmrTerminalReportOutboxStore(
-  db: SqliteDb,
+  db: Database.Database,
+  now: () => number = Date.now,
 ): AmrTerminalReportOutboxStore {
   const enqueueRow = db.prepare(`
-    INSERT INTO amr_terminal_report_outbox (run_id, outcome, terminal_at)
-    VALUES (?, ?, ?)
+    INSERT INTO amr_terminal_report_outbox
+      (run_id, outcome, terminal_at, terminal_at_iso, state, attempt_count,
+       next_attempt_at, version, lease_until, created_at, updated_at)
+    VALUES (?, ?, ?, ?, 'pending', 0, ?, 0, NULL, ?, ?)
     ON CONFLICT(run_id) DO NOTHING
   `);
   const listRows = db.prepare(`
     SELECT run_id AS runId, outcome, terminal_at AS terminalAt
       FROM amr_terminal_report_outbox
+     WHERE state = 'pending'
      ORDER BY terminal_at ASC, run_id ASC
   `);
+  const dueRows = db.prepare(`
+    SELECT run_id AS runId, outcome, terminal_at AS terminalAt,
+           terminal_at_iso AS terminalAtIso, attempt_count AS attemptCount, version
+      FROM amr_terminal_report_outbox
+     WHERE state = 'pending' AND next_attempt_at <= ?
+       AND (lease_until IS NULL OR lease_until <= ?)
+     ORDER BY next_attempt_at ASC, created_at ASC, run_id ASC
+     LIMIT ?
+  `);
+  const claimRow = db.prepare(`
+    UPDATE amr_terminal_report_outbox
+       SET attempt_count = attempt_count + 1, version = version + 1,
+           lease_until = ?, updated_at = ?
+     WHERE run_id = ? AND state = 'pending' AND version = ?
+       AND next_attempt_at <= ? AND (lease_until IS NULL OR lease_until <= ?)
+  `);
+  const deliverRow = db.prepare(`
+    UPDATE amr_terminal_report_outbox
+       SET state = 'delivered', receipt = ?, lease_until = NULL,
+           last_error_code = NULL, last_error = NULL, updated_at = ?
+     WHERE run_id = ? AND state = 'pending' AND version = ?
+  `);
+  const deferRow = db.prepare(`
+    UPDATE amr_terminal_report_outbox
+       SET next_attempt_at = ?, lease_until = NULL, last_error_code = ?,
+           last_error = ?, updated_at = ?
+     WHERE run_id = ? AND state = 'pending' AND version = ?
+  `);
+  const failRow = db.prepare(`
+    UPDATE amr_terminal_report_outbox
+       SET state = 'terminal_failed', lease_until = NULL, last_error_code = ?,
+           last_error = ?, updated_at = ?
+     WHERE run_id = ? AND state = 'pending' AND version = ?
+  `);
+  const claimTransaction = db.transaction((timestamp: number, leaseMs: number, limit: number) => {
+    const rows = dueRows.all(timestamp, timestamp, limit) as ClaimedAmrTerminalReport[];
+    const claimed: ClaimedAmrTerminalReport[] = [];
+    for (const row of rows) {
+      if (claimRow.run(timestamp + leaseMs, timestamp, row.runId, row.version, timestamp, timestamp).changes > 0) {
+        claimed.push({ ...row, attemptCount: row.attemptCount + 1, version: row.version + 1 });
+      }
+    }
+    return claimed;
+  });
 
   return {
     enqueue(report) {
-      enqueueRow.run(report.runId, report.outcome, report.terminalAt);
+      const timestamp = now();
+      const terminalAtIso = new Date(report.terminalAt).toISOString();
+      enqueueRow.run(report.runId, report.outcome, report.terminalAt, terminalAtIso, timestamp, timestamp, timestamp);
     },
-    listPending() {
-      return listRows.all() as PendingAmrTerminalReport[];
+    listPending: () => listRows.all() as PendingAmrTerminalReport[],
+    claimDue(timestamp, leaseMs, limit = 32) {
+      return claimTransaction(timestamp, Math.max(1, leaseMs), Math.max(1, Math.floor(limit)));
+    },
+    deliver(record, receipt) {
+      return deliverRow.run(safeEvidence(receipt, 2048), now(), record.runId, record.version).changes > 0;
+    },
+    defer(record, nextAttemptAt, code, message) {
+      return deferRow.run(nextAttemptAt, safeErrorCode(code), safeEvidence(message, 512), now(), record.runId, record.version).changes > 0;
+    },
+    fail(record, code, message) {
+      return failRow.run(safeErrorCode(code), safeEvidence(message, 512), now(), record.runId, record.version).changes > 0;
+    },
+    diagnostics(timestamp = now()) {
+      const counts = db.prepare(`
+        SELECT
+          SUM(CASE WHEN state = 'pending' THEN 1 ELSE 0 END) AS pending,
+          SUM(CASE WHEN state = 'delivered' THEN 1 ELSE 0 END) AS delivered,
+          SUM(CASE WHEN state = 'terminal_failed' AND last_error_code = 'unsupported' THEN 1 ELSE 0 END) AS unsupported,
+          SUM(CASE WHEN state = 'terminal_failed' AND last_error_code != 'unsupported' THEN 1 ELSE 0 END) AS terminalFailed,
+          MIN(CASE WHEN state = 'pending' THEN created_at END) AS oldestPendingAt
+        FROM amr_terminal_report_outbox
+      `).get() as { pending: number | null; delivered: number | null; unsupported: number | null; terminalFailed: number | null; oldestPendingAt: number | null };
+      return {
+        pending: Number(counts.pending ?? 0),
+        delivered: Number(counts.delivered ?? 0),
+        unsupported: Number(counts.unsupported ?? 0),
+        terminalFailed: Number(counts.terminalFailed ?? 0),
+        oldestPendingAgeMs: counts.oldestPendingAt == null ? null : Math.max(0, timestamp - Number(counts.oldestPendingAt)),
+      };
     },
   };
 }
 
-/**
- * Run-service terminal callback. It has no delivery dependency: finalization
- * synchronously persists only billing-terminal local handoffs before the
- * terminal SSE event is published.
- */
+export interface AmrTerminalReportDeliveryService {
+  start(): void;
+  stop(): void;
+  processDue(): Promise<void>;
+}
+
+interface DeliveryFailure {
+  terminal: boolean;
+  code: string;
+  message: string;
+}
+
+function jsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(text) as unknown;
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : null;
+  } catch { return null; }
+}
+
+function stableEnvelopeCode(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z][a-z0-9_]{0,63}$/u.test(normalized)) return null;
+  if (normalized === 'unknown_command') return 'unsupported';
+  if (normalized === 'unauthenticated') return 'auth_required';
+  return STORED_ERROR_CODES.has(normalized) ? normalized : null;
+}
+
+function classifiedCode(code: unknown, message: string): string | null {
+  const stable = stableEnvelopeCode(code);
+  if (stable) return stable;
+  if (classifyAmrAccountFailure(message)?.code === 'AMR_AUTH_REQUIRED') return 'auth_required';
+  const normalized = message.toLowerCase();
+  if (normalized.includes('unknown command') || normalized.includes('unsupported')) return 'unsupported';
+  if (normalized.includes('user_banned') || normalized.includes('user banned')) return 'user_banned';
+  if (normalized.includes('invalid_input') || normalized.includes('invalid input')) return 'invalid_input';
+  if (normalized === 'forbidden' || normalized.includes('access denied')) return 'forbidden';
+  return null;
+}
+
+function failureFrom(error: unknown): DeliveryFailure {
+  const output = velaCommandStdout(error).trim();
+  const envelope = jsonObject(output);
+  const detail = envelope?.error;
+  const detailObject = detail !== null && typeof detail === 'object' && !Array.isArray(detail)
+    ? detail as Record<string, unknown>
+    : null;
+  const message = String(
+    detailObject?.message
+      ?? (typeof detail === 'string' ? detail : envelope?.message)
+      ?? (error instanceof Error ? error.message : 'Vela terminal delivery failed'),
+  );
+  const retryable = typeof detailObject?.retryable === 'boolean'
+    ? detailObject.retryable
+    : typeof envelope?.retryable === 'boolean'
+      ? envelope.retryable
+      : null;
+  const code = classifiedCode(detailObject?.code ?? envelope?.code ?? detail, message);
+  if (retryable !== null) {
+    return {
+      terminal: !retryable,
+      code: code ?? (retryable ? 'retryable' : 'non_retryable'),
+      message,
+    };
+  }
+  const deterministic = code === 'unsupported'
+    || code === 'auth_required'
+    || code === 'forbidden'
+    || code === 'user_banned'
+    || code === 'invalid_input';
+  return { terminal: deterministic, code: code ?? 'transport', message };
+}
+
+function canonicalReceipt(
+  record: ClaimedAmrTerminalReport,
+  stdout: string,
+): string | null {
+  const receipt = jsonObject(stdout.trim());
+  if (
+    receipt?.runId !== record.runId
+    || receipt.outcome !== record.outcome
+    || receipt.terminalAt !== record.terminalAtIso
+  ) return null;
+  return JSON.stringify({
+    runId: record.runId,
+    outcome: record.outcome,
+    terminalAt: record.terminalAtIso,
+    ...(typeof receipt.replay === 'boolean' ? { replay: receipt.replay } : {}),
+  });
+}
+
+export function createAmrTerminalReportDeliveryService(input: {
+  store: AmrTerminalReportOutboxStore;
+  run?: (args: string[], options?: VelaCommandOptions) => Promise<string>;
+  now?: () => number;
+  pollIntervalMs?: number;
+  leaseMs?: number;
+  timeoutMs?: number;
+  baseBackoffMs?: number;
+  maxBackoffMs?: number;
+}): AmrTerminalReportDeliveryService {
+  const run = input.run ?? runVelaCommand;
+  const now = input.now ?? Date.now;
+  const pollIntervalMs = input.pollIntervalMs ?? 5_000;
+  const leaseMs = input.leaseMs ?? 60_000;
+  const timeoutMs = input.timeoutMs ?? 30_000;
+  const baseBackoffMs = input.baseBackoffMs ?? 1_000;
+  const maxBackoffMs = input.maxBackoffMs ?? 60 * 60_000;
+  let stopped = true;
+  let active: Promise<void> | null = null;
+  let timer: NodeJS.Timeout | null = null;
+  let controller = new AbortController();
+
+  const schedule = (): void => {
+    if (stopped || timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void processDue().finally(schedule);
+    }, Math.max(1, pollIntervalMs));
+    timer.unref();
+  };
+  const processDue = async (): Promise<void> => {
+    if (active) return active;
+    active = (async () => {
+      // Claim one row at a time so a later row never waits behind enough
+      // commands for its lease to expire before delivery begins. Continue the
+      // startup sweep until no due row remains.
+      while (true) {
+        if (stopped && controller.signal.aborted) break;
+        const [record] = input.store.claimDue(now(), leaseMs, 1);
+        if (!record) break;
+        const args = ['run', 'terminal', '--run-id', record.runId, '--outcome', record.outcome, '--terminal-at', record.terminalAtIso, '--json'];
+        try {
+          const receipt = await run(args, {
+            configuredEnv: { VELA_INVOCATION_SOURCE: 'open-design' },
+            timeoutMs,
+            maxBuffer: 64 * 1024,
+            signal: controller.signal,
+          });
+          const storedReceipt = canonicalReceipt(record, receipt);
+          if (storedReceipt) {
+            input.store.deliver(record, storedReceipt);
+          } else {
+            input.store.fail(record, 'invalid_receipt', 'Vela returned a malformed or mismatched terminal receipt');
+          }
+        } catch (error) {
+          const failure = failureFrom(error);
+          if (failure.terminal) input.store.fail(record, failure.code, failure.message);
+          else {
+            const exponent = Math.max(0, Math.min(30, record.attemptCount - 1));
+            const delay = Math.min(maxBackoffMs, baseBackoffMs * (2 ** exponent));
+            input.store.defer(record, now() + delay, failure.code, failure.message);
+          }
+          console.warn(`[od] amr_terminal_delivery runId=${record.runId} outcome=${record.outcome} attempt=${record.attemptCount} code=${safeErrorCode(failure.code)}`);
+        }
+      }
+    })().finally(() => { active = null; });
+    return active;
+  };
+  return {
+    start() {
+      if (!stopped) return;
+      stopped = false;
+      if (controller.signal.aborted) controller = new AbortController();
+      void processDue().finally(schedule);
+    },
+    stop() {
+      stopped = true;
+      controller.abort(new Error('AMR terminal delivery stopped'));
+      if (timer) clearTimeout(timer);
+      timer = null;
+    },
+    processDue,
+  };
+}
+
+/** Run finalization persists only; remote delivery remains background work. */
 export function createAmrTerminalReportFinalizer(
   outbox: AmrTerminalReportOutboxStore,
 ): (run: AmrTerminalReportRun, status: string, terminalAt: number) => void {

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -452,9 +452,51 @@ export function createAmrTerminalReportDeliveryService(input: {
 /** Run finalization persists only; remote delivery remains background work. */
 export function createAmrTerminalReportFinalizer(
   outbox: AmrTerminalReportOutboxStore,
+  options: { baseRetryMs?: number; maxRetryMs?: number } = {},
 ): (run: AmrTerminalReportRun, status: string, terminalAt: number) => void {
+  const baseRetryMs = Math.max(1, options.baseRetryMs ?? 1_000);
+  const maxRetryMs = Math.max(baseRetryMs, options.maxRetryMs ?? 60_000);
+  const pending = new Map<string, {
+    report: PendingAmrTerminalReport;
+    attemptCount: number;
+    timer: NodeJS.Timeout | null;
+  }>();
+
+  const scheduleRetry = (runId: string): void => {
+    const entry = pending.get(runId);
+    if (!entry || entry.timer) return;
+    const exponent = Math.max(0, Math.min(30, entry.attemptCount - 1));
+    const delay = Math.min(maxRetryMs, baseRetryMs * (2 ** exponent));
+    entry.timer = setTimeout(() => {
+      entry.timer = null;
+      try {
+        outbox.enqueue(entry.report);
+        pending.delete(runId);
+      } catch {
+        entry.attemptCount += 1;
+        console.warn(
+          `[od] amr_terminal_enqueue_retry runId=${runId} attempt=${entry.attemptCount} code=local_storage`,
+        );
+        scheduleRetry(runId);
+      }
+    }, delay);
+    entry.timer.unref();
+  };
+
   return (run, status, terminalAt) => {
     if (!isBillingTerminalAmrRun(run, status)) return;
-    outbox.enqueue({ runId: run.id, outcome: status, terminalAt });
+    if (pending.has(run.id)) return;
+    const report: PendingAmrTerminalReport = {
+      runId: run.id,
+      outcome: status,
+      terminalAt,
+    };
+    try {
+      outbox.enqueue(report);
+    } catch (error) {
+      pending.set(run.id, { report, attemptCount: 1, timer: null });
+      scheduleRetry(run.id);
+      throw error;
+    }
   };
 }

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -1,0 +1,100 @@
+// Durable local handoff for AMR terminal outcomes. Delivery is intentionally
+// deferred to the separately owned runner; this store only preserves the first
+// terminal outcome so a late child callback cannot rewrite what will be sent.
+
+interface SqliteRunResult {
+  changes: number;
+}
+
+interface SqliteStatement {
+  run(...values: unknown[]): SqliteRunResult;
+  all(...values: unknown[]): unknown[];
+}
+
+interface SqliteDb {
+  exec(sql: string): void;
+  prepare(sql: string): SqliteStatement;
+}
+
+export type AmrTerminalReportOutcome = 'failed' | 'canceled';
+
+export interface PendingAmrTerminalReport {
+  runId: string;
+  outcome: AmrTerminalReportOutcome;
+  terminalAt: number;
+}
+
+export interface AmrTerminalReportOutboxStore {
+  enqueue(report: PendingAmrTerminalReport): void;
+  listPending(): PendingAmrTerminalReport[];
+}
+
+export interface AmrTerminalReportRun {
+  id: string;
+  agentId?: string | null;
+  errorCode?: string | null;
+  failureAction?: string | null;
+  status?: string | null;
+}
+
+export function isBillingTerminalAmrRun(
+  run: AmrTerminalReportRun,
+  status = run.status,
+): status is AmrTerminalReportOutcome {
+  if (run.agentId !== 'amr') return false;
+  if (status !== 'failed' && status !== 'canceled') return false;
+  if (status === 'canceled') return true;
+  return run.failureAction !== 'recharge'
+    && run.errorCode !== 'AMR_INSUFFICIENT_BALANCE';
+}
+
+export function migrateAmrTerminalReportOutbox(db: SqliteDb): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS amr_terminal_report_outbox (
+      run_id TEXT PRIMARY KEY,
+      outcome TEXT NOT NULL CHECK (outcome IN ('failed', 'canceled')),
+      terminal_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_amr_terminal_report_outbox_terminal_at
+      ON amr_terminal_report_outbox(terminal_at, run_id);
+  `);
+}
+
+export function createAmrTerminalReportOutboxStore(
+  db: SqliteDb,
+): AmrTerminalReportOutboxStore {
+  const enqueueRow = db.prepare(`
+    INSERT INTO amr_terminal_report_outbox (run_id, outcome, terminal_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(run_id) DO NOTHING
+  `);
+  const listRows = db.prepare(`
+    SELECT run_id AS runId, outcome, terminal_at AS terminalAt
+      FROM amr_terminal_report_outbox
+     ORDER BY terminal_at ASC, run_id ASC
+  `);
+
+  return {
+    enqueue(report) {
+      enqueueRow.run(report.runId, report.outcome, report.terminalAt);
+    },
+    listPending() {
+      return listRows.all() as PendingAmrTerminalReport[];
+    },
+  };
+}
+
+/**
+ * Run-service terminal callback. It has no delivery dependency: finalization
+ * synchronously persists only billing-terminal local handoffs before the
+ * terminal SSE event is published.
+ */
+export function createAmrTerminalReportFinalizer(
+  outbox: AmrTerminalReportOutboxStore,
+): (run: AmrTerminalReportRun, status: string, terminalAt: number) => void {
+  return (run, status, terminalAt) => {
+    if (!isBillingTerminalAmrRun(run, status)) return;
+    outbox.enqueue({ runId: run.id, outcome: status, terminalAt });
+  };
+}

--- a/apps/daemon/src/storage/amr-terminal-report-outbox.ts
+++ b/apps/daemon/src/storage/amr-terminal-report-outbox.ts
@@ -23,12 +23,22 @@ export interface ClaimedAmrTerminalReport extends PendingAmrTerminalReport {
   version: number;
 }
 
+export interface AmrTerminalReportDiagnostic {
+  runId: string;
+  outcome: AmrTerminalReportOutcome;
+  state: AmrTerminalReportState;
+  attemptCount: number;
+  terminalAt: string;
+  errorCode: string | null;
+}
+
 export interface AmrTerminalReportDiagnostics {
   pending: number;
   delivered: number;
   unsupported: number;
   terminalFailed: number;
   oldestPendingAgeMs: number | null;
+  reports: AmrTerminalReportDiagnostic[];
 }
 
 export interface AmrTerminalReportOutboxStore {
@@ -195,6 +205,13 @@ export function createAmrTerminalReportOutboxStore(
            last_error = ?, updated_at = ?
      WHERE run_id = ? AND state = 'pending' AND version = ?
   `);
+  const diagnosticRows = db.prepare(`
+    SELECT run_id AS runId, outcome, state, attempt_count AS attemptCount,
+           terminal_at_iso AS terminalAt, last_error_code AS errorCode
+      FROM amr_terminal_report_outbox
+     ORDER BY updated_at DESC, run_id ASC
+     LIMIT 50
+  `);
   const claimTransaction = db.transaction((timestamp: number, leaseMs: number, limit: number) => {
     const rows = dueRows.all(timestamp, timestamp, limit) as ClaimedAmrTerminalReport[];
     const claimed: ClaimedAmrTerminalReport[] = [];
@@ -241,6 +258,7 @@ export function createAmrTerminalReportOutboxStore(
         unsupported: Number(counts.unsupported ?? 0),
         terminalFailed: Number(counts.terminalFailed ?? 0),
         oldestPendingAgeMs: counts.oldestPendingAt == null ? null : Math.max(0, timestamp - Number(counts.oldestPendingAt)),
+        reports: diagnosticRows.all() as AmrTerminalReportDiagnostic[],
       };
     },
   };
@@ -342,6 +360,7 @@ function canonicalReceipt(
 export function createAmrTerminalReportDeliveryService(input: {
   store: AmrTerminalReportOutboxStore;
   run?: (args: string[], options?: VelaCommandOptions) => Promise<string>;
+  env?: NodeJS.ProcessEnv;
   now?: () => number;
   pollIntervalMs?: number;
   leaseMs?: number;
@@ -349,7 +368,8 @@ export function createAmrTerminalReportDeliveryService(input: {
   baseBackoffMs?: number;
   maxBackoffMs?: number;
 }): AmrTerminalReportDeliveryService {
-  const run = input.run ?? runVelaCommand;
+  const run = input.run ?? ((args, options) =>
+    runVelaCommand(args, { ...options, env: input.env ?? process.env }));
   const now = input.now ?? Date.now;
   const pollIntervalMs = input.pollIntervalMs ?? 5_000;
   const leaseMs = input.leaseMs ?? 60_000;

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -638,7 +638,7 @@ if (argv[2] === 'run' && argv[3] === 'terminal') {
     stdout.write(`${JSON.stringify(failures[mode])}\n`);
     exit(1);
   }
-  stdout.write(`${JSON.stringify({ runId, outcome, terminalAt, replay: mode === 'replay' })}\n`);
+  stdout.write(`${JSON.stringify({ runId, outcome, terminalAt, recorded: mode !== 'replay' })}\n`);
   exit(0);
 }
 

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -16,6 +16,9 @@
  *                                         login route only care that the
  *                                         config file appears.
  *
+ *   `vela run terminal ... --json`      → emits a terminal receipt or a stable
+ *                                         JSON error envelope.
+ *
  *   `vela models`                       → prints production-shaped public
  *                                         model ids from the Vela catalog.
  *
@@ -32,6 +35,9 @@
  *                            { stopReason: 'end_turn', usage }
  *
  * Behaviour can be tweaked through env vars set by the test:
+ *   FAKE_VELA_TERMINAL_MODE       – success, replay, transient, unsupported,
+ *                                   auth, forbidden, or invalid
+ *   FAKE_VELA_TERMINAL_LOG        – optional JSONL argv/environment log
  *   FAKE_VELA_SESSION_ID         – session id returned by session/new
  *   FAKE_VELA_TEXT               – assistant text streamed back to the host
  *   FAKE_VELA_THOUGHT            – optional thought chunk streamed before text
@@ -602,6 +608,38 @@ function loginAndExit() {
   stdout.write('Code: FAKE-CODE\n');
   if (delayMs > 0) setTimeout(finish, delayMs);
   else finish();
+}
+
+// `vela run terminal`: idempotent AMR terminal report fixture. It logs no
+// secrets and returns the same receipt fields the delivery worker validates.
+if (argv[2] === 'run' && argv[3] === 'terminal') {
+  const flag = (name) => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] : undefined;
+  };
+  const runId = flag('--run-id');
+  const outcome = flag('--outcome');
+  const terminalAt = flag('--terminal-at');
+  if (env.FAKE_VELA_TERMINAL_LOG) {
+    appendFileSync(env.FAKE_VELA_TERMINAL_LOG, `${JSON.stringify({
+      args: argv.slice(2),
+      invocationSource: env.VELA_INVOCATION_SOURCE || null,
+    })}\n`);
+  }
+  const mode = env.FAKE_VELA_TERMINAL_MODE || 'success';
+  const failures = {
+    transient: { error: 'server_error', retryable: true },
+    unsupported: { error: 'unsupported', retryable: false },
+    auth: { error: 'auth_required', retryable: false },
+    forbidden: { error: 'forbidden', retryable: false },
+    invalid: { error: 'invalid_input', retryable: false },
+  };
+  if (failures[mode]) {
+    stdout.write(`${JSON.stringify(failures[mode])}\n`);
+    exit(1);
+  }
+  stdout.write(`${JSON.stringify({ runId, outcome, terminalAt, replay: mode === 'replay' })}\n`);
+  exit(0);
 }
 
 // `vela --version`: the daemon's executable-resolution probe (def.versionArgs)

--- a/apps/daemon/tests/integrations/vela-terminal-command.test.ts
+++ b/apps/daemon/tests/integrations/vela-terminal-command.test.ts
@@ -2,11 +2,17 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
 
 import {
   runVelaCommand,
   velaCommandStdout,
 } from '../../src/integrations/vela-command.js';
+import {
+  createAmrTerminalReportDeliveryService,
+  createAmrTerminalReportOutboxStore,
+  migrateAmrTerminalReportOutbox,
+} from '../../src/storage/amr-terminal-report-outbox.js';
 
 const fakeVela = path.resolve('tests/fixtures/fake-vela.mjs');
 let tempDir: string | null = null;
@@ -59,5 +65,53 @@ describe('canonical Vela terminal command integration', () => {
       error: 'unsupported',
       retryable: false,
     });
+  });
+
+  it('uses the settings-backed Vela binary from the resolved daemon data root', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-vela-terminal-settings-'));
+    const logPath = path.join(tempDir, 'terminal.jsonl');
+    fs.writeFileSync(
+      path.join(tempDir, 'app-config.json'),
+      JSON.stringify({
+        agentCliEnv: {
+          amr: {
+            VELA_BIN: fakeVela,
+            FAKE_VELA_TERMINAL_LOG: logPath,
+          },
+        },
+      }),
+    );
+    const db = new Database(':memory:');
+    try {
+      migrateAmrTerminalReportOutbox(db);
+      const store = createAmrTerminalReportOutboxStore(db);
+      const terminalAt = Date.parse('2026-08-05T02:03:04.567Z');
+      store.enqueue({ runId: 'settings-run', outcome: 'failed', terminalAt });
+      const service = createAmrTerminalReportDeliveryService({
+        store,
+        env: {
+          ...process.env,
+          OD_DATA_DIR: tempDir,
+          FAKE_VELA_TERMINAL_LOG: logPath,
+        },
+      });
+
+      await service.processDue();
+
+      expect(store.diagnostics()).toMatchObject({ pending: 0, delivered: 1 });
+      const log = JSON.parse(fs.readFileSync(logPath, 'utf8').trim()) as {
+        args: string[];
+        invocationSource: string;
+      };
+      expect(log).toEqual({
+        args: [
+          'run', 'terminal', '--run-id', 'settings-run', '--outcome', 'failed',
+          '--terminal-at', '2026-08-05T02:03:04.567Z', '--json',
+        ],
+        invocationSource: 'open-design',
+      });
+    } finally {
+      db.close();
+    }
   });
 });

--- a/apps/daemon/tests/integrations/vela-terminal-command.test.ts
+++ b/apps/daemon/tests/integrations/vela-terminal-command.test.ts
@@ -44,7 +44,7 @@ describe('canonical Vela terminal command integration', () => {
     };
 
     await expect(runVelaCommand(args, common)).resolves.toBe(
-      '{"runId":"integration-run","outcome":"failed","terminalAt":"2026-08-05T01:02:03.456Z","replay":false}\n',
+      '{"runId":"integration-run","outcome":"failed","terminalAt":"2026-08-05T01:02:03.456Z","recorded":true}\n',
     );
     const successLog = JSON.parse(fs.readFileSync(logPath, 'utf8').trim()) as {
       args: string[];

--- a/apps/daemon/tests/integrations/vela-terminal-command.test.ts
+++ b/apps/daemon/tests/integrations/vela-terminal-command.test.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  runVelaCommand,
+  velaCommandStdout,
+} from '../../src/integrations/vela-command.js';
+
+const fakeVela = path.resolve('tests/fixtures/fake-vela.mjs');
+let tempDir: string | null = null;
+
+afterEach(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+});
+
+describe('canonical Vela terminal command integration', () => {
+  it('uses the resolved fake binary, exact args/source, and preserves a failure envelope', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-vela-terminal-command-'));
+    const logPath = path.join(tempDir, 'terminal.jsonl');
+    const args = [
+      'run', 'terminal', '--run-id', 'integration-run', '--outcome', 'failed',
+      '--terminal-at', '2026-08-05T01:02:03.456Z', '--json',
+    ];
+    const common = {
+      env: {
+        ...process.env,
+        OD_DATA_DIR: '',
+        FAKE_VELA_TERMINAL_LOG: logPath,
+      },
+      configuredEnv: {
+        VELA_BIN: fakeVela,
+        VELA_INVOCATION_SOURCE: 'open-design',
+      },
+      maxBuffer: 64 * 1024,
+    };
+
+    await expect(runVelaCommand(args, common)).resolves.toBe(
+      '{"runId":"integration-run","outcome":"failed","terminalAt":"2026-08-05T01:02:03.456Z","replay":false}\n',
+    );
+    const successLog = JSON.parse(fs.readFileSync(logPath, 'utf8').trim()) as {
+      args: string[];
+      invocationSource: string;
+    };
+    expect(successLog).toEqual({ args, invocationSource: 'open-design' });
+
+    let failure: unknown;
+    try {
+      await runVelaCommand(args, {
+        ...common,
+        env: { ...common.env, FAKE_VELA_TERMINAL_MODE: 'unsupported' },
+      });
+    } catch (error) {
+      failure = error;
+    }
+    expect(JSON.parse(velaCommandStdout(failure))).toEqual({
+      error: 'unsupported',
+      retryable: false,
+    });
+  });
+});

--- a/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
@@ -19,6 +19,7 @@ const createRuns = (options: Record<string, unknown>): any =>
 let tempDir: string | null = null;
 
 afterEach(() => {
+  vi.useRealTimers();
   closeDatabase();
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   tempDir = null;
@@ -83,6 +84,124 @@ describe('AMR terminal report delivery', () => {
         errorCode: null,
       }],
     });
+  });
+
+  it('contains an initial background claim failure and succeeds on the next poll', async () => {
+    vi.useFakeTimers();
+    const { db, store, now } = fixture();
+    vi.setSystemTime(now);
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    store.enqueue({ runId: 'initial-claim-storage-run', outcome: 'failed', terminalAt: now });
+    const run = vi.fn(async (args: string[]) => JSON.stringify({
+      runId: args[3], outcome: args[5], terminalAt: args[7], recorded: true,
+    }));
+    const service = createAmrTerminalReportDeliveryService({
+      store, run, now: () => now, pollIntervalMs: 1_000,
+    });
+    db.pragma('busy_timeout = 0');
+    const blocker = new Database(db.name);
+    blocker.exec('BEGIN IMMEDIATE');
+    try {
+      service.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(run).not.toHaveBeenCalled();
+      expect(warning).toHaveBeenCalledWith(
+        '[od] amr_terminal_delivery_storage stage=claim runId=none code=local_storage',
+      );
+      blocker.exec('ROLLBACK');
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(run).toHaveBeenCalledOnce();
+      expect(store.diagnostics(now)).toMatchObject({ pending: 0, delivered: 1 });
+    } finally {
+      if (blocker.inTransaction) blocker.exec('ROLLBACK');
+      blocker.close();
+      service.stop();
+    }
+  });
+
+  it('contains a timed background claim failure and keeps polling after recovery', async () => {
+    vi.useFakeTimers();
+    const { db, store, now } = fixture();
+    vi.setSystemTime(now);
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const run = vi.fn(async (args: string[]) => JSON.stringify({
+      runId: args[3], outcome: args[5], terminalAt: args[7], recorded: true,
+    }));
+    const service = createAmrTerminalReportDeliveryService({
+      store, run, now: () => now, pollIntervalMs: 1_000,
+    });
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+    store.enqueue({ runId: 'timed-claim-storage-run', outcome: 'failed', terminalAt: now });
+    db.pragma('busy_timeout = 0');
+    const blocker = new Database(db.name);
+    blocker.exec('BEGIN IMMEDIATE');
+    try {
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(run).not.toHaveBeenCalled();
+      expect(warning).toHaveBeenCalledWith(
+        '[od] amr_terminal_delivery_storage stage=claim runId=none code=local_storage',
+      );
+      blocker.exec('ROLLBACK');
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(run).toHaveBeenCalledOnce();
+      expect(store.diagnostics(now)).toMatchObject({ pending: 0, delivered: 1 });
+    } finally {
+      if (blocker.inTransaction) blocker.exec('ROLLBACK');
+      blocker.close();
+      service.stop();
+    }
+  });
+
+  it('contains receipt persistence failure and idempotently replays after lease expiry', async () => {
+    const { db, store, now } = fixture();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let currentTime = now;
+    store.enqueue({ runId: 'receipt-storage-run', outcome: 'canceled', terminalAt: now });
+    let releaseFirstReceipt!: (receipt: string) => void;
+    const firstReceipt = new Promise<string>((resolve) => { releaseFirstReceipt = resolve; });
+    const run = vi.fn()
+      .mockImplementationOnce(() => firstReceipt)
+      .mockImplementationOnce(async (args: string[]) => JSON.stringify({
+        runId: args[3], outcome: args[5], terminalAt: args[7], recorded: false,
+      }));
+    const service = createAmrTerminalReportDeliveryService({
+      store,
+      run,
+      now: () => currentTime,
+      leaseMs: 1_000,
+    });
+    const processing = service.processDue();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce());
+
+    db.pragma('busy_timeout = 0');
+    const blocker = new Database(db.name);
+    blocker.exec('BEGIN IMMEDIATE');
+    try {
+      const firstArgs = run.mock.calls[0]?.[0] as string[];
+      releaseFirstReceipt(JSON.stringify({
+        runId: firstArgs[3],
+        outcome: firstArgs[5],
+        terminalAt: firstArgs[7],
+        recorded: true,
+      }));
+      await expect(processing).resolves.toBeUndefined();
+      expect(warning).toHaveBeenCalledWith(
+        '[od] amr_terminal_delivery_storage stage=persist_result runId=receipt-storage-run code=local_storage',
+      );
+      expect(warning.mock.calls.flat().join(' ')).not.toContain(
+        'amr_terminal_delivery runId=receipt-storage-run',
+      );
+    } finally {
+      blocker.exec('ROLLBACK');
+      blocker.close();
+    }
+
+    currentTime += 1_000;
+    await service.processDue();
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toEqual(run.mock.calls[0]?.[0]);
+    expect(store.diagnostics(currentTime)).toMatchObject({ pending: 0, delivered: 1 });
   });
 
   it('uses the exact canonical Vela command, source environment, and bounded receipt', async () => {

--- a/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
@@ -74,6 +74,14 @@ describe('AMR terminal report delivery', () => {
       unsupported: 0,
       terminalFailed: 0,
       oldestPendingAgeMs: 5_000,
+      reports: [{
+        runId: 'legacy-run',
+        outcome: 'failed',
+        state: 'pending',
+        attemptCount: 1,
+        terminalAt: new Date(now - 5_000).toISOString(),
+        errorCode: null,
+      }],
     });
   });
 
@@ -197,6 +205,33 @@ describe('AMR terminal report delivery', () => {
       store, run: vi.fn().mockRejectedValue(error), now: () => now,
     }).processDue();
     expect(store.diagnostics(now)).toMatchObject({ pending: 1, terminalFailed: 0 });
+  });
+
+  it('returns at most 50 deterministic safe per-Run diagnostics', () => {
+    const { store, now } = fixture();
+    for (let index = 0; index < 55; index += 1) {
+      store.enqueue({
+        runId: `diagnostic-run-${String(index).padStart(2, '0')}`,
+        outcome: index % 2 === 0 ? 'failed' : 'canceled',
+        terminalAt: now + index,
+      });
+    }
+
+    const diagnostics = store.diagnostics(now + 100);
+
+    expect(diagnostics.reports).toHaveLength(50);
+    expect(diagnostics.reports[0]).toEqual({
+      runId: 'diagnostic-run-00',
+      outcome: 'failed',
+      state: 'pending',
+      attemptCount: 0,
+      terminalAt: new Date(now).toISOString(),
+      errorCode: null,
+    });
+    expect(diagnostics.reports.at(-1)?.runId).toBe('diagnostic-run-49');
+    expect(Object.keys(diagnostics.reports[0] ?? {}).sort()).toEqual([
+      'attemptCount', 'errorCode', 'outcome', 'runId', 'state', 'terminalAt',
+    ]);
   });
 
   it('tracks unsupported separately from other terminal failures', async () => {

--- a/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
@@ -1,0 +1,305 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { closeDatabase, openDatabase } from '../../src/db.js';
+import {
+  createAmrTerminalReportDeliveryService,
+  createAmrTerminalReportFinalizer,
+  createAmrTerminalReportOutboxStore,
+} from '../../src/storage/amr-terminal-report-outbox.js';
+import { createChatRunService } from '../../src/runtimes/runs.js';
+import type { VelaCommandOptions } from '../../src/integrations/vela-command.js';
+
+const createRuns = (options: Record<string, unknown>): any =>
+  createChatRunService(options as never);
+
+let tempDir: string | null = null;
+
+afterEach(() => {
+  closeDatabase();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+  vi.restoreAllMocks();
+});
+
+function fixture(now = 1_800_000_000_000) {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-terminal-delivery-'));
+  const db = openDatabase(tempDir);
+  return { db, store: createAmrTerminalReportOutboxStore(db, () => now), now };
+}
+
+function rejectedEnvelope(error: unknown, retryable: boolean): Error {
+  return Object.assign(new Error('command failed'), {
+    stdout: JSON.stringify({ error, retryable }),
+  });
+}
+
+describe('AMR terminal report delivery', () => {
+  it('upgrades the #7392 row and claims it once with a stable timestamp', () => {
+    const now = 1_800_000_000_000;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-terminal-delivery-'));
+    const dataDir = path.join(tempDir, '.od');
+    fs.mkdirSync(dataDir, { recursive: true });
+    const legacy = new Database(path.join(dataDir, 'app.sqlite'));
+    legacy.exec(`
+      CREATE TABLE amr_terminal_report_outbox (
+        run_id TEXT PRIMARY KEY,
+        outcome TEXT NOT NULL CHECK (outcome IN ('failed', 'canceled')),
+        terminal_at INTEGER NOT NULL
+      )
+    `);
+    legacy.prepare(`
+      INSERT INTO amr_terminal_report_outbox (run_id, outcome, terminal_at)
+      VALUES (?, 'failed', ?)
+    `).run('legacy-run', now - 5_000);
+    legacy.close();
+
+    const reopened = openDatabase(tempDir);
+    const first = createAmrTerminalReportOutboxStore(reopened, () => now);
+    const claimed = first.claimDue(now, 10_000);
+    const second = createAmrTerminalReportOutboxStore(reopened, () => now);
+
+    expect(claimed).toEqual([expect.objectContaining({
+      runId: 'legacy-run',
+      attemptCount: 1,
+      terminalAtIso: new Date(now - 5_000).toISOString(),
+    })]);
+    expect(second.claimDue(now, 10_000)).toEqual([]);
+    expect(first.diagnostics(now)).toEqual({
+      pending: 1,
+      delivered: 0,
+      unsupported: 0,
+      terminalFailed: 0,
+      oldestPendingAgeMs: 5_000,
+    });
+  });
+
+  it('uses the exact canonical Vela command, source environment, and bounded receipt', async () => {
+    const { db, store, now } = fixture();
+    store.enqueue({ runId: 'run-1', outcome: 'canceled', terminalAt: now });
+    const run = vi.fn(async (args: string[]) => JSON.stringify({
+      runId: args[3], outcome: args[5], terminalAt: args[7], replay: false,
+    }));
+    const service = createAmrTerminalReportDeliveryService({ store, run, now: () => now });
+
+    await service.processDue();
+
+    expect(run).toHaveBeenCalledWith([
+      'run', 'terminal', '--run-id', 'run-1', '--outcome', 'canceled',
+      '--terminal-at', new Date(now).toISOString(), '--json',
+    ], expect.objectContaining({
+      configuredEnv: { VELA_INVOCATION_SOURCE: 'open-design' },
+    }));
+    expect(store.diagnostics(now)).toMatchObject({ pending: 0, delivered: 1 });
+    expect(db.prepare('SELECT receipt FROM amr_terminal_report_outbox WHERE run_id = ?').get('run-1'))
+      .toMatchObject({ receipt: expect.stringContaining('"replay":false') });
+  });
+
+  it('persists exponential backoff and resumes unchanged after reconstruction', async () => {
+    const { store, now } = fixture();
+    const terminalAt = now - 123;
+    store.enqueue({ runId: 'retry-run', outcome: 'failed', terminalAt });
+    const transient = vi.fn().mockRejectedValue(new Error('network reset'));
+    await createAmrTerminalReportDeliveryService({
+      store, run: transient, now: () => now, baseBackoffMs: 1_000,
+    }).processDue();
+    expect(store.claimDue(now + 999, 1_000)).toEqual([]);
+
+    closeDatabase();
+    const reopened = openDatabase(tempDir!);
+    const recovered = createAmrTerminalReportOutboxStore(reopened, () => now + 1_000);
+    const run = vi.fn(async (args: string[], _options?: VelaCommandOptions) => JSON.stringify({
+      runId: args[3], outcome: args[5], terminalAt: args[7], replay: true,
+    }));
+    await createAmrTerminalReportDeliveryService({
+      store: recovered, run, now: () => now + 1_000,
+    }).processDue();
+
+    expect(run.mock.calls[0]?.[0]).toEqual([
+      'run', 'terminal', '--run-id', 'retry-run', '--outcome', 'failed',
+      '--terminal-at', new Date(terminalAt).toISOString(), '--json',
+    ]);
+    expect(run.mock.calls[0]?.[1]).toMatchObject({
+      configuredEnv: { VELA_INVOCATION_SOURCE: 'open-design' },
+      maxBuffer: 64 * 1024,
+    });
+    expect(recovered.diagnostics()).toMatchObject({ pending: 0, delivered: 1 });
+  });
+
+  it('never changes the local terminal Run or event when delivery fails', async () => {
+    const { store, now } = fixture();
+    const runs = createRuns({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      onTerminal: createAmrTerminalReportFinalizer(store),
+    });
+    const localRun = runs.create({ agentId: 'amr' });
+    runs.finish(localRun, 'failed', 1, null);
+    const terminalEvent = structuredClone(localRun.events.at(-1));
+
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockRejectedValue(rejectedEnvelope({ code: 'forbidden' }, false)),
+      now: () => now,
+    }).processDue();
+
+    expect(localRun.status).toBe('failed');
+    expect(localRun.events.at(-1)).toEqual(terminalEvent);
+    expect(localRun.events.filter((event: { event: string }) => event.event === 'end')).toHaveLength(1);
+    expect(store.diagnostics(now)).toMatchObject({ pending: 0, terminalFailed: 1 });
+  });
+
+  it('aborts in-flight runner work and leaves the report pending when stopped', async () => {
+    const { store, now } = fixture();
+    store.enqueue({ runId: 'stop-run', outcome: 'failed', terminalAt: now });
+    let observedSignal: AbortSignal | undefined;
+    const run = vi.fn((_args, options) => new Promise<string>((_resolve, reject) => {
+      observedSignal = options?.signal;
+      observedSignal?.addEventListener('abort', () => reject(observedSignal?.reason), { once: true });
+    }));
+    const service = createAmrTerminalReportDeliveryService({ store, run, now: () => now });
+
+    service.start();
+    await vi.waitFor(() => expect(observedSignal).toBeDefined());
+    service.stop();
+    await service.processDue();
+
+    expect(observedSignal?.aborted).toBe(true);
+    expect(store.diagnostics(now)).toMatchObject({ pending: 1, delivered: 0 });
+  });
+
+  it.each([
+    ['canonical top-level false', rejectedEnvelope('server declined', false)],
+    ['nested false', rejectedEnvelope({ code: 'forbidden', message: 'denied', retryable: false }, true)],
+    ['invalid', rejectedEnvelope({ code: 'invalid_input', retryable: false }, true)],
+  ])('stops deterministic failure: %s', async (_name, error) => {
+    const { store, now } = fixture();
+    store.enqueue({ runId: 'terminal-run', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store, run: vi.fn().mockRejectedValue(error), now: () => now,
+    }).processDue();
+    expect(store.diagnostics(now)).toMatchObject({ pending: 0, terminalFailed: 1 });
+    expect(store.claimDue(now + 99_999, 100)).toEqual([]);
+  });
+
+  it.each([
+    rejectedEnvelope('temporary server overload', true),
+    rejectedEnvelope({ code: 'rate_limited', retryable: true }, false),
+    rejectedEnvelope({ code: 'server_error', retryable: true }, false),
+    new Error('spawn uncertainty'),
+  ])('retries canonical or nested transient failure %#', async (error) => {
+    const { store, now } = fixture();
+    store.enqueue({ runId: 'pending-run', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store, run: vi.fn().mockRejectedValue(error), now: () => now,
+    }).processDue();
+    expect(store.diagnostics(now)).toMatchObject({ pending: 1, terminalFailed: 0 });
+  });
+
+  it('tracks unsupported separately from other terminal failures', async () => {
+    const { db, store, now } = fixture();
+    store.enqueue({ runId: 'unsupported-run', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockRejectedValue(rejectedEnvelope('unknown command "terminal"', false)),
+      now: () => now,
+    }).processDue();
+
+    expect(store.diagnostics(now)).toMatchObject({
+      pending: 0,
+      unsupported: 1,
+      terminalFailed: 0,
+    });
+    expect(db.prepare(`SELECT last_error_code AS code FROM amr_terminal_report_outbox`).get())
+      .toEqual({ code: 'unsupported' });
+  });
+
+  it.each([
+    'auth_required',
+    'authentication required',
+    'not authenticated',
+    'not logged in',
+    'login missing',
+    'please sign in again',
+    'sign-in-again',
+    'token has expired',
+    'expired session',
+    'invalid session',
+  ])('terminal-fails established AMR auth signal: %s', async (message) => {
+    const { db, store, now } = fixture();
+    store.enqueue({ runId: 'auth-run', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockRejectedValue(new Error(message)),
+      now: () => now,
+    }).processDue();
+    expect(store.diagnostics(now)).toMatchObject({ pending: 0, terminalFailed: 1 });
+    expect(db.prepare(`SELECT last_error_code AS code FROM amr_terminal_report_outbox`).get())
+      .toEqual({ code: 'auth_required' });
+  });
+
+  it('stores only safe codes, redacted errors, and canonical receipt fields', async () => {
+    const { db, store, now } = fixture();
+    const secret = 'sk-proj-abcdefghijklmnopqrstuvwxyz1234567890';
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    store.enqueue({ runId: 'secret-error', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockRejectedValue(rejectedEnvelope({
+        code: `arbitrary-${secret}`,
+        message: `Authorization: Bearer ${secret}`,
+        retryable: false,
+      }, true)),
+      now: () => now,
+    }).processDue();
+    const failed = db.prepare(`
+      SELECT last_error_code AS code, last_error AS error
+        FROM amr_terminal_report_outbox WHERE run_id = 'secret-error'
+    `).get() as { code: string; error: string };
+    expect(failed.code).toBe('non_retryable');
+    expect(failed.error).toContain('[REDACTED:');
+    expect(failed.error).not.toContain(secret);
+    expect(JSON.stringify(warning.mock.calls)).not.toContain(secret);
+
+    store.enqueue({ runId: 'secret-receipt', outcome: 'canceled', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockResolvedValue(JSON.stringify({
+        runId: 'secret-receipt',
+        outcome: 'canceled',
+        terminalAt: new Date(now).toISOString(),
+        replay: true,
+        token: secret,
+        raw: { prompt: 'private' },
+      })),
+      now: () => now,
+    }).processDue();
+    const delivered = db.prepare(`
+      SELECT receipt FROM amr_terminal_report_outbox WHERE run_id = 'secret-receipt'
+    `).get() as { receipt: string };
+    expect(JSON.parse(delivered.receipt)).toEqual({
+      runId: 'secret-receipt',
+      outcome: 'canceled',
+      terminalAt: new Date(now).toISOString(),
+      replay: true,
+    });
+    expect(delivered.receipt).not.toContain(secret);
+    expect(delivered.receipt).not.toContain('private');
+  });
+
+  it.each([
+    ['not json'],
+    [JSON.stringify({ runId: 'other', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString() })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'canceled', terminalAt: new Date(1_800_000_000_000).toISOString() })],
+  ])('terminal-fails malformed or mismatched receipt %#', async (receipt) => {
+    const { store, now } = fixture();
+    store.enqueue({ runId: 'receipt-run', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store, run: vi.fn().mockResolvedValue(receipt), now: () => now,
+    }).processDue();
+    expect(store.diagnostics(now)).toMatchObject({ pending: 0, terminalFailed: 1 });
+  });
+});

--- a/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts
@@ -89,7 +89,7 @@ describe('AMR terminal report delivery', () => {
     const { db, store, now } = fixture();
     store.enqueue({ runId: 'run-1', outcome: 'canceled', terminalAt: now });
     const run = vi.fn(async (args: string[]) => JSON.stringify({
-      runId: args[3], outcome: args[5], terminalAt: args[7], replay: false,
+      runId: args[3], outcome: args[5], terminalAt: args[7], recorded: true,
     }));
     const service = createAmrTerminalReportDeliveryService({ store, run, now: () => now });
 
@@ -103,7 +103,7 @@ describe('AMR terminal report delivery', () => {
     }));
     expect(store.diagnostics(now)).toMatchObject({ pending: 0, delivered: 1 });
     expect(db.prepare('SELECT receipt FROM amr_terminal_report_outbox WHERE run_id = ?').get('run-1'))
-      .toMatchObject({ receipt: expect.stringContaining('"replay":false') });
+      .toMatchObject({ receipt: expect.stringContaining('"recorded":true') });
   });
 
   it('persists exponential backoff and resumes unchanged after reconstruction', async () => {
@@ -120,7 +120,7 @@ describe('AMR terminal report delivery', () => {
     const reopened = openDatabase(tempDir!);
     const recovered = createAmrTerminalReportOutboxStore(reopened, () => now + 1_000);
     const run = vi.fn(async (args: string[], _options?: VelaCommandOptions) => JSON.stringify({
-      runId: args[3], outcome: args[5], terminalAt: args[7], replay: true,
+      runId: args[3], outcome: args[5], terminalAt: args[7], recorded: false,
     }));
     await createAmrTerminalReportDeliveryService({
       store: recovered, run, now: () => now + 1_000,
@@ -306,7 +306,7 @@ describe('AMR terminal report delivery', () => {
         runId: 'secret-receipt',
         outcome: 'canceled',
         terminalAt: new Date(now).toISOString(),
-        replay: true,
+        recorded: false,
         token: secret,
         raw: { prompt: 'private' },
       })),
@@ -319,16 +319,51 @@ describe('AMR terminal report delivery', () => {
       runId: 'secret-receipt',
       outcome: 'canceled',
       terminalAt: new Date(now).toISOString(),
-      replay: true,
+      recorded: false,
     });
     expect(delivered.receipt).not.toContain(secret);
     expect(delivered.receipt).not.toContain('private');
   });
 
   it.each([
+    ['2027-01-15T08:00:00.120Z', '2027-01-15T08:00:00.12Z'],
+    ['2027-01-15T08:00:00.100Z', '2027-01-15T08:00:00.1Z'],
+    ['2027-01-15T08:00:00.000Z', '2027-01-15T08:00:00Z'],
+  ])('accepts equivalent Go RFC3339 timestamps: %s -> %s', async (requested, returned) => {
+    const now = Date.parse(requested);
+    const { db, store } = fixture(now);
+    store.enqueue({ runId: 'equivalent-time', outcome: 'failed', terminalAt: now });
+    await createAmrTerminalReportDeliveryService({
+      store,
+      run: vi.fn().mockResolvedValue(JSON.stringify({
+        runId: 'equivalent-time',
+        outcome: 'failed',
+        terminalAt: returned,
+        recorded: true,
+      })),
+      now: () => now,
+    }).processDue();
+
+    expect(store.diagnostics(now)).toMatchObject({ delivered: 1, terminalFailed: 0 });
+    const row = db.prepare(`
+      SELECT receipt FROM amr_terminal_report_outbox WHERE run_id = 'equivalent-time'
+    `).get() as { receipt: string };
+    expect(JSON.parse(row.receipt)).toEqual({
+      runId: 'equivalent-time',
+      outcome: 'failed',
+      terminalAt: new Date(now).toISOString(),
+      recorded: true,
+    });
+  });
+
+  it.each([
     ['not json'],
-    [JSON.stringify({ runId: 'other', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString() })],
-    [JSON.stringify({ runId: 'receipt-run', outcome: 'canceled', terminalAt: new Date(1_800_000_000_000).toISOString() })],
+    [JSON.stringify({ runId: 'other', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString(), recorded: true })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'canceled', terminalAt: new Date(1_800_000_000_000).toISOString(), recorded: true })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString() })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString(), recorded: 'true' })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString(), recorded: 1 })],
+    [JSON.stringify({ runId: 'receipt-run', outcome: 'failed', terminalAt: new Date(1_800_000_000_000).toISOString(), recorded: null })],
   ])('terminal-fails malformed or mismatched receipt %#', async (receipt) => {
     const { store, now } = fixture();
     store.enqueue({ runId: 'receipt-run', outcome: 'failed', terminalAt: now });

--- a/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
@@ -197,6 +197,30 @@ describe("AMR terminal report outbox", () => {
     await expect(wait).resolves.toMatchObject({ status: 'failed' });
   });
 
+  it('persists artifact metadata added by the terminal finalizer before publishing end', () => {
+    const { runs } = createFixture();
+    const run = runs.create({ agentId: 'amr' });
+    run.onFinalize = () => {
+      run.artifactCount = 2;
+      run.artifactPaths = ['artifacts/index.html', 'artifacts/preview.png'];
+    };
+
+    runs.finish(run, 'failed', 1, null);
+
+    expect(run.events.at(-1)).toMatchObject({
+      event: 'end',
+      data: {
+        artifactCount: 2,
+        artifactPaths: ['artifacts/index.html', 'artifacts/preview.png'],
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(run.statePath, 'utf8'))).toMatchObject({
+      status: 'failed',
+      artifactCount: 2,
+      artifactPaths: ['artifacts/index.html', 'artifacts/preview.png'],
+    });
+  });
+
   it('stamps and backfills an AMR Run interrupted by restart with one terminal instant', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-05T04:00:00.000Z'));

--- a/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
@@ -1,0 +1,281 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { closeDatabase, openDatabase } from "../../src/db.js";
+import {
+  createAmrTerminalReportFinalizer,
+  createAmrTerminalReportOutboxStore,
+} from "../../src/storage/amr-terminal-report-outbox.js";
+import { createChatRunService } from "../../src/runtimes/runs.js";
+import { reconcileDurableRunTerminals } from "../../src/runtimes/run-terminal-reconciliation.js";
+
+let tempDir: string | null = null;
+
+afterEach(() => {
+  vi.useRealTimers();
+  closeDatabase();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+});
+
+function createFixture() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-amr-terminal-reports-"));
+  const db = openDatabase(tempDir);
+  const outbox = createAmrTerminalReportOutboxStore(db);
+  const runs = createChatRunService({
+    createSseResponse: () => ({
+      send: vi.fn(),
+      end: vi.fn(),
+      cleanup: vi.fn(),
+    }),
+    createSseErrorPayload: (code: string, message: string) => ({
+      error: { code, message },
+    }),
+    onTerminal: createAmrTerminalReportFinalizer(outbox),
+    runsLogDir: path.join(tempDir, "runs"),
+  });
+  return { db, outbox, runs };
+}
+
+describe("AMR terminal report outbox", () => {
+  it("records failed and stopped AMR Runs once with durable state and terminal event timestamp parity", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T01:02:03.456Z"));
+    const { outbox, runs } = createFixture();
+    const failed = runs.create({ agentId: "amr" });
+
+    runs.finish(failed, "failed", 1, null);
+
+    const failedAt = Date.now();
+    expect(failed.updatedAt).toBe(failedAt);
+    expect(failed.terminalAt).toBe(failedAt);
+    expect(failed.events.at(-1)).toMatchObject({
+      event: "end",
+      timestamp: failedAt,
+      data: { status: "failed", terminalAt: failedAt },
+    });
+    expect(JSON.parse(fs.readFileSync(failed.statePath, "utf8"))).toMatchObject(
+      {
+        status: "failed",
+        updatedAt: failedAt,
+        terminalAt: failedAt,
+      },
+    );
+    expect(outbox.listPending()).toEqual([
+      { runId: failed.id, outcome: "failed", terminalAt: failedAt },
+    ]);
+
+    vi.setSystemTime(new Date("2026-08-05T01:02:04.567Z"));
+    const stopped = runs.create({ agentId: "amr" });
+    await runs.cancel(stopped, "user_stop");
+    const stoppedAt = Date.now();
+
+    expect(stopped.events.at(-1)).toMatchObject({
+      event: "end",
+      timestamp: stoppedAt,
+      data: { status: "canceled", terminalAt: stoppedAt },
+    });
+    expect(outbox.listPending()).toEqual([
+      { runId: failed.id, outcome: "failed", terminalAt: failedAt },
+      { runId: stopped.id, outcome: "canceled", terminalAt: stoppedAt },
+    ]);
+  });
+
+  it("keeps the first AMR terminal report when late terminal callbacks arrive", () => {
+    vi.useFakeTimers();
+    const { outbox, runs } = createFixture();
+    const run = runs.create({ agentId: "amr" });
+    vi.setSystemTime(new Date("2026-08-05T02:00:00.000Z"));
+    runs.finish(run, "failed", 1, null);
+    vi.setSystemTime(new Date("2026-08-05T02:01:00.000Z"));
+    runs.finish(run, "canceled", null, "SIGTERM");
+
+    expect(outbox.listPending()).toEqual([
+      {
+        runId: run.id,
+        outcome: "failed",
+        terminalAt: Date.parse("2026-08-05T02:00:00.000Z"),
+      },
+    ]);
+    expect(
+      run.events.filter((event: { event: string }) => event.event === "end"),
+    ).toHaveLength(1);
+  });
+
+  it("retains pending reports across SQLite store reconstruction", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T03:00:00.000Z"));
+    const { outbox, runs } = createFixture();
+    const run = runs.create({ agentId: "amr" });
+    runs.finish(run, "failed", 1, null);
+    const expected = [
+      { runId: run.id, outcome: "failed", terminalAt: Date.now() },
+    ];
+    expect(outbox.listPending()).toEqual(expected);
+
+    closeDatabase();
+    const reopened = openDatabase(tempDir!);
+    const reopenedOutbox = createAmrTerminalReportOutboxStore(reopened);
+    reopenedOutbox.enqueue({
+      runId: run.id,
+      outcome: 'canceled',
+      terminalAt: Date.now() + 1,
+    });
+    expect(reopenedOutbox.listPending()).toEqual(expected);
+  });
+
+  it("does not enqueue succeeded, non-AMR/BYOK, or SSE-disconnect-only Runs", () => {
+    const { outbox, runs } = createFixture();
+    const succeeded = runs.create({ agentId: "amr" });
+    const nonAmr = runs.create({ agentId: "codex" });
+    const byok = runs.create({ agentId: "byok-opencode" });
+    const disconnected = runs.create({ agentId: "amr" });
+
+    runs.finish(succeeded, "succeeded", 0, null);
+    runs.finish(nonAmr, "failed", 1, null);
+    runs.finish(byok, "canceled", null, "SIGTERM");
+    runs.stream(
+      disconnected,
+      { get: () => null, query: {} } as never,
+      { on: (_event: string, listener: () => void) => listener() } as never,
+    );
+
+    expect(disconnected.status).toBe("queued");
+    expect(outbox.listPending()).toEqual([]);
+  });
+
+  it.each([
+    { field: 'failureAction', value: 'recharge' },
+    { field: 'errorCode', value: 'AMR_INSUFFICIENT_BALANCE' },
+  ] as const)('keeps AMR %s recharge recovery eligible for same-Run continuation', ({ field, value }) => {
+    const { outbox, runs } = createFixture();
+    const run = runs.create({ agentId: 'amr' });
+    run[field] = value;
+    runs.finish(run, 'failed', 1, null);
+
+    expect(outbox.listPending()).toEqual([]);
+    expect(runs.prepareRestart(run)).toBe(run);
+  });
+
+  it('reports ordinary AMR failures and cancellation even with stale recharge classification', () => {
+    const { outbox, runs } = createFixture();
+    const ordinary = runs.create({ agentId: 'amr' });
+    const canceled = runs.create({ agentId: 'amr' });
+    canceled.failureAction = 'recharge';
+    canceled.errorCode = 'AMR_INSUFFICIENT_BALANCE';
+
+    runs.finish(ordinary, 'failed', 1, null);
+    runs.finish(canceled, 'canceled', null, 'SIGTERM');
+
+    expect(outbox.listPending().map(({ outcome }) => outcome).sort()).toEqual(['canceled', 'failed']);
+  });
+
+  it('finishes local terminal cleanup when the bounded outbox callback throws', async () => {
+    const finalizer = vi.fn(() => { throw new Error('SQLite unavailable'); });
+    const runs = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      onTerminal: finalizer,
+    });
+    const run = runs.create({ agentId: 'amr' });
+    const finalized = vi.fn();
+    run.onFinalize = finalized;
+    const wait = runs.wait(run);
+
+    runs.finish(run, 'failed', 1, null);
+
+    expect(finalizer).toHaveBeenCalledOnce();
+    expect(finalized).toHaveBeenCalledOnce();
+    expect(run.events.filter((event: { event: string }) => event.event === 'end')).toHaveLength(1);
+    await expect(wait).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('stamps and backfills an AMR Run interrupted by restart with one terminal instant', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-05T04:00:00.000Z'));
+    const { outbox, runs } = createFixture();
+    const active = runs.create({ agentId: 'amr' });
+    active.status = 'running';
+    runs.persistState(active);
+
+    const restarted = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      onTerminal: createAmrTerminalReportFinalizer(outbox),
+      runsLogDir: path.join(tempDir!, 'runs'),
+    });
+    const recovered = restarted.get(active.id);
+    const terminalAt = Date.now();
+
+    expect(recovered).toMatchObject({ status: 'failed', terminalAt });
+    expect(recovered.events.at(-1)).toMatchObject({
+      event: 'end',
+      timestamp: terminalAt,
+      data: { status: 'failed', terminalAt },
+    });
+    expect(JSON.parse(fs.readFileSync(active.statePath, 'utf8'))).toMatchObject({
+      status: 'failed',
+      updatedAt: terminalAt,
+      terminalAt,
+    });
+    expect(outbox.listPending()).toEqual([{ runId: active.id, outcome: 'failed', terminalAt }]);
+  });
+
+  it("backfills an existing terminal AMR state that has no outbox row during startup reconciliation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T05:00:00.000Z"));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-amr-terminal-reports-"));
+    const db = openDatabase(tempDir);
+    const outbox = createAmrTerminalReportOutboxStore(db);
+    const runsLogDir = path.join(tempDir, "runs");
+    const bareRuns = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      runsLogDir,
+    });
+    const run = bareRuns.create({ agentId: "amr" });
+    bareRuns.finish(run, "failed", 1, null);
+    const expected = { runId: run.id, outcome: "failed", terminalAt: run.terminalAt };
+    expect(outbox.listPending()).toEqual([]);
+
+    await reconcileDurableRunTerminals({
+      analytics: { capture: vi.fn() },
+      appVersion: "0.20.3",
+      db,
+      finalizeTerminalLocally: createAmrTerminalReportFinalizer(outbox),
+      reportLangfuse: vi.fn(),
+      runsLogDir,
+    });
+
+    expect(outbox.listPending()).toEqual([expected]);
+  });
+
+  it("backfills a terminal AMR state only when lazy get hydrates it", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-05T06:00:00.000Z"));
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-amr-terminal-reports-"));
+    const db = openDatabase(tempDir);
+    const outbox = createAmrTerminalReportOutboxStore(db);
+    const runsLogDir = path.join(tempDir, "runs");
+    const recoveringRuns = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      onTerminal: createAmrTerminalReportFinalizer(outbox),
+      runsLogDir,
+    });
+    const bareRuns = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      runsLogDir,
+    });
+    const run = bareRuns.create({ agentId: "amr" });
+    bareRuns.finish(run, "failed", 1, null);
+    const expected = { runId: run.id, outcome: "failed", terminalAt: run.terminalAt };
+    expect(outbox.listPending()).toEqual([]);
+
+    expect(recoveringRuns.get(run.id)).toMatchObject({ id: run.id, status: "failed" });
+    expect(outbox.listPending()).toEqual([expected]);
+  });
+});

--- a/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
@@ -2,9 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
 
 import { closeDatabase, openDatabase } from "../../src/db.js";
 import {
+  createAmrTerminalReportDeliveryService,
   createAmrTerminalReportFinalizer,
   createAmrTerminalReportOutboxStore,
 } from "../../src/storage/amr-terminal-report-outbox.js";
@@ -195,6 +197,53 @@ describe("AMR terminal report outbox", () => {
     expect(finalized).toHaveBeenCalledOnce();
     expect(run.events.filter((event: { event: string }) => event.event === 'end')).toHaveLength(1);
     await expect(wait).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('automatically delivers after a transient SQLite enqueue failure', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-05T04:00:00.000Z'));
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { db, outbox, runs } = createFixture();
+    const send = vi.fn(async (args: string[]) => JSON.stringify({
+      runId: args[3],
+      outcome: args[5],
+      terminalAt: args[7],
+      recorded: true,
+    }));
+    const delivery = createAmrTerminalReportDeliveryService({
+      store: outbox,
+      run: send,
+      now: Date.now,
+      pollIntervalMs: 1_000,
+    });
+    delivery.start();
+
+    db.pragma('busy_timeout = 0');
+    const blocker = new Database(db.name);
+    blocker.exec('BEGIN IMMEDIATE');
+    const run = runs.create({ agentId: 'amr' });
+    try {
+      runs.finish(run, 'failed', 1, null);
+      expect(outbox.listPending()).toEqual([]);
+      expect(run.events.at(-1)).toMatchObject({
+        event: 'end',
+        data: { status: 'failed', terminalAt: run.terminalAt },
+      });
+
+      blocker.exec('ROLLBACK');
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(send).toHaveBeenCalledOnce();
+      expect(outbox.diagnostics(Date.now())).toMatchObject({
+        pending: 0,
+        delivered: 1,
+      });
+    } finally {
+      if (blocker.inTransaction) blocker.exec('ROLLBACK');
+      blocker.close();
+      delivery.stop();
+      warning.mockRestore();
+    }
   });
 
   it('persists artifact metadata added by the terminal finalizer before publishing end', () => {

--- a/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
+++ b/apps/daemon/tests/runtimes/amr-terminal-reports.test.ts
@@ -11,6 +11,11 @@ import {
 import { createChatRunService } from "../../src/runtimes/runs.js";
 import { reconcileDurableRunTerminals } from "../../src/runtimes/run-terminal-reconciliation.js";
 
+// runs.ts is intentionally @ts-nocheck and its inferred public factory type is
+// narrower than its runtime options/records. Keep this test adapter local.
+const createRuns = (options: Record<string, unknown>): any =>
+  createChatRunService(options as never);
+
 let tempDir: string | null = null;
 
 afterEach(() => {
@@ -24,7 +29,7 @@ function createFixture() {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-amr-terminal-reports-"));
   const db = openDatabase(tempDir);
   const outbox = createAmrTerminalReportOutboxStore(db);
-  const runs = createChatRunService({
+  const runs = createRuns({
     createSseResponse: () => ({
       send: vi.fn(),
       end: vi.fn(),
@@ -174,7 +179,7 @@ describe("AMR terminal report outbox", () => {
 
   it('finishes local terminal cleanup when the bounded outbox callback throws', async () => {
     const finalizer = vi.fn(() => { throw new Error('SQLite unavailable'); });
-    const runs = createChatRunService({
+    const runs = createRuns({
       createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
       createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
       onTerminal: finalizer,
@@ -200,7 +205,7 @@ describe("AMR terminal report outbox", () => {
     active.status = 'running';
     runs.persistState(active);
 
-    const restarted = createChatRunService({
+    const restarted = createRuns({
       createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
       createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
       onTerminal: createAmrTerminalReportFinalizer(outbox),
@@ -230,7 +235,7 @@ describe("AMR terminal report outbox", () => {
     const db = openDatabase(tempDir);
     const outbox = createAmrTerminalReportOutboxStore(db);
     const runsLogDir = path.join(tempDir, "runs");
-    const bareRuns = createChatRunService({
+    const bareRuns = createRuns({
       createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
       createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
       runsLogDir,
@@ -259,13 +264,13 @@ describe("AMR terminal report outbox", () => {
     const db = openDatabase(tempDir);
     const outbox = createAmrTerminalReportOutboxStore(db);
     const runsLogDir = path.join(tempDir, "runs");
-    const recoveringRuns = createChatRunService({
+    const recoveringRuns = createRuns({
       createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
       createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
       onTerminal: createAmrTerminalReportFinalizer(outbox),
       runsLogDir,
     });
-    const bareRuns = createChatRunService({
+    const bareRuns = createRuns({
       createSseResponse: () => ({ send: vi.fn(), end: vi.fn(), cleanup: vi.fn() }),
       createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
       runsLogDir,

--- a/apps/daemon/tests/version-route.test.ts
+++ b/apps/daemon/tests/version-route.test.ts
@@ -1,5 +1,6 @@
 import type http from 'node:http';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { openDatabase } from '../src/db.js';
 import { startAmrTerminalReportDeliveryAfterBind, startServer } from '../src/server.js';
 
 describe('/api/version', () => {
@@ -93,8 +94,62 @@ describe('/api/version', () => {
     expect(health).toEqual({
       ok: true,
       version: version.version?.version,
-      amrTerminalReporter: { status: 'active' },
+      amrTerminalReporter: {
+        status: 'active',
+        pending: 0,
+        delivered: 0,
+        unsupported: 0,
+        terminalFailed: 0,
+        oldestPendingAgeMs: null,
+      },
     });
+  });
+
+  it('exposes uncached terminal-report aggregate health without per-Run details', async () => {
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required by the daemon test harness');
+    const db = openDatabase(process.cwd(), { dataDir });
+    const now = Date.now();
+    const runIds = [
+      'health-pending-run',
+      'health-delivered-run',
+      'health-unsupported-run',
+      'health-terminal-failed-run',
+    ];
+    const insert = db.prepare(`
+      INSERT INTO amr_terminal_report_outbox (
+        run_id, outcome, terminal_at, terminal_at_iso, state,
+        next_attempt_at, last_error_code, created_at, updated_at
+      ) VALUES (?, 'failed', ?, ?, ?, ?, ?, ?, ?)
+    `);
+    db.transaction(() => {
+      insert.run(runIds[0], now - 10_000, new Date(now - 10_000).toISOString(), 'pending', now + 60_000, null, now - 10_000, now);
+      insert.run(runIds[1], now - 9_000, new Date(now - 9_000).toISOString(), 'delivered', now, null, now - 9_000, now);
+      insert.run(runIds[2], now - 8_000, new Date(now - 8_000).toISOString(), 'terminal_failed', now, 'unsupported', now - 8_000, now);
+      insert.run(runIds[3], now - 7_000, new Date(now - 7_000).toISOString(), 'terminal_failed', now, 'invalid_receipt', now - 7_000, now);
+    })();
+
+    try {
+      const res = await fetch(`${baseUrl}/api/health`);
+      const health = await res.json() as {
+        amrTerminalReporter?: Record<string, unknown>;
+      };
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(health.amrTerminalReporter).toEqual({
+        status: 'active',
+        pending: 1,
+        delivered: 1,
+        unsupported: 1,
+        terminalFailed: 1,
+        oldestPendingAgeMs: expect.any(Number),
+      });
+      expect(health.amrTerminalReporter).not.toHaveProperty('reports');
+      expect(Number(health.amrTerminalReporter?.oldestPendingAgeMs)).toBeGreaterThanOrEqual(10_000);
+    } finally {
+      db.prepare(`DELETE FROM amr_terminal_report_outbox WHERE run_id IN (?, ?, ?, ?)`).run(...runIds);
+    }
   });
 
   it('keeps detailed terminal-report counts on local-authorized diagnostics', async () => {

--- a/apps/daemon/tests/version-route.test.ts
+++ b/apps/daemon/tests/version-route.test.ts
@@ -106,6 +106,7 @@ describe('/api/version', () => {
       unsupported: 0,
       terminalFailed: 0,
       oldestPendingAgeMs: null,
+      reports: [],
     });
 
     const denied = await fetch(`${baseUrl}/api/diagnostics/amr-terminal-reports`, {

--- a/apps/daemon/tests/version-route.test.ts
+++ b/apps/daemon/tests/version-route.test.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { startServer } from '../src/server.js';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { startAmrTerminalReportDeliveryAfterBind, startServer } from '../src/server.js';
 
 describe('/api/version', () => {
   let server: http.Server;
@@ -16,6 +16,15 @@ describe('/api/version', () => {
   });
 
   afterAll(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+  it('starts terminal delivery only after a valid listener bind', () => {
+    const start = vi.fn();
+    expect(startAmrTerminalReportDeliveryAfterBind({ start }, null)).toBe(false);
+    expect(start).not.toHaveBeenCalled();
+
+    expect(startAmrTerminalReportDeliveryAfterBind({ start }, 7456)).toBe(true);
+    expect(start).toHaveBeenCalledOnce();
+  });
 
   it('returns current app version info', async () => {
     const res = await fetch(`${baseUrl}/api/version`);
@@ -81,6 +90,27 @@ describe('/api/version', () => {
 
     expect(healthRes.ok).toBe(true);
     expect(versionRes.ok).toBe(true);
-    expect(health).toEqual({ ok: true, version: version.version?.version });
+    expect(health).toEqual({
+      ok: true,
+      version: version.version?.version,
+      amrTerminalReporter: { status: 'active' },
+    });
+  });
+
+  it('keeps detailed terminal-report counts on local-authorized diagnostics', async () => {
+    const allowed = await fetch(`${baseUrl}/api/diagnostics/amr-terminal-reports`);
+    expect(allowed.status).toBe(200);
+    await expect(allowed.json()).resolves.toEqual({
+      pending: 0,
+      delivered: 0,
+      unsupported: 0,
+      terminalFailed: 0,
+      oldestPendingAgeMs: null,
+    });
+
+    const denied = await fetch(`${baseUrl}/api/diagnostics/amr-terminal-reports`, {
+      headers: { origin: 'https://example.com' },
+    });
+    expect(denied.status).toBe(403);
   });
 });

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -668,6 +668,8 @@ export interface ChatRunStatusResponse {
   status: ChatRunStatus;
   createdAt: number;
   updatedAt: number;
+  /** The immutable instant this Run entered its terminal status, when terminal. */
+  terminalAt?: number | null;
   cancelRequested?: boolean;
   /**
    * Actor or lifecycle path that requested cancellation. Only `user_stop`

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -83,6 +83,8 @@ export interface ChatSseEndPayload {
   code: number | null;
   signal?: string | null;
   status?: 'succeeded' | 'failed' | 'canceled';
+  /** The immutable instant the Run entered its terminal status. */
+  terminalAt?: number;
   /** Authoritative count of artifact files created or modified by this run.
    *  Present when the daemon resolved the run's filesystem/tool-stream diff
    *  before publishing the terminal frame. */


### PR DESCRIPTION
Closes #7392
Closes #7393

Part of #7371. Depends on powerformer/vela#1762.

## Why

Open Design already knows when an AMR Run has failed or been canceled, but that fact was not durably reported to Vela. The UI could show a terminal Run while later same-Run model requests continued to be admitted and charged.

This PR captures one authoritative terminal fact at the Run service seam and delivers it reliably through the user's login-backed Vela CLI without exposing internal credentials.

## What users will see

- failed and canceled Vela-backed AMR Runs stop future model admission after terminal delivery
- local Run finalization remains responsive when Vela is unavailable
- transient delivery failures retry across daemon restarts
- unsupported/auth/input failures become bounded local diagnostics instead of retrying forever
- already-admitted model work remains billable
- a new user turn uses a new Run ID and remains usable

Pre-admission recharge failures (`failureAction=recharge` / `AMR_INSUFFICIENT_BALANCE`) are intentionally excluded because the existing recharge flow safely resumes that same Run ID after funds are restored.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — no UI surface changed.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/amr-terminal-reports.test.ts`
  - `apps/daemon/tests/runtimes/amr-terminal-report-delivery.test.ts`
  - `apps/daemon/tests/integrations/vela-terminal-command.test.ts`
  - `apps/daemon/tests/version-route.test.ts`
- Did the tests go red on `main` and green on this branch? **Yes** — the persistence, restart reconciliation, delivery, and diagnostics contracts do not exist on `main`.
- Local cross-repo validation also exercised the accepted outbox through a source-built real Vela CLI against a named Vela sandbox.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- focused terminal persistence/delivery/runner/diagnostics suites — 46/46 after rebase
- real SQLite migration, first-write-wins, lease/version fencing, backoff, restart recovery, and exception-safe finalization tests
- local named sandbox:
  - pending → canonical runner → source-built Vela CLI → live sandbox API → delivered
  - transient failure → persisted backoff → store reconstruction → real CLI delivery
  - original Run ID, outcome, and terminal timestamp stayed unchanged
- exact-commit reviews: lifecycle, durability, concurrency, privacy, auth taxonomy, and scope all passed

No production provider, publish, deployment, or production mutation was performed. Released-artifact rollout remains tracked by #7394 and Vela #1755.
