### PR TITLE
fix(daemon): honor selected examples on ordinary runs

### DIFF
--- a/apps/daemon/src/plugins/resolve-snapshot.ts
+++ b/apps/daemon/src/plugins/resolve-snapshot.ts
@@ -88,6 +88,13 @@ export interface ResolveSnapshotInput {
    */
   requireSnapshotProjectMatch?: boolean | undefined;
   /**
+   * Whether a request that names no plugin or snapshot may implicitly reuse
+   * the project's durable pin. Run creation normally enables this behavior;
+   * callers that have rejected a stale daemon-owned selection can disable it
+   * so that rejection cannot fall through to an unrelated historical pin.
+   */
+  allowProjectPinFallback?: boolean | undefined;
+  /**
    * Internal Coordinator-only activation. This is not parsed from an HTTP or
    * CLI request body, so ordinary catalog/apply paths stay fail closed.
    */
@@ -195,7 +202,12 @@ export function resolvePluginSnapshot(input: ResolveSnapshotInput): ResolveSnaps
   // conversation create that ran the plugin), reuse it. This is what
   // makes ChatComposer's "start a run" path work after the user picked a
   // plugin in NewProjectPanel — the body only carries `projectId`.
-  if (!fields.pluginId && !fields.snapshotId && input.projectId) {
+  if (
+    !fields.pluginId
+    && !fields.snapshotId
+    && input.projectId
+    && input.allowProjectPinFallback !== false
+  ) {
     const pinned = readProjectPinnedSnapshotId(input.db, input.projectId);
     if (pinned) {
       fields.snapshotId = pinned;

--- a/apps/daemon/src/plugins/resolve-snapshot.ts
+++ b/apps/daemon/src/plugins/resolve-snapshot.ts
@@ -97,6 +97,12 @@ export interface ResolveSnapshotInput {
     plugin: InstalledPluginRecord;
   } | undefined;
   /**
+   * Apply an exact daemon-selected plugin for this Run without replacing the
+   * project's or conversation's durable plugin pin. The Run route links the
+   * resulting immutable snapshot after it claims the Run.
+   */
+  runScopedActivation?: boolean | undefined;
+  /**
    * Daemon-owned provenance to stamp when this call changes the durable
    * project pin. Omit for fallback reuse; explicit request fields default to
    * `explicit_user`.
@@ -177,7 +183,10 @@ function pickPluginFields(body: Record<string, unknown> | null | undefined) {
 export function resolvePluginSnapshot(input: ResolveSnapshotInput): ResolveSnapshotResult {
   const fields = pickPluginFields(input.body);
   const requestNamedBinding = Boolean(fields.pluginId || fields.snapshotId);
-  const projectBinding = input.internalStrategyActivation
+  const runScopedActivation = Boolean(
+    input.internalStrategyActivation || input.runScopedActivation,
+  );
+  const projectBinding = runScopedActivation
     ? null
     : input.projectBinding
       ?? (requestNamedBinding ? { provenance: 'explicit_user' as const } : null);
@@ -419,8 +428,10 @@ function finalizeOk(args: {
   // Rollout activation is run-scoped authority. It must not replace the
   // user's durable project/conversation plugin pin; rollback then affects new
   // tasks while this run remains linked to its immutable strategy snapshot.
-  const runScopedStrategy = Boolean(args.input.internalStrategyActivation);
-  if (args.input.projectId && !runScopedStrategy) {
+  const runScopedActivation = Boolean(
+    args.input.internalStrategyActivation || args.input.runScopedActivation,
+  );
+  if (args.input.projectId && !runScopedActivation) {
     linkSnapshotToProject(db, snap.snapshotId, args.input.projectId);
     if (args.projectBinding) {
       writeProjectScenarioBinding(db, {
@@ -434,7 +445,7 @@ function finalizeOk(args: {
       });
     }
   }
-  if (args.input.conversationId && !runScopedStrategy) {
+  if (args.input.conversationId && !runScopedActivation) {
     linkSnapshotToConversation(db, snap.snapshotId, args.input.conversationId);
   }
   if (args.input.runId) {

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1743,6 +1743,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         && verifiedScenarioBinding?.provenance === 'automatic_default'
         && verifiedScenarioBinding.pluginId === defaultPluginId,
       );
+      const suppressAutomaticDefaultPinFallback = Boolean(
+        projectPinIsAutomaticDefault
+        && verifiedExampleBinding
+        && !selectedExamplePlugin,
+      );
       const suppliedContextPluginWasNamed = Boolean(
         Array.isArray((rolloutProject?.metadata as ContractProjectMetadata | undefined)?.contextPlugins)
         && (rolloutProject?.metadata as ContractProjectMetadata).contextPlugins!.length > 0
@@ -1992,6 +1997,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           registry: registryView,
           connectorProbe: buildConnectorProbe(connectorService),
           requireSnapshotProjectMatch: true,
+          allowProjectPinFallback: !suppressAutomaticDefaultPinFallback,
           ...(selectedExamplePlugin ? { plugin: selectedExamplePlugin } : {}),
           ...(selectedExamplePlugin ? { runScopedActivation: true } : {}),
           ...(!selectedExamplePlugin && defaultPluginId
@@ -2016,6 +2022,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         registry: registryView,
         connectorProbe: buildConnectorProbe(connectorService),
         requireSnapshotProjectMatch: true,
+        allowProjectPinFallback: !suppressAutomaticDefaultPinFallback,
         ...(selectedExamplePlugin ? { plugin: selectedExamplePlugin } : {}),
         ...(selectedExamplePlugin && runResolveBody.pluginId === selectedExamplePlugin.id
           ? { runScopedActivation: true }

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1918,7 +1918,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             pluginId: 'od-next-strategy',
             appliedPluginSnapshotId: undefined,
           };
-        } else if (!hasPin) {
+        } else if (!hasPin || (projectPinIsAutomaticDefault && selectedExamplePlugin)) {
           // An official example card is the user's concrete choice inside this
           // task type. When OD Next is not active, execute that exact example
           // on the ordinary route instead of silently substituting the
@@ -1976,7 +1976,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       if (!explicitUserPlugin && strategyRolloutDecision?.effectiveMode === 'active') {
         automaticOrdinaryFallbackPluginId = selectedExamplePlugin?.id
           ?? (verifiedExampleBinding ? null : defaultPluginId);
-        const fallbackBody = !projectHasExplicitPin && automaticOrdinaryFallbackPluginId
+        const fallbackBody = (
+          !projectHasExplicitPin
+          || (projectPinIsAutomaticDefault && selectedExamplePlugin)
+        )
+          && automaticOrdinaryFallbackPluginId
           && (selectedExamplePlugin || getInstalledPlugin(db, automaticOrdinaryFallbackPluginId))
           ? { ...requestBody, pluginId: automaticOrdinaryFallbackPluginId }
           : requestBody;

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -6,12 +6,14 @@ import { createHash, randomUUID } from 'node:crypto';
 import {
   composeOdNextStrategyContinuationV2,
   defaultScenarioPluginIdForProjectMetadata,
+  InstalledPluginRecordSchema,
   RUN_RESULT_PACKAGE_SCHEMA,
   type AppliedPluginSnapshot,
   type ArtifactManifest,
   type ByokChatProviderConfig,
   type ChatRunStatus,
   type ChatRunStatusResponse,
+  type InstalledPluginRecord,
   type StrategyTaskProjectionV2,
   type ProjectMetadata as ContractProjectMetadata,
   type RunResultPackageResponse,
@@ -130,6 +132,10 @@ import {
   type ResolveSnapshotResult,
 } from '../plugins/index.js';
 import { getSnapshot, linkSnapshotToRun } from '../plugins/snapshots.js';
+import {
+  digestExampleSkillManifest,
+  readVerifiedProjectExampleBinding,
+} from '../plugins/example-binding.js';
 import {
   assertSandboxProjectRootAvailable,
   isSafeId,
@@ -1703,6 +1709,35 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       const verifiedStrategyBinding = readVerifiedProjectStrategyBinding(
         rolloutProject?.metadata as ContractProjectMetadata | null | undefined,
       );
+      const verifiedExampleBinding = readVerifiedProjectExampleBinding(
+        rolloutProject?.metadata as ContractProjectMetadata | null | undefined,
+      );
+      let selectedExamplePlugin: InstalledPluginRecord | null = null;
+      if (verifiedExampleBinding) {
+        try {
+          const candidate = await ctx.plugins.getLocalPluginBySource?.(
+            verifiedExampleBinding.pluginId,
+            verifiedExampleBinding.pluginSource,
+          );
+          const parsed = InstalledPluginRecordSchema.safeParse(candidate);
+          if (
+            !parsed.success
+            || parsed.data.id !== verifiedExampleBinding.pluginId
+            || parsed.data.source !== verifiedExampleBinding.pluginSource
+            || await digestExampleSkillManifest(parsed.data.fsPath)
+              !== verifiedExampleBinding.manifestSourceDigest
+          ) {
+            throw new Error('the bound example no longer resolves to its frozen identity');
+          }
+          selectedExamplePlugin = parsed.data;
+        } catch (error) {
+          console.warn(
+            `[plugins] selected example ${verifiedExampleBinding.pluginId} is unavailable for ordinary fallback: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
       const projectPinIsAutomaticDefault = Boolean(
         projectHasExplicitPin
         && verifiedScenarioBinding?.provenance === 'automatic_default'
@@ -1884,10 +1919,20 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             appliedPluginSnapshotId: undefined,
           };
         } else if (!hasPin) {
-          const fallbackPluginId = defaultPluginId;
-          if (fallbackPluginId && getInstalledPlugin(db, fallbackPluginId)) {
+          // An official example card is the user's concrete choice inside this
+          // task type. When OD Next is not active, execute that exact example
+          // on the ordinary route instead of silently substituting the
+          // project-kind default (for decks, the unrelated simple-deck/COO
+          // template). A stale/unavailable binding deliberately yields no
+          // plugin rather than a different template.
+          const fallbackPluginId = selectedExamplePlugin?.id
+            ?? (verifiedExampleBinding ? null : defaultPluginId);
+          if (
+            fallbackPluginId
+            && (selectedExamplePlugin || getInstalledPlugin(db, fallbackPluginId))
+          ) {
             runResolveBody = { ...requestBody, pluginId: fallbackPluginId };
-            synthesizedAutomaticDefault = true;
+            synthesizedAutomaticDefault = !selectedExamplePlugin;
           }
         }
       }
@@ -1929,10 +1974,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         return res.status(500).json({ error: String(err) });
       }
       if (!explicitUserPlugin && strategyRolloutDecision?.effectiveMode === 'active') {
-        automaticOrdinaryFallbackPluginId = defaultPluginId;
-        const fallbackBody = !projectHasExplicitPin && defaultPluginId
-          && getInstalledPlugin(db, defaultPluginId)
-          ? { ...requestBody, pluginId: defaultPluginId }
+        automaticOrdinaryFallbackPluginId = selectedExamplePlugin?.id
+          ?? (verifiedExampleBinding ? null : defaultPluginId);
+        const fallbackBody = !projectHasExplicitPin && automaticOrdinaryFallbackPluginId
+          && (selectedExamplePlugin || getInstalledPlugin(db, automaticOrdinaryFallbackPluginId))
+          ? { ...requestBody, pluginId: automaticOrdinaryFallbackPluginId }
           : requestBody;
         resolveAutomaticOrdinaryFallback = () => resolvePluginSnapshot({
           db,
@@ -1942,7 +1988,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           registry: registryView,
           connectorProbe: buildConnectorProbe(connectorService),
           requireSnapshotProjectMatch: true,
-          ...(defaultPluginId
+          ...(selectedExamplePlugin ? { plugin: selectedExamplePlugin } : {}),
+          ...(selectedExamplePlugin ? { runScopedActivation: true } : {}),
+          ...(!selectedExamplePlugin && defaultPluginId
             ? {
                 projectBinding: {
                   provenance: 'automatic_default' as const,
@@ -1964,6 +2012,10 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         registry: registryView,
         connectorProbe: buildConnectorProbe(connectorService),
         requireSnapshotProjectMatch: true,
+        ...(selectedExamplePlugin ? { plugin: selectedExamplePlugin } : {}),
+        ...(selectedExamplePlugin && runResolveBody.pluginId === selectedExamplePlugin.id
+          ? { runScopedActivation: true }
+          : {}),
         ...(!activatingStrategy && !explicitExecutablePlugin
           && (projectPinIsAutomaticDefault || synthesizedAutomaticDefault)
           && defaultPluginId

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -273,6 +273,118 @@ describe('OD Next automatic production through the real server', () => {
     expect(invocations[0]?.stdin).not.toContain('克制的 COO');
   });
 
+  it('lets a verified example replace an existing automatic-default pin for only the current run', async () => {
+    const fixture = await createPublicRolloutFixture('selected-example-upgrade', 'design');
+    started = fixture.started;
+    binDir = fixture.binDir;
+    clearOdNextRolloutStop(database());
+
+    const createAffectedProject = async (label: string) => {
+      const project = await createProjectForScenario(
+        started!.url,
+        label,
+        { kind: 'deck' },
+        undefined,
+        undefined,
+        {
+          pluginId: 'example-fs-creative-voltage',
+          source: CREATIVE_VOLTAGE_EXAMPLE_DIR,
+        },
+      );
+      expect(project.appliedPluginSnapshotId).toEqual(expect.any(String));
+      expect(project.metadata?.scenarioBinding).toMatchObject({
+        provenance: 'automatic_default',
+        pluginId: 'example-simple-deck',
+        snapshotId: project.appliedPluginSnapshotId,
+      });
+      expect(project.metadata?.exampleBinding).toMatchObject({
+        provenance: 'example_card',
+        pluginId: 'example-fs-creative-voltage',
+        pluginSource: CREATIVE_VOLTAGE_EXAMPLE_DIR,
+      });
+      return project;
+    };
+    const expectRunScopedExample = (
+      project: Awaited<ReturnType<typeof createAffectedProject>>,
+      created: {
+        pluginId?: string;
+        appliedPluginSnapshotId?: string;
+        runId?: string;
+      },
+    ) => {
+      expect(created.pluginId).toBe('example-fs-creative-voltage');
+      expect(created.appliedPluginSnapshotId).toEqual(expect.any(String));
+      expect(created.appliedPluginSnapshotId).not.toBe(project.appliedPluginSnapshotId);
+      expect(database().prepare(`
+        SELECT applied_plugin_snapshot_id AS snapshotId
+          FROM projects
+         WHERE id = ?
+      `).get(project.projectId)).toEqual({ snapshotId: project.appliedPluginSnapshotId });
+      expect(database().prepare(`
+        SELECT applied_plugin_snapshot_id AS snapshotId
+          FROM conversations
+         WHERE id = ?
+      `).get(project.conversationId)).toEqual({ snapshotId: project.appliedPluginSnapshotId });
+      expect(database().prepare(`
+        SELECT plugin_id AS pluginId, run_id AS runId
+          FROM applied_plugin_snapshots
+         WHERE id = ?
+      `).get(created.appliedPluginSnapshotId)).toEqual({
+        pluginId: 'example-fs-creative-voltage',
+        runId: created.runId,
+      });
+    };
+
+    const rolloutOffProject = await createAffectedProject('selected-example-upgrade-off');
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+    const ordinary = await postRun(started.url, publicRunRequest(
+      rolloutOffProject,
+      'Use the selected example after upgrading the ordinary route.',
+      'selected-example-upgrade-off',
+    ));
+    expect(ordinary.strategyTask).toBeUndefined();
+    await waitForRunTerminal(started.url, ordinary.runId as string);
+    expectRunScopedExample(rolloutOffProject, ordinary);
+
+    const prestartFallbackProject = await createAffectedProject(
+      'selected-example-upgrade-prestart',
+    );
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'active';
+    process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY = '1';
+    database().exec(`
+      CREATE TRIGGER reject_selected_example_strategy_task
+      BEFORE INSERT ON strategy_task_executions
+      BEGIN
+        SELECT RAISE(ABORT, 'fixture selected-example strategy preparation rejected');
+      END
+    `);
+    try {
+      const fallback = await postRun(started.url, publicRunRequest(
+        prestartFallbackProject,
+        'Use the selected example after automatic pre-start fallback.',
+        'selected-example-upgrade-prestart',
+      ));
+      expect(fallback.strategyTask).toBeUndefined();
+      expect(fallback.taskExecutionId).toBeUndefined();
+      await waitForRunTerminal(started.url, fallback.runId as string);
+      expectRunScopedExample(prestartFallbackProject, fallback);
+    } finally {
+      database().exec('DROP TRIGGER IF EXISTS reject_selected_example_strategy_task');
+    }
+
+    const invocations = await readProjectInvocations(fixture.logPath, rolloutOffProject.projectId);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]?.stdin).toContain('Creative Voltage');
+    expect(invocations[0]?.stdin).not.toContain('克制的 COO');
+    const fallbackInvocations = await readProjectInvocations(
+      fixture.logPath,
+      prestartFallbackProject.projectId,
+    );
+    expect(fallbackInvocations).toHaveLength(1);
+    expect(fallbackInvocations[0]?.stdin).toContain('Creative Voltage');
+    expect(fallbackInvocations[0]?.stdin).not.toContain('克制的 COO');
+  });
+
   // ACCEPTANCE for the opt-in switch. Nothing configured takes the ordinary
   // route; the SAME running daemon takes the OD Next route on the next run
   // once `odNextStrategyMode` is saved through the public app-config API. No

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from 'node:http';
 import { execFile } from 'node:child_process';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -34,7 +34,11 @@ vi.mock('node:crypto', async (importOriginal) => {
 
 import { closeDatabase, openDatabase } from '../src/db.js';
 import { createSnapshot, linkSnapshotToProject } from '../src/plugins/snapshots.js';
-import { resolvePluginFolder, upsertInstalledPlugin } from '../src/plugins/registry.js';
+import {
+  getInstalledPlugin,
+  resolvePluginFolder,
+  upsertInstalledPlugin,
+} from '../src/plugins/registry.js';
 import { createBundledStrategyBindingV2 } from '../src/plugins/strategy-package.js';
 import { startServer, type StartServerOptions } from '../src/server.js';
 import {
@@ -383,6 +387,112 @@ describe('OD Next automatic production through the real server', () => {
     expect(fallbackInvocations).toHaveLength(1);
     expect(fallbackInvocations[0]?.stdin).toContain('Creative Voltage');
     expect(fallbackInvocations[0]?.stdin).not.toContain('克制的 COO');
+  });
+
+  it('does not reuse an automatic-default pin when the bound example identity is stale', async () => {
+    const fixture = await createPublicRolloutFixture('stale-selected-example', 'design');
+    started = fixture.started;
+    binDir = fixture.binDir;
+    clearOdNextRolloutStop(database());
+    const exampleDir = path.join(binDir, 'stale-selected-example');
+    await cp(CREATIVE_VOLTAGE_EXAMPLE_DIR, exampleDir, { recursive: true });
+    const staleExamplePluginId = 'example-stale-creative-voltage';
+    const manifestPath = path.join(exampleDir, 'open-design.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as Record<string, unknown>;
+    await writeFile(manifestPath, JSON.stringify({
+      ...manifest,
+      name: staleExamplePluginId,
+    }), 'utf8');
+    const installResponse = await fetch(`${started.url}/api/plugins/install`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+      body: JSON.stringify({ source: exampleDir }),
+    });
+    const installEvents = await installResponse.text();
+    expect(installEvents).toContain('event: success');
+    const installedExample = getInstalledPlugin(database(), staleExamplePluginId);
+    expect(installedExample).not.toBeNull();
+
+    const createAffectedProject = async (label: string) => {
+      const project = await createProjectForScenario(
+        started!.url,
+        label,
+        { kind: 'deck' },
+        undefined,
+        undefined,
+        {
+          pluginId: staleExamplePluginId,
+          source: installedExample!.source,
+        },
+      );
+      expect(project.appliedPluginSnapshotId).toEqual(expect.any(String));
+      expect(project.metadata?.scenarioBinding).toMatchObject({
+        provenance: 'automatic_default',
+        pluginId: 'example-simple-deck',
+        snapshotId: project.appliedPluginSnapshotId,
+      });
+      return project;
+    };
+    const rolloutOffProject = await createAffectedProject('stale-selected-example-off');
+    const prestartFallbackProject = await createAffectedProject(
+      'stale-selected-example-prestart',
+    );
+
+    // Both projects froze the original manifest identity. Mutating it now
+    // reproduces an example that was removed or upgraded after selection.
+    await writeFile(
+      path.join(installedExample!.fsPath, 'SKILL.md'),
+      '# Changed after the project selected this example\n',
+      'utf8',
+    );
+
+    const expectDefaultWasNotReused = async (
+      project: Awaited<ReturnType<typeof createAffectedProject>>,
+      created: { pluginId?: string; runId?: string },
+    ) => {
+      expect(created.pluginId).toBeUndefined();
+      await waitForRunTerminal(started!.url, created.runId as string);
+      expect(database().prepare(`
+        SELECT applied_plugin_snapshot_id AS snapshotId
+          FROM projects
+         WHERE id = ?
+      `).get(project.projectId)).toEqual({ snapshotId: project.appliedPluginSnapshotId });
+      const invocations = await readProjectInvocations(fixture.logPath, project.projectId);
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]?.stdin).not.toContain('Creative Voltage');
+      expect(invocations[0]?.stdin).not.toContain('克制的 COO');
+    };
+
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+    const ordinary = await postRun(started.url, publicRunRequest(
+      rolloutOffProject,
+      'Do not substitute an unrelated default for the stale example.',
+      'stale-selected-example-off',
+    ));
+    expect(ordinary.strategyTask).toBeUndefined();
+    await expectDefaultWasNotReused(rolloutOffProject, ordinary);
+
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'active';
+    process.env.OD_NEXT_STRATEGY_LOCAL_SYNTHETIC_CANARY = '1';
+    database().exec(`
+      CREATE TRIGGER reject_stale_example_strategy_task
+      BEFORE INSERT ON strategy_task_executions
+      BEGIN
+        SELECT RAISE(ABORT, 'fixture stale-example strategy preparation rejected');
+      END
+    `);
+    try {
+      const fallback = await postRun(started.url, publicRunRequest(
+        prestartFallbackProject,
+        'Do not substitute an unrelated default after pre-start fallback.',
+        'stale-selected-example-prestart',
+      ));
+      expect(fallback.strategyTask).toBeUndefined();
+      expect(fallback.taskExecutionId).toBeUndefined();
+      await expectDefaultWasNotReused(prestartFallbackProject, fallback);
+    } finally {
+      database().exec('DROP TRIGGER IF EXISTS reject_stale_example_strategy_task');
+    }
   });
 
   // ACCEPTANCE for the opt-in switch. Nothing configured takes the ordinary

--- a/apps/daemon/tests/od-next-automatic-simple-server.test.ts
+++ b/apps/daemon/tests/od-next-automatic-simple-server.test.ts
@@ -87,6 +87,13 @@ const THREAD_ID = '019fffaa-0000-7000-8000-000000000010';
 const execFileP = promisify(execFile);
 const DAEMON_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const REPO_ROOT = path.resolve(DAEMON_ROOT, '../..');
+const CREATIVE_VOLTAGE_EXAMPLE_DIR = path.join(
+  REPO_ROOT,
+  'plugins',
+  '_official',
+  'examples',
+  'fs-creative-voltage',
+);
 const CLI_SRC = path.resolve(DAEMON_ROOT, 'src/cli.ts');
 const TSX_CLI = path.resolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
 const EXECUTION_PREFLIGHT = {
@@ -196,6 +203,74 @@ describe('OD Next automatic production through the real server', () => {
     const researchContract = invocations[0]!.stdin.slice(researchStart, researchEnd);
     expect(researchContract).toContain('ORDINARY_PRIOR_MARKER');
     expect(researchContract).toContain('Run the ordinary public fixture.');
+  });
+
+  it('runs the selected official example on the ordinary route without pinning it to the project', async () => {
+    const fixture = await createPublicRolloutFixture('selected-example-ordinary', 'design');
+    started = fixture.started;
+    binDir = fixture.binDir;
+    process.env.OD_NEXT_STRATEGY_ROLLOUT = 'off';
+
+    const selected = await createProjectForScenario(
+      started.url,
+      'selected-example-deck',
+      { kind: 'deck' },
+      undefined,
+      'ppt',
+      {
+        pluginId: 'example-fs-creative-voltage',
+        source: CREATIVE_VOLTAGE_EXAMPLE_DIR,
+      },
+    );
+    expect(selected.appliedPluginSnapshotId).toBeUndefined();
+    expect(selected.metadata?.exampleBinding).toMatchObject({
+      provenance: 'example_card',
+      pluginId: 'example-fs-creative-voltage',
+      pluginSource: CREATIVE_VOLTAGE_EXAMPLE_DIR,
+    });
+
+    const created = await postRun(started.url, publicRunRequest(
+      selected,
+      'Build the selected fundraising deck.',
+      'selected-example-ordinary',
+    ));
+    expect(created.strategyTask).toBeUndefined();
+    expect(created.pluginId).toBe('example-fs-creative-voltage');
+    expect(created.appliedPluginSnapshotId).toEqual(expect.any(String));
+    await waitForRunTerminal(started.url, created.runId as string);
+
+    expect(database().prepare(`
+      SELECT applied_plugin_snapshot_id AS snapshotId
+        FROM projects
+       WHERE id = ?
+    `).get(selected.projectId)).toEqual({ snapshotId: null });
+    expect(database().prepare(`
+      SELECT applied_plugin_snapshot_id AS snapshotId
+        FROM conversations
+       WHERE id = ?
+    `).get(selected.conversationId)).toEqual({ snapshotId: null });
+    expect(database().prepare(`
+      SELECT plugin_id AS pluginId, run_id AS runId
+        FROM applied_plugin_snapshots
+       WHERE id = ?
+    `).get(created.appliedPluginSnapshotId)).toEqual({
+      pluginId: 'example-fs-creative-voltage',
+      runId: created.runId,
+    });
+    const userMessage = database().prepare(`
+      SELECT applied_plugin_snapshot_json AS snapshotJson
+        FROM messages
+       WHERE id = ?
+    `).get('user-selected-example-ordinary') as { snapshotJson: string };
+    expect(JSON.parse(userMessage.snapshotJson)).toMatchObject({
+      pluginId: 'example-fs-creative-voltage',
+      pluginTitle: 'Write a Seed Pitch like a Top Pre-Seed Founder',
+    });
+
+    const invocations = await readProjectInvocations(fixture.logPath, selected.projectId);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]?.stdin).toContain('Creative Voltage');
+    expect(invocations[0]?.stdin).not.toContain('克制的 COO');
   });
 
   // ACCEPTANCE for the opt-in switch. Nothing configured takes the ordinary
@@ -2310,6 +2385,7 @@ async function createProjectForScenario(
     pluginInputs: Record<string, unknown>;
   },
   automaticStrategyTaskProfile?: ProjectScenarioTaskProfile,
+  exampleReference?: { pluginId: string; source: string },
 ) {
   const projectId = `od-next-public-${label}-${Date.now()}`;
   const response = await fetch(`${url}/api/projects`, {
@@ -2321,6 +2397,7 @@ async function createProjectForScenario(
       metadata,
       ...plugin,
       ...(automaticStrategyTaskProfile ? { automaticStrategyTaskProfile } : {}),
+      ...(exampleReference ? { exampleReference } : {}),
       conversationMode: 'design',
       skipDiscoveryBrief: true,
     }),
@@ -2341,6 +2418,11 @@ async function createProjectForScenario(
           provenance: string;
           taskProfile: ProjectScenarioTaskProfile;
           boundAt: number;
+        };
+        exampleBinding?: {
+          provenance: string;
+          pluginId: string;
+          pluginSource: string;
         };
       };
     };


### PR DESCRIPTION
Fixes #7532

## Why

While validating homepage example cards in the desktop beta, selecting the pre-seed fundraising deck opened a chat that actually ran the unrelated `example-simple-deck` / 克制的 COO 经营复盘 template. The homepage stores an example reference without durably pinning a plugin so OD Next can remain eligible, but the ordinary Run fallback ignored that reference whenever OD Next was off, observing, ineligible, or failed before start. That also persisted the wrong snapshot onto the user turn, making the chat plugin indicator missing or incorrect.

## What users will see

A project created from an official homepage example now uses that exact example when it takes the ordinary Run path. The chat shows the selected example plugin, and enabling OD Next later remains possible because the example snapshot is scoped to the Run rather than pinned to the project or conversation. If the bound example no longer matches its frozen identity, Open Design will not silently substitute an unrelated default template.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: the fix changes daemon-side Run resolution without adding or changing UI components. The persisted snapshot feeding the existing chat plugin indicator is covered by the regression test.

## Bug fix verification

- Test path: `apps/daemon/tests/od-next-automatic-simple-server.test.ts`
- Red on current `main`: expected `example-fs-creative-voltage`, received `example-simple-deck`.
- Green on this branch: selected example, Run snapshot link, non-pinned project/conversation state, persisted user-turn plugin metadata, and prompt content all pass.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/od-next-automatic-simple-server.test.ts` (29/29)
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/plugins-strategy-package.test.ts tests/plugins-dod-e2e.test.ts` (17/17)