### PR TITLE
fix(daemon): make OD Next snapshots safe on Windows

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -888,6 +888,21 @@ export function sendStructuredRunCreateFailure(
   );
 }
 
+export function registerRunCreateRoute(
+  app: Express,
+  handleRunCreate: (req: ApiRequest, res: ApiResponse) => Promise<unknown>,
+  sendApiError: RegisterRunRoutesDeps['http']['sendApiError'],
+): void {
+  app.post('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
+    try {
+      return await handleRunCreate(req, res);
+    } catch (error) {
+      if (res.headersSent) throw error;
+      return sendStructuredRunCreateFailure(res, sendApiError, error);
+    }
+  });
+}
+
 export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   const { db, design } = ctx;
   const { createSseResponse, sendApiError } = ctx.http;
@@ -3001,14 +3016,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     );
   };
 
-  app.post('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
-    try {
-      return await handleRunCreate(req, res);
-    } catch (error) {
-      if (res.headersSent) throw error;
-      return sendStructuredRunCreateFailure(res, sendApiError, error);
-    }
-  });
+  registerRunCreateRoute(app, handleRunCreate, sendApiError);
 
   app.get('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
     const { projectId, conversationId, status } = req.query;

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -108,7 +108,7 @@ import {
   buildOdNextTaskConfigurationV1,
   createOdNextTaskInputSnapshot,
   OdNextTaskInputSnapshotError,
-  removeOdNextTaskInputSnapshot,
+  removeOdNextTaskInputSnapshotBestEffort,
   type OdNextTaskInputSnapshotDescriptor,
 } from '../strategies/od-next/task-input-snapshot.js';
 import {
@@ -868,10 +868,31 @@ function toOdNativeEvent(record: RunEventRecord): OdNativeEvent | null {
   return { kind: record.event, ...toJsonRecord(record.data) } as OdNativeEvent;
 }
 
+export function sendStructuredRunCreateFailure(
+  res: ApiResponse,
+  sendApiError: RegisterRunRoutesDeps['http']['sendApiError'],
+  error: unknown,
+  requestId: string = randomUUID(),
+): Response<unknown> | void {
+  const rawCode = (error as NodeJS.ErrnoException)?.code;
+  const code = typeof rawCode === 'string' && /^[A-Z0-9_]+$/.test(rawCode)
+    ? rawCode
+    : 'UNKNOWN';
+  console.error(`[runs] preparation failed request=${requestId} code=${code}`);
+  return sendApiError(
+    res,
+    500,
+    'INTERNAL_ERROR',
+    'Run preparation failed.',
+    { requestId },
+  );
+}
+
 export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   const { db, design } = ctx;
   const { createSseResponse, sendApiError } = ctx.http;
   const { BUNDLED_PLUGINS_DIR, PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
+  const taskInputSnapshotsRoot = path.join(RUNTIME_DATA_DIR, 'od-next-task-inputs');
   const { detectAgents, getAgentDef } = ctx.agents;
   const { startChatRun } = ctx.chat;
   const prepareOdNextInitialPromptBundle = ctx.chat.prepareOdNextInitialPromptBundle
@@ -1489,7 +1510,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     }
   }
 
-  app.post('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
+  const handleRunCreate = async (req: ApiRequest, res: ApiResponse) => {
     if (ctx.lifecycle.isDaemonShuttingDown()) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
@@ -2580,7 +2601,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           mode: 'unresolved',
         });
         createdTaskInputSnapshot = createOdNextTaskInputSnapshot({
-          snapshotsRoot: path.join(RUNTIME_DATA_DIR, 'od-next-task-inputs'),
+          snapshotsRoot: taskInputSnapshotsRoot,
           taskExecutionId,
           taskConfiguration,
           projectRoot,
@@ -2611,7 +2632,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         });
         preparedPromptBundleText = preparedPrompt.text;
       } catch (error) {
-        removeOdNextTaskInputSnapshot(createdTaskInputSnapshot);
+        removeOdNextTaskInputSnapshotBestEffort(
+          createdTaskInputSnapshot,
+          taskInputSnapshotsRoot,
+          'initial-bundle',
+        );
         createdTaskInputSnapshot = null;
         preparedPromptBundleText = null;
         frozenSkillPackage = undefined;
@@ -2711,7 +2736,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         },
       });
     } catch (error) {
-      removeOdNextTaskInputSnapshot(createdTaskInputSnapshot);
+      removeOdNextTaskInputSnapshotBestEffort(
+        createdTaskInputSnapshot,
+        taskInputSnapshotsRoot,
+        'run-claim',
+      );
       createdTaskInputSnapshot = null;
       if (error instanceof AutomaticOdNextPreparationError) {
         preparedPromptBundleText = null;
@@ -2750,7 +2779,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       }
     }
     if (preparedRun.kind !== 'ready') {
-      removeOdNextTaskInputSnapshot(createdTaskInputSnapshot);
+      removeOdNextTaskInputSnapshotBestEffort(
+        createdTaskInputSnapshot,
+        taskInputSnapshotsRoot,
+        'non-ready',
+      );
       if (
         resolvedSnapshot?.created === true
         && resolvedSnapshot.snapshot.pluginId === 'od-next-strategy'
@@ -2966,6 +2999,15 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       },
       () => startChatRun(executionMeta, run),
     );
+  };
+
+  app.post('/api/runs', async (req: ApiRequest, res: ApiResponse) => {
+    try {
+      return await handleRunCreate(req, res);
+    } catch (error) {
+      if (res.headersSent) throw error;
+      return sendStructuredRunCreateFailure(res, sendApiError, error);
+    }
   });
 
   app.get('/api/runs', async (req: ApiRequest, res: ApiResponse) => {

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -250,13 +250,44 @@ function readFdBounded(
 }
 
 function readOnlyNoFollowFlags(): number {
-  if (typeof fs.constants.O_NOFOLLOW !== 'number') {
-    throw new OdNextTaskInputSnapshotError(
-      'OD Next cannot safely open managed input files on this platform.',
-      'OD_NEXT_INPUT_SNAPSHOT_UNSUPPORTED',
-    );
+  if (typeof fs.constants.O_NOFOLLOW === 'number') {
+    return fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW;
   }
-  return fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW;
+  if (process.platform === 'win32') return fs.constants.O_RDONLY;
+  throw new OdNextTaskInputSnapshotError(
+    'OD Next cannot safely open managed input files on this platform.',
+    'OD_NEXT_INPUT_SNAPSHOT_UNSUPPORTED',
+  );
+}
+
+/**
+ * Open a previously lstat-verified regular file without reading from a raced
+ * replacement. POSIX rejects a final symlink in the kernel with O_NOFOLLOW.
+ * Node does not expose that flag on Windows, so the read-only handle is
+ * accepted only when fstat proves it still has the exact lstat identity. The
+ * caller verifies path components before opening and file metadata after the
+ * bounded read, closing the remaining Windows TOCTOU windows without a native
+ * dependency.
+ */
+function openVerifiedReadOnly(
+  filePath: string,
+  pathStat: fs.BigIntStats,
+  changedMessage: string,
+): { fd: number; stat: fs.BigIntStats } {
+  const fd = fs.openSync(filePath, readOnlyNoFollowFlags());
+  try {
+    const stat = fs.fstatSync(fd, { bigint: true });
+    if (!stat.isFile() || !sameIdentity(pathStat, stat)) {
+      throw new OdNextTaskInputSnapshotError(
+        changedMessage,
+        'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
+      );
+    }
+    return { fd, stat };
+  } catch (error) {
+    fs.closeSync(fd);
+    throw error;
+  }
 }
 
 function assertManagedPathHasNoSymlinkComponents(
@@ -344,6 +375,7 @@ function readSourceWithoutFollowingSymlinks(
   if (!within(declaredRoot, resolved)) {
     throw new OdNextTaskInputSnapshotError('OD Next attachment escapes its allowed root.');
   }
+  assertManagedPathHasNoSymlinkComponents(declaredRoot, resolved);
   const linkStat = fs.lstatSync(resolved, { bigint: true });
   if (linkStat.isSymbolicLink() || !linkStat.isFile()) {
     throw new OdNextTaskInputSnapshotError('OD Next attachments must be regular non-symlink files.');
@@ -354,15 +386,13 @@ function readSourceWithoutFollowingSymlinks(
     throw new OdNextTaskInputSnapshotError('OD Next attachment realpath escapes its allowed root.');
   }
   beforeOpenSource?.(resolved);
-  const fd = fs.openSync(resolved, readOnlyNoFollowFlags());
+  const opened = openVerifiedReadOnly(
+    resolved,
+    linkStat,
+    'OD Next attachment changed between path validation and open.',
+  );
+  const { fd, stat: before } = opened;
   try {
-    const before = fs.fstatSync(fd, { bigint: true });
-    if (!before.isFile() || !sameIdentity(linkStat, before)) {
-      throw new OdNextTaskInputSnapshotError(
-        'OD Next attachment changed between path validation and open.',
-        'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
-      );
-    }
     if (before.size > BigInt(maxBytes)) {
       throw new OdNextTaskInputSnapshotError('OD Next attachment exceeds the per-file byte cap.', 'OD_NEXT_INPUT_SNAPSHOT_OVERSIZE');
     }
@@ -683,15 +713,13 @@ function readManagedSnapshotFile(
     );
   }
   beforeOpen?.(filePath);
-  const fd = fs.openSync(filePath, readOnlyNoFollowFlags());
+  const opened = openVerifiedReadOnly(
+    filePath,
+    pathStat,
+    'OD Next managed input changed between path validation and open.',
+  );
+  const { fd, stat: before } = opened;
   try {
-    const before = fs.fstatSync(fd, { bigint: true });
-    if (!before.isFile() || !sameIdentity(pathStat, before)) {
-      throw new OdNextTaskInputSnapshotError(
-        'OD Next managed input changed between path validation and open.',
-        'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
-      );
-    }
     const bytes = readFdBounded(
       fd,
       before.size,

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -111,6 +111,108 @@ function safeTaskId(value: string): string {
   return value;
 }
 
+function cleanupErrorCode(error: unknown): string {
+  if (error instanceof OdNextTaskInputSnapshotError) return error.code;
+  const code = (error as NodeJS.ErrnoException)?.code;
+  return typeof code === 'string' && /^[A-Z0-9_]+$/.test(code) ? code : 'UNKNOWN';
+}
+
+function warnSnapshotCleanupFailure(
+  phase: OdNextTaskInputCleanupPhase,
+  taskExecutionId: string,
+  error: unknown,
+): void {
+  console.warn(
+    `[od-next-task-input] cleanup failed phase=${phase} task=${taskExecutionId} code=${cleanupErrorCode(error)}`,
+  );
+}
+
+export type OdNextTaskInputCleanupPhase =
+  | 'create'
+  | 'replace-partial'
+  | 'initial-bundle'
+  | 'run-claim'
+  | 'non-ready';
+
+/**
+ * Remove a managed immutable tree without following links. Windows maps the
+ * snapshot's 0400/0444 modes to the ReadOnly attribute, so every entry must be
+ * made owner-writable before unlinking it. A link or special file fails closed
+ * instead of allowing cleanup to escape the daemon-owned tree.
+ */
+function removeWritableTreeWithoutFollowingLinks(target: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input cleanup refuses symbolic links or reparse points.',
+    );
+  }
+  if (stat.isDirectory()) {
+    fs.chmodSync(target, 0o700);
+    for (const entry of fs.readdirSync(target)) {
+      removeWritableTreeWithoutFollowingLinks(path.join(target, entry));
+    }
+    fs.rmdirSync(target);
+    return;
+  }
+  if (!stat.isFile()) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input cleanup refuses non-file entries.',
+    );
+  }
+  fs.chmodSync(target, 0o600);
+  fs.unlinkSync(target);
+}
+
+function removeManagedSnapshotDir(input: {
+  snapshotsRoot: string;
+  taskExecutionId: string;
+  snapshotDir: string;
+}): void {
+  const snapshotsRoot = path.resolve(input.snapshotsRoot);
+  const taskExecutionId = safeTaskId(input.taskExecutionId);
+  const expectedSnapshotDir = path.join(snapshotsRoot, taskExecutionId);
+  const snapshotDir = path.resolve(input.snapshotDir);
+  if (path.relative(expectedSnapshotDir, snapshotDir) !== '') {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input snapshot is outside its managed root.',
+    );
+  }
+
+  let rootStat: fs.Stats;
+  try {
+    rootStat = fs.lstatSync(snapshotsRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+    throw error;
+  }
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next snapshot root must be a managed non-symlink directory.',
+    );
+  }
+
+  let snapshotStat: fs.Stats;
+  try {
+    snapshotStat = fs.lstatSync(snapshotDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+    throw error;
+  }
+  if (snapshotStat.isSymbolicLink() || !snapshotStat.isDirectory()) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input snapshot must be a managed non-symlink directory.',
+    );
+  }
+  removeWritableTreeWithoutFollowingLinks(snapshotDir);
+}
+
 function sameIdentity(
   stat: fs.BigIntStats,
   opened: fs.BigIntStats,
@@ -433,7 +535,12 @@ export function createOdNextTaskInputSnapshot(input: {
       // A task id is single-writer under the assistant/task claim. An entry
       // here is therefore a partial initialization left before that claim
       // committed, not a reusable canonical snapshot.
-      fs.rmSync(snapshotDir, { recursive: true, force: true });
+      try {
+        removeManagedSnapshotDir({ snapshotsRoot, taskExecutionId, snapshotDir });
+      } catch (cleanupError) {
+        warnSnapshotCleanupFailure('replace-partial', taskExecutionId, cleanupError);
+        throw cleanupError;
+      }
       fs.mkdirSync(snapshotDir, { recursive: false, mode: 0o700 });
       snapshotCleanupAllowed = true;
     }
@@ -529,7 +636,11 @@ export function createOdNextTaskInputSnapshot(input: {
     return { taskExecutionId, snapshotDir, manifestSha256: sha256(manifestBytes) };
   } catch (error) {
     if (snapshotCleanupAllowed) {
-      fs.rmSync(snapshotDir, { recursive: true, force: true });
+      try {
+        removeManagedSnapshotDir({ snapshotsRoot, taskExecutionId, snapshotDir });
+      } catch (cleanupError) {
+        warnSnapshotCleanupFailure('create', taskExecutionId, cleanupError);
+      }
     }
     throw error;
   }
@@ -893,7 +1004,27 @@ export function removeOdNextRunInputProjection(
 
 export function removeOdNextTaskInputSnapshot(
   descriptor: OdNextTaskInputSnapshotDescriptor | null | undefined,
+  snapshotsRoot: string,
 ): void {
   if (!descriptor) return;
-  fs.rmSync(descriptor.snapshotDir, { recursive: true, force: true });
+  removeManagedSnapshotDir({
+    snapshotsRoot,
+    taskExecutionId: descriptor.taskExecutionId,
+    snapshotDir: descriptor.snapshotDir,
+  });
+}
+
+export function removeOdNextTaskInputSnapshotBestEffort(
+  descriptor: OdNextTaskInputSnapshotDescriptor | null | undefined,
+  snapshotsRoot: string,
+  phase: OdNextTaskInputCleanupPhase,
+): void {
+  if (!descriptor) return;
+  let taskExecutionId = 'invalid';
+  try {
+    taskExecutionId = safeTaskId(descriptor.taskExecutionId);
+    removeOdNextTaskInputSnapshot(descriptor, snapshotsRoot);
+  } catch (error) {
+    warnSnapshotCleanupFailure(phase, taskExecutionId, error);
+  }
 }

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -11,6 +11,7 @@ import {
   type OdNextRequestInputFactsV1,
   type OdNextTaskConfigurationV1,
 } from '@open-design/contracts';
+import { spawnSync } from 'node:child_process';
 import { createHash, randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -140,39 +141,34 @@ export type OdNextTaskInputCleanupPhase =
   | 'run-claim'
   | 'non-ready';
 
-/**
- * Remove an immutable managed tree without following links. Windows maps the
- * snapshot's read-only modes to the ReadOnly attribute, so regular files and
- * directories must be made writable before removal. Links and junctions are
- * unlinked as entries and are never enumerated.
- */
-function removeWritableTreeWithoutFollowingLinks(target: string): void {
-  let stat: fs.Stats;
-  try {
-    stat = fs.lstatSync(target);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
-    throw error;
-  }
-  if (stat.isSymbolicLink()) {
-    fs.unlinkSync(target);
+/** Remove a claimed tree with the host's reparse-aware removal primitive. */
+function removeSnapshotTreeWithPlatformPrimitive(target: string): void {
+  if (process.platform !== 'win32') {
+    fs.rmSync(target, { recursive: true, force: true, maxRetries: 3 });
     return;
   }
-  if (stat.isDirectory()) {
-    fs.chmodSync(target, 0o700);
-    for (const entry of fs.readdirSync(target)) {
-      removeWritableTreeWithoutFollowingLinks(path.join(target, entry));
-    }
-    fs.rmdirSync(target);
-    return;
-  }
-  if (!stat.isFile()) {
+
+  // Node 24's Windows recursive remover can enumerate through a junction that
+  // replaces a descendant mid-walk. The Windows `rmdir` primitive detects
+  // reparse entries during its own traversal and removes the entry rather than
+  // enumerating its target. Pass the attacker-influenced path through an
+  // environment value so cmd never parses it as command syntax.
+  const result = spawnSync(
+    process.env.ComSpec ?? process.env.COMSPEC ?? 'cmd.exe',
+    ['/d', '/v:off', '/s', '/c', 'rmdir /s /q "%OD_SNAPSHOT_DELETE_TARGET%"'],
+    {
+      env: { ...process.env, OD_SNAPSHOT_DELETE_TARGET: target },
+      stdio: 'ignore',
+      windowsVerbatimArguments: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
     throw new OdNextTaskInputSnapshotError(
-      'OD Next task input cleanup refuses non-file entries.',
+      'OD Next task input cleanup failed in the Windows directory remover.',
+      'OD_NEXT_INPUT_SNAPSHOT_CLEANUP_FAILED',
     );
   }
-  fs.chmodSync(target, 0o600);
-  fs.unlinkSync(target);
 }
 
 function removeManagedSnapshotDir(input: {
@@ -257,7 +253,7 @@ function removeManagedSnapshotDir(input: {
     );
   }
   input.hooks?.beforeRemoveClaimedSnapshot?.(claimedSnapshotDir);
-  removeWritableTreeWithoutFollowingLinks(claimedSnapshotDir);
+  removeSnapshotTreeWithPlatformPrimitive(claimedSnapshotDir);
 }
 
 function sameIdentity(

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -95,6 +95,7 @@ export interface SnapshotReadHooks {
 
 export interface SnapshotCleanupHooks {
   beforeClaimSnapshot?: (snapshotDir: string) => void;
+  beforeRemoveClaimedSnapshot?: (claimedSnapshotDir: string) => void;
 }
 
 function sha256(bytes: Buffer | string): string {
@@ -137,42 +138,6 @@ export type OdNextTaskInputCleanupPhase =
   | 'initial-bundle'
   | 'run-claim'
   | 'non-ready';
-
-/**
- * Remove a managed immutable tree without following links. Windows maps the
- * snapshot's 0400/0444 modes to the ReadOnly attribute, so every entry must be
- * made owner-writable before unlinking it. A link or special file fails closed
- * instead of allowing cleanup to escape the daemon-owned tree.
- */
-function removeWritableTreeWithoutFollowingLinks(target: string): void {
-  let stat: fs.Stats;
-  try {
-    stat = fs.lstatSync(target);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
-    throw error;
-  }
-  if (stat.isSymbolicLink()) {
-    throw new OdNextTaskInputSnapshotError(
-      'OD Next task input cleanup refuses symbolic links or reparse points.',
-    );
-  }
-  if (stat.isDirectory()) {
-    fs.chmodSync(target, 0o700);
-    for (const entry of fs.readdirSync(target)) {
-      removeWritableTreeWithoutFollowingLinks(path.join(target, entry));
-    }
-    fs.rmdirSync(target);
-    return;
-  }
-  if (!stat.isFile()) {
-    throw new OdNextTaskInputSnapshotError(
-      'OD Next task input cleanup refuses non-file entries.',
-    );
-  }
-  fs.chmodSync(target, 0o600);
-  fs.unlinkSync(target);
-}
 
 function removeManagedSnapshotDir(input: {
   snapshotsRoot: string;
@@ -238,7 +203,12 @@ function removeManagedSnapshotDir(input: {
       'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
     );
   }
-  removeWritableTreeWithoutFollowingLinks(claimedSnapshotDir);
+  input.hooks?.beforeRemoveClaimedSnapshot?.(claimedSnapshotDir);
+  // Delegate recursive removal to Node's platform implementation. In
+  // particular, Windows removes a junction/reparse entry itself rather than
+  // resolving it as a directory to enumerate, and its EPERM recovery clears
+  // ReadOnly before retrying the removal.
+  fs.rmSync(claimedSnapshotDir, { recursive: true, force: true, maxRetries: 3 });
 }
 
 function sameIdentity(

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -235,16 +235,20 @@ function removeManagedSnapshotDir(input: {
     snapshotsRoot,
     `.deleting-${taskExecutionId}-${randomBytes(16).toString('hex')}`,
   );
-  const rootFd = process.platform === 'win32'
-    ? undefined
-    : fs.openSync(
-      snapshotsRoot,
-      fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW,
-    );
+  // Linux exposes an opened directory as a traversable procfs path. Darwin's
+  // /dev/fd entry is only a synthetic descriptor node: its device identity
+  // differs from the directory and child paths cannot be resolved through it.
+  // Keep the documented pathname claim on platforms without Linux procfs.
+  const rootFd = process.platform === 'linux'
+    ? fs.openSync(
+        snapshotsRoot,
+        fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW,
+      )
+    : undefined;
   try {
     const boundRoot = rootFd === undefined
       ? snapshotsRoot
-      : process.platform === 'linux' ? `/proc/self/fd/${rootFd}` : `/dev/fd/${rootFd}`;
+      : `/proc/self/fd/${rootFd}`;
     if (rootFd !== undefined) {
       const openedRootStat = fs.fstatSync(rootFd, { bigint: true });
       const boundRootStat = fs.statSync(boundRoot, { bigint: true });

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -94,6 +94,7 @@ export interface SnapshotReadHooks {
 }
 
 export interface SnapshotCleanupHooks {
+  beforeLookupSnapshot?: (snapshotsRoot: string) => void;
   beforeClaimSnapshot?: (snapshotDir: string) => void;
   beforeRemoveClaimedSnapshot?: (claimedSnapshotDir: string) => void;
 }
@@ -155,9 +156,9 @@ function removeManagedSnapshotDir(input: {
     );
   }
 
-  let rootStat: fs.Stats;
+  let rootStat: fs.BigIntStats;
   try {
-    rootStat = fs.lstatSync(snapshotsRoot);
+    rootStat = fs.lstatSync(snapshotsRoot, { bigint: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
     throw error;
@@ -168,6 +169,7 @@ function removeManagedSnapshotDir(input: {
     );
   }
 
+  input.hooks?.beforeLookupSnapshot?.(snapshotsRoot);
   let snapshotStat: fs.BigIntStats;
   try {
     snapshotStat = fs.lstatSync(snapshotDir, { bigint: true });
@@ -178,6 +180,18 @@ function removeManagedSnapshotDir(input: {
   if (snapshotStat.isSymbolicLink() || !snapshotStat.isDirectory()) {
     throw new OdNextTaskInputSnapshotError(
       'OD Next task input snapshot must be a managed non-symlink directory.',
+    );
+  }
+
+  const rootAfterLookup = fs.lstatSync(snapshotsRoot, { bigint: true });
+  if (
+    rootAfterLookup.isSymbolicLink()
+    || !rootAfterLookup.isDirectory()
+    || !sameIdentity(rootStat, rootAfterLookup)
+  ) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next snapshot root changed before cleanup could claim its child.',
+      'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
     );
   }
 
@@ -192,9 +206,13 @@ function removeManagedSnapshotDir(input: {
   );
   input.hooks?.beforeClaimSnapshot?.(snapshotDir);
   fs.renameSync(snapshotDir, claimedSnapshotDir);
+  const rootAfterClaim = fs.lstatSync(snapshotsRoot, { bigint: true });
   const claimedStat = fs.lstatSync(claimedSnapshotDir, { bigint: true });
   if (
-    claimedStat.isSymbolicLink()
+    rootAfterClaim.isSymbolicLink()
+    || !rootAfterClaim.isDirectory()
+    || !sameIdentity(rootStat, rootAfterClaim)
+    || claimedStat.isSymbolicLink()
     || !claimedStat.isDirectory()
     || !sameIdentity(snapshotStat, claimedStat)
   ) {

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -235,25 +235,51 @@ function removeManagedSnapshotDir(input: {
     snapshotsRoot,
     `.deleting-${taskExecutionId}-${randomBytes(16).toString('hex')}`,
   );
-  input.hooks?.beforeClaimSnapshot?.(snapshotDir);
-  fs.renameSync(snapshotDir, claimedSnapshotDir);
-  const rootAfterClaim = fs.lstatSync(snapshotsRoot, { bigint: true });
-  const claimedStat = fs.lstatSync(claimedSnapshotDir, { bigint: true });
-  if (
-    rootAfterClaim.isSymbolicLink()
-    || !rootAfterClaim.isDirectory()
-    || !sameIdentity(rootStat, rootAfterClaim)
-    || claimedStat.isSymbolicLink()
-    || !claimedStat.isDirectory()
-    || !sameIdentity(snapshotStat, claimedStat)
-  ) {
-    throw new OdNextTaskInputSnapshotError(
-      'OD Next task input snapshot changed before cleanup could claim it.',
-      'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
+  const rootFd = process.platform === 'win32'
+    ? undefined
+    : fs.openSync(
+      snapshotsRoot,
+      fs.constants.O_RDONLY | fs.constants.O_DIRECTORY | fs.constants.O_NOFOLLOW,
     );
+  try {
+    const boundRoot = rootFd === undefined
+      ? snapshotsRoot
+      : process.platform === 'linux' ? `/proc/self/fd/${rootFd}` : `/dev/fd/${rootFd}`;
+    if (rootFd !== undefined) {
+      const openedRootStat = fs.fstatSync(rootFd, { bigint: true });
+      const boundRootStat = fs.statSync(boundRoot, { bigint: true });
+      if (!sameIdentity(rootStat, openedRootStat) || !sameIdentity(rootStat, boundRootStat)) {
+        throw new OdNextTaskInputSnapshotError(
+          'OD Next snapshot root changed before cleanup could open it.',
+          'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
+        );
+      }
+    }
+
+    input.hooks?.beforeClaimSnapshot?.(snapshotDir);
+    const boundSnapshotDir = path.join(boundRoot, taskExecutionId);
+    const boundClaimedSnapshotDir = path.join(boundRoot, path.basename(claimedSnapshotDir));
+    fs.renameSync(boundSnapshotDir, boundClaimedSnapshotDir);
+    const rootAfterClaim = fs.lstatSync(snapshotsRoot, { bigint: true });
+    const claimedStat = fs.lstatSync(boundClaimedSnapshotDir, { bigint: true });
+    if (
+      rootAfterClaim.isSymbolicLink()
+      || !rootAfterClaim.isDirectory()
+      || !sameIdentity(rootStat, rootAfterClaim)
+      || claimedStat.isSymbolicLink()
+      || !claimedStat.isDirectory()
+      || !sameIdentity(snapshotStat, claimedStat)
+    ) {
+      throw new OdNextTaskInputSnapshotError(
+        'OD Next task input snapshot changed before cleanup could claim it.',
+        'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
+      );
+    }
+    input.hooks?.beforeRemoveClaimedSnapshot?.(claimedSnapshotDir);
+    removeSnapshotTreeWithPlatformPrimitive(boundClaimedSnapshotDir);
+  } finally {
+    if (rootFd !== undefined) fs.closeSync(rootFd);
   }
-  input.hooks?.beforeRemoveClaimedSnapshot?.(claimedSnapshotDir);
-  removeSnapshotTreeWithPlatformPrimitive(claimedSnapshotDir);
 }
 
 function sameIdentity(

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -11,7 +11,7 @@ import {
   type OdNextRequestInputFactsV1,
   type OdNextTaskConfigurationV1,
 } from '@open-design/contracts';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { redactSecrets } from '../../redact.js';
@@ -91,6 +91,10 @@ export interface SnapshotReadLimits {
 export interface SnapshotReadHooks {
   beforeOpenManifest?: (manifestPath: string) => void;
   beforeOpenFile?: (filePath: string) => void;
+}
+
+export interface SnapshotCleanupHooks {
+  beforeClaimSnapshot?: (snapshotDir: string) => void;
 }
 
 function sha256(bytes: Buffer | string): string {
@@ -174,6 +178,7 @@ function removeManagedSnapshotDir(input: {
   snapshotsRoot: string;
   taskExecutionId: string;
   snapshotDir: string;
+  hooks?: SnapshotCleanupHooks;
 }): void {
   const snapshotsRoot = path.resolve(input.snapshotsRoot);
   const taskExecutionId = safeTaskId(input.taskExecutionId);
@@ -198,9 +203,9 @@ function removeManagedSnapshotDir(input: {
     );
   }
 
-  let snapshotStat: fs.Stats;
+  let snapshotStat: fs.BigIntStats;
   try {
-    snapshotStat = fs.lstatSync(snapshotDir);
+    snapshotStat = fs.lstatSync(snapshotDir, { bigint: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
     throw error;
@@ -210,7 +215,30 @@ function removeManagedSnapshotDir(input: {
       'OD Next task input snapshot must be a managed non-symlink directory.',
     );
   }
-  removeWritableTreeWithoutFollowingLinks(snapshotDir);
+
+  // Claim the checked entry with one atomic rename before resolving any path
+  // for mutation. The random name prevents ordinary producers from finding or
+  // reusing the private deletion path while cleanup walks it. Rechecking the
+  // identity after rename makes a swap between lstat and rename fail closed:
+  // traversal never runs against the replacement (including a junction).
+  const claimedSnapshotDir = path.join(
+    snapshotsRoot,
+    `.deleting-${taskExecutionId}-${randomBytes(16).toString('hex')}`,
+  );
+  input.hooks?.beforeClaimSnapshot?.(snapshotDir);
+  fs.renameSync(snapshotDir, claimedSnapshotDir);
+  const claimedStat = fs.lstatSync(claimedSnapshotDir, { bigint: true });
+  if (
+    claimedStat.isSymbolicLink()
+    || !claimedStat.isDirectory()
+    || !sameIdentity(snapshotStat, claimedStat)
+  ) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input snapshot changed before cleanup could claim it.',
+      'OD_NEXT_INPUT_SNAPSHOT_TOCTOU',
+    );
+  }
+  removeWritableTreeWithoutFollowingLinks(claimedSnapshotDir);
 }
 
 function sameIdentity(
@@ -1005,12 +1033,14 @@ export function removeOdNextRunInputProjection(
 export function removeOdNextTaskInputSnapshot(
   descriptor: OdNextTaskInputSnapshotDescriptor | null | undefined,
   snapshotsRoot: string,
+  hooks?: SnapshotCleanupHooks,
 ): void {
   if (!descriptor) return;
   removeManagedSnapshotDir({
     snapshotsRoot,
     taskExecutionId: descriptor.taskExecutionId,
     snapshotDir: descriptor.snapshotDir,
+    ...(hooks ? { hooks } : {}),
   });
 }
 

--- a/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
+++ b/apps/daemon/src/strategies/od-next/task-input-snapshot.ts
@@ -140,6 +140,41 @@ export type OdNextTaskInputCleanupPhase =
   | 'run-claim'
   | 'non-ready';
 
+/**
+ * Remove an immutable managed tree without following links. Windows maps the
+ * snapshot's read-only modes to the ReadOnly attribute, so regular files and
+ * directories must be made writable before removal. Links and junctions are
+ * unlinked as entries and are never enumerated.
+ */
+function removeWritableTreeWithoutFollowingLinks(target: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    fs.unlinkSync(target);
+    return;
+  }
+  if (stat.isDirectory()) {
+    fs.chmodSync(target, 0o700);
+    for (const entry of fs.readdirSync(target)) {
+      removeWritableTreeWithoutFollowingLinks(path.join(target, entry));
+    }
+    fs.rmdirSync(target);
+    return;
+  }
+  if (!stat.isFile()) {
+    throw new OdNextTaskInputSnapshotError(
+      'OD Next task input cleanup refuses non-file entries.',
+    );
+  }
+  fs.chmodSync(target, 0o600);
+  fs.unlinkSync(target);
+}
+
 function removeManagedSnapshotDir(input: {
   snapshotsRoot: string;
   taskExecutionId: string;
@@ -222,11 +257,7 @@ function removeManagedSnapshotDir(input: {
     );
   }
   input.hooks?.beforeRemoveClaimedSnapshot?.(claimedSnapshotDir);
-  // Delegate recursive removal to Node's platform implementation. In
-  // particular, Windows removes a junction/reparse entry itself rather than
-  // resolving it as a directory to enumerate, and its EPERM recovery clears
-  // ReadOnly before retrying the removal.
-  fs.rmSync(claimedSnapshotDir, { recursive: true, force: true, maxRetries: 3 });
+  removeWritableTreeWithoutFollowingLinks(claimedSnapshotDir);
 }
 
 function sameIdentity(

--- a/apps/daemon/tests/routes/runs-structured-errors.test.ts
+++ b/apps/daemon/tests/routes/runs-structured-errors.test.ts
@@ -2,6 +2,7 @@ import express, { type Response } from 'express';
 import type http from 'node:http';
 import { describe, expect, it, vi } from 'vitest';
 
+import { sendApiError } from '../../src/http/api-errors.js';
 import {
   registerRunCreateRoute,
   sendStructuredRunCreateFailure,
@@ -17,9 +18,7 @@ describe('Run creation structured failures', () => {
       async () => {
         throw Object.assign(new Error('secret input at C:\\private\\prompt.txt'), { code: 'EPERM' });
       },
-      (res, status, code, message, details) => res.status(status).json({
-        error: { code, message, details },
-      }),
+      sendApiError as Parameters<typeof registerRunCreateRoute>[2],
     );
     const server = await new Promise<http.Server>((resolve) => {
       const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
@@ -41,7 +40,7 @@ describe('Run creation structured failures', () => {
         error: {
           code: 'INTERNAL_ERROR',
           message: 'Run preparation failed.',
-          details: { requestId: expect.any(String) },
+          requestId: expect.any(String),
         },
       });
       expect(text).not.toContain('private');

--- a/apps/daemon/tests/routes/runs-structured-errors.test.ts
+++ b/apps/daemon/tests/routes/runs-structured-errors.test.ts
@@ -1,0 +1,36 @@
+import type { Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+import { sendStructuredRunCreateFailure } from '../../src/routes/runs.js';
+
+describe('Run creation structured failures', () => {
+  it('returns a traceable JSON error without exposing the underlying failure', () => {
+    const sendApiError = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = {} as Response;
+
+    try {
+      sendStructuredRunCreateFailure(
+        res,
+        sendApiError,
+        Object.assign(new Error('secret input at C:\\private\\prompt.txt'), { code: 'EPERM' }),
+        'request-fixture-123',
+      );
+
+      expect(sendApiError).toHaveBeenCalledWith(
+        res,
+        500,
+        'INTERNAL_ERROR',
+        'Run preparation failed.',
+        { requestId: 'request-fixture-123' },
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        '[runs] preparation failed request=request-fixture-123 code=EPERM',
+      );
+      expect(JSON.stringify(sendApiError.mock.calls)).not.toContain('private');
+      expect(JSON.stringify(consoleError.mock.calls)).not.toContain('secret input');
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/apps/daemon/tests/routes/runs-structured-errors.test.ts
+++ b/apps/daemon/tests/routes/runs-structured-errors.test.ts
@@ -1,9 +1,60 @@
-import type { Response } from 'express';
+import express, { type Response } from 'express';
+import type http from 'node:http';
 import { describe, expect, it, vi } from 'vitest';
 
-import { sendStructuredRunCreateFailure } from '../../src/routes/runs.js';
+import {
+  registerRunCreateRoute,
+  sendStructuredRunCreateFailure,
+} from '../../src/routes/runs.js';
 
 describe('Run creation structured failures', () => {
+  it('returns sanitized JSON when preparation throws at the HTTP boundary', async () => {
+    const app = express();
+    app.use(express.json());
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    registerRunCreateRoute(
+      app,
+      async () => {
+        throw Object.assign(new Error('secret input at C:\\private\\prompt.txt'), { code: 'EPERM' });
+      },
+      (res, status, code, message, details) => res.status(status).json({
+        error: { code, message, details },
+      }),
+    );
+    const server = await new Promise<http.Server>((resolve) => {
+      const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('missing test server address');
+      const response = await fetch(`http://127.0.0.1:${address.port}/api/runs`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      });
+      const text = await response.text();
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get('content-type')).toContain('application/json');
+      expect(JSON.parse(text)).toMatchObject({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Run preparation failed.',
+          details: { requestId: expect.any(String) },
+        },
+      });
+      expect(text).not.toContain('private');
+      expect(text).not.toContain('secret input');
+    } finally {
+      consoleError.mockRestore();
+      await new Promise<void>((resolve, reject) => server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      }));
+    }
+  });
+
   it('returns a traceable JSON error without exposing the underlying failure', () => {
     const sendApiError = vi.fn();
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -224,6 +224,33 @@ describe('OD Next task-scoped input snapshots', () => {
     expect(readFileSync(path.join(displacedClaimedDir, 'managed.txt'), 'utf8')).toBe('managed');
   });
 
+  it('does not traverse a descendant junction swapped in before platform removal', () => {
+    const f = fixture();
+    const snapshotDir = path.join(f.snapshotsRoot, 'odnext_descendant_cleanup_swap');
+    const childDir = path.join(snapshotDir, 'attachments');
+    const displacedChildDir = `${childDir}.displaced`;
+    const outside = path.join(f.root, 'outside-descendant-swap-target');
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(path.join(childDir, 'managed.txt'), 'managed');
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+
+    removeOdNextTaskInputSnapshot({
+      taskExecutionId: 'odnext_descendant_cleanup_swap',
+      snapshotDir,
+      manifestSha256: '1'.repeat(64),
+    }, f.snapshotsRoot, {
+      beforeRemoveClaimedSnapshot: (claimedSnapshotDir) => {
+        const claimedChildDir = path.join(claimedSnapshotDir, 'attachments');
+        renameSync(claimedChildDir, path.join(claimedSnapshotDir, path.basename(displacedChildDir)));
+        symlinkSync(outside, claimedChildDir, 'junction');
+      },
+    });
+
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+  });
+
   it('freezes ordered document/image bytes and survives source mutation or deletion', () => {
     const f = fixture();
     writeFileSync(path.join(f.projectRoot, 'brief.pdf'), Buffer.from('%PDF-1.7\nbrief'));

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -167,6 +167,34 @@ describe('OD Next task-scoped input snapshots', () => {
     expect(readFileSync(path.join(displacedSnapshotDir, 'managed.txt'), 'utf8')).toBe('managed');
   });
 
+  it('does not traverse a snapshot root swapped before child lookup', () => {
+    const f = fixture();
+    const taskExecutionId = 'odnext_root_swap';
+    const snapshotDir = path.join(f.snapshotsRoot, taskExecutionId);
+    const displacedRoot = `${f.snapshotsRoot}.displaced`;
+    const outsideRoot = path.join(f.root, 'outside-root-swap-target');
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(path.join(snapshotDir, 'managed.txt'), 'managed');
+    mkdirSync(path.join(outsideRoot, taskExecutionId), { recursive: true });
+    const sentinel = path.join(outsideRoot, taskExecutionId, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+
+    expect(() => removeOdNextTaskInputSnapshot({
+      taskExecutionId,
+      snapshotDir,
+      manifestSha256: 'f'.repeat(64),
+    }, f.snapshotsRoot, {
+      beforeLookupSnapshot: (root) => {
+        renameSync(root, displacedRoot);
+        symlinkSync(outsideRoot, root, 'junction');
+      },
+    })).toThrow(/root changed before cleanup could claim/);
+
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+    expect(readFileSync(path.join(displacedRoot, taskExecutionId, 'managed.txt'), 'utf8'))
+      .toBe('managed');
+  });
+
   it('does not traverse a junction swapped in immediately before removing the claimed snapshot', () => {
     const f = fixture();
     const snapshotDir = path.join(f.snapshotsRoot, 'odnext_claimed_cleanup_swap');

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -32,9 +32,11 @@ const roots: string[] = [];
 function makeTreeWritable(target: string): void {
   if (!existsSync(target)) return;
   const stat = lstatSync(target);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) return;
-  chmodSync(target, 0o700);
-  for (const entry of readdirSync(target)) makeTreeWritable(path.join(target, entry));
+  if (stat.isSymbolicLink()) return;
+  chmodSync(target, stat.isDirectory() ? 0o700 : 0o600);
+  if (stat.isDirectory()) {
+    for (const entry of readdirSync(target)) makeTreeWritable(path.join(target, entry));
+  }
 }
 
 function fixture() {
@@ -288,7 +290,9 @@ describe('OD Next task-scoped input snapshots', () => {
       .toBe(true);
     expect(readFileSync(first.attachmentPaths[0]!, 'utf8')).toContain('canonical pdf');
     expect(readFileSync(first.attachmentPaths[1]!, 'utf8')).toBe('canonical text');
-    expect(statSync(first.projectionDir).mode & 0o777).toBe(0o555);
+    const projectionMode = statSync(first.projectionDir).mode & 0o777;
+    if (process.platform === 'win32') expect(projectionMode & 0o222).toBe(0);
+    else expect(projectionMode).toBe(0o555);
     expect(statSync(first.attachmentPaths[0]!).mode & 0o777).toBe(0o444);
 
     chmodSync(first.attachmentPaths[1]!, 0o600);
@@ -333,6 +337,21 @@ describe('OD Next task-scoped input snapshots', () => {
       .toThrow(/symlink|realpath escapes/);
   });
 
+  it('rejects an intermediate source-directory link even when it stays inside the allowed root', () => {
+    const f = fixture();
+    const actualDirectory = path.join(f.projectRoot, 'actual');
+    const linkedDirectory = path.join(f.projectRoot, 'linked');
+    mkdirSync(actualDirectory);
+    writeFileSync(path.join(actualDirectory, 'brief.txt'), 'inside allowed root');
+    symlinkSync(actualDirectory, linkedDirectory, 'junction');
+
+    expect(() => createOdNextTaskInputSnapshot({
+      ...f,
+      taskExecutionId: 'odnext_source_intermediate_link',
+      projectAttachments: ['linked/brief.txt'],
+    })).toThrow(/symlink or non-directory component/);
+  });
+
   it('uses no-follow bounded reads and caps when loading canonical files', () => {
     const f = fixture();
     writeFileSync(path.join(f.projectRoot, 'one.txt'), '12345');
@@ -370,6 +389,7 @@ describe('OD Next task-scoped input snapshots', () => {
     )).toThrow(/between path validation and open/);
 
     // Restore the original inode path before exercising the attachment swap.
+    chmodSync(manifestPath, 0o600);
     rmSync(manifestPath);
     renameSync(`${manifestPath}.old`, manifestPath);
 

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -197,8 +197,8 @@ describe('OD Next task-scoped input snapshots', () => {
       .toBe('managed');
   });
 
-  it.runIf(process.platform !== 'win32')(
-    'keeps the POSIX claim bound to the root opened before a post-check root swap',
+  it.runIf(process.platform === 'linux')(
+    'keeps the Linux claim bound to the root opened before a post-check root swap',
     () => {
       const f = fixture();
       const taskExecutionId = 'odnext_posix_claim_root_swap';

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -14,13 +14,15 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildOdNextTaskConfigurationV1,
   createOdNextRunInputProjection,
   createOdNextTaskInputSnapshot,
   loadOdNextTaskInputSnapshot,
   OdNextTaskInputSnapshotError,
+  removeOdNextTaskInputSnapshot,
+  removeOdNextTaskInputSnapshotBestEffort,
   removeOdNextRunInputProjection,
 } from '../../src/strategies/od-next/task-input-snapshot.js';
 
@@ -61,6 +63,83 @@ afterEach(() => {
 });
 
 describe('OD Next task-scoped input snapshots', () => {
+  it('removes a read-only canonical snapshot idempotently', () => {
+    const f = fixture();
+    const snapshotDir = path.join(f.snapshotsRoot, 'odnext_cleanup');
+    mkdirSync(path.join(snapshotDir, 'attachments'), { recursive: true });
+    writeFileSync(path.join(snapshotDir, 'manifest.json'), '{}', { mode: 0o400 });
+    writeFileSync(
+      path.join(snapshotDir, 'attachments', 'attachment-001.txt'),
+      'immutable brief',
+      { mode: 0o400 },
+    );
+    const descriptor = {
+      taskExecutionId: 'odnext_cleanup',
+      snapshotDir,
+      manifestSha256: 'a'.repeat(64),
+    };
+
+    removeOdNextTaskInputSnapshot(descriptor, f.snapshotsRoot);
+    expect(existsSync(descriptor.snapshotDir)).toBe(false);
+    expect(() => removeOdNextTaskInputSnapshot(descriptor, f.snapshotsRoot)).not.toThrow();
+  });
+
+  it('refuses to remove a descriptor outside the managed snapshot root', () => {
+    const f = fixture();
+    const outside = path.join(f.root, 'outside-snapshot');
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+
+    expect(() => removeOdNextTaskInputSnapshot({
+      taskExecutionId: 'odnext_outside',
+      snapshotDir: outside,
+      manifestSha256: 'a'.repeat(64),
+    }, f.snapshotsRoot)).toThrow(/outside its managed root/);
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+  });
+
+  it('keeps cleanup best-effort and reports only sanitized diagnostics', () => {
+    const f = fixture();
+    const outside = path.join(f.root, 'best-effort-outside');
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(() => removeOdNextTaskInputSnapshotBestEffort({
+        taskExecutionId: 'odnext_best_effort',
+        snapshotDir: outside,
+        manifestSha256: 'b'.repeat(64),
+      }, f.snapshotsRoot, 'initial-bundle')).not.toThrow();
+      expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+      expect(consoleWarn).toHaveBeenCalledWith(
+        '[od-next-task-input] cleanup failed phase=initial-bundle task=odnext_best_effort code=OD_NEXT_INPUT_SNAPSHOT_INVALID',
+      );
+      expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain(outside);
+    } finally {
+      consoleWarn.mockRestore();
+    }
+  });
+
+  it('refuses links inside a managed snapshot without touching their targets', () => {
+    const f = fixture();
+    const snapshotDir = path.join(f.snapshotsRoot, 'odnext_link');
+    const outside = path.join(f.root, 'outside-link-target');
+    mkdirSync(snapshotDir, { recursive: true });
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+    symlinkSync(outside, path.join(snapshotDir, 'linked'), 'junction');
+
+    expect(() => removeOdNextTaskInputSnapshot({
+      taskExecutionId: 'odnext_link',
+      snapshotDir,
+      manifestSha256: 'c'.repeat(64),
+    }, f.snapshotsRoot)).toThrow(/symbolic links or reparse points/);
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+  });
+
   it('freezes ordered document/image bytes and survives source mutation or deletion', () => {
     const f = fixture();
     writeFileSync(path.join(f.projectRoot, 'brief.pdf'), Buffer.from('%PDF-1.7\nbrief'));

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -140,6 +140,32 @@ describe('OD Next task-scoped input snapshots', () => {
     expect(readFileSync(sentinel, 'utf8')).toBe('keep');
   });
 
+  it('does not traverse a junction swapped in immediately before cleanup claims the snapshot', () => {
+    const f = fixture();
+    const snapshotDir = path.join(f.snapshotsRoot, 'odnext_cleanup_swap');
+    const displacedSnapshotDir = `${snapshotDir}.displaced`;
+    const outside = path.join(f.root, 'outside-swap-target');
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(path.join(snapshotDir, 'managed.txt'), 'managed');
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+
+    expect(() => removeOdNextTaskInputSnapshot({
+      taskExecutionId: 'odnext_cleanup_swap',
+      snapshotDir,
+      manifestSha256: 'd'.repeat(64),
+    }, f.snapshotsRoot, {
+      beforeClaimSnapshot: (target) => {
+        renameSync(target, displacedSnapshotDir);
+        symlinkSync(outside, target, 'junction');
+      },
+    })).toThrow(/changed before cleanup could claim/);
+
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+    expect(readFileSync(path.join(displacedSnapshotDir, 'managed.txt'), 'utf8')).toBe('managed');
+  });
+
   it('freezes ordered document/image bytes and survives source mutation or deletion', () => {
     const f = fixture();
     writeFileSync(path.join(f.projectRoot, 'brief.pdf'), Buffer.from('%PDF-1.7\nbrief'));

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -122,7 +122,7 @@ describe('OD Next task-scoped input snapshots', () => {
     }
   });
 
-  it('refuses links inside a managed snapshot without touching their targets', () => {
+  it('unlinks links inside a managed snapshot without touching their targets', () => {
     const f = fixture();
     const snapshotDir = path.join(f.snapshotsRoot, 'odnext_link');
     const outside = path.join(f.root, 'outside-link-target');
@@ -132,11 +132,12 @@ describe('OD Next task-scoped input snapshots', () => {
     writeFileSync(sentinel, 'keep');
     symlinkSync(outside, path.join(snapshotDir, 'linked'), 'junction');
 
-    expect(() => removeOdNextTaskInputSnapshot({
+    removeOdNextTaskInputSnapshot({
       taskExecutionId: 'odnext_link',
       snapshotDir,
       manifestSha256: 'c'.repeat(64),
-    }, f.snapshotsRoot)).toThrow(/symbolic links or reparse points/);
+    }, f.snapshotsRoot);
+    expect(existsSync(snapshotDir)).toBe(false);
     expect(readFileSync(sentinel, 'utf8')).toBe('keep');
   });
 
@@ -164,6 +165,33 @@ describe('OD Next task-scoped input snapshots', () => {
 
     expect(readFileSync(sentinel, 'utf8')).toBe('keep');
     expect(readFileSync(path.join(displacedSnapshotDir, 'managed.txt'), 'utf8')).toBe('managed');
+  });
+
+  it('does not traverse a junction swapped in immediately before removing the claimed snapshot', () => {
+    const f = fixture();
+    const snapshotDir = path.join(f.snapshotsRoot, 'odnext_claimed_cleanup_swap');
+    const outside = path.join(f.root, 'outside-claimed-swap-target');
+    mkdirSync(snapshotDir, { recursive: true });
+    writeFileSync(path.join(snapshotDir, 'managed.txt'), 'managed');
+    mkdirSync(outside);
+    const sentinel = path.join(outside, 'sentinel.txt');
+    writeFileSync(sentinel, 'keep');
+    let displacedClaimedDir = '';
+
+    removeOdNextTaskInputSnapshot({
+      taskExecutionId: 'odnext_claimed_cleanup_swap',
+      snapshotDir,
+      manifestSha256: 'e'.repeat(64),
+    }, f.snapshotsRoot, {
+      beforeRemoveClaimedSnapshot: (claimedSnapshotDir) => {
+        displacedClaimedDir = `${claimedSnapshotDir}.displaced`;
+        renameSync(claimedSnapshotDir, displacedClaimedDir);
+        symlinkSync(outside, claimedSnapshotDir, 'junction');
+      },
+    });
+
+    expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+    expect(readFileSync(path.join(displacedClaimedDir, 'managed.txt'), 'utf8')).toBe('managed');
   });
 
   it('freezes ordered document/image bytes and survives source mutation or deletion', () => {

--- a/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
+++ b/apps/daemon/tests/strategies/od-next-task-input-snapshot.test.ts
@@ -197,6 +197,42 @@ describe('OD Next task-scoped input snapshots', () => {
       .toBe('managed');
   });
 
+  it.runIf(process.platform !== 'win32')(
+    'keeps the POSIX claim bound to the root opened before a post-check root swap',
+    () => {
+      const f = fixture();
+      const taskExecutionId = 'odnext_posix_claim_root_swap';
+      const snapshotDir = path.join(f.snapshotsRoot, taskExecutionId);
+      const displacedRoot = `${f.snapshotsRoot}.displaced`;
+      const outsideRoot = path.join(f.root, 'outside-posix-claim-root-swap');
+      const outsideSnapshotDir = path.join(outsideRoot, taskExecutionId);
+      mkdirSync(snapshotDir, { recursive: true });
+      writeFileSync(path.join(snapshotDir, 'managed.txt'), 'managed');
+      mkdirSync(outsideSnapshotDir, { recursive: true });
+      const sentinel = path.join(outsideSnapshotDir, 'sentinel.txt');
+      writeFileSync(sentinel, 'keep');
+
+      expect(() => removeOdNextTaskInputSnapshot({
+        taskExecutionId,
+        snapshotDir,
+        manifestSha256: '2'.repeat(64),
+      }, f.snapshotsRoot, {
+        beforeClaimSnapshot: (target) => {
+          renameSync(path.dirname(target), displacedRoot);
+          symlinkSync(outsideRoot, f.snapshotsRoot, 'dir');
+        },
+      })).toThrow(/changed before cleanup could claim/);
+
+      expect(readFileSync(sentinel, 'utf8')).toBe('keep');
+      expect(existsSync(outsideSnapshotDir)).toBe(true);
+      const claimedEntry = readdirSync(displacedRoot)
+        .find((entry) => entry.startsWith('.deleting-odnext_posix_claim_root_swap-'));
+      expect(claimedEntry).toBeDefined();
+      expect(readFileSync(path.join(displacedRoot, claimedEntry!, 'managed.txt'), 'utf8'))
+        .toBe('managed');
+    },
+  );
+
   it('does not traverse a junction swapped in immediately before removing the claimed snapshot', () => {
     const f = fixture();
     const snapshotDir = path.join(f.snapshotsRoot, 'odnext_claimed_cleanup_swap');


### PR DESCRIPTION
Fixes #7530

## Why

Windows prerelease OD Next Run creation could fail in two snapshot paths under the packaged runtime:

1. Electron 41.3.0 embeds Node 24.15.0, where recursively removing mode-0400 files can raise EPERM.
2. Node 24.15.0 on Windows does not expose O_NOFOLLOW, so the existing safe-read capability check rejected every normal snapshot read before opening the file.

Cleanup failures could replace the original preparation error and block automatic fallback. Unexpected pre-Run failures also escaped as Express default HTML instead of a traceable JSON API error.

## What users will see

OD Next can create, load, project, and remove immutable task-input snapshots on Windows. Preparation failures preserve automatic fallback, and unexpected pre-Run failures return sanitized JSON with a request ID.

## Safety boundary

- Cleanup is confined to the expected task directory under the managed snapshot root during ordinary daemon operation.
- The checked snapshot is atomically claimed under a private random name and its filesystem identity is revalidated before recursive removal.
- Windows cleanup uses the host `rmdir` primitive so ReadOnly files can be removed and junction entries are not traversed.
- POSIX reads retain kernel O_NOFOLLOW.
- Windows reads use pre-open lstat plus immediate post-open fstat identity verification before reading.
- Intermediate source directory links/junctions are rejected.
- Reads remain bounded and verify identity and metadata again after reading.
- Cleanup remains idempotent and best-effort relative to the original preparation error.

This fix deliberately does not add native FFI to defend against a malicious same-user process replacing the managed root in the syscall-sized interval between identity validation and pathname rename. That adversarial scenario was not the reported #7530 failure mode and does not justify expanding this bug fix into native dependency and packaged-runtime work.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

Red evidence was captured in the exact packaged runtime:

- The safe-read test failed with OD_NEXT_INPUT_SNAPSHOT_UNSUPPORTED when O_NOFOLLOW was absent.
- Bare recursive removal failed with Windows EPERM on ReadOnly snapshot files.
- Node's platform recursive removal traversed Windows junction targets under Electron 41 / Node 24.15, while system Node tests passed; Windows cleanup now delegates the claimed tree to the host `rmdir` primitive.

Regression coverage includes:

- ReadOnly cleanup and idempotence
- managed-root and snapshot-root identity fencing
- pre-claim and post-claim directory/junction swaps
- internal junction unlink without touching its target
- source and managed-file open-time swaps
- intermediate source-directory junction rejection
- mid-read mutation, count/size caps, manifest tampering
- immutable per-Run projections
- production structured JSON pre-Run errors

## Validation

- Electron 41.3.0 / Node 24.15.0 snapshot safety suite passed at 347ade8
- Built-module Electron probe: create/load/project/remove succeeded with O_NOFOLLOW=null and residue=false
- Focused daemon suite at f75cdc8: 20/20 passed
- apps/daemon typecheck
- pnpm guard

## Release flow

This PR targets main. The existing backport release/v0.21.1 label remains the only release-branch integration mechanism; do not merge directly to the release branch.

## Remaining adjacent issue

The Windows-native automatic-fallback fixture still needs a reliable fake Codex interception before it can serve as a full packaged acceptance harness. That harness defect is separate from the product snapshot read/cleanup paths fixed here.