### PR TITLE
fix(web): keep pure BYOK API runs independent of OpenCode

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -113,10 +113,12 @@ import {
   trackRunRecoveryActionClick,
   trackRunStartBlockedSurfaceView,
 } from '../analytics/events';
+import type { Track } from '../analytics/events';
 import {
   buildByokRunCreatedProps,
   buildByokRunFinishedProps,
   byokSessionModeForTracking,
+  type ByokRunBaseInput,
 } from '../analytics/byok-run';
 import { byokPreflightBlockReason } from './byok/preflight';
 import {
@@ -1087,6 +1089,30 @@ function historyWithWorkspaceContext(
   );
 }
 
+async function historyForByokRun(input: {
+  history: ChatMessage[];
+  userMessageId: string;
+  runContext: ChatSendMeta['context'] | undefined;
+  projectId: string;
+  projectFiles: ProjectFile[];
+  omitNativeImageAttachments: boolean;
+  workspaceContext: WorkspaceCollabContext | null;
+}): Promise<ChatMessage[]> {
+  return historyWithApiAttachmentContext(
+    historyWithCommentAttachmentContext(
+      historyWithWorkspaceContext(input.history, input.userMessageId, input.runContext),
+      input.userMessageId,
+    ),
+    input.userMessageId,
+    input.projectId,
+    input.projectFiles,
+    {
+      omitNativeImageAttachments: input.omitNativeImageAttachments,
+      workspaceContext: input.workspaceContext,
+    },
+  );
+}
+
 function commentTaskQuery(attachment: ChatCommentAttachment): string {
   return (attachment.comment ?? '').trim();
 }
@@ -1727,6 +1753,184 @@ function isOpenCodeByokChatProtocol(
     protocol === 'senseaudio' ||
     protocol === 'aihubmix'
   );
+}
+
+type ByokMemoryChatProvider = {
+  provider: ByokChatProtocol;
+  apiKey: string;
+  baseUrl: string;
+  apiVersion: string;
+  model: string;
+};
+
+function byokMemoryChatProviderFromConfig(
+  config: AppConfig,
+): ByokMemoryChatProvider | undefined {
+  if (!isOpenCodeByokChatProtocol(config.apiProtocol) || !config.apiKey) {
+    return undefined;
+  }
+  return {
+    provider: config.apiProtocol,
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+    apiVersion: config.apiProtocol === 'azure' ? config.apiVersion ?? '' : '',
+    model: config.model,
+  };
+}
+
+function byokMemoryChatProviderFromOpenCodeProvider(
+  provider: ByokChatProviderConfig | undefined,
+): ByokMemoryChatProvider | undefined {
+  if (!provider) return undefined;
+  return {
+    provider: provider.protocol,
+    apiKey: provider.apiKey,
+    baseUrl: provider.baseUrl ?? '',
+    apiVersion: provider.apiVersion ?? '',
+    model: provider.model ?? '',
+  };
+}
+
+async function postByokMemoryExtraction(input: {
+  userMessage: string;
+  assistantMessage?: string;
+  projectId: string;
+  conversationId: string;
+  chatProvider?: ByokMemoryChatProvider;
+}): Promise<void> {
+  if (input.userMessage.length === 0) return;
+  try {
+    await fetch('/api/memory/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userMessage: input.userMessage,
+        ...(input.assistantMessage ? { assistantMessage: input.assistantMessage } : {}),
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        chatProvider: input.chatProvider,
+      }),
+    });
+  } catch {
+    // Memory extraction is best-effort and must never block a chat run.
+  }
+}
+
+type DirectByokStreamHandlers = {
+  onDelta: (textDelta: string) => void;
+  onAgentEvent: (event: AgentEvent) => void;
+  onDone: (fullText: string) => void | Promise<void>;
+  onError: (error: Error) => void | Promise<void>;
+};
+
+type DirectByokRunResult = 'success' | 'failed' | 'cancelled';
+
+async function streamDirectByokRun(input: {
+  config: AppConfig;
+  systemPrompt: string;
+  history: ChatMessage[];
+  signal: AbortSignal;
+  context?: Parameters<typeof streamMessage>[5];
+  handlers: DirectByokStreamHandlers;
+  userText: string;
+  projectId: string;
+  conversationId: string;
+  chatProvider?: ByokMemoryChatProvider;
+  track: Track;
+  runBase: ByokRunBaseInput;
+  startedAt: number;
+  countProducedArtifacts: () => Promise<number>;
+}): Promise<void> {
+  let accumulatedAssistantText = '';
+  let terminal: { result: DirectByokRunResult; text: string } | null = null;
+  let analyticsFinished = false;
+
+  const emitRunFinished = (
+    result: DirectByokRunResult,
+    artifactCount: number,
+  ): void => {
+    if (analyticsFinished) return;
+    analyticsFinished = true;
+    trackRunFinished(
+      input.track,
+      buildByokRunFinishedProps({
+        ...input.runBase,
+        result,
+        artifactCount,
+        askedUserQuestion: (terminal?.text ?? accumulatedAssistantText).includes('<question-form'),
+        totalDurationMs: Math.max(0, Date.now() - input.startedAt),
+      }),
+    );
+  };
+
+  const acceptDone = (fullText = ''): void => {
+    if (terminal) return;
+    const text = fullText.trim().length > 0 ? fullText : accumulatedAssistantText;
+    terminal = {
+      result: text.trim().length > 0 ? 'success' : 'failed',
+      text,
+    };
+    input.handlers.onDone(text);
+  };
+
+  const acceptError = (error: Error): void => {
+    if (terminal) return;
+    const result = input.signal.aborted || error.name === 'AbortError'
+      ? 'cancelled'
+      : 'failed';
+    terminal = { result, text: accumulatedAssistantText };
+    if (result === 'failed') void input.handlers.onError(error);
+  };
+
+  try {
+    await streamMessage(
+      input.config,
+      input.systemPrompt,
+      input.history,
+      input.signal,
+      {
+        onDelta: (delta) => {
+          if (terminal) return;
+          accumulatedAssistantText += delta;
+          input.handlers.onDelta(delta);
+          input.handlers.onAgentEvent({ kind: 'text', text: delta });
+        },
+        onDone: acceptDone,
+        onError: acceptError,
+      },
+      input.context,
+    );
+  } catch (error) {
+    acceptError(error instanceof Error ? error : new Error(String(error)));
+  }
+
+  if (!terminal) {
+    if (input.signal.aborted) {
+      terminal = { result: 'cancelled', text: accumulatedAssistantText };
+    } else {
+      // A provider that resolves without a terminal callback is still a
+      // completed provider operation. Feed the accumulated text through the
+      // normal UI finalizer so an empty operation becomes failed, not success.
+      acceptDone(accumulatedAssistantText);
+    }
+  }
+
+  if (!terminal) return;
+  if (terminal.result === 'success') {
+    const artifactCount = await input.countProducedArtifacts().catch(() => 0);
+    emitRunFinished('success', artifactCount);
+    if (terminal.text.trim().length > 0) {
+      void postByokMemoryExtraction({
+        userMessage: input.userText,
+        assistantMessage: terminal.text,
+        projectId: input.projectId,
+        conversationId: input.conversationId,
+        chatProvider: input.chatProvider,
+      });
+    }
+    return;
+  }
+  emitRunFinished(terminal.result, 0);
 }
 
 function projectEventToAgentEvent(evt: ProjectEvent): LiveArtifactEventItem['event'] | null {
@@ -8505,55 +8709,29 @@ export function ProjectView({
           // those users retain tool execution, but use the browser-side
           // provider path as the API-only fallback when it is not installed.
           const userText = (userMsg.content ?? '').trim();
-          const chatProvider =
-            config.apiProtocol && config.apiKey
-              ? {
-                  provider: config.apiProtocol,
-                  apiKey: config.apiKey,
-                  baseUrl: config.baseUrl,
-                  apiVersion:
-                    config.apiProtocol === 'azure'
-                      ? config.apiVersion ?? ''
-                      : '',
-                  model: config.model,
-                }
-              : undefined;
-          if (userText.length > 0) {
-            try {
-              await fetch('/api/memory/extract', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  userMessage: userText,
-                  projectId: project.id,
-                  conversationId: runConversationId,
-                  chatProvider,
-                }),
-              });
-            } catch {
-              // Best-effort: memory extraction must never block the chat.
-            }
-          }
+          const chatProvider = byokMemoryChatProviderFromConfig(config);
+          await postByokMemoryExtraction({
+            userMessage: userText,
+            projectId: project.id,
+            conversationId: runConversationId,
+            chatProvider,
+          });
           const systemPrompt = await composedSystemPrompt(runSessionMode);
-          const apiHistory = await historyWithApiAttachmentContext(
-            historyWithCommentAttachmentContext(
-              historyWithWorkspaceContext(nextHistory, userMsg.id, runContext),
-              userMsg.id,
-            ),
-            userMsg.id,
-            project.id,
+          const apiHistory = await historyForByokRun({
+            history: nextHistory,
+            userMessageId: userMsg.id,
+            runContext,
+            projectId: project.id,
             projectFiles,
-            {
-              omitNativeImageAttachments: usesAnthropicProxy(config),
-              workspaceContext: projectRunWorkspaceContext,
-            },
-          );
+            omitNativeImageAttachments: usesAnthropicProxy(config),
+            workspaceContext: projectRunWorkspaceContext,
+          });
           pushEvent({ kind: 'status', label: 'requesting', detail: config.model });
 
           // Direct API runs do not reach the daemon, so emit their lifecycle
           // events client-side just as the historical direct path did.
           const byokRunId = randomUUID();
-          const byokRunBase = {
+          const byokRunBase: ByokRunBaseInput = {
             projectId: project.id,
             conversationId: runConversationId,
             runId: byokRunId,
@@ -8570,76 +8748,35 @@ export function ProjectView({
             ),
           };
           trackRunCreated(analytics.track, buildByokRunCreatedProps(byokRunBase));
-          const byokRunStartedAt = startedAt;
-          let accumulatedAssistantText = '';
-          let byokRunFinished = false;
-          const emitByokRunFinished = (
-            result: 'success' | 'failed' | 'cancelled',
-            artifactCount: number,
-          ): void => {
-            if (byokRunFinished) return;
-            byokRunFinished = true;
-            trackRunFinished(
-              analytics.track,
-              buildByokRunFinishedProps({
-                ...byokRunBase,
-                result,
-                artifactCount,
-                askedUserQuestion: accumulatedAssistantText.includes('<question-form'),
-                totalDurationMs: Math.max(0, Date.now() - byokRunStartedAt),
-              }),
-            );
-          };
-
-          void streamMessage(config, systemPrompt, apiHistory, controller.signal, {
-            onDelta: (delta) => {
-              accumulatedAssistantText += delta;
-              handlers.onDelta(delta);
-              handlers.onAgentEvent({ kind: 'text', text: delta });
-            },
-            onDone: (fullText) => {
-              const assistantText = (fullText || accumulatedAssistantText).trim();
-              handlers.onDone(fullText || accumulatedAssistantText);
-              void (async () => {
-                let artifactCount = 0;
-                try {
-                  const files = await refreshProjectFiles();
-                  artifactCount = (computeProducedFiles(beforeFileNames, files) ?? []).filter(
-                    (file) => Boolean(file.artifactManifest),
-                  ).length;
-                } catch {
-                  // A file refresh failure must not leave the run unfinished.
-                }
-                emitByokRunFinished('success', artifactCount);
-              })();
-              if (userText.length === 0 || assistantText.length === 0) return;
-              void fetch('/api/memory/extract', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  userMessage: userText,
-                  assistantMessage: accumulatedAssistantText,
-                  projectId: project.id,
-                  conversationId: runConversationId,
-                  chatProvider,
-                }),
-              }).catch(() => {
-                // Best-effort: see the pre-turn memory extraction above.
-              });
-            },
-            onError: (err) => {
-              handlers.onError(err);
-              emitByokRunFinished(controller.signal.aborted ? 'cancelled' : 'failed', 0);
-            },
-          }, {
+          void streamDirectByokRun({
+            config,
+            systemPrompt,
+            history: apiHistory,
+            signal: controller.signal,
+            handlers,
+            userText,
             projectId: project.id,
-            byokImageModel:
-              byokImageModelOverride || config.byokImageModel || byokImageModelOptionsPV[0]?.id,
-            byokVideoModel:
-              byokVideoModelOverride || config.byokVideoModel || byokVideoModelOptionsPV[0]?.id,
-            byokSpeechModel:
-              byokSpeechModelOverride || config.byokSpeechModel || byokSpeechModelOptionsPV[0]?.id,
-            byokSpeechVoice: byokSpeechVoiceOverride || config.byokSpeechVoice,
+            conversationId: runConversationId,
+            chatProvider,
+            track: analytics.track,
+            runBase: byokRunBase,
+            startedAt,
+            countProducedArtifacts: async () => {
+              const files = await refreshProjectFiles();
+              return (computeProducedFiles(beforeFileNames, files) ?? []).filter(
+                (file) => Boolean(file.artifactManifest),
+              ).length;
+            },
+            context: {
+              projectId: project.id,
+              byokImageModel:
+                byokImageModelOverride || config.byokImageModel || byokImageModelOptionsPV[0]?.id,
+              byokVideoModel:
+                byokVideoModelOverride || config.byokVideoModel || byokVideoModelOptionsPV[0]?.id,
+              byokSpeechModel:
+                byokSpeechModelOverride || config.byokSpeechModel || byokSpeechModelOptionsPV[0]?.id,
+              byokSpeechVoice: byokSpeechVoiceOverride || config.byokSpeechVoice,
+            },
           });
           return true;
         }
@@ -8658,47 +8795,25 @@ export function ProjectView({
         // Forward the per-call BYOK provider snapshot so "Same as chat"
         // memory extraction uses the same vendor, endpoint, key and model as
         // the run. The daemon consumes it for this request only.
-        const byokChatProvider = byokOpenCodeProvider
-          ? {
-              provider: byokOpenCodeProvider.protocol,
-              apiKey: byokOpenCodeProvider.apiKey,
-              baseUrl: byokOpenCodeProvider.baseUrl,
-              apiVersion: byokOpenCodeProvider.apiVersion,
-              model: byokOpenCodeProvider.model,
-            }
-          : undefined;
-        if (userText.length > 0) {
-          try {
-            await fetch('/api/memory/extract', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                userMessage: userText,
-                projectId: project.id,
-                conversationId: runConversationId,
-                byokChatProvider,
-              }),
-            });
-          } catch {
-            // Best-effort: memory extraction must never block the
-            // chat. The daemon's SSE bus will catch up the Memory tab
-            // on the next event.
-          }
-        }
-        pushEvent({ kind: 'status', label: 'requesting', detail: config.model });
-        const byokOpenCodeHistory = await historyWithApiAttachmentContext(
-          historyWithCommentAttachmentContext(
-            historyWithWorkspaceContext(nextHistory, userMsg.id, runContext),
-            userMsg.id,
-          ),
-          userMsg.id,
-          project.id,
-          projectFiles,
-          {
-            omitNativeImageAttachments: usesAnthropicProxy(config),
-            workspaceContext: projectRunWorkspaceContext,
-          },
+        const byokChatProvider = byokMemoryChatProviderFromOpenCodeProvider(
+          byokOpenCodeProvider,
         );
+        await postByokMemoryExtraction({
+          userMessage: userText,
+          projectId: project.id,
+          conversationId: runConversationId,
+          chatProvider: byokChatProvider,
+        });
+        pushEvent({ kind: 'status', label: 'requesting', detail: config.model });
+        const byokOpenCodeHistory = await historyForByokRun({
+          history: nextHistory,
+          userMessageId: userMsg.id,
+          runContext,
+          projectId: project.id,
+          projectFiles,
+          omitNativeImageAttachments: usesAnthropicProxy(config),
+          workspaceContext: projectRunWorkspaceContext,
+        });
         // Session-dimension hints on the BYOK-OpenCode path too, so
         // run_created / run_finished carry the same session-global and
         // project-scoped run sequence on every runtime (cli / amr / byok).

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -19,7 +19,6 @@ import { validateHtmlArtifact } from '../artifacts/validate';
 import { recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument, resolvePersistedArtifactHtml } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import { useI18n } from '../i18n';
-import { streamMessage } from '../providers/anthropic';
 import {
   fetchChatRunStatus,
   GENERIC_DAEMON_DISCONNECT_CODE,
@@ -115,6 +114,7 @@ import {
   trackRunStartBlockedSurfaceView,
 } from '../analytics/events';
 import type { Track } from '../analytics/events';
+import type { ProxyContext } from '../providers/api-proxy';
 import {
   buildByokRunCreatedProps,
   buildByokRunFinishedProps,
@@ -1846,7 +1846,7 @@ async function streamDirectByokRun(input: {
   systemPrompt: string;
   history: ChatMessage[];
   signal: AbortSignal;
-  context?: Parameters<typeof streamMessage>[5];
+  context?: ProxyContext;
   handlers: DirectByokStreamHandlers;
   userText: string;
   projectId: string;
@@ -1913,6 +1913,7 @@ async function streamDirectByokRun(input: {
     if (input.signal.aborted) {
       acceptCancelled();
     } else {
+      const { streamMessage } = await import('../providers/anthropic');
       await streamMessage(
         input.config,
         input.systemPrompt,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1859,6 +1859,7 @@ async function streamDirectByokRun(input: {
 }): Promise<void> {
   let accumulatedAssistantText = '';
   let terminal: { result: DirectByokRunResult; text: string } | null = null;
+  let terminalCallbackPromise: Promise<void> | undefined;
   let analyticsFinished = false;
 
   const emitRunFinished = (
@@ -1895,7 +1896,7 @@ async function streamDirectByokRun(input: {
       result: text.trim().length > 0 ? 'success' : 'failed',
       text,
     };
-    input.handlers.onDone(text);
+    terminalCallbackPromise = Promise.resolve(input.handlers.onDone(text));
   };
 
   const acceptError = (error: Error): void => {
@@ -1950,6 +1951,7 @@ async function streamDirectByokRun(input: {
   }
 
   if (!terminal) return;
+  await terminalCallbackPromise?.catch(() => undefined);
   if (terminal.result === 'success') {
     const artifactCount = await input.countProducedArtifacts().catch(() => 0);
     emitRunFinished('success', artifactCount);
@@ -8007,7 +8009,7 @@ export function ProjectView({
             },
           }));
         },
-        onDone: (fullText = '') => {
+        onDone: async (fullText = '') => {
           // The daemon delivers onDone even for a canceled run, so a run
           // superseded by a "send now" interrupt can still land here and must
           // not apply its completion side effects over the replacement. A run
@@ -8102,7 +8104,7 @@ export function ProjectView({
           // refresh signal) so we can diff against the pre-turn snapshot
           // and attach the new files to the assistant message as download
           // chips.
-          void (async () => {
+          await (async () => {
             try {
               // A settled shared file-list read from before the daemon exit can
               // otherwise win the race with the file-change invalidation and
@@ -8796,7 +8798,7 @@ export function ProjectView({
             runBase: byokRunBase,
             startedAt,
             countProducedArtifacts: async () => {
-              const files = await refreshProjectFiles();
+              const files = await refreshProjectFiles({ fresh: true });
               return (computeProducedFiles(beforeFileNames, files) ?? []).filter(
                 (file) => Boolean(file.artifactManifest),
               ).length;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -1879,8 +1879,17 @@ async function streamDirectByokRun(input: {
     );
   };
 
+  const acceptCancelled = (): void => {
+    if (terminal) return;
+    terminal = { result: 'cancelled', text: accumulatedAssistantText };
+  };
+
   const acceptDone = (fullText = ''): void => {
     if (terminal) return;
+    if (input.signal.aborted) {
+      acceptCancelled();
+      return;
+    }
     const text = fullText.trim().length > 0 ? fullText : accumulatedAssistantText;
     terminal = {
       result: text.trim().length > 0 ? 'success' : 'failed',
@@ -1891,31 +1900,40 @@ async function streamDirectByokRun(input: {
 
   const acceptError = (error: Error): void => {
     if (terminal) return;
-    const result = input.signal.aborted || error.name === 'AbortError'
-      ? 'cancelled'
-      : 'failed';
-    terminal = { result, text: accumulatedAssistantText };
-    if (result === 'failed') void input.handlers.onError(error);
+    if (input.signal.aborted || error.name === 'AbortError') {
+      acceptCancelled();
+      return;
+    }
+    terminal = { result: 'failed', text: accumulatedAssistantText };
+    void input.handlers.onError(error);
   };
 
   try {
-    await streamMessage(
-      input.config,
-      input.systemPrompt,
-      input.history,
-      input.signal,
-      {
-        onDelta: (delta) => {
-          if (terminal) return;
-          accumulatedAssistantText += delta;
-          input.handlers.onDelta(delta);
-          input.handlers.onAgentEvent({ kind: 'text', text: delta });
+    if (input.signal.aborted) {
+      acceptCancelled();
+    } else {
+      await streamMessage(
+        input.config,
+        input.systemPrompt,
+        input.history,
+        input.signal,
+        {
+          onDelta: (delta) => {
+            if (terminal) return;
+            if (input.signal.aborted) {
+              acceptCancelled();
+              return;
+            }
+            accumulatedAssistantText += delta;
+            input.handlers.onDelta(delta);
+            input.handlers.onAgentEvent({ kind: 'text', text: delta });
+          },
+          onDone: acceptDone,
+          onError: acceptError,
         },
-        onDone: acceptDone,
-        onError: acceptError,
-      },
-      input.context,
-    );
+        input.context,
+      );
+    }
   } catch (error) {
     acceptError(error instanceof Error ? error : new Error(String(error)));
   }
@@ -8785,6 +8803,7 @@ export function ProjectView({
             },
             context: {
               projectId: project.id,
+              workspaceContext: projectRunWorkspaceContext,
               byokImageModel:
                 byokImageModelOverride || config.byokImageModel || byokImageModelOptionsPV[0]?.id,
               byokVideoModel:

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -73,6 +73,7 @@ import {
   type ByokMediaDefaults,
   type ByokChatProtocol,
   type ChatTaskExecutionAnalytics,
+  type ExtractMemoryRequest,
   type MemorySystemPromptResponse,
   type ProjectWorkspaceScope,
   type ResearchOptions,
@@ -1755,22 +1756,33 @@ function isOpenCodeByokChatProtocol(
   );
 }
 
-type ByokMemoryChatProvider = {
-  provider: ByokChatProtocol;
-  apiKey: string;
-  baseUrl: string;
-  apiVersion: string;
-  model: string;
-};
+type ByokMemoryChatProvider = NonNullable<ExtractMemoryRequest['chatProvider']>;
+
+function memoryExtractionProviderForByokProtocol(
+  protocol: AppConfig['apiProtocol'],
+): ByokMemoryChatProvider['provider'] | undefined {
+  switch (protocol) {
+    case 'anthropic':
+    case 'openai':
+    case 'azure':
+    case 'google':
+    case 'ollama':
+      return protocol;
+    default:
+      // The chat picker has protocols the memory daemon does not consume.
+      return undefined;
+  }
+}
 
 function byokMemoryChatProviderFromConfig(
   config: AppConfig,
 ): ByokMemoryChatProvider | undefined {
-  if (!isOpenCodeByokChatProtocol(config.apiProtocol) || !config.apiKey) {
+  const provider = memoryExtractionProviderForByokProtocol(config.apiProtocol);
+  if (!provider || !config.apiKey) {
     return undefined;
   }
   return {
-    provider: config.apiProtocol,
+    provider,
     apiKey: config.apiKey,
     baseUrl: config.baseUrl,
     apiVersion: config.apiProtocol === 'azure' ? config.apiVersion ?? '' : '',
@@ -1781,9 +1793,12 @@ function byokMemoryChatProviderFromConfig(
 function byokMemoryChatProviderFromOpenCodeProvider(
   provider: ByokChatProviderConfig | undefined,
 ): ByokMemoryChatProvider | undefined {
-  if (!provider) return undefined;
+  const memoryProvider = provider
+    ? memoryExtractionProviderForByokProtocol(provider.protocol)
+    : undefined;
+  if (!provider || !memoryProvider) return undefined;
   return {
-    provider: provider.protocol,
+    provider: memoryProvider,
     apiKey: provider.apiKey,
     baseUrl: provider.baseUrl ?? '',
     apiVersion: provider.apiVersion ?? '',
@@ -1800,16 +1815,17 @@ async function postByokMemoryExtraction(input: {
 }): Promise<void> {
   if (input.userMessage.length === 0) return;
   try {
+    const request = {
+      userMessage: input.userMessage,
+      ...(input.assistantMessage ? { assistantMessage: input.assistantMessage } : {}),
+      projectId: input.projectId,
+      conversationId: input.conversationId,
+      ...(input.chatProvider ? { chatProvider: input.chatProvider } : {}),
+    } satisfies ExtractMemoryRequest;
     await fetch('/api/memory/extract', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        userMessage: input.userMessage,
-        ...(input.assistantMessage ? { assistantMessage: input.assistantMessage } : {}),
-        projectId: input.projectId,
-        conversationId: input.conversationId,
-        chatProvider: input.chatProvider,
-      }),
+      body: JSON.stringify(request),
     });
   } catch {
     // Memory extraction is best-effort and must never block a chat run.

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -19,6 +19,7 @@ import { validateHtmlArtifact } from '../artifacts/validate';
 import { recoverHtmlDocumentFromMarkdownFence, recoverStandaloneHtmlDocument, resolvePersistedArtifactHtml } from '../artifacts/recover';
 import { createArtifactParser } from '../artifacts/parser';
 import { useI18n } from '../i18n';
+import { streamMessage } from '../providers/anthropic';
 import {
   fetchChatRunStatus,
   GENERIC_DAEMON_DISCONNECT_CODE,
@@ -35,6 +36,8 @@ import {
   deletePreviewComment,
   fetchConnectorStatuses,
   fetchPreviewComments,
+  fetchDesignSystem,
+  fetchDesignTemplate,
   fetchProjectDesignSystemPackageAudit,
   fetchLiveArtifacts,
   fetchProjectFiles,
@@ -48,6 +51,7 @@ import {
   upsertPreviewComment,
   writeProjectTextFile,
 } from '../providers/registry';
+import { fetchElevenLabsVoiceOptions } from '../providers/elevenlabs-voices';
 import { useProjectFileEvents, type ProjectEvent } from '../providers/project-events';
 import { claimProjectTurnIndex, claimRunTurnIndex } from '../analytics/identity';
 import {
@@ -62,11 +66,14 @@ import {
   strategySettledMessageFields,
 } from '../runtime/strategy-question-continuation';
 import {
+  composeSystemPrompt,
   type AmrWalletSnapshot,
+  type AudioVoiceOption,
   type ByokChatProviderConfig,
   type ByokMediaDefaults,
   type ByokChatProtocol,
   type ChatTaskExecutionAnalytics,
+  type MemorySystemPromptResponse,
   type ProjectWorkspaceScope,
   type ResearchOptions,
 } from '@open-design/contracts';
@@ -101,9 +108,16 @@ import {
   trackOnboardingPromptPrefilled,
   trackOnboardingFirstPromptSent,
   trackOnboardingFirstGenerationCompleted,
+  trackRunCreated,
+  trackRunFinished,
   trackRunRecoveryActionClick,
   trackRunStartBlockedSurfaceView,
 } from '../analytics/events';
+import {
+  buildByokRunCreatedProps,
+  buildByokRunFinishedProps,
+  byokSessionModeForTracking,
+} from '../analytics/byok-run';
 import { byokPreflightBlockReason } from './byok/preflight';
 import {
   clearOnboardingSessionId,
@@ -194,6 +208,7 @@ import {
   deleteConversation as deleteConversationApi,
   duplicatePluginAsProject,
   fetchAppliedPluginSnapshot,
+  getTemplate,
   getProject,
   installGeneratedPluginFolder,
   listConversations,
@@ -239,6 +254,7 @@ import type {
   PreviewCommentAttachment,
   PreviewCommentTarget,
   ProjectFile,
+  ProjectTemplate,
   LiveArtifactEventItem,
   LiveArtifactSummary,
   SkillSummary,
@@ -1522,6 +1538,14 @@ export function projectSplitStyle(
   };
 }
 
+function shouldFetchElevenLabsVoiceOptions(project: Project): boolean {
+  const metadata = project.metadata;
+  return metadata?.kind === 'audio'
+    && metadata.audioKind === 'speech'
+    && metadata.audioModel === 'elevenlabs-v3'
+    && !metadata.voice;
+}
+
 // Writes the two animatable width custom properties directly (see the
 // `@property` registrations + `.split` / `.split.split-focus` transition
 // rules in shell.css) instead of composing a `gridTemplateColumns` string —
@@ -2315,6 +2339,7 @@ export function ProjectView({
   const setRunError = useCallback((message: string, sourceAssistantId: string) => {
     setPaneError({ message, sourceAssistantId });
   }, []);
+  const [audioVoiceOptionsError, setAudioVoiceOptionsError] = useState<string | null>(null);
   const [artifact, setArtifact] = useState<Artifact | null>(null);
   const [filesRefresh, setFilesRefresh] = useState(0);
   const filesRefreshRequestKeyRef = useRef(0);
@@ -2624,6 +2649,15 @@ export function ProjectView({
   const messagesRef = useRef<ChatMessage[]>([]);
   const startingQueuedChatSendIdRef = useRef<string | null>(null);
   const [queuedAutoStartTick, setQueuedAutoStartTick] = useState(0);
+  const skillCache = useRef<Map<string, string>>(new Map());
+  const designCache = useRef<Map<string, string>>(new Map());
+  const templateCache = useRef<Map<string, ProjectTemplate>>(new Map());
+  // The composed prompt memoizes design-system bodies. Whenever the systems
+  // list refreshes, drop the cached bodies so the next API turn consumes the
+  // latest content from the project.
+  useEffect(() => {
+    designCache.current.clear();
+  }, [designSystems]);
   // We auto-save the most recent artifact to the project folder. Track the
   // last name we persisted so re-renders during streaming don't spawn
   // duplicate writes.
@@ -2752,6 +2786,7 @@ export function ProjectView({
     setPendingEmptyConversationSeed(null);
     setConversationLoadError(null);
     setError(null);
+    setAudioVoiceOptionsError(null);
     if (!revalidatingCurrentProject) {
       setConversations([]);
       setActiveConversationId(null);
@@ -4232,6 +4267,135 @@ export function ProjectView({
   const handleEnsureProject = useCallback(async (): Promise<string | null> => {
     return project.id;
   }, [project.id]);
+
+  const composedSystemPrompt = useCallback(async (
+    sessionModeOverride: ChatSessionMode = activeSessionMode,
+  ): Promise<string> => {
+    let skillBody: string | undefined;
+    let skillName: string | undefined;
+    let skillMode: SkillSummary['mode'] | undefined;
+    let designSystemBody: string | undefined;
+    let designSystemTitle: string | undefined;
+
+    if (project.skillId) {
+      // A project skill id can resolve to either the functional-skills or
+      // design-templates registry. Check both so template-backed projects
+      // keep their source body in direct API mode.
+      const summary =
+        skills.find((skill) => skill.id === project.skillId) ??
+        designTemplates.find((template) => template.id === project.skillId);
+      skillName = summary?.name;
+      skillMode = summary?.mode;
+      const cached = skillCache.current.get(project.skillId);
+      if (cached !== undefined) {
+        skillBody = cached;
+      } else {
+        const detail =
+          (await fetchSkill(project.skillId, projectRunWorkspaceContext)) ??
+          (await fetchDesignTemplate(project.skillId));
+        if (detail) {
+          skillBody = detail.body;
+          skillCache.current.set(project.skillId, detail.body);
+        }
+      }
+    }
+
+    if (projectDesignSystemId) {
+      const summary = designSystems.find((system) => system.id === projectDesignSystemId);
+      designSystemTitle = summary?.title;
+      const cached = designCache.current.get(projectDesignSystemId);
+      if (cached !== undefined) {
+        designSystemBody = cached;
+      } else {
+        const detail = await fetchDesignSystem(
+          projectDesignSystemId,
+          projectRunWorkspaceContext,
+        );
+        if (detail) {
+          designSystemBody = detail.body;
+          designCache.current.set(projectDesignSystemId, detail.body);
+        }
+      }
+    }
+
+    let template: ProjectTemplate | undefined;
+    const templateId = project.metadata?.templateId;
+    if (project.metadata?.kind === 'template' && templateId) {
+      const cached = templateCache.current.get(templateId);
+      if (cached) {
+        template = cached;
+      } else {
+        const fetched = await getTemplate(templateId);
+        if (fetched) {
+          templateCache.current.set(templateId, fetched);
+          template = fetched;
+        }
+      }
+    }
+
+    // Keep direct API runs aligned with daemon runs by including the same
+    // best-effort personal-memory block in the composed system prompt.
+    let memoryBody: string | undefined;
+    try {
+      const response = await fetch('/api/memory/system-prompt');
+      if (response.ok) {
+        const json = (await response.json()) as MemorySystemPromptResponse;
+        if (typeof json.body === 'string' && json.body.trim().length > 0) {
+          memoryBody = json.body;
+        }
+      }
+    } catch {
+      // Memory is context enrichment, never a reason to block a chat turn.
+    }
+
+    let audioVoiceOptions: AudioVoiceOption[] | undefined;
+    let audioVoiceOptionsLookupError: string | undefined;
+    if (shouldFetchElevenLabsVoiceOptions(project)) {
+      try {
+        audioVoiceOptions = await fetchElevenLabsVoiceOptions();
+        setAudioVoiceOptionsError(null);
+      } catch (err) {
+        const message = err instanceof Error
+          ? err.message
+          : 'ElevenLabs voice list could not be loaded.';
+        audioVoiceOptionsLookupError = message;
+        setAudioVoiceOptionsError(message);
+      }
+    } else {
+      setAudioVoiceOptionsError(null);
+    }
+
+    return composeSystemPrompt({
+      skillBody,
+      skillName,
+      skillMode,
+      designSystemBody,
+      designSystemTitle,
+      memoryBody,
+      metadata: project.metadata,
+      template,
+      audioVoiceOptions,
+      audioVoiceOptionsError: audioVoiceOptionsLookupError,
+      streamFormat: config.mode === 'api' ? 'plain' : undefined,
+      sessionMode: sessionModeOverride,
+      locale,
+      userInstructions: config.customInstructions,
+      projectInstructions: project.customInstructions,
+    });
+  }, [
+    activeSessionMode,
+    config.customInstructions,
+    config.mode,
+    designSystems,
+    designTemplates,
+    locale,
+    project.customInstructions,
+    project.metadata,
+    project.skillId,
+    projectDesignSystemId,
+    projectRunWorkspaceContext,
+    skills,
+  ]);
 
   const persistMessage = useCallback(
     (m: ChatMessage, options?: SaveMessageOptions) => {
@@ -8336,7 +8500,147 @@ export function ProjectView({
           return true;
         }
         if (!agentsById.get('byok-opencode')?.available) {
-          handlers.onError(new Error(BYOK_OPENCODE_UNAVAILABLE_MESSAGE));
+          // Pure API/BYOK runs must not have a hidden OpenCode prerequisite.
+          // Keep the existing daemon route when OpenCode is available so
+          // those users retain tool execution, but use the browser-side
+          // provider path as the API-only fallback when it is not installed.
+          const userText = (userMsg.content ?? '').trim();
+          const chatProvider =
+            config.apiProtocol && config.apiKey
+              ? {
+                  provider: config.apiProtocol,
+                  apiKey: config.apiKey,
+                  baseUrl: config.baseUrl,
+                  apiVersion:
+                    config.apiProtocol === 'azure'
+                      ? config.apiVersion ?? ''
+                      : '',
+                  model: config.model,
+                }
+              : undefined;
+          if (userText.length > 0) {
+            try {
+              await fetch('/api/memory/extract', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  userMessage: userText,
+                  projectId: project.id,
+                  conversationId: runConversationId,
+                  chatProvider,
+                }),
+              });
+            } catch {
+              // Best-effort: memory extraction must never block the chat.
+            }
+          }
+          const systemPrompt = await composedSystemPrompt(runSessionMode);
+          const apiHistory = await historyWithApiAttachmentContext(
+            historyWithCommentAttachmentContext(
+              historyWithWorkspaceContext(nextHistory, userMsg.id, runContext),
+              userMsg.id,
+            ),
+            userMsg.id,
+            project.id,
+            projectFiles,
+            {
+              omitNativeImageAttachments: usesAnthropicProxy(config),
+              workspaceContext: projectRunWorkspaceContext,
+            },
+          );
+          pushEvent({ kind: 'status', label: 'requesting', detail: config.model });
+
+          // Direct API runs do not reach the daemon, so emit their lifecycle
+          // events client-side just as the historical direct path did.
+          const byokRunId = randomUUID();
+          const byokRunBase = {
+            projectId: project.id,
+            conversationId: runConversationId,
+            runId: byokRunId,
+            projectKind: null,
+            hasAttachment: runAttachments.length > 0,
+            userQueryTokens: userText.length > 0 ? Math.ceil(userText.length / 4) : 0,
+            model: config.model,
+            apiProtocol: config.apiProtocol,
+            skillId: project.skillId ?? null,
+            sessionMode: byokSessionModeForTracking(runSessionMode),
+            taskAnalytics,
+            hasExistingArtifact: projectFilesRef.current.some(
+              (file) => Boolean(file.artifactManifest),
+            ),
+          };
+          trackRunCreated(analytics.track, buildByokRunCreatedProps(byokRunBase));
+          const byokRunStartedAt = startedAt;
+          let accumulatedAssistantText = '';
+          let byokRunFinished = false;
+          const emitByokRunFinished = (
+            result: 'success' | 'failed' | 'cancelled',
+            artifactCount: number,
+          ): void => {
+            if (byokRunFinished) return;
+            byokRunFinished = true;
+            trackRunFinished(
+              analytics.track,
+              buildByokRunFinishedProps({
+                ...byokRunBase,
+                result,
+                artifactCount,
+                askedUserQuestion: accumulatedAssistantText.includes('<question-form'),
+                totalDurationMs: Math.max(0, Date.now() - byokRunStartedAt),
+              }),
+            );
+          };
+
+          void streamMessage(config, systemPrompt, apiHistory, controller.signal, {
+            onDelta: (delta) => {
+              accumulatedAssistantText += delta;
+              handlers.onDelta(delta);
+              handlers.onAgentEvent({ kind: 'text', text: delta });
+            },
+            onDone: (fullText) => {
+              const assistantText = (fullText || accumulatedAssistantText).trim();
+              handlers.onDone(fullText || accumulatedAssistantText);
+              void (async () => {
+                let artifactCount = 0;
+                try {
+                  const files = await refreshProjectFiles();
+                  artifactCount = (computeProducedFiles(beforeFileNames, files) ?? []).filter(
+                    (file) => Boolean(file.artifactManifest),
+                  ).length;
+                } catch {
+                  // A file refresh failure must not leave the run unfinished.
+                }
+                emitByokRunFinished('success', artifactCount);
+              })();
+              if (userText.length === 0 || assistantText.length === 0) return;
+              void fetch('/api/memory/extract', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  userMessage: userText,
+                  assistantMessage: accumulatedAssistantText,
+                  projectId: project.id,
+                  conversationId: runConversationId,
+                  chatProvider,
+                }),
+              }).catch(() => {
+                // Best-effort: see the pre-turn memory extraction above.
+              });
+            },
+            onError: (err) => {
+              handlers.onError(err);
+              emitByokRunFinished(controller.signal.aborted ? 'cancelled' : 'failed', 0);
+            },
+          }, {
+            projectId: project.id,
+            byokImageModel:
+              byokImageModelOverride || config.byokImageModel || byokImageModelOptionsPV[0]?.id,
+            byokVideoModel:
+              byokVideoModelOverride || config.byokVideoModel || byokVideoModelOptionsPV[0]?.id,
+            byokSpeechModel:
+              byokSpeechModelOverride || config.byokSpeechModel || byokSpeechModelOptionsPV[0]?.id,
+            byokSpeechVoice: byokSpeechVoiceOverride || config.byokSpeechVoice,
+          });
           return true;
         }
         // Mirror the daemon chat-route memory hook for BYOK chats. The
@@ -8538,6 +8842,7 @@ export function ProjectView({
       attachedComments,
       activeConversationId,
       activeSessionMode,
+      analytics.track,
       currentConversationBusy,
       queueChatSendForCurrentConversation,
       messages,
@@ -8569,6 +8874,7 @@ export function ProjectView({
       onProjectsRefresh,
       onProjectChange,
       onOpenSettings,
+      composedSystemPrompt,
       byokImageModelOverride,
       byokVideoModelOverride,
       byokSpeechModelOverride,
@@ -9901,7 +10207,7 @@ export function ProjectView({
 	            loading: currentConversationLoading,
 	            sendDisabled: currentConversationSendDisabled,
             queuedItems: currentConversationQueuedItems,
-            error: conversationLoadError ?? error,
+            error: conversationLoadError ?? error ?? audioVoiceOptionsError,
             errorSourceAssistantId:
               conversationLoadError ? null : errorSourceAssistantId,
             onSend: handleComposerSend,
@@ -9916,6 +10222,7 @@ export function ProjectView({
         : undefined,
     [
       activeConversationId,
+      audioVoiceOptionsError,
       conversationLoadError,
       currentConversationActionDisabled,
 	      currentConversationQueuedItems,
@@ -11414,7 +11721,7 @@ export function ProjectView({
                   : undefined
               }
               queuedItems={currentConversationQueuedItems}
-              error={conversationLoadError ?? error}
+              error={conversationLoadError ?? error ?? audioVoiceOptionsError}
               errorSourceAssistantId={
                 conversationLoadError ? null : errorSourceAssistantId
               }

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -29,6 +29,7 @@ import type {
   Conversation,
   DesignSystemSummary,
   Project,
+  ProjectFile,
   SkillSummary,
 } from '../../src/types';
 import { workspaceContextFixture } from '../helpers/workspace-context';
@@ -944,6 +945,68 @@ describe('ProjectView API empty response handling', () => {
     await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
     expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({ result: 'success' });
     expect(screen.queryByText('late provider error')).toBeNull();
+  });
+
+  it('waits for direct API artifact persistence before publishing the artifact count', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    const artifact =
+      '<artifact identifier="landing-page" type="text/html" title="Landing Page">' +
+      '<!doctype html><html><head><title>Landing</title></head><body><main><h1>Landing page</h1><p>Generated design artifact with enough structure to persist.</p></main></body></html>' +
+      '</artifact>';
+    const persistedArtifact: ProjectFile = {
+      name: 'landing-page.html',
+      path: 'landing-page.html',
+      kind: 'html',
+      mime: 'text/html',
+      size: 1,
+      mtime: 1,
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Landing Page',
+        entry: 'landing-page.html',
+        renderer: 'html',
+        exports: ['html'],
+        metadata: { identifier: 'landing-page', inferred: false },
+      },
+    };
+    let projectFiles: ProjectFile[] = [];
+    let releaseWrite: (() => void) | undefined;
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    mockedFetchProjectFiles.mockImplementation(async () => projectFiles);
+    mockedWriteProjectTextFile.mockImplementation(async () => {
+      await writeGate;
+      projectFiles = [persistedArtifact];
+      return persistedArtifact;
+    });
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+      handlers.onDelta(artifact);
+      handlers.onDone('');
+    });
+    renderProjectView(project, [
+      {
+        id: 'byok-opencode',
+        name: 'BYOK OpenCode',
+        bin: 'opencode',
+        available: false,
+        models: [],
+      } as AgentInfo,
+    ]);
+
+    await sendTestPrompt();
+    await waitFor(() => expect(mockedWriteProjectTextFile).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished).not.toHaveBeenCalled();
+
+    releaseWrite?.();
+
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({
+      result: 'success',
+      artifact_count: 1,
+    });
   });
 
   it('does not include saved project instructions in the BYOK system prompt', async () => {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -5,6 +5,7 @@ import { useLayoutEffect, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectView } from '../../src/components/ProjectView';
+import { trackRunCreated, trackRunFinished } from '../../src/analytics/events';
 import { streamMessage } from '../../src/providers/anthropic';
 import { streamViaDaemon } from '../../src/providers/daemon';
 import type { DaemonStreamOptions } from '../../src/providers/daemon';
@@ -44,6 +45,17 @@ vi.mock('../../src/router', () => ({
 vi.mock('../../src/providers/anthropic', () => ({
   streamMessage: vi.fn(),
 }));
+
+vi.mock('../../src/analytics/events', async () => {
+  const actual = await vi.importActual<typeof import('../../src/analytics/events')>(
+    '../../src/analytics/events',
+  );
+  return {
+    ...actual,
+    trackRunCreated: vi.fn(),
+    trackRunFinished: vi.fn(),
+  };
+});
 
 vi.mock('../../src/providers/daemon', () => ({
   fetchChatRunStatus: vi.fn(),
@@ -165,6 +177,7 @@ vi.mock('../../src/components/ChatPane', () => ({
     messages,
     onSend,
     onRetry,
+    onStop,
     error,
     projectHeader,
     onCollapse,
@@ -177,6 +190,7 @@ vi.mock('../../src/components/ChatPane', () => ({
       commentAttachments: ChatCommentAttachment[],
     ) => void;
     onRetry?: (assistantMessage: ChatMessage) => void;
+    onStop?: () => void;
     error?: string | null;
     projectHeader?: ReactNode;
     onCollapse?: () => void;
@@ -207,6 +221,11 @@ vi.mock('../../src/components/ChatPane', () => ({
       >
         send
       </button>
+      {onStop ? (
+        <button type="button" onClick={onStop}>
+          stop
+        </button>
+      ) : null}
       {/* Mirrors the real ChatPane: when the collapse control is lifted into
           the tabs dock, the header slot renders nothing — otherwise two
           controls would share this testid. */}
@@ -234,6 +253,8 @@ vi.mock('../../src/components/ChatPane', () => ({
 
 const mockedStreamViaDaemon = vi.mocked(streamViaDaemon);
 const mockedStreamMessage = vi.mocked(streamMessage);
+const mockedTrackRunCreated = vi.mocked(trackRunCreated);
+const mockedTrackRunFinished = vi.mocked(trackRunFinished);
 const mockedFetchProjectFilePreview = vi.mocked(fetchProjectFilePreview);
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 const mockedFetchProjectFiles = vi.mocked(fetchProjectFiles);
@@ -313,6 +334,8 @@ describe('ProjectView API empty response handling', () => {
     chatPaneMockState.resizeObserverCallbacks = [];
     mockedStreamViaDaemon.mockReset();
     mockedStreamMessage.mockReset();
+    mockedTrackRunCreated.mockReset();
+    mockedTrackRunFinished.mockReset();
     mockedFetchProjectFilePreview.mockReset();
     mockedFetchProjectFileText.mockReset();
     mockedFetchProjectFiles.mockReset();
@@ -617,7 +640,7 @@ describe('ProjectView API empty response handling', () => {
   });
 
   it('routes pure BYOK API sends without requiring OpenCode', async () => {
-    const fetchMock = vi.fn(async () => Response.json({}));
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
     vi.stubGlobal('fetch', fetchMock);
     mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
       handlers.onDelta('hello');
@@ -638,6 +661,130 @@ describe('ProjectView API empty response handling', () => {
     await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
     expect(mockedStreamViaDaemon).not.toHaveBeenCalled();
     expect(screen.queryByText(/BYOK API runs require OpenCode/i)).toBeNull();
+    expect(mockedTrackRunCreated).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    const memoryRequests = fetchMock.mock.calls
+      .filter(([url]) => url === '/api/memory/extract')
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+    expect(memoryRequests).toHaveLength(2);
+    expect(memoryRequests.every((request) => (
+      typeof request.chatProvider === 'object' &&
+      request.chatProvider !== null &&
+      (request.chatProvider as Record<string, unknown>).provider === 'openai'
+    ))).toBe(true);
+    expect(memoryRequests.every((request) => !('byokChatProvider' in request))).toBe(true);
+  });
+
+  it('uses the shared memory payload for the daemon-backed BYOK route', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      options.handlers.onDelta('hello');
+      options.handlers.onDone('hello');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedStreamViaDaemon).toHaveBeenCalledTimes(1));
+    const memoryRequest = fetchMock.mock.calls.find(([url]) => url === '/api/memory/extract');
+    expect(memoryRequest).toBeTruthy();
+    const body = JSON.parse(String((memoryRequest?.[1] as RequestInit).body)) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      chatProvider: {
+        provider: 'openai',
+        model: 'deepseek-chat',
+      },
+    });
+    expect(body).not.toHaveProperty('byokChatProvider');
+  });
+
+  it('records an empty direct API completion as failed', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+      handlers.onDone('');
+    });
+    renderProjectView(project, [
+      {
+        id: 'byok-opencode',
+        name: 'BYOK OpenCode',
+        bin: 'opencode',
+        available: false,
+        models: [],
+      } as AgentInfo,
+    ]);
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({
+      result: 'failed',
+      artifact_count: 0,
+    });
+    expect(screen.getByText('empty_response:deepseek-chat')).toBeTruthy();
+  });
+
+  it('records a stopped direct API run as cancelled after the provider settles', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    let releaseProvider: (() => void) | undefined;
+    let providerSignal: AbortSignal | undefined;
+    const providerSettled = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, signal) => {
+      providerSignal = signal;
+      await providerSettled;
+    });
+    renderProjectView(project, [
+      {
+        id: 'byok-opencode',
+        name: 'BYOK OpenCode',
+        bin: 'opencode',
+        available: false,
+        models: [],
+      } as AgentInfo,
+    ]);
+
+    await sendTestPrompt();
+    await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'stop' }));
+    await waitFor(() => expect(providerSignal?.aborted).toBe(true));
+    releaseProvider?.();
+
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({
+      result: 'cancelled',
+      artifact_count: 0,
+    });
+    expect(screen.getByText('canceled')).toBeTruthy();
+  });
+
+  it('ignores a late provider callback after the direct API run is terminal', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+      handlers.onDelta('hello');
+      handlers.onDone('hello');
+      handlers.onError(new Error('late provider error'));
+    });
+    renderProjectView(project, [
+      {
+        id: 'byok-opencode',
+        name: 'BYOK OpenCode',
+        bin: 'opencode',
+        available: false,
+        models: [],
+      } as AgentInfo,
+    ]);
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({ result: 'success' });
+    expect(screen.queryByText('late provider error')).toBeNull();
   });
 
   it('does not include saved project instructions in the BYOK system prompt', async () => {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useLayoutEffect, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectWorkspaceScope, WorkspaceCollabContext } from '@open-design/contracts';
 
 import { ProjectView } from '../../src/components/ProjectView';
 import { trackRunCreated, trackRunFinished } from '../../src/analytics/events';
@@ -30,6 +31,7 @@ import type {
   Project,
   SkillSummary,
 } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
 
 const chatPaneMockState = vi.hoisted(() => ({
   attachments: [] as ChatAttachment[],
@@ -44,6 +46,34 @@ vi.mock('../../src/router', () => ({
 
 vi.mock('../../src/providers/anthropic', () => ({
   streamMessage: vi.fn(),
+}));
+
+// Keep the collaboration writer gate outside these provider-routing tests.
+// The Team case below seeds an already-resolved project scope; this stub models
+// the separate status proof that lets its owner send a run.
+vi.mock('../../src/collab/useProjectCollab', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useProjectCollab')>()),
+  useProjectCollab: () => ({
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'allowed' as const,
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    materializationPending: false,
+    reportChange: () => undefined,
+    requestPublish: () => undefined,
+    refreshPresence: () => undefined,
+    checkStatusNow: () => undefined,
+    applyContentTransferState: () => undefined,
+  }),
 }));
 
 vi.mock('../../src/analytics/events', async () => {
@@ -302,10 +332,16 @@ function renderProjectView(
     } as AgentInfo,
   ],
   renderConfig: AppConfig = config,
+  options: {
+    workspaceContextOverride?: WorkspaceCollabContext | null;
+    initialWorkspaceScope?: ProjectWorkspaceScope | null;
+  } = {},
 ) {
   return render(
     <ProjectView
       project={renderProject}
+      workspaceContextOverride={options.workspaceContextOverride}
+      initialWorkspaceScope={options.initialWorkspaceScope}
       routeFileName={null}
       config={renderConfig}
       agents={agents}
@@ -798,6 +834,93 @@ describe('ProjectView API empty response handling', () => {
     expect(screen.getByText('canceled')).toBeTruthy();
   });
 
+  it('keeps a direct API stop cancelled when the provider completes after abort', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    let providerSignal: AbortSignal | undefined;
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, signal, handlers) => {
+      providerSignal = signal;
+      await new Promise<void>((resolve) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            handlers.onDone('late success');
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    });
+    renderProjectView(project, [
+      {
+        id: 'byok-opencode',
+        name: 'BYOK OpenCode',
+        bin: 'opencode',
+        available: false,
+        models: [],
+      } as AgentInfo,
+    ]);
+
+    await sendTestPrompt();
+    await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'stop' }));
+
+    await waitFor(() => expect(providerSignal?.aborted).toBe(true));
+    await waitFor(() => expect(mockedTrackRunFinished).toHaveBeenCalledTimes(1));
+    expect(mockedTrackRunFinished.mock.calls[0]?.[1]).toMatchObject({
+      result: 'cancelled',
+      artifact_count: 0,
+    });
+    expect(screen.queryByText('late success')).toBeNull();
+    expect(screen.getByText('canceled')).toBeTruthy();
+  });
+
+  it('forwards the captured Team Workspace context to a direct API provider run', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+    vi.stubGlobal('fetch', fetchMock);
+    const workspaceContext: WorkspaceCollabContext & { workspaceType: 'team' } = {
+      ...workspaceContextFixture({
+        workspaceId: 'team-workspace',
+        workspaceMemberId: 'team-member',
+      }),
+      workspaceType: 'team',
+    };
+    const teamProject = { ...project, workspaceId: workspaceContext.workspaceId };
+    const initialWorkspaceScope: ProjectWorkspaceScope = {
+      kind: 'team',
+      projectId: teamProject.id,
+      workspaceId: workspaceContext.workspaceId,
+      visibility: 'team',
+      context: workspaceContext,
+    };
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+      handlers.onDone('hello');
+    });
+    renderProjectView(
+      teamProject,
+      [
+        {
+          id: 'byok-opencode',
+          name: 'BYOK OpenCode',
+          bin: 'opencode',
+          available: false,
+          models: [],
+        } as AgentInfo,
+      ],
+      config,
+      { workspaceContextOverride: workspaceContext, initialWorkspaceScope },
+    );
+
+    await sendTestPrompt(teamProject.id, workspaceContext);
+
+    await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
+    expect(mockedStreamMessage.mock.calls[0]?.[5]).toMatchObject({
+      projectId: teamProject.id,
+      workspaceContext,
+    });
+  });
+
   it('ignores a late provider callback after the direct API run is terminal', async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
     vi.stubGlobal('fetch', fetchMock);
@@ -1236,9 +1359,16 @@ describe('ProjectView API empty response handling', () => {
   });
 });
 
-async function sendTestPrompt() {
+async function sendTestPrompt(
+  expectedProjectId = project.id,
+  expectedWorkspaceContext: WorkspaceCollabContext | null = null,
+) {
   await waitFor(() => {
-    expect(mockedListMessages).toHaveBeenCalledWith(project.id, 'conv-project-1', null);
+    expect(mockedListMessages).toHaveBeenCalledWith(
+      expectedProjectId,
+      `conv-${expectedProjectId}`,
+      expectedWorkspaceContext,
+    );
   });
   await new Promise((resolve) => setTimeout(resolve, 0));
   await waitFor(() => expect(screen.getByRole('button', { name: 'send' })).toBeTruthy());

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -5,6 +5,7 @@ import { useLayoutEffect, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectView } from '../../src/components/ProjectView';
+import { streamMessage } from '../../src/providers/anthropic';
 import { streamViaDaemon } from '../../src/providers/daemon';
 import type { DaemonStreamOptions } from '../../src/providers/daemon';
 import {
@@ -232,6 +233,7 @@ vi.mock('../../src/components/ChatPane', () => ({
 }));
 
 const mockedStreamViaDaemon = vi.mocked(streamViaDaemon);
+const mockedStreamMessage = vi.mocked(streamMessage);
 const mockedFetchProjectFilePreview = vi.mocked(fetchProjectFilePreview);
 const mockedFetchProjectFileText = vi.mocked(fetchProjectFileText);
 const mockedFetchProjectFiles = vi.mocked(fetchProjectFiles);
@@ -310,6 +312,7 @@ describe('ProjectView API empty response handling', () => {
     chatPaneMockState.fireResizeObserverOnFocusedLayout = false;
     chatPaneMockState.resizeObserverCallbacks = [];
     mockedStreamViaDaemon.mockReset();
+    mockedStreamMessage.mockReset();
     mockedFetchProjectFilePreview.mockReset();
     mockedFetchProjectFileText.mockReset();
     mockedFetchProjectFiles.mockReset();
@@ -613,9 +616,13 @@ describe('ProjectView API empty response handling', () => {
     expect(userMessage?.content).toContain('Second line');
   });
 
-  it('fails BYOK API sends before daemon routing when OpenCode is unavailable', async () => {
+  it('routes pure BYOK API sends without requiring OpenCode', async () => {
     const fetchMock = vi.fn(async () => Response.json({}));
     vi.stubGlobal('fetch', fetchMock);
+    mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+      handlers.onDelta('hello');
+      handlers.onDone('hello');
+    });
     renderProjectView(project, [
       {
         id: 'byok-opencode',
@@ -628,14 +635,9 @@ describe('ProjectView API empty response handling', () => {
 
     await sendTestPrompt();
 
-    await waitFor(() =>
-      expect(screen.getAllByText(/BYOK API runs require OpenCode/i).length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
     expect(mockedStreamViaDaemon).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalledWith(
-      '/api/memory/extract',
-      expect.any(Object),
-    );
+    expect(screen.queryByText(/BYOK API runs require OpenCode/i)).toBeNull();
   });
 
   it('does not include saved project instructions in the BYOK system prompt', async () => {

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -301,12 +301,13 @@ function renderProjectView(
       models: [],
     } as AgentInfo,
   ],
+  renderConfig: AppConfig = config,
 ) {
   return render(
     <ProjectView
       project={renderProject}
       routeFileName={null}
-      config={config}
+      config={renderConfig}
       agents={agents}
       skills={[] as SkillSummary[]}
       designTemplates={[] as SkillSummary[]}
@@ -674,6 +675,41 @@ describe('ProjectView API empty response handling', () => {
     ))).toBe(true);
     expect(memoryRequests.every((request) => !('byokChatProvider' in request))).toBe(true);
   });
+
+  it.each(['senseaudio', 'aihubmix'] as const)(
+    'omits unsupported %s chat protocols from memory extraction payloads',
+    async (apiProtocol) => {
+      const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));
+      vi.stubGlobal('fetch', fetchMock);
+      mockedStreamMessage.mockImplementation(async (_config, _system, _history, _signal, handlers) => {
+        handlers.onDone('hello');
+      });
+      renderProjectView(
+        project,
+        [
+          {
+            id: 'byok-opencode',
+            name: 'BYOK OpenCode',
+            bin: 'opencode',
+            available: false,
+            models: [],
+          } as AgentInfo,
+        ],
+        { ...config, apiProtocol },
+      );
+
+      await sendTestPrompt();
+
+      await waitFor(() => expect(mockedStreamMessage).toHaveBeenCalledTimes(1));
+      await waitFor(() => {
+        expect(fetchMock.mock.calls.filter(([url]) => url === '/api/memory/extract')).toHaveLength(2);
+      });
+      const memoryRequests = fetchMock.mock.calls
+        .filter(([url]) => url === '/api/memory/extract')
+        .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+      expect(memoryRequests.every((request) => !('chatProvider' in request))).toBe(true);
+    },
+  );
 
   it('uses the shared memory payload for the daemon-backed BYOK route', async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => Response.json({}));


### PR DESCRIPTION
Fixes #7538

## Why

A pure BYOK/API configuration could be fully populated, but the ProjectView API branch still required the locally discovered `byok-opencode` agent before it invoked the configured provider. This made OpenCode a hidden prerequisite for API-only users and caused the failure reported in #7538.

When OpenCode is unavailable, the API branch now uses the existing browser-side BYOK provider path. The explicit daemon-mode BYOK OpenCode path keeps its availability guard.

## What users will see

Pure API/BYOK chat sends proceed when the configured provider is valid even if OpenCode is not installed or discovered. If OpenCode is installed, the existing daemon route continues to provide tool execution. Explicit daemon-mode BYOK OpenCode runs keep the existing availability requirement.

## Follow-up hardening

- Shared history and memory preparation is used by both direct API and daemon-backed BYOK paths.
- The direct path is centralized in `streamDirectByokRun`, so the routing site only chooses the provider path.
- Direct runs now finalize exactly once: non-empty output is `success`, a genuinely empty response is `failed`, and Stop/Abort is `cancelled`. Abort wins over late provider deltas and completions.
- Late provider callbacks cannot overwrite the accepted terminal result or emit duplicate `run_finished` analytics. The direct proxy receives the exact turn-captured Workspace context for bound Team projects.
- The memory extraction payload satisfies the shared `ExtractMemoryRequest` contract; unsupported `senseaudio` and `aihubmix` chat protocols are explicitly omitted.
- Regression coverage includes direct routing, shared memory payloads, empty responses, Stop cancellation, late callbacks after abort, exact Team Workspace forwarding, and unsupported provider omission.

## Surface area

- [ ] **UI** — no new page, dialog, panel, menu item, setting, or empty state
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — none
- [ ] **API / contract** — no new endpoint or contract shape
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — existing pure API/BYOK users can send without opting into a local OpenCode installation
- [ ] **None** — this changes existing runtime behavior

## Screenshots

No new UI surface. Failure and source evidence screenshots are attached to issue #7538.

## Bug fix verification

- Test path: `apps/web/tests/components/ProjectView.api-empty-response.test.tsx`
- Red on `main`: yes — the direct API regression path stopped at the old OpenCode-unavailable guard before calling `streamMessage`.
- Green on this branch: yes — focused regression suite passes 28/28.
- The test asserts `streamViaDaemon` is not called when `byok-opencode` is unavailable.
- The suite also locks down the terminal lifecycle: success, empty-response failure, cancellation, and exactly-once finalization.

## Validation

- `cd apps/web && node_modules/.bin/vitest run -c vitest.config.ts tests/components/ProjectView.api-empty-response.test.tsx --pool=forks --maxWorkers=1` — passed (28/28)
- Adjacent ProjectView regression suites — passed (2 files, 123 tests)
- `cd apps/web && corepack pnpm run typecheck` — passed
- `corepack pnpm exec tsc -p scripts/tsconfig.json --noEmit` — passed
- `corepack pnpm guard` — passed
- `cd apps/web && corepack pnpm run build` — passed (production compilation, TypeScript, static generation, and optimization)
- `apps/web/tests/providers/api-proxy.test.ts` — passed (7/7)
- `git diff --check` — passed

The local build emitted the repository's existing Node 24 engine warning under the available Node 20 runtime, but exited 0 without a source or build error.

## Manual QA

Required before merge: verify a real pure API/BYOK send with OpenCode unavailable, verify Stop produces a cancelled run, verify an empty provider response is reported as failed, and confirm the explicit daemon-mode BYOK route remains unchanged. Please hold off self-merging until that QA pass is complete.