### PR TITLE
fix(web): keep asking for a project scope the daemon has not materialized yet

### DIFF
--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -195,28 +195,30 @@ export function projectWorkspaceScopeAuthorizesAmr(
 }
 
 /**
- * Which kind of "no scope" this response is — the answer decides whether the
- * reader ever asks again.
+ * How to read a non-OK scope response: which failure kind the app should see,
+ * and whether asking again can change it.
  *
- * A 404 from this endpoint carries two unrelated meanings and they must not be
- * collapsed. A daemon that never had the route is authoritatively
- * `unsupported`, and polling it forever would be pointless. But
- * `PROJECT_NOT_FOUND` says only that this daemon has no local row for the
- * project YET — the first open of a project pulled from the hub, where the row
- * appears a few seconds later once materialization lands. That is exactly the
- * transient condition `unavailable` already models.
+ * A 404 from this endpoint carries two unrelated meanings. A daemon that never
+ * had the route is authoritatively `unsupported` and asking again is
+ * pointless. But `PROJECT_NOT_FOUND` says only that this daemon has no local
+ * row for the project YET — the first open of a project pulled from the hub,
+ * where the row appears a few seconds later once materialization lands.
  *
- * Treating the second as the first is not a cosmetic misclassification: the
- * scope stays null forever, and every consumer that needs a resolved scope
- * KIND silently stalls with it. Measured on a first open of a team project,
- * the chat pane spun indefinitely because the empty-conversation seed can only
- * act once the scope resolves to personal/unbound/team (OPEND-2283 follow-up).
+ * Both report the same failure KIND, because to every consumer of that kind
+ * the project is equally unusable right now. They differ only in whether the
+ * reader keeps asking. Treating "not yet" as final is not cosmetic: the scope
+ * stays null forever and everything needing a resolved scope kind stalls with
+ * it — measured on a first open, the chat pane spun indefinitely because the
+ * empty-conversation seed can only act once the scope resolves.
  */
 async function classifyScopeFetchFailure(
   response: Response,
-): Promise<'unsupported' | 'forbidden' | 'unavailable'> {
-  if (response.status === 403) return 'forbidden';
-  if (response.status !== 404) return 'unavailable';
+): Promise<{
+  failure: NonNullable<ProjectWorkspaceScopeState['failure']>;
+  retryable: boolean;
+}> {
+  if (response.status === 403) return { failure: 'forbidden', retryable: false };
+  if (response.status !== 404) return { failure: 'unavailable', retryable: true };
   let code: unknown;
   try {
     const body = (await response.json()) as { error?: { code?: unknown } } | null;
@@ -225,12 +227,22 @@ async function classifyScopeFetchFailure(
     // A body-less or non-JSON 404 is the old-daemon shape.
     code = undefined;
   }
-  return code === 'PROJECT_NOT_FOUND' ? 'unavailable' : 'unsupported';
+  return { failure: 'unsupported', retryable: code === 'PROJECT_NOT_FOUND' };
 }
 
 class ProjectWorkspaceScopeFetchError extends Error {
   constructor(
     readonly failure: NonNullable<ProjectWorkspaceScopeState['failure']>,
+    /**
+     * Whether asking again can change the answer. Deliberately independent of
+     * `failure`: the failure kind is what the REST of the app reads to decide
+     * how much authority this project has, so widening a kind just to unlock a
+     * retry silently changes those decisions too. (Reclassifying a
+     * not-yet-materialized project as `unavailable` did exactly that — it
+     * flipped `projectResourceAuthority` from `denied` to `workspace` during
+     * first open.)
+     */
+    readonly retryable: boolean,
   ) {
     super(`project workspace scope ${failure}`);
     this.name = 'ProjectWorkspaceScopeFetchError';
@@ -292,9 +304,8 @@ async function fetchProjectWorkspaceScope(
         },
       );
       if (!response.ok) {
-        throw new ProjectWorkspaceScopeFetchError(
-          await classifyScopeFetchFailure(response),
-        );
+        const { failure, retryable } = await classifyScopeFetchFailure(response);
+        throw new ProjectWorkspaceScopeFetchError(failure, retryable);
       }
       const body = (await response.json()) as ProjectWorkspaceScopeResponse;
       if (!body.scope || !validScopeForProject(body.scope, projectId)) {
@@ -662,13 +673,14 @@ export function useProjectWorkspaceScope(
                 failure,
               };
         });
-        // Only a transient directory/backend outage earns polling. Forbidden
-        // is an authoritative access decision; unsupported is an authoritative
-        // daemon capability decision. Both still revalidate on explicit
-        // identity, page-lifecycle, or workspace invalidation events.
-        if (failure === 'unavailable') {
-          scheduleRetry();
-        }
+        // Poll only what asking again can change. A forbidden access decision
+        // and an old daemon without the route are both final; they still
+        // revalidate on explicit identity, page-lifecycle, or workspace
+        // invalidation events.
+        const retryable = error instanceof ProjectWorkspaceScopeFetchError
+          ? error.retryable
+          : true;
+        if (retryable) scheduleRetry();
       }
     };
 

--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -183,6 +183,40 @@ export function projectWorkspaceScopeAuthorizesAmr(
   return scope?.kind === 'personal' || scope?.kind === 'team';
 }
 
+/**
+ * Which kind of "no scope" this response is — the answer decides whether the
+ * reader ever asks again.
+ *
+ * A 404 from this endpoint carries two unrelated meanings and they must not be
+ * collapsed. A daemon that never had the route is authoritatively
+ * `unsupported`, and polling it forever would be pointless. But
+ * `PROJECT_NOT_FOUND` says only that this daemon has no local row for the
+ * project YET — the first open of a project pulled from the hub, where the row
+ * appears a few seconds later once materialization lands. That is exactly the
+ * transient condition `unavailable` already models.
+ *
+ * Treating the second as the first is not a cosmetic misclassification: the
+ * scope stays null forever, and every consumer that needs a resolved scope
+ * KIND silently stalls with it. Measured on a first open of a team project,
+ * the chat pane spun indefinitely because the empty-conversation seed can only
+ * act once the scope resolves to personal/unbound/team (OPEND-2283 follow-up).
+ */
+async function classifyScopeFetchFailure(
+  response: Response,
+): Promise<'unsupported' | 'forbidden' | 'unavailable'> {
+  if (response.status === 403) return 'forbidden';
+  if (response.status !== 404) return 'unavailable';
+  let code: unknown;
+  try {
+    const body = (await response.json()) as { error?: { code?: unknown } } | null;
+    code = body?.error?.code;
+  } catch {
+    // A body-less or non-JSON 404 is the old-daemon shape.
+    code = undefined;
+  }
+  return code === 'PROJECT_NOT_FOUND' ? 'unavailable' : 'unsupported';
+}
+
 class ProjectWorkspaceScopeFetchError extends Error {
   constructor(
     readonly failure: NonNullable<ProjectWorkspaceScopeState['failure']>,
@@ -248,11 +282,7 @@ async function fetchProjectWorkspaceScope(
       );
       if (!response.ok) {
         throw new ProjectWorkspaceScopeFetchError(
-          response.status === 404
-            ? 'unsupported'
-            : response.status === 403
-              ? 'forbidden'
-              : 'unavailable',
+          await classifyScopeFetchFailure(response),
         );
       }
       const body = (await response.json()) as ProjectWorkspaceScopeResponse;

--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -26,6 +26,17 @@ const PROJECT_SCOPE_RETRY_MS = 5_000;
  * still settles into a cheap poll rather than hammering the daemon.
  */
 const PROJECT_SCOPE_FIRST_RETRY_MS = 500;
+/**
+ * How long "the daemon has not materialized this project yet" stays worth
+ * re-asking.
+ *
+ * That answer can only become true while materialization is actually running.
+ * A project that is simply gone returns the same 404 forever, so without a
+ * deadline a stale tab pointed at a deleted project polls for as long as it
+ * stays open. A transient backend outage deliberately keeps its unbounded
+ * poll — that one can start succeeding at any moment.
+ */
+const PROJECT_SCOPE_MATERIALIZATION_WINDOW_MS = 120_000;
 
 interface ProjectWorkspaceAuthority {
   workspaceId: string;
@@ -533,7 +544,16 @@ export function useProjectWorkspaceScope(
     // Scoped to this effect run, so a project / authority change restarts the
     // tight probe instead of inheriting the previous run's relaxed delay.
     let retryAttempt = 0;
-    const scheduleRetry = () => {
+    let retryDeadline: number | null = null;
+    /**
+     * `windowMs` bounds how long this condition is worth re-asking; `null`
+     * means it can succeed at any time and keeps the unbounded poll.
+     */
+    const scheduleRetry = (windowMs: number | null) => {
+      if (windowMs !== null) {
+        if (retryDeadline === null) retryDeadline = Date.now() + windowMs;
+        if (Date.now() >= retryDeadline) return;
+      }
       const delay = Math.min(
         PROJECT_SCOPE_RETRY_MS,
         PROJECT_SCOPE_FIRST_RETRY_MS * 2 ** retryAttempt,
@@ -628,7 +648,7 @@ export function useProjectWorkspaceScope(
                   resolvedCallerIdentityKey: callerIdentityKey,
                 };
           });
-          scheduleRetry();
+          scheduleRetry(null);
         } else {
           setState({
             loading: false,
@@ -680,7 +700,13 @@ export function useProjectWorkspaceScope(
         const retryable = error instanceof ProjectWorkspaceScopeFetchError
           ? error.retryable
           : true;
-        if (retryable) scheduleRetry();
+        if (retryable) {
+          // Only the materialization case is time-boxed; an outage keeps the
+          // unbounded poll it has always had.
+          scheduleRetry(
+            failure === 'unsupported' ? PROJECT_SCOPE_MATERIALIZATION_WINDOW_MS : null,
+          );
+        }
       }
     };
 

--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -15,6 +15,17 @@ import { useWorkspaceInvalidation } from './workspace-events';
 import { workspaceIdentityCacheKey } from './workspace-identity';
 
 const PROJECT_SCOPE_RETRY_MS = 5_000;
+/**
+ * First retry delay, doubling up to {@link PROJECT_SCOPE_RETRY_MS}.
+ *
+ * What this polls for is almost always a project row the daemon has not
+ * written yet — the first open of a project pulled from the hub — and that
+ * clears in a second or two. At a flat steady cadence the reader spends most
+ * of the wait idle AFTER the row exists, which is dead time the user reads as
+ * a slow open. Probe tightly first, then relax so a genuinely long outage
+ * still settles into a cheap poll rather than hammering the daemon.
+ */
+const PROJECT_SCOPE_FIRST_RETRY_MS = 500;
 
 interface ProjectWorkspaceAuthority {
   workspaceId: string;
@@ -508,6 +519,17 @@ export function useProjectWorkspaceScope(
     const controller = new AbortController();
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let firstAttempt = true;
+    // Scoped to this effect run, so a project / authority change restarts the
+    // tight probe instead of inheriting the previous run's relaxed delay.
+    let retryAttempt = 0;
+    const scheduleRetry = () => {
+      const delay = Math.min(
+        PROJECT_SCOPE_RETRY_MS,
+        PROJECT_SCOPE_FIRST_RETRY_MS * 2 ** retryAttempt,
+      );
+      retryAttempt += 1;
+      retryTimer = setTimeout(() => void load(), delay);
+    };
     const refreshRevision = refreshRequest.revision;
 
     if (refreshRevision === 0 && initialScopeCanSeed && seededFromInitialScopeRef.current) {
@@ -595,7 +617,7 @@ export function useProjectWorkspaceScope(
                   resolvedCallerIdentityKey: callerIdentityKey,
                 };
           });
-          retryTimer = setTimeout(() => void load(), PROJECT_SCOPE_RETRY_MS);
+          scheduleRetry();
         } else {
           setState({
             loading: false,
@@ -645,7 +667,7 @@ export function useProjectWorkspaceScope(
         // daemon capability decision. Both still revalidate on explicit
         // identity, page-lifecycle, or workspace invalidation events.
         if (failure === 'unavailable') {
-          retryTimer = setTimeout(() => void load(), PROJECT_SCOPE_RETRY_MS);
+          scheduleRetry();
         }
       }
     };

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -506,6 +506,38 @@ describe('useProjectWorkspaceScope', () => {
     view.unmount();
   });
 
+  // "Not materialized yet" is only worth re-asking while it can still become
+  // true. A project that is simply gone answers the same 404 forever, and a
+  // stale tab pointed at a deleted project would otherwise poll for as long as
+  // it stays open. Give the materialization window a deadline; a transient
+  // backend outage keeps its existing unbounded poll because that one can
+  // still start succeeding at any moment.
+  it('stops polling a project that never materializes', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: 'PROJECT_NOT_FOUND', message: 'not found' } }),
+      { status: 404 },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = renderHook(() => useProjectWorkspaceScope('project-never-arrives'));
+    await act(async () => {
+      for (let turn = 0; turn < 10; turn += 1) await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150_000);
+    });
+    const settled = fetchMock.mock.calls.length;
+    expect(settled).toBeGreaterThan(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+    expect(fetchMock.mock.calls.length).toBe(settled);
+    view.unmount();
+  });
+
   it('does not poll a settled forbidden scope on the retry timer', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn(async () => new Response('{}', { status: 403 }));

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -421,6 +421,47 @@ describe('useProjectWorkspaceScope', () => {
     outage.unmount();
   });
 
+  // A 404 from this endpoint means two very different things. An old daemon
+  // that never had the route is authoritatively unsupported. But
+  // `PROJECT_NOT_FOUND` on a team project simply means the daemon has not
+  // materialized the local row YET -- the first open of a project pulled from
+  // the hub. That clears within seconds, so giving up on it permanently leaves
+  // the scope null forever, which in turn wedges every consumer that needs a
+  // resolved scope kind (measured: the chat pane spun indefinitely because the
+  // empty-conversation seed can only act once the scope resolves).
+  it('keeps polling a project the daemon has not materialized yet', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const fetchMock = vi.fn(async () => {
+      attempts += 1;
+      if (attempts <= 2) {
+        return new Response(
+          JSON.stringify({ error: { code: 'PROJECT_NOT_FOUND', message: 'not found' } }),
+          { status: 404 },
+        );
+      }
+      return new Response(
+        JSON.stringify(teamScope('project-materializing', 'ws-1', 'wm-1')),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = renderHook(() => useProjectWorkspaceScope('project-materializing'));
+    await act(async () => {
+      for (let turn = 0; turn < 10; turn += 1) await Promise.resolve();
+    });
+    expect(view.result.current.scope).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    expect(view.result.current.scope?.kind).toBe('team');
+    view.unmount();
+  });
+
   it('does not poll a settled forbidden scope on the retry timer', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn(async () => new Response('{}', { status: 403 }));

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -462,6 +462,45 @@ describe('useProjectWorkspaceScope', () => {
     view.unmount();
   });
 
+  // The condition being retried is usually "the daemon has not written this
+  // project's row yet", which clears in a second or two. A flat 5s cadence
+  // therefore spends most of the wait idle AFTER the row already exists, and
+  // that dead time is what a user sees as a slow first open. Probe tightly
+  // first, then relax to the steady cadence.
+  it('probes again quickly before settling into the steady retry cadence', async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    const fetchMock = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          JSON.stringify({ error: { code: 'PROJECT_NOT_FOUND', message: 'not found' } }),
+          { status: 404 },
+        );
+      }
+      return new Response(
+        JSON.stringify(teamScope('project-backoff', 'ws-1', 'wm-1')),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = renderHook(() => useProjectWorkspaceScope('project-backoff'));
+    await act(async () => {
+      for (let turn = 0; turn < 10; turn += 1) await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Well inside the steady 5s cadence.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+    expect(view.result.current.scope?.kind).toBe('team');
+    view.unmount();
+  });
+
   it('does not poll a settled forbidden scope on the retry timer', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn(async () => new Response('{}', { status: 403 }));

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -452,6 +452,11 @@ describe('useProjectWorkspaceScope', () => {
       for (let turn = 0; turn < 10; turn += 1) await Promise.resolve();
     });
     expect(view.result.current.scope).toBeNull();
+    // Retrying must not widen the failure KIND. Consumers read that kind to
+    // decide how much authority the project has -- reporting `unavailable`
+    // here flipped `projectResourceAuthority` from `denied` to `workspace`
+    // mid-materialization and broke the first-open P0.
+    expect(view.result.current.failure).toBe('unsupported');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);


### PR DESCRIPTION
## Why

Found while verifying an unrelated project-entry PR against a real team workspace on the `test` environment. Opening a team project for the first time on a client that has never seen it left the **chat pane spinning forever**. It reproduced 3 times out of 3 on a fresh data directory; one instance sat there for over 200 seconds before I gave up on it.

The pain is a dead end, not slowness: nothing recovers it except a manual page reload. Anyone who reinstalls the client, signs in, and opens a shared project hits it.

## What users will see

Open a team project the client has never downloaded before — the chat panel now finishes loading on its own instead of spinning indefinitely. Previously the only way out was to reload the page.

Nothing else changes. The fix does not make the download itself faster; it only stops the client from giving up on a condition that clears by itself.

## Root cause

The project workspace scope is read while the daemon is still materializing the project, so `/workspace-scope` answers `404 PROJECT_NOT_FOUND` — the local row does not exist **yet**. This reader classified *every* 404 as `unsupported`, which its retry policy deliberately treats as final ("an authoritative daemon capability decision"), so it never asked again. Seconds later the scope was available and nobody was listening.

A null scope then wedges everything downstream that needs a resolved scope **kind**. `emptyConversationWriterAuthorized` requires `personal` / `unbound` / `team`, so with `scope === null` all three disjuncts are false: the empty-conversation seed can neither create a conversation nor settle into the read-only state, and `ChatPane` renders neither. Measured in the browser at the moment of the stall:

```
scopeKind = null          writerAuthority = allowed    writerAuthorized = false
conversationsLen = 0      seed present                 conversationLoadError = none
```

Both meanings of 404 are real, and the daemon already distinguishes them in the response body — so the fix classifies on that. `PROJECT_NOT_FOUND` is the transient condition `unavailable` already models (and earns the existing retry); a body-less or non-JSON 404 stays `unsupported` for an old daemon that never had the route.

## Surface area

- [x] **None** — one client-side failure classification plus its spec. No new endpoint, contract, key, or setting.

## Bug fix verification

Red spec first: `keeps polling a project the daemon has not materialized yet` failed with `expected 1 to be greater than 1` — exactly one request, no retry, matching production. Green after the change.

The two neighbouring specs that pin the *other* 404 meaning stay green, and they are the reason this fix is a classification change rather than a blanket retry:

- `distinguishes old-daemon, revoked and directory-outage failures` — a body-less 404 is still `unsupported`
- `does not poll a settled forbidden scope on the retry timer` — 403 still never polls

Verified afterwards in a real browser against a live team workspace, not just in jsdom. Before: 3 of 3 first opens stalled with `scopeKind = null`. After: the same flow resolves (`scopeKind = team`, chat renders), with the scope reader visibly retrying until the daemon has the row.

## Validation

- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run` across the suites that touch `useProjectWorkspaceScope` / `workspace-scope` — 920 passed for the first commit; re-run in batches after the backoff (123 + 201 passed, no new failures)
- Mutation check: with the classification reverted, the new spec goes red
- Real-browser first-open against a team workspace with 29 hub projects, on a fresh `OD_DATA_DIR`

## Second commit: back off instead of a flat 5s

Same file, same symptom. The condition being retried clears in a second or two, so a flat 5s cadence spent most of the wait idle *after* the row already existed. Now it probes at 500ms and doubles to the existing 5s ceiling, so a genuinely long outage still settles into the same cheap poll the flat cadence was designed for. The counter is scoped to the effect run, so a project or authority change restarts the tight probe.

Red spec: `probes again quickly before settling into the steady retry cadence` failed with `expected 1 to be greater than 1` — at 800ms the flat cadence had not retried at all. Mutation-checked by pinning the delay back to the constant.

## Third commit: retryability is its own field, not a widened failure kind

CI caught a regression the first commit introduced — `[P0] successful first-open materialization opens one read-only local mirror with the catalog title` went red here while passing on main in both preceding runs.

Reclassifying the 404 as `unavailable` did more than unlock the retry. The failure *kind* is what the rest of the app reads to decide how much authority a project has:

- `projectWorkspaceContextForRun` treats `unavailable` as grounds to fall back to the caller's own bound context instead of returning null.
- `ProjectView`'s `projectResourceAuthority` maps `forbidden`/`unsupported` to `denied`; with the kind widened it fell through to `workspace`.

So first open briefly ran with workspace authority over a project the daemon had not materialized — a bigger change than "ask again", and not one this PR set out to make.

Both 404s now report the kind they always reported, and retryability rides on its own field on the fetch error. A not-yet-materialized project stays `unsupported`, so every authority decision is byte-for-byte main's; only the retry predicate changes. The spec pins the kind explicitly, so widening it again turns a unit test red instead of a P0 three minutes into CI.

## Fourth commit: time-box the materialization retry

Adding `PROJECT_NOT_FOUND` to the retryable set inherited this reader's unbounded poll, and that suits the two conditions differently. An outage can start succeeding at any moment — a P0 covers exactly that (`an open Team project stays usable while Workspace authority retries a 503`) — so it keeps polling forever, untouched. "Not materialized yet" can only become true while materialization is running; a project that is simply gone answers the same 404 forever, so a stale tab pointed at a deleted project would have polled every 5s for as long as it stayed open.

Only the materialization case is time-boxed, at two minutes.

Red spec: `stops polling a project that never materializes` failed with 57 requests where 33 were expected. Mutation-checked by deleting the deadline.

## Adjacent issues (not fixed here)

- A **background tab** has its retry timer throttled by the browser, so a first open behind another tab still settles more slowly than the backoff above suggests. That is a browser behaviour, not a cadence choice.
- The scope reader runs on **every** project open, not just team first-open. That blast radius is what the third commit's regression came from, and it is worth keeping in mind for anything else that widens a failure kind here.
- One project in the sample had its content transfer sit at `idle` on version 2 while the published head was 3, with zero files pulled. Separate from this fix and not investigated.
