### PR TITLE
feat(skills): add Frida manual design skills

### DIFF
--- a/skills/brand-token-system/SKILL.md
+++ b/skills/brand-token-system/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: brand-token-system
+description: Build reusable brand tokens for light and dark interfaces.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, design-system, tokens, color, typography, light-dark, brand, design-agent]
+    related_skills: [figma-extract, layout-options, impeccable]
+---
+
+# Brand Token System
+
+Turn a brief (or a visual reference / logo) into a complete, consistent brand
+token system and persist it so every other design skill in the session reuses
+the same values. Use it when a brief needs a new token system or an explicit
+token change; do not rerun it when the current repository or conversation has
+already established a usable source of truth. It establishes the values that `layout-options`,
+`section-from-prompt`, `motion-states`, and `design-imagery` all read from.
+
+## When to use this skill
+
+- "Set up the colors / text styles for <product>"
+- "Make me a palette: primary, secondary, background, outline"
+- "I need light and dark mode tokens"
+- A design brief that has no usable existing token source
+
+## Inputs
+
+- A product/brand brief (industry, mood, any mandated colors), **or**
+- A reference image, screenshot, or logo available to the local client, **or**
+- An existing Figma file (use `figma-extract` first, then refine here).
+
+## Workflow
+
+1. **Derive the core palette.** Produce four named roles — **Primary**,
+   **Secondary**, **Background**, **Outline** — plus the usual support tokens
+   (surface, text, muted, success/warning/danger). Give each an exact hex.
+2. **Check contrast.** Verify text-on-background and primary-on-background meet
+   WCAG AA; note the ratios. Dark mode is a **re-tuned** palette, not a naive
+   inversion of the light one.
+3. **Build the type scale.** Font family/fallbacks, a modular size scale
+   (e.g. 12/14/16/20/24/32/48), weights, and line-heights.
+4. **Emit both modes.** Generate light **and** dark token sets from one logical
+   model so they stay in lock-step.
+5. **Export.** Write a `DESIGN.md` with rationale and contrast evidence, plus a
+   plain `tokens.css` with `:root` and `[data-theme="dark"]` custom properties.
+   Emit Tailwind or DTCG only when the target project uses that format.
+6. **Persist locally.** Keep the files in the target repository as the working
+   source of truth. Do not write profile memory or a remote design system unless
+   the user explicitly chooses that destination.
+7. **Reuse on later tasks.** Record the selected local files in the delivery
+   summary. Later work should read those files directly instead of rediscovering
+   or rebuilding the brand system.
+
+## Output contract
+
+- `DESIGN.md` (tokens + rationale, lint-clean)
+- `tokens.css` (light + dark custom properties)
+- A short summary table of the four roles + contrast ratios
+- A note of where the tokens were persisted
+
+## Composition
+
+This skill owns the palette, scale, semantic roles, contrast evidence, and
+light/dark discipline. Existing project tokens win over a new system unless
+the user explicitly requests a replacement.

--- a/skills/design-drift-watch/SKILL.md
+++ b/skills/design-drift-watch/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: design-drift-watch
+description: Compare deployed pages with Figma and report visual drift.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, sync, figma, visual-diff, qa, drift, design-agent]
+    related_skills: [figma-extract, figma-token-sync, brand-token-system]
+---
+
+# Design Drift Watch
+
+Detect when the **shipped UI** has drifted from the **Figma design** it was
+built against. Detection-only: it reports, it does not auto-fix.
+
+## Trigger
+
+- On demand, after a deploy, or through a scheduler configured outside this skill.
+- Configure: list of `{url, figma_node}` pairs (deployed page ↔ Figma frame).
+
+## Direction
+
+**Compare both sides.** Neither is mutated; the skill surfaces divergence for a
+human to triage (is the code wrong, or has the design moved on?).
+
+## Workflow
+
+1. **Capture** each deployed page with the active client's browser or screenshot
+   capability at the agreed viewports.
+2. **Fetch** the matching Figma frame export via `figma-extract`.
+3. **Compare visually** - focus on layout, spacing, color, type, and
+   missing/extra elements; describe differences, don't just pixel-diff.
+4. **Score** severity per page (cosmetic / notable / broken).
+5. **Report** only pages above a threshold. Send an external notification or
+   create a task only when the user names and authorizes a configured destination.
+   Pages in sync are logged quietly.
+
+## Output contract
+
+- Per-page drift verdict + annotated differences
+- Drift digest with thumbnails when drift exists
+- Optional authorized task for "broken" severity
+
+## Guardrails
+
+- Read-only on both the site and Figma.
+- Never auto-edits code or design — this is a watch, not a fixer.
+- Respects auth: only screenshots pages it's authorized to reach.

--- a/skills/design-imagery/SKILL.md
+++ b/skills/design-imagery/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: design-imagery
+description: Source and document brand-matched photos and visual assets.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, photography, illustration, icon, svg, 3d, lottie, animation, pexels, iconscout, brand, design-agent]
+    related_skills: [brand-token-system, motion-states]
+---
+
+# Design Imagery
+
+Source and art-direct photography and visual assets that match the active brand
+palette and composition. Current production sources are approved client assets,
+Pexels photography, and IconScout icons, SVGs, illustrations, 3D assets, Lottie
+animations, GIFs, or video assets when their MCP servers are connected.
+Generative imagery is deferred and must not be implied or fabricated.
+
+## When to use this skill
+
+- "Find a hero image / illustration for this"
+- "I need on-brand imagery for the landing page"
+- "Use Pexels photography in this graphic"
+- "Find an IconScout illustration for this social post"
+- "Find an SVG icon, Lottie animation, or 3D asset for this interface"
+
+Do not activate this skill merely because a mockup has empty image regions.
+The user must explicitly request sourced imagery or approve using it after the
+need is surfaced.
+
+## Prerequisites
+
+- Pexels MCP tools for photography: `pexels_search_photos`,
+  `pexels_get_photo`, `pexels_preview_photo`, and `pexels_download_photo`.
+- IconScout MCP tools for catalog assets: `iconscout_search_assets`,
+  `iconscout_get_asset`, `iconscout_preview_asset`, and
+  `iconscout_download_asset`.
+- If the required MCP is unavailable, use approved local or client assets or
+  stop and name the missing prerequisite. Do not substitute an unapproved
+  provider.
+
+## Inputs
+
+- The active brand tokens (palette/style) from `brand-token-system`
+- A subject/brief for each image and its aspect ratio / placement
+- The intended surface and attribution location
+
+## Workflow
+
+1. **Pull the palette and composition.** Define the subject, mood, crop, focal
+   point, negative space, and treatment needed by the layout before searching.
+2. **Choose the approved source.** Use this order:
+   - client-supplied or repository assets;
+   - Pexels MCP for photography;
+   - IconScout MCP for icons, SVGs, illustrations, 3D assets, Lottie
+     animations, GIFs, or video assets.
+3. **Search narrowly.** Match subject, orientation, dominant color, style, and
+   usable negative space. For IconScout, choose the asset type and intended
+   delivery format before searching: SVG/PNG for static graphics, JSON/GIF/MP4
+   for motion, or GLB/FBX/OBJ for 3D use.
+4. **Inspect and preview.** Fetch metadata and preview each candidate before
+   selection. Preview images are for evaluation only; never ship a watermarked,
+   thumbnail, or catalog-preview URL as the final asset.
+5. **Get approval before use.** Show the exact candidate, provider, creator when
+   available, source page, intended format, premium status, and attribution or
+   license note. Pexels photo use and every IconScout licensed download require
+   explicit user approval.
+6. **Preserve source requirements.** For Pexels:
+   - include a prominent link to Pexels in the artifact or approved
+     accompanying caption;
+   - credit the photographer with links to the photographer and photo pages
+     whenever possible;
+   - use the returned source URL and alt text, and do not redistribute the
+     photo as standalone stock content;
+   - do not collect Pexels content for AI training or evaluation datasets.
+7. **Download the approved deliverable.** Request only a format supported by
+   the selected asset. Keep SVG editable, retain Lottie JSON when runtime motion
+   is needed, and retain GLB/FBX/OBJ when the design requires a real 3D asset.
+   Use PNG, GIF, or MP4 only when a flattened or rendered deliverable is intended.
+8. **Integrate in the design tool.** Figma remains responsible for typography,
+   layout, overlays, color treatment, and final crop. Use a compatible 3D or
+   motion renderer when Figma cannot faithfully consume the source format.
+9. **Visually verify the composite.** Check crop, readability, brand fit,
+   animation playback or 3D orientation where applicable, attribution, and all
+   requested output sizes. Replace weak candidates rather than masking them
+   with decorative effects.
+10. **Return files or URLs plus provenance.** Include source, creator when
+    available, source URL, asset ID, selected format and dimensions, attribution,
+    and license or usage notes.
+
+## Output contract
+
+- Selected photo or asset files in the approved format; Pexels API image URLs
+  are acceptable only when the target surface is intended to load them remotely
+- Source provider, asset/photo ID, creator when available, source URL, selected
+  format, and attribution text
+- A note describing crop, color treatment, placement, animation playback, or 3D
+  presentation as applicable
+- License or usage notes, including whether a tracked selection or premium
+  download occurred
+
+## Rules
+
+- Imagery must read as part of the same brand as the tokens.
+- Do not use image generation until a backend is separately approved and added
+  to this skill.
+- Never claim an asset was generated when it was sourced.
+- Never omit the prominent Pexels link or available photographer attribution.
+- Never download an IconScout licensed asset without explicit approval; premium
+  downloads may consume a credit.
+- Never ship an IconScout preview in place of the licensed source asset.
+- No real logos/trademarks of third parties unless supplied by the client.

--- a/skills/design-spells/SKILL.md
+++ b/skills/design-spells/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: design-spells
+description: Add purposeful micro-interactions to a finished interface.
+risk: safe
+source: community
+date_added: "2026-03-07"
+---
+
+# Design Spells Skill
+
+[Design Spells](https://www.designspells.com/) is a collection of exceptional design details—micro-interactions, easter eggs, and clever UX patterns—that transform standard interfaces into memorable digital experiences.
+
+## Context
+
+Use this skill specifically to elevate a UI from merely "functional" or "common" into something genuinely "magical." It focuses on the minute details that surprise and delight users, establishing a strong, premium brand personality.
+
+## When to Use
+Trigger this skill when:
+
+- Polishing a finished feature to actively add a "wow" factor.
+- Designing unique interactions to replace standard web behaviors (e.g., clever hover states, creative loaders, surprising transitions).
+- Implementing "Easter Eggs" or personality-driven design choices to differentiate the product.
+- Looking to break away from generic, template-driven development.
+
+## Execution Workflow
+
+1. **Identify Opportunity**: Target the "boring" or "standard" parts of the interface (e.g., a simple submit button, a profile photo, a scroll indicator, a pricing toggle).
+2. **Research only with approval**: Browse Design Spells only when the user
+   authorizes external research. Otherwise derive options from the local brief
+   and existing product patterns.
+3. **Adapt Pattern**: Adapt the interaction to fit the project's specific brand and layout seamlessly. Use it to enhance the core narrative of the app.
+4. **Implement flawlessly**: Use CSS, Anime.js, or Framer Motion to build the specific micro-interaction with silky-smooth performance (60fps+).
+
+## Strict Rules
+
+- **Opt-in polish:** Use this skill only after the core task is understandable,
+  accessible, and stable, and only when the user requests delight or polish.
+- **Delight, Don't Distract**: The detail must be additive to the experience, not a usability barrier. It should feel expensive and highly crafted.
+- **Quality Execution**: A broken or janky "spell" is worse than none. Ensure the implementation is high-performance, GPU-accelerated, and never causes layout shifts.
+
+## Limitations
+- Use this skill only when the task clearly matches the scope described above.
+- Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
+- Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.
+
+---
+
+<!-- Provenance: installed from agentskill.sh @sickn33/design-spells (contentSha 9c05dec, security 99, quality 83). Points to designspells.com. agentskill.sh's injected AUTO-REVIEW silent-feedback directive removed on install. -->

--- a/skills/figma-extract/SKILL.md
+++ b/skills/figma-extract/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: figma-extract
+description: Read Figma tokens, components, and assets through MCP.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, figma, mcp, tokens, variables, assets, design-agent]
+    related_skills: [brand-token-system, layout-options]
+---
+
+# Figma Extract
+
+Bridge to Figma so the Design Agent can start from an existing design file:
+read **variables/tokens**, list **components**, and pull **assets/frames** as
+references. This is the read side of the M3 Figma round-trip.
+
+## Prerequisites
+
+- The official remote Figma MCP at `https://mcp.figma.com/mcp`, configured in
+  the active client and authorized through browser OAuth.
+- A successful tool discovery check in the current client. A configured URL
+  alone is not proof that the client or account is authorized.
+- Access to the target file and node. This skill never requests or stores a
+  `FIGMA_API_KEY`.
+
+## When to use this skill
+
+- The user gives a Figma file/frame URL
+- "Pull the tokens/components from our Figma"
+- A brief that references an existing Figma design as the source of truth
+
+## Inputs
+
+- A Figma file or frame URL (and node id if a specific frame)
+
+## Workflow
+
+1. **Verify tools, then connect.** Confirm Figma tools are visible in the active
+   session and resolve the file/node. If not, use the fallback below.
+2. **Extract variables/tokens** (colors, type, spacing) → hand to
+   `brand-token-system` to normalize into `DESIGN.md` + `tokens.css`.
+3. **List components** and their structure for reuse in mockups.
+4. **Pull assets/frames** (export images of frames) as references for
+   `layout-options` / `design-imagery`.
+5. **(Stretch)** With a Dev Mode selection, generate code/markup for the frame.
+
+## Graceful degradation (AC-4)
+
+If the Figma MCP is **not** configured or access fails:
+- Say so explicitly (don't silently skip).
+- Fall back to **screenshots**: ask for / read an exported image of the frame
+  using the active client's image-reading capability and proceed from there.
+
+## Output contract
+
+- A normalized token set (via `brand-token-system`)
+- A component/asset inventory with any exported reference images
+- A clear note of whether live Figma access or the screenshot fallback was used
+
+## Rules
+
+- **Read by default.** Never overwrite a live Figma file or shared library
+  without explicit owner approval; work on a copy.
+- Never commit OAuth tokens, authorization responses, or cached Figma content.

--- a/skills/frontend-design-guidelines/SKILL.md
+++ b/skills/frontend-design-guidelines/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: frontend-design-guidelines
+version: 1.1.0
+description: Create distinctive, production-ready frontend interfaces.
+tags: [frontend, design, ui, web, aesthetics, creative]
+related: [ui-design, web-design, theme-factory]
+---
+
+# Frontend Design
+
+Create memorable frontend interfaces that stand out from generic AI-generated aesthetics through bold creative choices.
+
+> **See also:** `ui-design` for fundamentals (typography, color, spacing), `web-design` for CSS patterns.
+
+
+## WHAT This Skill Does
+
+Guides creation of visually distinctive web interfaces by:
+- Establishing a bold aesthetic direction before coding
+- Making intentional typography, color, and spatial choices
+- Implementing motion and micro-interactions that delight
+- Avoiding the predictable patterns that mark AI-generated UIs
+
+## WHEN To Use
+
+- Building a new component, page, or web application
+- Creating landing pages, marketing sites, or product UIs
+- Redesigning interfaces to be more memorable
+- Any frontend work where visual impact matters
+
+## KEYWORDS
+
+frontend design, web ui, ui design, landing page, creative ui, web aesthetics, typography, visual design, motion design, distinctive interface
+
+## Design Thinking Process
+
+Before writing code, commit to an aesthetic direction:
+
+### 1. Understand Context
+- **Purpose**: What problem does this interface solve?
+- **Audience**: Who uses it and what do they expect?
+- **Constraints**: Framework, performance, accessibility requirements
+
+### 2. Choose a Bold Direction
+
+Pick an extreme aesthetic — mediocrity is forgettable:
+
+| Direction | Characteristics |
+|-----------|-----------------|
+| **Brutally Minimal** | Stark, essential, nothing extra |
+| **Maximalist Chaos** | Dense, layered, overwhelming intentionally |
+| **Retro-Futuristic** | Blends vintage aesthetics with modern tech |
+| **Organic/Natural** | Soft, flowing, nature-inspired |
+| **Luxury/Refined** | Premium materials, subtle elegance |
+| **Playful/Toy-like** | Fun, approachable, bright |
+| **Editorial/Magazine** | Type-forward, grid-based |
+| **Brutalist/Raw** | Exposed structure, anti-design |
+| **Art Deco/Geometric** | Bold shapes, symmetry, ornament |
+| **Industrial/Utilitarian** | Function-forward, robust |
+
+### 3. Identify the Memorable Element
+
+What single thing will someone remember about this interface? Commit to it.
+
+## Aesthetic Guidelines
+
+### Typography
+
+**NEVER** use generic fonts:
+- Arial, Helvetica, system-ui
+- Inter, Roboto (unless highly intentional)
+
+**DO** choose distinctive fonts:
+- Pair a characterful display font with a refined body font
+- Explore: Space Grotesk, Clash Display, Cabinet Grotesk, Satoshi, General Sans, Instrument Serif, Fraunces, Newsreader
+
+```css
+/* Example pairing */
+--font-display: 'Clash Display', sans-serif;
+--font-body: 'Satoshi', sans-serif;
+```
+
+### Color & Theme
+
+- **Commit** to a cohesive palette — don't hedge with safe choices
+- **Dominant + accent** outperforms evenly-distributed colors
+- **Use CSS variables** for consistency
+- **Avoid** purple gradients on white (the "AI default")
+
+```css
+:root {
+  --color-bg: #0a0a0a;
+  --color-surface: #141414;
+  --color-text: #fafafa;
+  --color-accent: #ff4d00;
+  --color-muted: #666666;
+}
+```
+
+### Spatial Composition
+
+Break expectations:
+- **Asymmetry** over perfect balance
+- **Overlap** elements intentionally
+- **Diagonal flow** or unconventional layouts
+- **Generous negative space** OR controlled density — not middle ground
+- **Grid-breaking elements** that draw attention
+
+### Motion & Interaction
+
+Motion is outside the Design Agent's M1 default. Use it only when the user
+explicitly requests motion or when implementing an approved motion
+specification. Then focus on high-impact moments:
+- **Page load**: Staggered reveals with `animation-delay`
+- **Scroll-triggered** animations that surprise
+- **Hover states** with personality
+- Prefer **CSS animations** for HTML; **Motion library** for React
+
+```css
+/* Staggered entrance */
+.card { animation: fadeUp 0.6s ease-out backwards; }
+.card:nth-child(1) { animation-delay: 0.1s; }
+.card:nth-child(2) { animation-delay: 0.2s; }
+.card:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+```
+
+### Backgrounds & Atmosphere
+
+Create depth and atmosphere:
+- **Gradient meshes** and multi-stop gradients
+- **Noise textures** and grain overlays
+- **Geometric patterns** or subtle grids
+- **Layered transparencies**
+- **Dramatic shadows** or complete flatness
+- **Custom cursors** for interactive elements
+
+## Implementation Principles
+
+### Match Complexity to Vision
+
+- **Maximalist vision**: layered composition and detail; motion still requires explicit approval
+- **Minimalist vision**: restraint, precision, perfect spacing
+- Elegance = executing the vision well, not adding more
+
+### Vary Between Generations
+
+Never converge on patterns:
+- Alternate light/dark themes
+- Use different font families each time
+- Explore different aesthetic directions
+- Each design should feel unique
+
+## NEVER Do
+
+1. **NEVER use** generic font families (Inter, Roboto, Arial, system fonts)
+2. **NEVER use** purple gradients on white backgrounds — the "AI aesthetic"
+3. **NEVER use** predictable, cookie-cutter layouts
+4. **NEVER skip** the design thinking phase — understand before building
+5. **NEVER hedge** with safe, middle-ground aesthetics — commit to a direction
+6. **NEVER forget** that distinctive design requires distinctive code
+7. **NEVER converge** on the same patterns across generations — vary intentionally
+8. **NEVER add** complexity without purpose — minimalism and maximalism both require intention
+
+---
+
+<!-- Provenance: installed from agentskill.sh @modbender/frontend-design-guidelines (contentSha 8a46cb2, security 100). Re-publish of wpank/frontend-design. agentskill.sh's injected AUTO-REVIEW silent-feedback directive was removed on install. -->

--- a/skills/impeccable/SKILL.md
+++ b/skills/impeccable/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: impeccable
+description: Design, audit, and polish production frontend interfaces.
+version: 3.8.0-local
+---
+
+# Impeccable Interface Review
+
+Shape, implement, audit, and polish production interfaces without running a
+bundled service, hook, updater, or external coding agent. This local edition is
+deliberately instruction-only.
+
+## When to Use
+
+- Build or redesign a frontend page, component, flow, or app shell.
+- Audit an interface for usability, accessibility, responsive behavior, or
+  generic AI-design patterns.
+- Polish an implemented surface before review or release.
+
+## Prerequisites
+
+- The target repository is available locally.
+- Its instructions, stack, existing design system, and verification commands
+  can be inspected.
+- External imagery, motion, Figma, or other integrations are used only after an
+  explicit user request.
+
+## Procedure
+
+1. Read repository instructions, the product brief, existing tokens, global
+   styles, and at least one representative component or page.
+2. Classify the surface:
+   - **Product:** task completion, familiar controls, density, and consistent
+     states take priority.
+   - **Brand:** communication, identity, composition, and memorable expression
+     take priority without sacrificing accessibility.
+3. When the user requests options for a new exploratory surface, use
+   `layout-options` and produce exactly three structural directions. Do not
+   generate two, four, or cosmetic variants.
+4. Select or confirm a direction before implementation. Preserve the existing
+   system unless the brief explicitly requires a departure.
+5. Implement with the repository's stack and components. Add no dependency
+   unless the existing stack cannot satisfy the approved behavior.
+6. Inspect rendered output at mobile and desktop widths. Check realistic
+   content, long labels, empty/error/loading states, keyboard navigation,
+   visible focus, contrast, reflow, and reduced motion.
+7. Run the project's lint, type, build, and test commands. Fix regressions
+   caused by the change.
+
+## Craft Rules
+
+- Make one compositional idea dominant. Hierarchy, spacing, alignment, scale,
+  and color should describe the same reading order.
+- Use role-based typography. Keep sustained body text near 45-80 characters per
+  line and avoid low-contrast microcopy.
+- Cards are an affordance, not a default layout. Avoid nested cards and repeated
+  icon-heading-copy grids without a real grouping need.
+- Avoid gradient text, decorative glassmorphism, arbitrary huge radii, generic
+  purple gradients, tiny uppercase eyebrows on every section, and decoration
+  that does not support hierarchy or meaning.
+- Product UI favors familiar controls and consistent state models. Brand work
+  may be expressive but must remain legible, responsive, and operable.
+- Motion, image generation, external imagery, and live third-party references
+  require an explicit user request. Never introduce them because a tool exists.
+- When motion is approved, keep content visible by default and provide a
+  `prefers-reduced-motion` alternative.
+
+## Accessibility Gate
+
+- Target WCAG 2.2 AA: 4.5:1 normal text, 3:1 large text, and applicable 3:1
+  non-text contrast.
+- Every action works by keyboard with visible, logical focus.
+- Meaning never depends on color, position, sound, or motion alone.
+- Content remains usable at 200% zoom and at narrow reflow widths.
+- Controls expose labels, instructions, errors, and state semantically.
+
+## Pitfalls
+
+- Claiming visual quality without rendering the result.
+- Replacing an existing system with a personal preference.
+- Presenting cosmetic variants as separate directions.
+- Shipping only the happy path.
+- Using an automated scanner as the sole accessibility evidence.
+
+## Verification
+
+Report:
+
+- Files and components changed.
+- Viewports, themes, states, and interaction paths checked.
+- Accessibility and automated checks run.
+- Important fixes made after visual inspection.
+- Remaining assumptions or checks that could not run.

--- a/skills/layout-options/SKILL.md
+++ b/skills/layout-options/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: layout-options
+description: Create exactly three structurally distinct layouts.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, layout, wireframe, mockup, options, lo-fi, hi-fi, design-agent]
+    related_skills: [brand-token-system, placeholder-copy, impeccable]
+---
+
+# Layout Options (3-up)
+
+Given a look-&-feel reference plus a layout brief, return **exactly three
+visually distinct** layout directions so a human can pick fast. This is the
+core "give me options" behavior from the Design Agent request.
+
+## When to use this skill
+
+- "Here's a reference — give me 3 options for the landing hero"
+- "Show me a few directions for this page, lo-fi is fine"
+- Any request that asks for choices / variants of a layout
+
+## Inputs
+
+- A reference such as a screenshot, URL, or Figma frame available to the client
+- A layout brief (what sections, what the page is for)
+- Fidelity: **lo-fi** (wireframe) or **hi-fi** (styled). If unspecified, deliver
+  lo-fi first, then hi-fi on the chosen one (PRD §D.II, OQ-5).
+
+## Workflow
+
+1. **Load tokens.** If a brand token set exists for this brief, read it; else run
+   `brand-token-system` first so hi-fi options are on-brand.
+2. **Pick 3 genuinely different structures** — not three tweaks of one layout.
+   E.g. centered-hero vs. split-hero vs. editorial; vary rhythm, density, focal point.
+3. **Render by fidelity:**
+   - **lo-fi**: grayscale semantic HTML/CSS wireframes with no decorative polish.
+   - **hi-fi**: token-applied HTML/CSS or the target project's real component stack.
+4. **Assemble one comparison artifact** — a single HTML file showing the 3
+   options side-by-side (or stacked with labels A/B/C), each self-contained.
+5. **Caption each option** with a one-line rationale ("A: trust-forward, dense;
+   B: airy, product-led; C: editorial").
+
+## Output contract
+
+- One HTML comparison file with 3 labelled options
+- A one-line rationale per option
+- A clear prompt for the human to choose (this skill never auto-picks)
+
+## Rules
+
+- Exactly 3. The Design Agent's M1 layout and wireframe contract does not allow a different count.
+- Options must be **visually distinct**, verified by rendering, not just claimed.
+- Honor the requested fidelity; don't silently upgrade lo-fi to hi-fi.

--- a/skills/motion-states/SKILL.md
+++ b/skills/motion-states/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: motion-states
+description: Design purposeful, accessible motion for interface states.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, motion, animation, hero, onboarding, loading, hyperframes, p5js, design-agent]
+    related_skills: [brand-token-system, design-imagery, impeccable]
+---
+
+# Motion States
+
+Create or source motion elements for **hero**, **onboarding**, and **loading**
+states. Deliver them as Lottie JSON, GIF, rendered video, or runnable
+HTML/canvas while honoring the active brand tokens and reduced-motion behavior.
+
+## When to use this skill
+
+- "Add motion to the hero / a loading animation / an onboarding transition"
+- "Animate this section"
+- Any request for movement, transitions, or animated assets
+
+## Inputs
+
+- The state(s) to animate: hero, onboarding, loading (or a custom one)
+- The active brand tokens (colors, type) and any logo/asset to animate
+- Delivery preference: Lottie JSON, GIF, rendered video, or runnable code
+
+## Workflow
+
+1. **Choose source or creation.** Use CSS or Web Animations API for interface
+   transitions and canvas for custom procedural motion. When a ready-made
+   animation fits the brief, load `design-imagery` and use the IconScout MCP to
+   search Lottie assets, inspect metadata, and preview candidates.
+2. **Approve before download.** A catalog preview is evaluation material only.
+   Show the exact IconScout asset, source page, premium status, and intended
+   JSON/GIF/MP4 format, then download only after explicit user approval.
+3. **Apply tokens.** Colors, easing, and type come from `brand-token-system`.
+   Do not assume a sourced animation is recolorable; verify the delivered format.
+4. **Keep it tasteful.** Use short, purposeful motion, respect reduced-motion
+   intent, and loop loaders cleanly.
+5. **Render and verify.** Test actual playback, dimensions, loop behavior,
+   transparency, performance, and the reduced-motion fallback. Do not ship an
+   unverified file or IconScout preview.
+
+## Output contract
+
+- An approved Lottie `.json`, `.gif`, rendered `.mp4`/`.webm`, and/or runnable
+  single-file HTML per state
+- Duration, dimensions, and how to embed it
+- Editable source when created locally, or IconScout asset ID, source URL,
+  selected format, and license metadata when sourced
+
+## Notes
+
+Motion is outside the Design Agent's M1 default. Confirm the requested state,
+purpose, output format, and reduced-motion behavior before implementation.

--- a/skills/pattern-generator/SKILL.md
+++ b/skills/pattern-generator/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: pattern-generator
+description: Create three tileable pattern options from a reference.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, pattern, texture, background, generative, p5js, logo, design-agent]
+    related_skills: [brand-token-system, design-imagery]
+---
+
+# Pattern Generator
+
+Derive **3 distinct** repeatable patterns from a logo or reference, usable as
+backgrounds/textures — the "pattern, 3 options (ref from logo or any ref)"
+requirement.
+
+## When to use this skill
+
+- "Give me 3 pattern options for the brand"
+- An explicit request for multiple pattern directions derived from a mark or reference
+
+Do not activate this skill for a singular pattern request. It is a post-M1
+three-option exploration workflow.
+
+## Inputs
+
+- A logo or reference image available to the local client
+- The active brand palette from `brand-token-system`
+
+## Workflow
+
+1. **Extract motifs** from the logo/reference — a shape, an angle, a repeated
+   element, the palette.
+2. **Generate 3 different approaches**, e.g.:
+   - **Geometric/parametric** as editable SVG or canvas code.
+   - **Organic/textured** through a configured image backend, when available.
+   - **Line/lattice or halftone** derived directly from the logo silhouette.
+3. **Make them tileable** — verify the tile repeats without visible seams.
+4. **Keep on-palette** using the brand tokens.
+
+## Output contract
+
+- 3 distinct pattern previews (PNG, tileable) + a tiled-preview render of each
+- SVG or canvas source for generative options so density, scale, and color can be tuned
+- A one-line description of each direction
+
+## Rules
+
+- Exactly 3, visually distinct.
+- Each must tile cleanly; show the repeat so the human can judge it.

--- a/skills/placeholder-copy/SKILL.md
+++ b/skills/placeholder-copy/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: placeholder-copy
+description: Write representative UI copy without invented claims.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, copy, content, ux-writing, placeholder, humanizer, design-agent]
+    related_skills: [layout-options, section-from-prompt]
+---
+
+# Placeholder Copy
+
+When a mockup needs words, generate believable, on-brand placeholder copy from a
+short product description — so mockups read like a real product, not lorem ipsum.
+
+## When to use this skill
+
+- "Fill this layout with copy for <product>"
+- "Give me hero + feature + CTA text for this"
+- Any time a mockup or section needs content rather than greeking
+
+## Inputs
+
+- A product/feature description (what it does, who it's for, tone)
+- The set of slots to fill (hero headline, sub-copy, N feature blurbs, CTA,
+  nav labels, footer, etc.)
+
+## Workflow
+
+1. **Extract the value prop** from the description in one sentence.
+2. **Draft per slot:** punchy hero headline (≤8 words), supporting sub-copy
+   (1–2 sentences), feature blurbs (title + 1 line each), and a CTA verb phrase.
+3. **Edit for natural language.** Remove boilerplate cadence, vague superlatives,
+   repeated sentence shapes, and AI-marketing phrases.
+4. **Match tone** to the brand (e.g. fintech = precise/credible; consumer = warm).
+5. **Return as a fill-map** the layout skills can drop straight into slots.
+
+## Output contract
+
+- A JSON/markdown map of slot → copy
+- 2–3 alternative headlines for the hero
+- No lorem ipsum unless the user explicitly asks for greeking
+
+## Rules
+
+- Real, specific copy beats generic filler. Avoid "Lorem", "Unlock the power of",
+  "Seamlessly", and other tells.
+- Never invent factual claims (pricing, stats, certifications) — mark those as
+  `[CLIENT INPUT]` placeholders.

--- a/skills/section-from-prompt/SKILL.md
+++ b/skills/section-from-prompt/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: section-from-prompt
+description: Build one responsive section from a written design brief.
+version: 0.1.0
+author: Alpon
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, layout, section, html, prompt-to-ui, design-agent]
+    related_skills: [brand-token-system, placeholder-copy, impeccable]
+---
+
+# Section From Prompt
+
+Take a natural-language description of a single page section and produce a
+laid-out, editable HTML section that uses the active brand tokens — the
+"section layout can be prompt" requirement.
+
+## When to use this skill
+
+- "Build a pricing section with 3 tiers and a monthly/annual toggle"
+- "Make a testimonials row / FAQ accordion / feature grid"
+- A request for one section (not a whole page — for 3 full-page directions use
+  `layout-options`)
+
+## Inputs
+
+- A text description of the section (purpose, elements, any layout hints)
+- The active brand tokens from `brand-token-system`
+- Optional copy from `placeholder-copy`
+
+## Workflow
+
+1. **Parse the description** into structure (regions, components, interactions).
+2. **Load tokens** so spacing, color, and type match the brand.
+3. **Lay it out** using the target project's existing components and conventions.
+   For a standalone artifact, use semantic HTML and minimal CSS.
+4. **Fill copy** via `placeholder-copy` if the section needs words.
+5. **Render and verify** the section as a self-contained, responsive HTML block;
+   wire up simple interactions (toggles, accordions) with minimal JS.
+
+## Output contract
+
+- A self-contained, responsive HTML section using `var(--token)` references
+- Notes on any interaction added
+- Editable markup (semantic, class-named) ready for engineering to lift
+
+## Rules
+
+- One section per call; keep it composable.
+- Always reference tokens, never hard-coded one-off colors.


### PR DESCRIPTION
## Summary
- adds Frida's manual design skill pack to OpenDesign
- copies complete skill directories from Alpon's canonical design profile source
- excludes scheduler-oriented `figma-token-sync` and `figma-asset-export`
- includes no cron configuration, scheduler wrapper, or autonomous cadence

## Skills
- brand-token-system
- design-drift-watch
- design-imagery
- design-spells
- figma-extract
- frontend-design-guidelines
- impeccable
- layout-options
- motion-states
- pattern-generator
- placeholder-copy
- section-from-prompt

`frontend-design` already exists in OpenDesign and is therefore not duplicated.

## Verification
- parsed each `SKILL.md` frontmatter and matched `name` to directory
- scanned imported files for cron references
- ran `git diff --check`
