### PR TITLE
fix(daemon,web): report analytics for daemon-started Runs and mid-write Labs toggles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,14 @@ root `pnpm tools-pr` script without a new explicit maintainer decision.
 - `RuntimeAgentDef.promptInputFormat` selects how the daemon writes the prompt to a child's stdin. The default `'text'` writes the composed prompt and ends stdin immediately. `'stream-json'` wraps the prompt as one JSONL `user` message and KEEPS stdin open so the daemon can stream further user messages back in mid-turn. Claude (`apps/daemon/src/runtimes/defs/claude.ts`) ships `'stream-json'` together with `--input-format stream-json` as generic mid-turn input infrastructure; the daemon closes stdin once the turn terminates cleanly. Every other agent stays on `'text'`.
 - `apps/daemon/src/server.ts` tracks `run.stdinOpen` on the run object. `applyClaudeStreamJsonRunBookkeeping` closes stdin (and records `turnCompletedCleanly`) when a `turn_end` (or `usage`) event arrives with a non `tool_use` `stop_reason`. The `tool_use` stop reason means the model paused mid tool (waiting on claude-code's internal runner); closing stdin there would truncate the follow up response.
 - `claude-stream.ts` emits the `turn_end` event AFTER iterating the assistant message's content blocks, not before, so the daemon sees the final `stop_reason` and every tool_use of the turn before deciding whether to close stdin.
+## Starting a physical Run
+
+- Every physical Run is started through `internalRunCreation.start(run, analytics, starter)` (`apps/daemon/src/services/internal-run-service.ts`). Calling the run registry's `start` directly bypasses the Run analytics lifecycle, so the Run reports no `run_created` and no `run_finished` and nothing says so. `pnpm guard`'s "run start choke point" check enforces this; the only allowed caller of `.runs.start(` is the service itself.
+- The `analytics` argument is required on purpose. A caller with no identity to attribute the Run to — a scheduled Automation, a background refresh — passes `requestAnalyticsContext: null` explicitly; the lifecycle then stays silent instead of inventing one. Stating "no identity" is a decision the code has to record, not a step a caller can skip.
+- A daemon-created Run that continues an existing task inherits its analytics identity and lineage from the Run that caused it, via `inheritedRunLineageHints` (`apps/daemon/src/services/run-analytics-lifecycle.ts`). Resolve lineage through that helper rather than from the source Run's `analyticsRecovery`: the lifecycle re-reads host facts before it captures, so a short Run can hand off before its own recovery record exists.
+
+## Asking the user questions
+
 - The host asks the user clarifying questions through the `<question-form>` artifact (see "Asking the user questions" below), NOT through a stdin-injected `tool_result`. There is no `AskUserQuestion` tool wiring, no `/api/runs/:id/tool-result` endpoint, and no host-answer return path; the stream-json input skeleton is retained only as generic infrastructure.
 
 ## Asking the user questions

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -198,6 +198,23 @@ import {
   normalizeCommentAttachments,
   UPLOAD_DIR,
 } from '../runtimes/chat-prompt-inputs.js';
+import { createRunAnalyticsLifecycle } from '../services/run-analytics-lifecycle.js';
+import {
+  runTouchedArtifactPaths,
+  toJsonRecord,
+  toProjectRecord,
+  validateChatRunDeliverable,
+  type ChatRun,
+  type JsonRecord,
+  type RunArtifactBaselines,
+  type RunCreatedFallbackInput,
+  type RunProjectKindInput,
+  type RunRetryAnalyticsEvent,
+  type ProjectMetadata,
+  type ProjectRecord,
+  type RunEventRecord,
+  type SseClient,
+} from '../runtimes/chat-run-records.js';
 
 // Keep in sync with the web uploader's `looksLikeImage` (apps/web registry):
 // omit-pin seeds must classify the same extensions as `image` so reload chips
@@ -214,10 +231,8 @@ const SEEDED_USER_IMAGE_EXTS = new Set([
 ]);
 
 type SqliteDb = Database.Database;
-type JsonRecord = Record<string, unknown>;
 type ApiRequest = Request<Record<string, string>, unknown, JsonRecord>;
 type ApiResponse = Response<unknown>;
-type ProjectMetadata = (Partial<ContractProjectMetadata> & JsonRecord) | null | undefined;
 type AgentCliEnv = Parameters<typeof agentCliEnvForAgent>[0];
 type RunDeliveryTarget = 'managed-project' | 'external-project' | 'none';
 type SeededCommentAttachment = ReturnType<typeof normalizeCommentAttachments>[number] & {
@@ -322,131 +337,8 @@ function seededUserMessageTurnMetadataFields(
   };
 }
 
-interface ProjectRecord {
-  id: string;
-  name: string;
-  createdAt?: number;
-  updatedAt?: number;
-  skillId?: string | null;
-  designSystemId?: string | null;
-  metadata?: ProjectMetadata;
-  appliedPluginSnapshotId?: string | null;
-}
 
-interface RunEventRecord
-  extends RunEventForAnalyticsObservability,
-    RunEventForDiagnostics,
-    RunEventForFailureClassification {
-  id: number;
-  event: string;
-  data: unknown;
-  timestamp?: number;
-}
 
-interface SseClient {
-  send(event: string, data: unknown, id?: number): void;
-  end(): void;
-  cleanup?(): void;
-}
-
-interface ChatRun {
-  id: string;
-  projectId: string | null;
-  conversationId: string | null;
-  assistantMessageId: string | null;
-  clientRequestId?: string | null;
-  requestFingerprint?: string | null;
-  strategyRolloutDecision?: OdNextRolloutDecision | null;
-  agentId: string | null;
-  workspaceScope?: RunWorkspaceScope | null;
-  model?: string | null;
-  status: ChatRunStatus;
-  createdAt: number;
-  updatedAt: number;
-  cancelRequested?: boolean;
-  cancelOrigin?: ChatRunStatusResponse['cancelOrigin'];
-  terminalTrigger?: ChatRunStatusResponse['terminalTrigger'];
-  exitCode?: number | null;
-  signal?: string | null;
-  error?: string | null;
-  errorCode?: string | null;
-  failureAction?: string | null;
-  projectMetadata?: ProjectMetadata;
-  appliedPluginSnapshotId?: string | null;
-  pluginId?: string | null;
-  clientType?: 'desktop' | 'web' | 'external_mcp';
-  sessionMode?: string | null;
-  context?: Record<string, unknown> | null;
-  events: RunEventRecord[];
-  clients: Set<SseClient>;
-  analyticsContext?: AnalyticsContext;
-  analyticsRecovery?: { context?: AnalyticsContext } | null;
-  externalPluginAnalytics?: Record<string, unknown> | null;
-  manualResumeAttemptCount?: number;
-  rechargeWaitDurationMs?: number;
-  artifactOriginStatus?:
-    | 'matched'
-    | 'missing_version'
-    | 'digest_mismatch'
-    | 'invalid_origin'
-    | 'unknown';
-  artifactVersionId?: string;
-  deliverableValid?: boolean;
-  deliverableValidation?: ChatRunStatusResponse['deliverableValidation'];
-  deliverableEntryFile?: string;
-  deliverableArtifactKind?: ChatRunStatusResponse['deliverableArtifactKind'];
-  /** Shells staged for an OD Next prototype run, project-relative. */
-  odNextStagedDeviceFrames?: string[];
-  /** Run-finish observation: did the delivered entry carry the staged handset shell? */
-  odNextDeviceShell?: {
-    platform: 'ios' | 'android' | 'mobile-neutral';
-    resolvedFrom: 'request-text' | 'project-metadata';
-    entryFile: string;
-    shellPresent: boolean;
-  };
-  /** Run-finish observation: how the delivered entry carries the staged layout primitives. */
-  odNextLayoutPrimitives?: 'verbatim' | 'modified' | 'linked' | 'absent';
-  analyticsTelemetry?: RunTelemetryTimestamps;
-  resolvedModelId?: string | null;
-  preflightAgentCliVersion?: string | null;
-  // E-lite root-cause telemetry read at run_finished. `stdinBackpressure`: the
-  // prompt write to child stdin was queued (pipe buffer full). `lastAgentActivityAt`:
-  // the inactivity-watchdog clock, used to derive `last_progress_age_ms`.
-  stdinBackpressure?: boolean;
-  lastAgentActivityAt?: number;
-  retryAttemptCount?: number;
-  retryFinalResult?: string;
-  retrySuppressedReason?: string;
-  retryOriginalFailure?: {
-    failure_category?: string;
-    failure_detail?: string;
-    failure_stage?: string;
-    retryable?: boolean;
-    user_action?: string;
-  };
-  artifactOutcome?: {
-    artifactCount: number;
-    artifactsCreated?: number;
-    artifactsModified?: number;
-    designSystemCreated: boolean;
-    previewModuleCount: number;
-    filesWritten?: number;
-    diff?: RunArtifactDiff;
-  };
-  artifactPaths?: string[];
-  designSystemId?: string | null;
-  designSystemRequestedId?: string | null;
-  designSystemSelectionSource?: string | null;
-  designSystemDigest?: string | null;
-  promptCache?: {
-    stablePromptHash?: string;
-    hit?: boolean;
-    missReason?: string | null;
-    changedSections?: string[] | null;
-  };
-  strategyTask?: StrategyTaskProjectionV2;
-  odNextTaskInputSnapshot?: OdNextTaskInputSnapshotDescriptor | null;
-}
 
 interface RunCreateMeta extends InternalRunCreateInput, JsonRecord {
   projectId?: string;
@@ -582,30 +474,10 @@ interface ProjectFileEntry {
   artifactManifest?: ArtifactManifest | JsonRecord | null;
 }
 
-interface RunRetryAnalyticsEvent {
-  event: string;
-  data: Record<string, unknown>;
-}
-
-interface RunArtifactBaselines {
-  take(runId: string): RunArtifactBaseline | undefined;
-}
-
 interface SseResponse {
   send(event: string, data: unknown, id?: number): void;
   end(): void;
   cleanup?(): void;
-}
-
-interface RunCreatedFallbackInput {
-  analyticsContext: AnalyticsContext | null;
-  run: ChatRun;
-  status: string;
-}
-
-interface RunProjectKindInput {
-  hintProjectKind: string | null;
-  projectMetadata?: ProjectMetadata;
 }
 
 class AutomaticOdNextPreparationError extends Error {
@@ -832,14 +704,6 @@ export interface RegisterRunRoutesDeps {
   };
 }
 
-type TerminalRunStatus = RunStatusForAnalytics & {
-  status: string;
-  error?: string | null;
-  errorCode?: string | null;
-  exitCode?: number | null;
-  signal?: string | null;
-};
-
 const AGUI_NATIVE_EVENT_KINDS: ReadonlySet<OdNativeEvent['kind']> = new Set([
   'message_chunk',
   'tool_call',
@@ -853,63 +717,6 @@ const AGUI_NATIVE_EVENT_KINDS: ReadonlySet<OdNativeEvent['kind']> = new Set([
   'genui_surface_timeout',
   'genui_state_synced',
 ]);
-
-function toJsonRecord(value: unknown): JsonRecord {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as JsonRecord
-    : {};
-}
-
-function toProjectRecord(value: unknown): ProjectRecord | null {
-  if (!value || typeof value !== 'object') return null;
-  const record = value as JsonRecord;
-  return typeof record.id === 'string'
-    ? value as ProjectRecord
-    : null;
-}
-
-async function validateChatRunDeliverable(input: {
-  db: SqliteDb;
-  projectsRoot: string;
-  run: ChatRun;
-  runStatus: ChatRunStatus;
-  artifactCount: number;
-  touchedPaths?: string[];
-}): Promise<RunDeliverableValidationResult> {
-  const project = input.run.projectId
-    ? toProjectRecord(getProject(input.db, input.run.projectId))
-    : null;
-  return validateRunDeliverable({
-    projectsRoot: input.projectsRoot,
-    projectId: input.run.projectId,
-    projectMetadata:
-      project?.metadata ?? input.run.projectMetadata ?? null,
-    runStatus: input.runStatus,
-    artifactCount: input.artifactCount,
-    ...(input.touchedPaths ? { touchedPaths: input.touchedPaths } : {}),
-  });
-}
-
-function runTouchedArtifactPaths(run: ChatRun): string[] | undefined {
-  const diff = (
-    run.artifactOutcome as
-      | { diff?: { touchedPaths?: unknown } }
-      | undefined
-  )?.diff;
-  return Array.isArray(diff?.touchedPaths)
-    ? diff.touchedPaths.filter(
-        (value): value is string => typeof value === 'string' && value.length > 0,
-      )
-    : undefined;
-}
-
-function isProjectEnrichableDesignSystem(project: ProjectRecord): boolean {
-  if (typeof project.designSystemId === 'string' && project.designSystemId.length > 0) {
-    return true;
-  }
-  const metadata = project.metadata;
-  return metadata?.importedFrom === 'brand-extraction' || metadata?.importedFrom === 'design-system';
-}
 
 function toProjectFiles(value: unknown): ProjectFileEntry[] {
   return Array.isArray(value)
@@ -946,63 +753,6 @@ function toScenarioProjectMetadata(
 }
 
 type DesignSystemSelectionSource = 'request' | 'plugin' | 'project' | 'app-default' | 'none';
-
-function normalizedDesignSystemId(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
-}
-
-function resolveEffectiveDesignSystemSelection({
-  requestDesignSystemId,
-  pluginDesignSystemId,
-  projectDesignSystemId,
-  appDefaultDesignSystemId,
-  disabledDesignSystemIds,
-  allowAppDefault = true,
-}: {
-  requestDesignSystemId?: unknown;
-  pluginDesignSystemId?: unknown;
-  projectDesignSystemId?: unknown;
-  appDefaultDesignSystemId?: unknown;
-  disabledDesignSystemIds?: unknown;
-  allowAppDefault?: boolean;
-}): { id: string | null; source: DesignSystemSelectionSource } {
-  const requestId = normalizedDesignSystemId(requestDesignSystemId);
-  if (requestId) return { id: requestId, source: 'request' };
-
-  const pluginId = normalizedDesignSystemId(pluginDesignSystemId);
-  if (pluginId) return { id: pluginId, source: 'plugin' };
-
-  const disabledIds = Array.isArray(disabledDesignSystemIds)
-    ? disabledDesignSystemIds.map(normalizedDesignSystemId).filter(
-        (value): value is string => value !== null,
-      )
-    : [];
-  const projectId = normalizedDesignSystemId(projectDesignSystemId);
-  if (projectId && !disabledIds.includes(projectId)) {
-    return { id: projectId, source: 'project' };
-  }
-
-  if (allowAppDefault) {
-    const appDefaultId = normalizedDesignSystemId(appDefaultDesignSystemId);
-    if (appDefaultId) return { id: appDefaultId, source: 'app-default' };
-  }
-
-  return { id: null, source: 'none' };
-}
-
-function designSystemIdFromPluginSnapshot(snapshot: unknown): string | null {
-  const items = (snapshot as { resolvedContext?: { items?: unknown } } | null | undefined)
-    ?.resolvedContext?.items;
-  if (!Array.isArray(items)) return null;
-  const designSystemItems = items.filter(
-    (item): item is { kind: string; id?: unknown; primary?: unknown } =>
-      item !== null &&
-      typeof item === 'object' &&
-      (item as { kind?: unknown }).kind === 'design-system',
-  );
-  const primary = designSystemItems.find((item) => item.primary === true);
-  return normalizedDesignSystemId(primary?.id ?? designSystemItems[0]?.id);
-}
 
 function routeParamId(req: ApiRequest): string | null {
   return typeof req.params.id === 'string' && req.params.id.length > 0
@@ -1149,6 +899,13 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     runs: design.runs,
     claimAssistantMessage: (run, options) =>
       pinAssistantMessageOnRunCreate(db, run, options),
+    analyticsLifecycle: createRunAnalyticsLifecycle({
+      db,
+      design,
+      paths: { PROJECTS_DIR, RUNTIME_DATA_DIR },
+      agents: { detectAgents },
+      telemetry: ctx.telemetry,
+    }),
   });
   const strategyTaskForRun = (run: ChatRun): StrategyTaskExecutionRecord | null => {
     const task = getStrategyTaskExecutionByRunId(db, run.id);
@@ -3191,861 +2948,24 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         ? { byokProvider: requestBody.byokProvider }
         : {}),
     };
-    internalRuns.start(run, () => startChatRun(executionMeta, run));
-
-    const reqBody = requestBody;
-    const analyticsHints =
-      (reqBody as { analyticsHints?: Record<string, unknown> | null }).analyticsHints
-        && typeof (reqBody as { analyticsHints?: unknown }).analyticsHints === 'object'
-        ? ((reqBody as { analyticsHints?: Record<string, unknown> }).analyticsHints ?? {})
-        : {};
-    // Marks the AI-optimize (deep enrichment) run so completion can flag the DS
-    // ai_refined even when analytics is unavailable or disabled.
-    const hintDsEnrichment = analyticsHints.dsEnrichment === true;
-    const requestProjectId = typeof reqBody.projectId === 'string' ? reqBody.projectId : null;
-    if (hintDsEnrichment && requestProjectId) {
-      design.runs.wait(run).then((status: TerminalRunStatus) => {
-        if (runResultFromStatus(status.status) !== 'success') return;
-        try {
-          const enrichedProject = toProjectRecord(getProject(db, requestProjectId));
-          if (enrichedProject && isProjectEnrichableDesignSystem(enrichedProject)) {
-            updateProject(db, requestProjectId, {
-              metadata: {
-                ...(enrichedProject.metadata ?? {}),
-                enrichmentStatus: 'ai_refined',
-                enrichmentCompletedAt: Date.now(),
-              },
-            });
-          }
-        } catch {
-          // Best-effort flag; do not fail run completion if metadata refresh fails.
-        }
-      }).catch(() => {});
-    }
-
-    const recoveredAnalyticsContext =
-      run.analyticsRecovery
-      && typeof run.analyticsRecovery === 'object'
-      && (run.analyticsRecovery as { context?: unknown }).context
-      && typeof (run.analyticsRecovery as { context?: unknown }).context === 'object'
-        ? ((run.analyticsRecovery as { context: AnalyticsContext }).context)
-        : null;
-    // Source/identity is first-write immutable for a logical run. A retry or
-    // recharge resume cannot relabel a prior ordinary request as Plugin (or
-    // vice versa) by changing analytics-only headers.
-    const analyticsContext =
-      run.analyticsContext
-      ?? recoveredAnalyticsContext
-      ?? requestAnalyticsContext;
-    if (!run.analyticsContext && analyticsContext) {
-      run.analyticsContext = analyticsContext;
-    }
-    design.runs.wait(run).then((status: { status: string }) => {
-      reportRunCompletionTelemetryFallback({
-        analyticsContext: analyticsContext ?? null,
-        run,
-        status: status.status,
-      });
-    }).catch(() => {});
-    if (analyticsContext) {
-      const runInsertId = newInsertId();
-      const appCfgForAnalytics = await readAppConfig(RUNTIME_DATA_DIR).catch(
-        () => ({} as Record<string, unknown>),
-      );
-      const detectedAgentsForAnalytics = await detectAgents(
-        toJsonRecord((appCfgForAnalytics as { agentCliEnv?: unknown }).agentCliEnv),
-      ).catch((): Array<{ id: string; available: boolean }> => []);
-      const velaStatusForAnalytics = (() => {
-        try {
-          const configuredAmrEnv = agentCliEnvForAgent(
-            (appCfgForAnalytics as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
-            'amr',
-          );
-          return readVelaLoginStatus(process.env, configuredAmrEnv);
-        } catch {
-          return null;
-        }
-      })();
-      const configureGlobals = deriveConfigureGlobals({
-        mode: 'daemon',
-        agentId: typeof reqBody.agentId === 'string' ? reqBody.agentId : null,
-        agents: detectedAgentsForAnalytics,
-        amrAuthorized: velaStatusForAnalytics?.loggedIn === true,
-      });
-      const promptText =
-        typeof reqBody.currentPrompt === 'string'
-          ? reqBody.currentPrompt
-          : typeof reqBody.message === 'string'
-            ? reqBody.message
-            : '';
-      const userQueryTokens = promptText.length > 0
-        ? Math.ceil(promptText.length / 4)
-        : 0;
-      const hintEntryFrom = typeof analyticsHints.entryFrom === 'string'
-        ? analyticsHints.entryFrom
-        : undefined;
-      const hintProjectKind = typeof analyticsHints.projectKind === 'string'
-        ? analyticsHints.projectKind
-        : null;
-      const hintTurnIndex = typeof analyticsHints.turnIndex === 'number'
-        ? analyticsHints.turnIndex
-        : undefined;
-      const hintIsFirstRun = typeof analyticsHints.isFirstRun === 'boolean'
-        ? analyticsHints.isFirstRun
-        : undefined;
-      const hintHasExistingArtifact = typeof analyticsHints.hasExistingArtifact === 'boolean'
-        ? analyticsHints.hasExistingArtifact
-        : undefined;
-      const hintProjectTurnIndex = typeof analyticsHints.projectTurnIndex === 'number'
-        ? analyticsHints.projectTurnIndex
-        : undefined;
-      const taskExecutionId = typeof analyticsHints.taskExecutionId === 'string'
-        && analyticsHints.taskExecutionId.length > 0
-        ? analyticsHints.taskExecutionId
-        : run.clientRequestId ?? run.id;
-      const initialRunId = typeof analyticsHints.initialRunId === 'string'
-        && analyticsHints.initialRunId.length > 0
-        ? analyticsHints.initialRunId
-        : run.id;
-      const taskRunIndex = typeof analyticsHints.taskRunIndex === 'number'
-        && Number.isInteger(analyticsHints.taskRunIndex)
-        && analyticsHints.taskRunIndex >= 0
-        ? analyticsHints.taskRunIndex
-        : 0;
-      const recoveryActionTypes: ReadonlySet<TrackingRunRecoveryActionType> = new Set([
-        'manual_retry',
-        'resume_run',
-        'authorize_and_retry',
-        'switch_model_retry',
-        'switch_runtime_retry',
-        'question_answer',
-      ]);
-      const recoveryActionType = typeof analyticsHints.recoveryActionType === 'string'
-        && recoveryActionTypes.has(
-          analyticsHints.recoveryActionType as TrackingRunRecoveryActionType,
-        )
-        ? analyticsHints.recoveryActionType as TrackingRunRecoveryActionType
-        : undefined;
-      const taskLineage: RunTaskLineageProps = {
-        task_execution_id: taskExecutionId,
-        initial_run_id: initialRunId,
-        task_run_index: taskRunIndex,
-        ...(typeof analyticsHints.sourceRunId === 'string' && analyticsHints.sourceRunId.length > 0
-          ? { source_run_id: analyticsHints.sourceRunId }
-          : {}),
-        ...(recoveryActionType ? { recovery_action_type: recoveryActionType } : {}),
-        ...(typeof analyticsHints.recoveryActionInstanceId === 'string'
-          && analyticsHints.recoveryActionInstanceId.length > 0
-          ? { recovery_action_instance_id: analyticsHints.recoveryActionInstanceId }
-          : {}),
-      };
-      const conversationTurnIndex = run.conversationId
-        ? conversationTurnIndexForRun(db, run.conversationId, run.id)
-        : null;
-      const sessionDimensionProps = {
-        ...(hintTurnIndex !== undefined ? { turn_index: hintTurnIndex } : {}),
-        ...(hintIsFirstRun !== undefined ? { is_first_run: hintIsFirstRun } : {}),
-        ...(hintProjectTurnIndex !== undefined
-          ? { project_turn_index: hintProjectTurnIndex }
-          : {}),
-        ...(conversationTurnIndex !== null
-          ? { conversation_turn_index: conversationTurnIndex }
-          : {}),
-        ...(hintHasExistingArtifact !== undefined
-          ? { has_existing_artifact: hintHasExistingArtifact }
-          : {}),
-      };
-      const runProjectForAnalytics = requestProjectId
-        ? toProjectRecord(getProject(db, requestProjectId))
-        : null;
-      const analyticsDesignSystemSelection = resolveEffectiveDesignSystemSelection({
-        requestDesignSystemId: reqBody.designSystemId,
-        pluginDesignSystemId: resolvedSnapshot?.ok
-          ? designSystemIdFromPluginSnapshot(resolvedSnapshot.snapshot)
-          : null,
-        projectDesignSystemId: runProjectForAnalytics?.designSystemId,
-        appDefaultDesignSystemId: (appCfgForAnalytics as { designSystemId?: unknown }).designSystemId,
-        disabledDesignSystemIds: (appCfgForAnalytics as { disabledDesignSystems?: unknown }).disabledDesignSystems,
-        allowAppDefault: runProjectForAnalytics === null,
-      });
-      const runProjectKind = resolveRunProjectKindForAnalytics({
-        hintProjectKind,
-        projectMetadata: runProjectForAnalytics?.metadata,
-      });
-      const dsRunContext =
-        analyticsHints.designSystemRunContext
-          && typeof analyticsHints.designSystemRunContext === 'object'
-          ? (analyticsHints.designSystemRunContext as Record<string, unknown>)
-          : {};
-      const isDesignSystemRun =
-        runProjectKind === 'design_system'
-        || hintEntryFrom === 'design_system_create'
-        || hintEntryFrom === 'onboarding_design_system'
-        || hintEntryFrom === 'regenerate_from_review';
-      const reqContext =
-        reqBody.context && typeof reqBody.context === 'object'
-          ? (reqBody.context as Record<string, unknown>)
-          : {};
-      const runMcpServerIds = Array.isArray(reqContext.mcpServerIds)
-        ? (reqContext.mcpServerIds as unknown[]).filter(
-            (id): id is string => typeof id === 'string',
-          )
-        : [];
-      const runTurnSkillIds = Array.isArray(reqBody.skillIds)
-        ? (reqBody.skillIds as unknown[]).filter(
-            (id): id is string => typeof id === 'string',
-          )
-        : [];
-      const runSkillIds = [
-        ...new Set(
-          [reqBody.skillId, ...runTurnSkillIds].filter(
-            (id): id is string => typeof id === 'string' && id.length > 0,
-          ),
-        ),
-      ];
-      // Map the internal DS selection source -> the wire `design_system_source`
-      // enum (previously hard-wired to unknown/not_applicable). And derive
-      // official-vs-custom from the id shape (`user:<id>` => custom). See the
-      // design-system tracking spec §3.5 (U3/U4).
-      const dsSelectedId = analyticsDesignSystemSelection.id;
-      const designSystemSourceForRun: TrackingDesignSystemSource = (() => {
-        switch (analyticsDesignSystemSelection.source) {
-          case 'request':
-            return 'user_selected';
-          case 'plugin':
-            return 'template_inherited';
-          case 'project':
-            return 'project_saved';
-          case 'app-default':
-            return 'default';
-          case 'none':
-          default:
-            return dsSelectedId ? 'unknown' : 'not_applicable';
-        }
-      })();
-      const designSystemKindForRun: TrackingDesignSystemKind | undefined = dsSelectedId
-        ? dsSelectedId.startsWith('user:')
-          ? 'custom'
-          : 'official'
-        : undefined;
-      const designSystemSlugForRun =
-        dsSelectedId && !dsSelectedId.startsWith('user:') ? dsSelectedId : undefined;
-      // E1 (tracking spec §3.4): a DS-project run that edits an EXISTING design
-      // system carries which surface drove it. comment/mark ride their own
-      // entry_from; everything else editing an existing DS is the chat surface.
-      // First-generation runs (no existing artifact) get no edit_surface.
-      const editSurfaceForRun: TrackingDesignSystemEditSurface | undefined =
-        runProjectKind === 'design_system' && hintHasExistingArtifact === true
-          ? hintEntryFrom === 'comment'
-            ? 'comment'
-            : hintEntryFrom === 'mark'
-              ? 'mark'
-              : 'chat'
-          : undefined;
-      const baseProps: Record<string, unknown> = {
-        page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
-        area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
-        ...configureGlobals,
-        ...odNextRolloutAnalyticsProperties(strategyRolloutDecision),
-        runtime_type: runtimeTypeForRunAnalytics({
-          derived: configureGlobals.runtime_type,
-          hint: analyticsHints.runtimeType,
-        }),
-        ...amrUserIdForRunAnalytics(velaStatusForAnalytics),
-        project_id: requestProjectId,
-        conversation_id:
-          typeof reqBody.conversationId === 'string' ? reqBody.conversationId : null,
-        run_id: run.id,
-        project_kind: runProjectKind,
-        ...(hintEntryFrom ? { entry_from: hintEntryFrom } : {}),
-        ...sessionDimensionProps,
-        design_system_id: dsSelectedId ?? undefined,
-        design_system_selection_source: analyticsDesignSystemSelection.source,
-        design_system_source: designSystemSourceForRun,
-        ...(designSystemKindForRun ? { design_system_kind: designSystemKindForRun } : {}),
-        ...(designSystemSlugForRun ? { design_system_slug: designSystemSlugForRun } : {}),
-        ...(editSurfaceForRun ? { edit_surface: editSurfaceForRun } : {}),
-        ...(isDesignSystemRun ? {
-          ds_source_origin: typeof dsRunContext.origin === 'string'
-            ? dsRunContext.origin
-            : undefined,
-          source_count: typeof dsRunContext.sourceCount === 'number'
-            ? dsRunContext.sourceCount
-            : undefined,
-          has_brand_description: typeof dsRunContext.hasBrandDescription === 'boolean'
-            ? dsRunContext.hasBrandDescription
-            : undefined,
-          brand_description_length_bucket:
-            typeof dsRunContext.brandDescriptionLengthBucket === 'string'
-              ? dsRunContext.brandDescriptionLengthBucket
-              : undefined,
-          github_repo_count: typeof dsRunContext.githubRepoCount === 'number'
-            ? dsRunContext.githubRepoCount
-            : undefined,
-          local_folder_count: typeof dsRunContext.localFolderCount === 'number'
-            ? dsRunContext.localFolderCount
-            : undefined,
-          fig_file_count: typeof dsRunContext.figFileCount === 'number'
-            ? dsRunContext.figFileCount
-            : undefined,
-          asset_file_count: typeof dsRunContext.assetFileCount === 'number'
-            ? dsRunContext.assetFileCount
-            : undefined,
-        } : {}),
-        has_attachment: Array.isArray(reqBody.attachments)
-          ? (reqBody.attachments as unknown[]).length > 0
-          : false,
-        user_query_tokens: userQueryTokens,
-        model_id: modelIdForTracking(
-          typeof reqBody.model === 'string' ? reqBody.model : null,
-        ),
-        agent_provider_id: agentProviderIdForRunAnalytics({
-          agentId: reqBody.agentId,
-          byokProvider: reqBody.byokProvider,
-        }),
-        skill_id: typeof reqBody.skillId === 'string' ? reqBody.skillId : null,
-        ...(!isDesignSystemRun && typeof reqBody.sessionMode === 'string'
-          ? { session_mode: sessionModeToTracking(reqBody.sessionMode) }
-          : {}),
-        plugin_id: resolvedSnapshot?.ok
-          ? resolvedSnapshot.snapshot.pluginId
-          : typeof reqBody.pluginId === 'string'
-            ? reqBody.pluginId
-            : null,
-        mcp_ids: runMcpServerIds,
-        mcp_id: runMcpServerIds[0] ?? null,
-        skill_ids: runSkillIds,
-        token_count_source: userQueryTokens > 0 ? 'estimated' : 'unknown',
-        ...(run.externalPluginAnalytics
-          ? {
-              entry_surface:
-                run.externalPluginAnalytics.entrySurface,
-              host_product:
-                run.externalPluginAnalytics.hostProduct,
-              external_plugin_id:
-                run.externalPluginAnalytics.externalPluginId,
-              external_plugin_version:
-                run.externalPluginAnalytics.externalPluginVersion,
-              distribution_mechanism:
-                run.externalPluginAnalytics.distributionMechanism,
-              publisher_class:
-                run.externalPluginAnalytics.publisherClass,
-              attribution_quality:
-                run.externalPluginAnalytics.attributionQuality,
-              plugin_workflow_id:
-                run.externalPluginAnalytics.pluginWorkflowId,
-              logical_request_digest:
-                run.externalPluginAnalytics.logicalRequestDigest,
-              logical_request_digest_version:
-                run.externalPluginAnalytics.logicalRequestDigestVersion,
-              brief_state:
-                run.externalPluginAnalytics.briefState,
-              generation_slo_window_ms:
-                run.externalPluginAnalytics.generationSloWindowMs,
-              deduplicated: preparedRun.creationKind === 'reused',
-              resume: resumed,
-              attempt_count: (run.manualResumeAttemptCount ?? 0) + 1,
-              recharge_wait_duration_ms:
-                run.rechargeWaitDurationMs ?? 0,
-              ...(analyticsAttributionMismatch
-                ? { source_metadata_mismatch: true }
-                : {}),
-            }
-          : {}),
-      };
-      // Read off the run rather than the local decision variable: the run is
-      // what `run_finished` and the crash-recovery replay both see, so stamping
-      // it here is the only place this dimension has to be added.
-      Object.assign(baseProps, harnessAnalyticsFromRolloutDecision(run.strategyRolloutDecision));
-      Object.assign(baseProps, buildRunCreatedV4Aliases(baseProps, taskLineage));
-      design.runs.setAnalyticsRecovery?.(run, {
-        context: analyticsContext,
-        properties: baseProps,
-        insertId: runInsertId,
-      });
-      design.analytics.capture({
-        eventName: 'run_created',
-        context: analyticsContext,
-        appVersion: design.getAppVersion(),
-        properties: baseProps,
-        insertId: runInsertId,
-      });
-      design.runs.wait(run).then(async (status: TerminalRunStatus) => {
-        const appCfgAtFinish = await readAppConfig(RUNTIME_DATA_DIR).catch(
-          () => ({} as Record<string, unknown>),
-        );
-        const langfuseDeliveryForAnalytics = deriveLangfuseDeliveryState(
-          (appCfgAtFinish as { telemetry?: Record<string, unknown> }).telemetry ?? {},
-          readTelemetrySinkConfig(),
-        );
-        const result = runResultFromStatus(status.status);
-        const errorCode = deriveRunErrorCode(status);
-        // C14/C15: AI-optimize (enrichment) run settled. Emit the dedicated
-        // result event; the success metadata flag runs outside this analytics gate.
-        if (hintDsEnrichment && analyticsContext) {
-          design.analytics.capture({
-            eventName: 'design_system_enrich_result',
-            context: analyticsContext,
-            appVersion: design.getAppVersion(),
-            properties: {
-              page_name: 'design_system_project',
-              area: 'design_system_enrich',
-              result,
-              design_system_id: dsSelectedId ?? undefined,
-              project_id: requestProjectId,
-              run_id: run.id,
-              ...(errorCode ? { error_code: errorCode } : {}),
-              duration_ms: Math.max(0, Date.now() - run.createdAt),
-            },
-            insertId: newInsertId(),
-          });
-        }
-        const failure = classifyRunFailure({
-          result,
-          status,
-          ...(errorCode ? { errorCode } : {}),
-          agentId: run.agentId,
-          cancelOrigin: run.cancelOrigin ?? null,
-          terminalTrigger: run.terminalTrigger ?? null,
-          events: run.events,
-        });
-        const usageAnalytics = scanRunEventsForUsageAnalytics(
-          run.events,
-          reqBody.model,
-          userQueryTokens,
-        );
-        // Whether this run is a non-first turn in its conversation — i.e. a
-        // prior completed assistant turn exists (excluding this run's own
-        // placeholder). The session-reuse cache win only applies to follow-up
-        // turns, so slicing `first_call_cache_hit_ratio` by this flag is the
-        // baseline-vs-optimized comparison. Mirrors server.ts hasPriorAssistantTurn.
-        const isFollowupTurn = run.conversationId
-          ? Boolean(
-              db
-                .prepare(
-                  `SELECT 1 FROM messages
-                     WHERE conversation_id = ?
-                       AND role = 'assistant'
-                       AND COALESCE(content, '') <> ''
-                       AND id <> COALESCE(?, '')
-                     LIMIT 1`,
-                )
-                .get(run.conversationId, run.assistantMessageId ?? ''),
-            )
-          : false;
-        // Resolve the turn's first-call usage (cache-hit of the OPENING model
-        // call — the signal session reuse moves). Every coding agent except
-        // codex reports per-call usage on the stream, so the forward-scanned
-        // first usage event IS the opening call. codex reports only a single
-        // cumulative `turn.completed` usage on the stream, so its first stream
-        // event is the whole-session aggregate; its real per-call number lives
-        // in the rollout `last_token_usage`, read here best-effort.
-        const firstCallUsage = await (async (): Promise<{
-          first_call_input_tokens?: number;
-          first_call_input_tokens_effective?: number;
-          first_call_cache_read_input_tokens?: number;
-          first_call_cache_creation_input_tokens?: number;
-          first_call_cache_hit_ratio?: number;
-        } | null> => {
-          if (run.agentId === 'codex') {
-            // Best-effort: a throw anywhere here (env resolution, rollout read)
-            // must degrade to "no codex first-call fields", never bubble to the
-            // outer run_finished .catch and drop the whole completion event.
-            try {
-              const sessionId = codexSessionIdFromRunEvents(run.events);
-              const codexHome = spawnEnvForAgent(
-                'codex',
-                { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
-                agentCliEnvForAgent(
-                  (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
-                  'codex',
-                ),
-              ).CODEX_HOME;
-              const codexUsage = await readCodexRolloutFirstCall({ codexHome, sessionId });
-              return codexUsage
-                ? {
-                    ...codexUsage,
-                    first_call_input_tokens_effective:
-                      codexUsage.first_call_input_tokens,
-                  }
-                : null;
-            } catch {
-              return null;
-            }
-          }
-          if (usageAnalytics.first_call_input_tokens === undefined) return null;
-          return {
-            first_call_input_tokens: usageAnalytics.first_call_input_tokens,
-            ...(usageAnalytics.first_call_input_tokens_effective !== undefined
-              ? {
-                  first_call_input_tokens_effective:
-                    usageAnalytics.first_call_input_tokens_effective,
-                }
-              : {}),
-            ...(usageAnalytics.first_call_cache_read_input_tokens !== undefined
-              ? {
-                  first_call_cache_read_input_tokens:
-                    usageAnalytics.first_call_cache_read_input_tokens,
-                }
-              : {}),
-            ...(usageAnalytics.first_call_cache_creation_input_tokens !== undefined
-              ? {
-                  first_call_cache_creation_input_tokens:
-                    usageAnalytics.first_call_cache_creation_input_tokens,
-                }
-              : {}),
-            ...(usageAnalytics.first_call_cache_hit_ratio !== undefined
-              ? { first_call_cache_hit_ratio: usageAnalytics.first_call_cache_hit_ratio }
-              : {}),
-          };
-        })();
-        const analyticsCapturedAt = Date.now();
-        const timingAnalytics = summarizeRunTimingAnalytics({
-          runCreatedAt: run.createdAt,
-          runUpdatedAt: run.updatedAt,
-          analyticsCapturedAt,
-        ...(run.analyticsTelemetry ? { telemetry: run.analyticsTelemetry } : {}),
-          events: run.events,
-        });
-        const toolAnalytics = summarizeToolAnalytics(run.events);
-        const toolStreamArtifactCount = (): number => runArtifactCountForRun(run);
-        const toolStreamDesignSystemCreated = (): boolean =>
-          runDesignSystemCreatedForRun(run);
-        const toolStreamPreviewModuleCount = (): number =>
-          runPreviewModuleCountForRun(run);
-        const toolStreamFilesWritten = (): number => runFilesWrittenForRun(run);
-        let artifactCount: number;
-        let artifactsCreated: number | undefined;
-        let artifactsModified: number | undefined;
-        let designSystemCreated: boolean;
-        let previewModuleCount: number;
-        let filesWritten: number | undefined;
-        let artifactDiff: RunArtifactDiff | undefined;
-        const artifactOutcome = run.artifactOutcome;
-        if (artifactOutcome) {
-          artifactCount = artifactOutcome.artifactCount;
-          artifactsCreated = artifactOutcome.artifactsCreated;
-          artifactsModified = artifactOutcome.artifactsModified;
-          designSystemCreated = artifactOutcome.designSystemCreated;
-          previewModuleCount = artifactOutcome.previewModuleCount;
-          filesWritten = artifactOutcome.filesWritten;
-          artifactDiff = artifactOutcome.diff;
-        } else {
-          const artifactBaseline = runArtifactBaselines.take(run.id);
-          if (artifactBaseline && !artifactBaseline.contended) {
-            let diff: ReturnType<typeof diffRunArtifacts> | null = null;
-            try {
-              diff = diffRunArtifacts(
-                artifactBaseline.before,
-                snapshotProjectArtifacts(artifactBaseline.cwd),
-              );
-            } catch {
-              diff = null;
-            }
-            if (diff) {
-              artifactDiff = diff;
-              artifactCount = diff.touched;
-              artifactsCreated = diff.created;
-              artifactsModified = diff.modified;
-              designSystemCreated = diff.designSystemCreated;
-              previewModuleCount = diff.previewModuleCount;
-              filesWritten = diff.filesWritten;
-            } else {
-              artifactCount = toolStreamArtifactCount();
-              designSystemCreated = toolStreamDesignSystemCreated();
-              previewModuleCount = toolStreamPreviewModuleCount();
-              filesWritten = toolStreamFilesWritten();
-            }
-          } else {
-            artifactCount = toolStreamArtifactCount();
-            designSystemCreated = toolStreamDesignSystemCreated();
-            previewModuleCount = toolStreamPreviewModuleCount();
-            filesWritten = toolStreamFilesWritten();
-          }
-        }
-        const touchedArtifactPaths = runTouchedArtifactPaths(run);
-        const deliverable = run.externalPluginAnalytics
-          ? await validateChatRunDeliverable({
-              db,
-              projectsRoot: PROJECTS_DIR,
-              run,
-              runStatus: run.status,
-              artifactCount,
-              ...(touchedArtifactPaths
-                ? { touchedPaths: touchedArtifactPaths }
-                : {}),
-            })
-          : null;
-        if (deliverable) {
-          design.runs.setDeliverableValidation?.(run, deliverable);
-        }
-        const activationMilestones = deriveActivationMilestones({
-          result,
-          artifactCount,
-          designSystemCreated,
-          isDesignSystemRun,
-          capturedAtIso: new Date(analyticsCapturedAt).toISOString(),
-        });
-        const diagnosticsAnalytics = summarizeRunDiagnosticsForAnalytics({
-          events: run.events,
-          exitCode: status.exitCode ?? null,
-          signal: status.signal ?? null,
-          cancelRequested: !!run.cancelRequested,
-          firstTokenSeen: Boolean(run.analyticsTelemetry?.firstTokenAt),
-          artifactWriteSeen: artifactCount > 0 || designSystemCreated || previewModuleCount > 0,
-        });
-        const finishedModelId = hasExplicitRequestedModelForAnalytics(reqBody.model)
-          ? modelIdForTracking(reqBody.model)
-          : modelIdForTracking(
-              usageAnalytics.agent_reported_model ?? run.resolvedModelId,
-            );
-        const runtimeVersions = getDetectedRuntimeVersions(run.agentId);
-        const agentCliVersion =
-          run.preflightAgentCliVersion ?? runtimeVersions?.agentCliVersion;
-        for (const [index, retryEvent] of runRetryEventsForAnalytics(run.events).entries()) {
-          design.analytics.capture({
-            eventName: retryEvent.event,
-            context: analyticsContext,
-            appVersion: design.getAppVersion(),
-            properties: retryEvent.data,
-            insertId: `${runInsertId}-${retryEvent.event}-${index}`,
-          });
-        }
-        const clarificationRequested = runAskedUserQuestion(run.events);
-        const interactionMode = typeof reqBody.sessionMode === 'string'
-          ? sessionModeToTracking(reqBody.sessionMode)
-          : undefined;
-        const primaryArtifactChange = artifactDiff
-          ? primaryArtifactChangeForRun({
-              diff: artifactDiff,
-              projectKind: runProjectKind,
-              hadExistingArtifacts: hintHasExistingArtifact === true,
-              ...(interactionMode ? { interactionMode } : {}),
-              clarificationRequested,
-            })
-          : undefined;
-        const supportingAssetFilesChanged = artifactDiff
-          ? supportingAssetFilesChangedForRun(artifactDiff, runProjectKind)
-          : undefined;
-        const finishedProperties: Record<string, unknown> = {
-            ...baseProps,
-            design_system_id: run.designSystemId ?? undefined,
-            design_system_digest: run.designSystemDigest ?? undefined,
-            design_system_selection_source: run.designSystemSelectionSource ?? 'none',
-            stable_prompt_hash: run.promptCache?.stablePromptHash,
-            stable_prompt_cache_hit: run.promptCache?.hit,
-            stable_prompt_cache_miss_reason: run.promptCache?.missReason,
-            // Which stable-prefix input drifted, for miss_reason
-            // 'stable-prompt-changed' only. `unattributed` means the prefix
-            // moved but no tracked section did — a coverage gap in
-            // prompts/stable-sections.ts, not a cause.
-            stable_prompt_changed_sections: run.promptCache?.changedSections ?? undefined,
-            area: isDesignSystemRun ? 'design_system_generation' : 'chat_panel',
-            result,
-            ...(activationMilestones ? { $set_once: activationMilestones } : {}),
-            model_id: finishedModelId,
-            artifact_count: artifactCount,
-            // Finish-time observations live on the run object only after the
-            // physical run resolved; baseProps was frozen at creation, so
-            // these must be read live here or they never reach analytics.
-            ...(run.odNextDeviceShell
-              ? {
-                  od_next_device_platform: run.odNextDeviceShell.platform,
-                  od_next_device_platform_source: run.odNextDeviceShell.resolvedFrom,
-                  od_next_device_shell_present: run.odNextDeviceShell.shellPresent,
-                }
-              : {}),
-            ...(run.odNextLayoutPrimitives
-              ? { od_next_layout_primitives: run.odNextLayoutPrimitives }
-              : {}),
-            ...(run.externalPluginAnalytics
-              ? {
-                  deliverable_valid: deliverable?.valid === true,
-                  deliverable_validation:
-                    deliverable?.valid === true ? 'valid' : 'invalid',
-                  artifact_origin_status:
-                    run.artifactOriginStatus ?? 'missing_version',
-                  ...(run.artifactVersionId
-                    ? { artifact_version_id: run.artifactVersionId }
-                    : {}),
-                  resume: (run.manualResumeAttemptCount ?? 0) > 0,
-                  attempt_count: (run.manualResumeAttemptCount ?? 0) + 1,
-                  recharge_wait_duration_ms:
-                    run.rechargeWaitDurationMs ?? 0,
-                }
-              : {}),
-            ...(artifactsCreated !== undefined ? { artifacts_created: artifactsCreated } : {}),
-            ...(artifactsModified !== undefined ? { artifacts_modified: artifactsModified } : {}),
-            ...(filesWritten !== undefined ? { files_written_count: filesWritten } : {}),
-            asked_user_question: clarificationRequested,
-            retry_attempt_count: run.retryAttemptCount ?? 0,
-            retry_final_result: run.retryFinalResult ?? 'not_attempted',
-            ...(agentCliVersion
-              ? { agent_cli_version: agentCliVersion }
-              : {}),
-            ...(runtimeVersions?.runtimeCompanionName
-              ? { runtime_companion_name: runtimeVersions.runtimeCompanionName }
-              : {}),
-            ...(runtimeVersions?.runtimeCompanionVersion
-              ? { runtime_companion_version: runtimeVersions.runtimeCompanionVersion }
-              : {}),
-            ...(run.retryOriginalFailure?.failure_category
-              ? {
-                  retry_original_failure_category:
-                    run.retryOriginalFailure.failure_category,
-                }
-              : {}),
-            ...(run.retryOriginalFailure?.failure_detail
-              ? {
-                  retry_original_failure_detail:
-                    run.retryOriginalFailure.failure_detail,
-                }
-              : {}),
-            ...(run.retryOriginalFailure?.failure_stage
-              ? {
-                  retry_original_failure_stage:
-                    run.retryOriginalFailure.failure_stage,
-                }
-              : {}),
-            ...(run.retrySuppressedReason
-              ? { retry_suppressed_reason: run.retrySuppressedReason }
-              : {}),
-            ...(isDesignSystemRun ? {
-              design_system_created: designSystemCreated,
-              preview_module_count: previewModuleCount,
-              missing_font_count: 0,
-            } : {}),
-            ...timingAnalytics,
-            ...diagnosticsAnalytics,
-            // E-lite: `approval_requested`/`tool_result_sent` ride in via
-            // `...diagnosticsAnalytics`; these two come off the run object.
-            stdin_backpressure: run.stdinBackpressure === true,
-            ...(typeof run.lastAgentActivityAt === 'number'
-              ? { last_progress_age_ms: Math.max(0, analyticsCapturedAt - run.lastAgentActivityAt) }
-              : {}),
-            langfuse_trace_id: run.id,
-            ...langfuseDeliveryForAnalytics,
-            ...(errorCode ? { error_code: errorCode } : {}),
-            ...(failure ?? {}),
-            ...(usageAnalytics.input_tokens !== undefined
-              ? { input_tokens: usageAnalytics.input_tokens }
-              : {}),
-            ...(usageAnalytics.input_tokens_provider !== undefined
-              ? { input_tokens_provider: usageAnalytics.input_tokens_provider }
-              : {}),
-            ...(usageAnalytics.input_tokens_effective !== undefined
-              ? { input_tokens_effective: usageAnalytics.input_tokens_effective }
-              : {}),
-            ...(usageAnalytics.output_tokens !== undefined
-              ? { output_tokens: usageAnalytics.output_tokens }
-              : {}),
-            ...(usageAnalytics.total_tokens !== undefined
-              ? { total_tokens: usageAnalytics.total_tokens }
-              : {}),
-            ...(usageAnalytics.thought_tokens !== undefined
-              ? { thought_tokens: usageAnalytics.thought_tokens }
-              : {}),
-            ...(usageAnalytics.cache_read_input_tokens !== undefined
-              ? { cache_read_input_tokens: usageAnalytics.cache_read_input_tokens }
-              : {}),
-            ...(usageAnalytics.cache_creation_input_tokens !== undefined
-              ? {
-                  cache_creation_input_tokens:
-                    usageAnalytics.cache_creation_input_tokens,
-                }
-              : {}),
-            ...(usageAnalytics.uncached_input_tokens !== undefined
-              ? { uncached_input_tokens: usageAnalytics.uncached_input_tokens }
-              : {}),
-            ...(usageAnalytics.estimated_context_tokens !== undefined
-              ? { estimated_context_tokens: usageAnalytics.estimated_context_tokens }
-              : {}),
-            ...(usageAnalytics.cache_hit_ratio !== undefined
-              ? { cache_hit_ratio: usageAnalytics.cache_hit_ratio }
-              : {}),
-            // First-call cache-hit of the turn's opening model call (per-call
-            // usage for claude/opencode/codebuddy/pi from the stream; codex from
-            // its rollout). Sliced by is_followup_turn, this isolates the
-            // session-reuse cache win on non-first turns.
-            ...(firstCallUsage ?? {}),
-            is_followup_turn: isFollowupTurn,
-            cache_token_source: usageAnalytics.cache_token_source,
-            // Prefer provider scan over run_created baseProps (`estimated`).
-            token_count_source: usageAnalytics.token_count_source,
-            tool_error_count: toolAnalytics.tool_error_count,
-            tool_name_count: toolAnalytics.tool_name_count,
-            tool_names: toolAnalytics.tool_names_csv,
-            ...runMessageEventPersistenceAnalytics(run),
-          };
-        Object.assign(
-          finishedProperties,
-          buildRunFinishedV4Aliases(finishedProperties, taskLineage, {
-            inputAccountingMode: usageAnalytics.input_accounting_mode,
-            ...(firstCallUsage
-              ? {
-                  firstModelCall: {
-                    ...(firstCallUsage.first_call_input_tokens !== undefined
-                      ? { provider_input_tokens: firstCallUsage.first_call_input_tokens }
-                      : {}),
-                    ...(firstCallUsage.first_call_input_tokens_effective !== undefined
-                      ? { effective_input_tokens: firstCallUsage.first_call_input_tokens_effective }
-                      : {}),
-                    ...(firstCallUsage.first_call_cache_read_input_tokens !== undefined
-                      ? { cache_read_tokens: firstCallUsage.first_call_cache_read_input_tokens }
-                      : {}),
-                    ...(firstCallUsage.first_call_cache_creation_input_tokens !== undefined
-                      ? { cache_write_tokens: firstCallUsage.first_call_cache_creation_input_tokens }
-                      : {}),
-                  },
-                }
-              : {}),
-            ...(primaryArtifactChange
-              ? { primaryArtifactChange }
-              : {}),
-            ...(artifactDiff
-              ? {
-                  artifactFiles: {
-                    changed_file_count: artifactDiff.contentTouched,
-                    created_file_count: artifactDiff.contentCreated,
-                    modified_file_count: artifactDiff.contentModified,
-                    ...(supportingAssetFilesChanged !== undefined
-                      ? {
-                          supporting_asset_files_changed_count:
-                            supportingAssetFilesChanged,
-                        }
-                      : {}),
-                  },
-                }
-              : {}),
-            ...(isDesignSystemRun
-              ? {
-                  designSystemChangeType: designSystemCreated
-                    ? hintHasExistingArtifact === true ? 'modified' : 'created'
-                    : 'none',
-                }
-              : {}),
-          }),
-        );
-        // Refresh local recovery snapshot so crash recovery matches PostHog
-        // `run_finished` (usage/timing/tools), not only run_created baseProps.
-        // Keep the base insertId here: reconcileDurableRunTerminals appends
-        // `-finish` when replaying. Storing `${runInsertId}-finish` would
-        // produce `…-finish-finish` and can duplicate PostHog events.
-        design.runs.setAnalyticsRecovery?.(run, {
-          context: analyticsContext,
-          properties: finishedProperties,
-          insertId: runInsertId,
-        });
-        await Promise.resolve(design.analytics.capture({
-          eventName: 'run_finished',
-          context: analyticsContext,
-          appVersion: design.getAppVersion(),
-          properties: finishedProperties,
-          insertId: `${runInsertId}-finish`,
-        }));
-        design.runs.markAnalyticsCompleted?.(run);
-      }).catch(() => {});
-    }
+    internalRuns.start(
+      run,
+      {
+        body: requestBody,
+        requestAnalyticsContext,
+        snapshot: resolvedSnapshot,
+        // The decision this request evaluated, not the one stamped on the Run:
+        // an idempotent retry reuses a Run that already carries an earlier
+        // decision, and `run_created`'s rollout dimensions have always
+        // described the request. See `harnessAnalyticsFromRolloutDecision`,
+        // which deliberately reads the Run instead.
+        rolloutDecision: strategyRolloutDecision,
+        creationKind: preparedRun.creationKind,
+        resumed,
+        attributionMismatch: analyticsAttributionMismatch,
+      },
+      () => startChatRun(executionMeta, run),
+    );
   });
 
   app.get('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
@@ -4764,7 +3684,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         ? { byokProvider: requestBody.byokProvider }
         : {}),
     };
-    internalRuns.start(run, () => startChatRun(executionMeta, run));
+    internalRuns.start(
+      run,
+      { body: requestBody, requestAnalyticsContext: readAnalyticsContext(req) },
+      () => startChatRun(executionMeta, run),
+    );
   });
 }
 

--- a/apps/daemon/src/runtimes/chat-run-records.ts
+++ b/apps/daemon/src/runtimes/chat-run-records.ts
@@ -1,0 +1,262 @@
+// Shapes and narrowing guards for the loosely-typed rows the run routes and
+// the run analytics lifecycle both read.
+//
+// These live outside `routes/runs.ts` so the analytics lifecycle can consume
+// them without importing the route module back — a run's project row and its
+// touched-artifact list are facts about the run, not about HTTP.
+//
+// Each guard takes the narrowest shape it actually reads rather than the full
+// `ChatRun`, so a caller can hand over any object that carries those fields.
+
+import type {
+  ChatRunStatus,
+  ChatRunStatusResponse,
+  ProjectMetadata as ContractProjectMetadata,
+  StrategyTaskProjectionV2,
+} from '@open-design/contracts';
+import type { AnalyticsContext } from '../analytics.js';
+import type { RunArtifactBaseline } from '../run-artifact-fs.js';
+import type {
+  RunEventForAnalyticsObservability,
+  RunTelemetryTimestamps,
+} from '../run-analytics-observability.js';
+import type { RunArtifactDiff } from '../run-artifact-fs.js';
+import type { RunEventForDiagnostics } from '../run-diagnostics.js';
+import type { RunEventForFailureClassification } from '../run-failure-classification.js';
+import type { RunWorkspaceScope } from './project-amr-trace-env.js';
+import type { OdNextRolloutDecision } from '../strategies/od-next/rollout.js';
+import type { OdNextTaskInputSnapshotDescriptor } from '../strategies/od-next/task-input-snapshot.js';
+
+import { getProject } from '../db.js';
+import {
+  validateRunDeliverable,
+  type RunDeliverableValidationResult,
+} from '../run-deliverable-validation.js';
+
+export type JsonRecord = Record<string, unknown>;
+export type ProjectMetadata = (Partial<ContractProjectMetadata> & JsonRecord) | null | undefined;
+
+export interface ProjectRecord {
+  id: string;
+  name: string;
+  createdAt?: number;
+  updatedAt?: number;
+  skillId?: string | null;
+  designSystemId?: string | null;
+  metadata?: ProjectMetadata;
+  appliedPluginSnapshotId?: string | null;
+}
+
+export function toJsonRecord(value: unknown): JsonRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : {};
+}
+
+export function toProjectRecord(value: unknown): ProjectRecord | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as JsonRecord;
+  return typeof record.id === 'string'
+    ? value as ProjectRecord
+    : null;
+}
+
+/** The run facts `validateChatRunDeliverable` reads. */
+export interface RunForDeliverableValidation {
+  projectId: string | null;
+  projectMetadata?: ProjectMetadata;
+}
+
+export async function validateChatRunDeliverable(input: {
+  db: Parameters<typeof getProject>[0];
+  projectsRoot: string;
+  run: RunForDeliverableValidation;
+  runStatus: Parameters<typeof validateRunDeliverable>[0]['runStatus'];
+  artifactCount: number;
+  touchedPaths?: string[];
+}): Promise<RunDeliverableValidationResult> {
+  const project = input.run.projectId
+    ? toProjectRecord(getProject(input.db, input.run.projectId))
+    : null;
+  return validateRunDeliverable({
+    projectsRoot: input.projectsRoot,
+    projectId: input.run.projectId,
+    projectMetadata:
+      project?.metadata ?? input.run.projectMetadata ?? null,
+    runStatus: input.runStatus,
+    artifactCount: input.artifactCount,
+    ...(input.touchedPaths ? { touchedPaths: input.touchedPaths } : {}),
+  });
+}
+
+/** The run facts `runTouchedArtifactPaths` reads. */
+export interface RunForTouchedArtifactPaths {
+  artifactOutcome?: { diff?: { touchedPaths?: unknown } } | undefined;
+}
+
+export function runTouchedArtifactPaths(
+  run: RunForTouchedArtifactPaths,
+): string[] | undefined {
+  const diff = (
+    run.artifactOutcome as
+      | { diff?: { touchedPaths?: unknown } }
+      | undefined
+  )?.diff;
+  return Array.isArray(diff?.touchedPaths)
+    ? diff.touchedPaths.filter(
+        (value): value is string => typeof value === 'string' && value.length > 0,
+      )
+    : undefined;
+}
+
+export interface RunEventRecord
+  extends RunEventForAnalyticsObservability,
+    RunEventForDiagnostics,
+    RunEventForFailureClassification {
+  id: number;
+  event: string;
+  data: unknown;
+  timestamp?: number;
+}
+
+export interface SseClient {
+  send(event: string, data: unknown, id?: number): void;
+  end(): void;
+  cleanup?(): void;
+}
+
+export interface ChatRun {
+  id: string;
+  projectId: string | null;
+  conversationId: string | null;
+  assistantMessageId: string | null;
+  clientRequestId?: string | null;
+  requestFingerprint?: string | null;
+  strategyRolloutDecision?: OdNextRolloutDecision | null;
+  agentId: string | null;
+  workspaceScope?: RunWorkspaceScope | null;
+  model?: string | null;
+  status: ChatRunStatus;
+  createdAt: number;
+  updatedAt: number;
+  cancelRequested?: boolean;
+  cancelOrigin?: ChatRunStatusResponse['cancelOrigin'];
+  terminalTrigger?: ChatRunStatusResponse['terminalTrigger'];
+  exitCode?: number | null;
+  signal?: string | null;
+  error?: string | null;
+  errorCode?: string | null;
+  failureAction?: string | null;
+  projectMetadata?: ProjectMetadata;
+  appliedPluginSnapshotId?: string | null;
+  pluginId?: string | null;
+  clientType?: 'desktop' | 'web' | 'external_mcp';
+  sessionMode?: string | null;
+  context?: Record<string, unknown> | null;
+  events: RunEventRecord[];
+  clients: Set<SseClient>;
+  analyticsContext?: AnalyticsContext;
+  analyticsRecovery?: { context?: AnalyticsContext } | null;
+  externalPluginAnalytics?: Record<string, unknown> | null;
+  manualResumeAttemptCount?: number;
+  rechargeWaitDurationMs?: number;
+  artifactOriginStatus?:
+    | 'matched'
+    | 'missing_version'
+    | 'digest_mismatch'
+    | 'invalid_origin'
+    | 'unknown';
+  artifactVersionId?: string;
+  deliverableValid?: boolean;
+  deliverableValidation?: ChatRunStatusResponse['deliverableValidation'];
+  deliverableEntryFile?: string;
+  deliverableArtifactKind?: ChatRunStatusResponse['deliverableArtifactKind'];
+  /** Shells staged for an OD Next prototype run, project-relative. */
+  odNextStagedDeviceFrames?: string[];
+  /** Run-finish observation: did the delivered entry carry the staged handset shell? */
+  odNextDeviceShell?: {
+    platform: 'ios' | 'android' | 'mobile-neutral';
+    resolvedFrom: 'request-text' | 'project-metadata';
+    entryFile: string;
+    shellPresent: boolean;
+  };
+  /** Run-finish observation: how the delivered entry carries the staged layout primitives. */
+  odNextLayoutPrimitives?: 'verbatim' | 'modified' | 'linked' | 'absent';
+  analyticsTelemetry?: RunTelemetryTimestamps;
+  resolvedModelId?: string | null;
+  preflightAgentCliVersion?: string | null;
+  // E-lite root-cause telemetry read at run_finished. `stdinBackpressure`: the
+  // prompt write to child stdin was queued (pipe buffer full). `lastAgentActivityAt`:
+  // the inactivity-watchdog clock, used to derive `last_progress_age_ms`.
+  stdinBackpressure?: boolean;
+  lastAgentActivityAt?: number;
+  retryAttemptCount?: number;
+  retryFinalResult?: string;
+  retrySuppressedReason?: string;
+  retryOriginalFailure?: {
+    failure_category?: string;
+    failure_detail?: string;
+    failure_stage?: string;
+    retryable?: boolean;
+    user_action?: string;
+  };
+  artifactOutcome?: {
+    artifactCount: number;
+    artifactsCreated?: number;
+    artifactsModified?: number;
+    designSystemCreated: boolean;
+    previewModuleCount: number;
+    filesWritten?: number;
+    diff?: RunArtifactDiff;
+  };
+  artifactPaths?: string[];
+  designSystemId?: string | null;
+  designSystemRequestedId?: string | null;
+  designSystemSelectionSource?: string | null;
+  designSystemDigest?: string | null;
+  promptCache?: {
+    stablePromptHash?: string;
+    hit?: boolean;
+    missReason?: string | null;
+    changedSections?: string[] | null;
+  };
+  strategyTask?: StrategyTaskProjectionV2;
+  odNextTaskInputSnapshot?: OdNextTaskInputSnapshotDescriptor | null;
+}
+
+/** Design-system selection provenance recorded on `run_created`. */
+export type DesignSystemSelectionSource =
+  | 'request'
+  | 'plugin'
+  | 'project'
+  | 'app-default'
+  | 'none';
+
+export interface RunRetryAnalyticsEvent {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+export interface RunArtifactBaselines {
+  take(runId: string): RunArtifactBaseline | undefined;
+}
+
+export interface RunCreatedFallbackInput {
+  analyticsContext: AnalyticsContext | null;
+  run: ChatRun;
+  status: string;
+}
+
+export interface RunProjectKindInput {
+  hintProjectKind: string | null;
+  projectMetadata?: ProjectMetadata;
+}
+
+/** A settled Run, as the analytics lifecycle reads it. */
+export type TerminalRunStatus = {
+  status: string;
+  error?: string | null;
+  errorCode?: string | null;
+  exitCode?: number | null;
+  signal?: string | null;
+};

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -504,6 +504,10 @@ import {
 } from './storage/amr-terminal-report-outbox.js';
 import { createInternalRunCreationService } from './services/internal-run-service.js';
 import {
+  createRunAnalyticsLifecycle,
+  inheritedRunLineageHints,
+} from './services/run-analytics-lifecycle.js';
+import {
   createOdNextRunInputProjection,
   OdNextTaskInputSnapshotError,
   removeOdNextRunInputProjection,
@@ -7522,11 +7526,6 @@ export async function startServer({
     getAppVersion: () => telemetry.getCachedAppVersion()?.version ?? '0.0.0',
     readAnalyticsContext,
   };
-  const internalRunCreation = createInternalRunCreationService({
-    runs: design.runs,
-    claimAssistantMessage: (run, options) =>
-      pinAssistantMessageOnRunCreate(db, run, options),
-  });
   const taskObservationRollout = createTaskObservationRolloutService({
     db,
     dataDir: RUNTIME_DATA_DIR,
@@ -7649,6 +7648,29 @@ export async function startServer({
     timer.unref?.();
   };
 
+  // Every physical Run is started through this service so the analytics
+  // lifecycle is installed once, for whoever asked for the Run — an HTTP
+  // client, an OD Next automatic continuation, a scheduled Automation, or a
+  // live-artifact refresh. Starting a Run any other way drops its analytics
+  // silently, which is what OPEND-2365 was.
+  const runAnalyticsLifecycle = createRunAnalyticsLifecycle({
+    db,
+    design,
+    paths: { PROJECTS_DIR, RUNTIME_DATA_DIR },
+    agents: { detectAgents },
+    telemetry: {
+      reportRunCompletionTelemetryFallback,
+      resolveRunProjectKindForAnalytics,
+      runArtifactBaselines,
+      runRetryEventsForAnalytics,
+    },
+  });
+  const internalRunCreation = createInternalRunCreationService({
+    runs: design.runs,
+    claimAssistantMessage: (run, options) =>
+      pinAssistantMessageOnRunCreate(db, run, options),
+    analyticsLifecycle: runAnalyticsLifecycle,
+  });
   const reportFeedback = telemetry.reportFeedback;
 
   // DNS-aware wrapper. The sync `validateBaseUrl` only inspects the literal
@@ -15663,6 +15685,13 @@ export async function startServer({
                   .digest('hex');
                 const meta = {
                   ...chatBody,
+                  // One logical task, several physical Runs. The chain is only
+                  // reassemblable downstream if each Run reports the lineage of
+                  // the Run that caused it.
+                  analyticsHints: {
+                    ...(chatBody.analyticsHints ?? {}),
+                    ...inheritedRunLineageHints(run, chatBody, taskRunIndex),
+                  },
                   projectId: strategyTaskAtStart.projectId,
                   conversationId: strategyTaskAtStart.conversationId,
                   agentId: strategyTaskAtStart.selectedAgentId,
@@ -15752,24 +15781,38 @@ export async function startServer({
             : null,
         });
         reconcileAssistantMessageOnRunEnd(db, design.runs, continuation.run);
-        internalRunCreation.start(continuation.run, async () => {
-          try {
-            return await startChatRun(continuation.chatBody, continuation.run);
-          } catch (error) {
-            reconcileStrategyTaskRunTerminal(db, {
-              runId: continuation.run.id,
-              status: 'failed',
-            });
-            const latestTask = getStrategyTaskExecutionByRunId(db, continuation.run.id);
-            if (latestTask) {
-              continuation.run.strategyTask = projectStrategyTask(
-                latestTask,
-                continuation.run.id,
-              );
+        internalRunCreation.start(
+          continuation.run,
+          {
+            // The continuation is composed from the source Run's body, so it
+            // carries the same project, agent, plugin and Skill facts. Identity
+            // is inherited rather than re-derived: nobody made a request for
+            // this Run, and the task it continues is the user's.
+            body: continuation.chatBody,
+            requestAnalyticsContext:
+              run.analyticsContext ?? run.analyticsRecovery?.context ?? null,
+            creationKind: 'created',
+            resumed: false,
+          },
+          async () => {
+            try {
+              return await startChatRun(continuation.chatBody, continuation.run);
+            } catch (error) {
+              reconcileStrategyTaskRunTerminal(db, {
+                runId: continuation.run.id,
+                status: 'failed',
+              });
+              const latestTask = getStrategyTaskExecutionByRunId(db, continuation.run.id);
+              if (latestTask) {
+                continuation.run.strategyTask = projectStrategyTask(
+                  latestTask,
+                  continuation.run.id,
+                );
+              }
+              throw error;
             }
-            throw error;
-          }
-        });
+          },
+        );
       }
       } finally {
         // Best-effort cleanup of the per-run agy log file on every close
@@ -15928,7 +15971,7 @@ export async function startServer({
     }
 
     const modelPrefs = appConfig.agentModels?.[agentId] ?? {};
-    design.runs.start(run, () => startChatRun({
+    const orbitRunBody = {
       agentId,
       projectId,
       conversationId: run.conversationId,
@@ -15949,7 +15992,16 @@ export async function startServer({
         'Do not ask follow-up questions, do not emit <question-form>, and do not wait for user input. This run is unattended; pick reasonable defaults and complete the artifact.',
         'Keep connector credentials and OD_TOOL_TOKEN private; never print or persist secrets.',
       ].join('\n'),
-    }, run));
+    };
+    // Nothing asked for this Run: it is a background refresh with no caller to
+    // attribute it to, so the analytics lifecycle finds no identity and stays
+    // silent. It still goes through the one start path, so the day a
+    // background Run gets an identity, it reports without further plumbing.
+    internalRunCreation.start(
+      run,
+      { body: orbitRunBody, requestAnalyticsContext: null },
+      () => startChatRun(orbitRunBody, run),
+    );
 
     const completion = (async () => {
       const finalStatus = await design.runs.wait(run);
@@ -16346,7 +16398,7 @@ export async function startServer({
       // surface phantom conversations (#1361).
       if (conversationCreatedEvent) emitProjectEvent(projectId, conversationCreatedEvent);
       const persistedDesignSystemId = getProject(db, projectId)?.designSystemId ?? null;
-      design.runs.start(run, () => startChatRun({
+      const routineRunBody = {
         agentId,
         projectId,
         conversationId: run.conversationId,
@@ -16363,7 +16415,14 @@ export async function startServer({
           `You are running an unattended scheduled routine named "${routine.name}".`,
           'Do not ask follow-up questions, do not emit <question-form>, and do not wait for user input. Pick reasonable defaults and finish the task.',
         ].join('\n'),
-      }, run));
+      };
+      // A scheduled Automation has no caller either — see the live-artifact
+      // note above. Same start path, same reason.
+      internalRunCreation.start(
+        run,
+        { body: routineRunBody, requestAnalyticsContext: null },
+        () => startChatRun(routineRunBody, run),
+      );
     };
 
     // Tear-down for the case where the durable routine_run row was never

--- a/apps/daemon/src/services/internal-run-service.ts
+++ b/apps/daemon/src/services/internal-run-service.ts
@@ -7,6 +7,17 @@
  * coordinator can reuse the same create -> claim -> start transaction without
  * calling the daemon through HTTP.
  */
+import type { RunAnalyticsFacts } from './run-analytics-lifecycle.js';
+
+/**
+ * `RunAnalyticsFacts` is a REQUIRED argument of `start` on purpose. Analytics
+ * used to be installed by whichever caller remembered to do it, and four
+ * daemon-internal Run creators silently reported nothing (OPEND-2365). Making
+ * the facts part of the start contract means a new caller has to state its
+ * analytics identity — including stating that it has none — instead of dropping
+ * the Run. The type is owned by the lifecycle so the choke point and the
+ * lifecycle cannot drift apart.
+ */
 export interface InternalRunCreateInput extends Record<string, unknown> {
   projectId?: string;
   conversationId?: string;
@@ -32,6 +43,10 @@ export interface InternalRunCreateInput extends Record<string, unknown> {
 export interface InternalPhysicalRun {
   id: string;
   status: string;
+}
+
+export interface InternalRunAnalyticsLifecycle<TRun> {
+  install(input: RunAnalyticsFacts & { run: TRun }): void;
 }
 
 export interface InternalRunRegistry<
@@ -86,7 +101,11 @@ export interface InternalRunCreationService<
   TRun extends InternalPhysicalRun,
 > {
   prepare(input: PrepareInternalRunInput<TMeta, TRun>): PreparedInternalRunResult<TRun>;
-  start(run: TRun, starter: (run: TRun) => Promise<unknown>): TRun;
+  start(
+    run: TRun,
+    analytics: RunAnalyticsFacts,
+    starter: (run: TRun) => Promise<unknown>,
+  ): TRun;
 }
 
 export function createInternalRunCreationService<
@@ -98,6 +117,11 @@ export function createInternalRunCreationService<
     run: TRun,
     options?: AssistantRunClaimOptions,
   ) => AssistantRunClaimResult;
+  /**
+   * Armed for every physical Run this service starts, whoever asked for it.
+   * Optional only so a test harness can leave it out.
+   */
+  analyticsLifecycle?: InternalRunAnalyticsLifecycle<TRun>;
 }): InternalRunCreationService<TMeta, TRun> {
   const isRunActive = (runId: string): boolean => {
     const existing = deps.runs.get(runId);
@@ -161,7 +185,11 @@ export function createInternalRunCreationService<
 
   return {
     prepare,
-    start(run, starter) {
+    start(run, analytics, starter) {
+      // Before the child is spawned: `run_created` describes a Run that has
+      // been accepted, and the terminal half must already be attached when the
+      // Run settles — including a Run that fails on its first tick.
+      deps.analyticsLifecycle?.install({ ...analytics, run });
       return deps.runs.start(run, () => starter(run));
     },
   };

--- a/apps/daemon/src/services/run-analytics-lifecycle.ts
+++ b/apps/daemon/src/services/run-analytics-lifecycle.ts
@@ -1,0 +1,1171 @@
+// The physical-Run analytics lifecycle: `run_created` on start, `run_finished`
+// on terminal, and the durable recovery record that lets a daemon restart
+// replay the pair.
+//
+// This used to live inline in `POST /api/runs`, which meant a Run only entered
+// the lifecycle if a client had asked for it over HTTP. Every physical Run the
+// daemon allocates on its own — an OD Next automatic continuation, a scheduled
+// Automation, a live-artifact refresh — started outside it and reported
+// nothing, so per-Run rates were computed on the client-started stage alone
+// (OPEND-2365). It is a module now so `internalRunCreation.start` can install
+// it for every physical Run from one place, whoever asked for the Run.
+//
+// Nothing here may throw into the caller: analytics is an observer of the Run,
+// never a participant in it.
+
+import {
+  buildRunCreatedV4Aliases,
+  buildRunFinishedV4Aliases,
+  deriveConfigureGlobals,
+  harnessAnalyticsFromRolloutDecision,
+  modelIdForTracking,
+  sessionModeToTracking,
+  type RunTaskLineageProps,
+  type TrackingDesignSystemEditSurface,
+  type TrackingDesignSystemKind,
+  type TrackingDesignSystemSource,
+  type TrackingRunRecoveryActionType,
+} from '@open-design/contracts/analytics';
+import { spawnEnvForAgent } from '../agents.js';
+import { newInsertId } from '../analytics.js';
+import type { AnalyticsContext } from '../analytics.js';
+import { agentCliEnvForAgent, readAppConfig } from '../app-config.js';
+import {
+  codexSessionIdFromRunEvents,
+  readCodexRolloutFirstCall,
+} from '../codex-rollout-usage.js';
+import {
+  conversationTurnIndexForRun,
+  getProject,
+  updateProject,
+} from '../db.js';
+import { readVelaLoginStatus } from '../integrations/vela.js';
+import {
+  deriveLangfuseDeliveryState,
+  readTelemetrySinkConfig,
+} from '../langfuse-trace.js';
+import {
+  agentProviderIdForRunAnalytics,
+  amrUserIdForRunAnalytics,
+  hasExplicitRequestedModelForAnalytics,
+  runtimeTypeForRunAnalytics,
+  scanRunEventsForUsageAnalytics,
+  summarizeRunTimingAnalytics,
+  summarizeToolAnalytics,
+} from '../run-analytics-observability.js';
+import {
+  diffRunArtifacts,
+  primaryArtifactChangeForRun,
+  snapshotProjectArtifacts,
+  supportingAssetFilesChangedForRun,
+  type RunArtifactDiff,
+} from '../run-artifact-fs.js';
+import { summarizeRunDiagnosticsForAnalytics } from '../run-diagnostics.js';
+import { classifyRunFailure } from '../run-failure-classification.js';
+import { deriveRunErrorCode, runResultFromStatus } from '../run-result.js';
+import { runMessageEventPersistenceAnalytics } from '../runtimes/chat-run-messages.js';
+import { getDetectedRuntimeVersions } from '../runtimes/detection.js';
+import {
+  deriveActivationMilestones,
+  runAskedUserQuestion,
+} from '../runtimes/run-artifacts.js';
+import {
+  runArtifactCountForRun,
+  runDesignSystemCreatedForRun,
+  runFilesWrittenForRun,
+  runPreviewModuleCountForRun,
+} from '../runtimes/run-lifecycle-analytics.js';
+import { odNextRolloutAnalyticsProperties } from '../strategies/od-next/rollout-analytics.js';
+import type { AppliedPluginSnapshot } from '@open-design/contracts';
+import type { OdNextRolloutDecision } from '../strategies/od-next/rollout.js';
+import {
+  runTouchedArtifactPaths,
+  toJsonRecord,
+  toProjectRecord,
+  validateChatRunDeliverable,
+  type ChatRun,
+  type DesignSystemSelectionSource,
+  type JsonRecord,
+  type ProjectRecord,
+  type RunArtifactBaselines,
+  type RunCreatedFallbackInput,
+  type RunProjectKindInput,
+  type RunRetryAnalyticsEvent,
+  type TerminalRunStatus,
+} from '../runtimes/chat-run-records.js';
+
+type AgentCliEnv = Parameters<typeof agentCliEnvForAgent>[0];
+
+function isProjectEnrichableDesignSystem(project: ProjectRecord): boolean {
+  if (typeof project.designSystemId === 'string' && project.designSystemId.length > 0) {
+    return true;
+  }
+  const metadata = project.metadata;
+  return metadata?.importedFrom === 'brand-extraction' || metadata?.importedFrom === 'design-system';
+}
+
+function normalizedDesignSystemId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveEffectiveDesignSystemSelection({
+  requestDesignSystemId,
+  pluginDesignSystemId,
+  projectDesignSystemId,
+  appDefaultDesignSystemId,
+  disabledDesignSystemIds,
+  allowAppDefault = true,
+}: {
+  requestDesignSystemId?: unknown;
+  pluginDesignSystemId?: unknown;
+  projectDesignSystemId?: unknown;
+  appDefaultDesignSystemId?: unknown;
+  disabledDesignSystemIds?: unknown;
+  allowAppDefault?: boolean;
+}): { id: string | null; source: DesignSystemSelectionSource } {
+  const requestId = normalizedDesignSystemId(requestDesignSystemId);
+  if (requestId) return { id: requestId, source: 'request' };
+
+  const pluginId = normalizedDesignSystemId(pluginDesignSystemId);
+  if (pluginId) return { id: pluginId, source: 'plugin' };
+
+  const disabledIds = Array.isArray(disabledDesignSystemIds)
+    ? disabledDesignSystemIds.map(normalizedDesignSystemId).filter(
+        (value): value is string => value !== null,
+      )
+    : [];
+  const projectId = normalizedDesignSystemId(projectDesignSystemId);
+  if (projectId && !disabledIds.includes(projectId)) {
+    return { id: projectId, source: 'project' };
+  }
+
+  if (allowAppDefault) {
+    const appDefaultId = normalizedDesignSystemId(appDefaultDesignSystemId);
+    if (appDefaultId) return { id: appDefaultId, source: 'app-default' };
+  }
+
+  return { id: null, source: 'none' };
+}
+
+function designSystemIdFromPluginSnapshot(snapshot: unknown): string | null {
+  const items = (snapshot as { resolvedContext?: { items?: unknown } } | null | undefined)
+    ?.resolvedContext?.items;
+  if (!Array.isArray(items)) return null;
+  const designSystemItems = items.filter(
+    (item): item is { kind: string; id?: unknown; primary?: unknown } =>
+      item !== null &&
+      typeof item === 'object' &&
+      (item as { kind?: unknown }).kind === 'design-system',
+  );
+  const primary = designSystemItems.find((item) => item.primary === true);
+  return normalizedDesignSystemId(primary?.id ?? designSystemItems[0]?.id);
+}
+
+/**
+ * The lineage hints a daemon-created Run inherits from the Run that caused it.
+ *
+ * A logical task can span several physical Runs (request -> contract_repair ->
+ * production). Without this, every Run falls back to its own id and lands in
+ * the warehouse as an unrelated one-Run task: the chain cannot be reassembled
+ * and per-stage rates cannot be compared.
+ *
+ * Resolved from the source Run's request facts, NOT from the recovery record
+ * its own `run_created` wrote. The lifecycle re-reads host facts before it
+ * captures, so a short Run can hand off to its continuation before that record
+ * exists; inheriting from it would silently start a second task. The fallback
+ * chain below is the same one `install` applies to the source Run, so both
+ * resolve to the same id whether or not the record has landed yet.
+ */
+export function inheritedRunLineageHints(
+  sourceRun: { id: string; clientRequestId?: string | null },
+  sourceBody: { analyticsHints?: unknown } | null | undefined,
+  taskRunIndex: number,
+): {
+  taskExecutionId: string;
+  initialRunId: string;
+  taskRunIndex: number;
+  sourceRunId: string;
+} {
+  const hints = toJsonRecord((sourceBody ?? {}).analyticsHints);
+  const hint = (key: string): string | null =>
+    typeof hints[key] === 'string' && hints[key] ? hints[key] as string : null;
+  return {
+    taskExecutionId:
+      hint('taskExecutionId') ?? sourceRun.clientRequestId ?? sourceRun.id,
+    initialRunId: hint('initialRunId') ?? sourceRun.id,
+    taskRunIndex,
+    sourceRunId: sourceRun.id,
+  };
+}
+
+/**
+ * What the lifecycle reads from the daemon. `telemetry` is the same group the
+ * run routes already own — it exists only to serve these two events.
+ */
+export interface RunAnalyticsLifecycleDeps {
+  db: Parameters<typeof getProject>[0];
+  design: {
+    runs: {
+      wait(run: ChatRun): Promise<TerminalRunStatus>;
+      setAnalyticsRecovery?(run: ChatRun, recovery: {
+        context: AnalyticsContext;
+        properties: Record<string, unknown>;
+        insertId: string;
+      }): void;
+      markAnalyticsCompleted?(run: ChatRun): void;
+      setDeliverableValidation?(run: ChatRun, result: unknown): void;
+    };
+    analytics: {
+      capture(args: {
+        eventName: string;
+        context: AnalyticsContext;
+        appVersion: string;
+        properties: Record<string, unknown>;
+        insertId: string;
+      }): void | Promise<void>;
+    };
+    getAppVersion(): string;
+  };
+  paths: { PROJECTS_DIR: string; RUNTIME_DATA_DIR: string };
+  agents: {
+    detectAgents: (
+      agentCliEnv?: Record<string, unknown>,
+    ) => Promise<Array<{ id: string; available: boolean }>>;
+  };
+  telemetry: RunAnalyticsTelemetryDeps;
+}
+
+export interface RunAnalyticsTelemetryDeps {
+  reportRunCompletionTelemetryFallback: (input: RunCreatedFallbackInput) => void;
+  resolveRunProjectKindForAnalytics: (input: RunProjectKindInput) => string | null;
+  runArtifactBaselines: RunArtifactBaselines;
+  runRetryEventsForAnalytics: (events: ChatRun['events']) => RunRetryAnalyticsEvent[];
+}
+
+/**
+ * Everything about one physical Run that is not readable off the Run itself.
+ *
+ * A daemon-started Run supplies the same facts its HTTP sibling would: the
+ * request body it was composed from, and the analytics identity it inherits
+ * from the Run that caused it. `analyticsContext` resolution stays first-write
+ * immutable — a continuation cannot relabel the identity of the task it
+ * continues.
+ */
+export interface RunAnalyticsFacts {
+  body: JsonRecord;
+  /**
+   * Identity of the caller that asked for this Run. Absent for a Run nothing
+   * asked for (a scheduled Automation, a background refresh): the lifecycle
+   * then finds no context and stays silent rather than inventing one.
+   */
+  requestAnalyticsContext?: AnalyticsContext | null;
+  /**
+   * The resolved plugin snapshot, when the caller had one. Declared as the
+   * narrow shape this module actually reads rather than the resolver's full
+   * union, so a caller that only holds the successful resolution can hand it
+   * over without a cast.
+   */
+  snapshot?: { ok: boolean; snapshot: AppliedPluginSnapshot } | null;
+  /**
+   * The rollout decision the caller evaluated for this Run. Defaults to the
+   * one stamped on the Run, which is what `run_finished` and the crash-recovery
+   * replay both read.
+   */
+  rolloutDecision?: OdNextRolloutDecision | null;
+  creationKind?: 'created' | 'reused';
+  resumed?: boolean;
+  attributionMismatch?: boolean;
+}
+
+/** The facts plus the Run they describe. */
+export type RunAnalyticsInstallInput = RunAnalyticsFacts & { run: ChatRun };
+
+export interface RunAnalyticsLifecycle {
+  /**
+   * Arm both events for one physical Run. Safe to call before the Run starts;
+   * the terminal half attaches to `runs.wait` and settles on its own.
+   */
+  install(input: RunAnalyticsInstallInput): void;
+}
+
+export function createRunAnalyticsLifecycle(
+  deps: RunAnalyticsLifecycleDeps,
+): RunAnalyticsLifecycle {
+  const { db, design } = deps;
+  const { PROJECTS_DIR, RUNTIME_DATA_DIR } = deps.paths;
+  const { detectAgents } = deps.agents;
+  const {
+    reportRunCompletionTelemetryFallback,
+    resolveRunProjectKindForAnalytics,
+    runArtifactBaselines,
+    runRetryEventsForAnalytics,
+  } = deps.telemetry;
+
+  const install = (input: RunAnalyticsInstallInput): void => {
+    const run = input.run;
+    const strategyRolloutDecision =
+      input.rolloutDecision !== undefined
+        ? input.rolloutDecision
+        : run.strategyRolloutDecision ?? null;
+    void (async () => {
+      const reqBody = input.body;
+      const analyticsHints =
+        (reqBody as { analyticsHints?: Record<string, unknown> | null }).analyticsHints
+          && typeof (reqBody as { analyticsHints?: unknown }).analyticsHints === 'object'
+          ? ((reqBody as { analyticsHints?: Record<string, unknown> }).analyticsHints ?? {})
+          : {};
+      // Marks the AI-optimize (deep enrichment) run so completion can flag the DS
+      // ai_refined even when analytics is unavailable or disabled.
+      const hintDsEnrichment = analyticsHints.dsEnrichment === true;
+      const requestProjectId = typeof reqBody.projectId === 'string' ? reqBody.projectId : null;
+      if (hintDsEnrichment && requestProjectId) {
+        design.runs.wait(run).then((status: TerminalRunStatus) => {
+          if (runResultFromStatus(status.status) !== 'success') return;
+          try {
+            const enrichedProject = toProjectRecord(getProject(db, requestProjectId));
+            if (enrichedProject && isProjectEnrichableDesignSystem(enrichedProject)) {
+              updateProject(db, requestProjectId, {
+                metadata: {
+                  ...(enrichedProject.metadata ?? {}),
+                  enrichmentStatus: 'ai_refined',
+                  enrichmentCompletedAt: Date.now(),
+                },
+              });
+            }
+          } catch {
+            // Best-effort flag; do not fail run completion if metadata refresh fails.
+          }
+        }).catch(() => {});
+      }
+
+      const recoveredAnalyticsContext =
+        run.analyticsRecovery
+        && typeof run.analyticsRecovery === 'object'
+        && (run.analyticsRecovery as { context?: unknown }).context
+        && typeof (run.analyticsRecovery as { context?: unknown }).context === 'object'
+          ? ((run.analyticsRecovery as { context: AnalyticsContext }).context)
+          : null;
+      // Source/identity is first-write immutable for a logical run. A retry or
+      // recharge resume cannot relabel a prior ordinary request as Plugin (or
+      // vice versa) by changing analytics-only headers.
+      const analyticsContext =
+        run.analyticsContext
+        ?? recoveredAnalyticsContext
+        ?? input.requestAnalyticsContext
+        ?? null;
+      if (!run.analyticsContext && analyticsContext) {
+        run.analyticsContext = analyticsContext;
+      }
+      design.runs.wait(run).then((status: { status: string }) => {
+        reportRunCompletionTelemetryFallback({
+          analyticsContext: analyticsContext ?? null,
+          run,
+          status: status.status,
+        });
+      }).catch(() => {});
+      if (analyticsContext) {
+        const runInsertId = newInsertId();
+        const appCfgForAnalytics = await readAppConfig(RUNTIME_DATA_DIR).catch(
+          () => ({} as Record<string, unknown>),
+        );
+        const detectedAgentsForAnalytics = await detectAgents(
+          toJsonRecord((appCfgForAnalytics as { agentCliEnv?: unknown }).agentCliEnv),
+        ).catch((): Array<{ id: string; available: boolean }> => []);
+        const velaStatusForAnalytics = (() => {
+          try {
+            const configuredAmrEnv = agentCliEnvForAgent(
+              (appCfgForAnalytics as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+              'amr',
+            );
+            return readVelaLoginStatus(process.env, configuredAmrEnv);
+          } catch {
+            return null;
+          }
+        })();
+        const configureGlobals = deriveConfigureGlobals({
+          mode: 'daemon',
+          agentId: typeof reqBody.agentId === 'string' ? reqBody.agentId : null,
+          agents: detectedAgentsForAnalytics,
+          amrAuthorized: velaStatusForAnalytics?.loggedIn === true,
+        });
+        const promptText =
+          typeof reqBody.currentPrompt === 'string'
+            ? reqBody.currentPrompt
+            : typeof reqBody.message === 'string'
+              ? reqBody.message
+              : '';
+        const userQueryTokens = promptText.length > 0
+          ? Math.ceil(promptText.length / 4)
+          : 0;
+        const hintEntryFrom = typeof analyticsHints.entryFrom === 'string'
+          ? analyticsHints.entryFrom
+          : undefined;
+        const hintProjectKind = typeof analyticsHints.projectKind === 'string'
+          ? analyticsHints.projectKind
+          : null;
+        const hintTurnIndex = typeof analyticsHints.turnIndex === 'number'
+          ? analyticsHints.turnIndex
+          : undefined;
+        const hintIsFirstRun = typeof analyticsHints.isFirstRun === 'boolean'
+          ? analyticsHints.isFirstRun
+          : undefined;
+        const hintHasExistingArtifact = typeof analyticsHints.hasExistingArtifact === 'boolean'
+          ? analyticsHints.hasExistingArtifact
+          : undefined;
+        const hintProjectTurnIndex = typeof analyticsHints.projectTurnIndex === 'number'
+          ? analyticsHints.projectTurnIndex
+          : undefined;
+        const taskExecutionId = typeof analyticsHints.taskExecutionId === 'string'
+          && analyticsHints.taskExecutionId.length > 0
+          ? analyticsHints.taskExecutionId
+          : run.clientRequestId ?? run.id;
+        const initialRunId = typeof analyticsHints.initialRunId === 'string'
+          && analyticsHints.initialRunId.length > 0
+          ? analyticsHints.initialRunId
+          : run.id;
+        const taskRunIndex = typeof analyticsHints.taskRunIndex === 'number'
+          && Number.isInteger(analyticsHints.taskRunIndex)
+          && analyticsHints.taskRunIndex >= 0
+          ? analyticsHints.taskRunIndex
+          : 0;
+        const recoveryActionTypes: ReadonlySet<TrackingRunRecoveryActionType> = new Set([
+          'manual_retry',
+          'resume_run',
+          'authorize_and_retry',
+          'switch_model_retry',
+          'switch_runtime_retry',
+          'question_answer',
+        ]);
+        const recoveryActionType = typeof analyticsHints.recoveryActionType === 'string'
+          && recoveryActionTypes.has(
+            analyticsHints.recoveryActionType as TrackingRunRecoveryActionType,
+          )
+          ? analyticsHints.recoveryActionType as TrackingRunRecoveryActionType
+          : undefined;
+        const taskLineage: RunTaskLineageProps = {
+          task_execution_id: taskExecutionId,
+          initial_run_id: initialRunId,
+          task_run_index: taskRunIndex,
+          ...(typeof analyticsHints.sourceRunId === 'string' && analyticsHints.sourceRunId.length > 0
+            ? { source_run_id: analyticsHints.sourceRunId }
+            : {}),
+          ...(recoveryActionType ? { recovery_action_type: recoveryActionType } : {}),
+          ...(typeof analyticsHints.recoveryActionInstanceId === 'string'
+            && analyticsHints.recoveryActionInstanceId.length > 0
+            ? { recovery_action_instance_id: analyticsHints.recoveryActionInstanceId }
+            : {}),
+        };
+        const conversationTurnIndex = run.conversationId
+          ? conversationTurnIndexForRun(db, run.conversationId, run.id)
+          : null;
+        const sessionDimensionProps = {
+          ...(hintTurnIndex !== undefined ? { turn_index: hintTurnIndex } : {}),
+          ...(hintIsFirstRun !== undefined ? { is_first_run: hintIsFirstRun } : {}),
+          ...(hintProjectTurnIndex !== undefined
+            ? { project_turn_index: hintProjectTurnIndex }
+            : {}),
+          ...(conversationTurnIndex !== null
+            ? { conversation_turn_index: conversationTurnIndex }
+            : {}),
+          ...(hintHasExistingArtifact !== undefined
+            ? { has_existing_artifact: hintHasExistingArtifact }
+            : {}),
+        };
+        const runProjectForAnalytics = requestProjectId
+          ? toProjectRecord(getProject(db, requestProjectId))
+          : null;
+        const analyticsDesignSystemSelection = resolveEffectiveDesignSystemSelection({
+          requestDesignSystemId: reqBody.designSystemId,
+          pluginDesignSystemId: input.snapshot?.ok
+            ? designSystemIdFromPluginSnapshot(input.snapshot.snapshot)
+            : null,
+          projectDesignSystemId: runProjectForAnalytics?.designSystemId,
+          appDefaultDesignSystemId: (appCfgForAnalytics as { designSystemId?: unknown }).designSystemId,
+          disabledDesignSystemIds: (appCfgForAnalytics as { disabledDesignSystems?: unknown }).disabledDesignSystems,
+          allowAppDefault: runProjectForAnalytics === null,
+        });
+        const runProjectKind = resolveRunProjectKindForAnalytics({
+          hintProjectKind,
+          projectMetadata: runProjectForAnalytics?.metadata,
+        });
+        const dsRunContext =
+          analyticsHints.designSystemRunContext
+            && typeof analyticsHints.designSystemRunContext === 'object'
+            ? (analyticsHints.designSystemRunContext as Record<string, unknown>)
+            : {};
+        const isDesignSystemRun =
+          runProjectKind === 'design_system'
+          || hintEntryFrom === 'design_system_create'
+          || hintEntryFrom === 'onboarding_design_system'
+          || hintEntryFrom === 'regenerate_from_review';
+        const reqContext =
+          reqBody.context && typeof reqBody.context === 'object'
+            ? (reqBody.context as Record<string, unknown>)
+            : {};
+        const runMcpServerIds = Array.isArray(reqContext.mcpServerIds)
+          ? (reqContext.mcpServerIds as unknown[]).filter(
+              (id): id is string => typeof id === 'string',
+            )
+          : [];
+        const runTurnSkillIds = Array.isArray(reqBody.skillIds)
+          ? (reqBody.skillIds as unknown[]).filter(
+              (id): id is string => typeof id === 'string',
+            )
+          : [];
+        const runSkillIds = [
+          ...new Set(
+            [reqBody.skillId, ...runTurnSkillIds].filter(
+              (id): id is string => typeof id === 'string' && id.length > 0,
+            ),
+          ),
+        ];
+        // Map the internal DS selection source -> the wire `design_system_source`
+        // enum (previously hard-wired to unknown/not_applicable). And derive
+        // official-vs-custom from the id shape (`user:<id>` => custom). See the
+        // design-system tracking spec §3.5 (U3/U4).
+        const dsSelectedId = analyticsDesignSystemSelection.id;
+        const designSystemSourceForRun: TrackingDesignSystemSource = (() => {
+          switch (analyticsDesignSystemSelection.source) {
+            case 'request':
+              return 'user_selected';
+            case 'plugin':
+              return 'template_inherited';
+            case 'project':
+              return 'project_saved';
+            case 'app-default':
+              return 'default';
+            case 'none':
+            default:
+              return dsSelectedId ? 'unknown' : 'not_applicable';
+          }
+        })();
+        const designSystemKindForRun: TrackingDesignSystemKind | undefined = dsSelectedId
+          ? dsSelectedId.startsWith('user:')
+            ? 'custom'
+            : 'official'
+          : undefined;
+        const designSystemSlugForRun =
+          dsSelectedId && !dsSelectedId.startsWith('user:') ? dsSelectedId : undefined;
+        // E1 (tracking spec §3.4): a DS-project run that edits an EXISTING design
+        // system carries which surface drove it. comment/mark ride their own
+        // entry_from; everything else editing an existing DS is the chat surface.
+        // First-generation runs (no existing artifact) get no edit_surface.
+        const editSurfaceForRun: TrackingDesignSystemEditSurface | undefined =
+          runProjectKind === 'design_system' && hintHasExistingArtifact === true
+            ? hintEntryFrom === 'comment'
+              ? 'comment'
+              : hintEntryFrom === 'mark'
+                ? 'mark'
+                : 'chat'
+            : undefined;
+        const baseProps: Record<string, unknown> = {
+          page_name: isDesignSystemRun ? 'design_system_project' : 'chat_panel',
+          area: isDesignSystemRun ? 'design_system_generation' : 'chat_composer',
+          ...configureGlobals,
+          ...odNextRolloutAnalyticsProperties(strategyRolloutDecision),
+          runtime_type: runtimeTypeForRunAnalytics({
+            derived: configureGlobals.runtime_type,
+            hint: analyticsHints.runtimeType,
+          }),
+          ...amrUserIdForRunAnalytics(velaStatusForAnalytics),
+          project_id: requestProjectId,
+          conversation_id:
+            typeof reqBody.conversationId === 'string' ? reqBody.conversationId : null,
+          run_id: run.id,
+          project_kind: runProjectKind,
+          ...(hintEntryFrom ? { entry_from: hintEntryFrom } : {}),
+          ...sessionDimensionProps,
+          design_system_id: dsSelectedId ?? undefined,
+          design_system_selection_source: analyticsDesignSystemSelection.source,
+          design_system_source: designSystemSourceForRun,
+          ...(designSystemKindForRun ? { design_system_kind: designSystemKindForRun } : {}),
+          ...(designSystemSlugForRun ? { design_system_slug: designSystemSlugForRun } : {}),
+          ...(editSurfaceForRun ? { edit_surface: editSurfaceForRun } : {}),
+          ...(isDesignSystemRun ? {
+            ds_source_origin: typeof dsRunContext.origin === 'string'
+              ? dsRunContext.origin
+              : undefined,
+            source_count: typeof dsRunContext.sourceCount === 'number'
+              ? dsRunContext.sourceCount
+              : undefined,
+            has_brand_description: typeof dsRunContext.hasBrandDescription === 'boolean'
+              ? dsRunContext.hasBrandDescription
+              : undefined,
+            brand_description_length_bucket:
+              typeof dsRunContext.brandDescriptionLengthBucket === 'string'
+                ? dsRunContext.brandDescriptionLengthBucket
+                : undefined,
+            github_repo_count: typeof dsRunContext.githubRepoCount === 'number'
+              ? dsRunContext.githubRepoCount
+              : undefined,
+            local_folder_count: typeof dsRunContext.localFolderCount === 'number'
+              ? dsRunContext.localFolderCount
+              : undefined,
+            fig_file_count: typeof dsRunContext.figFileCount === 'number'
+              ? dsRunContext.figFileCount
+              : undefined,
+            asset_file_count: typeof dsRunContext.assetFileCount === 'number'
+              ? dsRunContext.assetFileCount
+              : undefined,
+          } : {}),
+          has_attachment: Array.isArray(reqBody.attachments)
+            ? (reqBody.attachments as unknown[]).length > 0
+            : false,
+          user_query_tokens: userQueryTokens,
+          model_id: modelIdForTracking(
+            typeof reqBody.model === 'string' ? reqBody.model : null,
+          ),
+          agent_provider_id: agentProviderIdForRunAnalytics({
+            agentId: reqBody.agentId,
+            byokProvider: reqBody.byokProvider,
+          }),
+          skill_id: typeof reqBody.skillId === 'string' ? reqBody.skillId : null,
+          ...(!isDesignSystemRun && typeof reqBody.sessionMode === 'string'
+            ? { session_mode: sessionModeToTracking(reqBody.sessionMode) }
+            : {}),
+          plugin_id: input.snapshot?.ok
+            ? input.snapshot.snapshot.pluginId
+            : typeof reqBody.pluginId === 'string'
+              ? reqBody.pluginId
+              : null,
+          mcp_ids: runMcpServerIds,
+          mcp_id: runMcpServerIds[0] ?? null,
+          skill_ids: runSkillIds,
+          token_count_source: userQueryTokens > 0 ? 'estimated' : 'unknown',
+          ...(run.externalPluginAnalytics
+            ? {
+                entry_surface:
+                  run.externalPluginAnalytics.entrySurface,
+                host_product:
+                  run.externalPluginAnalytics.hostProduct,
+                external_plugin_id:
+                  run.externalPluginAnalytics.externalPluginId,
+                external_plugin_version:
+                  run.externalPluginAnalytics.externalPluginVersion,
+                distribution_mechanism:
+                  run.externalPluginAnalytics.distributionMechanism,
+                publisher_class:
+                  run.externalPluginAnalytics.publisherClass,
+                attribution_quality:
+                  run.externalPluginAnalytics.attributionQuality,
+                plugin_workflow_id:
+                  run.externalPluginAnalytics.pluginWorkflowId,
+                logical_request_digest:
+                  run.externalPluginAnalytics.logicalRequestDigest,
+                logical_request_digest_version:
+                  run.externalPluginAnalytics.logicalRequestDigestVersion,
+                brief_state:
+                  run.externalPluginAnalytics.briefState,
+                generation_slo_window_ms:
+                  run.externalPluginAnalytics.generationSloWindowMs,
+                deduplicated: input.creationKind === 'reused',
+                resume: input.resumed === true,
+                attempt_count: (run.manualResumeAttemptCount ?? 0) + 1,
+                recharge_wait_duration_ms:
+                  run.rechargeWaitDurationMs ?? 0,
+                ...(input.attributionMismatch
+                  ? { source_metadata_mismatch: true }
+                  : {}),
+              }
+            : {}),
+        };
+        // Read off the run rather than the local decision variable: the run is
+        // what `run_finished` and the crash-recovery replay both see, so stamping
+        // it here is the only place this dimension has to be added.
+        Object.assign(baseProps, harnessAnalyticsFromRolloutDecision(run.strategyRolloutDecision));
+        Object.assign(baseProps, buildRunCreatedV4Aliases(baseProps, taskLineage));
+        design.runs.setAnalyticsRecovery?.(run, {
+          context: analyticsContext,
+          properties: baseProps,
+          insertId: runInsertId,
+        });
+        design.analytics.capture({
+          eventName: 'run_created',
+          context: analyticsContext,
+          appVersion: design.getAppVersion(),
+          properties: baseProps,
+          insertId: runInsertId,
+        });
+        design.runs.wait(run).then(async (status: TerminalRunStatus) => {
+          const appCfgAtFinish = await readAppConfig(RUNTIME_DATA_DIR).catch(
+            () => ({} as Record<string, unknown>),
+          );
+          const langfuseDeliveryForAnalytics = deriveLangfuseDeliveryState(
+            (appCfgAtFinish as { telemetry?: Record<string, unknown> }).telemetry ?? {},
+            readTelemetrySinkConfig(),
+          );
+          const result = runResultFromStatus(status.status);
+          const errorCode = deriveRunErrorCode(status);
+          // C14/C15: AI-optimize (enrichment) run settled. Emit the dedicated
+          // result event; the success metadata flag runs outside this analytics gate.
+          if (hintDsEnrichment && analyticsContext) {
+            design.analytics.capture({
+              eventName: 'design_system_enrich_result',
+              context: analyticsContext,
+              appVersion: design.getAppVersion(),
+              properties: {
+                page_name: 'design_system_project',
+                area: 'design_system_enrich',
+                result,
+                design_system_id: dsSelectedId ?? undefined,
+                project_id: requestProjectId,
+                run_id: run.id,
+                ...(errorCode ? { error_code: errorCode } : {}),
+                duration_ms: Math.max(0, Date.now() - run.createdAt),
+              },
+              insertId: newInsertId(),
+            });
+          }
+          const failure = classifyRunFailure({
+            result,
+            status,
+            ...(errorCode ? { errorCode } : {}),
+            agentId: run.agentId,
+            cancelOrigin: run.cancelOrigin ?? null,
+            terminalTrigger: run.terminalTrigger ?? null,
+            events: run.events,
+          });
+          const usageAnalytics = scanRunEventsForUsageAnalytics(
+            run.events,
+            reqBody.model,
+            userQueryTokens,
+          );
+          // Whether this run is a non-first turn in its conversation — i.e. a
+          // prior completed assistant turn exists (excluding this run's own
+          // placeholder). The session-reuse cache win only applies to follow-up
+          // turns, so slicing `first_call_cache_hit_ratio` by this flag is the
+          // baseline-vs-optimized comparison. Mirrors server.ts hasPriorAssistantTurn.
+          const isFollowupTurn = run.conversationId
+            ? Boolean(
+                db
+                  .prepare(
+                    `SELECT 1 FROM messages
+                       WHERE conversation_id = ?
+                         AND role = 'assistant'
+                         AND COALESCE(content, '') <> ''
+                         AND id <> COALESCE(?, '')
+                       LIMIT 1`,
+                  )
+                  .get(run.conversationId, run.assistantMessageId ?? ''),
+              )
+            : false;
+          // Resolve the turn's first-call usage (cache-hit of the OPENING model
+          // call — the signal session reuse moves). Every coding agent except
+          // codex reports per-call usage on the stream, so the forward-scanned
+          // first usage event IS the opening call. codex reports only a single
+          // cumulative `turn.completed` usage on the stream, so its first stream
+          // event is the whole-session aggregate; its real per-call number lives
+          // in the rollout `last_token_usage`, read here best-effort.
+          const firstCallUsage = await (async (): Promise<{
+            first_call_input_tokens?: number;
+            first_call_input_tokens_effective?: number;
+            first_call_cache_read_input_tokens?: number;
+            first_call_cache_creation_input_tokens?: number;
+            first_call_cache_hit_ratio?: number;
+          } | null> => {
+            if (run.agentId === 'codex') {
+              // Best-effort: a throw anywhere here (env resolution, rollout read)
+              // must degrade to "no codex first-call fields", never bubble to the
+              // outer run_finished .catch and drop the whole completion event.
+              try {
+                const sessionId = codexSessionIdFromRunEvents(run.events);
+                const codexHome = spawnEnvForAgent(
+                  'codex',
+                  { ...process.env, OD_DATA_DIR: RUNTIME_DATA_DIR },
+                  agentCliEnvForAgent(
+                    (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+                    'codex',
+                  ),
+                ).CODEX_HOME;
+                const codexUsage = await readCodexRolloutFirstCall({ codexHome, sessionId });
+                return codexUsage
+                  ? {
+                      ...codexUsage,
+                      first_call_input_tokens_effective:
+                        codexUsage.first_call_input_tokens,
+                    }
+                  : null;
+              } catch {
+                return null;
+              }
+            }
+            if (usageAnalytics.first_call_input_tokens === undefined) return null;
+            return {
+              first_call_input_tokens: usageAnalytics.first_call_input_tokens,
+              ...(usageAnalytics.first_call_input_tokens_effective !== undefined
+                ? {
+                    first_call_input_tokens_effective:
+                      usageAnalytics.first_call_input_tokens_effective,
+                  }
+                : {}),
+              ...(usageAnalytics.first_call_cache_read_input_tokens !== undefined
+                ? {
+                    first_call_cache_read_input_tokens:
+                      usageAnalytics.first_call_cache_read_input_tokens,
+                  }
+                : {}),
+              ...(usageAnalytics.first_call_cache_creation_input_tokens !== undefined
+                ? {
+                    first_call_cache_creation_input_tokens:
+                      usageAnalytics.first_call_cache_creation_input_tokens,
+                  }
+                : {}),
+              ...(usageAnalytics.first_call_cache_hit_ratio !== undefined
+                ? { first_call_cache_hit_ratio: usageAnalytics.first_call_cache_hit_ratio }
+                : {}),
+            };
+          })();
+          const analyticsCapturedAt = Date.now();
+          const timingAnalytics = summarizeRunTimingAnalytics({
+            runCreatedAt: run.createdAt,
+            runUpdatedAt: run.updatedAt,
+            analyticsCapturedAt,
+          ...(run.analyticsTelemetry ? { telemetry: run.analyticsTelemetry } : {}),
+            events: run.events,
+          });
+          const toolAnalytics = summarizeToolAnalytics(run.events);
+          const toolStreamArtifactCount = (): number => runArtifactCountForRun(run);
+          const toolStreamDesignSystemCreated = (): boolean =>
+            runDesignSystemCreatedForRun(run);
+          const toolStreamPreviewModuleCount = (): number =>
+            runPreviewModuleCountForRun(run);
+          const toolStreamFilesWritten = (): number => runFilesWrittenForRun(run);
+          let artifactCount: number;
+          let artifactsCreated: number | undefined;
+          let artifactsModified: number | undefined;
+          let designSystemCreated: boolean;
+          let previewModuleCount: number;
+          let filesWritten: number | undefined;
+          let artifactDiff: RunArtifactDiff | undefined;
+          const artifactOutcome = run.artifactOutcome;
+          if (artifactOutcome) {
+            artifactCount = artifactOutcome.artifactCount;
+            artifactsCreated = artifactOutcome.artifactsCreated;
+            artifactsModified = artifactOutcome.artifactsModified;
+            designSystemCreated = artifactOutcome.designSystemCreated;
+            previewModuleCount = artifactOutcome.previewModuleCount;
+            filesWritten = artifactOutcome.filesWritten;
+            artifactDiff = artifactOutcome.diff;
+          } else {
+            const artifactBaseline = runArtifactBaselines.take(run.id);
+            if (artifactBaseline && !artifactBaseline.contended) {
+              let diff: ReturnType<typeof diffRunArtifacts> | null = null;
+              try {
+                diff = diffRunArtifacts(
+                  artifactBaseline.before,
+                  snapshotProjectArtifacts(artifactBaseline.cwd),
+                );
+              } catch {
+                diff = null;
+              }
+              if (diff) {
+                artifactDiff = diff;
+                artifactCount = diff.touched;
+                artifactsCreated = diff.created;
+                artifactsModified = diff.modified;
+                designSystemCreated = diff.designSystemCreated;
+                previewModuleCount = diff.previewModuleCount;
+                filesWritten = diff.filesWritten;
+              } else {
+                artifactCount = toolStreamArtifactCount();
+                designSystemCreated = toolStreamDesignSystemCreated();
+                previewModuleCount = toolStreamPreviewModuleCount();
+                filesWritten = toolStreamFilesWritten();
+              }
+            } else {
+              artifactCount = toolStreamArtifactCount();
+              designSystemCreated = toolStreamDesignSystemCreated();
+              previewModuleCount = toolStreamPreviewModuleCount();
+              filesWritten = toolStreamFilesWritten();
+            }
+          }
+          const touchedArtifactPaths = runTouchedArtifactPaths(run);
+          const deliverable = run.externalPluginAnalytics
+            ? await validateChatRunDeliverable({
+                db,
+                projectsRoot: PROJECTS_DIR,
+                run,
+                runStatus: run.status,
+                artifactCount,
+                ...(touchedArtifactPaths
+                  ? { touchedPaths: touchedArtifactPaths }
+                  : {}),
+              })
+            : null;
+          if (deliverable) {
+            design.runs.setDeliverableValidation?.(run, deliverable);
+          }
+          const activationMilestones = deriveActivationMilestones({
+            result,
+            artifactCount,
+            designSystemCreated,
+            isDesignSystemRun,
+            capturedAtIso: new Date(analyticsCapturedAt).toISOString(),
+          });
+          const diagnosticsAnalytics = summarizeRunDiagnosticsForAnalytics({
+            events: run.events,
+            exitCode: status.exitCode ?? null,
+            signal: status.signal ?? null,
+            cancelRequested: !!run.cancelRequested,
+            firstTokenSeen: Boolean(run.analyticsTelemetry?.firstTokenAt),
+            artifactWriteSeen: artifactCount > 0 || designSystemCreated || previewModuleCount > 0,
+          });
+          const finishedModelId = hasExplicitRequestedModelForAnalytics(reqBody.model)
+            ? modelIdForTracking(reqBody.model)
+            : modelIdForTracking(
+                usageAnalytics.agent_reported_model ?? run.resolvedModelId,
+              );
+          const runtimeVersions = getDetectedRuntimeVersions(run.agentId);
+          const agentCliVersion =
+            run.preflightAgentCliVersion ?? runtimeVersions?.agentCliVersion;
+          for (const [index, retryEvent] of runRetryEventsForAnalytics(run.events).entries()) {
+            design.analytics.capture({
+              eventName: retryEvent.event,
+              context: analyticsContext,
+              appVersion: design.getAppVersion(),
+              properties: retryEvent.data,
+              insertId: `${runInsertId}-${retryEvent.event}-${index}`,
+            });
+          }
+          const clarificationRequested = runAskedUserQuestion(run.events);
+          const interactionMode = typeof reqBody.sessionMode === 'string'
+            ? sessionModeToTracking(reqBody.sessionMode)
+            : undefined;
+          const primaryArtifactChange = artifactDiff
+            ? primaryArtifactChangeForRun({
+                diff: artifactDiff,
+                projectKind: runProjectKind,
+                hadExistingArtifacts: hintHasExistingArtifact === true,
+                ...(interactionMode ? { interactionMode } : {}),
+                clarificationRequested,
+              })
+            : undefined;
+          const supportingAssetFilesChanged = artifactDiff
+            ? supportingAssetFilesChangedForRun(artifactDiff, runProjectKind)
+            : undefined;
+          const finishedProperties: Record<string, unknown> = {
+              ...baseProps,
+              design_system_id: run.designSystemId ?? undefined,
+              design_system_digest: run.designSystemDigest ?? undefined,
+              design_system_selection_source: run.designSystemSelectionSource ?? 'none',
+              stable_prompt_hash: run.promptCache?.stablePromptHash,
+              stable_prompt_cache_hit: run.promptCache?.hit,
+              stable_prompt_cache_miss_reason: run.promptCache?.missReason,
+              // Which stable-prefix input drifted, for miss_reason
+              // 'stable-prompt-changed' only. `unattributed` means the prefix
+              // moved but no tracked section did — a coverage gap in
+              // prompts/stable-sections.ts, not a cause.
+              stable_prompt_changed_sections: run.promptCache?.changedSections ?? undefined,
+              area: isDesignSystemRun ? 'design_system_generation' : 'chat_panel',
+              result,
+              ...(activationMilestones ? { $set_once: activationMilestones } : {}),
+              model_id: finishedModelId,
+              artifact_count: artifactCount,
+              // Finish-time observations live on the run object only after the
+              // physical run resolved; baseProps was frozen at creation, so
+              // these must be read live here or they never reach analytics.
+              ...(run.odNextDeviceShell
+                ? {
+                    od_next_device_platform: run.odNextDeviceShell.platform,
+                    od_next_device_platform_source: run.odNextDeviceShell.resolvedFrom,
+                    od_next_device_shell_present: run.odNextDeviceShell.shellPresent,
+                  }
+                : {}),
+              ...(run.odNextLayoutPrimitives
+                ? { od_next_layout_primitives: run.odNextLayoutPrimitives }
+                : {}),
+              ...(run.externalPluginAnalytics
+                ? {
+                    deliverable_valid: deliverable?.valid === true,
+                    deliverable_validation:
+                      deliverable?.valid === true ? 'valid' : 'invalid',
+                    artifact_origin_status:
+                      run.artifactOriginStatus ?? 'missing_version',
+                    ...(run.artifactVersionId
+                      ? { artifact_version_id: run.artifactVersionId }
+                      : {}),
+                    resume: (run.manualResumeAttemptCount ?? 0) > 0,
+                    attempt_count: (run.manualResumeAttemptCount ?? 0) + 1,
+                    recharge_wait_duration_ms:
+                      run.rechargeWaitDurationMs ?? 0,
+                  }
+                : {}),
+              ...(artifactsCreated !== undefined ? { artifacts_created: artifactsCreated } : {}),
+              ...(artifactsModified !== undefined ? { artifacts_modified: artifactsModified } : {}),
+              ...(filesWritten !== undefined ? { files_written_count: filesWritten } : {}),
+              asked_user_question: clarificationRequested,
+              retry_attempt_count: run.retryAttemptCount ?? 0,
+              retry_final_result: run.retryFinalResult ?? 'not_attempted',
+              ...(agentCliVersion
+                ? { agent_cli_version: agentCliVersion }
+                : {}),
+              ...(runtimeVersions?.runtimeCompanionName
+                ? { runtime_companion_name: runtimeVersions.runtimeCompanionName }
+                : {}),
+              ...(runtimeVersions?.runtimeCompanionVersion
+                ? { runtime_companion_version: runtimeVersions.runtimeCompanionVersion }
+                : {}),
+              ...(run.retryOriginalFailure?.failure_category
+                ? {
+                    retry_original_failure_category:
+                      run.retryOriginalFailure.failure_category,
+                  }
+                : {}),
+              ...(run.retryOriginalFailure?.failure_detail
+                ? {
+                    retry_original_failure_detail:
+                      run.retryOriginalFailure.failure_detail,
+                  }
+                : {}),
+              ...(run.retryOriginalFailure?.failure_stage
+                ? {
+                    retry_original_failure_stage:
+                      run.retryOriginalFailure.failure_stage,
+                  }
+                : {}),
+              ...(run.retrySuppressedReason
+                ? { retry_suppressed_reason: run.retrySuppressedReason }
+                : {}),
+              ...(isDesignSystemRun ? {
+                design_system_created: designSystemCreated,
+                preview_module_count: previewModuleCount,
+                missing_font_count: 0,
+              } : {}),
+              ...timingAnalytics,
+              ...diagnosticsAnalytics,
+              // E-lite: `approval_requested`/`tool_result_sent` ride in via
+              // `...diagnosticsAnalytics`; these two come off the run object.
+              stdin_backpressure: run.stdinBackpressure === true,
+              ...(typeof run.lastAgentActivityAt === 'number'
+                ? { last_progress_age_ms: Math.max(0, analyticsCapturedAt - run.lastAgentActivityAt) }
+                : {}),
+              langfuse_trace_id: run.id,
+              ...langfuseDeliveryForAnalytics,
+              ...(errorCode ? { error_code: errorCode } : {}),
+              ...(failure ?? {}),
+              ...(usageAnalytics.input_tokens !== undefined
+                ? { input_tokens: usageAnalytics.input_tokens }
+                : {}),
+              ...(usageAnalytics.input_tokens_provider !== undefined
+                ? { input_tokens_provider: usageAnalytics.input_tokens_provider }
+                : {}),
+              ...(usageAnalytics.input_tokens_effective !== undefined
+                ? { input_tokens_effective: usageAnalytics.input_tokens_effective }
+                : {}),
+              ...(usageAnalytics.output_tokens !== undefined
+                ? { output_tokens: usageAnalytics.output_tokens }
+                : {}),
+              ...(usageAnalytics.total_tokens !== undefined
+                ? { total_tokens: usageAnalytics.total_tokens }
+                : {}),
+              ...(usageAnalytics.thought_tokens !== undefined
+                ? { thought_tokens: usageAnalytics.thought_tokens }
+                : {}),
+              ...(usageAnalytics.cache_read_input_tokens !== undefined
+                ? { cache_read_input_tokens: usageAnalytics.cache_read_input_tokens }
+                : {}),
+              ...(usageAnalytics.cache_creation_input_tokens !== undefined
+                ? {
+                    cache_creation_input_tokens:
+                      usageAnalytics.cache_creation_input_tokens,
+                  }
+                : {}),
+              ...(usageAnalytics.uncached_input_tokens !== undefined
+                ? { uncached_input_tokens: usageAnalytics.uncached_input_tokens }
+                : {}),
+              ...(usageAnalytics.estimated_context_tokens !== undefined
+                ? { estimated_context_tokens: usageAnalytics.estimated_context_tokens }
+                : {}),
+              ...(usageAnalytics.cache_hit_ratio !== undefined
+                ? { cache_hit_ratio: usageAnalytics.cache_hit_ratio }
+                : {}),
+              // First-call cache-hit of the turn's opening model call (per-call
+              // usage for claude/opencode/codebuddy/pi from the stream; codex from
+              // its rollout). Sliced by is_followup_turn, this isolates the
+              // session-reuse cache win on non-first turns.
+              ...(firstCallUsage ?? {}),
+              is_followup_turn: isFollowupTurn,
+              cache_token_source: usageAnalytics.cache_token_source,
+              // Prefer provider scan over run_created baseProps (`estimated`).
+              token_count_source: usageAnalytics.token_count_source,
+              tool_error_count: toolAnalytics.tool_error_count,
+              tool_name_count: toolAnalytics.tool_name_count,
+              tool_names: toolAnalytics.tool_names_csv,
+              ...runMessageEventPersistenceAnalytics(run),
+            };
+          Object.assign(
+            finishedProperties,
+            buildRunFinishedV4Aliases(finishedProperties, taskLineage, {
+              inputAccountingMode: usageAnalytics.input_accounting_mode,
+              ...(firstCallUsage
+                ? {
+                    firstModelCall: {
+                      ...(firstCallUsage.first_call_input_tokens !== undefined
+                        ? { provider_input_tokens: firstCallUsage.first_call_input_tokens }
+                        : {}),
+                      ...(firstCallUsage.first_call_input_tokens_effective !== undefined
+                        ? { effective_input_tokens: firstCallUsage.first_call_input_tokens_effective }
+                        : {}),
+                      ...(firstCallUsage.first_call_cache_read_input_tokens !== undefined
+                        ? { cache_read_tokens: firstCallUsage.first_call_cache_read_input_tokens }
+                        : {}),
+                      ...(firstCallUsage.first_call_cache_creation_input_tokens !== undefined
+                        ? { cache_write_tokens: firstCallUsage.first_call_cache_creation_input_tokens }
+                        : {}),
+                    },
+                  }
+                : {}),
+              ...(primaryArtifactChange
+                ? { primaryArtifactChange }
+                : {}),
+              ...(artifactDiff
+                ? {
+                    artifactFiles: {
+                      changed_file_count: artifactDiff.contentTouched,
+                      created_file_count: artifactDiff.contentCreated,
+                      modified_file_count: artifactDiff.contentModified,
+                      ...(supportingAssetFilesChanged !== undefined
+                        ? {
+                            supporting_asset_files_changed_count:
+                              supportingAssetFilesChanged,
+                          }
+                        : {}),
+                    },
+                  }
+                : {}),
+              ...(isDesignSystemRun
+                ? {
+                    designSystemChangeType: designSystemCreated
+                      ? hintHasExistingArtifact === true ? 'modified' : 'created'
+                      : 'none',
+                  }
+                : {}),
+            }),
+          );
+          // Refresh local recovery snapshot so crash recovery matches PostHog
+          // `run_finished` (usage/timing/tools), not only run_created baseProps.
+          // Keep the base insertId here: reconcileDurableRunTerminals appends
+          // `-finish` when replaying. Storing `${runInsertId}-finish` would
+          // produce `…-finish-finish` and can duplicate PostHog events.
+          design.runs.setAnalyticsRecovery?.(run, {
+            context: analyticsContext,
+            properties: finishedProperties,
+            insertId: runInsertId,
+          });
+          await Promise.resolve(design.analytics.capture({
+            eventName: 'run_finished',
+            context: analyticsContext,
+            appVersion: design.getAppVersion(),
+            properties: finishedProperties,
+            insertId: `${runInsertId}-finish`,
+          }));
+          design.runs.markAnalyticsCompleted?.(run);
+        }).catch(() => {});
+      }
+    })().catch(() => {
+      // An observer must never take the Run down with it.
+    });
+  };
+
+  return { install };
+}

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -1342,6 +1342,77 @@ describe('OD Next automatic production through the real server', () => {
     await waitForRunTerminal(started.url, automatic.runId as string);
   });
 
+  // OPEND-2365 (P1). Only the HTTP-created Run passes through the analytics
+  // lifecycle installed on POST /api/runs; the repair and production Runs the
+  // daemon allocates for the SAME logical task are started straight off
+  // `internalRunCreation.start(...)` and never enter it. Every OD Next rate
+  // computed per physical Run — volume, success, failure, cancellation,
+  // duration — is therefore measured on the request stage alone.
+  it('installs the run analytics lifecycle on every physical Run of an automatic chain', async () => {
+    const fixture = await createFixture('repair');
+    const analyticsHeaders = {
+      'x-od-analytics-device-id': 'device-opend-2365',
+      'x-od-analytics-session-id': 'session-opend-2365',
+      'x-od-analytics-client-type': 'desktop',
+    };
+
+    queueFixtureIds(fixture);
+    const created = await postRun(
+      started!.url,
+      createRunRequest(fixture, 'Build the operator prototype.'),
+      analyticsHeaders,
+    );
+    expect(created.runId).toBe(fixture.initialRunId);
+
+    await waitForRunTerminal(started!.url, fixture.initialRunId);
+    const terminal = await waitForTask(fixture.taskExecutionId, 'completed');
+    expect(terminal.runs.map((run) => run.inputStage)).toEqual([
+      'request',
+      'contract_repair',
+      'production',
+    ]);
+
+    const recoveries = await waitForRunAnalyticsRecoveries(
+      terminal.runs.map((mapping) => mapping.runId),
+    );
+    // Reported at all.
+    expect(
+      terminal.runs
+        .map((mapping, index) => (recoveries[index] ? null : mapping.inputStage))
+        .filter(Boolean),
+    ).toEqual([]);
+    // One stable identity per physical Run — a shared insert id would collapse
+    // three Runs into one row on ingest.
+    const insertIds = recoveries.map((recovery) => recovery?.insertId);
+    expect(new Set(insertIds).size).toBe(3);
+    // The continuation inherits the requesting client's identity rather than
+    // inventing one, so the chain stays attributable to the same person.
+    for (const recovery of recoveries) {
+      expect(recovery?.context?.deviceId).toBe('device-opend-2365');
+    }
+    // The terminal listener ran for each Run, which is what emits run_finished.
+    for (const recovery of recoveries) {
+      expect(typeof recovery?.completedAt).toBe('number');
+    }
+    // The lineage is what stitches the physical Runs back into one turn: one
+    // shared task id, one shared first Run, and a Run index that advances.
+    const lineage = recoveries.map((recovery) => recovery?.properties ?? {});
+    expect(new Set(lineage.map((props) => props.task_execution_id)).size).toBe(1);
+    expect(new Set(lineage.map((props) => props.initial_run_id))).toEqual(
+      new Set([fixture.initialRunId]),
+    );
+    expect(lineage.map((props) => props.task_run_index)).toEqual([0, 1, 2]);
+    // The rollout decision is daemon-owned truth; every Run of an admitted
+    // task reports the harness it actually ran under.
+    expect(lineage.map((props) => props.harness)).toEqual([
+      'od_next',
+      'od_next',
+      'od_next',
+    ]);
+    // The lifecycle re-reads host facts (app config, agent detection) before
+    // it captures, so three physical Runs settle well past the shared default.
+  }, 90_000);
+
   it('runs parsed plan -> serialization repair -> production after each source end and remains exactly-once across restart', async () => {
     const fixture = await createFixture('repair');
     const sourcePdfAttachment = path.join(
@@ -2849,10 +2920,14 @@ function queueFixtureIds(fixture: {
   uuidControl.forced.push(fixture.initialRunId);
 }
 
-async function postRun(url: string, body: Record<string, unknown>) {
+async function postRun(
+  url: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
   const response = await fetch(`${url}/api/runs`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...headers },
     body: JSON.stringify(body),
   });
   expect(response.headers.get('content-type')).toContain('application/json');
@@ -2895,6 +2970,53 @@ async function waitForTask(taskExecutionId: string, outcome: string) {
   throw new Error(
     `task ${taskExecutionId} did not reach ${outcome}: ${JSON.stringify(latest)}`,
   );
+}
+
+/**
+ * The persisted analytics recovery record for one physical Run.
+ *
+ * This is the daemon's own durable evidence that a Run entered the analytics
+ * lifecycle: `run_created` was captured under this `insertId`, and the terminal
+ * listener replays `run_finished` from it after a restart. A physical Run that
+ * has no record never reported, and never will.
+ */
+async function readRunAnalyticsRecovery(runId: string): Promise<{
+  insertId?: string;
+  context?: { deviceId?: string };
+  properties?: Record<string, unknown>;
+  completedAt?: number;
+} | null> {
+  const statePath = path.join(process.env.OD_DATA_DIR!, 'runs', runId, 'state.json');
+  try {
+    const raw = await readFile(statePath, 'utf8');
+    return (JSON.parse(raw) as { analyticsRecovery?: any }).analyticsRecovery ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Poll until each Run's recovery record has settled.
+ *
+ * The lifecycle installs after the response is sent and re-reads host facts
+ * (app config, agent detection) before it captures, so the record appears a
+ * beat behind the Run itself and is stamped complete only once the terminal
+ * listener has run.
+ */
+async function waitForRunAnalyticsRecoveries(
+  runIds: string[],
+  timeoutMs = 45_000,
+): Promise<Array<Awaited<ReturnType<typeof readRunAnalyticsRecovery>>>> {
+  const deadline = Date.now() + timeoutMs;
+  let latest = await Promise.all(runIds.map(readRunAnalyticsRecovery));
+  while (
+    Date.now() < deadline
+    && !latest.every((recovery) => recovery && typeof recovery.completedAt === 'number')
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    latest = await Promise.all(runIds.map(readRunAnalyticsRecovery));
+  }
+  return latest;
 }
 
 async function readProjectInvocations(logPath: string, projectId: string): Promise<Invocation[]> {

--- a/apps/daemon/tests/services/internal-run-service.test.ts
+++ b/apps/daemon/tests/services/internal-run-service.test.ts
@@ -55,11 +55,13 @@ function createHarness(initial: {
     options?.beforeClaimCommit?.();
     return { ok: true as const };
   });
+  const install = vi.fn();
   const service = createInternalRunCreationService({
     runs: registry,
     claimAssistantMessage,
+    analyticsLifecycle: { install },
   });
-  return { claimAssistantMessage, drop, registry, run, service, start };
+  return { claimAssistantMessage, drop, install, registry, run, service, start };
 }
 
 describe('internal run creation service', () => {
@@ -87,9 +89,49 @@ describe('internal run creation service', () => {
 
     const starter = vi.fn(async () => undefined);
     if (prepared.kind !== 'ready') throw new Error('expected ready run');
-    harness.service.start(prepared.run, starter);
+    harness.service.start(prepared.run, { body: { ...meta } }, starter);
     expect(harness.start).toHaveBeenCalledOnce();
     expect(starter).toHaveBeenCalledWith(harness.run);
+  });
+
+  // Every physical Run is started here, so this is the one place that can
+  // guarantee analytics without each caller remembering to ask for it. Four
+  // daemon-internal callers used to start Runs another way and reported
+  // nothing at all (OPEND-2365).
+  it('arms the analytics lifecycle for the run before it starts', async () => {
+    const harness = createHarness();
+    const starter = vi.fn(async () => undefined);
+    const facts = {
+      body: { projectId: 'project-1' },
+      requestAnalyticsContext: {
+        deviceId: 'device-1',
+        sessionId: 'session-1',
+        clientType: 'web' as const,
+        locale: 'en',
+        requestId: null,
+      },
+      creationKind: 'created' as const,
+      resumed: false,
+    };
+
+    harness.service.start(harness.run, facts, starter);
+
+    expect(harness.install).toHaveBeenCalledWith({ ...facts, run: harness.run });
+    expect(harness.install.mock.invocationCallOrder[0]!)
+      .toBeLessThan(harness.start.mock.invocationCallOrder[0]!);
+  });
+
+  it('starts the run even when no caller identity is available', async () => {
+    // A scheduled Automation has nobody to attribute the Run to. It still goes
+    // through the one start path so the Run is never silently uninstrumented
+    // for a reason other than "there was no identity".
+    const harness = createHarness();
+    const starter = vi.fn(async () => undefined);
+
+    harness.service.start(harness.run, { body: {}, requestAnalyticsContext: null }, starter);
+
+    expect(harness.install).toHaveBeenCalledOnce();
+    expect(harness.start).toHaveBeenCalledOnce();
   });
 
   it('drops an optimistic run when the assistant ownership claim is rejected', () => {

--- a/apps/daemon/tests/services/run-analytics-lifecycle.test.ts
+++ b/apps/daemon/tests/services/run-analytics-lifecycle.test.ts
@@ -1,0 +1,188 @@
+// The physical-Run analytics lifecycle, driven directly.
+//
+// The real-server chain test proves the lifecycle is installed for every Run
+// of an automatic chain; this one proves what it reports once a Run settles.
+// Cancellation is the case that motivated it: a Run the user stopped has to
+// land as `cancelled`, not as a missing row, or the cancellation rate is
+// computed against a smaller denominator than the truth.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRunAnalyticsLifecycle,
+  inheritedRunLineageHints,
+} from '../../src/services/run-analytics-lifecycle.js';
+
+type Captured = {
+  eventName: string;
+  properties: Record<string, unknown>;
+  insertId: string;
+  context: { deviceId: string };
+};
+
+function harness() {
+  const captured: Captured[] = [];
+  const recoveries: Array<{ runId: string; properties: Record<string, unknown>; insertId: string }> = [];
+  const completed: string[] = [];
+  let settle: (status: { status: string; errorCode?: string | null; exitCode?: number | null }) => void = () => {};
+  const terminal = new Promise<{ status: string }>((resolve) => {
+    settle = (status) => resolve(status as { status: string });
+  });
+
+  const lifecycle = createRunAnalyticsLifecycle({
+    db: {} as never,
+    design: {
+      runs: {
+        wait: () => terminal as never,
+        setAnalyticsRecovery: (run, recovery) => {
+          recoveries.push({
+            runId: run.id,
+            properties: recovery.properties,
+            insertId: recovery.insertId,
+          });
+        },
+        markAnalyticsCompleted: (run) => { completed.push(run.id); },
+        setDeliverableValidation: () => {},
+      },
+      analytics: {
+        capture: (args) => { captured.push(args as Captured); },
+      },
+      getAppVersion: () => '0.0.0-test',
+    },
+    paths: { PROJECTS_DIR: '/nonexistent/projects', RUNTIME_DATA_DIR: '/nonexistent/data' },
+    agents: { detectAgents: async () => [] },
+    telemetry: {
+      reportRunCompletionTelemetryFallback: () => {},
+      resolveRunProjectKindForAnalytics: () => null,
+      runArtifactBaselines: { take: () => undefined },
+      runRetryEventsForAnalytics: () => [],
+    },
+  });
+
+  return { captured, completed, lifecycle, recoveries, settle };
+}
+
+function fakeRun(overrides: Record<string, unknown> = {}) {
+  const now = Date.now();
+  return {
+    id: 'run-under-test',
+    projectId: null,
+    conversationId: null,
+    assistantMessageId: null,
+    clientRequestId: 'client-request-1',
+    agentId: 'codex',
+    status: 'running',
+    createdAt: now,
+    updatedAt: now,
+    events: [],
+    clients: new Set(),
+    ...overrides,
+  } as never;
+}
+
+const CONTEXT = { deviceId: 'device-1', sessionId: 'session-1', clientType: 'web', locale: 'en' };
+
+async function settled(h: ReturnType<typeof harness>, eventName: string) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const found = h.captured.find((event) => event.eventName === eventName);
+    if (found) return found;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(
+    `no ${eventName} captured; saw ${JSON.stringify(h.captured.map((e) => e.eventName))}`,
+  );
+}
+
+describe('run analytics lifecycle', () => {
+  it('reports a created run and pairs its finish under the same insert id', async () => {
+    const h = harness();
+    h.lifecycle.install({
+      run: fakeRun(),
+      body: { agentId: 'codex' },
+      requestAnalyticsContext: CONTEXT as never,
+    });
+
+    const created = await settled(h, 'run_created');
+    expect(created.context.deviceId).toBe('device-1');
+    h.settle({ status: 'succeeded' });
+
+    const finished = await settled(h, 'run_finished');
+    expect(finished.properties.result).toBe('success');
+    // The replay in `reconcileDurableRunTerminals` appends `-finish` to the
+    // stored id, so the stored id must stay the base one.
+    expect(finished.insertId).toBe(`${created.insertId}-finish`);
+    expect(h.recoveries.at(-1)?.insertId).toBe(created.insertId);
+    expect(h.completed).toEqual(['run-under-test']);
+  });
+
+  it.each([
+    ['canceled', 'cancelled'],
+    ['failed', 'failed'],
+    ['succeeded', 'success'],
+  ])('reports a %s run as result %s', async (status, result) => {
+    const h = harness();
+    h.lifecycle.install({
+      run: fakeRun(),
+      body: {},
+      requestAnalyticsContext: CONTEXT as never,
+    });
+    await settled(h, 'run_created');
+    h.settle({ status, errorCode: status === 'failed' ? 'AGENT_EXIT_1' : null });
+
+    const finished = await settled(h, 'run_finished');
+    expect(finished.properties.result).toBe(result);
+    if (result === 'failed') {
+      // Dashboards keyed on error_code must never see a blank cell.
+      expect(finished.properties.error_code).toBeTruthy();
+    }
+  });
+
+  it('stays silent for a run nobody asked for', async () => {
+    // A scheduled Automation has no caller to attribute the Run to. Silence is
+    // the correct outcome — inventing an identity would be worse than a gap.
+    const h = harness();
+    h.lifecycle.install({ run: fakeRun(), body: {}, requestAnalyticsContext: null });
+    h.settle({ status: 'succeeded' });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(h.captured).toEqual([]);
+    expect(h.recoveries).toEqual([]);
+  });
+});
+
+describe('inherited run lineage', () => {
+  it('carries the source run resolved lineage onto the next physical run', () => {
+    expect(
+      inheritedRunLineageHints(
+        { id: 'run-2', clientRequestId: 'odnext_run_b' },
+        { analyticsHints: { taskExecutionId: 'task-1', initialRunId: 'run-1' } },
+        2,
+      ),
+    ).toEqual({
+      taskExecutionId: 'task-1',
+      initialRunId: 'run-1',
+      taskRunIndex: 2,
+      sourceRunId: 'run-2',
+    });
+  });
+
+  it('falls back the same way the lifecycle does when the source carried no hints', () => {
+    // The first Run of a task resolves its own id from `clientRequestId`, so
+    // inheriting must land on the same value — otherwise the second Run starts
+    // a second task in the warehouse.
+    expect(
+      inheritedRunLineageHints({ id: 'run-1', clientRequestId: 'client-request-1' }, {}, 1),
+    ).toEqual({
+      taskExecutionId: 'client-request-1',
+      initialRunId: 'run-1',
+      taskRunIndex: 1,
+      sourceRunId: 'run-1',
+    });
+  });
+
+  it('falls back to the run id when there is no client request id either', () => {
+    expect(inheritedRunLineageHints({ id: 'run-1' }, undefined, 1)).toMatchObject({
+      taskExecutionId: 'run-1',
+      initialRunId: 'run-1',
+    });
+  });
+});

--- a/apps/web/src/components/LabsSection.tsx
+++ b/apps/web/src/components/LabsSection.tsx
@@ -326,7 +326,13 @@ export function LabsSection({ onAutosaveStatus }: LabsSectionProps) {
         // `'off'` rather than clearing the key: an absent value reads as
         // "never touched", and the two are worth telling apart later.
         await writeHarnessMode(next ? 'active' : 'off');
-        if (token !== writeTokenRef.current || !mountedRef.current) return;
+        // Only staleness ends the write here. `mountedRef` guards this
+        // component's own state and nothing else: leaving Labs mid-write is
+        // the ordinary case — flip the switch, click another section — and the
+        // preference is on the machine either way. Letting the guard reach
+        // this far turned every one of those into a missing event and left the
+        // dialog's pill on "Saving" for an edit that had already landed.
+        if (token !== writeTokenRef.current) return;
         // After the write, not on click: a failed write rolls the switch back,
         // and an event for a preference the machine does not hold is worse
         // than a missing one.
@@ -342,19 +348,30 @@ export function LabsSection({ onAutosaveStatus }: LabsSectionProps) {
           // here keeps the invariant every count depends on: one reported
           // opt-out, one reason row.
           answerOptOut({ reason: ['skipped'] });
-        } else {
+        } else if (mountedRef.current) {
           // The opt-out itself is already reported above; the reason arrives
           // as a second event once the user answers. Counting opt-outs from
           // the first and reasons from the second keeps the opt-out count
           // whole even when nobody answers.
           reasonPendingRef.current = true;
           setAskingReason(true);
+        } else {
+          // Nobody is left to ask, and the unmount settler has already run.
+          // Recording the non-answer here keeps the same invariant: an
+          // opt-out reported without a reason row would never be paired.
+          reasonPendingRef.current = true;
+          answerOptOut({ reason: ['skipped'] });
         }
         reportSaved();
       } catch {
-        if (token !== writeTokenRef.current || !mountedRef.current) return;
-        setState((current) => (current ? { ...current, on: previous } : current));
-        onAutosaveStatus?.('error');
+        if (token !== writeTokenRef.current) return;
+        if (mountedRef.current) {
+          setState((current) => (current ? { ...current, on: previous } : current));
+        }
+        // Reported even after unmount: the pill belongs to the dialog, which
+        // outlives this section, and a failed save it never hears about stays
+        // on "Saving" forever.
+        autosaveRef.current?.('error');
       } finally {
         if (token === writeTokenRef.current) {
           writeInFlightRef.current = false;

--- a/apps/web/tests/components/LabsSection.test.tsx
+++ b/apps/web/tests/components/LabsSection.test.tsx
@@ -41,6 +41,8 @@ interface Stub {
   rolloutStatus?: OdNextRolloutControlStatus;
   rolloutFails?: boolean;
   writeFails?: boolean;
+  /** Held open to keep a PUT in flight while the section unmounts. */
+  writeGate?: Promise<void>;
 }
 
 function stubFetch(options: Stub = {}) {
@@ -56,6 +58,7 @@ function stubFetch(options: Stub = {}) {
     }
     if (url === '/api/app-config') {
       writes.push(JSON.parse(String(init?.body ?? '{}')));
+      if (options.writeGate) await options.writeGate;
       if (options.writeFails) return new Response('{}', { status: 500 });
       return new Response('{"config":{}}', { status: 200 });
     }
@@ -423,6 +426,113 @@ describe('LabsSection', () => {
     cleanup();
 
     expect(onAutosaveStatus).toHaveBeenCalledWith('idle');
+  });
+
+  // OPEND-2365 (P2). Leaving Labs mid-write is the ordinary case — the user
+  // flips the switch and immediately clicks another settings section. The
+  // write still lands, so the installation holds the preference the event
+  // asserts; a `mounted` guard that also swallows the report turns every one
+  // of those into a silently missing data point.
+  describe('left while the write is still in flight', () => {
+    function heldWrite() {
+      let release = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = () => resolve();
+      });
+      return { gate, release };
+    }
+
+    it('still reports the toggle once the successful write lands', async () => {
+      const { gate, release } = heldWrite();
+      const { writes } = stubFetch({ writeGate: gate });
+      renderSection();
+      await waitFor(() => expect(switchEl().getAttribute('aria-disabled')).toBe('false'));
+
+      fireEvent.click(switchEl());
+      await waitFor(() => expect(writes).toHaveLength(1));
+      cleanup();
+      release();
+
+      await waitFor(() => expect(track).toHaveBeenCalledTimes(1));
+      expect(track.mock.calls[0]?.[0]).toBe('labs_item_toggled');
+      expect(track.mock.calls[0]?.[1]).toEqual({
+        item_id: 'design_harness',
+        to: 'on',
+        source: 'settings',
+      });
+    });
+
+    it('settles the dialog autosave pill instead of leaving it on saving', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const { gate, release } = heldWrite();
+        const { writes } = stubFetch({ writeGate: gate });
+        const onAutosaveStatus = vi.fn();
+        renderSection(onAutosaveStatus);
+        await waitFor(() => expect(switchEl().getAttribute('aria-disabled')).toBe('false'));
+
+        fireEvent.click(switchEl());
+        await waitFor(() => expect(writes).toHaveLength(1));
+        expect(onAutosaveStatus).toHaveBeenCalledWith('saving');
+        cleanup();
+        release();
+
+        await waitFor(() => expect(onAutosaveStatus).toHaveBeenCalledWith('saved'));
+        await vi.advanceTimersByTimeAsync(3_000);
+        await waitFor(() => expect(onAutosaveStatus).toHaveBeenCalledWith('idle'));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reports the failed write as an error rather than stranding the pill', async () => {
+      const { gate, release } = heldWrite();
+      const { writes } = stubFetch({ writeGate: gate, writeFails: true });
+      const onAutosaveStatus = vi.fn();
+      renderSection(onAutosaveStatus);
+      await waitFor(() => expect(switchEl().getAttribute('aria-disabled')).toBe('false'));
+
+      fireEvent.click(switchEl());
+      await waitFor(() => expect(writes).toHaveLength(1));
+      cleanup();
+      release();
+
+      await waitFor(() => expect(onAutosaveStatus).toHaveBeenCalledWith('error'));
+      expect(track).not.toHaveBeenCalled();
+    });
+
+    it('keeps an opt-out paired with exactly one reason row', async () => {
+      // The reason panel cannot be shown to a section that is gone, and the
+      // unmount settler has already run by the time the write lands. Without
+      // an immediate skip the opt-out would be counted with no reason row at
+      // all, which is the one thing the pairing invariant exists to prevent.
+      const { gate, release } = heldWrite();
+      const { writes } = stubFetch({
+        rolloutStatus: status({ requestedMode: 'active', requestedModeSource: 'app_config' }),
+        writeGate: gate,
+      });
+      renderSection();
+      await waitFor(() => expect(switchEl().getAttribute('aria-checked')).toBe('true'));
+
+      fireEvent.click(switchEl());
+      await waitFor(() => expect(writes).toHaveLength(1));
+      cleanup();
+      release();
+
+      await waitFor(() => expect(track).toHaveBeenCalledTimes(2));
+      expect(track.mock.calls[0]?.[1]).toEqual({
+        item_id: 'design_harness',
+        to: 'off',
+        source: 'settings',
+      });
+      expect(track.mock.calls[1]?.[1]).toMatchObject({
+        item_id: 'design_harness',
+        to: 'off',
+        source: 'settings',
+        reason: ['skipped'],
+        has_custom_reason: false,
+      });
+    });
   });
 
   it('locks the switch and explains when an environment variable owns the mode', async () => {

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1437,6 +1437,46 @@ function checkCrossAppImportsOnce(): Promise<boolean> {
   return crossAppImportsResult;
 }
 
+
+// Only the internal run-creation service may start a physical Run.
+//
+// The run analytics lifecycle is installed there, once, for every Run. Four
+// daemon-internal callers used to reach past it and call the run registry
+// directly; each of those Runs reported no `run_created` and no `run_finished`,
+// and nothing said so (OPEND-2365). The service's `start` now requires the
+// caller to declare its analytics identity, but that only binds callers who go
+// through it — this check is what keeps the bypass from coming back.
+const RUN_START_BYPASS_ALLOWLIST = new Set([
+  "apps/daemon/src/services/internal-run-service.ts",
+]);
+
+async function checkRunStartChokePoint(): Promise<boolean> {
+  const violations: string[] = [];
+  const daemonSource = path.join(repoRoot, "apps", "daemon", "src");
+  if (!(await repositoryDirectoryExists("apps/daemon/src"))) return true;
+
+  for (const repositoryPath of await collectRepositoryFiles(daemonSource)) {
+    if (!repositoryPath.endsWith(".ts")) continue;
+    if (RUN_START_BYPASS_ALLOWLIST.has(repositoryPath)) continue;
+    const source = await readFile(path.join(repoRoot, repositoryPath), "utf8");
+    source.split("\n").forEach((line, index) => {
+      if (!/\.runs\.start\s*\(/.test(line)) return;
+      violations.push(`${repositoryPath}:${index + 1} ${line.trim()}`);
+    });
+  }
+
+  if (violations.length > 0) {
+    console.error("Run start choke-point violations found:");
+    console.error("Start physical Runs through `internalRunCreation.start(run, analytics, starter)`");
+    console.error("so the Run analytics lifecycle is installed. See AGENTS.md -> Starting a physical Run.");
+    for (const violation of violations) console.error(`- ${violation}`);
+    return false;
+  }
+
+  console.log("Run start choke-point check passed: every physical Run starts through the internal run-creation service.");
+  return true;
+}
+
 const checks: GuardCheck[] = [
   { name: "residual JavaScript", run: checkResidualJavaScript },
   { name: "package dependency specs", run: checkPackageDependencySpecs },
@@ -1450,6 +1490,7 @@ const checks: GuardCheck[] = [
   { name: "e2e layout", run: checkE2eLayout },
   { name: "web test layout", run: checkWebTestLayout },
   { name: "web import isolation", run: checkWebImportIsolation },
+  { name: "run start choke point", run: checkRunStartChokePoint },
   { name: "tools layout", run: checkToolsLayout },
   { name: "style policy", run: checkStylePolicy },
   { name: "craft references", run: checkCraftReferences },


### PR DESCRIPTION
Fixes #7485

## Why

OD Next runs as a chain of physical Runs: the user's request, then the `contract_repair` and production continuations the daemon starts itself. Run analytics was installed only in `POST /api/runs`, so daemon-started Runs recorded no `run_created`, no `run_finished` and no recovery record — volume and success rate were computed from the request stage alone and the production stage was invisible. Toggling the Design Harness and leaving Labs immediately could also persist the preference while dropping `labs_item_toggled`, leaving the save pill on "Saving".

## What users will see

No product change. Instrumentation only, with one visible side effect: leaving Labs while its write is in flight now settles the dialog's save indicator to "Saved" instead of stranding it.

## Surface area

- [x] **None** — internal refactor, tests and analytics plumbing only

## Screenshots

—

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/daemon/tests/services/run-analytics-lifecycle.test.ts` (8 tests)
  - `apps/daemon/tests/services/internal-run-service.test.ts` (9 tests)
  - `apps/web/tests/components/LabsSection.test.tsx` — "left while the write is still in flight" (4 cases)
- Did the tests go red on `main` and green on this branch? Yes — daemon continuation Runs lacked recovery records, and the Labs toggle dropped its event and left the pill on "Saving".

## Validation

- `pnpm guard` (including the run start choke-point check)
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest` — lifecycle and internal-run-service suites
- `pnpm --filter @open-design/web exec vitest` — LabsSection suite (32 passed)
