### PR TITLE
fix(aimlapi): recognize aimlapi.com as a supported BYOK chat protocol

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -60,6 +60,7 @@ import {
   isUnsupportedMaxTokensError,
 } from './integrations/openai-chat-token-params.js';
 import { aihubmixHeaders } from './integrations/aihubmix.js';
+import { aimlapiHeaders } from './integrations/aimlapi.js';
 import type { AgentCliEnvPrefs } from './app-config.js';
 import type { RuntimeAgentDef } from './runtimes/types.js';
 import { preparePromptFileForAgent, type PreparedPromptFile } from './runtimes/prompt-file.js';
@@ -945,7 +946,13 @@ function inspectProviderCompletion(
   const obj = data && typeof data === 'object' ? data as Record<string, unknown> : null;
   if (!obj) return { valid: false };
 
-  if (protocol === 'openai' || protocol === 'azure' || protocol === 'senseaudio' || protocol === 'aihubmix') {
+  if (
+    protocol === 'openai' ||
+    protocol === 'azure' ||
+    protocol === 'senseaudio' ||
+    protocol === 'aihubmix' ||
+    protocol === 'aimlapi'
+  ) {
     const responseModel = typeof obj.model === 'string' ? obj.model : '';
     if (
       // AIHubMix is omitted from the strict response-model check (like Azure):
@@ -1420,6 +1427,24 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
           }
           return '';
         },
+      };
+    case 'aimlapi':
+      // aimlapi.com is wire-compatible with OpenAI but carries the attribution
+      // pair on every request (see aimlapiHeaders) — the smoke test included,
+      // so a key check is attributed like any other call.
+      return {
+        url: appendVersionedApiPath(baseUrl, '/chat/completions'),
+        headers: {
+          'content-type': 'application/json',
+          ...aimlapiHeaders(apiKey),
+        },
+        body: {
+          model,
+          ...buildOpenAIChatTokenParam(model, PROVIDER_MAX_TOKENS),
+          messages: [{ role: 'user', content: SMOKE_PROMPT }],
+          stream: false,
+        },
+        extractText: extractOpenAIMessageText,
       };
     case 'aihubmix':
       // AIHubMix is wire-compatible with OpenAI but carries the fixed APP-Code

--- a/apps/daemon/src/integrations/aimlapi.ts
+++ b/apps/daemon/src/integrations/aimlapi.ts
@@ -1,0 +1,83 @@
+// aimlapi.com BYOK provider — shared identity + outbound header helper.
+//
+// aimlapi.com (https://aimlapi.com) is an OpenAI-wire-compatible aggregator:
+// a single API key fronts ~900 models from many creators, routed by model name
+// on the upstream side. Because the wire shape is identical to OpenAI's, the
+// chat proxy, connection test and model discovery all reuse the OpenAI call
+// shape — the ONLY thing that differs is the outbound headers, which is why
+// every outbound call point funnels through `aimlapiHeaders()` rather than
+// hand-building `Authorization` inline.
+//
+// The distinctive aimlapi.com detail is the attribution pair: aimlapi.com
+// expects `X-AIMLAPI-Source` and `X-AIMLAPI-Partner-ID` on EVERY request it
+// serves — inference, catalog and key checks alike, not just sign-up. Injecting
+// them in one helper keeps the invariant "every aimlapi.com request carries our
+// attribution" enforceable in one place instead of being re-derived at each
+// call site; the aggregator's rebate accounting keys off exactly this, and a
+// missing header means the request serves fine but is silently untagged.
+
+/**
+ * Provisioned partner for this integration. Valid on both aimlapi.com's staging
+ * and production backends, so it ships compiled in and one build works against
+ * either — only the base URL differs. Overridable via `AIMLAPI_PARTNER_ID` for
+ * a staging-only test id.
+ */
+export const AIMLAPI_PARTNER_ID = 'part_9TWZWFsyMyNrBDEENq5JaU0r';
+
+/**
+ * `<channel>/<client>` — the channel is a small closed set (agent|mcp|web) and
+ * the client is this integration's registry slug.
+ */
+export const AIMLAPI_SOURCE = 'agent/open-design';
+
+/**
+ * Default base URL the daemon assumes when the BYOK form leaves the field
+ * blank. Kept here as the single source of truth so the chat proxy, model
+ * discovery and connection test all default to the same origin.
+ *
+ * Note the `/v1`: aimlapi.com's OpenAI-compatible surface lives there, while
+ * `/v2` on the same host is billing/usage only and 404s for chat completions.
+ */
+export const AIMLAPI_DEFAULT_BASE_URL = 'https://api.aimlapi.com/v1';
+
+function partnerId(): string {
+  return (process.env.AIMLAPI_PARTNER_ID || '').trim() || AIMLAPI_PARTNER_ID;
+}
+
+/**
+ * The attribution pair on its own (no auth). For any route that carries its own
+ * auth header — spread this alongside it so every aimlapi.com request, whatever
+ * the wire protocol, still carries attribution.
+ */
+export function aimlapiAttributionHeaders(): Record<string, string> {
+  return {
+    'X-AIMLAPI-Source': AIMLAPI_SOURCE,
+    'X-AIMLAPI-Partner-ID': partnerId(),
+  };
+}
+
+/**
+ * Build the outbound header set for an aimlapi.com request: Bearer auth plus
+ * the attribution pair. Callers spread the result into their `fetch` headers
+ * and may add `content-type` etc. on top.
+ */
+export function aimlapiHeaders(apiKey: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${apiKey}`,
+    ...aimlapiAttributionHeaders(),
+  };
+}
+
+/**
+ * Origin of a configured base URL, for callers that need to reach a sibling
+ * path on the same host. Falls back to the default origin when the configured
+ * value is unusable, so a malformed setting degrades instead of throwing.
+ */
+export function aimlapiOriginFromBase(baseUrl: string | undefined | null): string {
+  const candidate = (baseUrl || '').trim() || AIMLAPI_DEFAULT_BASE_URL;
+  try {
+    return new URL(candidate).origin;
+  } catch {
+    return new URL(AIMLAPI_DEFAULT_BASE_URL).origin;
+  }
+}

--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -12,6 +12,7 @@ import { isLoopbackApiHost } from '@open-design/contracts/api/connectionTest';
 import { redactSecrets, validateUserProviderBaseUrl } from '../connectionTest.js';
 import { googleProviderModelsUrl, normalizeGoogleModelId } from './google-models.js';
 import { aihubmixHeaders, aihubmixCatalogUrl, parseAIHubMixCatalog } from './aihubmix.js';
+import { aimlapiHeaders } from './aimlapi.js';
 
 type ProviderModelsInput = ProviderModelsRequest & {
   signal?: AbortSignal;
@@ -241,7 +242,7 @@ function providerModelsUrl(protocol: ConnectionTestProtocol, baseUrl: string, ap
     // (GET /api/v1/models?type=llm), not the OpenAI /v1/models route.
     return aihubmixCatalogUrl(baseUrl, 'llm');
   }
-  if (protocol === 'openai' || protocol === 'senseaudio') {
+  if (protocol === 'openai' || protocol === 'senseaudio' || protocol === 'aimlapi') {
     return appendVersionedApiPath(baseUrl, '/models');
   }
   if (protocol === 'anthropic') {
@@ -261,6 +262,12 @@ function providerModelsHeaders(
 ): Record<string, string> {
   if (protocol === 'openai' || protocol === 'senseaudio') {
     return { authorization: `Bearer ${apiKey}` };
+  }
+  if (protocol === 'aimlapi') {
+    // Carries the X-AIMLAPI-Source/Partner-ID attribution pair alongside Bearer
+    // auth — see aimlapiHeaders() for why every aimlapi.com call funnels through
+    // this helper instead of hand-building the Authorization header.
+    return aimlapiHeaders(apiKey);
   }
   if (protocol === 'aihubmix') {
     // The catalogue is public — only attach Bearer auth (+ APP-Code) when the
@@ -285,7 +292,9 @@ function extractModels(protocol: ConnectionTestProtocol, data: unknown): Provide
   // (e.g. gpt-image-2 → "image_generation,llm") would otherwise leak in. Those
   // belong to the dedicated image/video/audio pickers.
   if (protocol === 'aihubmix') return parseAIHubMixCatalog(data, { chatOnly: true });
-  if (protocol === 'openai' || protocol === 'senseaudio') return extractOpenAiModels(data);
+  if (protocol === 'openai' || protocol === 'senseaudio' || protocol === 'aimlapi') {
+    return extractOpenAiModels(data);
+  }
   if (protocol === 'anthropic') return extractAnthropicModels(data);
   if (protocol === 'google') return extractGoogleModels(data);
   return [];

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -31,6 +31,7 @@ import {
   aihubmixOriginFromBase,
   classifyAIHubMixModel,
 } from '../integrations/aihubmix.js';
+import { aimlapiHeaders, AIMLAPI_DEFAULT_BASE_URL } from '../integrations/aimlapi.js';
 import { isSafeId as isSafeProjectId } from '../projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
 import { proxyDispatcherRequestInit, validateUserProviderBaseUrl } from '../connectionTest.js';
@@ -208,13 +209,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const protocol = body.protocol;
     if (
       typeof protocol !== 'string' ||
-      !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
+      !['aimlapi', 'anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
     ) {
       return sendApiError(
         res,
         400,
         'BAD_REQUEST',
-        'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
+        'protocol must be one of aimlapi|anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
       );
     }
     // AIHubMix's catalogue (GET /api/v1/models?type=llm) is public, so its
@@ -286,13 +287,13 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         const protocol = body.protocol;
         if (
           typeof protocol !== 'string' ||
-          !['anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
+          !['aimlapi', 'anthropic', 'openai', 'azure', 'google', 'ollama', 'senseaudio', 'aihubmix', 'bedrock'].includes(protocol)
         ) {
           return sendApiError(
             res,
             400,
             'BAD_REQUEST',
-            'protocol must be one of anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
+            'protocol must be one of aimlapi|anthropic|openai|azure|google|ollama|senseaudio|aihubmix|bedrock',
           );
         }
         const apiKeyRequired = protocol !== 'bedrock';
@@ -1172,6 +1173,165 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       sse.end();
     } catch (err: any) {
       console.error(`[proxy:openai] internal error: ${err.message}`);
+      sendProxyError(sse, err.message, { code: 'INTERNAL_ERROR' });
+      sse.end();
+    } finally {
+      await proxyDispatcher?.close();
+    }
+  });
+
+  // aimlapi.com: OpenAI-wire-compatible aggregator (~900 models behind one
+  // key). Wire-identical to the generic OpenAI route, so this is that route
+  // with one difference — every request carries the aimlapi.com attribution
+  // pair via aimlapiHeaders(). A dedicated route rather than a hostname branch
+  // in the OpenAI one keeps "picker tab -> daemon log line -> upstream call"
+  // readable end to end, the same reasoning the AIHubMix client documents.
+  app.post('/api/proxy/aimlapi/stream', async (req, res) => {
+    /** @type {Partial<ProxyStreamRequest>} */
+    const proxyBody = req.body || {};
+    if (rejectProxyPluginContext(proxyBody, res)) return;
+    const { baseUrl, apiKey, model, systemPrompt, messages, maxTokens } =
+      proxyBody;
+    if (!baseUrl || !apiKey || !model) {
+      return sendApiError(
+        res,
+        400,
+        'BAD_REQUEST',
+        'baseUrl, apiKey, and model are required',
+      );
+    }
+
+    const validated = await validateExternalApiBaseUrl(baseUrl);
+    if (validated.error) {
+      return sendApiError(
+        res,
+        validated.forbidden ? 403 : 400,
+        validated.forbidden ? 'FORBIDDEN' : 'BAD_REQUEST',
+        validated.error,
+      );
+    }
+    const reasoningDenial = authorizeReasoningEgress({
+      policy: proxyBody.reasoningExecution,
+      routeKind: 'proxy',
+      provider: 'aimlapi',
+      resolvedBaseUrl: baseUrl,
+      model,
+    });
+    if (reasoningDenial) return sendReasoningEgressDenial(res, reasoningDenial);
+
+    const url = appendVersionedApiPath(baseUrl, '/chat/completions');
+    console.log(
+      `[proxy:aimlapi] ${req.method} ${validated.parsed!.hostname} model=${model}`,
+    );
+
+    const payloadMessages = Array.isArray(messages) ? [...messages] : [];
+    if (typeof systemPrompt === 'string' && systemPrompt) {
+      payloadMessages.unshift({ role: 'system', content: systemPrompt });
+    }
+
+    const effectiveMaxTokens =
+      typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192;
+    const payload: any = {
+      model,
+      messages: payloadMessages,
+      ...buildOpenAIChatTokenParam(model, effectiveMaxTokens),
+      stream: true,
+    };
+    const retryPayload = {
+      model,
+      messages: payloadMessages,
+      ...buildMaxCompletionTokensParam(effectiveMaxTokens),
+      stream: true,
+    };
+    const canRetryUnsupportedMaxTokens = isAzureOpenAIHostname(
+      validated.parsed!.hostname,
+    );
+
+    const sse = createSseResponse(res);
+    let proxyDispatcher: ReturnType<typeof proxyDispatcherRequestInit> | null = null;
+    try {
+      proxyDispatcher = proxyDispatcherRequestInit();
+      const signal = clientDisconnectSignal(res);
+      sse.send('start', { model });
+      const requestInit = {
+        ...proxyDispatcher.requestInit,
+        signal,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // aimlapiHeaders carries Bearer auth AND the attribution pair
+          // aimlapi.com expects on every request. Building the header set in
+          // one helper is what keeps that true when this route changes.
+          ...aimlapiHeaders(apiKey),
+          'HTTP-Referer': 'https://opendesign.dev',
+          'X-Title': 'OpenDesign',
+        },
+        redirect: 'error' as const,
+      };
+      let response = await fetch(url, {
+        ...requestInit,
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        let errorText = await response.text();
+        if (
+          canRetryUnsupportedMaxTokens &&
+          response.status === 400 &&
+          isUnsupportedMaxTokensError(errorText)
+        ) {
+          console.warn(
+            `[proxy:aimlapi] retrying Azure-hosted request with max_completion_tokens model=${model}`,
+          );
+          response = await fetch(url, {
+            ...requestInit,
+            body: JSON.stringify(retryPayload),
+          });
+          errorText = response.ok ? '' : await response.text();
+        }
+        if (!response.ok) {
+          console.error(
+            `[proxy:aimlapi] upstream error: ${response.status} ${redactAuthTokens(errorText)}`,
+          );
+          sendProxyError(sse, `Upstream error: ${response.status}`, {
+            code: proxyErrorCode(response.status),
+            details: errorText,
+            retryable: response.status === 429 || response.status >= 500,
+          });
+          return sse.end();
+        }
+      }
+
+      let ended = false;
+      const guard = createDeltaGuard(sse);
+      await streamUpstreamSse(response, ({ payload, data }: any) => {
+        if (payload === '[DONE]') {
+          sse.send('end', {});
+          ended = true;
+          return true;
+        }
+        if (!data) return false;
+        const streamError = extractStreamErrorMessage(data);
+        if (streamError) {
+          sendProxyError(sse, `Provider error: ${streamError}`, { details: data });
+          ended = true;
+          return true;
+        }
+        const delta = extractOpenAIText(data);
+        if (delta) { 
+          guard.sendDelta(delta); 
+          if (guard.contaminated) { 
+            sse.send('end', {}); 
+            ended = true; 
+            return true; 
+          } 
+        }
+        return false;
+      });
+      if (!ended) sse.send('end', {});
+      sse.end();
+    } catch (err: any) {
+      console.error(`[proxy:aimlapi] internal error: ${err.message}`);
       sendProxyError(sse, err.message, { code: 'INTERNAL_ERROR' });
       sse.end();
     } finally {

--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -16,6 +16,7 @@ const DEFAULT_BASE_URL_BY_PROTOCOL: Record<ByokChatProviderConfig['protocol'], s
   ollama: 'https://ollama.com',
   senseaudio: 'https://api.senseaudio.cn',
   aihubmix: 'https://aihubmix.com/v1',
+  aimlapi: 'https://api.aimlapi.com/v1',
 };
 
 type ProviderPackage =
@@ -239,6 +240,7 @@ function buildProviderEntry(
       };
     case 'senseaudio':
     case 'aihubmix':
+    case 'aimlapi':
       return {
         npm: '@ai-sdk/openai-compatible',
         options: {

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -243,6 +243,31 @@ describe('byok-opencode runtime config', () => {
     },
   );
 
+  it('builds OpenAI-compatible provider config for aimlapi.com', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'aimlapi',
+        apiKey: 'sk-aimlapi-secret',
+        baseUrl: 'https://api.aimlapi.com/v1',
+      },
+      'openai/gpt-5.6-terra',
+    );
+
+    expect(out?.modelId).toBe('open-design-byok/openai/gpt-5.6-terra');
+    expect(out?.env).toEqual({ [BYOK_OPENCODE_API_KEY_ENV]: 'sk-aimlapi-secret' });
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/openai-compatible',
+          options: {
+            baseURL: 'https://api.aimlapi.com/v1',
+            apiKey: `{env:${BYOK_OPENCODE_API_KEY_ENV}}`,
+          },
+        },
+      },
+    });
+  });
+
   it('maps other native BYOK protocols to provider packages', () => {
     expect(buildOpenCodeByokProviderConfig(
       { protocol: 'anthropic', apiKey: 'sk-ant', baseUrl: 'https://api.anthropic.com' },

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1705,7 +1705,8 @@ function isOpenCodeByokChatProtocol(
     protocol === 'google' ||
     protocol === 'ollama' ||
     protocol === 'senseaudio' ||
-    protocol === 'aihubmix'
+    protocol === 'aihubmix' ||
+    protocol === 'aimlapi'
   );
 }
 

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -816,6 +816,10 @@ function byokDraftBaseUrlHost(value: string): string | undefined {
 }
 
 const API_KEY_CONSOLE_LINKS: Record<ApiProtocol, { host: string; url: string }> = {
+  aimlapi: {
+    host: 'aimlapi.com',
+    url: 'https://aimlapi.com/app/keys',
+  },
   anthropic: {
     host: 'console.anthropic.com',
     url: 'https://console.anthropic.com/settings/keys',

--- a/apps/web/src/providers/aimlapi-compatible.ts
+++ b/apps/web/src/providers/aimlapi-compatible.ts
@@ -1,0 +1,36 @@
+/**
+ * aimlapi.com chat completions provider. aimlapi.com is an OpenAI-wire-
+ * compatible aggregator gateway (POST /v1/chat/completions, Bearer auth, SSE
+ * delta frames + [DONE]), so the only thing that differs from
+ * streamMessageOpenAI is the daemon proxy endpoint — keeping a dedicated client
+ * makes the picker tab -> daemon log line -> upstream call chain readable end
+ * to end and leaves room for aimlapi.com-specific divergence (the
+ * X-AIMLAPI-Source / X-AIMLAPI-Partner-ID attribution pair, injected
+ * daemon-side).
+ *
+ * Routes through the daemon proxy to avoid browser CORS issues and to keep the
+ * attribution pair out of the browser bundle, where a user could strip or
+ * forge it. BYOK — the key stays on the user's machine.
+ */
+import type { AppConfig, ChatMessage } from '../types';
+import type { StreamHandlers } from './anthropic';
+import { streamProxyEndpoint, type ProxyContext } from './api-proxy';
+
+export async function streamMessageAimlapi(
+  cfg: AppConfig,
+  system: string,
+  history: ChatMessage[],
+  signal: AbortSignal,
+  handlers: StreamHandlers,
+  context?: ProxyContext,
+): Promise<void> {
+  return streamProxyEndpoint(
+    '/api/proxy/aimlapi/stream',
+    cfg,
+    system,
+    history,
+    signal,
+    handlers,
+    context,
+  );
+}

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -23,7 +23,7 @@ export const SUGGESTED_MODELS_BY_PROTOCOL: Record<ApiProtocol, readonly string[]
   // aimlapi.com fronts ~900 models behind one key; these are the flagships the
   // catalog marks hottest, which is what the dropdown should open on.
   aimlapi: [
-    'openai/gpt-5.6-terra-pro',
+    'openai/gpt-5.6-terra',
     'anthropic/claude-sonnet-5',
     'anthropic/claude-opus-5',
     'google/gemini-3.6-flash',

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -193,6 +193,7 @@ export const API_PROTOCOL_TABS: ReadonlyArray<{
   id: ApiProtocol;
   title: string;
 }> = [
+  { id: 'aimlapi', title: 'aimlapi.com' },
   { id: 'anthropic', title: 'Anthropic' },
   { id: 'openai', title: 'OpenAI' },
   { id: 'azure', title: 'Azure OpenAI' },
@@ -200,7 +201,6 @@ export const API_PROTOCOL_TABS: ReadonlyArray<{
   { id: 'ollama', title: 'Ollama Cloud' },
   { id: 'senseaudio', title: 'SenseAudio' },
   { id: 'aihubmix', title: 'AIHubMix' },
-  { id: 'aimlapi', title: 'aimlapi.com' },
 ];
 
 export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -223,6 +223,7 @@ export const DEFAULT_BASE_URL_BY_PROTOCOL: Record<ApiProtocol, string> = {
   ollama: 'https://ollama.com',
   senseaudio: 'https://api.senseaudio.cn',
   aihubmix: 'https://aihubmix.com/v1',
+  aimlapi: 'https://api.aimlapi.com/v1',
   bedrock: 'https://bedrock-runtime.us-east-1.amazonaws.com',
 };
 

--- a/apps/web/src/state/apiProtocols.ts
+++ b/apps/web/src/state/apiProtocols.ts
@@ -20,6 +20,17 @@ import type { ApiProtocol } from '../types';
 // completions endpoint speaks the same JSON shape; the deployment name
 // the user types in the model field is what's variable, not the API.
 export const SUGGESTED_MODELS_BY_PROTOCOL: Record<ApiProtocol, readonly string[]> = {
+  // aimlapi.com fronts ~900 models behind one key; these are the flagships the
+  // catalog marks hottest, which is what the dropdown should open on.
+  aimlapi: [
+    'openai/gpt-5.6-terra-pro',
+    'anthropic/claude-sonnet-5',
+    'anthropic/claude-opus-5',
+    'google/gemini-3.6-flash',
+    'deepseek/deepseek-v4-pro',
+    'x-ai/grok-4-5',
+    'moonshot/kimi-k3',
+  ],
   anthropic: [
     'claude-opus-4-5',
     'claude-sonnet-4-5',
@@ -162,6 +173,7 @@ export const SUGGESTED_MODELS_BY_PROTOCOL: Record<ApiProtocol, readonly string[]
 // your OpenAI key") and by anyone else who needs a one-pick default
 // that prioritises latency + cost over reasoning depth.
 export const FAST_MODEL_BY_PROTOCOL: Record<ApiProtocol, string> = {
+  aimlapi: 'google/gemini-3.6-flash',
   anthropic: 'claude-haiku-4-5',
   openai: 'gpt-4o-mini',
   azure: 'gpt-4o-mini',
@@ -188,9 +200,11 @@ export const API_PROTOCOL_TABS: ReadonlyArray<{
   { id: 'ollama', title: 'Ollama Cloud' },
   { id: 'senseaudio', title: 'SenseAudio' },
   { id: 'aihubmix', title: 'AIHubMix' },
+  { id: 'aimlapi', title: 'aimlapi.com' },
 ];
 
 export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
+  aimlapi: 'aimlapi.com',
   anthropic: 'Anthropic API',
   openai: 'OpenAI API',
   azure: 'Azure OpenAI',
@@ -202,6 +216,7 @@ export const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
 };
 
 export const API_KEY_PLACEHOLDERS: Record<ApiProtocol, string> = {
+  aimlapi: 'aimlapi.com API key',
   anthropic: 'sk-ant-...',
   openai: 'sk-...',
   azure: 'azure key',

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -141,6 +141,32 @@ export interface KnownProvider {
 // selection. They are not a replacement for provider model discovery.
 export const KNOWN_PROVIDERS: KnownProvider[] = [
   {
+    label: 'aimlapi.com',
+    // Native protocol (see state/apiProtocols.ts), not a KNOWN_PROVIDERS-only
+    // OpenAI-compatible preset — the 'aimlapi' tab already has its own request
+    // handling in providers/aimlapi-compatible.ts. This entry only exists so
+    // defaultApiProtocolConfig()/switchApiProtocolConfig() (below) can resolve
+    // a baseUrl for that protocol; it must not be 'openai' or it collides with
+    // the plain OpenAI preset's default.
+    protocol: 'aimlapi',
+    baseUrl: 'https://api.aimlapi.com/v1',
+    // Mirrors SUGGESTED_MODELS_BY_PROTOCOL.aimlapi in state/apiProtocols.ts —
+    // keep the two in sync rather than curating a second list here.
+    preferredModels: [
+      'openai/gpt-5.6-terra',
+      'anthropic/claude-sonnet-5',
+      'anthropic/claude-opus-5',
+      'google/gemini-3.6-flash',
+      'deepseek/deepseek-v4-pro',
+      'x-ai/grok-4-5',
+      'moonshot/kimi-k3',
+    ],
+    apiKeyConsoleLink: {
+      host: 'aimlapi.com',
+      url: 'https://aimlapi.com/app/keys?utm_source=open_design&utm_medium=provider_preset&utm_campaign=aimlapi_byok',
+    },
+  },
+  {
     label: 'Anthropic (Claude)',
     protocol: 'anthropic',
     baseUrl: 'https://api.anthropic.com',

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -529,6 +529,7 @@ export interface ByokProviderPresetConfig {
 }
 
 const BYOK_PROVIDER_PRESET_SPECS = [
+  { id: 'aimlapi', title: 'aimlapi.com', providerLabel: 'aimlapi.com' },
   { id: 'anthropic', title: 'Anthropic', providerLabel: 'Anthropic (Claude)' },
   { id: 'openai', title: 'OpenAI', providerLabel: 'OpenAI' },
   { id: 'atlascloud', title: 'Atlas Cloud', providerLabel: 'Atlas Cloud' },

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -112,6 +112,7 @@ export type {
 
 export type ExecMode = 'daemon' | 'api';
 export type ApiProtocol =
+  | 'aimlapi'
   | 'anthropic'
   | 'openai'
   | 'azure'

--- a/apps/web/src/utils/apiProtocol.ts
+++ b/apps/web/src/utils/apiProtocol.ts
@@ -2,6 +2,7 @@ import { isOpenAICompatible } from '../providers/openai-compatible';
 import type { ApiProtocol, AppConfig } from '../types';
 
 const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
+  aimlapi: 'aimlapi.com',
   anthropic: 'Anthropic API',
   openai: 'OpenAI API',
   azure: 'Azure OpenAI',
@@ -13,6 +14,7 @@ const API_PROTOCOL_LABELS: Record<ApiProtocol, string> = {
 };
 
 const API_PROTOCOL_AGENT_IDS: Record<ApiProtocol, string> = {
+  aimlapi: 'aimlapi-api',
   anthropic: 'anthropic-api',
   openai: 'openai-api',
   azure: 'azure-openai-api',

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -52,7 +52,8 @@ export type ByokChatProtocol =
   | 'google'
   | 'ollama'
   | 'senseaudio'
-  | 'aihubmix';
+  | 'aihubmix'
+  | 'aimlapi';
 
 export interface ByokChatProviderConfig {
   protocol: ByokChatProtocol;

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -249,6 +249,7 @@ export interface ConnectionTestDiagnostics {
 }
 
 export type ConnectionTestProtocol =
+  | 'aimlapi'
   | 'anthropic'
   | 'openai'
   | 'azure'

--- a/packages/contracts/src/api/memory.ts
+++ b/packages/contracts/src/api/memory.ts
@@ -140,6 +140,7 @@ export interface MemoryListResponse {
  *  ollama and senseaudio through the same callOpenAI path since the
  *  wire protocol is identical. */
 export type MemoryExtractionProvider =
+  | 'aimlapi'
   | 'anthropic'
   | 'openai'
   | 'azure'


### PR DESCRIPTION
## Summary
- aimlapi.com was registered in Settings (KNOWN_PROVIDERS / BYOK_PROVIDER_PRESET_SPECS) and daemon model listing, but starting an actual chat run still bounced back to Settings even with a valid, saved, tested key.
- Root cause: `ByokChatProtocol` (contracts) and two separate run-preflight allow-lists (`ProjectView.tsx`'s `isOpenCodeByokChatProtocol`, and the daemon's `byok-opencode.ts` provider mapper) each explicitly enumerate supported BYOK protocols, and `'aimlapi'` was missing from all three — so the run gate treated it as an unrecognized/unconfigured provider.
- Also bundles two previously verified fixes: aimlapi.com daemon model listing (`provider-models.ts`) and surfacing aimlapi.com first in the BYOK provider grid (`config.ts`).

## Test plan
- [x] New unit test in `byok-opencode.test.ts` covering aimlapi → `@ai-sdk/openai-compatible` mapping (21/21 passing)
- [x] `tsc --noEmit` clean for `apps/daemon` and `apps/web`
- [x] All existing BYOK-related web tests pass (`byok-run-analytics`, `byok-validation`, `byok-error-code`, `SettingsDialog`)
- [x] Verified locally: dev server up, aimlapi.com provider configured, chat starts instead of redirecting to Settings