### PR TITLE
fix(web): keep top-right controls clickable on first launch

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5415,8 +5415,8 @@ function AppInner() {
           onboardingCompleted={config.onboardingCompleted === true}
           identityScopeKey={workspaceTabsIdentityScopeKey}
         />
-        {/* Avatar + credits keep their home-view spot (the fixed top-right
-            corner over the tabs chrome) while a project tab is open, even
+        {/* Avatar + credits keep their home-view spot (the top-right actions
+            host inside the tabs chrome) while a project tab is open, even
             though EntryShell — the cluster's usual owner — is unmounted here.
             Home and the other entry views mount theirs through EntryNavRail;
             the routes are mutually exclusive, so exactly one is on screen. */}

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -97,6 +97,7 @@ import {
   workspaceAnalyticsDimensions,
 } from '../analytics/workspace';
 import { WorkbenchCampaignBadge } from './WorkbenchCampaignBadge';
+import { workspaceChromeAccountActionsHost } from './workspaceChromeActions';
 
 const REPO_URL = 'https://github.com/nexu-io/open-design';
 const GITHUB_HELP_URL = `${REPO_URL}/issues/new`;
@@ -210,7 +211,7 @@ interface Props {
   newProjectDisabled?: boolean;
   /** When false the rail is collapsed (hidden off-canvas) on the entry view. */
   open: boolean;
-  /** Extra content for the floating top-right cluster, rendered LEFT of the
+  /** Extra content for the top-right chrome cluster, rendered LEFT of the
    *  account module (e.g. the DeepSeek campaign badge). */
   topRightSlot?: ReactNode;
   /** The one shared workspace context; null → local (no cloud identity) state. */
@@ -233,7 +234,7 @@ interface Props {
    * The update-ready host (`UpdaterPopup`), which renders nothing until the
    * updater reports a downloaded, unopened installer.
    *
-   * It is an independent control in the floating top-right cluster
+   * It is an independent control in the top-right chrome cluster
    * (`.entry-nav-rail__account-updater`), immediately after the account capsule
    * when one is present.
    */
@@ -546,7 +547,7 @@ interface EntryTopRightClusterProps {
 }
 
 /**
- * Top-right floating cluster (portaled to document.body): an optional leading
+ * Top-right chrome cluster: an optional leading
  * slot, the standalone credits pill, and the avatar account module with its
  * hover menu — one flex row riding the workbench top-right corner.
  *
@@ -575,6 +576,21 @@ export function EntryTopRightCluster({
   const { t } = useI18n();
   const analytics = useAnalytics();
   const workspaceDimensions = workspaceAnalyticsDimensions(context);
+  const [chromeActionsHost, setChromeActionsHost] = useState<HTMLElement | null>(
+    workspaceChromeAccountActionsHost,
+  );
+
+  // On the initial App render the tabs chrome and this cluster are committed
+  // in the same pass, so the host does not exist while this component renders.
+  // A layout effect finds it after the DOM commit and moves the controls before
+  // paint. Electron can then build its first draggable-region hit map with the
+  // no-drag controls as real descendants of the drag header.
+  useLayoutEffect(() => {
+    // Isolated component harnesses do not mount the application chrome. Keep
+    // those public component tests usable without re-creating the whole App;
+    // the real shell always supplies the dedicated host above.
+    setChromeActionsHost(workspaceChromeAccountActionsHost() ?? document.body);
+  }, []);
 
   const isTeam = Boolean(context) && context!.workspaceType === 'team';
   const permissions = context?.permissions;
@@ -642,7 +658,7 @@ export function EntryTopRightCluster({
     const observer = new MutationObserver(syncVisibility);
     observer.observe(host, { childList: true });
     return () => observer.disconnect();
-  }, [updaterSlot]);
+  }, [chromeActionsHost, updaterSlot]);
   const accountOpen = accountMenuMode !== 'closed';
   const closeAccountMenu = () => setAccountMenuMode('closed');
   useEffect(() => {
@@ -784,7 +800,7 @@ export function EntryTopRightCluster({
     });
   }
 
-  if (typeof document === 'undefined') return null;
+  if (typeof document === 'undefined' || !chromeActionsHost) return null;
   if (!leadingSlot && !context && !updaterSlot) return null;
 
   const clusterVisible = Boolean(leadingSlot || context || updaterControlVisible);
@@ -1058,7 +1074,7 @@ export function EntryTopRightCluster({
             {updaterSlot}
           </div>
         </div>,
-        document.body,
+        chromeActionsHost,
       )}
       {/* Panel + unread polling live here (outside the hover menu, which
           unmounts when closed); the 消息中心 menu row above just opens it.
@@ -1910,9 +1926,9 @@ export function EntryNavRail({
             : undefined
         }
       />
-      {/* Top-right floating cluster: campaign badge (slot) + credits pill +
-          the account module, portaled to document.body so all ride the
-          workbench top-right corner in one flex row. Extracted so the project
+      {/* Top-right chrome cluster: campaign badge (slot) + credits pill +
+          the account module, mounted into the tabs chrome's no-drag actions
+          host so Electron includes it in the first native hit map. Extracted so the project
           route can mount the same cluster without the rail (see
           `EntryTopRightCluster`). */}
       <EntryTopRightCluster

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -30,6 +30,7 @@ import {
 import { homeHeroChipLabel } from './home-hero/chip-labels';
 import { useGlideIndicator } from '../hooks/useGlideIndicator';
 import { useLiquidGlass } from '../hooks/useLiquidGlass';
+import { WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID } from './workspaceChromeActions';
 
 type WorkspaceChromeTab =
   | {
@@ -1685,9 +1686,9 @@ export function WorkspaceTabsBar({
       aria-label="Workspace tabs"
     >
       <div className="app-chrome-traffic-space workspace-tabs-traffic" aria-hidden />
-      {/* Docked mode: the chrome row keeps only the brand-logo button (the
-          floating account cluster rides fixed at the window's top-right on
-          its own); the strip renders in the chat column's dock, level with
+      {/* Docked mode: the chrome row keeps the brand-logo button plus the
+          account actions host at the window's top-right; the strip renders in
+          the chat column's dock, level with
           the workspace 设计文件 row. The strip's own pinned entry tab hides
           inside the dock (CSS) — this button is its chrome-row stand-in.
           In chat the logo means 回到首页. */}
@@ -1866,6 +1867,11 @@ export function WorkspaceTabsBar({
       </div>
       </>,
       )}
+      <div
+        id={WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID}
+        className="workspace-chrome-account-actions"
+        data-testid="workspace-chrome-account-actions"
+      />
       {radialMenu ? createPortal(
         <div className="workspace-radial-layer" onMouseDown={() => setRadialMenu(null)}>
           <div

--- a/apps/web/src/components/workspaceChromeActions.ts
+++ b/apps/web/src/components/workspaceChromeActions.ts
@@ -1,0 +1,6 @@
+export const WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID = 'workspace-chrome-account-actions';
+
+export function workspaceChromeAccountActionsHost(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID);
+}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1163,29 +1163,14 @@
   scrollbar-gutter: stable;
 }
 
-/* Floating top-right cluster (portaled to document.body): campaign badge on
-   the left, account module on the right, one flex row. Owns the fixed
-   position + z-index that used to live on the badge itself. Must clear
-   .workspace-tabs-chrome (z-index: 120).
-
-   `top` vertically centers the cluster's 26px pills in the 44px tabs-chrome
-   row — (44 − 26) / 2 = 9 — so their centerline matches the pinned Home
-   tab's (32px, strip-centered). The chrome height is a hard 44px in shell.css; its
-   --workspace-tabs-chrome-height var is scoped to .workspace-shell and
-   unreadable from this body-level portal. */
+/* Top-right cluster inside the tabs chrome's dedicated no-drag actions host:
+   campaign badge on the left, account module on the right, one flex row. */
 .entry-top-right-cluster {
-  position: fixed;
-  z-index: 150;
-  top: 9px;
-  right: 22px;
   display: flex;
   align-items: center;
   gap: 10px;
 }
-/* The cluster overlaps the desktop window's draggable chrome strip
-   (.workspace-tabs-chrome). app-region is not inherited, so without an
-   explicit no-drag on every node the drag region swallows hover/click —
-   the account menu could never open. */
+/* app-region is not inherited, so keep every interactive descendant explicit. */
 .entry-top-right-cluster,
 .entry-top-right-cluster * {
   -webkit-app-region: no-drag;
@@ -1243,11 +1228,6 @@
 }
 
 @media (max-width: 760px) {
-  /* Tighter right inset only — the vertical centering against the 44px
-     chrome row is the same at every width. */
-  .entry-top-right-cluster {
-    right: 12px;
-  }
   .entry-deepseek-campaign-badge {
     max-width: calc(100vw - 88px);
   }

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -84,7 +84,7 @@
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
-  margin-left: 12px;
+  margin-left: auto;
   margin-right: 12px;
   -webkit-app-region: no-drag;
 }

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -37,11 +37,10 @@
   backdrop-filter: none;
   overflow: hidden;
 }
-/* The shell grid owns exactly two children: the tabs chrome and the body.
-   Pin each to its row so a stray extra shell child (e.g. an inline popover
-   anchor mounted at shell level — the floating account cluster renders its
-   MessageCenter anchor there) falls into a zero-height implicit row instead
-   of auto-placing into (and stealing) the 1fr body row. */
+/* The shell grid owns exactly two layout children: the tabs chrome and the
+   body. Pin each to its row so any non-layout shell child falls into a
+   zero-height implicit row instead of auto-placing into (and stealing) the
+   1fr body row. */
 .workspace-shell > .workspace-tabs-chrome {
   grid-row: 1;
 }
@@ -77,9 +76,17 @@
   border-bottom: 0;
   user-select: none;
   -webkit-app-region: drag;
-  overflow: hidden;
+  overflow: visible;
   position: relative;
   z-index: 120;
+}
+.workspace-chrome-account-actions {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-left: 12px;
+  margin-right: 12px;
+  -webkit-app-region: no-drag;
 }
 .workspace-tabs-chrome .workspace-tabs-traffic {
   margin-right: var(--app-chrome-traffic-margin);

--- a/apps/web/tests/components/App.project-account-cluster.test.tsx
+++ b/apps/web/tests/components/App.project-account-cluster.test.tsx
@@ -3,7 +3,7 @@
 // The floating avatar + credits cluster must survive opening a project.
 //
 // The entry refresh moved the account module (avatar chip + credits pill)
-// into a fixed top-right cluster owned by EntryNavRail — which unmounts with
+// into a top-right chrome cluster owned by EntryNavRail — which unmounts with
 // EntryShell the moment a project tab opens. Product: the avatar and credits
 // stay visible on the project view too, in the same top-right spot. App.tsx
 // therefore mounts `WorkspaceTopRightAccountCluster` with the route-owned
@@ -332,8 +332,8 @@ describe('project route — floating account cluster', () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null);
     render(<App />);
 
-    // Both cluster members ride the portal on document.body; they appear once
-    // the workspace context read resolves.
+    // Both cluster members ride the shared chrome portal; they appear once the
+    // workspace context read resolves.
     const avatar = await screen.findByTestId('entry-nav-account');
     expect(avatar.closest('.entry-top-right-cluster')).not.toBeNull();
 

--- a/apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
 import { I18nProvider } from '../../src/i18n';
+import { WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID } from '../../src/components/workspaceChromeActions';
 
 function teamContext(): WorkspaceCollabContext {
   return {
@@ -52,11 +53,19 @@ function stubFetch() {
   );
 }
 
+let chromeActionsHost: HTMLDivElement;
+
 beforeEach(() => {
   vi.useFakeTimers();
   localStorage.clear();
   resetWorkspaceDirectoryCache();
   stubFetch();
+  const chrome = document.createElement('header');
+  chrome.className = 'workspace-tabs-chrome';
+  chromeActionsHost = document.createElement('div');
+  chromeActionsHost.id = WORKSPACE_CHROME_ACCOUNT_ACTIONS_ID;
+  chrome.append(chromeActionsHost);
+  document.body.append(chrome);
 });
 
 afterEach(() => {
@@ -65,6 +74,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   vi.useRealTimers();
+  document.querySelector('.workspace-tabs-chrome')?.remove();
 });
 
 async function advancePastHoverClose() {
@@ -74,6 +84,14 @@ async function advancePastHoverClose() {
 }
 
 describe('EntryNavRail account menu interaction state', () => {
+  it('mounts the first account controls inside the workspace chrome no-drag host', async () => {
+    renderRail();
+
+    await act(async () => {});
+    expect(screen.getByTestId('entry-nav-account').closest('#workspace-chrome-account-actions'))
+      .toBe(chromeActionsHost);
+  });
+
   it('pins a hover-open menu when the avatar is clicked', async () => {
     renderRail();
     const trigger = screen.getByTestId('entry-nav-account');

--- a/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-after-avatar.test.tsx
@@ -255,7 +255,7 @@ describe('standalone updater rocket placement in the top-right cluster', () => {
 
     const rocket = screen.getByTestId('entry-nav-updater');
     expect(screen.queryByTestId('entry-nav-account')).toBeNull();
-    expect(rocket.closest('.entry-top-right-cluster')).not.toBeNull();
+    await waitFor(() => expect(rocket.closest('.entry-top-right-cluster')).not.toBeNull());
     expect(rocket.closest('.entry-nav-rail__footer')).toBeNull();
   });
 

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -27,6 +27,17 @@ function ruleValue(block: string, property: string): string {
 }
 
 describe('workspace tabs chrome styles', () => {
+  it('keeps the account actions clickable inside the native draggable chrome', () => {
+    const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
+    const actions = cssDeclarations(shellCss, '.workspace-chrome-account-actions');
+    const cluster = cssDeclarations(entryLayoutCss, '.entry-top-right-cluster');
+
+    expect(ruleValue(chrome, '-webkit-app-region')).toBe('drag');
+    expect(ruleValue(chrome, 'overflow')).toBe('visible');
+    expect(ruleValue(actions, '-webkit-app-region')).toBe('no-drag');
+    expect(cluster).not.toContain('position:');
+  });
+
   it('keeps only a small intentional inset before the first tab', () => {
     const chrome = cssDeclarations(shellCss, '.workspace-tabs-chrome.app-chrome-header');
     const traffic = cssDeclarations(shellCss, '.workspace-tabs-chrome .workspace-tabs-traffic');

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -35,6 +35,7 @@ describe('workspace tabs chrome styles', () => {
     expect(ruleValue(chrome, '-webkit-app-region')).toBe('drag');
     expect(ruleValue(chrome, 'overflow')).toBe('visible');
     expect(ruleValue(actions, '-webkit-app-region')).toBe('no-drag');
+    expect(ruleValue(actions, 'margin-left')).toBe('auto');
     expect(cluster).not.toContain('position:');
   });
 

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -319,6 +319,13 @@ type LauncherSnapshot = {
   versionsRoot: string;
 };
 
+type NativeChromeActionProbe = {
+  clickCount: number;
+  targetMatches: boolean;
+  x: number;
+  y: number;
+};
+
 type LauncherPointer = {
   generation: number;
   version: string;
@@ -440,6 +447,7 @@ macDescribe('packaged mac runtime smoke', () => {
       firstRunStarted = true;
       expect(start.source).toBe('installed');
       await waitForHealthyDesktop();
+      await assertFirstNativeChromeActionClick(firstRunInstalledAppPath);
 
       const setup = await runToolsPackJson<MacInspectResult>('inspect', [
         '--expr',
@@ -2303,6 +2311,88 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   }
 
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
+}
+
+async function assertFirstNativeChromeActionClick(installedAppPath: string): Promise<void> {
+  const probeId = 'packaged-native-chrome-action-probe';
+  const setup = await runToolsPackJson<MacInspectResult>('inspect', [
+    '--expr',
+    `(() => {
+      const host = document.querySelector('[data-testid="workspace-chrome-account-actions"]');
+      if (!(host instanceof HTMLElement)) {
+        throw new Error('workspace chrome account actions host is missing');
+      }
+      document.getElementById(${JSON.stringify(probeId)})?.remove();
+      const button = document.createElement('button');
+      button.id = ${JSON.stringify(probeId)};
+      button.type = 'button';
+      button.tabIndex = -1;
+      button.setAttribute('aria-hidden', 'true');
+      Object.assign(button.style, {
+        appearance: 'none',
+        border: '0',
+        height: '24px',
+        margin: '0',
+        opacity: '0.01',
+        padding: '0',
+        pointerEvents: 'auto',
+        width: '24px',
+        WebkitAppRegion: 'no-drag',
+      });
+      button.addEventListener('click', () => {
+        button.dataset.clickCount = String(Number(button.dataset.clickCount || '0') + 1);
+      });
+      button.dataset.clickCount = '0';
+      host.append(button);
+      const rect = button.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2;
+      const clientY = rect.top + rect.height / 2;
+      return {
+        clickCount: 0,
+        targetMatches: document.elementFromPoint(clientX, clientY) === button,
+        x: window.screenX + clientX,
+        y: window.screenY + clientY,
+      };
+    })()`,
+  ]);
+  if (setup.eval?.ok !== true) {
+    throw new Error(`native chrome action setup failed: ${formatUnknown(setup.eval)}`);
+  }
+  const probe = setup.eval.value as NativeChromeActionProbe;
+  expect(probe.targetMatches).toBe(true);
+  expect(Number.isFinite(probe.x)).toBe(true);
+  expect(Number.isFinite(probe.y)).toBe(true);
+
+  try {
+    await execFileAsync('/usr/bin/open', ['-a', installedAppPath]);
+    await delay(250);
+    const swiftSource = `
+      import CoreGraphics
+      import Darwin
+      let point = CGPoint(x: ${probe.x}, y: ${probe.y})
+      let source = CGEventSource(stateID: .hidSystemState)
+      CGEvent(mouseEventSource: source, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+      CGEvent(mouseEventSource: source, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+      usleep(50_000)
+      CGEvent(mouseEventSource: source, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+    `;
+    await execFileAsync('/usr/bin/xcrun', ['swift', '-e', swiftSource], { timeout: 30_000 });
+    await waitFor(async () => {
+      const snapshot = await runToolsPackJson<MacInspectResult>('inspect', [
+        '--expr',
+        `(() => {
+          const button = document.getElementById(${JSON.stringify(probeId)});
+          return { clickCount: Number(button?.dataset.clickCount || '0') };
+        })()`,
+      ]);
+      expect((snapshot.eval?.value as { clickCount?: number } | undefined)?.clickCount).toBe(1);
+    }, 5_000);
+  } finally {
+    await runToolsPackJson<MacInspectResult>('inspect', [
+      '--expr',
+      `(() => { document.getElementById(${JSON.stringify(probeId)})?.remove(); return true; })()`,
+    ]).catch(() => undefined);
+  }
 }
 
 async function waitForPackagedHomeFirstRunOutput(): Promise<PackagedHomeFirstRunResult> {

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -447,7 +447,7 @@ macDescribe('packaged mac runtime smoke', () => {
       firstRunStarted = true;
       expect(start.source).toBe('installed');
       await waitForHealthyDesktop();
-      await assertFirstNativeChromeActionClick(firstRunInstalledAppPath);
+      await assertFirstNativeChromeActionClick();
 
       const setup = await runToolsPackJson<MacInspectResult>('inspect', [
         '--expr',
@@ -2313,43 +2313,33 @@ async function waitForHealthyDesktop(): Promise<MacInspectResult> {
   throw new Error(`packaged mac runtime did not become healthy: ${formatUnknown(lastResult)}`);
 }
 
-async function assertFirstNativeChromeActionClick(installedAppPath: string): Promise<void> {
-  const probeId = 'packaged-native-chrome-action-probe';
+async function assertFirstNativeChromeActionClick(): Promise<void> {
+  const probeKey = '__odPackagedNativeChromeActionProbe';
   const setup = await runToolsPackJson<MacInspectResult>('inspect', [
     '--expr',
     `(() => {
-      const host = document.querySelector('[data-testid="workspace-chrome-account-actions"]');
-      if (!(host instanceof HTMLElement)) {
-        throw new Error('workspace chrome account actions host is missing');
+      const target = document.querySelector('[data-testid="entry-top-right-github"]');
+      if (!(target instanceof HTMLElement)) {
+        throw new Error('first-render GitHub chrome action is missing');
       }
-      document.getElementById(${JSON.stringify(probeId)})?.remove();
-      const button = document.createElement('button');
-      button.id = ${JSON.stringify(probeId)};
-      button.type = 'button';
-      button.tabIndex = -1;
-      button.setAttribute('aria-hidden', 'true');
-      Object.assign(button.style, {
-        appearance: 'none',
-        border: '0',
-        height: '24px',
-        margin: '0',
-        opacity: '0.01',
-        padding: '0',
-        pointerEvents: 'auto',
-        width: '24px',
-        WebkitAppRegion: 'no-drag',
-      });
-      button.addEventListener('click', () => {
-        button.dataset.clickCount = String(Number(button.dataset.clickCount || '0') + 1);
-      });
-      button.dataset.clickCount = '0';
-      host.append(button);
-      const rect = button.getBoundingClientRect();
+      window[${JSON.stringify(probeKey)}]?.cleanup?.();
+      const probe = { clickCount: 0 };
+      const onClick = (event) => {
+        probe.clickCount += 1;
+        event.preventDefault();
+      };
+      target.addEventListener('click', onClick, true);
+      window[${JSON.stringify(probeKey)}] = {
+        cleanup: () => target.removeEventListener('click', onClick, true),
+        probe,
+      };
+      const rect = target.getBoundingClientRect();
       const clientX = rect.left + rect.width / 2;
       const clientY = rect.top + rect.height / 2;
+      const hitTarget = document.elementFromPoint(clientX, clientY);
       return {
         clickCount: 0,
-        targetMatches: document.elementFromPoint(clientX, clientY) === button,
+        targetMatches: hitTarget != null && target.contains(hitTarget),
         x: window.screenX + clientX,
         y: window.screenY + clientY,
       };
@@ -2364,8 +2354,6 @@ async function assertFirstNativeChromeActionClick(installedAppPath: string): Pro
   expect(Number.isFinite(probe.y)).toBe(true);
 
   try {
-    await execFileAsync('/usr/bin/open', ['-a', installedAppPath]);
-    await delay(250);
     const swiftSource = `
       import CoreGraphics
       import Darwin
@@ -2381,8 +2369,8 @@ async function assertFirstNativeChromeActionClick(installedAppPath: string): Pro
       const snapshot = await runToolsPackJson<MacInspectResult>('inspect', [
         '--expr',
         `(() => {
-          const button = document.getElementById(${JSON.stringify(probeId)});
-          return { clickCount: Number(button?.dataset.clickCount || '0') };
+          const state = window[${JSON.stringify(probeKey)}];
+          return { clickCount: Number(state?.probe?.clickCount || '0') };
         })()`,
       ]);
       expect((snapshot.eval?.value as { clickCount?: number } | undefined)?.clickCount).toBe(1);
@@ -2390,7 +2378,12 @@ async function assertFirstNativeChromeActionClick(installedAppPath: string): Pro
   } finally {
     await runToolsPackJson<MacInspectResult>('inspect', [
       '--expr',
-      `(() => { document.getElementById(${JSON.stringify(probeId)})?.remove(); return true; })()`,
+      `(() => {
+        const state = window[${JSON.stringify(probeKey)}];
+        state?.cleanup?.();
+        delete window[${JSON.stringify(probeKey)}];
+        return true;
+      })()`,
     ]).catch(() => undefined);
   }
 }

--- a/e2e/ui/visual-workspace.test.ts
+++ b/e2e/ui/visual-workspace.test.ts
@@ -34,6 +34,22 @@ test('[P2] captures the project workspace surface', async ({ page }) => {
   await captureVisual(page, 'visual-project-workspace');
 });
 
+test('[P1] keeps the project account action host anchored to the right edge', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await configureVisualPage(page);
+  await gotoVisualHome(page);
+  await gotoVisualWorkspace(page);
+
+  const accountActionsRect = await page
+    .getByTestId('workspace-chrome-account-actions')
+    .evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right };
+    });
+  expect(accountActionsRect.left).toBeGreaterThan(1000);
+  expect(1280 - accountActionsRect.right).toBeLessThanOrEqual(24);
+});
+
 test('[P2] captures the workspace staged contexts surface', async ({ page }) => {
   await configureVisualPage(page);
   await gotoVisualHome(page);


### PR DESCRIPTION
Fixes [OPEND-2369](https://plane.powerformer.net/open-design/browse/OPEND-2369)

## Why

Open Design Prerelease 0.21.1-prerelease.8 on macOS swallowed the first physical click on the GitHub, credits, and avatar controls after a cold launch. The account cluster was portaled to `document.body` over a full-width Electron drag region, so the first native draggable-region hit map could omit its separate `no-drag` branch until another navigation forced a layout refresh.

## What users will see

The top-right controls keep the same appearance and position. On macOS Electron, GitHub, credits, and the avatar respond to the first physical click after a cold launch; visiting Settings first is no longer required. Empty chrome remains draggable, and account menus remain visible outside the header row.

## Surface area

- [x] **UI** — fixes first-click behavior in the existing top-right chrome controls
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual change: the existing top-right row retains its layout. This repair changes native hit-region ownership, which is not visible in a screenshot.

## Bug fix verification

- Red spec: `apps/web/tests/components/EntryNavRail.account-menu-interaction.test.tsx` — the account trigger had no `#workspace-chrome-account-actions` ancestor on `main`; assertion received `null`.
- RED on current `main`: yes.
- GREEN on this branch: yes.
- `e2e/specs/mac.spec.ts` now sends the first click through macOS CoreGraphics `CGEvent` in the cold packaged Home smoke and confirms the no-drag chrome action receives it. It does not use DOM `.click()`.
- The packaged mac smoke requires a built mac artifact and its dedicated CI environment, so it was typechecked locally but not executed locally.

## Validation

- `corepack pnpm --filter @open-design/web typecheck` — passed.
- Focused Vitest set covering account cluster ownership, updater placement, project-route persistence, tabs chrome, and CSS drag/no-drag boundaries — 71 passed, 1 skipped.
- `corepack pnpm --filter @open-design/e2e typecheck` — passed.
- `corepack pnpm guard` — all relevant checks passed; command remains red on current `main` because `apps/landing-page/public/enhancers/cobe.js` and `matter.min.js` are existing residual JS files outside the allowlist.
- Full `@open-design/web` Vitest run was stopped after several minutes of existing jsdom Canvas/Media warnings without a final summary; no failure was observed before termination.