### PR TITLE
fix(daemon): defer invalid-payload until launcher state is eligible

### DIFF
--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -165,7 +165,43 @@ async function resolvePayloadExecutable(options: {
     manifest.version !== options.appVersion ||
     manifest.platform !== options.platform ||
     typeof manifest.entry?.executable !== "string"
-  ) return null;
+  ) {
+    // Fallback when manifest is missing or mismatched but the payload
+    // executable already exists on disk (e.g., corrupted manifest during
+    // first install or a partial installer write). Check the conventional
+    // payload locations directly so a valid payload is not reported as
+    // invalid-payload and `prepareLegacyPayloadDesktopHandoff` can return the
+    // more accurate `launcher-state-not-eligible` instead of masking the
+    // state.
+    const fallbackCandidates: string[] = [];
+    if (options.platform === "win32") {
+      const baseNames =
+        options.launcherPaths.channel === "beta"
+          ? ["Open Design Beta.exe", "Open Design.exe"]
+          : options.launcherPaths.channel === "prerelease"
+            ? ["Open Design Prerelease.exe", "Open Design.exe"]
+            : options.launcherPaths.channel === "preview"
+              ? ["Open Design Preview.exe", "Open Design.exe"]
+              : ["Open Design.exe", "Open Design Beta.exe"];
+      for (const name of baseNames) fallbackCandidates.push(join(versionPaths.payloadRoot, name));
+    } else if (options.platform === "darwin") {
+      const baseNames =
+        options.launcherPaths.channel === "beta"
+          ? ["Open Design Beta", "Open Design"]
+          : options.launcherPaths.channel === "prerelease"
+            ? ["Open Design Prerelease", "Open Design"]
+            : ["Open Design", "Open Design Beta"];
+      for (const name of baseNames) {
+        fallbackCandidates.push(join(versionPaths.payloadRoot, `${name}.app`, "Contents", "MacOS", name));
+      }
+    }
+    for (const candidate of fallbackCandidates) {
+      if (!containsPath(versionPaths.versionRoot, candidate)) continue;
+      const entry = await lstat(candidate).catch(() => null);
+      if (entry != null && entry.isFile() && !entry.isSymbolicLink()) return candidate;
+    }
+    return null;
+  }
   const executablePath = resolve(versionPaths.versionRoot, manifest.entry.executable);
   if (!containsPath(versionPaths.versionRoot, executablePath)) return null;
   const entry = await lstat(executablePath).catch(() => null);
@@ -309,8 +345,7 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
   ]);
   if (runtime == null) return { kind: "none", reason: "invalid-runtime" };
   if (outer == null) return { kind: "none", reason: "invalid-install-anchor" };
-  if (payloadExecutablePath == null) return { kind: "none", reason: "invalid-payload" };
-  if (identity != null && samePath(identity.executablePath, payloadExecutablePath, platform)) {
+  if (payloadExecutablePath != null && identity != null && samePath(identity.executablePath, payloadExecutablePath, platform)) {
     return { kind: "none", reason: "payload-desktop-active" };
   }
   if (identity != null && (
@@ -355,6 +390,7 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
   if (!canCaptureInitialState && !canCaptureConfirmedBinding && !canResumePreparedState) {
     return { kind: "none", reason: "launcher-state-not-eligible" };
   }
+  if (payloadExecutablePath == null) return { kind: "none", reason: "invalid-payload" };
 
   const now = (options.now ?? (() => new Date()))().toISOString();
   const descriptor: LauncherDesktopHandoffDescriptor = canResumePreparedState && existing != null

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -297,8 +297,7 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
   ]);
   if (runtime == null) return { kind: "none", reason: "invalid-runtime" };
   if (outer == null) return { kind: "none", reason: "invalid-install-anchor" };
-  if (payloadExecutablePath == null) return { kind: "none", reason: "invalid-payload" };
-  if (desktopStatus != null && desktopStatus.pid === outer.pid &&
+  if (payloadExecutablePath != null && desktopStatus != null && desktopStatus.pid === outer.pid &&
       typeof desktopStatus.executablePath === "string" &&
       await samePath(desktopStatus.executablePath, payloadExecutablePath, platform)) {
     return { kind: "none", reason: "payload-desktop-active" };
@@ -346,6 +345,7 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
   if (!canCaptureInitialState && !canCaptureConfirmedBinding && !canResumePreparedState) {
     return { kind: "none", reason: "launcher-state-not-eligible" };
   }
+  if (payloadExecutablePath == null) return { kind: "none", reason: "invalid-payload" };
 
   const now = (options.now ?? (() => new Date()))().toISOString();
   const descriptor: LauncherDesktopHandoffDescriptor = canResumePreparedState && existing != null

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff-6074-regression.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff-6074-regression.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { LAUNCHER_SCHEMA_VERSION, resolveLauncherPaths } from "@open-design/launcher-proto";
+import { SIDECAR_SOURCES } from "@open-design/sidecar-proto";
+import { describe, expect, it } from "vitest";
+
+import { prepareLegacyPayloadDesktopHandoff } from "../../src/sidecar/payload-desktop-handoff.js";
+
+/**
+ * Regression for issue #6074:
+ * On Windows packaged first install, the daemon logged
+ * `[packaged desktop handoff] skipped { reason: 'invalid-payload' }`
+ * because `versions/0.16.1/manifest.json` and `payload/Open Design.exe`
+ * were absent (no versions/ tree). The trustedWebOriginPort therefore
+ * stayed null and /api fell back to HTML.
+ *
+ * A missing payload on a fresh install where the launcher state is
+ * `active == lastSuccessful` (generation 0) should be reported as
+ * `launcher-state-not-eligible` rather than `invalid-payload`, so the
+ * handoff is not masked as a payload error and the daemon's web-port
+ * registration path can still succeed. The web proxy already answers
+ * /api with 502 when OD_PORT is unset (PR #7399); this test pins the
+ * desktop handoff classification.
+ */
+describe("6074 desktop handoff invalid-payload regression", () => {
+  it("fresh install with missing versions/manifest reports launcher-state-not-eligible, not invalid-payload", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-6074-regression-"));
+    try {
+      const namespace = "release-stable-win";
+      const version = "0.16.1";
+      const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+      const launcherPaths = resolveLauncherPaths({ channel: "stable", namespace, root });
+
+      // Outer executable exists at the installed location (NSIS install dir)
+      const outerExecutablePath = join(root, "installed", "Open Design.exe");
+      await mkdir(join(root, "installed"), { recursive: true });
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(outerExecutablePath, "");
+
+      // No versions/ directory at all — the field failure mode from #6074
+      // install.json points at the outer location
+      await writeFile(launcherPaths.installPath, `${JSON.stringify({
+        channel: "stable",
+        launchPath: outerExecutablePath,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+
+      // runtime.json with generation 0 active == lastSuccessful (fresh install)
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 0, version },
+        channel: "stable",
+        lastSuccessful: { generation: 0, version },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+
+      // No attempt.json, no handoff.json, no versions/0.16.1/manifest.json
+
+      const result = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: version,
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace,
+        parentPid: 12345,
+        platform: "win32",
+        runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      // Before fix: { kind: "none", reason: "invalid-payload" }
+      // After fix:  { kind: "none", reason: "launcher-state-not-eligible" }
+      expect(result).toEqual({ kind: "none", reason: "launcher-state-not-eligible" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still reports invalid-payload when launcher state is eligible but payload missing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-6074-regression-eligible-"));
+    try {
+      const namespace = "release-beta";
+      const version = "1.2.3-beta.5";
+      const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+      const launcherPaths = resolveLauncherPaths({ channel: "beta", namespace, root });
+      const outerExecutablePath = join(root, "installed", "Open Design Beta.app", "Contents", "MacOS", "Open Design Beta");
+      await mkdir(join(outerExecutablePath, ".."), { recursive: true });
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(outerExecutablePath, "");
+
+      // Do NOT create payload/manifest, so payloadExecutablePath will be null
+      await writeFile(launcherPaths.installPath, `${JSON.stringify({
+        channel: "beta",
+        launchPath: join(root, "installed", "Open Design Beta.app"),
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+
+      // Make launcher state eligible: active gen 1, lastSuccessful gen 0, attempt matches active
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version },
+        channel: "beta",
+        lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+        channel: "beta",
+        generation: 1,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version,
+      })}\n`);
+
+      const result = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: version,
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace,
+        parentPid: 4321,
+        platform: "darwin",
+        runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(result).toEqual({ kind: "none", reason: "invalid-payload" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff-6074-regression.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff-6074-regression.test.ts
@@ -1,0 +1,231 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  resolveLauncherPaths,
+  resolveLauncherVersionPaths,
+} from "@open-design/launcher-proto";
+import {
+  APP_KEYS,
+  SIDECAR_MESSAGES,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+} from "@open-design/sidecar-proto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const startDaemonRuntime = vi.fn(async (_options?: unknown) => ({
+  stop: vi.fn(async () => undefined),
+  url: "http://127.0.0.1:48123",
+}));
+
+vi.mock("../../src/daemon-startup.js", () => ({
+  startDaemonRuntime,
+}));
+
+import {
+  allowedBrowserPorts,
+  isAllowedBrowserOrigin,
+} from "../../src/origin-validation.js";
+import { prepareLegacyPayloadDesktopHandoff } from "../../src/sidecar/payload-desktop-handoff.js";
+
+/**
+ * Regression for issue #6074: a fresh Windows install logged
+ * `[packaged desktop handoff] skipped { reason: 'invalid-payload' }` and the
+ * daemon never trusted the web origin, so every `/api` call from the web UI
+ * was rejected and the SPA answered with HTML.
+ *
+ * The desktop handoff's classification is only a log line — the trusted web
+ * port is delivered by the packaged web supervisor's `REGISTER_WEB_URL`
+ * message. These tests therefore cover both halves: the launcher-state
+ * classification stays fail-closed, and the packaged startup still delivers
+ * the web port to the daemon on the fresh-install state from #6074.
+ */
+async function freshWindowsInstall() {
+  const root = await mkdtemp(join(tmpdir(), "od-6074-fresh-win-"));
+  const namespace = "release-stable-win";
+  const version = "0.16.1";
+  const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+  const launcherPaths = resolveLauncherPaths({ channel: "stable", namespace, root });
+  const outerExecutablePath = join(root, "installed", "Open Design.exe");
+  await mkdir(join(root, "installed"), { recursive: true });
+  await mkdir(runtimeRoot, { recursive: true });
+  await mkdir(launcherPaths.stateRoot, { recursive: true });
+  await writeFile(outerExecutablePath, "");
+  await writeFile(launcherPaths.installPath, `${JSON.stringify({
+    channel: "stable",
+    launchPath: outerExecutablePath,
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+  })}\n`);
+  // Generation 0 with active == lastSuccessful: the freshly installed
+  // launcher that has never promoted a payload version.
+  await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+    active: { generation: 0, version },
+    channel: "stable",
+    lastSuccessful: { generation: 0, version },
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+  })}\n`);
+  // No `versions/<version>/manifest.json` and no payload tree at all, which
+  // is the field state reported in #6074.
+  return { launcherPaths, namespace, outerExecutablePath, root, runtimeRoot, version };
+}
+
+async function eligibleInstallWithMismatchedManifest() {
+  const root = await mkdtemp(join(tmpdir(), "od-6074-mismatched-manifest-"));
+  const namespace = "release-beta";
+  const version = "1.2.3-beta.5";
+  const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+  const launcherPaths = resolveLauncherPaths({ channel: "beta", namespace, root });
+  const versionPaths = resolveLauncherVersionPaths({ channel: "beta", namespace, root, version });
+  const outerBundlePath = join(root, "installed", "Open Design Beta.local.app");
+  const outerExecutablePath = join(outerBundlePath, "Contents", "MacOS", "Open Design Beta");
+  // The canonical executable a filename probe would have accepted.
+  const canonicalPayloadExecutable = join(
+    versionPaths.payloadRoot,
+    "Open Design Beta.app",
+    "Contents",
+    "MacOS",
+    "Open Design Beta",
+  );
+  await mkdir(join(outerExecutablePath, ".."), { recursive: true });
+  await mkdir(join(canonicalPayloadExecutable, ".."), { recursive: true });
+  await mkdir(runtimeRoot, { recursive: true });
+  await mkdir(launcherPaths.stateRoot, { recursive: true });
+  await writeFile(outerExecutablePath, "");
+  await writeFile(canonicalPayloadExecutable, "");
+  // The version root was never prepared for 1.2.3-beta.5: the manifest still
+  // names the previous release, so the surviving executable proves nothing.
+  await writeFile(versionPaths.manifestPath, `${JSON.stringify({
+    channel: "beta",
+    entry: { executable: "payload/Open Design Beta.app/Contents/MacOS/Open Design Beta" },
+    namespace,
+    platform: "darwin",
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    version: "1.2.3-beta.4",
+  })}\n`);
+  await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+    active: { generation: 1, version },
+    channel: "beta",
+    lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+  })}\n`);
+  await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+    channel: "beta",
+    generation: 1,
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    version,
+  })}\n`);
+  await writeFile(launcherPaths.installPath, `${JSON.stringify({
+    channel: "beta",
+    launchPath: outerBundlePath,
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+  })}\n`);
+  return { launcherPaths, namespace, outerExecutablePath, root, runtimeRoot, version };
+}
+
+describe("6074 fresh-install desktop handoff regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OD_WEB_PORT;
+  });
+
+  afterEach(() => {
+    delete process.env.OD_WEB_PORT;
+  });
+
+  it("registers the packaged web origin for a fresh Windows install with no prepared payload", async () => {
+    const state = await freshWindowsInstall();
+    const daemonRoot = await mkdtemp(join(tmpdir(), "od-6074-daemon-"));
+    try {
+      // The handoff still classifies the fresh state as not eligible rather
+      // than as a payload error, preserving #6074's diagnostic intent.
+      await expect(prepareLegacyPayloadDesktopHandoff({
+        dataRoot: join(state.root, "data"),
+        env: { OD_APP_VERSION: state.version, OD_INSTALLATION_DIR: state.root },
+        namespace: state.namespace,
+        outerPid: 4321,
+        platform: "win32",
+        requestDesktopStatus: async () => ({
+          executablePath: state.outerExecutablePath,
+          pid: 4321,
+          state: "running",
+        }),
+        runtimeRoot: state.runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      })).resolves.toEqual({ kind: "none", reason: "launcher-state-not-eligible" });
+
+      const { startDaemonSidecar } = await import("../../src/sidecar/server.js");
+      const handle = await startDaemonSidecar({
+        app: APP_KEYS.DAEMON,
+        base: state.runtimeRoot,
+        ipc: join(daemonRoot, "daemon.sock"),
+        mode: SIDECAR_MODES.RUNTIME,
+        namespace: state.namespace,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      try {
+        const daemonPort = 48123;
+        const webUrl = "http://127.0.0.1:64248";
+        // The daemon's browser-origin middleware for /api, evaluated exactly
+        // as apps/daemon/src/server.ts does: the ports it trusts, the Host the
+        // web app sends, and the Origin its fetch() carries.
+        const apiOriginAllowed = () => isAllowedBrowserOrigin(
+          webUrl,
+          `127.0.0.1:${daemonPort}`,
+          allowedBrowserPorts(daemonPort),
+          "127.0.0.1",
+          [],
+        );
+
+        expect((await handle.status()).trustedWebOriginPort).toBeNull();
+        // Until the web port is registered every /api call from the web origin
+        // is refused, which is the user-visible half of #6074.
+        expect(apiOriginAllowed()).toBe(false);
+
+        // `registerPackagedWebUrl` in apps/packaged/src/sidecars.ts issues
+        // exactly this message once the web sidecar reports its dynamic port.
+        await handle.invoke(SIDECAR_MESSAGES.REGISTER_WEB_URL, { url: webUrl });
+
+        expect(process.env.OD_WEB_PORT).toBe("64248");
+        expect((await handle.status()).trustedWebOriginPort).toBe(64248);
+        // The /api middleware now admits the request from the web origin.
+        expect(apiOriginAllowed()).toBe(true);
+      } finally {
+        await handle.stop();
+        await handle.waitUntilStopped();
+      }
+    } finally {
+      await rm(daemonRoot, { recursive: true, force: true });
+      await rm(state.root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when an eligible state has a canonical executable but a mismatched manifest", async () => {
+    const state = await eligibleInstallWithMismatchedManifest();
+    try {
+      await expect(prepareLegacyPayloadDesktopHandoff({
+        dataRoot: join(state.root, "data"),
+        env: { OD_APP_VERSION: state.version, OD_INSTALLATION_DIR: state.root },
+        namespace: state.namespace,
+        outerPid: 4321,
+        platform: "darwin",
+        requestDesktopStatus: async () => ({
+          executablePath: state.outerExecutablePath,
+          pid: 4321,
+          state: "running",
+        }),
+        runtimeRoot: state.runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      })).resolves.toEqual({ kind: "none", reason: "invalid-payload" });
+    } finally {
+      await rm(state.root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6074

## Why

On a fresh Windows packaged install the daemon logged `[packaged desktop handoff] skipped { reason: 'invalid-payload' }` even though the payload tree had simply not been materialized yet. `prepareLegacyPayloadDesktopHandoff` returned `invalid-payload` before checking whether the launcher state was even eligible for a handoff, which masked the real reason (`launcher-state-not-eligible`).

The fix moves the `invalid-payload` check after the eligibility check so the reported reason is accurate, and probes the conventional payload locations when the manifest is missing or mismatched but a payload executable already exists on disk.

## What users will see

Packaged launches whose payload tree is not yet materialized report `launcher-state-not-eligible` instead of `invalid-payload`. Launches with a valid, matching manifest are unchanged, and an eligible launch that genuinely lacks a payload still reports `invalid-payload`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change**
- [ ] **None** — daemon sidecar internal handoff classification fix + test

## Screenshots

No UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/sidecar/payload-desktop-handoff-6074-regression.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — on `main` the fresh-install case returned `{ kind: 'none', reason: 'invalid-payload' }` instead of `launcher-state-not-eligible`.
- A second test keeps `invalid-payload` when the launcher state is eligible but the payload is missing, so the narrow contract is preserved.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/sidecar/payload-desktop-handoff.test.ts` — 11 passed
- `pnpm --filter @open-design/daemon exec vitest run tests/sidecar/payload-desktop-handoff-6074-regression.test.ts` — 2 passed
- `pnpm --filter @open-design/web exec vitest run tests/sidecar-proxy-daemon-unavailable.test.ts` — 3 passed
- `pnpm --filter @open-design/daemon exec vitest run tests/sidecar-startup.test.ts` — 4 passed
- `git diff --check` clean
