### PR TITLE
fix(web): align Website clone prompt examples

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2164,7 +2164,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
         />
       ) : activePromptExamples.length > 0 ? (
         <div
-          className="home-hero__prompt-examples"
+          className={`home-hero__prompt-examples${activeChipId === 'web-clone' ? ' home-hero__prompt-examples--wide' : ''}`}
           data-testid="home-hero-prompt-examples"
         >
           <div className="home-hero__prompt-examples-title">

--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -2491,11 +2491,17 @@
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 
-/* Break out of the hero's 960px column to the full home column, so the strip
-   is exactly as wide as the 最近项目 grid below. 100cqw reads the .home-view
-   size container; the symmetric margins re-center the wider box inside the
-   centered hero (they collapse to 0 when the viewport is narrower than the
-   hero cap and the two widths coincide). */
+/* Break wide example rails out of the hero's 960px column to the full home
+   column, so they share the same geometry as the 最近项目 grid below.
+   100cqw reads the .home-view size container; the symmetric margins re-center
+   the wider box inside the centered hero (they collapse to 0 when the
+   viewport is narrower than the hero cap and the two widths coincide). */
+.home-hero__prompt-examples--wide,
+.home-hero__plugin-presets-wrap {
+  width: 100cqw;
+  max-width: 100cqw;
+  margin-inline: calc((100% - 100cqw) / 2);
+}
 .home-hero__plugin-presets-wrap {
   /* One geometry contract for both the loading shell and settled cards.
      The fixed card height is the natural rendered height of the preview,
@@ -2503,9 +2509,6 @@
   --home-plugin-preset-width: 248px;
   --home-plugin-preset-preview-h: 150px;
   --home-plugin-preset-card-h: 194px;
-  width: 100cqw;
-  max-width: 100cqw;
-  margin-inline: calc((100% - 100cqw) / 2);
 }
 
 /* Positioning context so the edge auto-scroll zones anchor to just the

--- a/apps/web/tests/components/HomeHero.rail.test.tsx
+++ b/apps/web/tests/components/HomeHero.rail.test.tsx
@@ -285,6 +285,16 @@ describe('HomeHero intent rail', () => {
     expect(screen.queryByTestId('home-hero-active-example')).toBeNull();
   });
 
+  it('widens the Website clone example rail to match the hero surfaces', () => {
+    renderHero({ activeChipId: 'web-clone' });
+
+    const examples = screen.getByTestId('home-hero-prompt-examples');
+    expect(examples.classList.contains('home-hero__prompt-examples--wide')).toBe(true);
+    expect(
+      screen.getByTestId('home-hero-prompt-examples').querySelector('.home-hero__prompt-examples-grid'),
+    ).toBeTruthy();
+  });
+
   it('reserves the example rail while the plugin catalog is still loading', () => {
     renderHero({ activeChipId: null, pluginsLoading: true });
 


### PR DESCRIPTION
Fixes #7396

## Why

The Website clone example rail is narrower than the other wide Home surfaces, so the example cards appear shifted to the right of the main Home column.

## What users will see

Website clone example cards now align with the wider Home example surfaces.

## Surface area

- [x] **UI** — the Website clone example rail layout changes.
- [ ] Keyboard navigation or focus behavior
- [ ] Runtime or network behavior
- [ ] None

## Screenshots

No screenshot attached: the local dev instance opened to first-run onboarding in this environment, so a representative Home screenshot was not available. The layout regression is covered by the component test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/HomeHero.rail.test.tsx`
- Did the test go red on `main` and green on this branch? Yes.
- The regression test verifies that the Website clone example rail uses the wider Home-surface geometry.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm --filter @open-design/web test -- tests/components/HomeHero.rail.test.tsx` (27 passed)
- `pnpm --filter @open-design/web test` (7,019 passed; 7 failures outside the changed files, involving a Windows socket permission test and existing style-contract assertions; 1 expected failure and 11 skipped)