### PR TITLE
fix(desktop,web): packaged-only opendesign:// registration, signed-in-only campaign badge

### DIFF
--- a/apps/desktop/src/main/invite-deeplink-core.ts
+++ b/apps/desktop/src/main/invite-deeplink-core.ts
@@ -63,6 +63,40 @@ export function isWorkspaceOpenDeeplink(url: string): boolean {
   );
 }
 
+/** How this process may claim the `opendesign://` scheme with the OS, if at all. */
+export type ProtocolClientRegistration =
+  | { register: false }
+  /** `clientPath` is the executable to register, or null to register this process. */
+  | { register: true; clientPath: string | null };
+
+/**
+ * Only a packaged install may claim `opendesign://` with the OS.
+ *
+ * A source/dev run is hosted by the shared `electron` binary from
+ * `node_modules`, so claiming the scheme there points the OS at that binary —
+ * `com.github.electron` in macOS LaunchServices, a throwaway `electron.exe` in
+ * the Windows registry — for every channel at once. The cloud authorization
+ * page's `opendesign://workspace/open` hand-off then launches a bare Electron
+ * welcome window from a checkout that may not even exist any more, instead of
+ * focusing the installed app (OPEND-2352).
+ *
+ * Packaged builds already declare the scheme statically (Info.plist
+ * `CFBundleURLTypes` on macOS, `Software\Classes\opendesign` from the Windows
+ * installer) and re-assert it on every start, which is also what takes a
+ * handler back from a dev run that poisoned it before this fix shipped.
+ */
+export function planProtocolClientRegistration(input: {
+  platform: NodeJS.Platform;
+  isPackaged: boolean;
+  protocolClientPath?: string | null;
+}): ProtocolClientRegistration {
+  if (!input.isPackaged) return { register: false };
+  // Windows registers a stable installed launcher rather than the versioned
+  // payload executable, which an update can delete; see `protocolClientPath`.
+  const clientPath = input.platform === "win32" ? input.protocolClientPath ?? null : null;
+  return { clientPath, register: true };
+}
+
 export interface InviteDeeplinkDeps {
   /** Resolve the running daemon's base URL; rejects when it is not up yet. */
   resolveDaemonBaseUrl: () => Promise<string>;

--- a/apps/desktop/src/main/invite-deeplink.ts
+++ b/apps/desktop/src/main/invite-deeplink.ts
@@ -4,6 +4,7 @@ import {
   createInviteDeeplinkDispatcher,
   continueInviteFromUrl,
   findDeeplinkArg,
+  planProtocolClientRegistration,
   type InviteDeeplinkDeps,
 } from "./invite-deeplink-core.js";
 
@@ -24,6 +25,7 @@ export {
   continueInviteFromUrl,
   createInviteDeeplinkDispatcher,
   findDeeplinkArg,
+  planProtocolClientRegistration,
   INVITE_DEEPLINK_SCHEME,
   type InviteDeeplinkDeps,
 } from "./invite-deeplink-core.js";
@@ -63,12 +65,23 @@ export function dispatchInviteDeeplink(url: string | null): void {
  * {@link continueInviteFromUrl}. macOS delivers via `open-url`; Windows/Linux via
  * a second-instance argv (requires the single-instance lock the app already
  * holds). A cold start through the deeplink carries it in the initial argv.
+ *
+ * Claiming the scheme with the OS is gated by
+ * {@link planProtocolClientRegistration}; the dispatcher wiring below is not,
+ * so a source/dev run still handles a deeplink handed to it directly.
  */
 export function registerInviteDeeplink(deps: InviteDeeplinkDeps): void {
-  if (process.platform === "win32" && deps.protocolClientPath) {
-    app.setAsDefaultProtocolClient(INVITE_DEEPLINK_SCHEME, deps.protocolClientPath);
-  } else {
-    app.setAsDefaultProtocolClient(INVITE_DEEPLINK_SCHEME);
+  const registration = planProtocolClientRegistration({
+    isPackaged: app?.isPackaged === true,
+    platform: process.platform,
+    protocolClientPath: deps.protocolClientPath,
+  });
+  if (registration.register) {
+    if (registration.clientPath) {
+      app.setAsDefaultProtocolClient(INVITE_DEEPLINK_SCHEME, registration.clientPath);
+    } else {
+      app.setAsDefaultProtocolClient(INVITE_DEEPLINK_SCHEME);
+    }
   }
   deeplinkDispatcher.setDeps(deps);
 

--- a/apps/desktop/tests/main/invite-deeplink-protocol-registration.test.ts
+++ b/apps/desktop/tests/main/invite-deeplink-protocol-registration.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression for OPEND-2352: a source/dev run used to claim the `opendesign://`
+// scheme for whatever Electron binary happened to host it. On macOS that binds
+// the scheme to `com.github.electron` in LaunchServices, so the cloud
+// authorization page's `opendesign://workspace/open` hand-off later launched a
+// bare Electron welcome window from a throwaway checkout instead of focusing
+// the installed app. Only the packaged app — which owns a channel-distinct
+// bundle id and declares the scheme in its Info.plist — may register it.
+const electron = vi.hoisted(() => ({
+  isPackaged: true,
+  on: vi.fn(),
+  setAsDefaultProtocolClient: vi.fn(),
+  whenReady: vi.fn(async () => undefined),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    get isPackaged() {
+      return electron.isPackaged;
+    },
+    on: electron.on,
+    setAsDefaultProtocolClient: electron.setAsDefaultProtocolClient,
+    whenReady: electron.whenReady,
+  },
+}));
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+async function registerOn(
+  platform: NodeJS.Platform,
+  isPackaged: boolean,
+  protocolClientPath?: string,
+): Promise<void> {
+  setPlatform(platform);
+  electron.isPackaged = isPackaged;
+  vi.resetModules();
+  const { registerInviteDeeplink } = await import("../../src/main/invite-deeplink.js");
+  registerInviteDeeplink({
+    resolveDaemonBaseUrl: async () => "http://127.0.0.1:17456",
+    protocolClientPath,
+  });
+}
+
+beforeEach(() => {
+  electron.on.mockClear();
+  electron.setAsDefaultProtocolClient.mockClear();
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { configurable: true, value: realPlatform });
+});
+
+describe("registerInviteDeeplink protocol-client registration", () => {
+  it("does not claim the scheme from a macOS source/dev run", async () => {
+    await registerOn("darwin", false);
+    expect(electron.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the scheme from a Windows source/dev run", async () => {
+    await registerOn("win32", false, "C:\\Users\\qa\\AppData\\Local\\OpenDesign\\OpenDesign.exe");
+    expect(electron.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the scheme from a Linux source/dev run", async () => {
+    await registerOn("linux", false);
+    expect(electron.setAsDefaultProtocolClient).not.toHaveBeenCalled();
+  });
+
+  it("claims the scheme for a packaged macOS app", async () => {
+    await registerOn("darwin", true);
+    expect(electron.setAsDefaultProtocolClient).toHaveBeenCalledWith("opendesign");
+  });
+
+  it("claims the scheme for a packaged Windows app via the stable launcher path", async () => {
+    const launcher = "C:\\Users\\qa\\AppData\\Local\\OpenDesign\\OpenDesign.exe";
+    await registerOn("win32", true, launcher);
+    expect(electron.setAsDefaultProtocolClient).toHaveBeenCalledWith("opendesign", launcher);
+  });
+
+  it("still wires the deeplink dispatcher on a source/dev run", async () => {
+    await registerOn("darwin", false);
+    expect(electron.on).toHaveBeenCalledWith("second-instance", expect.any(Function));
+  });
+});

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -1127,6 +1127,7 @@ export function WorkspaceTopRightAccountCluster({
           page="project"
           metricsConsent={metricsConsent}
           installationId={installationId}
+          loggedIn={amrLoggedIn}
         />
       ) : null}
       updaterSlot={updaterSlot}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1633,6 +1633,7 @@ export function EntryShell({
                 page="home"
                 metricsConsent={config.telemetry?.metrics === true}
                 installationId={config.installationId}
+                loggedIn={amrLoggedIn}
               />
             ) : null
           }

--- a/apps/web/src/components/WorkbenchCampaignBadge.tsx
+++ b/apps/web/src/components/WorkbenchCampaignBadge.tsx
@@ -15,21 +15,39 @@ import { goPlanPricingUrl } from '../campaigns/go-plan';
 import { useI18n } from '../i18n';
 import { Icon } from './Icon';
 
+/**
+ * The campaign badge is a signed-in-only surface.
+ *
+ * It sits inside the top-right account cluster — beside the plan chip, the
+ * wallet balance and the avatar — and its click hands off to Pricing with AMR
+ * attribution. None of that means anything to a client that is not signed in
+ * to Vela, so a signed-out (or not-yet-resolved) login state renders nothing
+ * and burns no campaign impression. `loggedIn` is deliberately REQUIRED: the
+ * badge is mounted from the entry rail and from the project-detail cluster,
+ * which between them cover nearly every page, and a future third mount point
+ * must fail typecheck rather than quietly greet signed-out users.
+ *
+ * This gate is about the badge alone. The in-app campaign dialog keeps its own
+ * audience rules and still greets signed-out users.
+ */
 export function WorkbenchCampaignBadge({
   audience,
   page,
   metricsConsent,
   installationId,
+  loggedIn,
 }: {
   audience: Exclude<DeepSeekV4FlashCampaignAudience, 'unknown'>;
   page: 'home' | 'project';
   metricsConsent: boolean;
   installationId?: string | null;
+  loggedIn: boolean | null | undefined;
 }) {
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
 
   useEffect(() => {
+    if (loggedIn !== true) return;
     // The current campaign analytics contract scopes badge impressions to
     // Home. Project-detail visibility is intentionally UI-only until that
     // contract gains a project page variant.
@@ -41,7 +59,7 @@ export function WorkbenchCampaignBadge({
       campaign_id: 'deepseek_v4_pro',
       user_state: audience,
     });
-  }, [analytics.track, audience, page]);
+  }, [analytics.track, audience, loggedIn, page]);
 
   const openCampaignPricing = useCallback(() => {
     const pricingUrl = goPlanPricingUrl(locale);
@@ -75,6 +93,8 @@ export function WorkbenchCampaignBadge({
       'noopener,noreferrer',
     );
   }, [analytics.track, audience, installationId, locale, metricsConsent, page]);
+
+  if (loggedIn !== true) return null;
 
   return (
     <button

--- a/apps/web/tests/campaigns/workbench-campaign-badge-signed-in-only.test.tsx
+++ b/apps/web/tests/campaigns/workbench-campaign-badge-signed-in-only.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkbenchCampaignBadge } from '../../src/components/WorkbenchCampaignBadge';
+import { I18nProvider } from '../../src/i18n';
+
+// The DeepSeek campaign badge is an upsell pinned into the top-right account
+// cluster, next to the plan chip, wallet balance and avatar — surfaces that
+// only exist once the client is signed in to Vela. It must never greet a
+// signed-out client, on any page that mounts the cluster.
+const trackSpy = vi.fn();
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({ track: trackSpy }),
+}));
+
+vi.mock('../../src/analytics/client', () => ({
+  getResolvedDeviceId: () => null,
+}));
+
+const badgeSource = readFileSync(
+  resolve(process.cwd(), 'src/components/WorkbenchCampaignBadge.tsx'),
+  'utf8',
+);
+const entryShellSource = readFileSync(
+  resolve(process.cwd(), 'src/components/EntryShell.tsx'),
+  'utf8',
+);
+const entryNavRailSource = readFileSync(
+  resolve(process.cwd(), 'src/components/EntryNavRail.tsx'),
+  'utf8',
+);
+
+function renderBadge(loggedIn: boolean | null | undefined) {
+  render(
+    <I18nProvider initial="zh-CN">
+      <WorkbenchCampaignBadge
+        audience="unpaid"
+        page="home"
+        metricsConsent={false}
+        loggedIn={loggedIn}
+      />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  trackSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('workbench campaign badge is signed-in only', () => {
+  it('renders nothing for a signed-out client', () => {
+    renderBadge(false);
+    expect(screen.queryByTestId('deepseek-campaign-pricing-badge')).toBeNull();
+  });
+
+  it('renders nothing while the Vela login state is still unresolved', () => {
+    renderBadge(null);
+    expect(screen.queryByTestId('deepseek-campaign-pricing-badge')).toBeNull();
+    cleanup();
+    renderBadge(undefined);
+    expect(screen.queryByTestId('deepseek-campaign-pricing-badge')).toBeNull();
+  });
+
+  it('does not burn a campaign impression on a client that cannot see the badge', () => {
+    renderBadge(false);
+    expect(trackSpy).not.toHaveBeenCalled();
+  });
+
+  it('still renders and reports for a signed-in client', () => {
+    renderBadge(true);
+    expect(screen.getByTestId('deepseek-campaign-pricing-badge')).toBeTruthy();
+    expect(trackSpy).toHaveBeenCalledWith(
+      'surface_view',
+      expect.objectContaining({ area: 'campaign_badge' }),
+      undefined,
+    );
+  });
+
+  it('makes `loggedIn` a required prop so a new mount point cannot forget it', () => {
+    // A future third mount point is caught by typecheck, not by review.
+    expect(badgeSource).toMatch(/\n\s*loggedIn: boolean \| null \| undefined;/);
+    expect(badgeSource).not.toMatch(/\n\s*loggedIn\?:/);
+  });
+
+  it('passes the Vela login state from both mount points', () => {
+    // Entry shell rail: home plus every entry tab (projects, design systems,
+    // plugins, community, members …). Workspace cluster: project detail.
+    expect(entryShellSource).toMatch(
+      /<WorkbenchCampaignBadge[\s\S]{0,400}?loggedIn=\{amrLoggedIn\}/,
+    );
+    expect(entryNavRailSource).toMatch(
+      /<WorkbenchCampaignBadge[\s\S]{0,400}?loggedIn=\{amrLoggedIn\}/,
+    );
+  });
+});

--- a/apps/web/tests/campaigns/workbench-campaign-badge.test.tsx
+++ b/apps/web/tests/campaigns/workbench-campaign-badge.test.tsx
@@ -36,6 +36,7 @@ describe('DeepSeek workbench campaign badge', () => {
           audience="unpaid"
           page="home"
           metricsConsent={false}
+          loggedIn
         />
       </I18nProvider>,
     );


### PR DESCRIPTION
Two desktop/web fixes that both surfaced from the same prerelease QA pass.

## Why

**1. Bare Electron window after Cloud authorization** — Plane [OPEND-2352](https://plane.powerformer.net/open-design/browse/OPEND-2352/), P1. Choosing **Open Design Cloud** and finishing authorization in the browser reliably popped up a window titled `Electron` showing the default Electron welcome page, instead of bringing the prerelease client back to the front.

The authorization success page fires `opendesign://workspace/open`. `registerInviteDeeplink` claimed that scheme with the OS **unconditionally**, so any source/dev run of the app claimed it for the shared `electron` binary in `node_modules`. On macOS that writes `com.github.electron` into LaunchServices as the handler, and the executable path in the QA screenshot matched exactly that binary (a throwaway `od6268-qa.*` checkout). Electron 41.3 was not the cause — the handler was. The same shape applies on Windows (a throwaway `electron.exe` in `HKCU\Software\Classes\opendesign`) and Linux (`mimeapps.list`), so the gate is platform-independent.

**2. Campaign badge shown to signed-out clients** — the DeepSeek badge sits in the top-right account cluster, beside the plan chip, wallet balance and avatar, and its click hands off to Pricing with AMR attribution. All of that is signed-in surface, but the badge rendered for a signed-out client too, on every page that mounts the cluster.

## What users will see

**Deeplink**: after signing in to Open Design Cloud, the desktop app comes back to the front the way it always should have — no stray `Electron` window, no "run this on the command line" page. Developers running the app from source no longer hijack `opendesign://` for the whole machine, so an installed stable / prerelease / beta client keeps its own deeplinks. Already-poisoned machines self-heal: a packaged install re-asserts the scheme on every start (verified below), so launching the client once is enough.

**Campaign badge**: a signed-out client no longer sees the "DeepSeek V4 Pro + V4 Flash 无限免费用" pill in the top-right — on any page. Signed-in clients are unchanged. An unresolved login state is treated as signed out, so the badge appears once rather than flashing in.

## Surface area

- [x] **UI** — the campaign badge no longer renders for signed-out clients
- [x] **Default behavior change** — a source/dev run no longer registers `opendesign://` with the OS (packaged installs are unchanged)

## Screenshots

The deeplink half is not a visual change — the bug is the extra `Electron` window in the Plane report.

For the badge, the top-right cluster on a local runtime, campaign window open, same build, only the Vela login state differing:

- signed out → `… 91.8K` `登录` (no pill)
- signed in → `… DeepSeek V4 Pro + V4 Flash 无限免费用` `91.8K` `$0.00` `杨`

## Bug fix verification

**Deeplink** — `apps/desktop/tests/main/invite-deeplink-protocol-registration.test.ts`. Red on `main`, green here: with the source change reverted, the three dev-run cases fail (`expected "vi.fn()" to not be called at all, but actually been called 1 times` with `["opendesign"]`). The three packaged cases and the dispatcher-wiring case pass on both sides, so they lock the fix from over-reaching.

Because the user-visible symptom lives in macOS LaunchServices rather than in app code, the unit test was backed by a real-handler probe on a macOS machine (Electron 41.3, `app.getApplicationNameForProtocol("opendesign://workspace/open")`), and then by actually firing the deeplink:

| step | action | reported handler | what opened |
| --- | --- | --- | --- |
| baseline | machine as found (dev runs had happened) | `Electron.app` ← the bug | |
| 1 | `removeAsDefaultProtocolClient` | `Open Design Prerelease.app` | |
| 2 | **this branch's** `registerInviteDeeplink`, `isPackaged: false` | `Open Design Prerelease.app` (unchanged) | |
| 3 | `open "opendesign://workspace/open"` | | **Open Design Prerelease**, no Electron process |
| 4 | pre-fix behavior (unconditional `setAsDefaultProtocolClient`) | `Electron.app` | |
| 5 | `open "opendesign://workspace/open"` again | | **bare Electron welcome window** — symptom reproduced, with the prerelease client running at the time, exactly as QA hit it |
| 6 | launch the installed `Open Design Prerelease.app` | `Open Design Prerelease.app` | self-heal confirmed |

Step 6 is why this PR carries no LaunchServices repair code: the packaged app already takes the handler back on its own.

Not covered: no packaged build of this branch was produced, so "packaged still registers" rests on the unit tests; and the probe fired the deeplink directly rather than driving a full browser authorization round-trip.

**Campaign badge** — `apps/web/tests/campaigns/workbench-campaign-badge-signed-in-only.test.tsx`. Red before the source change (5 of 6 cases fail: badge renders for `false` / `null` / `undefined`, impression event still fires, `loggedIn` not required, mount points do not pass it), green after.

Verified on a real local runtime (`tools-dev`, isolated `OD_DATA_DIR`, campaign window open) with a real browser, toggling only the Vela login state via `AMR_HOME`:

- `AMR_HOME` pointed at an empty dir → `/api/integrations/vela/status` reports `signed_out` → top-right renders `… 91.8K 登录`, no campaign pill
- `AMR_HOME` left at the real one → status reports `authenticated` → top-right renders `… DeepSeek V4 Pro + V4 Flash 无限免费用  91.8K  $0.00  杨`

Note for reviewers: the campaign window closes `2026-08-27T20:00:00+08:00`. After that the badge is hidden for everyone by the window check, so reproducing either state needs the `window` constant temporarily widened.

## Validation

- `pnpm guard` (exit 0)
- `pnpm typecheck` (exit 0)
- `pnpm --filter @open-design/desktop test` — 41 files, 411 passed / 1 skipped
- `pnpm --filter @open-design/desktop typecheck` and `build`
- `pnpm --filter @open-design/packaged test` — 22 files, 322 passed
- `pnpm --filter @open-design/web typecheck` (exit 0)
- `pnpm --filter @open-design/web test` — 667/668 files pass. The 3 failures are in `tests/components/FileViewer.test.tsx` (tweaks toolbar), unrelated to these files and timeout-flaky under the full-suite worker load; that file passes 313/313 when run on its own.
- macOS handler probe + real-runtime browser check described above (machine left clean, handler restored)

## Adjacent issues (not in this PR)

- A signed-out client still sees the full-screen DeepSeek campaign **dialog** (the "付费用户免费开放 / 升级套餐,立即使用" modal). That is a separate surface with its own audience rules — this PR only covers the top-right badge that was reported. Say the word and it can follow the same gate.
- The mac Info.plist declares `CFBundleURLName: "Open Design Invite"` for every channel (`tools/pack/src/mac/builder.ts`). It does not affect handler binding — that follows the channel-distinct `appId` — but Apple recommends a unique reverse-DNS name per URL type. No observed symptom, so no speculative change here.
- With several channels installed side by side, macOS still allows exactly one default handler for `opendesign://`; last writer wins. That is a platform constraint, not a regression, and this PR only guarantees the winner is always a real installed app.
