### PR TITLE
fix(daemon): decode raw stdout Buffer chunks safely in the shared JSON-line stream parser

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -1177,7 +1177,12 @@ export function attachAcpSession({
     }
   });
 
-  stdout.on('data', (chunk: string) => parser.feed(chunk));
+  // `stdout` is never put into utf8-string mode (no `setEncoding` call in
+  // this function) -- `chunk` is actually a raw Buffer here. `feed` decodes
+  // it itself with a stateful stream decoder (see json-line-stream.ts) so a
+  // multi-byte UTF-8 character split across a chunk boundary comes through
+  // intact.
+  stdout.on('data', (chunk: Buffer | string) => parser.feed(chunk));
   child.stderr?.setEncoding('utf8');
   child.stderr?.on('data', (chunk: string) => {
     if (!modelUnavailableErrorCode || finished) return;

--- a/apps/daemon/src/agent-protocol/core/json-line-stream.ts
+++ b/apps/daemon/src/agent-protocol/core/json-line-stream.ts
@@ -23,6 +23,21 @@
 export function createJsonLineStream(onMessage: (message: unknown, rawLine: string) => void) {
   let buffer = '';
   let pendingJsonLines: string[] = [];
+  // Some callers (e.g. `agent-protocol/pi-rpc/session.ts`, `agent-protocol/
+  // acp/session.ts`) feed raw stdout `Buffer` chunks without ever calling
+  // `stream.setEncoding('utf8')` on their side. Decoding each chunk
+  // independently (`chunk.toString('utf8')`, or the implicit coercion
+  // `buffer += chunk` performs on a Buffer) corrupts any multi-byte UTF-8
+  // character split across a chunk boundary into U+FFFD, since neither
+  // decode has any memory of the previous chunk's trailing bytes. `feed`
+  // must hold that invariant itself rather than depend on every current and
+  // future caller remembering to `setEncoding` first — one `TextDecoder` per
+  // stream instance, `{ stream: true }` so a split sequence's leading bytes
+  // are held back until the rest arrives on the next `feed` call. A caller
+  // that already hands over a decoded `string` (because it *did*
+  // `setEncoding`) skips this entirely — `TextDecoder.decode` is only for
+  // raw bytes.
+  const textDecoder = new TextDecoder('utf-8');
 
   const emit = (candidate: string): boolean => {
     try {
@@ -96,8 +111,9 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
   };
 
   return {
-    feed(chunk: string) {
-      buffer += chunk;
+    feed(chunk: Buffer | string) {
+      const piece = typeof chunk === 'string' ? chunk : textDecoder.decode(chunk, { stream: true });
+      buffer += piece;
       const lines = buffer.split('\n');
       buffer = lines.pop() || '';
       for (const line of lines) {
@@ -105,6 +121,13 @@ export function createJsonLineStream(onMessage: (message: unknown, rawLine: stri
       }
     },
     flush() {
+      // Flush any byte sequence the decoder was still holding back waiting
+      // for its continuation bytes -- at end-of-stream those bytes are truly
+      // incomplete (not merely split across a chunk boundary), so this is
+      // the one place `{ stream: true }` is intentionally NOT set: let the
+      // decoder emit its default U+FFFD for genuinely truncated input
+      // instead of silently discarding it.
+      buffer += textDecoder.decode();
       const trimmed = buffer.trim();
       buffer = '';
       if (trimmed) {

--- a/apps/daemon/src/agent-protocol/pi-rpc/session.ts
+++ b/apps/daemon/src/agent-protocol/pi-rpc/session.ts
@@ -386,7 +386,12 @@ export function attachPiRpcSession({
 
   stdout.on('data', (chunk: Buffer | string) => {
     try {
-      parser.feed(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      // `feed` decodes raw Buffer chunks itself with a stateful stream
+      // decoder (see json-line-stream.ts) -- do not pre-decode here. A
+      // per-chunk `chunk.toString('utf8')` would corrupt any multi-byte
+      // UTF-8 character split across a chunk boundary into U+FFFD before
+      // `feed` ever sees it, defeating that decoder entirely.
+      parser.feed(chunk);
     } catch (err) {
       fail(`parser: ${errorMessage(err)}`);
     }

--- a/apps/daemon/tests/agent-protocol/json-line-stream-chunk-boundary.test.ts
+++ b/apps/daemon/tests/agent-protocol/json-line-stream-chunk-boundary.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { createJsonLineStream } from '../../src/agent-protocol/core/json-line-stream.js';
+
+/** Splits `text`'s UTF-8 bytes into two Buffers, cutting one byte into the
+ * multi-byte sequence for `char` so the character straddles the boundary. */
+function splitUtf8(text: string, char: string): [Buffer, Buffer] {
+  const full = Buffer.from(text, 'utf8');
+  const marker = Buffer.from(char, 'utf8');
+  const index = full.indexOf(marker);
+  if (index < 0) throw new Error(`test setup error: ${JSON.stringify(char)} not found in text`);
+  const splitPoint = index + 1;
+  return [full.subarray(0, splitPoint), full.subarray(splitPoint)];
+}
+
+describe('createJsonLineStream — UTF-8 chunk-boundary safety', () => {
+  // Real path: `agent-protocol/pi-rpc/session.ts`'s
+  // `stdout.on('data', (chunk) => parser.feed(chunk))`. `stdout` there is
+  // never put into utf8-string mode, so `chunk` arrives as a raw Buffer;
+  // pi's JSON-RPC stream carries arbitrary assistant text (including
+  // CJK/emoji) in string fields, so a message boundary landing mid-character
+  // is a real, reproducible failure mode. Before this fix, pi-rpc/session.ts
+  // additionally ran each chunk through its own `chunk.toString('utf8')`
+  // ahead of `feed`, which is the same bug one layer earlier -- that call
+  // has been removed; `feed` now owns decoding.
+  it('reassembles a JSON-RPC line whose multi-byte character is split across two raw Buffer chunks (pi-rpc/session.ts shape)', () => {
+    const message = `${JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { text: '前中后文测试' },
+    })}\n`;
+    const [chunk1, chunk2] = splitUtf8(message, '中');
+
+    const received: unknown[] = [];
+    const stream = createJsonLineStream((msg) => received.push(msg));
+    stream.feed(chunk1);
+    stream.feed(chunk2);
+
+    expect(received).toEqual([
+      { jsonrpc: '2.0', method: 'session/update', params: { text: '前中后文测试' } },
+    ]);
+  });
+
+  // Real path: `agent-protocol/acp/session.ts`'s
+  // `stdout.on('data', (chunk) => parser.feed(chunk))`. That function calls
+  // `setEncoding('utf8')` on `child.stderr` but never on `child.stdout` --
+  // `stdout` stays in raw Buffer mode despite the (pre-fix) `chunk: string`
+  // parameter annotation. ACP `session/update` notifications stream
+  // assistant message text verbatim, including emoji.
+  it('reassembles a JSON-RPC line whose multi-byte character is split across two raw Buffer chunks (acp/session.ts shape)', () => {
+    const message = `${JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'emoji test 🎉 done' },
+        },
+      },
+    })}\n`;
+    const [chunk1, chunk2] = splitUtf8(message, '🎉');
+
+    const received: unknown[] = [];
+    const stream = createJsonLineStream((msg) => received.push(msg));
+    stream.feed(chunk1);
+    stream.feed(chunk2);
+
+    expect(received).toHaveLength(1);
+    const parsed = received[0] as {
+      params: { update: { content: { text: string } } };
+    };
+    expect(parsed.params.update.content.text).toBe('emoji test 🎉 done');
+  });
+
+  // Regression guard for the fix itself: a caller that DOES call
+  // `setEncoding('utf8')` (e.g. `acp/models.ts`) hands over an
+  // already-decoded string. `feed` must pass that through untouched rather
+  // than run it back through `TextDecoder.decode`, which expects raw bytes.
+  it('passes an already-decoded string chunk through unchanged, split at an arbitrary character boundary', () => {
+    const line = `${JSON.stringify({ text: '前中后文测试 🎉' })}\n`;
+    const received: unknown[] = [];
+    const stream = createJsonLineStream((msg) => received.push(msg));
+    // Split as a STRING mid-character (valid for JS strings, meaningless for
+    // bytes) -- this must not be treated as a byte split.
+    stream.feed(line.slice(0, 12));
+    stream.feed(line.slice(12));
+    expect(received).toEqual([{ text: '前中后文测试 🎉' }]);
+  });
+});


### PR DESCRIPTION
Fixes #

## Why

`agent-protocol/core/json-line-stream.ts`'s `createJsonLineStream().feed()` accumulates incoming chunks with `buffer += chunk`. Two of its real callers hand it raw, non-`setEncoding`'d stdout `Buffer` chunks: `agent-protocol/pi-rpc/session.ts` (used by the `pi` adapter) never calls `setEncoding` on `stdout` and, before this PR, additionally ran each chunk through its own `chunk.toString('utf8')` ahead of `feed`; `agent-protocol/acp/session.ts` (used by every ACP-backed adapter) calls `setEncoding('utf8')` on `child.stderr` but never on `child.stdout` — the pre-existing `(chunk: string)` parameter annotation on that handler was misleading, the runtime value is a raw Buffer.

Decoding a Buffer chunk independently of its neighbors — whether via `chunk.toString('utf8')` or the implicit coercion `buffer += chunk` performs — has no memory of a previous chunk's trailing bytes. A multi-byte UTF-8 character (any CJK character, most emoji) whose bytes straddle a chunk boundary gets corrupted into U+FFFD on each side of the split independently. Assistant text and tool-call arguments streamed over these two paths can contain arbitrary UTF-8, so this is a live, reproducible corruption bug for any non-ASCII content that happens to land on a chunk boundary, not a contrived edge case.

## What users will see

- ACP-backed adapters (e.g. AMR/Vela) and the `pi` adapter no longer occasionally corrupt CJK/emoji characters in streamed assistant text into �.
- No other user-visible change — the parser's line-buffering, multiline-JSON aggregation, and public API are otherwise unchanged.

## Surface area

- [x] None — internal correctness fix to an existing stream parser; no new UI, API, or config surface.

Files touched: the shared parser (`json-line-stream.ts`) plus the two call sites that needed a type/decode-ownership correction (`pi-rpc/session.ts`, `acp/session.ts`), and a new regression test file.

`json-event-stream.ts` / `copilot-stream.ts` / `claude-stream.ts` have the identical-looking `feed(chunk: string) { buffer += chunk; ... }` shape but are not touched here: their only real callers (`server.ts`, `connectionTest.ts`) already call `setEncoding('utf8')` before attaching a `'data'` listener, and Node's `StringDecoder` (which `setEncoding` uses internally) is itself stream-safe for multi-byte sequences split across the underlying Buffer reads — by the time `feed()` sees a chunk on those paths, it's already a complete, valid string. Verified this with the same split-byte harness used for the two paths that do reproduce, before deciding what to touch, rather than assuming all four parsers were equally affected because they look the same. Happy to harden those three the same way in a follow-up if maintainers would rather not depend on every caller remembering `setEncoding` — kept this PR's diff limited to paths with a demonstrated failure.

## Bug fix verification

- Test path: `apps/daemon/tests/agent-protocol/json-line-stream-chunk-boundary.test.ts` — two tests reproduce each real call site's exact shape (raw Buffer chunks split mid multi-byte-character): one modeled on `pi-rpc/session.ts`'s stream (a CJK character split), one on `acp/session.ts`'s (an emoji split). A third test pins the companion invariant: a caller that *did* call `setEncoding('utf8')` hands over an already-decoded string, which must pass through unchanged rather than be re-run through `TextDecoder.decode` (which expects raw bytes).
- Did the test go red on `main` and green on this branch? **Yes.** Confirmed by reverting `feed`'s decode change and `pi-rpc/session.ts`'s `parser.feed(chunk)` call locally and re-running: 2 of the 3 new tests fail with U+FFFD in the reassembled JSON on the pre-fix code, all 3 pass after.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean, 0 errors.
- `pnpm guard` — clean.
- `pnpm exec vitest run -c vitest.config.ts tests/agent-protocol/json-line-stream-chunk-boundary.test.ts tests/acp.test.ts tests/pi-rpc.test.ts` — 151/153 passed. The 2 failures (`pi-rpc.test.ts` symlink-upload tests) are `EPERM: operation not permitted, symlink` in my local sandbox (no Windows Developer Mode / symlink privilege) and reproduce identically on a clean `main` checkout with none of this PR's changes applied — pre-existing environment limitation, not a regression from this change.
