### PR TITLE
fix daemon anonymous Langfuse registration shells

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -22,7 +22,6 @@ import type { OdNextRolloutDecision, SafeRunQualityV1 } from '@open-design/contr
 import { agentCliEnvForAgent, readAppConfig, type TelemetryPrefs } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
-import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-relay.js';
 import {
   deriveLangfuseDeliveryState,
   buildSafeRunQualityProjectionV1,
@@ -242,56 +241,6 @@ function mergeTraceSafeManifests(
     artifactManifest,
     ...(inputTextSnapshotManifest ? { inputTextSnapshotManifest } : {}),
     completeness: deriveManifestCompleteness(entries, selectedFallbackUnavailable),
-  };
-}
-
-function inferObjectRegistrationRelayUrl(env: NodeJS.ProcessEnv = process.env): string | null {
-  const objectRelayUrl = env.OPEN_DESIGN_OBJECT_RELAY_URL?.trim();
-  if (!objectRelayUrl) {
-    const telemetryRelayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
-    return telemetryRelayUrl
-      ? normalizeOpenDesignTelemetryRelayUrl(telemetryRelayUrl)
-      : null;
-  }
-  const normalizedObjectRelayUrl = normalizeOpenDesignTelemetryRelayUrl(
-    objectRelayUrl,
-  );
-  try {
-    const url = new URL(normalizedObjectRelayUrl);
-    url.pathname = url.pathname.replace(/\/api\/objects\/batch\/?$/, '/api/langfuse');
-    return url.toString().replace(/\/+$/, '');
-  } catch {
-    return normalizedObjectRelayUrl
-      .replace(/\/api\/objects\/batch\/?$/, '/api/langfuse')
-      .replace(/\/+$/, '');
-  }
-}
-
-function parsePositiveInt(value: string | undefined, fallback: number): number {
-  if (value === undefined) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function parseNonNegativeInt(value: string | undefined, fallback: number): number {
-  if (value === undefined) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
-}
-
-function objectRegistrationTelemetryConfig(
-  env: NodeJS.ProcessEnv = process.env,
-): Extract<TelemetrySinkConfig, { kind: 'relay' }> | null {
-  const relayUrl = inferObjectRegistrationRelayUrl(env);
-  if (!relayUrl) return null;
-  return {
-    kind: 'relay',
-    relayUrl,
-    timeoutMs: parsePositiveInt(
-      env.OPEN_DESIGN_OBJECT_RELAY_TIMEOUT_MS ?? env.OPEN_DESIGN_TELEMETRY_TIMEOUT_MS,
-      20_000,
-    ),
-    retries: parseNonNegativeInt(env.OPEN_DESIGN_TELEMETRY_RETRIES, 1),
   };
 }
 
@@ -1362,26 +1311,21 @@ export async function reportRunCompletedFromDaemon(
     let uploadedManifests: TraceObjectUploadManifests | undefined;
     let finalObjectManifests = registrationManifests;
 
-    if (registrationManifests) {
-      // Authenticated runs register object authority through Vela's signed
-      // service path. Anonymous/direct runs retain the legacy relay boundary.
-      // The authority worker handles registration_only without writing a
-      // content-free Langfuse trace.
-      const registrationTelemetryConfig = finalTelemetryConfig?.kind === 'vela'
-        ? finalTelemetryConfig
-        : objectRegistrationTelemetryConfig();
-      if (registrationTelemetryConfig) {
-        await reportRunCompleted(
-          buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
-          {
-            config: registrationTelemetryConfig,
-            deliveryPurpose: 'object-registration',
-            ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
-          },
-        );
-        uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
-        finalObjectManifests = uploadedManifests ?? registrationManifests;
-      }
+    if (registrationManifests && finalTelemetryConfig?.kind === 'vela') {
+      // Only Vela's signed service path can establish object authority. An
+      // anonymous relay/direct client must not create a content-free Langfuse
+      // registration trace or obtain upload permission from self-reported
+      // object metadata.
+      await reportRunCompleted(
+        buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
+        {
+          config: finalTelemetryConfig,
+          deliveryPurpose: 'object-registration',
+          ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+        },
+      );
+      uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
+      finalObjectManifests = uploadedManifests ?? registrationManifests;
     }
 
     const finalManifests = mergeTraceSafeManifests(manifests, finalObjectManifests);

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1000,6 +1000,72 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(trace.metadata.registration_only).not.toBe(true);
   });
 
+  it('reports a consented relay completion without anonymous registration or object upload', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const projectDir = path.join(dataDir, 'projects', 'proj-1');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+
+    const velaTelemetryEnabled = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    const velaControlKey = process.env.VELA_CONTROL_KEY;
+    const amrHome = process.env.AMR_HOME;
+    process.env.OPEN_DESIGN_VELA_TELEMETRY = 'on';
+    delete process.env.VELA_CONTROL_KEY;
+    process.env.AMR_HOME = path.join(dataDir, 'signed-out-relay-amr-home');
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    process.env.OPEN_DESIGN_OBJECT_RELAY_URL =
+      'https://telemetry.open-design.ai/api/objects/batch';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            { id: 'user-1', role: 'user', content: 'Build it through relay.' },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'relay done',
+              producedFiles: [{ name: 'index.html', kind: 'html', size: 35 }],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({ userPrompt: 'Build it through relay.' }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      if (velaTelemetryEnabled === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = velaTelemetryEnabled;
+      if (velaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+      else process.env.VELA_CONTROL_KEY = velaControlKey;
+      if (amrHome === undefined) delete process.env.AMR_HOME;
+      else process.env.AMR_HOME = amrHome;
+      delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]![0]).toBe(
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/api/objects/')))
+      .toBe(false);
+    const batch = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
+    expect(batch.filter((event) => event.type === 'trace-create')).toHaveLength(1);
+    const trace = bodyOf(batch, 'trace-create');
+    expect(trace.input).toBe('Build it through relay.');
+    expect(trace.output).toBe('relay done');
+    expect(trace.metadata).not.toHaveProperty('registration_only');
+  });
+
   it('registers object authority through Vela without an anonymous trace shell', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -110,6 +110,24 @@ function bodyOf(
   return event!.body;
 }
 
+const TEST_VELA_TELEMETRY_URL =
+  'https://vela.example.test/api/v1/open-design/telemetry';
+
+function enableTestVelaTelemetry(): void {
+  vi.stubEnv('OPEN_DESIGN_VELA_TELEMETRY', 'on');
+  vi.stubEnv('VELA_CONTROL_KEY', 'ck_test');
+  vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
+}
+
+function velaTraceBody(call: [string, RequestInit]): Record<string, any> {
+  const envelope = JSON.parse(call[1].body as string) as {
+    events: Array<{ kind: string; data: Record<string, any> }>;
+  };
+  const event = envelope.events.find((candidate) => candidate.kind === 'trace');
+  expect(event).toBeTruthy();
+  return event!.data;
+}
+
 describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
   let dataDir: string;
   let telemetryRelayUrl: string | undefined;
@@ -178,6 +196,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     else process.env.OPEN_DESIGN_OBJECT_RELAY_URL = objectRelayUrl;
     await rm(dataDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   async function writeAppCfg(cfg: Record<string, unknown>) {
@@ -659,7 +678,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
   });
 
-  it('derives production object uploads from the telemetry relay while keeping bodies out of Langfuse', async () => {
+  it('derives authenticated object uploads through Vela while keeping bodies out of telemetry', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true, artifactManifest: true },
@@ -669,6 +688,9 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     await writeFile(path.join(projectDir, 'brief.txt'), 'private attachment body');
     await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>private artifact</h1>');
     const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url === TEST_VELA_TELEMETRY_URL) {
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
+      }
       if (url.includes('/api/objects/authorize')) {
         const parsed = JSON.parse(init.body as string) as {
           objects: Array<{ storage_ref: string; sha256: string; size_bytes: number }>;
@@ -699,6 +721,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
     const priorNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
+    enableTestVelaTelemetry();
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = 'https://telemetry.open-design.ai/api/langfuse';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk';
     process.env.LANGFUSE_SECRET_KEY = 'sk';
@@ -745,16 +768,14 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     }
 
     expect(fetchSpy).toHaveBeenCalledTimes(4);
-    expect(fetchSpy.mock.calls[0]![0]).toContain('/api/langfuse');
+    expect(fetchSpy.mock.calls[0]![0]).toBe(TEST_VELA_TELEMETRY_URL);
     expect(fetchSpy.mock.calls[1]![0]).toBe('https://telemetry.open-design.ai/api/objects/authorize');
     expect(fetchSpy.mock.calls[2]![0]).toBe('https://telemetry.open-design.ai/api/objects/batch');
-    expect(fetchSpy.mock.calls[3]![0]).toContain('/api/langfuse');
-    const init = fetchSpy.mock.calls[3]![1] as RequestInit;
-    const langfuseBody = init.body as string;
-    expect(langfuseBody).not.toContain('private attachment body');
-    expect(langfuseBody).not.toContain('<!doctype html><h1>private artifact</h1>');
-    const batch = JSON.parse(langfuseBody).batch as any[];
-    const trace = batch[0].body;
+    expect(fetchSpy.mock.calls[3]![0]).toBe(TEST_VELA_TELEMETRY_URL);
+    const telemetryBody = fetchSpy.mock.calls[3]![1]!.body as string;
+    expect(telemetryBody).not.toContain('private attachment body');
+    expect(telemetryBody).not.toContain('<!doctype html><h1>private artifact</h1>');
+    const trace = velaTraceBody(fetchSpy.mock.calls[3] as [string, RequestInit]);
     expect(trace.metadata.manifest_completeness).toBe('complete');
     expect(trace.metadata.attachment_manifest[0]).toMatchObject({
       object_class: 'attachment',
@@ -770,7 +791,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
   });
 
-  it('uploads trace objects with worker-issued authority before reporting Langfuse manifests', async () => {
+  it('uploads trace objects with Vela-issued authority before reporting final manifests', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true, artifactManifest: true },
@@ -788,6 +809,9 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const tailMarker = 'TAIL_MARKER_SHOULD_NOT_REACH_LANGFUSE';
     const prompt = `${'长'.repeat(70 * 1024)}${tailMarker}`;
     const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url === TEST_VELA_TELEMETRY_URL) {
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
+      }
       if (url.includes('/api/objects/authorize')) {
         const parsed = JSON.parse(init.body as string) as {
           objects: Array<{ storage_ref: string; sha256: string; size_bytes: number }>;
@@ -824,6 +848,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       return new Response('{}', { status: 207 });
     });
 
+    enableTestVelaTelemetry();
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = 'https://telemetry.open-design.ai/api/langfuse';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk';
     process.env.LANGFUSE_SECRET_KEY = 'sk';
@@ -865,10 +890,10 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     }
 
     expect(fetchSpy).toHaveBeenCalledTimes(4);
-    expect(fetchSpy.mock.calls[0]![0]).toContain('/api/langfuse');
-    const registrationBody = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
-    expect(registrationBody).toHaveLength(1);
-    const registrationTrace = registrationBody[0].body;
+    expect(fetchSpy.mock.calls[0]![0]).toBe(TEST_VELA_TELEMETRY_URL);
+    const registrationTrace = velaTraceBody(
+      fetchSpy.mock.calls[0] as [string, RequestInit],
+    );
     expect(registrationTrace).not.toHaveProperty('input');
     expect(registrationTrace).not.toHaveProperty('output');
     expect(registrationTrace.metadata.attachment_manifest[0]).not.toHaveProperty('reason');
@@ -876,14 +901,12 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(registrationTrace.metadata.input_text_snapshot_manifest[0]).not.toHaveProperty('reason');
     expect(fetchSpy.mock.calls[1]![0]).toContain('/api/objects/authorize');
     expect(fetchSpy.mock.calls[2]![0]).toContain('/api/objects/batch');
-    expect(fetchSpy.mock.calls[3]![0]).toContain('/api/langfuse');
-    const langfuseInit = fetchSpy.mock.calls[3]![1] as RequestInit;
-    const langfuseBody = langfuseInit.body as string;
-    expect(langfuseBody).not.toContain('attachment body should stay out of langfuse');
-    expect(langfuseBody).not.toContain('<!doctype html><h1>artifact body</h1>');
-    expect(langfuseBody).not.toContain(tailMarker);
-    const batch = JSON.parse(langfuseBody).batch as any[];
-    const trace = batch[0].body;
+    expect(fetchSpy.mock.calls[3]![0]).toBe(TEST_VELA_TELEMETRY_URL);
+    const telemetryBody = fetchSpy.mock.calls[3]![1]!.body as string;
+    expect(telemetryBody).not.toContain('attachment body should stay out of langfuse');
+    expect(telemetryBody).not.toContain('<!doctype html><h1>artifact body</h1>');
+    expect(telemetryBody).not.toContain(tailMarker);
+    const trace = velaTraceBody(fetchSpy.mock.calls[3] as [string, RequestInit]);
     expect(trace.metadata.manifest_completeness).toBe('complete');
     expect(trace.metadata.attachment_manifest).toHaveLength(1);
     expect(trace.metadata.artifact_manifest).toHaveLength(1);
@@ -918,7 +941,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     );
   });
 
-  it('registers object upload authority through the object relay when traces use direct Langfuse', async () => {
+  it('reports a consented direct completion without an anonymous registration trace', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true, artifactManifest: true },
@@ -926,35 +949,16 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     const projectDir = path.join(dataDir, 'projects', 'proj-1');
     await mkdir(projectDir, { recursive: true });
     await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
-    const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
-      if (url.includes('/api/objects/authorize')) {
-        const parsed = JSON.parse(init.body as string) as {
-          objects: Array<{ storage_ref: string; object_class: string }>;
-        };
-        expect(parsed.objects).toHaveLength(1);
-        expect(parsed.objects[0]).toMatchObject({ object_class: 'artifact' });
-        return new Response(JSON.stringify({ upload_token: 'upload-token' }), { status: 200 });
-      }
-      if (url.includes('/api/objects/batch')) {
-        const parsed = JSON.parse(init.body as string) as {
-          objects: Array<{ storage_ref: string; content_base64: string }>;
-        };
-        return new Response(
-          JSON.stringify({
-            objects: parsed.objects.map((object) => ({
-              storage_ref: object.storage_ref,
-              status: 'available',
-              size_bytes: Buffer.from(object.content_base64, 'base64').byteLength,
-              sha256: 'sha256:uploaded-artifact',
-            })),
-          }),
-          { status: 200 },
-        );
-      }
-      return new Response('{}', { status: 207 });
-    });
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
 
-    process.env.OPEN_DESIGN_OBJECT_RELAY_URL = 'https://telemetry.open-design.ai/api/objects/batch';
+    const velaTelemetryEnabled = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    const velaControlKey = process.env.VELA_CONTROL_KEY;
+    const amrHome = process.env.AMR_HOME;
+    process.env.OPEN_DESIGN_VELA_TELEMETRY = 'on';
+    delete process.env.VELA_CONTROL_KEY;
+    process.env.AMR_HOME = path.join(dataDir, 'signed-out-amr-home');
+    process.env.OPEN_DESIGN_OBJECT_RELAY_URL =
+      'https://telemetry.open-design.ai/api/objects/batch';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk';
     process.env.LANGFUSE_SECRET_KEY = 'sk';
     try {
@@ -971,34 +975,29 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
           ],
         }),
         dataDir,
-        run: makeRun() as any,
+        run: makeRun({ userPrompt: 'Build it.' }) as any,
         fetchImpl: fetchSpy as any,
       });
     } finally {
+      if (velaTelemetryEnabled === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = velaTelemetryEnabled;
+      if (velaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+      else process.env.VELA_CONTROL_KEY = velaControlKey;
+      if (amrHome === undefined) delete process.env.AMR_HOME;
+      else process.env.AMR_HOME = amrHome;
       delete process.env.OPEN_DESIGN_OBJECT_RELAY_URL;
       delete process.env.LANGFUSE_PUBLIC_KEY;
       delete process.env.LANGFUSE_SECRET_KEY;
     }
 
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
-    expect(fetchSpy.mock.calls[0]![0]).toBe('https://telemetry.open-design.ai/api/langfuse');
-    expect(fetchSpy.mock.calls[1]![0]).toBe('https://telemetry.open-design.ai/api/objects/authorize');
-    expect(fetchSpy.mock.calls[2]![0]).toBe('https://telemetry.open-design.ai/api/objects/batch');
-    expect(fetchSpy.mock.calls[3]![0]).toBe('https://us.cloud.langfuse.com/api/public/ingestion');
-    const registrationBatch = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
-    const finalBatch = JSON.parse(fetchSpy.mock.calls[3]![1]!.body as string).batch as any[];
-    expect(registrationBatch[0].id).not.toBe(finalBatch[0].id);
-    expect(registrationBatch[0].body.metadata.artifact_manifest[0]).toMatchObject({
-      object_class: 'artifact',
-      storage_ref: expect.stringContaining(
-        'od://objects/workspaces/unknown/projects/proj-1/runs/run-id-1/artifact/',
-      ),
-    });
-    expect(finalBatch[0].body.metadata.artifact_manifest[0]).toMatchObject({
-      object_class: 'artifact',
-      status: 'ok',
-      stored_in_open_design: true,
-    });
+    expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
+      'https://us.cloud.langfuse.com/api/public/ingestion',
+    ]);
+    const batch = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
+    const trace = batch[0].body;
+    expect(trace.input).toBe('Build it.');
+    expect(trace.output).toBe('done');
+    expect(trace.metadata.registration_only).not.toBe(true);
   });
 
   it('registers object authority through Vela without an anonymous trace shell', async () => {
@@ -1125,6 +1124,9 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     await writeFile(path.join(projectDir, 'existing.html'), '<!doctype html><h1>modified</h1>');
     const uploadedFilenames: string[] = [];
     const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url === TEST_VELA_TELEMETRY_URL) {
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
+      }
       if (url.includes('/api/objects/authorize')) {
         return new Response(JSON.stringify({ upload_token: 'upload-token' }), { status: 200 });
       }
@@ -1148,6 +1150,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       return new Response('{}', { status: 207 });
     });
 
+    enableTestVelaTelemetry();
     process.env.OPEN_DESIGN_OBJECT_RELAY_URL = 'https://telemetry.open-design.ai/api/objects/batch';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk';
     process.env.LANGFUSE_SECRET_KEY = 'sk';
@@ -1183,8 +1186,10 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     }
 
     expect(uploadedFilenames).toEqual(['existing.html']);
-    const finalBatch = JSON.parse(fetchSpy.mock.calls.at(-1)![1]!.body as string).batch as any[];
-    expect(finalBatch[0].body.metadata.trace_object_summary).toEqual({
+    const finalTrace = velaTraceBody(
+      fetchSpy.mock.calls.at(-1) as [string, RequestInit],
+    );
+    expect(finalTrace.metadata.trace_object_summary).toEqual({
       new_file_count: 0,
       modified_file_count: 1,
       recovered_file_count: 0,
@@ -1193,7 +1198,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       skipped_file_count: 0,
       skip_reasons: {},
     });
-    expect(finalBatch[0].body.metadata.artifacts).toEqual([
+    expect(finalTrace.metadata.artifacts).toEqual([
       { slug: 'existing.html', type: 'html', sizeBytes: 34 },
     ]);
   });
@@ -1207,6 +1212,9 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     await mkdir(projectDir, { recursive: true });
     await writeFile(path.join(projectDir, 'index.html'), '<!doctype html><h1>artifact body</h1>');
     const fetchSpy = vi.fn(async (url: string, init: RequestInit) => {
+      if (url === TEST_VELA_TELEMETRY_URL) {
+        return new Response(JSON.stringify({ ok: true }), { status: 202 });
+      }
       if (url.includes('/api/objects/authorize')) {
         const parsed = JSON.parse(init.body as string) as {
           objects: Array<{ storage_ref: string; object_class: string }>;
@@ -1234,6 +1242,7 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       return new Response('{}', { status: 207 });
     });
 
+    enableTestVelaTelemetry();
     process.env.OPEN_DESIGN_OBJECT_RELAY_URL = 'https://telemetry.open-design.ai/api/objects/batch';
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = 'https://telemetry.open-design.ai/api/langfuse';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk';
@@ -1268,12 +1277,11 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     }
 
     expect(fetchSpy).toHaveBeenCalledTimes(4);
-    expect(fetchSpy.mock.calls[0]![0]).toContain('/api/langfuse');
+    expect(fetchSpy.mock.calls[0]![0]).toBe(TEST_VELA_TELEMETRY_URL);
     expect(fetchSpy.mock.calls[1]![0]).toContain('/api/objects/authorize');
     expect(fetchSpy.mock.calls[2]![0]).toContain('/api/objects/batch');
-    const langfuseInit = fetchSpy.mock.calls[3]![1] as RequestInit;
-    const batch = JSON.parse(langfuseInit.body as string).batch as any[];
-    const trace = batch[0].body;
+    expect(fetchSpy.mock.calls[3]![0]).toBe(TEST_VELA_TELEMETRY_URL);
+    const trace = velaTraceBody(fetchSpy.mock.calls[3] as [string, RequestInit]);
     expect(trace.metadata.manifest_completeness).toBe('partial');
     expect(trace.metadata.attachment_manifest[0]).toMatchObject({
       object_class: 'attachment',


### PR DESCRIPTION
## Why

A production cohort review found that users who enabled telemetry metrics and content, but were signed out or had no usable Vela Control Key, could emit a content-free `registration_only=true` trace before the completed-run trace. That anonymous registration could not safely establish object authority, yet it still created empty Langfuse trace shells and added avoidable relay traffic.

This PR keeps completed-run telemetry intact while removing the unsafe and ineffective anonymous object-registration step. It deliberately leaves the authenticated Vela path unchanged.

## What users will see

There is no UI change. For users who opted into both metrics and content but are signed out or lack a usable Vela Control Key, completed runs still send their final contentful telemetry report through the existing relay/direct sink. They no longer pre-register or upload trace objects through the anonymous path, so new clients do not create registration-only Langfuse shells.

Signed-in users with a usable Vela identity retain the existing signed registration, object authorization/upload, and final telemetry flow.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — anonymous relay/direct runs no longer perform object registration or upload before final telemetry
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: no UI surface changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/langfuse-bridge.test.ts` — `reports a consented direct completion without an anonymous registration trace`
- Did the test go red on `main` and green on this branch? **Yes.**
- RED on unmodified production code:
  - Command: `pnpm exec vitest run -c vitest.config.ts tests/langfuse-bridge.test.ts -t "reports a consented direct completion without an anonymous registration trace"`
  - Expected only `https://us.cloud.langfuse.com/api/public/ingestion`.
  - Received, in order: anonymous `https://telemetry.open-design.ai/api/langfuse`, `https://telemetry.open-design.ai/api/objects/authorize`, then final direct ingestion.
- GREEN after the fix: the same focused command passed `1 passed`; the full bridge file passed `34 passed`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/langfuse-bridge.test.ts` — 34 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed (existing landing-page hints only; 0 errors)
- `git diff --check` — passed

Local runtime note: the checks ran on Node 24.16.0; `shells/terminal` declares 24.18.0 and emitted an engine warning, but every command above completed successfully.

## Privacy and security boundaries

- Privacy-off behavior is unchanged: metrics disabled still exits before any telemetry request.
- Langfuse content telemetry still requires both `prefs.metrics === true` and `prefs.content === true`; this PR does not loosen consent.
- Only `finalTelemetryConfig.kind === "vela"` may send `deliveryPurpose: "object-registration"` and proceed to object authorization/upload.
- Anonymous relay/direct metadata cannot establish object upload authority.
- The authenticated Vela registration path remains signed and covered by the bridge regression suite.
- No Worker or Vela repository change is required.

## Out of scope

- Upgrading legacy clients or deleting historical registration-only traces.
- Diagnosing or fixing final telemetry `langfuse_4xx` and `network_error` failures.