### PR TITLE
feat(runtimes): support companion setup for local DSH profiles

### DIFF
--- a/apps/daemon/src/agent-companion-setup.ts
+++ b/apps/daemon/src/agent-companion-setup.ts
@@ -184,6 +184,7 @@ function commandFailureDetail(error: unknown): string | null {
 }
 
 const activeSetups = new Map<string, Promise<AgentCompanionSetupResponse>>();
+let setupQueue: Promise<void> = Promise.resolve();
 
 export function installDshProfileCompanion(agentId: string, options: {
   projectRoot: string;
@@ -192,9 +193,10 @@ export function installDshProfileCompanion(agentId: string, options: {
 }): Promise<AgentCompanionSetupResponse> {
   const active = activeSetups.get(agentId);
   if (active) return active;
-  const setup = installDshProfileCompanionOnce(agentId, options).finally(() => {
+  const setup = setupQueue.then(() => installDshProfileCompanionOnce(agentId, options)).finally(() => {
     if (activeSetups.get(agentId) === setup) activeSetups.delete(agentId);
   });
+  setupQueue = setup.then(() => undefined, () => undefined);
   activeSetups.set(agentId, setup);
   return setup;
 }

--- a/apps/daemon/src/agent-companion-setup.ts
+++ b/apps/daemon/src/agent-companion-setup.ts
@@ -22,7 +22,7 @@ import {
 } from './runtimes/defs/deepseek-harness.js';
 
 const execFileAsync = promisify(execFile);
-const DSH_AGENT_ID = 'deepseek-harness';
+const DSH_RUNTIME_RESOURCE_ID = 'deepseek-harness';
 const DSH_RUNTIME_RESOURCE_DIRECTORY = path.join('agent-runtimes', 'deepseek-harness');
 const DSH_RUNTIME_PACKAGE_NAME = '@open-design/dsh-runtime';
 
@@ -37,6 +37,7 @@ type RuntimeManifest = {
 export class AgentCompanionSetupError extends Error {
   constructor(
     readonly code:
+      | 'AGENT_UNSUPPORTED'
       | 'AGENT_NOT_INSTALLED'
       | 'BUNDLED_COMPANION_INVALID'
       | 'COMPANION_INSTALL_FAILED'
@@ -78,7 +79,7 @@ async function materializeDevelopmentBundle(
       'This OpenDesign build does not contain the DeepSeek Harness connection component.',
     );
   }
-  const destination = path.join(runtimeDataDir, 'runtime-packages', DSH_AGENT_ID);
+  const destination = path.join(runtimeDataDir, 'runtime-packages', DSH_RUNTIME_RESOURCE_ID);
   await rm(destination, { force: true, recursive: true });
   await mkdir(destination, { recursive: true });
   await runPackageManager(['--filter', DSH_RUNTIME_PACKAGE_NAME, 'build'], projectRoot);
@@ -182,31 +183,36 @@ function commandFailureDetail(error: unknown): string | null {
   return parts.length > 0 ? parts.join(' ') : null;
 }
 
-let activeSetup: Promise<AgentCompanionSetupResponse> | null = null;
+const activeSetups = new Map<string, Promise<AgentCompanionSetupResponse>>();
 
-export function installDeepSeekHarnessCompanion(options: {
+export function installDshProfileCompanion(agentId: string, options: {
   projectRoot: string;
   resourceRoot: string;
   runtimeDataDir: string;
 }): Promise<AgentCompanionSetupResponse> {
-  if (activeSetup) return activeSetup;
-  activeSetup = installDeepSeekHarnessCompanionOnce(options).finally(() => {
-    activeSetup = null;
+  const active = activeSetups.get(agentId);
+  if (active) return active;
+  const setup = installDshProfileCompanionOnce(agentId, options).finally(() => {
+    if (activeSetups.get(agentId) === setup) activeSetups.delete(agentId);
   });
-  return activeSetup;
+  activeSetups.set(agentId, setup);
+  return setup;
 }
 
-async function installDeepSeekHarnessCompanionOnce(options: {
+async function installDshProfileCompanionOnce(agentId: string, options: {
   projectRoot: string;
   resourceRoot: string;
   runtimeDataDir: string;
 }): Promise<AgentCompanionSetupResponse> {
-  const def = getAgentDef(DSH_AGENT_ID);
-  if (!def) {
-    throw new AgentCompanionSetupError('BUNDLED_COMPANION_INVALID', 'DeepSeek Harness runtime is not registered.');
+  const def = getAgentDef(agentId);
+  if (!def || def.streamFormat !== 'dsh-profile-jsonl') {
+    throw new AgentCompanionSetupError(
+      'AGENT_UNSUPPORTED',
+      'This agent has no OpenDesign connection component.',
+    );
   }
   const appConfig = await readAppConfig(options.runtimeDataDir);
-  const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, DSH_AGENT_ID);
+  const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, agentId);
   const before = await detectAgent(def, configuredEnv);
   const { bytes, manifest } = await resolveVerifiedBundle(options);
   if (before.available) {
@@ -217,11 +223,11 @@ async function installDeepSeekHarnessCompanionOnce(options: {
   if (!launch.launchPath) {
     throw new AgentCompanionSetupError(
       'AGENT_NOT_INSTALLED',
-      'DeepSeek Harness is not installed. Install the official dsh CLI, then scan again.',
+      `${def.name} is not installed. Install its CLI, then scan again.`,
     );
   }
   const childEnv = applyAgentLaunchEnv(
-    spawnEnvForAgent(DSH_AGENT_ID, process.env, configuredEnv),
+    spawnEnvForAgent(agentId, { ...process.env, ...(def.env || {}) }, configuredEnv),
     launch,
   );
   const profileWasPresent = hasOpenDesignProfile(childEnv);
@@ -234,12 +240,12 @@ async function installDeepSeekHarnessCompanionOnce(options: {
     );
   } catch (error) {
     console.error(
-      '[od] DeepSeek Harness connection component install failed',
+      '[od] DSH profile connection component install failed',
       commandFailureDetail(error) ?? 'no command diagnostics were available',
     );
     throw new AgentCompanionSetupError(
       'COMPANION_INSTALL_FAILED',
-      'DeepSeek Harness could not install the OpenDesign connection component. No agent selection was changed.',
+      `${def.name} could not install the OpenDesign connection component. No agent selection was changed.`,
     );
   }
 

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -531,11 +531,11 @@ async function runStrategy(args) {
 }
 
 function printAgentHelp() {
-  console.log(`Usage: od agent setup deepseek-harness [options]
+  console.log(`Usage: od agent setup <agent-id> [options]
 
-Install or repair OpenDesign's bundled connection component in the user's
-official DeepSeek Harness installation. The dsh CLI itself is not installed
-or upgraded by OpenDesign.
+Install or repair OpenDesign's bundled connection component for a selected
+DSH-compatible agent profile. The agent CLI itself is not installed or
+upgraded by OpenDesign.
 
 Options:
   --json                  Print a machine-readable result.
@@ -555,14 +555,15 @@ async function runAgent(args) {
     printAgentHelp();
     return;
   }
-  if (positional[0] !== 'setup' || positional[1] !== 'deepseek-harness') {
+  const agentId = positional[1];
+  if (positional[0] !== 'setup' || !agentId) {
     printAgentHelp();
     process.exit(2);
   }
   const base = await cliDaemonBaseUrl(flags);
   let response;
   try {
-    response = await fetch(`${base}/api/agents/deepseek-harness/companion/install`, {
+    response = await fetch(`${base}/api/agents/${encodeURIComponent(agentId)}/companion/install`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: '{}',
@@ -578,7 +579,7 @@ async function runAgent(args) {
     return;
   }
   const verb = result.action === 'already-compatible' ? 'already compatible' : result.action;
-  console.log(`DeepSeek Harness connection component ${verb} (${result.packageVersion}).`);
+  console.log(`Agent "${agentId}" connection component ${verb} (${result.packageVersion}).`);
 }
 
 const EXPORT_STRING_FLAGS = new Set([

--- a/apps/daemon/src/routes/daemon.ts
+++ b/apps/daemon/src/routes/daemon.ts
@@ -7,7 +7,7 @@ import { evaluateRollout } from '../critique/ratchet.js';
 import { parseRolloutPhase } from '../critique/rollout.js';
 import {
   AgentCompanionSetupError,
-  installDeepSeekHarnessCompanion,
+  installDshProfileCompanion,
 } from '../agent-companion-setup.js';
 
 export interface RegisterDaemonRoutesDeps {
@@ -99,11 +99,12 @@ export function registerDaemonRoutes(app: Express, deps: RegisterDaemonRoutesDep
   });
 
   app.post('/api/agents/:agentId/companion/install', requireLocalDaemonRequest, async (req, res) => {
-    if (req.params.agentId !== 'deepseek-harness') {
-      return sendApiError(res, 400, 'BAD_REQUEST', 'This agent has no OpenDesign connection component.');
+    const agentId = req.params.agentId;
+    if (typeof agentId !== 'string' || agentId.length === 0) {
+      return sendApiError(res, 400, 'BAD_REQUEST', 'A valid agent ID is required.');
     }
     try {
-      const result = await installDeepSeekHarnessCompanion({
+      const result = await installDshProfileCompanion(agentId, {
         projectRoot: paths.PROJECT_ROOT,
         resourceRoot: paths.RESOURCE_ROOT,
         runtimeDataDir: paths.RUNTIME_DATA_DIR,
@@ -111,13 +112,17 @@ export function registerDaemonRoutes(app: Express, deps: RegisterDaemonRoutesDep
       return res.json(result);
     } catch (error) {
       if (error instanceof AgentCompanionSetupError) {
-        const status = error.code === 'AGENT_NOT_INSTALLED' ? 409 : 500;
+        const status = error.code === 'AGENT_UNSUPPORTED'
+          ? 400
+          : error.code === 'AGENT_NOT_INSTALLED'
+            ? 409
+            : 500;
         return res.status(status).json({
           error: { code: error.code, message: error.message },
         });
       }
       console.warn('[agent-companion-setup] unexpected failure', error);
-      return sendApiError(res, 500, 'INTERNAL_ERROR', 'DeepSeek Harness connection setup failed.');
+      return sendApiError(res, 500, 'INTERNAL_ERROR', 'DSH profile connection setup failed.');
     }
   });
 

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { execAgentFile } from './invocation.js';
-import { AGENT_DEFS } from './registry.js';
+import { currentAgentDefs, getAgentDef } from './registry.js';
 import {
   DEFAULT_MODEL_OPTION,
   getRememberedLiveModels,
@@ -93,7 +93,7 @@ export async function ensureDetectedRuntimeVersions(
   configuredAgentEnv: Record<string, string> = {},
 ): Promise<DetectedRuntimeVersions | null> {
   if (!agentId) return null;
-  const def = AGENT_DEFS.find((candidate) => candidate.id === agentId);
+  const def = getAgentDef(agentId);
   if (!def) return null;
   const context = runtimeVersionProbeContext(def, configuredAgentEnv);
   if (!context) return null;
@@ -139,7 +139,7 @@ export async function ensureDetectedRuntimeCapabilities(
   configuredAgentEnv: Record<string, string> = {},
 ): Promise<RuntimeCapabilityMap | null> {
   if (!agentId) return null;
-  const def = AGENT_DEFS.find((candidate) => candidate.id === agentId);
+  const def = getAgentDef(agentId);
   if (!def) return null;
   const context = runtimeVersionProbeContext(def, configuredAgentEnv);
   if (!context) return null;
@@ -789,14 +789,15 @@ function rememberDetectedLiveModels(
 export async function detectAgents(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
 ) {
+  const agentDefs = currentAgentDefs();
   const results = await Promise.all(
-    AGENT_DEFS.map((def) => detectAgent(def, configuredEnvForAgent(configuredEnvByAgent, def.id))),
+    agentDefs.map((def) => detectAgent(def, configuredEnvForAgent(configuredEnvByAgent, def.id))),
   );
   // Refresh the validation cache from whatever we just surfaced to the UI
   // so /api/chat can accept any model the user could have just picked,
   // including ones that only showed up after a CLI re-auth.
   for (const [index, agent] of results.entries()) {
-    const def = AGENT_DEFS[index];
+    const def = agentDefs[index];
     if (!def) continue;
     rememberDetectedLiveModels(def, configuredEnvForAgent(configuredEnvByAgent, def.id), agent);
   }
@@ -812,7 +813,8 @@ export async function detectAgents(
 export async function* detectAgentsStream(
   configuredEnvByAgent: Record<string, Record<string, string>> = {},
 ): AsyncGenerator<DetectedAgent> {
-  const tagged = AGENT_DEFS.map((def, index) =>
+  const agentDefs = currentAgentDefs();
+  const tagged = agentDefs.map((def, index) =>
     detectAgent(def, configuredEnvForAgent(configuredEnvByAgent, def.id)).then((agent) => {
       rememberDetectedLiveModels(def, configuredEnvForAgent(configuredEnvByAgent, def.id), agent);
       return { index, agent };

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -31,11 +31,11 @@ import type { RuntimeAgentDef } from './types.js';
 /**
  * The agents this build ships, before anything a particular machine adds.
  *
- * `AGENT_DEFS` below appends whatever local profiles the user has declared, so
- * it answers "what can this machine run" — a different question from "what do
- * we ship", and the wrong list for anything that must hold everywhere. A local
- * profile id is required not to collide with one of these (see
- * `createLocalAgentDef`), so it is always an id we have never heard of.
+ * `currentAgentDefs()` below appends whatever local profiles the user has
+ * declared, so it answers "what can this machine run" — a different question
+ * from "what do we ship", and the wrong list for anything that must hold
+ * everywhere. A local profile id is required not to collide with one of these
+ * (see `createLocalAgentDef`), so it is always an id we have never heard of.
  */
 export const SHIPPED_AGENT_DEFS: RuntimeAgentDef[] = [
   amrAgentDef,
@@ -73,19 +73,26 @@ export function readLocalAgentProfileDefs(
   return readLocalAgentProfileDefsFromFile(baseDefs);
 }
 
-export const AGENT_DEFS: RuntimeAgentDef[] = [
-  ...SHIPPED_AGENT_DEFS,
-  ...readLocalAgentProfileDefs(SHIPPED_AGENT_DEFS),
-];
-
-const ids = new Set();
-for (const def of AGENT_DEFS) {
-  if (ids.has(def.id)) {
-    throw new Error(`Duplicate agent definition id: ${def.id}`);
+export function currentAgentDefs(): RuntimeAgentDef[] {
+  const defs = [
+    ...SHIPPED_AGENT_DEFS,
+    ...readLocalAgentProfileDefs(SHIPPED_AGENT_DEFS),
+  ];
+  const ids = new Set();
+  for (const def of defs) {
+    if (ids.has(def.id)) {
+      throw new Error(`Duplicate agent definition id: ${def.id}`);
+    }
+    ids.add(def.id);
   }
-  ids.add(def.id);
+  return defs;
 }
 
+// Backward-compatible startup snapshot for callers that only describe the
+// shipped registry. Runtime discovery uses currentAgentDefs() so Rescan also
+// sees local profiles created after the daemon started.
+export const AGENT_DEFS: RuntimeAgentDef[] = currentAgentDefs();
+
 export function getAgentDef(id: string): RuntimeAgentDef | null {
-  return AGENT_DEFS.find((a) => a.id === id) || null;
+  return currentAgentDefs().find((a) => a.id === id) || null;
 }

--- a/apps/daemon/tests/agent-companion-cli.test.ts
+++ b/apps/daemon/tests/agent-companion-cli.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'node:child_process';
+import { createServer } from 'node:http';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileP = promisify(execFile);
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const daemonRoot = pathResolve(currentDir, '..');
+const repoRoot = pathResolve(currentDir, '../../..');
+const cliSource = pathResolve(currentDir, '../src/cli.ts');
+const tsxCli = pathResolve(repoRoot, 'node_modules/tsx/dist/cli.mjs');
+
+async function runCli(args: string[]) {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(process.execPath, [tsxCli, cliSource, ...args], {
+      cwd: daemonRoot,
+      env,
+      timeout: 15_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (error) {
+    const failed = error as { stdout?: string; stderr?: string; code?: number | null };
+    return {
+      stdout: failed.stdout ?? '',
+      stderr: failed.stderr ?? '',
+      code: failed.code ?? 1,
+    };
+  }
+}
+
+describe('od agent setup', () => {
+  it('installs the companion for a selected local profile and preserves JSON output', async () => {
+    let requestedUrl = '';
+    const server = createServer((req, res) => {
+      requestedUrl = req.url ?? '';
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ action: 'installed', packageVersion: '1.2.3' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('missing test server address');
+      const result = await runCli([
+        'agent',
+        'setup',
+        'local dsh',
+        '--json',
+        '--daemon-url',
+        `http://127.0.0.1:${address.port}`,
+      ]);
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(JSON.parse(result.stdout)).toEqual({ action: 'installed', packageVersion: '1.2.3' });
+      expect(requestedUrl).toBe('/api/agents/local%20dsh/companion/install');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/apps/daemon/tests/agent-companion-setup.test.ts
+++ b/apps/daemon/tests/agent-companion-setup.test.ts
@@ -2,11 +2,11 @@ import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AgentCompanionSetupError,
-  installDeepSeekHarnessCompanion,
+  installDshProfileCompanion,
 } from '../src/agent-companion-setup.js';
 
 const roots: string[] = [];
@@ -14,6 +14,7 @@ const originalDshBin = process.env.DSH_BIN;
 const originalDshHome = process.env.DSH_HOME;
 const originalMode = process.env.OD_DSH_SETUP_FAKE_MODE;
 const originalAgentHome = process.env.OD_AGENT_HOME;
+const originalAgentProfilesConfig = process.env.OD_AGENT_PROFILES_CONFIG;
 const originalPath = process.env.PATH;
 
 afterEach(async () => {
@@ -25,6 +26,8 @@ afterEach(async () => {
   else process.env.OD_DSH_SETUP_FAKE_MODE = originalMode;
   if (originalAgentHome === undefined) delete process.env.OD_AGENT_HOME;
   else process.env.OD_AGENT_HOME = originalAgentHome;
+  if (originalAgentProfilesConfig === undefined) delete process.env.OD_AGENT_PROFILES_CONFIG;
+  else process.env.OD_AGENT_PROFILES_CONFIG = originalAgentProfilesConfig;
   if (originalPath === undefined) delete process.env.PATH;
   else process.env.PATH = originalPath;
   await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
@@ -107,6 +110,8 @@ if (args[0] === '--version') {
   process.env.DSH_HOME = dshHome;
   delete process.env.OD_DSH_SETUP_FAKE_MODE;
   return {
+    carrier,
+    dshHome,
     options: { projectRoot: root, resourceRoot, runtimeDataDir },
     profileRoot: path.join(dshHome, 'profiles', 'open-design'),
     stateFile,
@@ -120,18 +125,18 @@ async function expectSetupError(promise: Promise<unknown>, code: AgentCompanionS
 describe('DeepSeek Harness companion setup', () => {
   it('installs into an empty profile and is idempotent', async () => {
     const test = await fixture();
-    const first = await installDeepSeekHarnessCompanion(test.options);
+    const first = await installDshProfileCompanion('deepseek-harness', test.options);
     expect(first).toMatchObject({ action: 'installed', ok: true, packageVersion: '0.1.0' });
     expect(first.agent.available).toBe(true);
 
-    const second = await installDeepSeekHarnessCompanion(test.options);
+    const second = await installDshProfileCompanion('deepseek-harness', test.options);
     expect(second).toMatchObject({ action: 'already-compatible', ok: true });
     await expect(readFile(test.stateFile, 'utf8')).resolves.toBe('1');
   });
 
   it('reports repaired only when a profile existed before setup', async () => {
     const test = await fixture({ existingProfile: true });
-    await expect(installDeepSeekHarnessCompanion(test.options)).resolves.toMatchObject({
+    await expect(installDshProfileCompanion('deepseek-harness', test.options)).resolves.toMatchObject({
       action: 'repaired',
       ok: true,
     });
@@ -140,7 +145,7 @@ describe('DeepSeek Harness companion setup', () => {
   it('rejects a corrupt bundled package before invoking dsh', async () => {
     const test = await fixture({ validHash: false });
     await expectSetupError(
-      installDeepSeekHarnessCompanion(test.options),
+      installDshProfileCompanion('deepseek-harness', test.options),
       'BUNDLED_COMPANION_INVALID',
     );
     await expect(readFile(test.stateFile, 'utf8')).rejects.toThrow();
@@ -152,24 +157,59 @@ describe('DeepSeek Harness companion setup', () => {
     process.env.OD_AGENT_HOME = path.join(path.dirname(test.stateFile), 'empty-agent-home');
     process.env.PATH = '';
     await expectSetupError(
-      installDeepSeekHarnessCompanion(test.options),
+      installDshProfileCompanion('deepseek-harness', test.options),
       'AGENT_NOT_INSTALLED',
     );
     await expect(readFile(test.stateFile, 'utf8')).rejects.toThrow();
+  });
+
+  it('rejects agents that do not use the DSH profile protocol', async () => {
+    const test = await fixture();
+    await expectSetupError(
+      installDshProfileCompanion('claude', test.options),
+      'AGENT_UNSUPPORTED',
+    );
+  });
+
+  it('installs for a local DSH profile using that profile\'s own environment', async () => {
+    const test = await fixture();
+    const profilesFile = path.join(path.dirname(test.dshHome), 'agents.local.json');
+    await writeFile(profilesFile, JSON.stringify({
+      agents: [{
+        id: 'local-dsh',
+        name: 'Local DSH',
+        baseAgent: 'deepseek-harness',
+        bin: 'dsh',
+        env: { DSH_HOME: test.dshHome },
+      }],
+    }), 'utf8');
+    process.env.OD_AGENT_PROFILES_CONFIG = profilesFile;
+    process.env.DSH_HOME = path.join(path.dirname(test.dshHome), 'unrelated-native-home');
+    process.env.PATH = [path.dirname(test.carrier), originalPath].filter(Boolean).join(path.delimiter);
+
+    vi.resetModules();
+    const { installDshProfileCompanion: installLocalCompanion } = await import(
+      '../src/agent-companion-setup.js'
+    );
+    await expect(installLocalCompanion('local-dsh', test.options)).resolves.toMatchObject({
+      action: 'installed',
+      ok: true,
+    });
+    await expect(readFile(test.stateFile, 'utf8')).resolves.toBe('1');
   });
 
   it('classifies install and post-install probe failures', async () => {
     const installFailure = await fixture();
     process.env.OD_DSH_SETUP_FAKE_MODE = 'install-fail';
     await expectSetupError(
-      installDeepSeekHarnessCompanion(installFailure.options),
+      installDshProfileCompanion('deepseek-harness', installFailure.options),
       'COMPANION_INSTALL_FAILED',
     );
 
     const probeFailure = await fixture();
     process.env.OD_DSH_SETUP_FAKE_MODE = 'probe-fail';
     await expectSetupError(
-      installDeepSeekHarnessCompanion(probeFailure.options),
+      installDshProfileCompanion('deepseek-harness', probeFailure.options),
       'COMPANION_STILL_INCOMPATIBLE',
     );
   });
@@ -178,7 +218,7 @@ describe('DeepSeek Harness companion setup', () => {
     const test = await fixture();
     process.env.OD_DSH_SETUP_FAKE_MODE = 'require-profile-bundle';
 
-    await expect(installDeepSeekHarnessCompanion(test.options)).resolves.toMatchObject({
+    await expect(installDshProfileCompanion('deepseek-harness', test.options)).resolves.toMatchObject({
       action: 'installed',
       ok: true,
     });
@@ -186,8 +226,8 @@ describe('DeepSeek Harness companion setup', () => {
 
   it('deduplicates concurrent setup requests', async () => {
     const test = await fixture();
-    const first = installDeepSeekHarnessCompanion(test.options);
-    const second = installDeepSeekHarnessCompanion(test.options);
+    const first = installDshProfileCompanion('deepseek-harness', test.options);
+    const second = installDshProfileCompanion('deepseek-harness', test.options);
     expect(second).toBe(first);
     await expect(first).resolves.toMatchObject({ action: 'installed', ok: true });
     await expect(readFile(test.stateFile, 'utf8')).resolves.toBe('1');

--- a/apps/daemon/tests/agent-companion-setup.test.ts
+++ b/apps/daemon/tests/agent-companion-setup.test.ts
@@ -62,7 +62,7 @@ async function fixture(options: { existingProfile?: boolean; validHash?: boolean
 
   const script = path.join(root, 'fake-dsh.mjs');
   await writeFile(script, `
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 const args = process.argv.slice(2);
 const home = process.env.DSH_HOME;
@@ -79,6 +79,18 @@ if (args[0] === '--version') {
   }
 } else if (args[0] === 'plugin' && args[1] === '--profile' && args[2] === 'open-design' && args[3] === 'add') {
   if (process.env.OD_DSH_SETUP_FAKE_MODE === 'install-fail') process.exit(7);
+  await mkdir(profileRoot, { recursive: true });
+  const installLock = path.join(profileRoot, '.install-lock');
+  let ownsInstallLock = false;
+  if (process.env.OD_DSH_SETUP_FAKE_MODE === 'detect-overlap') {
+    try {
+      await mkdir(installLock);
+      ownsInstallLock = true;
+    } catch {
+      await writeFile(path.join(profileRoot, '.install-overlap'), 'overlap', 'utf8');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
   if (process.env.OD_DSH_SETUP_FAKE_MODE === 'require-profile-bundle') {
     const [directory, filename, extra] = args[4].split('/');
     const digest = filename?.endsWith('.tgz') ? filename.slice(0, -4) : '';
@@ -87,12 +99,12 @@ if (args[0] === '--version') {
     const bundle = await readFile(path.join(profileRoot, args[4]), 'utf8');
     if (bundle !== 'fixture runtime package') process.exit(9);
   }
-  await mkdir(profileRoot, { recursive: true });
   let count = 0;
   try { count = Number(await readFile(${JSON.stringify(stateFile)}, 'utf8')); } catch {}
   await writeFile(${JSON.stringify(stateFile)}, String(count + 1), 'utf8');
   await writeFile(path.join(profileRoot, 'package.json'), '{}\\n', 'utf8');
   if (process.env.OD_DSH_SETUP_FAKE_MODE !== 'probe-fail') await writeFile(marker, 'ok', 'utf8');
+  if (ownsInstallLock) await rm(installLock, { recursive: true });
 } else {
   process.exitCode = 2;
 }
@@ -231,5 +243,34 @@ describe('DeepSeek Harness companion setup', () => {
     expect(second).toBe(first);
     await expect(first).resolves.toMatchObject({ action: 'installed', ok: true });
     await expect(readFile(test.stateFile, 'utf8')).resolves.toBe('1');
+  });
+
+  it('serializes different agents that share one DSH home', async () => {
+    const test = await fixture();
+    const profilesFile = path.join(path.dirname(test.dshHome), 'agents.local.json');
+    await writeFile(profilesFile, JSON.stringify({
+      agents: ['local-dsh-a', 'local-dsh-b'].map((id) => ({
+        id,
+        name: id,
+        baseAgent: 'deepseek-harness',
+        bin: 'dsh',
+        env: { DSH_HOME: test.dshHome },
+      })),
+    }), 'utf8');
+    process.env.OD_AGENT_PROFILES_CONFIG = profilesFile;
+    process.env.OD_DSH_SETUP_FAKE_MODE = 'detect-overlap';
+    process.env.PATH = [path.dirname(test.carrier), originalPath].filter(Boolean).join(path.delimiter);
+
+    vi.resetModules();
+    const { installDshProfileCompanion: installLocalCompanion } = await import(
+      '../src/agent-companion-setup.js'
+    );
+    const results = await Promise.all([
+      installLocalCompanion('local-dsh-a', test.options),
+      installLocalCompanion('local-dsh-b', test.options),
+    ]);
+
+    expect(results.map((result) => result.agent.id)).toEqual(['local-dsh-a', 'local-dsh-b']);
+    await expect(readFile(path.join(test.profileRoot, '.install-overlap'), 'utf8')).rejects.toThrow();
   });
 });

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -4,7 +4,11 @@ import {
 } from './helpers/test-helpers.js';
 import { codexNeedsDangerFullAccessSandbox } from '../../src/runtimes/defs/codex.js';
 import { isKnownServiceTier } from '../../src/runtimes/models.js';
-import { readLocalAgentProfileDefs } from '../../src/runtimes/registry.js';
+import {
+  currentAgentDefs,
+  getAgentDef,
+  readLocalAgentProfileDefs,
+} from '../../src/runtimes/registry.js';
 
 test('AGENT_DEFS ids are unique', () => {
   const ids = AGENT_DEFS.map((a) => a.id);
@@ -70,6 +74,36 @@ test('local agent profiles inherit a base adapter and can pin the default model'
 
       const explicitArgs = profile.buildArgs('', [], [], { model: 'zyb-gpt' });
       assert.equal(explicitArgs[explicitArgs.indexOf('--model') + 1], 'zyb-gpt');
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('local agent profiles become visible to rescan without restarting the daemon', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-local-agent-profiles-rescan-'));
+  try {
+    await withEnvSnapshot(['OD_AGENT_PROFILES_CONFIG'], async () => {
+      const config = join(dir, 'agents.local.json');
+      process.env.OD_AGENT_PROFILES_CONFIG = config;
+
+      assert.equal(currentAgentDefs().some((def) => def.id === 'late-agent'), false);
+      assert.equal(getAgentDef('late-agent'), null);
+
+      writeFileSync(
+        config,
+        JSON.stringify({
+          agents: [{ id: 'late-agent', baseAgent: 'deepseek-harness', bin: 'late-agent' }],
+        }),
+      );
+
+      assert.equal(currentAgentDefs().some((def) => def.id === 'late-agent'), true);
+      assert.equal(getAgentDef('late-agent')?.bin, 'late-agent');
+      assert.equal((await detectAgents()).some((agent) => agent.id === 'late-agent'), true);
+
+      writeFileSync(config, JSON.stringify({ agents: [] }));
+      assert.equal(currentAgentDefs().some((def) => def.id === 'late-agent'), false);
+      assert.equal(getAgentDef('late-agent'), null);
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -113,7 +113,7 @@ import { UpdaterPopup } from './UpdaterPopup';
 import { WhatsNewPopup } from './WhatsNewPopup';
 import { DeepSeekHarnessSetupDialog } from './DeepSeekHarnessSetupDialog';
 import { AmrBalanceDialog } from './AmrBalanceDialog';
-import { installDeepSeekHarnessCompanion } from '../providers/agent-companion';
+import { installAgentCompanion } from '../providers/agent-companion';
 import { AmrLowBalanceDialog, type AmrLowBalanceDecision } from './AmrLowBalanceDialog';
 import {
   amrBalanceGateScopeForWorkspaceContext,
@@ -225,7 +225,7 @@ import { closeAmrActivationWindowBestEffort } from './AmrLoginPill';
 import { isMacPlatform } from '../utils/platform';
 import { smoothScrollToTop } from '../utils/smoothScrollToTop';
 import { summarizeProjectNameFromPrompt } from '../utils/projectName';
-import { deepSeekHarnessNeedsSetup } from '../utils/visibleAgents';
+import { agentNeedsCompanionSetup } from '../utils/visibleAgents';
 import { LIBRARY_UI_VISIBLE } from '../features/libraryUi';
 import {
   providerModelsCacheKey,
@@ -2107,7 +2107,11 @@ function OnboardingView({
     if (!amrLoginPending) setActivationHintClosed(false);
   }, [amrLoginPending]);
   const [visibleAgentIds, setVisibleAgentIds] = useState<string[]>([]);
-  const [dshSetup, setDshSetup] = useState<{ busy: boolean; error: string | null } | null>(null);
+  const [dshSetup, setDshSetup] = useState<{
+    agentId: string;
+    busy: boolean;
+    error: string | null;
+  } | null>(null);
   const [providerTestState, setProviderTestState] = useState<
     | { status: 'idle' }
     | { status: 'running'; inputKey: string }
@@ -2204,7 +2208,7 @@ function OnboardingView({
       ),
   ) ?? null;
   const candidateCliAgents = agents.filter(
-    (agent) => agent.id !== 'amr' && (agent.available || deepSeekHarnessNeedsSetup(agent)),
+    (agent) => agent.id !== 'amr' && (agent.available || agentNeedsCompanionSetup(agent)),
   );
   const visibleAgents = candidateCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
   const amrSignedIn = isAmrSessionAuthenticated(amrStatus);
@@ -3101,7 +3105,7 @@ function OnboardingView({
   async function scanCliAgents(options: { preferExisting?: boolean } = {}) {
     const scanToken = beginCliScan({ clearVisible: !options.preferExisting });
     const currentCandidateAgents = agents.filter(
-      (agent) => agent.id !== 'amr' && (agent.available || deepSeekHarnessNeedsSetup(agent)),
+      (agent) => agent.id !== 'amr' && (agent.available || agentNeedsCompanionSetup(agent)),
     );
     const currentAvailableAgents = currentCandidateAgents.filter((agent) => agent.available);
     if (options.preferExisting && currentCandidateAgents.length > 0) {
@@ -3127,7 +3131,7 @@ function OnboardingView({
       cliRefreshPendingTokenRef.current = null;
       const availableAgents = nextAgents.filter((agent) => agent.available && agent.id !== 'amr');
       const candidateAgents = nextAgents.filter(
-        (agent) => agent.id !== 'amr' && (agent.available || deepSeekHarnessNeedsSetup(agent)),
+        (agent) => agent.id !== 'amr' && (agent.available || agentNeedsCompanionSetup(agent)),
       );
       const selectedCliAgent = selectDefaultCliAgent(availableAgents);
       // Scan-result semantics: zero available CLIs is a `failed` outcome
@@ -3231,18 +3235,20 @@ function OnboardingView({
 
   async function confirmDshSetup() {
     if (dshSetup?.busy) return;
-    setDshSetup({ busy: true, error: null });
+    const agentId = dshSetup?.agentId;
+    if (!agentId) return;
+    setDshSetup({ agentId, busy: true, error: null });
     try {
-      await installDeepSeekHarnessCompanion();
+      await installAgentCompanion(agentId);
       const nextAgents = await onRefreshAgents();
       const installed = nextAgents.find(
-        (agent) => agent.id === 'deepseek-harness' && agent.available,
+        (agent) => agent.id === agentId && agent.available,
       );
       if (!installed) throw new Error(t('settings.dshSetupRequired'));
       showCliAgents(
         cliScanTokenRef.current,
         nextAgents.filter(
-          (agent) => agent.id !== 'amr' && (agent.available || deepSeekHarnessNeedsSetup(agent)),
+          (agent) => agent.id !== 'amr' && (agent.available || agentNeedsCompanionSetup(agent)),
         ),
         { stagger: false },
       );
@@ -3265,6 +3271,7 @@ function OnboardingView({
       setAgentTestState({ status: 'done', inputKey, result });
     } catch (error) {
       setDshSetup({
+        agentId,
         busy: false,
         error: error instanceof Error ? error.message : t('settings.dshSetupRequired'),
       });
@@ -3673,8 +3680,8 @@ function OnboardingView({
                   onRefresh={() => void scanCliAgents()}
                   onSelectAgent={(agentId) => {
                     const agent = visibleAgents.find((candidate) => candidate.id === agentId);
-                    if (agent && deepSeekHarnessNeedsSetup(agent)) {
-                      setDshSetup({ busy: false, error: null });
+                    if (agent && agentNeedsCompanionSetup(agent)) {
+                      setDshSetup({ agentId: agent.id, busy: false, error: null });
                       return;
                     }
                     onModeChange('daemon');

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -58,11 +58,11 @@ import {
   formatVelaBalanceUsd,
   type VelaLoginStatus,
 } from '../providers/daemon';
-import { installDeepSeekHarnessCompanion } from '../providers/agent-companion';
+import { installAgentCompanion } from '../providers/agent-companion';
 import { amrProfileBadgeLabel } from '../runtime/amr-guidance';
 import {
   availableVisibleAgentCount,
-  deepSeekHarnessNeedsSetup,
+  agentNeedsCompanionSetup,
   isVisibleLocalCliAgent,
 } from '../utils/visibleAgents';
 import { ExportDiagnosticsRow } from './ExportDiagnosticsButton';
@@ -1687,7 +1687,11 @@ export function SettingsDialog({
   // authorize button — once the user has found it, the hint has done its job.
   const [amrCoachmarkDismissed, setAmrCoachmarkDismissed] = useState(false);
   const [agentRescanRunning, setAgentRescanRunning] = useState(false);
-  const [dshSetup, setDshSetup] = useState<{ busy: boolean; error: string | null } | null>(null);
+  const [dshSetup, setDshSetup] = useState<{
+    agentId: string;
+    busy: boolean;
+    error: string | null;
+  } | null>(null);
   const [agentRescanNotice, setAgentRescanNotice] =
     useState<RescanNotice | null>(null);
   const [agentTestState, setAgentTestState] = useState<TestState>({
@@ -2359,13 +2363,15 @@ export function SettingsDialog({
   };
   const handleConfirmDshSetup = async () => {
     if (dshSetup?.busy) return;
-    setDshSetup({ busy: true, error: null });
+    const agentId = dshSetup?.agentId;
+    if (!agentId) return;
+    setDshSetup({ agentId, busy: true, error: null });
     try {
-      await installDeepSeekHarnessCompanion();
+      await installAgentCompanion(agentId);
       const refreshed = await onRefreshAgents(agentRefreshOptionsForConfig(cfg));
       const nextAgents = Array.isArray(refreshed) ? refreshed : agents;
       const installed = nextAgents.find(
-        (agent) => agent.id === 'deepseek-harness' && agent.available,
+        (agent) => agent.id === agentId && agent.available,
       );
       if (!installed) throw new Error(t('settings.dshSetupRequired'));
       setCfg((current) => ({ ...current, agentId: installed.id, mode: 'daemon' }));
@@ -2382,6 +2388,7 @@ export function SettingsDialog({
       setAgentTestState({ status: 'done', result });
     } catch (error) {
       setDshSetup({
+        agentId,
         busy: false,
         error: error instanceof Error ? error.message : t('settings.dshSetupRequired'),
       });
@@ -3928,10 +3935,10 @@ export function SettingsDialog({
   const activeHeader = sectionHeader[activeSection];
   const visibleAgents = agents.filter(isVisibleLocalCliAgent);
   const installedAgents = orderAgentsWithOpenDesignFirst(
-    visibleAgents.filter((agent) => agent.available || deepSeekHarnessNeedsSetup(agent)),
+    visibleAgents.filter((agent) => agent.available || agentNeedsCompanionSetup(agent)),
   );
   const unavailableAgents = visibleAgents.filter(
-    (agent) => !agent.available && !deepSeekHarnessNeedsSetup(agent),
+    (agent) => !agent.available && !agentNeedsCompanionSetup(agent),
   );
   const initialAgentScanRunning = agentsLoading && agents.length === 0;
   const agentModelOptionLabel = (
@@ -4673,7 +4680,7 @@ export function SettingsDialog({
                     {installedAgents.length > 0 ? (
                       <div className="agent-grid agent-grid-installed">
                         {installedAgents.map((a) => {
-                          const needsSetup = deepSeekHarnessNeedsSetup(a);
+                          const needsSetup = agentNeedsCompanionSetup(a);
                           const active = !needsSetup && cfg.agentId === a.id;
                           const running =
                             active && agentTestState.status === 'running';
@@ -4845,7 +4852,7 @@ export function SettingsDialog({
                                       install_status: 'installed',
                                     });
                                     if (needsSetup) {
-                                      setDshSetup({ busy: false, error: null });
+                                      setDshSetup({ agentId: a.id, busy: false, error: null });
                                       return;
                                     }
                                     if (isAmrAgent) {

--- a/apps/web/src/providers/agent-companion.ts
+++ b/apps/web/src/providers/agent-companion.ts
@@ -1,7 +1,7 @@
 import type { AgentCompanionSetupResponse } from '@open-design/contracts';
 
-export async function installDeepSeekHarnessCompanion(): Promise<AgentCompanionSetupResponse> {
-  const response = await fetch('/api/agents/deepseek-harness/companion/install', {
+export async function installAgentCompanion(agentId: string): Promise<AgentCompanionSetupResponse> {
+  const response = await fetch(`/api/agents/${encodeURIComponent(agentId)}/companion/install`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: '{}',

--- a/apps/web/src/utils/visibleAgents.ts
+++ b/apps/web/src/utils/visibleAgents.ts
@@ -18,9 +18,10 @@ export function availableVisibleAgentCount(agents: AgentInfo[]): number {
     .length;
 }
 
-export function deepSeekHarnessNeedsSetup(agent: AgentInfo): boolean {
+export function agentNeedsCompanionSetup(agent: AgentInfo): boolean {
+  // This diagnostic currently belongs only to the DSH compatibility probe;
+  // local profiles inheriting that adapter keep their own ids.
   return (
-    agent.id === 'deepseek-harness' &&
     !agent.available &&
     Boolean(agent.path) &&
     Boolean(

--- a/apps/web/tests/providers/agent-companion.test.ts
+++ b/apps/web/tests/providers/agent-companion.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { installAgentCompanion } from '../../src/providers/agent-companion';
+
+describe('installAgentCompanion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('targets the selected local DSH profile', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ action: 'installed', ok: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await installAgentCompanion('local-dsh');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/agents/local-dsh/companion/install',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      },
+    );
+  });
+});

--- a/apps/web/tests/utils/visibleAgents.test.ts
+++ b/apps/web/tests/utils/visibleAgents.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AgentInfo } from '../../src/types';
 import {
   availableVisibleAgentCount,
-  deepSeekHarnessNeedsSetup,
+  agentNeedsCompanionSetup,
   isVisibleLocalCliAgent,
 } from '../../src/utils/visibleAgents';
 
@@ -59,7 +59,7 @@ describe('isVisibleLocalCliAgent', () => {
   });
 });
 
-describe('deepSeekHarnessNeedsSetup', () => {
+describe('agentNeedsCompanionSetup', () => {
   // The picker renders an unavailable DSH only when detection reported the
   // path it found. Detection that drops the path leaves the row invisible,
   // which is exactly how a broken CLI disappears instead of offering a fix.
@@ -76,7 +76,8 @@ describe('deepSeekHarnessNeedsSetup', () => {
       diagnostics: [{ reason: 'runtime-profile-incompatible', severity: 'error', message: '' }],
     });
 
-    expect(deepSeekHarnessNeedsSetup(withPath)).toBe(true);
-    expect(deepSeekHarnessNeedsSetup(withoutPath)).toBe(false);
+    expect(agentNeedsCompanionSetup(withPath)).toBe(true);
+    expect(agentNeedsCompanionSetup({ ...withPath, id: 'local-dsh-profile' })).toBe(true);
+    expect(agentNeedsCompanionSetup(withoutPath)).toBe(false);
   });
 });

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -401,6 +401,11 @@ the active-run staging implementation is in
   confirmation installs the embedded component through the user's `dsh`,
   rescans, selects, and connection-tests it. Cancelling changes nothing. Only a
   missing `dsh` executable belongs in the installable-agent group.
+- A local agent profile may inherit `baseAgent: "deepseek-harness"` while
+  declaring its own id, name, binary, and `DSH_HOME`. It appears alongside the
+  shipped DeepSeek Harness adapter and uses the same setup dialog; companion
+  installation targets the selected profile's executable and environment, so
+  it does not modify another Harness installation.
 - Each OD run starts a fresh `dsh --profile open-design --stdio` process. The
   JSONL profile protocol creates a Harness session on the first turn and cold
   resumes that exact session on later turns. This is profile-stdio resume, not


### PR DESCRIPTION
## Why

OpenDesign already supports local agent profiles that inherit `baseAgent: "deepseek-harness"`, but the bundled companion setup path was hard-coded to the shipped `deepseek-harness` ID. I hit this while integrating a separately managed DSH-compatible CLI: OpenDesign could detect the local profile, but could not install the bundled connection component for it without sharing the native Harness executable and home.

This change keeps the existing local-profile extension point and makes companion setup follow the selected DSH profile. It does not add vendor-specific fields or broaden setup to arbitrary agent transports.

## What users will see

A local DSH-compatible profile that needs the OpenDesign connection component remains selectable. Choosing it opens the existing setup dialog; setup then uses that exact profile ID, executable, and environment. After installation, OpenDesign rescans and selects the same profile. A separately installed native DeepSeek Harness profile remains untouched and can appear alongside it.

The backend still rejects agents whose runtime does not use `dsh-profile-jsonl`, and the existing verified bundle and staging flow remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This reuses the existing companion setup dialog and adds no new UI surface.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 673 files, 7,129 tests passed
- `pnpm exec vitest run -c vitest.config.ts tests/agent-companion-setup.test.ts` — 9 tests passed
- `pnpm exec vitest run -c vitest.config.ts tests/utils/visibleAgents.test.ts tests/providers/agent-companion.test.ts` — 6 tests passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`