### PR TITLE
perf(collab): make background materialization volume observable

### DIFF
--- a/apps/daemon/src/collab/background-pull-size-guard.ts
+++ b/apps/daemon/src/collab/background-pull-size-guard.ts
@@ -116,6 +116,30 @@ export interface BackgroundPullSizeGuardDeps {
   onError?: (error: unknown) => void;
 }
 
+/**
+ * How much this process has let the BACKGROUND lanes materialize. Reported
+ * unconditionally — including while the cumulative ceiling is disabled, which
+ * is the shipping default — because choosing that ceiling is a capacity
+ * decision that needs real per-launch volume, and a counter that only runs
+ * once the ceiling is already set can never supply it.
+ */
+export interface BackgroundPullVolume {
+  /** Entries cleared for background materialization, summed over every
+   *  allowed decision that carried a count. */
+  entries: number;
+  /** Allowed decisions that carried a count — pairs with `entries` to give a
+   *  per-project mean without a second reading. */
+  countedProjects: number;
+  /**
+   * Allowed decisions whose version carried NO count (old server output, so
+   * the guard fails open). Reported separately because a small `entries` is
+   * otherwise ambiguous: a fleet that counts nothing looks identical to a
+   * fleet that pulls nothing, and reading the first as the second would set
+   * the ceiling far below what real teams need.
+   */
+  uncountedProjects: number;
+}
+
 export interface BackgroundPullSizeGuard {
   /**
    * Decide whether the background lane may materialize this exact
@@ -126,6 +150,9 @@ export interface BackgroundPullSizeGuard {
     scope: BackgroundPullSizeGuardScope,
     version: number,
   ): Promise<'pull' | 'defer'>;
+  /** Snapshot of what this process has cleared so far. Read-only; callers
+   *  must never mutate the returned object. */
+  volume(): BackgroundPullVolume;
 }
 
 export function createBackgroundPullSizeGuard(
@@ -146,8 +173,16 @@ export function createBackgroundPullSizeGuard(
   const deferredVersions = new Map<string, number>();
   /** Entries already cleared for background materialization this process. Only
    *  counted for decisions this guard actually allowed, so a project deferred
-   *  for size never consumes budget it did not spend. */
+   *  for size never consumes budget it did not spend.
+   *
+   *  Accumulated whether or not a ceiling is set: with `maxCumulativeEntries`
+   *  unset this number enforces nothing and exists purely to be reported, so
+   *  the ceiling can be chosen from what real launches actually pull. */
   let cumulativeEntries = 0;
+  /** Allowed decisions that carried a count, and those that did not. See
+   *  `BackgroundPullVolume` for why the two must stay distinguishable. */
+  let countedProjects = 0;
+  let uncountedProjects = 0;
   /** Versions deferred because the session budget was spent. Kept apart from
    *  `deferredVersions` (which means "permanently too big") so the two reasons
    *  stay distinguishable, while both avoid re-probing. */
@@ -181,6 +216,7 @@ export function createBackgroundPullSizeGuard(
     }
     if (inspection.kind === 'uncounted') {
       allowedVersions.set(key, version);
+      uncountedProjects += 1;
       return 'pull';
     }
     // Per-project ceiling FIRST. Exceeding it is a permanent property of the
@@ -234,7 +270,12 @@ export function createBackgroundPullSizeGuard(
       return 'defer';
     }
     allowedVersions.set(key, version);
-    if (cumulativeLimit > 0) cumulativeEntries += inspection.entryCount;
+    // Unconditional: `cumulativeLimit` decides whether this number STOPS a
+    // pull, never whether it is measured. Gating the counter on the ceiling
+    // meant every default-configured client reported zero, which left the
+    // ceiling unchoosable for exactly as long as it stayed unset.
+    cumulativeEntries += inspection.entryCount;
+    countedProjects += 1;
     return 'pull';
   };
 
@@ -266,6 +307,13 @@ export function createBackgroundPullSizeGuard(
       };
       void probe.then(clear, clear);
       return probe;
+    },
+    volume() {
+      return {
+        entries: cumulativeEntries,
+        countedProjects,
+        uncountedProjects,
+      };
     },
   };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5211,12 +5211,23 @@ export async function startServer({
         );
         return;
       }
+      // `candidates` counts projects CONSIDERED, which is not what the
+      // background lanes cost a member: a sweep with candidates=25 says
+      // nothing about whether 25 files or 25,000 landed on their disk. The
+      // `process*` fields below are this daemon process's running totals (not
+      // this sweep's), and they are the reading that makes
+      // OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES choosable from a
+      // diagnostics bundle instead of from a synthetic workspace.
+      const backgroundVolume = backgroundPullSizeGuard.volume();
       console.info(
         `[od] shared-project content catch-up completed mode=${event.mode} lane=${event.lane} ` +
           `workspaceId=${event.workspaceId ?? 'unknown'} scanned=${event.scanned ?? 0} ` +
           `candidates=${event.candidates ?? 0} headChecks=${event.headChecks ?? 0} ` +
           `heads=${event.heads ?? 0} ` +
-          `suppressed=${event.suppressed ?? 0} complete=${event.complete === true}`,
+          `suppressed=${event.suppressed ?? 0} complete=${event.complete === true} ` +
+          `processEntries=${backgroundVolume.entries} ` +
+          `processProjects=${backgroundVolume.countedProjects} ` +
+          `processUncounted=${backgroundVolume.uncountedProjects}`,
       );
     },
   });

--- a/apps/daemon/tests/collab/background-pull-size-guard.test.ts
+++ b/apps/daemon/tests/collab/background-pull-size-guard.test.ts
@@ -225,6 +225,61 @@ describe('createBackgroundPullSizeGuard', () => {
     }
   });
 
+  // Volume reporting. The cumulative ceiling ships disabled (a capacity number
+  // nobody could justify without production data), and the counter that would
+  // have produced that data ran only when the ceiling was already on. Every
+  // default-configured client therefore measured nothing, which is why the
+  // ceiling stayed unset. Counting always — and enforcing only when a ceiling
+  // is set — is what makes it choosable.
+  it('reports the volume it cleared even when the cumulative ceiling is off', async () => {
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      inspect: async () => countedInspect(12),
+    });
+
+    await guard.assess(scope, 1);
+    await guard.assess({ ...scope, projectId: 'proj-2' }, 1);
+
+    expect(guard.volume()).toEqual({
+      entries: 24,
+      countedProjects: 2,
+      uncountedProjects: 0,
+    });
+  });
+
+  it('keeps uncounted allowances apart so a zero is not read as a quiet fleet', async () => {
+    // An old server returns no manifest count, and the guard fails open. If
+    // those allowances vanished from the report, a fleet that pulls plenty
+    // would look idle and the ceiling would be set far too low.
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      inspect: async () => ({ kind: 'uncounted' }) as const,
+    });
+
+    await guard.assess(scope, 1);
+
+    expect(guard.volume()).toEqual({
+      entries: 0,
+      countedProjects: 0,
+      uncountedProjects: 1,
+    });
+  });
+
+  it('does not report a deferred project as materialized volume', async () => {
+    const guard = createBackgroundPullSizeGuard({
+      maxEntries: 2000,
+      inspect: async () => countedInspect(7442),
+    });
+
+    await expect(guard.assess(scope, 1)).resolves.toBe('defer');
+
+    expect(guard.volume()).toEqual({
+      entries: 0,
+      countedProjects: 0,
+      uncountedProjects: 0,
+    });
+  });
+
   it('pulls a version at or below the threshold', async () => {
     const guard = createBackgroundPullSizeGuard({
       maxEntries: 2000,
@@ -549,8 +604,30 @@ describe('background size guard composed with the proactive pull lanes', () => {
         return { status: 'pulled', version: expectedVersion ?? null };
       },
     };
-    return { deps, inspect };
+    return { deps, inspect, guard };
   }
+
+  it('reports what the background lane actually materialized, through the real lane', async () => {
+    // Reading `volume()` off a direct `assess()` call proves the counter
+    // increments; it does not prove the counter is fed by the code path that
+    // costs a member their disk. Drive the real lane instead, so a future
+    // change that stops consulting the guard shows up here.
+    const { deps, guard } = makeComposedDeps(async () => countedInspect(12));
+    const pull = createProactiveContentPull(deps);
+
+    await pull.handleContentChanged({
+      projectId: 'proj-1',
+      workspaceId: 'ws-1',
+      version: 12,
+    });
+
+    expect(deps.pullCalls).toEqual([{ projectId: 'proj-1', version: 12 }]);
+    expect(guard.volume()).toEqual({
+      entries: 12,
+      countedProjects: 1,
+      uncountedProjects: 0,
+    });
+  });
 
   it('background lanes probe once, defer, and stay quiet across sweep rounds', async () => {
     const { deps, inspect } = makeComposedDeps(async () =>

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -281,9 +281,24 @@ describe('server.ts wiring (source boundary)', () => {
   });
 
   it('logs broad-head cooldown deferrals in catch-up completion diagnostics', () => {
+    // Matched without the closing backtick so the assertion survives further
+    // fields being appended to the same template — it is here to pin that
+    // suppressed/complete are still reported, not to freeze the line's length.
     expect(source).toContain(
-      '`suppressed=${event.suppressed ?? 0} complete=${event.complete === true}`',
+      'suppressed=${event.suppressed ?? 0} complete=${event.complete === true}',
     );
+  });
+
+  it('reports background materialization volume in catch-up completion diagnostics', () => {
+    // `candidates` counts projects CONSIDERED, which says nothing about what
+    // actually landed on a member's disk. These totals are the only reading
+    // that makes OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES choosable
+    // from a diagnostics bundle, so the guard's `volume()` has to reach this
+    // sink — a counter nothing reads is why that ceiling stayed unset.
+    expect(source).toContain('const backgroundVolume = backgroundPullSizeGuard.volume();');
+    expect(source).toContain('processEntries=${backgroundVolume.entries}');
+    expect(source).toContain('processProjects=${backgroundVolume.countedProjects}');
+    expect(source).toContain('processUncounted=${backgroundVolume.uncountedProjects}');
   });
 
   it('wires exact-scope recovery pollers through reconciliation and bounded full recovery', () => {


### PR DESCRIPTION
## Why

**My use case.** I have been working through the launch-performance list, and
item 3 on it is "background content pull has no upper bound". Going to close it
out, I found the mechanism already exists — I added it in #7403 — but ships
disabled, and the reason it is disabled is a loop it cannot get out of on its
own.

**The pain.** `OD_COLLAB_BACKGROUND_PULL_MAX_CUMULATIVE_ENTRIES` defaults to
`0`. The docblock says why: choosing that number is a capacity decision that
needs production data on real team sizes rather than a value inferred from a
synthetic workspace. That is the right instinct. But the counter that would
produce the data is itself gated on the ceiling:

```ts
if (cumulativeLimit > 0) cumulativeEntries += inspection.entryCount;
```

So every default-configured client measures nothing, and the data needed to set
the ceiling cannot exist until someone sets the ceiling. The per-project ceiling
(2000, active) already stops one 7442-file project from landing on every
member's disk — incident #6512 — but it cannot see accumulation, which is the
half this item is actually about: twelve small projects each clear it
individually while a member who only opened the client pulls 23 MB across eight
projects in 50 seconds.

Nothing here decides the number. This makes it possible to decide it, from a
diagnostics bundle off a real workspace rather than from a several-hundred-project
team someone has to construct.

## What users will see

Nothing, unless they open a diagnostics bundle. The shared-project catch-up
diagnostic gains three totals:

```
[od] shared-project content catch-up completed mode=… candidates=25 … \
     processEntries=312 processProjects=18 processUncounted=2
```

`candidates` counts projects *considered*; these count what this daemon process
actually let the background lanes materialize. `processUncounted` is separate on
purpose — an old server returns no manifest count and the guard fails open, so
those pulls are real but uncounted. Folded into one number, a fleet that counts
nothing would look identical to a fleet that pulls nothing, and reading the
first as the second would set the ceiling far below what teams need.

No thresholds, defaults or decisions move. The budget branch is still guarded by
`cumulativeLimit > 0`, so accumulating unconditionally changes no outcome while
the ceiling is unset.

## Surface area

- [x] **None** — the only behavioural surface is an existing diagnostic log
      line gaining three fields. No new `OD_*` variable (both were introduced in
      #7403), no new endpoint, no UI. Not a user-facing capability, so the
      UI/CLI dual-track rule in `AGENTS.md` does not apply — there is nothing to
      expose through `od`.

## Bug fix verification

Not a bug fix in the user-facing sense, but the specs follow the same
discipline. Every one was verified red against the unfixed source by reverting
the change and re-running:

| Spec | Red evidence |
| --- | --- |
| `reports the volume it cleared even when the cumulative ceiling is off` | `entries: 0` vs `entries: 24` |
| `reports what the background lane actually materialized, through the real lane` | `entries: 0` vs `entries: 12` |
| `keeps uncounted allowances apart so a zero is not read as a quiet fleet` | new field absent |
| `does not report a deferred project as materialized volume` | new field absent |

The lane spec is the one that matters most: reading `volume()` off a direct
`assess()` call only proves the counter increments, not that it is fed by the
code path that costs a member their disk. It drives the real
`createProactiveContentPull` lane, so a future change that stops consulting the
guard fails here rather than silently reporting zero.

`workspace-projects-hub-wiring` gains the sink assertions. It already pinned the
catch-up line by exact source text, and appending fields broke it — I had
earlier concluded that line had no test coverage, which was wrong; my grep
missed how it asserts. Its existing check now matches without the closing
backtick, so a later field does not break it again.

## Validation

- `@open-design/daemon`: 9,533 passed. One failure remains in
  `od-next-automatic-simple-server.test.ts`; it is a pre-existing 20s-plus
  timeout in that file, failing on `main` too (solo run on `main`: 1 failure;
  solo run on this branch: 1 failure, a *different* test each time).
- `pnpm guard` clean, `pnpm typecheck` clean.

## Adjacent issues

- The ceiling itself stays unset. Picking it is a follow-up that should read
  `processEntries` off real diagnostics bundles first.
- Background materialization has no analytics at all — `onDeferred` only writes
  `console.info`. Adding fleet-wide telemetry would need a daemon-internal
  analytics context, which `readAnalyticsContext`'s own docblock explicitly
  says background sweeps must not use. That is a new convention and wants a
  maintainer decision, so it is deliberately not in this PR.
