### PR TITLE
fix(web): bound and scrub resource error telemetry

### DIFF
--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -208,10 +208,14 @@ function captureException(
 export function reportSafetyEvent(
   eventName: string,
   properties: Record<string, unknown> = {},
+  options: { currentUrlOverride?: string } = {},
 ): void {
   const merged: Record<string, unknown> = {
     ...properties,
-    $current_url: scrubUrl(typeof window !== 'undefined' ? window.location.href : ''),
+    $current_url: scrubUrl(
+      options.currentUrlOverride
+        ?? (typeof window !== 'undefined' ? window.location.href : ''),
+    ),
     $insert_id: randomId(),
     capture_source: 'web/error-tracking',
   };

--- a/apps/web/src/observability/resource-error.ts
+++ b/apps/web/src/observability/resource-error.ts
@@ -156,7 +156,7 @@ export function installResourceErrorObserver(): () => void {
       defer_attr: target.getAttribute('defer') != null ? true : false,
       crossorigin_mode: normalizeCrossorigin(target.getAttribute('crossorigin')),
     };
-    const key = `${tag}\0${resource.normalized_resource}`;
+    const key = resourceWindowKey(src, tag);
     const entry = windows.get(key);
     if (entry) {
       entry.repeatCount += 1;
@@ -175,7 +175,7 @@ export function installResourceErrorObserver(): () => void {
     if (src == null) return;
     const tag = target.tagName.toLowerCase();
     const resource = normalizeResource(src, tag);
-    const key = `${tag}\0${resource.normalized_resource}`;
+    const key = resourceWindowKey(src, tag);
     const entry = windows.get(key);
     if (entry) closeWindow(key, entry);
   };
@@ -220,7 +220,7 @@ function normalizeResource(rawUrl: string, tag: string): NormalizedResource {
 
   const type = resourceType(tag);
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return privateResource(parsed.protocol.replace(':', '') || 'opaque', tag);
+    return privateResource('opaque', tag);
   }
   const extension = resourceExtension(parsed.pathname);
 
@@ -251,7 +251,8 @@ function normalizeResource(rawUrl: string, tag: string): NormalizedResource {
   if (productRoute) {
     return {
       category: 'product_asset',
-      normalized_resource: parsed.pathname,
+      normalized_resource:
+        `${productRoute}:${type}${extension ? `.${extension}` : ''}`,
       origin_relation: 'same_origin',
       resource_extension: extension,
       resource_route: productRoute,
@@ -268,6 +269,21 @@ function normalizeResource(rawUrl: string, tag: string): NormalizedResource {
     resource_route: route,
     resource_type: type,
   };
+}
+
+// This identity never leaves the browser. Keep it separate from the scrubbed,
+// low-cardinality telemetry value so distinct private resources do not share a
+// retry/recovery window merely because they have the same route template.
+function resourceWindowKey(rawUrl: string, tag: string): string {
+  try {
+    const parsed = new URL(rawUrl, window.location.href);
+    const identity = parsed.origin === 'null'
+      ? parsed.href
+      : `${parsed.origin}${parsed.pathname}`;
+    return `${tag}\0${identity}`;
+  } catch {
+    return `${tag}\0${rawUrl}`;
+  }
 }
 
 function privateResource(
@@ -287,10 +303,10 @@ function privateResource(
 
 function safeNextChunkId(pathname: string): string {
   const basename = pathname.split('/').at(-1) ?? '';
-  if (basename.length > 120 || !/^[A-Za-z0-9._%+-]+\.(?:js|css)$/i.test(basename)) {
-    return 'unknown';
-  }
-  return basename;
+  if (basename.length > 120) return 'unknown';
+  const match = basename.match(/(?:^|-)([a-f0-9]{6,64})\.(js|css)$/i);
+  if (!match?.[1] || !match[2]) return 'unknown';
+  return `${match[1].toLowerCase()}.${match[2].toLowerCase()}`;
 }
 
 function productAssetRoute(pathname: string): string | null {

--- a/apps/web/src/observability/resource-error.ts
+++ b/apps/web/src/observability/resource-error.ts
@@ -8,10 +8,12 @@
 // want to know about: a missing `_next/static/chunks/xxx.js` results in
 // a non-functional app with no JS exception.
 //
-// Each event includes the failed tag + its URL. The URL is left alone
-// here — the runtime-side scrub pipeline does not redact static-asset
-// URLs, but since these are our own host-served chunks they don't leak
-// anything sensitive.
+// Resource URLs are not assumed to be product-owned. Project files, generated
+// artifacts, third-party media, signed query strings, and even credentials can
+// all reach a resource-bearing DOM attribute. This observer therefore owns a
+// strict allowlist boundary: only known product paths and Next.js chunk paths
+// retain a path; every user/external resource is reduced to a route template,
+// tag-derived type, extension, and origin relation.
 
 import { reportSafetyEvent } from '../analytics/error-tracking';
 
@@ -26,6 +28,72 @@ const RESOURCE_TAGS = new Set([
   'TRACK',
 ]);
 
+const RESOURCE_ERROR_WINDOW_MS = 60_000;
+const MAX_TRACKED_RESOURCES = 128;
+
+const PRODUCT_ASSET_ROOTS = new Set([
+  'agent-icons',
+  'community-templates',
+  'editor-icons',
+  'fonts',
+  'go-plan',
+  'mock-covers',
+  'model-icons',
+  'onboarding',
+  'team-avatars',
+  'upgrade',
+]);
+
+const PRODUCT_ROOT_FILES = new Set([
+  'app-icon.png',
+  'app-icon.svg',
+  'avatar.png',
+  'brand-icon.svg',
+  'composer-matrix-loader.svg',
+  'composer-send.mp4',
+  'drafts-empty-mark.png',
+  'logo-03.svg',
+  'logo-mark.svg',
+  'logo-scan.svg',
+  'logo-tiles.svg',
+  'logo.png',
+  'logo.svg',
+  'od-notifications-sw.js',
+  'official_badge.svg',
+  'remixicon.ttf',
+  'remixicon.woff2',
+  'startup-animation.webm',
+]);
+
+const SAFE_RESOURCE_EXTENSIONS = new Set([
+  'aac', 'avif', 'bmp', 'cjs', 'css', 'csv', 'eot', 'flac', 'gif', 'htm',
+  'html', 'ico', 'jpeg', 'jpg', 'js', 'json', 'm4a', 'm4v', 'md', 'mjs',
+  'mov', 'mp3', 'mp4', 'ogg', 'otf', 'pdf', 'png', 'srt', 'svg', 'tsv',
+  'ttf', 'txt', 'vtt', 'wav', 'webm', 'webp', 'woff', 'woff2', 'xml', 'yaml',
+  'yml', 'zip',
+]);
+
+type ResourceCategory =
+  | 'next_chunk'
+  | 'product_asset'
+  | 'user_artifact'
+  | 'external_media';
+
+interface NormalizedResource {
+  category: ResourceCategory;
+  normalized_resource: string;
+  origin_relation: 'same_origin' | 'cross_origin' | 'opaque';
+  resource_extension: string;
+  resource_route: string;
+  resource_type: string;
+}
+
+interface ResourceWindow {
+  properties: Record<string, unknown>;
+  repeatCount: number;
+  timer: number;
+}
+
 let installed = false;
 
 export function installResourceErrorObserver(): () => void {
@@ -33,30 +101,286 @@ export function installResourceErrorObserver(): () => void {
   if (typeof window === 'undefined') return () => undefined;
   installed = true;
 
+  const windows = new Map<string, ResourceWindow>();
+
+  const closeWindow = (key: string, entry: ResourceWindow): void => {
+    if (windows.get(key) !== entry) return;
+    windows.delete(key);
+    window.clearTimeout(entry.timer);
+    if (entry.repeatCount === 0) return;
+    reportResourceEvent(entry.properties, 'repeat_summary', entry.repeatCount);
+  };
+
+  const flushWindows = (): void => {
+    for (const [key, entry] of [...windows]) closeWindow(key, entry);
+  };
+
+  const startWindow = (
+    key: string,
+    properties: Record<string, unknown>,
+  ): void => {
+    if (windows.size >= MAX_TRACKED_RESOURCES) {
+      const oldestKey = windows.keys().next().value as string | undefined;
+      if (oldestKey != null) {
+        const oldest = windows.get(oldestKey);
+        if (oldest) closeWindow(oldestKey, oldest);
+      }
+    }
+
+    const entry: ResourceWindow = {
+      properties,
+      repeatCount: 0,
+      timer: 0,
+    };
+    entry.timer = window.setTimeout(() => {
+      closeWindow(key, entry);
+    }, RESOURCE_ERROR_WINDOW_MS);
+    windows.set(key, entry);
+    reportResourceEvent(properties, 'first', 0);
+  };
+
   const listener = (event: Event): void => {
     const target = event.target;
     if (!(target instanceof Element)) return;
     if (!RESOURCE_TAGS.has(target.tagName)) return;
     const src = readSrc(target);
     if (src == null) return;
-    reportSafetyEvent('client_resource_error', {
-      tag: target.tagName.toLowerCase(),
+    const tag = target.tagName.toLowerCase();
+    const resource = normalizeResource(src, tag);
+    const properties: Record<string, unknown> = {
+      ...resource,
+      tag,
       // crossorigin / async / defer are useful signals for diagnosing
       // chunk-load problems that depend on CDN cache + SW interaction.
       async_attr: target.getAttribute('async') != null ? true : false,
       defer_attr: target.getAttribute('defer') != null ? true : false,
-      crossorigin: target.getAttribute('crossorigin'),
-      url: src,
-    });
+      crossorigin_mode: normalizeCrossorigin(target.getAttribute('crossorigin')),
+    };
+    const key = `${tag}\0${resource.normalized_resource}`;
+    const entry = windows.get(key);
+    if (entry) {
+      entry.repeatCount += 1;
+      return;
+    }
+    startWindow(key, properties);
+  };
+
+  // A later successful load closes the failure window. This avoids carrying a
+  // stale repeat count into a future, independent failure after recovery.
+  const loadListener = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    if (!RESOURCE_TAGS.has(target.tagName)) return;
+    const src = readSrc(target);
+    if (src == null) return;
+    const tag = target.tagName.toLowerCase();
+    const resource = normalizeResource(src, tag);
+    const key = `${tag}\0${resource.normalized_resource}`;
+    const entry = windows.get(key);
+    if (entry) closeWindow(key, entry);
   };
 
   // capture=true is required — resource error events do not bubble.
   window.addEventListener('error', listener, /*useCapture=*/ true);
+  document.addEventListener('load', loadListener, /*useCapture=*/ true);
+  window.addEventListener('pagehide', flushWindows);
 
   return () => {
     window.removeEventListener('error', listener, /*useCapture=*/ true);
+    document.removeEventListener('load', loadListener, /*useCapture=*/ true);
+    window.removeEventListener('pagehide', flushWindows);
+    flushWindows();
     installed = false;
   };
+}
+
+function reportResourceEvent(
+  properties: Record<string, unknown>,
+  eventKind: 'first' | 'repeat_summary',
+  repeatCount: number,
+): void {
+  reportSafetyEvent(
+    'client_resource_error',
+    {
+      ...properties,
+      event_kind: eventKind,
+      repeat_count: repeatCount,
+    },
+    { currentUrlOverride: safeCurrentUrl() },
+  );
+}
+
+function normalizeResource(rawUrl: string, tag: string): NormalizedResource {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl, window.location.href);
+  } catch {
+    return privateResource('invalid', tag);
+  }
+
+  const type = resourceType(tag);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return privateResource(parsed.protocol.replace(':', '') || 'opaque', tag);
+  }
+  const extension = resourceExtension(parsed.pathname);
+
+  if (parsed.origin !== window.location.origin) {
+    return {
+      category: 'external_media',
+      normalized_resource: `external:${type}${extension ? `.${extension}` : ''}`,
+      origin_relation: 'cross_origin',
+      resource_extension: extension,
+      resource_route: 'external',
+      resource_type: type,
+    };
+  }
+
+  if (parsed.pathname.startsWith('/_next/static/chunks/')) {
+    const chunkId = safeNextChunkId(parsed.pathname);
+    return {
+      category: 'next_chunk',
+      normalized_resource: `next:${chunkId}`,
+      origin_relation: 'same_origin',
+      resource_extension: extension,
+      resource_route: '/_next/static/chunks/:chunk',
+      resource_type: type,
+    };
+  }
+
+  const productRoute = productAssetRoute(parsed.pathname);
+  if (productRoute) {
+    return {
+      category: 'product_asset',
+      normalized_resource: parsed.pathname,
+      origin_relation: 'same_origin',
+      resource_extension: extension,
+      resource_route: productRoute,
+      resource_type: type,
+    };
+  }
+
+  const route = userArtifactRoute(parsed.pathname);
+  return {
+    category: 'user_artifact',
+    normalized_resource: `${route}${extension ? `.${extension}` : ''}`,
+    origin_relation: 'same_origin',
+    resource_extension: extension,
+    resource_route: route,
+    resource_type: type,
+  };
+}
+
+function privateResource(
+  route: string,
+  tag: string,
+): NormalizedResource {
+  const type = resourceType(tag);
+  return {
+    category: 'user_artifact',
+    normalized_resource: `${route}:${type}`,
+    origin_relation: 'opaque',
+    resource_extension: '',
+    resource_route: route,
+    resource_type: type,
+  };
+}
+
+function safeNextChunkId(pathname: string): string {
+  const basename = pathname.split('/').at(-1) ?? '';
+  if (basename.length > 120 || !/^[A-Za-z0-9._%+-]+\.(?:js|css)$/i.test(basename)) {
+    return 'unknown';
+  }
+  return basename;
+}
+
+function productAssetRoute(pathname: string): string | null {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] === '_next' && segments[1] === 'static') {
+    return '/_next/static/:asset';
+  }
+  if (segments.length === 1 && PRODUCT_ROOT_FILES.has(segments[0]!)) {
+    return '/:product_asset';
+  }
+  const root = segments[0];
+  return root && PRODUCT_ASSET_ROOTS.has(root) ? `/${root}/:asset` : null;
+}
+
+function userArtifactRoute(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] === 'api' && segments[1] === 'projects' && segments[2]) {
+    if (segments[3] === 'raw') return '/api/projects/:project_id/raw/:file';
+    if (segments[3] === 'files') return '/api/projects/:project_id/files/:file';
+    if (segments[3] === 'preview') return '/api/projects/:project_id/preview/:file';
+    return '/api/projects/:project_id/:resource';
+  }
+  if (segments[0] === 'api' && segments[1] === 'live-artifacts') {
+    return '/api/live-artifacts/:artifact_id/:resource';
+  }
+  if (segments[0] === 'api' && segments[1] === 'design-systems') {
+    return '/api/design-systems/:design_system_id/:resource';
+  }
+  if (segments[0] === 'api' && segments[1] === 'artifacts') {
+    return '/api/artifacts/:resource';
+  }
+  if (segments[0] === 'artifacts') return '/artifacts/:resource';
+  if (segments[0] === 'frames') return '/frames/:resource';
+  return '/same-origin/:resource';
+}
+
+function resourceExtension(pathname: string): string {
+  let basename = pathname.split('/').at(-1) ?? '';
+  try {
+    basename = decodeURIComponent(basename);
+  } catch {
+    // A malformed escape is still private; it simply has no extension.
+  }
+  const candidate = basename.match(/\.([a-z0-9]{1,10})$/i)?.[1]?.toLowerCase();
+  if (!candidate) return '';
+  return SAFE_RESOURCE_EXTENSIONS.has(candidate) ? candidate : 'other';
+}
+
+function resourceType(tag: string): string {
+  switch (tag) {
+    case 'script': return 'script';
+    case 'link': return 'style';
+    case 'img': return 'image';
+    case 'iframe': return 'frame';
+    case 'audio': return 'audio';
+    case 'video': return 'video';
+    case 'source': return 'source';
+    case 'track': return 'track';
+    default: return 'other';
+  }
+}
+
+function normalizeCrossorigin(value: string | null): string {
+  if (value == null) return 'unset';
+  const normalized = value.toLowerCase();
+  if (normalized === '' || normalized === 'anonymous') return 'anonymous';
+  if (normalized === 'use-credentials') return 'use-credentials';
+  return 'invalid';
+}
+
+function safeCurrentUrl(): string {
+  const { origin, pathname } = window.location;
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] === 'projects' && segments[1]) {
+    let route = '/projects/:project_id';
+    if (segments[2] === 'conversations' && segments[3]) {
+      route += '/conversations/:conversation_id';
+      if (segments[4] === 'files') route += '/files/:file';
+    } else if (segments[2] === 'files') {
+      route += '/files/:file';
+    }
+    return `${origin}${route}`;
+  }
+  if (segments[0] === 'design-systems' && segments[1] && segments[1] !== 'create') {
+    return `${origin}/design-systems/:design_system_id`;
+  }
+  if (segments[0] === 'collab-demo' && segments[1]) {
+    return `${origin}/collab-demo/:project_id`;
+  }
+  return origin;
 }
 
 function readSrc(el: Element): string | null {

--- a/apps/web/tests/observability/resource-error.test.ts
+++ b/apps/web/tests/observability/resource-error.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearExceptionTrackingContext,
+  setExceptionTrackingContext,
+} from '../../src/analytics/error-tracking';
+import { installResourceErrorObserver } from '../../src/observability/resource-error';
+
+const fetchMock = vi.fn();
+const ORIGINAL_FETCH = globalThis.fetch;
+
+let uninstall: (() => void) | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response('', { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  clearExceptionTrackingContext();
+  setExceptionTrackingContext({
+    apiKey: 'phc_test',
+    host: 'https://us.i.posthog.com',
+    distinctId: 'device-1',
+    sessionId: 'session-1',
+  });
+  window.history.replaceState(
+    {},
+    '',
+    '/projects/project-secret/conversations/conversation-secret/files/Customer%20Plan.pdf?auth=page-secret#slide-4',
+  );
+  uninstall = installResourceErrorObserver();
+});
+
+afterEach(() => {
+  uninstall?.();
+  uninstall = null;
+  clearExceptionTrackingContext();
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.useRealTimers();
+});
+
+function dispatchResourceError(tag: string, url: string): void {
+  const element = document.createElement(tag);
+  if (element instanceof HTMLLinkElement) {
+    element.href = url;
+    element.rel = 'stylesheet';
+  } else {
+    element.setAttribute('src', url);
+  }
+  document.body.append(element);
+  element.dispatchEvent(new Event('error'));
+  element.remove();
+}
+
+function fetchedProperties(index: number): Record<string, unknown> {
+  const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
+  expect(init?.body).toEqual(expect.any(String));
+  const body = JSON.parse(init!.body as string) as {
+    properties: Record<string, unknown>;
+  };
+  return body.properties;
+}
+
+describe('resource error privacy and volume boundary', () => {
+  it('classifies resources without sending user paths, URL secrets, or external locations', () => {
+    const origin = window.location.origin;
+    const cases = [
+      {
+        tag: 'script',
+        url: `${origin}/_next/static/chunks/app/projects/%5Bid%5D/page-a1b2c3.js?build=chunk-secret#runtime`,
+        expected: {
+          category: 'next_chunk',
+          resource_route: '/_next/static/chunks/:chunk',
+          normalized_resource: 'next:page-a1b2c3.js',
+          resource_type: 'script',
+          resource_extension: 'js',
+          origin_relation: 'same_origin',
+        },
+      },
+      {
+        tag: 'link',
+        url: `${origin}/fonts/remixicon.woff2?v=font-secret#font`,
+        expected: {
+          category: 'product_asset',
+          resource_route: '/fonts/:asset',
+          normalized_resource: '/fonts/remixicon.woff2',
+          resource_type: 'style',
+          resource_extension: 'woff2',
+          origin_relation: 'same_origin',
+        },
+      },
+      {
+        tag: 'iframe',
+        url: `${origin}/api/projects/prj-private-123/raw/Finance/Customer%20Board.pdf?downloadToken=file-secret#page=9`,
+        expected: {
+          category: 'user_artifact',
+          resource_route: '/api/projects/:project_id/raw/:file',
+          normalized_resource: '/api/projects/:project_id/raw/:file.pdf',
+          resource_type: 'frame',
+          resource_extension: 'pdf',
+          origin_relation: 'same_origin',
+        },
+      },
+      {
+        tag: 'video',
+        url: 'https://viewer:password@media.customer.example/private/Alice%20Interview.mp4?X-Amz-Credential=external-secret#clip',
+        expected: {
+          category: 'external_media',
+          resource_route: 'external',
+          normalized_resource: 'external:video.mp4',
+          resource_type: 'video',
+          resource_extension: 'mp4',
+          origin_relation: 'cross_origin',
+        },
+      },
+    ] as const;
+
+    for (const item of cases) dispatchResourceError(item.tag, item.url);
+
+    expect(fetchMock).toHaveBeenCalledTimes(cases.length);
+    for (const [index, item] of cases.entries()) {
+      expect(fetchedProperties(index)).toMatchObject({
+        ...item.expected,
+        tag: item.tag,
+        event_kind: 'first',
+        repeat_count: 0,
+        $current_url: `${origin}/projects/:project_id/conversations/:conversation_id/files/:file`,
+      });
+    }
+
+    const serialized = fetchMock.mock.calls
+      .map((call) => String((call[1] as RequestInit).body))
+      .join('\n');
+    for (const secret of [
+      'project-secret',
+      'conversation-secret',
+      'Customer%20Plan.pdf',
+      'prj-private-123',
+      'Customer%20Board.pdf',
+      'chunk-secret',
+      'font-secret',
+      'file-secret',
+      'Alice%20Interview.mp4',
+      'external-secret',
+      'viewer:password',
+      'media.customer.example',
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('emits one immediate event and one bounded repeat summary per resource window', () => {
+    const resource =
+      `${window.location.origin}/api/projects/private-project/raw/Private%20deck.pdf?token=private-token`;
+
+    for (let count = 0; count < 5; count += 1) {
+      dispatchResourceError('iframe', resource);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchedProperties(0)).toMatchObject({
+      category: 'user_artifact',
+      event_kind: 'first',
+      repeat_count: 0,
+    });
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchedProperties(1)).toMatchObject({
+      category: 'user_artifact',
+      event_kind: 'repeat_summary',
+      repeat_count: 4,
+    });
+    expect(JSON.stringify(fetchedProperties(1))).not.toContain('private-project');
+    expect(JSON.stringify(fetchedProperties(1))).not.toContain('Private%20deck.pdf');
+    expect(JSON.stringify(fetchedProperties(1))).not.toContain('private-token');
+  });
+
+  it('closes a repeat window once the resource loads and starts fresh after recovery', () => {
+    const resource = document.createElement('img');
+    resource.src = `${window.location.origin}/api/projects/private/raw/Recovered%20image.png?token=secret`;
+    document.body.append(resource);
+
+    resource.dispatchEvent(new Event('error'));
+    resource.dispatchEvent(new Event('error'));
+    resource.dispatchEvent(new Event('load'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchedProperties(1)).toMatchObject({
+      event_kind: 'repeat_summary',
+      repeat_count: 1,
+    });
+
+    resource.dispatchEvent(new Event('error'));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchedProperties(2)).toMatchObject({
+      event_kind: 'first',
+      repeat_count: 0,
+    });
+    resource.remove();
+  });
+
+  it('flushes the repeat count when the page session ends before the window expires', () => {
+    const resource =
+      `${window.location.origin}/api/projects/private/raw/Leaving%20page.pdf?token=secret`;
+    dispatchResourceError('iframe', resource);
+    dispatchResourceError('iframe', resource);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchedProperties(1)).toMatchObject({
+      event_kind: 'repeat_summary',
+      repeat_count: 1,
+    });
+  });
+
+  it('bounds tracked resource windows and allows an evicted chunk to report again', () => {
+    const origin = window.location.origin;
+    for (let index = 0; index < 129; index += 1) {
+      dispatchResourceError(
+        'script',
+        `${origin}/_next/static/chunks/chunk-${index}.js`,
+      );
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(129);
+
+    dispatchResourceError('script', `${origin}/_next/static/chunks/chunk-0.js`);
+    expect(fetchMock).toHaveBeenCalledTimes(130);
+    expect(fetchedProperties(129)).toMatchObject({
+      category: 'next_chunk',
+      normalized_resource: 'next:chunk-0.js',
+      event_kind: 'first',
+    });
+  });
+});

--- a/apps/web/tests/observability/resource-error.test.ts
+++ b/apps/web/tests/observability/resource-error.test.ts
@@ -73,7 +73,7 @@ describe('resource error privacy and volume boundary', () => {
         expected: {
           category: 'next_chunk',
           resource_route: '/_next/static/chunks/:chunk',
-          normalized_resource: 'next:page-a1b2c3.js',
+          normalized_resource: 'next:a1b2c3.js',
           resource_type: 'script',
           resource_extension: 'js',
           origin_relation: 'same_origin',
@@ -85,7 +85,7 @@ describe('resource error privacy and volume boundary', () => {
         expected: {
           category: 'product_asset',
           resource_route: '/fonts/:asset',
-          normalized_resource: '/fonts/remixicon.woff2',
+          normalized_resource: '/fonts/:asset:style.woff2',
           resource_type: 'style',
           resource_extension: 'woff2',
           origin_relation: 'same_origin',
@@ -151,6 +151,48 @@ describe('resource error privacy and volume boundary', () => {
     }
   });
 
+  it('does not serialize private names hidden by product prefixes or custom schemes', () => {
+    const productLookingPrivateUrl =
+      `${window.location.origin}/fonts/Customer%20Contract.pdf`;
+    const customSchemeUrl = 'customer-project-123:payload';
+
+    dispatchResourceError('link', productLookingPrivateUrl);
+    dispatchResourceError('img', customSchemeUrl);
+
+    expect(fetchedProperties(0)).toMatchObject({
+      category: 'product_asset',
+      resource_route: '/fonts/:asset',
+      resource_extension: 'pdf',
+    });
+    expect(fetchedProperties(1)).toMatchObject({
+      category: 'user_artifact',
+      resource_route: 'opaque',
+      normalized_resource: 'opaque:image',
+    });
+
+    const serialized = fetchMock.mock.calls
+      .map((call) => String((call[1] as RequestInit).body))
+      .join('\n');
+    expect(serialized).not.toContain('Customer%20Contract.pdf');
+    expect(serialized).not.toContain('customer-project-123');
+    expect(serialized).not.toContain('payload');
+  });
+
+  it('retains only a restrictive bundler identifier from chunk filenames', () => {
+    dispatchResourceError(
+      'script',
+      `${window.location.origin}/_next/static/chunks/Customer%20Contract-a1b2c3.js`,
+    );
+
+    expect(fetchedProperties(0)).toMatchObject({
+      category: 'next_chunk',
+      normalized_resource: 'next:a1b2c3.js',
+      resource_route: '/_next/static/chunks/:chunk',
+    });
+    expect(JSON.stringify(fetchedProperties(0))).not.toContain('Customer');
+    expect(JSON.stringify(fetchedProperties(0))).not.toContain('Contract');
+  });
+
   it('emits one immediate event and one bounded repeat summary per resource window', () => {
     const resource =
       `${window.location.origin}/api/projects/private-project/raw/Private%20deck.pdf?token=private-token`;
@@ -203,6 +245,41 @@ describe('resource error privacy and volume boundary', () => {
     resource.remove();
   });
 
+  it('tracks private resources independently when their telemetry classifications collide', () => {
+    const first = document.createElement('iframe');
+    first.src = `${window.location.origin}/api/projects/private/raw/First%20deck.pdf`;
+    const second = document.createElement('iframe');
+    second.src = `${window.location.origin}/api/projects/private/raw/Second%20deck.pdf`;
+    document.body.append(first, second);
+
+    first.dispatchEvent(new Event('error'));
+    first.dispatchEvent(new Event('error'));
+    second.dispatchEvent(new Event('error'));
+    second.dispatchEvent(new Event('error'));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchedProperties(0).normalized_resource).toBe(
+      fetchedProperties(1).normalized_resource,
+    );
+
+    first.dispatchEvent(new Event('load'));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchedProperties(2)).toMatchObject({
+      event_kind: 'repeat_summary',
+      repeat_count: 1,
+    });
+
+    vi.advanceTimersByTime(60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchedProperties(3)).toMatchObject({
+      event_kind: 'repeat_summary',
+      repeat_count: 1,
+    });
+
+    first.remove();
+    second.remove();
+  });
+
   it('flushes the repeat count when the page session ends before the window expires', () => {
     const resource =
       `${window.location.origin}/api/projects/private/raw/Leaving%20page.pdf?token=secret`;
@@ -222,18 +299,22 @@ describe('resource error privacy and volume boundary', () => {
   it('bounds tracked resource windows and allows an evicted chunk to report again', () => {
     const origin = window.location.origin;
     for (let index = 0; index < 129; index += 1) {
+      const chunkId = index.toString(16).padStart(6, '0');
       dispatchResourceError(
         'script',
-        `${origin}/_next/static/chunks/chunk-${index}.js`,
+        `${origin}/_next/static/chunks/chunk-${chunkId}.js`,
       );
     }
     expect(fetchMock).toHaveBeenCalledTimes(129);
 
-    dispatchResourceError('script', `${origin}/_next/static/chunks/chunk-0.js`);
+    dispatchResourceError(
+      'script',
+      `${origin}/_next/static/chunks/chunk-000000.js`,
+    );
     expect(fetchMock).toHaveBeenCalledTimes(130);
     expect(fetchedProperties(129)).toMatchObject({
       category: 'next_chunk',
-      normalized_resource: 'next:chunk-0.js',
+      normalized_resource: 'next:000000.js',
       event_kind: 'first',
     });
   });


### PR DESCRIPTION
## Why

Production stability reporting on 2026-08-25 UTC showed one device emitting 16,839 `client_resource_error` events from a project PDF path. The existing observer sent each failed DOM resource's full URL through the direct safety transport, so project IDs, user filenames, query strings, and external media locations could reach PostHog. The same window still contained real `_next/static/chunks` failures across roughly 60–70 devices, so dropping or globally sampling the event would erase an important cross-device reliability signal.

This PR makes resource-error telemetry privacy-safe and volume-bounded while preserving an immediate per-device signal for real Next.js chunk failures. It also makes repeated counts explicit so stability analysis can distinguish affected devices/resources from one resource retrying thousands of times.

## What users will see

There is no visual UI change. Resource failures continue to produce safety diagnostics, but user and third-party resource URLs are reduced to low-sensitivity classifications and route templates. A repeatedly failing image, PDF, iframe, or media element no longer floods reliability telemetry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — safety telemetry now classifies, scrubs, and window-aggregates resource errors by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes the browser safety-telemetry pipeline and has no UI entry point.

## Bug fix verification

- Regression test: `apps/web/tests/observability/resource-error.test.ts`
- Red on `main`:
  - privacy/classification assertions received the raw project, conversation, and file route in `$current_url`, with no safe resource classification;
  - five errors for the same project resource produced five ingest requests instead of one immediate event;
  - `pagehide` did not flush the pending repeat count.
- Green on this branch:
  - `next_chunk`, `product_asset`, `user_artifact`, and `external_media` payloads contain only their allowed fields;
  - project IDs, filenames, query/fragment data, credentials, and external hosts/paths are absent from serialized payloads;
  - the first event is immediate and later occurrences become an exact `repeat_summary` after 60 seconds, successful load, `pagehide`, teardown, or bounded-map eviction;
  - tracking state is capped at 128 resource keys, while each device retains its own first-event signal.

## Validation

- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/observability/resource-error.test.ts tests/analytics/error-tracking.test.ts tests/analytics-scrub.test.ts tests/observability/iframe-error.test.ts` — 50 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
- Full `pnpm --filter @open-design/web test` was started but not counted as validation: it was manually interrupted after about nine minutes without a terminal summary while emitting existing jsdom canvas/navigation warnings. The focused web/analytics suites above completed cleanly.
- Local runtime was Node 24.16.0; the workspace warned that its exact target is Node 24.18.0.
