### PR TITLE
fix(daemon): silence ACP process trees before terminal

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -132,6 +132,13 @@ export interface AttachAcpSessionOptions {
   onCliReady?: () => void;
   onSessionInit?: () => void;
   onPromptComplete?: () => void;
+  /**
+   * Transfers process-tree teardown ownership to the caller once this
+   * one-prompt session has a clean or fatal verdict. When provided, the ACP
+   * bridge does not fall back to direct-child SIGTERM; the caller must stop the
+   * complete owned tree and gate terminal publication on its quiescence.
+   */
+  onTerminal?: (kind: 'completed' | 'fatal') => void;
 }
 /**
  * Attaches an ACP protocol session to an already-spawned child process and
@@ -179,6 +186,7 @@ export function attachAcpSession({
   onCliReady,
   onSessionInit,
   onPromptComplete,
+  onTerminal,
 }: AttachAcpSessionOptions) {
   const runStartedAt = Date.now();
   const effectiveCwd = path.resolve(cwd || process.cwd());
@@ -389,8 +397,15 @@ export function attachAcpSession({
     finished = true;
     fatal = true;
     clearStageTimer();
+    let terminalOwnedByCaller = false;
+    try {
+      onTerminal?.('fatal');
+      terminalOwnedByCaller = onTerminal != null;
+    } catch {
+      // Fall back to direct-child termination below.
+    }
     send('error', payload);
-    if (!child.killed) child.kill('SIGTERM');
+    if (!terminalOwnedByCaller && !child.killed) child.kill('SIGTERM');
   };
 
   const fail = (
@@ -404,6 +419,13 @@ export function attachAcpSession({
     finished = true;
     fatal = true;
     clearStageTimer();
+    let terminalOwnedByCaller = false;
+    try {
+      onTerminal?.('fatal');
+      terminalOwnedByCaller = onTerminal != null;
+    } catch {
+      // Fall back to direct-child termination below.
+    }
     const useModelUnavailable =
       modelUnavailableErrorCode &&
       (options.forceModelUnavailable || isModelUnavailableError(message));
@@ -423,7 +445,7 @@ export function attachAcpSession({
               },
             },
     );
-    if (!child.killed) child.kill('SIGTERM');
+    if (!terminalOwnedByCaller && !child.killed) child.kill('SIGTERM');
   };
 
   const writeRpc = (id: JsonRpcId, method: string, params: unknown, timeoutLabel: string) => {
@@ -681,13 +703,22 @@ export function attachAcpSession({
     emitUsageIfPresent(usageSource);
     clearStageTimer();
     stdin.end();
+    let terminalOwnedByCaller = false;
+    try {
+      onTerminal?.('completed');
+      terminalOwnedByCaller = onTerminal != null;
+    } catch {
+      // Fall back to the direct-child timer below.
+    }
     // Some ACP agents keep the child process alive after stdin closes,
     // waiting for another prompt. Each OpenDesign run owns one process per
     // turn, so close it once this prompt is cleanly complete.
-    const cleanExitTimer = setTimeout(() => {
-      if (!child.killed) child.kill('SIGTERM');
-    }, 500);
-    child.once('close', () => clearTimeout(cleanExitTimer));
+    if (!terminalOwnedByCaller) {
+      const cleanExitTimer = setTimeout(() => {
+        if (!child.killed) child.kill('SIGTERM');
+      }, 500);
+      child.once('close', () => clearTimeout(cleanExitTimer));
+    }
   };
 
   const replyPermission = (raw: JsonObject) => {

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1549,6 +1549,7 @@ export function createChatRunService({
         ) {
           return { quiescent: true, forced: false, remainingPids: [] };
         }
+        if (gracefulWaitMs > 0) closeRunStdin(run);
         signalProcessGroup(processGroupId, 'SIGTERM');
         if (await waitForProcessGroupExit(processGroupId, termGraceMs)) {
           return { quiescent: true, forced: false, remainingPids: [] };
@@ -1569,6 +1570,7 @@ export function createChatRunService({
         ) {
           return { quiescent: true, forced: false, remainingPids: [] };
         }
+        if (gracefulWaitMs > 0) closeRunStdin(run);
         signalChildProcess(child, null, 'SIGTERM');
         if (await waitForChildExit(child, termGraceMs)) {
           return { quiescent: true, forced: false, remainingPids: [] };
@@ -1582,19 +1584,54 @@ export function createChatRunService({
         };
       }
 
-      const snapshots = await listProcessSnapshots();
-      const pids = collectProcessTreePids(snapshots, [child?.pid]);
+      const initialSnapshots = await listProcessSnapshots();
+      let enumerationVerified = initialSnapshots.length > 0;
+      let childExitedDuringGrace = childHasExited(child);
       if (gracefulWaitMs > 0) {
-        await waitForChildExit(child, gracefulWaitMs);
+        childExitedDuringGrace = await waitForChildExit(child, gracefulWaitMs);
+        if (!childExitedDuringGrace) closeRunStdin(run);
       }
-      const result = await stopProcesses(
-        pids.length > 0 ? pids : [child?.pid],
-        { termGraceMs, killGraceMs },
-      );
+      const refreshedSnapshots = await listProcessSnapshots();
+      enumerationVerified &&= refreshedSnapshots.length > 0;
+      const snapshots = [...initialSnapshots, ...refreshedSnapshots];
+      const pids = collectProcessTreePids(snapshots, [child.pid])
+        .filter((pid) => !childExitedDuringGrace || pid !== child.pid);
+      const terminationPids = pids.length > 0 || childExitedDuringGrace
+        ? pids
+        : [child.pid];
+      const result = await stopProcesses(terminationPids, { termGraceMs, killGraceMs });
+
+      const verificationSnapshots = await listProcessSnapshots();
+      enumerationVerified &&= verificationSnapshots.length > 0;
+      const livePids = new Set(verificationSnapshots.map((snapshot) => snapshot.pid));
+      let remainingPids = collectProcessTreePids(
+        [...snapshots, ...verificationSnapshots],
+        [child.pid, ...pids],
+      ).filter((pid) => livePids.has(pid));
+      let forcedPids = result.forcedPids;
+
+      // A wrapper may create one last descendant while handling SIGTERM. Reap
+      // anything the post-escalation verification newly attaches to the
+      // captured ownership tree, then verify once more before terminalizing.
+      if (enumerationVerified && remainingPids.length > 0) {
+        const followUp = await stopProcesses(remainingPids, {
+          termGraceMs: 0,
+          killGraceMs,
+        });
+        forcedPids = [...new Set([...forcedPids, ...followUp.forcedPids])];
+        const finalSnapshots = await listProcessSnapshots();
+        enumerationVerified &&= finalSnapshots.length > 0;
+        const finalLivePids = new Set(finalSnapshots.map((snapshot) => snapshot.pid));
+        remainingPids = collectProcessTreePids(
+          [...snapshots, ...verificationSnapshots, ...finalSnapshots],
+          [...pids, ...remainingPids],
+        ).filter((pid) => finalLivePids.has(pid));
+      }
       return {
-        quiescent: result.remainingPids.length === 0,
-        forced: result.forcedPids.length > 0,
-        remainingPids: result.remainingPids,
+        quiescent: enumerationVerified && remainingPids.length === 0,
+        forced: forcedPids.length > 0,
+        remainingPids,
+        ...(!enumerationVerified ? { error: 'process enumeration unavailable' } : {}),
       };
     })().catch((error) => ({
       quiescent: false,
@@ -1703,13 +1740,12 @@ export function createChatRunService({
       } catch {
         // Signal fallback below owns eventual process termination.
       }
-      const childExitedDuringAbort = await waitForChildExit(targetChild, graceMs);
-      if (!childExitedDuringAbort) closeRunStdin(run);
       const termination = terminateProcessTree(
         run,
         targetChild,
         targetProcessGroupId,
         {
+          gracefulWaitMs: graceMs,
           termGraceMs: graceMs,
           killGraceMs: forceWaitMs(),
           reason: 'run_cancel',

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -3,6 +3,11 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { strategyTaskProvesDelivery, todoSnapshotHasUnfinishedWork } from '@open-design/contracts';
+import {
+  collectProcessTreePids,
+  listProcessSnapshots,
+  stopProcesses,
+} from '@open-design/platform';
 import { normalizeMediaExecutionPolicyForRun } from '../media/policy.js';
 import {
   normalizeRunToolBundleForRun,
@@ -1159,6 +1164,12 @@ export function createChatRunService({
   };
 
   const emit = (run, event, data) => {
+    // Once a terminal verdict is waiting only on process-tree quiescence, the
+    // attempt no longer owns transcript or error state. Shutdown bytes and
+    // duplicate child callbacks must not overwrite the classified verdict
+    // during that bounded window. The termination barrier itself may still
+    // publish `termination_failed` evidence before the final `end` event.
+    if (run.pendingTerminalFinish && event !== 'diagnostic') return null;
     if (event === 'error') {
       const details = extractErrorDetails(data);
       if (details.error) run.error = details.error;
@@ -1267,7 +1278,7 @@ export function createChatRunService({
       : {}),
   });
 
-  const finish = (run, status, code: number | null = null, signal: string | null = null) => {
+  const commitFinish = (run, status, code: number | null = null, signal: string | null = null) => {
     if (TERMINAL_RUN_STATUSES.has(run.status)) return;
     if (beforeFinish) beforeFinish(run, status, code, signal);
     run.status = status;
@@ -1323,6 +1334,21 @@ export function createChatRunService({
     // Any event emitted after this point must not lazily re-open the log.
     run.eventsLogClosed = true;
     scheduleCleanup(run);
+  };
+
+  // A run may reach its logical verdict before the attempt's complete process
+  // tree is quiet. Keep the public status/SSE/analytics terminal behind every
+  // registered teardown barrier: `run_finished` is a claim that this run can no
+  // longer produce model traffic, not merely that its direct child emitted
+  // `close`. The first verdict owns the terminal fields; duplicate close/error
+  // paths wait on the same pending finish instead of publishing twice.
+  const finish = (run, status, code: number | null = null, signal: string | null = null) => {
+    if (TERMINAL_RUN_STATUSES.has(run.status) || run.pendingTerminalFinish) return;
+    if ((run.processTreeTerminationPending ?? 0) > 0) {
+      run.pendingTerminalFinish = { status, code, signal };
+      return;
+    }
+    commitFinish(run, status, code, signal);
   };
 
   const fail = (run, code, message, init = {}) => {
@@ -1401,20 +1427,6 @@ export function createChatRunService({
     });
   };
 
-  // A runtime error can be emitted while the child is still draining stdout.
-  // When that happened before cancellation, wait for `close` so server.ts's
-  // earlier close listener can classify and finalize the failure before the
-  // cancel route applies its canceled fallback. Ordinary cancellation keeps
-  // the faster exit-or-close behavior.
-  const waitForCanceledChildExit = (run, timeoutMs) => {
-    if (TERMINAL_RUN_STATUSES.has(run.status)) return Promise.resolve(true);
-    return waitForChildExit(
-      run.child,
-      timeoutMs,
-      { closeOnly: run.runtimeFailureObservedBeforeCancellation === true },
-    );
-  };
-
   const forceWaitMs = () => {
     const raw = Number(process.env.OD_CHAT_RUN_CANCEL_FORCE_WAIT_MS);
     return Number.isFinite(raw) && raw > 0 ? raw : 500;
@@ -1483,6 +1495,120 @@ export function createChatRunService({
     return true;
   };
 
+  const processGroupIsAlive = (processGroupId) => {
+    if (process.platform === 'win32' || !Number.isInteger(processGroupId)) return false;
+    try {
+      process.kill(-processGroupId, 0);
+      return true;
+    } catch (err) {
+      return err?.code !== 'ESRCH';
+    }
+  };
+
+  const waitForProcessGroupExit = async (processGroupId, timeoutMs) => {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    while (Date.now() < deadline) {
+      if (!processGroupIsAlive(processGroupId)) return true;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    return !processGroupIsAlive(processGroupId);
+  };
+
+  /**
+   * Terminate one captured attempt's complete process ownership boundary and
+   * register it as a terminal-publication barrier on the logical run.
+   *
+   * POSIX agents are spawned as process-group leaders, so pgid signalling also
+   * catches descendants created after teardown starts. Windows has no matching
+   * group primitive here; reuse the platform package's process-tree snapshot +
+   * bounded SIGTERM/SIGKILL escalation while the direct child is still alive.
+   * The captured child/pgid key makes repeated verdict/close callbacks
+   * idempotent and prevents a retry generation from targeting its successor.
+   */
+  const terminateProcessTree = (run, child, processGroupId, {
+    gracefulWaitMs = 0,
+    termGraceMs = cancelGraceMs(),
+    killGraceMs = forceWaitMs(),
+    reason = 'run_terminal',
+  } = {}) => {
+    const key = child ?? processGroupId;
+    run.processTreeTerminations ??= new Map();
+    if (key != null && run.processTreeTerminations.has(key)) {
+      return run.processTreeTerminations.get(key);
+    }
+
+    run.processTreeTerminationPending = (run.processTreeTerminationPending ?? 0) + 1;
+    const task = (async () => {
+      if (process.platform !== 'win32' && Number.isInteger(processGroupId)) {
+        if (!processGroupIsAlive(processGroupId)) {
+          return { quiescent: true, forced: false, remainingPids: [] };
+        }
+        if (
+          gracefulWaitMs > 0
+          && await waitForProcessGroupExit(processGroupId, gracefulWaitMs)
+        ) {
+          return { quiescent: true, forced: false, remainingPids: [] };
+        }
+        signalProcessGroup(processGroupId, 'SIGTERM');
+        if (await waitForProcessGroupExit(processGroupId, termGraceMs)) {
+          return { quiescent: true, forced: false, remainingPids: [] };
+        }
+        signalProcessGroup(processGroupId, 'SIGKILL');
+        const quiescent = await waitForProcessGroupExit(processGroupId, killGraceMs);
+        return {
+          quiescent,
+          forced: true,
+          remainingPids: quiescent ? [] : [processGroupId],
+        };
+      }
+
+      const snapshots = await listProcessSnapshots();
+      const pids = collectProcessTreePids(snapshots, [child?.pid]);
+      if (gracefulWaitMs > 0) {
+        await waitForChildExit(child, gracefulWaitMs);
+      }
+      const result = await stopProcesses(
+        pids.length > 0 ? pids : [child?.pid],
+        { termGraceMs, killGraceMs },
+      );
+      return {
+        quiescent: result.remainingPids.length === 0,
+        forced: result.forcedPids.length > 0,
+        remainingPids: result.remainingPids,
+      };
+    })().catch((error) => ({
+      quiescent: false,
+      forced: false,
+      remainingPids: [],
+      error: error instanceof Error ? error.message : String(error),
+    })).then((result) => {
+      if (!result.quiescent) {
+        emit(run, 'diagnostic', {
+          type: 'termination_failed',
+          reason,
+          child_pid: child?.pid ?? null,
+          process_group_id: processGroupId ?? null,
+          remaining_pids: result.remainingPids,
+          ...(result.error ? { error: result.error } : {}),
+        });
+      }
+      return result;
+    }).finally(() => {
+      run.processTreeTerminationPending = Math.max(
+        0,
+        (run.processTreeTerminationPending ?? 1) - 1,
+      );
+      if (run.processTreeTerminationPending === 0 && run.pendingTerminalFinish) {
+        const pending = run.pendingTerminalFinish;
+        run.pendingTerminalFinish = null;
+        commitFinish(run, pending.status, pending.code, pending.signal);
+      }
+    });
+
+    if (key != null) run.processTreeTerminations.set(key, task);
+    return task;
+  };
+
   // Reap a torn-down attempt's whole process group: SIGTERM now, then SIGKILL any
   // survivors after the grace window. Both target the CAPTURED pgid passed in —
   // callers must snapshot run.processGroupId before a same-run retry overwrites
@@ -1544,37 +1670,47 @@ export function createChatRunService({
       return statusBody(run);
     }
 
+    const targetChild = run.child;
+    const targetProcessGroupId = run.processGroupId;
+
     // Prefer RPC-level abort for agents that support it (pi, ACP adapters).
     // If the adapter does not exit within its grace window, fall back to
     // process signals and finally SIGKILL the process group.
     if (run.acpSession?.abort) {
+      const graceMs = Number(process.env.PI_ABORT_GRACE_MS) || 3000;
+      const termination = terminateProcessTree(
+        run,
+        targetChild,
+        targetProcessGroupId,
+        {
+          gracefulWaitMs: graceMs,
+          termGraceMs: graceMs,
+          killGraceMs: forceWaitMs(),
+          reason: 'run_cancel',
+        },
+      );
       try {
         run.acpSession.abort();
       } catch {
         // Signal fallback below owns eventual process termination.
       }
-      const graceMs = Number(process.env.PI_ABORT_GRACE_MS) || 3000;
-      if (await waitForCanceledChildExit(run, graceMs)) {
-        return finishCanceledFromChildState(run, 'SIGTERM');
-      }
       closeRunStdin(run);
-      killChild(run, 'SIGTERM');
-      if (await waitForCanceledChildExit(run, graceMs)) {
-        return finishCanceledFromChildState(run, 'SIGTERM');
-      }
-      killChild(run, 'SIGKILL');
-      await waitForCanceledChildExit(run, forceWaitMs());
-      return finishCanceledFromChildState(run, 'SIGKILL');
+      const terminationResult = await termination;
+      return finishCanceledFromChildState(run, terminationResult.forced ? 'SIGKILL' : 'SIGTERM');
     }
 
     closeRunStdin(run);
-    killChild(run, 'SIGTERM');
-    if (await waitForCanceledChildExit(run, cancelGraceMs())) {
-      return finishCanceledFromChildState(run, 'SIGTERM');
-    }
-    killChild(run, 'SIGKILL');
-    await waitForCanceledChildExit(run, forceWaitMs());
-    return finishCanceledFromChildState(run, 'SIGKILL');
+    const termination = await terminateProcessTree(
+      run,
+      targetChild,
+      targetProcessGroupId,
+      {
+        termGraceMs: cancelGraceMs(),
+        killGraceMs: forceWaitMs(),
+        reason: 'run_cancel',
+      },
+    );
+    return finishCanceledFromChildState(run, termination.forced ? 'SIGKILL' : 'SIGTERM');
   };
 
   const shutdownActive = async ({ graceMs = shutdownGraceMs } = {}) => {
@@ -1584,6 +1720,17 @@ export function createChatRunService({
       run.cancelOrigin = 'daemon_shutdown';
       run.updatedAt = Date.now();
       clearPendingRetryRestart(run);
+      const termination = terminateProcessTree(
+        run,
+        run.child,
+        run.processGroupId,
+        {
+          gracefulWaitMs: graceMs,
+          termGraceMs: graceMs,
+          killGraceMs: 500,
+          reason: 'daemon_shutdown',
+        },
+      );
       if (run.acpSession?.abort) {
         try {
           run.acpSession.abort();
@@ -1592,12 +1739,8 @@ export function createChatRunService({
         }
       }
       closeRunStdin(run);
-      killChild(run, 'SIGTERM');
-      finish(run, 'canceled', null, 'SIGTERM');
-      if (run.child && !(await waitForChildExit(run.child, graceMs))) {
-        killChild(run, 'SIGKILL');
-        await waitForChildExit(run.child, 500);
-      }
+      const terminationResult = await termination;
+      finish(run, 'canceled', null, terminationResult.forced ? 'SIGKILL' : 'SIGTERM');
     }));
   };
 
@@ -1680,6 +1823,7 @@ export function createChatRunService({
     drop,
     signalChild: killChild,
     reapProcessGroup,
+    terminateProcessTree,
     signalProcessGroup,
     statusBody,
     signalChildProcess,

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1562,6 +1562,26 @@ export function createChatRunService({
         };
       }
 
+      if (!Number.isInteger(child?.pid)) {
+        if (
+          gracefulWaitMs > 0
+          && await waitForChildExit(child, gracefulWaitMs)
+        ) {
+          return { quiescent: true, forced: false, remainingPids: [] };
+        }
+        signalChildProcess(child, null, 'SIGTERM');
+        if (await waitForChildExit(child, termGraceMs)) {
+          return { quiescent: true, forced: false, remainingPids: [] };
+        }
+        signalChildProcess(child, null, 'SIGKILL');
+        const quiescent = await waitForChildExit(child, killGraceMs);
+        return {
+          quiescent,
+          forced: true,
+          remainingPids: [],
+        };
+      }
+
       const snapshots = await listProcessSnapshots();
       const pids = collectProcessTreePids(snapshots, [child?.pid]);
       if (gracefulWaitMs > 0) {
@@ -1678,23 +1698,23 @@ export function createChatRunService({
     // process signals and finally SIGKILL the process group.
     if (run.acpSession?.abort) {
       const graceMs = Number(process.env.PI_ABORT_GRACE_MS) || 3000;
-      const termination = terminateProcessTree(
-        run,
-        targetChild,
-        targetProcessGroupId,
-        {
-          gracefulWaitMs: graceMs,
-          termGraceMs: graceMs,
-          killGraceMs: forceWaitMs(),
-          reason: 'run_cancel',
-        },
-      );
       try {
         run.acpSession.abort();
       } catch {
         // Signal fallback below owns eventual process termination.
       }
-      closeRunStdin(run);
+      const childExitedDuringAbort = await waitForChildExit(targetChild, graceMs);
+      if (!childExitedDuringAbort) closeRunStdin(run);
+      const termination = terminateProcessTree(
+        run,
+        targetChild,
+        targetProcessGroupId,
+        {
+          termGraceMs: graceMs,
+          killGraceMs: forceWaitMs(),
+          reason: 'run_cancel',
+        },
+      );
       const terminationResult = await termination;
       return finishCanceledFromChildState(run, terminationResult.forced ? 'SIGKILL' : 'SIGTERM');
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11769,16 +11769,12 @@ export async function startServer({
       // the CAPTURED pgid — the SIGKILL escalation is bound to it, so it can
       // never hit the next attempt's group (the cross-generation kill fixed in
       // #5202). On win32 / no pgid, fall back to signalling the direct child.
-      const reaped = design.runs.reapProcessGroup(priorProcessGroupId);
-      if (
-        !reaped &&
-        priorChild &&
-        typeof priorChild.kill === 'function' &&
-        priorChild.exitCode === null &&
-        !priorChild.killed
-      ) {
-        try { priorChild.kill('SIGTERM'); } catch {}
-      }
+      const termination = design.runs.terminateProcessTree(
+        run,
+        priorChild,
+        priorProcessGroupId,
+        { reason: 'retry_generation_replaced' },
+      );
       run.status = 'queued';
       run.updatedAt = Date.now();
       run.child = null;
@@ -11807,6 +11803,7 @@ export async function startServer({
         ...run.analyticsTelemetry,
         startRequestedAt: run.analyticsTelemetry?.startRequestedAt ?? run.createdAt,
       };
+      return termination;
     };
     const spawnRetryAttempt = (retryChatBody = chatBody) => {
       void startChatRun(retryChatBody, run).catch((err) => {
@@ -11832,16 +11829,31 @@ export async function startServer({
     // and finalizes the queued run, and the callback re-checks cancel/terminal
     // state in case it fires first.
     const scheduleRetryRestart = (delayMs, retryChatBody = chatBody) => {
-      tearDownAttemptForRetry();
+      const termination = tearDownAttemptForRetry();
       const wait = Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
+      const spawnWhenQuiescent = () => {
+        void Promise.resolve(termination).then((result) => {
+          if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
+          if (!result?.quiescent) {
+            send('error', createSseErrorPayload(
+              'AGENT_EXECUTION_FAILED',
+              'The previous agent process tree could not be terminated; the retry was stopped before another model request was started.',
+              { retryable: false },
+            ));
+            finishWithRetryDecision('failed', 1, null, { allowRetry: false });
+            return;
+          }
+          spawnRetryAttempt(retryChatBody);
+        });
+      };
       if (wait <= 0) {
-        spawnRetryAttempt(retryChatBody);
+        spawnWhenQuiescent();
         return;
       }
       run.retryRestartTimer = setTimeout(() => {
         run.retryRestartTimer = null;
         if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
-        spawnRetryAttempt(retryChatBody);
+        spawnWhenQuiescent();
       }, wait);
     };
     const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
@@ -11926,7 +11938,12 @@ export async function startServer({
       const finished = finishRun(status, code, signal);
       return finished;
     };
-    const finishWithRetryDecision = (status, code = null, signal = null) => {
+    const finishWithRetryDecision = (
+      status,
+      code = null,
+      signal = null,
+      { allowRetry = true } = {},
+    ) => {
       lifecycle.mark('finalize_start');
       flushRunMessageEvents(run);
       // Persist the transport-level close mechanism before classifying this
@@ -12003,6 +12020,7 @@ export async function startServer({
         hasNativeSession: !!run.conversationId && !!liveSessionId,
       });
       if (
+        allowRetry &&
         postToolResumeDecision?.shouldRetry &&
         !design.runs.isTerminal(run.status) &&
         run.conversationId &&
@@ -12059,7 +12077,7 @@ export async function startServer({
         attemptCount: run.retryAttemptCount ?? 0,
         sideEffects,
       });
-      if (decision.shouldRetry && !design.runs.isTerminal(run.status)) {
+      if (allowRetry && decision.shouldRetry && !design.runs.isTerminal(run.status)) {
         run.retryOriginalFailure ??= failure ?? undefined;
         if ((run.retryAttemptCount ?? 0) === 0) {
           run.retryOriginFailure = failure ? { ...failure } : null;
@@ -12892,6 +12910,25 @@ export async function startServer({
       }
     };
     let forcedChildShutdownTimers = [];
+    let acpAttemptTermination = null;
+    const beginAcpAttemptTermination = (
+      reason = 'acp_terminal',
+      { gracefulWaitMs = 0 } = {},
+    ) => {
+      if (acpAttemptTermination) return acpAttemptTermination;
+      acpAttemptTermination = design.runs.terminateProcessTree(
+        run,
+        child,
+        run.processGroupId,
+        {
+          gracefulWaitMs,
+          termGraceMs: inactivityKillGraceMs,
+          killGraceMs: inactivityKillGraceMs,
+          reason,
+        },
+      );
+      return acpAttemptTermination;
+    };
     const clearForcedChildShutdown = () => {
       for (const timer of forcedChildShutdownTimers) clearTimeout(timer);
       forcedChildShutdownTimers = [];
@@ -12936,10 +12973,15 @@ export async function startServer({
         // only signals from this watchdog branch should be.
         artifactQuietShutdownRequested = true;
         if (acpSession?.abort) {
+          beginAcpAttemptTermination(
+            'acp_artifact_quiet_timeout',
+            { gracefulWaitMs: 100 },
+          );
           acpSession.abort();
+        } else {
+          if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
+          scheduleForcedChildShutdown();
         }
-        if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
-        scheduleForcedChildShutdown();
         return;
       }
       // OpenCode retries a 429 usage-limit silently and emits nothing on
@@ -12981,6 +13023,13 @@ export async function startServer({
         ? 'first_output_deadline'
         : 'inactivity_watchdog';
       send('error', stallPayload);
+      if (acpSession?.abort) {
+        beginAcpAttemptTermination(
+          `acp_${reason}_timeout`,
+          { gracefulWaitMs: 100 },
+        );
+        acpSession.abort();
+      }
       // A silent first-token hang is one of the safe transient failure shapes
       // this run is allowed to recover: classifyRunFailure maps the stall text
       // to a retryable `timeout` at `first_token_wait`, and decideSafeRunRetry
@@ -12992,11 +13041,10 @@ export async function startServer({
       if (retried) {
         watchdogRetryRestarted = true;
       }
-      if (acpSession?.abort) {
-        acpSession.abort();
+      if (!acpSession?.abort) {
+        if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
+        scheduleForcedChildShutdown();
       }
-      if (child && !child.killed) design.runs.signalChild(run, 'SIGTERM');
-      scheduleForcedChildShutdown();
     };
     const armFirstOutputWatchdog = () => {
       if (firstOutputSeen || firstOutputTimer || firstOutputTimeoutMs <= 0) return;
@@ -13052,27 +13100,23 @@ export async function startServer({
       progressClockFrozen = true;
     };
     /**
-     * The ACP bridge has reached a terminal verdict for this attempt: it has
-     * already emitted the error and SIGTERMed the child. Hand the attempt over
-     * to the close handler under THAT verdict.
+     * The ACP bridge has reached a terminal verdict for this attempt. Hand the
+     * attempt over to the close handler under THAT verdict while the
+     * generation-bound process-tree terminator owns teardown.
      *
-     * Retiring the outer chat inactivity watchdog is the point. `fail()` issues
-     * one direct SIGTERM and nothing escalates it, while the outer watchdog is
-     * still armed from the agent's last real output — so a child that lingers
-     * past that ceiling lets `failForInactivity` fire on a run it does not yet
-     * consider terminal, overwrite `terminal_trigger` with `inactivity_watchdog`,
-     * and emit a second failure. The stall then reads as the wrong clock, which
-     * is the confusion `acp_stage_timeout` exists to remove.
+     * Retiring the outer chat inactivity watchdog is the point. Without that
+     * ownership transfer, a child that lingers past the ceiling lets
+     * `failForInactivity` overwrite `terminal_trigger` with
+     * `inactivity_watchdog` and emit a second failure.
      *
-     * Escalating the teardown is the other half: without it, retiring the
-     * watchdog would leave a SIGTERM-ignoring child with nothing to reap it.
-     * `scheduleForcedChildShutdown` captures this attempt's child, so a retry
-     * that swaps `run.child` inside the grace window is not affected.
+     * The terminator captures this attempt's child and process group, waits for
+     * quiescence, and escalates without ever consulting a retry's replacement
+     * `run.child`.
      */
     const retireAttemptOnAcpVerdict = () => {
       freezeProgressClock();
       clearInactivityWatchdog();
-      scheduleForcedChildShutdown();
+      beginAcpAttemptTermination('acp_verdict');
     };
     const noteAgentActivity = () => {
       // Once this attempt has a terminal verdict, nothing the child says may
@@ -14392,6 +14436,10 @@ export async function startServer({
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
         onPromptComplete: () => clearFirstOutputWatchdog(),
+        onTerminal: (kind) => beginAcpAttemptTermination(
+          `acp_${kind}`,
+          { gracefulWaitMs: kind === 'completed' ? 500 : 0 },
+        ),
         send: (event, data, meta) => {
           if (event === 'error') {
             clearFirstOutputWatchdog();
@@ -14693,7 +14741,9 @@ export async function startServer({
       revokeToolToken('child_exit');
       if (!attemptStillOwnsRun()) return;
       unregisterChatAgentEventSink();
+      if (run.pendingTerminalFinish) return;
       if (finishCanceledIfRequested(1, null)) return;
+      if (acpSession) beginAcpAttemptTermination('acp_child_error');
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
       finishWithRetryDecision('failed', 1, null);
     });
@@ -14714,6 +14764,8 @@ export async function startServer({
       }
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
+      if (run.pendingTerminalFinish) return;
+      if (acpSession) beginAcpAttemptTermination('acp_child_close');
       if (
         def.id === 'codex' &&
         strategyTaskAtStart &&

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -65,6 +65,11 @@
  *                                   alive, modelling a CLI (or a wrapper shim)
  *                                   that is slow to die or never honours the
  *                                   signal at all
+ *   FAKE_VELA_DESCENDANT_ACTIVITY_FILE – when set, spawn a SIGTERM-ignoring
+ *                                   descendant that appends activity ticks to
+ *                                   this file while the ACP prompt is stalled
+ *   FAKE_VELA_DESCENDANT_PID_FILE – optional file that receives that
+ *                                   descendant's pid for leak-safe test cleanup
  *   FAKE_VELA_PROMPT_RESULT_DELAY_MS – delay the terminal session/prompt result
  *                                      after streaming substantive output
  *   FAKE_VELA_MODELS             – newline-separated `vela models` stdout
@@ -106,6 +111,8 @@ const TEXT_BEFORE_STALL = env.FAKE_VELA_TEXT_BEFORE_STALL === '1';
 const OPEN_TOOL_BEFORE_STALL = env.FAKE_VELA_OPEN_TOOL_BEFORE_STALL === '1';
 const STDERR_ON_SIGTERM = env.FAKE_VELA_STDERR_ON_SIGTERM === '1';
 const IGNORE_SIGTERM = env.FAKE_VELA_IGNORE_SIGTERM === '1';
+const DESCENDANT_ACTIVITY_FILE = env.FAKE_VELA_DESCENDANT_ACTIVITY_FILE || '';
+const DESCENDANT_PID_FILE = env.FAKE_VELA_DESCENDANT_PID_FILE || '';
 const PROMPT_RESULT_DELAY_MS = Number(env.FAKE_VELA_PROMPT_RESULT_DELAY_MS) || 0;
 const OMIT_PROMPT_USAGE = env.FAKE_VELA_OMIT_PROMPT_USAGE === '1';
 const STAY_ALIVE_AFTER_PROMPT_MS = Number(env.FAKE_VELA_STAY_ALIVE_AFTER_PROMPT_MS) || 0;
@@ -353,6 +360,18 @@ function handleMessage(msg) {
       }
       if (STALL_AFTER_PROMPT) {
         if (TEXT_BEFORE_STALL) emitSessionUpdates(sessionId);
+        if (DESCENDANT_ACTIVITY_FILE) {
+          const descendant = spawnChild(process.execPath, [
+            '-e',
+            `const fs = require('node:fs');
+const activityFile = ${JSON.stringify(DESCENDANT_ACTIVITY_FILE)};
+process.on('SIGTERM', () => {});
+const tick = () => fs.appendFileSync(activityFile, String(Date.now()) + '\\n');
+tick();
+setInterval(tick, 25);`,
+          ], { stdio: 'ignore' });
+          if (DESCENDANT_PID_FILE) writeFileSync(DESCENDANT_PID_FILE, String(descendant.pid));
+        }
         // A concrete tool the agent never closes. `kind: 'read'` is a
         // recognized non-think, non-write family, and `in_progress` is not a
         // terminal status, so the host keeps this call open in

--- a/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
+++ b/apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts
@@ -83,8 +83,13 @@ describe('ACP stall progress age', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
   let binDir: string | null = null;
+  let descendantPids: number[] = [];
 
   afterEach(async () => {
+    for (const pid of descendantPids) {
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+    descendantPids = [];
     await Promise.resolve(started?.shutdown?.());
     if (started?.server) {
       await new Promise<void>((resolve) => started?.server.close(() => resolve()));
@@ -322,6 +327,55 @@ describe('ACP stall progress age', () => {
     ).toBeGreaterThanOrEqual(ACP_STAGE_TIMEOUT_MS * 0.8);
   }, 60_000);
 
+  it('publishes run_finished only after the stalled ACP process group is silent', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-acp-terminal-silence-bin-'));
+    const activityFile = path.join(binDir, 'descendant-activity.log');
+    const descendantPidFile = path.join(binDir, 'descendant.pid');
+    const fakeVela = await writeSilentlyStallingVela(binDir, 'vela-terminal-silence', {
+      descendantActivityFile: activityFile,
+      descendantPidFile,
+    });
+
+    process.env.POSTHOG_KEY = 'phc_test_acp_terminal_silence';
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.VELA_RUNTIME_KEY = `fake-runtime-key-${randomUUID()}`;
+    process.env.VELA_LINK_URL = 'https://amr-link.open-design.ai/v1';
+    process.env.OD_ACP_STAGE_TIMEOUT_MS = String(ACP_STAGE_TIMEOUT_MS);
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = String(OUTER_INACTIVITY_TIMEOUT_MS);
+    process.env.OD_CHAT_RUN_FIRST_OUTPUT_TIMEOUT_MS = '0';
+    process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS = '250';
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'amr',
+      agentCliEnv: { amr: { VELA_BIN: fakeVela } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForAmrRun(started.url);
+    expect(run.status).toBe('failed');
+    await waitForRunFinished(run.id);
+
+    const descendantPid = Number(readFileSync(descendantPidFile, 'utf8').trim());
+    expect(Number.isInteger(descendantPid)).toBe(true);
+    descendantPids.push(descendantPid);
+    expect(processAlive(descendantPid)).toBe(false);
+
+    const activityAtTerminal = activityTickCount(activityFile);
+    expect(activityAtTerminal).toBeGreaterThan(0);
+
+    // This real wait protects an OS process-tree boundary: after run_finished
+    // there is no application completion signal left to await. A surviving
+    // descendant makes the counter advance; a quiescent group leaves it fixed.
+    await delay(300);
+    expect(activityTickCount(activityFile)).toBe(activityAtTerminal);
+  }, 60_000);
+
   // The worst case is a child that does BOTH: keeps logging on stderr and keeps
   // refusing to die. Retiring the watchdog at the verdict is not enough on its
   // own, because every late stderr byte reaches `noteAgentActivity` through the
@@ -454,6 +508,8 @@ async function writeSilentlyStallingVela(
     openToolBeforeStall?: boolean;
     stderrOnSigterm?: boolean;
     ignoreSigterm?: boolean;
+    descendantActivityFile?: string;
+    descendantPidFile?: string;
   } = {},
 ): Promise<string> {
   const bin = path.join(dir, name);
@@ -463,11 +519,28 @@ if [ "$1" = "agent" ] && [ "$2" = "run" ]; then
   export FAKE_VELA_TEXT_BEFORE_STALL=1
   export FAKE_VELA_STALL_HEARTBEAT_MS=0
   export FAKE_VELA_REQUIRE_SET_MODEL=0
-${options.openToolBeforeStall ? '  export FAKE_VELA_OPEN_TOOL_BEFORE_STALL=1\n' : ''}${options.stderrOnSigterm ? '  export FAKE_VELA_STDERR_ON_SIGTERM=1\n' : ''}${options.ignoreSigterm ? '  export FAKE_VELA_IGNORE_SIGTERM=1\n' : ''}fi
+${options.openToolBeforeStall ? '  export FAKE_VELA_OPEN_TOOL_BEFORE_STALL=1\n' : ''}${options.stderrOnSigterm ? '  export FAKE_VELA_STDERR_ON_SIGTERM=1\n' : ''}${options.ignoreSigterm ? '  export FAKE_VELA_IGNORE_SIGTERM=1\n' : ''}${options.descendantActivityFile ? `  export FAKE_VELA_DESCENDANT_ACTIVITY_FILE=${JSON.stringify(options.descendantActivityFile)}\n` : ''}${options.descendantPidFile ? `  export FAKE_VELA_DESCENDANT_PID_FILE=${JSON.stringify(options.descendantPidFile)}\n` : ''}fi
 exec ${JSON.stringify(process.execPath)} ${JSON.stringify(FAKE_VELA)} "$@"
 `, 'utf8');
   await chmod(bin, 0o755);
   return bin;
+}
+
+function activityTickCount(file: string): number {
+  try {
+    return readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).length;
+  } catch {
+    return 0;
+  }
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -6,7 +6,38 @@ import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const platformMocks = vi.hoisted(() => ({
+  listProcessSnapshots: vi.fn(),
+  stopProcesses: vi.fn(),
+  actualListProcessSnapshots: null as null | typeof import('@open-design/platform').listProcessSnapshots,
+  actualStopProcesses: null as null | typeof import('@open-design/platform').stopProcesses,
+}));
+
+vi.mock('@open-design/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@open-design/platform')>();
+  platformMocks.actualListProcessSnapshots = actual.listProcessSnapshots;
+  platformMocks.actualStopProcesses = actual.stopProcesses;
+  platformMocks.listProcessSnapshots.mockImplementation(actual.listProcessSnapshots);
+  platformMocks.stopProcesses.mockImplementation(actual.stopProcesses);
+  return {
+    ...actual,
+    listProcessSnapshots: platformMocks.listProcessSnapshots,
+    stopProcesses: platformMocks.stopProcesses,
+  };
+});
+
 import { createChatRunService } from '../../src/runtimes/runs.js';
+
+afterEach(() => {
+  platformMocks.listProcessSnapshots.mockReset();
+  platformMocks.stopProcesses.mockReset();
+  platformMocks.listProcessSnapshots.mockImplementation(
+    platformMocks.actualListProcessSnapshots as typeof import('@open-design/platform').listProcessSnapshots,
+  );
+  platformMocks.stopProcesses.mockImplementation(
+    platformMocks.actualStopProcesses as typeof import('@open-design/platform').stopProcesses,
+  );
+});
 
 describe('chat run service shutdown', () => {
   it('exports terminal diagnostics without confusing a measured zero with missing data', () => {
@@ -664,6 +695,75 @@ describe('chat run service shutdown', () => {
       expect(run.signal).toBe('SIGKILL');
     });
 
+    it('includes descendants created during ACP abort grace in no-pgid teardown', async () => {
+      vi.useFakeTimers();
+      vi.stubEnv('PI_ABORT_GRACE_MS', '30');
+      const childPid = 41_000;
+      const descendantPid = 41_001;
+      const child = new FakeChildProcess({ closeOn: 'SIGKILL', pid: childPid });
+      platformMocks.listProcessSnapshots
+        .mockResolvedValueOnce([{ pid: childPid, ppid: 1, command: 'wrapper' }])
+        .mockResolvedValueOnce([
+          { pid: childPid, ppid: 1, command: 'wrapper' },
+          { pid: descendantPid, ppid: childPid, command: 'late descendant' },
+        ])
+        .mockResolvedValueOnce([{ pid: process.pid, ppid: 1, command: 'vitest' }]);
+      platformMocks.stopProcesses.mockResolvedValue({
+        alreadyStopped: false,
+        forcedPids: [childPid, descendantPid],
+        matchedPids: [childPid, descendantPid],
+        remainingPids: [],
+        stoppedPids: [childPid, descendantPid],
+      });
+      const runs = createRuns();
+      const run = runs.create() as any;
+      run.status = 'running';
+      run.child = child;
+      run.acpSession = { abort: vi.fn() };
+
+      const cancelPromise = runs.cancel(run);
+      await vi.advanceTimersByTimeAsync(30);
+      await cancelPromise;
+
+      expect(platformMocks.stopProcesses).toHaveBeenCalledWith(
+        [descendantPid, childPid],
+        { termGraceMs: 30, killGraceMs: 500 },
+      );
+      expect(run.events).not.toContainEqual(expect.objectContaining({
+        event: 'diagnostic',
+        data: expect.objectContaining({ type: 'termination_failed' }),
+      }));
+    });
+
+    it('records termination_failed when no-pgid process enumeration is unverifiable', async () => {
+      const childPid = 42_000;
+      const child = new FakeChildProcess({ closeOn: 'SIGTERM', pid: childPid });
+      platformMocks.listProcessSnapshots.mockResolvedValue([]);
+      platformMocks.stopProcesses.mockResolvedValue({
+        alreadyStopped: false,
+        forcedPids: [],
+        matchedPids: [childPid],
+        remainingPids: [],
+        stoppedPids: [childPid],
+      });
+      const runs = createRuns();
+      const run = runs.create() as any;
+      run.status = 'running';
+      run.child = child;
+
+      await runs.cancel(run);
+
+      expect(run.events).toContainEqual(expect.objectContaining({
+        event: 'diagnostic',
+        data: expect.objectContaining({
+          type: 'termination_failed',
+          reason: 'run_cancel',
+          child_pid: childPid,
+        }),
+      }));
+      expect(run.events.at(-1)).toMatchObject({ event: 'end', data: { status: 'canceled' } });
+    });
+
     it('waits for a real process group to exit before returning canceled status', async () => {
       if (process.platform === 'win32') return;
       vi.stubEnv('OD_CHAT_RUN_CANCEL_GRACE_MS', '25');
@@ -1151,6 +1251,7 @@ async function expectPidGone(pid: number): Promise<void> {
 }
 
 class FakeChildProcess extends EventEmitter {
+  pid: number | undefined;
   exitCode: number | null = null;
   signalCode: string | null = null;
   killed = false;
@@ -1164,8 +1265,9 @@ class FakeChildProcess extends EventEmitter {
     }),
   };
 
-  constructor(private readonly options: { closeOn: 'SIGTERM' | 'SIGKILL' }) {
+  constructor(private readonly options: { closeOn: 'SIGTERM' | 'SIGKILL'; pid?: number }) {
     super();
+    this.pid = options.pid;
   }
 
   kill(signal: string): boolean {


### PR DESCRIPTION
Fixes #7431

## Why

Production investigation of ACP `post_tool_resume` timeouts found Vela model requests continuing after Open Design had already emitted `run_finished`, in some cases for tens of minutes. The local lifecycle treated direct-child close as terminal even though ACP wrappers can leave descendants alive; `child.killed` only records that a signal was sent and is not proof that the owned process tree stopped.

This change establishes the local terminal-silence boundary that complements #7424's remote Vela terminal admission fence. Open Design now waits for the attempt's complete process tree to become quiescent before claiming the Run is terminal.

## What users will see

ACP Runs that time out, fail, are canceled, shut down, or replace an attempt for retry no longer leave descendant agents running after the Run reaches its terminal state. If the daemon cannot prove process-tree quiescence after bounded escalation, it records an explicit `termination_failed` diagnostic; a retry is not started on top of a non-quiescent prior generation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a daemon lifecycle change with no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/acp-stall-last-progress-age.test.ts` (`publishes run_finished only after the stalled ACP process group is silent`)
- Red on `main`: yes. The descendant activity count advanced after `run_finished` (`expected 118 to be 106`).
- Green on this branch: yes. The fixture's SIGTERM-ignoring descendant is dead when `run_finished` is observed, and its activity counter remains unchanged after the terminal boundary.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/acp-stall-last-progress-age.test.ts -t "publishes run_finished only after"` — 1 passed
- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/acp-stall-last-progress-age.test.ts tests/acp.test.ts tests/amr-acp-integration.test.ts tests/amr-session-resume.test.ts tests/retry-orphan-process-group.test.ts tests/retry-generation-terminal-fence.test.ts tests/retry-stale-turn-completed-flag.test.ts tests/run-retry-runtime.test.ts tests/runtimes/chat-run-inactivity-timeout.test.ts tests/runtimes/run-terminal-reconciliation.test.ts` — 10 files, 197 tests passed
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm guard`
- `git diff --check`

Not yet verified on Windows native or against live production Vela traffic. Local validation used Node v24.16.0; the workspace reports that `shells/terminal` prefers Node v24.18.0.
