### PR TITLE
fix(web): preserve BYOK after Cloud sign-out

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -390,9 +390,10 @@ function clearStaleAmrModelChoiceOnProfileChange(
 }
 
 /**
- * Active Cloud sign-out is an account boundary. Remove every saved execution
- * choice that could leak account A's Hosted/Local/BYOK setup into account B,
- * while preserving unrelated product preferences and authored content.
+ * Active Cloud sign-out is an account boundary for Cloud-owned execution
+ * state. Local BYOK credentials and provider choices belong to this install,
+ * not the signed-in Cloud account, so keep them available when onboarding asks
+ * the user to choose an execution path again.
  */
 export function resetExecutionConfigAfterSignOut(config: AppConfig): AppConfig {
   return {
@@ -403,20 +404,6 @@ export function resetExecutionConfigAfterSignOut(config: AppConfig): AppConfig {
     agentModels: {},
     agentCliEnv: {},
     agentCliEnvIntent: {},
-    apiProtocol: DEFAULT_CONFIG.apiProtocol,
-    apiKey: DEFAULT_CONFIG.apiKey,
-    apiVersion: DEFAULT_CONFIG.apiVersion,
-    baseUrl: DEFAULT_CONFIG.baseUrl,
-    model: DEFAULT_CONFIG.model,
-    byokImageModel: DEFAULT_CONFIG.byokImageModel,
-    byokVideoModel: DEFAULT_CONFIG.byokVideoModel,
-    byokSpeechModel: DEFAULT_CONFIG.byokSpeechModel,
-    byokSpeechVoice: DEFAULT_CONFIG.byokSpeechVoice,
-    byokProviderConfigDrafts: {},
-    byokPendingProviderKey: undefined,
-    maxTokens: DEFAULT_CONFIG.maxTokens,
-    apiProviderBaseUrl: DEFAULT_CONFIG.apiProviderBaseUrl,
-    apiProtocolConfigs: {},
   };
 }
 

--- a/apps/web/tests/components/App.onboarding-completion-persistence.test.tsx
+++ b/apps/web/tests/components/App.onboarding-completion-persistence.test.tsx
@@ -100,6 +100,8 @@ vi.mock('../../src/components/EntryView', () => ({
       <>
         <div data-testid="onboarding-completed">{String(config.onboardingCompleted)}</div>
         <div data-testid="agent-id">{String(config.agentId ?? 'none')}</div>
+        <div data-testid="api-key">{config.apiKey}</div>
+        <div data-testid="api-model">{config.model}</div>
       </>
     );
   },
@@ -285,7 +287,7 @@ describe('App onboarding completion persistence', () => {
     vi.clearAllMocks();
   });
 
-  it('clears only execution and onboarding state for an active Cloud sign-out', () => {
+  it('preserves local BYOK configuration across an active Cloud sign-out', () => {
     const current = {
       ...returningUserConfig(),
       mode: 'api',
@@ -333,27 +335,57 @@ describe('App onboarding completion persistence', () => {
       agentModels: {},
       agentCliEnv: {},
       agentCliEnvIntent: {},
-      apiKey: '',
-      apiProtocol: 'anthropic',
-      apiVersion: '',
-      baseUrl: 'https://api.anthropic.com',
-      model: 'claude-sonnet-4-5',
-      apiProviderBaseUrl: 'https://api.anthropic.com',
-      apiProtocolConfigs: {},
-      byokImageModel: undefined,
-      byokVideoModel: undefined,
-      byokSpeechModel: undefined,
-      byokSpeechVoice: undefined,
-      byokProviderConfigDrafts: {},
-      byokPendingProviderKey: undefined,
-      maxTokens: undefined,
+      apiKey: 'secret',
+      apiProtocol: 'openai',
+      apiVersion: '2026-01-01',
+      baseUrl: 'https://example.com/v1',
+      model: 'private-model',
+      apiProviderBaseUrl: 'https://example.com/v1',
+      apiProtocolConfigs: {
+        openai: {
+          apiKey: 'secret',
+          baseUrl: 'https://example.com/v1',
+          model: 'private-model',
+        },
+      },
+      byokImageModel: 'private-image-model',
+      byokVideoModel: 'private-video-model',
+      byokSpeechModel: 'private-speech-model',
+      byokSpeechVoice: 'private-voice',
+      byokProviderConfigDrafts: {
+        'openai:https://example.com/v1': {
+          apiConfig: {
+            apiKey: 'draft-secret',
+            baseUrl: 'https://example.com/v1',
+            model: 'draft-model',
+          },
+          maxTokens: 8192,
+        },
+      },
+      byokPendingProviderKey: 'openai:https://example.com/v1',
+      maxTokens: 12345,
       designSystemId: 'keep-design-system',
       telemetry: { metrics: false, content: false },
     });
   });
 
-  it('persists the cleared execution state and returns to onboarding after active sign-out', async () => {
-    mockedLoadConfig.mockReturnValue(returningUserConfig());
+  it('persists the Cloud reset without discarding BYOK and returns to onboarding', async () => {
+    mockedLoadConfig.mockReturnValue({
+      ...returningUserConfig(),
+      mode: 'api',
+      apiKey: 'persisted-key',
+      apiProtocol: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-5',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+      apiProtocolConfigs: {
+        openai: {
+          apiKey: 'persisted-key',
+          baseUrl: 'https://api.openai.com/v1',
+          model: 'gpt-5',
+        },
+      },
+    });
     mockedFetchDaemonConfig.mockResolvedValue({ onboardingCompleted: true });
 
     render(<App />);
@@ -367,14 +399,23 @@ describe('App onboarding completion persistence', () => {
 
     expect(screen.getByTestId('onboarding-completed').textContent).toBe('false');
     expect(screen.getByTestId('agent-id').textContent).toBe('none');
+    expect(screen.getByTestId('api-key').textContent).toBe('persisted-key');
+    expect(screen.getByTestId('api-model').textContent).toBe('gpt-5');
     expect(mockedSyncConfigToDaemon).toHaveBeenLastCalledWith(
       expect.objectContaining({
         onboardingCompleted: false,
         mode: 'daemon',
         agentId: null,
-        apiKey: '',
+        apiKey: 'persisted-key',
+        model: 'gpt-5',
         agentModels: {},
-        apiProtocolConfigs: {},
+        apiProtocolConfigs: {
+          openai: {
+            apiKey: 'persisted-key',
+            baseUrl: 'https://api.openai.com/v1',
+            model: 'gpt-5',
+          },
+        },
       }),
       { allowOnboardingReset: true },
     );

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -614,7 +614,7 @@ test('[P0] definitively expired Cloud auth also gates project deep links', async
   await expect(page.getByRole('alertdialog')).toHaveCount(0);
 });
 
-test('[P0] active Cloud sign-out clears execution setup, preserves unrelated preferences, and returns to sign-in', async ({ page }) => {
+test('[P0] active Cloud sign-out preserves BYOK and unrelated preferences while returning to sign-in', async ({ page }) => {
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
     initialLoggedIn: true,
@@ -646,7 +646,9 @@ test('[P0] active Cloud sign-out clears execution setup, preserves unrelated pre
   await expect(page.getByTestId('home-hero-input')).toHaveCount(0);
   await pollStoredConfig(page).toMatchObject({
     mode: 'daemon',
-    apiKey: '',
+    apiKey: 'private-key',
+    baseUrl: 'https://private.example/v1',
+    model: 'private-model',
     agentId: null,
     designSystemId: 'keep-design-system',
     onboardingCompleted: false,


### PR DESCRIPTION
## Why

[OPEND-2326](https://plane.powerformer.net/open-design/browse/OPEND-2326/) reports that signing out of OpenDesign Cloud erases the locally saved BYOK API key, Base URL, model, and provider settings. Users then have to re-enter credentials when they choose Bring Your Own Key during onboarding, even though BYOK belongs to the local installation rather than the Cloud account.

The Cloud sign-out reset treated Hosted, Local CLI, and BYOK settings as one account-owned execution bundle. This PR narrows that boundary so Cloud sign-out still reopens onboarding and clears the active Cloud/CLI execution choice without deleting local BYOK configuration.

## What users will see

After signing out of OpenDesign Cloud and choosing Bring Your Own Key again, the previously saved provider, API key, Base URL, model, media defaults, token limit, and provider drafts remain available. The user still returns to onboarding and must choose an execution path again.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: the PR does not change layout or visual appearance. It preserves the values already rendered by the existing BYOK onboarding form.

## Bug fix verification

- Test path: `apps/web/tests/components/App.onboarding-completion-persistence.test.tsx`
- Red on `main`: yes — the focused test showed every BYOK field reset to its default/empty value.
- Green on this branch: yes — the focused suite passes 8/8 and covers both the reset helper and the persisted App sign-out path.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/App.onboarding-completion-persistence.test.tsx`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/web test` — 666 files passed; 7038 tests passed, 1 expected failure, 11 skipped
- `corepack pnpm guard`
- `git diff --check`

Note: local Node is v24.16.0 while the repository requests 24.18.0; pnpm emitted the engine warning, and all commands above completed successfully.