### PR TITLE
fix(web): keep signed-out updater in top-right cluster

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -26,6 +26,7 @@
 
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -626,6 +627,22 @@ export function EntryTopRightCluster({
   const [accountMenuMode, setAccountMenuMode] = useState<'closed' | 'hover' | 'pinned'>(
     'closed',
   );
+  const updaterSlotHostRef = useRef<HTMLDivElement | null>(null);
+  const [updaterControlVisible, setUpdaterControlVisible] = useState(false);
+  // ReactNode truthiness cannot tell whether UpdaterPopup rendered its control;
+  // observe the stable host so signed-out chrome follows actual rendered content.
+  useLayoutEffect(() => {
+    const host = updaterSlotHostRef.current;
+    if (!host) {
+      setUpdaterControlVisible(false);
+      return;
+    }
+    const syncVisibility = () => setUpdaterControlVisible(host.hasChildNodes());
+    syncVisibility();
+    const observer = new MutationObserver(syncVisibility);
+    observer.observe(host, { childList: true });
+    return () => observer.disconnect();
+  }, [updaterSlot]);
   const accountOpen = accountMenuMode !== 'closed';
   const closeAccountMenu = () => setAccountMenuMode('closed');
   useEffect(() => {
@@ -767,28 +784,34 @@ export function EntryTopRightCluster({
     });
   }
 
-  if ((!leadingSlot && !context && !updaterSlot) || typeof document === 'undefined') return null;
+  if (typeof document === 'undefined') return null;
+  if (!leadingSlot && !context && !updaterSlot) return null;
+
+  const clusterVisible = Boolean(leadingSlot || context || updaterControlVisible);
+  const updaterHostVisible = Boolean(context || updaterControlVisible);
 
   return (
     <>
       {createPortal(
-        <div className="entry-top-right-cluster">
+        <div className={clusterVisible ? 'entry-top-right-cluster' : undefined}>
           {leadingSlot}
           {/* GitHub star chip: its own option in the cluster, right after the
               campaign badge (per product) — it used to live in the account
               menu's social row. */}
-          <a
-            className="entry-top-right-github"
-            href={REPO_URL}
-            {...externalLinkProps}
-            aria-label={`GitHub · ${githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)} stars`}
-            title={`GitHub · ${githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)} stars`}
-            data-testid="entry-top-right-github"
-            onClick={() => trackAccountAction('github')}
-          >
-            <Icon name="github-filled" size={14} />
-            <span>{githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)}</span>
-          </a>
+          {clusterVisible ? (
+            <a
+              className="entry-top-right-github"
+              href={REPO_URL}
+              {...externalLinkProps}
+              aria-label={`GitHub · ${githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)} stars`}
+              title={`GitHub · ${githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)} stars`}
+              data-testid="entry-top-right-github"
+              onClick={() => trackAccountAction('github')}
+            >
+              <Icon name="github-filled" size={14} />
+              <span>{githubStars == null ? GITHUB_STARS_FALLBACK_LABEL : formatStars(githubStars)}</span>
+            </a>
+          ) : null}
           {/* One shared capsule for the account module (per product: 头像和积分
               合并成一个胶囊): credits segment on the left (same availability
               rule as the menu's billing card; clicking jumps to B's billing
@@ -1027,7 +1050,11 @@ export function EntryTopRightCluster({
               the same position without inventing an empty account shell. The
               slot stays mounted so `:empty { display: none }` can remove it
               until an installer has downloaded. */}
-          <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
+          <div
+            ref={updaterSlotHostRef}
+            className={updaterHostVisible ? 'entry-nav-rail__account-updater' : undefined}
+            data-testid={updaterHostVisible ? 'entry-nav-account-updater' : undefined}
+          >
             {updaterSlot}
           </div>
         </div>,

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -232,9 +232,9 @@ interface Props {
    * The update-ready host (`UpdaterPopup`), which renders nothing until the
    * updater reports a downloaded, unopened installer.
    *
-   * It is an independent control immediately after the floating credits/avatar
-   * capsule (`.entry-nav-rail__account-updater`). The footer stays as the
-   * fallback home for the signed-out shell, which has no account capsule.
+   * It is an independent control in the floating top-right cluster
+   * (`.entry-nav-rail__account-updater`), immediately after the account capsule
+   * when one is present.
    */
   updaterSlot?: ReactNode;
   /** Optional notice shown above the footer controls. */
@@ -767,7 +767,7 @@ export function EntryTopRightCluster({
     });
   }
 
-  if ((!leadingSlot && !context) || typeof document === 'undefined') return null;
+  if ((!leadingSlot && !context && !updaterSlot) || typeof document === 'undefined') return null;
 
   return (
     <>
@@ -1020,15 +1020,16 @@ export function EntryTopRightCluster({
               ) : null}
               </div>
               </div>
-              {/* Update-ready rocket: an independent control immediately after
-                  the credits/avatar capsule. The slot stays mounted so
-                  `:empty { display: none }` can remove it from cluster layout
-                  until an installer has downloaded. */}
-              <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
-                {updaterSlot}
-              </div>
             </>
           ) : null}
+          {/* Update-ready rocket: an independent top-right control. With an
+              account it follows the credits/avatar capsule; signed-out keeps
+              the same position without inventing an empty account shell. The
+              slot stays mounted so `:empty { display: none }` can remove it
+              until an installer has downloaded. */}
+          <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
+            {updaterSlot}
+          </div>
         </div>,
         document.body,
       )}
@@ -1240,13 +1241,6 @@ export function EntryNavRail({
   const canInviteMembers = Boolean(permissions?.canInviteMembers);
   const canAccessInviteFlow = canAccessWorkspaceInviteFlow(context);
   const workspaceSettingsUrl = context?.workspaceSettingsUrl?.trim() || null;
-
-  // The updater host has exactly one home on screen at a time. The floating
-  // account row is the preferred one; the footer only takes it when there is
-  // no cloud identity, because the whole account module is absent then.
-  // Deriving both from one expression is what keeps "exactly one" true — two
-  // independent renders would double the rocket.
-  const footerUpdaterSlot = context ? null : updaterSlot;
 
   // Message-center panel for the SIGNED-OUT shell only (its rail item under
   // 设置 is the one opener there). The signed-in panel — plus the unread badge
@@ -1846,15 +1840,10 @@ export function EntryNavRail({
         )}
       </div>
       {/* The footer always has the social row to show now, so it no longer
-          collapses to nothing. `footerUpdaterSlot` is only ever set in the
-          signed-out shell: with a cloud identity the updater host rides the
-          account row instead (see `updaterSlot`), so the footer must not
-          render a second host. */}
+          collapses to nothing. The updater has one shared home in the
+          top-right cluster for both signed-in and signed-out shells. */}
       <div className="entry-nav-rail__footer">
         {footerNotice}
-        {footerUpdaterSlot ? (
-          <div className="entry-rail-actions">{footerUpdaterSlot}</div>
-        ) : null}
         <RailSocialRow page={analyticsPage} dimensions={workspaceDimensions} />
       </div>
       </div>

--- a/apps/web/src/components/UpdaterPopup.module.css
+++ b/apps/web/src/components/UpdaterPopup.module.css
@@ -1,7 +1,6 @@
 /* Update-ready indicator: a round brand-green rocket button shown as its own
-   top-right cluster control for signed-in users, with the rail footer retained
-   as the signed-out fallback. The state behind it is the real updater's
-   `shouldShowControl`.
+   top-right cluster control for signed-in and signed-out users. The state
+   behind it is the real updater's `shouldShowControl`.
 
    There is deliberately no progress ring here: the indicator only exists once
    the installer has finished downloading, so any percentage it drew would be

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -5710,8 +5710,8 @@
   padding-top: var(--spacing-10);
 }
 /* Update-ready slot: an independent top-right cluster item immediately AFTER
-   the credits/avatar capsule. The rail footer remains the signed-out fallback
-   because that shell has no account capsule.
+   the credits/avatar capsule when present. Signed-out shells keep the same
+   top-right position without rendering an account capsule.
 
    This stays a global selector next to the rest of the account block rather
    than a CSS Module: its only child is `.entry-updater-menu`, itself a global

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -258,4 +258,20 @@ describe('standalone updater rocket placement in the top-right cluster', () => {
     expect(rocket.closest('.entry-top-right-cluster')).not.toBeNull();
     expect(rocket.closest('.entry-nav-rail__footer')).toBeNull();
   });
+
+  it('keeps the signed-out top-right cluster absent while the updater is idle', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: { updater: { status: vi.fn(async () => idleStatus()) } },
+    });
+
+    renderRail(null);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
+    expect(screen.queryByTestId('entry-nav-account-updater')).toBeNull();
+    expect(screen.queryByTestId('entry-top-right-github')).toBeNull();
+    expect(document.querySelector('.entry-top-right-cluster')).toBeNull();
+  });
 });

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -144,7 +144,7 @@ async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null
   return view;
 }
 
-describe('standalone updater rocket placement after the account capsule', () => {
+describe('standalone updater rocket placement in the top-right cluster', () => {
   it('shows the shared DeepSeek campaign badge on an unpaid project detail route', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-20T10:00:00.000Z'));
@@ -250,13 +250,12 @@ describe('standalone updater rocket placement after the account capsule', () => 
     expect(slot.children.length).toBe(0);
   });
 
-  it('falls back to the rail footer when there is no account row to ride', async () => {
-    // Local (no cloud identity) shell: the account row is not rendered at all,
-    // so the rocket must keep its footer home instead of disappearing.
+  it('keeps the signed-out rocket in the top-right cluster without an account capsule', async () => {
     await renderWithDownloadedUpdate(null);
 
     const rocket = screen.getByTestId('entry-nav-updater');
     expect(screen.queryByTestId('entry-nav-account')).toBeNull();
-    expect(rocket.closest('.entry-nav-rail__footer')).not.toBeNull();
+    expect(rocket.closest('.entry-top-right-cluster')).not.toBeNull();
+    expect(rocket.closest('.entry-nav-rail__footer')).toBeNull();
   });
 });

--- a/e2e/ui/updater-popup-stacking.test.ts
+++ b/e2e/ui/updater-popup-stacking.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@/playwright/suite';
-import { applyStandardMocks } from '@/playwright/mock-factory';
+import {
+  applyStandardMocks,
+  routeSignedOutVelaStatus,
+} from '@/playwright/mock-factory';
 import { mockAmrPersonalWorkspace } from '@/playwright/amr';
-import { ensureRailOpen } from '@/playwright/rail';
 import { T } from '@/timeouts';
 
 const RECENT_PROJECTS = Array.from({ length: 6 }, (_, i) => ({
@@ -14,9 +16,10 @@ const RECENT_PROJECTS = Array.from({ length: 6 }, (_, i) => ({
 }));
 
 // Regression boundary: the desktop update-ready prompt and the home composer's
-// model picker can be open at the same time. The updater now lives in the nav
-// rail, but it must still paint above the raised composer card and its popover
-// wherever those independently positioned surfaces overlap.
+// model picker can be open at the same time. The updater lives in the shared
+// top-right cluster for both signed-in and signed-out shells. Signed-in keeps
+// the prompt within the viewport; signed-out stays clear of the raised composer
+// card and its popover in a compact window.
 
 test.beforeEach(async ({ page }) => {
   await applyStandardMocks(page);
@@ -125,27 +128,21 @@ for (const direction of ['ltr', 'rtl'] as const) {
   });
 }
 
-test('[P1] update ready prompt paints above the composer and its agent picker', async ({ page }) => {
-  test.fail(
-    true,
-    'The rail-hosted updater prompt currently paints behind the raised Home composer in compact windows.',
-  );
-  // In the current rail host the prompt grows upward from the footer. A compact
-  // desktop window puts it across the centered composer and model popover.
+test('[P1] signed-out update prompt stays clear of the composer and its agent picker', async ({ page }) => {
+  await routeSignedOutVelaStatus(page);
   await page.setViewportSize({ width: 700, height: 600 });
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.getByText('Loading OpenDesign…').waitFor({ state: 'hidden', timeout: T.long });
   await expect(page.getByTestId('home-hero')).toBeVisible();
 
-  // The updater host moved into the nav rail footer with the entry topbar's
-  // removal (#5517); the collapsed rail is inert, so expand it first. Open the
-  // control with the keyboard because this stacking test intentionally models
-  // the signed-out shell, whose Cloud sign-in card overlaps the footer pointer
-  // target. Updater pointer actionability is covered by its component tests.
-  await ensureRailOpen(page);
-  const updaterButton = page.getByTestId('entry-nav-updater');
-  await updaterButton.focus();
-  await page.keyboard.press('Enter');
+  // Signed-out has no account capsule, but the updater keeps the same
+  // top-right cluster home and remains directly actionable.
+  await expect(page.getByTestId('entry-nav-account')).toHaveCount(0);
+  const updaterButton = page
+    .locator('.entry-top-right-cluster')
+    .getByTestId('entry-nav-updater');
+  await expect(updaterButton).toBeVisible();
+  await updaterButton.click();
   const popup = page.getByTestId('updater-popup');
   await expect(popup).toBeVisible();
 
@@ -159,81 +156,34 @@ test('[P1] update ready prompt paints above the composer and its agent picker', 
   await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
   await expect(popup).toBeVisible();
 
-  // Require real overlap now that both surfaces are present so the stacking
-  // assertion cannot pass on separated geometry.
-  await expect
-    .poll(async () =>
-      page.evaluate(() => {
-        const popupEl = document.querySelector('[data-testid="updater-popup"]');
-        const card = document.querySelector('.home-hero__input-card');
-        const popover = document.querySelector('[data-testid="inline-model-switcher-popover"]');
-        if (popupEl == null || card == null || popover == null) return Number.NaN;
-        const popupRect = popupEl.getBoundingClientRect();
-        return Math.max(
-          ...[card, popover].map((element) => {
-            const rect = element.getBoundingClientRect();
-            const width = Math.min(popupRect.right, rect.right) - Math.max(popupRect.left, rect.left);
-            const height = Math.min(popupRect.bottom, rect.bottom) - Math.max(popupRect.top, rect.top);
-            return width > 0 && height > 0 ? width * height : 0;
-          }),
-        );
-      }),
-    )
-    .toBeGreaterThan(0);
   await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
   await expect(popup).toBeVisible();
 
-  // The prompt is a dialog: it must be the topmost element wherever the
-  // raised composer card or its agent-picker popover overlaps it. With the
-  // stacking bug, `elementFromPoint` resolves to composer/picker content
-  // instead of the prompt.
-  const probe = await page.evaluate(() => {
+  // Moving the signed-out updater from the rail footer to the top-right cluster
+  // removes the old collision altogether. Keep the geometry assertion after
+  // both surfaces open so a future repositioning cannot silently put the
+  // prompt back across the composer or its popover.
+  const overlapAreas = await page.evaluate(() => {
     const popupEl = document.querySelector('[data-testid="updater-popup"]');
     const overlays = [
       document.querySelector('.home-hero__input-card'),
       document.querySelector('[data-testid="inline-model-switcher-popover"]'),
     ];
     if (popupEl == null || overlays.some((el) => el == null)) {
-      return { ready: false, overlapArea: 0, samples: [] };
+      return null;
     }
     const p = popupEl.getBoundingClientRect();
-    let overlapArea = 0;
-    const samples: { x: number; y: number; insidePopup: boolean; hit: string }[] = [];
-    for (const overlay of overlays) {
+    return overlays.map((overlay) => {
       const r = (overlay as Element).getBoundingClientRect();
-      const left = Math.max(p.left, r.left);
-      const right = Math.min(p.right, r.right);
-      const top = Math.max(p.top, r.top);
-      const bottom = Math.min(p.bottom, r.bottom);
-      if (right - left < 4 || bottom - top < 4) continue;
-      overlapArea += (right - left) * (bottom - top);
-      for (const fx of [0.25, 0.5, 0.75]) {
-        for (const fy of [0.25, 0.5, 0.75]) {
-          const x = Math.round(left + (right - left) * fx);
-          const y = Math.round(top + (bottom - top) * fy);
-          const hit = document.elementFromPoint(x, y);
-          samples.push({
-            x,
-            y,
-            insidePopup: hit?.closest('[data-testid="updater-popup"]') != null,
-            hit:
-              hit instanceof HTMLElement
-                ? hit.className.toString().slice(0, 60) || hit.tagName
-                : (hit?.tagName ?? 'null'),
-          });
-        }
-      }
-    }
-    return { ready: true, overlapArea, samples };
+      const width = Math.min(p.right, r.right) - Math.max(p.left, r.left);
+      const height = Math.min(p.bottom, r.bottom) - Math.max(p.top, r.top);
+      return width > 0 && height > 0 ? width * height : 0;
+    });
   });
 
-  expect(probe.ready, 'popup, composer card, and agent picker must all be present').toBe(true);
-  // Geometry precondition: the composer surfaces actually reach under the
-  // prompt — otherwise this test would pass without exercising the stack.
-  expect(probe.overlapArea, 'composer must overlap the prompt area').toBeGreaterThan(0);
-  const leaks = probe.samples.filter((sample) => !sample.insidePopup);
   expect(
-    leaks,
-    `Composer content paints over the update prompt at: ${JSON.stringify(leaks)}`,
-  ).toEqual([]);
+    overlapAreas,
+    'popup, composer card, and agent picker must all be measurable',
+  ).not.toBeNull();
+  expect(overlapAreas, 'signed-out updater prompt must stay clear of composer surfaces').toEqual([0, 0]);
 });


### PR DESCRIPTION

## Why

A signed-out desktop user with a downloaded update saw the update-ready rocket in the nav rail footer, while signed-in users saw the same control in the top-right cluster. The split made the control inconsistent and let its prompt collide with the Home composer in compact windows.

## What users will see

When an update is ready, signed-out users now see the rocket in the top-right cluster. It uses the same standalone control as signed-in users without rendering an empty account capsule. The update prompt remains directly clickable and stays clear of the Home composer and model picker.

## Surface area

- [x] **UI** — changes the updater placement in apps/web
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new command, flag, or environment variable
- [ ] **API / contract** — new endpoint, event, or contract shape
- [ ] **Extension point** — skills, design systems, templates, or craft
- [ ] **i18n keys** — added translation keys
- [ ] **New top-level dependency** — root dependency change
- [x] **Default behavior change** — signed-out updater placement changes
- [ ] **None** — internal-only change

## Screenshots

After-state was verified locally at a 1280 x 720 viewport: signed out, no account capsule, and the 32 x 32 update rocket at the top-right edge. The local screenshot was not uploaded from the development environment.

## Bug fix verification

- Test path that reproduces the bug: apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
- Red on main: yes — the signed-out rocket was in the rail footer, not the top-right cluster.
- Green on this branch: yes — the focused component suite passes 6/6.
- Browser regression: e2e/ui/updater-popup-stacking.test.ts now covers the signed-out top-right host and verifies zero overlap with the composer and model picker.

## Validation

- corepack pnpm exec vitest run -c vitest.config.ts tests/components/EntryNavRail.updater-after-avatar.test.tsx tests/components/UpdaterPopup.rocket-indicator.test.tsx tests/components/App.update-dialog.test.tsx --maxWorkers=2 — 12 passed
- corepack pnpm exec playwright test -c playwright.config.ts ui/updater-popup-stacking.test.ts --workers=1 — 3 passed
- corepack pnpm --filter @open-design/web typecheck — passed
- corepack pnpm typecheck in e2e — passed
- corepack pnpm typecheck at repository root — passed
- corepack pnpm guard — passed
- git diff --check — passed

No Plane or GitHub issue is linked because OPEND-2355 was confirmed to be an unrelated ticket.
