### PR TITLE
fix(web): raise Settings and Dialog backdrops above popover tier

### DIFF
--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1909,11 +1909,11 @@
   position: fixed;
   right: 16px;
   bottom: 16px;
-  /* Above modal backdrops (z-index 100) so the banner remains visible and
+  /* Above modal backdrops (z-index 2000) so the banner remains visible and
      actionable even while Settings or any other modal is open. The banner
      uses pointer-events:none on the card itself with opt-in on interactive
      children, so it never intercepts clicks meant for the layer below. */
-  z-index: 110;
+  z-index: 2010;
   width: 380px;
   max-width: calc(100vw - 32px);
   display: flex;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -319,7 +319,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1700;
+  z-index: 2000;
   animation: fade-in 160ms ease-out;
 }
 .modal-backdrop--app-modal {

--- a/packages/components/src/dialog.module.css
+++ b/packages/components/src/dialog.module.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 2000;
   animation: dialog-backdrop-fade-in var(--duration-fast, 150ms) var(--curve-decelerate-mid, ease-out);
 }
 


### PR DESCRIPTION
## Summary

The Settings dialog `.modal-backdrop` sits at z-index 1700, the same tier as canvas edit popovers (1500-1900). When an edit popover is already open and the user clicks Settings, the Settings modal opens **behind** the popover instead of on top of it.

This commit raises the relevant backdrops to a tier above the popover range (2000/2010), so Settings reliably lands on top.

The previous attempt to fix this (PR #5091) was closed because rebase exposed pre-existing test failures unrelated to the z-index change. This is a fresh, minimal PR with only the 3 z-index values changed.

## Changes

| File | Change |
|---|---|
| `packages/components/src/dialog.module.css` | `.backdrop` z-index 100 → 2000 |
| `apps/web/src/styles/viewer/memory.css` | `.privacy-consent-banner` z-index 110 → 2010 (and update comment) |
| `apps/web/src/styles/workspace/mention-home.css` | `.modal-backdrop` (Settings) z-index 1700 → 2000 |

`.modal-backdrop--app-modal` stays at 10000 — app-modal Settings continues to outrank standard modals.

## Layer order after fix

| Tier | Element |
|---|---|
| 100 | base canvas |
| 1500–1900 | popovers / edit overlays |
| 2000 | Dialog backdrop + Settings `.modal-backdrop` |
| 2010 | privacy consent banner |
| 9000 | toast/overlays |
| 10000 | `.modal-backdrop--app-modal` |

## Reference

See nexu-io/open-design#4447 (the original bug report).

## Validation

The previous fix on PR #5091 was approved by `@nettee` and reviewed by `@lefarcen` — only the rebase against newer main triggered unrelated Playwright failures. This PR re-applies the same three z-index values on a fresh branch off the current main HEAD (`53e78ac1`) and produces a 4-line diff that touches only the 3 files in question.