### PR TITLE
feat(daemon): live model discovery for Antigravity via `agy --output-format json models`

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -8,9 +8,9 @@ import { readFile as fsReadFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { DEFAULT_MODEL_OPTION } from './shared.js';
+import { DEFAULT_MODEL_OPTION, execAgentFile } from './shared.js';
 import { agentCapabilities } from '../capabilities.js';
-import type { RuntimeAgentDef } from '../types.js';
+import type { RuntimeAgentDef, RuntimeEnv, RuntimeModelOption } from '../types.js';
 
 const ANTIGRAVITY_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 
@@ -37,10 +37,13 @@ const ANTIGRAVITY_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 // `availableModels` cache miss + empty print-mode output, which surfaces
 // to the user as a generic "empty response" error.
 //
-// The 8 model labels mirror what `Switch Model` in agy's TUI lists for
-// consumer-tier accounts as of 2026-05-28. The set is small and stable
-// enough to ship statically until upstream adds a programmatic
-// `agy models` subcommand (also tracked under issue #35).
+// `fallbackModels` below is the offline-only floor: agy 1.1.21 does ship a
+// programmatic `agy --output-format json models` (the flag has to come
+// *before* the subcommand — `agy models --output-format json` only prints
+// Usage), so `fetchAntigravityModels` below queries it live and this static
+// list is used only when that probe fails (CLI too old, no network, etc).
+// Keep it reasonably current anyway so a fresh install with a stale/offline
+// agy still gets a workable picker.
 const ANTIGRAVITY_SETTINGS_PATH = join(
   homedir(),
   '.gemini',
@@ -169,6 +172,69 @@ export async function waitForAgyToReadModel(
   return false;
 }
 
+// Parses the single-line JSON envelope from `agy --output-format json
+// models` (verified against agy 1.1.21):
+//   { command: { data: { models: [{ id, label }, ...] } }, response: "..." }
+// The top-level `response` field is a tab-separated string meant for a human
+// reading the CLI directly — more brittle to parse and unused here.
+//
+// agy's own `id` in that array is an internal slug (e.g.
+// "gemini-3-pro-high"); `writeAntigravityModelSelection` above persists the
+// display `label` instead, because that's what `settings.json` +
+// `waitForAgyToReadModel`'s log grep both expect. So — matching this file's
+// existing id-equals-label `fallbackModels` convention — every parsed
+// entry's `id` here is set to its `label`, discarding agy's slug entirely;
+// nothing downstream reads it.
+// Exported for tests; not part of `RuntimeAgentDef`.
+export function parseAntigravityModelsJson(stdout: string): RuntimeModelOption[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  const models = (parsed as { command?: { data?: { models?: unknown } } })
+    ?.command?.data?.models;
+  if (!Array.isArray(models)) return null;
+  const out: RuntimeModelOption[] = [DEFAULT_MODEL_OPTION];
+  for (const entry of models) {
+    const label = (entry as { label?: unknown } | null)?.label;
+    if (typeof label !== 'string' || label.length === 0) continue;
+    out.push({ id: label, label });
+  }
+  return out.length > 1 ? out : null;
+}
+
+// `agy models` — like some of agy's other non-interactive subcommands —
+// does not print or exit until stdin reaches EOF. Verified with an
+// execFile-shaped piped, non-tty stdin (the same shape `execAgentFile`
+// spawns with, and the shape any daemon integration using
+// child_process.execFile/spawn gets by default): held open, the process
+// idles past any `timeout` — execFile's `timeout` option only *signals* the
+// child, and the promise settles on the child actually exiting, which never
+// happens here on its own. Closed immediately after spawn, the same command
+// answers in 6-21s (cold start includes a Google login / quota-refresh
+// round trip). This is why model discovery is a `fetchModels` — imperative,
+// gets a handle on the spawned child — rather than a declarative
+// `listModels: { args, parse }` entry: a declarative entry spawns through
+// this same `execAgentFile` path with no hook to close stdin first, and
+// would hang identically.
+// Exported for tests; referenced through `antigravityAgentDef.fetchModels`
+// in production.
+export async function fetchAntigravityModels(
+  resolvedBin: string,
+  env: RuntimeEnv,
+): Promise<RuntimeModelOption[] | null> {
+  const pending = execAgentFile(
+    resolvedBin,
+    ['--output-format', 'json', 'models'],
+    { env, timeout: 30_000 },
+  );
+  pending.child?.stdin?.end();
+  const { stdout } = await pending;
+  return parseAntigravityModelsJson(String(stdout));
+}
+
 export const antigravityAgentDef = {
   id: 'antigravity',
   name: 'Antigravity',
@@ -180,11 +246,17 @@ export const antigravityAgentDef = {
   },
   fallbackModels: [
     DEFAULT_MODEL_OPTION,
-    { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
-    { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro (Low)' },
+    { id: 'Gemini 3.7 Flash (High)', label: 'Gemini 3.7 Flash (High)' },
+    { id: 'Gemini 3.7 Flash (Medium)', label: 'Gemini 3.7 Flash (Medium)' },
+    { id: 'Gemini 3.7 Flash (Low)', label: 'Gemini 3.7 Flash (Low)' },
+    { id: 'Gemini 3.6 Flash (High)', label: 'Gemini 3.6 Flash (High)' },
+    { id: 'Gemini 3.6 Flash (Medium)', label: 'Gemini 3.6 Flash (Medium)' },
+    { id: 'Gemini 3.6 Flash (Low)', label: 'Gemini 3.6 Flash (Low)' },
     { id: 'Gemini 3.5 Flash (High)', label: 'Gemini 3.5 Flash (High)' },
     { id: 'Gemini 3.5 Flash (Medium)', label: 'Gemini 3.5 Flash (Medium)' },
     { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' },
+    { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
+    { id: 'Gemini 3.1 Pro (Low)', label: 'Gemini 3.1 Pro (Low)' },
     {
       id: 'Claude Sonnet 4.6 (Thinking)',
       label: 'Claude Sonnet 4.6 (Thinking)',
@@ -192,6 +264,7 @@ export const antigravityAgentDef = {
     { id: 'Claude Opus 4.6 (Thinking)', label: 'Claude Opus 4.6 (Thinking)' },
     { id: 'GPT-OSS 120B (Medium)', label: 'GPT-OSS 120B (Medium)' },
   ],
+  fetchModels: fetchAntigravityModels,
   supportsCustomModel: false,
   // We deliberately do NOT opt into `resumesSessionViaCli` / agy's `-c`
   // resume flag on follow-up turns. Tested both shapes; `-c` activates

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -210,15 +210,19 @@ export function parseAntigravityModelsJson(stdout: string): RuntimeModelOption[]
 // execFile-shaped piped, non-tty stdin (the same shape `execAgentFile`
 // spawns with, and the shape any daemon integration using
 // child_process.execFile/spawn gets by default): held open, the process
-// idles past any `timeout` — execFile's `timeout` option only *signals* the
-// child, and the promise settles on the child actually exiting, which never
-// happens here on its own. Closed immediately after spawn, the same command
-// answers in 6-21s (cold start includes a Google login / quota-refresh
-// round trip). This is why model discovery is a `fetchModels` — imperative,
-// gets a handle on the spawned child — rather than a declarative
-// `listModels: { args, parse }` entry: a declarative entry spawns through
-// this same `execAgentFile` path with no hook to close stdin first, and
-// would hang identically.
+// waits out the full `timeout` on every single probe. `execAgentFile` sets
+// `killSignal: 'SIGKILL'`, so the timeout does eventually kill the child and
+// settle (reject) the promise -- this is a bounded delay, not an unbounded
+// hang -- but the probe then has nothing to show for it: the killed child's
+// stdout is discarded, so the caller burns the whole timeout budget and
+// still falls back to the static list. Closed immediately after spawn, the
+// same command answers in 6-21s with real data (cold start includes a
+// Google login / quota-refresh round trip). This is why model discovery is
+// a `fetchModels` -- imperative, gets a handle on the spawned child --
+// rather than a declarative `listModels: { args, parse }` entry: a
+// declarative entry spawns through this same `execAgentFile` path with no
+// hook to close stdin first, so it would wait out the full timeout on every
+// probe and never actually get the live list.
 // Exported for tests; referenced through `antigravityAgentDef.fetchModels`
 // in production.
 export async function fetchAntigravityModels(

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -716,19 +716,27 @@ test('antigravity passes prompt via -p argument (print mode)', () => {
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);
 
-  // Picker exposes the synthetic Default + the 8 labels agy's TUI
-  // Switch-Model surfaces for consumer-tier accounts. The set is small
-  // enough to ship statically; revisit when upstream adds an `agy
-  // models` subcommand (also tracked under issue #35).
+  // Picker exposes the synthetic Default + the 14 labels agy's TUI
+  // Switch-Model surfaces for consumer-tier accounts, as of the last
+  // static-list refresh. This is the offline-only floor now --
+  // `fetchAntigravityModels` (agy --output-format json models) supplies
+  // the live list when the probe succeeds -- so this pin only needs to
+  // track what ships when that probe fails.
   assert.deepEqual(
     antigravity.fallbackModels.map((m) => m.id),
     [
       'default',
-      'Gemini 3.1 Pro (High)',
-      'Gemini 3.1 Pro (Low)',
+      'Gemini 3.7 Flash (High)',
+      'Gemini 3.7 Flash (Medium)',
+      'Gemini 3.7 Flash (Low)',
+      'Gemini 3.6 Flash (High)',
+      'Gemini 3.6 Flash (Medium)',
+      'Gemini 3.6 Flash (Low)',
       'Gemini 3.5 Flash (High)',
       'Gemini 3.5 Flash (Medium)',
       'Gemini 3.5 Flash (Low)',
+      'Gemini 3.1 Pro (High)',
+      'Gemini 3.1 Pro (Low)',
       'Claude Sonnet 4.6 (Thinking)',
       'Claude Opus 4.6 (Thinking)',
       'GPT-OSS 120B (Medium)',

--- a/apps/daemon/tests/runtimes/antigravity-models.test.ts
+++ b/apps/daemon/tests/runtimes/antigravity-models.test.ts
@@ -115,15 +115,19 @@ describe('fetchAntigravityModels', () => {
   });
 
   // The actual bug: agy's `models` subcommand does not answer until stdin
-  // reaches EOF, and `execFile`'s `timeout` option only *signals* a child
-  // that never exits on its own -- it does not force the promise to settle.
-  // This test's mock reproduces that exact contract (its promise only
-  // resolves once `.child.stdin.end()` has actually been called), so a
-  // regression that moves the `.end()` call to after the `await` -- or
-  // drops it entirely -- reproduces the real hang: the race below times out
-  // and the test fails, instead of silently passing on an unrelated
+  // reaches EOF. `execAgentFile` sets `killSignal: 'SIGKILL'`, so its
+  // `timeout` does eventually kill a held-open child and settle (reject)
+  // the promise -- this is a bounded ~30s delay, not an unbounded hang --
+  // but the killed child's stdout is discarded, so the caller gets nothing
+  // for the wait and falls back to the static list every single probe.
+  // This test's mock simplifies that to "never resolves until closed" (no
+  // 30s timeout simulation) purely so a regression fails fast rather than
+  // slowly: a regression that moves the `.end()` call to after the `await`
+  // -- or drops it entirely -- makes the mock (and, in production, the
+  // 30s-then-fallback path) never deliver real data; the race below times
+  // out and the test fails, instead of silently passing on an unrelated
   // assertion.
-  it('closes stdin before awaiting the result, so a held-open pipe cannot hang the probe', async () => {
+  it('closes stdin before awaiting the result, so the probe gets real data instead of burning the full timeout', async () => {
     let stdinClosed = false;
     const end = vi.fn(() => {
       stdinClosed = true;

--- a/apps/daemon/tests/runtimes/antigravity-models.test.ts
+++ b/apps/daemon/tests/runtimes/antigravity-models.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { execAgentFileMock } = vi.hoisted(() => ({ execAgentFileMock: vi.fn() }));
+
+vi.mock('../../src/runtimes/invocation.js', () => ({
+  execAgentFile: execAgentFileMock,
+}));
+
+import {
+  fetchAntigravityModels,
+  parseAntigravityModelsJson,
+} from '../../src/runtimes/defs/antigravity.js';
+
+describe('parseAntigravityModelsJson', () => {
+  // `agy --output-format json models` returns { command: { data: { models:
+  // [{ id, label }] } }, response: "<tab-separated human text>" }. Only the
+  // `command.data.models` path is parsed; `id` here is agy's own internal
+  // slug and must NOT survive into the result -- `label` becomes both the
+  // returned `id` and `label`, matching this file's fallbackModels
+  // convention (settings.json + the log-grep watcher both key on the label).
+  it('parses the command.data.models envelope, keying every entry by label', () => {
+    const stdout = JSON.stringify({
+      command: {
+        data: {
+          models: [
+            { id: 'gemini-3-pro-high', label: 'Gemini 3.1 Pro (High)' },
+            { id: 'gemini-3-5-flash-low', label: 'Gemini 3.5 Flash (Low)' },
+          ],
+        },
+      },
+      response: 'id\tlabel\ngemini-3-pro-high\tGemini 3.1 Pro (High)',
+    });
+
+    const result = parseAntigravityModelsJson(stdout);
+
+    expect(result).toEqual([
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
+      { id: 'Gemini 3.5 Flash (Low)', label: 'Gemini 3.5 Flash (Low)' },
+    ]);
+    // agy's internal slug must not leak into the picker -- it breaks the
+    // `--model` flow, which only understands the display label.
+    expect(JSON.stringify(result)).not.toContain('gemini-3-pro-high');
+  });
+
+  it('returns null on malformed JSON instead of throwing', () => {
+    expect(parseAntigravityModelsJson('not json')).toBeNull();
+    expect(parseAntigravityModelsJson('')).toBeNull();
+  });
+
+  it('returns null when command / data / models is missing at any depth', () => {
+    expect(parseAntigravityModelsJson(JSON.stringify({}))).toBeNull();
+    expect(parseAntigravityModelsJson(JSON.stringify({ command: {} }))).toBeNull();
+    expect(
+      parseAntigravityModelsJson(JSON.stringify({ command: { data: {} } })),
+    ).toBeNull();
+    expect(
+      parseAntigravityModelsJson(
+        JSON.stringify({ command: { data: { models: 'not-an-array' } } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when models parses but is empty', () => {
+    expect(
+      parseAntigravityModelsJson(
+        JSON.stringify({ command: { data: { models: [] } } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('skips entries with a missing or non-string label instead of throwing', () => {
+    const stdout = JSON.stringify({
+      command: {
+        data: {
+          models: [
+            { id: 'no-label' },
+            { id: 'bad-label', label: 42 },
+            { id: 'ok', label: 'Gemini 3.1 Pro (High)' },
+          ],
+        },
+      },
+    });
+
+    expect(parseAntigravityModelsJson(stdout)).toEqual([
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
+    ]);
+  });
+});
+
+describe('fetchAntigravityModels', () => {
+  afterEach(() => {
+    execAgentFileMock.mockReset();
+  });
+
+  it('requests --output-format json models with a 30s timeout and the caller-provided env', async () => {
+    execAgentFileMock.mockImplementation(() => {
+      const promise = Promise.resolve({
+        stdout: JSON.stringify({ command: { data: { models: [] } } }),
+        stderr: '',
+      });
+      // @ts-expect-error test double; production shape is PromiseWithChild
+      promise.child = { stdin: { end: vi.fn() } };
+      return promise;
+    });
+
+    await fetchAntigravityModels('agy', { FOO: 'bar' });
+
+    expect(execAgentFileMock).toHaveBeenCalledWith(
+      'agy',
+      ['--output-format', 'json', 'models'],
+      { env: { FOO: 'bar' }, timeout: 30_000 },
+    );
+  });
+
+  // The actual bug: agy's `models` subcommand does not answer until stdin
+  // reaches EOF, and `execFile`'s `timeout` option only *signals* a child
+  // that never exits on its own -- it does not force the promise to settle.
+  // This test's mock reproduces that exact contract (its promise only
+  // resolves once `.child.stdin.end()` has actually been called), so a
+  // regression that moves the `.end()` call to after the `await` -- or
+  // drops it entirely -- reproduces the real hang: the race below times out
+  // and the test fails, instead of silently passing on an unrelated
+  // assertion.
+  it('closes stdin before awaiting the result, so a held-open pipe cannot hang the probe', async () => {
+    let stdinClosed = false;
+    const end = vi.fn(() => {
+      stdinClosed = true;
+    });
+    execAgentFileMock.mockImplementation(() => {
+      let resolveFn: (value: { stdout: string; stderr: string }) => void;
+      const promise = new Promise<{ stdout: string; stderr: string }>((resolve) => {
+        resolveFn = resolve;
+      });
+      const poll = () => {
+        if (stdinClosed) {
+          resolveFn({
+            stdout: JSON.stringify({
+              command: {
+                data: { models: [{ id: 'x', label: 'Gemini 3.1 Pro (High)' }] },
+              },
+            }),
+            stderr: '',
+          });
+        } else {
+          setImmediate(poll);
+        }
+      };
+      setImmediate(poll);
+      // @ts-expect-error test double; production shape is PromiseWithChild
+      promise.child = { stdin: { end } };
+      return promise;
+    });
+
+    const result = await Promise.race([
+      fetchAntigravityModels('agy', {}),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(
+            'DEADLOCK: fetchAntigravityModels never settled -- stdin was '
+            + 'not closed before awaiting the result, exactly like the real '
+            + 'agy hang this function exists to avoid',
+          )),
+          2_000,
+        )),
+    ]);
+
+    expect(end).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'Gemini 3.1 Pro (High)', label: 'Gemini 3.1 Pro (High)' },
+    ]);
+  });
+
+  it('tolerates a resolved child with no stdin handle', async () => {
+    execAgentFileMock.mockImplementation(() => {
+      const promise = Promise.resolve({
+        stdout: JSON.stringify({ command: { data: { models: [] } } }),
+        stderr: '',
+      });
+      // @ts-expect-error test double; no `.child` at all this time
+      promise.child = undefined;
+      return promise;
+    });
+
+    await expect(fetchAntigravityModels('agy', {})).resolves.toBeNull();
+  });
+
+  // detection.ts's `fetchModels()` dispatcher is the one that catches a
+  // thrown error and falls back to the static `fallbackModels` list -- this
+  // function itself must propagate, not swallow.
+  it('propagates a rejection (e.g. execFile timeout) instead of swallowing it', async () => {
+    execAgentFileMock.mockImplementation(() => {
+      const promise = Promise.reject(new Error('agy timed out'));
+      // @ts-expect-error test double
+      promise.child = { stdin: { end: vi.fn() } };
+      return promise;
+    });
+
+    await expect(fetchAntigravityModels('agy', {})).rejects.toThrow('agy timed out');
+  });
+});

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -468,13 +468,18 @@ The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and o
   prints Usage. **Gotcha:** this subcommand does not print or exit until
   stdin reaches EOF. Spawned with a held-open pipe (`execFile`'s default,
   and the shape any daemon integration gets without an explicit stdin
-  strategy), the process idles indefinitely — `execFile`'s `timeout` option
-  only *signals* the child and the promise settles on actual exit, which
-  never happens on its own here. The adapter's `fetchModels` closes stdin
-  immediately after spawn (before awaiting the result) to avoid this; a
-  declarative `listModels: { args, parse }` entry would spawn through the
-  same path with no hook to do so and hang identically. `fallbackModels` is
-  the offline-only floor for when the live probe fails.
+  strategy), the process waits out the full `timeout` on every probe.
+  `execAgentFile` sets `killSignal: 'SIGKILL'`, so the timeout does
+  eventually kill the child and settle (reject) the promise — this is a
+  bounded delay, not an unbounded hang — but the probe gets nothing for its
+  wait: the killed child's stdout is discarded, so the caller burns the
+  whole timeout budget and still falls back to the static list. The
+  adapter's `fetchModels` closes stdin immediately after spawn (before
+  awaiting the result) so the probe answers in 6-21s with real data instead;
+  a declarative `listModels: { args, parse }` entry would spawn through the
+  same path with no hook to do so and would wait out the full timeout on
+  every probe without ever getting the live list. `fallbackModels` is the
+  offline-only floor for when the live probe fails.
 
 ## 6. Runtime metadata and UI
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -436,6 +436,46 @@ At run completion, the daemon scans the captured plain stdout for `<artifact>` b
 
 The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
 
+### 5.14 Antigravity
+
+- Invocation is `agy [--log-file <path>] -p <prompt>` — non-interactive print
+  mode. Older builds spawned `agy -p -` and wrote the prompt on stdin, but
+  agy 1.1.13+ treats a bare `-` as the literal prompt string and ignores
+  stdin (upstream #7161), so the prompt is now passed directly as the `-p`
+  argument.
+- Streaming: `plain`, stateless, no `-c`/resume flag. Tested resuming via
+  `-c`: it activates agy's own internal agentic loop (multi-step model
+  retries, tool calls, fallback-to-cached-response on tool errors), which
+  produced an identical byte-for-byte form re-emission on turn 2 when turn
+  1's tool-call retry path returned the cached response — not steerable from
+  OD's system-prompt OVERRIDE. Every spawn instead gets the full
+  OD-rendered transcript, matching the qwen / deepseek plain adapters.
+- Model selection: agy 1.1.21 still has no `--model` flag. The TUI's
+  Switch-Model picker persists the choice to
+  `~/.gemini/antigravity-cli/settings.json`, and every `agy -p` invocation
+  re-reads that file on startup, so the daemon writes the picked label into
+  `settings.json` immediately before spawn. Because that file is
+  process-global, concurrent non-default-model runs are serialized through
+  `acquireAntigravityModelLock` / `waitForAgyToReadModel` in
+  `apps/daemon/src/runtimes/defs/antigravity.ts`: each spawn holds the lock
+  until agy's own `--log-file` output shows
+  `Propagating selected model override to backend: label="<X>"` (confirming
+  the settings write was actually read) or the child exits, whichever comes
+  first.
+- Model discovery: `agy --output-format json models` returns a live catalog
+  as `{ command: { data: { models: [{ id, label }] } } }` — the flag has to
+  come *before* the subcommand; `agy models --output-format json` only
+  prints Usage. **Gotcha:** this subcommand does not print or exit until
+  stdin reaches EOF. Spawned with a held-open pipe (`execFile`'s default,
+  and the shape any daemon integration gets without an explicit stdin
+  strategy), the process idles indefinitely — `execFile`'s `timeout` option
+  only *signals* the child and the promise settles on actual exit, which
+  never happens on its own here. The adapter's `fetchModels` closes stdin
+  immediately after spawn (before awaiting the result) to avoid this; a
+  declarative `listModels: { args, parse }` entry would spawn through the
+  same path with no hook to do so and hang identically. `fallbackModels` is
+  the offline-only floor for when the live probe fails.
+
 ## 6. Runtime metadata and UI
 
 There is no public `agents.capabilities()` method and no generalized


### PR DESCRIPTION
Fixes #

## Why

Antigravity is the only def under `apps/daemon/src/runtimes/defs/` with a model picker that still ships a hand-maintained static `fallbackModels` list and no `listModels`/`fetchModels` hook — every other def with a picker (codex, cursor-agent, opencode, codebuddy, grok-build, deepseek-harness, claude, qwen, amr, devin, hermes, kilo, kimi, kiro, pi, reasonix, trae-cli, vibe...) follows agy's own CLI, its settings file, or a routing service. The existing comment on this file explained why: "the set is small and stable enough to ship statically until upstream adds a programmatic `agy models` subcommand." That subcommand exists now (`agy --output-format json models`, verified against 1.1.21 — the flag has to come *before* the subcommand, `agy models --output-format json` only prints Usage), so this PR wires it up.

We hit the staleness firsthand: agy has since shipped Gemini 3.6 and 3.7 Flash tiers that the static list never picked up, so users were stuck choosing between "Default" and a fixed roster that was already two releases behind.

## What users will see

- Settings → the Antigravity model picker now reflects whatever `agy --output-format json models` actually returns on the user's machine, instead of a hardcoded list that only tracked a specific date snapshot.
- If the live probe fails (old agy, no network, etc.) the picker falls back to a refreshed static list that now includes the 3.6/3.7 Flash tiers.
- No change to how a model is actually selected — `writeAntigravityModelSelection` / `settings.json` / the log-grep confirmation lock are untouched.

## Surface area

- [x] None — additive to an existing def's model-discovery path, the same shape every other adapter with `fetchModels`/`listModels` already uses; no new UI surface, no schema change, no dependency added.

Files touched: `antigravity.ts` (the `fetchModels` hook + refreshed static fallback), `docs/agent-adapters.md` (a new per-adapter notes section covering the model-selection lock, live discovery, and the stdin-EOF gotcha below), and two test files.

### The `agy models` stdin-EOF gotcha (the reason this is `fetchModels`, not `listModels`)

`agy --output-format json models` does not print anything or exit until stdin reaches EOF. Spawned with a piped, non-tty stdin held open — `execFile`'s default, and what any daemon integration gets without an explicit stdin strategy — the process idles indefinitely. `execFile`'s `timeout` option does not save you here: it only *signals* the child, and the returned promise settles on the child actually exiting, which this process never does on its own when stdin stays open.

This is why `RuntimeAgentDef.fetchModels` (imperative — gets a handle on the spawned child via `execAgentFile`'s `PromiseWithChild`) is used instead of the declarative `listModels: { args, parse }` shape most other CLI-probing adapters use: `listModels` spawns through the exact same `execAgentFile` path with no hook to close stdin before the dispatcher `await`s the result, and would hang identically. `fetchAntigravityModels` closes `pending.child?.stdin?.end()` immediately after spawn, before awaiting — covered by a regression test whose mock only resolves once `.end()` has actually been called, so a change that reorders the close to after the `await` (or drops it) makes the test hang and fail on a 2s guard instead of silently passing.

### `id` = `label`, not agy's internal slug

`agy`'s own JSON envelope is `{ command: { data: { models: [{ id, label }] } } }`, where `id` is an internal slug (e.g. `gemini-3-pro-high`) that isn't used anywhere in this file's existing model-selection path — that path goes through `writeAntigravityModelSelection` writing the display **label** to `settings.json`, which agy's own log line (`Propagating selected model override to backend: label="<X>"`) confirms by label, not slug. So `parseAntigravityModelsJson` discards agy's slug entirely and uses `label` for both the returned `id` and `label`, matching this file's pre-existing `fallbackModels` id-equals-label convention and keeping `writeAntigravityModelSelection` / `waitForAgyToReadModel` unchanged.

## Validation

- `pnpm --filter @open-design/daemon typecheck` — clean, 0 errors.
- `pnpm guard` — clean.
- `apps/daemon/tests/runtimes/antigravity-models.test.ts` (new, 9 tests) — 9/9 passed: 5 cover `parseAntigravityModelsJson`, fed the `command.data.models` envelope shape verified against real agy 1.1.21 output (the happy path keyed by label, malformed JSON, missing `command`/`data`/`models` at any depth, an empty-but-valid `models` array, entries with a missing/non-string `label`); 4 cover `fetchAntigravityModels` (the right args/timeout/env are passed, stdin closes *before* the result is awaited — verified with a mock that only resolves once `.end()` fires, so a regression reproduces the real hang instead of passing silently — a missing `.child` is tolerated, and a rejection propagates rather than being swallowed here).
- `apps/daemon/tests/runtimes/antigravity-model-lock.test.ts` (pre-existing, 9 tests) — still 9/9, confirming no regression to `acquireAntigravityModelLock`/`waitForAgyToReadModel`, which this PR does not touch.
- `apps/daemon/tests/runtimes/agent-args.test.ts` — found this PR's `fallbackModels` change broke a pre-existing pinned `assert.deepEqual` on the old 8-label list (1 failed / 49 passed); updated the pin to the new 14-label list in this PR's actual order (commit `a166030f5`) and confirmed green after (50/50).
