### PR TITLE
fix(daemon): stop AMR prompts after model rejection

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -385,7 +385,8 @@ export function attachAcpSession({
       value.includes('model not found') ||
       value.includes('providermodelnotfounderror') ||
       value.includes('unknown model') ||
-      value.includes('invalid model')
+      value.includes('invalid model') ||
+      value.includes('modelid is not available')
     );
   };
 
@@ -773,14 +774,20 @@ export function attachAcpSession({
       if (finished) return;
       // JSON-RPC error handling:
       // -32603 unexpected-id errors are cleanup noise. Expected-id model
-      // selection failures are recoverable; all other RPC errors are real
-      // protocol failures for initialize/session/new/session/prompt.
+      // selection failures are recoverable for agents with an implicit
+      // default. AMR/Vela requires an explicit selection before prompt, so a
+      // rejected model must stay terminal instead of creating a secondary
+      // `session/set_model must be called before session/prompt` failure.
       if (
         obj.id === setModelRequestId &&
         modelSelectionErrorIsRecoverable(error?.code) &&
         promptRequestId === null
       ) {
-        recoverFromModelSelectionError();
+        if (modelUnavailableErrorCode) {
+          fail(rpcErr, { details: rpcErrorData(obj), retryable: false });
+        } else {
+          recoverFromModelSelectionError();
+        }
         return;
       }
       if (error?.code === -32603 && obj.id !== expectedId) {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -211,6 +211,99 @@ test('attachAcpSession keeps legacy session/set_model when no model config optio
   assert.equal(requests.some((entry) => entry.method === 'session/set_config_option'), false);
 });
 
+test('attachAcpSession stops an AMR turn when session/set_model rejects the selected model', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: 'claude-opus-5',
+    mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  try {
+    writeAcpResult(child, 1, {});
+    writeAcpResult(child, 2, {
+      sessionId: 'session-1',
+      models: { currentModelId: null },
+    });
+    writeAcpError(child, 3, {
+      code: -32602,
+      message: 'session/set_model modelId is not available',
+    });
+
+    const requests = parseRpcWrites(writes);
+    assert.equal(requests.some((entry) => entry.method === 'session/set_model'), true);
+    assert.equal(requests.some((entry) => entry.method === 'session/prompt'), false);
+    assert.deepEqual(agentModelStatuses(events), []);
+    assert.equal(session.hasFatalError(), true);
+    assert.equal(session.completedSuccessfully(), false);
+    assert.deepEqual(events.filter((entry) => entry.event === 'error'), [
+      {
+        event: 'error',
+        payload: {
+          message: 'json-rpc id 3: session/set_model modelId is not available',
+          error: {
+            code: 'AMR_MODEL_UNAVAILABLE',
+            message: 'json-rpc id 3: session/set_model modelId is not available',
+            retryable: false,
+            details: { kind: 'amr_model', action: 'choose_model' },
+          },
+        },
+      },
+    ]);
+  } finally {
+    session.abort();
+  }
+});
+
+test('attachAcpSession preserves default-model recovery for other ACP agents', () => {
+  const child = new FakeAcpChild();
+  const writes: string[] = [];
+  const events: Array<{ event: string; payload: unknown }> = [];
+  child.stdin.on('data', (chunk) => writes.push(String(chunk)));
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: 'optional-model',
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  try {
+    writeAcpResult(child, 1, {});
+    writeAcpResult(child, 2, {
+      sessionId: 'session-1',
+      models: { currentModelId: null },
+    });
+    writeAcpError(child, 3, {
+      code: -32602,
+      message: 'optional model selection is unavailable',
+    });
+
+    assert.equal(
+      parseRpcWrites(writes).some((entry) => entry.method === 'session/prompt'),
+      true,
+    );
+    assert.deepEqual(agentModelStatuses(events), ['default']);
+
+    writeAcpResult(child, 4, {});
+    assert.equal(session.hasFatalError(), false);
+    assert.equal(session.completedSuccessfully(), true);
+    assert.deepEqual(events.filter((entry) => entry.event === 'error'), []);
+  } finally {
+    session.abort();
+  }
+});
+
 test('attachAcpSession includes frozen PDF, text, and image attachments as ACP resource links', () => {
   const child = new FakeAcpChild();
   const writes: string[] = [];


### PR DESCRIPTION
Related: #6522

## Why

While investigating an AMR run that selected a model unavailable to its team workspace, Vela correctly rejected `session/set_model`. Open Design treated the `-32602` response as recoverable, switched the visible model status to `default`, and sent `session/prompt` anyway. Vela requires an explicit model selection, so the user saw the secondary `session/set_model must be called before session/prompt` failure instead of the actionable model rejection.

#6522 addresses the upstream workspace-scoping mismatch in model discovery. This PR independently hardens the runtime boundary so stale catalogs, races, or direct callers cannot turn a rejected AMR model into a misleading prompt failure and same-run retry.

## What users will see

When Vela rejects the selected AMR model, the run now stops immediately with the original model-selection error and the existing choose-model guidance. Open Design no longer reports `model default`, sends a doomed prompt, or marks this deterministic failure retryable. ACP agents that support implicit default-model recovery keep their existing behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes runtime error handling without changing UI layout or entry points.

## Bug fix verification

- Test path: `apps/daemon/tests/acp.test.ts` — `attachAcpSession stops an AMR turn when session/set_model rejects the selected model`
- Red on `main`: yes. Before the source change the test failed because `session/prompt` was sent after Vela rejected `session/set_model`.
- Green on this branch: yes. The test also verifies the original error, `AMR_MODEL_UNAVAILABLE`, `retryable: false`, and no synthetic `default` model status.
- Scope guard: a second test confirms non-AMR ACP agents still recover through their implicit default model.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/acp.test.ts tests/amr-acp-integration.test.ts` — 123 passed
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm guard`
- `git diff --check`
