### PR TITLE
fix(packaged): swallow EPIPE in console echo to stop main-process crash

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -64,6 +64,15 @@ import { reportStartupFailure, resolveStartupDistinctId } from "./startup-teleme
 import { resolvePackagedWindowTitle } from "./window-title.js";
 import { syncWindowsUninstallDisplayVersion } from "./windows-lifecycle.js";
 
+// The launcher inspection below runs with the raw `console` before
+// `createPackagedDesktopLogger` exists. On the normal first launch the desktop
+// IPC socket is absent, `requestJsonIpc` rejects, and
+// `inspectExistingDesktopForLauncher` echoes `inspect-unavailable` to a
+// detached stdout — the same EPIPE this guard exists to swallow. Install it
+// here, before `main()` can emit any pre-logger diagnostic, rather than
+// waiting for the structured logger. Safe to install again later.
+installStdioErrorGuard([process.stdout, process.stderr]);
+
 let packagedLogger: PackagedDesktopLogger | null = null;
 const secondInstanceHandoff = createPackagedSecondInstanceHandoff();
 
@@ -147,14 +156,6 @@ async function main(): Promise<void> {
   const namespace = argvStamp?.namespace ?? config.namespace;
   const namespaceConfig = namespace === config.namespace ? config : { ...config, namespace };
   const initialPaths = resolvePackagedNamespacePaths(namespaceConfig, namespace, process.env);
-  // The launcher diagnostics below run before `createPackagedDesktopLogger`
-  // (they only need `initialPaths`, and the structured logger is created
-  // later), so they echo through the raw `console`. On the normal first
-  // launch the desktop IPC socket is absent, `requestJsonIpc` rejects, and
-  // `inspectExistingDesktopForLauncher` logs `inspect-unavailable` to a
-  // detached stdout — the same EPIPE crash this guard exists to swallow.
-  // Install it before those diagnostics rather than waiting for the logger.
-  installStdioErrorGuard([process.stdout, process.stderr]);
   if (!await waitForLauncherAfterQuit(afterQuit, initialPaths)) {
     app.exit(1);
     return;

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -52,6 +52,7 @@ import {
 import {
   attachPackagedDesktopProcessLogging,
   createPackagedDesktopLogger,
+  installStdioErrorGuard,
   type PackagedDesktopLogger,
 } from "./logging.js";
 import { resolvePackagedNamespacePaths } from "./paths.js";
@@ -146,6 +147,14 @@ async function main(): Promise<void> {
   const namespace = argvStamp?.namespace ?? config.namespace;
   const namespaceConfig = namespace === config.namespace ? config : { ...config, namespace };
   const initialPaths = resolvePackagedNamespacePaths(namespaceConfig, namespace, process.env);
+  // The launcher diagnostics below run before `createPackagedDesktopLogger`
+  // (they only need `initialPaths`, and the structured logger is created
+  // later), so they echo through the raw `console`. On the normal first
+  // launch the desktop IPC socket is absent, `requestJsonIpc` rejects, and
+  // `inspectExistingDesktopForLauncher` logs `inspect-unavailable` to a
+  // detached stdout — the same EPIPE crash this guard exists to swallow.
+  // Install it before those diagnostics rather than waiting for the logger.
+  installStdioErrorGuard([process.stdout, process.stderr]);
   if (!await waitForLauncherAfterQuit(afterQuit, initialPaths)) {
     app.exit(1);
     return;

--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -218,24 +218,115 @@ export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): Pack
     warn: console.warn.bind(console),
   };
 
+  // Packaged Electron on Windows / Linux has no controlling terminal:
+  // `process.stdout` / `process.stderr` are typically detached or
+  // piped to a closed handle, so the very first `console.info(...)`
+  // a renderer lifecycle handler fires (e.g. `did-start-loading`)
+  // raises `Error: EPIPE: broken pipe, write` from
+  // `node:internal/streams/writable:508`. The error escapes the
+  // wrapper because the throws happen *inside* `Writable.write`, not
+  // at the call site, and lands in the packaged main process as an
+  // uncaught exception that crashes the whole app with Electron's
+  // native "JavaScript error in main process" dialog.
+  //
+  // The structured file logger above already swallows its own
+  // append failures (see `appendDesktopLogLine`). This wrapper does
+  // the same for the stdout / stderr echo: only the two known-safe
+  // stream-closure error codes are swallowed, and the matcher is
+  // intentionally narrow (a future `code: 'EACCES'`-style regression
+  // that broadens the filter trips the regression test in
+  // `tests/logging.test.ts`).
+  //
+  // This try/catch alone is NOT sufficient to stop the crash: it only
+  // catches a *synchronous* throw, and a detached stdout/stderr pipe
+  // fails asynchronously instead. See `installStdioErrorGuard` below
+  // for the layer that actually covers that path.
+  const safeEcho = (fn: (...a: unknown[]) => void) => (...args: unknown[]) => {
+    if (!echo) return;
+    try {
+      fn(...args);
+    } catch (error) {
+      if (isHarmlessStdoutError(error)) return;
+      throw error;
+    }
+  };
+
   console.log = (...args: unknown[]) => {
     logger.info("console.log", { args });
-    if (echo) originalConsole.log(...args);
+    safeEcho(originalConsole.log)(...args);
   };
   console.info = (...args: unknown[]) => {
     logger.info("console.info", { args });
-    if (echo) originalConsole.info(...args);
+    safeEcho(originalConsole.info)(...args);
   };
   console.warn = (...args: unknown[]) => {
     logger.warn("console.warn", { args });
-    if (echo) originalConsole.warn(...args);
+    safeEcho(originalConsole.warn)(...args);
   };
   console.error = (...args: unknown[]) => {
     logger.error("console.error", { args });
-    if (echo) originalConsole.error(...args);
+    safeEcho(originalConsole.error)(...args);
   };
 
+  // safeEcho's try/catch only covers a *synchronous* throw. It does not
+  // cover this failure mode: verified live on a packaged Windows build
+  // where safeEcho alone did not stop the crash. See installStdioErrorGuard.
+  installStdioErrorGuard([process.stdout, process.stderr]);
+
   return logger;
+}
+
+/**
+ * Second, independent layer on top of `safeEcho` above. `safeEcho`'s
+ * try/catch only catches a *synchronous* throw from the echo call, but
+ * `Writable#write` on a detached stdout/stderr pipe (no controlling
+ * terminal — the packaged Electron case) fails *asynchronously*
+ * instead: Node's internal `onwriteError` path schedules the stream's
+ * own `'error'` event via `process.nextTick` during `destroy()`, so by
+ * the time it fires, the `try { fn(...args) }` call has already
+ * returned normally and there is nothing left on the stack to catch.
+ *
+ * This is easy to miss because the resulting uncaught exception's
+ * `.stack` is misleading: V8 fixes `.stack` at `Error` *construction*
+ * time — deep inside the synchronous write attempt, which includes
+ * this file's `safeEcho` frames — not at throw time. It looks like the
+ * error went through `safeEcho` and escaped it, when it actually never
+ * reached that catch block at all.
+ *
+ * Streams are passed in (rather than reading `process.stdout` /
+ * `process.stderr` directly) so this can be unit tested against fakes.
+ */
+export function installStdioErrorGuard(streams: Iterable<NodeJS.WritableStream>): void {
+  for (const stream of streams) {
+    stream.on("error", (error) => {
+      if (isHarmlessStdoutError(error)) return;
+      throw error;
+    });
+  }
+}
+
+/**
+ * Recognise the two known-harmless stream-closure error codes that
+ * packaged Electron's stdout / stderr can raise when the underlying
+ * pipe has been detached (no controlling terminal, redirected to a
+ * closed handle, or explicitly `.destroy()`ed by the host).
+ *
+ *   - `EPIPE`                — classic POSIX broken-pipe on `write`
+ *   - `ERR_STREAM_DESTROYED` — Node's "stream was destroyed" state
+ *
+ * The matcher is intentionally narrow: it requires the structured
+ * `code` property to be present and to equal one of the two known
+ * values. A bare `Error` with "broken pipe" in its message but no
+ * `code` is rejected so that real I/O failures (e.g. an EACCES on
+ * a file write that happens to mention pipes) are not silently
+ * dropped. Tests in `tests/logging.test.ts` pin both edges.
+ *
+ * @see https://github.com/nexu-io/open-design/issues/6964
+ */
+export function isHarmlessStdoutError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
 }
 
 export function attachPackagedDesktopProcessLogging(options: {

--- a/apps/packaged/src/logging.ts
+++ b/apps/packaged/src/logging.ts
@@ -295,9 +295,20 @@ export function createPackagedDesktopLogger(paths: PackagedNamespacePaths): Pack
  *
  * Streams are passed in (rather than reading `process.stdout` /
  * `process.stderr` directly) so this can be unit tested against fakes.
+ *
+ * The packaged entry installs this early, before the launcher
+ * inspection echoes `inspect-unavailable` through the raw `console`;
+ * `createPackagedDesktopLogger` installs it again once the structured
+ * logger exists. Each stream is guarded at most once, so the second
+ * call cannot stack a duplicate `'error'` listener that would fire the
+ * handler twice for a single stream failure.
  */
+const guardedStdioStreams = new WeakSet<NodeJS.WritableStream>();
+
 export function installStdioErrorGuard(streams: Iterable<NodeJS.WritableStream>): void {
   for (const stream of streams) {
+    if (guardedStdioStreams.has(stream)) continue;
+    guardedStdioStreams.add(stream);
     stream.on("error", (error) => {
       if (isHarmlessStdoutError(error)) return;
       throw error;

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,7 @@ import {
   inspectExistingDesktopForLauncher,
   waitForLauncherAfterQuit,
 } from "../src/launcher-after-quit.js";
+import { installStdioErrorGuard } from "../src/logging.js";
 import type { PackagedNamespacePaths } from "../src/paths.js";
 
 /** Build a `stopProcesses` result without signalling any real PID. */
@@ -49,6 +51,28 @@ function fakePaths(root: string): PackagedNamespacePaths {
     updateRoot: join(root, "updates"),
     webIdentityPath: join(root, "runtime", "web-root.json"),
   };
+}
+
+/**
+ * A stdout/stderr stand-in for a packaged first launch: no controlling
+ * terminal, so every write fails *asynchronously* with EPIPE — the
+ * detached pipe that crashed the main process before the stdio guard
+ * existed (issue #6964). `onWrite` lets a test observe what was true at
+ * the moment the write happened.
+ */
+function detachedPipe(): NodeJS.WritableStream & { onWrite: () => void } {
+  const stream = new EventEmitter() as unknown as NodeJS.WritableStream & { onWrite: () => void };
+  stream.onWrite = () => {};
+  (stream as unknown as { write: (chunk: unknown) => boolean }).write = () => {
+    stream.onWrite();
+    process.nextTick(() => {
+      const error = new Error("write EPIPE") as NodeJS.ErrnoException;
+      error.code = "EPIPE";
+      stream.emit("error", error);
+    });
+    return true;
+  };
+  return stream;
 }
 
 describe("waitForLauncherAfterQuit", () => {
@@ -291,6 +315,45 @@ describe("inspectExistingDesktopForLauncher", () => {
       expect(result).toEqual({ action: "continue", reason: "inspect-failed" });
       const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
       expect(log).toContain("inspect-unavailable namespace=release-beta-win action=continue error=pipe closed");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("survives the pre-logger first-launch echo on a detached stdout", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-prelogger-stdio-"));
+    // The entry inspects the launcher with the raw `console` before
+    // `createPackagedDesktopLogger` exists, so the guard has to be in
+    // place first. Mirrors that ordering here: guard, then inspect.
+    const stdout = detachedPipe();
+    const stderr = detachedPipe();
+    const guardedAtWrite: boolean[] = [];
+    stdout.onWrite = () => guardedAtWrite.push(
+      (stdout as unknown as EventEmitter).listenerCount("error") > 0,
+    );
+
+    try {
+      const paths = fakePaths(root);
+      installStdioErrorGuard([stdout, stderr]);
+
+      const result = await inspectExistingDesktopForLauncher("release-beta-win", {
+        logger: {
+          info: (message: string) => stdout.write(message),
+          warn: (message: string) => stderr.write(message),
+        },
+        paths,
+        requestIpc: (async () => {
+          throw new Error("pipe closed");
+        }) as typeof import("@open-design/sidecar").requestJsonIpc,
+      });
+      // Drain the detached pipe's asynchronous EPIPE 'error' event.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(result).toEqual({ action: "continue", reason: "inspect-failed" });
+      // The guard must already be listening when the unguarded
+      // `console.info` echo that crashed first launches is written.
+      expect(guardedAtWrite.length).toBeGreaterThan(0);
+      expect(guardedAtWrite.every(Boolean)).toBe(true);
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +11,6 @@ import {
   inspectExistingDesktopForLauncher,
   waitForLauncherAfterQuit,
 } from "../src/launcher-after-quit.js";
-import { installStdioErrorGuard } from "../src/logging.js";
 import type { PackagedNamespacePaths } from "../src/paths.js";
 
 /** Build a `stopProcesses` result without signalling any real PID. */
@@ -51,28 +49,6 @@ function fakePaths(root: string): PackagedNamespacePaths {
     updateRoot: join(root, "updates"),
     webIdentityPath: join(root, "runtime", "web-root.json"),
   };
-}
-
-/**
- * A stdout/stderr stand-in for a packaged first launch: no controlling
- * terminal, so every write fails *asynchronously* with EPIPE — the
- * detached pipe that crashed the main process before the stdio guard
- * existed (issue #6964). `onWrite` lets a test observe what was true at
- * the moment the write happened.
- */
-function detachedPipe(): NodeJS.WritableStream & { onWrite: () => void } {
-  const stream = new EventEmitter() as unknown as NodeJS.WritableStream & { onWrite: () => void };
-  stream.onWrite = () => {};
-  (stream as unknown as { write: (chunk: unknown) => boolean }).write = () => {
-    stream.onWrite();
-    process.nextTick(() => {
-      const error = new Error("write EPIPE") as NodeJS.ErrnoException;
-      error.code = "EPIPE";
-      stream.emit("error", error);
-    });
-    return true;
-  };
-  return stream;
 }
 
 describe("waitForLauncherAfterQuit", () => {
@@ -315,45 +291,6 @@ describe("inspectExistingDesktopForLauncher", () => {
       expect(result).toEqual({ action: "continue", reason: "inspect-failed" });
       const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
       expect(log).toContain("inspect-unavailable namespace=release-beta-win action=continue error=pipe closed");
-    } finally {
-      await rm(root, { force: true, recursive: true });
-    }
-  });
-
-  it("survives the pre-logger first-launch echo on a detached stdout", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-launcher-prelogger-stdio-"));
-    // The entry inspects the launcher with the raw `console` before
-    // `createPackagedDesktopLogger` exists, so the guard has to be in
-    // place first. Mirrors that ordering here: guard, then inspect.
-    const stdout = detachedPipe();
-    const stderr = detachedPipe();
-    const guardedAtWrite: boolean[] = [];
-    stdout.onWrite = () => guardedAtWrite.push(
-      (stdout as unknown as EventEmitter).listenerCount("error") > 0,
-    );
-
-    try {
-      const paths = fakePaths(root);
-      installStdioErrorGuard([stdout, stderr]);
-
-      const result = await inspectExistingDesktopForLauncher("release-beta-win", {
-        logger: {
-          info: (message: string) => stdout.write(message),
-          warn: (message: string) => stderr.write(message),
-        },
-        paths,
-        requestIpc: (async () => {
-          throw new Error("pipe closed");
-        }) as typeof import("@open-design/sidecar").requestJsonIpc,
-      });
-      // Drain the detached pipe's asynchronous EPIPE 'error' event.
-      await new Promise((resolve) => setImmediate(resolve));
-
-      expect(result).toEqual({ action: "continue", reason: "inspect-failed" });
-      // The guard must already be listening when the unguarded
-      // `console.info` echo that crashed first launches is written.
-      expect(guardedAtWrite.length).toBeGreaterThan(0);
-      expect(guardedAtWrite.every(Boolean)).toBe(true);
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -14,7 +14,8 @@
  * @see https://github.com/nexu-io/open-design/issues/895
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -25,7 +26,9 @@ import {
   createPackagedDesktopLogger,
   createFatalUncaughtExceptionHandler,
   createFatalUnhandledRejectionHandler,
+  installStdioErrorGuard,
   isHarmlessSocketOptionError,
+  isHarmlessStdoutError,
   type PackagedDesktopLogger,
 } from '../src/logging.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
@@ -143,6 +146,185 @@ describe('isHarmlessSocketOptionError (issue #895)', () => {
     const error = new Error('') as NodeJS.ErrnoException;
     error.code = 'EINVAL';
     expect(isHarmlessSocketOptionError(error)).toBe(false);
+  });
+});
+
+/**
+ * Regression coverage for the packaged main-process EPIPE crash that
+ * surfaces the first time a renderer lifecycle handler calls
+ * `console.info(...)` in an Electron build with no controlling
+ * terminal. The wrapper installed by `createPackagedDesktopLogger`
+ * must swallow only the two known-safe stream-closure codes
+ * (`EPIPE`, `ERR_STREAM_DESTROYED`) and re-throw anything else, so
+ * real I/O failures are not silently dropped.
+ */
+describe('isHarmlessStdoutError (packaged console echo EPIPE guard)', () => {
+  it('matches an Error with code: EPIPE', () => {
+    const error = new Error('write EPIPE') as NodeJS.ErrnoException;
+    error.code = 'EPIPE';
+    expect(isHarmlessStdoutError(error)).toBe(true);
+  });
+
+  it('matches an Error with code: ERR_STREAM_DESTROYED', () => {
+    const error = new Error('stream destroyed') as NodeJS.ErrnoException;
+    error.code = 'ERR_STREAM_DESTROYED';
+    expect(isHarmlessStdoutError(error)).toBe(true);
+  });
+
+  it('does NOT match a bare Error that mentions "broken pipe" in its message but has no code', () => {
+    const error = new Error('broken pipe, write');
+    expect(isHarmlessStdoutError(error)).toBe(false);
+  });
+
+  it('does NOT match an unrelated errno like EACCES even if the message mentions pipes', () => {
+    const error = new Error('broken pipe while writing to log file') as NodeJS.ErrnoException;
+    error.code = 'EACCES';
+    expect(isHarmlessStdoutError(error)).toBe(false);
+  });
+
+  it('does NOT match non-objects (null, undefined, strings)', () => {
+    expect(isHarmlessStdoutError(null)).toBe(false);
+    expect(isHarmlessStdoutError(undefined)).toBe(false);
+    expect(isHarmlessStdoutError('EPIPE')).toBe(false);
+  });
+});
+
+describe('createPackagedDesktopLogger console echo EPIPE guard', () => {
+  it('swallows an EPIPE thrown by the original console.info echo and still records the call to the desktop log file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-echo-epipe-'));
+    const previousEcho = process.env.OD_DESKTOP_LOG_ECHO;
+    // echo must be on (the default) for safeEcho to be in the path.
+    delete process.env.OD_DESKTOP_LOG_ECHO;
+    // Stub the host's console.info BEFORE constructing the logger so
+    // the factory captures the throwing original as `originalConsole.info`
+    // (the wrapper then calls safeEcho(originalConsole.info), which is
+    // the only place the EPIPE filter is applied — see issue #6964).
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+    console.info = () => {
+      throw epipe;
+    };
+    const desktopLogPath = join(root, 'desktop.log');
+    try {
+      createPackagedDesktopLogger(makePaths(root, desktopLogPath));
+
+      // The wrapped call must NOT throw — the unwrapped version
+      // crashed the main process via an uncaught exception that
+      // propagated out of `Writable.write`.
+      expect(() =>
+        console.info('main window did-start-loading', { url: 'about:blank' }),
+      ).not.toThrow();
+
+      // The wrapper must have actually run (and called the file
+      // logger) — not the bare stub. If the wrapper had been
+      // bypassed, no record would land in the desktop log file.
+      const line = readFileSync(desktopLogPath, 'utf8');
+      expect(line).toContain('console.info');
+      expect(line).toContain('main window did-start-loading');
+    } finally {
+      if (previousEcho == null) {
+        delete process.env.OD_DESKTOP_LOG_ECHO;
+      } else {
+        process.env.OD_DESKTOP_LOG_ECHO = previousEcho;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still re-throws non-harmless errors thrown by the original console.error echo and records the call to the desktop log file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-packaged-echo-other-'));
+    const previousEcho = process.env.OD_DESKTOP_LOG_ECHO;
+    delete process.env.OD_DESKTOP_LOG_ECHO;
+    // Same before/after ordering as the EPIPE case: stub the host's
+    // console.error BEFORE the factory so originalConsole.error
+    // captures the throwing stub.
+    const eacces = new Error('permission denied writing to log file') as NodeJS.ErrnoException;
+    eacces.code = 'EACCES';
+    console.error = () => {
+      throw eacces;
+    };
+    const desktopLogPath = join(root, 'desktop.log');
+    try {
+      createPackagedDesktopLogger(makePaths(root, desktopLogPath));
+
+      // The wrapper must surface non-harmless errors so real I/O
+      // failures are not silently dropped.
+      expect(() => console.error('fatal write failure')).toThrow(eacces);
+
+      // The wrapper must have actually run (and called the file
+      // logger BEFORE the echo) — proving the throw escaped via
+      // safeEcho, not via the bare stub.
+      const line = readFileSync(desktopLogPath, 'utf8');
+      expect(line).toContain('console.error');
+      expect(line).toContain('fatal write failure');
+    } finally {
+      if (previousEcho == null) {
+        delete process.env.OD_DESKTOP_LOG_ECHO;
+      } else {
+        process.env.OD_DESKTOP_LOG_ECHO = previousEcho;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// Regression coverage for the gap `safeEcho`'s try/catch cannot close:
+// a detached stdout/stderr pipe fails *asynchronously* (the stream
+// emits its own 'error' event, e.g. from `process.nextTick` during
+// internal `destroy()`), not as a synchronous throw from `.write()`.
+// Reproduced live on a packaged Windows build: the crash's stack trace
+// still showed `safeEcho`'s frames (because V8 fixes `.stack` at Error
+// *construction* time, not throw time), which made it look like the
+// try/catch had been bypassed when in fact it was never reached at all.
+describe('installStdioErrorGuard (async stdio pipe-closure guard)', () => {
+  function fakeStream(): NodeJS.WritableStream {
+    return new EventEmitter() as unknown as NodeJS.WritableStream;
+  }
+
+  it('swallows an EPIPE emitted asynchronously on the stream, not thrown synchronously', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+
+    // This is exactly what safeEcho's try/catch cannot see: nothing on
+    // the call stack, just an 'error' event firing on its own.
+    expect(() => (stream as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
+  });
+
+  it('swallows an ERR_STREAM_DESTROYED emitted asynchronously on the stream', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const destroyed = new Error('stream destroyed') as NodeJS.ErrnoException;
+    destroyed.code = 'ERR_STREAM_DESTROYED';
+
+    expect(() => (stream as unknown as EventEmitter).emit('error', destroyed)).not.toThrow();
+  });
+
+  it('re-throws a non-harmless error emitted on the stream instead of silently dropping it', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+
+    const eacces = new Error('permission denied') as NodeJS.ErrnoException;
+    eacces.code = 'EACCES';
+
+    // EventEmitter re-throws synchronously out of emit() when an
+    // 'error' listener itself throws.
+    expect(() => (stream as unknown as EventEmitter).emit('error', eacces)).toThrow(eacces);
+  });
+
+  it('installs an independent guard per stream (stdout failure does not depend on stderr)', () => {
+    const stdout = fakeStream();
+    const stderr = fakeStream();
+    installStdioErrorGuard([stdout, stderr]);
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+
+    expect(() => (stdout as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
+    expect(() => (stderr as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
   });
 });
 

--- a/apps/packaged/tests/logging.test.ts
+++ b/apps/packaged/tests/logging.test.ts
@@ -326,6 +326,32 @@ describe('installStdioErrorGuard (async stdio pipe-closure guard)', () => {
     expect(() => (stdout as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
     expect(() => (stderr as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
   });
+
+  it('does not stack a duplicate listener when the same stream is guarded more than once', () => {
+    const stream = fakeStream();
+    // The packaged entry installs the guard before the launcher
+    // inspection, and `createPackagedDesktopLogger` installs it again
+    // once the structured logger exists (see index.ts).
+    installStdioErrorGuard([stream]);
+    installStdioErrorGuard([stream]);
+
+    expect((stream as unknown as EventEmitter).listenerCount('error')).toBe(1);
+
+    const epipe = new Error('write EPIPE') as NodeJS.ErrnoException;
+    epipe.code = 'EPIPE';
+    expect(() => (stream as unknown as EventEmitter).emit('error', epipe)).not.toThrow();
+  });
+
+  it('keeps re-throwing non-harmless errors after a repeated install', () => {
+    const stream = fakeStream();
+    installStdioErrorGuard([stream]);
+    installStdioErrorGuard([stream]);
+
+    const eacces = new Error('permission denied') as NodeJS.ErrnoException;
+    eacces.code = 'EACCES';
+
+    expect(() => (stream as unknown as EventEmitter).emit('error', eacces)).toThrow(eacces);
+  });
 });
 
 describe('createPackagedDesktopLogger log-write failures', () => {

--- a/apps/packaged/tests/pre-logger-stdio.test.ts
+++ b/apps/packaged/tests/pre-logger-stdio.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The packaged entry logs its launcher diagnostics with the raw `console`
+ * before `createPackagedDesktopLogger` exists (the structured logger needs the
+ * resolved paths). On the normal first launch the desktop IPC socket is
+ * absent, `requestJsonIpc` rejects, and `inspectExistingDesktopForLauncher`
+ * echoes `inspect-unavailable` — to a detached stdout when the packaged app
+ * has no controlling terminal, which is exactly the EPIPE crash the stdio
+ * guard exists to swallow (issue #6964). The entry installs the guard before
+ * `main()` runs, so these tests keep that pre-logger sequence covered.
+ */
+
+import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { inspectExistingDesktopForLauncher } from "../src/launcher-after-quit.js";
+import { installStdioErrorGuard } from "../src/logging.js";
+import type { PackagedNamespacePaths } from "../src/paths.js";
+
+function fakePaths(root: string): PackagedNamespacePaths {
+  return {
+    cacheRoot: join(root, "cache"),
+    dataRoot: join(root, "data"),
+    desktopIdentityPath: join(root, "runtime", "desktop-root.json"),
+    desktopLogPath: join(root, "logs", "desktop", "latest.log"),
+    desktopLogsRoot: join(root, "logs", "desktop"),
+    electronSessionDataRoot: join(root, "user-data", "session"),
+    electronUserDataRoot: join(root, "user-data"),
+    headlessIdentityPath: join(root, "runtime", "headless-root.json"),
+    installationRoot: root,
+    installerObservationRoot: join(root, "data", "observations", "installer"),
+    logsRoot: join(root, "logs"),
+    namespaceRoot: root,
+    resourceRoot: join(root, "resources", "open-design"),
+    runtimeRoot: join(root, "runtime"),
+    updateRoot: join(root, "updates"),
+    webIdentityPath: join(root, "runtime", "web-root.json"),
+  };
+}
+
+/**
+ * A stdout/stderr stand-in for a packaged first launch: no controlling
+ * terminal, so every write fails *asynchronously* with EPIPE. `onWrite` lets a
+ * test observe what was true at the moment the write happened.
+ */
+function detachedPipe(): NodeJS.WritableStream & { onWrite: () => void } {
+  const stream = new EventEmitter() as unknown as NodeJS.WritableStream & { onWrite: () => void };
+  stream.onWrite = () => {};
+  (stream as unknown as { write: (chunk: unknown) => boolean }).write = () => {
+    stream.onWrite();
+    process.nextTick(() => {
+      const error = new Error("write EPIPE") as NodeJS.ErrnoException;
+      error.code = "EPIPE";
+      stream.emit("error", error);
+    });
+    return true;
+  };
+  return stream;
+}
+
+describe("packaged pre-logger stdio guard", () => {
+  it("survives the first-launch launcher inspection on a detached stdout", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-prelogger-stdio-"));
+    const stdout = detachedPipe();
+    const stderr = detachedPipe();
+    const guardedAtWrite: boolean[] = [];
+    stdout.onWrite = () => guardedAtWrite.push(
+      (stdout as unknown as EventEmitter).listenerCount("error") > 0,
+    );
+
+    try {
+      const paths = fakePaths(root);
+      // Mirrors the entry: the guard is installed before the inspection,
+      // which still logs through the raw console.
+      installStdioErrorGuard([stdout, stderr]);
+
+      const result = await inspectExistingDesktopForLauncher("release-beta-win", {
+        logger: {
+          info: (message: string) => stdout.write(message),
+          warn: (message: string) => stderr.write(message),
+        },
+        paths,
+        requestIpc: (async () => {
+          throw new Error("pipe closed");
+        }) as typeof import("@open-design/sidecar").requestJsonIpc,
+      });
+      // Drain the detached pipe's asynchronous EPIPE 'error' event.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(result).toEqual({ action: "continue", reason: "inspect-failed" });
+      // The diagnostic really ran, and it ran with the guard already
+      // listening — the ordering the unguarded first launch crashed on.
+      const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
+      expect(log).toContain("inspect-unavailable namespace=release-beta-win action=continue error=pipe closed");
+      expect(guardedAtWrite.length).toBeGreaterThan(0);
+      expect(guardedAtWrite.every(Boolean)).toBe(true);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6964

## Why

Packaged Electron on Windows launches without a terminal, so the first `console.info` from `did-start-loading` throws `EPIPE` inside `Writable.write` and crashes the main process with an uncaught exception. The logger already writes to the desktop file but the stdout echo had no guard, so every default launch showed the native crash dialog.

## What users will see

Before, the first `console.*` echo to a detached stdout/stderr raised `EPIPE` inside `Writable.write` and crashed the packaged main process. After, the logger's stdout/stderr echo swallows the two known stream-closure errors (`EPIPE`, `ERR_STREAM_DESTROYED`), so that path no longer throws and the event is still recorded in the desktop log file. No API, env var or install layout change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — the bug was a native crash dialog; the fix restores “no dialog” with the same main window.

## Bug fix verification

- Test path: `apps/packaged/tests/logging.test.ts`
- Red on `main`, green on this branch: the new EPIPE guard cases fail without the wrapper and pass with it.

## Validation

`pnpm --filter @open-design/desktop build && pnpm --filter @open-design/packaged exec tsc -p tsconfig.json --noEmit && pnpm --filter @open-design/packaged exec tsc -p tsconfig.tests.json --noEmit && pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/logging.test.ts` — 29/29, typecheck clean, `git diff --check` clean.

Reviewers: @mrcfps @AmyShang-alt

