### PR TITLE
fix(dsh-runtime): include sources and build config in files field

### DIFF
--- a/packages/dsh-runtime/package.json
+++ b/packages/dsh-runtime/package.json
@@ -37,6 +37,7 @@
     }
   },
   "scripts": {
+    "prepare": "pnpm run build",
     "build": "tsx ./clean.ts && tsx ./esbuild.config.ts && tsc -p tsconfig.json --emitDeclarationOnly",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"


### PR DESCRIPTION
﻿Fixes #7471

## Why

Installing `@open-design/dsh-runtime` as a git dependency (`github:nexu-io/open-design#path:packages/dsh-runtime`) leaves `main` / `exports` pointing at `dist/*.js` that were never built. pnpm runs a git dependency's `prepare` hook at install time, but this package only declared `build` — so install completed with no `dist/`, and DSH Desktop then hard-failed the whole plugin tree (atomic loader) with `ERR_MODULE_NOT_FOUND` for `dist/startup.js` and `dist/index.js`.

Hit this while wiring the package into a DeepSeek Harness profile via git; there is still no npm publish fallback.

## What users will see

- Git / path installs of `@open-design/dsh-runtime` produce a package whose declared entry points exist (`dist/` built during install via `prepare`).
- DSH Desktop (and other consumers) can load `open-design-runtime` / `open-design-startup` without `ERR_MODULE_NOT_FOUND` from a missing build.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** - changes what existing users experience without opting in
- [x] **None** - internal packaging fix only (`packages/dsh-runtime/package.json` scripts)

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: package had `build` but no lifecycle hook pnpm runs for git deps; after install, `dist/index.js` / `dist/startup.js` are absent while `package.json` `main`/`exports` still point at them (as reported in #7471).
- Did the test go red on `main` and green on this branch? no — a red automated spec for install lifecycle was not cheap here (needs a full pnpm git-dep install of this package with its peer/dev toolchain).
- Verification instead: confirmed on `main` that `packages/dsh-runtime/package.json` scripts were only `build` / `test` / `typecheck`; this PR adds `"prepare": "pnpm run build"` so install-time lifecycle builds `dist/` before the package is linked (same fix suggested in #7471). Workspace / local `pnpm run build` behavior is unchanged.

## Validation

- Inspected `packages/dsh-runtime/package.json` before/after; single-line scripts change only.
- Did not run full monorepo `pnpm install` / `pnpm guard` in this environment (sparse checkout of `packages/dsh-runtime` only; disk-constrained). Change is additive lifecycle wiring over the existing `build` script.
