### PR TITLE
feat(desktop, web): surface Claude Code custom endpoint as a clickable badge

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -1673,6 +1673,20 @@ export function SettingsDialog({
   const settingsContentRef = useRef<HTMLDivElement | null>(null);
   // AMR-card focus, driven by the failed-run nudge (`initialHighlight==='amr'`).
   const amrCardRef = useRef<HTMLDivElement | null>(null);
+  // CLI env disclosure focus, driven by the per-agent card shortcut.
+  const agentCliEnvDetailsRef = useRef<HTMLDetailsElement | null>(null);
+  // Opens the "Advanced: proxy & custom paths" disclosure and brings it into
+  // view. The disclosure is a plain uncontrolled <details>, so `open` is set on
+  // the DOM node rather than through React state; scrolling waits a frame so it
+  // measures the expanded height instead of the collapsed one.
+  const revealAgentCliEnvSection = useCallback(() => {
+    const details = agentCliEnvDetailsRef.current;
+    if (!details) return;
+    details.open = true;
+    requestAnimationFrame(() => {
+      details.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+  }, []);
   // Card pulse: a brief attention flash that auto-clears after a few seconds.
   const [amrHighlightActive, setAmrHighlightActive] = useState(false);
   // Coachmark: persists (unlike the card pulse) until the real pointer reaches
@@ -4728,6 +4742,34 @@ export function SettingsDialog({
                             hoveredAgentCardId === a.id &&
                             !amrCardSignedIn &&
                             amrCardStatus?.loginInFlight === true;
+                          // Shortcut into the "Advanced: proxy & custom paths"
+                          // disclosure. Two things this must not do:
+                          //
+                          // 1. Gate on "already configured" — that inverted its
+                          //    own purpose, since the user who needs to *find*
+                          //    the proxy fields is exactly the one who has not
+                          //    filled them in yet.
+                          // 2. Single out one agent. Claude and Codex are
+                          //    structurally identical here (both declare a base
+                          //    URL, auth keys, and custom paths), so visibility
+                          //    is derived from the field table rather than an
+                          //    agent id — any agent that gains CLI env fields
+                          //    gets the shortcut for free.
+                          const showCliEnvShortcut =
+                            active &&
+                            AGENT_CLI_ENV_FIELDS.some(
+                              (field) => field.agentId === a.id,
+                            );
+                          // Configured only changes how the shortcut reads
+                          // (offer vs. status), never whether it renders. Reads
+                          // every stored key rather than the known field list so
+                          // values written out-of-band by `od` (e.g. the daemon
+                          // also accepts ANTHROPIC_AUTH_TOKEN) still count.
+                          const hasCliEnvOverrides =
+                            showCliEnvShortcut &&
+                            Object.values(cfg.agentCliEnv?.[a.id] ?? {}).some(
+                              (value) => Boolean(value),
+                            );
                           const cardEl = (
                             <div
                               key={a.id}
@@ -4972,6 +5014,48 @@ export function SettingsDialog({
                                       aria-hidden="true"
                                     />
                                   )
+                                ) : null}
+                                {showCliEnvShortcut ? (
+                                  <Button
+                                    variant="ghost"
+                                    className={
+                                      'agent-card-cli-env-link' +
+                                      (hasCliEnvOverrides
+                                        ? ' agent-card-cli-env-link--configured'
+                                        : '')
+                                    }
+                                    // Not `settings-agent-card-*`: that prefix
+                                    // is the agent cards' own namespace and is
+                                    // enumerated by regex elsewhere.
+                                    data-testid={`settings-cli-env-shortcut-${a.id}`}
+                                    data-configured={
+                                      hasCliEnvOverrides ? 'true' : 'false'
+                                    }
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      revealAgentCliEnvSection();
+                                    }}
+                                  >
+                                    {/* The label carries the hover underline on
+                                        its own: text and chevron are separate
+                                        flex items, so underlining the whole
+                                        control leaves a visible break across
+                                        the gap between them. */}
+                                    <span className="agent-card-cli-env-link__label">
+                                      {t('settings.cliEnvShortcut')}
+                                    </span>
+                                    {hasCliEnvOverrides ? (
+                                      <VisuallyHidden>
+                                        {`, ${t('settings.cliEnvShortcutConfigured')}`}
+                                      </VisuallyHidden>
+                                    ) : null}
+                                    <span
+                                      className="agent-card-cli-env-link__chevron"
+                                      aria-hidden="true"
+                                    >
+                                      ›
+                                    </span>
+                                  </Button>
                                 ) : null}
                                 {active && !isAmrAgent ? (
                                   <button
@@ -5313,6 +5397,7 @@ export function SettingsDialog({
                 if (cliEnvFields.length === 0) return null;
                 return (
                   <details
+                    ref={agentCliEnvDetailsRef}
                     className="agent-cli-env"
                     data-testid="settings-cli-env"
                   >

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -609,6 +609,8 @@ export const ar: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'تم تحديث النماذج من CLI المثبت.',
   'settings.modelPickerFallbackHint': 'يتم عرض الإعدادات الافتراضية المضمنة. انقر على إعادة المسح لجلب النماذج المباشرة من CLI.',
   'settings.cliEnvTitle': 'متقدّم: الوكيل والمسارات المخصّصة',
+  'settings.cliEnvShortcut': 'الوكيل والمسارات المخصّصة',
+  'settings.cliEnvShortcutConfigured': 'مُهيّأ',
   'settings.cliEnvHint': 'استخدم هذه الخيارات لتجاوز بيئة CLI المحدّد: مفاتيح API، وعناوين base URL للوكيل، ومجلدات home المخصّصة، أو مسارات تنفيذ غير قياسية. عند عدم ضبط base URL، يستخدم CLI نقطة النهاية الافتراضية الخاصة به. تبقى الأسرار في إعدادات التطبيق المحلية ولا يراها سوى CLI المحدّد.',
   'settings.cliEnvClaudeConfigDir': 'دليل إعدادات Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL لوكيل Claude',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -609,6 +609,8 @@ export const de: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Modelle wurden aus der installierten CLI aktualisiert.',
   'settings.modelPickerFallbackHint': 'Integrierte Standardwerte werden angezeigt. Klicken Sie auf Neu scannen, um Live-Modelle aus der CLI abzurufen.',
   'settings.cliEnvTitle': 'Erweitert: Proxy und benutzerdefinierte Pfade',
+  'settings.cliEnvShortcut': 'Proxy und benutzerdefinierte Pfade',
+  'settings.cliEnvShortcutConfigured': 'Konfiguriert',
   'settings.cliEnvHint': 'Nutze diese Felder, um die Umgebung der ausgewählten CLI zu überschreiben: API-Keys, Proxy-Base-URLs, eigene Homes oder nicht standardmäßige Binary-Pfade. Ohne Base URL nutzt die CLI ihren Standard-Endpunkt. Secrets bleiben in der lokalen App-Konfiguration und werden nur an die ausgewählte CLI weitergegeben.',
   'settings.cliEnvClaudeConfigDir': 'Claude Code-Konfigurationsverzeichnis',
   'settings.cliEnvClaudeBaseUrl': 'Claude-Proxy-Base-URL',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -609,6 +609,8 @@ export const en: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Model list comes from this CLI.',
   'settings.modelPickerFallbackHint': 'Showing built-in defaults. Click Rescan to pull live models from the CLI.',
   'settings.cliEnvTitle': 'Advanced: proxy & custom paths',
+  'settings.cliEnvShortcut': 'Proxy & custom paths',
+  'settings.cliEnvShortcutConfigured': 'Configured',
   'settings.cliEnvHint': 'Use these to override the selected CLI environment: API keys, proxy base URLs, custom homes, or non-standard binary paths. Without a base URL, the CLI uses its default endpoint. Secrets stay in local app config and only the selected CLI sees them.',
   'settings.cliEnvClaudeConfigDir': 'Claude Code config directory',
   'settings.cliEnvClaudeBaseUrl': 'Claude proxy base URL',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -609,6 +609,8 @@ export const esES: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Los modelos se actualizaron desde la CLI instalada.',
   'settings.modelPickerFallbackHint': 'Mostrando valores predeterminados integrados. Pulsa Reescanear para obtener modelos en vivo desde la CLI.',
   'settings.cliEnvTitle': 'Avanzado: proxy y rutas personalizadas',
+  'settings.cliEnvShortcut': 'Proxy y rutas personalizadas',
+  'settings.cliEnvShortcutConfigured': 'Configurado',
   'settings.cliEnvHint': 'Usa estos campos para sobrescribir el entorno de la CLI seleccionada: API keys, base URLs de proxy, homes personalizados o rutas de binarios no estándar. Sin base URL, la CLI usa su endpoint predeterminado. Los secretos permanecen en la configuración local de la app y solo los ve la CLI seleccionada.',
   'settings.cliEnvClaudeConfigDir': 'Directorio de configuración de Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL del proxy de Claude',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -609,6 +609,8 @@ export const fa: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'مدل‌ها از CLI نصب‌شده به‌روزرسانی شدند.',
   'settings.modelPickerFallbackHint': 'پیش‌فرض‌های داخلی نمایش داده می‌شوند. برای دریافت مدل‌های زنده از CLI روی اسکن مجدد کلیک کنید.',
   'settings.cliEnvTitle': 'پیشرفته: پراکسی و مسیرهای سفارشی',
+  'settings.cliEnvShortcut': 'پراکسی و مسیرهای سفارشی',
+  'settings.cliEnvShortcutConfigured': 'پیکربندی‌شده',
   'settings.cliEnvHint': 'از این گزینه‌ها برای بازنویسی محیط CLI انتخاب‌شده استفاده کنید: API key، base URL پراکسی، home سفارشی یا مسیر اجرایی غیر استاندارد. اگر base URL تنظیم نشود، CLI از endpoint پیش‌فرض خودش استفاده می‌کند. اطلاعات محرمانه در تنظیمات محلی برنامه می‌مانند و فقط CLI انتخاب‌شده آن‌ها را می‌بیند.',
   'settings.cliEnvClaudeConfigDir': 'پوشه پیکربندی Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL پروکسی Claude',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -609,6 +609,8 @@ export const fr: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Les modèles ont été actualisés depuis la CLI installée.',
   'settings.modelPickerFallbackHint': 'Valeurs par défaut intégrées affichées. Cliquez sur Réanalyser pour récupérer les modèles en direct depuis la CLI.',
   'settings.cliEnvTitle': 'Avancé : proxy et chemins personnalisés',
+  'settings.cliEnvShortcut': 'Proxy et chemins personnalisés',
+  'settings.cliEnvShortcutConfigured': 'Configuré',
   'settings.cliEnvHint': 'Utilisez ces champs pour remplacer l’environnement de la CLI sélectionnée : clés API, base URLs de proxy, homes personnalisés ou chemins de binaires non standard. Sans base URL, la CLI utilise son endpoint par défaut. Les secrets restent dans la configuration locale de l’app et seule la CLI sélectionnée les voit.',
   'settings.cliEnvClaudeConfigDir': 'Dossier de configuration Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'URL de base du proxy Claude',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -609,6 +609,8 @@ export const hu: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'A modellek frissültek a telepített CLI-ből.',
   'settings.modelPickerFallbackHint': 'A beépített alapértékek láthatók. Kattints az Újraellenőrzésre az élő CLI-modellek lekéréséhez.',
   'settings.cliEnvTitle': 'Speciális: proxy és egyéni útvonalak',
+  'settings.cliEnvShortcut': 'Proxy és egyéni útvonalak',
+  'settings.cliEnvShortcutConfigured': 'Beállítva',
   'settings.cliEnvHint': 'Ezekkel írhatod felül a kiválasztott CLI környezetét: API-kulcsok, proxy base URL-ek, egyéni home-ok vagy nem szabványos bináris útvonalak. Base URL nélkül a CLI a saját alapértelmezett endpointját használja. A titkok a helyi alkalmazás-konfigurációban maradnak, és csak a kiválasztott CLI kapja meg őket.',
   'settings.cliEnvClaudeConfigDir': 'Claude Code konfigurációs könyvtár',
   'settings.cliEnvClaudeBaseUrl': 'Claude proxy Base URL',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -609,6 +609,8 @@ export const id: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Model diperbarui dari CLI yang terpasang.',
   'settings.modelPickerFallbackHint': 'Menampilkan default bawaan. Klik Pindai ulang untuk mengambil model langsung dari CLI.',
   'settings.cliEnvTitle': 'Lanjutan: proxy & path kustom',
+  'settings.cliEnvShortcut': 'Proxy & path kustom',
+  'settings.cliEnvShortcutConfigured': 'Terkonfigurasi',
   'settings.cliEnvHint': 'Gunakan ini untuk menimpa environment CLI yang dipilih: API key, proxy base URL, home kustom, atau path binary non-standar. Tanpa base URL, CLI memakai endpoint defaultnya. Secret tetap berada di konfigurasi app lokal dan hanya dilihat oleh CLI yang dipilih.',
   'settings.cliEnvClaudeConfigDir': 'Direktori konfigurasi Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL proxy Claude',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -609,6 +609,8 @@ export const it: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'I modelli sono stati aggiornati dalla CLI installata.',
   'settings.modelPickerFallbackHint': 'Mostra i valori predefiniti integrati. Clicca su Rianalizza per recuperare i modelli live dalla CLI.',
   'settings.cliEnvTitle': 'Avanzate: proxy e percorsi personalizzati',
+  'settings.cliEnvShortcut': 'Proxy e percorsi personalizzati',
+  'settings.cliEnvShortcutConfigured': 'Configurato',
   'settings.cliEnvHint': 'Usa questi campi per sovrascrivere l’ambiente della CLI selezionata: API key, base URL proxy, home personalizzate o percorsi di binari non standard. Senza base URL, la CLI usa il proprio endpoint predefinito. I segreti restano nella configurazione locale dell’app e li vede solo la CLI selezionata.',
   'settings.cliEnvClaudeConfigDir': 'Directory di configurazione Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL del proxy Claude',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -609,6 +609,8 @@ export const ja: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'インストール済みの CLI からモデルを更新しました。',
   'settings.modelPickerFallbackHint': '組み込みのデフォルトを表示しています。再スキャンをクリックすると CLI から最新モデルを取得します。',
   'settings.cliEnvTitle': '詳細設定: プロキシとカスタムパス',
+  'settings.cliEnvShortcut': 'プロキシとカスタムパス',
+  'settings.cliEnvShortcutConfigured': '設定済み',
   'settings.cliEnvHint': '選択した CLI の環境を上書きするために使用します: API key、プロキシ base URL、カスタム home、標準以外の実行ファイルパス。base URL を設定しない場合、CLI は既定の endpoint を使用します。シークレットはローカルのアプリ設定内に保持され、選択した CLI のみが参照します。',
   'settings.cliEnvClaudeConfigDir': 'Claude Code 設定ディレクトリ',
   'settings.cliEnvClaudeBaseUrl': 'Claude プロキシの Base URL',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -609,6 +609,8 @@ export const ko: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': '설치된 CLI에서 모델을 새로 고쳤습니다.',
   'settings.modelPickerFallbackHint': '내장 기본값을 표시 중입니다. CLI에서 실시간 모델을 가져오려면 다시 스캔을 클릭하세요.',
   'settings.cliEnvTitle': '고급: 프록시 및 사용자 지정 경로',
+  'settings.cliEnvShortcut': '프록시 및 사용자 지정 경로',
+  'settings.cliEnvShortcutConfigured': '구성됨',
   'settings.cliEnvHint': '선택한 CLI 환경을 재정의할 때 사용하세요: API key, 프록시 base URL, 사용자 지정 home, 비표준 실행 파일 경로. base URL이 없으면 CLI는 자체 기본 endpoint를 사용합니다. 비밀 정보는 로컬 앱 설정에 저장되며 선택한 CLI만 볼 수 있습니다.',
   'settings.cliEnvClaudeConfigDir': 'Claude Code 설정 디렉터리',
   'settings.cliEnvClaudeBaseUrl': 'Claude 프록시 Base URL',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -609,6 +609,8 @@ export const pl: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Modele zostały odświeżone z zainstalowanego CLI.',
   'settings.modelPickerFallbackHint': 'Wyświetlane są wbudowane wartości domyślne. Kliknij Ponów skanowanie, aby pobrać modele na żywo z CLI.',
   'settings.cliEnvTitle': 'Zaawansowane: proxy i własne ścieżki',
+  'settings.cliEnvShortcut': 'Proxy i własne ścieżki',
+  'settings.cliEnvShortcutConfigured': 'Skonfigurowano',
   'settings.cliEnvHint': 'Użyj tych pól, aby nadpisać środowisko wybranej CLI: API keys, proxy base URL, własne home lub niestandardowe ścieżki binarne. Bez base URL CLI używa własnego domyślnego endpointu. Sekrety pozostają w lokalnej konfiguracji aplikacji i widzi je tylko wybrana CLI.',
   'settings.cliEnvClaudeConfigDir': 'Katalog konfiguracji Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL serwera proxy Claude',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -609,6 +609,8 @@ export const ptBR: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Os modelos foram atualizados a partir da CLI instalada.',
   'settings.modelPickerFallbackHint': 'Mostrando padrões integrados. Clique em Reescanear para buscar modelos ao vivo da CLI.',
   'settings.cliEnvTitle': 'Avançado: proxy e caminhos personalizados',
+  'settings.cliEnvShortcut': 'Proxy e caminhos personalizados',
+  'settings.cliEnvShortcutConfigured': 'Configurado',
   'settings.cliEnvHint': 'Use estes campos para sobrescrever o ambiente da CLI selecionada: API keys, base URLs de proxy, homes personalizados ou caminhos de binários fora do padrão. Sem base URL, a CLI usa seu endpoint padrão. Segredos ficam na configuração local do app e apenas a CLI selecionada os vê.',
   'settings.cliEnvClaudeConfigDir': 'Diretório de configuração do Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL do proxy do Claude',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -609,6 +609,8 @@ export const ru: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Модели обновлены из установленного CLI.',
   'settings.modelPickerFallbackHint': 'Показаны встроенные значения по умолчанию. Нажмите «Пересканировать», чтобы получить актуальные модели из CLI.',
   'settings.cliEnvTitle': 'Дополнительно: прокси и пользовательские пути',
+  'settings.cliEnvShortcut': 'Прокси и пользовательские пути',
+  'settings.cliEnvShortcutConfigured': 'Настроено',
   'settings.cliEnvHint': 'Используйте эти поля, чтобы переопределить окружение выбранной CLI: API key, proxy base URL, пользовательские home-каталоги или нестандартные пути к бинарникам. Без base URL CLI использует свой endpoint по умолчанию. Секреты остаются в локальной конфигурации приложения и передаются только выбранной CLI.',
   'settings.cliEnvClaudeConfigDir': 'Каталог конфигурации Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL прокси Claude',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -609,6 +609,8 @@ export const th: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'รีเฟรชโมเดลจาก CLI ที่ติดตั้งแล้ว',
   'settings.modelPickerFallbackHint': 'กำลังแสดงค่าเริ่มต้นในตัว คลิกสแกนอีกครั้งเพื่อดึงโมเดลสดจาก CLI',
   'settings.cliEnvTitle': 'ขั้นสูง: พร็อกซีและพาธกำหนดเอง',
+  'settings.cliEnvShortcut': 'พร็อกซีและพาธกำหนดเอง',
+  'settings.cliEnvShortcutConfigured': 'ตั้งค่าแล้ว',
   'settings.cliEnvHint': 'ใช้ค่านี้เพื่อ override environment ของ CLI ที่เลือก: API key, proxy base URL, home แบบกำหนดเอง หรือพาธ binary ที่ไม่ใช่มาตรฐาน หากไม่ใส่ base URL CLI จะใช้ endpoint เริ่มต้นของตัวเอง ข้อมูลลับจะอยู่ในการตั้งค่าแอปบนเครื่องและ CLI ที่เลือกเท่านั้นที่เห็นค่าเหล่านี้',
   'settings.cliEnvClaudeConfigDir': 'ไดเรกทอรีการตั้งค่า Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL ของ Claude proxy',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -609,6 +609,8 @@ export const tr: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Modeller kurulu CLI\'dan yenilendi.',
   'settings.modelPickerFallbackHint': 'Yerleşik varsayılanlar gösteriliyor. CLI\'dan canlı modelleri almak için Yeniden tara\'ya tıklayın.',
   'settings.cliEnvTitle': 'Gelişmiş: proxy ve özel yollar',
+  'settings.cliEnvShortcut': 'Proxy ve özel yollar',
+  'settings.cliEnvShortcutConfigured': 'Yapılandırıldı',
   'settings.cliEnvHint': 'Seçili CLI ortamını geçersiz kılmak için bunları kullanın: API key, proxy base URL, özel home veya standart dışı binary yolları. Base URL yoksa CLI kendi varsayılan endpointini kullanır. Gizli bilgiler yerel uygulama yapılandırmasında kalır ve yalnızca seçili CLI bunları görür.',
   'settings.cliEnvClaudeConfigDir': 'Claude Code yapılandırma dizini',
   'settings.cliEnvClaudeBaseUrl': 'Claude proxy Base URL',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -609,6 +609,8 @@ export const uk: Dict = {
   'settings.modelPickerLiveCatalogOnlyHint': 'Моделі оновлено з установленого CLI.',
   'settings.modelPickerFallbackHint': 'Показано вбудовані типові значення. Натисніть Переканувати, щоб отримати актуальні моделі з CLI.',
   'settings.cliEnvTitle': 'Додатково: проксі та власні шляхи',
+  'settings.cliEnvShortcut': 'Проксі та власні шляхи',
+  'settings.cliEnvShortcutConfigured': 'Налаштовано',
   'settings.cliEnvHint': 'Використовуйте ці поля, щоб перевизначити середовище вибраної CLI: API key, proxy base URL, власні home-каталоги або нестандартні шляхи до бінарників. Без base URL CLI використовує свій endpoint за замовчуванням. Секрети залишаються в локальній конфігурації застосунку й передаються лише вибраній CLI.',
   'settings.cliEnvClaudeConfigDir': 'Каталог конфігурації Claude Code',
   'settings.cliEnvClaudeBaseUrl': 'Base URL проксі Claude',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -613,6 +613,8 @@ export const zhCN: Dict = {
   "settings.modelPickerFallbackHint":
     "正在显示内置默认值。点击“重新扫描”可从 CLI 拉取实时模型。",
   "settings.cliEnvTitle": "高级：代理与自定义路径",
+  "settings.cliEnvShortcut": "代理与自定义路径",
+  "settings.cliEnvShortcutConfigured": "已配置",
   "settings.cliEnvHint":
     "用于覆盖所选 CLI 的底层环境变量：API key、代理 base URL、自定义 home 或非标准可执行文件路径。不填 base URL 时，CLI 会使用自己的默认接口地址。密钥只保存在本地应用配置中，并且只传给所选 CLI。",
   "settings.cliEnvClaudeConfigDir": "Claude Code 配置目录",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -614,6 +614,8 @@ export const zhTW: Dict = {
   "settings.modelPickerFallbackHint":
     "正在顯示內建預設值。點擊「重新掃描」可從 CLI 拉取即時模型。",
   "settings.cliEnvTitle": "進階：代理與自訂路徑",
+  "settings.cliEnvShortcut": "代理與自訂路徑",
+  "settings.cliEnvShortcutConfigured": "已設定",
   "settings.cliEnvHint":
     "用於覆蓋所選 CLI 的底層環境變數：API key、代理 base URL、自訂 home 或非標準可執行檔路徑。不填 base URL 時，CLI 會使用自己的預設端點。密鑰只保存在本機應用設定中，且只傳給所選 CLI。",
   "settings.cliEnvClaudeConfigDir": "Claude Code 設定目錄",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -569,6 +569,8 @@ export interface Dict {
   'settings.modelPickerLiveCatalogOnlyHint': string;
   'settings.modelPickerFallbackHint': string;
   'settings.cliEnvTitle': string;
+  'settings.cliEnvShortcut': string;
+  'settings.cliEnvShortcutConfigured': string;
   'settings.cliEnvHint': string;
   'settings.cliEnvClaudeConfigDir': string;
   'settings.cliEnvClaudeBaseUrl': string;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -2011,6 +2011,63 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
   line-height: 1;
   white-space: nowrap;
 }
+/* Shortcut into the per-agent "Advanced: proxy & custom paths" disclosure,
+   shown on every installed agent card that declares CLI env fields.
+
+   Deliberately NOT a second pill. The card's action row already owns one
+   affordance (.agent-card-test-btn), and Test performs work while this only
+   navigates; giving them equal weight would read as two peer actions and blunt
+   Test. So this renders as quiet inline text — no fill, no border — that sits
+   to Test's left and recedes until hovered.
+
+   It stays a real <button> (the shared ghost primitive) rather than an <a>:
+   there is no href, it drives an in-page disclosure, and keeping button
+   semantics is what makes keyboard / AT activation work. Scoping under
+   .agent-card-installed (0-2-0) outranks the primitive's own .button module
+   class (0-1-0), whose height/padding would otherwise fight this rule
+   depending on stylesheet injection order. */
+.agent-card-installed .agent-card-cli-env-link {
+  align-self: center;
+  flex-shrink: 0;
+  gap: 3px;
+  /* 8px here + .agent-card-test-btn's 4px left margin = a 12px gutter, enough
+     that the quiet link reads as separate from the Test button rather than as
+     its label. */
+  margin: 0 8px 0 0;
+  padding: 0 4px;
+  height: auto;
+  min-width: auto;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+.agent-card-installed .agent-card-cli-env-link:hover:not(:disabled) {
+  background: none;
+  color: var(--accent-strong);
+}
+/* Underline the label only. The label and the chevron are separate flex items,
+   so a decoration on the control itself paints two segments with the flex gap
+   unpainted between them, which reads as a broken rule rather than a link. */
+.agent-card-installed
+  .agent-card-cli-env-link:hover:not(:disabled)
+  .agent-card-cli-env-link__label {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+/* Configured: something in the panel is set, so the link carries a little more
+   weight. --accent is #353535, a neutral, so in this monochrome palette the
+   signal has to be text darkness rather than hue. */
+.agent-card-installed .agent-card-cli-env-link--configured {
+  color: var(--accent);
+  font-weight: 600;
+}
+.agent-card-cli-env-link__chevron {
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.75;
+}
 .agent-card-name-divider,
 .agent-card-tagline {
   color: var(--text-muted);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -2737,6 +2737,290 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     ]);
   });
 
+  /*
+    The CLI env shortcut is the discovery path into "Advanced: proxy & custom
+    paths". Two properties are load-bearing and each has a guard below:
+
+    1. It does NOT depend on already having a custom endpoint. Gating it on
+       "configured" made it invisible to the only people who needed it.
+    2. It is NOT Claude-specific. Claude and Codex both declare base-URL, auth
+       and custom-path fields in AGENT_CLI_ENV_FIELDS, so both get the shortcut;
+       visibility is derived from that table rather than an agent id.
+  */
+  it('offers the CLI env shortcut on the active Claude Code card before anything is configured', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'claude' },
+      { agents: [claudeAgent] },
+    );
+
+    const link = screen.getByTestId('settings-cli-env-shortcut-claude');
+    expect(link).toHaveTextContent(en['settings.cliEnvShortcut']);
+    expect(link.getAttribute('data-configured')).toBe('false');
+    expect(link.className).not.toContain('agent-card-cli-env-link--configured');
+  });
+
+  it('offers the same CLI env shortcut on the active Codex card', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      { agents: [availableAgents[0]!] },
+    );
+
+    // Regression guard for the agent special-case: Codex is structurally
+    // identical to Claude here, so singling one out is a design-language bug.
+    expect(
+      screen.getByTestId('settings-cli-env-shortcut-codex'),
+    ).toHaveTextContent(en['settings.cliEnvShortcut']);
+  });
+
+  it('marks the shortcut configured once a Claude base URL is stored', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'claude',
+        agentCliEnv: {
+          claude: { ANTHROPIC_BASE_URL: 'https://proxy.example.com' },
+        },
+      },
+      { agents: [claudeAgent] },
+    );
+
+    const link = screen.getByTestId('settings-cli-env-shortcut-claude');
+    expect(link.getAttribute('data-configured')).toBe('true');
+    expect(link.className).toContain('agent-card-cli-env-link--configured');
+    // Sighted users get the heavier text; AT users get the state in words.
+    expect(link).toHaveTextContent(en['settings.cliEnvShortcutConfigured']);
+  });
+
+  it('marks the shortcut configured from a Codex base URL', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'codex',
+        agentCliEnv: { codex: { OPENAI_BASE_URL: 'https://proxy.example.com/v1' } },
+      },
+      { agents: [availableAgents[0]!] },
+    );
+
+    expect(
+      screen
+        .getByTestId('settings-cli-env-shortcut-codex')
+        .getAttribute('data-configured'),
+    ).toBe('true');
+  });
+
+  it('counts auth keys the Advanced panel does not itself expose', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'claude',
+        // ANTHROPIC_AUTH_TOKEN has no field in AGENT_CLI_ENV_FIELDS but the
+        // daemon accepts it (AGENT_CLI_AUTH_ENV_KEYS) and `od` can write it, so
+        // the shortcut reads stored keys rather than the known field list.
+        agentCliEnv: { claude: { ANTHROPIC_AUTH_TOKEN: 'tok-test' } },
+      },
+      { agents: [claudeAgent] },
+    );
+
+    expect(
+      screen
+        .getByTestId('settings-cli-env-shortcut-claude')
+        .getAttribute('data-configured'),
+    ).toBe('true');
+  });
+
+  it('treats an empty stored value as not configured', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'claude',
+        agentCliEnv: { claude: { ANTHROPIC_BASE_URL: '' } },
+      },
+      { agents: [claudeAgent] },
+    );
+
+    expect(
+      screen
+        .getByTestId('settings-cli-env-shortcut-claude')
+        .getAttribute('data-configured'),
+    ).toBe('false');
+  });
+
+  it('does not render the CLI env shortcut on a card that is not the active agent', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'codex',
+        agentCliEnv: {
+          claude: { ANTHROPIC_BASE_URL: 'https://proxy.example.com' },
+        },
+      },
+      { agents: [availableAgents[0]!, claudeAgent] },
+    );
+
+    expect(
+      screen.queryByTestId('settings-cli-env-shortcut-claude'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId('settings-cli-env-shortcut-codex'),
+    ).toBeTruthy();
+  });
+
+  it('expands and scrolls to the Advanced CLI env panel when the shortcut is clicked', async () => {
+    const scrollIntoViewMock = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {});
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'claude' },
+      { agents: [claudeAgent] },
+    );
+
+    const details = screen.getByTestId('settings-cli-env') as HTMLDetailsElement;
+    expect(details.open).toBe(false);
+
+    fireEvent.click(
+      screen.getByTestId('settings-cli-env-shortcut-claude'),
+    );
+
+    expect(details.open).toBe(true);
+    await waitFor(() =>
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({
+        block: 'nearest',
+        behavior: 'smooth',
+      }),
+    );
+
+    scrollIntoViewMock.mockRestore();
+  });
+
+  /*
+    Keyboard activation (Enter / Space) is native <button> behaviour the browser
+    supplies; jsdom does not synthesise a click from a dispatched keydown, so
+    asserting on fireEvent.keyDown would only describe jsdom's gaps. The
+    reviewable invariant is the one that earned the original fixup: the shortcut
+    must stay a real, focusable, non-nested <button> — that is what makes
+    keyboard and AT activation work at all.
+  */
+  it('renders the CLI env shortcut as a real focusable button outside the card-select control', () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.196',
+      models: [{ id: 'default', label: 'Default' }],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 })),
+    );
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'claude' },
+      { agents: [claudeAgent] },
+    );
+
+    const link = screen.getByTestId('settings-cli-env-shortcut-claude');
+
+    expect(link.tagName).toBe('BUTTON');
+    // type=button keeps it inert if the dialog is ever wrapped in a form.
+    expect(link.getAttribute('type')).toBe('button');
+    // Never a descendant of the card-selection button: nested interactive
+    // controls are invalid markup and break AT activation.
+    expect(link.closest('.agent-card-select')).toBeNull();
+
+    link.focus();
+    expect(document.activeElement).toBe(link);
+  });
+
+
   it('lets users switch to Local CLI, select an installed agent, and autosave', async () => {
     const installed = availableAgents[0]!;
     const unavailable: AgentInfo = {


### PR DESCRIPTION
Add a 'Custom endpoint' pill to the active Claude Code card in Settings → Execution → Local CLI when ANTHROPIC_BASE_URL or ANTHROPIC_API_KEY is configured. Clicking the badge expands the existing 'Advanced: proxy & custom paths' disclosure and scrolls it into view, making third-party proxy / BYOK setup discoverable.

- Add agentCliEnvDetailsRef and badge click handler in SettingsDialog
- Add .agent-card-benefit--clickable hover style
- Add settings.claudeCustomEndpointBadge i18n key (19 locales)
- Add 5 unit tests covering visibility, agent scoping, and expand/scroll

<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots
before
<img width="1281" height="902" alt="Screenshot 2026-08-28 at 01 09 21" src="https://github.com/user-attachments/assets/a019a4f6-b266-4ed0-8154-d7f15c093eb4" />
<img width="1281" height="898" alt="Screenshot 2026-08-28 at 01 09 45" src="https://github.com/user-attachments/assets/7a249bff-22cf-4155-8491-926ae27351cb" />

after
<img width="1283" height="902" alt="Screenshot 2026-08-28 at 01 10 25" src="https://github.com/user-attachments/assets/58fa88e7-e094-4717-b425-8a37553354ef" />
<img width="1281" height="901" alt="Screenshot 2026-08-28 at 01 10 39" src="https://github.com/user-attachments/assets/083d163b-dc39-4c43-a3c6-f52397baf3b7" />


<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
