### PR TITLE
fix(web): render fixed-stage recent deck covers

### DIFF
--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -2489,11 +2489,17 @@ export function deckPreviewSrcDoc(html: string): string {
       display: block !important;
       scroll-snap-type: none !important;
     }
+    /* Scripts normally fit fixed-stage decks at runtime. Static covers remove
+       those scripts, so normalize both named wrappers as well as the direct
+       slide parent instead of letting an outer transform move slide 1 away. */
+    .deck-shell,
+    .deck-stage,
     :where(body *):has(> [data-od-cover-slide]) {
       position: absolute !important;
       inset: 0 !important;
       width: ${DECK_PREVIEW_WIDTH}px !important;
       height: ${DECK_PREVIEW_HEIGHT}px !important;
+      display: block !important;
       margin: 0 !important;
       overflow: hidden !important;
       transform: none !important;

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -220,15 +220,18 @@ describe('RecentProjectsStrip', () => {
   it('turns a script-activated deck into a deterministic visible first-page cover', () => {
     const cover = deckPreviewSrcDoc(`<!doctype html>
       <html><head><style>
-        #stage { position: fixed; top: 50%; left: 50%; width: 1920px; height: 1080px }
+        .deck-shell { position: fixed; transform: translateX(1400px) }
+        .deck-stage { position: relative; width: 1920px; height: 1080px; transform: scale(.6) }
         .slide { display: none; opacity: 0; visibility: hidden }
         .slide.active,
         .slide.is-active { display: flex; opacity: 1; visibility: visible }
         [data-anim] { opacity: 0; transform: translateY(24px) }
       </style></head><body>
-        <div id="stage">
-          <section class="slide orange"><h1 data-anim="fade-up">Launch</h1></section>
-          <section class="slide dark"><h1>Details</h1></section>
+        <div class="deck-shell">
+          <div class="deck-stage">
+            <section class="slide orange"><h1 data-anim="fade-up">Launch</h1></section>
+            <section class="slide dark"><h1>Details</h1></section>
+          </div>
         </div>
         <script>document.querySelector('.slide').classList.add('is-active')</script>
       </body></html>`);
@@ -238,7 +241,9 @@ describe('RecentProjectsStrip', () => {
       /<section class="slide orange active is-active" data-od-cover-slide(?:="")?>/,
     );
     expect(cover).toContain('[data-od-cover-slide] > *');
-    expect(cover).toContain(':where(body *):has(> [data-od-cover-slide])');
+    expect(cover).toMatch(
+      /\.deck-shell,\s*\.deck-stage,\s*:where\(body \*\):has\(> \[data-od-cover-slide\]\)\s*\{[^}]*display: block !important/s,
+    );
     expect(cover).toContain('transform-origin: 0 0 !important');
     expect(cover).toContain('[data-od-cover-slide] [data-anim]');
     expect(cover).toContain('opacity: 1 !important');

--- a/e2e/lib/playwright/resources.ts
+++ b/e2e/lib/playwright/resources.ts
@@ -1,4 +1,9 @@
+import { recentProjectFixedStageDeckHtml } from '../../resources/recent-project-fixed-stage-deck.ts';
 import { playwrightUiScenarios } from '../../resources/playwright.ts';
+
+export function fixedStageDeckFixtureHtml(): string {
+  return recentProjectFixedStageDeckHtml;
+}
 
 export type ScenarioKind = 'prototype' | 'deck' | 'hyperframes' | 'image' | 'audio' | 'template' | 'workspace';
 

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import type { Locator, Page, Route } from '@playwright/test';
+import type { Project } from '@open-design/contracts';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { fulfillAgentsRoute } from './mock-factory.js';
@@ -120,7 +121,7 @@ const VISUAL_PROJECTS = [
     createdAt: 1_700_000_000_000,
     updatedAt: 1_700_000_050_000,
     metadata: { kind: 'prototype' },
-    status: { label: 'Ready', tone: 'success' },
+    status: { value: 'succeeded' },
   },
   {
     id: 'visual-project-brand-kit',
@@ -130,20 +131,11 @@ const VISUAL_PROJECTS = [
     createdAt: 1_700_000_100_000,
     updatedAt: 1_700_000_150_000,
     metadata: { kind: 'image' },
-    status: { label: 'Needs input', tone: 'warning' },
+    status: { value: 'awaiting_input' },
   },
 ] as const;
 
-export type VisualProject = {
-  id: string;
-  name: string;
-  skillId: string | null;
-  designSystemId: string | null;
-  createdAt: number;
-  updatedAt: number;
-  metadata: { kind: string };
-  status: { label: string; tone: string };
-};
+export type VisualProject = Project;
 
 /** The single conversation every workspace capture opens into. */
 const VISUAL_CONVERSATION = {

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -134,7 +134,16 @@ const VISUAL_PROJECTS = [
   },
 ] as const;
 
-type VisualProject = (typeof VISUAL_PROJECTS)[number];
+export type VisualProject = {
+  id: string;
+  name: string;
+  skillId: string | null;
+  designSystemId: string | null;
+  createdAt: number;
+  updatedAt: number;
+  metadata: { kind: string };
+  status: { label: string; tone: string };
+};
 
 /** The single conversation every workspace capture opens into. */
 const VISUAL_CONVERSATION = {

--- a/e2e/resources/recent-project-fixed-stage-deck.ts
+++ b/e2e/resources/recent-project-fixed-stage-deck.ts
@@ -1,0 +1,34 @@
+export const recentProjectFixedStageDeckHtml = `<!doctype html>
+<html>
+  <head>
+    <style>
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      .deck-shell {
+        position: fixed;
+        inset: 0;
+        overflow: hidden;
+        transform: translateX(1400px);
+      }
+      .deck-stage {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        transform: translate(24px, 16px) scale(.6);
+        transform-origin: top left;
+      }
+      .slide { position: absolute; inset: 0; display: none; }
+      .slide.active { display: grid; place-items: center; background: rgb(21, 73, 117); }
+      .reveal { opacity: 0; transform: translateY(24px); }
+    </style>
+  </head>
+  <body>
+    <div class="deck-shell">
+      <div class="deck-stage">
+        <section class="slide s-title active">
+          <h1 class="reveal">A visible first slide</h1>
+        </section>
+      </div>
+    </div>
+    <script>document.querySelector('.deck-shell').style.transform = 'none'</script>
+  </body>
+</html>`;

--- a/e2e/ui/recent-project-covers.test.ts
+++ b/e2e/ui/recent-project-covers.test.ts
@@ -16,7 +16,7 @@ const PROJECT: VisualProject = {
   createdAt: 1_700_000_000_000,
   updatedAt: 1_700_000_050_000,
   metadata: { kind: 'deck' },
-  status: { label: 'Ready', tone: 'success' },
+  status: { value: 'succeeded' },
 };
 
 const DECK_HTML = `<!doctype html>

--- a/e2e/ui/recent-project-covers.test.ts
+++ b/e2e/ui/recent-project-covers.test.ts
@@ -5,6 +5,7 @@ import {
   type VisualProject,
   waitForVisualProjects,
 } from '@/playwright/visual';
+import { fixedStageDeckFixtureHtml } from '@/playwright/resources';
 import { T } from '@/timeouts';
 
 const PROJECT_ID = 'visual-fixed-stage-deck';
@@ -19,43 +20,9 @@ const PROJECT: VisualProject = {
   status: { value: 'succeeded' },
 };
 
-const DECK_HTML = `<!doctype html>
-<html>
-  <head>
-    <style>
-      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
-      .deck-shell {
-        position: fixed;
-        inset: 0;
-        overflow: hidden;
-        transform: translateX(1400px);
-      }
-      .deck-stage {
-        position: relative;
-        width: 1920px;
-        height: 1080px;
-        transform: translate(24px, 16px) scale(.6);
-        transform-origin: top left;
-      }
-      .slide { position: absolute; inset: 0; display: none; }
-      .slide.active { display: grid; place-items: center; background: rgb(21, 73, 117); }
-      .reveal { opacity: 0; transform: translateY(24px); }
-    </style>
-  </head>
-  <body>
-    <div class="deck-shell">
-      <div class="deck-stage">
-        <section class="slide s-title active">
-          <h1 class="reveal">A visible first slide</h1>
-        </section>
-      </div>
-    </div>
-    <script>document.querySelector('.deck-shell').style.transform = 'none'</script>
-  </body>
-</html>`;
-
 test('[P1] renders a nested fixed-stage deck cover inside Recent projects', async ({ page }) => {
   test.setTimeout(T.xlong);
+  const deckHtml = fixedStageDeckFixtureHtml();
   await configureVisualPage(page, { projects: [PROJECT] });
   await page.route(`**/api/projects/${PROJECT_ID}/files`, async (route) => {
     await route.fulfill({
@@ -64,7 +31,7 @@ test('[P1] renders a nested fixed-stage deck cover inside Recent projects', asyn
           name: 'index.html',
           path: 'index.html',
           type: 'file',
-          size: DECK_HTML.length,
+          size: deckHtml.length,
           mtime: PROJECT.updatedAt,
           kind: 'html',
           mime: 'text/html; charset=utf-8',
@@ -86,7 +53,7 @@ test('[P1] renders a nested fixed-stage deck cover inside Recent projects', asyn
     });
   });
   await page.route(`**/api/projects/${PROJECT_ID}/raw/index.html**`, async (route) => {
-    await route.fulfill({ contentType: 'text/html; charset=utf-8', body: DECK_HTML });
+    await route.fulfill({ contentType: 'text/html; charset=utf-8', body: deckHtml });
   });
 
   await gotoVisualHome(page);

--- a/e2e/ui/recent-project-covers.test.ts
+++ b/e2e/ui/recent-project-covers.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@/playwright/suite';
+import {
+  configureVisualPage,
+  gotoVisualHome,
+  type VisualProject,
+  waitForVisualProjects,
+} from '@/playwright/visual';
+import { T } from '@/timeouts';
+
+const PROJECT_ID = 'visual-fixed-stage-deck';
+const PROJECT: VisualProject = {
+  id: PROJECT_ID,
+  name: 'Fixed-stage sales deck',
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_050_000,
+  metadata: { kind: 'deck' },
+  status: { label: 'Ready', tone: 'success' },
+};
+
+const DECK_HTML = `<!doctype html>
+<html>
+  <head>
+    <style>
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      .deck-shell {
+        position: fixed;
+        inset: 0;
+        overflow: hidden;
+        transform: translateX(1400px);
+      }
+      .deck-stage {
+        position: relative;
+        width: 1920px;
+        height: 1080px;
+        transform: translate(24px, 16px) scale(.6);
+        transform-origin: top left;
+      }
+      .slide { position: absolute; inset: 0; display: none; }
+      .slide.active { display: grid; place-items: center; background: rgb(21, 73, 117); }
+      .reveal { opacity: 0; transform: translateY(24px); }
+    </style>
+  </head>
+  <body>
+    <div class="deck-shell">
+      <div class="deck-stage">
+        <section class="slide s-title active">
+          <h1 class="reveal">A visible first slide</h1>
+        </section>
+      </div>
+    </div>
+    <script>document.querySelector('.deck-shell').style.transform = 'none'</script>
+  </body>
+</html>`;
+
+test('[P1] renders a nested fixed-stage deck cover inside Recent projects', async ({ page }) => {
+  test.setTimeout(T.xlong);
+  await configureVisualPage(page, { projects: [PROJECT] });
+  await page.route(`**/api/projects/${PROJECT_ID}/files`, async (route) => {
+    await route.fulfill({
+      json: {
+        files: [{
+          name: 'index.html',
+          path: 'index.html',
+          type: 'file',
+          size: DECK_HTML.length,
+          mtime: PROJECT.updatedAt,
+          kind: 'html',
+          mime: 'text/html; charset=utf-8',
+          artifactKind: 'deck',
+          artifactManifest: {
+            version: 1,
+            kind: 'deck',
+            title: PROJECT.name,
+            entry: 'index.html',
+            renderer: 'html',
+            status: 'complete',
+            exports: ['html', 'pdf'],
+            primary: true,
+            createdAt: '2026-08-28T00:00:00.000Z',
+            updatedAt: '2026-08-28T00:00:00.000Z',
+          },
+        }],
+      },
+    });
+  });
+  await page.route(`**/api/projects/${PROJECT_ID}/raw/index.html**`, async (route) => {
+    await route.fulfill({ contentType: 'text/html; charset=utf-8', body: DECK_HTML });
+  });
+
+  await gotoVisualHome(page);
+  await waitForVisualProjects(page, [PROJECT]);
+
+  const card = page.locator(`.recent-projects__card[data-project-id="${PROJECT_ID}"]`);
+  const frame = card.locator('.recent-projects__deck-iframe').contentFrame();
+  const title = frame.getByRole('heading', { name: 'A visible first slide' });
+  await expect(title).toBeVisible({ timeout: T.medium });
+  await expect(title).toHaveCSS('opacity', '1');
+  await expect.poll(async () => title.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.right > 0
+      && rect.bottom > 0
+      && rect.left < window.innerWidth
+      && rect.top < window.innerHeight;
+  })).toBe(true);
+  await expect(frame.locator('[data-od-cover-slide]')).toHaveCSS(
+    'background-color',
+    'rgb(21, 73, 117)',
+  );
+});


### PR DESCRIPTION
Fixes #7554

## Why

A completed deck generated from the bundled fixed-stage example can render correctly in the project viewer while Home → Recent projects shows a blank white cover. The static cover path removes the deck runtime script but only normalized the immediate slide parent, so an outer `.deck-shell` transform could leave the first slide entirely outside the cover viewport.

This fixes the reported Windows prerelease regression and adds a real-browser witness for the geometry that string-only srcDoc assertions missed.

## What users will see

Completed decks that use nested `.deck-shell > .deck-stage > .slide` markup now show slide 1 in their Recent projects card after returning Home or reopening the app.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI chrome or layout is introduced. The Playwright regression renders the real Home card and asserts that the first-slide heading intersects the iframe viewport and retains the expected non-white background.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/recent-project-covers.test.ts`
- Did the test go red on `main` and green on this branch? yes
- RED: the rendered heading existed and was opacity 1, but its bounding box never intersected the 1280×720 iframe viewport.
- GREEN: explicitly normalizing both fixed-stage wrappers keeps slide 1 inside the cover viewport.

## Validation

- `pnpm exec playwright test -c playwright.config.ts ui/recent-project-covers.test.ts --workers=1` — pass
- `pnpm exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx --maxWorkers=1` — 35 passed
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm typecheck` in `e2e` — pass
- root `pnpm typecheck` — pass
- `git diff --check` — pass
- root `pnpm guard` — blocked by pre-existing residual JavaScript findings in `apps/landing-page/public/enhancers/cobe.js` and `apps/landing-page/public/enhancers/matter.min.js`; all other reported guard sections completed successfully.