### PR TITLE
perf(web): stop the message center re-syncing on every remount

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -143,7 +143,7 @@ import {
   useProjectRouteWorkspaceContext,
 } from './collab/useProjectRouteWorkspaceContext';
 import { resolvePlanTier } from './collab/team-plan';
-import { deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
+import { deriveAccountBucket, deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
 import { CommunityView } from './components/CommunityView';
 import { seedHomeComposerPrompt } from './components/HomeView';
 import {
@@ -1687,6 +1687,7 @@ function AppInner() {
   // snapshot updates `agents`, which makes Settings fetch status again and
   // creates a status -> models -> agents request loop.
   const amrLoginStatusRef = useRef<VelaLoginStatus | null>(null);
+  const amrAccountBucketRef = useRef<string | null>(null);
   const applyAmrLoginStatus = useCallback((
     status: VelaLoginStatus,
     options: { forceModelRefresh?: boolean; restartOnSignIn?: boolean } = {},
@@ -1708,6 +1709,23 @@ function AppInner() {
     // or a status read from before the session ended goes on to restart model
     // polling and repaint the signed-in surfaces.
     if (!noteAuthoritativeAuthMode(isLoggedIn, statusObservationOrder(status))) return;
+    // `loggedIn` says whether there IS an account, not which one. A credential
+    // can move from account A to account B with it true on both sides — a
+    // `vela login` in a terminal does it — and the workspace generation, which
+    // is what every account-scoped cache partitions by, moves on sign-in,
+    // sign-out and a profile switch only. So nothing retired account A's data:
+    // the message centre's settled snapshot, a joinable in-flight run, the
+    // mounted rows and any stale continuation all stayed eligible, and a
+    // remount inside the snapshot window showed A's targeted rows under B.
+    //
+    // The boundary already exists and everything already reads it; it just was
+    // not fired here.
+    const accountBucket = deriveAccountBucket(status);
+    const previousAccountBucket = amrAccountBucketRef.current;
+    amrAccountBucketRef.current = accountBucket;
+    if (previousAccountBucket !== null && previousAccountBucket !== accountBucket) {
+      notifyWorkspaceContextRefresh();
+    }
     const pendingRetry = amrAuthRetryContinuationRef.current;
     const accountChangedWhileAuthorizing = Boolean(
       pendingRetry

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -109,6 +109,7 @@ import {
   listProjectRuns,
   type VelaLoginStatus,
 } from './providers/daemon';
+import { statusObservationOrder } from './providers/status-observation';
 import {
   AMR_LOGIN_STATUS_EVENT,
   amrLoginStatusEventReason,
@@ -1686,10 +1687,24 @@ function AppInner() {
   // snapshot updates `agents`, which makes Settings fetch status again and
   // creates a status -> models -> agents request loop.
   const amrLoginStatusRef = useRef<VelaLoginStatus | null>(null);
+  const latestAppliedStatusObservationRef = useRef(0);
   const applyAmrLoginStatus = useCallback((
     status: VelaLoginStatus,
     options: { forceModelRefresh?: boolean; restartOnSignIn?: boolean } = {},
   ) => {
+    // Ordering lives here rather than in each reader because this is the one
+    // place that publishes an observation as authoritative, and every reader —
+    // this effect, the entry shell's landing read and login poll, the settings
+    // card — funnels into it. An observation that was overtaken while it was on
+    // the wire says nothing about the session any more; applying it re-publishes
+    // an authority that has already moved on, which re-authorises exactly the
+    // message-centre pull a sign-out was meant to refuse. Dropped before any
+    // side effect, including the authoritative note.
+    const observation = statusObservationOrder(status);
+    if (observation !== null) {
+      if (observation < latestAppliedStatusObservationRef.current) return;
+      latestAppliedStatusObservationRef.current = observation;
+    }
     const previousStatus = amrLoginStatusRef.current;
     const wasLoggedIn = isAmrSessionAuthenticated(previousStatus);
     const isLoggedIn = isAmrSessionAuthenticated(status);
@@ -1930,22 +1945,11 @@ function AppInner() {
   // unmounted before their poll settled.
   useEffect(() => {
     let cancelled = false;
-    // The initial run, the login-status event, focus and visibility all call
-    // this, so several requests can be on the wire at once and they answer in
-    // whatever order the daemon manages. Only the LATEST one issued may speak
-    // for the session: an older signed-in answer landing after a newer
-    // signed-out one used to re-publish `signed-in` as authoritative, which
-    // re-authorises the very message-centre pull that the sign-out was supposed
-    // to refuse.
-    let latestIssued = 0;
     const sync = async (
       options: { refresh?: boolean } = {},
       restartOnSignIn = false,
     ) => {
-      const issued = latestIssued + 1;
-      latestIssued = issued;
       const status = await fetchVelaLoginStatus(options);
-      if (issued !== latestIssued) return;
       if (!cancelled && status) {
         applyAmrLoginStatus(status, {
           forceModelRefresh: options.refresh === true,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4936,6 +4936,15 @@ function AppInner() {
     setSettingsOpen(false);
     settingsDraftConfigRef.current = null;
     setSettingsHighlight(null);
+    // Signing out IS an account boundary, and every account-scoped cache in the
+    // app is keyed on the generation this advances. Sign-IN has called this
+    // since AmrLoginPill stopped waiting for a tab reset to happen along; the
+    // sign-out half was never wired the same way, so caches from the previous
+    // account stayed 'current' — the message center's short-lived snapshot most
+    // visibly, since a signed-out host mounting inside its window adopted the
+    // previous account's rows, unread count and priority announcement without
+    // ever rechecking the auth status.
+    notifyWorkspaceContextRefresh();
     navigate({ kind: 'home', view: 'onboarding' });
     await syncConfigToDaemon(next, { allowOnboardingReset: true });
   }, []);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1687,32 +1687,27 @@ function AppInner() {
   // snapshot updates `agents`, which makes Settings fetch status again and
   // creates a status -> models -> agents request loop.
   const amrLoginStatusRef = useRef<VelaLoginStatus | null>(null);
-  const latestAppliedStatusObservationRef = useRef(0);
   const applyAmrLoginStatus = useCallback((
     status: VelaLoginStatus,
     options: { forceModelRefresh?: boolean; restartOnSignIn?: boolean } = {},
   ) => {
-    // Ordering lives here rather than in each reader because this is the one
-    // place that publishes an observation as authoritative, and every reader —
-    // this effect, the entry shell's landing read and login poll, the settings
-    // card — funnels into it. An observation that was overtaken while it was on
-    // the wire says nothing about the session any more; applying it re-publishes
-    // an authority that has already moved on, which re-authorises exactly the
-    // message-centre pull a sign-out was meant to refuse. Dropped before any
-    // side effect, including the authoritative note.
-    const observation = statusObservationOrder(status);
-    if (observation !== null) {
-      if (observation < latestAppliedStatusObservationRef.current) return;
-      latestAppliedStatusObservationRef.current = observation;
-    }
     const previousStatus = amrLoginStatusRef.current;
     const wasLoggedIn = isAmrSessionAuthenticated(previousStatus);
     const isLoggedIn = isAmrSessionAuthenticated(status);
     // The message centre caches rows per authority for a few seconds, and this
-    // is the one place that learns about a session ending REMOTELY — an expired
-    // or revoked session never goes through the sign-out handler, so nothing
-    // else would tell that cache its contents no longer belong to anyone.
-    noteAuthoritativeAuthMode(isLoggedIn);
+    // is one of the two places that learn about a session ending REMOTELY — an
+    // expired or revoked session never goes through the sign-out handler, so
+    // nothing else would tell that cache its contents no longer belong to
+    // anyone.
+    //
+    // It also decides whether this observation is still worth anything: several
+    // surfaces read the status independently and answer out of order, and the
+    // message centre publishes its own reads too, so being newer than this
+    // reader's previous request is not enough. A refused observation says
+    // nothing about the session any more — nothing below it should run either,
+    // or a status read from before the session ended goes on to restart model
+    // polling and repaint the signed-in surfaces.
+    if (!noteAuthoritativeAuthMode(isLoggedIn, statusObservationOrder(status))) return;
     const pendingRetry = amrAuthRetryContinuationRef.current;
     const accountChangedWhileAuthorizing = Boolean(
       pendingRetry

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1930,11 +1930,22 @@ function AppInner() {
   // unmounted before their poll settled.
   useEffect(() => {
     let cancelled = false;
+    // The initial run, the login-status event, focus and visibility all call
+    // this, so several requests can be on the wire at once and they answer in
+    // whatever order the daemon manages. Only the LATEST one issued may speak
+    // for the session: an older signed-in answer landing after a newer
+    // signed-out one used to re-publish `signed-in` as authoritative, which
+    // re-authorises the very message-centre pull that the sign-out was supposed
+    // to refuse.
+    let latestIssued = 0;
     const sync = async (
       options: { refresh?: boolean } = {},
       restartOnSignIn = false,
     ) => {
+      const issued = latestIssued + 1;
+      latestIssued = issued;
       const status = await fetchVelaLoginStatus(options);
+      if (issued !== latestIssued) return;
       if (!cancelled && status) {
         applyAmrLoginStatus(status, {
           forceModelRefresh: options.refresh === true,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ import type {
   WorkspaceProjectSummary,
 } from '@open-design/contracts';
 import { DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID } from '@open-design/contracts';
+import { noteAuthoritativeAuthMode } from './components/message-center-snapshot';
 import { EntryView } from './components/EntryView';
 import type { ProjectTitleHint } from './components/EntryShell';
 import type { IntegrationTab } from './components/IntegrationsView';
@@ -1692,6 +1693,11 @@ function AppInner() {
     const previousStatus = amrLoginStatusRef.current;
     const wasLoggedIn = isAmrSessionAuthenticated(previousStatus);
     const isLoggedIn = isAmrSessionAuthenticated(status);
+    // The message centre caches rows per authority for a few seconds, and this
+    // is the one place that learns about a session ending REMOTELY — an expired
+    // or revoked session never goes through the sign-out handler, so nothing
+    // else would tell that cache its contents no longer belong to anyone.
+    noteAuthoritativeAuthMode(isLoggedIn);
     const pendingRetry = amrAuthRetryContinuationRef.current;
     const accountChangedWhileAuthorizing = Boolean(
       pendingRetry

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -143,7 +143,7 @@ import {
   useProjectRouteWorkspaceContext,
 } from './collab/useProjectRouteWorkspaceContext';
 import { resolvePlanTier } from './collab/team-plan';
-import { deriveAccountBucket, deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
+import { ANONYMOUS_ACCOUNT_BUCKET, deriveAccountBucket, deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
 import { CommunityView } from './components/CommunityView';
 import { seedHomeComposerPrompt } from './components/HomeView';
 import {
@@ -1723,9 +1723,23 @@ function AppInner() {
     const accountBucket = deriveAccountBucket(status);
     const previousAccountBucket = amrAccountBucketRef.current;
     amrAccountBucketRef.current = accountBucket;
-    if (previousAccountBucket !== null && previousAccountBucket !== accountBucket) {
-      notifyWorkspaceContextRefresh();
-    }
+    // Only account -> account. Signing in and signing out both move the
+    // authoritative auth mode, which every account-scoped consumer here already
+    // subscribes to, and each sign-in owner (`CloudSignInTip.finishSignedIn`,
+    // `EntryShell.pollAmrLoginCompletion` and its onboarding helper,
+    // `AmrLoginPill`) already announces the boundary itself — announcing it
+    // here as well advanced the generation twice for one login and made a
+    // subscriber clear and resync twice, which is the duplicate work this
+    // change exists to remove.
+    //
+    // A switch between two accounts is the one transition neither covers: the
+    // auth mode is true on both sides, so nothing moves unless identity is
+    // compared.
+    const switchedBetweenAccounts = previousAccountBucket !== null
+      && previousAccountBucket !== accountBucket
+      && previousAccountBucket !== ANONYMOUS_ACCOUNT_BUCKET
+      && accountBucket !== ANONYMOUS_ACCOUNT_BUCKET;
+    if (switchedBetweenAccounts) notifyWorkspaceContextRefresh();
     const pendingRetry = amrAuthRetryContinuationRef.current;
     const accountChangedWhileAuthorizing = Boolean(
       pendingRetry

--- a/apps/web/src/collab/tab-scope.ts
+++ b/apps/web/src/collab/tab-scope.ts
@@ -23,6 +23,9 @@ export interface TabScopeLoginStatus {
  *  so the first resolution is never mistaken for an account change. */
 export const UNSET_ACCOUNT_BUCKET = '__unset__';
 
+/** The bucket for a session with no account at all. */
+export const ANONYMOUS_ACCOUNT_BUCKET = 'anon';
+
 export interface TabIdentityScopeInputs {
   /** App.tsx's merged AMR login status, or `null` before the first read
    *  completes. */
@@ -130,7 +133,7 @@ export interface TabIdentityScopeResult {
  * way; two answers to "which account is this" is how one of them goes stale.
  */
 export function deriveAccountBucket(status: TabScopeLoginStatus): string {
-  if (!status.loggedIn) return 'anon';
+  if (!status.loggedIn) return ANONYMOUS_ACCOUNT_BUCKET;
   // Ordered by how tightly each answer is bound to an ACCOUNT. A user id or
   // email survives re-authentication, so they come first — keying on the
   // credential there would call a routine token refresh an account switch.

--- a/apps/web/src/collab/tab-scope.ts
+++ b/apps/web/src/collab/tab-scope.ts
@@ -116,6 +116,23 @@ export interface TabIdentityScopeResult {
  * `amrLoginStatus === null` case below, instead of computing a scope key
  * against a workspace read that has not had its first confident settle.
  */
+/**
+ * Which account a status describes.
+ *
+ * `loggedIn` says whether there is an account, not WHICH one, and the two are
+ * different boundaries: a credential can move from one account to another with
+ * `loggedIn` true on both sides — a `vela login` in a terminal is enough — and
+ * everything scoped to an account has to move with it. Exported so the tab
+ * scope and the account-boundary notification below decide identity the same
+ * way; two answers to "which account is this" is how one of them goes stale.
+ */
+export function deriveAccountBucket(status: TabScopeLoginStatus): string {
+  if (!status.loggedIn) return 'anon';
+  return status.user?.id?.trim()
+    || status.user?.email?.trim()
+    || `profile:${status.profile}`;
+}
+
 export function deriveTabIdentityScope(
   inputs: TabIdentityScopeInputs,
 ): TabIdentityScopeResult {
@@ -148,11 +165,7 @@ export function deriveTabIdentityScope(
     };
   }
 
-  const accountBucket = amrLoginStatus.loggedIn
-    ? amrLoginStatus.user?.id?.trim()
-      || amrLoginStatus.user?.email?.trim()
-      || `profile:${amrLoginStatus.profile}`
-    : 'anon';
+  const accountBucket = deriveAccountBucket(amrLoginStatus);
   const accountChanged = accountBucket !== previousAccountBucket;
 
   const nextWorkspaceBucket =

--- a/apps/web/src/collab/tab-scope.ts
+++ b/apps/web/src/collab/tab-scope.ts
@@ -13,6 +13,9 @@ export interface TabScopeLoginStatus {
    *  session with no `user` object at all (see below). */
   profile: string;
   user: { id?: string; email?: string } | null;
+  /** Non-secret digest of the active credential. The only thing that separates
+   *  two accounts on one profile when the session carries no `user` at all. */
+  credentialRevision?: string;
 }
 
 /** Seed value for `previousAccountBucket` on the very first call — distinct
@@ -128,8 +131,20 @@ export interface TabIdentityScopeResult {
  */
 export function deriveAccountBucket(status: TabScopeLoginStatus): string {
   if (!status.loggedIn) return 'anon';
+  // Ordered by how tightly each answer is bound to an ACCOUNT. A user id or
+  // email survives re-authentication, so they come first — keying on the
+  // credential there would call a routine token refresh an account switch.
+  //
+  // An env-backed session is authenticated with `user: null` and no fabricated
+  // identity, and its credential digest is the only thing that distinguishes
+  // two accounts on one profile. The daemon's docblock on `credentialRevision`
+  // is explicit that this is why the field exists: without it, a switch that
+  // only rewrites the Settings-backed env reuses the previous account's cached
+  // data. The profile is a CLI environment, not an account, so it stays where
+  // it was — the last resort, for a session that offers nothing better.
   return status.user?.id?.trim()
     || status.user?.email?.trim()
+    || status.credentialRevision?.trim()
     || `profile:${status.profile}`;
 }
 

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -128,6 +128,28 @@ export function workspaceResourceReadContext(
  * project whose own workspace scope is `unbound` or `unavailable` says
  * nothing about whether the signed-in user has a wallet.
  */
+/**
+ * Whether the workspace identity is still undecided — i.e. a consumer must not
+ * yet act as though this shell is signed out.
+ *
+ * `loading` alone is not that question. A cold `/api/workspace/context` read
+ * that fails transiently settles to `loading: false`, `failure: 'unavailable'`
+ * and a null `context` (there is no cached context to fall back to on a first
+ * launch), which reads as "signed out" to anything gating on `loading` — and it
+ * is not. `unsupported` (404: a daemon with no workspace endpoint) and
+ * `reauth-required` (401/403: the server rejecting these credentials) are
+ * authoritative answers and deliberately excluded; only the transient outage
+ * leaves the question open.
+ *
+ * Sibling of `workspaceIdentityCanBillAmr`, which already treats any `failure`
+ * as "cannot rule a workspace out".
+ */
+export function workspaceIdentityStillResolving(state: WorkspaceContextState): boolean {
+  if (state.context !== null) return false;
+  if (state.loading) return true;
+  return state.failure === 'unavailable';
+}
+
 export function workspaceIdentityCanBillAmr(state: WorkspaceContextState): boolean {
   if (state.context !== null) return true;
   if (state.loading) return true;

--- a/apps/web/src/collab/workspace-identity.ts
+++ b/apps/web/src/collab/workspace-identity.ts
@@ -80,10 +80,45 @@ export function currentWorkspaceAccountGeneration(): number {
   return workspaceAccountGeneration;
 }
 
+/**
+ * Listeners for account-boundary changes. The counter alone only lets a caller
+ * ASK which account it is on; it cannot tell a component that the answer
+ * changed. A host that stays mounted across a sign-in/sign-out — which
+ * `notifyWorkspaceContextRefresh` deliberately allows by retaining the previous
+ * context while it resolves — therefore kept rendering the previous account's
+ * data until some unrelated refresh happened to fire.
+ */
+const workspaceAccountGenerationListeners = new Set<() => void>();
+
+/**
+ * Subscribe to account-boundary changes. Returns an unsubscribe function, and
+ * is shaped for `useSyncExternalStore` so a component can simply depend on the
+ * generation the way it depends on any other reactive value.
+ */
+export function subscribeWorkspaceAccountGeneration(listener: () => void): () => void {
+  workspaceAccountGenerationListeners.add(listener);
+  return () => {
+    workspaceAccountGenerationListeners.delete(listener);
+  };
+}
+
+function notifyWorkspaceAccountGenerationListeners(): void {
+  for (const listener of [...workspaceAccountGenerationListeners]) {
+    try {
+      listener();
+    } catch {
+      // One bad subscriber must not stop the rest from learning the boundary
+      // moved — a listener that throws is strictly less harmful than a
+      // component left rendering the previous account's data.
+    }
+  }
+}
+
 export function advanceWorkspaceAccountGeneration(stamp: string): void {
   if (workspaceAccountGenerationStamp === stamp) return;
   workspaceAccountGenerationStamp = stamp;
   workspaceAccountGeneration += 1;
+  notifyWorkspaceAccountGenerationListeners();
 }
 
 export function resetWorkspaceAccountGeneration(): void {

--- a/apps/web/src/collab/workspace-identity.ts
+++ b/apps/web/src/collab/workspace-identity.ts
@@ -106,10 +106,14 @@ function notifyWorkspaceAccountGenerationListeners(): void {
   for (const listener of [...workspaceAccountGenerationListeners]) {
     try {
       listener();
-    } catch {
-      // One bad subscriber must not stop the rest from learning the boundary
-      // moved — a listener that throws is strictly less harmful than a
-      // component left rendering the previous account's data.
+    } catch (error) {
+      // Isolated, but not swallowed. Stopping the loop would leave the
+      // remaining hosts rendering the previous account's data, which is worse
+      // than one broken subscriber; silently continuing would leave a host
+      // that never learned the boundary moved with no signal to find it by.
+      // The sibling stores in this codebase do not isolate at all — the
+      // account boundary is worth the deviation, an unreported failure is not.
+      console.error('[workspace-identity] account-boundary subscriber failed', error);
     }
   }
 }

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -1837,6 +1837,14 @@ export function EntryNavRail({
               buttonRef={messageCenterRailRef}
               ariaHasPopup="dialog"
               ariaExpanded={messageCenterOpen}
+              // The panel below is suppressed while the workspace context is
+              // still resolving, so this opener has nothing to open. Leaving it
+              // live let a click set `messageCenterOpen` on a rail that is
+              // about to be replaced by the signed-in cluster — which starts
+              // its own `messageCenterOpen` at false — and the click vanished
+              // with no dialog and no feedback. An opener with no panel must
+              // not accept input.
+              disabled={workspaceContextResolving}
             >
               <Icon name="bell" size={16} />
               {messageUnreadCount > 0 ? (

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -214,6 +214,10 @@ interface Props {
   topRightSlot?: ReactNode;
   /** The one shared workspace context; null → local (no cloud identity) state. */
   context: WorkspaceCollabContext | null;
+  /** Whether `/api/workspace/context` has answered yet. `context` alone cannot
+   *  tell "signed out" from "not answered", and the message-center instances
+   *  below are gated on that difference. */
+  workspaceContextResolving?: boolean;
   /** Account billing metadata (via the vela CLI 收口). Null → the billing
    *  chip falls back to the context plan-tier hint. */
   billing?: WorkspaceBillingSummary | null;
@@ -1193,6 +1197,23 @@ export function EntryNavRail({
   open,
   topRightSlot,
   context,
+  /**
+   * Whether `/api/workspace/context` has answered yet.
+   *
+   * The two MessageCenter instances below are gated on `context` so exactly one
+   * panel (and one unread poller) is alive. `context` alone cannot tell "signed
+   * out" from "not answered yet", so on every launch the signed-out instance
+   * mounted first and was replaced when the context arrived — and that
+   * replacement re-ran a full sync (`isAmrLoggedIn` plus a paginated
+   * `pullMessageCenter`). Waiting for the answer costs nothing observable: the
+   * panel is behind an opener, and the count it would report belongs to an
+   * identity that has not resolved.
+   *
+   * Passed down rather than read from `useWorkspaceContext` here: this
+   * component takes its context as a prop, and calling the hook would make the
+   * rail itself able to initiate a directory read it never used to.
+   */
+  workspaceContextResolving = false,
   billing,
   balanceUsd,
   onOpenSettings,
@@ -1233,6 +1254,7 @@ export function EntryNavRail({
   const [messageCenterOpen, setMessageCenterOpen] = useState(false);
   const [messageUnreadCount, setMessageUnreadCount] = useState(0);
   const messageCenterRailRef = useRef<HTMLButtonElement | null>(null);
+
   const [teamOpen, setTeamOpen] = useState(false);
   useEffect(() => {
     if (!teamOpen) return;
@@ -1842,7 +1864,7 @@ export function EntryNavRail({
           item above is its opener). Signed-in mounts move into
           `EntryTopRightCluster` — context-gating both sides is what keeps
           exactly one panel (and one unread poller) alive. */}
-      {context ? null : (
+      {context || workspaceContextResolving ? null : (
         <MessageCenter
           hideTrigger
           returnFocusRef={messageCenterRailRef}

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -1015,7 +1015,15 @@ export function EntryTopRightCluster({
                       // silently disappears with nothing left in its place.
                       resetCloudSignInTipDismissal();
                       notifyAmrLoginStatusChanged();
-                      notifyWorkspaceContextRefresh();
+                      // The account boundary is NOT notified here.
+                      // `handleActiveCloudSignOut` — awaited just above as
+                      // `onSignedOut`, and the one path every sign-out surface
+                      // shares — owns it. Notifying from both advanced the
+                      // generation twice for one sign-out, because each
+                      // unseeded call mints a fresh stamp: every account-scoped
+                      // consumer invalidated twice, and `MessageCenter`
+                      // (subscribed to the generation) ran a full
+                      // clear-and-resync per advance.
                       notifyWorkspaceBillingRefresh();
                       notifyTeamProjectsChanged();
                     });

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1611,6 +1611,7 @@ export function EntryShell({
       >
         <EntryNavRail
           view={view}
+          workspaceContextResolving={workspaceLoading}
           onViewChange={changeView}
           onNewProject={() => {
             trackHomeNavClick(analytics.track, {

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -156,6 +156,7 @@ import {
   workspaceResourceReadContext,
   workspaceBillingBalanceUsd,
   workspaceBillingSummaryForContext,
+  workspaceIdentityStillResolving,
 } from '../collab/useWorkspaceContext';
 import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import { resolvePlanLabelTier } from '../collab/team-plan';
@@ -1611,7 +1612,7 @@ export function EntryShell({
       >
         <EntryNavRail
           view={view}
-          workspaceContextResolving={workspaceLoading}
+          workspaceContextResolving={workspaceIdentityStillResolving(workspaceContextState)}
           onViewChange={changeView}
           onNewProject={() => {
             trackHomeNavClick(analytics.track, {

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -310,7 +310,14 @@ export function MessageCenter({
   const markRead = async (messageId: string) => {
     const message = messagesRef.current.find((item) => item.id === messageId);
     if (!message || message.readAt) return;
+    // Same rule as `sync`: capture the boundary this action began under. Two
+    // awaits follow, and if a sign-out/sign-in lands across them this write
+    // describes an account that is no longer current — it may not reach
+    // component state, and it certainly may not stamp its rows over a snapshot
+    // the new account has already published.
+    const issuedAccountGeneration = currentWorkspaceAccountGeneration();
     const account = await resolveLoggedInForWrite();
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const readAt = new Date().toISOString();
     if (account) await markAccountMessageRead(messageId);
     const nextIds = new Set(readIdsRef.current).add(messageId);
@@ -319,13 +326,18 @@ export function MessageCenter({
       pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
       clearAnonymousState(window.localStorage);
     }
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     invalidateSyncResponses();
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
     // Keep the cross-mount snapshot consistent with what the user just did.
     // Without this a remount inside the window adopts the pre-read rows and the
     // unread count comes back until the next network sync. The timestamp is
     // deliberately left alone: the underlying fetch is no fresher than it was.
-    if (lastSyncSnapshot && lastSyncSnapshot.accountGeneration === currentWorkspaceAccountGeneration()) {
+    //
+    // Matched against the CAPTURED generation, not the current one, so this can
+    // only ever update a snapshot belonging to the same account this read began
+    // under — never one a newer account published while the write was pending.
+    if (lastSyncSnapshot && lastSyncSnapshot.accountGeneration === issuedAccountGeneration) {
       lastSyncSnapshot = { ...lastSyncSnapshot, messages: nextMessages, readIds: nextIds };
     }
   };

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -22,6 +22,7 @@ import {
 import { GoPlanSunsetDialog } from './GoPlanSunsetDialog';
 import {
   adoptableSnapshot,
+  currentSnapshotWriteToken,
   issueSnapshotWriteToken,
   joinableSync,
   ownsLatestSnapshotWrite,
@@ -533,9 +534,13 @@ export function MessageCenter({
     // the new account has already published. Captured BEFORE the await, so the
     // announcement contract below still reports its own failure first.
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
-    // Claimed before the awaits so a sync issued while this read is in flight
-    // outranks it for the shared-cache clear below.
-    const readWriteToken = issueSnapshotWriteToken();
+    // OBSERVED, not claimed. The question below is only "has a sync been issued
+    // since this read began", and claiming a slot to answer it made every early
+    // return — a missing row, an already-read row, a moved boundary, an
+    // unavailable runtime — bump the counter for nothing, which strips a
+    // concurrent sync of its right to publish and costs the next host swap the
+    // very fetch this module exists to avoid.
+    const writeTokenAtStart = currentSnapshotWriteToken();
     const writeAuthMode = await resolveAuthModeForWrite();
     // `unavailable` is not an answer about the user, and every branch below
     // needs one: the account path would skip its POST, and the anonymous path
@@ -578,7 +583,7 @@ export function MessageCenter({
       // after a sign-out, and clearing then destroys read ids a signed-out run
       // has since persisted. The token claimed at entry loses to any sync
       // issued since, which is the run that knows better.
-      if (ownsLatestSnapshotWrite(readWriteToken)) clearAnonymousState(window.localStorage);
+      if (currentSnapshotWriteToken() === writeTokenAtStart) clearAnonymousState(window.localStorage);
     }
     invalidateSyncResponses();
     // Component state only — the durable anonymous cache is shared, so it takes

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -7,6 +7,7 @@ import {
   clearAnonymousState,
   findGoPlanSunsetMessage,
   isAmrLoggedIn,
+  readAmrAuthMode,
   markAccountMessageRead,
   pullMessageCenter,
   readAnonymousMessages,
@@ -190,7 +191,8 @@ export function MessageCenter({
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
     const writeToken = issueSnapshotWriteToken();
     if (messagesRef.current.length === 0) setSyncState('loading');
-    const account = await isAmrLoggedIn();
+    const authMode = await readAmrAuthMode();
+    const account = authMode === 'signed-in';
     // Before the writes, not after them. `account` describes the authority the
     // request was issued under; publishing it into component state once the
     // boundary has moved shows the previous account's signed-in state, and
@@ -228,7 +230,6 @@ export function MessageCenter({
     // describes an authority that is no longer current, so it may neither be
     // committed nor published as a snapshot.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
-    if (account) clearAnonymousState(window.localStorage);
     // Refs and React state are this host's own and its request id already
     // ordered them. The two SHARED sinks are the snapshot and the anonymous
     // localStorage cache, and both need the global ordering: an unmounted host
@@ -237,9 +238,24 @@ export function MessageCenter({
     // remount past the snapshot window — reads them back and resurrects
     // messages the user has already read.
     const ownsLatestWrite = ownsLatestSnapshotWrite(writeToken);
+    // CLEARING is a write to that same shared cache, and the account boundary
+    // does not cover it: `notifyWorkspaceContextRefresh` — the only thing that
+    // advances the generation — runs on sign-IN (AmrLoginPill) and not on
+    // sign-out (`handleActiveCloudSignOut`). So a run issued while signed in
+    // resumes after a sign-out with its captured `account === true` still
+    // looking current, and wipes the anonymous cache a newer signed-out run
+    // has already written. For an anonymous reader those read ids exist
+    // nowhere else, so the badges simply come back.
+    if (account && ownsLatestWrite) clearAnonymousState(window.localStorage);
     commitState(merged, overlayReadIds, { persistAnonymous: !account && ownsLatestWrite });
     setPriorityMessage(account ? findGoPlanSunsetMessage(merged) : null);
-    if (ownsLatestWrite) {
+    // `unavailable` is the daemon failing to ask, not an answer about the user,
+    // and `readAmrAuthMode` is the only place that can still tell them apart —
+    // by here it has already collapsed into `account === false`. Publishing a
+    // snapshot on it would serve the PUBLIC feed to a signed-in reader for the
+    // whole window, because a later mount adopts without re-asking. Committing
+    // it to this host is still right: it is what we could actually load.
+    if (ownsLatestWrite && authMode !== 'unavailable') {
       publishSnapshot({
         at: Date.now(),
         accountGeneration: issuedAccountGeneration,
@@ -441,6 +457,9 @@ export function MessageCenter({
     // the new account has already published. Captured BEFORE the await, so the
     // announcement contract below still reports its own failure first.
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
+    // Claimed before the awaits so a sync issued while this read is in flight
+    // outranks it for the shared-cache clear below.
+    const readWriteToken = issueSnapshotWriteToken();
     const account = await resolveLoggedInForWrite();
     if (options?.requireAccount && !account) {
       throw new Error('A signed-in account is required to acknowledge this announcement');
@@ -458,7 +477,11 @@ export function MessageCenter({
     const nextMessages = messagesRef.current.map((item) => (item.id === messageId ? { ...item, readAt } : item));
     if (account) {
       pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
-      clearAnonymousState(window.localStorage);
+      // Same rule as `sync`: a POST that started while signed in can resolve
+      // after a sign-out, and clearing then destroys read ids a signed-out run
+      // has since persisted. The token claimed at entry loses to any sync
+      // issued since, which is the run that knows better.
+      if (ownsLatestSnapshotWrite(readWriteToken)) clearAnonymousState(window.localStorage);
     }
     invalidateSyncResponses();
     // Component state only — the durable anonymous cache is shared, so it takes

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -446,8 +446,9 @@ export function MessageCenter({
   // successor kept the row unread until some later refresh, which is the very
   // thing a remount is supposed to preserve.
   useEffect(() => subscribeMessageCenterReads((delta) => {
+    // Account, yes; language, no. The id is the same row in either language, so
+    // a host rendering en must still honour a read recorded under zh-CN.
     if (delta.accountGeneration !== currentWorkspaceAccountGeneration()) return;
-    if (delta.locale !== locale) return;
     const rows = messagesRef.current;
     const target = rows.find((item) => item.id === delta.messageId);
     if (!target || target.readAt) return;
@@ -604,7 +605,6 @@ export function MessageCenter({
       messageId,
       readAt,
       accountGeneration: issuedAccountGeneration,
-      locale,
       account,
     });
     if (priorityMessage?.id === messageId) setPriorityMessage(null);

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -6,7 +6,6 @@ import { useI18n, type Locale } from '../i18n';
 import {
   clearAnonymousState,
   findGoPlanSunsetMessage,
-  isAmrLoggedIn,
   readAmrAuthMode,
   markAccountMessageRead,
   pullMessageCenter,
@@ -314,7 +313,16 @@ export function MessageCenter({
    * took the signed-out transition, and cleared read ids the new account had
    * already recorded.
    */
-  const resolveLoggedInForWrite = useCallback(async () => isAmrLoggedIn(), []);
+  /**
+   * Answers with the full three-valued mode, and does not publish.
+   *
+   * Returning a boolean here collapsed `unavailable` into `false`, so a
+   * signed-in click during an outage took the ANONYMOUS write path: no account
+   * POST, a write to the shared anonymous cache, and a snapshot delta recorded
+   * as `account: false`. Publishing is still the caller's job, after its
+   * boundary check.
+   */
+  const resolveAuthModeForWrite = useCallback(async () => readAmrAuthMode(), []);
 
   const retrySync = useCallback(() => {
     // Publish the run so a mount that lands mid-flight can wait for it instead
@@ -528,7 +536,14 @@ export function MessageCenter({
     // Claimed before the awaits so a sync issued while this read is in flight
     // outranks it for the shared-cache clear below.
     const readWriteToken = issueSnapshotWriteToken();
-    const account = await resolveLoggedInForWrite();
+    const writeAuthMode = await resolveAuthModeForWrite();
+    // `unavailable` is not an answer about the user, and every branch below
+    // needs one: the account path would skip its POST, and the anonymous path
+    // would write a signed-in user's read into shared anonymous state. The
+    // click is dropped rather than guessed at; a later attempt, once the
+    // runtime answers, records it properly.
+    if (writeAuthMode === 'unavailable') return;
+    const account = writeAuthMode === 'signed-in';
     // Published only once the boundary is confirmed, below.
     if (options?.requireAccount && !account) {
       throw new Error('A signed-in account is required to acknowledge this announcement');

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useId, useRef, useState, type RefObject , useSy
 import { createPortal } from 'react-dom';
 
 import { useI18n, type Locale } from '../i18n';
+import { issueStatusObservation } from '../providers/status-observation';
 import {
   clearAnonymousState,
   findGoPlanSunsetMessage,
@@ -239,6 +240,9 @@ export function MessageCenter({
     // to clear and let a signed-out session survive the sign-in.
     const anonSeqAtStart = currentAnonymousWriteSeq();
     if (messagesRef.current.length === 0) setSyncState('loading');
+    // Taken before the read goes out — which of two answers is newer is a
+    // question about the requests, not about when they were consumed.
+    const issuedStatusObservation = issueStatusObservation();
     const authMode = await readAmrAuthMode();
     const account = authMode === 'signed-in';
     // Before the writes, not after them. `account` describes the authority the
@@ -264,7 +268,12 @@ export function MessageCenter({
     if (authMode !== 'unavailable') {
       // Recorded for every host, not just this one: snapshot admission needs the
       // latest authoritative answer, and a non-answer must not overwrite it.
-      noteAuthoritativeAuthMode(account);
+      //
+      // Ordered against the app's status reads as well as against this
+      // component's own, because both publish here. If this read was overtaken
+      // while it was on the wire it no longer describes the session, and the
+      // rest of the run is working from it.
+      if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) return;
       loggedInRef.current = account;
       setLoggedIn(account);
     }

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -539,10 +539,21 @@ export function MessageCenter({
     const writeAuthMode = await resolveAuthModeForWrite();
     // `unavailable` is not an answer about the user, and every branch below
     // needs one: the account path would skip its POST, and the anonymous path
-    // would write a signed-in user's read into shared anonymous state. The
-    // click is dropped rather than guessed at; a later attempt, once the
-    // runtime answers, records it properly.
-    if (writeAuthMode === 'unavailable') return;
+    // would write a signed-in user's read into shared anonymous state.
+    //
+    // How it declines depends on who asked. An ordinary row click is dropped —
+    // a later click, once the runtime answers, records it properly. The
+    // announcement path cannot be dropped silently: `GoPlanSunsetDialog` sets
+    // `dismissing` before awaiting and reads a resolved promise as success, so
+    // returning normally left the notice mounted with every control disabled
+    // and no way back short of a remount. Its `catch` clears `dismissing` and
+    // surfaces a retry, which is exactly the signal a non-answer should send.
+    if (writeAuthMode === 'unavailable') {
+      if (options?.requireAccount) {
+        throw new Error('The AMR runtime is unavailable; the announcement could not be acknowledged');
+      }
+      return;
+    }
     const account = writeAuthMode === 'signed-in';
     // Published only once the boundary is confirmed, below.
     if (options?.requireAccount && !account) {

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -201,7 +201,14 @@ export function MessageCenter({
     const wasAccount = loggedInRef.current;
     loggedInRef.current = account;
     setLoggedIn(account);
-    if (wasAccount && !account) {
+    // Only a real sign-out discards the signed-in overlay. `account` has
+    // already collapsed `unavailable` into `false`, and taking this branch on
+    // a 503 threw away `pendingReadIdsRef` — the optimistic reads the server
+    // projection has not caught up on — so when the runtime came back before
+    // the projection did, the badge returned for rows the user had read. The
+    // public rows are still committed and shown; it is only the transition
+    // that is withheld until someone actually answers.
+    if (wasAccount && authMode === 'signed-out') {
       readIdsRef.current = new Set();
       pendingReadIdsRef.current = new Set();
       setPriorityMessage(null);
@@ -269,12 +276,16 @@ export function MessageCenter({
     setSyncState('ready');
   }, [commitState, locale]);
 
-  const resolveLoggedInForWrite = useCallback(async () => {
-    const account = await isAmrLoggedIn();
-    loggedInRef.current = account;
-    setLoggedIn(account);
-    return account;
-  }, []);
+  /**
+   * Answers, and does not publish. It used to assign `loggedInRef` and call
+   * `setLoggedIn` before returning, which put the write BEFORE the caller's
+   * boundary check no matter where that check sat: a status request issued
+   * under the old account could resolve after a sign-out, stamp `true`, and
+   * only then be turned away. The next sync then read `wasAccount === true`,
+   * took the signed-out transition, and cleared read ids the new account had
+   * already recorded.
+   */
+  const resolveLoggedInForWrite = useCallback(async () => isAmrLoggedIn(), []);
 
   const retrySync = useCallback(() => {
     // Publish the run so a mount that lands mid-flight can wait for it instead
@@ -461,6 +472,7 @@ export function MessageCenter({
     // outranks it for the shared-cache clear below.
     const readWriteToken = issueSnapshotWriteToken();
     const account = await resolveLoggedInForWrite();
+    // Published only once the boundary is confirmed, below.
     if (options?.requireAccount && !account) {
       throw new Error('A signed-in account is required to acknowledge this announcement');
     }
@@ -473,6 +485,8 @@ export function MessageCenter({
     // same-id message read for whoever signed in — and the anonymous cache
     // had already been cleared on the way out of a signed-in session.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
+    loggedInRef.current = account;
+    setLoggedIn(account);
     const nextIds = new Set(readIdsRef.current).add(messageId);
     const nextMessages = messagesRef.current.map((item) => (item.id === messageId ? { ...item, readAt } : item));
     if (account) {

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -198,6 +198,14 @@ export function MessageCenter({
     // boundary has moved shows the previous account's signed-in state, and
     // nothing re-syncs on a generation change to correct it.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
+    // The generation guard answers "is this still the right ACCOUNT"; it says
+    // nothing about whether this run is still the right RUN. Refreshes overlap
+    // routinely — open, visibility, the 60s interval, a remount joining and
+    // then refreshing — so a held status answer can land after a newer run has
+    // already captured the transition, and re-stamp the authority it moved on
+    // from. The request-id check used to sit only after the pull, which is
+    // after every mutation below.
+    if (requestId !== syncRequestIdRef.current) return;
     const wasAccount = loggedInRef.current;
     // Publish only an ANSWER. `unavailable` is the daemon failing to ask, and
     // writing `false` for it spent the very transition marker the branch below

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -303,6 +303,16 @@ export function MessageCenter({
     // so blanking it during an outage makes a required notice vanish and
     // reappear — the regression fixed two rounds ago, by a different route.
     // Both wait for an answer; neither guesses from a non-answer.
+    // The boundary effect clears this host, but it only supersedes THIS run
+    // when it has to issue a fresh sync. With a run already on the wire it
+    // joins instead, so a pull answered for a session that has since ended
+    // arrives with its request id, its generation and its captured account all
+    // still current — and commits. Refusing its snapshot afterwards cannot take
+    // host-local writes back. Reachable on the process's first pull, where
+    // there is no published snapshot for the invalidation to compare against
+    // and `inFlightSync` therefore survives.
+    const authoritativeNow = currentAuthoritativeLoggedIn();
+    if (authoritativeNow !== null && authoritativeNow !== account) return;
     const authoritative = authMode !== 'unavailable';
     commitState(merged, overlayReadIds, {
       persistAnonymous: authMode === 'signed-out' && ownsLatestWrite,

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@open-design/components';
-import { useCallback, useEffect, useId, useRef, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type RefObject , useSyncExternalStore} from 'react';
 import { createPortal } from 'react-dom';
 
 import { useI18n, type Locale } from '../i18n';
@@ -13,7 +13,10 @@ import {
   type MessageCenterMessage,
   writeAnonymousState,
 } from '../message-center-client';
-import { currentWorkspaceAccountGeneration } from '../collab/workspace-identity';
+import {
+  currentWorkspaceAccountGeneration,
+  subscribeWorkspaceAccountGeneration,
+} from '../collab/workspace-identity';
 import { Icon } from './Icon';
 import styles from './MessageCenter.module.css';
 
@@ -155,6 +158,20 @@ export function MessageCenter({
   const readIdsRef = useRef<Set<string>>(new Set());
   const pendingReadIdsRef = useRef<Set<string>>(new Set());
   const syncRequestIdRef = useRef(0);
+  // Reactive view of the account boundary. Capturing the generation inside
+  // `sync` stops a stale RESPONSE from landing, but it cannot tell a host that
+  // is already mounted that the account changed underneath it — the mount
+  // effect's dependencies never mentioned the boundary, and
+  // `notifyWorkspaceContextRefresh` retains the previous context while a
+  // sign-in/sign-out resolves, so the host is not remounted either. The
+  // previous account's rows and unread count simply stayed on screen until an
+  // open, a visibility change, or the 60s poll happened along.
+  const accountGeneration = useSyncExternalStore(
+    subscribeWorkspaceAccountGeneration,
+    currentWorkspaceAccountGeneration,
+    currentWorkspaceAccountGeneration,
+  );
+  const seenAccountGenerationRef = useRef(accountGeneration);
 
   const commitState = useCallback(
     (nextMessages: MessageCenterMessage[], nextReadIds: Set<string>, options?: { persistAnonymous?: boolean }) => {
@@ -276,6 +293,19 @@ export function MessageCenter({
   }, [commitState]);
 
   useEffect(() => {
+    // A boundary crossed under a host that stayed mounted: drop the previous
+    // account's rows before deciding anything, so they are never shown to
+    // whoever signed in. Initialised to the current generation, so a first
+    // mount does not wipe the anonymous state restored just above.
+    if (seenAccountGenerationRef.current !== accountGeneration) {
+      seenAccountGenerationRef.current = accountGeneration;
+      messagesRef.current = [];
+      readIdsRef.current = new Set();
+      pendingReadIdsRef.current = new Set();
+      setMessages([]);
+      setReadIds(new Set());
+      setSyncState('loading');
+    }
     // A remount that lands within the window adopts what the previous mount
     // already fetched; everything else below still goes to the network.
     let cancelled = false;
@@ -316,7 +346,7 @@ export function MessageCenter({
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [retrySync, commitState, locale]);
+  }, [retrySync, commitState, locale, accountGeneration]);
 
   useEffect(() => {
     if (open) retrySync();

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -11,6 +11,7 @@ import {
   pullMessageCenter,
   readAnonymousMessages,
   readAnonymousReadIds,
+  currentAnonymousWriteSeq,
   recordAnonymousRead,
   type MessageCenterMessage,
   writeAnonymousState,
@@ -22,7 +23,6 @@ import {
 import { GoPlanSunsetDialog } from './GoPlanSunsetDialog';
 import {
   adoptableSnapshot,
-  currentSnapshotWriteToken,
   issueSnapshotWriteToken,
   joinableSync,
   ownsLatestSnapshotWrite,
@@ -191,6 +191,13 @@ export function MessageCenter({
     // account's messages as current.
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
     const writeToken = issueSnapshotWriteToken();
+    // Separate obligations, separate counters. The publication token orders
+    // SNAPSHOT writes; the anonymous cache has its own writer sequence, because
+    // the only thing that should stop this run from clearing that cache is a
+    // newer ANONYMOUS write actually landing — not an unrelated sync moving the
+    // publication token, which used to make both this run and the read decline
+    // to clear and let a signed-out session survive the sign-in.
+    const anonSeqAtStart = currentAnonymousWriteSeq();
     if (messagesRef.current.length === 0) setSyncState('loading');
     const authMode = await readAmrAuthMode();
     const account = authMode === 'signed-in';
@@ -270,7 +277,7 @@ export function MessageCenter({
     // looking current, and wipes the anonymous cache a newer signed-out run
     // has already written. For an anonymous reader those read ids exist
     // nowhere else, so the badges simply come back.
-    if (account && ownsLatestWrite) clearAnonymousState(window.localStorage);
+    if (account && currentAnonymousWriteSeq() === anonSeqAtStart) clearAnonymousState(window.localStorage);
     // Two more readings of the same collapsed boolean, found by walking the
     // rest of this function rather than waiting for them to be reported.
     //
@@ -534,13 +541,10 @@ export function MessageCenter({
     // the new account has already published. Captured BEFORE the await, so the
     // announcement contract below still reports its own failure first.
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
-    // OBSERVED, not claimed. The question below is only "has a sync been issued
-    // since this read began", and claiming a slot to answer it made every early
-    // return — a missing row, an already-read row, a moved boundary, an
-    // unavailable runtime — bump the counter for nothing, which strips a
-    // concurrent sync of its right to publish and costs the next host swap the
-    // very fetch this module exists to avoid.
-    const writeTokenAtStart = currentSnapshotWriteToken();
+    // The anonymous cache's own writer sequence, observed rather than claimed:
+    // the question is "did a newer anonymous write land while this read was in
+    // flight", and nothing about snapshot publication answers it.
+    const anonSeqAtStart = currentAnonymousWriteSeq();
     const writeAuthMode = await resolveAuthModeForWrite();
     // `unavailable` is not an answer about the user, and every branch below
     // needs one: the account path would skip its POST, and the anonymous path
@@ -583,7 +587,7 @@ export function MessageCenter({
       // after a sign-out, and clearing then destroys read ids a signed-out run
       // has since persisted. The token claimed at entry loses to any sync
       // issued since, which is the run that knows better.
-      if (currentSnapshotWriteToken() === writeTokenAtStart) clearAnonymousState(window.localStorage);
+      if (currentAnonymousWriteSeq() === anonSeqAtStart) clearAnonymousState(window.localStorage);
     }
     invalidateSyncResponses();
     // Component state only — the durable anonymous cache is shared, so it takes

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -69,6 +69,9 @@ const MOUNT_SNAPSHOT_WINDOW_MS = 10_000;
 let lastSyncSnapshot: {
   at: number;
   accountGeneration: number;
+  /** `pullMessageCenter` asks for locale-specific fields, so a snapshot is only
+   *  valid for the language it was fetched under. */
+  locale: string;
   loggedIn: boolean;
   messages: MessageCenterMessage[];
   readIds: Set<string>;
@@ -84,7 +87,7 @@ let lastSyncSnapshot: {
  * are needed. A mount that finds a sync already running waits for it instead of
  * starting its own.
  */
-let inFlightSync: { generation: number; run: Promise<void> } | null = null;
+let inFlightSync: { generation: number; locale: string; run: Promise<void> } | null = null;
 
 /** Test hook: module state must not leak between cases. */
 export function resetMessageCenterSnapshot(): void {
@@ -92,10 +95,11 @@ export function resetMessageCenterSnapshot(): void {
   inFlightSync = null;
 }
 
-function adoptableSnapshot(): typeof lastSyncSnapshot {
+function adoptableSnapshot(locale: string): typeof lastSyncSnapshot {
   const snapshot = lastSyncSnapshot;
   if (!snapshot) return null;
   if (snapshot.accountGeneration !== currentWorkspaceAccountGeneration()) return null;
+  if (snapshot.locale !== locale) return null;
   if (Date.now() - snapshot.at >= MOUNT_SNAPSHOT_WINDOW_MS) return null;
   return snapshot;
 }
@@ -185,6 +189,7 @@ export function MessageCenter({
     lastSyncSnapshot = {
       at: Date.now(),
       accountGeneration: issuedAccountGeneration,
+      locale,
       loggedIn: account,
       messages: merged,
       readIds: overlayReadIds,
@@ -204,8 +209,9 @@ export function MessageCenter({
     // of starting a second identical sync. Keyed by the account boundary it was
     // started under, so a post-boundary mount never joins pre-boundary work.
     const generation = currentWorkspaceAccountGeneration();
-    const entry: { generation: number; run: Promise<void> } = {
+    const entry: { generation: number; locale: string; run: Promise<void> } = {
       generation,
+      locale,
       run: Promise.resolve(),
     };
     entry.run = sync()
@@ -239,15 +245,19 @@ export function MessageCenter({
       commitState(snapshot.messages, snapshot.readIds);
       setSyncState('ready');
     };
-    const adopted = adoptableSnapshot();
+    const adopted = adoptableSnapshot(locale);
     if (adopted) {
       adopt(adopted);
-    } else if (inFlightSync && inFlightSync.generation === currentWorkspaceAccountGeneration()) {
+    } else if (
+      inFlightSync
+      && inFlightSync.generation === currentWorkspaceAccountGeneration()
+      && inFlightSync.locale === locale
+    ) {
       // Someone else's sync is already on the wire for this same data and the
       // same account; take its result rather than racing a second copy of it.
       if (messagesRef.current.length === 0) setSyncState('loading');
       void inFlightSync.run.then(() => {
-        const settled = adoptableSnapshot();
+        const settled = adoptableSnapshot(locale);
         if (settled) adopt(settled);
         else if (!cancelled) retrySync();
       });
@@ -264,7 +274,7 @@ export function MessageCenter({
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [retrySync, commitState]);
+  }, [retrySync, commitState, locale]);
 
   useEffect(() => {
     if (open) retrySync();
@@ -337,7 +347,11 @@ export function MessageCenter({
     // Matched against the CAPTURED generation, not the current one, so this can
     // only ever update a snapshot belonging to the same account this read began
     // under — never one a newer account published while the write was pending.
-    if (lastSyncSnapshot && lastSyncSnapshot.accountGeneration === issuedAccountGeneration) {
+    if (
+      lastSyncSnapshot
+      && lastSyncSnapshot.accountGeneration === issuedAccountGeneration
+      && lastSyncSnapshot.locale === locale
+    ) {
       lastSyncSnapshot = { ...lastSyncSnapshot, messages: nextMessages, readIds: nextIds };
     }
   };

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -13,6 +13,7 @@ import {
   type MessageCenterMessage,
   writeAnonymousState,
 } from '../message-center-client';
+import { currentWorkspaceAccountGeneration } from '../collab/workspace-identity';
 import { Icon } from './Icon';
 import styles from './MessageCenter.module.css';
 
@@ -44,6 +45,60 @@ interface Props {
 }
 
 type SyncState = 'loading' | 'ready' | 'error';
+
+/**
+ * The last successful sync, shared across mounts.
+ *
+ * `EntryNavRail` and `App` own two mutually-exclusive hosts for this panel —
+ * the rail's cluster on the entry views, `WorkspaceTopRightAccountCluster` on a
+ * project route — so every project↔home navigation unmounts one and mounts the
+ * other. Without this, each of those remounts re-ran the whole sync:
+ * `isAmrLoggedIn` plus a paginated `pullMessageCenter`, for a panel the user
+ * has not opened and whose contents cannot have changed in the time it takes to
+ * switch routes.
+ *
+ * Only the MOUNT sync consults this. The 60s interval, the visibility listener
+ * and opening the panel all still fetch, so nothing that exists to observe a
+ * change is weakened — the snapshot only answers "did we just fetch this?".
+ *
+ * Keyed on the account boundary: a sign-out/sign-in makes the previous
+ * account's messages inadmissible no matter how recent they are.
+ */
+const MOUNT_SNAPSHOT_WINDOW_MS = 10_000;
+
+let lastSyncSnapshot: {
+  at: number;
+  accountGeneration: number;
+  loggedIn: boolean;
+  messages: MessageCenterMessage[];
+  readIds: Set<string>;
+} | null = null;
+
+/**
+ * The sync a mount is currently running, if any.
+ *
+ * The snapshot alone only dedupes SEQUENTIAL remounts: it is written when a
+ * sync finishes, so mounts that start while one is still in flight all miss it
+ * and stampede. A route switch produces exactly that shape — the outgoing host
+ * unmounts and the incoming one mounts within the same frame — so both halves
+ * are needed. A mount that finds a sync already running waits for it instead of
+ * starting its own.
+ */
+let inFlightSync: Promise<void> | null = null;
+
+/** Test hook: module state must not leak between cases. */
+export function resetMessageCenterSnapshot(): void {
+  lastSyncSnapshot = null;
+  inFlightSync = null;
+}
+
+function adoptableSnapshot(): typeof lastSyncSnapshot {
+  const snapshot = lastSyncSnapshot;
+  if (!snapshot) return null;
+  if (snapshot.accountGeneration !== currentWorkspaceAccountGeneration()) return null;
+  if (Date.now() - snapshot.at >= MOUNT_SNAPSHOT_WINDOW_MS) return null;
+  return snapshot;
+}
 
 export function MessageCenter({
   onOpenNotificationSettings,
@@ -118,6 +173,13 @@ export function MessageCenter({
     }));
     if (account) clearAnonymousState(window.localStorage);
     commitState(merged, overlayReadIds, { persistAnonymous: !account });
+    lastSyncSnapshot = {
+      at: Date.now(),
+      accountGeneration: currentWorkspaceAccountGeneration(),
+      loggedIn: account,
+      messages: merged,
+      readIds: overlayReadIds,
+    };
     setSyncState('ready');
   }, [commitState, locale]);
 
@@ -129,7 +191,15 @@ export function MessageCenter({
   }, []);
 
   const retrySync = useCallback(() => {
-    void sync().catch(() => setSyncState('error'));
+    // Publish the run so a mount that lands mid-flight can wait for it instead
+    // of starting a second identical sync.
+    const run = sync()
+      .catch(() => setSyncState('error'))
+      .finally(() => {
+        if (inFlightSync === run) inFlightSync = null;
+      });
+    inFlightSync = run;
+    void run;
   }, [sync]);
 
   const invalidateSyncResponses = useCallback(() => {
@@ -144,17 +214,42 @@ export function MessageCenter({
   }, [commitState]);
 
   useEffect(() => {
-    retrySync();
+    // A remount that lands within the window adopts what the previous mount
+    // already fetched; everything else below still goes to the network.
+    let cancelled = false;
+    const adopt = (snapshot: NonNullable<typeof lastSyncSnapshot>) => {
+      if (cancelled) return;
+      loggedInRef.current = snapshot.loggedIn;
+      setLoggedIn(snapshot.loggedIn);
+      commitState(snapshot.messages, snapshot.readIds);
+      setSyncState('ready');
+    };
+    const adopted = adoptableSnapshot();
+    if (adopted) {
+      adopt(adopted);
+    } else if (inFlightSync) {
+      // Someone else's sync is already on the wire for this same data; take its
+      // result rather than racing a second copy of it.
+      if (messagesRef.current.length === 0) setSyncState('loading');
+      void inFlightSync.then(() => {
+        const settled = adoptableSnapshot();
+        if (settled) adopt(settled);
+        else if (!cancelled) retrySync();
+      });
+    } else {
+      retrySync();
+    }
     const interval = window.setInterval(retrySync, 60_000);
     const onVisibility = () => {
       if (document.visibilityState === 'visible') retrySync();
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => {
+      cancelled = true;
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [retrySync]);
+  }, [retrySync, commitState]);
 
   useEffect(() => {
     if (open) retrySync();

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -119,6 +119,9 @@ export function resetMessageCenterSnapshot(): void {
  */
 let snapshotWriteToken = 0;
 
+/** Stable identity for the empty view, so deriving it never churns children. */
+const EMPTY_MESSAGES: MessageCenterMessage[] = [];
+
 function adoptableSnapshot(locale: string): typeof lastSyncSnapshot {
   const snapshot = lastSyncSnapshot;
   if (!snapshot) return null;
@@ -150,6 +153,15 @@ export function MessageCenter({
     [onOpenChange],
   );
   const [messages, setMessages] = useState<MessageCenterMessage[]>([]);
+  /**
+   * The account the rows in `messages` were fetched for. Kept in state rather
+   * than a ref because the answer is needed while RENDERING: clearing in an
+   * effect happens after React has already committed, so the boundary render
+   * still paints the previous account's rows and unread badge.
+   */
+  const [stateAccountGeneration, setStateAccountGeneration] = useState(
+    currentWorkspaceAccountGeneration,
+  );
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
   const [loggedIn, setLoggedIn] = useState(false);
   const [syncState, setSyncState] = useState<SyncState>('loading');
@@ -179,6 +191,7 @@ export function MessageCenter({
       readIdsRef.current = nextReadIds;
       setMessages(nextMessages);
       setReadIds(nextReadIds);
+      setStateAccountGeneration(currentWorkspaceAccountGeneration());
       if (options?.persistAnonymous) writeAnonymousState(window.localStorage, nextMessages, nextReadIds);
     },
     [],
@@ -352,7 +365,15 @@ export function MessageCenter({
     if (open) retrySync();
   }, [open, retrySync]);
 
-  const unreadCount = messages.filter((message) => !message.readAt).length;
+  // Fail closed DURING the boundary render, not after it. `useSyncExternalStore`
+  // re-renders this component with the new generation while `messages` still
+  // holds the previous account's rows; the effect that clears them runs only
+  // after that render is committed. Deriving the view here means the previous
+  // account's rows and badge are never rendered for the new one, and the effect
+  // below is left to do the refetch rather than the hiding.
+  const rowsBelongToThisAccount = stateAccountGeneration === accountGeneration;
+  const visibleMessages = rowsBelongToThisAccount ? messages : EMPTY_MESSAGES;
+  const unreadCount = visibleMessages.filter((message) => !message.readAt).length;
 
   useEffect(() => {
     onUnreadCountChange?.(unreadCount);
@@ -469,7 +490,7 @@ export function MessageCenter({
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
       <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><Button size="icon" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={18} strokeWidth={2}/></Button></header>
       <div className={styles.list} aria-live="polite">
-        {syncState === 'error' && messages.length > 0 ? (
+        {syncState === 'error' && visibleMessages.length > 0 ? (
           <div className={styles.syncStatus} role="status">
             <span>{t('settings.updateStatusFailed')}</span>
             <button type="button" onClick={retrySync}>
@@ -477,12 +498,12 @@ export function MessageCenter({
             </button>
           </div>
         ) : null}
-        {syncState === 'loading' && messages.length === 0 ? (
+        {syncState === 'loading' && visibleMessages.length === 0 ? (
           <div className={styles.empty} role="status">
             <Icon name="spinner" size={20} className="icon-spin" />
             <strong>{t('settings.updateStatusChecking')}</strong>
           </div>
-        ) : syncState === 'error' && messages.length === 0 ? (
+        ) : syncState === 'error' && visibleMessages.length === 0 ? (
           <div className={styles.empty}>
             <Icon name="bell" size={20}/>
             <div className={styles.emptyError} role="status">
@@ -492,7 +513,7 @@ export function MessageCenter({
               </button>
             </div>
           </div>
-        ) : messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : messages.map((message) => <MessageItem key={message.id} locale={locale} message={message} onRead={markRead} onError={() => setSyncState('error')}/>)}
+        ) : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} locale={locale} message={message} onRead={markRead} onError={() => setSyncState('error')}/>)}
       </div>
       <footer className={styles.footer}><p>{t('messageCenter.desktopSettingsHint')}</p>{onOpenNotificationSettings ? <Button variant="ghost" onClick={() => { closePanel(); onOpenNotificationSettings(); }}>{t('messageCenter.desktopSettings')}</Button> : null}</footer>
     </aside></div>, document.body) : null}

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -199,8 +199,16 @@ export function MessageCenter({
     // nothing re-syncs on a generation change to correct it.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const wasAccount = loggedInRef.current;
-    loggedInRef.current = account;
-    setLoggedIn(account);
+    // Publish only an ANSWER. `unavailable` is the daemon failing to ask, and
+    // writing `false` for it spent the very transition marker the branch below
+    // depends on: the outage set `loggedInRef` to false, so a genuine sign-out
+    // arriving afterwards saw `wasAccount === false`, never ran the clear, and
+    // let the signed-in overlay survive into the anonymous view. The last
+    // authoritative mode is what carries across an outage.
+    if (authMode !== 'unavailable') {
+      loggedInRef.current = account;
+      setLoggedIn(account);
+    }
     // Only a real sign-out discards the signed-in overlay. `account` has
     // already collapsed `unavailable` into `false`, and taking this branch on
     // a 503 threw away `pendingReadIdsRef` — the optimistic reads the server
@@ -254,8 +262,20 @@ export function MessageCenter({
     // has already written. For an anonymous reader those read ids exist
     // nowhere else, so the badges simply come back.
     if (account && ownsLatestWrite) clearAnonymousState(window.localStorage);
-    commitState(merged, overlayReadIds, { persistAnonymous: !account && ownsLatestWrite });
-    setPriorityMessage(account ? findGoPlanSunsetMessage(merged) : null);
+    // Two more readings of the same collapsed boolean, found by walking the
+    // rest of this function rather than waiting for them to be reported.
+    //
+    // Persisting on `unavailable` writes an overlay derived from the SIGNED-IN
+    // session into the anonymous cache, which is the leak the clear above is
+    // careful to avoid. And the announcement is picked out of a signed-in pull,
+    // so blanking it during an outage makes a required notice vanish and
+    // reappear — the regression fixed two rounds ago, by a different route.
+    // Both wait for an answer; neither guesses from a non-answer.
+    const authoritative = authMode !== 'unavailable';
+    commitState(merged, overlayReadIds, {
+      persistAnonymous: authMode === 'signed-out' && ownsLatestWrite,
+    });
+    if (authoritative) setPriorityMessage(account ? findGoPlanSunsetMessage(merged) : null);
     // `unavailable` is the daemon failing to ask, not an answer about the user,
     // and `readAmrAuthMode` is the only place that can still tell them apart —
     // by here it has already collapsed into `account === false`. Publishing a

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -169,6 +169,11 @@ export function MessageCenter({
     const writeToken = ++snapshotWriteToken;
     if (messagesRef.current.length === 0) setSyncState('loading');
     const account = await isAmrLoggedIn();
+    // Before the writes, not after them. `account` describes the authority the
+    // request was issued under; publishing it into component state once the
+    // boundary has moved shows the previous account's signed-in state, and
+    // nothing re-syncs on a generation change to correct it.
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const wasAccount = loggedInRef.current;
     loggedInRef.current = account;
     setLoggedIn(account);
@@ -178,6 +183,9 @@ export function MessageCenter({
     }
     const pulled = await pullMessageCenter({ locale, loggedIn: account });
     if (requestId !== syncRequestIdRef.current) return;
+    // Same rule again: `serverReadIds` below is the OLD authority's view of
+    // what is read, and the filter it feeds mutates `pendingReadIdsRef`.
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const serverReadIds = new Set(pulled.filter((message) => Boolean(message.readAt)).map((message) => message.id));
     if (account) {
       pendingReadIdsRef.current = new Set(
@@ -348,7 +356,6 @@ export function MessageCenter({
     const account = await resolveLoggedInForWrite();
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const readAt = new Date().toISOString();
-    const snapshotAtIssue = lastSyncSnapshot;
     if (account) await markAccountMessageRead(messageId);
     // Immediately after the await, before ANY mutation. Bailing out further
     // down was too late: `pendingReadIdsRef` had already taken the old
@@ -372,16 +379,36 @@ export function MessageCenter({
     // Matched against the CAPTURED generation, not the current one, so this can
     // only ever update a snapshot belonging to the same account this read began
     // under — never one a newer account published while the write was pending.
-    // Identity, not just shape: `nextMessages` is derived from the rows this
-    // read began on, so patching a snapshot some sync published in the
-    // meantime would drop that sync's newer rows.
+    // A durable read outranks every pull that was issued before it. Patching
+    // the snapshot is not enough on its own: `invalidateSyncResponses` only
+    // bumps THIS component's request id, so a pull started by a host that has
+    // since unmounted still holds a globally current write token and would
+    // republish the pre-read rows straight over this patch — and the next
+    // remount would restore the unread badge. Taking the next token bars every
+    // run issued before the read; a run issued after it takes a higher one and
+    // may still publish, which is correct because the server knows the read by
+    // then.
+    snapshotWriteToken += 1;
+    // Apply the read as a DELTA to whatever snapshot is current, rather than
+    // writing this host's whole row set over it. Writing `nextMessages`
+    // wholesale drops rows a sync published in the meantime; guarding that
+    // with snapshot identity instead made concurrent reads lose each other —
+    // two quick clicks both capture the same snapshot, the first replaces it,
+    // and the second finds the identity no longer matching and records
+    // nothing, so its badge came back on the next remount. A delta needs
+    // neither guard: it only ever adds this one id.
     if (
       lastSyncSnapshot
-      && lastSyncSnapshot === snapshotAtIssue
       && lastSyncSnapshot.accountGeneration === issuedAccountGeneration
       && lastSyncSnapshot.locale === locale
     ) {
-      lastSyncSnapshot = { ...lastSyncSnapshot, messages: nextMessages, readIds: nextIds };
+      lastSyncSnapshot = {
+        ...lastSyncSnapshot,
+        messages: lastSyncSnapshot.messages.map((item) => (
+          item.id === messageId ? { ...item, readAt: item.readAt ?? readAt } : item
+        )),
+        readIds: new Set(lastSyncSnapshot.readIds).add(messageId),
+      };
     }
   };
 

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -311,6 +311,13 @@ export function MessageCenter({
       setLoggedIn(snapshot.loggedIn);
       pendingReadIdsRef.current = new Set(snapshot.pendingReadIds);
       commitState(snapshot.messages, snapshot.readIds);
+      // Derived here for the same reason `sync` derives it: the announcement is
+      // a function of the rows and the signed-in state, both of which the
+      // snapshot carries. Adopting the rows without it dropped the required
+      // notice — and its `onPriorityAnnouncementPendingChange(true)` — for the
+      // length of the window on every project<->home remount, which is also
+      // long enough for a lower-priority campaign to take the screen instead.
+      setPriorityMessage(snapshot.loggedIn ? findGoPlanSunsetMessage(snapshot.messages) : null);
       setSyncState('ready');
     };
     const adopted = adoptableSnapshot(locale);

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -27,6 +27,7 @@ import {
   joinableSync,
   ownsLatestSnapshotWrite,
   publishInFlightSync,
+  currentAuthModeEpoch,
   currentAuthoritativeLoggedIn,
   noteAuthoritativeAuthMode,
   subscribeAuthoritativeAuthMode,
@@ -97,6 +98,25 @@ type SyncState = 'loading' | 'ready' | 'error';
  */
 /** Stable identity for the empty view, so deriving it never churns children. */
 const EMPTY_MESSAGES: MessageCenterMessage[] = [];
+
+/**
+ * Whether the authoritative answer moved while this run was awaiting.
+ *
+ * Every network answer here is authorised by the session that was valid when
+ * the request went out, and a remote or expired session ends WITHOUT advancing
+ * the workspace generation — so the generation checks that guard a workspace
+ * switch cannot see it. A run that was overtaken must not touch host state,
+ * shared state, or the read broadcast; refusing its snapshot afterwards cannot
+ * take those writes back.
+ *
+ * Compared as an epoch rather than as "does my answer still match the current
+ * one", because a run whose own answer is FRESHER than the last observation —
+ * a mid-session login is the ordinary case — legitimately disagrees with it and
+ * has to be allowed through.
+ */
+function overtakenByAuthorityChange(issuedAuthModeEpoch: number): boolean {
+  return currentAuthModeEpoch() !== issuedAuthModeEpoch;
+}
 
 export function MessageCenter({
   onOpenNotificationSettings,
@@ -179,7 +199,14 @@ export function MessageCenter({
   // The Go Plan announcement is account-scoped too — it is picked out of the
   // signed-in pull — so it is derived the same way rather than being allowed to
   // stay on screen across a boundary.
-  const rowsBelongToThisAccount = stateAccountGeneration === accountGeneration;
+  // Two boundaries, both render-time. The workspace generation moves on a
+  // switch or a sign-in; a remote or expired session changes the AUTHORITY
+  // without moving it, and `useSyncExternalStore` re-renders on that too — so
+  // comparing the generation alone left one committed render still showing the
+  // finished session's badge and announcement. `null` is "nothing observed
+  // yet", which contradicts nothing.
+  const rowsBelongToThisAccount = stateAccountGeneration === accountGeneration
+    && (authoritativeLoggedIn === null || loggedIn === authoritativeLoggedIn);
   const visibleMessages = rowsBelongToThisAccount ? messages : EMPTY_MESSAGES;
   const visiblePriorityMessage = rowsBelongToThisAccount ? priorityMessage : null;
 
@@ -241,6 +268,9 @@ export function MessageCenter({
       loggedInRef.current = account;
       setLoggedIn(account);
     }
+    // Captured AFTER this run's own note, so the run is never overtaken by
+    // itself.
+    const issuedAuthModeEpoch = currentAuthModeEpoch();
     // Only a real sign-out discards the signed-in overlay. `account` has
     // already collapsed `unavailable` into `false`, and taking this branch on
     // a 503 threw away `pendingReadIdsRef` — the optimistic reads the server
@@ -303,16 +333,8 @@ export function MessageCenter({
     // so blanking it during an outage makes a required notice vanish and
     // reappear — the regression fixed two rounds ago, by a different route.
     // Both wait for an answer; neither guesses from a non-answer.
-    // The boundary effect clears this host, but it only supersedes THIS run
-    // when it has to issue a fresh sync. With a run already on the wire it
-    // joins instead, so a pull answered for a session that has since ended
-    // arrives with its request id, its generation and its captured account all
-    // still current — and commits. Refusing its snapshot afterwards cannot take
-    // host-local writes back. Reachable on the process's first pull, where
-    // there is no published snapshot for the invalidation to compare against
-    // and `inFlightSync` therefore survives.
-    const authoritativeNow = currentAuthoritativeLoggedIn();
-    if (authoritativeNow !== null && authoritativeNow !== account) return;
+    // The pull was answered for the session that was valid when it went out.
+    if (overtakenByAuthorityChange(issuedAuthModeEpoch)) return;
     const authoritative = authMode !== 'unavailable';
     commitState(merged, overlayReadIds, {
       persistAnonymous: authMode === 'signed-out' && ownsLatestWrite,
@@ -603,6 +625,7 @@ export function MessageCenter({
       throw new Error('A signed-in account is required to acknowledge this announcement');
     }
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
+    const issuedAuthModeEpoch = currentAuthModeEpoch();
     const readAt = new Date().toISOString();
     if (account) await markAccountMessageRead(messageId);
     // Immediately after the await, before ANY mutation. Bailing out further
@@ -611,6 +634,12 @@ export function MessageCenter({
     // same-id message read for whoever signed in — and the anonymous cache
     // had already been cleared on the way out of a signed-in session.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
+    // Same rule, same reason: the POST was authorised by the session that was
+    // valid when it went out. Without this, a read that crossed the end of a
+    // session took `loggedInRef` back to signed-in, added pending read ids,
+    // cleared the anonymous cache and broadcast an account-scoped delta that
+    // another same-generation host consumes.
+    if (overtakenByAuthorityChange(issuedAuthModeEpoch)) return;
     loggedInRef.current = account;
     setLoggedIn(account);
     const nextIds = new Set(readIdsRef.current).add(messageId);

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -610,6 +610,13 @@ export function MessageCenter({
     // the question is "did a newer anonymous write land while this read was in
     // flight", and nothing about snapshot publication answers it.
     const anonSeqAtStart = currentAnonymousWriteSeq();
+    // The write's own status read is a status read like any other: stamped
+    // before it goes out, and published through the ordered authority so it is
+    // refused if something newer answered first. Capturing the epoch AFTER this
+    // await was too late — a sign-out observed while the read was on the wire
+    // had already been counted by then, so the post-POST comparison saw no
+    // change and let the write through for a session that had ended.
+    const issuedStatusObservation = issueStatusObservation();
     const writeAuthMode = await resolveAuthModeForWrite();
     // `unavailable` is not an answer about the user, and every branch below
     // needs one: the account path would skip its POST, and the anonymous path
@@ -629,11 +636,16 @@ export function MessageCenter({
       return;
     }
     const account = writeAuthMode === 'signed-in';
+    // Refused means this answer was overtaken while it was on the wire; it no
+    // longer describes the session, and the whole write is working from it.
+    if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) return;
     // Published only once the boundary is confirmed, below.
     if (options?.requireAccount && !account) {
       throw new Error('A signed-in account is required to acknowledge this announcement');
     }
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
+    // Captured after this write's own publication, so the write is never
+    // overtaken by itself, and before the POST it guards.
     const issuedAuthModeEpoch = currentAuthModeEpoch();
     const readAt = new Date().toISOString();
     if (account) await markAccountMessageRead(messageId);

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -11,6 +11,7 @@ import {
   pullMessageCenter,
   readAnonymousMessages,
   readAnonymousReadIds,
+  recordAnonymousRead,
   type MessageCenterMessage,
   writeAnonymousState,
 } from '../message-center-client';
@@ -269,8 +270,21 @@ export function MessageCenter({
       locale,
       run: Promise.resolve(),
     };
-    entry.run = sync()
-      .catch(() => setSyncState('error'))
+    // `sync` claims its request id synchronously, before its first await, so
+    // reading the ref straight after the call gives THIS run's id.
+    const started = sync();
+    const issuedRequestId = syncRequestIdRef.current;
+    entry.run = started
+      .catch(() => {
+        // Only the run that is still this host's current request may report a
+        // failure. An overlapping open/visibility retry — or a run issued under
+        // a previous account — can reject after a newer one has already
+        // succeeded, and painting the error banner then contradicts what is on
+        // screen.
+        if (issuedRequestId !== syncRequestIdRef.current) return;
+        if (generation !== currentWorkspaceAccountGeneration()) return;
+        setSyncState('error');
+      })
       .finally(() => retireInFlightSync(entry));
     publishInFlightSync(entry);
     void entry.run;
@@ -320,19 +334,27 @@ export function MessageCenter({
       setPriorityMessage(snapshot.loggedIn ? findGoPlanSunsetMessage(snapshot.messages) : null);
       setSyncState('ready');
     };
+    // A settled snapshot is shown FIRST when there is one, so a remount never
+    // flashes empty — but it is not the end of the story. An in-flight run is
+    // by definition fresher than the snapshot that preceded it, and nothing
+    // pushes its result into a host that merely adopted: module state updates
+    // and this component never hears about it, leaving it stale until an open,
+    // a visibility change, or the 60s poll. So adopt AND then take that run's
+    // result when it lands.
     const adopted = adoptableSnapshot(locale);
-    if (adopted) {
-      adopt(adopted);
-    } else if (joinableSync(locale)) {
+    if (adopted) adopt(adopted);
+    const running = joinableSync(locale);
+    if (running) {
       // Someone else's sync is already on the wire for this same data and the
       // same account; take its result rather than racing a second copy of it.
-      if (messagesRef.current.length === 0) setSyncState('loading');
-      void joinableSync(locale)!.run.then(() => {
+      if (!adopted && messagesRef.current.length === 0) setSyncState('loading');
+      void running.run.then(() => {
+        if (cancelled) return;
         const settled = adoptableSnapshot(locale);
         if (settled) adopt(settled);
-        else if (!cancelled) retrySync();
+        else if (!adopted) retrySync();
       });
-    } else {
+    } else if (!adopted) {
       retrySync();
     }
     const interval = window.setInterval(retrySync, 60_000);
@@ -439,7 +461,12 @@ export function MessageCenter({
       clearAnonymousState(window.localStorage);
     }
     invalidateSyncResponses();
-    commitState(nextMessages, nextIds, { persistAnonymous: !account });
+    // Component state only — the durable anonymous cache is shared, so it takes
+    // a delta below rather than this host's whole row set. Persisting the full
+    // array here dropped a read a successor had already written while this
+    // continuation was awaiting.
+    commitState(nextMessages, nextIds);
+    if (!account) recordAnonymousRead(window.localStorage, messageId, readAt);
     // A durable read outranks every pull issued before it, and the snapshot
     // patch itself is a delta — both live in `message-center-snapshot` because
     // both are shared across hosts, unlike everything committed above.

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -75,6 +75,15 @@ let lastSyncSnapshot: {
   loggedIn: boolean;
   messages: MessageCenterMessage[];
   readIds: Set<string>;
+  /**
+   * The optimistic reads not yet visible in the server's projection. Adopting
+   * a snapshot restores `readIdsRef`, but a signed-in sync builds its overlay
+   * from `serverReadIds` plus `pendingReadIdsRef` and never consults
+   * `readIdsRef` — so without carrying these, a remount inside the window
+   * followed by any refresh drops them and marks a just-read row unread again,
+   * which is the exact regression the pending set exists to prevent.
+   */
+  pendingReadIds: Set<string>;
 } | null = null;
 
 /**
@@ -206,12 +215,16 @@ export function MessageCenter({
     // committed nor published as a snapshot.
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     if (account) clearAnonymousState(window.localStorage);
-    commitState(merged, overlayReadIds, { persistAnonymous: !account });
-    // Component state above is this host's own business and its own request id
-    // already ordered it. The snapshot is shared, so it is published only by
-    // the newest run: a later run has strictly fresher rows, and if it fails
-    // the absent snapshot simply sends the next mount to the network.
-    if (writeToken === snapshotWriteToken) {
+    // Refs and React state are this host's own and its request id already
+    // ordered them. The two SHARED sinks are the snapshot and the anonymous
+    // localStorage cache, and both need the global ordering: an unmounted host
+    // passes its own request id forever, so without this its stale rows
+    // overwrite the cache a newer run just wrote, and a reload — or any
+    // remount past the snapshot window — reads them back and resurrects
+    // messages the user has already read.
+    const ownsLatestWrite = writeToken === snapshotWriteToken;
+    commitState(merged, overlayReadIds, { persistAnonymous: !account && ownsLatestWrite });
+    if (ownsLatestWrite) {
       lastSyncSnapshot = {
         at: Date.now(),
         accountGeneration: issuedAccountGeneration,
@@ -219,6 +232,7 @@ export function MessageCenter({
         loggedIn: account,
         messages: merged,
         readIds: overlayReadIds,
+        pendingReadIds: new Set(pendingReadIdsRef.current),
       };
     }
     setSyncState('ready');
@@ -269,6 +283,7 @@ export function MessageCenter({
       if (cancelled) return;
       loggedInRef.current = snapshot.loggedIn;
       setLoggedIn(snapshot.loggedIn);
+      pendingReadIdsRef.current = new Set(snapshot.pendingReadIds);
       commitState(snapshot.messages, snapshot.readIds);
       setSyncState('ready');
     };
@@ -408,6 +423,9 @@ export function MessageCenter({
           item.id === messageId ? { ...item, readAt: item.readAt ?? readAt } : item
         )),
         readIds: new Set(lastSyncSnapshot.readIds).add(messageId),
+        pendingReadIds: account
+          ? new Set(lastSyncSnapshot.pendingReadIds).add(messageId)
+          : lastSyncSnapshot.pendingReadIds,
       };
     }
   };

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -27,6 +27,7 @@ import {
   joinableSync,
   ownsLatestSnapshotWrite,
   publishInFlightSync,
+  noteAuthoritativeAuthMode,
   publishSnapshot,
   recordSnapshotRead,
   subscribeMessageCenterReads,
@@ -222,6 +223,9 @@ export function MessageCenter({
     // let the signed-in overlay survive into the anonymous view. The last
     // authoritative mode is what carries across an outage.
     if (authMode !== 'unavailable') {
+      // Recorded for every host, not just this one: snapshot admission needs the
+      // latest authoritative answer, and a non-answer must not overwrite it.
+      noteAuthoritativeAuthMode(account);
       loggedInRef.current = account;
       setLoggedIn(account);
     }

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -84,7 +84,7 @@ let lastSyncSnapshot: {
  * are needed. A mount that finds a sync already running waits for it instead of
  * starting its own.
  */
-let inFlightSync: Promise<void> | null = null;
+let inFlightSync: { generation: number; run: Promise<void> } | null = null;
 
 /** Test hook: module state must not leak between cases. */
 export function resetMessageCenterSnapshot(): void {
@@ -145,6 +145,11 @@ export function MessageCenter({
   const sync = useCallback(async () => {
     const requestId = syncRequestIdRef.current + 1;
     syncRequestIdRef.current = requestId;
+    // Capture the account boundary the request is issued under. Reading it
+    // again at completion would stamp a pre-boundary response with the new
+    // account's generation, and a later mount would adopt the previous
+    // account's messages as current.
+    const issuedAccountGeneration = currentWorkspaceAccountGeneration();
     if (messagesRef.current.length === 0) setSyncState('loading');
     const account = await isAmrLoggedIn();
     const wasAccount = loggedInRef.current;
@@ -171,11 +176,15 @@ export function MessageCenter({
       ...message,
       readAt: message.readAt ?? (overlayReadIds.has(message.id) ? new Date().toISOString() : null),
     }));
+    // A sign-out/sign-in landed while this was in flight: the response
+    // describes an authority that is no longer current, so it may neither be
+    // committed nor published as a snapshot.
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     if (account) clearAnonymousState(window.localStorage);
     commitState(merged, overlayReadIds, { persistAnonymous: !account });
     lastSyncSnapshot = {
       at: Date.now(),
-      accountGeneration: currentWorkspaceAccountGeneration(),
+      accountGeneration: issuedAccountGeneration,
       loggedIn: account,
       messages: merged,
       readIds: overlayReadIds,
@@ -192,14 +201,20 @@ export function MessageCenter({
 
   const retrySync = useCallback(() => {
     // Publish the run so a mount that lands mid-flight can wait for it instead
-    // of starting a second identical sync.
-    const run = sync()
+    // of starting a second identical sync. Keyed by the account boundary it was
+    // started under, so a post-boundary mount never joins pre-boundary work.
+    const generation = currentWorkspaceAccountGeneration();
+    const entry: { generation: number; run: Promise<void> } = {
+      generation,
+      run: Promise.resolve(),
+    };
+    entry.run = sync()
       .catch(() => setSyncState('error'))
       .finally(() => {
-        if (inFlightSync === run) inFlightSync = null;
+        if (inFlightSync === entry) inFlightSync = null;
       });
-    inFlightSync = run;
-    void run;
+    inFlightSync = entry;
+    void entry.run;
   }, [sync]);
 
   const invalidateSyncResponses = useCallback(() => {
@@ -227,11 +242,11 @@ export function MessageCenter({
     const adopted = adoptableSnapshot();
     if (adopted) {
       adopt(adopted);
-    } else if (inFlightSync) {
-      // Someone else's sync is already on the wire for this same data; take its
-      // result rather than racing a second copy of it.
+    } else if (inFlightSync && inFlightSync.generation === currentWorkspaceAccountGeneration()) {
+      // Someone else's sync is already on the wire for this same data and the
+      // same account; take its result rather than racing a second copy of it.
       if (messagesRef.current.length === 0) setSyncState('loading');
-      void inFlightSync.then(() => {
+      void inFlightSync.run.then(() => {
         const settled = adoptableSnapshot();
         if (settled) adopt(settled);
         else if (!cancelled) retrySync();
@@ -306,6 +321,13 @@ export function MessageCenter({
     }
     invalidateSyncResponses();
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
+    // Keep the cross-mount snapshot consistent with what the user just did.
+    // Without this a remount inside the window adopts the pre-read rows and the
+    // unread count comes back until the next network sync. The timestamp is
+    // deliberately left alone: the underlying fetch is no fresher than it was.
+    if (lastSyncSnapshot && lastSyncSnapshot.accountGeneration === currentWorkspaceAccountGeneration()) {
+      lastSyncSnapshot = { ...lastSyncSnapshot, messages: nextMessages, readIds: nextIds };
+    }
   };
 
   const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -438,14 +438,19 @@ export function MessageCenter({
     if (delta.account) {
       pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(delta.messageId);
     }
+    const nextRows = rows.map((item) => (
+      item.id === delta.messageId ? { ...item, readAt: item.readAt ?? delta.readAt } : item
+    ));
     // Component state only: whoever recorded the delta already wrote both
     // shared sinks, and persisting again here would race their write.
-    commitState(
-      rows.map((item) => (
-        item.id === delta.messageId ? { ...item, readAt: item.readAt ?? delta.readAt } : item
-      )),
-      new Set(readIdsRef.current).add(delta.messageId),
-    );
+    commitState(nextRows, new Set(readIdsRef.current).add(delta.messageId));
+    // The announcement is derived state, like it is in `sync` and `adopt`, and
+    // it is the fourth piece of read state this delta has to reach. Updating
+    // the rows without it left a successor holding a modal for a notice the
+    // predecessor's acknowledgement had already recorded, so the user had to
+    // confirm the same thing twice. Deriving rather than comparing ids also
+    // keeps a DIFFERENT unread targeted row on screen.
+    if (loggedInRef.current) setPriorityMessage(findGoPlanSunsetMessage(nextRows));
   }), [commitState, locale]);
 
   useEffect(() => {

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -243,8 +243,8 @@ export function MessageCenter({
     // Taken before the read goes out — which of two answers is newer is a
     // question about the requests, not about when they were consumed.
     const issuedStatusObservation = issueStatusObservation();
-    const authMode = await readAmrAuthMode();
-    const account = authMode === 'signed-in';
+    let authMode = await readAmrAuthMode();
+    let account = authMode === 'signed-in';
     // Before the writes, not after them. `account` describes the authority the
     // request was issued under; publishing it into component state once the
     // boundary has moved shows the previous account's signed-in state, and
@@ -273,7 +273,17 @@ export function MessageCenter({
       // component's own, because both publish here. If this read was overtaken
       // while it was on the wire it no longer describes the session, and the
       // rest of the run is working from it.
-      if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) return;
+      // A refusal orders this answer; it does not say the answer was wrong.
+      // Another host's read can be issued later and come back first with the
+      // SAME mode, and abandoning the run there left a first mount with an
+      // empty bell until the user opened the panel or the 60s poll came round —
+      // `retrySync` sees a resolved promise, so nothing reports it or tries
+      // again. Adopt what won instead: it is by definition the better answer,
+      // and it costs no second request.
+      if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) {
+        account = currentAuthoritativeLoggedIn() ?? account;
+        authMode = account ? 'signed-in' : 'signed-out';
+      }
       loggedInRef.current = account;
       setLoggedIn(account);
     }
@@ -332,6 +342,12 @@ export function MessageCenter({
     // looking current, and wipes the anonymous cache a newer signed-out run
     // has already written. For an anonymous reader those read ids exist
     // nowhere else, so the badges simply come back.
+    // Ahead of the clear, not after it. This clear is a write to shared
+    // storage, and a run that is about to be discarded must not make it: a
+    // signed-in pull resuming after a remote sign-out erased the anonymous
+    // messages and read ids and was only then thrown away, putting nothing
+    // back. For an anonymous reader those read ids exist nowhere else.
+    if (overtakenByAuthorityChange(issuedAuthModeEpoch)) return;
     if (account && currentAnonymousWriteSeq() === anonSeqAtStart) clearAnonymousState(window.localStorage);
     // Two more readings of the same collapsed boolean, found by walking the
     // rest of this function rather than waiting for them to be reported.
@@ -342,8 +358,6 @@ export function MessageCenter({
     // so blanking it during an outage makes a required notice vanish and
     // reappear — the regression fixed two rounds ago, by a different route.
     // Both wait for an answer; neither guesses from a non-answer.
-    // The pull was answered for the session that was valid when it went out.
-    if (overtakenByAuthorityChange(issuedAuthModeEpoch)) return;
     const authoritative = authMode !== 'unavailable';
     commitState(merged, overlayReadIds, {
       persistAnonymous: authMode === 'signed-out' && ownsLatestWrite,
@@ -635,10 +649,17 @@ export function MessageCenter({
       }
       return;
     }
-    const account = writeAuthMode === 'signed-in';
-    // Refused means this answer was overtaken while it was on the wire; it no
-    // longer describes the session, and the whole write is working from it.
-    if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) return;
+    let account = writeAuthMode === 'signed-in';
+    // Same adoption as `sync`, and here returning was actively harmful:
+    // `GoPlanSunsetDialog` sets `dismissing` before awaiting and only clears it
+    // if the promise REJECTS, so a silent success left the notice mounted with
+    // every control disabled and no way back short of a remount. Adopting lets
+    // the write finish when the winning answer agrees, and lets the
+    // `requireAccount` contract below raise its own retryable error when it
+    // does not.
+    if (!noteAuthoritativeAuthMode(account, issuedStatusObservation)) {
+      account = currentAuthoritativeLoggedIn() ?? account;
+    }
     // Published only once the boundary is confirmed, below.
     if (options?.requireAccount && !account) {
       throw new Error('A signed-in account is required to acknowledge this announcement');

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -29,6 +29,7 @@ import {
   publishInFlightSync,
   publishSnapshot,
   recordSnapshotRead,
+  subscribeMessageCenterReads,
   retireInFlightSync,
   supersedeEarlierSnapshotWrites,
   type MessageCenterInFlightSync,
@@ -423,6 +424,29 @@ export function MessageCenter({
       document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [retrySync, commitState, locale, accountGeneration]);
+
+  // A read recorded by ANOTHER host — typically this host's predecessor,
+  // finishing a write the user started just before navigating. Without this the
+  // successor kept the row unread until some later refresh, which is the very
+  // thing a remount is supposed to preserve.
+  useEffect(() => subscribeMessageCenterReads((delta) => {
+    if (delta.accountGeneration !== currentWorkspaceAccountGeneration()) return;
+    if (delta.locale !== locale) return;
+    const rows = messagesRef.current;
+    const target = rows.find((item) => item.id === delta.messageId);
+    if (!target || target.readAt) return;
+    if (delta.account) {
+      pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(delta.messageId);
+    }
+    // Component state only: whoever recorded the delta already wrote both
+    // shared sinks, and persisting again here would race their write.
+    commitState(
+      rows.map((item) => (
+        item.id === delta.messageId ? { ...item, readAt: item.readAt ?? delta.readAt } : item
+      )),
+      new Set(readIdsRef.current).add(delta.messageId),
+    );
+  }), [commitState, locale]);
 
   useEffect(() => {
     if (open) retrySync();

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -27,7 +27,9 @@ import {
   joinableSync,
   ownsLatestSnapshotWrite,
   publishInFlightSync,
+  currentAuthoritativeLoggedIn,
   noteAuthoritativeAuthMode,
+  subscribeAuthoritativeAuthMode,
   publishSnapshot,
   recordSnapshotRead,
   subscribeMessageCenterReads,
@@ -154,6 +156,16 @@ export function MessageCenter({
     currentWorkspaceAccountGeneration,
   );
   const seenAccountGenerationRef = useRef(accountGeneration);
+  // Ending a session is the same kind of boundary as switching workspace, and
+  // it needs the same treatment: a host that stays mounted across it must drop
+  // what it fetched under the old authority instead of waiting for its next
+  // scheduled sync.
+  const authoritativeLoggedIn = useSyncExternalStore(
+    subscribeAuthoritativeAuthMode,
+    currentAuthoritativeLoggedIn,
+    currentAuthoritativeLoggedIn,
+  );
+  const seenAuthoritativeRef = useRef(authoritativeLoggedIn);
   const priorityPendingCallbackRef = useRef(onPriorityAnnouncementPendingChange);
   priorityPendingCallbackRef.current = onPriorityAnnouncementPendingChange;
 
@@ -382,7 +394,14 @@ export function MessageCenter({
     // account's rows before deciding anything, so they are never shown to
     // whoever signed in. Initialised to the current generation, so a first
     // mount does not wipe the anonymous state restored just above.
-    if (seenAccountGenerationRef.current !== accountGeneration) {
+    // `null` means nothing authoritative has been observed yet, so the first
+    // answer is not a boundary — treating it as one wiped the anonymous state
+    // this host had just hydrated. Matches how the module decides the same
+    // question.
+    const authorityChanged = seenAuthoritativeRef.current !== null
+      && seenAuthoritativeRef.current !== authoritativeLoggedIn;
+    seenAuthoritativeRef.current = authoritativeLoggedIn;
+    if (seenAccountGenerationRef.current !== accountGeneration || authorityChanged) {
       seenAccountGenerationRef.current = accountGeneration;
       messagesRef.current = [];
       readIdsRef.current = new Set();
@@ -443,7 +462,7 @@ export function MessageCenter({
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [retrySync, commitState, locale, accountGeneration]);
+  }, [retrySync, commitState, locale, accountGeneration, authoritativeLoggedIn]);
 
   // A read recorded by ANOTHER host — typically this host's predecessor,
   // finishing a write the user started just before navigating. Without this the

--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -93,7 +93,19 @@ let inFlightSync: { generation: number; locale: string; run: Promise<void> } | n
 export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
   inFlightSync = null;
+  snapshotWriteToken = 0;
 }
+
+/**
+ * Orders snapshot PUBLICATION across every host, which `syncRequestIdRef`
+ * cannot: that ref lives on one component, so a host which has since unmounted
+ * still matches its own counter forever. Rail and account cluster swap on a
+ * route change, so a slow pull issued by the host that went away resolves with
+ * its request id, account generation and locale all still valid — and would
+ * write its older rows over the snapshot its successor already published, which
+ * the next remount then adopts. Only the newest issued run may publish.
+ */
+let snapshotWriteToken = 0;
 
 function adoptableSnapshot(locale: string): typeof lastSyncSnapshot {
   const snapshot = lastSyncSnapshot;
@@ -154,6 +166,7 @@ export function MessageCenter({
     // account's generation, and a later mount would adopt the previous
     // account's messages as current.
     const issuedAccountGeneration = currentWorkspaceAccountGeneration();
+    const writeToken = ++snapshotWriteToken;
     if (messagesRef.current.length === 0) setSyncState('loading');
     const account = await isAmrLoggedIn();
     const wasAccount = loggedInRef.current;
@@ -186,14 +199,20 @@ export function MessageCenter({
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     if (account) clearAnonymousState(window.localStorage);
     commitState(merged, overlayReadIds, { persistAnonymous: !account });
-    lastSyncSnapshot = {
-      at: Date.now(),
-      accountGeneration: issuedAccountGeneration,
-      locale,
-      loggedIn: account,
-      messages: merged,
-      readIds: overlayReadIds,
-    };
+    // Component state above is this host's own business and its own request id
+    // already ordered it. The snapshot is shared, so it is published only by
+    // the newest run: a later run has strictly fresher rows, and if it fails
+    // the absent snapshot simply sends the next mount to the network.
+    if (writeToken === snapshotWriteToken) {
+      lastSyncSnapshot = {
+        at: Date.now(),
+        accountGeneration: issuedAccountGeneration,
+        locale,
+        loggedIn: account,
+        messages: merged,
+        readIds: overlayReadIds,
+      };
+    }
     setSyncState('ready');
   }, [commitState, locale]);
 
@@ -329,14 +348,20 @@ export function MessageCenter({
     const account = await resolveLoggedInForWrite();
     if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const readAt = new Date().toISOString();
+    const snapshotAtIssue = lastSyncSnapshot;
     if (account) await markAccountMessageRead(messageId);
+    // Immediately after the await, before ANY mutation. Bailing out further
+    // down was too late: `pendingReadIdsRef` had already taken the old
+    // account's message id — which the next sync replays, marking a
+    // same-id message read for whoever signed in — and the anonymous cache
+    // had already been cleared on the way out of a signed-in session.
+    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     const nextIds = new Set(readIdsRef.current).add(messageId);
     const nextMessages = messagesRef.current.map((item) => (item.id === messageId ? { ...item, readAt } : item));
     if (account) {
       pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
       clearAnonymousState(window.localStorage);
     }
-    if (currentWorkspaceAccountGeneration() !== issuedAccountGeneration) return;
     invalidateSyncResponses();
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
     // Keep the cross-mount snapshot consistent with what the user just did.
@@ -347,8 +372,12 @@ export function MessageCenter({
     // Matched against the CAPTURED generation, not the current one, so this can
     // only ever update a snapshot belonging to the same account this read began
     // under — never one a newer account published while the write was pending.
+    // Identity, not just shape: `nextMessages` is derived from the rows this
+    // read began on, so patching a snapshot some sync published in the
+    // meantime would drop that sync's newer rows.
     if (
       lastSyncSnapshot
+      && lastSyncSnapshot === snapshotAtIssue
       && lastSyncSnapshot.accountGeneration === issuedAccountGeneration
       && lastSyncSnapshot.locale === locale
     ) {

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -48,6 +48,39 @@ export interface MessageCenterInFlightSync {
   run: Promise<void>;
 }
 
+/**
+ * The last AUTHORITATIVE answer about whether anyone is signed in.
+ *
+ * The account generation cannot stand in for this. It advances on a workspace
+ * identity change, and a signed-out answer does not always come with one — the
+ * component's own signed-out transition is written to work without it, and the
+ * app's status polling can observe a remote or expired session the same way. A
+ * snapshot published while signed in therefore stayed adoptable after the
+ * account went away, and a remount inside the window showed the previous
+ * account's rows, unread count and targeted announcement to a signed-out
+ * reader.
+ *
+ * Kept only as the last observation; admission does not consult it. Comparing
+ * at admission time is redundant with dropping the snapshot when the answer
+ * changes, and two mechanisms for one rule means a test can pass with either
+ * one deleted — so there is one.
+ */
+let lastAuthoritativeLoggedIn: boolean | null = null;
+
+export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
+  lastAuthoritativeLoggedIn = loggedIn;
+  // Compared against what is actually CACHED, not against the previous
+  // observation. Keying off the previous value meant the first authoritative
+  // answer could never invalidate anything — and the first answer after a fresh
+  // load is exactly when a snapshot from the old authority is still sitting
+  // there. Admission-time comparison cannot cover this either: a mount adopts
+  // before it syncs, so it would still be reading the stale answer.
+  if (lastSyncSnapshot && lastSyncSnapshot.loggedIn !== loggedIn) {
+    lastSyncSnapshot = null;
+    inFlightSync = null;
+  }
+}
+
 let lastSyncSnapshot: MessageCenterSnapshot | null = null;
 
 /**
@@ -77,6 +110,7 @@ let snapshotWriteToken = 0;
 /** Test hook: module state must not leak between cases. */
 export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
+  lastAuthoritativeLoggedIn = null;
   inFlightSync = null;
   snapshotWriteToken = 0;
   readListeners.clear();
@@ -195,6 +229,9 @@ export function recordSnapshotRead(args: MessageCenterReadDelta): void {
   // published was dropped, and the next remount adopted rows that still showed
   // it unread.
   if (snapshot.accountGeneration !== args.accountGeneration) return;
+  // A signed-out read must not patch a signed-in snapshot, or the mismatch
+  // outlives the transition that produced it.
+  if (snapshot.loggedIn !== args.account) return;
   lastSyncSnapshot = {
     ...snapshot,
     messages: snapshot.messages.map((item) => (

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -96,8 +96,29 @@ export function subscribeAuthoritativeAuthMode(listener: () => void): () => void
   };
 }
 
+/**
+ * How many times the authoritative answer has moved.
+ *
+ * A run captures this before it awaits and compares afterwards. That is a
+ * strictly different question from "does my answer match the current one":
+ * a run whose own answer is FRESHER than the last observation — a mid-session
+ * login is the ordinary case — legitimately disagrees with it and must be
+ * allowed through, while a run that was overtaken during its await must not.
+ * Only a counter can tell those two apart.
+ *
+ * Unlike the subscriber notification below, this moves on the FIRST answer too:
+ * a run that captured "nothing observed yet" and finished after the session was
+ * observed to have ended was overtaken just the same.
+ */
+let authModeEpoch = 0;
+
+export function currentAuthModeEpoch(): number {
+  return authModeEpoch;
+}
+
 export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
   const changed = lastAuthoritativeLoggedIn !== null && lastAuthoritativeLoggedIn !== loggedIn;
+  if (lastAuthoritativeLoggedIn !== loggedIn) authModeEpoch += 1;
   lastAuthoritativeLoggedIn = loggedIn;
   // Compared against what is actually CACHED, not against the previous
   // observation. Keying off the previous value meant the first authoritative
@@ -149,6 +170,7 @@ let snapshotWriteToken = 0;
 export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
   lastAuthoritativeLoggedIn = null;
+  authModeEpoch = 0;
   authModeListeners.clear();
   inFlightSync = null;
   snapshotWriteToken = 0;

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -68,7 +68,36 @@ export interface MessageCenterInFlightSync {
  */
 let lastAuthoritativeLoggedIn: boolean | null = null;
 
+/**
+ * The latest authoritative answer, or `null` if none has been observed. A run
+ * that captured the opposite answer before its awaits must not commit anything
+ * — refusing its snapshot is not enough, because component state is written
+ * first and a refused publication cannot undo a rendered row.
+ */
+export function currentAuthoritativeLoggedIn(): boolean | null {
+  return lastAuthoritativeLoggedIn;
+}
+
+const authModeListeners = new Set<() => void>();
+
+/**
+ * Subscribe to authoritative auth-mode changes.
+ *
+ * The account generation has had listeners since a host that stayed mounted
+ * across a workspace switch kept rendering the previous account's rows. Ending
+ * a SESSION is the same kind of boundary and had none: a mounted host learned
+ * about it only through its own next sync, so content fetched under the old
+ * authority stayed on screen until an open, a visibility change or the poll.
+ */
+export function subscribeAuthoritativeAuthMode(listener: () => void): () => void {
+  authModeListeners.add(listener);
+  return () => {
+    authModeListeners.delete(listener);
+  };
+}
+
 export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
+  const changed = lastAuthoritativeLoggedIn !== null && lastAuthoritativeLoggedIn !== loggedIn;
   lastAuthoritativeLoggedIn = loggedIn;
   // Compared against what is actually CACHED, not against the previous
   // observation. Keying off the previous value meant the first authoritative
@@ -79,6 +108,14 @@ export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
   if (lastSyncSnapshot && lastSyncSnapshot.loggedIn !== loggedIn) {
     lastSyncSnapshot = null;
     inFlightSync = null;
+  }
+  if (!changed) return;
+  for (const listener of [...authModeListeners]) {
+    try {
+      listener();
+    } catch (error) {
+      console.error('[message-center] auth-mode subscriber failed', error);
+    }
   }
 }
 
@@ -112,6 +149,7 @@ let snapshotWriteToken = 0;
 export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
   lastAuthoritativeLoggedIn = null;
+  authModeListeners.clear();
   inFlightSync = null;
   snapshotWriteToken = 0;
   readListeners.clear();

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -88,6 +88,18 @@ export function issueSnapshotWriteToken(): number {
   return snapshotWriteToken;
 }
 
+/**
+ * Read the counter WITHOUT claiming a slot.
+ *
+ * A caller that only needs to know "has anything been issued since I started"
+ * must not consume a token to find out: every early return then bumps the
+ * counter for nothing, and a concurrent sync loses its right to publish — which
+ * costs exactly the redundant fetch this module exists to prevent.
+ */
+export function currentSnapshotWriteToken(): number {
+  return snapshotWriteToken;
+}
+
 /** Whether the run holding `token` is still the newest issued one. */
 export function ownsLatestSnapshotWrite(token: number): boolean {
   return token === snapshotWriteToken;

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -79,6 +79,7 @@ export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
   inFlightSync = null;
   snapshotWriteToken = 0;
+  readListeners.clear();
 }
 
 /** Claim a publication slot. Taken when a run is ISSUED, not when it lands. */
@@ -119,6 +120,38 @@ export function adoptableSnapshot(locale: string): MessageCenterSnapshot | null 
 }
 
 /**
+ * A durable read, broadcast to every mounted host.
+ *
+ * Patching the shared snapshot only helps hosts that adopt it AFTERWARDS. A
+ * successor that mounted while the read was still in flight has already
+ * rendered from the pre-read snapshot and finished its mount effect, so the row
+ * stayed unread on screen until an open, a visibility refresh or the 60s poll —
+ * which is exactly the guarantee a remount is supposed to preserve.
+ *
+ * Broadcasting is safe because a read is monotonic: a row only ever goes from
+ * unread to read, so applying the delta late, twice, or to a host that already
+ * has it are all no-ops.
+ */
+export interface MessageCenterReadDelta {
+  messageId: string;
+  readAt: string;
+  accountGeneration: number;
+  locale: string;
+  account: boolean;
+}
+
+const readListeners = new Set<(delta: MessageCenterReadDelta) => void>();
+
+export function subscribeMessageCenterReads(
+  listener: (delta: MessageCenterReadDelta) => void,
+): () => void {
+  readListeners.add(listener);
+  return () => {
+    readListeners.delete(listener);
+  };
+}
+
+/**
  * Record a read against the current snapshot as a DELTA.
  *
  * Writing a host's whole row set here would drop rows a sync published in the
@@ -128,13 +161,17 @@ export function adoptableSnapshot(locale: string): MessageCenterSnapshot | null 
  * Adding one id needs neither guard. The timestamp is deliberately untouched:
  * the underlying fetch is no fresher than it was.
  */
-export function recordSnapshotRead(args: {
-  messageId: string;
-  readAt: string;
-  accountGeneration: number;
-  locale: string;
-  account: boolean;
-}): void {
+export function recordSnapshotRead(args: MessageCenterReadDelta): void {
+  // Announced before the snapshot work and regardless of whether a snapshot
+  // exists: the delta is about the READ, and a host that fetched its own rows
+  // needs it just as much as one that adopted.
+  for (const listener of [...readListeners]) {
+    try {
+      listener(args);
+    } catch (error) {
+      console.error('[message-center] read-delta subscriber failed', error);
+    }
+  }
   const snapshot = lastSyncSnapshot;
   if (!snapshot) return;
   // Matched against the generation the read BEGAN under, so this can only ever

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -60,10 +60,11 @@ export interface MessageCenterInFlightSync {
  * account's rows, unread count and targeted announcement to a signed-out
  * reader.
  *
- * Kept only as the last observation; admission does not consult it. Comparing
- * at admission time is redundant with dropping the snapshot when the answer
- * changes, and two mechanisms for one rule means a test can pass with either
- * one deleted — so there is one.
+ * Two moments consult it, and they are not redundant: dropping the cache when
+ * the answer changes handles what is already stored, and refusing a
+ * disagreeing PUBLICATION handles a run that was in flight when it changed.
+ * Neither reaches the other's case. Admission does not consult it — that would
+ * be the redundant third.
  */
 let lastAuthoritativeLoggedIn: boolean | null = null;
 
@@ -149,6 +150,13 @@ export function supersedeEarlierSnapshotWrites(): void {
 }
 
 export function publishSnapshot(next: MessageCenterSnapshot): void {
+  // Validated at the moment of WRITING, which is a different moment from
+  // dropping the cache. Dropping removes what is there and the joinable
+  // pointer; it cannot reach a run that is already in flight, and that run
+  // still holds a publication token that was valid when it was issued. So a
+  // pull that started while signed in, and resolves after an authoritative
+  // sign-out, would write the previous account's rows straight back.
+  if (lastAuthoritativeLoggedIn !== null && next.loggedIn !== lastAuthoritativeLoggedIn) return;
   lastSyncSnapshot = next;
 }
 

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -111,12 +111,38 @@ export function subscribeAuthoritativeAuthMode(listener: () => void): () => void
  * observed to have ended was overtaken just the same.
  */
 let authModeEpoch = 0;
+let lastAppliedAuthObservation = 0;
 
 export function currentAuthModeEpoch(): number {
   return authModeEpoch;
 }
 
-export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
+/**
+ * Publish what the session is, and say whether the observation was accepted.
+ *
+ * There is more than one reader of the session status — the app's status effect
+ * and the surfaces that feed it, and `MessageCenter.sync`, which reads the auth
+ * mode itself — and they answer in whatever order the daemon manages. Ordering
+ * each reader against its own previous requests does not order it against the
+ * OTHER reader, so this is where the single order has to be applied: it is the
+ * one place an observation becomes the truth about the session.
+ *
+ * `observation` is the issue order from `providers/status-observation`, taken
+ * before the read went out. An observation older than the one already applied
+ * says nothing about the session any more and is refused; the caller should
+ * drop everything else it was going to do with that answer, which is what the
+ * boolean is for. An observation of `null` is treated as current — nothing
+ * synthesises one today, and failing closed there would reject a reader that
+ * never raced.
+ */
+export function noteAuthoritativeAuthMode(
+  loggedIn: boolean,
+  observation: number | null = null,
+): boolean {
+  if (observation !== null) {
+    if (observation < lastAppliedAuthObservation) return false;
+    lastAppliedAuthObservation = observation;
+  }
   const changed = lastAuthoritativeLoggedIn !== null && lastAuthoritativeLoggedIn !== loggedIn;
   if (lastAuthoritativeLoggedIn !== loggedIn) authModeEpoch += 1;
   lastAuthoritativeLoggedIn = loggedIn;
@@ -130,7 +156,7 @@ export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
     lastSyncSnapshot = null;
     inFlightSync = null;
   }
-  if (!changed) return;
+  if (!changed) return true;
   for (const listener of [...authModeListeners]) {
     try {
       listener();
@@ -138,6 +164,7 @@ export function noteAuthoritativeAuthMode(loggedIn: boolean): void {
       console.error('[message-center] auth-mode subscriber failed', error);
     }
   }
+  return true;
 }
 
 let lastSyncSnapshot: MessageCenterSnapshot | null = null;
@@ -171,6 +198,7 @@ export function resetMessageCenterSnapshot(): void {
   lastSyncSnapshot = null;
   lastAuthoritativeLoggedIn = null;
   authModeEpoch = 0;
+  lastAppliedAuthObservation = 0;
   authModeListeners.clear();
   inFlightSync = null;
   snapshotWriteToken = 0;

--- a/apps/web/src/components/message-center-snapshot.ts
+++ b/apps/web/src/components/message-center-snapshot.ts
@@ -148,7 +148,6 @@ export interface MessageCenterReadDelta {
   messageId: string;
   readAt: string;
   accountGeneration: number;
-  locale: string;
   account: boolean;
 }
 
@@ -188,8 +187,14 @@ export function recordSnapshotRead(args: MessageCenterReadDelta): void {
   if (!snapshot) return;
   // Matched against the generation the read BEGAN under, so this can only ever
   // update a snapshot belonging to that account.
+  //
+  // Deliberately NOT matched on locale. A snapshot is language-specific because
+  // its ROWS are; a read is not — the message id is stable across languages, so
+  // "the user read this" stays true after a switch. Requiring the locales to
+  // agree meant a read begun in zh-CN and finishing after an en snapshot had
+  // published was dropped, and the next remount adopted rows that still showed
+  // it unread.
   if (snapshot.accountGeneration !== args.accountGeneration) return;
-  if (snapshot.locale !== args.locale) return;
   lastSyncSnapshot = {
     ...snapshot,
     messages: snapshot.messages.map((item) => (

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -50,11 +50,32 @@ export function readAnonymousReadIds(storage: Storage): Set<string> {
   return new Set(parseArray<string>(storage.getItem(READ_KEY)));
 }
 
+/**
+ * Advances whenever anonymous state is WRITTEN. The obligation to clear that
+ * cache on a successful account read belongs to the cache, not to snapshot
+ * publication: gating the clear on the publication token meant an unrelated
+ * sync could move that token, both the read and the sync would then decline to
+ * clear, and a signed-out session's rows survived the sign-in. The only thing
+ * that should stop an account run from clearing is a newer ANONYMOUS write
+ * actually landing.
+ */
+let anonymousWriteSeq = 0;
+
+export function currentAnonymousWriteSeq(): number {
+  return anonymousWriteSeq;
+}
+
+/** Test hook — module counters must not leak between cases. */
+export function resetAnonymousWriteSeq(): void {
+  anonymousWriteSeq = 0;
+}
+
 export function writeAnonymousState(
   storage: Storage,
   messages: MessageCenterMessage[],
   readIds: Set<string>,
 ): void {
+  anonymousWriteSeq += 1;
   storage.setItem(MESSAGES_KEY, JSON.stringify(messages));
   storage.setItem(READ_KEY, JSON.stringify([...readIds]));
 }

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -59,6 +59,33 @@ export function writeAnonymousState(
   storage.setItem(READ_KEY, JSON.stringify([...readIds]));
 }
 
+/**
+ * Record ONE anonymous read against whatever is already persisted.
+ *
+ * `writeAnonymousState` replaces both keys with a host's whole view, which is
+ * correct for a settled sync but wrong for a read: a `markRead` continuation
+ * can pause across its awaits, its host can unmount, and a successor can
+ * persist a read of its own in the meantime. Writing the full array on resume
+ * dropped that read from the durable cache — the in-memory snapshot delta hid
+ * it until the snapshot expired or the page reloaded, at which point the badge
+ * came back.
+ *
+ * Re-reads storage at write time so it composes with whatever landed while the
+ * caller was awaiting.
+ */
+export function recordAnonymousRead(
+  storage: Storage,
+  messageId: string,
+  readAt: string,
+): void {
+  const messages = readAnonymousMessages(storage).map((message) => (
+    message.id === messageId ? { ...message, readAt: message.readAt ?? readAt } : message
+  ));
+  const readIds = readAnonymousReadIds(storage);
+  readIds.add(messageId);
+  writeAnonymousState(storage, messages, readIds);
+}
+
 export function clearAnonymousState(storage: Storage): void {
   storage.removeItem(MESSAGES_KEY);
   storage.removeItem(READ_KEY);

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -92,15 +92,28 @@ export function clearAnonymousState(storage: Storage): void {
   storage.removeItem(LEGACY_WINDOW_KEY);
 }
 
-export async function isAmrLoggedIn(): Promise<boolean> {
+/**
+ * Three answers, not two. A 503 `amr-runtime-unavailable` means the daemon
+ * could not ASK — it is not a statement about the user — and collapsing it into
+ * "signed out" is only safe for a caller that is about to act once. A caller
+ * that caches its result must be able to tell the difference, or it will serve
+ * the public feed to a signed-in reader for as long as the cache lives.
+ */
+export type AmrAuthMode = 'signed-in' | 'signed-out' | 'unavailable';
+
+export async function readAmrAuthMode(): Promise<AmrAuthMode> {
   const response = await fetch('/api/integrations/vela/status', { cache: 'no-store' });
   if (response.status === 503) {
     const payload = (await response.clone().json().catch(() => null)) as { error?: string } | null;
-    if (payload?.error === 'amr-runtime-unavailable') return false;
+    if (payload?.error === 'amr-runtime-unavailable') return 'unavailable';
   }
   if (!response.ok) throw new Error(`AMR status failed: ${response.status}`);
   const payload = (await response.json()) as { loggedIn?: boolean };
-  return payload.loggedIn === true;
+  return payload.loggedIn === true ? 'signed-in' : 'signed-out';
+}
+
+export async function isAmrLoggedIn(): Promise<boolean> {
+  return (await readAmrAuthMode()) === 'signed-in';
 }
 
 export async function pullMessageCenter(input: {

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -1,3 +1,5 @@
+import type { AmrSessionState } from '@open-design/contracts';
+
 export type MessageCenterFilter = 'all' | 'unread' | 'read';
 
 export interface MessageCenterMessage {
@@ -129,8 +131,19 @@ export async function readAmrAuthMode(): Promise<AmrAuthMode> {
     if (payload?.error === 'amr-runtime-unavailable') return 'unavailable';
   }
   if (!response.ok) throw new Error(`AMR status failed: ${response.status}`);
-  const payload = (await response.json()) as { loggedIn?: boolean };
-  return payload.loggedIn === true ? 'signed-in' : 'signed-out';
+  const payload = (await response.json()) as {
+    loggedIn?: boolean;
+    sessionState?: AmrSessionState;
+  };
+  // `loggedIn` answers "is a credential present", not "can it be used" — the
+  // daemon keeps it true for an expired one and puts the verdict in
+  // `sessionState`. This reader publishes what it finds as the shared
+  // authority, and `App.isAmrSessionAuthenticated` reads the same status the
+  // same way; disagreeing with it would let a reauth-required answer take the
+  // authority back to signed-in and admit account pulls under a session that
+  // cannot be used.
+  const usable = payload.loggedIn === true && payload.sessionState !== 'reauth_required';
+  return usable ? 'signed-in' : 'signed-out';
 }
 
 export async function isAmrLoggedIn(): Promise<boolean> {

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -9,6 +9,7 @@
  *   - 'stderr'  : incidental stderr. Shown only when the process exits
  *                 non-zero (tail appended to the error message).
  */
+import { issueStatusObservation, stampStatusObservation } from './status-observation';
 import type { AgentEvent, ChatCommentAttachment, ChatMessage } from '../types';
 import type { AmrEntryAttribution } from '../analytics/amr-attribution';
 import type {
@@ -1035,11 +1036,15 @@ export interface VelaLoginAuthStage {
 //   POST /api/integrations/vela/logout   — clear ~/.amr auth and Settings-backed AMR auth env
 // The Settings UI polls /status after kicking off /login to detect completion.
 export async function fetchVelaLoginStatus(options: { refresh?: boolean } = {}): Promise<VelaLoginStatus | null> {
+  // Taken before the request goes out — see `status-observation`. Which of two
+  // concurrent status answers is newer is a question about the requests, not
+  // about when their answers happened to be consumed.
+  const observation = issueStatusObservation();
   try {
     const query = options.refresh ? '?refresh=1' : '';
     const resp = await fetch(`/api/integrations/vela/status${query}`, { cache: 'no-store' });
     if (!resp.ok) return null;
-    const status = (await resp.json()) as VelaLoginStatus;
+    const status = stampStatusObservation((await resp.json()) as VelaLoginStatus, observation);
     // Every AMR status read refreshes the runtime console origin, so the console
     // links stay correct no matter which surface (login pill, model switcher,
     // avatar menu, low-balance dialog) triggered the fetch. Doing it here rather

--- a/apps/web/src/providers/status-observation.ts
+++ b/apps/web/src/providers/status-observation.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue order for AMR status reads.
+ *
+ * Several surfaces read the session status independently — the app-level effect
+ * (initial, login-status event, focus, visibility), the entry shell's landing
+ * read and its login poll, the settings card — and they answer in whatever
+ * order the daemon manages. Only one of them may speak for the session at a
+ * time: an older signed-in answer landing after a newer signed-out one used to
+ * re-publish `signed-in` as authoritative, which re-authorises exactly the
+ * message-centre pull the sign-out was meant to refuse.
+ *
+ * The order is taken where the request is ISSUED, not where the answer is
+ * consumed, because "which answer is newer" is a question about the requests.
+ * Stamping here rather than in each consumer is what keeps a future caller from
+ * silently reintroducing the race: it only has to hand the status on, and it is
+ * ordered by construction.
+ *
+ * A status that carries no stamp is treated as current. Nothing in the app
+ * synthesises one today, and refusing an unstamped status would fail closed on
+ * the wrong thing — a surface that never raced.
+ */
+const observationOrder = new WeakMap<object, number>();
+let issued = 0;
+
+export function issueStatusObservation(): number {
+  issued += 1;
+  return issued;
+}
+
+export function stampStatusObservation<T extends object>(status: T, order: number): T {
+  observationOrder.set(status, order);
+  return status;
+}
+
+export function statusObservationOrder(status: object): number | null {
+  return observationOrder.get(status) ?? null;
+}

--- a/apps/web/tests/collab/message-center-snapshot-auth-mode.test.ts
+++ b/apps/web/tests/collab/message-center-snapshot-auth-mode.test.ts
@@ -74,6 +74,27 @@ describe('snapshot admission across an auth-mode change', () => {
     expect(adoptableSnapshot('zh-CN')).not.toBeNull();
   });
 
+  it('refuses a publication from a run that started under the other authority', () => {
+    // Dropping the cache reaches what is STORED and the joinable pointer. It
+    // cannot reach a pull that is already on the wire, and that pull still holds
+    // a publication token that was valid when it was issued — so it would write
+    // the previous account's rows straight back over the sign-out.
+    publishSnapshot(snapshot(true));
+    noteAuthoritativeAuthMode(false);
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
+
+    // The signed-in pull finally resolves and tries to publish.
+    publishSnapshot(snapshot(true));
+
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
+  });
+
+  it('still accepts a publication that agrees with the authority', () => {
+    noteAuthoritativeAuthMode(false);
+    publishSnapshot(snapshot(false));
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+  });
+
   it('refuses a read recorded under the other authority', () => {
     publishSnapshot(snapshot(true));
 

--- a/apps/web/tests/collab/message-center-snapshot-auth-mode.test.ts
+++ b/apps/web/tests/collab/message-center-snapshot-auth-mode.test.ts
@@ -1,0 +1,91 @@
+// Snapshot admission has to answer two different questions, and the account
+// generation only answers one of them. It advances when the workspace identity
+// changes; it does NOT necessarily advance when the AMR session ends — the
+// message centre's own signed-out transition is written to work without one,
+// and the app's status polling can observe a remote or expired session the same
+// way. A snapshot published while signed in therefore stayed adoptable after
+// the account went away.
+//
+// Pinned here rather than through the component: the component adopts before it
+// syncs, so it cannot discover the change itself. `noteAuthoritativeAuthMode`
+// is the entry point the app calls from `applyAmrLoginStatus`, and these assert
+// the contract that entry point carries.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  adoptableSnapshot,
+  noteAuthoritativeAuthMode,
+  publishSnapshot,
+  recordSnapshotRead,
+  resetMessageCenterSnapshot,
+  type MessageCenterSnapshot,
+} from '../../src/components/message-center-snapshot';
+import { currentWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
+
+function snapshot(loggedIn: boolean): MessageCenterSnapshot {
+  return {
+    at: Date.now(),
+    accountGeneration: currentWorkspaceAccountGeneration(),
+    locale: 'zh-CN',
+    loggedIn,
+    messages: [{
+      id: 'row-1',
+      audienceType: 'global',
+      typeName: 'Product update',
+      title: 'row-1',
+      body: 'row-1',
+      ctaLabel: null,
+      ctaUrl: null,
+      publishedAt: '2026-07-16T12:00:00.000Z',
+      readAt: null,
+    }] as MessageCenterSnapshot['messages'],
+    readIds: new Set<string>(),
+    pendingReadIds: new Set<string>(),
+  };
+}
+
+beforeEach(() => {
+  resetMessageCenterSnapshot();
+});
+
+describe('snapshot admission across an auth-mode change', () => {
+  it('drops a signed-in snapshot when an authoritative sign-out is observed', () => {
+    publishSnapshot(snapshot(true));
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+
+    noteAuthoritativeAuthMode(false);
+
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
+  });
+
+  it('drops a signed-out snapshot when an authoritative sign-in is observed', () => {
+    publishSnapshot(snapshot(false));
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+
+    noteAuthoritativeAuthMode(true);
+
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
+  });
+
+  it('keeps a snapshot when the observation agrees with it', () => {
+    publishSnapshot(snapshot(true));
+    noteAuthoritativeAuthMode(true);
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+  });
+
+  it('refuses a read recorded under the other authority', () => {
+    publishSnapshot(snapshot(true));
+
+    recordSnapshotRead({
+      messageId: 'row-1',
+      readAt: '2026-07-16T13:00:00.000Z',
+      accountGeneration: currentWorkspaceAccountGeneration(),
+      account: false,
+    });
+
+    const kept = adoptableSnapshot('zh-CN');
+    expect(kept?.messages[0]?.readAt).toBeNull();
+    expect(kept?.readIds.has('row-1')).toBe(false);
+  });
+});

--- a/apps/web/tests/collab/workspace-account-generation-subscribers.test.ts
+++ b/apps/web/tests/collab/workspace-account-generation-subscribers.test.ts
@@ -1,0 +1,63 @@
+// The account generation is what every account-scoped cache keys on, so a host
+// that misses a boundary keeps rendering the previous account's data. That makes
+// subscriber notification worth isolating — one broken listener must not stop
+// the others from hearing it — but isolation must not become silence: a host
+// that never learned the boundary moved needs to leave a signal behind.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  advanceWorkspaceAccountGeneration,
+  currentWorkspaceAccountGeneration,
+  resetWorkspaceAccountGeneration,
+  subscribeWorkspaceAccountGeneration,
+} from '../../src/collab/workspace-identity';
+
+beforeEach(() => {
+  resetWorkspaceAccountGeneration();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('account-boundary subscribers', () => {
+  it('notifies every subscriber even when one throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const seen: string[] = [];
+    const unsubs = [
+      subscribeWorkspaceAccountGeneration(() => { seen.push('first'); }),
+      subscribeWorkspaceAccountGeneration(() => { throw new Error('subscriber blew up'); }),
+      subscribeWorkspaceAccountGeneration(() => { seen.push('third'); }),
+    ];
+
+    advanceWorkspaceAccountGeneration('boundary-1');
+
+    expect(seen).toEqual(['first', 'third']);
+    expect(currentWorkspaceAccountGeneration()).toBe(1);
+    unsubs.forEach((u) => u());
+  });
+
+  it('reports the failure instead of swallowing it', () => {
+    const reported = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const boom = new Error('subscriber blew up');
+    const unsub = subscribeWorkspaceAccountGeneration(() => { throw boom; });
+
+    advanceWorkspaceAccountGeneration('boundary-1');
+
+    expect(reported).toHaveBeenCalledWith(expect.stringContaining('subscriber failed'), boom);
+    unsub();
+  });
+
+  it('does not re-notify for a repeated stamp', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let calls = 0;
+    const unsub = subscribeWorkspaceAccountGeneration(() => { calls += 1; });
+
+    advanceWorkspaceAccountGeneration('same');
+    advanceWorkspaceAccountGeneration('same');
+
+    expect(calls).toBe(1);
+    unsub();
+  });
+});

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -24,10 +24,13 @@ import {
 } from '../../src/providers/status-observation';
 import { AMR_LOGIN_STATUS_EVENT } from '../../src/components/amrLoginPolling';
 import {
+  adoptableSnapshot,
   currentAuthoritativeLoggedIn,
   noteAuthoritativeAuthMode,
+  publishSnapshot,
   resetMessageCenterSnapshot,
 } from '../../src/components/message-center-snapshot';
+import { currentWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 
 // Settings is now a full-page route (`/settings`): App.openSettings navigates
 // instead of toggling a modal flag, so the router mock must feed navigate()
@@ -317,6 +320,67 @@ describe('App AMR polling', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it('retires the previous account\'s message-centre cache on a direct account switch', async () => {
+    // A signed-in account A -> signed-in account B switch is a supported shape:
+    // `deriveTabIdentityScope` identifies the account by `user.id`, then email,
+    // then profile, precisely so a tab can be reset across one. It happens with
+    // no sign-out — a `vela login` in a terminal is enough — so `loggedIn` is
+    // true on both sides of it.
+    //
+    // Nothing fired the account boundary for that. The workspace generation
+    // moves on sign-in, sign-out and a profile switch only, and the authority
+    // this PR publishes is a boolean, so neither noticed. Everything the
+    // message centre partitions by that boundary — the settled snapshot, a
+    // joinable in-flight run, the mounted rows, a stale continuation — stayed
+    // eligible, and a remount inside the 10s window could show account A's
+    // targeted rows, unread badge and announcement under account B.
+    resetMessageCenterSnapshot();
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    const accountA = {
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: { id: 'account-a', email: 'a@example.com' },
+      configPath: '/tmp/amr-config.json',
+    };
+    const accountB = { ...accountA, user: { id: 'account-b', email: 'b@example.com' } };
+    let current: unknown = accountA;
+    mockedFetchVelaLoginStatus.mockImplementation(async () => (
+      stampStatusObservation({ ...(current as object) }, issueStatusObservation()) as never
+    ));
+
+    render(<App />);
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(true));
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+
+    // Account A's rows land in the shared cache.
+    publishSnapshot({
+      at: Date.now(),
+      accountGeneration: currentWorkspaceAccountGeneration(),
+      locale: 'zh-CN',
+      loggedIn: true,
+      messages: [],
+      readIds: new Set(['account-a-row']),
+      pendingReadIds: new Set(),
+    });
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+
+    // The credential switches to account B. Still signed in throughout.
+    current = accountB;
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
   });
 
   it('keeps the authoritative auth mode signed out when the message centre observed the end first', async () => {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -18,6 +18,10 @@ import {
 } from '../../src/providers/registry';
 import { fetchAmrModels, fetchVelaLoginStatus } from '../../src/providers/daemon';
 import { listProjects, listTemplates } from '../../src/state/projects';
+import {
+  issueStatusObservation,
+  stampStatusObservation,
+} from '../../src/providers/status-observation';
 import { AMR_LOGIN_STATUS_EVENT } from '../../src/components/amrLoginPolling';
 import {
   currentAuthoritativeLoggedIn,
@@ -51,15 +55,22 @@ vi.mock('../../src/router', async () => {
   };
 });
 
+// The entry shell reads AMR status on its own (landing read, login poll) and
+// hands what it gets to `onAmrLoginStatusChange`. Exposed here so a spec can
+// push a status up the same way a child surface does.
+let mockChildStatus: unknown = null;
+
 vi.mock('../../src/components/EntryView', () => ({
   EntryView: ({
     agents,
     config,
     onOpenSettings,
+    onAmrLoginStatusChange,
   }: {
     agents: Array<{ id: string; models?: Array<{ id: string }>; authStatus?: string }>;
     config: AppConfig;
     onOpenSettings: () => void;
+    onAmrLoginStatusChange?: (status: unknown) => void;
   }) => (
     <>
       <div data-testid="amr-model">
@@ -75,6 +86,12 @@ vi.mock('../../src/components/EntryView', () => ({
         {agents.find((agent) => agent.id === 'codex')?.authStatus ?? 'none'}
       </div>
       <button onClick={() => onOpenSettings()}>open settings</button>
+      <button
+        data-testid="push-child-status"
+        onClick={() => { if (mockChildStatus) onAmrLoginStatusChange?.(mockChildStatus); }}
+      >
+        push child status
+      </button>
     </>
   ),
 }));
@@ -301,6 +318,57 @@ describe('App AMR polling', () => {
     vi.clearAllMocks();
   });
 
+  it('keeps the authoritative auth mode signed out when a child surface pushes an older status', async () => {
+    // The entry shell and the settings card read status on their own and hand
+    // what they get to `onAmrLoginStatusChange`, bypassing anything the app
+    // effect does to order its OWN reads. A child read issued while signed in
+    // can therefore be pushed up after the app has already accepted a newer
+    // signed-out answer, flipping the authority back and re-authorising the
+    // message-centre pull the sign-out was meant to refuse.
+    //
+    // Which is why the order is taken where the request is issued and checked
+    // where it is published, rather than per reader: a future reader only has
+    // to hand the status on.
+    resetMessageCenterSnapshot();
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    // Issued FIRST — while the session was still valid — and held by the child.
+    const childObservation = issueStatusObservation();
+    mockChildStatus = stampStatusObservation({
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: { id: 'user-1', email: 'user-1@example.com' },
+      configPath: '/tmp/amr-config.json',
+    }, childObservation);
+
+    // Issued second, and applied: the session has ended.
+    mockedFetchVelaLoginStatus.mockImplementation(async () => {
+      const observation = issueStatusObservation();
+      return stampStatusObservation(
+        { loggedIn: false, loginInFlight: false, profile: 'local' },
+        observation,
+      ) as never;
+    });
+
+    render(<App />);
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(false));
+
+    // The child finally pushes what it read before the sign-out.
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('push-child-status'));
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(currentAuthoritativeLoggedIn()).toBe(false);
+    mockChildStatus = null;
+  });
+
   it('keeps the authoritative auth mode signed out when an older signed-in status resolves last', async () => {
     // The status effect starts overlapping `fetchVelaLoginStatus()` calls — the
     // initial run, the login-status event, focus and visibility all call the
@@ -334,15 +402,18 @@ describe('App AMR polling', () => {
 
     let releaseStale: (() => void) | null = null;
     let call = 0;
+    // The mock stands in for the provider, so it takes the issue order the
+    // provider takes — before the await, which is the whole point of the order.
     mockedFetchVelaLoginStatus.mockImplementation(async () => {
       call += 1;
+      const observation = issueStatusObservation();
       if (call === 2) {
         // Issued before the sign-out is observed; answered after it.
         await new Promise<void>((resolve) => { releaseStale = resolve; });
-        return signedIn as never;
+        return stampStatusObservation({ ...signedIn }, observation) as never;
       }
-      if (call >= 3) return signedOut as never;
-      return signedIn as never;
+      if (call >= 3) return stampStatusObservation({ ...signedOut }, observation) as never;
+      return stampStatusObservation({ ...signedIn }, observation) as never;
     });
 
     render(<App />);

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -322,6 +322,54 @@ describe('App AMR polling', () => {
     vi.clearAllMocks();
   });
 
+  it('leaves the sign-in boundary to the surfaces that own it', async () => {
+    // Every shipped sign-in owner already calls `notifyWorkspaceContextRefresh`
+    // — `CloudSignInTip.finishSignedIn`, `EntryShell.pollAmrLoginCompletion` and
+    // its onboarding helper, `AmrLoginPill`. Announcing the boundary here as
+    // well advances the generation TWICE for one login and dispatches two
+    // differently keyed refreshes, so a subscriber like the message centre
+    // clears and resyncs twice — the duplicate work this PR exists to remove.
+    //
+    // Signing in and signing out are covered without this branch anyway: both
+    // move the authoritative auth mode, and the message centre subscribes to
+    // that. The case nothing covers is account -> account, where the auth mode
+    // is true on both sides, and that is the only case this branch is for.
+    resetMessageCenterSnapshot();
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    const signedOut = { loggedIn: false, loginInFlight: false, profile: 'local' };
+    const signedIn = {
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: { id: 'account-a', email: 'a@example.com' },
+      configPath: '/tmp/amr-config.json',
+    };
+    let current: unknown = signedOut;
+    mockedFetchVelaLoginStatus.mockImplementation(async () => (
+      stampStatusObservation({ ...(current as object) }, issueStatusObservation()) as never
+    ));
+
+    render(<App />);
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(false));
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+    const generationWhileSignedOut = currentWorkspaceAccountGeneration();
+
+    current = signedIn;
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(true));
+
+    expect(currentWorkspaceAccountGeneration()).toBe(generationWhileSignedOut);
+  });
+
   it('retires the previous account\'s message-centre cache on a direct account switch', async () => {
     // A signed-in account A -> signed-in account B switch is a supported shape:
     // `deriveTabIdentityScope` identifies the account by `user.id`, then email,

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -383,6 +383,59 @@ describe('App AMR polling', () => {
     expect(adoptableSnapshot('zh-CN')).toBeNull();
   });
 
+  it('retires the previous account\'s cache when an identity-less credential switches account', async () => {
+    // Same boundary as the sibling above, on the shape that carries no identity
+    // to compare. An env-backed session is authenticated with `user: null`, so
+    // both sides of a switch that only rewrites the Settings-backed env derive
+    // the same profile — and the profile is a CLI environment, not an account.
+    // The credential digest is what separates them, which is the reason the
+    // daemon returns it.
+    resetMessageCenterSnapshot();
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    const envAccountA = {
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: null,
+      credentialRevision: 'revision-a',
+      configPath: '/tmp/amr-config.json',
+    };
+    const envAccountB = { ...envAccountA, credentialRevision: 'revision-b' };
+    let current: unknown = envAccountA;
+    mockedFetchVelaLoginStatus.mockImplementation(async () => (
+      stampStatusObservation({ ...(current as object) }, issueStatusObservation()) as never
+    ));
+
+    render(<App />);
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(true));
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+
+    publishSnapshot({
+      at: Date.now(),
+      accountGeneration: currentWorkspaceAccountGeneration(),
+      locale: 'zh-CN',
+      loggedIn: true,
+      messages: [],
+      readIds: new Set(['env-account-a-row']),
+      pendingReadIds: new Set(),
+    });
+    expect(adoptableSnapshot('zh-CN')).not.toBeNull();
+
+    current = envAccountB;
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(adoptableSnapshot('zh-CN')).toBeNull();
+  });
+
   it('keeps the authoritative auth mode signed out when the message centre observed the end first', async () => {
     // `applyAmrLoginStatus` is not the only publisher of the authority:
     // `MessageCenter.sync` reads the auth mode itself and publishes what it got.

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -25,6 +25,7 @@ import {
 import { AMR_LOGIN_STATUS_EVENT } from '../../src/components/amrLoginPolling';
 import {
   currentAuthoritativeLoggedIn,
+  noteAuthoritativeAuthMode,
   resetMessageCenterSnapshot,
 } from '../../src/components/message-center-snapshot';
 
@@ -316,6 +317,78 @@ describe('App AMR polling', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it('keeps the authoritative auth mode signed out when the message centre observed the end first', async () => {
+    // `applyAmrLoginStatus` is not the only publisher of the authority:
+    // `MessageCenter.sync` reads the auth mode itself and publishes what it got.
+    // Ordering the two publishers separately does not order them against EACH
+    // OTHER — a stamped app request issued while signed in could still land
+    // after the message centre had already observed and published the end of
+    // the session, and take the authority back to signed-in.
+    resetMessageCenterSnapshot();
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    const signedIn = {
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: { id: 'user-1', email: 'user-1@example.com' },
+      configPath: '/tmp/amr-config.json',
+    };
+    let releaseStale: (() => void) | null = null;
+    let holdNext = false;
+    let call = 0;
+    // Held by flag rather than by call index: settling the app issues several
+    // status reads of its own, and holding one of those means holding a request
+    // from an effect instance that has already been cancelled — which drops the
+    // response for a reason that has nothing to do with ordering.
+    mockedFetchVelaLoginStatus.mockImplementation(async () => {
+      call += 1;
+      const observation = issueStatusObservation();
+      if (holdNext) {
+        holdNext = false;
+        await new Promise<void>((resolve) => { releaseStale = resolve; });
+      }
+      return stampStatusObservation({ ...signedIn }, observation) as never;
+    });
+
+    render(<App />);
+    // Settle first: `daemonLive` flipping re-runs the effect, and its
+    // `cancelled` flag would drop the held response for a reason that has
+    // nothing to do with ordering.
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(true));
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+
+    // The latest app request goes out while the session is still valid, and is
+    // held. Nothing app-side is issued after it, so only the message centre's
+    // publication is newer.
+    const callsBeforeHold = call;
+    holdNext = true;
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(releaseStale).not.toBeNull();
+    expect(call).toBe(callsBeforeHold + 1);
+
+    // The message centre reads the auth mode and publishes the end of the
+    // session — this is exactly the call `MessageCenter.sync` makes.
+    noteAuthoritativeAuthMode(false, issueStatusObservation());
+    expect(currentAuthoritativeLoggedIn()).toBe(false);
+
+    // The older app request finally answers signed-in.
+    await act(async () => {
+      releaseStale!();
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(currentAuthoritativeLoggedIn()).toBe(false);
   });
 
   it('keeps the authoritative auth mode signed out when a child surface pushes an older status', async () => {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -18,6 +18,11 @@ import {
 } from '../../src/providers/registry';
 import { fetchAmrModels, fetchVelaLoginStatus } from '../../src/providers/daemon';
 import { listProjects, listTemplates } from '../../src/state/projects';
+import { AMR_LOGIN_STATUS_EVENT } from '../../src/components/amrLoginPolling';
+import {
+  currentAuthoritativeLoggedIn,
+  resetMessageCenterSnapshot,
+} from '../../src/components/message-center-snapshot';
 
 // Settings is now a full-page route (`/settings`): App.openSettings navigates
 // instead of toggling a modal flag, so the router mock must feed navigate()
@@ -294,6 +299,80 @@ describe('App AMR polling', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+  });
+
+  it('keeps the authoritative auth mode signed out when an older signed-in status resolves last', async () => {
+    // The status effect starts overlapping `fetchVelaLoginStatus()` calls — the
+    // initial run, the login-status event, focus and visibility all call the
+    // same `sync` — and until now only unmount could stop a response from being
+    // applied. So an older signed-in response could land after a newer
+    // signed-out one and re-publish `signed-in` as authoritative.
+    //
+    // That matters because the message centre now treats this value as the
+    // truth about the session: a pull answered before the sign-out is rejected
+    // by comparing against it, and flipping it back re-authorises exactly the
+    // pull that was meant to be refused. The producer has to be ordered for the
+    // consumer's guard to mean anything.
+    resetMessageCenterSnapshot();
+    // `clearAllMocks` does not drain a `mockResolvedValueOnce` queue, so a spec
+    // that leaves entries behind shifts the next one's catalog. This spec has
+    // no interest in the model poll: give it one stable answer instead.
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+    const signedIn = {
+      loggedIn: true,
+      loginInFlight: false,
+      profile: 'local',
+      user: { id: 'user-1', email: 'user-1@example.com' },
+      configPath: '/tmp/amr-config.json',
+    };
+    const signedOut = { loggedIn: false, loginInFlight: false, profile: 'local' };
+
+    let releaseStale: (() => void) | null = null;
+    let call = 0;
+    mockedFetchVelaLoginStatus.mockImplementation(async () => {
+      call += 1;
+      if (call === 2) {
+        // Issued before the sign-out is observed; answered after it.
+        await new Promise<void>((resolve) => { releaseStale = resolve; });
+        return signedIn as never;
+      }
+      if (call >= 3) return signedOut as never;
+      return signedIn as never;
+    });
+
+    render(<App />);
+    // Let the app settle so the remaining calls come from ONE effect instance —
+    // `daemonLive` flipping re-runs it, and its `cancelled` flag would drop the
+    // held response for reasons that have nothing to do with ordering.
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(true));
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+
+    // A status request goes out and is held on the wire.
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(releaseStale).not.toBeNull();
+
+    // A newer one goes out and answers signed-out.
+    await act(async () => {
+      window.dispatchEvent(new Event(AMR_LOGIN_STATUS_EVENT));
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    await waitFor(() => expect(currentAuthoritativeLoggedIn()).toBe(false));
+
+    // The older request finally answers signed-in.
+    await act(async () => {
+      releaseStale!();
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(currentAuthoritativeLoggedIn()).toBe(false);
   });
 
   it('keeps polling AMR models until the remote catalog replaces the preset list', async () => {

--- a/apps/web/tests/components/App.onboarding-completion-persistence.test.tsx
+++ b/apps/web/tests/components/App.onboarding-completion-persistence.test.tsx
@@ -18,6 +18,7 @@ import { cleanup, act, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App, resetExecutionConfigAfterSignOut } from '../../src/App';
+import { currentWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 import type { AppConfig } from '../../src/types';
 import { loadConfig, fetchDaemonConfig, syncConfigToDaemon } from '../../src/state/config';
 import {
@@ -379,6 +380,29 @@ describe('App onboarding completion persistence', () => {
       { allowOnboardingReset: true },
     );
     expect(await navigatedToOnboarding()).toBe(true);
+  });
+
+  it('advances the account boundary so no cache outlives the sign-out', async () => {
+    // Sign-IN advances it (AmrLoginPill calls `notifyWorkspaceContextRefresh`)
+    // and sign-out did not, so every consumer keyed on the account generation
+    // treated the previous account's data as still current. The message
+    // center's ten-second snapshot is the sharpest case: a signed-out host
+    // mounting inside that window adopted the previous account's rows, unread
+    // count and priority announcement without rechecking `/vela/status`.
+    mockedLoadConfig.mockReturnValue(returningUserConfig());
+    mockedFetchDaemonConfig.mockResolvedValue({ onboardingCompleted: true });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(entryViewCapture.activeSignOut).toEqual(expect.any(Function));
+    });
+    const before = currentWorkspaceAccountGeneration();
+    await act(async () => {
+      await entryViewCapture.activeSignOut?.();
+    });
+
+    expect(currentWorkspaceAccountGeneration()).toBeGreaterThan(before);
   });
 
   it('keeps a completed user out of onboarding when the daemon copy still says false', async () => {

--- a/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+//
+// `EntryNavRail` renders two mutually-exclusive MessageCenter instances: the
+// signed-in one lives in the account cluster, the signed-out one on the rail.
+// The gate is the `context` prop alone, so during launch — before
+// `/api/workspace/context` has answered — `context` is null and the SIGNED-OUT
+// instance mounts. When the context arrives it unmounts and the signed-in one
+// mounts in its place, and that second mount re-runs a full sync:
+// `isAmrLoggedIn` plus a paginated `pullMessageCenter`.
+//
+// Measured on a cold Home launch, that remount is what puts
+// `/api/integrations/vela/status` and `/api/integrations/vela/message-center/messages`
+// on the duplicate list. Nothing about the panel needs the early mount: it is
+// hidden behind an opener, and the count it would report belongs to an identity
+// that has not resolved yet.
+
+import { cleanup, render } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../src/i18n';
+
+const workspaceContextState = {
+  context: null as WorkspaceCollabContext | null,
+  loading: true,
+  failure: null,
+  identityChangePending: false,
+  accountGeneration: 0,
+  resourceReadIdentity: null,
+};
+
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
+  useWorkspaceContext: () => workspaceContextState,
+}));
+
+const mountCounter = vi.hoisted(() => ({ mounts: 0 }));
+
+vi.mock('../../src/components/MessageCenter', async () => {
+  const { useEffect } = await import('react');
+  return {
+    // Count MOUNTS, not renders: the point of the gate is that the component
+    // is never constructed twice per launch, and a re-render is not a resync.
+    MessageCenter: () => {
+      useEffect(() => {
+        mountCounter.mounts += 1;
+      }, []);
+      return null;
+    },
+  };
+});
+
+function teamContext(): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team_plus',
+    displayName: 'Leaf',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: { canInviteMembers: true, canViewWorkspaceSettings: true },
+  } as unknown as WorkspaceCollabContext;
+}
+
+async function renderRail() {
+  const { EntryNavRail } = await import('../../src/components/EntryNavRail');
+  return render(
+    <I18nProvider initial="zh-CN">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={workspaceContextState.context}
+        workspaceContextResolving={workspaceContextState.loading}
+        billing={null}
+      />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mountCounter.mounts = 0;
+  workspaceContextState.context = null;
+  workspaceContextState.loading = true;
+  vi.stubGlobal('fetch', vi.fn(async () => Response.json({ items: [] })));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EntryNavRail message-center mounting', () => {
+  it('does not mount the message center while the workspace context is still loading', async () => {
+    await renderRail();
+    expect(mountCounter.mounts).toBe(0);
+  });
+
+  it('mounts exactly once across a launch that resolves into a workspace', async () => {
+    // The launch shape: context unresolved, then it arrives. Before this gate
+    // that was two mounts — signed-out, then signed-in — and the second one
+    // re-ran the whole sync.
+    const view = await renderRail();
+    expect(mountCounter.mounts).toBe(0);
+
+    workspaceContextState.context = teamContext();
+    workspaceContextState.loading = false;
+    const { EntryNavRail } = await import('../../src/components/EntryNavRail');
+    view.rerender(
+      <I18nProvider initial="zh-CN">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          open
+          context={workspaceContextState.context}
+          billing={null}
+        />
+      </I18nProvider>,
+    );
+
+    expect(mountCounter.mounts).toBe(1);
+  });
+
+  it('still mounts for a shell that resolves as signed out', async () => {
+    // The gate delays the signed-out instance; it must not suppress it.
+    workspaceContextState.loading = false;
+    await renderRail();
+    expect(mountCounter.mounts).toBe(1);
+  });
+});

--- a/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
@@ -14,7 +14,7 @@
 // hidden behind an opener, and the count it would report belongs to an identity
 // that has not resolved yet.
 
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -125,6 +125,41 @@ describe('EntryNavRail message-center mounting', () => {
       </I18nProvider>,
     );
 
+    expect(mountCounter.mounts).toBe(1);
+  });
+
+  it('does not accept a click on the opener while its panel is suppressed', async () => {
+    // The gate suppresses the panel but the rail's bell sits in the
+    // signed-out branch, which `context === null` keeps rendering throughout
+    // resolution. Left enabled, a click set the rail's own `messageCenterOpen`
+    // — and when the context resolved into a workspace, the signed-in cluster
+    // took over with its own state at false, so the click was swallowed with
+    // no dialog and no feedback. An opener with nothing to open must not take
+    // input.
+    const view = await renderRail();
+    const opener = screen.getByTestId('entry-nav-message-center');
+    expect(opener).toBeDisabled();
+
+    fireEvent.click(opener);
+    expect(mountCounter.mounts).toBe(0);
+
+    // Resolving as signed out hands the panel back, opener and all.
+    workspaceContextState.loading = false;
+    const { EntryNavRail } = await import('../../src/components/EntryNavRail');
+    view.rerender(
+      <I18nProvider initial="zh-CN">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          open
+          context={null}
+          workspaceContextResolving={false}
+          billing={null}
+        />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId('entry-nav-message-center')).toBeEnabled();
     expect(mountCounter.mounts).toBe(1);
   });
 

--- a/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.message-center-mount.test.tsx
@@ -19,11 +19,15 @@ import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { I18nProvider } from '../../src/i18n';
+import {
+  workspaceIdentityStillResolving,
+  type WorkspaceContextState,
+} from '../../src/collab/useWorkspaceContext';
 
 const workspaceContextState = {
   context: null as WorkspaceCollabContext | null,
   loading: true,
-  failure: null,
+  failure: undefined as WorkspaceContextState['failure'],
   identityChangePending: false,
   accountGeneration: 0,
   resourceReadIdentity: null,
@@ -76,7 +80,7 @@ async function renderRail() {
         onNewProject={() => {}}
         open
         context={workspaceContextState.context}
-        workspaceContextResolving={workspaceContextState.loading}
+        workspaceContextResolving={workspaceIdentityStillResolving(workspaceContextState)}
         billing={null}
       />
     </I18nProvider>,
@@ -88,6 +92,7 @@ beforeEach(() => {
   mountCounter.mounts = 0;
   workspaceContextState.context = null;
   workspaceContextState.loading = true;
+  workspaceContextState.failure = undefined;
   vi.stubGlobal('fetch', vi.fn(async () => Response.json({ items: [] })));
 });
 
@@ -160,6 +165,30 @@ describe('EntryNavRail message-center mounting', () => {
       </I18nProvider>,
     );
     expect(screen.getByTestId('entry-nav-message-center')).toBeEnabled();
+    expect(mountCounter.mounts).toBe(1);
+  });
+
+  it('stays closed when a cold context read fails transiently', async () => {
+    // The failure branch settles to `loading: false`, `failure: 'unavailable'`
+    // and a null `context` — there is no cached context on a first launch — so
+    // a gate reading `loading` alone opened during an unresolved identity.
+    // `isAmrLoggedIn()` maps the 503 to `false`, so this host would fetch and
+    // publish an ANONYMOUS snapshot; when the retry then resolves to a signed-in
+    // context without an account-generation bump, the signed-in host adopts the
+    // public rows for the length of the window.
+    workspaceContextState.loading = false;
+    workspaceContextState.failure = 'unavailable';
+    await renderRail();
+    expect(mountCounter.mounts).toBe(0);
+  });
+
+  it('opens for the authoritative failures, which are real answers', async () => {
+    // 404 means a daemon with no workspace endpoint and 401/403 means the
+    // server rejecting these credentials. Both are answers, not outages, so the
+    // signed-out panel belongs on screen.
+    workspaceContextState.loading = false;
+    workspaceContextState.failure = 'unsupported';
+    await renderRail();
     expect(mountCounter.mounts).toBe(1);
   });
 

--- a/apps/web/tests/components/EntryNavRail.signout-restores-cloud-tip.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.signout-restores-cloud-tip.test.tsx
@@ -22,6 +22,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
 import { CloudSignInTip } from '../../src/components/CloudSignInTip';
 import { I18nProvider } from '../../src/i18n';
+import { currentWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
+import { notifyWorkspaceContextRefresh } from '../../src/collab/useWorkspaceContext';
 
 const DISMISSED_KEY = 'od.entry.cloudSignInTip.dismissed';
 const originalFetch = globalThis.fetch;
@@ -90,6 +92,43 @@ describe('EntryNavRail sign-out (recvqbkcLqIFH7)', () => {
     await waitFor(() => {
       expect(window.localStorage.getItem(DISMISSED_KEY)).toBeNull();
     });
+  });
+
+  it('advances the account boundary exactly once for one sign-out', async () => {
+    // The rail used to be the only caller, so it notified after awaiting
+    // `onSignedOut`. Now the shared handler owns that boundary, and keeping
+    // both meant one sign-out advanced the generation twice — every
+    // account-scoped consumer invalidating twice, and `MessageCenter`
+    // (subscribed to it) running a full clear-and-resync per advance, which is
+    // the redundant traffic this work exists to remove.
+    const advances: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          open
+          context={context()}
+          onSignedOut={() => {
+            // Stands in for `handleActiveCloudSignOut`, which is the owner.
+            notifyWorkspaceContextRefresh();
+            advances.push(currentWorkspaceAccountGeneration());
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    const before = currentWorkspaceAccountGeneration();
+    fireEvent.click(screen.getByTestId('entry-nav-account'));
+    fireEvent.click(screen.getByText('退出登录'));
+    fireEvent.click(screen.getByTestId('sign-out-confirm-accept'));
+
+    await waitFor(() => expect(advances.length).toBe(1));
+    // Let anything the rail queues after `onSignedOut` settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(currentWorkspaceAccountGeneration()).toBe(before + 1);
   });
 
   it('renders the sign-in card once the stale dismissal is gone and context is null (post sign-out shape)', () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1097,6 +1097,77 @@ describe('MessageCenter remount snapshot', () => {
       .toContain('anon-ack');
   });
 
+  it('reaches a successor that mounted while the read was still in flight', async () => {
+    // Click an unread row, then navigate before the write lands. The old host
+    // unmounts mid-flight; the successor adopts the still-unread snapshot and
+    // finishes its mount effect. Patching the shared snapshot afterwards only
+    // helps hosts that adopt LATER — the one already on screen kept the row
+    // unread until an open, a visibility refresh or the 60s poll.
+    const hold = { armed: false, release: null as (() => void) | null };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        if (hold.armed) {
+          hold.armed = false;
+          await new Promise<void>((resolve) => {
+            hold.release = resolve;
+          });
+        }
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('in-flight-read', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const first = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBe(1));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /in-flight-read/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The read starts and its POST is held.
+    hold.armed = true;
+    fireEvent.click(target);
+    await waitFor(() => expect(hold.release).not.toBeNull());
+
+    // The user navigates: this host goes away, a successor takes over and
+    // adopts the snapshot as it stands — still unread.
+    first.unmount();
+    // Opening the panel already cost a sync of its own, so the meaningful
+    // measure is that nothing further goes out once the successor is up.
+    const pullsBeforeSuccessor = messageCalls;
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+
+    // The predecessor's write lands.
+    hold.release!();
+
+    // The successor must learn about it without another round trip.
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+    expect(messageCalls).toBe(pullsBeforeSuccessor);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -265,6 +265,127 @@ describe('MessageCenter remount snapshot', () => {
     expect(counts[counts.length - 1]).toBe(0);
   });
 
+  it('does not let an abandoned host overwrite the shared anonymous cache', async () => {
+    // `commitState` also writes `localStorage`, which is shared, not
+    // host-local. Gating only the snapshot left the cache unordered: an
+    // unmounted host passes its own request id forever, so its stale rows land
+    // on top of what a newer run just wrote, and a reload — or any remount
+    // past the snapshot window — reads them back with the read marks gone.
+    let releaseSecondPull: (() => void) | null = null;
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        if (pulls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseSecondPull = resolve;
+          });
+          return Response.json({
+            messages: [row('gamma-notice', null)],
+            nextCursor: null,
+            unreadCount: 1,
+          });
+        }
+        // From the third pull on, the server reports the row as read.
+        return Response.json({
+          messages: [row('gamma-notice', pulls >= 3 ? '2026-07-16T13:00:00.000Z' : null)],
+          nextCursor: null,
+          unreadCount: pulls >= 3 ? 0 : 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const seed = mount();
+    await waitFor(() => expect(messageCalls).toBe(1));
+    seed.unmount();
+
+    const abandoned = mount();
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(2));
+    abandoned.unmount();
+
+    const successor = mount();
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(3));
+    await waitFor(() => expect(
+      localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '',
+    ).toContain('gamma-notice'));
+    successor.unmount();
+
+    // Only now does the abandoned pull land, carrying pre-read rows.
+    releaseSecondPull!();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(
+      localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '',
+    ).toContain('gamma-notice');
+  });
+
+  it('carries optimistic reads through a remount while the server projection lags', async () => {
+    // The signed-in overlay is `serverReadIds` plus `pendingReadIdsRef`, and
+    // never `readIdsRef`. Adoption restored the latter only, so a remount
+    // inside the window followed by any refresh dropped the optimistic read
+    // and put the badge back — the exact case the pending set exists for.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        // The projection never catches up for the length of this test.
+        return Response.json({
+          messages: [row('delta-notice', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const host = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    fireEvent.click(await screen.findByRole('button', { name: /delta-notice/ }));
+    await new Promise((r) => setTimeout(r, 30));
+    host.unmount();
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts.length).toBeGreaterThan(0));
+
+    // The refresh that used to lose it.
+    const before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(counts[counts.length - 1]).toBe(0);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1599,6 +1599,84 @@ describe('MessageCenter remount snapshot', () => {
     expect(counts[counts.length - 1]).toBe(0);
   });
 
+  it('does not render the previous account\'s rows when the authority ends mid-pull', async () => {
+    // A remote or expired session is observed by status polling, not by the
+    // sign-out handler, so the workspace generation never moves. Refusing the
+    // run\'s SNAPSHOT is not enough on its own — component state is committed
+    // first, so the rows, the signed-in flag and the announcement would render
+    // in the still-mounted host and a refused publication cannot take them back.
+    // Every pull after the first is parked. The post-boundary resync is what
+    // used to refill the view and mask which mechanism was doing the work —
+    // with it held, the three states are distinguishable: cleared and kept
+    // clear, never cleared, or cleared and re-filled by the stale run.
+    let parkPulls = false;
+    const parked: Array<() => void> = [];
+    // The upstream answers according to the session that was valid when the
+    // request went out — the targeted row belongs to the ACCOUNT. A stub that
+    // returns it either way lets the post-boundary resync put it straight back,
+    // and the spec then fails no matter what the code does.
+    let sessionValid = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: sessionValid });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        const answeredFor = sessionValid;
+        if (parkPulls) {
+          await new Promise<void>((resolve) => { parked.push(resolve); });
+        }
+        if (!answeredFor) return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+        return Response.json({
+          messages: [{
+            ...row('PRIOR-ACCOUNT-row', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const pending: boolean[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pending.push(v)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    await new Promise((r) => setTimeout(r, 30));
+
+    // A refresh parks on its pull while the session is still valid.
+    parkPulls = true;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(parked.length).toBe(1));
+
+    // Polling elsewhere observes the session ending. No generation change.
+    sessionValid = false;
+    noteAuthoritativeAuthMode(false);
+
+    // The boundary's own resync is parked too, so nothing refills the view.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The stale pull lands.
+    parked[0]!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    // The still-mounted host must show nothing of that account.
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.queryByRole('button', { name: /PRIOR-ACCOUNT-row/ })).toBeNull();
+    expect(pending[pending.length - 1] ?? false).toBe(false);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -10,7 +10,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { I18nProvider } from '../../src/i18n';
+import { I18nProvider, useI18n } from '../../src/i18n';
 import { MessageCenter, resetMessageCenterSnapshot } from '../../src/components/MessageCenter';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 
@@ -232,6 +232,70 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(secondCounts.length).toBeGreaterThan(0));
     await new Promise((r) => setTimeout(r, 30));
     expect(secondCounts.at(-1)).toBe(0);
+  });
+
+  it('does not serve the previous locale\'s rows after a language switch', async () => {
+    // `pullMessageCenter` asks the server for locale-specific fields, so a
+    // snapshot is only valid for the language it was fetched under. Changing
+    // language re-runs the mount effect (via `sync`'s identity); without the
+    // locale in the key that re-run adopts the old language's rows and the
+    // panel stays in the wrong language until an open, a visibility refresh or
+    // the 60s poll.
+    const seen: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        const locale = new URL(url, 'http://x').searchParams.get('locale') || '?';
+        seen.push(locale);
+        return Response.json({
+          messages: [{
+            id: 'm1',
+            title: `row for ${locale}`,
+            body: 'b',
+            typeName: 't',
+            publishedAt: '2026-08-01T00:00:00.000Z',
+            readAt: null,
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    // `I18nProvider` seeds its locale from `initial` once, so switching has to
+    // go through the provider's own `setLocale`.
+    function Harness() {
+      const { setLocale } = useI18n();
+      return (
+        <>
+          <button type="button" data-testid="to-en" onClick={() => setLocale('en')}>en</button>
+          {/* Closed on purpose: the `open` effect re-runs on any `retrySync`
+              identity change and would fetch regardless of the snapshot logic,
+              hiding the defect this pins. */}
+          <MessageCenter hideTrigger open={false} onOpenChange={() => {}} />
+        </>
+      );
+    }
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <Harness />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    const firstLocale = seen[0];
+
+    fireEvent.click(screen.getByTestId('to-en'));
+
+    // The mount effect must fetch for the new locale rather than adopt the
+    // previous language's snapshot.
+    await waitFor(() => expect(seen.some((l) => l !== firstLocale)).toBe(true));
   });
 
   it('still syncs when the panel is opened', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1518,6 +1518,86 @@ describe('MessageCenter remount snapshot', () => {
     expect(window.localStorage.getItem('open-design.message-center.anonymous-messages.v1')).toBeNull();
   });
 
+  it('keeps a read that finishes after a language switch', async () => {
+    // `markRead` closes over the locale of the render the user clicked in. If
+    // the POST is still pending when the language changes, the new-locale sync
+    // publishes first and the read\'s delta was then rejected for a locale
+    // mismatch — so the shared snapshot still showed the row unread, and a
+    // remount inside the window brought the badge back. The message id is the
+    // same row in either language; only the ROWS are language-specific.
+    const post = { armed: false, release: null as (() => void) | null };
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        if (post.armed) {
+          post.armed = false;
+          await new Promise<void>((resolve) => { post.release = resolve; });
+        }
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        return Response.json({ messages: [row('bilingual-row', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    function Harness() {
+      const { setLocale } = useI18n();
+      return (
+        <>
+          <button type="button" data-testid="to-en" onClick={() => setLocale('en')}>en</button>
+          <MessageCenter />
+        </>
+      );
+    }
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <Harness />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /bilingual-row/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The read parks on its POST, then the language changes and the new-locale
+    // sync publishes a snapshot of its own.
+    post.armed = true;
+    fireEvent.click(target);
+    await waitFor(() => expect(post.release).not.toBeNull());
+    const before = messageCalls;
+    fireEvent.click(screen.getByTestId('to-en'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+
+    // Only now does the read land, carrying the previous locale.
+    post.release!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    // A remount inside the window must not resurrect the badge.
+    cleanup();
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="en">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts.length).toBeGreaterThan(0));
+    expect(counts[counts.length - 1]).toBe(0);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -63,7 +63,150 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+
+function row(id: string, readAt: string | null) {
+  return {
+    id,
+    audienceType: 'global',
+    typeName: 'Product update',
+    title: id,
+    body: id,
+    ctaLabel: null,
+    ctaUrl: null,
+    publishedAt: '2026-07-16T12:00:00.000Z',
+    readAt,
+  };
+}
+
+/** fetch stub whose FIRST message pull is held open until released. */
+function stubFetchWithGatedFirstPull(first: unknown[], later: unknown[]) {
+  let releaseFirst: (() => void) | null = null;
+  let pulls = 0;
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/integrations/vela/status')) {
+      statusCalls += 1;
+      return Response.json({ loggedIn: false });
+    }
+    if (url.includes('/message-center') && url.includes('/messages')) {
+      messageCalls += 1;
+      pulls += 1;
+      if (pulls === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        return Response.json({ messages: first, nextCursor: null, unreadCount: first.length });
+      }
+      return Response.json({ messages: later, nextCursor: null, unreadCount: later.length });
+    }
+    return Response.json({});
+  }));
+  return { release: () => releaseFirst?.() };
+}
+
 describe('MessageCenter remount snapshot', () => {
+  it('does not let a host that already unmounted publish over a newer snapshot', async () => {
+    // `syncRequestIdRef` lives on ONE component, so it can only order that
+    // component's own runs. A host that unmounts mid-flight never bumps its
+    // ref again: when its slow pull finally lands, its request id, the account
+    // generation and the locale all still match, and it wrote its older rows
+    // straight over the snapshot its successor had already published. The next
+    // remount then adopted the stale rows and the unread count went backwards.
+    const gate = stubFetchWithGatedFirstPull(
+      [row('a', null), row('b', null)],   // stale: 2 unread
+      [row('a', '2026-07-16T13:00:00.000Z'), row('b', null)],   // fresh: 1 unread
+    );
+
+    const first = mount();
+    await waitFor(() => expect(messageCalls).toBe(1));
+    first.unmount();
+
+    // The successor joins the in-flight run rather than racing it, so a second
+    // run needs a refresh trigger — the same visibility refresh the component
+    // wires up in production.
+    const second = mount();
+    await Promise.resolve();
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(2));
+
+    // The fresh run has published. Now let the abandoned host land.
+    gate.release();
+    await new Promise((r) => setTimeout(r, 20));
+    second.unmount();
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+
+    // Adopted, not refetched — otherwise this asserts the network, not the
+    // snapshot the stale writer was supposed to have corrupted.
+    await waitFor(() => expect(counts.length).toBeGreaterThan(0));
+    expect(messageCalls).toBe(2);
+    expect(counts[counts.length - 1]).toBe(1);
+  });
+
+  it('does not replay the previous account\'s read after a boundary crosses mid-POST', async () => {
+    // `markAccountMessageRead` is an await, and the boundary re-check used to
+    // sit BELOW the mutations that follow it. A sign-out/sign-in landing across
+    // that POST therefore left the old account's message id sitting in
+    // `pendingReadIdsRef` (and the anonymous cache already cleared) before the
+    // function bailed out — and the next sync replays that overlay, so a
+    // same-id message belonging to whoever signed in came back already read.
+    let releaseRead: (() => void) | null = null;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        await new Promise<void>((resolve) => {
+          releaseRead = resolve;
+        });
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('zeta-notice', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    fireEvent.click(await screen.findByRole('button', { name: /zeta-notice/ }));
+    await waitFor(() => expect(releaseRead).not.toBeNull());
+
+    // The account changes underneath the pending write.
+    advanceWorkspaceAccountGeneration('mark-read-post-boundary');
+    releaseRead!();
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The new account's sync must not inherit that read.
+    const before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -10,6 +10,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { flushSync } from 'react-dom';
+
 import { I18nProvider, useI18n } from '../../src/i18n';
 import { MessageCenter, resetMessageCenterSnapshot } from '../../src/components/MessageCenter';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
@@ -431,6 +433,65 @@ describe('MessageCenter remount snapshot', () => {
     advanceWorkspaceAccountGeneration('mounted-host-account-switch');
     await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
     await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+  });
+
+  it('shows nothing from the previous account on the boundary render itself', async () => {
+    // Clearing in an effect is too late: `useSyncExternalStore` re-renders with
+    // the new generation while the state still holds the previous account's
+    // rows, and the effect runs only after that render is committed — so the
+    // panel and badge painted the old account's data for the new one. This
+    // asserts at the boundary, before any refetch has had a chance to resolve.
+    // A holder object rather than a bare `let`: TS narrows the latter to
+    // `null` because the only assignment is inside a callback it cannot prove
+    // runs, which makes the optional call below uncallable.
+    const held: { release: (() => void) | null } = { release: null };
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        if (pulls >= 2) {
+          // The post-boundary refetch never resolves for this test, so the only
+          // thing that can empty the view is the render-time derivation.
+          await new Promise<void>((resolve) => {
+            held.release = resolve;
+          });
+        }
+        return Response.json({
+          messages: [row('prior-tenant-row', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    expect(await screen.findByRole('button', { name: /prior-tenant-row/ })).toBeTruthy();
+
+    // `flushSync` runs the boundary render and its layout effects but NOT the
+    // passive effects, which is exactly the gap being pinned: waiting with
+    // `waitFor` would let the clearing effect run and pass either way (it did,
+    // the first time this spec was written).
+    flushSync(() => {
+      advanceWorkspaceAccountGeneration('boundary-render-paint');
+    });
+
+    expect(screen.queryByRole('button', { name: /prior-tenant-row/ })).toBeNull();
+    expect(counts[counts.length - 1]).toBe(0);
+    held.release?.();
   });
 
   it('does not re-sync when it is remounted straight away', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1301,6 +1301,78 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
   });
 
+  it('keeps the announcement dismissible after an outage', async () => {
+    // `markRead` returning normally on `unavailable` reads as SUCCESS to
+    // `GoPlanSunsetDialog`, which sets `dismissing` before awaiting. The notice
+    // therefore stayed mounted with every control disabled, and recovering the
+    // runtime did not help: without an error the dialog never re-enabled
+    // itself, so there was no way to acknowledge short of a remount.
+    let mode: 'up' | 'down' = 'down';
+    let readPosts = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (mode === 'down') {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        readPosts += 1;
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            ...row('go-plan-sunset', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    // Seed the announcement while the runtime is up, then take it away.
+    mode = 'up';
+    const pending: boolean[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pending.push(v)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(pending[pending.length - 1]).toBe(true));
+
+    mode = 'down';
+    const acknowledge = await screen.findByRole('button', { name: /我知道了/ });
+    fireEvent.click(acknowledge);
+
+    // The failure must come back to the dialog so it re-enables itself.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /我知道了/ })).not.toBeDisabled();
+    });
+    expect(readPosts).toBe(0);
+
+    // With the runtime back, the same control works.
+    mode = 'up';
+    fireEvent.click(screen.getByRole('button', { name: /我知道了/ }));
+    await waitFor(() => expect(readPosts).toBe(1));
+    await waitFor(() => expect(pending[pending.length - 1]).toBe(false));
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1432,6 +1432,92 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(currentSnapshotWriteToken()).toBeGreaterThan(tokenBefore));
   });
 
+  it('clears the anonymous cache on sign-in even when a sync overlaps the read', async () => {
+    // Both halves must be in flight at once for the hole to open: the read
+    // observes token N, a successor sync is issued at N+1 so the read declines
+    // to clear, the read then supersedes to N+2 so the SYNC declines too, and a
+    // signed-out session's rows survive the sign-in. Gating only one of them
+    // lets the other clear and the spec passes against the broken code — which
+    // is how the first two versions of this test were written.
+    const seedAnonymous = () => {
+      window.localStorage.setItem(
+        'open-design.message-center.anonymous-messages.v1',
+        JSON.stringify([row('stale-anon', null)]),
+      );
+      window.localStorage.setItem(
+        'open-design.message-center.anonymous-read-ids.v1',
+        JSON.stringify(['stale-anon']),
+      );
+    };
+
+    const post = { armed: false, release: null as (() => void) | null };
+    const pull = { armed: false, release: null as (() => void) | null };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        if (post.armed) {
+          post.armed = false;
+          await new Promise<void>((resolve) => { post.release = resolve; });
+        }
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        if (pull.armed) {
+          pull.armed = false;
+          await new Promise<void>((resolve) => { pull.release = resolve; });
+        }
+        return Response.json({ messages: [row('acct-row', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /acct-row/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Seeded HERE, not before the render: the mount sync is already signed in,
+    // so it clears the anonymous cache on its way through and an earlier seed
+    // would be gone before the scenario starts — which made the first three
+    // versions of this spec assert `null` against a cache nothing had left.
+    seedAnonymous();
+
+    // The read parks on its POST.
+    post.armed = true;
+    fireEvent.click(target);
+    await waitFor(() => expect(post.release).not.toBeNull());
+
+    // A successor sync is issued and parks on its PULL, so it cannot clear
+    // before the read resumes.
+    pull.armed = true;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(pull.release).not.toBeNull());
+
+    // The premise, asserted rather than assumed: the cache is still there when
+    // the two overlapping operations are about to resolve.
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1'))
+      .toContain('stale-anon');
+
+    // Read first, then the sync.
+    post.release!();
+    await new Promise((r) => setTimeout(r, 30));
+    pull.release!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toBeNull();
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-messages.v1')).toBeNull();
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -16,12 +16,14 @@ import { I18nProvider, useI18n } from '../../src/i18n';
 import { MessageCenter } from '../../src/components/MessageCenter';
 import { recordAnonymousRead } from '../../src/message-center-client';
 import {
+  currentAuthoritativeLoggedIn,
   currentSnapshotWriteToken,
   noteAuthoritativeAuthMode,
   resetMessageCenterSnapshot,
   subscribeMessageCenterReads,
 } from '../../src/components/message-center-snapshot';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
+import { issueStatusObservation } from '../../src/providers/status-observation';
 
 let statusCalls = 0;
 let messageCalls = 0;
@@ -1788,6 +1790,45 @@ describe('MessageCenter remount snapshot', () => {
     await new Promise((r) => setTimeout(r, 20));
     expect(screen.queryByRole('button', { name: /PRIOR-ACCOUNT-row/ })).toBeNull();
     expect(pending[pending.length - 1] ?? false).toBe(false);
+  });
+
+  it('does not publish an auth read that was overtaken by the app\'s newer one', async () => {
+    // The other direction of the same race. This component reads the auth mode
+    // itself and publishes what it got, so ordering it only against its own
+    // previous reads leaves it free to overwrite a NEWER answer that the app's
+    // status effect published while this read was on the wire — taking the
+    // authority back to a session that has ended.
+    let releaseStatus!: () => void;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        await new Promise<void>((resolve) => { releaseStatus = resolve; });
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(releaseStatus).toBeTypeOf('function'));
+
+    // The app's status effect answers first, with a newer read: the session has
+    // ended. This is the call `applyAmrLoginStatus` makes.
+    expect(noteAuthoritativeAuthMode(false, issueStatusObservation())).toBe(true);
+
+    // This component's older read finally comes back saying signed-in.
+    releaseStatus();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(currentAuthoritativeLoggedIn()).toBe(false);
   });
 
   it('does not commit a pull that was answered for a session which has since ended', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -386,6 +386,53 @@ describe('MessageCenter remount snapshot', () => {
     expect(counts[counts.length - 1]).toBe(0);
   });
 
+  it('drops the previous account\'s rows on a boundary crossed while mounted', async () => {
+    // `notifyWorkspaceContextRefresh` retains the previous context while a
+    // sign-in/sign-out resolves, so the host is NOT remounted. Capturing the
+    // generation inside `sync` only stops a stale response from landing; a
+    // settled list was left on screen for whoever signed in, until an open, a
+    // visibility change or the 60s poll happened along.
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        return pulls === 1
+          ? Response.json({
+              messages: [row('previous-account', null), row('previous-account-2', null)],
+              nextCursor: null,
+              unreadCount: 2,
+            })
+          : Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(2));
+
+    // The account changes under the still-mounted host.
+    const before = messageCalls;
+    advanceWorkspaceAccountGeneration('mounted-host-account-switch');
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -207,6 +207,64 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
   });
 
+  it('records both of two concurrent reads in the shared snapshot', async () => {
+    // Two clicks land before either account POST resolves, so both capture the
+    // same snapshot. Patching by wholesale replacement guarded on snapshot
+    // identity meant the first completion replaced it and the second found the
+    // identity no longer matching, committed only host-local state, and left
+    // its row unread in the snapshot — so the badge came back on the next
+    // remount.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('alpha-notice', null), row('beta-notice', null)],
+          nextCursor: null,
+          unreadCount: 2,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const host = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const alpha = await screen.findByRole('button', { name: /alpha-notice/ });
+    const beta = await screen.findByRole('button', { name: /beta-notice/ });
+
+    // Back-to-back: neither POST has resolved when the second one starts.
+    fireEvent.click(alpha);
+    fireEvent.click(beta);
+    await new Promise((r) => setTimeout(r, 40));
+    host.unmount();
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts.length).toBeGreaterThan(0));
+    expect(counts[counts.length - 1]).toBe(0);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1168,6 +1168,81 @@ describe('MessageCenter remount snapshot', () => {
     expect(messageCalls).toBe(pullsBeforeSuccessor);
   });
 
+  it('retires a successor\'s announcement when the predecessor\'s acknowledgement lands', async () => {
+    // The successor adopted an UNREAD targeted notice, so `adopt` put the modal
+    // up. The predecessor's acknowledgement then succeeds and reaches the read
+    // subscriber, which updated the rows and read ids but not the announcement
+    // — leaving the successor holding a modal for something already
+    // acknowledged, so the user had to confirm it twice.
+    const hold = { armed: false, release: null as (() => void) | null };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        if (hold.armed) {
+          hold.armed = false;
+          await new Promise<void>((resolve) => {
+            hold.release = resolve;
+          });
+        }
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            ...row('go-plan-sunset', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const first = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /go-plan-sunset/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Acknowledge it; the POST is held.
+    hold.armed = true;
+    fireEvent.click(target);
+    await waitFor(() => expect(hold.release).not.toBeNull());
+
+    // Navigate away mid-flight; the successor adopts the still-unread notice.
+    first.unmount();
+    const pending: boolean[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pending.push(v)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(pending[pending.length - 1]).toBe(true));
+
+    // The predecessor's acknowledgement lands.
+    hold.release!();
+
+    // The successor must retire the notice rather than ask again.
+    await waitFor(() => expect(pending[pending.length - 1]).toBe(false));
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -495,6 +495,68 @@ describe('MessageCenter remount snapshot', () => {
     held.release?.();
   });
 
+  it('keeps the targeted announcement alive across a remount that adopts', async () => {
+    // The announcement is derived from the rows plus the signed-in state, both
+    // of which the snapshot carries — but adoption restored the rows only, so a
+    // project<->home remount inside the window dropped the required notice (and
+    // its pending signal) until the next network sync, which is also long
+    // enough for a lower-priority campaign to take the screen instead.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            ...row('go-plan-sunset', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const pending: boolean[] = [];
+    const first = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pending.push(v)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(pending[pending.length - 1]).toBe(true));
+    const afterFirst = messageCalls;
+    first.unmount();
+
+    const pendingAfter: boolean[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pendingAfter.push(v)}
+        />
+      </I18nProvider>,
+    );
+
+    // Adopted, not refetched — so this is asserting the snapshot path.
+    await waitFor(() => expect(pendingAfter.length).toBeGreaterThan(0));
+    expect(messageCalls).toBe(afterFirst);
+    expect(pendingAfter[pendingAfter.length - 1]).toBe(true);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1677,6 +1677,80 @@ describe('MessageCenter remount snapshot', () => {
     expect(pending[pending.length - 1] ?? false).toBe(false);
   });
 
+  it('does not commit a pull that was answered for a session which has since ended', async () => {
+    // The sibling spec above releases the held pull after the boundary effect
+    // has run. That effect issues a fresh sync, whose request id supersedes the
+    // held run\'s, so the held run bails on identity and nothing it fetched can
+    // reach the host. That is the ordering the earlier version of this spec
+    // exercised, and it is covered without any new code.
+    //
+    // The effect only issues that sync when there is nothing to join. On the
+    // FIRST pull of the process there is no published snapshot yet, so
+    // `noteAuthoritativeAuthMode` has nothing to compare against and leaves
+    // `inFlightSync` alone; the effect then JOINS the held signed-in run
+    // instead of replacing it. Its request id, its workspace generation and its
+    // captured account are all still current when it lands, so it commits the
+    // previous account\'s rows and its targeted announcement into a host that
+    // has already been told the session ended. Refusing its snapshot afterwards
+    // cannot take those host-local writes back.
+    //
+    // Reachable as: the app opens, the message centre\'s first pull is on the
+    // wire, and status polling observes a revoked or expired session.
+    const parked: Array<() => void> = [];
+    let sessionValid = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: sessionValid });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        const answeredFor = sessionValid;
+        await new Promise<void>((resolve) => { parked.push(resolve); });
+        if (!answeredFor) return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+        return Response.json({
+          messages: [{
+            ...row('PRIOR-ACCOUNT-row', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const pending: boolean[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          priorityAnnouncementActive
+          onPriorityAnnouncementPendingChange={(v) => pending.push(v)}
+        />
+      </I18nProvider>,
+    );
+    // The very first pull, held on the wire with no snapshot behind it.
+    await waitFor(() => expect(parked.length).toBe(1));
+
+    // Everything from here is what the host may show once the session is over.
+    const afterBoundary = pending.length;
+    sessionValid = false;
+    noteAuthoritativeAuthMode(false);
+    // Let the boundary effect run. With nothing to adopt and a run to join, it
+    // joins — the held run stays the current one.
+    await new Promise((r) => setTimeout(r, 30));
+
+    parked[0]!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(pending.slice(afterBoundary)).not.toContain(true);
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.queryByRole('button', { name: /PRIOR-ACCOUNT-row/ })).toBeNull();
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -7,7 +7,7 @@
 // for a panel the user has not opened and whose contents cannot have changed in
 // the time a route switch takes.
 
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { I18nProvider } from '../../src/i18n';
@@ -137,6 +137,101 @@ describe('MessageCenter remount snapshot', () => {
 
     mount();
     await waitFor(() => expect(messageCalls).toBeGreaterThan(afterFirst));
+  });
+
+  it('never adopts a response that was fetched before an account boundary', async () => {
+    // The generation must be captured when the sync STARTS. Stamping the
+    // snapshot at completion labels a pre-boundary response with the new
+    // account's generation, and a post-boundary mount then renders the previous
+    // account's messages as current.
+    let release: (value: Response) => void = () => {};
+    const gate = new Promise<Response>((r) => { release = r; });
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        pulls += 1;
+        messageCalls += 1;
+        if (pulls === 1) return gate;
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      return Response.json({});
+    }));
+
+    const first = mount();
+    await waitFor(() => expect(pulls).toBe(1));
+
+    // Sign-out/sign-in lands while the first pull is still open.
+    advanceWorkspaceAccountGeneration('mid-flight-boundary');
+    release(Response.json({
+      messages: [{ id: 'stale', title: 'previous account', readAt: null }],
+      nextCursor: null,
+      unreadCount: 1,
+    }));
+    await new Promise((r) => setTimeout(r, 20));
+    first.unmount();
+
+    // A mount after the boundary must fetch rather than adopt that response.
+    mount();
+    await waitFor(() => expect(pulls).toBeGreaterThan(1));
+  });
+
+  it('keeps a message read after marking it and remounting', async () => {
+    // `markRead` updates component state; the module snapshot was left holding
+    // the pre-read rows, so a project<->home switch inside the window restored
+    // the unread count until the next network sync. The count is the
+    // component's own contract (`onUnreadCountChange`), so assert on that.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        if ((init?.method ?? 'GET') !== 'GET') return Response.json({});
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            id: 'm1',
+            title: 'unread one',
+            body: 'b',
+            typeName: 't',
+            publishedAt: '2026-08-01T00:00:00.000Z',
+            readAt: null,
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const firstCounts: number[] = [];
+    const view = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter hideTrigger open onOpenChange={() => {}} onUnreadCountChange={(n) => firstCounts.push(n)} />
+      </I18nProvider>,
+    );
+    const row = await screen.findByText('unread one');
+    await waitFor(() => expect(firstCounts.at(-1)).toBe(1));
+
+    fireEvent.click(row.closest('button') as HTMLButtonElement);
+    await waitFor(() => expect(firstCounts.at(-1)).toBe(0));
+    view.unmount();
+
+    const secondCounts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter hideTrigger open onOpenChange={() => {}} onUnreadCountChange={(n) => secondCounts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(secondCounts.length).toBeGreaterThan(0));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(secondCounts.at(-1)).toBe(0);
   });
 
   it('still syncs when the panel is opened', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -831,6 +831,139 @@ describe('MessageCenter remount snapshot', () => {
     expect(pulled[1]).toBe('account');
   });
 
+  it('does not stamp a pre-boundary login answer into component state', async () => {
+    // `resolveLoggedInForWrite` used to assign `loggedInRef`/`setLoggedIn`
+    // before returning, so the write landed BEFORE the caller's boundary check
+    // wherever that check sat. A status request issued while signed in then
+    // resolved after the sign-out, re-stamped `true` over the settled
+    // signed-out state, and the next sync read `wasAccount === true`, took the
+    // signed-out transition a second time, and wiped the read the signed-out
+    // user had just made.
+    const hold = { armed: false, release: null as (() => void) | null };
+    let loggedIn = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        // The answer reflects the moment the request was ISSUED, which is the
+        // point: it returns describing an authority that has moved on.
+        const answeredWith = loggedIn;
+        if (hold.armed) {
+          hold.armed = false;
+          await new Promise<void>((resolve) => {
+            hold.release = resolve;
+          });
+        }
+        return Response.json({ loggedIn: answeredWith });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('boundary-row', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    await new Promise((r) => setTimeout(r, 30));
+
+    // A read begins while signed in; its status call is held on the wire.
+    hold.armed = true;
+    fireEvent.click(await screen.findByRole('button', { name: /boundary-row/ }));
+    await waitFor(() => expect(hold.release).not.toBeNull());
+
+    // The user signs out and a signed-out sync settles first.
+    loggedIn = false;
+    advanceWorkspaceAccountGeneration('read-status-boundary');
+    let before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+
+    // The signed-out user reads it for themselves.
+    fireEvent.click(await screen.findByRole('button', { name: /boundary-row/ }));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+
+    // Only now does the pre-sign-out status answer land, carrying `true`.
+    hold.release!();
+    await new Promise((r) => setTimeout(r, 30));
+
+    // A later sync must not treat this host as a signed-in predecessor and
+    // discard that read.
+    before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(counts[counts.length - 1]).toBe(0);
+  });
+
+  it('does not take the signed-out transition on a transient 503', async () => {
+    // `account` collapses `unavailable` into `false`, so the signed-out branch
+    // ran during a runtime outage and discarded `pendingReadIdsRef` — the
+    // optimistic reads the server projection has not caught up on. When the
+    // runtime returned before the projection did, the badge came back for a row
+    // the user had already read.
+    let mode: 'up' | 'down' = 'up';
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (mode === 'down') {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        // The projection never catches up for the length of this test.
+        return Response.json({ messages: [row('pending-ack', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    fireEvent.click(await screen.findByRole('button', { name: /pending-ack/ }));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+
+    // The runtime goes away and a refresh lands during the outage.
+    mode = 'down';
+    let before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+
+    // It comes back before the projection does; the optimistic read must have
+    // survived the outage.
+    mode = 'up';
+    before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(counts[counts.length - 1]).toBe(0);
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1024,6 +1024,79 @@ describe('MessageCenter remount snapshot', () => {
       .not.toContain('shared-id');
   });
 
+  it('ignores a superseded run\'s auth answer before it touches component state', async () => {
+    // Refreshes overlap routinely — open, visibility, the interval, a remount
+    // that joins and then refreshes. The request-id check sat only after the
+    // pull, so a held status answer from run A landed after run B had already
+    // captured the signed-out transition, and re-stamped `loggedInRef` to
+    // `true`. The next signed-out refresh then read `wasAccount === true`,
+    // cleared the anonymous overlay, and persisted an empty read-id set —
+    // erasing a read the current anonymous session had just made.
+    const hold = { armed: false, release: null as (() => void) | null };
+    let loggedIn = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        const answeredWith = loggedIn;
+        if (hold.armed) {
+          hold.armed = false;
+          await new Promise<void>((resolve) => {
+            hold.release = resolve;
+          });
+        }
+        return Response.json({ loggedIn: answeredWith });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('anon-ack', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+
+    // Run A: a refresh whose status answer is held while still signed in.
+    hold.armed = true;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(hold.release).not.toBeNull());
+
+    // Run B overtakes it and settles the signed-out transition. No account
+    // boundary is crossed — this is one identity's runs racing each other.
+    loggedIn = false;
+    let before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+
+    // The anonymous session reads the row.
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    fireEvent.click(await screen.findByRole('button', { name: /anon-ack/ }));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+
+    // Only now does run A's stale `signed-in` answer land.
+    hold.release!();
+    await new Promise((r) => setTimeout(r, 30));
+
+    // A later refresh must not see a signed-in predecessor and wipe the read.
+    before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(counts[counts.length - 1]).toBe(0);
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '')
+      .toContain('anon-ack');
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -17,6 +17,7 @@ import { MessageCenter } from '../../src/components/MessageCenter';
 import { recordAnonymousRead } from '../../src/message-center-client';
 import {
   currentSnapshotWriteToken,
+  noteAuthoritativeAuthMode,
   resetMessageCenterSnapshot,
 } from '../../src/components/message-center-snapshot';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -556,14 +556,58 @@ describe('MessageCenter remount snapshot', () => {
     expect(screen.queryByTestId('go-plan-sunset-dialog')).toBeNull();
   });
 
-  it('does not POST an account read whose auth check crossed the end of the session', async () => {
-    // The sibling spec below holds the POST. This one holds the STATUS READ
-    // that authorises it — which is the earlier and worse case, because the
-    // epoch was captured after that read came back, by which time the change it
-    // was meant to detect had already been counted. The post-POST comparison
-    // then saw no change at all, so the write went through: an account POST for
-    // a session that had ended, plus the read state, the anonymous clear and
-    // the delta behind it.
+  it('still pulls when its own status read loses the order to an identical answer', async () => {
+    // Refusing an observation orders it; it does not mean the answer was wrong.
+    // Another host's read can be issued later and answer first with the SAME
+    // mode, and this run is then refused for ordering alone. Returning there
+    // abandoned the pull: `retrySync` sees a resolved promise, so nothing
+    // reports an error or schedules a retry, and a first mount finishes with an
+    // empty bell until the user opens the panel or the 60s poll comes round.
+    let releaseStatus: (() => void) | null = null;
+    let holdStatus = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (holdStatus) {
+          holdStatus = false;
+          await new Promise<void>((resolve) => { releaseStatus = resolve; });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('late-order-row', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(releaseStatus).not.toBeNull());
+
+    // Another host's read was issued later and answers first — same mode.
+    noteAuthoritativeAuthMode(true, issueStatusObservation());
+
+    releaseStatus!();
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+    expect(messageCalls).toBeGreaterThan(0);
+  });
+
+  it('finishes the announcement dismissal when its auth read loses the order', async () => {
+    // Same refusal on the write path, where returning normally is worse than
+    // useless: `GoPlanSunsetDialog` sets `dismissing` before awaiting and only
+    // clears it if the promise REJECTS, so a silent success leaves the notice
+    // mounted with every control disabled and no way back short of a remount —
+    // the exact failure the `unavailable` branch above already guards against.
     let releaseStatus: (() => void) | null = null;
     let holdStatus = false;
     const posted: string[] = [];
@@ -576,6 +620,120 @@ describe('MessageCenter remount snapshot', () => {
           await new Promise<void>((resolve) => { releaseStatus = resolve; });
         }
         return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        posted.push(url);
+        return Response.json({});
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            ...row('announcement-row', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter priorityAnnouncementActive />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(screen.queryByTestId('go-plan-sunset-dialog')).not.toBeNull());
+
+    // The dismissal's own auth read is held, and loses the order to an
+    // identical answer from elsewhere.
+    holdStatus = true;
+    fireEvent.click(screen.getByLabelText('关闭弹窗'));
+    await waitFor(() => expect(releaseStatus).not.toBeNull());
+    noteAuthoritativeAuthMode(true, issueStatusObservation());
+    releaseStatus!();
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(posted.length).toBe(1);
+    expect(screen.queryByTestId('go-plan-sunset-dialog')).toBeNull();
+  });
+
+  it('leaves the anonymous cache alone when the pull that would clear it is discarded', async () => {
+    // The clear ran BEFORE the authority revalidation, so a signed-in pull that
+    // resumed after a remote sign-out erased the anonymous messages and read
+    // ids and was only then discarded — and being discarded, it put nothing
+    // back. The session that is now signed out loses read state that exists
+    // nowhere else.
+    let releasePull!: () => void;
+    window.localStorage.setItem(
+      'open-design.message-center.anonymous-messages.v1',
+      JSON.stringify([{ ...row('seeded-row', '2026-08-01T00:00:00.000Z') }]),
+    );
+    window.localStorage.setItem(
+      'open-design.message-center.anonymous-read-ids.v1',
+      JSON.stringify(['seeded-row']),
+    );
+    const seededKeys = [
+      'open-design.message-center.anonymous-messages.v1',
+      'open-design.message-center.anonymous-read-ids.v1',
+    ];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        await new Promise<void>((resolve) => { releasePull = resolve; });
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(releasePull).toBeTypeOf('function'));
+
+    // Polling observes the session ending. No generation change.
+    noteAuthoritativeAuthMode(false, issueStatusObservation());
+    releasePull();
+    await new Promise((r) => setTimeout(r, 40));
+
+    for (const key of seededKeys) expect(window.localStorage.getItem(key)).not.toBeNull();
+  });
+
+  it('does not POST an account read whose auth check crossed the end of the session', async () => {
+    // The sibling spec below holds the POST. This one holds the STATUS READ
+    // that authorises it — which is the earlier and worse case, because the
+    // epoch was captured after that read came back, by which time the change it
+    // was meant to detect had already been counted. The post-POST comparison
+    // then saw no change at all, so the write went through: an account POST for
+    // a session that had ended, plus the read state, the anonymous clear and
+    // the delta behind it.
+    let releaseStatus: (() => void) | null = null;
+    let holdStatus = false;
+    // The upstream answers for the session that was valid when the request went
+    // out. A stub that keeps saying signed-in after the sign-out is not the
+    // scenario: the boundary's own resync would then legitimately put the
+    // authority back, and the write would be right to proceed.
+    let sessionValid = true;
+    const posted: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        const answeredFor = sessionValid;
+        if (holdStatus) {
+          holdStatus = false;
+          await new Promise<void>((resolve) => { releaseStatus = resolve; });
+        }
+        return Response.json({ loggedIn: answeredFor });
       }
       if (url.includes('/read') && init?.method === 'POST') {
         posted.push(url);
@@ -610,6 +768,7 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(releaseStatus).not.toBeNull());
 
     // Polling elsewhere observes the session ending. No generation change.
+    sessionValid = false;
     noteAuthoritativeAuthMode(false, issueStatusObservation());
     await new Promise((r) => setTimeout(r, 20));
 

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -556,6 +556,72 @@ describe('MessageCenter remount snapshot', () => {
     expect(screen.queryByTestId('go-plan-sunset-dialog')).toBeNull();
   });
 
+  it('does not POST an account read whose auth check crossed the end of the session', async () => {
+    // The sibling spec below holds the POST. This one holds the STATUS READ
+    // that authorises it — which is the earlier and worse case, because the
+    // epoch was captured after that read came back, by which time the change it
+    // was meant to detect had already been counted. The post-POST comparison
+    // then saw no change at all, so the write went through: an account POST for
+    // a session that had ended, plus the read state, the anonymous clear and
+    // the delta behind it.
+    let releaseStatus: (() => void) | null = null;
+    let holdStatus = false;
+    const posted: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (holdStatus) {
+          holdStatus = false;
+          await new Promise<void>((resolve) => { releaseStatus = resolve; });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        posted.push(url);
+        return Response.json({});
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('auth-held-row', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const deltas: Array<{ account: boolean }> = [];
+    const stop = subscribeMessageCenterReads((delta) => { deltas.push({ account: delta.account }); });
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const rowButton = await screen.findByRole('button', { name: /auth-held-row/ });
+
+    // The click's own auth read is held on the wire.
+    holdStatus = true;
+    fireEvent.click(rowButton);
+    await waitFor(() => expect(releaseStatus).not.toBeNull());
+
+    // Polling elsewhere observes the session ending. No generation change.
+    noteAuthoritativeAuthMode(false, issueStatusObservation());
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The held read answers with the session that was valid when it went out.
+    releaseStatus!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(posted).toEqual([]);
+    expect(deltas.filter((d) => d.account)).toEqual([]);
+    stop();
+  });
+
   it('does not record an account read whose POST crossed the end of the session', async () => {
     // Same rule as the pull path, on the write path. The post-await check here
     // only compared the workspace generation, and a remote or expired session

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -19,6 +19,7 @@ import {
   currentSnapshotWriteToken,
   noteAuthoritativeAuthMode,
   resetMessageCenterSnapshot,
+  subscribeMessageCenterReads,
 } from '../../src/components/message-center-snapshot';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 
@@ -498,6 +499,118 @@ describe('MessageCenter remount snapshot', () => {
     expect(screen.queryByRole('button', { name: /prior-tenant-row/ })).toBeNull();
     expect(counts[counts.length - 1]).toBe(0);
     held.release?.();
+  });
+
+  it('hides the previous session\'s badge and announcement in the boundary render itself', async () => {
+    // Sibling of the generation-boundary spec above, for the other boundary.
+    // The docblock on `rowsBelongToThisAccount` promises to fail closed DURING
+    // the boundary render — but it only compared the workspace generation, and
+    // a remote or expired session changes the authority WITHOUT advancing it.
+    // `useSyncExternalStore` re-renders on that change while the state still
+    // holds the previous session's rows, so there was one committed render
+    // still showing its unread badge and its targeted announcement.
+    //
+    // Both assertions are on the DOM rather than the `onUnreadCountChange` /
+    // `onPriorityAnnouncementPendingChange` callbacks: those fire from passive
+    // effects, which `flushSync` deliberately does not run, so they would still
+    // be reporting the render before this one.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [{
+            ...row('prior-session-row', null),
+            audienceType: 'targeted',
+            messageKey: 'go-plan-sunset-2026-08',
+          }],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter priorityAnnouncementActive />
+      </I18nProvider>,
+    );
+    // Panel left closed: the trigger's badge is the render-time surface, and
+    // opening it would put the announcement dialog's modal over everything.
+    await waitFor(() => expect(screen.queryByTestId('go-plan-sunset-dialog')).not.toBeNull());
+    expect(screen.getByTestId('message-center-trigger').textContent).toContain('1');
+
+    // The session ends remotely. No generation change.
+    flushSync(() => {
+      noteAuthoritativeAuthMode(false);
+    });
+
+    expect(screen.getByTestId('message-center-trigger').textContent).not.toContain('1');
+    expect(screen.queryByTestId('go-plan-sunset-dialog')).toBeNull();
+  });
+
+  it('does not record an account read whose POST crossed the end of the session', async () => {
+    // Same rule as the pull path, on the write path. The post-await check here
+    // only compared the workspace generation, and a remote or expired session
+    // does not move it — so a read that started while signed in could resume
+    // after the session ended and still take `loggedInRef` back to signed-in,
+    // add pending read ids, clear the anonymous cache, and broadcast an
+    // account-scoped read delta that another same-generation host consumes.
+    let releaseRead!: () => void;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        await new Promise<void>((resolve) => { releaseRead = resolve; });
+        return Response.json({});
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('account-read-row', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const deltas: Array<{ account: boolean; messageId: string }> = [];
+    const stop = subscribeMessageCenterReads((delta) => {
+      deltas.push({ account: delta.account, messageId: delta.messageId });
+    });
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const rowButton = await screen.findByRole('button', { name: /account-read-row/ });
+
+    // The read goes out while the session is still valid, and is held.
+    fireEvent.click(rowButton);
+    await waitFor(() => expect(releaseRead).toBeTypeOf('function'));
+
+    // Polling observes the session ending. No generation change.
+    noteAuthoritativeAuthMode(false);
+    await new Promise((r) => setTimeout(r, 20));
+
+    const afterBoundary = deltas.length;
+    releaseRead();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(deltas.slice(afterBoundary).filter((d) => d.account)).toEqual([]);
+    stop();
   });
 
   it('keeps the targeted announcement alive across a remount that adopts', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -15,7 +15,10 @@ import { flushSync } from 'react-dom';
 import { I18nProvider, useI18n } from '../../src/i18n';
 import { MessageCenter } from '../../src/components/MessageCenter';
 import { recordAnonymousRead } from '../../src/message-center-client';
-import { resetMessageCenterSnapshot } from '../../src/components/message-center-snapshot';
+import {
+  currentSnapshotWriteToken,
+  resetMessageCenterSnapshot,
+} from '../../src/components/message-center-snapshot';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 
 let statusCalls = 0;
@@ -1371,6 +1374,62 @@ describe('MessageCenter remount snapshot', () => {
     fireEvent.click(screen.getByRole('button', { name: /我知道了/ }));
     await waitFor(() => expect(readPosts).toBe(1));
     await waitFor(() => expect(pending[pending.length - 1]).toBe(false));
+  });
+
+  it('does not spend a publication slot on a click it cannot act on', async () => {
+    // `markRead` CLAIMED a slot before it knew whether it could act, so an
+    // `unavailable` click returned having done nothing while the counter had
+    // moved — stripping a sync already waiting on its pull of the right to
+    // publish, and costing the next host swap the fetch this module exists to
+    // avoid.
+    //
+    // Asserted as the property rather than the downstream fetch on purpose: to
+    // observe the consequence, the parked sync would have to be the ONLY
+    // publisher, and a row can only be clicked once some earlier sync has
+    // settled — which has already published a snapshot the remount would adopt
+    // regardless. The property is what the guard is; the fetch follows from it.
+    let statusMode: 'up' | 'down' = 'up';
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (statusMode === 'down') {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('slot-row', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /slot-row/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The runtime drops; the click can do nothing.
+    statusMode = 'down';
+    const tokenBefore = currentSnapshotWriteToken();
+    fireEvent.click(target);
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(currentSnapshotWriteToken()).toBe(tokenBefore);
+
+    // And a click it CAN act on still supersedes earlier pulls, as it must.
+    statusMode = 'up';
+    fireEvent.click(screen.getByRole('button', { name: /slot-row/ }));
+    await waitFor(() => expect(currentSnapshotWriteToken()).toBeGreaterThan(tokenBefore));
   });
 
   it('does not re-sync when it is remounted straight away', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+//
+// The panel has two mutually-exclusive hosts — the rail's cluster on the entry
+// views, `WorkspaceTopRightAccountCluster` on a project route — so every
+// project<->home navigation unmounts one and mounts the other. Each remount
+// re-ran the whole sync: `isAmrLoggedIn`, then a paginated `pullMessageCenter`,
+// for a panel the user has not opened and whose contents cannot have changed in
+// the time a route switch takes.
+
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nProvider } from '../../src/i18n';
+import { MessageCenter, resetMessageCenterSnapshot } from '../../src/components/MessageCenter';
+import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
+
+let statusCalls = 0;
+let messageCalls = 0;
+
+function stubFetch() {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/integrations/vela/status')) {
+      statusCalls += 1;
+      return Response.json({ loggedIn: false });
+    }
+    // Signed-out pulls go through `message-center-public`; match both proxies.
+    if (url.includes('/message-center') && url.includes('/messages')) {
+      messageCalls += 1;
+      return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+    }
+    return Response.json({});
+  }));
+}
+
+function mount() {
+  return render(
+    <I18nProvider initial="zh-CN">
+      <MessageCenter hideTrigger open={false} onOpenChange={() => {}} />
+    </I18nProvider>,
+  );
+}
+
+async function mountAndSettle() {
+  const view = mount();
+  await waitFor(() => expect(statusCalls).toBeGreaterThan(0));
+  await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+  return view;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  statusCalls = 0;
+  messageCalls = 0;
+  resetMessageCenterSnapshot();
+  vi.useRealTimers();
+  stubFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('MessageCenter remount snapshot', () => {
+  it('does not re-sync when it is remounted straight away', async () => {
+    const first = await mountAndSettle();
+    const afterFirst = { status: statusCalls, messages: messageCalls };
+    first.unmount();
+
+    mount();
+    // Give the mount effect a turn; nothing new may go out.
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(statusCalls).toBe(afterFirst.status);
+    expect(messageCalls).toBe(afterFirst.messages);
+  });
+
+  it('does not stampede when a remount lands while a sync is still in flight', async () => {
+    // Found in a real browser, not by reading: a route switch unmounts the
+    // outgoing host and mounts the incoming one within the same frame, so the
+    // second mount starts BEFORE the first sync has written its snapshot.
+    // Sequential dedupe alone misses that case entirely — measured four syncs
+    // for one project<->home round trip.
+    let release: (value: Response) => void = () => {};
+    const gate = new Promise<Response>((r) => { release = r; });
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return gate;
+      }
+      return Response.json({});
+    }));
+
+    const first = mount();
+    await waitFor(() => expect(messageCalls).toBe(1));
+
+    // Second host mounts while the first pull is still open.
+    const second = mount();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(messageCalls).toBe(1);
+
+    release(Response.json({ messages: [], nextCursor: null, unreadCount: 0 }));
+    await waitFor(() => expect(messageCalls).toBe(1));
+    first.unmount();
+    second.unmount();
+  });
+
+  it('syncs again once the snapshot window has passed', async () => {
+    const first = await mountAndSettle();
+    const afterFirst = messageCalls;
+    first.unmount();
+
+    // 10s window; jump past it without waiting for real time.
+    const realNow = Date.now;
+    vi.spyOn(Date, 'now').mockImplementation(() => realNow() + 11_000);
+
+    mount();
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(afterFirst));
+  });
+
+  it('never adopts a snapshot from the previous account', async () => {
+    // A sign-out/sign-in makes the previous account's messages inadmissible no
+    // matter how recent they are.
+    const first = await mountAndSettle();
+    const afterFirst = messageCalls;
+    first.unmount();
+
+    advanceWorkspaceAccountGeneration('message-center-remount-boundary');
+
+    mount();
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(afterFirst));
+  });
+
+  it('still syncs when the panel is opened', async () => {
+    // The snapshot only answers the MOUNT question. Opening the panel is a
+    // user asking for the current state and must go to the network.
+    const view = await mountAndSettle();
+    const afterFirst = messageCalls;
+
+    view.rerender(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter hideTrigger open onOpenChange={() => {}} />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(afterFirst));
+  });
+});

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -733,6 +733,104 @@ describe('MessageCenter remount snapshot', () => {
     expect(screen.queryByText('检查失败，请重试')).toBeNull();
   });
 
+  it('does not wipe the anonymous cache from a run issued before a sign-out', async () => {
+    // The account generation is the only guard on the clear, and it does not
+    // move on sign-out: `notifyWorkspaceContextRefresh` is called on sign-IN by
+    // AmrLoginPill and not by `handleActiveCloudSignOut`. So a signed-in run
+    // resumes after the user signs out, still believing `account === true`, and
+    // destroys read ids a signed-out run has since persisted — which for an
+    // anonymous reader exist nowhere else.
+    let releasePull: (() => void) | null = null;
+    let pulls = 0;
+    let loggedIn = true;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        if (pulls === 1) {
+          await new Promise<void>((resolve) => {
+            releasePull = resolve;
+          });
+        }
+        return Response.json({ messages: [row('kept-read', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    // A signed-in host puts a pull on the wire and then goes away.
+    const signedIn = mount();
+    await waitFor(() => expect(messageCalls).toBe(1));
+    signedIn.unmount();
+
+    // The user signs out; a signed-out run persists what it read.
+    loggedIn = false;
+    const anon = mount();
+    // The first pull is still on the wire, so this mount JOINS it rather than
+    // starting its own; the visibility refresh is what gives the signed-out
+    // state a run of its own (the app navigates on sign-out, so a refresh here
+    // is the realistic shape).
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(2));
+    recordAnonymousRead(window.localStorage, 'kept-read', '2026-07-16T13:00:00.000Z');
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '')
+      .toContain('kept-read');
+
+    // Only now does the signed-in pull land.
+    releasePull!();
+    await new Promise((r) => setTimeout(r, 30));
+    anon.unmount();
+
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '')
+      .toContain('kept-read');
+  });
+
+  it('does not let a runtime-unavailable read stand in for a signed-out answer', async () => {
+    // `isAmrLoggedIn` maps a 503 `amr-runtime-unavailable` to `false`, which is
+    // indistinguishable from a real signed-out state. Publishing a snapshot on
+    // that reading served the PUBLIC feed to a signed-in reader for the whole
+    // window: a remount adopts without re-asking, so a runtime that recovered
+    // in the meantime went unnoticed and the targeted messages stayed missing.
+    let runtimeUp = false;
+    const pulled: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (!runtimeUp) {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulled.push(url.includes('message-center-public') ? 'public' : 'account');
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      return Response.json({});
+    }));
+
+    const down = await mountAndSettle();
+    expect(pulled).toEqual(['public']);
+    down.unmount();
+
+    // The runtime comes back; the workspace identity never changed, so the
+    // account generation has not moved and the window has not elapsed.
+    runtimeUp = true;
+    mount();
+
+    // The remount must ask again rather than reuse an answer nobody gave.
+    await waitFor(() => expect(pulled.length).toBe(2));
+    expect(pulled[1]).toBe('account');
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -14,6 +14,7 @@ import { flushSync } from 'react-dom';
 
 import { I18nProvider, useI18n } from '../../src/i18n';
 import { MessageCenter } from '../../src/components/MessageCenter';
+import { recordAnonymousRead } from '../../src/message-center-client';
 import { resetMessageCenterSnapshot } from '../../src/components/message-center-snapshot';
 import { advanceWorkspaceAccountGeneration } from '../../src/collab/workspace-identity';
 
@@ -555,6 +556,181 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(pendingAfter.length).toBeGreaterThan(0));
     expect(messageCalls).toBe(afterFirst);
     expect(pendingAfter[pendingAfter.length - 1]).toBe(true);
+  });
+
+  it('keeps a successor\'s anonymous read when an older continuation lands after it', async () => {
+    // `markRead` used to persist this host's WHOLE row set. A continuation can
+    // pause across its awaits, its host can unmount, and a successor can
+    // persist a read of its own meanwhile — the full-array write on resume then
+    // dropped it from the durable cache, and the badge came back after the
+    // snapshot expired or the page reloaded.
+    // Gated by an explicit flag, not by call ordinal: opening the panel fires a
+    // sync of its own, so "the second status call" was that one and the read's
+    // continuation never actually paused — which is why the first version of
+    // this spec passed against the unfixed code.
+    const hold = { armed: false, release: null as (() => void) | null };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        if (hold.armed) {
+          hold.armed = false;
+          await new Promise<void>((resolve) => {
+            hold.release = resolve;
+          });
+        }
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({
+          messages: [row('anon-one', null), row('anon-two', null)],
+          nextCursor: null,
+          unreadCount: 2,
+        });
+      }
+      return Response.json({});
+    }));
+
+    const host = render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /anon-one/ });
+    // Let the open effect's own sync settle first, THEN arm the gate.
+    await new Promise((r) => setTimeout(r, 30));
+    hold.armed = true;
+    fireEvent.click(target);
+    await waitFor(() => expect(hold.release).not.toBeNull());
+
+    // While that read is parked, a successor persists a different one.
+    recordAnonymousRead(window.localStorage, 'anon-two', '2026-07-16T13:00:00.000Z');
+
+    hold.release!();
+    await new Promise((r) => setTimeout(r, 30));
+    host.unmount();
+
+    const persisted = window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '';
+    expect(persisted).toContain('anon-two');
+    expect(persisted).toContain('anon-one');
+  });
+
+  it('takes an in-flight refresh even when a settled snapshot was adopted', async () => {
+    // Adoption showed the older rows and stopped there: the run already on the
+    // wire is fresher, but nothing pushes its result into a host that merely
+    // adopted, so it stayed stale until an open, a visibility change or the 60s
+    // poll.
+    let releaseSecond: (() => void) | null = null;
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        if (pulls === 1) {
+          return Response.json({
+            messages: [row('stale-a', null), row('stale-b', null)],
+            nextCursor: null,
+            unreadCount: 2,
+          });
+        }
+        if (pulls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseSecond = resolve;
+          });
+        }
+        return Response.json({ messages: [row('stale-a', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const seed = mount();
+    await waitFor(() => expect(messageCalls).toBe(1));
+
+    // A refresh goes on the wire and is held there.
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(2));
+    seed.unmount();
+
+    // The successor adopts the settled snapshot (2 unread) while that refresh
+    // is still pending.
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter
+          hideTrigger
+          open={false}
+          onOpenChange={() => {}}
+          onUnreadCountChange={(n) => counts.push(n)}
+        />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(2));
+
+    // When the refresh lands, this host must move to its result.
+    releaseSecond!();
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(1));
+    expect(messageCalls).toBe(2);
+  });
+
+  it('does not paint an error when a superseded run rejects after a newer one succeeds', async () => {
+    // Overlapping runs are normal — open, visibility and the 60s poll all call
+    // `retrySync`. The catch was unconditional, so a slow first run failing
+    // after a fast second one succeeded put the error banner over rows that
+    // were on screen and correct.
+    let failFirst: (() => void) | null = null;
+    let pulls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        return Response.json({ loggedIn: false });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        pulls += 1;
+        if (pulls === 1) {
+          await new Promise<void>((resolve) => {
+            failFirst = resolve;
+          });
+          throw new Error('first run failed late');
+        }
+        return Response.json({
+          messages: [row('survivor', null)],
+          nextCursor: null,
+          unreadCount: 1,
+        });
+      }
+      return Response.json({});
+    }));
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBe(1));
+
+    // A second run overtakes it and succeeds.
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBe(2));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    expect(await screen.findByRole('button', { name: /survivor/ })).toBeTruthy();
+
+    // Only now does the superseded run reject.
+    failFirst!();
+    await new Promise((r) => setTimeout(r, 40));
+
+    expect(screen.queryByRole('button', { name: /survivor/ })).not.toBeNull();
+    // The real banner copy, not a guessed regex — the first version of this
+    // spec matched nothing and passed against the unfixed code.
+    expect(screen.queryByText('检查失败，请重试')).toBeNull();
   });
 
   it('does not re-sync when it is remounted straight away', async () => {

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -964,6 +964,66 @@ describe('MessageCenter remount snapshot', () => {
     expect(counts[counts.length - 1]).toBe(0);
   });
 
+  it('still clears the signed-in overlay when a sign-out follows an outage', async () => {
+    // The 503 assigned `loggedInRef = false` even though it answered nothing,
+    // spending the transition marker. A genuine sign-out arriving afterwards
+    // then saw `wasAccount === false`, skipped the clear, and the signed-in
+    // read ids survived — overlaid onto the public feed and persisted as
+    // anonymous reads, so a message the anonymous reader had never opened
+    // showed as read.
+    let mode: 'in' | 'down' | 'out' = 'in';
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (mode === 'down') {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: mode === 'in' });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('shared-id', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    fireEvent.click(await screen.findByRole('button', { name: /shared-id/ }));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+
+    // An outage refresh lands. It answers nothing.
+    mode = 'down';
+    let before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+
+    // Then a genuine sign-out, with no generation advance.
+    mode = 'out';
+    before = messageCalls;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(before));
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The anonymous reader has read nothing.
+    expect(counts[counts.length - 1]).toBe(1);
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '[]')
+      .not.toContain('shared-id');
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
+++ b/apps/web/tests/components/MessageCenter.remount-snapshot.test.tsx
@@ -1243,6 +1243,64 @@ describe('MessageCenter remount snapshot', () => {
     await waitFor(() => expect(pending[pending.length - 1]).toBe(false));
   });
 
+  it('does not write anonymous state for a signed-in click during an outage', async () => {
+    // `markRead` resolved a BOOLEAN, so a 503 collapsed to `false` and a
+    // signed-in click took the anonymous path: no account POST, a write to the
+    // shared anonymous cache, and a snapshot delta recorded as `account: false`.
+    let mode: 'up' | 'down' = 'up';
+    let readPosts = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/integrations/vela/status')) {
+        statusCalls += 1;
+        if (mode === 'down') {
+          return new Response(JSON.stringify({ error: 'amr-runtime-unavailable' }), {
+            status: 503,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Response.json({ loggedIn: true });
+      }
+      if (url.includes('/read') && init?.method === 'POST') {
+        readPosts += 1;
+        return Response.json({ read: true, markedCount: 1 });
+      }
+      if (url.includes('/message-center') && url.includes('/messages')) {
+        messageCalls += 1;
+        return Response.json({ messages: [row('outage-click', null)], nextCursor: null, unreadCount: 1 });
+      }
+      return Response.json({});
+    }));
+
+    const counts: number[] = [];
+    render(
+      <I18nProvider initial="zh-CN">
+        <MessageCenter onUnreadCountChange={(n) => counts.push(n)} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(messageCalls).toBeGreaterThan(0));
+    fireEvent.click(screen.getByTestId('message-center-trigger'));
+    const target = await screen.findByRole('button', { name: /outage-click/ });
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The runtime drops, and the signed-in user clicks an unread row.
+    mode = 'down';
+    fireEvent.click(target);
+    await new Promise((r) => setTimeout(r, 40));
+
+    // Nothing may have been guessed at: no POST, no anonymous cache, and the
+    // shared snapshot untouched — a remount must not replay it either.
+    expect(readPosts).toBe(0);
+    expect(window.localStorage.getItem('open-design.message-center.anonymous-read-ids.v1') ?? '')
+      .not.toContain('outage-click');
+
+    // Once the runtime answers again, the same click records properly.
+    mode = 'up';
+    fireEvent.click(screen.getByRole('button', { name: /outage-click/ }));
+    await waitFor(() => expect(readPosts).toBe(1));
+    await waitFor(() => expect(counts[counts.length - 1]).toBe(0));
+  });
+
   it('does not re-sync when it is remounted straight away', async () => {
     const first = await mountAndSettle();
     const afterFirst = { status: statusCalls, messages: messageCalls };

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -388,18 +388,31 @@ describe('MessageCenter', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Checking for updates...');
     expect(screen.queryByText('No messages yet')).toBeNull();
 
+    // Wait for the pull to actually be on the wire before releasing it.
+    // Opening used to produce TWO pulls — the mount's superseded run issued one
+    // before bailing — so a synchronous `releaseFirstRequest?.()` happened to
+    // find the mount's already gated. Superseded runs now bail before pulling,
+    // which is the point of this branch, so there is exactly one pull and the
+    // release has to wait for it.
+    await waitFor(() => expect(releaseFirstRequest).toBeDefined());
     releaseFirstRequest?.();
     await waitFor(() => expect(screen.getByText('No messages yet')).toBeTruthy());
   });
 
   it('shows retry controls instead of the empty copy when the first empty sync fails', async () => {
     let messageRequests = 0;
+    // Keyed on "has the user retried yet", not on a pull count. The count used
+    // to be 2 because opening produced a second pull from the mount's
+    // superseded run; that run now bails before pulling, so a count-based
+    // fixture would have failed the retry as well and the empty copy would
+    // never arrive.
+    let failing = true;
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes('/status')) return Response.json({ loggedIn: false });
       if (url.includes('/messages?')) {
         messageRequests += 1;
-        if (messageRequests <= 2) return new Response(null, { status: 500 });
+        if (failing) return new Response(null, { status: 500 });
         return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
       }
       if (url.includes('/read')) return Response.json({ read: true, markedCount: 1 });
@@ -413,6 +426,7 @@ describe('MessageCenter', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
     expect(screen.queryByText('No messages yet')).toBeNull();
 
+    failing = false;
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     await waitFor(() => expect(screen.getByText('No messages yet')).toBeTruthy());
     expect(messageRequests).toBeGreaterThanOrEqual(2);

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -5,6 +5,7 @@ import {
   findGoPlanSunsetMessage,
   GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX,
   pullMessageCenter,
+  readAmrAuthMode,
   type MessageCenterMessage,
 } from '../src/message-center-client';
 
@@ -81,6 +82,24 @@ describe('message center client', () => {
       pullMessageCenter({ locale: 'en', loggedIn: false }),
     ).rejects.toThrow('Message Center pagination cursor did not advance');
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an expired credential as signed out', async () => {
+    // The daemon keeps `loggedIn: true` when a credential is PRESENT but
+    // expired, and says so in `sessionState` — its own comment calls `loggedIn`
+    // the backwards-compatible "credential is present" projection and directs
+    // new callers to `sessionState` for validity. `App.isAmrSessionAuthenticated`
+    // already reads it that way.
+    //
+    // This is the other reader of the same status, and it now publishes what it
+    // finds as the shared authority. Disagreeing with App about what counts as
+    // a session means a reauth-required answer can take the authority back to
+    // signed-in after App has moved it to signed-out, which admits account
+    // pulls and targeted rows under a session that cannot be used.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      Response.json({ loggedIn: true, sessionState: 'reauth_required' }),
+    ));
+    await expect(readAmrAuthMode()).resolves.toBe('signed-out');
   });
 
   it('uses the credential-scoped daemon route for logged-in pulls', async () => {

--- a/apps/web/tests/providers/status-observation.test.ts
+++ b/apps/web/tests/providers/status-observation.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchVelaLoginStatus } from '../../src/providers/daemon';
+import { statusObservationOrder } from '../../src/providers/status-observation';
+
+describe('AMR status issue order', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('orders answers by when their request went out, not by when it came back', async () => {
+    // The whole point of ordering the authority is that answers arrive out of
+    // order. If the stamp were taken on the way back it would agree with
+    // arrival order and rank the stale answer highest, which is exactly the
+    // ranking that lets an old signed-in read override a newer sign-out.
+    let releaseFirst!: () => void;
+    let call = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      call += 1;
+      if (call === 1) await new Promise<void>((resolve) => { releaseFirst = resolve; });
+      return {
+        ok: true,
+        json: async () => ({ loggedIn: call === 1, loginInFlight: false, profile: 'local' }),
+      };
+    }));
+
+    const first = fetchVelaLoginStatus();
+    await vi.waitFor(() => expect(releaseFirst).toBeTypeOf('function'));
+    const second = await fetchVelaLoginStatus();
+    releaseFirst();
+    const settledFirst = await first;
+
+    expect(statusObservationOrder(settledFirst!)).toBeLessThan(
+      statusObservationOrder(second!)!,
+    );
+  });
+});

--- a/apps/web/tests/setup/coalesced-get-reset.ts
+++ b/apps/web/tests/setup/coalesced-get-reset.ts
@@ -13,6 +13,8 @@ import { resetHtmlThumbnailSourceCache } from '../../src/components/html-thumbna
 import { resetProjectCoverSnapshots } from '../../src/lib/project-cover-cache';
 import { resetThumbnailLoadGateForTests } from '../../src/lib/thumbnail-load-gate';
 import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import { resetMessageCenterSnapshot } from '../../src/components/MessageCenter';
+
 
 beforeEach(() => {
   resetCoalescedGet();
@@ -29,4 +31,8 @@ beforeEach(() => {
   resetProjectCoverSnapshots();
   resetThumbnailLoadGateForTests();
   resetSharedCancellableGet();
+  // MessageCenter keeps its last successful sync at module scope so a remount
+  // (project<->home swaps its host) does not refetch; clear it so one test's
+  // messages never satisfy the next test's mount.
+  resetMessageCenterSnapshot();
 });

--- a/apps/web/tests/setup/coalesced-get-reset.ts
+++ b/apps/web/tests/setup/coalesced-get-reset.ts
@@ -14,6 +14,7 @@ import { resetProjectCoverSnapshots } from '../../src/lib/project-cover-cache';
 import { resetThumbnailLoadGateForTests } from '../../src/lib/thumbnail-load-gate';
 import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
 import { resetMessageCenterSnapshot } from '../../src/components/message-center-snapshot';
+import { resetAnonymousWriteSeq } from '../../src/message-center-client';
 
 
 beforeEach(() => {
@@ -35,4 +36,7 @@ beforeEach(() => {
   // (project<->home swaps its host) does not refetch; clear it so one test's
   // messages never satisfy the next test's mount.
   resetMessageCenterSnapshot();
+  // The anonymous cache keeps its own writer sequence; a value carried over
+  // from a previous case would make an account run decline to clear.
+  resetAnonymousWriteSeq();
 });

--- a/apps/web/tests/tab-scope.test.ts
+++ b/apps/web/tests/tab-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  deriveAccountBucket,
   deriveTabIdentityScope,
   UNSET_ACCOUNT_BUCKET,
   type TabIdentityScopeInputs,
@@ -232,3 +233,28 @@ describe('deriveTabIdentityScope', () => {
     });
   });
 });
+
+describe('deriveAccountBucket', () => {
+  it('separates two credentials on one profile when the session has no user', () => {
+    // Env-backed sessions are authenticated and report `user: null` — no
+    // fabricated blank identity. The daemon's own docblock on
+    // `credentialRevision` says why that field exists: without it, an account
+    // switch that only rewrites the Settings-backed env reuses the previous
+    // account's cached data. Falling back to the profile made both credentials
+    // the same account, so nothing fired the boundary and the previous
+    // account's message-centre snapshot, in-flight run, mounted rows and stale
+    // continuations stayed eligible under the new one.
+    const a = { loggedIn: true, profile: 'local', user: null, credentialRevision: 'rev-a' };
+    const b = { ...a, credentialRevision: 'rev-b' };
+    expect(deriveAccountBucket(a)).not.toBe(deriveAccountBucket(b));
+  });
+
+  it('prefers a stable identity over the credential, which rotates within one account', () => {
+    // A credential revision changes when the same user re-authenticates, so it
+    // must never outrank an identity that does not.
+    const base = { loggedIn: true, profile: 'local', user: { id: 'user-1' } };
+    expect(deriveAccountBucket({ ...base, credentialRevision: 'rev-a' }))
+      .toBe(deriveAccountBucket({ ...base, credentialRevision: 'rev-b' }));
+  });
+});
+


### PR DESCRIPTION
## Why

Follow-on to #7413, closing the item its "Adjacent issues" section named: on a
cold Home load `/api/integrations/vela/status` appears four times and
`/api/integrations/vela/message-center/messages` twice, and both were attributed
to `MessageCenter` remounting.

There are two hosts for this panel and they are mutually exclusive by design —
the rail's cluster on the entry views, `WorkspaceTopRightAccountCluster` on a
project route, with the code's own comment noting "the routes are mutually
exclusive, so exactly one is on screen". Two things follow from that, and this
PR fixes both:

**1. Launch.** The rail's signed-out instance is gated on `context` alone, which
cannot tell "signed out" from "`/api/workspace/context` has not answered yet".
So every launch mounted the signed-out instance first and replaced it when the
context arrived — and the replacement re-ran a full sync.

**2. Route switches.** Every project↔home navigation swaps the host, so the panel
remounts and re-syncs: `isAmrLoggedIn`, then a paginated `pullMessageCenter`, for
a panel the user has not opened and whose contents cannot have changed in the
time a route switch takes.

## What users will see

Nothing. The panel shows the same messages and the same unread count; it simply
stops re-fetching them when its host is swapped. Opening it, the 60s poll, and
returning to the tab all still go to the network unchanged.

## Measured

Real browser against a local `tools-dev` runtime, `window.fetch` wrapped with
stack attribution so every call is traced to its caller. One project↔home round
trip:

| | before | after |
| --- | --- | --- |
| requests from `MessageCenter.sync` | **8** (4 status + 4 messages) | **0** within the snapshot window, **2** outside it |

Both after-numbers are the design: inside the window the mount adopts what the
previous one fetched; outside it exactly one sync runs, where before there were
four.

## The part the unit tests missed

Worth stating because it changed the implementation. The first version kept only
a settled snapshot, written when a sync finishes. Its specs passed. In the
browser it did nothing at all: a route switch unmounts the outgoing host and
mounts the incoming one within the same frame, so all four syncs started *before*
the first one had written a snapshot. Sequential dedupe cannot see a stampede.

The fix needed both halves — the settled snapshot for sequential remounts, and a
shared in-flight promise so concurrent mounts join the sync already running.
`does not stampede when a remount lands while a sync is still in flight` pins the
second half with a gated fetch.

## What is deliberately not weakened

- The 60s interval, the `visibilitychange` listener and opening the panel all
  still sync. The snapshot only ever answers "did we just fetch this?", never
  "is this still true?".
- The snapshot carries the account generation and is refused across a boundary,
  so a sign-out/sign-in cannot serve the previous account's messages no matter
  how recent they are.
- Marking a message read is a local overlay (`pendingReadIdsRef`), unaffected.
- `resetMessageCenterSnapshot` is wired into the global test setup so module
  state never crosses a test boundary.

## Adjacent issues

**A refresh that never publishes still consumes the snapshot write token.**
`sync` claims the token before it knows whether it will publish. If a run that
turns out not to publish — it received `unavailable`, or its pull failed —
overlaps a valid run already on the wire, the valid run then fails
`ownsLatestSnapshotWrite` and neither updates `lastSyncSnapshot`. The next mount
cannot adopt and refetches, which is the work this PR removes.

Not fixed here. The token has to stay claimed at the start: claiming it after
the status answer would let the run whose status resolved first claim first, so
an older run could publish over a newer one's data. The fix is to hand the claim
back when a run turns out not to publish, reaching every no-publish exit — a
control-flow change to the most-reviewed function in this diff, for a
non-blocking degradation that needs a refresh to land inside another run's pull
AND resolve `unavailable` or fail. Separate PR, straight after this merges.
Reported by @nettee.

**A sign-in nobody owns does not retire generation-keyed caches.**
`applyAmrLoginStatus` announces the account boundary only for account-to-account,
because each sign-in surface announces its own. A sign-in discovered without one
— `vela login` while the app is backgrounded, found by the focus/visibility
refresh — therefore leaves the generation unchanged.

Not a regression: `main` never announced the boundary from this function either,
so anonymous-to-account is unchanged by this PR, and `useWorkspaceContext`
refreshes on the same two events. Doing it properly means threading an
ownership flag through `applyAmrLoginStatus` — an API change to the function
that just produced a double-notify regression, so it gets its own PR rather
than a thirty-seventh amendment here. Reported by @Siri-Ray.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the panel's data survives a host swap instead of being refetched; the signed-out instance mounts after the context resolves rather than before
- [ ] **None**

## Bug fix verification

Red specs, all failing before the change:

- `EntryNavRail.message-center-mount.test.tsx` — `does not mount the message center while the workspace context is still loading`, and `mounts exactly once across a launch that resolves into a workspace` (was two).
- `MessageCenter.remount-snapshot.test.tsx` — `does not re-sync when it is remounted straight away`, and the stampede spec above.

Guard rails that were green before and after: the signed-out shell still mounts
its instance; the window expiry still fetches; an account boundary still forces a
fetch; opening the panel still fetches.

## Focus behaviour

`returnFocusRef`, `triggerRef`, `closePanel` and the portal are untouched — the
diff only changes when the component mounts and where its first data comes from.
The dedicated suite for that behaviour,
`EntryNavRail.message-center-entry.test.tsx`, covers all three close paths plus
the openers' dialog semantics and passes. I did not additionally drive the
open/close by hand in the browser: the opener lives in a hover menu that is
awkward to drive over CDP, and the change does not reach that code.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — 665 files / 7,032 tests pass. One
  failure in the run, `EntryShell.blank-project-naming`, is a 4.4s timeout in a
  file that takes ~44s standalone; it passes in isolation, and the previous full
  run failed a *different* test in the same file — load flake, and the file is
  not in this diff.
- Real-browser before/after for the route-switch half, as above.

**What I did not measure in a browser**, stated rather than glossed: the launch
half. Its mechanism is a render gate, and the three mount-count specs cover it
directly (zero mounts while the context is loading, exactly one across a launch
that resolves, still one for a shell that resolves signed-out) — all confirmed
red without the change. The machine was saturated by an unrelated job while I
was set up to measure it, and the browser measurement would only re-derive what
the mount counts already pin.


---

## Scope as it stands after review (updated 2026-08-26)

QA flagged that this description had fallen behind the diff, and that is fair —
it opened as a launch/route-switch performance change and eighteen review rounds
turned it into a concurrency and account-boundary change that happens to deliver
that performance. **Do not accept it as a simple perf tweak.** Current diff: 15
files.

**What it does now, grouped by what a reviewer or tester has to think about:**

1. **Reuse across a host swap** (the original goal) — a settled sync is adoptable
   for 10s by the same account and locale; concurrent mounts share one in-flight
   run instead of stampeding; the rail's instance waits for the workspace
   identity to resolve, including the transient-failure case that settles to
   `loading: false` with a null context.

2. **Account boundary** — `handleActiveCloudSignOut` now advances the account
   generation (sign-in already did; sign-out never had), with a single owner so
   the rail's own notification does not double it. `MessageCenter` subscribes to
   that generation and empties its view during the boundary RENDER, not in an
   effect afterwards.

3. **Ordering of shared writes** — the snapshot, its publication token, the
   in-flight entry and the anonymous `localStorage` cache are all module-level
   and outlive any host, so every write to them is ordered by a publication
   token, re-validated after each await, and applied as a delta rather than a
   wholesale overwrite. A durable read supersedes pulls issued before it and is
   broadcast to hosts that are already mounted.

4. **Auth mode is three-valued** — `readAmrAuthMode` distinguishes
   `unavailable` (the daemon could not ask) from `signed-out` (it asked and the
   answer was no). Only an answer moves the auth state, publishes a snapshot,
   persists the anonymous cache, or clears the signed-in overlay.

**Not changed:** billing, permissions, the delivery protocol, plan entitlements,
analytics events, and — see below — the existing "signing in clears the
anonymous cache" behaviour.

## On the QA report's case 5

Case 5 ("anonymous reads survive sign-in then sign-out") failed, and the
expectation was wrong, not the code. I wrote that acceptance item myself without
checking the product's actual behaviour.

`clearAnonymousState` on a successful signed-in sync is on `base` at the same two
call sites (`MessageCenter.tsx:136` and `:252` at `ebb5b24`), and it has always
removed the anonymous read ids along with the cached rows. This PR added a
"only the latest writer may clear" guard so a stale continuation cannot wipe a
cache a newer run just wrote; it did not change the rule that signing in discards
anonymous history.

QA's reading is the right one: this is an acceptance-criteria mismatch, not a
regression, and it must not be "fixed" by dropping the clears — that is what
keeps the previous account's read state from leaking into the anonymous view
(items 1–3). Preserving anonymous history across a sign-in would mean storing
anonymous and account read state separately, which is its own change with its own
boundary questions.

**Adjacent issue, not fixed here:** anonymous read marks are lost on sign-in and
do not come back on sign-out. Worth a product call on whether that matters.

## Verification status

Automated: 669 files / 7,074 tests green, typecheck and `pnpm guard` clean. Every
fix in the review rounds ships with a spec verified red against the unfixed code;
the failing assertion is quoted on each thread.

Measured end-to-end in a real browser against two isolated runtimes (this branch
vs `origin/main`, separate `OD_DATA_DIR` and namespace, project seeded through
the production API): three home↔project swaps inside the window cost **3 message
pulls on `main` and 1 on this branch**, with per-branch instrumentation showing
the zero-cost swaps taking the adopt path and the component genuinely
remounting each time.

**Known gap, and it is a P0:** none of the account-boundary items (1–3) has been
exercised with two real accounts. My own runtime was signed in throughout, and
QA's was signed out throughout; both cover the boundary only through automation.
That is the verification this change most needs and the one neither of us has
done.


