### PR TITLE
fix(web): stop expired DeepSeek unlimited badges

### DIFF
--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -747,10 +747,11 @@ export function InlineModelSwitcher({
       // by the user's own provider, and the dormant AMR selection must not
       // leak an entitlement claim onto it.
       if (config.mode !== 'daemon' || currentAgent?.id !== 'amr') return null;
-      if (
-        deepSeekCampaignVisibleForCurrentExecution
-        && isDeepSeekV4FlashCampaignModel(modelId)
-      ) {
+      // Campaign models are governed exclusively by the campaign window. Do
+      // not let a paid plan's Coding Plan list keep the campaign badge alive
+      // after that window closes.
+      if (isDeepSeekV4FlashCampaignModel(modelId)) {
+        if (!deepSeekCampaignVisibleForCurrentExecution) return null;
         return {
           label: campaignModelBadge,
           tooltip: campaignModelTooltip,

--- a/apps/web/tests/components/InlineModelSwitcher.unlimited-badge.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.unlimited-badge.test.tsx
@@ -2,11 +2,10 @@
 //
 // The 「无限使用」 badge in the model chip + compact model list.
 //
-// The badge used to be hard-wired to the DeepSeek V4 campaign, so it marked
-// exactly two models for everyone and nothing at all once the campaign window
-// closes. The Vela wallet snapshot is now the source of truth for which models
-// are included in Coding Plan, so the badge must follow that response instead
-// of a duplicated per-tier table in Open Design.
+// DeepSeek V4 campaign badges must stop at the campaign boundary, including
+// for paid users whose Coding Plan model list still contains those models.
+// Other Coding Plan badges follow Vela's wallet snapshot instead of a
+// duplicated per-tier table in Open Design.
 
 import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type {
@@ -224,7 +223,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('unlimited badge follows the subscription tier', () => {
+describe('unlimited badge follows campaign and subscription boundaries', () => {
   it('badges a newly configured model from the Vela wallet snapshot', async () => {
     setPlan('go');
     providerState.codingPlanModels = ['new-coding-plan-model'];
@@ -235,14 +234,12 @@ describe('unlimited badge follows the subscription tier', () => {
     expect(await badgedModelIds()).toContain('new-coding-plan-model');
   });
 
-  it('badges the five models Pro includes, and none of the metered ones', async () => {
+  it('badges non-campaign models included by Pro, and none of the metered ones', async () => {
     mockNow(AFTER_CAMPAIGN);
     setPlan('pro');
     renderSwitcher();
     expect((await badgedModelIds()).sort()).toEqual(
       [
-        'deepseek-v4-flash',
-        'deepseek-v4-pro',
         'glm-5.2',
         'kimi-k2.7-code',
         'mimo-v2.5-pro',
@@ -250,20 +247,18 @@ describe('unlimited badge follows the subscription tier', () => {
     );
   });
 
-  it('badges the three models Go includes', async () => {
+  it('stops badging the two DeepSeek campaign models for paid plans after the window closes', async () => {
     mockNow(AFTER_CAMPAIGN);
     setPlan('go');
     renderSwitcher();
-    expect((await badgedModelIds()).sort()).toEqual(
-      ['deepseek-v4-flash', 'deepseek-v4-pro', 'glm-5.2'].sort(),
-    );
+    expect(await badgedModelIds()).toEqual(['glm-5.2']);
   });
 
-  it('badges every popular model on Max', async () => {
+  it('badges every non-campaign popular model on Max', async () => {
     mockNow(AFTER_CAMPAIGN);
     setPlan('max');
     renderSwitcher();
-    expect(await badgedModelIds()).toHaveLength(8);
+    expect(await badgedModelIds()).toHaveLength(6);
   });
 
   it.each(['team_plus', 'team_pro', 'team_max_yearly'])(
@@ -277,7 +272,7 @@ describe('unlimited badge follows the subscription tier', () => {
       mockNow(AFTER_CAMPAIGN);
       setPlan('plus');
       const view = renderSwitcher();
-      expect(await badgedModelIds()).toContain('deepseek-v4-flash');
+      expect(await badgedModelIds()).toContain('kimi-k2.7-code');
       workspaceState.context = {
         ...workspaceState.context,
         workspaceType: 'team',
@@ -295,7 +290,7 @@ describe('unlimited badge follows the subscription tier', () => {
     mockNow(AFTER_CAMPAIGN);
     setPlan('plus');
     const view = renderSwitcher();
-    expect(await badgedModelIds()).toContain('deepseek-v4-flash');
+    expect(await badgedModelIds()).toContain('kimi-k2.7-code');
 
     workspaceState.loading = true;
     view.rerender(switcher());


### PR DESCRIPTION
## Why

A paid user reported that DeepSeek V4 Flash and Pro still showed the unlimited-use badge after the promotion ended. The campaign closed at 2026-08-27 20:00 +08:00, but the model switcher let those campaign models fall through to the paid Coding Plan badge branch, so the expired campaign claim remained visible for subscribers.

## What users will see

After the DeepSeek V4 campaign window closes, paid users no longer see the unlimited-use badge beside DeepSeek V4 Flash or DeepSeek V4 Pro. Other models that Vela identifies as Coding Plan models keep their subscription badge, and runtime balance/entitlement behavior is unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in apps/web or apps/desktop (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new od subcommand or flag, new tools-dev / tools-pack flag, or new OD_* env var
- [ ] **API / contract** — new /api/* endpoint, new SSE event, or changed shape in packages/contracts
- [ ] **Extension point** — new entry under skills/, design-systems/, design-templates/, or craft/, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root package.json
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the reporter supplied a screenshot showing both expired badges in the paid-user model menu. An after screenshot was not captured locally because validation was moved to remote CI at the reporter's request; the regression assertion verifies the same visible model-menu state.

## Bug fix verification

- Test path that reproduces the bug: apps/web/tests/components/InlineModelSwitcher.unlimited-badge.test.tsx
- Did the test go red on main and green on this branch? yes
- Red result on origin/main behavior: expected only glm-5.2 to remain badged after the campaign, but DeepSeek V4 Flash and Pro were also present.
- Green result: the focused file passes all 13 tests after campaign models are made window-exclusive.

## Validation

- Focused red spec: failed before the source change as expected
- Focused component suite: 13 passed
- Full web Vitest suite: 673 files passed; 7135 passed, 1 expected fail, 11 skipped
- pnpm --filter @open-design/web typecheck: passed
- pnpm guard: passed
- Root typecheck and web production build: delegated to PR CI; local jobs were stopped before completion at the reporter's request
