### PR TITLE
fix(web): position caret correctly after inserting skill mention

### DIFF
--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -775,6 +775,7 @@ export const LexicalComposerInput = forwardRef<
           const active = $getSelection();
           if ($isRangeSelection(active)) {
             active.insertNodes([node]);
+            selectAfterMention(node);
             const after = $getSelection();
             if ($isRangeSelection(after)) after.insertText(' ');
           }

--- a/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
+++ b/apps/web/tests/components/composer/LexicalComposerInput.test.tsx
@@ -449,4 +449,149 @@ describe('LexicalComposerInput', () => {
 
     await waitFor(() => expect(onEnterSend).not.toHaveBeenCalled());
   });
+
+  // ─── Issue #2638 regression suite ────────────────────────────────────────
+  // After insertMention the caret must sit AFTER the inserted pill+trailing
+  // space, not inside the non-editable mention span. The selection anchor must
+  // be in the trailing-space text node at offset 1 so typing continues from
+  // the correct logical position.
+
+  it('#2638: caret lands in the trailing-space node after the pill, not inside the mention', async () => {
+    const { ref, getByTestId } = setup();
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    const host = getByTestId('chat-composer-input');
+    const editor = liveEditor(host);
+
+    act(() => {
+      ref.current?.insertMention({
+        token: '@Deck Builder',
+        entity: { id: 'deck-builder', kind: 'skill', label: 'Deck Builder' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelector('.composer-inline-mention--skill')).not.toBeNull(),
+    );
+
+    const anchor = selectionAnchor(editor);
+    expect(anchor.text).not.toBe('@Deck Builder');
+    expect(anchor.text).toBe(' ');
+    expect(anchor.offset).toBe(1);
+  });
+
+  it('#2638: text typed immediately after insertMention appears after the pill', async () => {
+    const { ref, getByTestId } = setup();
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    const host = getByTestId('chat-composer-input');
+
+    act(() => {
+      ref.current?.insertMention({
+        token: '@Deck Builder',
+        entity: { id: 'deck-builder', kind: 'skill', label: 'Deck Builder' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelector('.composer-inline-mention--skill')).not.toBeNull(),
+    );
+
+    act(() => {
+      ref.current?.insertText('please');
+    });
+    await waitFor(() =>
+      expect(ref.current?.getText()).toBe('@Deck Builder please'),
+    );
+    expect(host.querySelectorAll('.composer-inline-mention')).toHaveLength(1);
+  });
+
+  it('#2638: insertMention into non-empty composer leaves caret after pill+space', async () => {
+    const { ref, getByTestId } = setup();
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    const host = getByTestId('chat-composer-input');
+    const editor = liveEditor(host);
+
+    act(() => { ref.current?.insertText('Use '); });
+    act(() => {
+      ref.current?.insertMention({
+        token: '@Deck Builder',
+        entity: { id: 'deck-builder', kind: 'skill', label: 'Deck Builder' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelector('.composer-inline-mention--skill')).not.toBeNull(),
+    );
+
+    const anchor = selectionAnchor(editor);
+    expect(anchor.text).not.toBe('@Deck Builder');
+
+    act(() => { ref.current?.insertText('for this'); });
+    await waitFor(() =>
+      expect(ref.current?.getText()).toBe('Use @Deck Builder for this'),
+    );
+  });
+
+  it('#2638: second insertMention also leaves caret after pill, not inside it', async () => {
+    const { ref, getByTestId } = setup();
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    const host = getByTestId('chat-composer-input');
+    const editor = liveEditor(host);
+
+    act(() => {
+      ref.current?.insertMention({
+        token: '@Deck Builder',
+        entity: { id: 'deck-builder', kind: 'skill', label: 'Deck Builder' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelectorAll('.composer-inline-mention')).toHaveLength(1),
+    );
+
+    act(() => {
+      ref.current?.insertText('and ');
+      ref.current?.insertMention({
+        token: '@designs/landing.html',
+        entity: { id: 'designs/landing.html', kind: 'file', label: 'designs/landing.html' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelectorAll('.composer-inline-mention')).toHaveLength(2),
+    );
+
+    const anchor = selectionAnchor(editor);
+    expect(anchor.text).not.toBe('@designs/landing.html');
+    expect(ref.current?.getText()).toBe('@Deck Builder and @designs/landing.html ');
+  });
+
+  it('#2638: deleting the inserted mention pill removes it from the serialized text', async () => {
+    const { ref, onChange, getByTestId } = setup();
+    await waitFor(() => expect(ref.current).not.toBeNull());
+    const host = getByTestId('chat-composer-input');
+    const editor = liveEditor(host);
+
+    act(() => {
+      ref.current?.insertMention({
+        token: '@Deck Builder',
+        entity: { id: 'deck-builder', kind: 'skill', label: 'Deck Builder' },
+      });
+    });
+    await waitFor(() =>
+      expect(host.querySelector('.composer-inline-mention')).not.toBeNull(),
+    );
+
+    act(() => {
+      editor.update(
+        () => {
+          const mention = findMention($getRoot().getFirstChild());
+          mention?.remove();
+        },
+        { discrete: true },
+      );
+    });
+    await waitFor(() =>
+      expect(host.querySelector('.composer-inline-mention')).toBeNull(),
+    );
+
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1]!;
+    const presentEntities: InlineMentionEntity[] = lastCall[1];
+    expect(presentEntities.some((e) => e.id === 'deck-builder')).toBe(false);
+    expect(ref.current?.getText()).not.toContain('@Deck Builder');
+  });
 });


### PR DESCRIPTION
Fixes #2638

## Why

When a skill reference is picked from the `@` mention popover in the chat composer, the caret does not land at the visible end of the inserted chip — it can sit inside/over the chip — so the next keystrokes start from the wrong place (reported in #2638). The fix makes the selection placement explicit: after the atomic `MentionNode` is inserted, `selectAfterMention(node)` moves the Lexical selection to just outside the chip (parent paragraph, index + 1) *before* the trailing space is inserted, so typing continues at the logical position after the chip + space.

Scope note (review follow-up): per review, the unrelated `e2e/ui/amr-onboarding.test.ts` timing stabilization that rode along earlier has been removed from this PR; it will be proposed separately if still needed. The branch is now a single commit on top of current `main`, touching only the two files shown in the diff.

## What users will see

- Picking a skill from the `@` popover drops the caret immediately after the chip and its trailing space.
- Typing right after picking a mention continues at the correct spot (e.g. `@Deck Builder please`) instead of landing inside or before the chip.
- Nothing else changes: Backspace/Delete still remove the whole chip, and the staged skill list still prunes when a mention is deleted.

## Surface area

- [x] **None** — caret/selection fix inside an existing composer component plus focused regression tests; no new pages, dialogs, menus, settings, endpoints, contracts, CLI flags, or i18n keys.

## Screenshots

N/A — no new UI surface; the change is caret placement in the existing composer. The behavioral acceptance is the manual QA checklist below (requested before merge).

## Bug fix verification

- Test path: `apps/web/tests/components/composer/LexicalComposerInput.test.tsx` — the `#2638` suite (5 tests): caret lands in the trailing-space node after the pill; immediate typing; non-empty composer; multiple mentions; mention deletion prunes `presentEntities`.
- Red/green honesty note: in jsdom, Lexical's `insertNodes` already leaves the model selection after the atomic node, so the automated suite passes with or without the one-line `selectAfterMention(node)` call — that line normalizes real-browser DOM-selection placement, which jsdom does not reconcile and therefore cannot falsify. The suite still genuinely pins the required behavior: with the trailing-space insertion removed, 6 tests in this file fail (the 5 `#2638` tests plus the pre-existing pill test). Visual acceptance for the reported symptom is the manual QA checklist below.
- Wrapped lines: jsdom cannot measure caret geometry on wrapped lines. The logical selection position that wrapped-line correctness depends on is covered by the automated tests; the visual case is in the manual QA checklist.

## Manual QA (requested before merge)

- [ ] Insert a single skill reference; caret is immediately after the chip.
- [ ] Type text immediately; it appears after chip + space.
- [ ] Insert a mention into a composer that already has text.
- [ ] Insert multiple references.
- [ ] Verify on a wrapped line.
- [ ] Delete a skill mention; confirm no stale skill is staged/sent.

## Validation

- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/composer/LexicalComposerInput.test.tsx` (in `apps/web`) — PASS (18 passed, 1 intentionally skipped IME-composition guard)
- `pnpm --filter @open-design/web typecheck` — PASS
- `pnpm guard` — PASS
