### PR TITLE
fix(byok): normalize Gemini run config for third-party gateways

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -1,8 +1,5 @@
 import type { ByokChatProviderConfig } from '@open-design/contracts';
-import {
-  googleGenerativeLanguageBaseUrl,
-  normalizeGoogleModelId,
-} from '../integrations/google-models.js';
+import { normalizeGoogleModelId } from '../integrations/google-models.js';
 
 export const BYOK_OPENCODE_AGENT_ID = 'byok-opencode';
 export const BYOK_OPENCODE_PROVIDER_ID = 'open-design-byok';
@@ -119,7 +116,7 @@ function normalizeProviderBaseUrl(
   }
   if (protocol === 'google') {
     try {
-      return `${googleGenerativeLanguageBaseUrl(trimmed)}/v1beta`;
+      return normalizeGoogleRunBaseUrl(trimmed);
     } catch {
       return trimmed;
     }
@@ -130,6 +127,19 @@ function normalizeProviderBaseUrl(
     if (trimmed.endsWith('/api')) return `${trimmed.slice(0, -4)}/v1`;
   }
   return trimmed;
+}
+
+function normalizeGoogleRunBaseUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  url.search = '';
+  url.hash = '';
+  const pathname = url.pathname.replace(/\/+$/, '');
+  if (pathname && /\/v\d+(?:alpha|beta)?(?:\/|$)/i.test(pathname)) {
+    url.pathname = pathname;
+    return url.toString();
+  }
+  url.pathname = pathname ? `${pathname}/v1beta` : '/v1beta';
+  return url.toString();
 }
 
 function requiresApiKey(

--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -1,4 +1,8 @@
 import type { ByokChatProviderConfig } from '@open-design/contracts';
+import {
+  googleGenerativeLanguageBaseUrl,
+  normalizeGoogleModelId,
+} from '../integrations/google-models.js';
 
 export const BYOK_OPENCODE_AGENT_ID = 'byok-opencode';
 export const BYOK_OPENCODE_PROVIDER_ID = 'open-design-byok';
@@ -62,7 +66,11 @@ export function buildOpenCodeByokProviderConfig(
   if (!rawModel || rawModel.toLowerCase() === 'default') return null;
   if (!baseUrl) return null;
 
-  const modelId = opencodeByokModelId(rawModel);
+  const runModel =
+    protocol === 'google'
+      ? `models/${normalizeGoogleModelId(rawModel)}`
+      : rawModel;
+  const modelId = opencodeByokModelId(runModel);
   if (!modelId) return null;
 
   const providerEntry = buildProviderEntry(
@@ -77,7 +85,7 @@ export function buildOpenCodeByokProviderConfig(
         name: 'OpenDesign BYOK',
         ...providerEntry,
         models: {
-          [rawModel]: {
+          [runModel]: {
             name: rawModel,
             limit: {
               context: DEFAULT_CONTEXT_TOKEN_LIMIT,
@@ -109,8 +117,12 @@ function normalizeProviderBaseUrl(
   if (protocol === 'openai' && isExactOrigin(trimmed, 'https://api.openai.com')) {
     return 'https://api.openai.com/v1';
   }
-  if (protocol === 'google' && isExactOrigin(trimmed, 'https://generativelanguage.googleapis.com')) {
-    return 'https://generativelanguage.googleapis.com/v1beta';
+  if (protocol === 'google') {
+    try {
+      return `${googleGenerativeLanguageBaseUrl(trimmed)}/v1beta`;
+    } catch {
+      return trimmed;
+    }
   }
   if (protocol === 'ollama') {
     if (isExactOrigin(trimmed, 'https://ollama.com')) return 'https://ollama.com/v1';

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -245,16 +245,101 @@ describe('byok-opencode runtime config', () => {
 
   it('maps other native BYOK protocols to provider packages', () => {
     expect(buildOpenCodeByokProviderConfig(
-      { protocol: 'anthropic', apiKey: 'sk-ant', baseUrl: 'https://api.anthropic.com' },
+      { protocol: 'anthropic', apiKey: 'ak', baseUrl: 'https://api.anthropic.com' },
       'claude-sonnet-4-5',
     )?.config).toMatchObject({
       provider: { [BYOK_OPENCODE_PROVIDER_ID]: { npm: '@ai-sdk/anthropic' } },
     });
     expect(buildOpenCodeByokProviderConfig(
-      { protocol: 'google', apiKey: 'AIza', baseUrl: 'https://generativelanguage.googleapis.com' },
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://generativelanguage.googleapis.com' },
       'gemini-2.5-flash',
     )?.config).toMatchObject({
       provider: { [BYOK_OPENCODE_PROVIDER_ID]: { npm: '@ai-sdk/google' } },
+    });
+  });
+
+  it('normalizes third-party Gemini-compatible base URLs to /v1beta for the run path', () => {
+    const withoutV1beta = buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini' },
+      'google/gemini-3.7-flash',
+    );
+    expect(withoutV1beta?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/google',
+          options: { baseURL: 'https://api.ofox.io/gemini/v1beta' },
+        },
+      },
+    });
+
+    const withV1beta = buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini/v1beta' },
+      'google/gemini-3.7-flash',
+    );
+    expect(withV1beta?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          options: { baseURL: 'https://api.ofox.io/gemini/v1beta' },
+        },
+      },
+    });
+  });
+
+  it('preserves models/ routing for vendor-prefixed Gemini model ids on third-party gateways', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini' },
+      'google/gemini-3.7-flash',
+    );
+    expect(out?.modelId).toBe('open-design-byok/models/google/gemini-3.7-flash');
+    expect(out?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          models: {
+            'models/google/gemini-3.7-flash': {
+              name: 'google/gemini-3.7-flash',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it.each([
+    { input: 'gemini-1.5-flash', expected: 'models/gemini-1.5-flash' },
+    { input: 'models/google/gemini-3.7-flash', expected: 'models/google/gemini-3.7-flash' },
+  ])(
+    'normalizes non-prefixed and already-prefixed Gemini model ids to models/ form: $input',
+    ({ input, expected }) => {
+      const out = buildOpenCodeByokProviderConfig(
+        { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini' },
+        input,
+      );
+      expect(out?.modelId).toBe(`open-design-byok/${expected}`);
+      expect(out?.config).toMatchObject({
+        provider: {
+          [BYOK_OPENCODE_PROVIDER_ID]: {
+            models: {
+              [expected]: {
+                name: input,
+              },
+            },
+          },
+        },
+      });
+    },
+  );
+
+  it('falls back to the raw base URL when a Google base URL is malformed', () => {
+    expect(buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'not a url' },
+      'gemini-1.5-flash',
+    )?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          npm: '@ai-sdk/google',
+          options: { baseURL: 'not a url' },
+        },
+      },
     });
   });
 

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -283,6 +283,30 @@ describe('byok-opencode runtime config', () => {
         },
       },
     });
+
+    const withV1alpha = buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini/v1alpha' },
+      'google/gemini-3.7-flash',
+    );
+    expect(withV1alpha?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          options: { baseURL: 'https://api.ofox.io/gemini/v1alpha' },
+        },
+      },
+    });
+
+    const withV1 = buildOpenCodeByokProviderConfig(
+      { protocol: 'google', apiKey: 'gk', baseUrl: 'https://api.ofox.io/gemini/v1' },
+      'google/gemini-3.7-flash',
+    );
+    expect(withV1?.config).toMatchObject({
+      provider: {
+        [BYOK_OPENCODE_PROVIDER_ID]: {
+          options: { baseURL: 'https://api.ofox.io/gemini/v1' },
+        },
+      },
+    });
   });
 
   it('preserves models/ routing for vendor-prefixed Gemini model ids on third-party gateways', () => {


### PR DESCRIPTION
## Why

Fixes #7546.

The Settings connection-test path for Google Gemini BYOK normalizes base URLs through `googleGenerativeLanguageBaseUrl()` and always emits `models/` model paths, but the OpenCode run path added in #4876 did not reuse those helpers. For third-party Gemini-compatible gateways this produced mismatched URLs:

- `https://gateway.example/gemini` → run used `…/gemini` instead of `…/gemini/v1beta`.
- Vendor-prefixed model ids such as `google/gemini-3.7-flash` → run dropped the required `models/` segment.

After review feedback, the run-path normalization now also preserves any explicitly-versioned endpoint the user configured (`/v1`, `/v1alpha`, `/v1beta`) instead of rewriting it to `/v1beta`, preventing double-version paths like `…/v1alpha/v1beta`.

## What users will see

- Google Gemini BYOK runs against third-party gateways now use the same `/v1beta` base and `models/` model form as the connection test.
- If a gateway is configured with an explicit version suffix (`…/gemini/v1`, `…/gemini/v1alpha`, or `…/gemini/v1beta`), that version is preserved unchanged.
- Vendor-prefixed model ids (`google/gemini-3.7-flash`) are routed as `models/google/gemini-3.7-flash`.
- Malformed Google base URLs still fall back to the raw value; non-Google BYOK protocols are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Ticking **Default behavior change** deliberately, so the outbound-request change
gets reviewed rather than assumed safe. Nothing here is a new setting or a new
default value; what changes without an opt-in is the request an already-configured
BYOK gateway receives:

- A user whose base URL has no version suffix (`…/gemini`) previously had that
  value sent as-is and now has `/v1beta` appended.
- A vendor-prefixed model id (`google/gemini-3.7-flash`) previously went out
  without the `models/` segment and now carries it.

Explicitly versioned endpoints (`/v1`, `/v1alpha`, `/v1beta`), malformed-URL
fallback, and every other BYOK protocol are unchanged, so a user who had
already worked around this by configuring the version themselves sees no
difference.

Files touched:

- `apps/daemon/src/runtimes/byok-opencode.ts`
- `apps/daemon/tests/runtimes/byok-opencode.test.ts`

Only the OpenCode BYOK run config builder is touched; the generic
`google-models.ts` helpers and the connection-test path are unchanged.

## Bug fix verification

- Added focused regression tests covering:
  - unversioned third-party base `…/gemini` → `…/gemini/v1beta`
  - idempotent `…/gemini/v1beta` → unchanged
  - explicitly-versioned `…/gemini/v1alpha` and `…/gemini/v1` → unchanged
  - vendor-prefixed model id `google/gemini-3.7-flash` → `models/google/gemini-3.7-flash`
  - non-prefixed and already-prefixed model ids
  - malformed Google base URL graceful fallback
  - non-Google protocols unchanged

## Validation

- `apps/daemon/tests/runtimes/byok-opencode.test.ts`: 25/25 pass.
- `pnpm typecheck`: clean.
- `git diff --check`: clean.
- OCR/OpenCodeReview: 0 findings on the final exact diff.

## Overlap note

#7550 addresses the same issue and was opened slightly earlier. This PR additionally preserves explicitly versioned Google-compatible endpoints (`/v1`, `/v1alpha`, `/v1beta`), following review feedback that identified version rewriting as a regression risk. Happy for maintainers to choose the preferred landing path.

