### PR TITLE
fix(daemon): find the real </body> for URL-load preview bridge injection

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -1313,7 +1313,20 @@ function wantsUrlPreviewObservabilityBridge(value: unknown): boolean {
 
 function injectBeforeBodyClose(html: string, marker: string, injection: string): string {
   if (html.includes(marker)) return html;
-  const bodyCloseIndex = html.search(/<\/body\s*>/i);
+  // Find the real </body> (the last one before the real </html>), not the
+  // first literal match anywhere in the document. An artifact's own inline
+  // script commonly builds nested HTML strings with code like
+  // `html.replace('</body>', ...)`, which puts a literal `</body>` inside the
+  // artifact's <script> tag long before the document's real closing tag. The
+  // first-match version spliced this bridge into the middle of that script,
+  // and the bridge's own </script> then closed the artifact's <script> tag
+  // early — everything after it fell out of script-parsing mode and rendered
+  // as literal page text (nexu-io/open-design, "UX aChiral Carbon" report).
+  // Mirrors injectBeforeBodyEnd in apps/web/src/runtime/srcdoc.ts.
+  const lower = html.toLowerCase();
+  const htmlEnd = lower.lastIndexOf('</html>');
+  const limit = htmlEnd >= 0 ? htmlEnd : lower.length;
+  const bodyCloseIndex = lower.lastIndexOf('</body>', limit - 1);
   if (bodyCloseIndex >= 0) {
     return `${html.slice(0, bodyCloseIndex)}${injection}${html.slice(bodyCloseIndex)}`;
   }
@@ -1348,7 +1361,7 @@ function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | '
   return injectBeforeBodyClose(html, 'data-od-url-snapshot-bridge', URL_PREVIEW_SNAPSHOT_BRIDGE);
 }
 
-function applyUrlPreviewBridgesToHtml(
+export function applyUrlPreviewBridgesToHtml(
   transformed: string | Buffer,
   mime: string,
   requestedBridge: unknown,

--- a/apps/daemon/tests/project-routes-url-preview-bridge.test.ts
+++ b/apps/daemon/tests/project-routes-url-preview-bridge.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for the URL-load preview bridge injection point
+ * ("UX aChiral Carbon" visualization bug report).
+ *
+ * The daemon's /api/projects/:id/raw/:file handler injects a scroll/
+ * selection/snapshot bridge <script> into HTML previews requested with
+ * ?odPreviewBridge=... via applyUrlPreviewBridgesToHtml -> injectUrlPreviewBridge
+ * -> injectBeforeBodyClose (routes/project/index.ts).
+ *
+ * Bug: injectBeforeBodyClose used html.search(/<\/body\s*>/i), the FIRST
+ * literal "</body>" anywhere in the document. Artifacts commonly build nested
+ * HTML pages from an inline <script> using code like
+ * `html.replace('</body>', ...)`, which puts a literal "</body>" string deep
+ * inside the artifact's own <script> tag, long before the document's real
+ * closing tag. The first-match version spliced the bridge <script>...</script>
+ * into the middle of the artifact's script; the bridge's own </script> then
+ * closed the artifact's <script> tag early, and everything after that point
+ * fell out of script-parsing mode and rendered as literal visible page text
+ * instead of executing as JavaScript.
+ *
+ * Fix mirrors injectBeforeBodyEnd in apps/web/src/runtime/srcdoc.ts: find the
+ * LAST "</body>" before the real "</html>", not the first occurrence anywhere.
+ */
+import { describe, expect, it } from 'vitest';
+import { applyUrlPreviewBridgesToHtml } from '../src/routes/project/index.js';
+
+/** An artifact whose own inline script builds a nested page via a literal
+ * `</body>` string — the exact pattern that broke on the naive first-match
+ * search. */
+function artifactWithScriptedBodyLiteral(): string {
+  return `<!doctype html>
+<html>
+<head><title>Artifact</title></head>
+<body>
+  <script>
+    function buildNestedPage(html){
+      // This literal '</body>' inside a JS string is what the naive
+      // first-match search used to find instead of the real closing tag.
+      return html.replace('</body>', '<div class="injected"></div></body>');
+    }
+    function afterTheTrap(){
+      return 'this statement must still be inside the artifact script';
+    }
+  </script>
+</body>
+</html>`;
+}
+
+describe('applyUrlPreviewBridgesToHtml – bridge injection point', () => {
+  it('does not splice the bridge into a literal "</body>" inside the artifact\'s own <script>', () => {
+    const html = artifactWithScriptedBodyLiteral();
+    const result = applyUrlPreviewBridgesToHtml(html, 'text/html', 'snapshot') as string;
+
+    // The artifact's own script must remain a single, intact, correctly
+    // closed element — the bridge must not have landed inside it.
+    const scriptOpens = (result.match(/<script\b/gi) || []).length;
+    const scriptCloses = (result.match(/<\/script\s*>/gi) || []).length;
+    expect(scriptOpens).toBe(scriptCloses);
+
+    // The statement that follows the trap inside the artifact's script must
+    // still be present as executable script source, not as page text cut
+    // loose by a premature </script>.
+    expect(result).toContain("function afterTheTrap(){");
+    expect(result).toContain("return 'this statement must still be inside the artifact script';");
+
+    // The bridge must be injected right before the document's real closing
+    // </body>, i.e. after the artifact's own script has fully closed.
+    const bridgeMarkerIndex = result.indexOf('data-od-url-snapshot-bridge');
+    const realBodyCloseIndex = result.lastIndexOf('</body>');
+    expect(bridgeMarkerIndex).toBeGreaterThan(-1);
+    expect(bridgeMarkerIndex).toBeLessThan(realBodyCloseIndex);
+    // And the bridge must come after the artifact's own script content, not
+    // spliced inside it.
+    const afterTheTrapIndex = result.indexOf('afterTheTrap');
+    expect(bridgeMarkerIndex).toBeGreaterThan(afterTheTrapIndex);
+  });
+
+  it('injects at the real </body> for a normal document with no scripted "</body>" literal', () => {
+    const html = `<!doctype html>
+<html>
+<head><title>Simple</title></head>
+<body>
+  <p>Hello</p>
+</body>
+</html>`;
+
+    const result = applyUrlPreviewBridgesToHtml(html, 'text/html', 'scroll') as string;
+    expect(result).toContain('data-od-url-scroll-bridge');
+    expect(result.indexOf('data-od-url-scroll-bridge')).toBeLessThan(result.lastIndexOf('</body>'));
+    expect(result).toContain('<p>Hello</p>');
+  });
+
+  it('leaves non-HTML responses untouched', () => {
+    const json = '{"a":1}';
+    const result = applyUrlPreviewBridgesToHtml(json, 'application/json', 'snapshot');
+    expect(result).toBe(json);
+  });
+
+  it('leaves HTML untouched when no bridge is requested', () => {
+    const html = artifactWithScriptedBodyLiteral();
+    const result = applyUrlPreviewBridgesToHtml(html, 'text/html', undefined);
+    expect(result).toBe(html);
+  });
+});


### PR DESCRIPTION
## Why

A user reported that a large generated prototype's live preview ("UX aChiral Carbon", a multi-screen HTML prototype with a big inline `<script>` that builds nested pages) rendered as garbled visible JavaScript source text instead of the actual UI, with `Uncaught SyntaxError: Invalid or unexpected token` in the console. This surfaced specifically on the URL-load preview path with a scroll/selection/snapshot bridge active (`?odPreviewBridge=...`).

Root cause: `injectBeforeBodyClose` in `apps/daemon/src/routes/project/index.ts` used `html.search(/<\/body\s*>/i)` — the first literal `</body>` anywhere in the document. Artifacts that build nested HTML pages from their own inline script commonly contain code like `html.replace('</body>', ...)`, which puts a literal `</body>` string deep inside the artifact's own `<script>` tag, long before the document's real closing tag. The daemon spliced the bridge `<script>...</script>` into that fake match; the bridge's own `</script>` then closed the artifact's `<script>` tag early, and everything after that point fell out of script-parsing mode and rendered as literal visible page text.

The web app's srcDoc path already had the correct fix for the identical problem (`injectBeforeBodyEnd` in `apps/web/src/runtime/srcdoc.ts`, which finds the *last* `</body>` before the real `</html>`) — this port applies the same fix to the daemon's URL-load bridge injection, which never got it.

## What users will see

Large/complex HTML previews with a scroll, selection, or snapshot bridge active on the URL-load path no longer risk rendering as broken/garbled text when the artifact's own script happens to contain a literal `</body>` string. No visible change for documents that don't hit this edge case.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — bug fix in existing daemon preview-serving logic, plus a regression test

## Screenshots

Not applicable — server-side HTML string transform, no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/project-routes-url-preview-bridge.test.ts`
- Did the test go red on the old code and green on this branch? **Yes** — confirmed locally by reverting just the fixed line and re-running the test (fails with `bodyMarkerIndex` landing inside the artifact's script instead of after its real content), then restoring the fix (passes).
- Additionally reproduced the exact reported symptom end-to-end: fed the real reported artifact through the (buggy) daemon transform and loaded the result in a real sandboxed Chromium iframe (matching the app's `sandbox="allow-scripts allow-downloads"`) — got the identical `Uncaught SyntaxError: Invalid or unexpected token` and garbled visible text. Re-ran with the fix applied: clean render, no console errors.

## Validation

- `pnpm --filter @open-design/daemon test project-routes-url-preview-bridge project-routes-title-sanitize` — 18 passed
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm guard` — no new failures (pre-existing, unrelated failures only: untracked `tools/pr` and `apps/telemetry-worker` leftover directories with no source/package.json)
