### PR TITLE
fix(media): preserve bound Workspace billing scope

### DIFF
--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -136,7 +136,7 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       : null;
   const { orbitService } = ctx.orbit;
   const { openBrowser, openNativeFolderDialog } = ctx.nativeDialogs;
-  const { findTeamWorkspaceIdForProject, getProject } = ctx.projectStore;
+  const { getWorkspaceProjectByProjectId, getProject } = ctx.projectStore;
   const { resolveProjectDir } = ctx.projectFiles;
   const { insertConversation, upsertMessage } = ctx.conversations;
   const { searchResearch, ResearchError } = ctx.research;
@@ -256,7 +256,12 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
       });
       task.status = 'running';
       persistMediaTask(task);
-      const workspaceId = findTeamWorkspaceIdForProject(db, projectId) ?? undefined;
+      // Media billing follows the project's Workspace binding, not its sharing
+      // visibility. A private project inside a team Workspace must still spend
+      // that Workspace's balance; `findTeamWorkspaceIdForProject` deliberately
+      // answers the narrower collaboration question and excludes it.
+      const workspaceId =
+        getWorkspaceProjectByProjectId(db, projectId)?.workspaceId?.trim() || undefined;
       generateMedia({
         projectRoot: PROJECT_ROOT,
         projectsRoot: PROJECTS_DIR,

--- a/apps/daemon/tests/media/vela-workspace-routes.test.ts
+++ b/apps/daemon/tests/media/vela-workspace-routes.test.ts
@@ -37,7 +37,7 @@ function task(id: string, projectId: string) {
 
 async function startRouteServer(options: {
   generateMedia: ReturnType<typeof vi.fn>;
-  teamWorkspaceId: string | null;
+  workspaceBinding: { workspaceId: string; visibility: 'personal' | 'team' } | null;
 }) {
   const toolGrant = {
     token: 'tool-token',
@@ -88,7 +88,7 @@ async function startRouteServer(options: {
     nativeDialogs: functionProxy(),
     projectStore: functionProxy({
       getProject: (_db: unknown, projectId: string) => ({ id: projectId }),
-      findTeamWorkspaceIdForProject: () => options.teamWorkspaceId,
+      getWorkspaceProjectByProjectId: () => options.workspaceBinding,
     }),
     projectFiles: functionProxy(),
     conversations: functionProxy(),
@@ -108,7 +108,11 @@ async function startRouteServer(options: {
   return `http://127.0.0.1:${address.port}`;
 }
 
-async function postGenerate(url: string, route: string) {
+async function postGenerate(
+  url: string,
+  route: string,
+  surface: 'image' | 'video' = 'image',
+) {
   const response = await fetch(`${url}${route}`, {
     method: 'POST',
     headers: {
@@ -116,8 +120,11 @@ async function postGenerate(url: string, route: string) {
       'content-type': 'application/json',
     },
     body: JSON.stringify({
-      surface: 'image',
-      model: 'vela/gpt-image-2',
+      surface,
+      model:
+        surface === 'image'
+          ? 'vela/gpt-image-2'
+          : 'vela/doubao-seedance-2-0-260128',
       prompt: 'test trusted workspace routing',
     }),
   });
@@ -125,13 +132,16 @@ async function postGenerate(url: string, route: string) {
 }
 
 describe('Vela media route Workspace attribution', () => {
-  it('passes the persisted team workspace through both project and tool-token routes', async () => {
+  it('uses a team Workspace binding even when the project remains personal', async () => {
     const generateMedia = vi.fn(async (_args: { workspaceId?: string }) => ({
       name: 'result.png',
     }));
     const url = await startRouteServer({
       generateMedia,
-      teamWorkspaceId: 'workspace-from-database',
+      workspaceBinding: {
+        workspaceId: 'workspace-from-database',
+        visibility: 'personal',
+      },
     });
 
     await postGenerate(url, '/api/projects/team-project/media/generate');
@@ -142,11 +152,31 @@ describe('Vela media route Workspace attribution', () => {
     expect(generateMedia.mock.calls[1]![0].workspaceId).toBe('workspace-from-database');
   });
 
-  it('does not fabricate a Vela workspace for a personal project', async () => {
+  it('uses the same Workspace binding for Vela video generation', async () => {
+    const generateMedia = vi.fn(async (_args: { workspaceId?: string }) => ({
+      name: 'result.mp4',
+    }));
+    const url = await startRouteServer({
+      generateMedia,
+      workspaceBinding: {
+        workspaceId: 'workspace-from-database',
+        visibility: 'personal',
+      },
+    });
+
+    await postGenerate(url, '/api/projects/team-project/media/generate', 'video');
+    await vi.waitFor(() => expect(generateMedia).toHaveBeenCalledOnce());
+    expect(generateMedia.mock.calls[0]![0]).toMatchObject({
+      surface: 'video',
+      workspaceId: 'workspace-from-database',
+    });
+  });
+
+  it('does not fabricate a Vela workspace for an unbound project', async () => {
     const generateMedia = vi.fn(async (_args: { workspaceId?: string }) => ({
       name: 'result.png',
     }));
-    const url = await startRouteServer({ generateMedia, teamWorkspaceId: null });
+    const url = await startRouteServer({ generateMedia, workspaceBinding: null });
 
     await postGenerate(url, '/api/projects/personal-project/media/generate');
     await vi.waitFor(() => expect(generateMedia).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Why

A team Workspace project that remains private (`visibility = personal`) lost its Workspace ID before Vela media generation. Vela then charged the personal fallback scope, which can have no balance despite the team Workspace having funds. This surfaced during prerelease image generation and also affects the shared Vela video route.

This patch keeps project visibility as an access/sharing concern and uses the project’s persisted Workspace binding for media billing.

## What users will see

Private projects inside a team Workspace can generate Vela images and videos using that team Workspace’s balance. The project remains private; no sharing state changes.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — existing Vela media calls now preserve a persisted Workspace binding regardless of project visibility
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this is daemon-side billing scope routing with no UI change.

## Bug fix verification

- Test path: `apps/daemon/tests/media/vela-workspace-routes.test.ts`
- The added private-team-Workspace image and video cases were red against the legacy `findTeamWorkspaceIdForProject` lookup (2 failures: Workspace ID was `undefined`) and green with this patch (3/3).

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/media/vela-workspace-routes.test.ts` (3/3)
- `pnpm --filter @open-design/daemon typecheck`
- `git diff --check`