### PR TITLE
docs: align daemon language guidance with TypeScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,7 +244,10 @@ We're not pedantic about formatting (Prettier on save is fine), but two rules ar
 Beyond that:
 
 - **Don't narrate.** No `// import the module`, no `// loop through items`. If the code reads obviously, the comment is noise. Save comments for non-obvious intent or constraints the code can't express.
-- **TypeScript** for `apps/web/src/`. The daemon (`apps/daemon/`) is plain ESM JavaScript with JSDoc when types matter — keep it that way.
+- **TypeScript-first.** Keep project-owned entrypoints, modules, scripts, tests,
+  reporters, and configs in TypeScript, including code in `apps/web/src/` and
+  `apps/daemon/src/`. New `.js`, `.mjs`, or `.cjs` files need an explicit
+  generated, vendored, or compatibility reason and must pass `pnpm guard`.
 - **No new top-level dependencies** without a paragraph in the PR description on what we get vs. what bytes we ship. The dep list in [`package.json`](package.json) is small on purpose.
 - **Run `pnpm typecheck`** before pushing. CI runs it; failing it earns a "please fix" comment.
 

--- a/docs/i18n/CONTRIBUTING.de.md
+++ b/docs/i18n/CONTRIBUTING.de.md
@@ -218,7 +218,12 @@ Wir sind beim Formatting nicht pedantisch (Prettier on save ist okay), aber zwei
 Außerdem:
 
 - **Nicht erzählen.** Kein `// import the module`, kein `// loop through items`.
-- **TypeScript** für `apps/web/src/`. Der daemon (`apps/daemon/`) ist plain ESM JavaScript mit JSDoc, wenn Typen wichtig sind.
+- **TypeScript-first.** Verwende TypeScript für projekteigene Einstiegspunkte,
+  Module, Skripte, Tests, Reporter und Konfigurationen, einschließlich des Codes
+  in `apps/web/src/` und `apps/daemon/src/`. Neue `.js`-, `.mjs`- oder
+  `.cjs`-Dateien sind nur als generierte Dateien, eingebundener Fremdcode oder
+  aus ausdrücklich dokumentierten Kompatibilitätsgründen zulässig und müssen
+  `pnpm guard` bestehen.
 - **Keine neuen Top-Level Dependencies** ohne Absatz in der PR-Beschreibung, was sie bringen und wie viele Bytes sie kosten.
 - **Vor dem Push `pnpm typecheck` ausführen.** CI tut es auch.
 

--- a/docs/i18n/CONTRIBUTING.fr.md
+++ b/docs/i18n/CONTRIBUTING.fr.md
@@ -361,10 +361,12 @@ Au-delà de ça :
   `// loop through items`. Si le code se lit déjà, le commentaire est du bruit.
   Gardez les commentaires pour l'intention non évidente ou les contraintes que
   le code ne peut pas exprimer.
-- **TypeScript** pour le code source de `apps/web/src/` et `apps/daemon/src/`.
-  Le JavaScript généré appartient aux dossiers `dist/`; les nouveaux fichiers
-  `.js`, `.mjs` ou `.cjs` doivent avoir une raison générée, vendored ou
-  compatibility explicite.
+- **TypeScript-first.** Conservez en TypeScript les points d'entrée, modules,
+  scripts, tests, reporters et configurations propres au projet, y compris le
+  code de `apps/web/src/` et `apps/daemon/src/`. Tout nouveau fichier `.js`,
+  `.mjs` ou `.cjs` n'est autorisé que s'il est généré, intègre du code tiers ou
+  répond à un besoin de compatibilité explicitement documenté, et doit passer
+  `pnpm guard`.
 - **Pas de nouvelle dépendance top-level** sans paragraphe dans la description
   de la PR expliquant ce qu'elle apporte et combien d'octets elle coûte. La liste
   des dépendances dans [`package.json`](../../package.json) est petite volontairement.

--- a/docs/i18n/CONTRIBUTING.ja-JP.md
+++ b/docs/i18n/CONTRIBUTING.ja-JP.md
@@ -214,7 +214,11 @@ export const fooAgentDef = {
 その他：
 
 - **ナレーションしない。** `// import the module`、`// loop through items` は不要。コードが明らかに読める場合、コメントはノイズです。コメントはコードで表現できない非自明な意図や制約のために残してください。
-- **TypeScript** は `apps/web/src/` 用。daemon（`apps/daemon/`）は型が重要な箇所で JSDoc 付きのプレーン ESM JavaScript です — そのまま維持してください。
+- **TypeScript-first。** `apps/web/src/` と `apps/daemon/src/` のコードを含め、
+  プロジェクト所有のエントリーポイント、モジュール、スクリプト、テスト、
+  レポーター、設定は TypeScript で記述してください。新しい `.js`、`.mjs`、
+  `.cjs` ファイルは、生成物、取り込んだサードパーティコード、または明示的に
+  文書化された互換性対応に限り使用でき、`pnpm guard` に合格しなければなりません。
 - **新しいトップレベル依存関係は追加しない**（PR の説明で得られるものと出荷バイト数について 1 段落の説明がない限り）。[`package.json`](../../package.json) の依存関係リストは意図的に小さく保っています。
 - **プッシュ前に `pnpm typecheck` を実行。** CI で実行されます。失敗すると「please fix」コメントが付きます。
 

--- a/docs/i18n/CONTRIBUTING.ko.md
+++ b/docs/i18n/CONTRIBUTING.ko.md
@@ -244,7 +244,11 @@ node --experimental-strip-types scripts/sync-litellm-models.ts
 그 외에:
 
 - **설명조 주석은 쓰지 마세요.** `// import the module`이나 `// loop through items` 같은 것 말입니다. 코드만 봐도 명백하다면 그 주석은 잡음입니다. 주석은 코드로 표현할 수 없는 의도나 제약에만 쓰세요.
-- **`apps/web/src/`는 TypeScript를 씁니다.** daemon(`apps/daemon/`)은 타입이 중요한 곳에 JSDoc을 붙인 순수 ESM JavaScript입니다. 그대로 유지하세요.
+- **TypeScript-first.** `apps/web/src/`와 `apps/daemon/src/`의 코드를 포함해
+  프로젝트가 소유하는 진입점, 모듈, 스크립트, 테스트, 리포터, 설정은
+  TypeScript로 작성하세요. 새 `.js`, `.mjs`, `.cjs` 파일은 생성물, 저장소에
+  포함된 서드파티 코드 또는 명시적으로 문서화된 호환성 목적일 때만 허용되며
+  `pnpm guard`를 통과해야 합니다.
 - **새 최상위 의존성을 추가하지 마세요.** 추가한다면 얻는 것과 늘어나는 번들 크기를 PR 설명에 한 단락으로 적으세요. [`package.json`](../../package.json)의 의존성 목록은 일부러 작게 둡니다.
 - **푸시 전에 `pnpm typecheck`를 실행하세요.** CI에서도 돌립니다. 실패하면 "고쳐주세요" 코멘트를 받게 됩니다.
 

--- a/docs/i18n/CONTRIBUTING.pt-BR.md
+++ b/docs/i18n/CONTRIBUTING.pt-BR.md
@@ -244,7 +244,12 @@ Não somos pedantes com formatação (Prettier on save está ok), mas duas regra
 Além disso:
 
 - **Não narre.** Sem `// import the module`, sem `// loop through items`. Se o código se lê obviamente, o comentário é ruído. Reserve comentários para intenção não-óbvia ou restrições que o código não consegue expressar.
-- **TypeScript** em `apps/web/src/`. O daemon (`apps/daemon/`) é JavaScript ESM puro com JSDoc onde tipos importam — mantenha assim.
+- **TypeScript-first.** Mantenha em TypeScript os pontos de entrada, módulos,
+  scripts, testes, reporters e configurações pertencentes ao projeto, incluindo
+  o código em `apps/web/src/` e `apps/daemon/src/`. Novos arquivos `.js`, `.mjs`
+  ou `.cjs` só são permitidos quando forem gerados, incorporarem código de
+  terceiros ou forem necessários por um motivo de compatibilidade documentado
+  explicitamente; eles também devem passar no `pnpm guard`.
 - **Sem novas dependências top-level** sem um parágrafo na descrição do PR sobre o que ganhamos vs. quantos bytes despachamos. A lista de deps em [`package.json`](../../package.json) é pequena de propósito.
 - **Rode `pnpm typecheck`** antes do push. CI roda; falhar lá rende um comentário "please fix".
 

--- a/docs/i18n/CONTRIBUTING.th.md
+++ b/docs/i18n/CONTRIBUTING.th.md
@@ -244,7 +244,11 @@ Table OVERRIDES ใน `maxTokens.ts` มีไว้สำหรับกรณ
 นอกเหนือจากนั้น:
 
 - **อย่า narrate.** ไม่มี `// import the module`, ไม่มี `// loop through items`. ถ้า code อ่านชัดอยู่แล้ว comment คือ noise. เก็บ comment ไว้ให้ intent หรือ constraint ที่ code สื่อเองไม่ได้.
-- **TypeScript** สำหรับ `apps/web/src/`. Daemon (`apps/daemon/`) เป็น plain ESM JavaScript พร้อม JSDoc เมื่อ types สำคัญ — รักษาแบบนั้น.
+- **TypeScript-first.** ใช้ TypeScript สำหรับ entrypoint, module, script, test,
+  reporter และ config ที่โปรเจกต์เป็นเจ้าของ รวมถึงโค้ดใน `apps/web/src/` และ
+  `apps/daemon/src/` ไฟล์ `.js`, `.mjs` หรือ `.cjs` ใหม่อนุญาตเฉพาะเมื่อเป็นไฟล์
+  ที่สร้างขึ้นอัตโนมัติ โค้ดของบุคคลที่สามที่รวมเข้ามา หรือจำเป็นเพื่อความเข้ากันได้
+  ที่มีการบันทึกไว้อย่างชัดเจน และต้องผ่าน `pnpm guard`
 - **ไม่มี top-level dependencies ใหม่** ถ้าไม่มี paragraph ใน PR description อธิบายว่าเราได้อะไรเทียบกับ bytes ที่ ship. Dep list ใน [`package.json`](../../package.json) เล็กโดยตั้งใจ.
 - **รัน `pnpm typecheck`** ก่อน push. CI รันอยู่แล้ว; ถ้า fail จะได้ comment "please fix".
 

--- a/docs/i18n/CONTRIBUTING.zh-CN.md
+++ b/docs/i18n/CONTRIBUTING.zh-CN.md
@@ -235,7 +235,10 @@ node --experimental-strip-types scripts/sync-litellm-models.ts
 除此之外：
 
 - **不要写废话注释。** 不要 `// 引入这个模块`、不要 `// 遍历元素`。如果代码本身一眼能读，注释就是噪音。注释只用来说明非显而易见的意图、或者代码本身表达不出来的约束。
-- **`apps/web/src/` 用 TypeScript。** Daemon (`apps/daemon/`) 是纯 ESM JavaScript，类型重要的地方用 JSDoc —— 保持这样。
+- **TypeScript-first。** 项目自有的入口、模块、脚本、测试、报告器和配置均使用
+  TypeScript，包括 `apps/web/src/` 和 `apps/daemon/src/` 中的代码。仅允许出于
+  以下明确理由新增 `.js`、`.mjs` 或 `.cjs` 文件：生成文件、纳入仓库的第三方
+  代码，或有明确文档说明的兼容性需要；这些文件还必须通过 `pnpm guard`。
 - **不要随便加顶层依赖。** PR 描述里至少要有一段，说明引入它能换到什么、又新增了多少 bundle 字节。[`package.json`](../../package.json) 的依赖少是有意为之。
 - **推之前跑 `pnpm typecheck`。** CI 会跑；挂了会换来一句「请修一下」。
 


### PR DESCRIPTION
## Why

While checking the contributor guide against the repository's current source
layout, I found that it still describes `apps/daemon` as plain ESM JavaScript.
The root `AGENTS.md` instead requires project-owned entrypoints, modules,
scripts, tests, reporters, and configs to be TypeScript-first. The daemon source
also follows that rule today.

This mismatch can direct new contributors toward file types that require an
explicit compatibility exception and can fail the repository guard.

## What users will see

Contributors now get one language rule consistent with the repository source of
truth: project-owned web and daemon code is TypeScript-first, while new
JavaScript-family files require an explicit generated, vendored, or
compatibility reason and must pass `pnpm guard`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding a new root dependency
- [ ] **Default behavior change** — changes existing default behavior
- [x] **None** — documentation update only

## Screenshots

Not applicable; this PR changes contributor documentation only.

## Bug fix verification

Not a runtime bug. The wording was checked against the root `AGENTS.md` and the
current daemon source layout.

## Validation

- `git diff --check`
- Compared the wording with the environment baseline and boundary constraints in
  the root `AGENTS.md`
- Confirmed that current `apps/daemon/src` contains 624 `.ts` files and no
  `.js`, `.mjs`, or `.cjs` files