### PR TITLE
fix(web): match Go Plan sunset message prefixes

### DIFF
--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -16,8 +16,8 @@ export interface MessageCenterMessage {
 }
 
 /** One-off, client-owned announcement selector. The message center remains a
- * generic inbox: only this exact slug opts into the preset strong dialog. */
-export const GO_PLAN_SUNSET_MESSAGE_KEY = 'go-plan-sunset-2026-08';
+ * generic inbox: only slugs with this prefix opt into the preset strong dialog. */
+export const GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX = 'go-plan-sunset-2026-08';
 
 export function findGoPlanSunsetMessage(
   messages: readonly MessageCenterMessage[],
@@ -25,7 +25,7 @@ export function findGoPlanSunsetMessage(
   return messages.find((message) => (
     message.audienceType === 'targeted'
     && message.readAt == null
-    && message.messageKey === GO_PLAN_SUNSET_MESSAGE_KEY
+    && message.messageKey?.startsWith(GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX)
   )) ?? null;
 }
 

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearAnonymousState,
   findGoPlanSunsetMessage,
-  GO_PLAN_SUNSET_MESSAGE_KEY,
+  GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX,
   pullMessageCenter,
   type MessageCenterMessage,
 } from '../src/message-center-client';
@@ -26,13 +26,17 @@ describe('message center client', () => {
     ...overrides,
   });
 
-  it('selects only the unread targeted message with the allowlisted slug', () => {
-    const expected = message({ messageKey: GO_PLAN_SUNSET_MESSAGE_KEY });
+  it.each([
+    GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX,
+    `${GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX}-test`,
+    `${GO_PLAN_SUNSET_MESSAGE_KEY_PREFIX}-v2`,
+  ])('selects an unread targeted message with the allowlisted prefix: %s', (messageKey) => {
+    const expected = message({ messageKey });
     expect(findGoPlanSunsetMessage([
       message({ id: 'missing-key' }),
       message({ id: 'unknown-key', messageKey: 'another-announcement' }),
-      message({ id: 'global', audienceType: 'global', messageKey: GO_PLAN_SUNSET_MESSAGE_KEY }),
-      message({ id: 'read', messageKey: GO_PLAN_SUNSET_MESSAGE_KEY, readAt: '2026-08-26T01:00:00.000Z' }),
+      message({ id: 'global', audienceType: 'global', messageKey }),
+      message({ id: 'read', messageKey, readAt: '2026-08-26T01:00:00.000Z' }),
       expected,
     ])).toBe(expected);
   });


### PR DESCRIPTION
## Why

While validating the targeted Go Plan sunset rollout, we found that the web client only recognized the exact `go-plan-sunset-2026-08` message key. Campaign variants such as `go-plan-sunset-2026-08-test` and `go-plan-sunset-2026-08-v2` therefore stayed in the ordinary inbox instead of opening the existing sunset dialog.

This change lets the message service suffix the stable campaign key for testing or revisions without requiring another client release for each variant.

## What users will see

Signed-in recipients of an unread targeted message whose key starts with `go-plan-sunset-2026-08` will see the existing Go Plan sunset dialog. The dialog's visuals and copy are unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes only the message-key trigger; the existing dialog UI and copy are unchanged.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/message-center-client.test.ts`
- Did the test go red on `main` and green on this branch? Yes. With the prior exact-match selector restored, the `-test` and `-v2` cases fail; with this branch's prefix selector, all 8 cases pass.

## Validation

- `pnpm typecheck` — passed
- `pnpm --filter @open-design/web exec vitest run tests/message-center-client.test.ts` — passed (8 tests)
- `git diff --check` — passed
- `pnpm guard` — blocked by unrelated repository baseline issues: residual `apps/landing-page/public/enhancers/cobe.js` and `matter.min.js`, plus missing `apps/telemetry-worker/package.json` in the cross-app import check
