### PR TITLE
fix(web): ignore commented slide tags in covers

### DIFF
--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -2565,41 +2565,32 @@ export function deckPreviewSrcDoc(html: string): string {
 }
 
 function markFirstDeckPage(html: string): string {
-  const tags = [...html.matchAll(/<[a-z][\w:-]*\b[^>]*>/giu)];
-  const classSlide = tags.find((match) => {
-    const className = match[0].match(/\bclass\s*=\s*(["'])(.*?)\1/iu)?.[2];
-    return className?.split(/\s+/u).includes('slide') === true;
-  });
-  const page = classSlide
-    ?? tags.find((match) => /\sdata-slide(?:\s|=|>)/iu.test(match[0]))
-    ?? tags.find((match) => /\sdata-screen-label(?:\s|=|>)/iu.test(match[0]));
-  if (!page || page.index === undefined) return html;
-  const tag = page[0];
-  const classAttribute = tag.match(/\bclass\s*=\s*(["'])(.*?)\1/iu);
-  const activeClasses = ['active', 'is-active'];
-  let activated = tag;
-  if (classAttribute) {
-    const quote = classAttribute[1];
-    const classes = classAttribute[2]?.split(/\s+/u).filter(Boolean) ?? [];
-    for (const activeClass of activeClasses) {
-      if (!classes.includes(activeClass)) classes.push(activeClass);
-    }
-    activated = activated.replace(
-      classAttribute[0],
-      `class=${quote}${classes.join(' ')}${quote}`,
-    );
-  } else {
-    activated = activated.replace(/\s*\/?\s*>$/u, (ending) => (
-      ` class="${activeClasses.join(' ')}"${ending}`
-    ));
+  // The cover document is already inert after script removal. Parse it as HTML
+  // so examples inside comments and raw-text elements cannot impersonate a slide.
+  if (typeof DOMParser === 'undefined') return html;
+  let parsed: Document;
+  try {
+    parsed = new DOMParser().parseFromString(html, 'text/html');
+  } catch {
+    return html;
   }
-  activated = activated
-    .replace(/\saria-hidden\s*=\s*(["'])true\1/iu, ' aria-hidden="false"')
-    .replace(/\shidden(?:\s*=\s*(["'])?hidden\1?)?(?=\s|\/?\s*>)/iu, '');
-  const marked = activated.endsWith('/>')
-    ? `${activated.slice(0, -2)} data-od-cover-slide />`
-    : `${activated.slice(0, -1)} data-od-cover-slide>`;
-  return `${html.slice(0, page.index)}${marked}${html.slice(page.index + tag.length)}`;
+  const page = parsed.querySelector('.slide')
+    ?? parsed.querySelector('[data-slide]')
+    ?? parsed.querySelector('[data-screen-label]');
+  if (!page) return html;
+  const activeClasses = ['active', 'is-active'];
+  for (const activeClass of activeClasses) {
+    page.classList.add(activeClass);
+  }
+  if (page.getAttribute('aria-hidden')?.toLowerCase() === 'true') {
+    page.setAttribute('aria-hidden', 'false');
+  }
+  page.removeAttribute('hidden');
+  page.setAttribute('data-od-cover-slide', '');
+  const doctype = parsed.doctype && typeof XMLSerializer !== 'undefined'
+    ? new XMLSerializer().serializeToString(parsed.doctype)
+    : '';
+  return `${doctype}${parsed.documentElement.outerHTML}`;
 }
 
 function injectBefore(source: string, marker: string, addition: string): string {

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -245,6 +245,28 @@ describe('RecentProjectsStrip', () => {
     expect(cover).toContain('.slide:not([data-od-cover-slide])');
   });
 
+  it('marks the first real slide when a style comment contains a slide tag example', () => {
+    const cover = deckPreviewSrcDoc(`<!doctype html>
+      <html><head><style>
+        /* Put content inside <section class="slide"> bodies. */
+        .slide { display: none }
+        .slide.active { display: grid }
+      </style></head><body>
+        <div class="deck-shell"><div class="deck-stage">
+          <section class="slide s-title active"><h1>Real cover</h1></section>
+          <section class="slide s-details"><h2>Details</h2></section>
+        </div></div>
+      </body></html>`);
+
+    expect(cover).toContain('inside <section class="slide"> bodies');
+    expect(cover).toMatch(
+      /<section class="slide s-title active is-active" data-od-cover-slide(?:="")?>/,
+    );
+    expect(cover).not.toContain(
+      'inside <section class="slide active is-active" data-od-cover-slide> bodies',
+    );
+  });
+
   it('lets a 16:9 project cover determine its grid-card height without a taller minimum', () => {
     const css = readFileSync(
       join(process.cwd(), 'src/styles/home/recent-projects.css'),

--- a/e2e/ui/recent-project-comment-cover.test.ts
+++ b/e2e/ui/recent-project-comment-cover.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@/playwright/suite';
+import { configureVisualPage, gotoVisualHome } from '@/playwright/visual';
+import { T } from '@/timeouts';
+
+const PROJECT_ID = 'visual-comment-slide-deck';
+const PROJECT_NAME = 'Comment-safe sales deck';
+const UPDATED_AT = 1_700_000_050_000;
+const DECK_HTML = `<!doctype html>
+<html>
+  <head>
+    <style>
+      /* Put authored content inside <section class="slide"> bodies. */
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      .deck-shell { position: fixed; inset: 0; overflow: hidden; }
+      .deck-stage { position: relative; width: 1280px; height: 720px; }
+      .slide { position: absolute; inset: 0; display: none; }
+      .slide.active { display: grid; place-items: center; background: rgb(21, 73, 117); }
+    </style>
+  </head>
+  <body>
+    <div class="deck-shell">
+      <div class="deck-stage">
+        <section class="slide s-title active"><h1>Real comment-safe cover</h1></section>
+        <section class="slide s-details"><h2>Details</h2></section>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+test('[P1] ignores slide tag examples in comments when rendering a recent cover', async ({ page }) => {
+  test.setTimeout(T.xlong);
+  await configureVisualPage(page, { projects: [] });
+  await page.route('**/api/projects', async (route) => {
+    await route.fulfill({
+      json: {
+        projects: [{
+          id: PROJECT_ID,
+          name: PROJECT_NAME,
+          skillId: null,
+          designSystemId: null,
+          createdAt: 1_700_000_000_000,
+          updatedAt: UPDATED_AT,
+          metadata: { kind: 'deck' },
+          status: { label: 'Ready', tone: 'success' },
+        }],
+      },
+    });
+  });
+  await page.route(`**/api/projects/${PROJECT_ID}/files`, async (route) => {
+    await route.fulfill({
+      json: {
+        files: [{
+          name: 'index.html',
+          path: 'index.html',
+          type: 'file',
+          size: DECK_HTML.length,
+          mtime: UPDATED_AT,
+          kind: 'html',
+          mime: 'text/html; charset=utf-8',
+          artifactKind: 'deck',
+          artifactManifest: {
+            version: 1,
+            kind: 'deck',
+            title: PROJECT_NAME,
+            entry: 'index.html',
+            renderer: 'html',
+            status: 'complete',
+            exports: ['html', 'pdf'],
+            primary: true,
+            createdAt: '2026-08-28T00:00:00.000Z',
+            updatedAt: '2026-08-28T00:00:00.000Z',
+          },
+        }],
+      },
+    });
+  });
+  await page.route(`**/api/projects/${PROJECT_ID}/raw/index.html**`, async (route) => {
+    await route.fulfill({ contentType: 'text/html; charset=utf-8', body: DECK_HTML });
+  });
+
+  await gotoVisualHome(page);
+  const card = page.locator(`.recent-projects__card[data-project-id="${PROJECT_ID}"]`);
+  await expect(card.getByText(PROJECT_NAME, { exact: true })).toBeVisible({ timeout: T.medium });
+  const frame = card.locator('.recent-projects__deck-iframe').contentFrame();
+  const title = frame.getByRole('heading', { name: 'Real comment-safe cover' });
+  await expect(title).toBeVisible({ timeout: T.medium });
+  await expect.poll(async () => title.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return rect.right > 0
+      && rect.bottom > 0
+      && rect.left < window.innerWidth
+      && rect.top < window.innerHeight;
+  })).toBe(true);
+  await expect(frame.locator('[data-od-cover-slide]')).toHaveCSS(
+    'background-color',
+    'rgb(21, 73, 117)',
+  );
+});


### PR DESCRIPTION
Fixes #7555

## Why

A completed deck can render normally in the project viewer while Home → Recent projects shows a white cover when a leading HTML or CSS comment contains markup-like text such as `<section class="slide">`.

The cover transform scanned raw source text with a tag-shaped regular expression. That allowed inert examples inside comments or raw-text elements to receive `data-od-cover-slide`, after which the preview CSS hid every real slide.

## What users will see

Recent project covers now select the first real deck slide even when the generated HTML documents its slide contract with markup examples in comments. The actual first slide remains visible instead of producing a blank white card.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI chrome or layout is introduced. The Playwright regression renders the real Home card and asserts that the real first-slide heading intersects the iframe viewport and retains its non-white background.

## Bug fix verification

- RED test path: `apps/web/tests/components/RecentProjectsStrip.test.tsx`
- Browser regression: `e2e/ui/recent-project-comment-cover.test.ts`
- Did the test go red on `main` and green on this branch? yes
- RED: `deckPreviewSrcDoc()` inserted `active`, `is-active`, and `data-od-cover-slide` into the `<section class="slide">` example inside the style comment; the real first slide remained unmarked.
- GREEN: the inert cover document is parsed with browser HTML semantics, so only a real DOM slide can receive the marker.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx --maxWorkers=1` — 36 passed
- `pnpm exec playwright test -c playwright.config.ts ui/recent-project-comment-cover.test.ts --workers=1` — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm typecheck` in `e2e` — pass
- root `pnpm typecheck` — pass
- `git diff --check` — pass
- root `pnpm guard` — blocked by pre-existing residual JavaScript findings in `apps/landing-page/public/enhancers/cobe.js` and `apps/landing-page/public/enhancers/matter.min.js`; all other reported guard sections completed successfully.