### PR TITLE
feat(desktop): localize native menus in Chinese

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -56,6 +56,7 @@ import {
   desktopUpdateMenuItemKey,
   type DesktopUpdateMenuLabels,
 } from "./update-menu.js";
+import { resolveDesktopMenuLabels, type DesktopMenuLabels } from "./menu-i18n.js";
 import {
   createDesktopUpdater,
   createDesktopUpdaterScheduler,
@@ -414,6 +415,7 @@ type DesktopMenuController = {
 function installDesktopMenu(
   runtime: SidecarRuntimeContext<SidecarStamp>,
   options: Pick<DesktopMainOptions, "discoverDaemonUrl" | "discoverWebUrl"> & {
+    menuLabels: DesktopMenuLabels;
     onOpenUpdateDialog?: () => void;
     updater: DesktopUpdater;
   },
@@ -489,6 +491,7 @@ function installDesktopMenu(
   };
   let lastUpdateMenuItemKey: string | null = null;
   const rebuild = () => {
+    const menuLabels = options.menuLabels;
     const updateMenuItem = deriveDesktopUpdateMenuItem({
       labels: updateMenuLabels,
       platform: process.platform,
@@ -523,14 +526,14 @@ function installDesktopMenu(
           ]
         : [
             {
-              label: "File",
+              label: menuLabels.file,
               submenu: [
                 { role: "quit" as const },
               ],
             },
           ]),
       {
-        label: "Edit",
+        label: menuLabels.edit,
         submenu: [
           { role: "undo" },
           { role: "redo" },
@@ -542,7 +545,7 @@ function installDesktopMenu(
         ],
       },
       {
-        label: "View",
+        label: menuLabels.view,
         submenu: [
           { role: "reload" },
           { role: "forceReload" },
@@ -550,7 +553,7 @@ function installDesktopMenu(
           { type: "separator" },
           {
             accelerator: developMenuAccelerator,
-            label: developMenuVisible ? "Hide Develop Menu" : "Show Develop Menu",
+            label: developMenuVisible ? menuLabels.hideDevelopMenu : menuLabels.showDevelopMenu,
             click: toggleDevelopMenu,
           },
           { type: "separator" },
@@ -564,13 +567,13 @@ function installDesktopMenu(
       ...(developMenuVisible
         ? [
             {
-              label: "Develop",
+              label: menuLabels.develop,
               submenu: createAmrEnvironmentProfileMenuItems(lastKnownAmrProfile, selectAmrProfile),
             },
           ]
         : []),
       {
-        label: "Window",
+        label: menuLabels.window,
         submenu: [
           { role: "minimize" },
           { role: "zoom" },
@@ -580,36 +583,36 @@ function installDesktopMenu(
         ],
       },
       {
-        label: "Help",
+        label: menuLabels.help,
         role: "help",
         submenu: [
           {
-            label: "Documentation",
+            label: menuLabels.documentation,
             click() {
               void shell.openExternal("https://github.com/nexu-io/open-design#readme");
             },
           },
           { type: "separator" },
           {
-            label: "Contact Us",
+            label: menuLabels.contactUs,
             click() {
               void shell.openExternal("https://x.com/OpenDesignHQ");
             },
           },
           {
-            label: "Report Issue",
+            label: menuLabels.reportIssue,
             click() {
               void shell.openExternal("https://github.com/nexu-io/open-design/issues/new");
             },
           },
           {
-            label: "Join Discord",
+            label: menuLabels.joinDiscord,
             click() {
               void shell.openExternal("https://discord.gg/mHAjSMV6gz");
             },
           },
           { type: "separator" },
-          { label: "Export Diagnostics…", click: exportDiagnostics },
+          { label: menuLabels.exportDiagnostics, click: exportDiagnostics },
         ],
       },
     ];
@@ -962,6 +965,7 @@ export async function runDesktopMain(
 
   const menuController = installDesktopMenu(runtime, {
     ...options,
+    menuLabels: resolveDesktopMenuLabels(osLocale),
     onOpenUpdateDialog: () => {
       if (desktop == null) {
         pendingUpdateDialogRequest = true;

--- a/apps/desktop/src/main/menu-i18n.ts
+++ b/apps/desktop/src/main/menu-i18n.ts
@@ -1,0 +1,86 @@
+export type DesktopMenuLabels = {
+  contactUs: string;
+  develop: string;
+  documentation: string;
+  edit: string;
+  exportDiagnostics: string;
+  file: string;
+  help: string;
+  hideDevelopMenu: string;
+  joinDiscord: string;
+  reportIssue: string;
+  showDevelopMenu: string;
+  view: string;
+  window: string;
+};
+
+const ENGLISH_MENU_LABELS: DesktopMenuLabels = Object.freeze({
+  contactUs: "Contact Us",
+  develop: "Develop",
+  documentation: "Documentation",
+  edit: "Edit",
+  exportDiagnostics: "Export Diagnostics…",
+  file: "File",
+  help: "Help",
+  hideDevelopMenu: "Hide Develop Menu",
+  joinDiscord: "Join Discord",
+  reportIssue: "Report Issue",
+  showDevelopMenu: "Show Develop Menu",
+  view: "View",
+  window: "Window",
+});
+
+const SIMPLIFIED_CHINESE_MENU_LABELS: DesktopMenuLabels = Object.freeze({
+  contactUs: "联系我们",
+  develop: "开发",
+  documentation: "文档",
+  edit: "编辑",
+  exportDiagnostics: "导出诊断信息…",
+  file: "文件",
+  help: "帮助",
+  hideDevelopMenu: "隐藏开发菜单",
+  joinDiscord: "加入 Discord",
+  reportIssue: "报告问题",
+  showDevelopMenu: "显示开发菜单",
+  view: "查看",
+  window: "窗口",
+});
+
+const TRADITIONAL_CHINESE_MENU_LABELS: DesktopMenuLabels = Object.freeze({
+  contactUs: "聯絡我們",
+  develop: "開發",
+  documentation: "文件",
+  edit: "編輯",
+  exportDiagnostics: "匯出診斷資訊…",
+  file: "檔案",
+  help: "說明",
+  hideDevelopMenu: "隱藏開發選單",
+  joinDiscord: "加入 Discord",
+  reportIssue: "回報問題",
+  showDevelopMenu: "顯示開發選單",
+  view: "檢視",
+  window: "視窗",
+});
+
+function usesTraditionalChinese(tag: string): boolean {
+  const subtags = tag.toLowerCase().replaceAll("_", "-").split("-");
+  if (subtags.includes("hant")) return true;
+  if (subtags.includes("hans")) return false;
+  return subtags.some((subtag) => ["tw", "hk", "mo"].includes(subtag));
+}
+
+/**
+ * Resolve labels for the Electron-owned application menu from the same BCP-47
+ * OS locale that bootstraps the desktop renderer. Chinese variants get native
+ * Simplified/Traditional labels; every other locale keeps the existing English
+ * menu until it has an explicit native-menu translation.
+ */
+export function resolveDesktopMenuLabels(locale: string): DesktopMenuLabels {
+  const normalized = locale.trim();
+  if (!normalized) return ENGLISH_MENU_LABELS;
+  const language = normalized.toLowerCase().replaceAll("_", "-").split("-")[0];
+  if (language !== "zh") return ENGLISH_MENU_LABELS;
+  return usesTraditionalChinese(normalized)
+    ? TRADITIONAL_CHINESE_MENU_LABELS
+    : SIMPLIFIED_CHINESE_MENU_LABELS;
+}

--- a/apps/desktop/tests/main/menu-i18n.test.ts
+++ b/apps/desktop/tests/main/menu-i18n.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDesktopMenuLabels } from "../../src/main/menu-i18n.js";
+
+describe("desktop native menu i18n", () => {
+  it("uses Simplified Chinese for zh-CN and Hans locales", () => {
+    expect(resolveDesktopMenuLabels("zh-CN")).toMatchObject({
+      file: "文件",
+      edit: "编辑",
+      view: "查看",
+      window: "窗口",
+      help: "帮助",
+      documentation: "文档",
+      reportIssue: "报告问题",
+      exportDiagnostics: "导出诊断信息…",
+    });
+    expect(resolveDesktopMenuLabels("zh-Hans-CN").showDevelopMenu).toBe("显示开发菜单");
+    expect(resolveDesktopMenuLabels("zh_CN").contactUs).toBe("联系我们");
+  });
+
+  it("uses Traditional Chinese for Hant, Taiwan, Hong Kong, and Macao", () => {
+    for (const locale of ["zh-Hant", "zh-TW", "zh-HK", "zh-MO"]) {
+      expect(resolveDesktopMenuLabels(locale)).toMatchObject({
+        file: "檔案",
+        edit: "編輯",
+        help: "說明",
+        reportIssue: "回報問題",
+        exportDiagnostics: "匯出診斷資訊…",
+      });
+    }
+  });
+
+  it("lets an explicit script subtag win over a conflicting region", () => {
+    expect(resolveDesktopMenuLabels("zh-Hans-TW").file).toBe("文件");
+    expect(resolveDesktopMenuLabels("zh-Hant-CN").file).toBe("檔案");
+  });
+
+  it("keeps the existing English menu for unsupported or empty locales", () => {
+    expect(resolveDesktopMenuLabels("en-US").file).toBe("File");
+    expect(resolveDesktopMenuLabels("fr-FR").help).toBe("Help");
+    expect(resolveDesktopMenuLabels("").documentation).toBe("Documentation");
+  });
+});

--- a/apps/desktop/tests/main/updater-host-boundary.test.ts
+++ b/apps/desktop/tests/main/updater-host-boundary.test.ts
@@ -89,8 +89,8 @@ describe("desktop updater host boundary", () => {
     expect(main).toContain("DEFAULT_DESKTOP_UPDATE_MENU_LABELS");
     expect(main).toContain('source: "mac-app-menu"');
     expect(main).toContain("updateMenuItem.visible");
-    const fileMenuStart = main.indexOf('label: "File"');
-    const editMenuStart = main.indexOf('label: "Edit"', fileMenuStart);
+    const fileMenuStart = main.indexOf("label: menuLabels.file");
+    const editMenuStart = main.indexOf("label: menuLabels.edit", fileMenuStart);
     expect(fileMenuStart).toBeGreaterThanOrEqual(0);
     expect(editMenuStart).toBeGreaterThan(fileMenuStart);
     const fileMenu = main.slice(fileMenuStart, editMenuStart);


### PR DESCRIPTION
# Description

Localize the Electron desktop app's native application menu for Simplified and Traditional Chinese. The renderer already has Chinese locales; this fills the remaining native-menu gap while preserving English fallback behavior.

Locale resolution follows BCP-47 script/region semantics: explicit `Hans`/`Hant` wins, `TW`/`HK`/`MO` default to Traditional Chinese, other `zh-*` locales default to Simplified Chinese, and unsupported/empty locales fall back to English.

## Related Issue(s)

No linked issue.

## Surface Area

Select all that apply:

- [x] UI
- [ ] Agent runtime
- [ ] Tools
- [ ] Models / provider routing
- [ ] Evals / evaluation runners
- [ ] i18n keys / locale workflow
- [ ] Schema / persisted format / DB
- [ ] Git / worktree / checkpoint flow
- [ ] Network / authenticated requests / URL handling
- [ ] Filesystem / process execution / shell commands
- [ ] Extension points / manifests / contribution contracts
- [x] Default behavior change (changes what existing users experience without opting in)
- [ ] Other

The change does not add renderer i18n keys or modify the locale contribution workflow; it adds a small Electron-main-process label table for native menus.

## Safety / Security Review

- [x] I reviewed repo-derived execution paths (scripts/hooks/manifests).
- [x] I avoided direct shell execution for user-controlled instructions.
- [ ] Any manifest / config-generated runtime values are validated via typed + schema-checked loading paths.
- [ ] Any filesystem writes derived from repo/config data are containment-checked.
- [ ] Any privileged or side-effecting operation is exposed through structured typed boundaries.

The unchecked items are not applicable: this PR does not change manifests/config loading, filesystem writes, network/auth flows, shell/process execution, or introduce a new privileged/side-effecting boundary. It only changes native Electron `Menu` labels selected from `app.getLocale()`.

## Verification

- [ ] `pnpm test`
- [ ] `pnpm typecheck` (includes type hygiene checks)
- [ ] `pnpm guard` (includes out-of-band syntax checks)
- [x] Relevant evals / smoke tests
- [ ] Bug fix: added a regression test that fails before the fix and passes after it
- [ ] If package exports changed: verified package `exports` + built output alignment
- [ ] If manifest / extension metadata changed: tested validation and runtime loading
- [ ] If runtime-critical ESM/TS changed outside normal build/typecheck coverage: ran syntax validation

Focused desktop validation completed successfully for the changed surface:

- `pnpm --filter @open-design/desktop typecheck`
- `pnpm exec vitest run apps/desktop/tests/main/menu-i18n.test.ts apps/desktop/tests/main/updater-host-boundary.test.ts`
- standalone strict TypeScript validation for the locale resolver

The upstream workspace CI is currently blocked by an unrelated existing `@open-design/core` build failure (`TS2835` in `src/suggestions/index.ts`, requiring explicit file extensions). The failure is outside the files and package changed by this PR; the maintainer review also identified it as unrelated. Root workspace checkboxes remain unchecked until that upstream blocker is green.

## Screenshots / Artifacts

Not attached. This changes OS-native Electron menu labels rather than renderer UI; the locale mapping and menu-boundary behavior are covered by focused tests.
