### PR TITLE
fix: ensure Settings and Dialog render above edit popovers

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
## Summary

The Settings modal (and the shared `Dialog` backdrop it uses) renders below canvas edit popovers (which use the `1500-1900` tier). Opening Settings with a popover still on screen caused the modal to slide behind the popover.

This PR raises both the modal backdrop and dialog backdrop to `z-index: 2000` so they sit clearly above the popover tier, and bumps the privacy-consent banner to `2010` so it remains visible above the new modal tier.

## Changes

| File | Change |
| --- | --- |
| `packages/components/src/dialog.module.css` | `.backdrop` z-index: 100 → 2000 |
| `apps/web/src/styles/viewer/memory.css` | `.privacy-consent-banner` z-index: 110 → 2010 |
| `apps/web/src/styles/workspace/mention-home.css` | `.modal-backdrop` z-index: 1700 → 2000 |

## Repro

1. Open a deck/canvas with an edit popover (comments, assets, etc.) on screen.
2. Open Settings from the top bar.
3. **Before:** Settings renders behind the popover.
4. **After:** Settings renders above the popover as expected.

## Related

See nexu-io/open-design#4447